### PR TITLE
Run CrossHair property tests in CI

### DIFF
--- a/.github/requirements/pylock.crosshair.toml
+++ b/.github/requirements/pylock.crosshair.toml
@@ -1,0 +1,2442 @@
+lock-version = "1.0"
+environments = [
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
+    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
+    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
+    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
+    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
+    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
+    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
+    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
+    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
+    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
+    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
+    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
+    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
+]
+dependency-groups = [
+    "crosshair",
+]
+created-by = "nab"
+
+[[packages]]
+name = "anyio"
+version = "4.13.0"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "anyio-4.13.0.tar.gz"
+upload-time = 2026-03-24 12:59:09.671977+00:00
+url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz"
+size = 231622
+
+[packages.sdist.hashes]
+sha256 = "334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc"
+
+[[packages.wheels]]
+name = "anyio-4.13.0-py3-none-any.whl"
+upload-time = 2026-03-24 12:59:08.246651+00:00
+url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl"
+size = 114353
+
+[packages.wheels.hashes]
+sha256 = "08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708"
+
+[[packages]]
+name = "attrs"
+version = "26.1.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "attrs-26.1.0.tar.gz"
+upload-time = 2026-03-19 14:22:25.026315+00:00
+url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz"
+size = 952055
+
+[packages.sdist.hashes]
+sha256 = "d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32"
+
+[[packages.wheels]]
+name = "attrs-26.1.0-py3-none-any.whl"
+upload-time = 2026-03-19 14:22:23.645947+00:00
+url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl"
+size = 67548
+
+[packages.wheels.hashes]
+sha256 = "c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309"
+
+[[packages]]
+name = "build"
+version = "1.5.0"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "build-1.5.0.tar.gz"
+upload-time = 2026-04-30 03:18:25.170465+00:00
+url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz"
+size = 89796
+
+[packages.sdist.hashes]
+sha256 = "302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647"
+
+[[packages.wheels]]
+name = "build-1.5.0-py3-none-any.whl"
+upload-time = 2026-04-30 03:18:23.644906+00:00
+url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl"
+size = 26018
+
+[packages.wheels.hashes]
+sha256 = "13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f"
+
+[[packages]]
+name = "cattrs"
+version = "26.1.0"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "cattrs-26.1.0.tar.gz"
+upload-time = 2026-02-18 22:15:19.406296+00:00
+url = "https://files.pythonhosted.org/packages/a0/ec/ba18945e7d6e55a58364d9fb2e46049c1c2998b3d805f19b703f14e81057/cattrs-26.1.0.tar.gz"
+size = 495672
+
+[packages.sdist.hashes]
+sha256 = "fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40"
+
+[[packages.wheels]]
+name = "cattrs-26.1.0-py3-none-any.whl"
+upload-time = 2026-02-18 22:15:17.958002+00:00
+url = "https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl"
+size = 73054
+
+[packages.wheels.hashes]
+sha256 = "d1e0804c42639494d469d08d4f26d6b9de9b8ab26b446db7b5f8c2e97f7c3096"
+
+[[packages]]
+name = "certifi"
+version = "2026.4.22"
+requires-python = ">=3.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "certifi-2026.4.22.tar.gz"
+upload-time = 2026-04-22 11:26:11.191984+00:00
+url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz"
+size = 137077
+
+[packages.sdist.hashes]
+sha256 = "8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580"
+
+[[packages.wheels]]
+name = "certifi-2026.4.22-py3-none-any.whl"
+upload-time = 2026-04-22 11:26:09.372209+00:00
+url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl"
+size = 135707
+
+[packages.wheels.hashes]
+sha256 = "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a"
+
+[[packages]]
+name = "charset-normalizer"
+version = "3.4.7"
+requires-python = ">=3.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "charset_normalizer-3.4.7.tar.gz"
+upload-time = 2026-04-02 09:28:39.342869+00:00
+url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz"
+size = 144271
+
+[packages.sdist.hashes]
+sha256 = "ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-04-02 09:25:46.580440+00:00
+url = "https://files.pythonhosted.org/packages/20/e7/bed0024a0f4ab0c8a9c64d4445f39b30c99bd1acd228291959e3de664247/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 216930
+
+[packages.wheels.hashes]
+sha256 = "cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl"
+upload-time = 2026-04-02 09:25:57.074827+00:00
+url = "https://files.pythonhosted.org/packages/1d/98/3a45bf8247889cf28262ebd3d0872edff11565b2a1e3064ccb132db3fbb0/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl"
+size = 218884
+
+[packages.wheels.hashes]
+sha256 = "94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-py3-none-any.whl"
+upload-time = 2026-04-02 09:28:37.794693+00:00
+url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl"
+size = 61958
+
+[packages.wheels.hashes]
+sha256 = "3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-04-02 09:25:42.354016+00:00
+url = "https://files.pythonhosted.org/packages/24/47/b192933e94b546f1b1fe4df9cc1f84fcdbf2359f8d1081d46dd029b50207/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 209329
+
+[packages.wheels.hashes]
+sha256 = "e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl"
+upload-time = 2026-04-02 09:25:50.671425+00:00
+url = "https://files.pythonhosted.org/packages/71/94/8c61d8da9f062fdf457c80acfa25060ec22bf1d34bbeaca4350f13bcfd07/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl"
+size = 212785
+
+[packages.wheels.hashes]
+sha256 = "b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl"
+upload-time = 2026-04-02 09:25:40.673194+00:00
+url = "https://files.pythonhosted.org/packages/26/08/0f303cb0b529e456bb116f2d50565a482694fbb94340bf56d44677e7ed03/charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl"
+size = 315182
+
+[packages.wheels.hashes]
+sha256 = "cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl"
+upload-time = 2026-04-02 09:25:59.322069+00:00
+url = "https://files.pythonhosted.org/packages/35/1b/3b8c8c77184af465ee9ad88b5aea46ea6b2e1f7b9dc9502891e37af21e30/charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl"
+size = 159174
+
+[packages.wheels.hashes]
+sha256 = "6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-04-02 09:26:08.347975+00:00
+url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 214061
+
+[packages.wheels.hashes]
+sha256 = "2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl"
+upload-time = 2026-04-02 09:26:18.981084+00:00
+url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl"
+size = 216277
+
+[packages.wheels.hashes]
+sha256 = "ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-04-02 09:26:03.583935+00:00
+url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 206419
+
+[packages.wheels.hashes]
+sha256 = "202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl"
+upload-time = 2026-04-02 09:26:12.142221+00:00
+url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl"
+size = 209841
+
+[packages.wheels.hashes]
+sha256 = "e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl"
+upload-time = 2026-04-02 09:26:02.191455+00:00
+url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl"
+size = 309705
+
+[packages.wheels.hashes]
+sha256 = "7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl"
+upload-time = 2026-04-02 09:26:21.740282+00:00
+url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl"
+size = 159281
+
+[packages.wheels.hashes]
+sha256 = "8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-04-02 09:26:29.239485+00:00
+url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 216589
+
+[packages.wheels.hashes]
+sha256 = "5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl"
+upload-time = 2026-04-02 09:26:40.170193+00:00
+url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl"
+size = 218468
+
+[packages.wheels.hashes]
+sha256 = "bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-04-02 09:26:25.568153+00:00
+url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 208061
+
+[packages.wheels.hashes]
+sha256 = "6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl"
+upload-time = 2026-04-02 09:26:33.282753+00:00
+url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl"
+size = 211229
+
+[packages.wheels.hashes]
+sha256 = "708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl"
+upload-time = 2026-04-02 09:26:24.331339+00:00
+url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl"
+size = 311328
+
+[packages.wheels.hashes]
+sha256 = "eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl"
+upload-time = 2026-04-02 09:26:42.554156+00:00
+url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl"
+size = 159330
+
+[packages.wheels.hashes]
+sha256 = "5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-04-02 09:26:50.915844+00:00
+url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 215595
+
+[packages.wheels.hashes]
+sha256 = "e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl"
+upload-time = 2026-04-02 09:27:02.021863+00:00
+url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl"
+size = 217723
+
+[packages.wheels.hashes]
+sha256 = "64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-04-02 09:26:46.824388+00:00
+url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 207008
+
+[packages.wheels.hashes]
+sha256 = "0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl"
+upload-time = 2026-04-02 09:26:54.975572+00:00
+url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl"
+size = 210036
+
+[packages.wheels.hashes]
+sha256 = "7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl"
+upload-time = 2026-04-02 09:26:45.198440+00:00
+url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl"
+size = 309627
+
+[packages.wheels.hashes]
+sha256 = "f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl"
+upload-time = 2026-04-02 09:27:04.454986+00:00
+url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl"
+size = 158819
+
+[packages.wheels.hashes]
+sha256 = "3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-04-02 09:27:12.446519+00:00
+url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 215882
+
+[packages.wheels.hashes]
+sha256 = "bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl"
+upload-time = 2026-04-02 09:27:23.486452+00:00
+url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl"
+size = 217869
+
+[packages.wheels.hashes]
+sha256 = "7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-04-02 09:27:08.749412+00:00
+url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 208042
+
+[packages.wheels.hashes]
+sha256 = "1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl"
+upload-time = 2026-04-02 09:27:16.834768+00:00
+url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl"
+size = 211276
+
+[packages.wheels.hashes]
+sha256 = "e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl"
+upload-time = 2026-04-02 09:27:07.194784+00:00
+url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl"
+size = 309234
+
+[packages.wheels.hashes]
+sha256 = "c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl"
+upload-time = 2026-04-02 09:27:26.642081+00:00
+url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl"
+size = 159634
+
+[packages.wheels.hashes]
+sha256 = "92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f"
+
+[[packages]]
+name = "colorama"
+version = "0.4.6"
+marker = "(python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+requires-python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "colorama-0.4.6.tar.gz"
+upload-time = 2022-10-25 02:36:22.414799+00:00
+url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz"
+size = 27697
+
+[packages.sdist.hashes]
+sha256 = "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+
+[[packages.wheels]]
+name = "colorama-0.4.6-py2.py3-none-any.whl"
+upload-time = 2022-10-25 02:36:20.889702+00:00
+url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl"
+size = 25335
+
+[packages.wheels.hashes]
+sha256 = "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+
+[[packages]]
+name = "coverage"
+version = "7.14.0"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "coverage-7.14.0.tar.gz"
+upload-time = 2026-05-10 18:02:31.397557+00:00
+url = "https://files.pythonhosted.org/packages/23/7f/d0720730a397a999ffc0fd3f5bebef347338e3a47b727da66fbb228e2ff2/coverage-7.14.0.tar.gz"
+size = 919489
+
+[packages.sdist.hashes]
+sha256 = "057a6af2f160a85384cde4ab36f0d2777bae1057bae255f95413cdd382aa5c74"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-05-10 17:59:29.479819+00:00
+url = "https://files.pythonhosted.org/packages/b5/d9/92600e89486fd074c50f0117422b2c9592c3e144e2f25bd5ac0bc62bc7a0/coverage-7.14.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 248762
+
+[packages.wheels.hashes]
+sha256 = "3fd43f0616e765ab78d069cf8358def7363957a45cee446d65c502dcfeea7893"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp310-cp310-musllinux_1_2_x86_64.whl"
+upload-time = 2026-05-10 17:59:43.471850+00:00
+url = "https://files.pythonhosted.org/packages/70/db/cef0228de493f2c740c760a9057a61d00c6849480073b70a75b87c7d4bab/coverage-7.14.0-cp310-cp310-musllinux_1_2_x86_64.whl"
+size = 247544
+
+[packages.wheels.hashes]
+sha256 = "d128b1bba9361fbaaf6a19e179e6cfd6a9103ce0c0555876f72780acc93efd85"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-py3-none-any.whl"
+upload-time = 2026-05-10 18:02:29.538126+00:00
+url = "https://files.pythonhosted.org/packages/61/e8/cb8e80d6f9f55b99588625062822bf946cf03ed06315df4bd8397f5632a1/coverage-7.14.0-py3-none-any.whl"
+size = 211764
+
+[packages.wheels.hashes]
+sha256 = "8de5b61163aee3d05c8a2beab6f47913df7981dad1baf82c414d99158c286ab1"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-10 17:59:31.330855+00:00
+url = "https://files.pythonhosted.org/packages/0d/e1/9ea1eb9c311da7f15853559dc1d9d82bef88ecd3e59fbeb51f16bc2ffa91/coverage-7.14.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 250625
+
+[packages.wheels.hashes]
+sha256 = "731e535b1498b27d13594a0527a79b0510867b0ad891532be41cb883f2128e20"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp310-cp310-musllinux_1_2_aarch64.whl"
+upload-time = 2026-05-10 17:59:36.232646+00:00
+url = "https://files.pythonhosted.org/packages/f0/e2/0b7898cda21041cc67546e19b80ba66cbbb47cbece52a76a5904de6a3aaf/coverage-7.14.0-cp310-cp310-musllinux_1_2_aarch64.whl"
+size = 248666
+
+[packages.wheels.hashes]
+sha256 = "0a951308cde22cf77f953955a754d04dccb57fe3bb8e345d685778ed9fc1632a"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp310-cp310-macosx_11_0_arm64.whl"
+upload-time = 2026-05-10 17:59:26.095633+00:00
+url = "https://files.pythonhosted.org/packages/24/34/898546aefbd28f0af131201d0dc852c9e976f817bd7d5bfb8dc4e02863bb/coverage-7.14.0-cp310-cp310-macosx_11_0_arm64.whl"
+size = 220192
+
+[packages.wheels.hashes]
+sha256 = "7c843572c605ab51cfdb5c6b5f2586e2a8467c0d28eca4bdef4ec70c5fecbd82"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp310-cp310-macosx_10_9_x86_64.whl"
+upload-time = 2026-05-10 17:59:23.106199+00:00
+url = "https://files.pythonhosted.org/packages/59/9d/7c83ef51c3eb495f10010094e661833588b7709946da634c8b66520b97c7/coverage-7.14.0-cp310-cp310-macosx_10_9_x86_64.whl"
+size = 219668
+
+[packages.wheels.hashes]
+sha256 = "84c32d90bf4537f0e7b4dec9aaa9a938fb8205136b9d2ecf4d7629d5262dc075"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp310-cp310-win_amd64.whl"
+upload-time = 2026-05-10 17:59:46.779937+00:00
+url = "https://files.pythonhosted.org/packages/85/c0/30c454c7d3cf47b2805d4e06f12443f5eece8a5d030d3b0350e7b74ecb49/coverage-7.14.0-cp310-cp310-win_amd64.whl"
+size = 223215
+
+[packages.wheels.hashes]
+sha256 = "b34ece8065914f938ed7f2c5872bb865336977a52919149846eac3744327267a"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-05-10 17:59:53.244429+00:00
+url = "https://files.pythonhosted.org/packages/fd/35/202235eb5c3c14c212462cd91d61b7386bf8fc44bc7a77f4742d2a69174b/coverage-7.14.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 252633
+
+[packages.wheels.hashes]
+sha256 = "9336e23e8bb3a3925398261385e2a1533957d3e760e91070dcb0e98bfa514eed"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp311-cp311-musllinux_1_2_x86_64.whl"
+upload-time = 2026-05-10 18:00:06.858179+00:00
+url = "https://files.pythonhosted.org/packages/35/60/a4257538ce2f6b978aeb51870d6c4208c510928a03db7e0339bb625dccb7/coverage-7.14.0-cp311-cp311-musllinux_1_2_x86_64.whl"
+size = 251125
+
+[packages.wheels.hashes]
+sha256 = "bcb2e855b87321259a037429288ae85216d191c74de3e79bf57cd2bc0761992c"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-10 17:59:55.021505+00:00
+url = "https://files.pythonhosted.org/packages/bb/80/5f596e8995785124ee191c42535664c5e62c65995b66f4ca21e28ae04c81/coverage-7.14.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 254743
+
+[packages.wheels.hashes]
+sha256 = "9cd1169b2230f9cbe9c638ba38022ed7a2b1e641cc07f7cea0365e4be2a74980"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp311-cp311-musllinux_1_2_aarch64.whl"
+upload-time = 2026-05-10 17:59:59.688294+00:00
+url = "https://files.pythonhosted.org/packages/3d/1c/b94f9f5f36396021ee2f62c5834b12e6a3d31f0bed5d6fc6d1c3caec087c/coverage-7.14.0-cp311-cp311-musllinux_1_2_aarch64.whl"
+size = 252433
+
+[packages.wheels.hashes]
+sha256 = "5904abf7e18cddc463219b17552229650c6b79e061d31a1059283051169cf7d5"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp311-cp311-macosx_11_0_arm64.whl"
+upload-time = 2026-05-10 17:59:49.683626+00:00
+url = "https://files.pythonhosted.org/packages/7f/8d/46692d24b3f395d4cbf17bfcc57136b4f2f9c0c0df864b0bddfc1d71a014/coverage-7.14.0-cp311-cp311-macosx_11_0_arm64.whl"
+size = 220299
+
+[packages.wheels.hashes]
+sha256 = "a1816c505187592dcd1c5a5f226601a549f70365fbd00930ac88b0c225b76bb4"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp311-cp311-macosx_10_9_x86_64.whl"
+upload-time = 2026-05-10 17:59:48.198844+00:00
+url = "https://files.pythonhosted.org/packages/fc/e4/649c8d4f7f1709b6dbfc474358aa1bba02f67bcd52e2fec291a5014006cd/coverage-7.14.0-cp311-cp311-macosx_10_9_x86_64.whl"
+size = 219795
+
+[packages.wheels.hashes]
+sha256 = "6a78e2a9d9c5e3b8d4ab9b9d28c985ea66fced0a7d7c2aec1f216e03a2011480"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp311-cp311-win_amd64.whl"
+upload-time = 2026-05-10 18:00:10.746583+00:00
+url = "https://files.pythonhosted.org/packages/f0/f0/a71ddbd874431e7a7cd96071f0c331cfbbad07704833c765d24ffbab8a67/coverage-7.14.0-cp311-cp311-win_amd64.whl"
+size = 223241
+
+[packages.wheels.hashes]
+sha256 = "bfb0ed8ec5d25e93face268115d7964db9df8b9aae8edcde9ec6b16c726a7cc1"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-05-10 18:00:18.829529+00:00
+url = "https://files.pythonhosted.org/packages/69/ff/6699e7b71e60d3049eb2bdcbc95ee3f35707b2b0e48f32e9e63d3ce30c08/coverage-7.14.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 254576
+
+[packages.wheels.hashes]
+sha256 = "ca3d9cf2c32b521bd9518385608787fa86f38daf993695307531822c3430ed67"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp312-cp312-musllinux_1_2_x86_64.whl"
+upload-time = 2026-05-10 18:00:32.211009+00:00
+url = "https://files.pythonhosted.org/packages/18/9d/50f05a72dff8487464fdd4178dda5daed642a060e60afb644e3d45123559/coverage-7.14.0-cp312-cp312-musllinux_1_2_x86_64.whl"
+size = 253197
+
+[packages.wheels.hashes]
+sha256 = "fcaba850dd317c65423a9d63d88f9573c53b00354d6dd95724576cc98a131595"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-10 18:00:20.648358+00:00
+url = "https://files.pythonhosted.org/packages/22/ec/c936d495fcd67f48f03a9c4ad3297ff80d1f222a5df3980f15b34c186c21/coverage-7.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 255690
+
+[packages.wheels.hashes]
+sha256 = "92af52828e7f29d827346b0294e5a0853fa206db77db0395b282918d41e28db9"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp312-cp312-musllinux_1_2_aarch64.whl"
+upload-time = 2026-05-10 18:00:25.588879+00:00
+url = "https://files.pythonhosted.org/packages/f1/7f/9e65495298c3ea414742998539c37d048b5e81cc818fb1828cc6b51d10bf/coverage-7.14.0-cp312-cp312-musllinux_1_2_aarch64.whl"
+size = 253608
+
+[packages.wheels.hashes]
+sha256 = "8231ade007f37959fbf58acc677f26b922c02eda6f0428ea307da0fd39681bf3"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp312-cp312-macosx_11_0_arm64.whl"
+upload-time = 2026-05-10 18:00:15.264075+00:00
+url = "https://files.pythonhosted.org/packages/34/23/35c7aea1274aef7525bdd2dc92f710bdde6d11652239d71d1ec450067939/coverage-7.14.0-cp312-cp312-macosx_11_0_arm64.whl"
+size = 220329
+
+[packages.wheels.hashes]
+sha256 = "829994cfe1aeb773ca27bf246d4badc1e764893e3bfb98fff820fcecd1ca4662"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2026-05-10 18:00:13.756391+00:00
+url = "https://files.pythonhosted.org/packages/09/1e/2f996b2c8415cbb6f54b0f5ec1ee850c96d7911961afb4fc05f4a89d8c58/coverage-7.14.0-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 219967
+
+[packages.wheels.hashes]
+sha256 = "7ffd19fc8aed057fd686a17a4935eef5f9859d69208f96310e893e64b9b6ccf5"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp312-cp312-win_amd64.whl"
+upload-time = 2026-05-10 18:00:35.172847+00:00
+url = "https://files.pythonhosted.org/packages/85/19/93853133df2cb371083285ef6a93982a0173e7a233b0f61373ba9fd30eb2/coverage-7.14.0-cp312-cp312-win_amd64.whl"
+size = 223324
+
+[packages.wheels.hashes]
+sha256 = "70390b0da32cb90b501953716302906e8bcce087cb283e70d8c97729f22e92b2"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-05-10 18:00:44.079319+00:00
+url = "https://files.pythonhosted.org/packages/6f/5f/b5370068b2f57787454592ed7dcd1002f0f1703b7db1fa30f6a325a4ca6e/coverage-7.14.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 253961
+
+[packages.wheels.hashes]
+sha256 = "9d1aa57a1dc8e05bdc42e81c5d671d849577aeedf279f4c449d6d286f9ed88ca"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp313-cp313-musllinux_1_2_x86_64.whl"
+upload-time = 2026-05-10 18:00:57.967216+00:00
+url = "https://files.pythonhosted.org/packages/37/53/20c5009477660f084e6ed60bc02a91894b8e234e617e86ecfd9aaf78e27b/coverage-7.14.0-cp313-cp313-musllinux_1_2_x86_64.whl"
+size = 252885
+
+[packages.wheels.hashes]
+sha256 = "7b79d646cf46d5cf9a9f40281d4441df5849e445726e369006d2b117710b33fe"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-10 18:00:45.623804+00:00
+url = "https://files.pythonhosted.org/packages/29/1e/51adf17738976e8f2b85ddef7b7aa12a0838b056c92f175941d8862767c1/coverage-7.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 255193
+
+[packages.wheels.hashes]
+sha256 = "90c1a51bcfddf645b3bb7ec333d9e94393a8e94f55642380fa8a9a5a9e636cb7"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp313-cp313-musllinux_1_2_aarch64.whl"
+upload-time = 2026-05-10 18:00:51.252258+00:00
+url = "https://files.pythonhosted.org/packages/34/46/746704f95980ba220214e1a41e18cec5aea80a898eaa53c51bf2d645ff36/coverage-7.14.0-cp313-cp313-musllinux_1_2_aarch64.whl"
+size = 253325
+
+[packages.wheels.hashes]
+sha256 = "1b23b0c6f0b1db6ad769b7050c8b641c0bf215ded26c1816955b17b7f26edfa9"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp313-cp313-macosx_11_0_arm64.whl"
+upload-time = 2026-05-10 18:00:40.864715+00:00
+url = "https://files.pythonhosted.org/packages/b3/af/e567cbad5ba69c013a50146dfa886dc7193361fda77521f51274ff620e1b/coverage-7.14.0-cp313-cp313-macosx_11_0_arm64.whl"
+size = 220365
+
+[packages.wheels.hashes]
+sha256 = "23b81107f46d3f21d0cbce30664fcec0f5d9f585638a67081750f99738f6bf66"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2026-05-10 18:00:38.887090+00:00
+url = "https://files.pythonhosted.org/packages/6b/76/b7c66ee3c66e1b0f9d894c8125983aa0c03fb2336f2fd16559f9c966157f/coverage-7.14.0-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 219990
+
+[packages.wheels.hashes]
+sha256 = "f2bbb8254370eb4c628ff3d6fa8a7f74ddc40565394d4f7ab791d1fe568e37ef"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp313-cp313-win_amd64.whl"
+upload-time = 2026-05-10 18:01:01.531432+00:00
+url = "https://files.pythonhosted.org/packages/8f/b8/9228523e80321c2cb4880d1f589bc0171f2f71432c35118ad04dc01decce/coverage-7.14.0-cp313-cp313-win_amd64.whl"
+size = 223344
+
+[packages.wheels.hashes]
+sha256 = "0773d8329cf32b6fd222e4b52622c61fe8d503eb966cfc8d3c3c10c96266d50e"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-05-10 18:01:38.985686+00:00
+url = "https://files.pythonhosted.org/packages/d7/51/ec641c26e6dca1b25a7d2035ba6ecb7c884ef1a100a9e42fbe4ce4405139/coverage-7.14.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 253924
+
+[packages.wheels.hashes]
+sha256 = "5ebb8f4614a3787d567e610bbfdf96a4798dd69a1afb1bd8ad228d4111fe6ff3"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp314-cp314-musllinux_1_2_x86_64.whl"
+upload-time = 2026-05-10 18:01:54.506054+00:00
+url = "https://files.pythonhosted.org/packages/a4/66/2881853e0363a5e0a724d1103e53650795367471b6afb234f8b49e713bc6/coverage-7.14.0-cp314-cp314-musllinux_1_2_x86_64.whl"
+size = 252716
+
+[packages.wheels.hashes]
+sha256 = "65c86fb646d2bd2972e96bd1a8b45817ed907cee68655d6295fe7ec031d04cca"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-10 18:01:40.957470+00:00
+url = "https://files.pythonhosted.org/packages/33/c4/59c3de0bd1b538824173fd518fed51c1ce740ca5ed68e74545983f4053a9/coverage-7.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 255269
+
+[packages.wheels.hashes]
+sha256 = "6b9bf47223dd8db3d4c4b2e443b02bace480d428f0822c3f991600448a176c97"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp314-cp314-musllinux_1_2_aarch64.whl"
+upload-time = 2026-05-10 18:01:46.175307+00:00
+url = "https://files.pythonhosted.org/packages/ee/df/6770eaa576e604575e9a78055313250faef5faa84bd6f71a39fece519c43/coverage-7.14.0-cp314-cp314-musllinux_1_2_aarch64.whl"
+size = 253280
+
+[packages.wheels.hashes]
+sha256 = "15228a6800ce7bdf1b74800595e56db7138cecb338fdbf044806e10dcf182dfe"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp314-cp314-macosx_11_0_arm64.whl"
+upload-time = 2026-05-10 18:01:34.705980+00:00
+url = "https://files.pythonhosted.org/packages/f3/9b/4165a1d56ddc302a0e2d518fd9d412a4fd0b57562618c78c5f21c57194f5/coverage-7.14.0-cp314-cp314-macosx_11_0_arm64.whl"
+size = 220368
+
+[packages.wheels.hashes]
+sha256 = "ba3b8390db29296dbbf49e91b6fe08f990743a90c8f447ba4c2ffc29670dfa63"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp314-cp314-win_amd64.whl"
+upload-time = 2026-05-10 18:01:58.497925+00:00
+url = "https://files.pythonhosted.org/packages/f9/58/6e1b8f52fdc3184b47dc5037f5070d83a3d11042db1594b02d2a44d786c8/coverage-7.14.0-cp314-cp314-win_amd64.whl"
+size = 223600
+
+[packages.wheels.hashes]
+sha256 = "45e0f79d8351fa76e256716df91eab12890d32678b9590df7ae1042e4bd4cf5d"
+
+[[packages]]
+name = "crosshair-tool"
+version = "0.0.104"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "crosshair_tool-0.0.104.tar.gz"
+upload-time = 2026-04-26 11:39:24.845771+00:00
+url = "https://files.pythonhosted.org/packages/60/c7/ac2e7a78fa58d08b66919de9c9e13d45974976407e53ef8bfc64d62d11d5/crosshair_tool-0.0.104.tar.gz"
+size = 487964
+
+[packages.sdist.hashes]
+sha256 = "c92cc8554ec1f35e079c041025cf0534d8ce83f6a8aedb7dec68d60c6d6989c2"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-04-26 11:38:14.767081+00:00
+url = "https://files.pythonhosted.org/packages/ad/4e/75630ada8e56f666b6b496910c61d40b5070dd07f41f99a940a8f8e3b168/crosshair_tool-0.0.104-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 568122
+
+[packages.wheels.hashes]
+sha256 = "ab958b0d5f5af991039452ef91f0392eb179a292f63d6f7900dcb938e58468a6"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp310-cp310-musllinux_1_2_x86_64.whl"
+upload-time = 2026-04-26 11:38:15.965412+00:00
+url = "https://files.pythonhosted.org/packages/e3/0c/238d7b758f4b9ea8e1024f53a7d1d81f8f3b439fb2235f49afcc0574413f/crosshair_tool-0.0.104-cp310-cp310-musllinux_1_2_x86_64.whl"
+size = 568102
+
+[packages.wheels.hashes]
+sha256 = "cae55bc97afc15ff96f02e609f677ca4903e62814a9e621216d182e64aad2bf1"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp310-cp310-macosx_10_9_universal2.whl"
+upload-time = 2026-04-26 11:38:10.064742+00:00
+url = "https://files.pythonhosted.org/packages/7e/03/77c8e47a2e8b3622dbb96634f84b3366fbada89c23d2268fae464258eed4/crosshair_tool-0.0.104-cp310-cp310-macosx_10_9_universal2.whl"
+size = 552469
+
+[packages.wheels.hashes]
+sha256 = "9c4e54f8def1f450b111819f7ccef3df2a9605d1fa500729e279da236f8e0629"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp310-cp310-macosx_11_0_arm64.whl"
+upload-time = 2026-04-26 11:38:12.824077+00:00
+url = "https://files.pythonhosted.org/packages/8a/a5/e6c70570260317a4557d520ed73ad65774568bbeb234a48535798d38e181/crosshair_tool-0.0.104-cp310-cp310-macosx_11_0_arm64.whl"
+size = 545244
+
+[packages.wheels.hashes]
+sha256 = "dd90d1b5b7ee769cd3c2cbdd5c3e30072bca4500663696a95ecf3698bbb0aee0"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp310-cp310-macosx_10_9_x86_64.whl"
+upload-time = 2026-04-26 11:38:11.683527+00:00
+url = "https://files.pythonhosted.org/packages/2c/3d/4f251fa77d0ef501496e6ca3c74b0a93db3b17b2161a83d865c5c70521d5/crosshair_tool-0.0.104-cp310-cp310-macosx_10_9_x86_64.whl"
+size = 544488
+
+[packages.wheels.hashes]
+sha256 = "6cab5eb7c36cb7582252942a620be4a49207fc09838e31fc6cafc7360c8478b8"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp310-cp310-win_amd64.whl"
+upload-time = 2026-04-26 11:38:19.285117+00:00
+url = "https://files.pythonhosted.org/packages/09/57/1db86d10eed372c869032c5e40474a6b408e2be0fbc74c6166318bfb8165/crosshair_tool-0.0.104-cp310-cp310-win_amd64.whl"
+size = 548616
+
+[packages.wheels.hashes]
+sha256 = "b8842abff5fd9f214ec0218b1f797c8a00fa42d8af7b06c8acb7f63f9201cf21"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-04-26 11:38:25.757902+00:00
+url = "https://files.pythonhosted.org/packages/cd/b2/0f49cb9c9c09770973247c7c8026dc242d455edcf7747f90c5d80d248098/crosshair_tool-0.0.104-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 568540
+
+[packages.wheels.hashes]
+sha256 = "482b097763d415dd6cf9a3f32cebe43ed1da7a2a5711fd9d7cd250f09ca723c0"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp311-cp311-musllinux_1_2_x86_64.whl"
+upload-time = 2026-04-26 11:38:27.408094+00:00
+url = "https://files.pythonhosted.org/packages/31/b1/0744c244177fb41f19584dcfb9927aa10e68198d0e459f5145bf935da5fe/crosshair_tool-0.0.104-cp311-cp311-musllinux_1_2_x86_64.whl"
+size = 568537
+
+[packages.wheels.hashes]
+sha256 = "746547a6524f58e9ae37ea33a9d324009e9e5b89f9da5f70076637ac44ca8f41"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp311-cp311-macosx_10_9_universal2.whl"
+upload-time = 2026-04-26 11:38:21.060689+00:00
+url = "https://files.pythonhosted.org/packages/d3/8b/e8571130e46c11893e83ef4987ed24fd3e0c874eeda69b28073503252560/crosshair_tool-0.0.104-cp311-cp311-macosx_10_9_universal2.whl"
+size = 552570
+
+[packages.wheels.hashes]
+sha256 = "0fee67cef8472719f8cd4b38ff3d353ad50d1a318c1abf442e038de478fdcc1a"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp311-cp311-macosx_11_0_arm64.whl"
+upload-time = 2026-04-26 11:38:24.556834+00:00
+url = "https://files.pythonhosted.org/packages/99/fa/6bf6c9850518835f5ee403dbea9f110ffd630c08d04c9cfe95dc495221c6/crosshair_tool-0.0.104-cp311-cp311-macosx_11_0_arm64.whl"
+size = 545289
+
+[packages.wheels.hashes]
+sha256 = "044a030de364a8418e71ac21eb878c3a782d439e85c79481fed4e6a64399f0a7"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp311-cp311-macosx_10_9_x86_64.whl"
+upload-time = 2026-04-26 11:38:22.837326+00:00
+url = "https://files.pythonhosted.org/packages/f4/36/2e4d178c03944daf3da205120a2a668865891a4d4e45cc3808ec107eece2/crosshair_tool-0.0.104-cp311-cp311-macosx_10_9_x86_64.whl"
+size = 544540
+
+[packages.wheels.hashes]
+sha256 = "58a813295b3fce061ac74f6e42dd40c745bc21ccf0af48b2f7a1e0b97e96d040"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp311-cp311-win_amd64.whl"
+upload-time = 2026-04-26 11:38:30.420511+00:00
+url = "https://files.pythonhosted.org/packages/3b/32/a13631ce4d43057c305904611e69d2d800c159bdad9aba6df7cad46f6644/crosshair_tool-0.0.104-cp311-cp311-win_amd64.whl"
+size = 548644
+
+[packages.wheels.hashes]
+sha256 = "aa5b5892646d5a95191ea7182dbdf60561165ec75ebef5f24fad5bea9cd9dcff"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-04-26 11:38:36.529600+00:00
+url = "https://files.pythonhosted.org/packages/ef/33/286fa2180a7d328c3d8f047e40527b348f4d62debbdfa729cb112bf223f3/crosshair_tool-0.0.104-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 578527
+
+[packages.wheels.hashes]
+sha256 = "bb3f5c4f4c39b78c68f0d52889cf127da18994f5177faae90c7aedb79dbe4df5"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp312-cp312-musllinux_1_2_x86_64.whl"
+upload-time = 2026-04-26 11:38:38.040720+00:00
+url = "https://files.pythonhosted.org/packages/fc/a8/c8d0ed5a6b1e5889811c360b0e89028ef5d9d43caad62282b82b159fa444/crosshair_tool-0.0.104-cp312-cp312-musllinux_1_2_x86_64.whl"
+size = 577584
+
+[packages.wheels.hashes]
+sha256 = "6c2f33631751443c64f35d95daf44bcc262841acc22f24d0f1daa5edf49ced28"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp312-cp312-macosx_10_13_universal2.whl"
+upload-time = 2026-04-26 11:38:32.069823+00:00
+url = "https://files.pythonhosted.org/packages/f3/23/ec19144d79d09afef4042e5b8e464ddf8587941547a0b9abf2f42cd2a16a/crosshair_tool-0.0.104-cp312-cp312-macosx_10_13_universal2.whl"
+size = 556457
+
+[packages.wheels.hashes]
+sha256 = "aa131e3e486cd5b158399e939bd6e1231c26980a8006fa3162fa859bf34aecc0"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp312-cp312-macosx_11_0_arm64.whl"
+upload-time = 2026-04-26 11:38:34.775093+00:00
+url = "https://files.pythonhosted.org/packages/c1/48/8351d3c3ad9a172d4ddf98a63c466b78537aa0ae69e561a4d8e672a3f9be/crosshair_tool-0.0.104-cp312-cp312-macosx_11_0_arm64.whl"
+size = 547571
+
+[packages.wheels.hashes]
+sha256 = "15003ef84efed7d17de342792dc304661c6c9a093b7c5bcbaaf327a4252a3747"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2026-04-26 11:38:33.485445+00:00
+url = "https://files.pythonhosted.org/packages/68/aa/db67175ab75791384c4e0c55c359520611a73dcb927647d282b16c875cf1/crosshair_tool-0.0.104-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 546979
+
+[packages.wheels.hashes]
+sha256 = "cceb359a046e94ac50d123cdb6b6e120c26ed0029e75230bae2210c21ca33434"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp312-cp312-win_amd64.whl"
+upload-time = 2026-04-26 11:38:40.688601+00:00
+url = "https://files.pythonhosted.org/packages/f4/60/c6bf30b1c65950afd622f2aa77f66a8a87c2934295ec9c3c0cbba158470c/crosshair_tool-0.0.104-cp312-cp312-win_amd64.whl"
+size = 550451
+
+[packages.wheels.hashes]
+sha256 = "294e70a2c35b655d1214b99443e853844fa63fbf9d2d8ab658b842fb1575021d"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-04-26 11:38:47.195747+00:00
+url = "https://files.pythonhosted.org/packages/05/ea/3a2db77a94941df6e0c0dbd312b5289bf55df0ba6f5ae52227304a0318bd/crosshair_tool-0.0.104-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 585256
+
+[packages.wheels.hashes]
+sha256 = "c1c1cfe3fbb3054f1031ac3b2ca2cb268b6330efd4737e50a3b5d81e748002e4"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp313-cp313-musllinux_1_2_x86_64.whl"
+upload-time = 2026-04-26 11:38:49.011091+00:00
+url = "https://files.pythonhosted.org/packages/c9/14/d1c6f7540fe474eacf8da1a8e0be3ffba03ed5b98de30a229dc16c2d1be2/crosshair_tool-0.0.104-cp313-cp313-musllinux_1_2_x86_64.whl"
+size = 584271
+
+[packages.wheels.hashes]
+sha256 = "299cd2748313d2adab0aa22c890212efacd20560e071c3c9890e42648e728a3b"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp313-cp313-macosx_10_13_universal2.whl"
+upload-time = 2026-04-26 11:38:42.160349+00:00
+url = "https://files.pythonhosted.org/packages/af/52/66a5f834bd0c98558092f625cca1e06f22d2157e10a3ea68f664e5688710/crosshair_tool-0.0.104-cp313-cp313-macosx_10_13_universal2.whl"
+size = 565185
+
+[packages.wheels.hashes]
+sha256 = "946ab8b537ff35cde1c1e47582242f84cfbaec7a304438411b2cf399d32cfdd7"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp313-cp313-macosx_11_0_arm64.whl"
+upload-time = 2026-04-26 11:38:45.481606+00:00
+url = "https://files.pythonhosted.org/packages/b9/79/c09da37ce2f39fb24957ffd6b9afc8afa1797d797af8055cf01945b4802c/crosshair_tool-0.0.104-cp313-cp313-macosx_11_0_arm64.whl"
+size = 551440
+
+[packages.wheels.hashes]
+sha256 = "82fb84d44d7fde08dba2e77771ec9adead0b4e6953694f49e745531c75f75779"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2026-04-26 11:38:43.672933+00:00
+url = "https://files.pythonhosted.org/packages/f9/08/db7ac3f0876937e3fb05d19343b757571a8d3095e6e4daab023b5307f5a2/crosshair_tool-0.0.104-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 550775
+
+[packages.wheels.hashes]
+sha256 = "8ce233e4568b67bcf812413a7ffa20b807fd776551036aa98b3484bc26fa1914"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp313-cp313-win_amd64.whl"
+upload-time = 2026-04-26 11:38:52.428834+00:00
+url = "https://files.pythonhosted.org/packages/5a/9b/427700c38d9912993fc414c504c735a61e3c40f476fd3b3a3659e55276d0/crosshair_tool-0.0.104-cp313-cp313-win_amd64.whl"
+size = 550474
+
+[packages.wheels.hashes]
+sha256 = "beecba3d1d306cc3a1ab551fe22777cd0c162e97d61b81fa01a57eaa3b00fa21"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-04-26 11:38:57.834245+00:00
+url = "https://files.pythonhosted.org/packages/97/54/b4b9143d36634f281b0122e01a7b57902813b1ab7daf3ce7da69cae3a131/crosshair_tool-0.0.104-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 621829
+
+[packages.wheels.hashes]
+sha256 = "26e8ec24a65e4a0d0af48c1c2fa6aa35fe0ed9dba6a9a631b733306eb28627dc"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp314-cp314-musllinux_1_2_x86_64.whl"
+upload-time = 2026-04-26 11:38:59.327237+00:00
+url = "https://files.pythonhosted.org/packages/81/ec/cb3b1c419ec9353485a7df7f074def4af91e4b921011e916142a6b44683c/crosshair_tool-0.0.104-cp314-cp314-musllinux_1_2_x86_64.whl"
+size = 619940
+
+[packages.wheels.hashes]
+sha256 = "22aaa4f318a0b316c0b54dd9a0ebcd90bac17a4fc4a8f92159f9cb2d12510ba8"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp314-cp314-macosx_10_13_universal2.whl"
+upload-time = 2026-04-26 11:38:53.760757+00:00
+url = "https://files.pythonhosted.org/packages/f4/83/e851837d69ea3ebce1bd1c6d755e976aab03086de69070f1dd06ca183367/crosshair_tool-0.0.104-cp314-cp314-macosx_10_13_universal2.whl"
+size = 562899
+
+[packages.wheels.hashes]
+sha256 = "1cb7d856355954c371361cfe6f1e3de2aa4e3ec9c9e00c71bebd6344f72a5a53"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp314-cp314-macosx_11_0_arm64.whl"
+upload-time = 2026-04-26 11:38:56.513055+00:00
+url = "https://files.pythonhosted.org/packages/fb/84/d3b9868079d6e2970ec230954694d084aa76024c37223f2a83456286335b/crosshair_tool-0.0.104-cp314-cp314-macosx_11_0_arm64.whl"
+size = 550295
+
+[packages.wheels.hashes]
+sha256 = "efe35ed148effc6bd8cc3d997a87d85edc4419af3fa0fa96486d7b1284d36c17"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp314-cp314-macosx_10_13_x86_64.whl"
+upload-time = 2026-04-26 11:38:55.054959+00:00
+url = "https://files.pythonhosted.org/packages/ae/ca/d705535707dd4cadd0870540762d34ca3d287c8386b8a6678b761998ba03/crosshair_tool-0.0.104-cp314-cp314-macosx_10_13_x86_64.whl"
+size = 549622
+
+[packages.wheels.hashes]
+sha256 = "93651387e63549a2c7578f81bc93aae1a237582da45a96b52f91143009fb16fb"
+
+[[packages.wheels]]
+name = "crosshair_tool-0.0.104-cp314-cp314-win_amd64.whl"
+upload-time = 2026-04-26 11:39:02.291093+00:00
+url = "https://files.pythonhosted.org/packages/50/19/85fd7ea65d07368e3e7ec364b169d163e3bfdaac35fd11d779ffab523b38/crosshair_tool-0.0.104-cp314-cp314-win_amd64.whl"
+size = 549178
+
+[packages.wheels.hashes]
+sha256 = "d086515a49c881a2f234e75d62bfe59b9b19d954054be3ed18ea6150913db026"
+
+[[packages]]
+name = "docstring-parser"
+version = "0.18.0"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "docstring_parser-0.18.0.tar.gz"
+upload-time = 2026-04-14 04:09:19.867229+00:00
+url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz"
+size = 29341
+
+[packages.sdist.hashes]
+sha256 = "292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015"
+
+[[packages.wheels]]
+name = "docstring_parser-0.18.0-py3-none-any.whl"
+upload-time = 2026-04-14 04:09:18.638975+00:00
+url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl"
+size = 22484
+
+[packages.wheels.hashes]
+sha256 = "b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b"
+
+[[packages]]
+name = "exceptiongroup"
+version = "1.3.1"
+marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+requires-python = ">=3.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "exceptiongroup-1.3.1.tar.gz"
+upload-time = 2025-11-21 23:01:54.787772+00:00
+url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz"
+size = 30371
+
+[packages.sdist.hashes]
+sha256 = "8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219"
+
+[[packages.wheels]]
+name = "exceptiongroup-1.3.1-py3-none-any.whl"
+upload-time = 2025-11-21 23:01:53.443434+00:00
+url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl"
+size = 16740
+
+[packages.wheels.hashes]
+sha256 = "a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598"
+
+[[packages]]
+name = "h11"
+version = "0.16.0"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "h11-0.16.0.tar.gz"
+upload-time = 2025-04-24 03:35:25.427659+00:00
+url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz"
+size = 101250
+
+[packages.sdist.hashes]
+sha256 = "4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"
+
+[[packages.wheels]]
+name = "h11-0.16.0-py3-none-any.whl"
+upload-time = 2025-04-24 03:35:24.344199+00:00
+url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl"
+size = 37515
+
+[packages.wheels.hashes]
+sha256 = "63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"
+
+[[packages]]
+name = "h2"
+version = "4.3.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "h2-4.3.0.tar.gz"
+upload-time = 2025-08-23 18:12:19.778573+00:00
+url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz"
+size = 2152026
+
+[packages.sdist.hashes]
+sha256 = "6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1"
+
+[[packages.wheels]]
+name = "h2-4.3.0-py3-none-any.whl"
+upload-time = 2025-08-23 18:12:17.779568+00:00
+url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl"
+size = 61779
+
+[packages.wheels.hashes]
+sha256 = "c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd"
+
+[[packages]]
+name = "hpack"
+version = "4.1.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "hpack-4.1.0.tar.gz"
+upload-time = 2025-01-22 21:44:58.347520+00:00
+url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz"
+size = 51276
+
+[packages.sdist.hashes]
+sha256 = "ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca"
+
+[[packages.wheels]]
+name = "hpack-4.1.0-py3-none-any.whl"
+upload-time = 2025-01-22 21:44:56.920811+00:00
+url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl"
+size = 34357
+
+[packages.wheels.hashes]
+sha256 = "157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496"
+
+[[packages]]
+name = "httpcore"
+version = "1.0.9"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "httpcore-1.0.9.tar.gz"
+upload-time = 2025-04-24 22:06:22.219726+00:00
+url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz"
+size = 85484
+
+[packages.sdist.hashes]
+sha256 = "6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"
+
+[[packages.wheels]]
+name = "httpcore-1.0.9-py3-none-any.whl"
+upload-time = 2025-04-24 22:06:20.566605+00:00
+url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl"
+size = 78784
+
+[packages.wheels.hashes]
+sha256 = "2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"
+
+[[packages]]
+name = "httpx"
+version = "0.28.1"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "httpx-0.28.1.tar.gz"
+upload-time = 2024-12-06 15:37:23.222462+00:00
+url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz"
+size = 141406
+
+[packages.sdist.hashes]
+sha256 = "75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"
+
+[[packages.wheels]]
+name = "httpx-0.28.1-py3-none-any.whl"
+upload-time = 2024-12-06 15:37:21.509172+00:00
+url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl"
+size = 73517
+
+[packages.wheels.hashes]
+sha256 = "d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"
+
+[[packages]]
+name = "hyperframe"
+version = "6.1.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "hyperframe-6.1.0.tar.gz"
+upload-time = 2025-01-22 21:41:49.302049+00:00
+url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz"
+size = 26566
+
+[packages.sdist.hashes]
+sha256 = "f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08"
+
+[[packages.wheels]]
+name = "hyperframe-6.1.0-py3-none-any.whl"
+upload-time = 2025-01-22 21:41:47.295426+00:00
+url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl"
+size = 13007
+
+[packages.wheels.hashes]
+sha256 = "b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5"
+
+[[packages]]
+name = "hypothesis"
+version = "6.152.7"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "hypothesis-6.152.7.tar.gz"
+upload-time = 2026-05-13 04:19:34.124471+00:00
+url = "https://files.pythonhosted.org/packages/91/dd/19d273652eb20dac15f32bbc484f2f6d51ccd8fe51fdb27da3f85f9017e8/hypothesis-6.152.7.tar.gz"
+size = 468147
+
+[packages.sdist.hashes]
+sha256 = "741dedcede2ae0f32c32929a5992804b61f2b0400403b6a51a881a2b58482782"
+
+[[packages.wheels]]
+name = "hypothesis-6.152.7-py3-none-any.whl"
+upload-time = 2026-05-13 04:19:30.635768+00:00
+url = "https://files.pythonhosted.org/packages/0a/1e/8222edaee03c37350eaa726213614e343a62f1e56396dd000ad9277bfa3d/hypothesis-6.152.7-py3-none-any.whl"
+size = 533802
+
+[packages.wheels.hashes]
+sha256 = "c0b17dd428fcb6e962f60315f6f4a77816c72fbb281ce9ba73699dabead5ec82"
+
+[[packages]]
+name = "hypothesis-crosshair"
+version = "0.0.28"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "hypothesis_crosshair-0.0.28.tar.gz"
+upload-time = 2026-04-29 00:13:57.910514+00:00
+url = "https://files.pythonhosted.org/packages/81/2e/8c00562bdd92e5f27263b1e150a439f6949ba862c26eab124aed10d4f21f/hypothesis_crosshair-0.0.28.tar.gz"
+size = 13795
+
+[packages.sdist.hashes]
+sha256 = "5b881d6178162dfa393852bc92e59186894c48f3879c64382f4681494af9757e"
+
+[[packages.wheels]]
+name = "hypothesis_crosshair-0.0.28-py3-none-any.whl"
+upload-time = 2026-04-29 00:13:56.594230+00:00
+url = "https://files.pythonhosted.org/packages/15/ff/4e4b289884514859034154361855ba4ae8f163342b67f24a013f60a058ff/hypothesis_crosshair-0.0.28-py3-none-any.whl"
+size = 15968
+
+[packages.wheels.hashes]
+sha256 = "fa7651a4f74d219db84743370ddc206fcfed612d80a49d58988baf75f497f018"
+
+[[packages]]
+name = "idna"
+version = "3.15"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "idna-3.15.tar.gz"
+upload-time = 2026-05-12 22:45:57.011321+00:00
+url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz"
+size = 199245
+
+[packages.sdist.hashes]
+sha256 = "ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc"
+
+[[packages.wheels]]
+name = "idna-3.15-py3-none-any.whl"
+upload-time = 2026-05-12 22:45:55.733813+00:00
+url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl"
+size = 72340
+
+[packages.wheels.hashes]
+sha256 = "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"
+
+[[packages]]
+name = "importlib-metadata"
+version = "9.0.0"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "importlib_metadata-9.0.0.tar.gz"
+upload-time = 2026-03-20 06:42:56.999805+00:00
+url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz"
+size = 56405
+
+[packages.sdist.hashes]
+sha256 = "a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc"
+
+[[packages.wheels]]
+name = "importlib_metadata-9.0.0-py3-none-any.whl"
+upload-time = 2026-03-20 06:42:55.665400+00:00
+url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl"
+size = 27789
+
+[packages.wheels.hashes]
+sha256 = "2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7"
+
+[[packages]]
+name = "importlib-resources"
+version = "7.1.0"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "importlib_resources-7.1.0.tar.gz"
+upload-time = 2026-04-12 16:36:09.232308+00:00
+url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz"
+size = 44985
+
+[packages.sdist.hashes]
+sha256 = "0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708"
+
+[[packages.wheels]]
+name = "importlib_resources-7.1.0-py3-none-any.whl"
+upload-time = 2026-04-12 16:36:08.219817+00:00
+url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl"
+size = 37232
+
+[packages.wheels.hashes]
+sha256 = "1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1"
+
+[[packages]]
+name = "iniconfig"
+version = "2.3.0"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "iniconfig-2.3.0.tar.gz"
+upload-time = 2025-10-18 21:55:43.219048+00:00
+url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz"
+size = 20503
+
+[packages.sdist.hashes]
+sha256 = "c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"
+
+[[packages.wheels]]
+name = "iniconfig-2.3.0-py3-none-any.whl"
+upload-time = 2025-10-18 21:55:41.639305+00:00
+url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl"
+size = 7484
+
+[packages.wheels.hashes]
+sha256 = "f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"
+
+[[packages]]
+name = "installer"
+version = "1.0.1"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "installer-1.0.1.tar.gz"
+upload-time = 2026-05-11 18:13:28.158660+00:00
+url = "https://files.pythonhosted.org/packages/06/fe/b9f481cf0cc867958a21338baa900357b7b7d86cac9b025948049d77923c/installer-1.0.1.tar.gz"
+size = 481132
+
+[packages.sdist.hashes]
+sha256 = "052c7fc3721d54c696e2dea019be67539d7b144e924f559f54beb3121831c364"
+
+[[packages.wheels]]
+name = "installer-1.0.1-py3-none-any.whl"
+upload-time = 2026-05-11 18:13:26.252723+00:00
+url = "https://files.pythonhosted.org/packages/26/48/bedf3ba4163e7db392c9d4cbdfc8217423196c8fccbe5a404a0f094fde63/installer-1.0.1-py3-none-any.whl"
+size = 464455
+
+[packages.wheels.hashes]
+sha256 = "011d045df8b954ced7dde3a7e42ae4418da40ecda7990f2d11d5ed7c146fd98b"
+
+[[packages]]
+name = "jh2"
+version = "5.0.11"
+requires-python = ">=3.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "jh2-5.0.11.tar.gz"
+upload-time = 2026-04-05 07:33:51.119491+00:00
+url = "https://files.pythonhosted.org/packages/a3/ea/ebd7cbba422317fdd4be5e04a5aa9a54192b8c483f20eb38c85cf9fb8adc/jh2-5.0.11.tar.gz"
+size = 7320877
+
+[packages.sdist.hashes]
+sha256 = "6c835b0b38d795dde7aaa4581626490ca5fcfbd4eefe9572ac18d9eb2427d215"
+
+[[packages.wheels]]
+name = "jh2-5.0.11-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-04-05 07:31:51.855788+00:00
+url = "https://files.pythonhosted.org/packages/8c/a4/b80fd188fa006a144cd4f280fdfd3808e3715aaa805fa830e828406080ed/jh2-5.0.11-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 399371
+
+[packages.wheels.hashes]
+sha256 = "6d15672b32f0891940691bac16a854af164e694f0b9d21bebfddd13e3c7d2f03"
+
+[[packages.wheels]]
+name = "jh2-5.0.11-cp37-abi3-musllinux_1_1_x86_64.whl"
+upload-time = 2026-04-05 07:32:00.681248+00:00
+url = "https://files.pythonhosted.org/packages/82/55/db34614186693ce66c69af384659c5f37fa79699c81c8867cec2fe4dc566/jh2-5.0.11-cp37-abi3-musllinux_1_1_x86_64.whl"
+size = 603360
+
+[packages.wheels.hashes]
+sha256 = "b0ad821964a7701e2b80c6f8b424b6d4ca575fefb1aa04227967ef78fa15fcd5"
+
+[[packages.wheels]]
+name = "jh2-5.0.11-py3-none-any.whl"
+upload-time = 2026-04-05 07:33:49.430003+00:00
+url = "https://files.pythonhosted.org/packages/6a/17/512d0ac0484aca136e698498d6441b6072156fb2d618d8096a07578f67ad/jh2-5.0.11-py3-none-any.whl"
+size = 98207
+
+[packages.wheels.hashes]
+sha256 = "aafd357af8d0de5267d3bc88e2384da30f05c38446a61425ae565925bc2ca9ba"
+
+[[packages.wheels]]
+name = "jh2-5.0.11-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-04-05 07:31:43.814809+00:00
+url = "https://files.pythonhosted.org/packages/5f/61/fc161568713450214d3c48db614d871f9393bd88db471e10ac868f5a7214/jh2-5.0.11-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 393320
+
+[packages.wheels.hashes]
+sha256 = "85cf4f09f7159c29967212af685d2819f960d9136d931420fef107683d121f56"
+
+[[packages.wheels]]
+name = "jh2-5.0.11-cp37-abi3-musllinux_1_1_aarch64.whl"
+upload-time = 2026-04-05 07:31:55.228492+00:00
+url = "https://files.pythonhosted.org/packages/ac/8d/59dd21f1ed6f451f60581522e08e42f3e74275b1568ef9c7936a06445108/jh2-5.0.11-cp37-abi3-musllinux_1_1_aarch64.whl"
+size = 569633
+
+[packages.wheels.hashes]
+sha256 = "6cd51dd02943b703e10eb536722c5fd205b6084333dac5b9c114bdbbc2c46b3a"
+
+[[packages.wheels]]
+name = "jh2-5.0.11-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"
+upload-time = 2026-04-05 07:31:42.411086+00:00
+url = "https://files.pythonhosted.org/packages/0a/f0/0363ffb6ed11a76d47c6a543f16c3c3e6efedc27853fa1ef95df557c0724/jh2-5.0.11-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"
+size = 622317
+
+[packages.wheels.hashes]
+sha256 = "4dc82aee3ab2c4103f3d9092f4463dd6cc4a248ab6a27a4acab79bef0d3ac8dd"
+
+[[packages.wheels]]
+name = "jh2-5.0.11-cp37-abi3-win_amd64.whl"
+upload-time = 2026-04-05 07:32:04.021109+00:00
+url = "https://files.pythonhosted.org/packages/5a/60/69a4fcc00a01fa65bbf67279e21886325087491250bc54af3e12e86c8532/jh2-5.0.11-cp37-abi3-win_amd64.whl"
+size = 251415
+
+[packages.wheels.hashes]
+sha256 = "e28dabffcbd5525bf5f36d482764e3e56b513bce06a75b2fb4b540bedad80348"
+
+[[packages]]
+name = "lsprotocol"
+version = "2025.0.0"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "lsprotocol-2025.0.0.tar.gz"
+upload-time = 2025-06-17 21:30:18.156867+00:00
+url = "https://files.pythonhosted.org/packages/e9/26/67b84e6ec1402f0e6764ef3d2a0aaf9a79522cc1d37738f4e5bb0b21521a/lsprotocol-2025.0.0.tar.gz"
+size = 74896
+
+[packages.sdist.hashes]
+sha256 = "e879da2b9301e82cfc3e60d805630487ac2f7ab17492f4f5ba5aaba94fe56c29"
+
+[[packages.wheels]]
+name = "lsprotocol-2025.0.0-py3-none-any.whl"
+upload-time = 2025-06-17 21:30:19.455037+00:00
+url = "https://files.pythonhosted.org/packages/7b/f0/92f2d609d6642b5f30cb50a885d2bf1483301c69d5786286500d15651ef2/lsprotocol-2025.0.0-py3-none-any.whl"
+size = 76250
+
+[packages.wheels.hashes]
+sha256 = "f9d78f25221f2a60eaa4a96d3b4ffae011b107537facee61d3da3313880995c7"
+
+[[packages]]
+name = "mypy-extensions"
+version = "1.1.0"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "mypy_extensions-1.1.0.tar.gz"
+upload-time = 2025-04-22 14:54:24.164338+00:00
+url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz"
+size = 6343
+
+[packages.sdist.hashes]
+sha256 = "52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"
+
+[[packages.wheels]]
+name = "mypy_extensions-1.1.0-py3-none-any.whl"
+upload-time = 2025-04-22 14:54:22.983092+00:00
+url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl"
+size = 4963
+
+[packages.wheels.hashes]
+sha256 = "1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"
+
+[[packages]]
+name = "niquests"
+version = "3.18.8"
+requires-python = ">=3.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "niquests-3.18.8.tar.gz"
+upload-time = 2026-05-10 05:29:15.663354+00:00
+url = "https://files.pythonhosted.org/packages/ae/3f/3cbfd81c507c4d58b57afc04d75b6feb00cbcdeba43852a7506100af2eae/niquests-3.18.8.tar.gz"
+size = 1028824
+
+[packages.sdist.hashes]
+sha256 = "06244ef4d1c93b067295b22c1d7a8938be948af1227d368c22acf531f61fdf57"
+
+[[packages.wheels]]
+name = "niquests-3.18.8-py3-none-any.whl"
+upload-time = 2026-05-10 05:29:14.003251+00:00
+url = "https://files.pythonhosted.org/packages/1a/2c/01d6978e16536922baaafad903adbc55880b11f23595f90a3b52478ce234/niquests-3.18.8-py3-none-any.whl"
+size = 208878
+
+[packages.wheels.hashes]
+sha256 = "9b1a3a378277bfca4b2438877d0954e989e4d3f3f75da7bb83bf7204dfa5f1cf"
+
+[[packages]]
+name = "packaging"
+version = "26.2"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "packaging-26.2.tar.gz"
+upload-time = 2026-04-24 20:15:23.917886+00:00
+url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz"
+size = 228134
+
+[packages.sdist.hashes]
+sha256 = "ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"
+
+[[packages.wheels]]
+name = "packaging-26.2-py3-none-any.whl"
+upload-time = 2026-04-24 20:15:22.081511+00:00
+url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl"
+size = 100195
+
+[packages.wheels.hashes]
+sha256 = "5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"
+
+[[packages]]
+name = "pluggy"
+version = "1.6.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pluggy-1.6.0.tar.gz"
+upload-time = 2025-05-15 12:30:07.975376+00:00
+url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz"
+size = 69412
+
+[packages.sdist.hashes]
+sha256 = "7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"
+
+[[packages.wheels]]
+name = "pluggy-1.6.0-py3-none-any.whl"
+upload-time = 2025-05-15 12:30:06.134003+00:00
+url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl"
+size = 20538
+
+[packages.wheels.hashes]
+sha256 = "e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
+
+[[packages]]
+name = "pygls"
+version = "2.1.1"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pygls-2.1.1.tar.gz"
+upload-time = 2026-03-25 11:19:10.541043+00:00
+url = "https://files.pythonhosted.org/packages/da/2e/7bbe061d175c0baddde8fc9edb908a4c31ba5d9165b8c68e3439c3a9f138/pygls-2.1.1.tar.gz"
+size = 55091
+
+[packages.sdist.hashes]
+sha256 = "1da03ba9053201bb337dcdd8d121df70feb2a91e1a0dcc74de5da79755b1a201"
+
+[[packages.wheels]]
+name = "pygls-2.1.1-py3-none-any.whl"
+upload-time = 2026-03-25 11:19:11.374663+00:00
+url = "https://files.pythonhosted.org/packages/fd/1a/208293b6c350f5abea6941d5606080d4a492644052504f5312e5de30a902/pygls-2.1.1-py3-none-any.whl"
+size = 68975
+
+[packages.wheels.hashes]
+sha256 = "510a6dea2476177230c7d851125e5948efdf3fdb9ebfd8543fc434972f8faed4"
+
+[[packages]]
+name = "pygments"
+version = "2.20.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pygments-2.20.0.tar.gz"
+upload-time = 2026-03-29 13:29:33.898791+00:00
+url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz"
+size = 4955991
+
+[packages.sdist.hashes]
+sha256 = "6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"
+
+[[packages.wheels]]
+name = "pygments-2.20.0-py3-none-any.whl"
+upload-time = 2026-03-29 13:29:30.038266+00:00
+url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl"
+size = 1231151
+
+[packages.wheels.hashes]
+sha256 = "81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"
+
+[[packages]]
+name = "pyproject-hooks"
+version = "1.2.0"
+requires-python = ">=3.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pyproject_hooks-1.2.0.tar.gz"
+upload-time = 2024-09-29 09:24:13.293934+00:00
+url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz"
+size = 19228
+
+[packages.sdist.hashes]
+sha256 = "1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8"
+
+[[packages.wheels]]
+name = "pyproject_hooks-1.2.0-py3-none-any.whl"
+upload-time = 2024-09-29 09:24:11.978642+00:00
+url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl"
+size = 10216
+
+[packages.wheels.hashes]
+sha256 = "9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913"
+
+[[packages]]
+name = "pytest"
+version = "9.0.3"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pytest-9.0.3.tar.gz"
+upload-time = 2026-04-07 17:16:18.027317+00:00
+url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz"
+size = 1572165
+
+[packages.sdist.hashes]
+sha256 = "b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"
+
+[[packages.wheels]]
+name = "pytest-9.0.3-py3-none-any.whl"
+upload-time = 2026-04-07 17:16:16.130051+00:00
+url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl"
+size = 375249
+
+[packages.wheels.hashes]
+sha256 = "2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"
+
+[[packages]]
+name = "pytest-timeout"
+version = "2.4.0"
+requires-python = ">=3.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pytest_timeout-2.4.0.tar.gz"
+upload-time = 2025-05-05 19:44:34.990551+00:00
+url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz"
+size = 17973
+
+[packages.sdist.hashes]
+sha256 = "7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a"
+
+[[packages.wheels]]
+name = "pytest_timeout-2.4.0-py3-none-any.whl"
+upload-time = 2025-05-05 19:44:33.502941+00:00
+url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl"
+size = 14382
+
+[packages.wheels.hashes]
+sha256 = "c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2"
+
+[[packages]]
+name = "qh3"
+version = "1.8.1"
+requires-python = ">=3.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "qh3-1.8.1.tar.gz"
+upload-time = 2026-05-07 09:38:00.192710+00:00
+url = "https://files.pythonhosted.org/packages/0a/83/8a57595b1c8ba57f70abcb731db647b3beabad52f76e282e1fc7f666c5a0/qh3-1.8.1.tar.gz"
+size = 335758
+
+[packages.sdist.hashes]
+sha256 = "28d5d73903850d5733eb4c7f6cc3a81d40099f98204b5c8482330a1fb7ca92c8"
+
+[[packages.wheels]]
+name = "qh3-1.8.1-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-05-07 09:35:47.426062+00:00
+url = "https://files.pythonhosted.org/packages/53/96/c435fecb8d420ec2924c11fbc396ad8d9d7b4861ac4e48dfb8631fc1d3bf/qh3-1.8.1-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 2358583
+
+[packages.wheels.hashes]
+sha256 = "c23816f4f4e017528cb30eef697aa607578ad42d3111ae7552c73666021d5268"
+
+[[packages.wheels]]
+name = "qh3-1.8.1-cp37-abi3-musllinux_1_1_x86_64.whl"
+upload-time = 2026-05-07 09:35:57.745088+00:00
+url = "https://files.pythonhosted.org/packages/54/f3/6e16cf55f42aec85af2c2c5ae5fd46a2a8eefe80f1f6b669a1b5969a7172/qh3-1.8.1-cp37-abi3-musllinux_1_1_x86_64.whl"
+size = 2585895
+
+[packages.wheels.hashes]
+sha256 = "2bd4b95d4c9e9e5a4df36867aa344feae8d7b5a511d56035603ccbbb41b00a84"
+
+[[packages.wheels]]
+name = "qh3-1.8.1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-05-07 09:35:36.802088+00:00
+url = "https://files.pythonhosted.org/packages/50/82/282a7250c84ae3ece859f97a2023e063255be7e70c5b99b08fca7ed59d99/qh3-1.8.1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 2161987
+
+[packages.wheels.hashes]
+sha256 = "1d09950baf910e3cb0053d546a8fd8bdb7dae5f4d217a88f51ffcf2dd7b1397d"
+
+[[packages.wheels]]
+name = "qh3-1.8.1-cp37-abi3-musllinux_1_1_aarch64.whl"
+upload-time = 2026-05-07 09:35:50.701011+00:00
+url = "https://files.pythonhosted.org/packages/8c/14/faae208dfea35db41cf016c5622fd694b45f25fe09f29f683140de145529/qh3-1.8.1-cp37-abi3-musllinux_1_1_aarch64.whl"
+size = 2350931
+
+[packages.wheels.hashes]
+sha256 = "8e4cfc6d8ae494f0ae052492f1fc51ad1a3ce7eb3f4ed3bc0276fc7e3f4ee1c5"
+
+[[packages.wheels]]
+name = "qh3-1.8.1-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"
+upload-time = 2026-05-07 09:35:35.011094+00:00
+url = "https://files.pythonhosted.org/packages/b0/5b/2ea75701d7e9fe81d60f4307cbd370d023879e7ad65c30af5dcf335f5ab0/qh3-1.8.1-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"
+size = 4432070
+
+[packages.wheels.hashes]
+sha256 = "576cfd6a657f3b5f574e601500461d586b2e7037fa24ea876f5f724a10f2f552"
+
+[[packages.wheels]]
+name = "qh3-1.8.1-cp37-abi3-win_amd64.whl"
+upload-time = 2026-05-07 09:36:00.836853+00:00
+url = "https://files.pythonhosted.org/packages/1d/e8/3f871ea3f1d4e17536f38410c5c333b4aa3c60f74350eb91799d482243de/qh3-1.8.1-cp37-abi3-win_amd64.whl"
+size = 2129090
+
+[packages.wheels.hashes]
+sha256 = "d4c53c82f7cef0a2a8714cc3c48fca970f496132542483ad1489fb8f2b9c70c5"
+
+[[packages]]
+name = "respx"
+version = "0.23.1"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "respx-0.23.1.tar.gz"
+upload-time = 2026-04-08 14:37:16.008390+00:00
+url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz"
+size = 29243
+
+[packages.sdist.hashes]
+sha256 = "242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780"
+
+[[packages.wheels]]
+name = "respx-0.23.1-py2.py3-none-any.whl"
+upload-time = 2026-04-08 14:37:14.613510+00:00
+url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl"
+size = 25557
+
+[packages.wheels.hashes]
+sha256 = "b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a"
+
+[[packages]]
+name = "sortedcontainers"
+version = "2.4.0"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "sortedcontainers-2.4.0.tar.gz"
+upload-time = 2021-05-16 22:03:42.897871+00:00
+url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz"
+size = 30594
+
+[packages.sdist.hashes]
+sha256 = "25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"
+
+[[packages.wheels]]
+name = "sortedcontainers-2.4.0-py2.py3-none-any.whl"
+upload-time = 2021-05-16 22:03:41.177807+00:00
+url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl"
+size = 29575
+
+[packages.wheels.hashes]
+sha256 = "a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"
+
+[[packages]]
+name = "tomli"
+version = "2.4.1"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "tomli-2.4.1.tar.gz"
+upload-time = 2026-03-25 20:22:03.828102+00:00
+url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz"
+size = 17543
+
+[packages.sdist.hashes]
+sha256 = "7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-py3-none-any.whl"
+upload-time = 2026-03-25 20:22:03.012768+00:00
+url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl"
+size = 14583
+
+[packages.wheels.hashes]
+sha256 = "0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:14.569419+00:00
+url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 243824
+
+[packages.wheels.hashes]
+sha256 = "5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl"
+upload-time = 2026-03-25 20:21:17.001171+00:00
+url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl"
+size = 247859
+
+[packages.wheels.hashes]
+sha256 = "ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:13.098441+00:00
+url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 237561
+
+[packages.wheels.hashes]
+sha256 = "96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl"
+upload-time = 2026-03-25 20:21:15.712337+00:00
+url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl"
+size = 242227
+
+[packages.wheels.hashes]
+sha256 = "47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl"
+upload-time = 2026-03-25 20:21:12.036923+00:00
+url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl"
+size = 149454
+
+[packages.wheels.hashes]
+sha256 = "4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
+upload-time = 2026-03-25 20:21:10.473841+00:00
+url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
+size = 154704
+
+[packages.wheels.hashes]
+sha256 = "f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-win_amd64.whl"
+upload-time = 2026-03-25 20:21:18.978514+00:00
+url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl"
+size = 108084
+
+[packages.wheels.hashes]
+sha256 = "5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:25.177901+00:00
+url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 253341
+
+[packages.wheels.hashes]
+sha256 = "136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl"
+upload-time = 2026-03-25 20:21:27.460413+00:00
+url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl"
+size = 253290
+
+[packages.wheels.hashes]
+sha256 = "5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:24.040813+00:00
+url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 244948
+
+[packages.wheels.hashes]
+sha256 = "ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl"
+upload-time = 2026-03-25 20:21:26.364996+00:00
+url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl"
+size = 248159
+
+[packages.wheels.hashes]
+sha256 = "5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl"
+upload-time = 2026-03-25 20:21:23.002533+00:00
+url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl"
+size = 150018
+
+[packages.wheels.hashes]
+sha256 = "7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2026-03-25 20:21:21.626567+00:00
+url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 155924
+
+[packages.wheels.hashes]
+sha256 = "c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-win_amd64.whl"
+upload-time = 2026-03-25 20:21:29.386807+00:00
+url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl"
+size = 108847
+
+[packages.wheels.hashes]
+sha256 = "52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:36.012836+00:00
+url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 251628
+
+[packages.wheels.hashes]
+sha256 = "f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl"
+upload-time = 2026-03-25 20:21:38.298846+00:00
+url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl"
+size = 251674
+
+[packages.wheels.hashes]
+sha256 = "51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:34.510750+00:00
+url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 243704
+
+[packages.wheels.hashes]
+sha256 = "c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl"
+upload-time = 2026-03-25 20:21:37.136802+00:00
+url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl"
+size = 247180
+
+[packages.wheels.hashes]
+sha256 = "d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl"
+upload-time = 2026-03-25 20:21:33.028949+00:00
+url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl"
+size = 149887
+
+[packages.wheels.hashes]
+sha256 = "eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2026-03-25 20:21:31.650748+00:00
+url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 155866
+
+[packages.wheels.hashes]
+sha256 = "36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-win_amd64.whl"
+upload-time = 2026-03-25 20:21:40.248121+00:00
+url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl"
+size = 108755
+
+[packages.wheels.hashes]
+sha256 = "8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:45.620261+00:00
+url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 252084
+
+[packages.wheels.hashes]
+sha256 = "01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl"
+upload-time = 2026-03-25 20:21:48.467732+00:00
+url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl"
+size = 256223
+
+[packages.wheels.hashes]
+sha256 = "ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:44.474645+00:00
+url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 244713
+
+[packages.wheels.hashes]
+sha256 = "559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl"
+upload-time = 2026-03-25 20:21:46.937942+00:00
+url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl"
+size = 247973
+
+[packages.wheels.hashes]
+sha256 = "7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl"
+upload-time = 2026-03-25 20:21:43.386384+00:00
+url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl"
+size = 149859
+
+[packages.wheels.hashes]
+sha256 = "a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-win_amd64.whl"
+upload-time = 2026-03-25 20:21:50.506850+00:00
+url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl"
+size = 109082
+
+[packages.wheels.hashes]
+sha256 = "88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7"
+
+[[packages]]
+name = "tomli-w"
+version = "1.2.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "tomli_w-1.2.0.tar.gz"
+upload-time = 2025-01-15 12:07:24.262974+00:00
+url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz"
+size = 7184
+
+[packages.sdist.hashes]
+sha256 = "2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021"
+
+[[packages.wheels]]
+name = "tomli_w-1.2.0-py3-none-any.whl"
+upload-time = 2025-01-15 12:07:22.074224+00:00
+url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl"
+size = 6675
+
+[packages.wheels.hashes]
+sha256 = "188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90"
+
+[[packages]]
+name = "typeguard"
+version = "4.5.2"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "typeguard-4.5.2.tar.gz"
+upload-time = 2026-05-14 12:59:40.857502+00:00
+url = "https://files.pythonhosted.org/packages/67/1c/dfba5c4633cafc4c701f237d2ba63b416805047fd6d96aab4cfc40969f98/typeguard-4.5.2.tar.gz"
+size = 80240
+
+[packages.sdist.hashes]
+sha256 = "5a16dcac23502039299c97c8941651bc33d7ea8cc4b2f7d6bbb1b528f6eea423"
+
+[[packages.wheels]]
+name = "typeguard-4.5.2-py3-none-any.whl"
+upload-time = 2026-05-14 12:59:39.473017+00:00
+url = "https://files.pythonhosted.org/packages/5b/29/74eeb4d3f3ae61ca096b018ad486b3b3c74b17bec09ab4edab721cbefec3/typeguard-4.5.2-py3-none-any.whl"
+size = 36748
+
+[packages.wheels.hashes]
+sha256 = "fcf9de18bd945cdb4c7b996e12b4c51ce83f92f191314a6d7cf1739586ec98cf"
+
+[[packages]]
+name = "typeshed-client"
+version = "2.11.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "typeshed_client-2.11.0.tar.gz"
+upload-time = 2026-05-01 14:51:52.380574+00:00
+url = "https://files.pythonhosted.org/packages/85/7d/62fbae352d5fb7ce5ef4d9ca73bf7a9b02b790d2524ab6ef1e0e799a5d1b/typeshed_client-2.11.0.tar.gz"
+size = 522774
+
+[packages.sdist.hashes]
+sha256 = "0b8f2ab88f611f5e97b70d2a8123942d3d7d5c74cee8ae694db83422f32f9481"
+
+[[packages.wheels]]
+name = "typeshed_client-2.11.0-py3-none-any.whl"
+upload-time = 2026-05-01 14:51:51.005104+00:00
+url = "https://files.pythonhosted.org/packages/4f/22/fa16b462157bd869dfad528f5637506b9430ca63d48fb536ecf4cc78481a/typeshed_client-2.11.0-py3-none-any.whl"
+size = 787609
+
+[packages.wheels.hashes]
+sha256 = "5745e0990b80b29a286b22d68f81779c5c7adf1cac8969eeafba44b73b486c36"
+
+[[packages]]
+name = "typing-extensions"
+version = "4.15.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "typing_extensions-4.15.0.tar.gz"
+upload-time = 2025-08-25 13:49:26.313895+00:00
+url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz"
+size = 109391
+
+[packages.sdist.hashes]
+sha256 = "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"
+
+[[packages.wheels]]
+name = "typing_extensions-4.15.0-py3-none-any.whl"
+upload-time = 2025-08-25 13:49:24.860024+00:00
+url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl"
+size = 44614
+
+[packages.wheels.hashes]
+sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+
+[[packages]]
+name = "typing-inspect"
+version = "0.9.0"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "typing_inspect-0.9.0.tar.gz"
+upload-time = 2023-05-24 20:25:47.612134+00:00
+url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz"
+size = 13825
+
+[packages.sdist.hashes]
+sha256 = "b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78"
+
+[[packages.wheels]]
+name = "typing_inspect-0.9.0-py3-none-any.whl"
+upload-time = 2023-05-24 20:25:45.287357+00:00
+url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl"
+size = 8827
+
+[packages.wheels.hashes]
+sha256 = "9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f"
+
+[[packages]]
+name = "tyro"
+version = "1.0.13"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "tyro-1.0.13.tar.gz"
+upload-time = 2026-04-14 18:21:52.888049+00:00
+url = "https://files.pythonhosted.org/packages/24/d6/7126f9e7de139632134d59b5d1972e93c610ee2cb13829e8f4f48f6613cb/tyro-1.0.13.tar.gz"
+size = 489479
+
+[packages.sdist.hashes]
+sha256 = "731a90c9836b77fffe7c3fa0477ef2d3b6fa91252ddc0bb4d32dadd4fcc143d4"
+
+[[packages.wheels]]
+name = "tyro-1.0.13-py3-none-any.whl"
+upload-time = 2026-04-14 18:21:54.328769+00:00
+url = "https://files.pythonhosted.org/packages/93/4f/c43a0a8f0c66fd40a1d6cc47332a5a1d1043e9b331f7070ea701b91a7598/tyro-1.0.13-py3-none-any.whl"
+size = 185221
+
+[packages.wheels.hashes]
+sha256 = "a0bdb8462c551dd84fc00a76916ce4d37e879c84eefaf34e2165312407cc6c09"
+
+[[packages]]
+name = "urllib3"
+version = "2.7.0"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "urllib3-2.7.0.tar.gz"
+upload-time = 2026-05-07 16:13:18.596909+00:00
+url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz"
+size = 433602
+
+[packages.sdist.hashes]
+sha256 = "231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"
+
+[[packages.wheels]]
+name = "urllib3-2.7.0-py3-none-any.whl"
+upload-time = 2026-05-07 16:13:17.151740+00:00
+url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl"
+size = 131087
+
+[packages.wheels.hashes]
+sha256 = "9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
+
+[[packages]]
+name = "urllib3-future"
+version = "2.20.905"
+requires-python = ">=3.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "urllib3_future-2.20.905.tar.gz"
+upload-time = 2026-05-17 06:23:01.809895+00:00
+url = "https://files.pythonhosted.org/packages/21/17/4aefcade006227abd338c178abd7aedd967496d8663b6141f32e827a1622/urllib3_future-2.20.905.tar.gz"
+size = 1283641
+
+[packages.sdist.hashes]
+sha256 = "e7cde1cdf3657f0c80505212bebe952f1344a3dad656e91738acef60e01fae15"
+
+[[packages.wheels]]
+name = "urllib3_future-2.20.905-py3-none-any.whl"
+upload-time = 2026-05-17 06:22:59.267019+00:00
+url = "https://files.pythonhosted.org/packages/d9/cd/e54a8422d89a668a77852549d88ac75e31c72964ca37b082f5fc1f23b1b1/urllib3_future-2.20.905-py3-none-any.whl"
+size = 758083
+
+[packages.wheels.hashes]
+sha256 = "0179d7d5180f530065fe123889d108fb85eb26392c79477db3f4d4c28f3d9af0"
+
+[[packages]]
+name = "wassima"
+version = "2.1.0"
+requires-python = ">=3.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "wassima-2.1.0.tar.gz"
+upload-time = 2026-05-10 04:07:21.576289+00:00
+url = "https://files.pythonhosted.org/packages/58/e0/10e0ff85dc4d48b5000aa76567dfacf33b9518c2fadd410e850e213c36b9/wassima-2.1.0.tar.gz"
+size = 135950
+
+[packages.sdist.hashes]
+sha256 = "709f375c778d9be84568d802d1e1b62a2ed3942b1fa4c83830533a69cf36c243"
+
+[[packages.wheels]]
+name = "wassima-2.1.0-py3-none-any.whl"
+upload-time = 2026-05-10 04:07:19.900031+00:00
+url = "https://files.pythonhosted.org/packages/53/f9/077b0aacd337c31d3f97eef7acfa89bcd522360b56614f961af84db0a3ca/wassima-2.1.0-py3-none-any.whl"
+size = 128092
+
+[packages.wheels.hashes]
+sha256 = "4e8bc4b439f91f4da24bd2260be662fcb42d1cc439d7678420237d314e55a854"
+
+[[packages]]
+name = "z3-solver"
+version = "4.15.4.0"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "z3_solver-4.15.4.0.tar.gz"
+upload-time = 2025-10-29 18:12:03.062278+00:00
+url = "https://files.pythonhosted.org/packages/8a/8e/0c8f17309549d2e5cde9a3ccefa6365437f1e7bafe71878eaf9478e47b18/z3_solver-4.15.4.0.tar.gz"
+size = 5018600
+
+[packages.sdist.hashes]
+sha256 = "928c29b58c4eb62106da51c1914f6a4a55d0441f8f48a81b9da07950434a8946"
+
+[[packages.wheels]]
+name = "z3_solver-4.15.4.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2025-10-29 18:11:53.032680+00:00
+url = "https://files.pythonhosted.org/packages/21/c9/bb51a96af0091324c81b803f16c49f719f9f6ea0b0bb52200f5c97ec4892/z3_solver-4.15.4.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 29268352
+
+[packages.wheels.hashes]
+sha256 = "7e103a6f203f505b8b8b8e5c931cc407c95b61556512d4921c1ddc0b3f41b08e"
+
+[[packages.wheels]]
+name = "z3_solver-4.15.4.0-py3-none-win_amd64.whl"
+upload-time = 2025-10-29 18:12:01.140381+00:00
+url = "https://files.pythonhosted.org/packages/03/d6/a0b135e4419df475177ae78fc93c422430b0fd8875649486f9a5989772e6/z3_solver-4.15.4.0-py3-none-win_amd64.whl"
+size = 16259597
+
+[packages.wheels.hashes]
+sha256 = "00e35b02632ed085ea8199fb230f6015e6fc40554a6680c097bd5f060e827431"
+
+[[packages]]
+name = "zipp"
+version = "3.23.1"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "zipp-3.23.1.tar.gz"
+upload-time = 2026-04-13 23:21:46.600996+00:00
+url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz"
+size = 25965
+
+[packages.sdist.hashes]
+sha256 = "32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110"
+
+[[packages.wheels]]
+name = "zipp-3.23.1-py3-none-any.whl"
+upload-time = 2026-04-13 23:21:45.386171+00:00
+url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl"
+size = 10378
+
+[packages.wheels.hashes]
+sha256 = "0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc"
+
+[tool.nab]
+nab-version = "0.0.2"
+created-at = 2026-05-24 15:38:04.658978+00:00
+command-line = [
+    "/home/damian/opensource/remote/projects/resolver/nab/src/nab/__main__.py",
+    "lock",
+    "--groups",
+    "crosshair",
+    "--no-emit-workspace",
+    "--output",
+    ".github/requirements/pylock.crosshair.toml",
+]
+input-path = "pyproject.toml"
+mode = "universal"
+python-specifier = ">=3.10,<3.15"
+platforms = [
+    "linux_x86_64",
+    "linux_aarch64",
+    "macos_arm64",
+    "macos_x86_64",
+    "windows_amd64",
+]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,9 +83,38 @@ jobs:
         run: pip install --no-deps -e nab-resolver -e nab-python -e nab-index -e .
 
       - name: Run property-based tests
