### PR TITLE
Require a resolved commit SHA for VCS lock pins

### DIFF
--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "MissingHashError",
+    "MissingVcsCommitError",
     "build_lock_input_from_provider",
     "read_lockfile_anchor",
     "read_lockfile_packages",
@@ -108,6 +109,18 @@ class MissingHashError(ValueError):
     spec-compliant entry.  Surface the failure with the offending
     package and filename so the user can either add a hash to their
     local index or exclude the package.
+    """
+
+
+class MissingVcsCommitError(ValueError):
+    """A VCS source reached the lock writer without a resolved commit SHA.
+
+    PEP 751 requires ``packages.vcs.commit-id`` to be an immutable
+    identifier.  nab records the post-clone SHA on the provider during
+    materialisation, before any version can be pinned, so a missing SHA
+    here means a VCS source was pinned without being cloned.  Surface it
+    loudly rather than emit a branch name or empty string as the commit
+    id, which would silently produce a non-reproducible lock.
     """
 
 
@@ -395,30 +408,40 @@ def _vcs_pin_from_source(
 ) -> VcsPin:
     """Build a :class:`VcsPin` from a :class:`VcsSource`.
 
-    Prefer ``resolved_sha`` (the post-clone SHA recorded on the
-    provider) over the URL's ``@<ref>``: annotated tags and floating
-    refs only resolve to a commit after the clone runs.  Fall back to
-    the URL ref when the source was never materialised.
+    ``resolved_sha`` is the post-clone SHA recorded on the provider by
+    :func:`~nab_python._provider.sources.materialize_vcs_source`.  A VCS
+    source cannot be pinned without first being materialised, so a
+    ``None`` here is an internal invariant violation: raise
+    :class:`MissingVcsCommitError` rather than emit a branch name or
+    empty string as ``commit_id``.
 
     ``requested_revision`` is the URL's ``@<ref>``, kept only when it
     is a named ref that differs from ``commit_id`` (i.e. the user did
-    not pin the bare SHA).  An absent or unparseable ref leaves it
-    ``None``.
+    not pin the bare SHA).  ``subdirectory`` carries the
+    ``#subdirectory=`` fragment so an installer can locate the project
+    inside the repo.
     """
-    from nab_index.vcs import VcsCloneError, VcsRequest
+    from nab_index.vcs import VcsRequest
 
     from ..lockfile import VcsPin
 
-    try:
-        url_ref = VcsRequest.parse(source.url).ref
-    except VcsCloneError:
-        url_ref = ""
-    commit_id = resolved_sha if resolved_sha is not None else url_ref
-    requested_revision = url_ref if url_ref and url_ref != commit_id else None
+    if resolved_sha is None:
+        msg = (
+            f"{canonical}: VCS source pinned without a resolved commit SHA;"
+            " materialize_vcs_source records the post-clone SHA before any"
+            " version can be pinned, so this is an internal invariant"
+            " violation"
+        )
+        raise MissingVcsCommitError(msg)
+    parsed = VcsRequest.parse(source.url)
+    requested_revision = (
+        parsed.ref if parsed.ref and parsed.ref != resolved_sha else None
+    )
     return VcsPin(
         name=canonical,
         version=str(version),
         repo_url=_strip_userinfo(source.url),
-        commit_id=commit_id,
+        commit_id=resolved_sha,
+        subdirectory=parsed.subdirectory or None,
         requested_revision=requested_revision,
     )

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 
 from ._lockfile.builder import (
     MissingHashError,
+    MissingVcsCommitError,
     build_lock_input_from_provider,
     read_lockfile_anchor,
     read_lockfile_packages,
@@ -45,6 +46,7 @@ __all__ = [
     "LocalPin",
     "LockInput",
     "MissingHashError",
+    "MissingVcsCommitError",
     "PinShape",
     "Provenance",
     "SdistArtifact",

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -37,6 +37,7 @@ from nab_python.lockfile import (
     LocalPin,
     LockInput,
     MissingHashError,
+    MissingVcsCommitError,
     Provenance,
     SdistArtifact,
     VcsPin,
@@ -1324,7 +1325,8 @@ class TestBuildLockInputFromProvider:
                     name="foo",
                     url="git+https://example.com/r.git@" + "a" * 40,
                 ),
-            }
+            },
+            vcs_pins={"foo": "a" * 40},
         )
         lock_input = build_lock_input_from_provider(
             provider, {"foo": Version("0.0.0+vcs")}
@@ -1332,6 +1334,41 @@ class TestBuildLockInputFromProvider:
         pin = lock_input.pins["foo"]
         assert isinstance(pin, VcsPin)
         assert pin.commit_id == "a" * 40
+
+    def test_vcs_source_records_subdirectory(self) -> None:
+        """The ``#subdirectory=`` fragment survives into the VcsPin."""
+        sha = "a" * 40
+        provider = _FakeProvider(
+            vcs_sources={
+                "foo": VcsSource(
+                    name="foo",
+                    url=f"git+https://example.com/r.git@{sha}#subdirectory=pkg/sub",
+                ),
+            },
+            vcs_pins={"foo": sha},
+        )
+        lock_input = build_lock_input_from_provider(
+            provider, {"foo": Version("0.0.0+vcs")}
+        )
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, VcsPin)
+        assert pin.subdirectory == "pkg/sub"
+
+    def test_vcs_source_without_resolved_sha_raises(self) -> None:
+        """A pinned VCS source with no recorded SHA is an invariant breach.
+
+        materialize_vcs_source records the post-clone SHA before any
+        version can be pinned, so reaching the builder without one is
+        impossible through a real resolve; guard it loudly rather than
+        emit a branch name as the commit id.
+        """
+        provider = _FakeProvider(
+            vcs_sources={
+                "foo": VcsSource(name="foo", url="git+https://example.com/r.git@main"),
+            },
+        )
+        with pytest.raises(MissingVcsCommitError, match="resolved commit SHA"):
+            build_lock_input_from_provider(provider, {"foo": Version("0.0.0+vcs")})
 
     def test_vcs_source_prefers_resolved_sha_over_url_ref(self) -> None:
         """The post-clone SHA on the provider wins over the URL's ``@<ref>``."""
