### PR TITLE
Restrict VCS to git and fix review findings

### DIFF
--- a/docs/guides/lockfile.md
+++ b/docs/guides/lockfile.md
@@ -23,7 +23,7 @@ Each pinned package carries:
 * its name and version,
 * one of three pin shapes: an `IndexPin` (PyPI or another simple
   index), a `LocalPin` (a directory on disk), or a `VcsPin` (a
-  git/hg/etc. URL with a commit pin),
+  git URL with a commit pin),
 * every artefact downloaded for that pin (`sdist` and `wheels`),
   each with its filename, URL, `sha256`, and optional size.
 

--- a/docs/guides/vcs.md
+++ b/docs/guides/vcs.md
@@ -1,9 +1,9 @@
 # VCS dependencies
 
-nab resolves dependencies pulled from version-control URLs (git,
-hg, svn) through `[tool.nab.vcs]` and `[[tool.nab.vcs-sources]]`.
-The default posture is fully restrictive: nothing VCS-shaped
-resolves without an explicit policy.
+nab resolves dependencies pulled from git URLs through
+`[tool.nab.vcs]` and `[[tool.nab.vcs-sources]]`.  Only git is
+supported; hg, svn, and bzr are not.  The default posture is fully
+restrictive: nothing VCS-shaped resolves without an explicit policy.
 
 ## Default posture
 
@@ -25,20 +25,23 @@ allowlists.
 [tool.nab.vcs]
 policy = "allow"
 allowed-schemes = ["git+https"]
-allowed-repos = ["github.com/myorg/"]
+allowed-repos = ["https://github.com/myorg/"]
 require-pin = true
 ```
 
 Three layers, each AND-checked:
 
-1. `allowed-schemes`: pip-style scheme prefixes (`git+https`,
-   `git+ssh`, `hg+https`, ...).  Empty means "no scheme is allowed".
-2. `allowed-repos`: prefix match against the URL after the scheme
-   strip.  `github.com/myorg/` matches every repo under that org.
-   Empty means "no repo is allowed".
-3. `require-pin`: when `true`, the URL must include a commit
-   identifier (a tag or a sha after `@`).  Bare branch references
-   are rejected because they are mutable.
+1. `allowed-schemes`: pip-style scheme prefixes.  The supported set
+   is `git+https`, `git+ssh`, `git+http`, `git+file`, `git+git`.
+   Empty means "no scheme is allowed".  `git+http` and `git+git` are
+   unauthenticated; prefer `git+https` or `git+ssh`.
+2. `allowed-repos`: prefix match against the URL after the
+   `git+` prefix is stripped, so the value includes the inner
+   scheme.  `https://github.com/myorg/` matches every HTTPS repo
+   under that org.  Empty means "no repo is allowed".
+3. `require-pin`: when `true`, the URL must include a 40-char hex
+   commit SHA after `@`.  Branch and tag references are rejected
+   because they are mutable.
 
 ## Pinned VCS sources
 
@@ -48,7 +51,7 @@ The supported entry point is `[[tool.nab.vcs-sources]]`:
 [tool.nab.vcs]
 policy = "allow"
 allowed-schemes = ["git+https"]
-allowed-repos = ["github.com/myorg/"]
+allowed-repos = ["https://github.com/myorg/"]
 require-pin = true
 
 [[tool.nab.vcs-sources]]
@@ -59,7 +62,10 @@ url  = "git+https://github.com/myorg/my-fork.git@<sha>"
 The named package becomes a single-version source pinned to the
 commit you specified.  nab clones the repo, reads the static
 metadata (Layer 2: clone + static metadata), and treats the
-result as a normal dependency for the rest of the resolve.
+result as a normal dependency for the rest of the resolve.  The
+URL in each `[[tool.nab.vcs-sources]]` table is run through the
+same admission as project-root requirements, so it must pass
+`allowed-schemes`, `allowed-repos`, and `require-pin`.
 
 Reading static dependencies from the cloned tree works at any
 `build-policy` level.  Dynamic dependencies on a VCS clone
@@ -87,6 +93,8 @@ instead.
 ## Lockfile shape
 
 VCS pins land in the lockfile as `VcsPin` records carrying the
-repo URL, the resolved commit id, and an optional `subdirectory`.
-They do not carry a `sha256` (pip does not hash-check VCS forms),
-so `nab download` skips them.
+repo URL, the resolved 40-char commit SHA, and an optional
+`subdirectory`.  Annotated tags are dereferenced to their
+underlying commit so the lock never records a tag-object SHA.
+VcsPins do not carry a `sha256` (pip does not hash-check VCS
+forms), so `nab download` skips them.

