### PR TITLE
Use truststore for HTTPS verification

### DIFF
--- a/.github/requirements/pylock.crosshair.toml
+++ b/.github/requirements/pylock.crosshair.toml
@@ -2172,6 +2172,54 @@ size = 6675
 sha256 = "188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90"
 
 [[packages]]
+name = "tomlkit"
+version = "0.15.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "tomlkit-0.15.0.tar.gz"
+upload-time = 2026-05-10 07:38:22.245337+00:00
+url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz"
+size = 161875
+
+[packages.sdist.hashes]
+sha256 = "7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3"
+
+[[packages.wheels]]
+name = "tomlkit-0.15.0-py3-none-any.whl"
+upload-time = 2026-05-10 07:38:23.517364+00:00
+url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl"
+size = 41328
+
+[packages.wheels.hashes]
+sha256 = "4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738"
+
+[[packages]]
+name = "truststore"
+version = "0.10.4"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "truststore-0.10.4.tar.gz"
+upload-time = 2025-08-12 18:49:02.730234+00:00
+url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz"
+size = 26169
+
+[packages.sdist.hashes]
+sha256 = "9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301"
+
+[[packages.wheels]]
+name = "truststore-0.10.4-py3-none-any.whl"
+upload-time = 2025-08-12 18:49:01.460601+00:00
+url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl"
+size = 18660
+
+[packages.wheels.hashes]
+sha256 = "adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"
+
+[[packages]]
 name = "typeguard"
 version = "4.5.2"
 requires-python = ">=3.9"

--- a/.github/requirements/pylock.pre-commit.toml
+++ b/.github/requirements/pylock.pre-commit.toml
@@ -1014,6 +1014,30 @@ size = 6675
 sha256 = "188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90"
 
 [[packages]]
+name = "truststore"
+version = "0.10.4"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "truststore-0.10.4.tar.gz"
+upload-time = 2025-08-12 18:49:02.730234+00:00
+url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz"
+size = 26169
+
+[packages.sdist.hashes]
+sha256 = "9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301"
+
+[[packages.wheels]]
+name = "truststore-0.10.4-py3-none-any.whl"
+upload-time = 2025-08-12 18:49:01.460601+00:00
+url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl"
+size = 18660
+
+[packages.wheels.hashes]
+sha256 = "adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"
+
+[[packages]]
 name = "typeguard"
 version = "4.5.1"
 requires-python = ">=3.9"

--- a/.github/requirements/pylock.release.toml
+++ b/.github/requirements/pylock.release.toml
@@ -1792,6 +1792,30 @@ size = 14201
 sha256 = "5ec0800de5e2ddbd7c663cb4c0c15328f132dc168813897c18866c5c7b93db33"
 
 [[packages]]
+name = "truststore"
+version = "0.10.4"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "truststore-0.10.4.tar.gz"
+upload-time = 2025-08-12 18:49:02.730234+00:00
+url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz"
+size = 26169
+
+[packages.sdist.hashes]
+sha256 = "9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301"
+
+[[packages.wheels]]
+name = "truststore-0.10.4-py3-none-any.whl"
+upload-time = 2025-08-12 18:49:01.460601+00:00
+url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl"
+size = 18660
+
+[packages.wheels.hashes]
+sha256 = "adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"
+
+[[packages]]
 name = "twine"
 version = "6.2.0"
 requires-python = ">=3.9"

--- a/.github/requirements/pylock.tests.toml
+++ b/.github/requirements/pylock.tests.toml
@@ -1744,6 +1744,30 @@ size = 41328
 sha256 = "4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738"
 
 [[packages]]
