### PR TITLE
Add release pipeline

### DIFF
--- a/.github/requirements/pylock.release.toml
+++ b/.github/requirements/pylock.release.toml
@@ -27,33 +27,34 @@ environments = [
     "python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
 ]
 dependency-groups = [
-    "tests",
+    "release",
 ]
 created-by = "nab"
 
 [[packages]]
-name = "anyio"
-version = "4.13.0"
-requires-python = ">=3.10"
+name = "backports-tarfile"
+version = "1.2.0"
+marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+requires-python = ">=3.8"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "anyio-4.13.0.tar.gz"
-upload-time = 2026-03-24 12:59:09.671977+00:00
-url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz"
-size = 231622
+name = "backports_tarfile-1.2.0.tar.gz"
+upload-time = 2024-05-28 17:01:54.731337+00:00
+url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz"
+size = 86406
 
 [packages.sdist.hashes]
-sha256 = "334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc"
+sha256 = "d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991"
 
 [[packages.wheels]]
-name = "anyio-4.13.0-py3-none-any.whl"
-upload-time = 2026-03-24 12:59:08.246651+00:00
-url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl"
-size = 114353
+name = "backports.tarfile-1.2.0-py3-none-any.whl"
+upload-time = 2024-05-28 17:01:53.112046+00:00
+url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl"
+size = 30181
 
 [packages.wheels.hashes]
-sha256 = "08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708"
+sha256 = "77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34"
 
 [[packages]]
 name = "build"
@@ -102,6 +103,202 @@ size = 135707
 
 [packages.wheels.hashes]
 sha256 = "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a"
+
+[[packages]]
+name = "cffi"
+version = "2.0.0"
+marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\")"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "cffi-2.0.0.tar.gz"
+upload-time = 2025-09-08 23:24:04.541971+00:00
+url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz"
+size = 523588
+
+[packages.sdist.hashes]
+sha256 = "44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+upload-time = 2025-09-08 23:22:17.427460+00:00
+url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+size = 216475
+
+[packages.wheels.hashes]
+sha256 = "fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl"
+upload-time = 2025-09-08 23:22:22.143512+00:00
+url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl"
+size = 218036
+
+[packages.wheels.hashes]
+sha256 = "8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+upload-time = 2025-09-08 23:22:13.455255+00:00
+url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+size = 216402
+
+[packages.wheels.hashes]
+sha256 = "3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl"
+upload-time = 2025-09-08 23:22:19.069108+00:00
+url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl"
+size = 218829
+
+[packages.wheels.hashes]
+sha256 = "cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+upload-time = 2025-09-08 23:22:35.443762+00:00
+url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+size = 215574
+
+[packages.wheels.hashes]
+sha256 = "8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl"
+upload-time = 2025-09-08 23:22:39.776413+00:00
+url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl"
+size = 217078
+
+[packages.wheels.hashes]
+sha256 = "5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+upload-time = 2025-09-08 23:22:31.063786+00:00
+url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+size = 216476
+
+[packages.wheels.hashes]
+sha256 = "730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl"
+upload-time = 2025-09-08 23:22:36.805953+00:00
+url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl"
+size = 218971
+
+[packages.wheels.hashes]
+sha256 = "a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+upload-time = 2025-09-08 23:22:52.902102+00:00
+url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+size = 219572
+
+[packages.wheels.hashes]
+sha256 = "3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl"
+upload-time = 2025-09-08 23:22:55.867772+00:00
+url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl"
+size = 221361
+
+[packages.wheels.hashes]
+sha256 = "2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+upload-time = 2025-09-08 23:22:48.677087+00:00
+url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+size = 220097
+
+[packages.wheels.hashes]
+sha256 = "b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl"
+upload-time = 2025-09-08 23:22:54.518730+00:00
+url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl"
+size = 222963
+
+[packages.wheels.hashes]
+sha256 = "3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+upload-time = 2025-09-08 23:23:09.648916+00:00
+url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+size = 219499
+
+[packages.wheels.hashes]
+sha256 = "c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl"
+upload-time = 2025-09-08 23:23:12.420731+00:00
+url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl"
+size = 221302
+
+[packages.wheels.hashes]
+sha256 = "6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+upload-time = 2025-09-08 23:23:04.792027+00:00
+url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+size = 220101
+
+[packages.wheels.hashes]
+sha256 = "d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl"
+upload-time = 2025-09-08 23:23:10.928601+00:00
+url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl"
+size = 222928
+
+[packages.wheels.hashes]
+sha256 = "d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+upload-time = 2025-09-08 23:23:24.541361+00:00
+url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+size = 219244
+
+[packages.wheels.hashes]
+sha256 = "afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl"
+upload-time = 2025-09-08 23:23:27.873096+00:00
+url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl"
+size = 220926
+
+[packages.wheels.hashes]
+sha256 = "38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+upload-time = 2025-09-08 23:23:20.853101+00:00
+url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+size = 220049
+
+[packages.wheels.hashes]
+sha256 = "24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl"
+upload-time = 2025-09-08 23:23:26.143606+00:00
+url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl"
+size = 222828
+
+[packages.wheels.hashes]
+sha256 = "737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205"
 
 [[packages]]
 name = "charset-normalizer"
@@ -423,334 +620,92 @@ size = 25335
 sha256 = "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
 
 [[packages]]
-name = "coverage"
-version = "7.14.0"
-requires-python = ">=3.10"
+name = "cryptography"
+version = "48.0.0"
+marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\")"
+requires-python = "!=3.9.0,!=3.9.1,>=3.9"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "coverage-7.14.0.tar.gz"
-upload-time = 2026-05-10 18:02:31.397557+00:00
-url = "https://files.pythonhosted.org/packages/23/7f/d0720730a397a999ffc0fd3f5bebef347338e3a47b727da66fbb228e2ff2/coverage-7.14.0.tar.gz"
-size = 919489
+name = "cryptography-48.0.0.tar.gz"
+upload-time = 2026-05-04 22:59:38.133475+00:00
+url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz"
+size = 832984
 
 [packages.sdist.hashes]
-sha256 = "057a6af2f160a85384cde4ab36f0d2777bae1057bae255f95413cdd382aa5c74"
+sha256 = "5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-05-10 17:59:29.479819+00:00
-url = "https://files.pythonhosted.org/packages/b5/d9/92600e89486fd074c50f0117422b2c9592c3e144e2f25bd5ac0bc62bc7a0/coverage-7.14.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 248762
+name = "cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+upload-time = 2026-05-04 22:58:48.220595+00:00
+url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+size = 4696228
 
 [packages.wheels.hashes]
-sha256 = "3fd43f0616e765ab78d069cf8358def7363957a45cee446d65c502dcfeea7893"
+sha256 = "7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 17:59:43.471850+00:00
-url = "https://files.pythonhosted.org/packages/70/db/cef0228de493f2c740c760a9057a61d00c6849480073b70a75b87c7d4bab/coverage-7.14.0-cp310-cp310-musllinux_1_2_x86_64.whl"
-size = 247544
+name = "cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl"
+upload-time = 2026-05-04 22:59:09.851839+00:00
+url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl"
+size = 4960575
 
 [packages.wheels.hashes]
-sha256 = "d128b1bba9361fbaaf6a19e179e6cfd6a9103ce0c0555876f72780acc93efd85"
+sha256 = "a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-py3-none-any.whl"
-upload-time = 2026-05-10 18:02:29.538126+00:00
-url = "https://files.pythonhosted.org/packages/61/e8/cb8e80d6f9f55b99588625062822bf946cf03ed06315df4bd8397f5632a1/coverage-7.14.0-py3-none-any.whl"
-size = 211764
+name = "cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+upload-time = 2026-05-04 22:58:46.064772+00:00
+url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+size = 4683266
 
 [packages.wheels.hashes]
-sha256 = "8de5b61163aee3d05c8a2beab6f47913df7981dad1baf82c414d99158c286ab1"
+sha256 = "614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 17:59:31.330855+00:00
-url = "https://files.pythonhosted.org/packages/0d/e1/9ea1eb9c311da7f15853559dc1d9d82bef88ecd3e59fbeb51f16bc2ffa91/coverage-7.14.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 250625
+name = "cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl"
+upload-time = 2026-05-04 22:59:07.802300+00:00
+url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl"
+size = 4822059
 
 [packages.wheels.hashes]
-sha256 = "731e535b1498b27d13594a0527a79b0510867b0ad891532be41cb883f2128e20"
+sha256 = "1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 17:59:36.232646+00:00
-url = "https://files.pythonhosted.org/packages/f0/e2/0b7898cda21041cc67546e19b80ba66cbbb47cbece52a76a5904de6a3aaf/coverage-7.14.0-cp310-cp310-musllinux_1_2_aarch64.whl"
-size = 248666
+name = "cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+upload-time = 2026-05-04 22:57:42.935070+00:00
+url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+size = 4710620
 
 [packages.wheels.hashes]
-sha256 = "0a951308cde22cf77f953955a754d04dccb57fe3bb8e345d685778ed9fc1632a"
+sha256 = "7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-macosx_11_0_arm64.whl"
-upload-time = 2026-05-10 17:59:26.095633+00:00
-url = "https://files.pythonhosted.org/packages/24/34/898546aefbd28f0af131201d0dc852c9e976f817bd7d5bfb8dc4e02863bb/coverage-7.14.0-cp310-cp310-macosx_11_0_arm64.whl"
-size = 220192
+name = "cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl"
+upload-time = 2026-05-04 22:58:03.968945+00:00
+url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl"
+size = 4972574
 
 [packages.wheels.hashes]
-sha256 = "7c843572c605ab51cfdb5c6b5f2586e2a8467c0d28eca4bdef4ec70c5fecbd82"
+sha256 = "9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-macosx_10_9_x86_64.whl"
-upload-time = 2026-05-10 17:59:23.106199+00:00
-url = "https://files.pythonhosted.org/packages/59/9d/7c83ef51c3eb495f10010094e661833588b7709946da634c8b66520b97c7/coverage-7.14.0-cp310-cp310-macosx_10_9_x86_64.whl"
-size = 219668
+name = "cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+upload-time = 2026-05-04 22:57:40.373494+00:00
+url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+size = 4690433
 
 [packages.wheels.hashes]
-sha256 = "84c32d90bf4537f0e7b4dec9aaa9a938fb8205136b9d2ecf4d7629d5262dc075"
+sha256 = "f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-win_amd64.whl"
-upload-time = 2026-05-10 17:59:46.779937+00:00
-url = "https://files.pythonhosted.org/packages/85/c0/30c454c7d3cf47b2805d4e06f12443f5eece8a5d030d3b0350e7b74ecb49/coverage-7.14.0-cp310-cp310-win_amd64.whl"
-size = 223215
+name = "cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl"
+upload-time = 2026-05-04 22:58:01.996904+00:00
+url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl"
+size = 4826672
 
 [packages.wheels.hashes]
