### PR TITLE
Harden HTTP transports: retries and refuse unverified HTTPS

### DIFF
--- a/nab-index/src/nab_index/_retry.py
+++ b/nab-index/src/nab_index/_retry.py
@@ -1,0 +1,67 @@
+"""Shared HTTP retry policy for the nab-index transports.
+
+All transports issue only idempotent GETs, so retrying is safe.
+urllib3-future's default retry has ``backoff_factor=0``, so its attempts
+fire within milliseconds and cannot outlast a brief blip; this adds
+exponential backoff and retries transient server statuses too.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, TypeVar
+
+from urllib3.util.retry import Retry
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+TOTAL = 3
+BACKOFF_FACTOR = 0.5
+RETRY_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+_ResponseT = TypeVar("_ResponseT")
+
+
+def urllib3_retry() -> Retry:
+    """Retry policy for the urllib3 and niquests transports.
+
+    Both run on urllib3-future, so one :class:`~urllib3.util.retry.Retry`
+    covers connection, read, and status retries with backoff.  Scoped to
+    GET because that is all the transports send.
+    """
+    return Retry(
+        total=TOTAL,
+        backoff_factor=BACKOFF_FACTOR,
+        status_forcelist=RETRY_STATUSES,
+        allowed_methods=frozenset({"GET"}),
+        respect_retry_after_header=True,
+    )
+
+
+def _backoff(attempt: int) -> float:
+    return BACKOFF_FACTOR * (2.0**attempt)
+
+
+async def get_with_retry(
+    do_get: Callable[[], Awaitable[_ResponseT]],
+    *,
+    transient: type[BaseException] | tuple[type[BaseException], ...],
+    retry_status: Callable[[_ResponseT], bool],
+) -> _ResponseT:
+    """Retry an async GET on transient errors or statuses with backoff.
+
+    For transports whose library has no status-aware retry of its own
+    (httpx).  Makes up to ``TOTAL`` retries; the final attempt's result
+    or exception is returned or propagated unchanged.
+    """
+    for attempt in range(TOTAL):
+        try:
+            response = await do_get()
+        except transient:
+            await asyncio.sleep(_backoff(attempt))
+            continue
+        if not retry_status(response):
+            return response
+        await asyncio.sleep(_backoff(attempt))
+    return await do_get()

--- a/nab-index/src/nab_index/_tls.py
+++ b/nab-index/src/nab_index/_tls.py
@@ -1,0 +1,18 @@
+"""TLS hardening shared by the urllib3 and niquests transports.
+
+urllib3-future only emits an ``InsecureRequestWarning`` and then proceeds
+when a connection could not be verified.  nab must never send an
+unverified HTTPS request, so promote that warning to a hard error rather
+than let it become a silent downgrade.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import urllib3.exceptions
+
+
+def forbid_unverified_https() -> None:
+    """Make an unverified HTTPS request raise instead of warn-and-proceed."""
+    warnings.filterwarnings("error", category=urllib3.exceptions.InsecureRequestWarning)

--- a/nab-index/src/nab_index/httpx_async_transport.py
+++ b/nab-index/src/nab_index/httpx_async_transport.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 import httpx
 import truststore
 
+from ._retry import RETRY_STATUSES, get_with_retry
+
 if TYPE_CHECKING:
     from .transport import HttpResponse
 
@@ -34,12 +36,22 @@ class HttpxAsyncTransport:
     async def get(
         self, url: str, *, headers: dict[str, str] | None = None
     ) -> HttpResponse:
-        """Send a GET request."""
-        # httpx.Response satisfies the HttpResponse protocol structurally
-        # (headers, status_code, content, text, json, raise_for_status are
-        # all present); the disagreement is only that httpx's headers slot
-        # is its own Headers class rather than a literal Mapping[str, str].
-        return await self._client.get(url, headers=headers)  # type: ignore[return-value]
+        """Send a GET request, retrying transient failures with backoff.
+
+        httpx has no status-aware retry of its own, so the shared helper
+        retries connection/read errors and transient server statuses.
+        """
+
+        async def _send() -> httpx.Response:
+            return await self._client.get(url, headers=headers)
+
+        # httpx.Response satisfies the HttpResponse protocol structurally;
+        # the headers slot is httpx's own Headers, not a literal Mapping.
+        return await get_with_retry(  # type: ignore[return-value]
+            _send,
+            transient=httpx.TransportError,
+            retry_status=lambda r: r.status_code in RETRY_STATUSES,
+        )
 
     async def aclose(self) -> None:
         """Close the underlying client."""

--- a/nab-index/src/nab_index/niquests_async_transport.py
+++ b/nab-index/src/nab_index/niquests_async_transport.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import niquests
 
 from ._retry import urllib3_retry
+from ._tls import forbid_unverified_https
 
 if TYPE_CHECKING:
     from .transport import HttpResponse
