### PR TITLE
Write lockfile paths relative to the lock file

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -88,6 +88,11 @@ class WheelFile:
     order PEP 691 declared them (tuple form keeps the dataclass
     hashable).  ``has_metadata`` says whether the index advertised a
     PEP 658/714 sidecar; :attr:`metadata_url` derives the URL lazily.
+
+    ``local_path`` is the on-disk path of a wheel served from a local
+    index, and ``None`` for one fetched from a remote index.  It lets
+    downstream code use the path directly instead of reversing the
+    ``file:`` URL, which is lossy across platforms.
     """
 
     filename: str
@@ -98,6 +103,7 @@ class WheelFile:
     upload_time: str | None
     hashes: tuple[tuple[str, str], ...] = ()
     size: int | None = None
+    local_path: Path | None = None
 
     @property
     def metadata_url(self) -> str | None:
@@ -109,7 +115,8 @@ class WheelFile:
 class SdistFile:
     """A source distribution from the Simple API.
 
-    See :class:`WheelFile` for the meaning of ``hashes`` and ``size``.
+    See :class:`WheelFile` for the meaning of ``hashes``, ``size`` and
+    ``local_path``.
     """
 
     filename: str
@@ -119,6 +126,7 @@ class SdistFile:
     upload_time: str | None
     hashes: tuple[tuple[str, str], ...] = ()
     size: int | None = None
+    local_path: Path | None = None
 
 
 class AsyncSimpleClient:

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -101,10 +101,10 @@ def _scan_pep503_directory(
     parser.feed(index_html.read_text(encoding="utf-8"))
     files: list[WheelFile | SdistFile] = []
     for href, requires_python in parser.links:
-        filename, file_url, hashes = _resolve_local_link(href, package_dir)
+        filename, file_url, local_path, hashes = _resolve_local_link(href, package_dir)
         if filename is None:
             continue
-        record = _make_record(filename, file_url, requires_python, hashes)
+        record = _make_record(filename, file_url, local_path, requires_python, hashes)
         if record is not None:
             files.append(record)
     return files
@@ -113,14 +113,18 @@ def _scan_pep503_directory(
 def _resolve_local_link(
     href: str,
     package_dir: Path,
-) -> tuple[str | None, str, tuple[tuple[str, str], ...]]:
-    """Resolve an anchor href to ``(filename, absolute_file_url, hashes)``.
+) -> tuple[str | None, str, Path | None, tuple[tuple[str, str], ...]]:
+    """Resolve an anchor href to ``(filename, url, local_path, hashes)``.
 
     PEP 503 carries the artefact's hash in the URL fragment as
     ``#<algo>=<hexdigest>``; this is the only place the hash appears
     when the index has not opted into PEP 691 JSON.  The fragment is
     parsed here and surfaced as the file record's ``hashes`` tuple so
     the lockfile writer has something to round-trip.
+
+    ``local_path`` is the artefact's on-disk path when the href names
+    a local file, and ``None`` for an ``http``/``https`` href.  It is
+    carried so downstream code never has to reverse the ``file:`` URL.
     """
     href_no_frag, _, fragment = href.partition("#")
     hashes = _parse_pep503_hash_fragment(fragment)