+name = "truststore"
+version = "0.10.4"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "truststore-0.10.4.tar.gz"
+upload-time = 2025-08-12 18:49:02.730234+00:00
+url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz"
+size = 26169
+
+[packages.sdist.hashes]
+sha256 = "9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301"
+
+[[packages.wheels]]
+name = "truststore-0.10.4-py3-none-any.whl"
+upload-time = 2025-08-12 18:49:01.460601+00:00
+url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl"
+size = 18660
+
+[packages.wheels.hashes]
+sha256 = "adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"
+
+[[packages]]
 name = "typeguard"
 version = "4.5.1"
 requires-python = ">=3.9"

--- a/.github/requirements/pylock.types.toml
+++ b/.github/requirements/pylock.types.toml
@@ -2569,6 +2569,54 @@ size = 6675
 sha256 = "188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90"
 
 [[packages]]
+name = "tomlkit"
+version = "0.15.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "tomlkit-0.15.0.tar.gz"
+upload-time = 2026-05-10 07:38:22.245337+00:00
+url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz"
+size = 161875
+
+[packages.sdist.hashes]
+sha256 = "7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3"
+
+[[packages.wheels]]
+name = "tomlkit-0.15.0-py3-none-any.whl"
+upload-time = 2026-05-10 07:38:23.517364+00:00
+url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl"
+size = 41328
+
+[packages.wheels.hashes]
+sha256 = "4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738"
+
+[[packages]]
+name = "truststore"
+version = "0.10.4"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "truststore-0.10.4.tar.gz"
+upload-time = 2025-08-12 18:49:02.730234+00:00
+url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz"
+size = 26169
+
+[packages.sdist.hashes]
+sha256 = "9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301"
+
+[[packages.wheels]]
+name = "truststore-0.10.4-py3-none-any.whl"
+upload-time = 2025-08-12 18:49:01.460601+00:00
+url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl"
+size = 18660
+
+[packages.wheels.hashes]
+sha256 = "adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"
+
+[[packages]]
 name = "ty"
 version = "0.0.35"
 requires-python = ">=3.8"

--- a/nab-index/pyproject.toml
+++ b/nab-index/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "packaging>=24.0",
+    "truststore>=0.10",
     "typing_extensions>=4.6",
     "urllib3>=2.0",
 ]

--- a/nab-index/src/nab_index/httpx_async_transport.py
+++ b/nab-index/src/nab_index/httpx_async_transport.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import ssl
 from typing import TYPE_CHECKING
 
 import httpx
+import truststore
 
 if TYPE_CHECKING:
     from .transport import HttpResponse
@@ -24,7 +26,10 @@ class HttpxAsyncTransport:
 
     def __init__(self, *, http2: bool = True) -> None:
         """Create a transport."""