--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -198,7 +198,7 @@ class CachedAsyncSimpleClient:
         """
         pkg_info = self._cache.get_sdist_pkginfo(package, version)
         pyproject_toml = self._cache.get_sdist_pyproject(package, version)
-        if pkg_info is not None:
+        if pkg_info is not None or pyproject_toml is not None:
             return (pkg_info, pyproject_toml)
 
         if self._offline:

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -307,16 +307,14 @@ def _read_tar_sdist_files(data: bytes) -> tuple[str | None, str | None]:
 
     with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
         for member in tar:
-            if pkg_info is None and (
-                member.name.endswith("/PKG-INFO") or member.name == "PKG-INFO"
-            ):
+            depth, basename = _sdist_member_top_level(member.name)
+            if depth > 1:
+                continue
+            if pkg_info is None and basename == "PKG-INFO":
                 extracted = tar.extractfile(member)
                 if extracted is not None:
                     pkg_info = extracted.read().decode("utf-8")
-            elif pyproject_toml is None and (
-                member.name.endswith("/pyproject.toml")
-                or member.name == "pyproject.toml"
-            ):
+            elif pyproject_toml is None and basename == "pyproject.toml":
                 extracted = tar.extractfile(member)
                 if extracted is not None:
                     pyproject_toml = extracted.read().decode("utf-8")
@@ -325,6 +323,21 @@ def _read_tar_sdist_files(data: bytes) -> tuple[str | None, str | None]:
                 break
 
     return (pkg_info, pyproject_toml)
+
+
+def _sdist_member_top_level(name: str) -> tuple[int, str]:
+    """Return ``(depth, basename)`` for a tar member relative to the sdist root.
+
+    Strips a single leading ``./``.  Depth 0 means the file sits at the
+    archive root (rare); depth 1 means it sits directly under the
+    conventional ``<name>-<version>/`` top-level directory.  Anything
+    deeper is reported as-is so callers can ignore it.
+    """
+    stripped = name.removeprefix("./")
+    if not stripped or stripped.startswith("/"):
+        return (-1, "")
+    parts = stripped.split("/")
+    return (len(parts) - 1, parts[-1])
 
 
 def extract_sdist_archive(data: bytes, target_dir: Path) -> Path:
@@ -343,12 +356,17 @@ def extract_sdist_archive(data: bytes, target_dir: Path) -> Path:
     root: Path | None = None
     with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
         for member in tar:
-            member_name = member.name.lstrip("./")
+            raw_name = member.name
+            if not raw_name or raw_name.startswith(("/", "./.")) or "\\" in raw_name:
+                msg = f"unsafe sdist member: {raw_name!r}"
+                raise ValueError(msg)
+            member_name = raw_name.removeprefix("./")
             if not member_name or member_name.startswith("/"):
-                continue
+                msg = f"unsafe sdist member: {raw_name!r}"
+                raise ValueError(msg)
             parts = Path(member_name).parts
-            if any(p == ".." for p in parts):
-                msg = f"unsafe sdist member: {member.name!r}"
+            if any(p in ("..", "") for p in parts):
+                msg = f"unsafe sdist member: {raw_name!r}"
                 raise ValueError(msg)
             tar.extract(member, target_dir, filter="data")
             if root is None and member.isdir() and len(parts) == 1:

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -133,7 +133,12 @@ def _resolve_local_link(
         path = _parse_file_url(href_no_frag)
         return (path.name, href_no_frag, hashes)
 
-    target = (package_dir / unquote(href_no_frag)).resolve()
+    package_dir_resolved = package_dir.resolve()
+    target = (package_dir_resolved / unquote(href_no_frag)).resolve()
+    try:
+        target.relative_to(package_dir_resolved)
+    except ValueError:
+        return (None, "", ())
     return (target.name, target.as_uri(), hashes)
 
 

--- a/nab-index/src/nab_index/vcs.py
+++ b/nab-index/src/nab_index/vcs.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 # VCS-admission code in ``nab_python.provider`` shares one definition with
 # the clone-time validation in this module.
 FULL_GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
-_VCS_PREFIX_RE = re.compile(r"^(git|hg|bzr|svn)\+")
+_VCS_PREFIX_RE = re.compile(r"^git\+")
 
 
 class VcsCloneError(Exception):
@@ -90,7 +90,6 @@ class VcsRequest:
         if match is None:
             msg = f"not a recognised VCS URL: {url!r}"
             raise VcsCloneError(msg)
-        scheme = match.group(1)
         inner = url_no_frag[len(match.group(0)) :]
         repo, ref = _split_repo_ref(inner)
 
@@ -99,7 +98,7 @@ class VcsRequest:
             key, _, value = fragment_part.partition("=")
             if key == "subdirectory":
                 subdirectory = value
-        return cls(scheme=scheme, repo_url=repo, ref=ref, subdirectory=subdirectory)
+        return cls(scheme="git", repo_url=repo, ref=ref, subdirectory=subdirectory)
 
 
 def _split_repo_ref(inner: str) -> tuple[str, str]:
@@ -110,10 +109,17 @@ def _split_repo_ref(inner: str) -> tuple[str, str]:
     so branch names containing ``/`` (e.g. ``release/1.0``) survive.
     A ``user@`` in the authority section is left alone.
 
-    For the SSH shortcut form (``user@host:path``) there is no ref;
-    pip and uv require explicit ``@<ref>`` only on URL forms.
+    For the SSH shortcut form (``user@host:path[@<ref>]``), the first
+    ``:`` separates the auth+host from the path; an optional
+    ``@<ref>`` may follow the path.
     """
     if "://" not in inner:
+        if ":" not in inner:
+            return (inner, "")
+        host_part, _, path_part = inner.partition(":")
+        if "@" in path_part:
+            path_repo, _, ref = path_part.rpartition("@")
+            return (f"{host_part}:{path_repo}", ref)
         return (inner, "")
 
     scheme_part, _, rest = inner.partition("://")