-sha256 = "b34ece8065914f938ed7f2c5872bb865336977a52919149846eac3744327267a"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-05-10 17:59:53.244429+00:00
-url = "https://files.pythonhosted.org/packages/fd/35/202235eb5c3c14c212462cd91d61b7386bf8fc44bc7a77f4742d2a69174b/coverage-7.14.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 252633
-
-[packages.wheels.hashes]
-sha256 = "9336e23e8bb3a3925398261385e2a1533957d3e760e91070dcb0e98bfa514eed"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 18:00:06.858179+00:00
-url = "https://files.pythonhosted.org/packages/35/60/a4257538ce2f6b978aeb51870d6c4208c510928a03db7e0339bb625dccb7/coverage-7.14.0-cp311-cp311-musllinux_1_2_x86_64.whl"
-size = 251125
-
-[packages.wheels.hashes]
-sha256 = "bcb2e855b87321259a037429288ae85216d191c74de3e79bf57cd2bc0761992c"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 17:59:55.021505+00:00
-url = "https://files.pythonhosted.org/packages/bb/80/5f596e8995785124ee191c42535664c5e62c65995b66f4ca21e28ae04c81/coverage-7.14.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 254743
-
-[packages.wheels.hashes]
-sha256 = "9cd1169b2230f9cbe9c638ba38022ed7a2b1e641cc07f7cea0365e4be2a74980"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 17:59:59.688294+00:00
-url = "https://files.pythonhosted.org/packages/3d/1c/b94f9f5f36396021ee2f62c5834b12e6a3d31f0bed5d6fc6d1c3caec087c/coverage-7.14.0-cp311-cp311-musllinux_1_2_aarch64.whl"
-size = 252433
-
-[packages.wheels.hashes]
-sha256 = "5904abf7e18cddc463219b17552229650c6b79e061d31a1059283051169cf7d5"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-macosx_11_0_arm64.whl"
-upload-time = 2026-05-10 17:59:49.683626+00:00
-url = "https://files.pythonhosted.org/packages/7f/8d/46692d24b3f395d4cbf17bfcc57136b4f2f9c0c0df864b0bddfc1d71a014/coverage-7.14.0-cp311-cp311-macosx_11_0_arm64.whl"
-size = 220299
-
-[packages.wheels.hashes]
-sha256 = "a1816c505187592dcd1c5a5f226601a549f70365fbd00930ac88b0c225b76bb4"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-macosx_10_9_x86_64.whl"
-upload-time = 2026-05-10 17:59:48.198844+00:00
-url = "https://files.pythonhosted.org/packages/fc/e4/649c8d4f7f1709b6dbfc474358aa1bba02f67bcd52e2fec291a5014006cd/coverage-7.14.0-cp311-cp311-macosx_10_9_x86_64.whl"
-size = 219795
-
-[packages.wheels.hashes]
-sha256 = "6a78e2a9d9c5e3b8d4ab9b9d28c985ea66fced0a7d7c2aec1f216e03a2011480"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-win_amd64.whl"
-upload-time = 2026-05-10 18:00:10.746583+00:00
-url = "https://files.pythonhosted.org/packages/f0/f0/a71ddbd874431e7a7cd96071f0c331cfbbad07704833c765d24ffbab8a67/coverage-7.14.0-cp311-cp311-win_amd64.whl"
-size = 223241
-
-[packages.wheels.hashes]
-sha256 = "bfb0ed8ec5d25e93face268115d7964db9df8b9aae8edcde9ec6b16c726a7cc1"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-05-10 18:00:18.829529+00:00
-url = "https://files.pythonhosted.org/packages/69/ff/6699e7b71e60d3049eb2bdcbc95ee3f35707b2b0e48f32e9e63d3ce30c08/coverage-7.14.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 254576
-
-[packages.wheels.hashes]
-sha256 = "ca3d9cf2c32b521bd9518385608787fa86f38daf993695307531822c3430ed67"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 18:00:32.211009+00:00
-url = "https://files.pythonhosted.org/packages/18/9d/50f05a72dff8487464fdd4178dda5daed642a060e60afb644e3d45123559/coverage-7.14.0-cp312-cp312-musllinux_1_2_x86_64.whl"
-size = 253197
-
-[packages.wheels.hashes]
-sha256 = "fcaba850dd317c65423a9d63d88f9573c53b00354d6dd95724576cc98a131595"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 18:00:20.648358+00:00
-url = "https://files.pythonhosted.org/packages/22/ec/c936d495fcd67f48f03a9c4ad3297ff80d1f222a5df3980f15b34c186c21/coverage-7.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 255690
-
-[packages.wheels.hashes]
-sha256 = "92af52828e7f29d827346b0294e5a0853fa206db77db0395b282918d41e28db9"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 18:00:25.588879+00:00
-url = "https://files.pythonhosted.org/packages/f1/7f/9e65495298c3ea414742998539c37d048b5e81cc818fb1828cc6b51d10bf/coverage-7.14.0-cp312-cp312-musllinux_1_2_aarch64.whl"
-size = 253608
-
-[packages.wheels.hashes]
-sha256 = "8231ade007f37959fbf58acc677f26b922c02eda6f0428ea307da0fd39681bf3"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-macosx_11_0_arm64.whl"
-upload-time = 2026-05-10 18:00:15.264075+00:00
-url = "https://files.pythonhosted.org/packages/34/23/35c7aea1274aef7525bdd2dc92f710bdde6d11652239d71d1ec450067939/coverage-7.14.0-cp312-cp312-macosx_11_0_arm64.whl"
-size = 220329
-
-[packages.wheels.hashes]
-sha256 = "829994cfe1aeb773ca27bf246d4badc1e764893e3bfb98fff820fcecd1ca4662"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-macosx_10_13_x86_64.whl"
-upload-time = 2026-05-10 18:00:13.756391+00:00
-url = "https://files.pythonhosted.org/packages/09/1e/2f996b2c8415cbb6f54b0f5ec1ee850c96d7911961afb4fc05f4a89d8c58/coverage-7.14.0-cp312-cp312-macosx_10_13_x86_64.whl"
-size = 219967
-
-[packages.wheels.hashes]
-sha256 = "7ffd19fc8aed057fd686a17a4935eef5f9859d69208f96310e893e64b9b6ccf5"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-win_amd64.whl"
-upload-time = 2026-05-10 18:00:35.172847+00:00
-url = "https://files.pythonhosted.org/packages/85/19/93853133df2cb371083285ef6a93982a0173e7a233b0f61373ba9fd30eb2/coverage-7.14.0-cp312-cp312-win_amd64.whl"
-size = 223324
-
-[packages.wheels.hashes]
-sha256 = "70390b0da32cb90b501953716302906e8bcce087cb283e70d8c97729f22e92b2"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-05-10 18:00:44.079319+00:00
-url = "https://files.pythonhosted.org/packages/6f/5f/b5370068b2f57787454592ed7dcd1002f0f1703b7db1fa30f6a325a4ca6e/coverage-7.14.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 253961
-
-[packages.wheels.hashes]
-sha256 = "9d1aa57a1dc8e05bdc42e81c5d671d849577aeedf279f4c449d6d286f9ed88ca"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 18:00:57.967216+00:00
-url = "https://files.pythonhosted.org/packages/37/53/20c5009477660f084e6ed60bc02a91894b8e234e617e86ecfd9aaf78e27b/coverage-7.14.0-cp313-cp313-musllinux_1_2_x86_64.whl"
-size = 252885
-
-[packages.wheels.hashes]
-sha256 = "7b79d646cf46d5cf9a9f40281d4441df5849e445726e369006d2b117710b33fe"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 18:00:45.623804+00:00
-url = "https://files.pythonhosted.org/packages/29/1e/51adf17738976e8f2b85ddef7b7aa12a0838b056c92f175941d8862767c1/coverage-7.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 255193
-
-[packages.wheels.hashes]
-sha256 = "90c1a51bcfddf645b3bb7ec333d9e94393a8e94f55642380fa8a9a5a9e636cb7"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 18:00:51.252258+00:00
-url = "https://files.pythonhosted.org/packages/34/46/746704f95980ba220214e1a41e18cec5aea80a898eaa53c51bf2d645ff36/coverage-7.14.0-cp313-cp313-musllinux_1_2_aarch64.whl"
-size = 253325
-
-[packages.wheels.hashes]
-sha256 = "1b23b0c6f0b1db6ad769b7050c8b641c0bf215ded26c1816955b17b7f26edfa9"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-macosx_11_0_arm64.whl"
-upload-time = 2026-05-10 18:00:40.864715+00:00
-url = "https://files.pythonhosted.org/packages/b3/af/e567cbad5ba69c013a50146dfa886dc7193361fda77521f51274ff620e1b/coverage-7.14.0-cp313-cp313-macosx_11_0_arm64.whl"
-size = 220365
-
-[packages.wheels.hashes]
-sha256 = "23b81107f46d3f21d0cbce30664fcec0f5d9f585638a67081750f99738f6bf66"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-macosx_10_13_x86_64.whl"
-upload-time = 2026-05-10 18:00:38.887090+00:00
-url = "https://files.pythonhosted.org/packages/6b/76/b7c66ee3c66e1b0f9d894c8125983aa0c03fb2336f2fd16559f9c966157f/coverage-7.14.0-cp313-cp313-macosx_10_13_x86_64.whl"
-size = 219990
-
-[packages.wheels.hashes]
-sha256 = "f2bbb8254370eb4c628ff3d6fa8a7f74ddc40565394d4f7ab791d1fe568e37ef"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-win_amd64.whl"
-upload-time = 2026-05-10 18:01:01.531432+00:00
-url = "https://files.pythonhosted.org/packages/8f/b8/9228523e80321c2cb4880d1f589bc0171f2f71432c35118ad04dc01decce/coverage-7.14.0-cp313-cp313-win_amd64.whl"
-size = 223344
-
-[packages.wheels.hashes]
-sha256 = "0773d8329cf32b6fd222e4b52622c61fe8d503eb966cfc8d3c3c10c96266d50e"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-05-10 18:01:38.985686+00:00
-url = "https://files.pythonhosted.org/packages/d7/51/ec641c26e6dca1b25a7d2035ba6ecb7c884ef1a100a9e42fbe4ce4405139/coverage-7.14.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 253924
-
-[packages.wheels.hashes]
-sha256 = "5ebb8f4614a3787d567e610bbfdf96a4798dd69a1afb1bd8ad228d4111fe6ff3"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp314-cp314-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 18:01:54.506054+00:00
-url = "https://files.pythonhosted.org/packages/a4/66/2881853e0363a5e0a724d1103e53650795367471b6afb234f8b49e713bc6/coverage-7.14.0-cp314-cp314-musllinux_1_2_x86_64.whl"
-size = 252716
-
-[packages.wheels.hashes]
-sha256 = "65c86fb646d2bd2972e96bd1a8b45817ed907cee68655d6295fe7ec031d04cca"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 18:01:40.957470+00:00
-url = "https://files.pythonhosted.org/packages/33/c4/59c3de0bd1b538824173fd518fed51c1ce740ca5ed68e74545983f4053a9/coverage-7.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 255269
-
-[packages.wheels.hashes]
-sha256 = "6b9bf47223dd8db3d4c4b2e443b02bace480d428f0822c3f991600448a176c97"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp314-cp314-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 18:01:46.175307+00:00
-url = "https://files.pythonhosted.org/packages/ee/df/6770eaa576e604575e9a78055313250faef5faa84bd6f71a39fece519c43/coverage-7.14.0-cp314-cp314-musllinux_1_2_aarch64.whl"
-size = 253280
-
-[packages.wheels.hashes]
-sha256 = "15228a6800ce7bdf1b74800595e56db7138cecb338fdbf044806e10dcf182dfe"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp314-cp314-macosx_11_0_arm64.whl"
-upload-time = 2026-05-10 18:01:34.705980+00:00
-url = "https://files.pythonhosted.org/packages/f3/9b/4165a1d56ddc302a0e2d518fd9d412a4fd0b57562618c78c5f21c57194f5/coverage-7.14.0-cp314-cp314-macosx_11_0_arm64.whl"
-size = 220368
-
-[packages.wheels.hashes]
-sha256 = "ba3b8390db29296dbbf49e91b6fe08f990743a90c8f447ba4c2ffc29670dfa63"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp314-cp314-win_amd64.whl"
-upload-time = 2026-05-10 18:01:58.497925+00:00
-url = "https://files.pythonhosted.org/packages/f9/58/6e1b8f52fdc3184b47dc5037f5070d83a3d11042db1594b02d2a44d786c8/coverage-7.14.0-cp314-cp314-win_amd64.whl"
-size = 223600
-
-[packages.wheels.hashes]
-sha256 = "45e0f79d8351fa76e256716df91eab12890d32678b9590df7ae1042e4bd4cf5d"
+sha256 = "59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321"
 
 [[packages]]
 name = "docstring-parser"
@@ -777,197 +732,76 @@ size = 22484
 sha256 = "b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b"
 
 [[packages]]
-name = "exceptiongroup"
-version = "1.3.1"
-marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
-requires-python = ">=3.7"
-index = "https://pypi.org/simple/"
-
-[packages.sdist]
-name = "exceptiongroup-1.3.1.tar.gz"
-upload-time = 2025-11-21 23:01:54.787772+00:00
-url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz"
-size = 30371
-
-[packages.sdist.hashes]
-sha256 = "8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219"
-
-[[packages.wheels]]
-name = "exceptiongroup-1.3.1-py3-none-any.whl"
-upload-time = 2025-11-21 23:01:53.443434+00:00
-url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl"
-size = 16740
-
-[packages.wheels.hashes]
-sha256 = "a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598"
-
-[[packages]]
-name = "h11"
-version = "0.16.0"
-requires-python = ">=3.8"
-index = "https://pypi.org/simple/"
-
-[packages.sdist]
-name = "h11-0.16.0.tar.gz"
-upload-time = 2025-04-24 03:35:25.427659+00:00
-url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz"
-size = 101250
-
-[packages.sdist.hashes]
-sha256 = "4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"
-
-[[packages.wheels]]
-name = "h11-0.16.0-py3-none-any.whl"
-upload-time = 2025-04-24 03:35:24.344199+00:00
-url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl"
-size = 37515
-
-[packages.wheels.hashes]
-sha256 = "63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"
-
-[[packages]]
-name = "h2"
-version = "4.3.0"
+name = "docutils"
+version = "0.22.4"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "h2-4.3.0.tar.gz"
-upload-time = 2025-08-23 18:12:19.778573+00:00
-url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz"
-size = 2152026
+name = "docutils-0.22.4.tar.gz"
+upload-time = 2025-12-18 19:00:26.443107+00:00
+url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz"
+size = 2291750
 
 [packages.sdist.hashes]