@@ -14,6 +15,9 @@ if TYPE_CHECKING:
 __all__ = [
     "NiquestsAsyncTransport",
 ]
+
+# nab never sends an unverified HTTPS request; make the degrade fatal.
+forbid_unverified_https()
 
 
 class NiquestsAsyncTransport:

--- a/nab-index/src/nab_index/niquests_async_transport.py
+++ b/nab-index/src/nab_index/niquests_async_transport.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 
 import niquests
 
+from ._retry import urllib3_retry
+
 if TYPE_CHECKING:
     from .transport import HttpResponse
 
@@ -31,6 +33,7 @@ class NiquestsAsyncTransport:
             revocation_configuration=None,
             pool_connections=pool_maxsize,
             pool_maxsize=pool_maxsize,
+            retries=urllib3_retry(),
         )
 
     async def get(

--- a/nab-index/src/nab_index/urllib3_async_transport.py
+++ b/nab-index/src/nab_index/urllib3_async_transport.py
@@ -16,6 +16,8 @@ from typing import TYPE_CHECKING, Any
 import truststore
 import urllib3
 
+from ._retry import urllib3_retry
+
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
@@ -94,6 +96,7 @@ class Urllib3AsyncTransport:
             num_pools=num_pools,
             maxsize=maxsize,
             ssl_context=_SSLContext(ssl.PROTOCOL_TLS_CLIENT),
+            retries=urllib3_retry(),
         )
 
     async def get(

--- a/nab-index/src/nab_index/urllib3_async_transport.py
+++ b/nab-index/src/nab_index/urllib3_async_transport.py
@@ -17,6 +17,7 @@ import truststore
 import urllib3
 
 from ._retry import urllib3_retry
+from ._tls import forbid_unverified_https
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -24,6 +25,9 @@ if TYPE_CHECKING:
 __all__ = [
     "Urllib3AsyncTransport",
 ]
+
+# nab never sends an unverified HTTPS request; make the degrade fatal.
+forbid_unverified_https()
 
 
 _HTTP_BAD_REQUEST = 400

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -16,7 +16,15 @@ import pytest
 import respx
 import truststore
 import urllib3
+from urllib3.util.retry import Retry
 
+from nab_index._retry import (
+    BACKOFF_FACTOR,
+    RETRY_STATUSES,
+    TOTAL,
+    _backoff,
+    get_with_retry,
+)
 from nab_index.client import AsyncSimpleClient, _extract_sdist_files
 from nab_index.httpx_async_transport import HttpxAsyncTransport
 from nab_index.niquests_async_transport import NiquestsAsyncTransport
@@ -79,6 +87,26 @@ class TestHttpxAsyncTransport:
         verify = cls.call_args.kwargs["verify"]
         assert isinstance(verify, truststore.SSLContext)
 
+    def test_retries_transient_status_then_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A 503 is retried and the eventual 200 is returned."""
+        monkeypatch.setattr("nab_index._retry._backoff", lambda _attempt: 0.0)
+        transport = HttpxAsyncTransport()
+        transport._client.get = AsyncMock(
+            side_effect=[httpx.Response(503), httpx.Response(200, text="ok")]
+        )
+
+        async def go() -> int:
+            try:
+                resp = await transport.get("https://example.com/")
+                return resp.status_code
+            finally:
+                await transport.aclose()
+
+        assert asyncio.run(go()) == 200
+        assert transport._client.get.await_count == 2
+
 
 class TestNiquestsAsyncTransport:
     def test_get_calls_underlying_session(
@@ -113,6 +141,17 @@ class TestNiquestsAsyncTransport:
             "https://example.com/", headers={"a": "b"}
         )
         fake_session.close.assert_awaited_once()
+
+    def test_configures_retry_policy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """AsyncSession gets the shared GET retry policy."""
+        cls = MagicMock()
+        monkeypatch.setattr(
+            "nab_index.niquests_async_transport.niquests.AsyncSession", cls
+        )
+        NiquestsAsyncTransport()
+        retries = cls.call_args.kwargs["retries"]
+        assert isinstance(retries, Retry)
+        assert retries.status_forcelist == RETRY_STATUSES
 
 
 class TestUrllib3AsyncTransport:
@@ -265,6 +304,113 @@ class TestUrllib3AsyncTransport:
         ctx = _SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         stats = ctx.cert_store_stats()
         assert stats["x509_ca"] >= 1
+
+    def test_configures_retry_policy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """PoolManager gets the shared GET retry policy with backoff."""
+        captured: dict[str, Any] = {}
+
+        def fake_pool_manager(**kw: Any) -> MagicMock:
+            captured.update(kw)
+            return MagicMock(spec=urllib3.PoolManager)
+
+        monkeypatch.setattr(
+            "nab_index.urllib3_async_transport.urllib3.PoolManager", fake_pool_manager
+        )
+        Urllib3AsyncTransport()
+        retries = captured["retries"]
+        assert isinstance(retries, Retry)
+        assert retries.backoff_factor == BACKOFF_FACTOR
+        assert retries.status_forcelist == RETRY_STATUSES
+
+
+class TestGetWithRetry:
+    """The shared async retry helper used by the httpx transport."""
+
+    def test_backoff_is_exponential(self) -> None:
+        assert _backoff(0) == BACKOFF_FACTOR
+        assert _backoff(1) == BACKOFF_FACTOR * 2
+        assert _backoff(2) == BACKOFF_FACTOR * 4
+
+    def test_returns_first_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("nab_index._retry._backoff", lambda _a: 0.0)
+        calls = 0
+
+        async def do_get() -> Any:
+            nonlocal calls
+            calls += 1
+            return MagicMock(status_code=200)
+
+        out = asyncio.run(
+            get_with_retry(
+                do_get,
+                transient=ValueError,
+                retry_status=lambda r: r.status_code in RETRY_STATUSES,
+            )
+        )
+        assert out.status_code == 200
+        assert calls == 1
+
+    def test_retries_status_then_transient_then_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("nab_index._retry._backoff", lambda _a: 0.0)
+        results: list[Any] = [
+            MagicMock(status_code=503),
+            ValueError("boom"),
+            MagicMock(status_code=200),
+        ]
+
+        async def do_get() -> Any:
+            item = results.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return item
+
+        out = asyncio.run(
+            get_with_retry(
+                do_get,
+                transient=ValueError,
+                retry_status=lambda r: r.status_code in RETRY_STATUSES,
+            )
+        )
+        assert out.status_code == 200
+        assert results == []
+
+    def test_exhausts_status_retries_then_returns_last(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("nab_index._retry._backoff", lambda _a: 0.0)
+        calls = 0
+
+        async def do_get() -> Any:
+            nonlocal calls
+            calls += 1
+            return MagicMock(status_code=503)
+
+        out = asyncio.run(
+            get_with_retry(
+                do_get,
+                transient=ValueError,
+                retry_status=lambda r: r.status_code in RETRY_STATUSES,
+            )
+        )
+        assert out.status_code == 503
+        assert calls == TOTAL + 1
+
+    def test_propagates_persistent_transient(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("nab_index._retry._backoff", lambda _a: 0.0)
+
+        async def do_get() -> Any:
+            raise ValueError("always")
+
+        with pytest.raises(ValueError, match="always"):
+            asyncio.run(
+                get_with_retry(
+                    do_get, transient=ValueError, retry_status=lambda _r: False
+                )
+            )
 
 
 class TestAsyncSimpleClient:

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -7,6 +7,7 @@ import io
 import json
 import ssl
 import tarfile
+import warnings
 from collections.abc import Mapping
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -25,6 +26,7 @@ from nab_index._retry import (
     _backoff,
     get_with_retry,
 )
+from nab_index._tls import forbid_unverified_https
 from nab_index.client import AsyncSimpleClient, _extract_sdist_files
 from nab_index.httpx_async_transport import HttpxAsyncTransport
 from nab_index.niquests_async_transport import NiquestsAsyncTransport
@@ -411,6 +413,20 @@ class TestGetWithRetry:
                     do_get, transient=ValueError, retry_status=lambda _r: False
                 )
             )
+
+
+class TestForbidUnverifiedHttps:
+    def test_promotes_insecure_request_warning_to_error(self) -> None:
+        """An unverified HTTPS request raises rather than warning and proceeding."""
+        with warnings.catch_warnings():
+            warnings.resetwarnings()
+            forbid_unverified_https()
+            with pytest.raises(urllib3.exceptions.InsecureRequestWarning):
+                warnings.warn(
+                    "unverified",
+                    urllib3.exceptions.InsecureRequestWarning,
+                    stacklevel=2,
+                )
 
 
 class TestAsyncSimpleClient:


### PR DESCRIPTION
Hardens the three HTTP transports. Every request is a GET, so retrying is always safe.

## Retry policy

Today urllib3-future retries connection/read errors but with `backoff_factor=0` (immediate) and no status retries; httpx and niquests don't retry. Immediate back-to-back retries can't outlast a brief network blip on the host.

Adds exponential backoff, retries on 429/500/502/503/504, and respects `Retry-After`:

- urllib3 and niquests (both on urllib3-future): one shared `Retry`.
- httpx (no status-aware retry of its own): a small shared async helper.

## Refuse unverified HTTPS

urllib3-future only *warns* (`InsecureRequestWarning`) and then proceeds when a connection cannot be verified, which is a silent downgrade. nab now promotes that to a hard error, so it never sends an unverified request.