@@ -196,14 +202,21 @@ def _resolve_sha(request: VcsRequest, *, require_pin: bool) -> str:
         msg = f"git ls-remote {request.repo_url} {target}: {exc}"
         raise VcsCloneError(msg) from exc
 
-    line = proc.stdout.strip().splitlines()
-    if not line:
+    lines = proc.stdout.strip().splitlines()
+    if not lines:
         msg = f"no ref {target!r} found at {request.repo_url}"
         raise VcsCloneError(msg)
 
-    sha = line[0].split()[0]
+    # ``git ls-remote`` advertises the tag-object SHA on the
+    # ``refs/tags/<name>`` line for annotated tags, with the peeled
+    # commit on a companion ``refs/tags/<name>^{}`` line.  Prefer the
+    # peeled commit so the lock pins a commit, not a tag object.
+    peeled = next((ln for ln in lines if ln.split()[-1].endswith("^{}")), None)
+    chosen = peeled if peeled is not None else lines[0]
+
+    sha = chosen.split()[0]
     if not FULL_GIT_SHA_RE.match(sha):
-        msg = f"unexpected ls-remote output: {line[0]!r}"
+        msg = f"unexpected ls-remote output: {chosen!r}"
         raise VcsCloneError(msg)
 
     return sha

--- a/nab-python/src/nab_python/_build/env.py
+++ b/nab-python/src/nab_python/_build/env.py
@@ -117,7 +117,7 @@ class NabBuildEnv:
         self._requires = list(requires)
         self._config = config
         self._python_version = python_version
-        self._transport = transport_factory()
+        self._transport_factory = transport_factory
 
         self._tmpdir: tempfile.TemporaryDirectory[str] | None = None
         self._venv_path: Path | None = None
@@ -273,9 +273,13 @@ class NabBuildEnv:
             uploaded_prior_to=self._config.uploaded_prior_to,
             uploaded_prior_to_overrides=self._config.uploaded_prior_to_overrides,
         )
+        # download_lock closes its transport, and ``install`` may call
+        # this again for ``get_requires_for_build_wheel`` follow-ups;
+        # build a fresh transport each time.
+        transport = self._transport_factory()
         result = resolve_pyproject(
             synthetic,
-            self._transport,
+            transport,
             config=inner_config,
             python_version=self._python_version,
         )
@@ -298,7 +302,7 @@ class NabBuildEnv:
             )
             raise BuildEnvError(msg)
 
-        download_result = download_lock(result.lock_input, self._transport, wheel_dir)
+        download_result = download_lock(result.lock_input, transport, wheel_dir)
         # Both wheels and sdists are downloaded; only wheels feed
         # ``installer.install``.  The sdists are inert clutter under
         # the temp dir, cleaned up with the env.

--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -81,6 +81,10 @@ class LockInputProvider(Protocol):
         """Return the configured VcsSource for ``canonical_name`` or None."""
         ...
 
+    def vcs_pin_for(self, canonical_name: str, /) -> str | None:
+        """Return the resolved 40-char SHA captured during materialisation."""
+        ...
+
     def dist_files_for(
         self, canonical_name: str, version: Version, /
     ) -> list[WheelFile | SdistFile]:
