### PR TITLE
Intersect duplicate requirements, not overwrite

### DIFF
--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -430,7 +430,11 @@ def add_classified_dep(
     base_deps: dict[str, VersionRange],
     extra_deps_map: dict[str, dict[str, VersionRange]],
 ) -> None:
-    """Add a classified requirement to the appropriate dep set."""
+    """Add a classified requirement to the appropriate dep set.
+
+    A name appearing on several ``Requires-Dist`` lines is intersected
+    into one range.
+    """
     # Late import: ``pypi`` imports this module at module load.
     from ..provider import join_extra
 
@@ -439,12 +443,12 @@ def add_classified_dep(
     dep_extras: set[str] = req.extras
 
     if not req_extras:
-        base_deps[name] = vi
+        base_deps[name] = base_deps.get(name, VersionRange.full()) & vi
         for re in dep_extras:
             base_deps[join_extra(name, re)] = VersionRange.full()
     else:
         for extra_name in req_extras:
             edeps = extra_deps_map[extra_name]
-            edeps[name] = vi
+            edeps[name] = edeps.get(name, VersionRange.full()) & vi
             for re in dep_extras:
                 edeps[join_extra(name, re)] = VersionRange.full()

--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 
 import tomli
 
+from nab_resolver.errors import ResolutionError
+
 from ._vendor.packaging.dependency_groups import resolve_dependency_groups
 from ._vendor.packaging.requirements import Requirement
 from ._vendor.packaging.utils import canonicalize_name
@@ -14,8 +16,11 @@ if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from pathlib import Path
 
+    from ._vendor.packaging.ranges import VersionRange
+
 __all__ = [
     "expand_self_extras",
+    "raise_for_unsatisfiable",
     "read_pyproject_dependencies",
     "read_pyproject_groups",
     "read_pyproject_name",
@@ -178,3 +183,27 @@ def resolve_groups_to_requirements(
         return []
     resolved = resolve_dependency_groups(groups, *selected)
     return [Requirement(s) for s in resolved]
+
+
+def raise_for_unsatisfiable(
+    ranges: Mapping[str, VersionRange],
+    sources: Mapping[str, Sequence[str]],
+    *,
+    kind: str,
+) -> None:
+    """Raise :class:`ResolutionError` if any folded range is empty.
+
+    ``ranges`` holds one intersected range per package and ``sources``
+    the requirement strings folded into each.  An empty range means
+    those requirements share no version; the error lists them.
+
+    ``kind`` ("requirement" or "constraint") only shapes the wording.
+    """
+    unsatisfiable = [name for name, range_ in ranges.items() if range_.is_empty]
+    if not unsatisfiable:
+        return
+    detail = "\n".join(
+        f"  {name}: {', '.join(sources[name])}" for name in unsatisfiable
+    )
+    msg = f"conflicting {kind}s leave no satisfiable version:\n{detail}"
+    raise ResolutionError(msg)

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import sys
+from collections import defaultdict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -32,6 +33,7 @@ from .provider import (
 )
 from .requirements_file import (
     expand_self_extras,
+    raise_for_unsatisfiable,
     read_pyproject_dependencies,
     read_pyproject_groups,
     read_pyproject_name,
@@ -296,9 +298,11 @@ def _build_resolver_inputs(
 
     Requirements whose PEP 508 marker evaluates to ``False`` under
     ``environment`` are skipped, matching pip/uv's root-requirement
-    handling.
+    handling.  Repeated package names are intersected into one range;
+    an empty intersection raises :class:`ResolutionError`.
     """
     resolver_requirements: dict[str, VersionRange] = {}
+    sources: defaultdict[str, list[str]] = defaultdict(list)
     root_extras: set[tuple[str, str]] = set()
     for req in requirements:
         if req.marker is not None and not req.marker.evaluate(environment):
@@ -311,13 +315,16 @@ def _build_resolver_inputs(
             )
             raise NotImplementedError(msg)
         name = str(canonicalize_name(req.name))
-        resolver_requirements[name] = req.specifier.to_range()
+        previous = resolver_requirements.get(name, VersionRange.full())
+        resolver_requirements[name] = previous & req.specifier.to_range()
+        sources[name].append(str(req))
         for extra in req.extras:
             extra_key = join_extra(name, extra)
             resolver_requirements[extra_key] = VersionRange.full()
             _, normalized_extra = split_extra(extra_key)
             assert normalized_extra is not None  # join_extra always sets one
             root_extras.add((name, normalized_extra))
+    raise_for_unsatisfiable(resolver_requirements, sources, kind="requirement")
     return resolver_requirements, root_extras
 
 
@@ -482,8 +489,13 @@ def _resolve_target_python(specifier: str) -> str:
 
 
 def _build_constraints(config: NabProjectConfig) -> dict[str, VersionRange]:
-    """Parse constraint strings from config into resolver-input ranges."""
+    """Parse constraint strings from config into resolver-input ranges.
+
+    Repeated package names are intersected into one range; an empty
+    intersection raises :class:`ResolutionError`.
+    """
     out: dict[str, VersionRange] = {}
+    sources: defaultdict[str, list[str]] = defaultdict(list)
     for cstr in config.constraints:
         req = Requirement(cstr)
         if req.url is not None:
@@ -493,5 +505,8 @@ def _build_constraints(config: NabProjectConfig) -> dict[str, VersionRange]:
                 f" implemented: {req.name} @ {req.url}"
             )
             raise NotImplementedError(msg)
-        out[canonicalize_name(req.name)] = req.specifier.to_range()
+        name = str(canonicalize_name(req.name))
+        out[name] = out.get(name, VersionRange.full()) & req.specifier.to_range()
+        sources[name].append(cstr)
+    raise_for_unsatisfiable(out, sources, kind="constraint")
     return out

--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -43,6 +43,7 @@ from ..provider import (
     VcsSource,
     split_extra,
 )
+from ..requirements_file import raise_for_unsatisfiable
 from .provider import UniversalProvider
 
 __all__ = [
@@ -330,10 +331,16 @@ def _run_pass(  # noqa: PLR0913
     """
 
     def resolve(t: MatrixTuple, current_prefs: dict[str, Version]) -> TupleResult:
-        tuple_requirements = _parse_requirements(requirements, t.environment)
-        tuple_constraints = (
-            _parse_requirements(constraints, t.environment) if constraints else None
-        )
+        try:
+            tuple_requirements, tuple_constraints = _parse_tuple_inputs(
+                requirements, constraints, t.environment
+            )
+        except ResolutionError as exc:
+            return TupleResult(
+                tuple_=t,
+                success=False,
+                error=f"{type(exc).__name__}: {exc}"[:_ERROR_MESSAGE_LIMIT],
+            )
         return _resolve_one_tuple(
             coordinator,
             t,
@@ -409,6 +416,8 @@ def _direct_package_names(requirements: list[str]) -> set[str]:
 def _parse_requirements(
     reqs: list[str],
     environment: dict[str, str],
+    *,
+    kind: str = "requirement",
 ) -> dict[str, VersionRange]:
     """Convert PEP 508 strings to resolver requirements for ``environment``.
 
@@ -416,17 +425,42 @@ def _parse_requirements(
     ``environment`` are dropped.  This matches what
     ``Provider._classify_requirement`` does for transitive deps;
     we just apply the same rule at the root.
+
+    Repeated package names are intersected into one range; an empty
+    intersection raises :class:`ResolutionError`.  ``kind``
+    ("requirement" or "constraint") only shapes that error's wording.
     """
     out: dict[str, VersionRange] = {}
+    sources: defaultdict[str, list[str]] = defaultdict(list)
     for req_str in reqs:
         req = Requirement(req_str)
         if req.marker is not None and not req.marker.evaluate(environment):
             continue
         name = canonicalize_name(req.name)
-        out[name] = req.specifier.to_range()
+        out[name] = out.get(name, VersionRange.full()) & req.specifier.to_range()
+        sources[name].append(req_str)
         for extra in req.extras:
             out[f"{name}[{extra}]"] = VersionRange.full()
+    raise_for_unsatisfiable(out, sources, kind=kind)
     return out
+
+
+def _parse_tuple_inputs(
+    requirements: list[str],
+    constraints: list[str] | None,
+    environment: dict[str, str],
+) -> tuple[dict[str, VersionRange], dict[str, VersionRange] | None]:
+    """Parse a tuple's root requirements and constraints for its env.
+
+    Raises :class:`ResolutionError` if either folds to an empty range.
+    """
+    parsed_requirements = _parse_requirements(requirements, environment)
+    parsed_constraints = (
+        _parse_requirements(constraints, environment, kind="constraint")
+        if constraints
+        else None
+    )
+    return parsed_requirements, parsed_constraints
 
 
 def _resolve_one_tuple(  # noqa: PLR0913

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -12,6 +12,7 @@ import pytest
 
 from nab_index.client import SdistFile, WheelFile
 from nab_python._provider.metadata_resolver import (
+    add_classified_dep,
     classify_requirement,
     has_wheel_metadata_at,
     pick_dist_for_metadata,
@@ -633,6 +634,25 @@ class TestGetDependencies:
         assert "bar" in deps
         assert "baz" in deps
 
+    def test_duplicate_requires_dist_intersects(self) -> None:
+        """Two Requires-Dist lines for one name intersect, not overwrite."""
+        coordinator = make_coordinator(
+            [make_wheel("1.0")],
+            metadata_text=(
+                "Metadata-Version: 2.1\n"
+                "Name: foo\n"
+                "Version: 1.0\n"
+                "Requires-Dist: bar>=2.0\n"
+                "Requires-Dist: bar<5.0\n"
+            ),
+            package="foo",
+        )
+        provider = Provider(coordinator, python_version="3.12.0")
+        deps = provider.get_dependencies("foo", V("1.0"))
+        assert V("3.0") in deps["bar"]
+        assert V("1.0") not in deps["bar"]
+        assert V("9.0") not in deps["bar"]
+
     def test_caches_dependencies(self) -> None:
         """Second call returns cached deps."""
         coordinator = make_coordinator(
@@ -817,6 +837,30 @@ class TestGetDependencies:
         assert "custom-build" in deps["bar"]
         assert V("1.0") not in deps["bar"]
         assert "baz" in deps
+
+
+class TestAddClassifiedDep:
+    """``add_classified_dep`` intersects duplicate dependency names."""
+
+    def test_base_deps_intersect(self) -> None:
+        """A name seen twice as a base dep folds to the intersection."""
+        base: dict[str, VersionRange] = {}
+        extra_map: dict[str, dict[str, VersionRange]] = {}
+        add_classified_dep(Requirement("bar>=2.0"), set(), base, extra_map)
+        add_classified_dep(Requirement("bar<5.0"), set(), base, extra_map)
+        assert V("3.0") in base["bar"]
+        assert V("1.0") not in base["bar"]
+        assert V("9.0") not in base["bar"]
+
+    def test_extra_deps_intersect(self) -> None:
+        """A name seen twice under one extra folds to the intersection."""
+        base: dict[str, VersionRange] = {}
+        extra_map: dict[str, dict[str, VersionRange]] = {"x": {}}
+        add_classified_dep(Requirement("bar>=2.0"), {"x"}, base, extra_map)
+        add_classified_dep(Requirement("bar<5.0"), {"x"}, base, extra_map)
+        assert V("3.0") in extra_map["x"]["bar"]
+        assert V("1.0") not in extra_map["x"]["bar"]
+        assert V("9.0") not in extra_map["x"]["bar"]
 
 
 class TestLocalSources:

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import pytest
 
+from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python.requirements_file import (
     expand_self_extras,
+    raise_for_unsatisfiable,
     read_pyproject_dependencies,
     read_pyproject_groups,
     read_pyproject_name,
@@ -13,6 +15,7 @@ from nab_python.requirements_file import (
     resolve_groups_to_requirements,
     select_optional_dependencies,
 )
+from nab_resolver.errors import ResolutionError
 
 
 class TestReadPyprojectDependencies:
@@ -268,3 +271,50 @@ class TestExpandSelfExtras:
         """Duplicates in the user-supplied selection are deduped."""
         opt = {"a": ["depA"]}
         assert expand_self_extras(opt, "mypkg", ["a", "a", "a"]) == ["a"]
+
+
+class TestRaiseForUnsatisfiable:
+    """``raise_for_unsatisfiable`` flags a folded range that went empty."""
+
+    def test_satisfiable_ranges_are_silent(self) -> None:
+        """A non-empty range produces no error."""
+        ranges = {"foo": SpecifierSet(">=1.0").to_range()}
+        raise_for_unsatisfiable(ranges, {"foo": ["foo>=1.0"]}, kind="requirement")
+
+    def test_empty_range_raises_naming_every_source(self) -> None:
+        """An empty range raises and names every conflicting requirement."""
+        empty = SpecifierSet("==1.0").to_range() & SpecifierSet("==2.0").to_range()
+        with pytest.raises(ResolutionError) as info:
+            raise_for_unsatisfiable(
+                {"foo": empty},
+                {"foo": ["foo==1.0", "foo==2.0"]},
+                kind="requirement",
+            )
+        message = str(info.value)
+        assert "foo==1.0" in message
+        assert "foo==2.0" in message
+        assert "conflicting requirements" in message
+
+    def test_kind_shapes_the_wording(self) -> None:
+        """``kind`` selects the noun used in the message."""
+        empty = SpecifierSet("==1.0").to_range() & SpecifierSet("==2.0").to_range()
+        with pytest.raises(ResolutionError, match="conflicting constraints"):
+            raise_for_unsatisfiable(
+                {"foo": empty},
+                {"foo": ["foo==1.0", "foo==2.0"]},
+                kind="constraint",
+            )
+
+    def test_every_unsatisfiable_package_is_listed(self) -> None:
+        """Each package with an empty range appears in the message."""
+        empty_a = SpecifierSet("==1").to_range() & SpecifierSet("==2").to_range()
+        empty_b = SpecifierSet("==3").to_range() & SpecifierSet("==4").to_range()
+        with pytest.raises(ResolutionError) as info:
+            raise_for_unsatisfiable(
+                {"aaa": empty_a, "bbb": empty_b},
+                {"aaa": ["aaa==1", "aaa==2"], "bbb": ["bbb==3", "bbb==4"]},
+                kind="requirement",
+            )
+        message = str(info.value)
+        assert "aaa: aaa==1, aaa==2" in message
+        assert "bbb: bbb==3, bbb==4" in message

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.version import Version
 from nab_python.config import (
     MatrixConfig,
@@ -18,6 +19,8 @@ from nab_python.resolve import (
     ResolutionResult,
     UnsupportedModeError,
     _augment_resolution_error,
+    _build_constraints,
+    _build_resolver_inputs,
     _load_extra_requirements,
     _load_group_requirements,
     _resolve_target_python,
@@ -904,6 +907,74 @@ class TestLoadExtraRequirements:
         # original ``x[test]`` placeholder so the resolver still sees
         # the project's own extras-proxy.
         assert "pytest" in names
+
+
+class TestBuildResolverInputs:
+    """``_build_resolver_inputs`` folds duplicate names by intersection."""
+
+    def test_duplicate_name_intersects(self) -> None:
+        """Two requirements for one package combine to their overlap."""
+        reqs = [Requirement("foo>=2.0"), Requirement("foo<3.0")]
+        resolver_requirements, _ = _build_resolver_inputs(
+            reqs, NabProjectConfig(), environment={}
+        )
+        foo = resolver_requirements["foo"]
+        assert V("2.5") in foo
+        assert V("1.0") not in foo
+        assert V("5.0") not in foo
+
+    def test_conflicting_names_raise(self) -> None:
+        """Pinned-but-different requirements for one package raise."""
+        reqs = [Requirement("foo==1.0"), Requirement("foo==2.0")]
+        with pytest.raises(ResolutionError, match="foo==1.0"):
+            _build_resolver_inputs(reqs, NabProjectConfig(), environment={})
+
+
+class TestBuildConstraints:
+    """``_build_constraints`` folds duplicate constraint lines."""
+
+    def test_duplicate_constraint_intersects(self) -> None:
+        """Two constraint lines for one package combine to their overlap."""
+        out = _build_constraints(NabProjectConfig(constraints=("foo>=2.0", "foo<3.0")))
+        assert V("2.5") in out["foo"]
+        assert V("1.0") not in out["foo"]
+        assert V("5.0") not in out["foo"]
+
+    def test_conflicting_constraints_raise(self) -> None:
+        """Pinned-but-different constraint lines for one package raise."""
+        with pytest.raises(ResolutionError, match="conflicting constraints"):
+            _build_constraints(NabProjectConfig(constraints=("foo==1.0", "foo==2.0")))
+
+
+class TestResolvePyprojectConflicts:
+    """End-to-end: contradictory folded requirements fail loudly."""
+
+    def test_conflicting_groups_raise_resolution_error(self, tmp_path: Path) -> None:
+        """Two groups pinning one package to different versions raise.
+
+        The ``nab lock --all-groups`` shape: every group folds into the
+        root, so two groups that pin one package differently must fail.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = ["foo"]\n'
+            "[dependency-groups]\n"
+            'g1 = ["bar==1.0"]\n'
+            'g2 = ["bar==2.0"]\n'
+        )
+        # The conflict is caught while building resolver inputs, before
+        # any fetch; FetchCoordinator is patched so a regression fails
+        # offline instead of reaching PyPI.
+        with (
+            patch("nab_python.resolve.FetchCoordinator"),
+            pytest.raises(ResolutionError, match="bar=="),
+        ):
+            resolve_pyproject(
+                pyproject,
+                _FAKE_TRANSPORT,
+                python_version="3.12.0",
+                groups=["g1", "g2"],
+            )
 
 
 class TestAugmentResolutionError:

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -40,6 +40,7 @@ from nab_python.universal.resolve import (
     merge_universal_lock_inputs,
     resolve_with_coordinator,
 )
+from nab_resolver.errors import ResolutionError
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -209,6 +210,20 @@ class TestParseRequirements:
         assert "1.0.special" in out["pkg"]
         assert Version("1.0") not in out["pkg"]
         assert "pkg[ext]" in out
+
+    def test_duplicate_name_intersects(self) -> None:
+        """Two requirements for one package combine to their overlap."""
+        env = _linux_311().environment
+        out = _parse_requirements(["pkg>=2.0", "pkg<3.0"], env)
+        assert Version("2.5") in out["pkg"]
+        assert Version("1.0") not in out["pkg"]
+        assert Version("5.0") not in out["pkg"]
+
+    def test_conflicting_names_raise(self) -> None:
+        """Contradictory pins for one package raise ResolutionError."""
+        env = _linux_311().environment
+        with pytest.raises(ResolutionError, match="pkg==1.0"):
+            _parse_requirements(["pkg==1.0", "pkg==2.0"], env)
 
 
 class TestResolveOneTuple:
@@ -442,6 +457,36 @@ class TestRunPassSerial:
         )
         assert len(results) == 2
         assert all(r.success for r in results)
+
+
+class TestRunPassConflict:
+    """A contradictory root requirement fails each tuple cleanly."""
+
+    def test_conflicting_requirements_fail_the_tuple(self) -> None:
+        """Pinned-but-different reqs surface as a failed TupleResult.
+
+        ``_parse_requirements`` raises before the resolver runs, so
+        the failure has to be caught per tuple rather than escaping
+        the whole universal pass.
+        """
+        coordinator = _make_coordinator({})
+        results = _run_pass(
+            [_linux_311()],
+            requirements=["pkg==1.0", "pkg==2.0"],
+            constraints=None,
+            coordinator=coordinator,
+            uploaded_prior_to=None,
+            dist_policy=DistPolicy.WHEEL_OR_SDIST,
+            build_policy=BuildPolicy.NEVER,
+            resolution_strategy="highest",
+            direct_packages=frozenset({"pkg"}),
+            preferences={},
+            align_serial=True,
+        )
+        assert len(results) == 1
+        assert not results[0].success
+        assert results[0].error is not None
+        assert "ResolutionError" in results[0].error
 
 
 class TestUniversalResult:


### PR DESCRIPTION
Requirements are folded into a `dict[str, VersionRange]` keyed by
package name; a duplicate name overwrote the previous range instead
of intersecting it. So `nab lock --all-extras --all-groups` could
silently drop conflicting requirements and resolve when it should
fail.

All four folding sites now intersect, and a conflicting root
requirement or constraint raises `ResolutionError`.