-sha256 = "6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1"
+sha256 = "4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968"
 
 [[packages.wheels]]
-name = "h2-4.3.0-py3-none-any.whl"
-upload-time = 2025-08-23 18:12:17.779568+00:00
-url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl"
-size = 61779
+name = "docutils-0.22.4-py3-none-any.whl"
+upload-time = 2025-12-18 19:00:18.077803+00:00
+url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl"
+size = 633196
 
 [packages.wheels.hashes]
-sha256 = "c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd"
+sha256 = "d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de"
 
 [[packages]]
-name = "hpack"
-version = "4.1.0"
-requires-python = ">=3.9"
-index = "https://pypi.org/simple/"
-
-[packages.sdist]
-name = "hpack-4.1.0.tar.gz"
-upload-time = 2025-01-22 21:44:58.347520+00:00
-url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz"
-size = 51276
-
-[packages.sdist.hashes]
-sha256 = "ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca"
-
-[[packages.wheels]]
-name = "hpack-4.1.0-py3-none-any.whl"
-upload-time = 2025-01-22 21:44:56.920811+00:00
-url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl"
-size = 34357
-
-[packages.wheels.hashes]
-sha256 = "157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496"
-
-[[packages]]
-name = "httpcore"
-version = "1.0.9"
-requires-python = ">=3.8"
-index = "https://pypi.org/simple/"
-
-[packages.sdist]
-name = "httpcore-1.0.9.tar.gz"
-upload-time = 2025-04-24 22:06:22.219726+00:00
-url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz"
-size = 85484
-
-[packages.sdist.hashes]
-sha256 = "6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"
-
-[[packages.wheels]]
-name = "httpcore-1.0.9-py3-none-any.whl"
-upload-time = 2025-04-24 22:06:20.566605+00:00
-url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl"
-size = 78784
-
-[packages.wheels.hashes]
-sha256 = "2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"
-
-[[packages]]
-name = "httpx"
-version = "0.28.1"
-requires-python = ">=3.8"
-index = "https://pypi.org/simple/"
-
-[packages.sdist]
-name = "httpx-0.28.1.tar.gz"
-upload-time = 2024-12-06 15:37:23.222462+00:00
-url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz"
-size = 141406
-
-[packages.sdist.hashes]
-sha256 = "75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"
-
-[[packages.wheels]]
-name = "httpx-0.28.1-py3-none-any.whl"
-upload-time = 2024-12-06 15:37:21.509172+00:00
-url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl"
-size = 73517
-
-[packages.wheels.hashes]
-sha256 = "d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"
-
-[[packages]]
-name = "hyperframe"
-version = "6.1.0"
-requires-python = ">=3.9"
-index = "https://pypi.org/simple/"
-
-[packages.sdist]
-name = "hyperframe-6.1.0.tar.gz"
-upload-time = 2025-01-22 21:41:49.302049+00:00
-url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz"
-size = 26566
-
-[packages.sdist.hashes]
-sha256 = "f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08"
-
-[[packages.wheels]]
-name = "hyperframe-6.1.0-py3-none-any.whl"
-upload-time = 2025-01-22 21:41:47.295426+00:00
-url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl"
-size = 13007
-
-[packages.wheels.hashes]
-sha256 = "b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5"
-
-[[packages]]
-name = "hypothesis"
-version = "6.152.6"
+name = "hatchling"
+version = "1.29.0"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "hypothesis-6.152.6.tar.gz"
-upload-time = 2026-05-11 13:12:59.888173+00:00
-url = "https://files.pythonhosted.org/packages/f0/09/f5219c8fd75ff1f270a6f691df651c206e9316b9d0ce2cbd8b6f82844e1e/hypothesis-6.152.6.tar.gz"
-size = 467945
+name = "hatchling-1.29.0.tar.gz"
+upload-time = 2026-02-23 19:42:06.539606+00:00
+url = "https://files.pythonhosted.org/packages/cf/9c/b4cfe330cd4f49cff17fd771154730555fa4123beb7f292cf0098b4e6c20/hatchling-1.29.0.tar.gz"
+size = 55656
 
 [packages.sdist.hashes]
-sha256 = "4a3f21e9a7349a17616626e9010f04360b02e6bf8ff15fdc7c53e76d5517c1e8"
+sha256 = "793c31816d952cee405b83488ce001c719f325d9cda69f1fc4cd750527640ea6"
 
 [[packages.wheels]]
-name = "hypothesis-6.152.6-py3-none-any.whl"
-upload-time = 2026-05-11 13:12:56.182055+00:00
-url = "https://files.pythonhosted.org/packages/5f/1c/ed568eca3a963dc3e447b01961ae653e0d6f107c2cfd77b3f2b1a5cfc520/hypothesis-6.152.6-py3-none-any.whl"
-size = 533724
+name = "hatchling-1.29.0-py3-none-any.whl"
+upload-time = 2026-02-23 19:42:05.197639+00:00
+url = "https://files.pythonhosted.org/packages/d3/8a/44032265776062a89171285ede55a0bdaadc8ac00f27f0512a71a9e3e1c8/hatchling-1.29.0-py3-none-any.whl"
+size = 76356
 
 [packages.wheels.hashes]
-sha256 = "b20ffc532e5f2901229348d10ed7cb37fd9723ebf4799df663d2dce1cdce4e32"
+sha256 = "50af9343281f34785fab12da82e445ed987a6efb34fd8c2fc0f6e6630dbcc1b0"
+
+[[packages]]
+name = "id"
+version = "1.6.1"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "id-1.6.1.tar.gz"
+upload-time = 2026-02-04 16:19:41.260133+00:00
+url = "https://files.pythonhosted.org/packages/6d/04/c2156091427636080787aac190019dc64096e56a23b7364d3c1764ee3a06/id-1.6.1.tar.gz"
+size = 18088
+
+[packages.sdist.hashes]
+sha256 = "d0732d624fb46fd4e7bc4e5152f00214450953b9e772c182c1c22964def1a069"
+
+[[packages.wheels]]
+name = "id-1.6.1-py3-none-any.whl"
+upload-time = 2026-02-04 16:19:40.051745+00:00
+url = "https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl"
+size = 14689
+
+[packages.wheels.hashes]
+sha256 = "f5ec41ed2629a508f5d0988eda142e190c9c6da971100612c4de9ad9f9b237ca"
 
 [[packages]]
 name = "idna"
@@ -996,7 +830,7 @@ sha256 = "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"
 [[packages]]
 name = "importlib-metadata"
 version = "9.0.0"
-marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
@@ -1017,30 +851,6 @@ size = 27789
 
 [packages.wheels.hashes]
 sha256 = "2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7"
-
-[[packages]]
-name = "iniconfig"
-version = "2.3.0"
-requires-python = ">=3.10"
-index = "https://pypi.org/simple/"
-
-[packages.sdist]
-name = "iniconfig-2.3.0.tar.gz"
-upload-time = 2025-10-18 21:55:43.219048+00:00
-url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz"
-size = 20503
-
-[packages.sdist.hashes]
-sha256 = "c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"
-
-[[packages.wheels]]
-name = "iniconfig-2.3.0-py3-none-any.whl"
-upload-time = 2025-10-18 21:55:41.639305+00:00
-url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl"
-size = 7484
-
-[packages.wheels.hashes]
-sha256 = "f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"
 
 [[packages]]
 name = "installer"
@@ -1067,106 +877,266 @@ size = 464455
 sha256 = "011d045df8b954ced7dde3a7e42ae4418da40ecda7990f2d11d5ed7c146fd98b"
 
 [[packages]]
-name = "jh2"
-version = "5.0.11"
-requires-python = ">=3.7"
+name = "jaraco-classes"
+version = "3.4.0"
+requires-python = ">=3.8"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "jh2-5.0.11.tar.gz"
-upload-time = 2026-04-05 07:33:51.119491+00:00
-url = "https://files.pythonhosted.org/packages/a3/ea/ebd7cbba422317fdd4be5e04a5aa9a54192b8c483f20eb38c85cf9fb8adc/jh2-5.0.11.tar.gz"
-size = 7320877
+name = "jaraco.classes-3.4.0.tar.gz"
+upload-time = 2024-03-31 07:27:36.643708+00:00
+url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz"
+size = 11780
 
 [packages.sdist.hashes]
-sha256 = "6c835b0b38d795dde7aaa4581626490ca5fcfbd4eefe9572ac18d9eb2427d215"
+sha256 = "47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd"
 
 [[packages.wheels]]
-name = "jh2-5.0.11-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-upload-time = 2026-04-05 07:31:51.855788+00:00
-url = "https://files.pythonhosted.org/packages/8c/a4/b80fd188fa006a144cd4f280fdfd3808e3715aaa805fa830e828406080ed/jh2-5.0.11-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-size = 399371
+name = "jaraco.classes-3.4.0-py3-none-any.whl"
+upload-time = 2024-03-31 07:27:34.792832+00:00
+url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl"
+size = 6777
 
 [packages.wheels.hashes]
-sha256 = "6d15672b32f0891940691bac16a854af164e694f0b9d21bebfddd13e3c7d2f03"
-
-[[packages.wheels]]
-name = "jh2-5.0.11-cp37-abi3-musllinux_1_1_x86_64.whl"
-upload-time = 2026-04-05 07:32:00.681248+00:00
-url = "https://files.pythonhosted.org/packages/82/55/db34614186693ce66c69af384659c5f37fa79699c81c8867cec2fe4dc566/jh2-5.0.11-cp37-abi3-musllinux_1_1_x86_64.whl"
-size = 603360
-
-[packages.wheels.hashes]
-sha256 = "b0ad821964a7701e2b80c6f8b424b6d4ca575fefb1aa04227967ef78fa15fcd5"
-
-[[packages.wheels]]
-name = "jh2-5.0.11-py3-none-any.whl"
-upload-time = 2026-04-05 07:33:49.430003+00:00
-url = "https://files.pythonhosted.org/packages/6a/17/512d0ac0484aca136e698498d6441b6072156fb2d618d8096a07578f67ad/jh2-5.0.11-py3-none-any.whl"
-size = 98207
-
-[packages.wheels.hashes]
-sha256 = "aafd357af8d0de5267d3bc88e2384da30f05c38446a61425ae565925bc2ca9ba"
-
-[[packages.wheels]]
-name = "jh2-5.0.11-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-upload-time = 2026-04-05 07:31:43.814809+00:00
-url = "https://files.pythonhosted.org/packages/5f/61/fc161568713450214d3c48db614d871f9393bd88db471e10ac868f5a7214/jh2-5.0.11-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-size = 393320
-
-[packages.wheels.hashes]
-sha256 = "85cf4f09f7159c29967212af685d2819f960d9136d931420fef107683d121f56"
-
-[[packages.wheels]]
-name = "jh2-5.0.11-cp37-abi3-musllinux_1_1_aarch64.whl"
-upload-time = 2026-04-05 07:31:55.228492+00:00
-url = "https://files.pythonhosted.org/packages/ac/8d/59dd21f1ed6f451f60581522e08e42f3e74275b1568ef9c7936a06445108/jh2-5.0.11-cp37-abi3-musllinux_1_1_aarch64.whl"
-size = 569633
-
-[packages.wheels.hashes]
-sha256 = "6cd51dd02943b703e10eb536722c5fd205b6084333dac5b9c114bdbbc2c46b3a"
-
-[[packages.wheels]]
-name = "jh2-5.0.11-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"
-upload-time = 2026-04-05 07:31:42.411086+00:00
-url = "https://files.pythonhosted.org/packages/0a/f0/0363ffb6ed11a76d47c6a543f16c3c3e6efedc27853fa1ef95df557c0724/jh2-5.0.11-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"
-size = 622317
-
-[packages.wheels.hashes]
-sha256 = "4dc82aee3ab2c4103f3d9092f4463dd6cc4a248ab6a27a4acab79bef0d3ac8dd"
-
-[[packages.wheels]]
-name = "jh2-5.0.11-cp37-abi3-win_amd64.whl"
-upload-time = 2026-04-05 07:32:04.021109+00:00
-url = "https://files.pythonhosted.org/packages/5a/60/69a4fcc00a01fa65bbf67279e21886325087491250bc54af3e12e86c8532/jh2-5.0.11-cp37-abi3-win_amd64.whl"
-size = 251415
-
-[packages.wheels.hashes]
-sha256 = "e28dabffcbd5525bf5f36d482764e3e56b513bce06a75b2fb4b540bedad80348"
+sha256 = "f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790"
 
 [[packages]]