@@ -176,7 +180,12 @@ def build_lock_input_from_provider(
             continue
         vcs_source = provider.vcs_source_for(canonical)
         if vcs_source is not None:
-            lock_pins[canonical] = _vcs_pin_from_source(canonical, version, vcs_source)
+            lock_pins[canonical] = _vcs_pin_from_source(
+                canonical,
+                version,
+                vcs_source,
+                resolved_sha=provider.vcs_pin_for(canonical),
+            )
             continue
         lock_pins[canonical] = _index_pin_from_listing(
             provider, canonical, version, indexes
@@ -314,23 +323,32 @@ def _common_requires_python(files: Iterable[WheelFile | SdistFile]) -> str | Non
     return None
 
 
-def _vcs_pin_from_source(canonical: str, version: Version, source: VcsSource) -> VcsPin:
+def _vcs_pin_from_source(
+    canonical: str,
+    version: Version,
+    source: VcsSource,
+    *,
+    resolved_sha: str | None,
+) -> VcsPin:
     """Build a :class:`VcsPin` from a :class:`VcsSource`.
 
-    The commit id is the ``@<ref>`` portion of the source URL when
-    present, parsed via :class:`nab_index.vcs.VcsRequest`.  Unparseable
-    URLs fall through to an empty commit id; the source URL itself is
-    recorded verbatim.
+    Prefer ``resolved_sha`` (the post-clone SHA recorded on the
+    provider) over the URL's ``@<ref>``: annotated tags and floating
+    refs only resolve to a commit after the clone runs.  Fall back to
+    the URL ref when the source was never materialised.
     """
     from nab_index.vcs import VcsCloneError, VcsRequest
 
     from ..lockfile import VcsPin
 
-    try:
-        parsed = VcsRequest.parse(source.url)
-        commit_id = parsed.ref
-    except VcsCloneError:
-        commit_id = ""
+    if resolved_sha is not None:
+        commit_id = resolved_sha
+    else:
+        try:
+            parsed = VcsRequest.parse(source.url)
+            commit_id = parsed.ref
+        except VcsCloneError:
+            commit_id = ""
     return VcsPin(
         name=canonical,
         version=str(version),

--- a/nab-python/src/nab_python/_provider/sources.py
+++ b/nab-python/src/nab_python/_provider/sources.py
@@ -151,8 +151,13 @@ def index_vcs_sources(
     :func:`extract_source_metadata`).  ``VcsPolicy.BLOCK`` still refuses
     any declaration up-front because that is an independent decision
     about whether VCS fetching is permitted at all.
+
+    Each URL is passed through :func:`admit_vcs_url` so the scheme,
+    repo, and pin allowlists apply to ``[[tool.nab.vcs-sources]]``
+    just like project-root direct-URL requirements.
     """
     # Late import: ``pypi`` imports this module at module load.
+    from .._vcs_admission import admit_vcs_url
     from ..provider import VcsPolicy
 
     if not sources:
@@ -168,6 +173,7 @@ def index_vcs_sources(
 
     out: dict[str, VcsSource] = {}
     for src in sources:
+        admit_vcs_url(src.url, provider.vcs_config)
         canonical = canonicalize_name(src.name)
         if canonical in out or canonical in provider.local_sources:
             msg = f"duplicate source declared for {src.name!r}"
@@ -204,6 +210,7 @@ def materialize_vcs_source(
     except VcsCloneError as exc:
         msg = f"vcs source {source.name!r}: {exc}"
         raise UnsupportedSdistError(msg) from exc
+    provider.vcs_pins[canonicalize_name(source.name)] = clone.commit_sha
     path = clone.path / clone.subdirectory if clone.subdirectory else clone.path
     metadata = extract_source_metadata(
         provider,

--- a/nab-python/src/nab_python/_vcs_admission.py
+++ b/nab-python/src/nab_python/_vcs_admission.py
@@ -77,49 +77,26 @@ _VCS_SCHEMES: frozenset[str] = frozenset(
         "git+http",
         "git+file",
         "git+git",
-        "git",
-        "hg+https",
-        "hg+ssh",
-        "hg+http",
-        "hg+file",
-        "hg+static-http",
-        "bzr+https",
-        "bzr+ssh",
-        "bzr+sftp",
-        "bzr+ftp",
-        "bzr+lp",
-        "bzr+file",
-        "svn",
-        "svn+https",
-        "svn+ssh",
-        "svn+http",
-        "svn+file",
     }
 )
 
-_VCS_INSECURE_SCHEMES: frozenset[str] = frozenset(
-    {"git", "git+git", "git+http", "hg+http", "bzr+http", "svn", "svn+http"}
-)
+_VCS_INSECURE_SCHEMES: frozenset[str] = frozenset({"git+git", "git+http"})
 
 
 def split_vcs_scheme(url: str) -> tuple[str | None, str]:
     """Strip a recognized VCS scheme prefix.
 
     ``"git+https://example.com/r.git@v1"`` -> ``("git+https", "https://example.com/r.git@v1")``.
-    ``"svn://example.com/r"``              -> ``("svn",       "svn://example.com/r")``.
     ``"https://example.com/file.whl"``     -> ``(None,        "https://example.com/file.whl")``.
 
     Returns ``(None, url)`` for non-VCS URLs (e.g. plain ``https://``
     archives or ``file://`` paths) so the caller can refuse them
-    separately.  Pip-compatible scheme list; not standardized by any PEP.
+    separately.  Only ``git+`` schemes are recognised; ``hg+``/``bzr+``/``svn+``
+    are intentionally absent so they are refused as non-VCS.
     """
     for vcs_scheme in _VCS_SCHEMES:
-        if not url.startswith(f"{vcs_scheme}://"):
-            continue
-        inner_scheme, plus, _ = vcs_scheme.partition("+")
-        if not plus:
-            return (vcs_scheme, url)
-        return (vcs_scheme, url[len(inner_scheme) + 1 :])
+        if url.startswith(f"{vcs_scheme}://"):
+            return (vcs_scheme, url[len("git+") :])
     return (None, url)
 
 
@@ -128,9 +105,7 @@ def has_full_commit_sha(url: str) -> bool:
 
     Looks for ``@<sha>`` after the scheme://host portion; ignores any
     ``#`` fragment.  Tolerates ``user@host`` syntax by taking the last
-    ``@`` in the path/ref portion.  Mercurial uses 40-char SHA1 too, so
-    the same regex covers git+hg.  Bzr/svn revisions are not hashes;
-    ``vcs_require_pin = False`` is the way to allow those.
+    ``@`` in the path/ref portion.
     """
     fragmentless = url.split("#", 1)[0]
     after_authority = fragmentless.split("://", 1)[-1]
@@ -152,8 +127,9 @@ def admit_vcs_url(url: str, config: VcsConfig) -> str:
         msg = (
             "refusing direct-URL requirement (not a recognized VCS scheme)\n"
             f"    {url}\n"
-            "    note: nab supports git+/hg+/bzr+/svn+ schemes only;"
-            " plain http(s)/file archive URLs are not supported."
+            "    note: nab supports git+https / git+ssh / git+http /"
+            " git+file / git+git only; hg/bzr/svn and plain"
+            " http(s)/file archive URLs are not supported."
         )
         raise UnsupportedVcsError(msg)
 

--- a/nab-python/src/nab_python/download.py
+++ b/nab-python/src/nab_python/download.py
@@ -136,29 +136,36 @@ async def _run_downloads(
     client = AsyncSimpleClient(transport)
     written: list[Path] = []
     skipped: list[Path] = []
+
+    async def _one(entry: DownloadEntry) -> None:
+        async with sem:
+            target = output_dir / entry.filename
+            if _already_present(target, entry.hash_algo, entry.digest):
+                skipped.append(target)
+                logger.info("skip %s (%s matches)", entry.filename, entry.hash_algo)
+                return
+            data = await client.download(entry.url)
+            actual = hashlib.new(entry.hash_algo, data).hexdigest()
+            if actual != entry.digest:
+                msg = (
+                    f"{entry.package}=={entry.version}: {entry.hash_algo}"
+                    f" mismatch for {entry.filename}\n"
+                    f"  expected: {entry.digest}\n  actual:   {actual}"
+                )
+                raise DownloadError(msg)
+            target.write_bytes(data)
+            written.append(target)
+            logger.info("wrote %s", target)
+
+    tasks = [asyncio.create_task(_one(a)) for a in artefacts]
     try:
-
-        async def _one(entry: DownloadEntry) -> None:
-            async with sem:
-                target = output_dir / entry.filename
-                if _already_present(target, entry.hash_algo, entry.digest):
-                    skipped.append(target)
-                    logger.info("skip %s (%s matches)", entry.filename, entry.hash_algo)
-                    return
-                data = await client.download(entry.url)
-                actual = hashlib.new(entry.hash_algo, data).hexdigest()
-                if actual != entry.digest:
-                    msg = (
-                        f"{entry.package}=={entry.version}: {entry.hash_algo}"
-                        f" mismatch for {entry.filename}\n"
-                        f"  expected: {entry.digest}\n  actual:   {actual}"
-                    )
-                    raise DownloadError(msg)
-                target.write_bytes(data)
-                written.append(target)
-                logger.info("wrote %s", target)
-
-        await asyncio.gather(*(_one(a) for a in artefacts))
+        await asyncio.gather(*tasks)
+    except BaseException:
+        for t in tasks:
+            if not t.done():
+                t.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
     finally:
         await client.aclose()
     return DownloadResult(written=tuple(written), skipped=tuple(skipped))

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -740,6 +740,7 @@ class FetchCoordinator:
                 # transitive dep 404s or fails any other way.
                 if req.kind is FetchKind.LISTING:
                     self.index.store_listing(req.package, [])
+                    self._record_serving_index(client, req.package)
                 else:
                     assert req.version is not None
                     if req.kind is FetchKind.METADATA:

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -425,6 +425,7 @@ class Provider:
         self.vcs_config = vcs_config or VcsConfig()
         self.local_sources = _sources.index_local_sources(self, local_sources or [])
         self.vcs_cache_dir = vcs_cache_dir
+        self.vcs_pins: dict[str, str] = {}
         self.vcs_sources = _sources.index_vcs_sources(self, vcs_sources or [])
 
         # default_environment() returns a TypedDict whose ``.items()`` view
@@ -1222,6 +1223,14 @@ class Provider:
     def vcs_source_for(self, canonical_name: str) -> VcsSource | None:
         """Return the VCS source registered under ``canonical_name`` or None."""
         return self.vcs_sources.get(canonicalize_name(canonical_name))
+
+    def vcs_pin_for(self, canonical_name: str) -> str | None:
+        """Return the post-clone commit SHA for ``canonical_name``, or None.
+
+        Written by :func:`~nab_python._provider.sources.materialize_vcs_source`
+        after the shallow clone resolves the ref to a 40-char SHA.
+        """
+        return self.vcs_pins.get(canonicalize_name(canonical_name))
 
     def dist_files_for(self, canonical_name: str, version: Version) -> list[DistFile]:
         """Return every distribution file the resolver saw at ``version``.

--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -495,8 +495,16 @@ def _resolve_one_tuple(  # noqa: PLR0913
         lock_input = build_lock_input_from_provider(
             provider, pins, indexes=coordinator.indexes
         )
-    except MissingHashError:
-        lock_input = None
+    except MissingHashError as exc:
+        return TupleResult(
+            tuple_=t,
+            success=False,
+            pins=pins,
+            error=f"MissingHashError: {exc}"[:_ERROR_MESSAGE_LIMIT],
+            wall_time=elapsed,
+            rounds=resolver.stats.rounds,
+            decisions=resolver.stats.decisions,
+        )
     return TupleResult(
         tuple_=t,
         success=True,

--- a/nab-python/src/nab_python/universal/wheel_selection.py
+++ b/nab-python/src/nab_python/universal/wheel_selection.py
@@ -131,11 +131,12 @@ def _linux_platform_tags(
     out = [f"manylinux_{major}_{m}_{arch}" for m in range(minor, -1, -1)]
     # Legacy aliases (PEPs 513/571/599).  These map to specific
     # glibc versions: manylinux1=2.5, manylinux2010=2.12,
-    # manylinux2014=2.17.  We include them when they're <= floor.
+    # manylinux2014=2.17.  Listed highest-glibc first so the output
+    # stays in install-preference order alongside the PEP 600 forms.
     legacy_aliases = [
-        ("manylinux1", (2, 5)),
-        ("manylinux2010", (2, 12)),
         ("manylinux2014", (2, 17)),
+        ("manylinux2010", (2, 12)),
+        ("manylinux1", (2, 5)),
     ]
     out.extend(
         f"{name}_{arch}" for name, lver in legacy_aliases if lver <= manylinux_floor

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -287,15 +287,31 @@ class TestExtractSdistFiles:
         assert pkg_info == "Metadata-Version: 2.1\n"
 
     def test_skips_directory_named_pkg_info(self) -> None:
+        """A depth-1 directory named PKG-INFO yields no metadata text."""
         body = _build_tarball(
             [
                 ("pkg-1.0/PKG-INFO", None),
-                ("pkg-1.0/real/PKG-INFO", b"Metadata-Version: 2.1\nName: real\n"),
+                ("pkg-1.0/setup.py", b"# something"),
             ]
         )
         pkg_info, _ = _extract_sdist_files(body)
-        assert pkg_info is not None
-        assert "Name: real" in pkg_info
+        assert pkg_info is None
+
+    def test_ignores_pkg_info_below_top_level(self) -> None:
+        """A PKG-INFO buried below the conventional ``<name>-<version>/`` is ignored."""
+        body = _build_tarball(
+            [("pkg-1.0/sub/PKG-INFO", b"Metadata-Version: 2.1\nName: deep\n")]
+        )
+        pkg_info, _ = _extract_sdist_files(body)
+        assert pkg_info is None
+
+    def test_ignores_pyproject_below_top_level(self) -> None:
+        """A pyproject.toml buried below the top level is ignored."""
+        body = _build_tarball(
+            [("pkg-1.0/sub/pyproject.toml", b"[project]\nname = 'deep'\n")]
+        )
+        _, pyproject = _extract_sdist_files(body)
+        assert pyproject is None
 
     def test_returns_none_on_tar_error(self) -> None:
         assert _extract_sdist_files(b"not-a-tarball") == (None, None)

--- a/nab-python/tests/test_download.py
+++ b/nab-python/tests/test_download.py
@@ -213,6 +213,49 @@ class TestDownloadLock:
                 tmp_path,
             )
 
+    def test_failure_cancels_sibling_downloads(self, tmp_path: Path) -> None:
+        """One task raising cancels the in-flight siblings, then closes the transport."""
+        fail_pin = _index_pin(name="fail", wheel_sha="0" * 64)
+        slow_pin = _index_pin(name="slow", wheel_sha="a" * 64)
+
+        cancelled = asyncio.Event()
+
+        class _MixedTransport:
+            def __init__(self) -> None:
+                self.closed = False
+                self.requested: list[str] = []
+
+            async def get(
+                self,
+                url: str,
+                *,
+                headers: dict[str, str] | None = None,
+            ) -> _FakeResponse:
+                del headers
+                self.requested.append(url)
+                if "fail" in url:
+                    return _FakeResponse(content=b"REAL")
+                try:
+                    await asyncio.sleep(60)
+                except asyncio.CancelledError:
+                    cancelled.set()
+                    raise
+                return _FakeResponse(content=b"slow")  # pragma: no cover
+
+            async def aclose(self) -> None:
+                self.closed = True
+
+        transport = _MixedTransport()
+        with pytest.raises(DownloadError, match="sha256 mismatch"):
+            download_lock(
+                LockInput(pins={"fail": fail_pin, "slow": slow_pin}),
+                transport,  # type: ignore[arg-type]
+                tmp_path,
+                max_concurrency=2,
+            )
+        assert cancelled.is_set()
+        assert transport.closed
+
     def test_creates_output_dir(self, tmp_path: Path) -> None:
         target = tmp_path / "nested" / "vendor"
         download_lock(

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -1038,12 +1038,14 @@ class _FakeProvider:
         listings: dict[str, list[tuple[Version, WheelFile | SdistFile]]] | None = None,
         local_sources: dict[str, LocalSource] | None = None,
         vcs_sources: dict[str, VcsSource] | None = None,
+        vcs_pins: dict[str, str] | None = None,
         listing_indexes: dict[str, str] | None = None,
         dist_policy_overrides: dict[str, DistPolicy] | None = None,
     ) -> None:
         self._listings = listings or {}
         self._local = local_sources or {}
         self._vcs = vcs_sources or {}
+        self._vcs_pins = vcs_pins or {}
         self._dist_policy_overrides = dist_policy_overrides or {}
         self.coordinator = _FakeCoordinator(listing_indexes)
 
@@ -1052,6 +1054,9 @@ class _FakeProvider:
 
     def vcs_source_for(self, canonical: str) -> VcsSource | None:
         return self._vcs.get(canonical)
+
+    def vcs_pin_for(self, canonical: str) -> str | None:
+        return self._vcs_pins.get(canonical)
 
     def dist_files_for(
         self, canonical: str, version: Version
@@ -1213,6 +1218,25 @@ class TestBuildLockInputFromProvider:
         pin = lock_input.pins["foo"]
         assert isinstance(pin, VcsPin)
         assert pin.commit_id == "a" * 40
+
+    def test_vcs_source_prefers_resolved_sha_over_url_ref(self) -> None:
+        """The post-clone SHA on the provider wins over the URL's ``@<ref>``."""
+        resolved = "b" * 40
+        provider = _FakeProvider(
+            vcs_sources={
+                "foo": VcsSource(
+                    name="foo",
+                    url="git+https://example.com/r.git@v1.0",
+                ),
+            },
+            vcs_pins={"foo": resolved},
+        )
+        lock_input = build_lock_input_from_provider(
+            provider, {"foo": Version("0.0.0+vcs")}
+        )
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, VcsPin)
+        assert pin.commit_id == resolved
 
     def test_vcs_source_without_ref_yields_empty_commit(self) -> None:
         provider = _FakeProvider(

--- a/nab-python/tests/test_vcs.py
+++ b/nab-python/tests/test_vcs.py
@@ -73,10 +73,22 @@ class TestVcsRequestParse:
         with pytest.raises(VcsCloneError, match="not a recognised"):
             VcsRequest.parse("https://example.com/not-vcs")
 
-    def test_hg_scheme(self) -> None:
-        req = VcsRequest.parse("hg+https://hg.example.com/repo@v1.0")
-        assert req.scheme == "hg"
-        assert req.ref == "v1.0"
+    def test_hg_scheme_refused(self) -> None:
+        with pytest.raises(VcsCloneError, match="not a recognised"):
+            VcsRequest.parse("hg+https://hg.example.com/repo@v1.0")
+
+    def test_svn_scheme_refused(self) -> None:
+        with pytest.raises(VcsCloneError, match="not a recognised"):
+            VcsRequest.parse("svn+https://svn.example.com/repo")
+
+    def test_bzr_scheme_refused(self) -> None:
+        with pytest.raises(VcsCloneError, match="not a recognised"):
+            VcsRequest.parse("bzr+https://bzr.example.com/repo")
+
+    def test_ssh_shortcut_with_ref(self) -> None:
+        req = VcsRequest.parse("git+git@github.com:x/y.git@" + "c" * 40)
+        assert req.repo_url == "git@github.com:x/y.git"
+        assert req.ref == "c" * 40
 
 
 class TestSplitRepoRef:
@@ -109,6 +121,11 @@ class TestSplitRepoRef:
         repo, ref = _split_repo_ref("git@github.com:x/y.git")
         assert repo == "git@github.com:x/y.git"
         assert ref == ""
+
+    def test_ssh_shortcut_with_ref(self) -> None:
+        repo, ref = _split_repo_ref("git@github.com:x/y.git@v1.0")
+        assert repo == "git@github.com:x/y.git"
+        assert ref == "v1.0"
 
     def test_url_no_path_no_ref(self) -> None:
         repo, ref = _split_repo_ref("https://example.com")
@@ -324,6 +341,11 @@ class TestProviderVcsIntegration:
         versions = provider.fetch_versions("foo")
         assert len(versions) == 1
         assert str(versions[0][0]) == "1.0.0"
+        # Resolved commit SHA is recorded so the lockfile builder can
+        # emit a SHA-pinned VcsPin rather than the raw ``@<ref>`` token.
+        assert provider.vcs_pin_for("foo") == sha
+        # Unknown package returns None.
+        assert provider.vcs_pin_for("missing") is None
 
     def test_vcs_under_block_policy_raises(self, tmp_path: Path) -> None:
         with pytest.raises(ValueError, match="VcsPolicy.ALLOW"):

--- a/nab-python/tests/test_vcs_admission.py
+++ b/nab-python/tests/test_vcs_admission.py
@@ -42,15 +42,21 @@ class TestSplitVcsScheme:
         assert scheme == "git+ssh"
         assert inner == "ssh://git@github.com/foo/bar.git"
 
-    def test_bare_svn_keeps_url(self) -> None:
+    def test_bare_svn_refused(self) -> None:
         scheme, inner = split_vcs_scheme("svn://example.com/r")
-        assert scheme == "svn"
+        assert scheme is None
         assert inner == "svn://example.com/r"
 
-    def test_bare_git_keeps_url(self) -> None:
+    def test_bare_git_refused(self) -> None:
         scheme, inner = split_vcs_scheme("git://example.com/r.git")
-        assert scheme == "git"
+        assert scheme is None
         assert inner == "git://example.com/r.git"
+
+    def test_hg_https_refused(self) -> None:
+        url = "hg+https://hg.example.com/r"
+        scheme, inner = split_vcs_scheme(url)
+        assert scheme is None
+        assert inner == url
 
     def test_https_archive_returns_none(self) -> None:
         url = "https://example.com/pkg.whl"
@@ -254,3 +260,24 @@ class TestAdmitVcsUrlNonVcsRefusal:
         """Non-VCS direct URLs are refused before the BLOCK check."""
         with pytest.raises(UnsupportedVcsError, match="not a recognized VCS scheme"):
             admit_vcs_url("https://example.com/pkg.whl", VcsConfig())
+
+    def test_hg_url_refused(self) -> None:
+        with pytest.raises(UnsupportedVcsError, match="not a recognized VCS scheme"):
+            admit_vcs_url(
+                "hg+https://hg.example.com/r",
+                _allow_https(),
+            )
+
+    def test_svn_url_refused(self) -> None:
+        with pytest.raises(UnsupportedVcsError, match="not a recognized VCS scheme"):
+            admit_vcs_url(
+                "svn+https://svn.example.com/r",
+                _allow_https(),
+            )
+
+    def test_bzr_url_refused(self) -> None:
+        with pytest.raises(UnsupportedVcsError, match="not a recognized VCS scheme"):
+            admit_vcs_url(
+                "bzr+https://bzr.example.com/r",
+                _allow_https(),
+            )

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -53,6 +53,7 @@ def _make_wheel(version: str, *, package: str) -> WheelFile:
         requires_python=None,
         has_metadata=True,
         upload_time=None,
+        hashes=(("sha256", "a" * 64),),
     )
 
 
@@ -245,6 +246,31 @@ class TestResolveOneTuple:
         assert not tr.success
         assert tr.error is not None
         assert "ResolutionError" in tr.error
+
+    def test_missing_hash_reports_failed_tuple(self) -> None:
+        """An unhashed wheel resolves but the tuple fails with MissingHashError."""
+        unhashed = WheelFile(
+            filename="pkg-1.0-py3-none-any.whl",
+            url="https://example.com/pkg-1.0.whl",
+            version="1.0",
+            requires_python=None,
+            has_metadata=True,
+            upload_time=None,
+        )
+        coordinator = _make_coordinator({"pkg": [unhashed]})
+        tr = _resolve_one_tuple(
+            coordinator,
+            _linux_311(),
+            requirements={"pkg": VersionRange.full()},
+            constraints=None,
+            uploaded_prior_to=None,
+            dist_policy=DistPolicy.WHEEL_OR_SDIST,
+            build_policy=BuildPolicy.NEVER,
+        )
+        assert not tr.success
+        assert tr.error is not None
+        assert "MissingHashError" in tr.error
+        assert tr.pins == {"pkg": Version("1.0")}
 
 
 _FORTY_SHA = "0123456789abcdef0123456789abcdef01234567"

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -299,6 +299,23 @@ def _emit_universal_requirements(
         _write_one_tuple_requirements(successful[0], output, with_hashes=with_hashes)
         return
 
+    substituted_paths: dict[str, str] = {}
+    for tr in successful:
+        substituted = template.format(
+            python_version=tr.tuple_.python_version,
+            platform_id=tr.tuple_.platform_id,
+        )
+        if substituted in substituted_paths:
+            sys.stderr.write(
+                "Error: tuples"
+                f" {substituted_paths[substituted]!r} and {tr.tuple_.label!r}"
+                f" both map to {substituted!r}; --output {output} is missing"
+                " a template variable to disambiguate.  Use both"
+                " {python_version} and {platform_id} in the path.\n"
+            )
+            sys.exit(1)
+        substituted_paths[substituted] = tr.tuple_.label
+
     for tr in successful:
         substituted = template.format(
             python_version=tr.tuple_.python_version,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -687,6 +687,42 @@ class TestLockCommandUniversal:
         # No partial output written.
         assert not out.exists()
 
+    def test_partial_template_collision_errors(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A template missing ``{platform_id}`` on a multi-platform matrix exits 1."""
+        matrix = Matrix(python="==3.11", platforms=("linux_x86_64", "windows_amd64"))
+        tuples_results = []
+        for platform_id in ("linux_x86_64", "windows_amd64"):
+            env = {**_LINUX_311_ENV, "python_version": "3.11"}
+            tup = MatrixTuple(
+                python_version="3.11",
+                platform_id=platform_id,
+                environment=env,
+                platform_spec=PlatformSpec(platform_id),
+            )
+            tuples_results.append(
+                TupleResult(
+                    tuple_=tup,
+                    success=True,
+                    pins={"foo": V("1.0")},
+                    error=None,
+                    lock_input=LockInput(pins={"foo": _foo_index_pin()}),
+                )
+            )
+        result = UniversalResult(matrix=matrix, tuple_results=tuples_results)
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "constraints-{python_version}.txt"
+        with (
+            patch("nab.cli.resolve_universal_pyproject", return_value=result),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, format="requirements-without-hashes", output=out)
+        err = capsys.readouterr().err
+        assert "both map to" in err
+        assert "{platform_id}" in err
+        assert not (tmp_path / "constraints-3.11.txt").exists()
+
     def test_template_with_one_tuple_writes_one_file(self, tmp_path: Path) -> None:
         """A template with a single-tuple matrix still works."""
         pyproject = _universal_pyproject(tmp_path)


### PR DESCRIPTION
- Refuse hg/bzr/svn schemes; only git+https/ssh/http/file/git admitted
- Run `[[tool.nab.vcs-sources]]` URLs through `admit_vcs_url`
- Record post-clone SHA in `VcsPin.commit_id`, not the raw `@<ref>`
- Dereference annotated tags via the `ls-remote` `^{}` line
- Parse `@<ref>` on SSH-shortcut URLs (`git+user@host:path@<ref>`)
- Treat cached pyproject.toml as a hit even when PKG-INFO is absent
- Surface `MissingHashError` as a failed tuple in universal mode
- Reject absolute / `..` / `./.` members in `extract_sdist_archive`
- Clamp local-index hrefs to the package directory
- Only match top-level PKG-INFO and pyproject.toml in sdists
- Cancel in-flight downloads when one task fails
- Store serving index even when the listing fetch raises
- Build a fresh transport per `NabBuildEnv` provision
- Order legacy manylinux aliases highest-glibc first
- Error on per-tuple `--output` paths that collide