### PR TITLE
Fix a batch of lockfile and CLI issues

### DIFF
--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -14,8 +14,8 @@ nab download [PATH] [RUNTIME OPTIONS] [--output DIR] [--max-concurrency N]
 
 `PATH` is positional and defaults to `pyproject.toml` in the
 current directory. Run `nab lock --help` (or `-h`) for the full
-per-command flag list, including type-erased aliases like
-`--no-no-cache` that tyro generates for boolean flags.
+per-command flag list. Boolean flags render as a `--flag` /
+`--no-flag` pair (for example `--cache` / `--no-cache`).
 
 ## `nab lock`
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -15,6 +15,10 @@ mode = "specific"
 # into the resolution.
 constraints = ["urllib3<2"]
 
+# Dependency-group names recorded in the lockfile's
+# default-groups array.
+default-groups = ["dev"]
+
 # Override the host's Python for a single-environment resolve.
 # Single value, not a range; for multi-Python locking use the
 # [tool.nab.matrix] table below.
@@ -150,6 +154,11 @@ candidate for the named package.
 name = "my-fork"
 path = "../my-fork"
 ```
+
+Two optional keys are accepted.  `editable` (boolean, default
+`false`) records a PEP 660 editable install in the lockfile.
+`subdirectory` locates the package below `path`, for monorepo
+layouts.
 
 Reading static dependencies from a local pyproject.toml works at
 every `build-policy` level.  Dynamic dependencies require

--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -191,6 +191,8 @@ def build_lock_input_from_provider(
                 name=canonical,
                 version=str(version),
                 path=str(Path(local_source.path).resolve()),
+                editable=local_source.editable,
+                subdirectory=local_source.subdirectory,
             )
             continue
         vcs_source = provider.vcs_source_for(canonical)
@@ -297,7 +299,24 @@ def _build_artifact(
         url=source.url,
         hashes=hashes,
         size=source.size,
+        upload_time=_parse_upload_time(source.upload_time),
     )
+
+
+def _parse_upload_time(raw: str | None) -> datetime | None:
+    """Parse an index ``upload-time`` string to a ``datetime``.
+
+    Accepts the RFC 3339 form the Simple/JSON API serves (``Z`` or an
+    explicit offset).  Returns ``None`` when the field is absent or
+    unparseable; the timestamp is informational, so a bad value is
+    dropped rather than fatal.
+    """
+    if raw is None:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
 
 
 def _filter_acceptable_hashes(
@@ -351,22 +370,26 @@ def _vcs_pin_from_source(
     provider) over the URL's ``@<ref>``: annotated tags and floating
     refs only resolve to a commit after the clone runs.  Fall back to
     the URL ref when the source was never materialised.
+
+    ``requested_revision`` is the URL's ``@<ref>``, kept only when it
+    is a named ref that differs from ``commit_id`` (i.e. the user did
+    not pin the bare SHA).  An absent or unparseable ref leaves it
+    ``None``.
     """
     from nab_index.vcs import VcsCloneError, VcsRequest
 
     from ..lockfile import VcsPin
 
-    if resolved_sha is not None:
-        commit_id = resolved_sha
-    else:
-        try:
-            parsed = VcsRequest.parse(source.url)
-            commit_id = parsed.ref
-        except VcsCloneError:
-            commit_id = ""
+    try:
+        url_ref = VcsRequest.parse(source.url).ref
+    except VcsCloneError:
+        url_ref = ""
+    commit_id = resolved_sha if resolved_sha is not None else url_ref
+    requested_revision = url_ref if url_ref and url_ref != commit_id else None
     return VcsPin(
         name=canonical,
         version=str(version),
         repo_url=_strip_userinfo(source.url),
         commit_id=commit_id,
+        requested_revision=requested_revision,
     )

--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -18,6 +18,7 @@ import tomli
 
 from nab_index.client import SdistFile, WheelFile
 
+from .._vendor.packaging.pylock import Pylock, PylockValidationError
 from .._vendor.packaging.utils import canonicalize_name
 
 if TYPE_CHECKING:
@@ -41,6 +42,7 @@ __all__ = [
     "MissingHashError",
     "build_lock_input_from_provider",
     "read_lockfile_anchor",
+    "read_lockfile_packages",
 ]
 
 
@@ -139,6 +141,30 @@ def read_lockfile_anchor(path: Path) -> datetime | None:
             return None
         return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
     return None
+
+
+def read_lockfile_packages(path: Path) -> dict[str, Version] | None:
+    """Return the ``name -> version`` map from a prior pylock at ``path``.
+
+    Used by ``nab lock`` to diff a re-lock against the previous result.
+    Packages without a recorded version (direct-reference entries that
+    omit it) are skipped.
+
+    Returns ``None`` when ``path`` does not exist, is not valid TOML,
+    or is not a spec-compliant PEP 751 lockfile; the caller falls back
+    to a no-diff summary line.
+    """
+    if not path.is_file():
+        return None
+    try:
+        with path.open("rb") as f:
+            data = tomli.load(f)
+        pylock = Pylock.from_dict(data)
+    except (OSError, tomli.TOMLDecodeError, PylockValidationError):
+        return None
+    return {
+        str(pkg.name): pkg.version for pkg in pylock.packages if pkg.version is not None
+    }
 
 
 def _strip_userinfo(url: str) -> str:

--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, overload
+from urllib.parse import urlsplit, urlunsplit
 
 import tomli
 
@@ -140,6 +141,20 @@ def read_lockfile_anchor(path: Path) -> datetime | None:
     return None
 
 
+def _strip_userinfo(url: str) -> str:
+    """Return ``url`` with any ``user:password@`` userinfo removed.
+
+    Lockfiles are committed to version control, so an index or VCS
+    URL carrying embedded credentials must not be written verbatim.
+    Only the userinfo is dropped: host case and port are preserved
+    and a ``git+`` scheme prefix is left intact.  A no-op for URLs
+    without credentials.
+    """
+    parts = urlsplit(url)
+    netloc = parts.netloc.rpartition("@")[2]
+    return urlunsplit(parts._replace(netloc=netloc))
+
+
 def build_lock_input_from_provider(
     provider: LockInputProvider,
     pins: Mapping[str, Version],
@@ -252,7 +267,7 @@ def _index_pin_from_listing(
     return IndexPin(
         name=canonical,
         version=str(version),
-        index=index_url,
+        index=_strip_userinfo(index_url),
         sdist=sdist,
         wheels=wheels,
         requires_python=requires_python,
@@ -352,6 +367,6 @@ def _vcs_pin_from_source(
     return VcsPin(
         name=canonical,
         version=str(version),
-        repo_url=source.url,
+        repo_url=_strip_userinfo(source.url),
         commit_id=commit_id,
     )

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -57,8 +57,8 @@ def write_lock(
     """Serialise ``lock_input`` to PEP 751 TOML text.
 
     Returns the TOML text.  When ``output_path`` is provided, also
-    writes it atomically; the caller chooses the path (PEP 751 does
-    not mandate one).
+    writes it there; the caller chooses the path (PEP 751 does not
+    mandate one).
     """
     pylock = build_pylock(lock_input)
     pylock.validate()
@@ -137,16 +137,19 @@ def _pin_to_package(pin: PinShape, marker: Marker | None = None) -> Package:
             wheels=tuple(_wheel_to_package(w) for w in pin.wheels) or None,
         )
     if isinstance(pin, LocalPin):
+        # PEP 751: omit version for directory sources; it is not
+        # deterministic (the source tree may change at install time).
         return Package(
             name=canonicalize_name(pin.name),
-            version=Version(pin.version),
+            version=None,
             marker=marker,
             directory=PackageDirectory(path=pin.path, editable=False),
         )
     if isinstance(pin, VcsPin):
+        # PEP 751: omit version for VCS sources for the same reason.
         return Package(
             name=canonicalize_name(pin.name),
-            version=Version(pin.version),
+            version=None,
             marker=marker,
             vcs=PackageVcs(
                 type="git",

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -143,7 +143,11 @@ def _pin_to_package(pin: PinShape, marker: Marker | None = None) -> Package:
             name=canonicalize_name(pin.name),
             version=None,
             marker=marker,
-            directory=PackageDirectory(path=pin.path, editable=False),
+            directory=PackageDirectory(
+                path=pin.path,
+                editable=pin.editable,
+                subdirectory=pin.subdirectory,
+            ),
         )
     if isinstance(pin, VcsPin):
         # PEP 751: omit version for VCS sources for the same reason.
@@ -156,6 +160,7 @@ def _pin_to_package(pin: PinShape, marker: Marker | None = None) -> Package:
                 url=pin.repo_url,
                 commit_id=pin.commit_id,
                 subdirectory=pin.subdirectory,
+                requested_revision=pin.requested_revision,
             ),
         )
     msg = f"unknown pin shape: {pin!r}"
@@ -168,6 +173,7 @@ def _wheel_to_package(wheel: WheelArtifact) -> PackageWheel:
         url=wheel.url,
         size=wheel.size,
         hashes=dict(wheel.hashes),
+        upload_time=wheel.upload_time,
     )
 
 
@@ -177,6 +183,7 @@ def _sdist_to_package(sdist: SdistArtifact) -> PackageSdist:
         url=sdist.url,
         size=sdist.size,
         hashes=dict(sdist.hashes),
+        upload_time=sdist.upload_time,
     )
 
 
@@ -245,8 +252,18 @@ def _pin_discriminator(pin: PinShape) -> tuple:
     if isinstance(pin, IndexPin):
         return ("index", pin.version, pin.index)
     if isinstance(pin, LocalPin):
-        return ("local", pin.version, pin.path)
+        # editable and subdirectory change install behaviour, so two
+        # otherwise-identical local pins differing only here are distinct.
+        return (
+            "local",
+            pin.version,
+            pin.path,
+            pin.editable,
+            pin.subdirectory or "",
+        )
     if isinstance(pin, VcsPin):
+        # requested_revision is informational; it does not affect the
+        # checkout, so it is intentionally left out of the discriminator.
         return ("vcs", pin.commit_id, pin.repo_url, pin.subdirectory or "")
     msg = f"unknown pin shape: {pin!r}"
     raise TypeError(msg)

--- a/nab-python/src/nab_python/_provider/sources.py
+++ b/nab-python/src/nab_python/_provider/sources.py
@@ -57,6 +57,8 @@ def materialize_local_source(
     or looser; raises :class:`UnsupportedSdistError` otherwise.
     """
     path = Path(source.path)
+    if source.subdirectory:
+        path = path / source.subdirectory
     metadata = extract_source_metadata(
         provider,
         path,

--- a/nab-python/src/nab_python/_testing/coordinator_fake.py
+++ b/nab-python/src/nab_python/_testing/coordinator_fake.py
@@ -13,7 +13,8 @@ import threading
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
-from nab_python.fetch import InMemoryIndex
+from nab_index.multi_index import IndexConfig
+from nab_python.fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, InMemoryIndex
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
@@ -207,7 +208,8 @@ def make_coordinator(  # noqa: PLR0913
     Call sites that need request side effects beyond what this helper
     wires up (for example ``request_sdist_archive``) can reassign
     ``.side_effect`` on the returned mock; the index is exposed at
-    ``coordinator.index`` for direct manipulation.
+    ``coordinator.index`` for direct manipulation.  ``coordinator.indexes``
+    defaults to the single default-PyPI :class:`IndexConfig` list.
     """
     index = InMemoryIndex()
     failures = fetch_failures if fetch_failures is not None else set()
@@ -223,6 +225,7 @@ def make_coordinator(  # noqa: PLR0913
 
     coordinator = MagicMock()
     coordinator.index = index
+    coordinator.indexes = [IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL)]
 
     resolve_metadata = _make_metadata_resolver(
         metadata_text=metadata_text,

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -55,6 +55,7 @@ _TOP_LEVEL_KEYS = frozenset(
     {
         "mode",
         "constraints",
+        "default-groups",
         "requires-python",
         "uploaded-prior-to",
         "uploaded-prior-to-package",
@@ -107,6 +108,7 @@ class NabProjectConfig:
 
     mode: ResolveMode = ResolveMode.SPECIFIC
     constraints: tuple[str, ...] = ()
+    default_groups: tuple[str, ...] = ()
     requires_python: str | None = None
     uploaded_prior_to: datetime | None = None
     uploaded_prior_to_overrides: Mapping[str, datetime | None] = field(
@@ -233,6 +235,9 @@ def _parse_nab_table(
     return NabProjectConfig(
         mode=mode,
         constraints=_parse_string_list("constraints", raw.get("constraints", [])),
+        default_groups=_parse_string_list(
+            "default-groups", raw.get("default-groups", [])
+        ),
         requires_python=_parse_requires_python(raw.get("requires-python")),
         uploaded_prior_to=_parse_uploaded_prior_to(
             raw.get("uploaded-prior-to"), anchor=anchor

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -671,6 +671,9 @@ def _parse_build_policy_package(value: object) -> Mapping[str, BuildPolicy]:
     return out
 
 
+_LOCAL_SOURCE_KEYS = frozenset({"name", "path", "editable", "subdirectory"})
+
+
 def _parse_local_sources(
     value: object, *, pyproject_dir: Path
 ) -> tuple[LocalSource, ...]:
@@ -682,6 +685,13 @@ def _parse_local_sources(
         if not isinstance(entry, dict):
             msg = f"local-sources[{i}] must be a table, got {type(entry).__name__}"
             raise ConfigError(msg)
+        unknown = sorted(set(entry) - _LOCAL_SOURCE_KEYS)
+        if unknown:
+            msg = (
+                f"unknown local-sources[{i}] keys: {unknown!r};"
+                f" expected {sorted(_LOCAL_SOURCE_KEYS)!r}"
+            )
+            raise ConfigError(msg)
         try:
             name = entry["name"]
             path_value = entry["path"]
@@ -691,8 +701,23 @@ def _parse_local_sources(
         if not isinstance(name, str) or not isinstance(path_value, str):
             msg = f"local-sources[{i}] name and path must be strings"
             raise ConfigError(msg)
+        editable = entry.get("editable", False)
+        if not isinstance(editable, bool):
+            msg = f"local-sources[{i}] editable must be a boolean"
+            raise ConfigError(msg)
+        subdirectory = entry.get("subdirectory")
+        if subdirectory is not None and not isinstance(subdirectory, str):
+            msg = f"local-sources[{i}] subdirectory must be a string"
+            raise ConfigError(msg)
         resolved = str((pyproject_dir / path_value).resolve())
-        out.append(LocalSource(name=name, path=resolved))
+        out.append(
+            LocalSource(
+                name=name,
+                path=resolved,
+                editable=editable,
+                subdirectory=subdirectory,
+            )
+        )
     return tuple(out)
 
 

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -80,12 +80,16 @@ class WheelArtifact:
     published.  PEP 751 mandates at least one hash per artefact;
     nab requires at least one of ``sha256``, ``sha384``, ``sha512``
     so the lockfile is consumable by pip's hash-checking mode.
+
+    ``upload_time`` is the index's upload timestamp when available;
+    informational provenance per PEP 751 ``packages.wheels.upload-time``.
     """
 
     filename: str
     url: str
     hashes: tuple[tuple[str, str], ...]
     size: int | None = None
+    upload_time: datetime | None = None
 
     @property
     def primary_digest(self) -> tuple[str, str]:
@@ -101,13 +105,15 @@ class WheelArtifact:
 class SdistArtifact:
     """An sdist tarball to record in the lockfile.
 
-    See :class:`WheelArtifact` for the meaning of ``hashes``.
+    See :class:`WheelArtifact` for the meaning of ``hashes`` and
+    ``upload_time``.
     """
 
     filename: str
     url: str
     hashes: tuple[tuple[str, str], ...]
     size: int | None = None
+    upload_time: datetime | None = None
 
     @property
     def primary_digest(self) -> tuple[str, str]:
@@ -141,22 +147,34 @@ class LocalPin:
 
     ``path`` is the absolute filesystem path the resolver was pointed
     at.  Lockfile consumers walk the same tree to install.
+
+    ``editable`` records a PEP 660 editable install request;
+    ``subdirectory`` is a path under ``path`` for monorepo layouts.
+    Both come from the ``[[tool.nab.local-sources]]`` entry.
     """
 
     name: str
     version: str
     path: str
+    editable: bool = False
+    subdirectory: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
 class VcsPin:
-    """A package resolved from a VCS clone."""
+    """A package resolved from a VCS clone.
+
+    ``requested_revision`` is the human-readable ref (tag or branch)
+    the user pinned, recorded only when it differs from ``commit_id``;
+    informational per PEP 751 ``packages.vcs.requested-revision``.
+    """
 
     name: str
     version: str
     repo_url: str
     commit_id: str
     subdirectory: str | None = None
+    requested_revision: str | None = None
 
 
 PinShape = IndexPin | LocalPin | VcsPin

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -19,6 +19,7 @@ from ._lockfile.builder import (
     MissingHashError,
     build_lock_input_from_provider,
     read_lockfile_anchor,
+    read_lockfile_packages,
 )
 from ._lockfile.disjointness import DisjointnessError
 from ._lockfile.pylock import build_pylock, write_lock
@@ -26,6 +27,7 @@ from ._lockfile.requirements import (
     write_requirements_with_hashes,
     write_requirements_without_hashes,
 )
+from ._vendor.packaging.pylock import is_valid_pylock_path
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -49,7 +51,9 @@ __all__ = [
     "WheelArtifact",
     "build_lock_input_from_provider",
     "build_pylock",
+    "is_valid_pylock_path",
     "read_lockfile_anchor",
+    "read_lockfile_packages",
     "write_lock",
     "write_requirements_with_hashes",
     "write_requirements_without_hashes",

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -204,10 +204,15 @@ class LocalSource:
     single synthetic version derived from the directory's
     ``[project].version`` field (or ``"0.0.0+local"`` if absent).
     ``path`` is the absolute filesystem path to the source tree.
+
+    ``editable`` requests a PEP 660 editable install in the lockfile;
+    ``subdirectory`` is a path under ``path`` for monorepo layouts.
     """
 
     name: str
     path: str
+    editable: bool = False
+    subdirectory: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -191,7 +191,7 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
             requires_python=config.requires_python,
             extras=tuple(extras),
             dependency_groups=tuple(groups),
-            default_groups=tuple(groups),
+            default_groups=config.default_groups,
             indexes=config.indexes,
         )
         return ResolutionResult(pins=pins, lock_input=lock_input)

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -745,6 +745,63 @@ class TestLocalSources:
         with pytest.raises(ConfigError, match="name and path must be strings"):
             read_pyproject_config(path)
 
+    def test_editable_defaults_false(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[[tool.nab.local-sources]]\nname = "x"\npath = "../x"\n',
+        )
+        srcs = read_pyproject_config(path).local_sources
+        assert srcs[0].editable is False
+
+    def test_editable_parsed(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[[tool.nab.local-sources]]\nname = "x"\npath = "../x"\neditable = true\n',
+        )
+        srcs = read_pyproject_config(path).local_sources
+        assert srcs[0].editable is True
+
+    def test_editable_must_be_bool(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[[tool.nab.local-sources]]\nname = "x"\npath = "../x"\neditable = "y"\n',
+        )
+        with pytest.raises(ConfigError, match="editable must be a boolean"):
+            read_pyproject_config(path)
+
+    def test_subdirectory_defaults_none(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[[tool.nab.local-sources]]\nname = "x"\npath = "../x"\n',
+        )
+        srcs = read_pyproject_config(path).local_sources
+        assert srcs[0].subdirectory is None
+
+    def test_subdirectory_parsed(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[[tool.nab.local-sources]]\n"
+            'name = "x"\npath = "../x"\nsubdirectory = "pkg/lib"\n',
+        )
+        srcs = read_pyproject_config(path).local_sources
+        assert srcs[0].subdirectory == "pkg/lib"
+
+    def test_subdirectory_must_be_string(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[[tool.nab.local-sources]]\nname = "x"\npath = "../x"\nsubdirectory = 1\n',
+        )
+        with pytest.raises(ConfigError, match="subdirectory must be a string"):
+            read_pyproject_config(path)
+
+    def test_unknown_key_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[[tool.nab.local-sources]]\nname = "x"\npath = "../x"\nbogus = 1\n',
+        )
+        with pytest.raises(ConfigError, match="unknown local-sources"):
+            read_pyproject_config(path)
+
 
 class TestVcsSources:
     def test_round_trip(self, tmp_path: Path) -> None:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -111,6 +111,26 @@ class TestConstraints:
             read_pyproject_config(path)
 
 
+class TestDefaultGroups:
+    def test_default_is_empty(self, tmp_path: Path) -> None:
+        path = write(tmp_path, "[tool.nab]\n")
+        assert read_pyproject_config(path).default_groups == ()
+
+    def test_round_trip(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab]\ndefault-groups = ["dev", "test"]\n')
+        assert read_pyproject_config(path).default_groups == ("dev", "test")
+
+    def test_must_be_list(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab]\ndefault-groups = "dev"\n')
+        with pytest.raises(ConfigError, match="default-groups must be a list"):
+            read_pyproject_config(path)
+
+    def test_entries_must_be_strings(self, tmp_path: Path) -> None:
+        path = write(tmp_path, "[tool.nab]\ndefault-groups = [1]\n")
+        with pytest.raises(ConfigError, match="default-groups\\[0\\] must be a string"):
+            read_pyproject_config(path)
+
+
 class TestRequiresPython:
     def test_round_trip_specifier(self, tmp_path: Path) -> None:
         """A valid PEP 440 specifier round-trips as the raw string."""

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -1362,6 +1362,177 @@ class TestBuildLockInputFromProvider:
         assert isinstance(pin, VcsPin)
         assert pin.repo_url == "git+https://github.com/org/repo.git"
 
+    def test_vcs_source_records_requested_revision_for_floating_ref(self) -> None:
+        """A named ``@<ref>`` resolved to a different SHA is recorded."""
+        provider = _FakeProvider(
+            vcs_sources={
+                "foo": VcsSource(
+                    name="foo",
+                    url="git+https://example.com/r.git@v1.0",
+                ),
+            },
+            vcs_pins={"foo": "b" * 40},
+        )
+        lock_input = build_lock_input_from_provider(
+            provider, {"foo": Version("0.0.0+vcs")}
+        )
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, VcsPin)
+        assert pin.requested_revision == "v1.0"
+
+    def test_vcs_source_no_requested_revision_when_pinned_to_sha(self) -> None:
+        """When the user pinned the SHA, requested-revision stays None."""
+        sha = "a" * 40
+        provider = _FakeProvider(
+            vcs_sources={
+                "foo": VcsSource(
+                    name="foo",
+                    url="git+https://example.com/r.git@" + sha,
+                ),
+            },
+            vcs_pins={"foo": sha},
+        )
+        lock_input = build_lock_input_from_provider(
+            provider, {"foo": Version("0.0.0+vcs")}
+        )
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, VcsPin)
+        assert pin.requested_revision is None
+
+    def test_vcs_source_no_requested_revision_without_url_ref(self) -> None:
+        """A URL with no ``@<ref>`` yields no requested-revision."""
+        provider = _FakeProvider(
+            vcs_sources={
+                "foo": VcsSource(name="foo", url="git+https://example.com/r.git"),
+            },
+            vcs_pins={"foo": "a" * 40},
+        )
+        lock_input = build_lock_input_from_provider(
+            provider, {"foo": Version("0.0.0+vcs")}
+        )
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, VcsPin)
+        assert pin.requested_revision is None
+
+    def test_vcs_source_no_requested_revision_for_non_vcs_url(self) -> None:
+        """An unparseable VCS URL yields no requested-revision."""
+        provider = _FakeProvider(
+            vcs_sources={
+                "foo": VcsSource(name="foo", url="https://example.com/r.git"),
+            },
+            vcs_pins={"foo": "a" * 40},
+        )
+        lock_input = build_lock_input_from_provider(
+            provider, {"foo": Version("0.0.0+vcs")}
+        )
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, VcsPin)
+        assert pin.requested_revision is None
+
+    def test_local_source_threads_editable(self, tmp_path: Path) -> None:
+        provider = _FakeProvider(
+            local_sources={
+                "foo": LocalSource(name="foo", path=str(tmp_path), editable=True)
+            }
+        )
+        lock_input = build_lock_input_from_provider(
+            provider, {"foo": Version("0.0.0+local")}
+        )
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, LocalPin)
+        assert pin.editable is True
+
+    def test_local_source_threads_subdirectory(self, tmp_path: Path) -> None:
+        provider = _FakeProvider(
+            local_sources={
+                "foo": LocalSource(
+                    name="foo", path=str(tmp_path), subdirectory="pkg/lib"
+                )
+            }
+        )
+        lock_input = build_lock_input_from_provider(
+            provider, {"foo": Version("0.0.0+local")}
+        )
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, LocalPin)
+        assert pin.subdirectory == "pkg/lib"
+
+    def test_local_source_defaults_not_editable_no_subdirectory(
+        self, tmp_path: Path
+    ) -> None:
+        provider = _FakeProvider(
+            local_sources={"foo": LocalSource(name="foo", path=str(tmp_path))}
+        )
+        lock_input = build_lock_input_from_provider(
+            provider, {"foo": Version("0.0.0+local")}
+        )
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, LocalPin)
+        assert pin.editable is False
+        assert pin.subdirectory is None
+
+    def test_wheel_upload_time_parsed_from_index(self) -> None:
+        wheel = WheelFile(
+            filename="foo-1.0-py3-none-any.whl",
+            url="https://pypi.org/simple/foo/foo-1.0-py3-none-any.whl",
+            version="1.0",
+            requires_python=">=3.10",
+            has_metadata=False,
+            upload_time="2026-05-01T12:00:00Z",
+            hashes=(("sha256", "a" * 64),),
+            size=1234,
+        )
+        provider = _FakeProvider(listings={"foo": [(Version("1.0"), wheel)]})
+        lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0")})
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.wheels[0].upload_time == datetime(
+            2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc
+        )
+
+    def test_sdist_upload_time_parsed_from_index(self) -> None:
+        sdist = SdistFile(
+            filename="foo-1.0.tar.gz",
+            url="https://pypi.org/simple/foo/foo-1.0.tar.gz",
+            version="1.0",
+            requires_python=">=3.10",
+            upload_time="2026-05-01T12:00:00Z",
+            hashes=(("sha256", "b" * 64),),
+            size=4321,
+        )
+        provider = _FakeProvider(listings={"foo": [(Version("1.0"), sdist)]})
+        lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0")})
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.sdist is not None
+        assert pin.sdist.upload_time == datetime(
+            2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc
+        )
+
+    def test_upload_time_none_when_index_omits_it(self) -> None:
+        provider = _FakeProvider(listings={"foo": [(Version("1.0"), _wheel_file())]})
+        lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0")})
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.wheels[0].upload_time is None
+
+    def test_upload_time_invalid_string_is_dropped(self) -> None:
+        wheel = WheelFile(
+            filename="foo-1.0-py3-none-any.whl",
+            url="https://pypi.org/simple/foo/foo-1.0-py3-none-any.whl",
+            version="1.0",
+            requires_python=">=3.10",
+            has_metadata=False,
+            upload_time="not-a-timestamp",
+            hashes=(("sha256", "a" * 64),),
+            size=1234,
+        )
+        provider = _FakeProvider(listings={"foo": [(Version("1.0"), wheel)]})
+        lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0")})
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.wheels[0].upload_time is None
+
     def test_missing_acceptable_hash_raises(self) -> None:
         wheel = _wheel_file(sha256=None)
         provider = _FakeProvider(listings={"foo": [(Version("1.0"), wheel)]})
@@ -1464,6 +1635,172 @@ class TestBuildLockInputFromProvider:
         pin = lock_input.pins["foo"]
         assert isinstance(pin, IndexPin)
         assert pin.requires_python is None
+
+
+class TestDirectoryFields:
+    """PEP 751 ``packages.directory`` editable + subdirectory emission."""
+
+    def test_editable_emitted_when_true(self, tmp_path: Path) -> None:
+        text = write_lock(
+            LockInput(
+                pins={
+                    "foo": LocalPin(
+                        name="foo",
+                        version="1.0",
+                        path=str(tmp_path),
+                        editable=True,
+                    )
+                },
+            )
+        )
+        data = tomllib.loads(text)
+        assert data["packages"][0]["directory"]["editable"] is True
+
+    def test_editable_false_by_default(self, tmp_path: Path) -> None:
+        text = write_lock(
+            LockInput(
+                pins={"foo": LocalPin(name="foo", version="1.0", path=str(tmp_path))},
+            )
+        )
+        data = tomllib.loads(text)
+        assert data["packages"][0]["directory"]["editable"] is False
+
+    def test_subdirectory_emitted(self, tmp_path: Path) -> None:
+        text = write_lock(
+            LockInput(
+                pins={
+                    "foo": LocalPin(
+                        name="foo",
+                        version="1.0",
+                        path=str(tmp_path),
+                        subdirectory="pkg/lib",
+                    )
+                },
+            )
+        )
+        data = tomllib.loads(text)
+        assert data["packages"][0]["directory"]["subdirectory"] == "pkg/lib"
+
+    def test_subdirectory_omitted_when_none(self, tmp_path: Path) -> None:
+        text = write_lock(
+            LockInput(
+                pins={"foo": LocalPin(name="foo", version="1.0", path=str(tmp_path))},
+            )
+        )
+        data = tomllib.loads(text)
+        assert "subdirectory" not in data["packages"][0]["directory"]
+
+    def test_discriminator_separates_editable(self) -> None:
+        editable = LocalPin(name="foo", version="1.0", path="/a", editable=True)
+        plain = LocalPin(name="foo", version="1.0", path="/a", editable=False)
+        assert _pin_discriminator(editable) != _pin_discriminator(plain)
+
+    def test_discriminator_separates_subdirectory(self) -> None:
+        sub = LocalPin(name="foo", version="1.0", path="/a", subdirectory="lib")
+        plain = LocalPin(name="foo", version="1.0", path="/a")
+        assert _pin_discriminator(sub) != _pin_discriminator(plain)
+
+    def test_per_tuple_editable_diverges(self) -> None:
+        per_tuple = {
+            "py310": {
+                "foo": LocalPin(name="foo", version="1.0", path="/a", editable=True)
+            },
+            "py311": {
+                "foo": LocalPin(name="foo", version="1.0", path="/a", editable=False)
+            },
+        }
+        tuple_markers = {
+            "py310": Marker('python_version == "3.10"'),
+            "py311": Marker('python_version == "3.11"'),
+        }
+        text = write_lock(
+            LockInput(per_tuple_pins=per_tuple, tuple_markers=tuple_markers)
+        )
+        data = tomllib.loads(text)
+        assert len(data["packages"]) == 2
+
+
+class TestVcsRequestedRevision:
+    """PEP 751 ``packages.vcs.requested-revision`` emission."""
+
+    def test_requested_revision_emitted(self) -> None:
+        text = write_lock(
+            LockInput(
+                pins={
+                    "foo": VcsPin(
+                        name="foo",
+                        version="1.0",
+                        repo_url="https://github.com/x/y.git",
+                        commit_id="a" * 40,
+                        requested_revision="v2.1.0",
+                    ),
+                },
+            )
+        )
+        data = tomllib.loads(text)
+        assert data["packages"][0]["vcs"]["requested-revision"] == "v2.1.0"
+
+    def test_requested_revision_omitted_when_none(self) -> None:
+        text = write_lock(
+            LockInput(
+                pins={
+                    "foo": VcsPin(
+                        name="foo",
+                        version="1.0",
+                        repo_url="https://github.com/x/y.git",
+                        commit_id="a" * 40,
+                    ),
+                },
+            )
+        )
+        data = tomllib.loads(text)
+        assert "requested-revision" not in data["packages"][0]["vcs"]
+
+
+class TestUploadTime:
+    """PEP 751 ``packages.wheels/sdist.upload-time`` emission."""
+
+    def test_wheel_upload_time_emitted(self) -> None:
+        ts = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+        pin = IndexPin(
+            name="foo",
+            version="1.0",
+            index="pypi",
+            wheels=(
+                WheelArtifact(
+                    filename="foo-1.0-py3-none-any.whl",
+                    url="https://example.com/foo-1.0-py3-none-any.whl",
+                    hashes=(("sha256", "a" * 64),),
+                    upload_time=ts,
+                ),
+            ),
+        )
+        text = write_lock(LockInput(pins={"foo": pin}))
+        data = tomllib.loads(text)
+        assert data["packages"][0]["wheels"][0]["upload-time"] == ts
+
+    def test_sdist_upload_time_emitted(self) -> None:
+        ts = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+        pin = IndexPin(
+            name="foo",
+            version="1.0",
+            index="pypi",
+            sdist=SdistArtifact(
+                filename="foo-1.0.tar.gz",
+                url="https://example.com/foo-1.0.tar.gz",
+                hashes=(("sha256", "b" * 64),),
+                upload_time=ts,
+            ),
+        )
+        text = write_lock(LockInput(pins={"foo": pin}))
+        data = tomllib.loads(text)
+        assert data["packages"][0]["sdist"]["upload-time"] == ts
+
+    def test_upload_time_omitted_when_none(self) -> None:
+        text = write_lock(LockInput(pins={"foo": _index_pin()}))
+        data = tomllib.loads(text)
+        assert "upload-time" not in data["packages"][0]["wheels"][0]
+        assert "upload-time" not in data["packages"][0]["sdist"]
 
 
 class TestWriteRequirementsWithHashes:

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -42,6 +42,7 @@ from nab_python.lockfile import (
     WheelArtifact,
     build_lock_input_from_provider,
     build_pylock,
+    read_lockfile_packages,
     write_lock,
     write_requirements_with_hashes,
 )
@@ -770,6 +771,54 @@ class TestReadLockfileAnchor:
         path = tmp_path / "pylock.toml"
         path.write_text("[tool.nab]\ncreated-at = 1234\n")
         assert read_lockfile_anchor(path) is None
+
+
+class TestReadLockfilePackages:
+    """``read_lockfile_packages`` extracts the prior pin set for diffing."""
+
+    def test_returns_none_when_file_missing(self, tmp_path: Path) -> None:
+        assert read_lockfile_packages(tmp_path / "missing.toml") is None
+
+    def test_returns_none_when_file_is_directory(self, tmp_path: Path) -> None:
+        assert read_lockfile_packages(tmp_path) is None
+
+    def test_returns_none_when_toml_invalid(self, tmp_path: Path) -> None:
+        path = tmp_path / "pylock.toml"
+        path.write_text("this is not [[[ valid TOML")
+        assert read_lockfile_packages(path) is None
+
+    def test_returns_none_when_not_a_pylock(self, tmp_path: Path) -> None:
+        # Valid TOML but missing the required PEP 751 keys.
+        path = tmp_path / "pylock.toml"
+        path.write_text('title = "not a lockfile"\n')
+        assert read_lockfile_packages(path) is None
+
+    def test_reads_name_to_version_map(self, tmp_path: Path) -> None:
+        lock_input = LockInput(
+            pins={
+                "foo": _index_pin("foo", "1.2.3"),
+                "bar": _index_pin("bar", "4.5"),
+            }
+        )
+        path = tmp_path / "pylock.toml"
+        write_lock(lock_input, output_path=path)
+        assert read_lockfile_packages(path) == {
+            "foo": Version("1.2.3"),
+            "bar": Version("4.5"),
+        }
+
+    def test_skips_packages_without_version(self, tmp_path: Path) -> None:
+        # A directory (path) package carries no version key.
+        path = tmp_path / "pylock.toml"
+        path.write_text(
+            'lock-version = "1.0"\n'
+            'created-by = "nab"\n\n'
+            "[[packages]]\n"
+            'name = "foo"\n'
+            "[packages.directory]\n"
+            'path = "./foo"\n',
+        )
+        assert read_lockfile_packages(path) == {}
 
 
 class TestDependencyGroups:

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -15,6 +15,7 @@ else:
     import tomli as tomllib  # type: ignore[no-redef]
 
 from nab_index.client import SdistFile, WheelFile
+from nab_index.multi_index import IndexConfig
 from nab_python._lockfile.disjointness import (
     _restrict_to_referenced,
     validate_marker_disjointness,
@@ -105,6 +106,8 @@ class TestSingleTuple:
         assert package["directory"]["path"] == str(tmp_path)
         assert "wheels" not in package
         assert "sdist" not in package
+        # PEP 751: version omitted for directory sources (not deterministic).
+        assert "version" not in package
 
     def test_vcs_pin(self) -> None:
         text = write_lock(
@@ -121,11 +124,14 @@ class TestSingleTuple:
             )
         )
         data = tomllib.loads(text)
-        vcs = data["packages"][0]["vcs"]
+        package = data["packages"][0]
+        vcs = package["vcs"]
         assert vcs["type"] == "git"
         assert vcs["url"] == "https://github.com/x/y.git"
         assert vcs["commit-id"] == "a" * 40
         assert vcs["subdirectory"] == "pkg"
+        # PEP 751: version omitted for VCS sources (not deterministic).
+        assert "version" not in package
 
     def test_multiple_packages_sorted_by_name(self) -> None:
         text = write_lock(
@@ -1149,8 +1155,6 @@ class TestBuildLockInputFromProvider:
         assert pin.sdist.hashes == (("sha256", "b" * 64),)
 
     def test_index_pin_records_serving_index(self) -> None:
-        from nab_index.multi_index import IndexConfig
-
         provider = _FakeProvider(
             listings={
                 "foo": [
@@ -1173,8 +1177,6 @@ class TestBuildLockInputFromProvider:
         assert pin.index == "https://download.pytorch.org/whl/cpu/"
 
     def test_index_pin_falls_back_to_default_when_route_missing(self) -> None:
-        from nab_index.multi_index import IndexConfig
-
         provider = _FakeProvider(
             listings={
                 "foo": [
@@ -1191,6 +1193,52 @@ class TestBuildLockInputFromProvider:
         pin = lock_input.pins["foo"]
         assert isinstance(pin, IndexPin)
         assert pin.index == "https://custom.example/simple/"
+
+    def test_index_pin_strips_credentials_from_url(self) -> None:
+        provider = _FakeProvider(
+            listings={"foo": [(Version("1.0"), _wheel_file())]},
+            listing_indexes={"foo": "private"},
+        )
+        lock_input = build_lock_input_from_provider(
+            provider,
+            {"foo": Version("1.0")},
+            indexes=(
+                IndexConfig(
+                    "private", "https://user:token@Private.Example:8443/simple/"
+                ),
+            ),
+        )
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.index == "https://Private.Example:8443/simple/"
+
+    def test_index_pin_keeps_url_without_credentials(self) -> None:
+        provider = _FakeProvider(
+            listings={"foo": [(Version("1.0"), _wheel_file())]},
+            listing_indexes={"foo": "plain"},
+        )
+        lock_input = build_lock_input_from_provider(
+            provider,
+            {"foo": Version("1.0")},
+            indexes=(IndexConfig("plain", "https://Plain.Example/simple/"),),
+        )
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.index == "https://Plain.Example/simple/"
+
+    def test_index_pin_strips_username_only_credentials(self) -> None:
+        provider = _FakeProvider(
+            listings={"foo": [(Version("1.0"), _wheel_file())]},
+            listing_indexes={"foo": "useronly"},
+        )
+        lock_input = build_lock_input_from_provider(
+            provider,
+            {"foo": Version("1.0")},
+            indexes=(IndexConfig("useronly", "https://user@example.com/simple/"),),
+        )
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.index == "https://example.com/simple/"
 
     def test_local_source_emits_local_pin(self, tmp_path: Path) -> None:
         provider = _FakeProvider(
@@ -1283,6 +1331,37 @@ class TestBuildLockInputFromProvider:
         assert isinstance(pin, VcsPin)
         assert pin.commit_id == ""
 
+    def test_vcs_source_strips_credentials_from_url(self) -> None:
+        provider = _FakeProvider(
+            vcs_sources={
+                "foo": VcsSource(
+                    name="foo",
+                    url="git+https://user:token@GitHub.com/org/repo.git",
+                ),
+            },
+            vcs_pins={"foo": "a" * 40},
+        )
+        lock_input = build_lock_input_from_provider(
+            provider, {"foo": Version("0.0.0+vcs")}
+        )
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, VcsPin)
+        assert pin.repo_url == "git+https://GitHub.com/org/repo.git"
+
+    def test_vcs_source_keeps_url_without_credentials(self) -> None:
+        provider = _FakeProvider(
+            vcs_sources={
+                "foo": VcsSource(name="foo", url="git+https://github.com/org/repo.git"),
+            },
+            vcs_pins={"foo": "a" * 40},
+        )
+        lock_input = build_lock_input_from_provider(
+            provider, {"foo": Version("0.0.0+vcs")}
+        )
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, VcsPin)
+        assert pin.repo_url == "git+https://github.com/org/repo.git"
+
     def test_missing_acceptable_hash_raises(self) -> None:
         wheel = _wheel_file(sha256=None)
         provider = _FakeProvider(listings={"foo": [(Version("1.0"), wheel)]})
@@ -1346,8 +1425,6 @@ class TestBuildLockInputFromProvider:
         assert pin.requires_python is None
 
     def test_first_configured_index_url_used_when_route_missing(self) -> None:
-        from nab_index.multi_index import IndexConfig
-
         provider = _FakeProvider(listings={"foo": [(Version("1.0"), _wheel_file())]})
         lock_input = build_lock_input_from_provider(
             provider,

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -927,6 +927,25 @@ class TestLocalSources:
         provider.prefetch_new_deps({"foo": SpecifierSet("").to_range()})
         coordinator.request_listing.assert_not_called()
 
+    def test_local_source_reads_from_subdirectory(self, tmp_path: Path) -> None:
+        """A local source with a subdirectory resolves the package there."""
+        sub = tmp_path / "packages" / "foo"
+        sub.mkdir(parents=True)
+        (sub / "pyproject.toml").write_text(
+            '[project]\nname = "foo"\nversion = "4.5.6"\n', encoding="utf-8"
+        )
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(
+            coordinator,
+            local_sources=[
+                LocalSource("foo", str(tmp_path), subdirectory="packages/foo")
+            ],
+            build_policy=BuildPolicy.NEVER,
+        )
+        versions = provider.fetch_versions("foo")
+        assert len(versions) == 1
+        assert str(versions[0][0]) == "4.5.6"
+
     def test_local_source_dependencies(self, tmp_path: Path) -> None:
         """Local source deps round-trip through ``get_dependencies``."""
 

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -591,6 +591,64 @@ class TestResolvePyproject:
         # the strategy decision is keyed on the underlying package.
         assert kwargs["direct_packages"] == frozenset({"requests", "foo"})
 
+    @patch("nab_python.resolve.build_lock_input_from_provider")
+    @patch("nab_python.resolve.Resolver")
+    @patch("nab_python.resolve.Provider")
+    @patch("nab_python.resolve.FetchCoordinator")
+    def test_default_groups_from_config_not_cli_groups(
+        self,
+        mock_coord_cls: MagicMock,
+        mock_provider_cls: MagicMock,
+        mock_resolver_cls: MagicMock,
+        mock_build_lock: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """``default_groups`` is the project config value, not ``--groups``."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\ndependencies = ["foo>=1.0"]\n'
+            "[dependency-groups]\ndev = []\ntest = []\n"
+            '[tool.nab]\ndefault-groups = ["dev"]\n',
+        )
+        mock_coord_cls.return_value.__enter__ = lambda s: s
+        mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_resolver_cls.return_value.resolve.return_value = {}
+
+        resolve_pyproject(
+            pyproject, _FAKE_TRANSPORT, python_version="3.12.0", groups=("test",)
+        )
+
+        kwargs = mock_build_lock.call_args.kwargs
+        assert kwargs["dependency_groups"] == ("test",)
+        assert kwargs["default_groups"] == ("dev",)
+
+    @patch("nab_python.resolve.build_lock_input_from_provider")
+    @patch("nab_python.resolve.Resolver")
+    @patch("nab_python.resolve.Provider")
+    @patch("nab_python.resolve.FetchCoordinator")
+    def test_default_groups_empty_when_config_omits_it(
+        self,
+        mock_coord_cls: MagicMock,
+        mock_provider_cls: MagicMock,
+        mock_resolver_cls: MagicMock,
+        mock_build_lock: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """No ``default-groups`` in config: ``--groups`` does not leak in."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\ndependencies = ["foo>=1.0"]\n[dependency-groups]\ntest = []\n',
+        )
+        mock_coord_cls.return_value.__enter__ = lambda s: s
+        mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_resolver_cls.return_value.resolve.return_value = {}
+
+        resolve_pyproject(
+            pyproject, _FAKE_TRANSPORT, python_version="3.12.0", groups=("test",)
+        )
+
+        assert mock_build_lock.call_args.kwargs["default_groups"] == ()
+
 
 class TestResolveUniversalPyproject:
     @patch("nab_python.resolve.resolve_universal")

--- a/src/nab/_download.py
+++ b/src/nab/_download.py
@@ -35,10 +35,10 @@ def download(
     output: Path = Path("wheels"),
     http_backend: HttpBackend = "urllib3",
     cache_dir: Path | None = None,
-    no_cache: bool = False,
+    cache: bool = True,
     offline: bool = False,
     max_concurrency: int = 8,
-    no_workspace_discovery: bool = False,
+    workspace_discovery: bool = True,
 ) -> None:
     """Resolve and download every wheel/sdist into a local directory.
 
@@ -47,14 +47,14 @@ def download(
     left alone.  Local and VCS pins are skipped.
     """
     config = _cli._load_config(  # noqa: SLF001
-        path, discover_workspace=not no_workspace_discovery
+        path, discover_workspace=workspace_discovery
     )
     if config.mode is ResolveMode.UNIVERSAL:
         sys.stderr.write("Error: `nab download` is single-environment only.\n")
         sys.exit(1)
 
     effective_cache_dir = _cli._resolve_effective_cache_dir(  # noqa: SLF001
-        cache_dir, no_cache=no_cache
+        cache_dir, cache=cache
     )
     transport = _cli._make_transport(http_backend)  # noqa: SLF001
     result = _cli._resolve_specific(  # noqa: SLF001

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -25,7 +25,9 @@ from nab_python.config import (
 )
 from nab_python.lockfile import (
     Provenance,
+    is_valid_pylock_path,
     read_lockfile_anchor,
+    read_lockfile_packages,
 )
 from nab_python.provider import ResolutionStrategy
 from nab_python.requirements_file import (
@@ -43,7 +45,10 @@ from .cli import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from nab_index.transport import AsyncHttpTransport
+    from nab_python._vendor.packaging.version import Version
     from nab_python.resolve import ResolutionResult
     from nab_python.universal.resolve import TupleResult, UniversalResult
 
@@ -56,13 +61,13 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     format: LockFormat = "pylock",  # noqa: A002 - shadows builtin by convention
     http_backend: HttpBackend = "urllib3",
     cache_dir: Path | None = None,
-    no_cache: bool = False,
+    cache: bool = True,
     offline: bool = False,
     groups: tuple[str, ...] = (),
     all_groups: bool = False,
     extras: tuple[str, ...] = (),
     all_extras: bool = False,
-    no_workspace_discovery: bool = False,
+    workspace_discovery: bool = True,
     resolution: ResolutionFlag | None = None,
     upgrade: bool = False,
 ) -> None:
@@ -88,12 +93,13 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     ``--upgrade`` re-anchors the ``P<n>D`` cutoff to ``datetime.now(UTC)``
     instead of reusing the timestamp recorded in any existing lockfile.
     """
+    _validate_pylock_output_name(output=output, format=format)
     anchor = _determine_lock_anchor(output=output, format=format, upgrade=upgrade)
     config = _cli._load_config(  # noqa: SLF001
-        path, discover_workspace=not no_workspace_discovery, anchor=anchor
+        path, discover_workspace=workspace_discovery, anchor=anchor
     )
     effective_cache_dir = _cli._resolve_effective_cache_dir(  # noqa: SLF001
-        cache_dir, no_cache=no_cache
+        cache_dir, cache=cache
     )
     provenance = _build_provenance(path, config=config, anchor=anchor)
     selected_groups = _resolve_group_selection(
@@ -160,12 +166,52 @@ def _emit_specific(
 
     target = output if output is not None else Path(_cli._DEFAULT_OUTPUT[format])  # noqa: SLF001
     if format == "pylock":
+        # Read the prior pins before write_lock overwrites the file.
+        prior = read_lockfile_packages(target)
         _cli.write_lock(lock_input, output_path=target)
+        diff = _diff_summary(prior, result.pins)
     elif format == "requirements":
         _cli.write_requirements_with_hashes(lock_input, output_path=target)
+        diff = ""
     else:
         _cli.write_requirements_without_hashes(lock_input, output_path=target)
-    sys.stderr.write(f"Wrote {target} ({len(result.pins)} packages)\n")
+        diff = ""
+    sys.stderr.write(f"Wrote {target} ({len(result.pins)} packages{diff})\n")
+
+
+def _diff_summary(
+    prior: Mapping[str, Version] | None, current: Mapping[str, Version]
+) -> str:
+    """Return a ``: A added, B upgraded, ...`` suffix for a re-lock.
+
+    ``prior`` is the previous pylock's pins or ``None`` (first lock or
+    an unparseable prior file); both fall back to an empty suffix.  An
+    unchanged pin set also yields an empty suffix.
+    """
+    if prior is None:
+        return ""
+    added = sum(name not in prior for name in current)
+    removed = sum(name not in current for name in prior)
+    upgraded = downgraded = 0
+    for name, version in current.items():
+        old = prior.get(name)
+        if old is None or old == version:
+            continue
+        if version > old:
+            upgraded += 1
+        else:
+            downgraded += 1
+    parts = [
+        f"{count} {label}"
+        for count, label in (
+            (added, "added"),
+            (upgraded, "upgraded"),
+            (downgraded, "downgraded"),
+            (removed, "removed"),
+        )
+        if count
+    ]
+    return f": {', '.join(parts)}" if parts else ""
 
 
 def _emit_universal(  # noqa: PLR0913 - one wrapper per resolve_universal_pyproject kwarg
@@ -216,6 +262,7 @@ def _emit_universal(  # noqa: PLR0913 - one wrapper per resolve_universal_pyproj
     if format == "pylock":
         _emit_universal_pylock(
             result,
+            config=config,
             output=output,
             provenance=provenance,
             groups=groups,
@@ -230,17 +277,25 @@ def _emit_universal(  # noqa: PLR0913 - one wrapper per resolve_universal_pyproj
 def _emit_universal_pylock(
     result: UniversalResult,
     *,
+    config: NabProjectConfig | None = None,
     output: Path | None,
     provenance: Provenance | None = None,
     groups: tuple[str, ...] = (),
     extras: tuple[str, ...] = (),
 ) -> None:
-    """Merge per-tuple LockInputs into one pylock and write/print it."""
+    """Merge per-tuple LockInputs into one pylock and write/print it.
+
+    ``default_groups`` is taken from ``[tool.nab].default-groups``, not
+    from the CLI ``--groups`` selection: PEP 751 ``default-groups``
+    means the groups a default install applies, which is project
+    policy rather than this run's request.
+    """
+    default_groups = config.default_groups if config is not None else ()
     lock_input = _cli.merge_universal_lock_inputs(
         result,
         extras=extras,
         dependency_groups=groups,
-        default_groups=groups,
+        default_groups=default_groups,
     )
     if provenance is not None:
         lock_input.provenance = provenance
@@ -477,6 +532,32 @@ def _determine_lock_anchor(
     target = output if output is not None else Path(_cli._DEFAULT_OUTPUT[format])  # noqa: SLF001
     prior = read_lockfile_anchor(target)
     return prior if prior is not None else fresh
+
+
+def _validate_pylock_output_name(
+    *,
+    output: Path | None,
+    format: str,  # noqa: A002 - shadows builtin by convention
+) -> None:
+    """Reject a ``--output`` name that PEP 751 would not recognise.
+
+    A pylock-format lockfile must be ``pylock.toml`` or match
+    ``pylock.<name>.toml`` (dot separators).  stdout (``-``) and the
+    requirements formats are exempt; exits 1 on a bad name with a
+    suggested correction.
+    """
+    if format != "pylock" or output is None or _cli._is_stdout(output):  # noqa: SLF001
+        return
+    if is_valid_pylock_path(output):
+        return
+    dotted = output.with_name(output.name.replace("-", "."))
+    suggestion = dotted.name if is_valid_pylock_path(dotted) else "pylock.toml"
+    sys.stderr.write(
+        f"Error: output file name {output.name!r} must match 'pylock.toml'"
+        " or 'pylock.<name>.toml' per PEP 751 (note the dot separator,"
+        f" not a hyphen).  Try {suggestion!r}.\n"
+    )
+    sys.exit(1)
 
 
 def _print_universal_blocks(result: UniversalResult) -> None:

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -121,10 +121,8 @@ def _default_cache_dir() -> Path:
     return Path.home() / ".cache" / "nab"
 
 
-def _resolve_effective_cache_dir(
-    cache_dir: Path | None, *, no_cache: bool
-) -> Path | None:
-    if no_cache:
+def _resolve_effective_cache_dir(cache_dir: Path | None, *, cache: bool) -> Path | None:
+    if not cache:
         return None
     if cache_dir is not None:
         return cache_dir

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import builtins
+import contextlib
 import importlib
+import io
 import runpy
 import sys
 from datetime import datetime, timezone
@@ -13,6 +15,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import tomli
 
 from nab import _version as nab_version
 from nab._download import download
@@ -27,11 +30,13 @@ from nab._lock import (
 from nab.cli import (
     _default_cache_dir,
     _make_transport,
+    app,
     main,
 )
 from nab_index.httpx_async_transport import HttpxAsyncTransport
 from nab_index.niquests_async_transport import NiquestsAsyncTransport
 from nab_index.urllib3_async_transport import Urllib3AsyncTransport
+from nab_python._vendor.packaging.pylock import Pylock
 from nab_python._vendor.packaging.version import Version
 from nab_python.download import DownloadError
 from nab_python.lockfile import (
@@ -57,21 +62,21 @@ _LINUX_311_ENV = {
 }
 
 
-def _foo_index_pin(version: str = "1.0") -> IndexPin:
-    """Build a fully-formed IndexPin for ``foo`` with one wheel + sdist."""
+def _foo_index_pin(version: str = "1.0", name: str = "foo") -> IndexPin:
+    """Build a fully-formed IndexPin with one wheel + sdist."""
     return IndexPin(
-        name="foo",
+        name=name,
         version=version,
         index="pypi",
         sdist=SdistArtifact(
-            filename=f"foo-{version}.tar.gz",
-            url=f"https://example.com/foo-{version}.tar.gz",
+            filename=f"{name}-{version}.tar.gz",
+            url=f"https://example.com/{name}-{version}.tar.gz",
             hashes=(("sha256", "b" * 64),),
         ),
         wheels=(
             WheelArtifact(
-                filename=f"foo-{version}-py3-none-any.whl",
-                url=f"https://example.com/foo-{version}-py3-none-any.whl",
+                filename=f"{name}-{version}-py3-none-any.whl",
+                url=f"https://example.com/{name}-{version}-py3-none-any.whl",
                 hashes=(("sha256", "a" * 64),),
             ),
         ),
@@ -84,7 +89,7 @@ def _stub_resolution_result(
     """Build a real :class:`ResolutionResult` with a populated lock input."""
     real_pins = pins if pins is not None else {"foo": V(version)}
     lock_input = LockInput(
-        pins={name: _foo_index_pin(str(ver)) for name, ver in real_pins.items()},
+        pins={name: _foo_index_pin(str(ver), name) for name, ver in real_pins.items()},
     )
     return ResolutionResult(pins=real_pins, lock_input=lock_input)
 
@@ -344,6 +349,29 @@ class TestLockCommandUniversal:
         text = out.read_text()
         assert 'lock-version = "1.0"' in text
         assert 'name = "foo"' in text
+
+    def test_default_groups_from_config_not_cli_groups(self, tmp_path: Path) -> None:
+        """Universal pylock records ``default-groups`` from config, not ``--groups``."""
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\ndependencies = ["foo"]\n'
+            "[dependency-groups]\ndev = []\ntest = []\n"
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'default-groups = ["dev"]\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.11"\n'
+            'platforms = ["linux_x86_64"]\n',
+        )
+        out = tmp_path / "pylock.toml"
+        with patch(
+            "nab.cli.resolve_universal_pyproject",
+            return_value=_universal_result(success=True),
+        ):
+            lock(pyproject, output=out, groups=("test",))
+        pylock = Pylock.from_dict(tomli.loads(out.read_text()))
+        assert pylock.dependency_groups == ["test"]
+        assert pylock.default_groups == ["dev"]
 
     def test_offline_and_http_backend_passed_to_universal(self, tmp_path: Path) -> None:
         """--http-backend and --offline reach resolve_universal_pyproject."""
@@ -803,6 +831,175 @@ class TestLockCommandUniversal:
         assert not (tmp_path / "constraints-3.12.txt").exists()
 
 
+class TestRelockDiffSummary:
+    """``_emit_specific`` reports what changed against the prior pylock."""
+
+    def test_first_lock_prints_plain_line(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        out = tmp_path / "pylock.toml"
+        _emit_specific(
+            _stub_resolution_result(pins={"foo": V("1.0")}),
+            format="pylock",
+            output=out,
+            provenance=None,
+        )
+        err = capsys.readouterr().err
+        assert err.strip().endswith("(1 packages)")
+
+    def test_relock_reports_added_upgraded_removed(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        out = tmp_path / "pylock.toml"
+        _emit_specific(
+            _stub_resolution_result(pins={"foo": V("1.0"), "bar": V("1.0")}),
+            format="pylock",
+            output=out,
+            provenance=None,
+        )
+        capsys.readouterr()
+        # foo upgraded 1.0 -> 2.0, bar removed, baz added.
+        _emit_specific(
+            _stub_resolution_result(pins={"foo": V("2.0"), "baz": V("1.0")}),
+            format="pylock",
+            output=out,
+            provenance=None,
+        )
+        err = capsys.readouterr().err.strip()
+        assert err.endswith("(2 packages: 1 added, 1 upgraded, 1 removed)")
+
+    def test_relock_reports_downgrade(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        out = tmp_path / "pylock.toml"
+        _emit_specific(
+            _stub_resolution_result(pins={"foo": V("2.0")}),
+            format="pylock",
+            output=out,
+            provenance=None,
+        )
+        capsys.readouterr()
+        _emit_specific(
+            _stub_resolution_result(pins={"foo": V("1.0")}),
+            format="pylock",
+            output=out,
+            provenance=None,
+        )
+        assert capsys.readouterr().err.strip().endswith("(1 packages: 1 downgraded)")
+
+    def test_relock_unchanged_prints_plain_line(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A re-lock with identical pins prints no diff suffix."""
+        out = tmp_path / "pylock.toml"
+        for _ in range(2):
+            _emit_specific(
+                _stub_resolution_result(pins={"foo": V("1.0")}),
+                format="pylock",
+                output=out,
+                provenance=None,
+            )
+        assert capsys.readouterr().err.strip().endswith("(1 packages)")
+
+    def test_unparseable_prior_falls_back_to_plain_line(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        out = tmp_path / "pylock.toml"
+        out.write_text("this is not valid toml === {[\n")
+        _emit_specific(
+            _stub_resolution_result(pins={"foo": V("1.0")}),
+            format="pylock",
+            output=out,
+            provenance=None,
+        )
+        assert capsys.readouterr().err.strip().endswith("(1 packages)")
+
+    def test_stdout_emits_no_diff(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _emit_specific(
+            _stub_resolution_result(pins={"foo": V("1.0")}),
+            format="pylock",
+            output=Path("-"),
+            provenance=None,
+        )
+        captured = capsys.readouterr()
+        assert "added" not in captured.err
+        assert "packages" not in captured.err
+
+    def test_requirements_format_emits_no_diff(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A requirements re-lock keeps the plain line; only pylock diffs."""
+        out = tmp_path / "requirements.txt"
+        for _ in range(2):
+            _emit_specific(
+                _stub_resolution_result(pins={"foo": V("1.0")}),
+                format="requirements",
+                output=out,
+                provenance=None,
+            )
+        assert capsys.readouterr().err.strip().endswith("(1 packages)")
+
+
+class TestPylockOutputNameValidation:
+    """``--output`` is validated against the PEP 751 file-name rule."""
+
+    def test_specific_rejects_hyphen_name(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, output=tmp_path / "pylock-dev.toml")
+        err = capsys.readouterr().err
+        assert "PEP 751" in err
+        assert "pylock.dev.toml" in err
+
+    def test_universal_rejects_hyphen_name(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _universal_pyproject(tmp_path)
+        with (
+            patch(
+                "nab.cli.resolve_universal_pyproject",
+                return_value=_universal_result(success=True),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, output=tmp_path / "pylock-dev.toml")
+        assert "PEP 751" in capsys.readouterr().err
+
+    def test_specific_accepts_named_pylock(self, tmp_path: Path) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.dev.toml"
+        with patch("nab.cli.resolve_pyproject", return_value=_stub_resolution_result()):
+            lock(pyproject, output=out)
+        assert out.exists()
+
+    def test_unparseable_name_suggests_pylock_toml(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A name with no recoverable label suggests the bare ``pylock.toml``."""
+        pyproject = _make_pyproject(tmp_path)
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, output=tmp_path / "lock.toml")
+        assert "pylock.toml" in capsys.readouterr().err
+
+    def test_stdout_skips_validation(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        with patch("nab.cli.resolve_pyproject", return_value=_stub_resolution_result()):
+            lock(pyproject, output=Path("-"))
+        assert 'lock-version = "1.0"' in capsys.readouterr().out
+
+    def test_requirements_format_skips_validation(self, tmp_path: Path) -> None:
+        """A non-pylock format is free to use any output name."""
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "constraints.txt"
+        with patch("nab.cli.resolve_pyproject", return_value=_stub_resolution_result()):
+            lock(pyproject, output=out, format="requirements")
+        assert out.exists()
+
+
 class TestConfigErrors:
     """Errors in [tool.nab] surface as exit 1 with a clear message."""
 
@@ -1075,7 +1272,7 @@ class TestCacheFlags:
         assert mock_resolve.call_args.kwargs["cache_dir"] == cache
 
     def test_no_cache_disables_cache(self, tmp_path: Path) -> None:
-        """--no-cache wins over --cache-dir and disables persistence."""
+        """``cache=False`` wins over --cache-dir and disables persistence."""
         pyproject = _make_pyproject(tmp_path)
         with (
             patch(
@@ -1084,7 +1281,7 @@ class TestCacheFlags:
             ) as mock_resolve,
             patch("nab.cli.write_lock"),
         ):
-            lock(pyproject, no_cache=True, output=tmp_path / "pylock.toml")
+            lock(pyproject, cache=False, output=tmp_path / "pylock.toml")
         assert mock_resolve.call_args.kwargs["cache_dir"] is None
 
     def test_offline_passed_through(self, tmp_path: Path) -> None:
@@ -1114,6 +1311,35 @@ class TestCacheFlags:
         monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
         monkeypatch.setattr("nab.cli.Path.home", lambda: tmp_path)
         assert _default_cache_dir() == tmp_path / ".cache" / "nab"
+
+
+def _command_help(command: str) -> str:
+    """Return the ``--help`` text tyro renders for a subcommand."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf), contextlib.suppress(SystemExit):
+        app.cli(args=[command, "--help"], prog="nab")
+    return buf.getvalue()
+
+
+class TestHelpText:
+    """Boolean flags render without tyro's double-negated aliases."""
+
+    def test_lock_cache_flag_has_no_double_negative(self) -> None:
+        help_text = _command_help("lock")
+        assert "--no-no-cache" not in help_text
+        assert "--cache" in help_text
+        assert "--no-cache" in help_text
+
+    def test_lock_workspace_discovery_has_no_double_negative(self) -> None:
+        help_text = _command_help("lock")
+        assert "--no-no-workspace-discovery" not in help_text
+        assert "--workspace-discovery" in help_text
+        assert "--no-workspace-discovery" in help_text
+
+    def test_download_cache_flag_has_no_double_negative(self) -> None:
+        help_text = _command_help("download")
+        assert "--no-no-cache" not in help_text
+        assert "--no-cache" in help_text
 
 
 class TestPackageVersion:


### PR DESCRIPTION
Addresses a batch of issues from the public tracker.

Lockfile spec compliance:
- Fixes #2: redact `user:password@` credentials from the index URL in the lockfile
- Fixes #3: redact credentials from the VCS `repo_url`
- Fixes #9: drop the false "atomically" claim from the `write_lock` docstring
- Fixes #11: omit `version` for directory and VCS packages (PEP 751 treats it as non-deterministic)

New optional PEP 751 fields:
- Fixes #12: emit `packages.directory.editable` from a `[[tool.nab.local-sources]]` `editable` key
- Fixes #13: support a `subdirectory` key on `[[tool.nab.local-sources]]`, resolved and recorded under `path`
- Fixes #14: emit `packages.vcs.requested-revision` when the user pinned a named ref
- Fixes #15: emit `upload-time` for wheels and sdists from the index metadata

CLI:
- Fixes #7: take `default-groups` from `[tool.nab].default-groups` instead of mirroring `--groups`
- Fixes #33: reject an `--output` name PEP 751 would not recognise
- Fixes #36: print an added/upgraded/downgraded/removed summary after a re-lock
- Fixes #37: rename the cache and workspace-discovery flags so tyro stops emitting `--no-no-cache`

Suite stays green at 100% branch coverage.