-name = "niquests"
-version = "3.18.8"
+name = "jaraco-context"
+version = "6.1.2"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "jaraco_context-6.1.2.tar.gz"
+upload-time = 2026-03-20 22:13:33.922545+00:00
+url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz"
+size = 16801
+
+[packages.sdist.hashes]
+sha256 = "f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3"
+
+[[packages.wheels]]
+name = "jaraco_context-6.1.2-py3-none-any.whl"
+upload-time = 2026-03-20 22:13:32.808832+00:00
+url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl"
+size = 7871
+
+[packages.wheels.hashes]
+sha256 = "bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535"
+
+[[packages]]
+name = "jaraco-functools"
+version = "4.5.0"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "jaraco_functools-4.5.0.tar.gz"
+upload-time = 2026-05-15 21:34:10.025782+00:00
+url = "https://files.pythonhosted.org/packages/36/cf/ea4ef2920830dea3f5ab2ea4da6fb67724e6dca80ee2553788c3607243d0/jaraco_functools-4.5.0.tar.gz"
+size = 20272
+
+[packages.sdist.hashes]
+sha256 = "3bb5665ea4a020cf78a7040e89154c77edadb3ca74f366479669c5999aa70b03"
+
+[[packages.wheels]]
+name = "jaraco_functools-4.5.0-py3-none-any.whl"
+upload-time = 2026-05-15 21:34:08.595564+00:00
+url = "https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl"
+size = 10594
+
+[packages.wheels.hashes]
+sha256 = "79ce39246eddbde4b3a03b77ea5f0f7878dc669b166a66cf3fa8e266aa3fa2f4"
+
+[[packages]]
+name = "jeepney"
+version = "0.9.0"
+marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\")"
 requires-python = ">=3.7"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "niquests-3.18.8.tar.gz"
-upload-time = 2026-05-10 05:29:15.663354+00:00
-url = "https://files.pythonhosted.org/packages/ae/3f/3cbfd81c507c4d58b57afc04d75b6feb00cbcdeba43852a7506100af2eae/niquests-3.18.8.tar.gz"
-size = 1028824
+name = "jeepney-0.9.0.tar.gz"
+upload-time = 2025-02-27 18:51:01.684959+00:00
+url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz"
+size = 106758
 
 [packages.sdist.hashes]
-sha256 = "06244ef4d1c93b067295b22c1d7a8938be948af1227d368c22acf531f61fdf57"
+sha256 = "cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732"
 
 [[packages.wheels]]
-name = "niquests-3.18.8-py3-none-any.whl"
-upload-time = 2026-05-10 05:29:14.003251+00:00
-url = "https://files.pythonhosted.org/packages/1a/2c/01d6978e16536922baaafad903adbc55880b11f23595f90a3b52478ce234/niquests-3.18.8-py3-none-any.whl"
-size = 208878
+name = "jeepney-0.9.0-py3-none-any.whl"
+upload-time = 2025-02-27 18:51:00.104279+00:00
+url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl"
+size = 49010
 
 [packages.wheels.hashes]
-sha256 = "9b1a3a378277bfca4b2438877d0954e989e4d3f3f75da7bb83bf7204dfa5f1cf"
+sha256 = "97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683"
+
+[[packages]]
+name = "keyring"
+version = "25.7.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "keyring-25.7.0.tar.gz"
+upload-time = 2025-11-16 16:26:09.482176+00:00
+url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz"
+size = 63516
+
+[packages.sdist.hashes]
+sha256 = "fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b"
+
+[[packages.wheels]]
+name = "keyring-25.7.0-py3-none-any.whl"
+upload-time = 2025-11-16 16:26:08.402146+00:00
+url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl"
+size = 39160
+
+[packages.wheels.hashes]
+sha256 = "be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f"
+
+[[packages]]
+name = "markdown-it-py"
+version = "4.2.0"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "markdown_it_py-4.2.0.tar.gz"
+upload-time = 2026-05-07 12:08:28.360612+00:00
+url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz"
+size = 82454
+
+[packages.sdist.hashes]
+sha256 = "04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49"
+
+[[packages.wheels]]
+name = "markdown_it_py-4.2.0-py3-none-any.whl"
+upload-time = 2026-05-07 12:08:27.182789+00:00
+url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl"
+size = 91687
+
+[packages.wheels.hashes]
+sha256 = "9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a"
+
+[[packages]]
+name = "mdurl"
+version = "0.1.2"
+requires-python = ">=3.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "mdurl-0.1.2.tar.gz"
+upload-time = 2022-08-14 12:40:10.846281+00:00
+url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz"
+size = 8729
+
+[packages.sdist.hashes]
+sha256 = "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"
+
+[[packages.wheels]]
+name = "mdurl-0.1.2-py3-none-any.whl"
+upload-time = 2022-08-14 12:40:09.779676+00:00
+url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl"
+size = 9979
+
+[packages.wheels.hashes]
+sha256 = "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"
+
+[[packages]]
+name = "more-itertools"
+version = "11.0.2"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "more_itertools-11.0.2.tar.gz"
+upload-time = 2026-04-09 15:01:33.297914+00:00
+url = "https://files.pythonhosted.org/packages/a2/f7/139d22fef48ac78127d18e01d80cf1be40236ae489769d17f35c3d425293/more_itertools-11.0.2.tar.gz"
+size = 144659
+
+[packages.sdist.hashes]
+sha256 = "392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804"
+
+[[packages.wheels]]
+name = "more_itertools-11.0.2-py3-none-any.whl"
+upload-time = 2026-04-09 15:01:32.210520+00:00
+url = "https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl"
+size = 71939
+
+[packages.wheels.hashes]
+sha256 = "6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4"
+
+[[packages]]
+name = "nh3"
+version = "0.3.5"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "nh3-0.3.5.tar.gz"
+upload-time = 2026-04-25 10:44:16.066088+00:00
+url = "https://files.pythonhosted.org/packages/9c/5f/1d19bdc7d27238e37f3672cdc02cb77c56a4a86d140cd4f4f23c90df6e16/nh3-0.3.5.tar.gz"
+size = 20743
+
+[packages.sdist.hashes]
+sha256 = "45855e14ff056064fec77133bfcf7cd691838168e5e17bbef075394954dc9dc8"
+
+[[packages.wheels]]
+name = "nh3-0.3.5-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-04-25 10:44:01.743347+00:00
+url = "https://files.pythonhosted.org/packages/1b/0e/bf298920729f216adcb002acf7ea01b90842603d2e4e2ce9b900d9ee8fab/nh3-0.3.5-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 806976
+
+[packages.wheels.hashes]
+sha256 = "fe3a787dc76b50de6bee54ef242f26c41dfe47654428e3e94f0fae5bb6dd2cc1"
+
+[[packages.wheels]]
+name = "nh3-0.3.5-cp38-abi3-musllinux_1_2_x86_64.whl"
+upload-time = 2026-04-25 10:44:10.775616+00:00
+url = "https://files.pythonhosted.org/packages/ce/cb/7a39e72e668c8445bdd95e494b3e21cfdddc68329be8ea3522c8befb46c4/nh3-0.3.5-cp38-abi3-musllinux_1_2_x86_64.whl"
+size = 1040938
+
+[packages.wheels.hashes]
+sha256 = "e49c9b564e6bcb03ecd2f057213df9a0de15a95812ac9db9600b590db23d3ae9"
+
+[[packages.wheels]]
+name = "nh3-0.3.5-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-04-25 10:43:55.073909+00:00
+url = "https://files.pythonhosted.org/packages/25/8c/072120d506978ab053e1732d0efa7c86cb478fee0ee098fda0ac0d31cb34/nh3-0.3.5-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 837722
+
+[packages.wheels.hashes]
+sha256 = "50d401ab2d8e86d59e2126e3ab2a2f45840c405842b626d9a51624b3a33b6878"
+
+[[packages.wheels]]
+name = "nh3-0.3.5-cp38-abi3-musllinux_1_2_aarch64.whl"
+upload-time = 2026-04-25 10:44:06.180431+00:00
+url = "https://files.pythonhosted.org/packages/58/36/734d353dfaf292fed574b8b3092f0ef79dc6404f3879f7faaa61a4701fad/nh3-0.3.5-cp38-abi3-musllinux_1_2_aarch64.whl"
+size = 1018600
+
+[packages.wheels.hashes]
+sha256 = "eeedc90ed8c42c327e8e10e621ccfa314fc6cce35d5929f4297ff1cdb89667c4"
+
+[[packages.wheels]]
+name = "nh3-0.3.5-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"
+upload-time = 2026-04-25 10:43:53.556226+00:00
+url = "https://files.pythonhosted.org/packages/85/30/d162e99746a2fb1d98bb0ef23af3e201b156cf09f7de867c7390c8fe1c06/nh3-0.3.5-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"
+size = 1442393
+
+[packages.wheels.hashes]
+sha256 = "3bb854485c9b33e5bb143ff3e49e577073bc6bc320f0ff8fc316dd89c0d3c101"
+
+[[packages.wheels]]
+name = "nh3-0.3.5-cp38-abi3-win_amd64.whl"
+upload-time = 2026-04-25 10:44:13.682532+00:00
+url = "https://files.pythonhosted.org/packages/db/1a/e4c9b5e2ae13e6092c9ec16d8ca30646cb01fcdea245f36c5b08fd21fbd5/nh3-0.3.5-cp38-abi3-win_amd64.whl"
+size = 626502
+
+[packages.wheels.hashes]
+sha256 = "45e6a65dc88a300a2e3502cb9c8e6d1d6b831d6fba7470643333609c6aab1f30"
 
 [[packages]]
 name = "packaging"
@@ -1193,6 +1163,30 @@ size = 100195
 sha256 = "5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"
 
 [[packages]]
+name = "pathspec"
+version = "1.1.1"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pathspec-1.1.1.tar.gz"
+upload-time = 2026-04-27 01:46:08.907631+00:00
+url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz"
+size = 135180
+
+[packages.sdist.hashes]
+sha256 = "17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a"
+
+[[packages.wheels]]
+name = "pathspec-1.1.1-py3-none-any.whl"
+upload-time = 2026-04-27 01:46:07.060850+00:00
+url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl"
+size = 57328
+
+[packages.wheels.hashes]
+sha256 = "a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189"
+
+[[packages]]
 name = "pluggy"
 version = "1.6.0"
 requires-python = ">=3.9"
@@ -1215,6 +1209,31 @@ size = 20538
 
 [packages.wheels.hashes]
 sha256 = "e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
+
+[[packages]]
+name = "pycparser"
+version = "3.0"
+marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\")"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pycparser-3.0.tar.gz"
+upload-time = 2026-01-21 14:26:51.890565+00:00
+url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz"
+size = 103492
+
+[packages.sdist.hashes]
+sha256 = "600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"
+
+[[packages.wheels]]
+name = "pycparser-3.0-py3-none-any.whl"
+upload-time = 2026-01-21 14:26:50.693739+00:00
+url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl"
+size = 48172
+
+[packages.wheels.hashes]
+sha256 = "b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"
 
 [[packages]]
 name = "pygments"
@@ -1265,168 +1284,174 @@ size = 10216
 sha256 = "9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913"
 
 [[packages]]
-name = "pytest"
-version = "9.0.3"
+name = "pywin32-ctypes"
+version = "0.2.3"
+marker = "(python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+requires-python = ">=3.6"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pywin32-ctypes-0.2.3.tar.gz"
+upload-time = 2024-08-14 10:15:34.626878+00:00
+url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz"
+size = 29471
+
+[packages.sdist.hashes]
+sha256 = "d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755"
+
+[[packages.wheels]]
+name = "pywin32_ctypes-0.2.3-py3-none-any.whl"
+upload-time = 2024-08-14 10:15:33.187242+00:00
+url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl"
+size = 30756
+
+[packages.wheels.hashes]
+sha256 = "8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8"
+
+[[packages]]
+name = "readme-renderer"
+version = "44.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "readme_renderer-44.0.tar.gz"
+upload-time = 2024-07-08 15:00:57.805068+00:00
+url = "https://files.pythonhosted.org/packages/5a/a9/104ec9234c8448c4379768221ea6df01260cd6c2ce13182d4eac531c8342/readme_renderer-44.0.tar.gz"
+size = 32056
+
+[packages.sdist.hashes]
+sha256 = "8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1"
+
+[[packages.wheels]]
+name = "readme_renderer-44.0-py3-none-any.whl"
+upload-time = 2024-07-08 15:00:56.577790+00:00
+url = "https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl"
+size = 13310
+
+[packages.wheels.hashes]
+sha256 = "2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151"
+
+[[packages]]
+name = "requests"
+version = "2.34.2"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "pytest-9.0.3.tar.gz"
-upload-time = 2026-04-07 17:16:18.027317+00:00
-url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz"
-size = 1572165
+name = "requests-2.34.2.tar.gz"
+upload-time = 2026-05-14 19:25:27.735762+00:00
+url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz"
+size = 142856
 
 [packages.sdist.hashes]