-        # The crosshair file imports hypothesis-crosshair at module
-        # level; opt in via the [envs.crosshair] hatch env.
+        # CrossHair tests run in the dedicated crosshair-tests job; the
+        # crosshair backend is not installed here, so skip that file.
         run: python -m pytest -m property --ignore=nab-resolver/tests/property/test_crosshair_ranges.py
+
+  crosshair-tests:
+    name: CrossHair property tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          # CrossHair's concolic backend tracks stable CPython releases;
+          # use 3.12 rather than the prerelease pinned elsewhere.
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: .github/requirements/pylock.crosshair.toml
+
+      - name: Upgrade pip to PEP 751 install support
+        run: python -m pip install --upgrade "pip>=26.1"
+
+      - name: Install third-party deps
+        run: pip install -r .github/requirements/pylock.crosshair.toml
+
+      - name: Install workspace packages
+        run: pip install --no-deps -e nab-resolver -e nab-python -e nab-index -e .
+
+      - name: Run CrossHair property tests
+        run: python -m pytest -m crosshair
 
   pass:
     name: All tests pass
@@ -93,6 +122,7 @@ jobs:
     needs:
       - test
       - property-tests
+      - crosshair-tests
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/nab-resolver/tests/property/test_crosshair_ranges.py
+++ b/nab-resolver/tests/property/test_crosshair_ranges.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import pytest
 
