### PR TITLE
Document portable lockfile paths

### DIFF
--- a/docs/guides/local-sources.md
+++ b/docs/guides/local-sources.md
@@ -54,7 +54,9 @@ Setting `"never"` instead skips the version with
 
 ## Lockfile shape
 
-Local pins land in the lockfile as `LocalPin` records with the
-absolute path the resolver was pointed at.  They do not carry a
-`sha256` (the contents are not under nab's control), so
-`nab download` skips them.
+Local pins land in the lockfile as `LocalPin` records.  The path
+is written relative to the lockfile's own directory, with POSIX
+separators, as PEP 751 requires, so a committed lockfile stays
+usable on another machine.  They do not carry a `sha256` (the
+contents are not under nab's control), so `nab download` skips
+them.

--- a/docs/guides/lockfile.md
+++ b/docs/guides/lockfile.md
@@ -74,6 +74,16 @@ size = 286433
   requires at least one of the three so the lockfile is
   consumable by pip's hash-checking mode.
 
+### Portable paths
+
+A lockfile can reference content on disk: a `LocalPin`'s
+directory, or a wheel or sdist served from a local find-links
+directory. nab writes those paths relative to the lockfile's
+own directory, with POSIX separators, as PEP 751 requires. A
+committed lockfile therefore stays usable on another machine as
+long as the surrounding layout is preserved; it never carries an
+absolute, machine-specific path.
+
 ### Universal mode
 
 Under `[tool.nab].mode = "universal"`, `nab lock --format pylock`


### PR DESCRIPTION
Documentation follow-up to #43, which made `nab lock` write
directory, wheel and sdist paths relative to the lockfile.

- `lockfile.md`: new "Portable paths" section explaining that
  on-disk references are written relative to the lockfile.
- `local-sources.md`: the "Lockfile shape" note said local pins
  record an absolute path; corrected to relative.