-sha256 = "b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"
+sha256 = "f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed"
 
 [[packages.wheels]]
-name = "pytest-9.0.3-py3-none-any.whl"
-upload-time = 2026-04-07 17:16:16.130051+00:00
-url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl"
-size = 375249
+name = "requests-2.34.2-py3-none-any.whl"
+upload-time = 2026-05-14 19:25:26.443000+00:00
+url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl"
+size = 73075
 
 [packages.wheels.hashes]
-sha256 = "2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"
+sha256 = "2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"
 
 [[packages]]
-name = "pytest-timeout"
-version = "2.4.0"
+name = "requests-toolbelt"
+version = "1.0.0"
+requires-python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "requests-toolbelt-1.0.0.tar.gz"
+upload-time = 2023-05-01 04:11:33.229998+00:00
+url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz"
+size = 206888
+
+[packages.sdist.hashes]
+sha256 = "7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6"
+
+[[packages.wheels]]
+name = "requests_toolbelt-1.0.0-py2.py3-none-any.whl"
+upload-time = 2023-05-01 04:11:28.427086+00:00
+url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl"
+size = 54481
+
+[packages.wheels.hashes]
+sha256 = "cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06"
+
+[[packages]]
+name = "rfc3986"
+version = "2.0.0"
 requires-python = ">=3.7"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "pytest_timeout-2.4.0.tar.gz"
-upload-time = 2025-05-05 19:44:34.990551+00:00
-url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz"
-size = 17973
+name = "rfc3986-2.0.0.tar.gz"
+upload-time = 2022-01-10 00:52:30.832978+00:00
+url = "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz"
+size = 49026
 
 [packages.sdist.hashes]
-sha256 = "7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a"
+sha256 = "97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c"
 
 [[packages.wheels]]
-name = "pytest_timeout-2.4.0-py3-none-any.whl"
-upload-time = 2025-05-05 19:44:33.502941+00:00
-url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl"
-size = 14382
+name = "rfc3986-2.0.0-py2.py3-none-any.whl"
+upload-time = 2022-01-10 00:52:29.594625+00:00
+url = "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl"
+size = 31326
 
 [packages.wheels.hashes]
-sha256 = "c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2"
+sha256 = "50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd"
 
 [[packages]]
-name = "qh3"
-version = "1.8.1"
-requires-python = ">=3.7"
+name = "rich"
+version = "15.0.0"
+requires-python = ">=3.9.0"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "qh3-1.8.1.tar.gz"
-upload-time = 2026-05-07 09:38:00.192710+00:00
-url = "https://files.pythonhosted.org/packages/0a/83/8a57595b1c8ba57f70abcb731db647b3beabad52f76e282e1fc7f666c5a0/qh3-1.8.1.tar.gz"
-size = 335758
+name = "rich-15.0.0.tar.gz"
+upload-time = 2026-04-12 08:24:00.750018+00:00
+url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz"
+size = 230680
 
 [packages.sdist.hashes]
-sha256 = "28d5d73903850d5733eb4c7f6cc3a81d40099f98204b5c8482330a1fb7ca92c8"
+sha256 = "edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36"
 
 [[packages.wheels]]
-name = "qh3-1.8.1-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-upload-time = 2026-05-07 09:35:47.426062+00:00
-url = "https://files.pythonhosted.org/packages/53/96/c435fecb8d420ec2924c11fbc396ad8d9d7b4861ac4e48dfb8631fc1d3bf/qh3-1.8.1-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-size = 2358583
+name = "rich-15.0.0-py3-none-any.whl"
+upload-time = 2026-04-12 08:24:02.830783+00:00
+url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl"
+size = 310654
 
 [packages.wheels.hashes]
-sha256 = "c23816f4f4e017528cb30eef697aa607578ad42d3111ae7552c73666021d5268"
-
-[[packages.wheels]]
-name = "qh3-1.8.1-cp37-abi3-musllinux_1_1_x86_64.whl"
-upload-time = 2026-05-07 09:35:57.745088+00:00
-url = "https://files.pythonhosted.org/packages/54/f3/6e16cf55f42aec85af2c2c5ae5fd46a2a8eefe80f1f6b669a1b5969a7172/qh3-1.8.1-cp37-abi3-musllinux_1_1_x86_64.whl"
-size = 2585895
-
-[packages.wheels.hashes]
-sha256 = "2bd4b95d4c9e9e5a4df36867aa344feae8d7b5a511d56035603ccbbb41b00a84"
-
-[[packages.wheels]]
-name = "qh3-1.8.1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-upload-time = 2026-05-07 09:35:36.802088+00:00
-url = "https://files.pythonhosted.org/packages/50/82/282a7250c84ae3ece859f97a2023e063255be7e70c5b99b08fca7ed59d99/qh3-1.8.1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-size = 2161987
-
-[packages.wheels.hashes]
-sha256 = "1d09950baf910e3cb0053d546a8fd8bdb7dae5f4d217a88f51ffcf2dd7b1397d"
-
-[[packages.wheels]]
-name = "qh3-1.8.1-cp37-abi3-musllinux_1_1_aarch64.whl"
-upload-time = 2026-05-07 09:35:50.701011+00:00
-url = "https://files.pythonhosted.org/packages/8c/14/faae208dfea35db41cf016c5622fd694b45f25fe09f29f683140de145529/qh3-1.8.1-cp37-abi3-musllinux_1_1_aarch64.whl"
-size = 2350931
-
-[packages.wheels.hashes]
-sha256 = "8e4cfc6d8ae494f0ae052492f1fc51ad1a3ce7eb3f4ed3bc0276fc7e3f4ee1c5"
-
-[[packages.wheels]]
-name = "qh3-1.8.1-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"
-upload-time = 2026-05-07 09:35:35.011094+00:00
-url = "https://files.pythonhosted.org/packages/b0/5b/2ea75701d7e9fe81d60f4307cbd370d023879e7ad65c30af5dcf335f5ab0/qh3-1.8.1-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"
-size = 4432070
-
-[packages.wheels.hashes]
-sha256 = "576cfd6a657f3b5f574e601500461d586b2e7037fa24ea876f5f724a10f2f552"
-
-[[packages.wheels]]
-name = "qh3-1.8.1-cp37-abi3-win_amd64.whl"
-upload-time = 2026-05-07 09:36:00.836853+00:00
-url = "https://files.pythonhosted.org/packages/1d/e8/3f871ea3f1d4e17536f38410c5c333b4aa3c60f74350eb91799d482243de/qh3-1.8.1-cp37-abi3-win_amd64.whl"
-size = 2129090
-
-[packages.wheels.hashes]
-sha256 = "d4c53c82f7cef0a2a8714cc3c48fca970f496132542483ad1489fb8f2b9c70c5"
+sha256 = "33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb"
 
 [[packages]]
-name = "respx"
-version = "0.23.1"
-requires-python = ">=3.8"
+name = "secretstorage"
+version = "3.5.0"
+marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\")"
+requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "respx-0.23.1.tar.gz"
-upload-time = 2026-04-08 14:37:16.008390+00:00
-url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz"
-size = 29243
+name = "secretstorage-3.5.0.tar.gz"
+upload-time = 2025-11-23 19:02:53.191898+00:00
+url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz"
+size = 19884
 
 [packages.sdist.hashes]
-sha256 = "242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780"
+sha256 = "f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be"
 
 [[packages.wheels]]
-name = "respx-0.23.1-py2.py3-none-any.whl"
-upload-time = 2026-04-08 14:37:14.613510+00:00
-url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl"
-size = 25557
+name = "secretstorage-3.5.0-py3-none-any.whl"
+upload-time = 2025-11-23 19:02:51.545472+00:00
+url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl"
+size = 15554
 
 [packages.wheels.hashes]
-sha256 = "b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a"
-
-[[packages]]
-name = "sortedcontainers"
-version = "2.4.0"
-index = "https://pypi.org/simple/"
-
-[packages.sdist]
-name = "sortedcontainers-2.4.0.tar.gz"
-upload-time = 2021-05-16 22:03:42.897871+00:00
-url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz"
-size = 30594
-
-[packages.sdist.hashes]
-sha256 = "25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"
-
-[[packages.wheels]]
-name = "sortedcontainers-2.4.0-py2.py3-none-any.whl"
-upload-time = 2021-05-16 22:03:41.177807+00:00
-url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl"
-size = 29575
-
-[packages.wheels.hashes]
-sha256 = "a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"
+sha256 = "0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137"
 
 [[packages]]
 name = "tomli"
@@ -1744,28 +1769,75 @@ size = 41328
 sha256 = "4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738"
 
 [[packages]]
-name = "typeguard"
-version = "4.5.1"
+name = "trove-classifiers"
+version = "2026.5.7.17"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "trove_classifiers-2026.5.7.17.tar.gz"
+upload-time = 2026-05-07 17:48:01.931976+00:00
+url = "https://files.pythonhosted.org/packages/35/68/175e7c07c5be13200387d5c0995b0da1e198e360047c08eb17d1002fcd92/trove_classifiers-2026.5.7.17.tar.gz"
+size = 17041
+
+[packages.sdist.hashes]
+sha256 = "a04a48f8f0a787cb996514d3969ac7608aa3c60cb15d073c1e02801e60533e80"
+
+[[packages.wheels]]
+name = "trove_classifiers-2026.5.7.17-py3-none-any.whl"
+upload-time = 2026-05-07 17:48:00.488420+00:00
+url = "https://files.pythonhosted.org/packages/7b/e3/d81b065a2d866a33a541ac63a2a4cc5737e03ce2379ac3191c98bb8867e3/trove_classifiers-2026.5.7.17-py3-none-any.whl"
+size = 14201
+
+[packages.wheels.hashes]
+sha256 = "5ec0800de5e2ddbd7c663cb4c0c15328f132dc168813897c18866c5c7b93db33"
+
+[[packages]]
+name = "twine"
+version = "6.2.0"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "typeguard-4.5.1.tar.gz"
-upload-time = 2026-02-19 16:09:03.392674+00:00
-url = "https://files.pythonhosted.org/packages/2b/e8/66e25efcc18542d58706ce4e50415710593721aae26e794ab1dec34fb66f/typeguard-4.5.1.tar.gz"
-size = 80121
+name = "twine-6.2.0.tar.gz"
+upload-time = 2025-09-04 15:43:17.255745+00:00
+url = "https://files.pythonhosted.org/packages/e0/a8/949edebe3a82774c1ec34f637f5dd82d1cf22c25e963b7d63771083bbee5/twine-6.2.0.tar.gz"
+size = 172262
 
 [packages.sdist.hashes]
-sha256 = "f6f8ecbbc819c9bc749983cc67c02391e16a9b43b8b27f15dc70ed7c4a007274"
+sha256 = "e5ed0d2fd70c9959770dce51c8f39c8945c574e18173a7b81802dab51b4b75cf"
 
 [[packages.wheels]]
-name = "typeguard-4.5.1-py3-none-any.whl"
-upload-time = 2026-02-19 16:09:01.600074+00:00
-url = "https://files.pythonhosted.org/packages/91/88/b55b3117287a8540b76dbdd87733808d4d01c8067a3b339408c250bb3600/typeguard-4.5.1-py3-none-any.whl"
-size = 36745
+name = "twine-6.2.0-py3-none-any.whl"
+upload-time = 2025-09-04 15:43:15.994841+00:00
+url = "https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl"
+size = 42727
 
 [packages.wheels.hashes]