@@ -1351,51 +1388,6 @@ class TestBuildLockInputFromProvider:
         pin = lock_input.pins["foo"]
         assert isinstance(pin, VcsPin)
         assert pin.commit_id == resolved
-
-    def test_vcs_source_without_ref_yields_empty_commit(self) -> None:
-        provider = _FakeProvider(
-            vcs_sources={
-                "foo": VcsSource(
-                    name="foo",
-                    url="git+https://example.com/r.git",
-                ),
-            }
-        )
-        lock_input = build_lock_input_from_provider(
-            provider, {"foo": Version("0.0.0+vcs")}
-        )
-        pin = lock_input.pins["foo"]
-        assert isinstance(pin, VcsPin)
-        assert pin.commit_id == ""
-
-    def test_vcs_source_ssh_userinfo_without_ref(self) -> None:
-        provider = _FakeProvider(
-            vcs_sources={
-                "foo": VcsSource(
-                    name="foo",
-                    url="git+ssh://git@example.com/x/y.git",
-                ),
-            }
-        )
-        lock_input = build_lock_input_from_provider(
-            provider, {"foo": Version("0.0.0+vcs")}
-        )
-        pin = lock_input.pins["foo"]
-        assert isinstance(pin, VcsPin)
-        assert pin.commit_id == ""
-
-    def test_vcs_source_non_vcs_url_yields_empty_commit(self) -> None:
-        provider = _FakeProvider(
-            vcs_sources={
-                "foo": VcsSource(name="foo", url="https://example.com/r.git"),
-            }
-        )
-        lock_input = build_lock_input_from_provider(
-            provider, {"foo": Version("0.0.0+vcs")}
-        )
-        pin = lock_input.pins["foo"]
-        assert isinstance(pin, VcsPin)
-        assert pin.commit_id == ""
 
     def test_vcs_source_strips_credentials_from_url(self) -> None:
         provider = _FakeProvider(
@@ -1470,21 +1462,6 @@ class TestBuildLockInputFromProvider:
         provider = _FakeProvider(
             vcs_sources={
                 "foo": VcsSource(name="foo", url="git+https://example.com/r.git"),
-            },
-            vcs_pins={"foo": "a" * 40},
-        )
-        lock_input = build_lock_input_from_provider(
-            provider, {"foo": Version("0.0.0+vcs")}
-        )
-        pin = lock_input.pins["foo"]
-        assert isinstance(pin, VcsPin)
-        assert pin.requested_revision is None
-
-    def test_vcs_source_no_requested_revision_for_non_vcs_url(self) -> None:
-        """An unparseable VCS URL yields no requested-revision."""
-        provider = _FakeProvider(
-            vcs_sources={
-                "foo": VcsSource(name="foo", url="https://example.com/r.git"),
             },
             vcs_pins={"foo": "a" * 40},
         )

--- a/nab-python/tests/test_vcs.py
+++ b/nab-python/tests/test_vcs.py
@@ -20,7 +20,9 @@ from nab_index.vcs import (
     _split_repo_ref,
     prepare_clone,
 )
+from nab_python._vendor.packaging.version import Version
 from nab_python.fetch import InMemoryIndex
+from nab_python.lockfile import VcsPin, build_lock_input_from_provider
 from nab_python.provider import (
     BuildPolicy,
     LocalSource,
@@ -346,6 +348,55 @@ class TestProviderVcsIntegration:
         assert provider.vcs_pin_for("foo") == sha
         # Unknown package returns None.
         assert provider.vcs_pin_for("missing") is None
+
+    def test_floating_ref_lock_records_resolved_sha(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A branch ref under require_pin=False locks the resolved SHA.
+
+        End-to-end seam: the resolver materialises the clone (recording
+        the ls-remote SHA), then the lock builder reads it back.  PEP 751
+        wants commit_id to be the immutable SHA; the branch name lands in
+        requested_revision, never in commit_id.  Guards the path that
+        could otherwise emit a branch name as the commit id.
+        """
+        sha = "b" * 40
+        clone_dir = tmp_path / "cache" / "vcs" / "k" / sha
+        (clone_dir / ".git").mkdir(parents=True)
+        (clone_dir / "pyproject.toml").write_text(
+            '[project]\nname = "foo"\nversion = "1.0.0"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("nab_index.vcs._repo_key", lambda _url: "k")
+
+        def fake_run(cmd: list[str], **_kwargs: object) -> object:
+            assert cmd[:2] == ["git", "ls-remote"]
+            return type("P", (), {"stdout": f"{sha}\trefs/heads/main\n"})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        provider = Provider(
+            self.coordinator(),
+            vcs_config=VcsConfig(
+                policy=VcsPolicy.ALLOW,
+                allowed_schemes=frozenset({"git+https"}),
+                allowed_repos=("https://example.com/",),
+                require_pin=False,
+            ),
+            vcs_sources=[
+                VcsSource(name="foo", url="git+https://example.com/foo.git@main"),
+            ],
+            vcs_cache_dir=tmp_path / "cache",
+            build_policy=BuildPolicy.NEVER,
+        )
+        provider.fetch_versions("foo")
+        lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0.0")})
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, VcsPin)
+        assert pin.commit_id == sha
+        assert pin.requested_revision == "main"
 
     def test_vcs_under_block_policy_raises(self, tmp_path: Path) -> None:
         with pytest.raises(ValueError, match="VcsPolicy.ALLOW"):


### PR DESCRIPTION
Closes #5.

A VCS source's commit SHA is recorded during materialisation, before the resolver can pin the package: the clone resolves the ref to a 40-char commit SHA and the provider stores it. By the time the lock builder runs the SHA is always known, so the old fallback to the URL's `@<ref>` was unreachable for any package that made it into the lock. This replaces that silent fallback with an explicit raise if the SHA is ever missing, so `commit_id` can never be a branch name or empty string. A floating ref like `@main` records the resolved SHA as `commit_id` and keeps `main` in `requested_revision`, per PEP 751.

Separately, the builder now records the `#subdirectory=` fragment in the `VcsPin` instead of dropping it, so an installer can locate the project inside the repo.

Adds an end-to-end test: a real provider driven through the builder with a floating `@main` ref, checking the lock records the resolved SHA.
