### PR TITLE
Make serving-index attribution explicit

### DIFF
--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -257,8 +257,8 @@ def _index_pin_from_listing(
     served the package's listing during the resolve, looked up from
     the coordinator's :class:`InMemoryIndex` (which records the
     serving index by name) and resolved against ``indexes`` for the
-    URL.  When ``indexes`` is empty or the route is unknown the URL
-    falls back to the default Simple-API root.
+    URL.  A pinned package's serving index is always recorded and is
+    one of ``indexes``, so the URL is always known.
 
     Under :attr:`~nab_python.provider.DistPolicy.SDIST_INSTALL` the
     package's wheels stayed in ``versions_cache`` as a possible
@@ -287,12 +287,17 @@ def _index_pin_from_listing(
     requires_python = _common_requires_python(files)
     serving_name = provider.coordinator.index.get_listing_index(canonical)
     by_name = {ix.name: ix.url for ix in indexes}
-
-    if serving_name is not None and serving_name in by_name:
-        index_url = by_name[serving_name]
-    elif indexes:
-        index_url = indexes[0].url
-    else:
+    index_url = by_name.get(serving_name) if serving_name is not None else None
+    if index_url is None:
+        if by_name:
+            # Can't happen for a real pin (the serving index is always
+            # recorded and configured); raise, don't guess.
+            msg = (
+                f"{canonical}: recorded serving index {serving_name!r} is "
+                "not one of the configured indexes"
+            )
+            raise AssertionError(msg)
+        # No indexes configured (unit tests only); use the default root.
         index_url = DEFAULT_INDEX_URL
     return IndexPin(
         name=canonical,

--- a/nab-python/src/nab_python/_testing/coordinator_fake.py
+++ b/nab-python/src/nab_python/_testing/coordinator_fake.py
@@ -43,6 +43,8 @@ def _pre_populate_index(
     """Load listings and pre-store validator-visible slots into ``index``."""
     for pkg_name, pkg_wheels in listings_map.items():
         index.store_listing(pkg_name, pkg_wheels)
+        # Mirror production: every fetched listing records its serving index.
+        index.store_listing_index(pkg_name, DEFAULT_INDEX_NAME)
         if baseline_metadata is not None and pkg_name in baseline_metadata:
             for w in pkg_wheels:
                 index.store_metadata(pkg_name, w.version, baseline_metadata[pkg_name])

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -1242,7 +1242,8 @@ class TestBuildLockInputFromProvider:
         assert isinstance(pin, IndexPin)
         assert pin.index == "https://download.pytorch.org/whl/cpu/"
 
-    def test_index_pin_falls_back_to_default_when_route_missing(self) -> None:
+    def test_index_pin_raises_when_serving_index_unrecorded(self) -> None:
+        """No recorded serving index raises instead of guessing one."""
         provider = _FakeProvider(
             listings={
                 "foo": [
@@ -1251,14 +1252,12 @@ class TestBuildLockInputFromProvider:
                 ],
             },
         )
-        lock_input = build_lock_input_from_provider(
-            provider,
-            {"foo": Version("1.0")},
-            indexes=(IndexConfig("custom", "https://custom.example/simple/"),),
-        )
-        pin = lock_input.pins["foo"]
-        assert isinstance(pin, IndexPin)
-        assert pin.index == "https://custom.example/simple/"
+        with pytest.raises(AssertionError, match="not one of the configured indexes"):
+            build_lock_input_from_provider(
+                provider,
+                {"foo": Version("1.0")},
+                indexes=(IndexConfig("custom", "https://custom.example/simple/"),),
+            )
 
     def test_index_pin_strips_credentials_from_url(self) -> None:
         provider = _FakeProvider(
@@ -1661,16 +1660,18 @@ class TestBuildLockInputFromProvider:
         assert isinstance(pin, IndexPin)
         assert pin.requires_python is None
 
-    def test_first_configured_index_url_used_when_route_missing(self) -> None:
-        provider = _FakeProvider(listings={"foo": [(Version("1.0"), _wheel_file())]})
-        lock_input = build_lock_input_from_provider(
-            provider,
-            {"foo": Version("1.0")},
-            indexes=(IndexConfig("primary", "https://primary.example/simple/"),),
+    def test_index_pin_raises_when_serving_index_unconfigured(self) -> None:
+        """A serving index not among the configured indexes raises."""
+        provider = _FakeProvider(
+            listings={"foo": [(Version("1.0"), _wheel_file())]},
+            listing_indexes={"foo": "gone"},
         )
-        pin = lock_input.pins["foo"]
-        assert isinstance(pin, IndexPin)
-        assert pin.index == "https://primary.example/simple/"
+        with pytest.raises(AssertionError, match="not one of the configured indexes"):
+            build_lock_input_from_provider(
+                provider,
+                {"foo": Version("1.0")},
+                indexes=(IndexConfig("primary", "https://primary.example/simple/"),),
+            )
 
     def test_extras_passed_through(self) -> None:
         provider = _FakeProvider(listings={"foo": [(Version("1.0"), _wheel_file())]})


### PR DESCRIPTION
Closes #8.

A pinned package's serving index is always recorded during the resolve and is one of the configured indexes, so `packages.index` is always known. This replaces the old fallback (which guessed `indexes[0]`) with an explicit check that raises if that invariant is ever violated; `IndexPin.index` stays a required `str`.

Verified with a real two-index resolve: a package served only by a secondary index is attributed to that index, not `indexes[0]`.