-pytest.importorskip("hypothesis_crosshair")
+pytest.importorskip("hypothesis_crosshair_provider")
 
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,11 @@ tests = [
     "httpx[http2]>=0.28",
     "niquests>=3.18",
 ]
+crosshair = [
+    {include-group = "tests"},
+    "crosshair-tool>=0.0.104",
+    "hypothesis-crosshair>=0.0.28",
+]
 types = [
     {include-group = "tests"},
     "mypy>=1.19",

--- a/tasks/refresh-locks.sh
+++ b/tasks/refresh-locks.sh
@@ -18,7 +18,7 @@ fi
 
 EXTRA_ARGS=("$@")
 
-for group in tests types pre-commit; do
+for group in tests types pre-commit crosshair; do
     echo "==> Locking group: ${group}"
     "${NAB[@]}" lock \
         --groups "${group}" \


### PR DESCRIPTION
The CrossHair suite guarded on importorskip("hypothesis_crosshair"), but hypothesis-crosshair>=0.0.28 ships the module as hypothesis_crosshair_provider, so the suite silently skipped, even in the hatch crosshair env.

Fixes the guard and adds a crosshair-tests CI job (Python 3.12) that installs from a new pylock.crosshair.toml and runs pytest -m crosshair, gated by the pass job. The lock comes from a new crosshair dependency-group (tests plus the crosshair backend), wired into tasks/refresh-locks.sh.