-sha256 = "44d2bf329d49a244110a090b55f5f91aa82d9a9834ebfd30bcc73651e4a8cc40"
+sha256 = "418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8"
+
+[[packages]]
+name = "typeguard"
+version = "4.5.2"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "typeguard-4.5.2.tar.gz"
+upload-time = 2026-05-14 12:59:40.857502+00:00
+url = "https://files.pythonhosted.org/packages/67/1c/dfba5c4633cafc4c701f237d2ba63b416805047fd6d96aab4cfc40969f98/typeguard-4.5.2.tar.gz"
+size = 80240
+
+[packages.sdist.hashes]
+sha256 = "5a16dcac23502039299c97c8941651bc33d7ea8cc4b2f7d6bbb1b528f6eea423"
+
+[[packages.wheels]]
+name = "typeguard-4.5.2-py3-none-any.whl"
+upload-time = 2026-05-14 12:59:39.473017+00:00
+url = "https://files.pythonhosted.org/packages/5b/29/74eeb4d3f3ae61ca096b018ad486b3b3c74b17bec09ab4edab721cbefec3/typeguard-4.5.2-py3-none-any.whl"
+size = 36748
+
+[packages.wheels.hashes]
+sha256 = "fcf9de18bd945cdb4c7b996e12b4c51ce83f92f191314a6d7cf1739586ec98cf"
 
 [[packages]]
 name = "typing-extensions"
@@ -1840,57 +1912,9 @@ size = 131087
 sha256 = "9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
 
 [[packages]]
-name = "urllib3-future"
-version = "2.20.904"
-requires-python = ">=3.7"
-index = "https://pypi.org/simple/"
-
-[packages.sdist]
-name = "urllib3_future-2.20.904.tar.gz"
-upload-time = 2026-05-13 03:11:05.401055+00:00
-url = "https://files.pythonhosted.org/packages/63/d9/ef97b7a7364e4e14eff0a0a81e4ea359ec00e68412c656a4e21ba2ce5eb4/urllib3_future-2.20.904.tar.gz"
-size = 1276622
-
-[packages.sdist.hashes]
-sha256 = "11aa6b3eda9a1c8da9716c22481af8e3b761f0e9785b51baad0810e4cdb4db96"
-
-[[packages.wheels]]
-name = "urllib3_future-2.20.904-py3-none-any.whl"
-upload-time = 2026-05-13 03:11:03.608235+00:00
-url = "https://files.pythonhosted.org/packages/62/1a/d73ab2738c374c224b755545a8791112572d3d966a37d79749c56ec3f3fc/urllib3_future-2.20.904-py3-none-any.whl"
-size = 754436
-
-[packages.wheels.hashes]
-sha256 = "2813888d84e0ff461fb14e94ce6a808dc875c6a776335ad4a473fcaeb58cee67"
-
-[[packages]]
-name = "wassima"
-version = "2.1.0"
-requires-python = ">=3.7"
-index = "https://pypi.org/simple/"
-
-[packages.sdist]
-name = "wassima-2.1.0.tar.gz"
-upload-time = 2026-05-10 04:07:21.576289+00:00
-url = "https://files.pythonhosted.org/packages/58/e0/10e0ff85dc4d48b5000aa76567dfacf33b9518c2fadd410e850e213c36b9/wassima-2.1.0.tar.gz"
-size = 135950
-
-[packages.sdist.hashes]
-sha256 = "709f375c778d9be84568d802d1e1b62a2ed3942b1fa4c83830533a69cf36c243"
-
-[[packages.wheels]]
-name = "wassima-2.1.0-py3-none-any.whl"
-upload-time = 2026-05-10 04:07:19.900031+00:00
-url = "https://files.pythonhosted.org/packages/53/f9/077b0aacd337c31d3f97eef7acfa89bcd522360b56614f961af84db0a3ca/wassima-2.1.0-py3-none-any.whl"
-size = 128092
-
-[packages.wheels.hashes]
-sha256 = "4e8bc4b439f91f4da24bd2260be662fcb42d1cc439d7678420237d314e55a854"
-
-[[packages]]
 name = "zipp"
 version = "3.23.1"
-marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -1914,15 +1938,15 @@ sha256 = "0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc"
 
 [tool.nab]
 nab-version = "0.0.2"
-created-at = 2026-05-20 04:01:36.148929+00:00
+created-at = 2026-05-25 02:58:47.561385+00:00
 command-line = [
     "/home/damian/opensource/remote/projects/resolver/nab/src/nab/__main__.py",
     "lock",
     "--groups",
-    "tests",
+    "release",
     "--no-emit-workspace",
     "--output",
-    ".github/requirements/pylock.tests.toml",
+    ".github/requirements/pylock.release.toml",
 ]
 input-path = "pyproject.toml"
 mode = "universal"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,101 @@
+name: Release
+
+# Publishing a GitHub release (against a v* tag created by the release PR) is the
+# trigger and the human gate. Nothing publishes until you click Publish there.
+on:
+  release:
+    types: [published]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
+
+env:
+  FORCE_COLOR: "1"
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+jobs:
+  build:
+    name: Build and validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      # Default checkout ref for a release event is the tag's commit.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      # No pip cache: a workflow that publishes artifacts must not trust a
+      # runtime cache (zizmor cache-poisoning), and build deps are hash-pinned.
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Upgrade pip to PEP 751 install support
+        run: python -m pip install --upgrade "pip>=26.1"
+
+      - name: Install release toolchain
+        run: pip install -r .github/requirements/pylock.release.toml
+
+      - name: Verify the tag matches the package versions
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: python tasks/release.py check "${RELEASE_TAG}"
+
+      - name: Build, verify reproducibility, check metadata, smoke test
+        run: python tasks/build_dists.py
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # The pypi environment matches the trusted-publisher config (OIDC).
+    environment:
+      name: pypi
+      url: https://pypi.org/project/nab/
+    permissions:
+      id-token: write  # OIDC for PyPI trusted publishing; nothing else needs it
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: dist
+          path: dist
+
+      - name: Publish nab-resolver
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+        with:
+          packages-dir: dist/nab-resolver
+          print-hash: true
+          skip-existing: true
+
+      - name: Publish nab-index
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+        with:
+          packages-dir: dist/nab-index
+          print-hash: true
+          skip-existing: true
+
+      - name: Publish nab-python
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+        with:
+          packages-dir: dist/nab-python
+          print-hash: true
+          skip-existing: true
+
+      - name: Publish nab
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+        with:
+          packages-dir: dist/nab
+          print-hash: true
+          skip-existing: true

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,35 @@
+# Releasing
+
+All four packages release together at one version (lockstep).
+
+## Cut a release
+
+1. From an up-to-date, clean `main`, run:
+
+   ```
+   hatch run release:make 0.0.3
+   ```
+
+   This creates a `release/0.0.3` branch with two commits (the `0.0.3` release,
+   then a return to `0.0.4.dev0`), tags the release commit `v0.0.3`, pushes the
+   branch and tag, and prints a link to open the PR.
+
+2. Open the PR from that link and review the version bump.
+
+3. Merge it with a merge commit, not a squash, so the `0.0.3` commit and the tag
+   stay in history.
+
+4. Draft a GitHub release for the `v0.0.3` tag, click "Generate release notes",
+   and publish it. That triggers the release workflow, which builds and validates
+   all four packages and publishes them to PyPI via trusted publishing. Approve
+   the `pypi` deployment in the Actions tab when prompted.
+
+## Notes
+
+- Prereleases work: `hatch run release:make 0.0.3rc1`.
+- The changelog is the generated GitHub release notes (a list of merged PRs).
+- The workflow runs `tasks/release.py check` and `tasks/build_dists.py`; both
+  install only from `.github/requirements/pylock.release.toml`.
+- After changing a dependency group, regenerate the locks with
+  `tasks/refresh-locks.sh`.
+- To abort before publishing, delete the branch and the tag.

--- a/hatch.toml
+++ b/hatch.toml
@@ -70,3 +70,15 @@ dependencies = [
 build = "sphinx-build -W -b html docs docs/_build/html {args}"
 serve = "sphinx-autobuild docs docs/_build/html {args}"
 clean = "rm -rf docs/_build"
+
+[envs.release]
+detached = true
+
+[envs.release.scripts]
+# Install only the hash-pinned lock; never resolve unpinned dependencies.
+_sync = [
+    'python -m pip install --upgrade "pip>=26.1"',
+    "python -m pip install -r .github/requirements/pylock.release.toml",
+]
+make = ["_sync", "python tasks/release.py make {args}"]
+build = ["_sync", "python tasks/build_dists.py {args}"]

--- a/nab-index/pyproject.toml
+++ b/nab-index/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-index"
-version = "0.0.2"
+version = "0.0.3.dev0"
 description = "PyPI Simple-API client and on-disk cache for nab"
 readme = "README.md"
 license = "MIT"
@@ -33,7 +33,7 @@ Homepage = "https://github.com/notatallshaw/nab"
 Documentation = "https://nab.readthedocs.io/"
 Issues = "https://github.com/notatallshaw/nab/issues"
 Source = "https://github.com/notatallshaw/nab"
-Changelog = "https://github.com/notatallshaw/nab/blob/main/CHANGELOG.md"
+Changelog = "https://github.com/notatallshaw/nab/releases"
 
 [build-system]
 requires = ["hatchling"]

--- a/nab-python/pyproject.toml
+++ b/nab-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-python"
-version = "0.0.2"
+version = "0.0.3.dev0"
 description = "Index-backed provider, lockfile emitter, and downloader for nab"
 readme = "README.md"
 license = "MIT"
@@ -19,8 +19,8 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "nab-resolver==0.0.2",
-    "nab-index==0.0.2",
+    "nab-resolver==0.0.3.dev0",
+    "nab-index==0.0.3.dev0",
     "tomli>=2.0",
     "tomli_w>=1.2",
     "build>=1.2",
@@ -34,7 +34,7 @@ Homepage = "https://github.com/notatallshaw/nab"
 Documentation = "https://nab.readthedocs.io/"
 Issues = "https://github.com/notatallshaw/nab/issues"
 Source = "https://github.com/notatallshaw/nab"
-Changelog = "https://github.com/notatallshaw/nab/blob/main/CHANGELOG.md"
+Changelog = "https://github.com/notatallshaw/nab/releases"
 
 [build-system]
 requires = ["hatchling"]

--- a/nab-resolver/pyproject.toml
+++ b/nab-resolver/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-resolver"
-version = "0.0.2"
+version = "0.0.3.dev0"
 description = "Generic PubGrub dependency-resolver core"
 readme = "README.md"
 license = "MIT"
@@ -27,7 +27,7 @@ Homepage = "https://github.com/notatallshaw/nab"
 Documentation = "https://nab.readthedocs.io/"
 Issues = "https://github.com/notatallshaw/nab/issues"
 Source = "https://github.com/notatallshaw/nab"
-Changelog = "https://github.com/notatallshaw/nab/blob/main/CHANGELOG.md"
+Changelog = "https://github.com/notatallshaw/nab/releases"
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab"
-version = "0.0.2"
+version = "0.0.3.dev0"
 description = "PubGrub-based dependency resolver for Python packages"
 readme = "README.md"
 license = "MIT"
@@ -19,22 +19,22 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "nab-resolver==0.0.2",
-    "nab-python==0.0.2",
-    "nab-index==0.0.2",
+    "nab-resolver==0.0.3.dev0",
+    "nab-python==0.0.3.dev0",
+    "nab-index==0.0.3.dev0",
     "tyro>=1.0",
 ]
 
 [project.optional-dependencies]
-httpx = ["nab-index[httpx]==0.0.2"]
-niquests = ["nab-index[niquests]==0.0.2"]
+httpx = ["nab-index[httpx]==0.0.3.dev0"]
+niquests = ["nab-index[niquests]==0.0.3.dev0"]
 
 [project.urls]
 Homepage = "https://github.com/notatallshaw/nab"
 Documentation = "https://nab.readthedocs.io/"
 Issues = "https://github.com/notatallshaw/nab/issues"
 Source = "https://github.com/notatallshaw/nab"
-Changelog = "https://github.com/notatallshaw/nab/blob/main/CHANGELOG.md"
+Changelog = "https://github.com/notatallshaw/nab/releases"
 
 [project.scripts]
 nab = "nab.cli:main"
@@ -54,6 +54,7 @@ tests = [
     "respx>=0.22",
     "httpx[http2]>=0.28",
     "niquests>=3.18",
+    "tomlkit>=0.13",
 ]
 crosshair = [
     {include-group = "tests"},
@@ -70,6 +71,14 @@ types = [
 ]
 pre-commit = [
     "pre-commit>=4",
+]
+release = [
+    "packaging>=24.0",
+    "tomlkit>=0.13",
+    "tyro>=1.0",
+    "build>=1.2",
+    "hatchling>=1.27",
+    "twine>=6.1",
 ]
 
 # `nab lock` config: universal mode resolves the full matrix in one
@@ -201,6 +210,15 @@ extend-exclude = ["**/_vendor/**"]
     "PLR2004",  # Magic value in comparison (benchmark thresholds)
     "SLF001",   # Private member access (sibling scripts share helpers)
     "N818",     # Exception name not Error-suffixed (private signal types)
+]
+
+# Release tooling prints, shells out to git, and lives outside any package.
+"tasks/**" = [
+    "T201",     # print (CLI output)
+    "S603",     # subprocess call
+    "S607",     # subprocess with partial executable path (git)
+    "INP001",   # implicit namespace package (scripts live outside packages)
+    "PLC2801",  # direct __replace__ call (copy.replace is 3.13+, we support 3.10)
 ]
 
 # Tests use their own per-directory ruff.toml that extends this config.