-        self._client = httpx.AsyncClient(http2=http2)
+        self._client = httpx.AsyncClient(
+            http2=http2,
+            verify=truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT),
+        )
 
     async def get(
         self, url: str, *, headers: dict[str, str] | None = None

--- a/nab-index/src/nab_index/urllib3_async_transport.py
+++ b/nab-index/src/nab_index/urllib3_async_transport.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 
 import asyncio
 import json as _json
+import ssl
 from typing import TYPE_CHECKING, Any
 
+import truststore
 import urllib3
 
 if TYPE_CHECKING:
@@ -23,6 +25,25 @@ __all__ = [
 
 
 _HTTP_BAD_REQUEST = 400
+
+
+class _SSLContext(truststore.SSLContext):
+    """truststore SSLContext that answers urllib3-future's cert probe.
+
+    urllib3-future removed the ``ssl_context is None`` guard from
+    ``ssl_wrap_socket`` in commit ``23d13d6`` (Jun 2025) and now calls
+    ``context.cert_store_stats()`` whenever no ``ca_certs`` is supplied;
+    truststore's ``cert_store_stats`` raises ``NotImplementedError`` by
+    design (``sethmlarson/truststore`` commit ``63dc9e1``, Feb 2023).
+    Returning a non-empty count tells urllib3-future the context already
+    has trust roots, which is true: truststore delegates verification to
+    the OS framework. Upstream ``urllib3`` 2.x is unaffected because PR
+    1566 (Apr 2019) left the guard in place. Drop this subclass once
+    urllib3-future restores the guard.
+    """
+
+    def cert_store_stats(self) -> dict[str, int]:
+        return {"x509_ca": 1, "x509": 1, "crl": 0}
 
 
 class _Urllib3Response:
@@ -69,7 +90,11 @@ class Urllib3AsyncTransport:
 
     def __init__(self, *, num_pools: int = 10, maxsize: int = 50) -> None:
         """Create a transport."""
-        self._pool = urllib3.PoolManager(num_pools=num_pools, maxsize=maxsize)
+        self._pool = urllib3.PoolManager(
+            num_pools=num_pools,
+            maxsize=maxsize,
+            ssl_context=_SSLContext(ssl.PROTOCOL_TLS_CLIENT),
+        )
 
     async def get(
         self, url: str, *, headers: dict[str, str] | None = None

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import io
 import json
+import ssl
 import tarfile
 from collections.abc import Mapping
 from typing import Any
@@ -13,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 import respx
+import truststore
 import urllib3
 
 from nab_index.client import AsyncSimpleClient, _extract_sdist_files
@@ -20,6 +22,7 @@ from nab_index.httpx_async_transport import HttpxAsyncTransport
 from nab_index.niquests_async_transport import NiquestsAsyncTransport
 from nab_index.urllib3_async_transport import (
     Urllib3AsyncTransport,
+    _SSLContext,
     _Urllib3Response,
 )
 from nab_python.fetch import FetchCoordinator
@@ -67,6 +70,14 @@ class TestHttpxAsyncTransport:
                 await transport.aclose()
 
         assert asyncio.run(go()) == "hello"
+
+    def test_uses_truststore_ssl_context(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """AsyncClient gets a truststore SSLContext via verify=."""
+        cls = MagicMock()
+        monkeypatch.setattr("nab_index.httpx_async_transport.httpx.AsyncClient", cls)
+        HttpxAsyncTransport()
+        verify = cls.call_args.kwargs["verify"]
+        assert isinstance(verify, truststore.SSLContext)
 
 
 class TestNiquestsAsyncTransport:
@@ -228,6 +239,32 @@ class TestUrllib3AsyncTransport:
         adapter = _Urllib3Response(fake)
         assert adapter.status_code == 304
         assert adapter.headers["etag"] == "abc"
+
+    def test_uses_truststore_ssl_context(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """PoolManager gets a truststore SSLContext via ssl_context=."""
+        captured: dict[str, Any] = {}
+
+        def fake_pool_manager(**kw: Any) -> MagicMock:
+            captured.update(kw)
+            return MagicMock(spec=urllib3.PoolManager)
+
+        monkeypatch.setattr(
+            "nab_index.urllib3_async_transport.urllib3.PoolManager",
+            fake_pool_manager,
+        )
+        Urllib3AsyncTransport()
+        assert isinstance(captured["ssl_context"], truststore.SSLContext)
+
+    def test_ssl_context_satisfies_urllib3_cert_check(self) -> None:
+        """``_SSLContext`` returns a non-empty CA count for urllib3-future.
+
+        urllib3-future calls ``cert_store_stats()`` to decide whether to
+        load default certs; truststore raises ``NotImplementedError``
+        there, so the subclass returns a non-zero ``x509_ca`` count.
+        """
+        ctx = _SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        stats = ctx.cert_store_stats()
+        assert stats["x509_ca"] >= 1
 
 
 class TestAsyncSimpleClient:


### PR DESCRIPTION
Fixes #26

Addresses the OS certificate store part of #26: the urllib3 (default) and httpx transports verify via a truststore SSLContext, so HTTPS uses the system trust store.

`_SSLContext` works around urllib3-future calling `cert_store_stats()`, which truststore does not implement.

Regenerates the CI locks to include truststore. This also adds tomlkit to the types and crosshair locks, which were stale (they include the tests group but were missing it).