### PR TITLE
Use a per-thread truststore context in urllib3

### DIFF
--- a/nab-index/src/nab_index/urllib3_async_transport.py
+++ b/nab-index/src/nab_index/urllib3_async_transport.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import json as _json
 import ssl
+import threading
 from typing import TYPE_CHECKING, Any
 
 import truststore
@@ -83,18 +84,41 @@ class _Urllib3Response:
 class Urllib3AsyncTransport:
     """Async HTTP transport using urllib3 (sync) wrapped in to_thread.
 
-    Each ``get`` runs the underlying sync request on the asyncio
-    default executor. The PoolManager is thread-safe, so concurrent
-    requests from many tasks share connections cleanly.
+    Each ``get`` runs the underlying sync request on the asyncio default
+    executor.  A separate :class:`~urllib3.PoolManager` (and truststore
+    SSLContext) is kept per worker thread: truststore toggles the
+    context's ``verify_mode`` to ``CERT_NONE`` for the duration of each
+    ``wrap_socket`` (truststore#209), so sharing one context across the
+    executor threads races that toggle and trips spurious
+    ``InsecureRequestWarning``s.  One context per thread means no two
+    threads ever touch the same context; connections are still reused
+    within each thread.
     """
 
     def __init__(self, *, num_pools: int = 10, maxsize: int = 50) -> None:
         """Create a transport."""
-        self._pool = urllib3.PoolManager(
-            num_pools=num_pools,
-            maxsize=maxsize,
-            ssl_context=_SSLContext(ssl.PROTOCOL_TLS_CLIENT),
-        )
+        self._num_pools = num_pools
+        self._maxsize = maxsize
+        self._local = threading.local()
+        self._pools: list[urllib3.PoolManager] = []
+        self._pools_lock = threading.Lock()
+
+    def _pool(self) -> urllib3.PoolManager:
+        """Return this worker thread's pool, creating it on first use."""
+        pool: urllib3.PoolManager | None = getattr(self._local, "pool", None)
+        if pool is None:
+            pool = urllib3.PoolManager(
+                num_pools=self._num_pools,
+                maxsize=self._maxsize,
+                ssl_context=_SSLContext(ssl.PROTOCOL_TLS_CLIENT),
+            )
+            self._local.pool = pool
+            with self._pools_lock:
+                self._pools.append(pool)
+        return pool
+
+    def _request(self, url: str, headers: dict[str, str]) -> urllib3.BaseHTTPResponse:
+        return self._pool().request("GET", url, headers=headers)
 
     async def get(
         self, url: str, *, headers: dict[str, str] | None = None
@@ -107,11 +131,12 @@ class Urllib3AsyncTransport:
         request_headers = {"Accept-Encoding": "gzip"}
         if headers is not None:
             request_headers.update(headers)
-        response = await asyncio.to_thread(
-            self._pool.request, "GET", url, headers=request_headers
-        )
+        response = await asyncio.to_thread(self._request, url, request_headers)
         return _Urllib3Response(response)
 
     async def aclose(self) -> None:
-        """Close the underlying pool."""
-        await asyncio.to_thread(self._pool.clear)
+        """Close every per-thread pool."""
+        with self._pools_lock:
+            pools = list(self._pools)
+        for pool in pools:
+            await asyncio.to_thread(pool.clear)

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -241,7 +241,7 @@ class TestUrllib3AsyncTransport:
         assert adapter.headers["etag"] == "abc"
 
     def test_uses_truststore_ssl_context(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """PoolManager gets a truststore SSLContext via ssl_context=."""
+        """Each per-thread PoolManager gets a truststore SSLContext."""
         captured: dict[str, Any] = {}
 
         def fake_pool_manager(**kw: Any) -> MagicMock:
@@ -252,8 +252,24 @@ class TestUrllib3AsyncTransport:
             "nab_index.urllib3_async_transport.urllib3.PoolManager",
             fake_pool_manager,
         )
-        Urllib3AsyncTransport()
+        # Pools are created lazily per worker thread, so build one.
+        Urllib3AsyncTransport()._pool()
         assert isinstance(captured["ssl_context"], truststore.SSLContext)
+
+    def test_pool_is_per_thread(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Each thread gets its own PoolManager so the truststore context is unshared."""
+        monkeypatch.setattr(
+            "nab_index.urllib3_async_transport.urllib3.PoolManager",
+            lambda **kw: MagicMock(spec=urllib3.PoolManager),
+        )
+        transport = Urllib3AsyncTransport()
+        pools = [
+            asyncio.run(asyncio.to_thread(transport._pool)),
+            asyncio.run(asyncio.to_thread(transport._pool)),
+        ]
+        # Distinct worker threads -> distinct pools; all tracked for aclose.
+        assert pools[0] is not pools[1]
+        assert set(map(id, pools)) <= set(map(id, transport._pools))
 
     def test_ssl_context_satisfies_urllib3_cert_check(self) -> None:
         """``_SSLContext`` returns a non-empty CA count for urllib3-future.


### PR DESCRIPTION
The macos/Windows CI flake is truststore#209: truststore sets a shared context's `verify_mode` to `CERT_NONE` for the duration of each `wrap_socket` and only locks the configure step, so sharing one context across the urllib3 transport's `to_thread` workers races that toggle. urllib3 then reads `verify_mode == CERT_NONE` mid-handshake and emits a spurious `InsecureRequestWarning`. Verification still happens (truststore's `_verify_peercerts` always runs), so it is not a bypass. Each worker thread now gets its own `PoolManager` and context. httpx is async/single-threaded, so it is unaffected.
