### PR TITLE
Omit packages.index when source unknown

### DIFF
--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -254,18 +254,16 @@ def _index_pin_from_listing(
     """Construct an :class:`IndexPin` for an index-served package.
 
     The recorded ``index`` is the URL of the configured index that
-    served the package's listing during the resolve, looked up from
-    the coordinator's :class:`InMemoryIndex` (which records the
-    serving index by name) and resolved against ``indexes`` for the
-    URL.  When ``indexes`` is empty or the route is unknown the URL
-    falls back to the default Simple-API root.
+    served the package's listing during the resolve, or ``None`` when
+    the serving index cannot be identified.  ``packages.index`` is
+    optional under PEP 751; nab does not guess when the source is
+    unknown.
 
     Under :attr:`~nab_python.provider.DistPolicy.SDIST_INSTALL` the
     package's wheels stayed in ``versions_cache`` as a possible
     metadata source for the resolver; only the sdist is emitted
     into the lock so installers download and build that archive.
     """
-    from ..fetch import DEFAULT_INDEX_URL
     from ..lockfile import IndexPin, SdistArtifact, WheelArtifact
     from ..provider import DistPolicy
 
@@ -287,17 +285,11 @@ def _index_pin_from_listing(
     requires_python = _common_requires_python(files)
     serving_name = provider.coordinator.index.get_listing_index(canonical)
     by_name = {ix.name: ix.url for ix in indexes}
-
-    if serving_name is not None and serving_name in by_name:
-        index_url = by_name[serving_name]
-    elif indexes:
-        index_url = indexes[0].url
-    else:
-        index_url = DEFAULT_INDEX_URL
+    url = by_name.get(serving_name) if serving_name is not None else None
     return IndexPin(
         name=canonical,
         version=str(version),
-        index=_strip_userinfo(index_url),
+        index=_strip_userinfo(url) if url is not None else None,
         sdist=sdist,
         wheels=wheels,
         requires_python=requires_python,

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -142,12 +142,13 @@ class IndexPin:
     """A package resolved from a Simple-API index.
 
     ``index`` is the URL of the Simple-API root that served the
-    package, matching what PEP 751 expects for ``packages.index``.
+    package, or ``None`` when the serving index cannot be identified.
+    ``packages.index`` is optional under PEP 751.
     """
 
     name: str
     version: str
-    index: str
+    index: str | None = None
     sdist: SdistArtifact | None = None
     wheels: tuple[WheelArtifact, ...] = ()
     requires_python: str | None = None

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -1168,10 +1168,14 @@ class TestBuildLockInputFromProvider:
                     (Version("1.0"), _wheel_file()),
                     (Version("1.0"), _sdist_file()),
                 ]
-            }
+            },
+            listing_indexes={"foo": "pypi"},
         )
         lock_input = build_lock_input_from_provider(
-            provider, {"foo": Version("1.0")}, requires_python=">=3.10"
+            provider,
+            {"foo": Version("1.0")},
+            requires_python=">=3.10",
+            indexes=(IndexConfig("pypi", "https://pypi.org/simple/"),),
         )
         pin = lock_input.pins["foo"]
         assert isinstance(pin, IndexPin)
@@ -1242,7 +1246,7 @@ class TestBuildLockInputFromProvider:
         assert isinstance(pin, IndexPin)
         assert pin.index == "https://download.pytorch.org/whl/cpu/"
 
-    def test_index_pin_falls_back_to_default_when_route_missing(self) -> None:
+    def test_index_pin_omits_index_when_route_missing(self) -> None:
         provider = _FakeProvider(
             listings={
                 "foo": [
@@ -1258,7 +1262,21 @@ class TestBuildLockInputFromProvider:
         )
         pin = lock_input.pins["foo"]
         assert isinstance(pin, IndexPin)
-        assert pin.index == "https://custom.example/simple/"
+        assert pin.index is None
+
+    def test_index_pin_omits_index_when_route_name_unconfigured(self) -> None:
+        provider = _FakeProvider(
+            listings={"foo": [(Version("1.0"), _wheel_file())]},
+            listing_indexes={"foo": "gone"},
+        )
+        lock_input = build_lock_input_from_provider(
+            provider,
+            {"foo": Version("1.0")},
+            indexes=(IndexConfig("custom", "https://custom.example/simple/"),),
+        )
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.index is None
 
     def test_index_pin_strips_credentials_from_url(self) -> None:
         provider = _FakeProvider(
@@ -1660,17 +1678,6 @@ class TestBuildLockInputFromProvider:
         pin = lock_input.pins["foo"]
         assert isinstance(pin, IndexPin)
         assert pin.requires_python is None
-
-    def test_first_configured_index_url_used_when_route_missing(self) -> None:
-        provider = _FakeProvider(listings={"foo": [(Version("1.0"), _wheel_file())]})
-        lock_input = build_lock_input_from_provider(
-            provider,
-            {"foo": Version("1.0")},
-            indexes=(IndexConfig("primary", "https://primary.example/simple/"),),
-        )
-        pin = lock_input.pins["foo"]
-        assert isinstance(pin, IndexPin)
-        assert pin.index == "https://primary.example/simple/"
 
     def test_extras_passed_through(self) -> None:
         provider = _FakeProvider(listings={"foo": [(Version("1.0"), _wheel_file())]})


### PR DESCRIPTION
Closes #8.

Omit `packages.index` when the serving index can't be identified, instead of falling back to `indexes[0]` or the default Simple root. `IndexPin.index` is now optional, which PEP 751 allows.