@@ -128,18 +132,18 @@ def _resolve_local_link(
 
     if parsed.scheme in {"http", "https"}:
         filename = unquote(parsed.path.rsplit("/", 1)[-1]) or None
-        return (filename, href_no_frag, hashes)
+        return (filename, href_no_frag, None, hashes)
     if parsed.scheme == "file":
         path = _parse_file_url(href_no_frag)
-        return (path.name, href_no_frag, hashes)
+        return (path.name, href_no_frag, path, hashes)
 
     package_dir_resolved = package_dir.resolve()
     target = (package_dir_resolved / unquote(href_no_frag)).resolve()
     try:
         target.relative_to(package_dir_resolved)
     except ValueError:
-        return (None, "", ())
-    return (target.name, target.as_uri(), hashes)
+        return (None, "", None, ())
+    return (target.name, target.as_uri(), target, hashes)
 
 
 def _parse_pep503_hash_fragment(fragment: str) -> tuple[tuple[str, str], ...]:
@@ -167,7 +171,7 @@ def _scan_flat_wheelhouse(
         parsed_name = _parsed_dist_name(entry.name)
         if parsed_name is None or _canonical(parsed_name) != canonical:
             continue
-        record = _make_record(entry.name, entry.as_uri(), None, ())
+        record = _make_record(entry.name, entry.as_uri(), entry, None, ())
         if record is not None:
             files.append(record)
     return files
@@ -186,6 +190,7 @@ def _parsed_dist_name(filename: str) -> str | None:
 def _make_record(
     filename: str,
     file_url: str,
+    local_path: Path | None,
     requires_python: str | None,
     hashes: tuple[tuple[str, str], ...],
 ) -> WheelFile | SdistFile | None:
@@ -200,6 +205,7 @@ def _make_record(
             has_metadata=False,
             upload_time=None,
             hashes=hashes,
+            local_path=local_path,
         )
     parsed = _parse_sdist_filename(filename)
     if parsed is not None:
@@ -211,6 +217,7 @@ def _make_record(
             requires_python=requires_python,
             upload_time=None,
             hashes=hashes,
+            local_path=local_path,
         )
     return None
 

--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -326,6 +326,7 @@ def _build_artifact(
         hashes=hashes,
         size=source.size,
         upload_time=_parse_upload_time(source.upload_time),
+        local_path=source.local_path,
     )
 
 

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -11,9 +11,11 @@ disjointness validation lives in
 
 from __future__ import annotations
 
+import os
 from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from urllib.parse import unquote, urlsplit
 
 import tomli_w
 
@@ -32,7 +34,6 @@ from .._vendor.packaging.version import Version
 from .disjointness import validate_marker_disjointness
 
 if TYPE_CHECKING:
-    import os
     from collections.abc import Mapping, Sequence
 
     from ..lockfile import (
@@ -59,8 +60,14 @@ def write_lock(
     Returns the TOML text.  When ``output_path`` is provided, also
     writes it there; the caller chooses the path (PEP 751 does not
     mandate one).
+
+    Directory, wheel and sdist paths are written relative to
+    ``output_path``'s parent so the lockfile stays portable between
+    machines (PEP 751 records those paths relative to the lock file).
+    With no ``output_path`` the current directory is the base.
     """
-    pylock = build_pylock(lock_input)
+    lock_dir = Path(output_path).parent if output_path is not None else None
+    pylock = build_pylock(lock_input, lock_dir=lock_dir)
     pylock.validate()
     text = tomli_w.dumps(dict(pylock.to_dict()))
     if output_path is not None:
@@ -68,20 +75,28 @@ def write_lock(
     return text
 
 
-def build_pylock(lock_input: LockInput) -> Pylock:
+def build_pylock(lock_input: LockInput, *, lock_dir: Path | None = None) -> Pylock:
     """Build a :class:`Pylock` from the input shape.
 
     The resolver-side data structures have already been simplified
     when this function runs.  The remaining work is shape conversion:
     ``Pin`` -> ``Package``, plus marker attachment from the per-tuple
     map.
+
+    ``lock_dir`` is the directory the lockfile will be written to;
+    local-directory, wheel and sdist paths are emitted relative to it
+    so the lockfile is portable.  It defaults to the current working
+    directory when the caller has no path in mind (e.g. stdout).
     """
     from ..lockfile import LOCK_VERSION
 
+    base = (lock_dir if lock_dir is not None else Path.cwd()).resolve()
     if lock_input.per_tuple_pins:
-        package_records = _build_per_tuple_packages(lock_input)
+        package_records = _build_per_tuple_packages(lock_input, base)
     else:
-        package_records = [_pin_to_package(pin) for pin in lock_input.pins.values()]
+        package_records = [
+            _pin_to_package(pin, lock_dir=base) for pin in lock_input.pins.values()
+        ]
     package_records.sort(key=_package_sort_key)
     validate_marker_disjointness(
         package_records,
@@ -121,7 +136,38 @@ def build_pylock(lock_input: LockInput) -> Pylock:
     )
 
 
-def _pin_to_package(pin: PinShape, marker: Marker | None = None) -> Package:
+def _relativize_path(target: str | os.PathLike[str], lock_dir: Path) -> str:
+    """Return ``target`` as a POSIX path relative to ``lock_dir``.
+
+    PEP 751 records ``packages.directory.path`` and the wheel/sdist
+    ``path`` fields relative to the lock file so the lockfile stays
+    portable between machines.  :func:`os.path.relpath` is used
+    rather than :meth:`pathlib.Path.relative_to` so a ``target``
+    outside ``lock_dir`` still resolves, to a ``../``-prefixed path.
+    The result uses POSIX separators, which the spec recommends for
+    portable relative paths.
+    """
+    return Path(os.path.relpath(target, lock_dir)).as_posix()
+
+
+def _file_url_to_path(url: str) -> Path:
+    """Return the filesystem path a ``file:`` URL points at.
+
+    The inverse of :meth:`pathlib.Path.as_uri`, which nab-index uses
+    to label wheels and sdists discovered in a local find-links
+    directory.  A non-empty URL authority is kept as a leading
+    ``//host`` component.
+    """
+    parts = urlsplit(url)
+    raw = unquote(parts.path)
+    if parts.netloc:
+        raw = f"//{parts.netloc}{raw}"
+    return Path(raw)
+
+
+def _pin_to_package(
+    pin: PinShape, marker: Marker | None = None, *, lock_dir: Path
+) -> Package:
     from ..lockfile import IndexPin, LocalPin, VcsPin
 
     if isinstance(pin, IndexPin):
@@ -133,18 +179,22 @@ def _pin_to_package(pin: PinShape, marker: Marker | None = None) -> Package:
                 SpecifierSet(pin.requires_python) if pin.requires_python else None
             ),
             index=pin.index,
-            sdist=_sdist_to_package(pin.sdist) if pin.sdist else None,
-            wheels=tuple(_wheel_to_package(w) for w in pin.wheels) or None,
+            sdist=(
+                _sdist_to_package(pin.sdist, lock_dir=lock_dir) if pin.sdist else None
+            ),
+            wheels=tuple(_wheel_to_package(w, lock_dir=lock_dir) for w in pin.wheels)
+            or None,
         )
     if isinstance(pin, LocalPin):
         # PEP 751: omit version for directory sources; it is not
         # deterministic (the source tree may change at install time).
+        # The path is recorded relative to the lock file for portability.
         return Package(
             name=canonicalize_name(pin.name),
             version=None,
             marker=marker,
             directory=PackageDirectory(
-                path=pin.path,
+                path=_relativize_path(pin.path, lock_dir),
                 editable=pin.editable,
                 subdirectory=pin.subdirectory,
             ),
@@ -167,7 +217,21 @@ def _pin_to_package(pin: PinShape, marker: Marker | None = None) -> Package:
     raise TypeError(msg)
 
 
-def _wheel_to_package(wheel: WheelArtifact) -> PackageWheel:
+def _wheel_to_package(wheel: WheelArtifact, *, lock_dir: Path) -> PackageWheel:
+    """Convert a wheel artefact to its PEP 751 ``packages.wheels`` entry.
+
+    A ``file:`` URL (a wheel from a local find-links directory) is
+    rewritten to a ``path`` relative to the lock file so the lockfile
+    stays portable; a remote ``url`` is recorded verbatim.
+    """
+    if wheel.url.startswith("file:"):
+        return PackageWheel(
+            name=wheel.filename,
+            path=_relativize_path(_file_url_to_path(wheel.url).resolve(), lock_dir),
+            size=wheel.size,
+            hashes=dict(wheel.hashes),
+            upload_time=wheel.upload_time,
+        )
     return PackageWheel(
         name=wheel.filename,
         url=wheel.url,
@@ -177,7 +241,19 @@ def _wheel_to_package(wheel: WheelArtifact) -> PackageWheel:
     )
 
 
-def _sdist_to_package(sdist: SdistArtifact) -> PackageSdist:
+def _sdist_to_package(sdist: SdistArtifact, *, lock_dir: Path) -> PackageSdist:
+    """Convert an sdist artefact to its PEP 751 ``packages.sdist`` entry.
+
+    See :func:`_wheel_to_package` for the ``file:`` URL handling.
+    """
+    if sdist.url.startswith("file:"):
+        return PackageSdist(
+            name=sdist.filename,
+            path=_relativize_path(_file_url_to_path(sdist.url).resolve(), lock_dir),
+            size=sdist.size,
+            hashes=dict(sdist.hashes),
+            upload_time=sdist.upload_time,
+        )
     return PackageSdist(
         name=sdist.filename,
         url=sdist.url,
@@ -187,7 +263,7 @@ def _sdist_to_package(sdist: SdistArtifact) -> PackageSdist:
     )
 
 
-def _build_per_tuple_packages(lock_input: LockInput) -> list[Package]:
+def _build_per_tuple_packages(lock_input: LockInput, lock_dir: Path) -> list[Package]:
     """Collapse per-tuple pins into Package entries with markers.
 
     For each canonical package name:
@@ -210,12 +286,14 @@ def _build_per_tuple_packages(lock_input: LockInput) -> list[Package]:
         groups = _group_pins_by_pin(per_tuple)
         for pins, tuple_labels in groups:
             marker = _build_marker(tuple_labels, lock_input.tuple_markers, total_tuples)
-            out.append(_pin_to_package(_merge_pins_in_group(pins), marker))
+            out.append(
+                _pin_to_package(_merge_pins_in_group(pins), marker, lock_dir=lock_dir)
+            )
     # Pins only present in lock_input.pins (e.g. tuples agreed via the
     # single-source path) emit unconditionally.
     for canonical_name, pin in lock_input.pins.items():
         if canonical_name not in by_name:
-            out.append(_pin_to_package(pin))
+            out.append(_pin_to_package(pin, lock_dir=lock_dir))
     return out
 
 

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -15,7 +15,6 @@ import os
 from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from urllib.parse import unquote, urlsplit
 
 import tomli_w
 
@@ -150,21 +149,6 @@ def _relativize_path(target: str | os.PathLike[str], lock_dir: Path) -> str:
     return Path(os.path.relpath(target, lock_dir)).as_posix()
 
 
-def _file_url_to_path(url: str) -> Path:
-    """Return the filesystem path a ``file:`` URL points at.
-
-    The inverse of :meth:`pathlib.Path.as_uri`, which nab-index uses
-    to label wheels and sdists discovered in a local find-links
-    directory.  A non-empty URL authority is kept as a leading
-    ``//host`` component.
-    """
-    parts = urlsplit(url)
-    raw = unquote(parts.path)
-    if parts.netloc:
-        raw = f"//{parts.netloc}{raw}"
-    return Path(raw)
-
-
 def _pin_to_package(
     pin: PinShape, marker: Marker | None = None, *, lock_dir: Path
 ) -> Package:
@@ -220,14 +204,15 @@ def _pin_to_package(
 def _wheel_to_package(wheel: WheelArtifact, *, lock_dir: Path) -> PackageWheel:
     """Convert a wheel artefact to its PEP 751 ``packages.wheels`` entry.
 
-    A ``file:`` URL (a wheel from a local find-links directory) is
-    rewritten to a ``path`` relative to the lock file so the lockfile
-    stays portable; a remote ``url`` is recorded verbatim.
+    A wheel from a local find-links directory carries its on-disk
+    ``local_path``; it is written as a ``path`` relative to the lock
+    file so the lockfile stays portable.  A remote wheel records its
+    ``url`` verbatim.
     """
-    if wheel.url.startswith("file:"):
+    if wheel.local_path is not None:
         return PackageWheel(
             name=wheel.filename,
-            path=_relativize_path(_file_url_to_path(wheel.url).resolve(), lock_dir),
+            path=_relativize_path(wheel.local_path.resolve(), lock_dir),
             size=wheel.size,
             hashes=dict(wheel.hashes),
             upload_time=wheel.upload_time,
@@ -244,12 +229,12 @@ def _wheel_to_package(wheel: WheelArtifact, *, lock_dir: Path) -> PackageWheel:
 def _sdist_to_package(sdist: SdistArtifact, *, lock_dir: Path) -> PackageSdist:
     """Convert an sdist artefact to its PEP 751 ``packages.sdist`` entry.
 
-    See :func:`_wheel_to_package` for the ``file:`` URL handling.
+    See :func:`_wheel_to_package` for the ``local_path`` handling.
     """
-    if sdist.url.startswith("file:"):
+    if sdist.local_path is not None:
         return PackageSdist(
             name=sdist.filename,
-            path=_relativize_path(_file_url_to_path(sdist.url).resolve(), lock_dir),
+            path=_relativize_path(sdist.local_path.resolve(), lock_dir),
             size=sdist.size,
             hashes=dict(sdist.hashes),
             upload_time=sdist.upload_time,

--- a/nab-python/src/nab_python/_provider/sources.py
+++ b/nab-python/src/nab_python/_provider/sources.py
@@ -136,6 +136,7 @@ def seed_synthetic_listing(
             else None
         ),
         upload_time=None,
+        local_path=path,
     )
     version = metadata.version
     provider.metadata_cache[(normalized, version)] = metadata

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -32,6 +32,7 @@ from ._vendor.packaging.pylock import is_valid_pylock_path
 if TYPE_CHECKING:
     from collections.abc import Mapping
     from datetime import datetime
+    from pathlib import Path
 
     from ._vendor.packaging.markers import Marker
 
@@ -87,6 +88,11 @@ class WheelArtifact:
 
     ``upload_time`` is the index's upload timestamp when available;
     informational provenance per PEP 751 ``packages.wheels.upload-time``.
+
+    ``local_path`` is the on-disk path of a wheel from a local
+    find-links directory; the lockfile writer emits it as a relative
+    ``path`` instead of ``url`` so the lockfile is portable.  ``None``
+    for a wheel fetched from a remote index.
     """
 
     filename: str
@@ -94,6 +100,7 @@ class WheelArtifact:
     hashes: tuple[tuple[str, str], ...]
     size: int | None = None
     upload_time: datetime | None = None
+    local_path: Path | None = None
 
     @property
     def primary_digest(self) -> tuple[str, str]:
@@ -109,8 +116,8 @@ class WheelArtifact:
 class SdistArtifact:
     """An sdist tarball to record in the lockfile.
 
-    See :class:`WheelArtifact` for the meaning of ``hashes`` and
-    ``upload_time``.
+    See :class:`WheelArtifact` for the meaning of ``hashes``,
+    ``upload_time`` and ``local_path``.
     """
 
     filename: str
@@ -118,6 +125,7 @@ class SdistArtifact:
     hashes: tuple[tuple[str, str], ...]
     size: int | None = None
     upload_time: datetime | None = None
+    local_path: Path | None = None
 
     @property
     def primary_digest(self) -> tuple[str, str]:

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -54,6 +54,7 @@ class TestFlatWheelhouse:
         assert isinstance(files[0], WheelFile)
         assert files[0].filename == "foo-1.0-py3-none-any.whl"
         assert files[0].version == "1.0"
+        assert files[0].local_path == wheel
 
     def test_finds_sdist_tar_gz(self, tmp_path: Path) -> None:
         (tmp_path / "foo-1.0.tar.gz").write_bytes(b"")
@@ -139,6 +140,9 @@ class TestPep503Directory:
         client = LocalIndexClient(tmp_path.as_uri())
         result = run(client.get_files("foo"))
         assert result[0].url.endswith("foo-1.0-py3-none-any.whl")
+        assert (
+            result[0].local_path == package_dir.resolve() / "foo-1.0-py3-none-any.whl"
+        )
 
     def test_https_href_pass_through(self, tmp_path: Path) -> None:
         body = '<a href="https://example.com/foo/foo-1.0-py3-none-any.whl">foo</a>'
@@ -146,6 +150,7 @@ class TestPep503Directory:
         client = LocalIndexClient(tmp_path.as_uri())
         result = run(client.get_files("foo"))
         assert result[0].url == "https://example.com/foo/foo-1.0-py3-none-any.whl"
+        assert result[0].local_path is None
 
     def test_unrecognised_anchor_skipped(self, tmp_path: Path) -> None:
         body = '<a href="random.txt">junk</a><a href="foo-1.0-py3-none-any.whl">foo</a>'
@@ -179,6 +184,7 @@ class TestPep503Directory:
         result = run(client.get_files("foo"))
         assert len(result) == 1
         assert result[0].filename == "foo-1.0-py3-none-any.whl"
+        assert result[0].local_path == wheel_path
 
     def test_pep503_hash_fragment_extracted(self, tmp_path: Path) -> None:
         digest = "a" * 64
@@ -289,7 +295,16 @@ class TestMetadataAndSdist:
 
 class TestMakeRecord:
     def test_unrecognised_extension_returns_none(self) -> None:
-        assert _make_record("README.txt", "file:///tmp/README.txt", None, ()) is None
+        assert (
+            _make_record(
+                "README.txt",
+                "file:///tmp/README.txt",
+                Path("/tmp/README.txt"),
+                None,
+                (),
+            )
+            is None
+        )
 
 
 class TestContextManager:

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -21,9 +21,11 @@ from nab_python._lockfile.disjointness import (
     validate_marker_disjointness,
 )
 from nab_python._lockfile.pylock import (
+    _file_url_to_path,
     _or_markers,
     _pin_discriminator,
     _pin_to_package,
+    _relativize_path,
 )
 from nab_python._vendor.packaging.markers import Marker
 from nab_python._vendor.packaging.pylock import Package, PackageWheel, Pylock
@@ -97,14 +99,17 @@ class TestSingleTuple:
         assert package["sdist"]["url"].endswith("foo-1.0.tar.gz")
 
     def test_local_pin_directory(self, tmp_path: Path) -> None:
+        src = tmp_path / "libs" / "foo"
         text = write_lock(
             LockInput(
-                pins={"foo": LocalPin(name="foo", version="1.0", path=str(tmp_path))},
-            )
+                pins={"foo": LocalPin(name="foo", version="1.0", path=str(src))},
+            ),
+            output_path=tmp_path / "pylock.toml",
         )
         data = tomllib.loads(text)
         package = data["packages"][0]
-        assert package["directory"]["path"] == str(tmp_path)
+        # PEP 751: directory.path is relative to the lock file.
+        assert package["directory"]["path"] == "libs/foo"
         assert "wheels" not in package
         assert "sdist" not in package
         # PEP 751: version omitted for directory sources (not deterministic).
@@ -587,7 +592,7 @@ class TestErrorPaths:
             pass
 
         with pytest.raises(TypeError, match="unknown pin shape"):
-            _pin_to_package(Weird())  # type: ignore[arg-type]
+            _pin_to_package(Weird(), lock_dir=Path("/tmp"))  # type: ignore[arg-type]
 
     def test_or_markers_empty_raises(self) -> None:
         with pytest.raises(ValueError, match="at least one"):
@@ -1850,6 +1855,146 @@ class TestUploadTime:
         data = tomllib.loads(text)
         assert "upload-time" not in data["packages"][0]["wheels"][0]
         assert "upload-time" not in data["packages"][0]["sdist"]
+
+
+class TestRelativeDirectoryPath:
+    """PEP 751: ``packages.directory.path`` is relative to the lock file (#6)."""
+
+    def test_path_inside_lock_dir_is_relative(self, tmp_path: Path) -> None:
+        src = tmp_path / "libs" / "foo"
+        text = write_lock(
+            LockInput(pins={"foo": LocalPin(name="foo", version="1.0", path=str(src))}),
+            output_path=tmp_path / "pylock.toml",
+        )
+        data = tomllib.loads(text)
+        assert data["packages"][0]["directory"]["path"] == "libs/foo"
+
+    def test_path_outside_lock_dir_uses_parent_prefix(self, tmp_path: Path) -> None:
+        src = tmp_path / "src" / "foo"
+        out_dir = tmp_path / "locks"
+        out_dir.mkdir()
+        text = write_lock(
+            LockInput(pins={"foo": LocalPin(name="foo", version="1.0", path=str(src))}),
+            output_path=out_dir / "pylock.toml",
+        )
+        data = tomllib.loads(text)
+        assert data["packages"][0]["directory"]["path"] == "../src/foo"
+
+    def test_no_output_path_relativizes_to_cwd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        src = tmp_path / "pkg"
+        text = write_lock(
+            LockInput(pins={"foo": LocalPin(name="foo", version="1.0", path=str(src))})
+        )
+        data = tomllib.loads(text)
+        assert data["packages"][0]["directory"]["path"] == "pkg"
+
+    def test_build_pylock_honours_explicit_lock_dir(self, tmp_path: Path) -> None:
+        src = tmp_path / "a" / "b" / "foo"
+        pylock = build_pylock(
+            LockInput(pins={"foo": LocalPin(name="foo", version="1.0", path=str(src))}),
+            lock_dir=tmp_path / "a",
+        )
+        directory = pylock.packages[0].directory
+        assert directory is not None
+        assert directory.path == "b/foo"
+
+
+class TestRelativeArtifactPath:
+    """PEP 751: ``file:`` wheel/sdist URLs become relative paths (#22)."""
+
+    def test_file_url_wheel_emitted_as_relative_path(self, tmp_path: Path) -> None:
+        wheel_path = tmp_path / "wheels" / "foo-1.0-py3-none-any.whl"
+        pin = IndexPin(
+            name="foo",
+            version="1.0",
+            index="https://example.com/simple/",
+            wheels=(
+                WheelArtifact(
+                    filename="foo-1.0-py3-none-any.whl",
+                    url=wheel_path.as_uri(),
+                    hashes=(("sha256", "a" * 64),),
+                ),
+            ),
+        )
+        text = write_lock(
+            LockInput(pins={"foo": pin}), output_path=tmp_path / "pylock.toml"
+        )
+        wheel = tomllib.loads(text)["packages"][0]["wheels"][0]
+        assert wheel["path"] == "wheels/foo-1.0-py3-none-any.whl"
+        assert "url" not in wheel
+
+    def test_file_url_sdist_emitted_as_relative_path(self, tmp_path: Path) -> None:
+        sdist_path = tmp_path / "dist" / "foo-1.0.tar.gz"
+        pin = IndexPin(
+            name="foo",
+            version="1.0",
+            index="https://example.com/simple/",
+            sdist=SdistArtifact(
+                filename="foo-1.0.tar.gz",
+                url=sdist_path.as_uri(),
+                hashes=(("sha256", "b" * 64),),
+            ),
+        )
+        text = write_lock(
+            LockInput(pins={"foo": pin}), output_path=tmp_path / "pylock.toml"
+        )
+        sdist = tomllib.loads(text)["packages"][0]["sdist"]
+        assert sdist["path"] == "dist/foo-1.0.tar.gz"
+        assert "url" not in sdist
+
+    def test_remote_url_artifacts_keep_url(self, tmp_path: Path) -> None:
+        text = write_lock(
+            LockInput(pins={"foo": _index_pin()}),
+            output_path=tmp_path / "pylock.toml",
+        )
+        package = tomllib.loads(text)["packages"][0]
+        assert package["wheels"][0]["url"].startswith("https://")
+        assert "path" not in package["wheels"][0]
+        assert package["sdist"]["url"].startswith("https://")
+        assert "path" not in package["sdist"]
+
+    def test_file_url_artifact_outside_lock_dir(self, tmp_path: Path) -> None:
+        wheel_path = tmp_path / "wheelhouse" / "foo-1.0-py3-none-any.whl"
+        out_dir = tmp_path / "build" / "locks"
+        out_dir.mkdir(parents=True)
+        pin = IndexPin(
+            name="foo",
+            version="1.0",
+            index="https://example.com/simple/",
+            wheels=(
+                WheelArtifact(
+                    filename="foo-1.0-py3-none-any.whl",
+                    url=wheel_path.as_uri(),
+                    hashes=(("sha256", "a" * 64),),
+                ),
+            ),
+        )
+        text = write_lock(
+            LockInput(pins={"foo": pin}), output_path=out_dir / "pylock.toml"
+        )
+        wheel = tomllib.loads(text)["packages"][0]["wheels"][0]
+        assert wheel["path"] == "../../wheelhouse/foo-1.0-py3-none-any.whl"
+
+
+class TestPathHelpers:
+    """Unit coverage for the path-relativisation helpers."""
+
+    def test_file_url_to_path_plain(self) -> None:
+        original = Path("/tmp/wheels/foo bar.whl")
+        assert _file_url_to_path(original.as_uri()) == original
+
+    def test_file_url_to_path_with_authority(self) -> None:
+        assert _file_url_to_path("file://host/share/foo.whl") == Path(
+            "//host/share/foo.whl"
+        )
+
+    def test_relativize_path_uses_posix_separators(self, tmp_path: Path) -> None:
+        rel = _relativize_path(tmp_path / "a" / "b", tmp_path)
+        assert rel == "a/b"
+        assert "\\" not in rel
 
 
 class TestWriteRequirementsWithHashes:

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -21,7 +21,6 @@ from nab_python._lockfile.disjointness import (
     validate_marker_disjointness,
 )
 from nab_python._lockfile.pylock import (
-    _file_url_to_path,
     _or_markers,
     _pin_discriminator,
     _pin_to_package,
@@ -1133,6 +1132,7 @@ def _wheel_file(
     *,
     requires_python: str | None = ">=3.10",
     sha256: str | None = "a" * 64,
+    local_path: Path | None = None,
 ) -> WheelFile:
     hashes = (("sha256", sha256),) if sha256 is not None else ()
     return WheelFile(
@@ -1144,6 +1144,7 @@ def _wheel_file(
         upload_time=None,
         hashes=hashes,
         size=1234,
+        local_path=local_path,
     )
 
 
@@ -1182,6 +1183,17 @@ class TestBuildLockInputFromProvider:
         assert len(pin.wheels) == 1
         assert pin.wheels[0].hashes == (("sha256", "a" * 64),)
         assert lock_input.requires_python == ">=3.10"
+
+    def test_local_path_threads_to_artifact(self, tmp_path: Path) -> None:
+        """A WheelFile.local_path reaches the emitted WheelArtifact."""
+        wheel_path = tmp_path / "foo-1.0-py3-none-any.whl"
+        provider = _FakeProvider(
+            listings={"foo": [(Version("1.0"), _wheel_file(local_path=wheel_path))]}
+        )
+        lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0")})
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.wheels[0].local_path == wheel_path
 
     def test_index_pin_sdist_install_drops_wheels(self) -> None:
         """Wheels seen during resolution stay out of the pin under sdist-install.
@@ -1903,9 +1915,14 @@ class TestRelativeDirectoryPath:
 
 
 class TestRelativeArtifactPath:
-    """PEP 751: ``file:`` wheel/sdist URLs become relative paths (#22)."""
+    """PEP 751: local wheel/sdist artefacts become relative paths (#22).
 
-    def test_file_url_wheel_emitted_as_relative_path(self, tmp_path: Path) -> None:
+    A local artefact carries its filesystem path in ``local_path``;
+    the writer emits that as a relative ``path`` rather than reversing
+    the ``file:`` URL, which is lossy across platforms.
+    """
+
+    def test_local_wheel_emitted_as_relative_path(self, tmp_path: Path) -> None:
         wheel_path = tmp_path / "wheels" / "foo-1.0-py3-none-any.whl"
         pin = IndexPin(
             name="foo",
@@ -1916,6 +1933,7 @@ class TestRelativeArtifactPath:
                     filename="foo-1.0-py3-none-any.whl",
                     url=wheel_path.as_uri(),
                     hashes=(("sha256", "a" * 64),),
+                    local_path=wheel_path,
                 ),
             ),
         )
@@ -1926,7 +1944,7 @@ class TestRelativeArtifactPath:
         assert wheel["path"] == "wheels/foo-1.0-py3-none-any.whl"
         assert "url" not in wheel
 
-    def test_file_url_sdist_emitted_as_relative_path(self, tmp_path: Path) -> None:
+    def test_local_sdist_emitted_as_relative_path(self, tmp_path: Path) -> None:
         sdist_path = tmp_path / "dist" / "foo-1.0.tar.gz"
         pin = IndexPin(
             name="foo",
@@ -1936,6 +1954,7 @@ class TestRelativeArtifactPath:
                 filename="foo-1.0.tar.gz",
                 url=sdist_path.as_uri(),
                 hashes=(("sha256", "b" * 64),),
+                local_path=sdist_path,
             ),
         )
         text = write_lock(
@@ -1945,7 +1964,7 @@ class TestRelativeArtifactPath:
         assert sdist["path"] == "dist/foo-1.0.tar.gz"
         assert "url" not in sdist
 
-    def test_remote_url_artifacts_keep_url(self, tmp_path: Path) -> None:
+    def test_remote_artifacts_keep_url(self, tmp_path: Path) -> None:
         text = write_lock(
             LockInput(pins={"foo": _index_pin()}),
             output_path=tmp_path / "pylock.toml",
@@ -1956,7 +1975,7 @@ class TestRelativeArtifactPath:
         assert package["sdist"]["url"].startswith("https://")
         assert "path" not in package["sdist"]
 
-    def test_file_url_artifact_outside_lock_dir(self, tmp_path: Path) -> None:
+    def test_local_artifact_outside_lock_dir(self, tmp_path: Path) -> None:
         wheel_path = tmp_path / "wheelhouse" / "foo-1.0-py3-none-any.whl"
         out_dir = tmp_path / "build" / "locks"
         out_dir.mkdir(parents=True)
@@ -1969,6 +1988,7 @@ class TestRelativeArtifactPath:
                     filename="foo-1.0-py3-none-any.whl",
                     url=wheel_path.as_uri(),
                     hashes=(("sha256", "a" * 64),),
+                    local_path=wheel_path,
                 ),
             ),
         )
@@ -1980,16 +2000,7 @@ class TestRelativeArtifactPath:
 
 
 class TestPathHelpers:
-    """Unit coverage for the path-relativisation helpers."""
-
-    def test_file_url_to_path_plain(self) -> None:
-        original = Path("/tmp/wheels/foo bar.whl")
-        assert _file_url_to_path(original.as_uri()) == original
-
-    def test_file_url_to_path_with_authority(self) -> None:
-        assert _file_url_to_path("file://host/share/foo.whl") == Path(
-            "//host/share/foo.whl"
-        )
+    """Unit coverage for the path-relativisation helper."""
 
     def test_relativize_path_uses_posix_separators(self, tmp_path: Path) -> None:
         rel = _relativize_path(tmp_path / "a" / "b", tmp_path)

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -300,17 +300,23 @@ def _emit_universal_pylock(
     if provenance is not None:
         lock_input.provenance = provenance
 
+    target: Path | None
+    if _cli._is_stdout(output):  # noqa: SLF001
+        target = None
+    else:
+        target = output if output is not None else Path(_cli._DEFAULT_OUTPUT["pylock"])  # noqa: SLF001
+
     try:
-        text = _cli.write_lock(lock_input)
+        # Pass the target so wheel/sdist/directory paths are written
+        # relative to the lockfile's own directory, not the cwd.
+        text = _cli.write_lock(lock_input, output_path=target)
     except _cli.MissingHashError as e:
         sys.stderr.write(f"Cannot lock: {e}\n")
         sys.exit(1)
 
-    if _cli._is_stdout(output):  # noqa: SLF001
+    if target is None:
         sys.stdout.write(text)
         return
-    target = output if output is not None else Path(_cli._DEFAULT_OUTPUT["pylock"])  # noqa: SLF001
-    target.write_text(text, encoding="utf-8")
     sys.stderr.write(f"Wrote {target} ({len(result.tuple_results)} tuples)\n")
 
 


### PR DESCRIPTION
PEP 751 records `packages.directory.path` and the wheel/sdist
`path` fields relative to the lock file. nab emitted absolute,
machine-specific values, so lockfiles with a local source or a
local find-links directory were not portable.

`write_lock` now threads its output directory through `build_pylock`
to the emitters, which write directory, wheel and sdist paths
relative to it (POSIX separators, `../`-prefixed when the target
sits outside the lock directory).

Local wheels and sdists carry their filesystem path from the index
client onward (`WheelFile`/`SdistFile`/`WheelArtifact`/`SdistArtifact`
gain a `local_path` field), so the lockfile writer never has to
reverse a `file:` URL — that conversion is lossy across platforms
(drive letters, `localhost`/UNC authorities, version-dependent
`url2pathname` behaviour).

- Fixes #6
- Fixes #22