--- a/tasks/build_dists.py
+++ b/tasks/build_dists.py
@@ -1,0 +1,146 @@
+"""Build, verify, and smoke-test the nab distributions for a release.
+
+Builds all four packages into ``dist/<package>`` with a pinned timestamp, proves
+the build is reproducible by building a second time and comparing hashes, runs
+``twine check --strict``, and installs the built ``nab`` into a throwaway venv to
+confirm the CLI runs. The publish workflow calls this; nothing here uploads.
+
+Run through hatch::
+
+    hatch run release:build
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# The umbrella package lives at the repo root; the rest are subdirectories.
+PACKAGES = ("nab-resolver", "nab-index", "nab-python", "nab")
+
+
+def _require_tools(*tools: str) -> None:
+    """Exit early if any required external tool is missing from PATH."""
+    missing = [tool for tool in tools if shutil.which(tool) is None]
+    if missing:
+        msg = f"required tools not found on PATH: {', '.join(missing)}"
+        raise SystemExit(msg)
+
+
+def _run(
+    command: list[str], *, env: dict[str, str] | None = None, capture: bool = False
+) -> str:
+    """Run a command in the repo root, exiting cleanly if it is missing or fails."""
+    try:
+        result = subprocess.run(
+            command,
+            check=True,
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=capture,
+            text=True,
+        )
+    except FileNotFoundError:
+        msg = f"command not found: {command[0]}"
+        raise SystemExit(msg) from None
+    except subprocess.CalledProcessError as error:
+        details = (error.stderr or "").strip()
+        msg = f"command failed ({' '.join(command)}):\n{details}".rstrip()
+        raise SystemExit(msg) from error
+    return (result.stdout or "").strip() if capture else ""
+
+
+def _source_dir(package: str) -> Path:
+    """Return the source directory for a workspace package."""
+    return REPO_ROOT if package == "nab" else REPO_ROOT / package
+
+
+def _source_date_epoch() -> str:
+    """Return the committer timestamp of HEAD for reproducible builds."""
+    return _run(["git", "log", "-1", "--pretty=%ct"], capture=True)
+
+
+def build_all(outdir: Path, source_date_epoch: str) -> None:
+    """Build every package into ``outdir/<package>`` with a fixed timestamp."""
+    env = {**os.environ, "SOURCE_DATE_EPOCH": source_date_epoch}
+    for package in PACKAGES:
+        _run(
+            [
+                sys.executable,
+                "-m",
+                "build",
+                "--no-isolation",
+                "--outdir",
+                str(outdir / package),
+                str(_source_dir(package)),
+            ],
+            env=env,
+        )
+
+
+def _artifact_hashes(root: Path) -> dict[str, str]:
+    """Map each built sdist/wheel name under ``root`` to its sha256."""
+    hashes: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file() and path.name.endswith((".whl", ".tar.gz")):
+            hashes[path.name] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return hashes
+
+
+def verify_reproducible(dist: Path, source_date_epoch: str) -> None:
+    """Build into ``dist``, build again into a temp dir, and compare hashes."""
+    build_all(dist, source_date_epoch)
+    first = _artifact_hashes(dist)
+    with tempfile.TemporaryDirectory() as tmp:
+        build_all(Path(tmp), source_date_epoch)
+        second = _artifact_hashes(Path(tmp))
+    if first != second:
+        msg = "build is not reproducible: artifact hashes differ between builds"
+        raise SystemExit(msg)
+
+
+def twine_check(dist: Path) -> None:
+    """Run ``twine check --strict`` over every built artifact."""
+    artifacts = [
+        str(path)
+        for path in sorted(dist.rglob("*"))
+        if path.is_file() and path.name.endswith((".whl", ".tar.gz"))
+    ]
+    _run([sys.executable, "-m", "twine", "check", "--strict", *artifacts])
+
+
+def smoke_test(dist: Path) -> None:
+    """Install the built nab into a throwaway venv and run ``nab --help``."""
+    with tempfile.TemporaryDirectory() as tmp:
+        venv = Path(tmp) / "venv"
+        _run([sys.executable, "-m", "venv", str(venv)])
+        bindir = venv / ("Scripts" if os.name == "nt" else "bin")
+        python = str(bindir / "python")
+        _run([python, "-m", "pip", "install", "--upgrade", "pip"])
+        find_links: list[str] = []
+        for package in PACKAGES:
+            find_links += ["--find-links", str(dist / package)]
+        _run([python, "-m", "pip", "install", *find_links, "nab"])
+        _run([str(bindir / "nab"), "--help"])
+
+
+def main() -> None:
+    """Build, verify reproducibility, check metadata, and smoke-test."""
+    _require_tools("git")
+    dist = REPO_ROOT / "dist"
+    source_date_epoch = _source_date_epoch()
+    verify_reproducible(dist, source_date_epoch)
+    twine_check(dist)
+    smoke_test(dist)
+    print("dist/ built, reproducible, metadata-checked, and smoke-tested.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/refresh-locks.sh
+++ b/tasks/refresh-locks.sh
@@ -18,7 +18,7 @@ fi
 
 EXTRA_ARGS=("$@")
 
-for group in tests types pre-commit crosshair; do
+for group in tests types pre-commit crosshair release; do
     echo "==> Locking group: ${group}"
     "${NAB[@]}" lock \
         --groups "${group}" \

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1,0 +1,281 @@
+"""Cut a lockstep release of the nab workspace packages.
+
+``make X.Y.Z`` branches off main, writes two commits (the release version, then a
+return to development), tags the release commit, and pushes the branch and tag.
+You open the PR from that branch yourself. Publishing happens later: merge the PR
+with a merge commit, then publish the tag's release in the GitHub UI, which
+triggers the publish workflow. ``check`` verifies a tag matches the manifests and
+is what that workflow runs before building.
+
+Run through hatch::
+
+    hatch run release:make 0.0.3
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Annotated, Any
+
+import tomlkit
+import tyro
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+from packaging.version import InvalidVersion, Version
+from tyro.extras import SubcommandApp
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+WORKSPACE_PACKAGES = ("nab-resolver", "nab-python", "nab-index")
+_WORKSPACE = {canonicalize_name(name) for name in WORKSPACE_PACKAGES}
+
+PYPROJECT_PATHS = (
+    REPO_ROOT / "pyproject.toml",
+    REPO_ROOT / "nab-resolver" / "pyproject.toml",
+    REPO_ROOT / "nab-python" / "pyproject.toml",
+    REPO_ROOT / "nab-index" / "pyproject.toml",
+)
+
+
+def cross_pin(version: str) -> str:
+    """Return the cross-pin specifier for a workspace dependency."""
+    return f"=={version}"
+
+
+def is_dev_version(version: str) -> bool:
+    """Return whether the version is a PEP 440 development release."""
+    try:
+        return Version(version).is_devrelease
+    except InvalidVersion:
+        return False
+
+
+def is_release_version(version: str) -> bool:
+    """Return whether the version parses and is neither a dev nor a local version."""
+    try:
+        parsed = Version(version)
+    except InvalidVersion:
+        return False
+    return not parsed.is_devrelease and parsed.local is None
+
+
+def next_dev_version(release: str) -> str:
+    """Return the development version after a release, bumping the last component."""
+    version = Version(release)
+    bumped = (*version.release[:-1], version.release[-1] + 1)
+    return str(
+        version.__replace__(release=bumped, dev=0, pre=None, post=None, local=None)
+    )
+
+
+def _rewrite_requirement(dependency: str, version: str) -> str:
+    """Rewrite a workspace cross-pin to ``==version``; leave others unchanged."""
+    requirement = Requirement(dependency)
+    if canonicalize_name(requirement.name) not in _WORKSPACE:
+        return dependency
+    extras = f"[{','.join(sorted(requirement.extras))}]" if requirement.extras else ""
+    return f"{requirement.name}{extras}{cross_pin(version)}"
+
+
+def _dependency_arrays(project: Any) -> list[Any]:
+    """Return every dependency array in a parsed ``[project]`` table."""
+    arrays: list[Any] = []
+    if "dependencies" in project:
+        arrays.append(project["dependencies"])
+    if "optional-dependencies" in project:
+        arrays.extend(project["optional-dependencies"].values())
+    return arrays
+
+
+def apply_version(version: str) -> None:
+    """Write the version and rewrite workspace cross-pins in every pyproject."""
+    for path in PYPROJECT_PATHS:
+        document = tomlkit.parse(path.read_text(encoding="utf-8"))
+        document["project"]["version"] = version
+        for array in _dependency_arrays(document["project"]):
+            for index, dependency in enumerate(array):
+                array[index] = _rewrite_requirement(str(dependency), version)
+        path.write_text(tomlkit.dumps(document), encoding="utf-8")
+
+
+def read_current_version() -> str:
+    """Return the lockstep version, requiring every package to agree."""
+    versions: set[str] = set()
+    for path in PYPROJECT_PATHS:
+        document = tomlkit.parse(path.read_text(encoding="utf-8"))
+        versions.add(str(document["project"]["version"]))
+    if len(versions) != 1:
+        msg = f"workspace versions are not in lockstep: {sorted(versions)}"
+        raise ValueError(msg)
+    return versions.pop()
+
+
+def check_release(tag: str) -> None:
+    """Verify the working tree is a clean release matching ``tag``.
+
+    Confirms the ``vX.Y.Z`` tag matches every package version, that the version
+    is not a development version, and that every cross-pin is exactly
+    ``==X.Y.Z``. The publish workflow runs this before it builds.
+    """
+    if not tag.startswith("v"):
+        msg = f"release tag {tag!r} must start with 'v'"
+        raise SystemExit(msg)
+    expected = tag[1:]
+    version = read_current_version()
+    if version != expected:
+        msg = f"tag {tag!r} does not match package version {version!r}"
+        raise SystemExit(msg)
+    if is_dev_version(version):
+        msg = f"refusing to release a dev version {version!r}"
+        raise SystemExit(msg)
+    wanted = cross_pin(version)
+    for path in PYPROJECT_PATHS:
+        document = tomlkit.parse(path.read_text(encoding="utf-8"))
+        for array in _dependency_arrays(document["project"]):
+            for dependency in array:
+                requirement = Requirement(str(dependency))
+                specifier = str(requirement.specifier)
+                if (
+                    canonicalize_name(requirement.name) in _WORKSPACE
+                    and specifier != wanted
+                ):
+                    msg = (
+                        f"{path}: {requirement.name} is pinned "
+                        f"{specifier!r}, expected {wanted!r}"
+                    )
+                    raise SystemExit(msg)
+    print(f"{tag}: all packages at {version} with consistent cross-pins.")
+
+
+def _plan(
+    release: str, current: str, next_dev: str | None
+) -> tuple[str, str, str, str]:
+    """Validate inputs and return ``(release, dev, branch, tag)``."""
+    if not is_release_version(release):
+        msg = f"{release!r} is not a release version"
+        raise SystemExit(msg)
+    if not is_dev_version(current):
+        msg = f"current version is {current!r}, expected a .dev version"
+        raise SystemExit(msg)
+    dev = next_dev or next_dev_version(release)
+    if not is_dev_version(dev):
+        msg = f"{dev!r} is not a dev version"
+        raise SystemExit(msg)
+    return release, dev, f"release/{release}", f"v{release}"
+
+
+def _require_tools(*tools: str) -> None:
+    """Exit early if any required external tool is missing from PATH."""
+    missing = [tool for tool in tools if shutil.which(tool) is None]
+    if missing:
+        msg = f"required tools not found on PATH: {', '.join(missing)}"
+        raise SystemExit(msg)
+
+
+def _run(program: str, *args: str) -> str:
+    """Run a command in the repo root, exiting cleanly on failure."""
+    try:
+        result = subprocess.run(
+            [program, *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+        )
+    except FileNotFoundError:
+        msg = f"command not found: {program}"
+        raise SystemExit(msg) from None
+    except subprocess.CalledProcessError as error:
+        details = (error.stderr or error.stdout or "").strip()
+        msg = f"command failed ({program} {' '.join(args)}):\n{details}"
+        raise SystemExit(msg) from error
+    return result.stdout.strip()
+
+
+def _github_slug(remote_url: str) -> str | None:
+    """Return ``owner/repo`` from a GitHub remote URL, or None if not GitHub."""
+    if "github.com" not in remote_url:
+        return None
+    return remote_url.removesuffix(".git").split("github.com", 1)[-1].strip(":/")
+
+
+def _pr_url(branch: str) -> str | None:
+    """Return the GitHub create-PR URL for a pushed branch, if origin is GitHub."""
+    slug = _github_slug(_run("git", "remote", "get-url", "origin"))
+    if slug is None:
+        return None
+    return f"https://github.com/{slug}/pull/new/{branch}"
+
+
+def _make(release: str, next_dev: str | None, *, assume_yes: bool, push: bool) -> None:
+    """Make the release branch: two commits, the tag, and push it."""
+    _require_tools("git")
+    if _run("git", "rev-parse", "--abbrev-ref", "HEAD") != "main":
+        msg = "releases are cut from main"
+        raise SystemExit(msg)
+    if _run("git", "status", "--porcelain"):
+        msg = "working tree is not clean"
+        raise SystemExit(msg)
+    current = read_current_version()
+    release, dev, branch, tag = _plan(release, current, next_dev)
+    if _run("git", "tag", "--list", tag):
+        msg = f"tag {tag} already exists; delete it to redo"
+        raise SystemExit(msg)
+
+    print(f"Release {release} on {branch}, tag {tag}, then main to {dev}.")
+    if not assume_yes and input("Proceed? [y/N] ").strip().lower() != "y":
+        msg = "aborted"
+        raise SystemExit(msg)
+
+    _run("git", "switch", "--create", branch)
+    apply_version(release)
+    _run("git", "add", "--all")
+    _run("git", "commit", "--message", f"Release {release}")
+    _run("git", "tag", "--annotate", tag, "--message", tag)
+    apply_version(dev)
+    _run("git", "add", "--all")
+    _run("git", "commit", "--message", "Back to development")
+
+    if push:
+        _run("git", "push", "--set-upstream", "origin", branch)
+        _run("git", "push", "origin", tag)
+    _run("git", "switch", "main")
+
+    if not push:
+        print(f"Built {branch} and {tag} locally (not pushed).")
+        return
+    location = _pr_url(branch) or f"branch {branch}"
+    print(f"Pushed {branch} and {tag}.")
+    print(f"Open a PR into main ({location}); merge with a merge commit, not squash.")
+
+
+app = SubcommandApp()
+
+
+@app.command
+def make(
+    version: Annotated[str, tyro.conf.Positional],
+    next_dev: str | None = None,
+    *,
+    yes: bool = False,
+    no_push: bool = False,
+) -> None:
+    """Branch, bump, tag, and push a release, then open the PR yourself."""
+    _make(version, next_dev, assume_yes=yes, push=not no_push)
+
+
+@app.command
+def check(tag: Annotated[str, tyro.conf.Positional]) -> None:
+    """Verify the working tree matches a release tag (run by the publish workflow)."""
+    check_release(tag)
+
+
+def main() -> None:
+    """Entry point for the release tooling."""
+    app.cli(prog="release")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_build_dists.py
+++ b/tests/test_build_dists.py
@@ -1,0 +1,35 @@
+"""Tests for the distribution build helpers in tasks/build_dists.py."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+from pathlib import Path
+
+_PATH = Path(__file__).resolve().parents[1] / "tasks" / "build_dists.py"
+_spec = importlib.util.spec_from_file_location("nab_build_dists", _PATH)
+assert _spec is not None
+assert _spec.loader is not None
+build_dists = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(build_dists)
+
+
+def test_source_dir_maps_umbrella_to_root() -> None:
+    assert build_dists._source_dir("nab") == build_dists.REPO_ROOT
+    assert (
+        build_dists._source_dir("nab-resolver")
+        == build_dists.REPO_ROOT / "nab-resolver"
+    )
+
+
+def test_artifact_hashes_picks_only_distributions(tmp_path: Path) -> None:
+    pkg = tmp_path / "nab"
+    pkg.mkdir()
+    (pkg / "nab-0.0.3-py3-none-any.whl").write_bytes(b"wheel")
+    (pkg / "nab-0.0.3.tar.gz").write_bytes(b"sdist")
+    (pkg / "notes.txt").write_bytes(b"ignore me")
+
+    hashes = build_dists._artifact_hashes(tmp_path)
+
+    assert set(hashes) == {"nab-0.0.3-py3-none-any.whl", "nab-0.0.3.tar.gz"}
+    assert hashes["nab-0.0.3.tar.gz"] == hashlib.sha256(b"sdist").hexdigest()

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,0 +1,190 @@
+"""Tests for the release tooling in tasks/release.py."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+from packaging.version import InvalidVersion
+
+pytest.importorskip("tomlkit")
+
+_PATH = Path(__file__).resolve().parents[1] / "tasks" / "release.py"
+_spec = importlib.util.spec_from_file_location("nab_release_tasks", _PATH)
+assert _spec is not None
+assert _spec.loader is not None
+release = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(release)
+
+
+def _make_tree(tmp_path: Path, version: str, pin: str) -> tuple[Path, Path]:
+    root = tmp_path / "pyproject.toml"
+    member = tmp_path / "nab-python" / "pyproject.toml"
+    member.parent.mkdir()
+    root.write_text(
+        f'[project]\nname = "nab"\nversion = "{version}"\n'
+        f'dependencies = ["nab-python=={pin}"]\n',
+        encoding="utf-8",
+    )
+    member.write_text(
+        f'[project]\nname = "nab-python"\nversion = "{version}"\n'
+        'dependencies = ["typing_extensions>=4.6"]\n',
+        encoding="utf-8",
+    )
+    return root, member
+
+
+def test_cross_pin() -> None:
+    assert release.cross_pin("0.0.3") == "==0.0.3"
+
+
+def test_is_dev_version() -> None:
+    assert release.is_dev_version("0.0.4.dev0")
+    assert not release.is_dev_version("0.0.3")
+    assert not release.is_dev_version("0.0.3a0")
+    assert not release.is_dev_version("not-a-version")
+
+
+def test_is_release_version() -> None:
+    assert release.is_release_version("0.0.3")
+    assert release.is_release_version("0.0.3rc1")
+    assert not release.is_release_version("0.0.3.dev0")
+    assert not release.is_release_version("0.0.3+local")
+    assert not release.is_release_version("not-a-version")
+
+
+def test_next_dev_version() -> None:
+    assert release.next_dev_version("0.0.3") == "0.0.4.dev0"
+    assert release.next_dev_version("1.2.0") == "1.2.1.dev0"
+
+
+def test_next_dev_version_rejects_invalid() -> None:
+    with pytest.raises(InvalidVersion):
+        release.next_dev_version("not-a-version")
+
+
+def test_rewrite_requirement_updates_workspace_pins() -> None:
+    assert (
+        release._rewrite_requirement("nab-resolver==0.0.2", "0.0.3")
+        == "nab-resolver==0.0.3"
+    )
+    assert (
+        release._rewrite_requirement("nab-index[httpx]==0.0.2", "0.0.3")
+        == "nab-index[httpx]==0.0.3"
+    )
+
+
+def test_rewrite_requirement_leaves_third_party_alone() -> None:
+    assert release._rewrite_requirement("tyro>=1.0", "0.0.3") == "tyro>=1.0"
+    assert release._rewrite_requirement("packaging>=24.0", "0.0.3") == "packaging>=24.0"
+
+
+def test_apply_version_round_trips(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, member = _make_tree(tmp_path, "0.0.2", "0.0.2")
+    monkeypatch.setattr(release, "PYPROJECT_PATHS", (root, member))
+    release.apply_version("0.0.3")
+    assert release.read_current_version() == "0.0.3"
+    assert '"nab-python==0.0.3"' in root.read_text(encoding="utf-8")
+    assert "typing_extensions>=4.6" in member.read_text(encoding="utf-8")
+
+
+def test_read_current_version_rejects_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    a = tmp_path / "a.toml"
+    b = tmp_path / "b.toml"
+    a.write_text('[project]\nname = "a"\nversion = "0.0.2"\n', encoding="utf-8")
+    b.write_text('[project]\nname = "b"\nversion = "0.0.3"\n', encoding="utf-8")
+    monkeypatch.setattr(release, "PYPROJECT_PATHS", (a, b))
+    with pytest.raises(ValueError, match="not in lockstep"):
+        release.read_current_version()
+
+
+def test_check_release_passes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root, member = _make_tree(tmp_path, "0.0.3", "0.0.3")
+    monkeypatch.setattr(release, "PYPROJECT_PATHS", (root, member))
+    release.check_release("v0.0.3")
+
+
+def test_check_release_rejects_missing_v(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, member = _make_tree(tmp_path, "0.0.3", "0.0.3")
+    monkeypatch.setattr(release, "PYPROJECT_PATHS", (root, member))
+    with pytest.raises(SystemExit, match="must start with"):
+        release.check_release("0.0.3")
+
+
+def test_check_release_rejects_tag_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, member = _make_tree(tmp_path, "0.0.3", "0.0.3")
+    monkeypatch.setattr(release, "PYPROJECT_PATHS", (root, member))
+    with pytest.raises(SystemExit, match="does not match"):
+        release.check_release("v0.0.4")
+
+
+def test_check_release_rejects_dev(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, member = _make_tree(tmp_path, "0.0.3.dev0", "0.0.3.dev0")
+    monkeypatch.setattr(release, "PYPROJECT_PATHS", (root, member))
+    with pytest.raises(SystemExit, match="dev version"):
+        release.check_release("v0.0.3.dev0")
+
+
+def test_check_release_rejects_stale_pin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, member = _make_tree(tmp_path, "0.0.3", "0.0.2")
+    monkeypatch.setattr(release, "PYPROJECT_PATHS", (root, member))
+    with pytest.raises(SystemExit, match="pinned"):
+        release.check_release("v0.0.3")
+
+
+def test_plan_returns_branch_and_tag() -> None:
+    assert release._plan("0.0.3", "0.0.3.dev0", None) == (
+        "0.0.3",
+        "0.0.4.dev0",
+        "release/0.0.3",
+        "v0.0.3",
+    )
+
+
+def test_plan_respects_explicit_next_dev() -> None:
+    assert release._plan("0.0.3", "0.0.3.dev0", "0.1.0.dev0") == (
+        "0.0.3",
+        "0.1.0.dev0",
+        "release/0.0.3",
+        "v0.0.3",
+    )
+
+
+def test_plan_rejects_non_release_version() -> None:
+    with pytest.raises(SystemExit, match="not a release version"):
+        release._plan("0.0.3.dev0", "0.0.2.dev0", None)
+
+
+def test_plan_rejects_non_dev_current() -> None:
+    with pytest.raises(SystemExit, match="expected a .dev"):
+        release._plan("0.0.3", "0.0.2", None)
+
+
+def test_plan_rejects_bad_next_dev() -> None:
+    with pytest.raises(SystemExit, match="not a dev version"):
+        release._plan("0.0.3", "0.0.3.dev0", "0.1.0")
+
+
+def test_github_slug() -> None:
+    assert (
+        release._github_slug("https://github.com/notatallshaw/nab.git")
+        == "notatallshaw/nab"
+    )
+    assert (
+        release._github_slug("git@github.com:notatallshaw/nab.git")
+        == "notatallshaw/nab"
+    )
+    assert release._github_slug("https://gitlab.com/x/y.git") is None


### PR DESCRIPTION
Adds the PyPI release pipeline and moves the workspace to dev versioning.

Flow: `hatch run release:make X.Y.Z` branches off main, writes the release and back-to-development commits, tags the release commit, and pushes the branch and tag. You open the PR yourself and merge it with a merge commit, then publish the tag's release in the GitHub UI, which triggers publishing.

- `tasks/release.py` (tyro CLI, `make` and `check`): versions via packaging (`Version.__replace__`), manifest edits via tomlkit, no hand-rolled parsing. Probes `git` up front and turns subprocess failures into clean exits. No `gh` needed; the PR is manual.
- `tasks/build_dists.py`: builds all four packages, verifies the build is reproducible, runs `twine check --strict`, and smoke-installs the CLI.
- `.github/workflows/release.yml`: triggers on a published release; the build job validates and builds, the publish job uploads each package to PyPI via trusted publishing with attestations, gated by the `pypi` environment. Actions SHA-pinned, no pip cache, least-privilege permissions.
- `release` dependency-group locked to `pylock.release.toml`; the release hatch env installs only the hash-pinned lock, never unpinned dependencies.
- Changelog is the GitHub releases page; the workspace is set to `0.0.3.dev0`.
