### PR TITLE
Make pylock.toml output deterministic

### DIFF
--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -172,7 +172,10 @@ def _pin_to_package(
             sdist=(
                 _sdist_to_package(pin.sdist, lock_dir=lock_dir) if pin.sdist else None
             ),
-            wheels=tuple(_wheel_to_package(w, lock_dir=lock_dir) for w in pin.wheels)
+            wheels=tuple(
+                _wheel_to_package(w, lock_dir=lock_dir)
+                for w in sorted(pin.wheels, key=_wheel_sort_key)
+            )
             or None,
         )
     if isinstance(pin, LocalPin):
@@ -220,14 +223,14 @@ def _wheel_to_package(wheel: WheelArtifact, *, lock_dir: Path) -> PackageWheel:
             name=wheel.filename,
             path=_relativize_path(wheel.local_path.resolve(), lock_dir),
             size=wheel.size,
-            hashes=dict(wheel.hashes),
+            hashes=dict(sorted(wheel.hashes)),
             upload_time=wheel.upload_time,
         )
     return PackageWheel(
         name=wheel.filename,
         url=wheel.url,
         size=wheel.size,
-        hashes=dict(wheel.hashes),
+        hashes=dict(sorted(wheel.hashes)),
         upload_time=wheel.upload_time,
     )
 
@@ -242,14 +245,14 @@ def _sdist_to_package(sdist: SdistArtifact, *, lock_dir: Path) -> PackageSdist:
             name=sdist.filename,
             path=_relativize_path(sdist.local_path.resolve(), lock_dir),
             size=sdist.size,
-            hashes=dict(sdist.hashes),
+            hashes=dict(sorted(sdist.hashes)),
             upload_time=sdist.upload_time,
         )
     return PackageSdist(
         name=sdist.filename,
         url=sdist.url,
         size=sdist.size,
-        hashes=dict(sdist.hashes),
+        hashes=dict(sorted(sdist.hashes)),
         upload_time=sdist.upload_time,
     )
 
@@ -303,9 +306,14 @@ def _group_by_name(
 def _group_pins_by_pin(
     per_tuple: dict[str, PinShape],
 ) -> list[tuple[list[PinShape], list[str]]]:
-    """Bucket tuples by structural pin discriminator, keeping every pin."""
+    """Bucket tuples by pin discriminator, keeping every pin.
+
+    Walked in sorted label order so the output is independent of dict
+    insertion order.
+    """
     by_key: dict[tuple, tuple[list[PinShape], list[str]]] = {}
-    for tuple_label, pin in per_tuple.items():
+    for tuple_label in sorted(per_tuple):
+        pin = per_tuple[tuple_label]
         key = _pin_discriminator(pin)
         if key not in by_key:
             by_key[key] = ([], [])
@@ -372,7 +380,7 @@ def _merge_pins_in_group(pins: list[PinShape]) -> PinShape:
         version=head.version,
         index=head.index,
         sdist=sdist,
-        wheels=tuple(seen_wheels.values()),
+        wheels=tuple(sorted(seen_wheels.values(), key=_wheel_sort_key)),
         requires_python=requires_python,
     )
 
@@ -404,9 +412,29 @@ def _or_markers(markers: Sequence[Marker]) -> Marker:
         raise ValueError(msg)
     if len(markers) == 1:
         return markers[0]
-    parts = [f"({m})" for m in markers]
+    # str(Marker) does not canonicalise OR-clause order, so sort the
+    # fragments by string to keep the joined marker order-independent.
+    parts = [f"({m})" for m in sorted(markers, key=str)]
     return Marker(" or ".join(parts))
 
 
-def _package_sort_key(package: Package) -> tuple:
-    return (str(package.name), str(package.version) if package.version else "")
+def _wheel_sort_key(wheel: WheelArtifact) -> tuple[str, str, str]:
+    """Stable sort key for a wheel: filename, then url, then local path.
+
+    Wheel tags are not used as a key; they parse to a ``frozenset``,
+    which has no total order.
+    """
+    return (wheel.filename, wheel.url or "", str(wheel.local_path or ""))
+
+
+def _package_sort_key(package: Package) -> tuple[str, str, str]:
+    """Stable sort key for a package row: name, version, marker string.
+
+    The marker tiebreak separates two rows that share a name and version
+    but differ by environment marker, as a universal resolve emits.
+    """
+    return (
+        str(package.name),
+        str(package.version) if package.version else "",
+        str(package.marker) if package.marker else "",
+    )

--- a/nab-python/tests/property_python/test_lockfile_pep751.py
+++ b/nab-python/tests/property_python/test_lockfile_pep751.py
@@ -44,7 +44,7 @@ from .strategies import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Sequence
 
 pytestmark = pytest.mark.property
 
@@ -55,6 +55,16 @@ def _wheel(name: str, version: str, sha: str) -> WheelArtifact:
     return WheelArtifact(
         filename=f"{norm}-{version}-py3-none-any.whl",
         url=f"https://example.com/{norm}-{version}-py3-none-any.whl",
+        hashes=(("sha256", sha),),
+        size=1024,
+    )
+
+
+def _wheel_named(filename: str, sha: str) -> WheelArtifact:
+    """Build a ``WheelArtifact`` from a literal filename."""
+    return WheelArtifact(
+        filename=filename,
+        url=f"https://example.com/{filename}",
         hashes=(("sha256", sha),),
         size=1024,
     )
@@ -192,6 +202,218 @@ class TestDeterministicOutput:
         first = write_lock(lock_input)
         second = write_lock(lock_input)
         assert first == second
+
+
+def _multi_wheel(name: str, version: str) -> tuple[WheelArtifact, ...]:
+    """Build several wheels for one pin, each with several hashes.
+
+    The wheels are returned in a deliberately non-sorted filename order
+    so a caller can prove the emitter sorts them rather than echoing
+    insertion order.
+    """
+    norm = name.replace("-", "_")
+
+    def _wheel_with_hashes(tag: str, primary: str) -> WheelArtifact:
+        return WheelArtifact(
+            filename=f"{norm}-{version}-{tag}.whl",
+            url=f"https://example.com/{norm}-{version}-{tag}.whl",
+            hashes=(
+                ("sha512", primary * 128),
+                ("sha256", primary * 64),
+                ("sha384", primary * 96),
+            ),
+            size=1024,
+        )
+
+    return (
+        _wheel_with_hashes("cp312-cp312-win_amd64", "f"),
+        _wheel_with_hashes("cp310-cp310-manylinux_2_17_x86_64", "a"),
+        _wheel_with_hashes("cp311-cp311-macosx_11_0_arm64", "c"),
+    )
+
+
+def _reorder(seq: Sequence[object], shift: int) -> list[object]:
+    """Rotate ``seq`` by ``shift`` to get a different but complete order."""
+    items = list(seq)
+    if not items:
+        return items
+    shift %= len(items)
+    return items[shift:] + items[:shift]
+
+
+def _per_tuple_input(
+    *,
+    names: Sequence[str],
+    labels: Sequence[str],
+    versions_by_label: Mapping[str, str],
+    markers_by_label: Mapping[str, str],
+    wheel_shift: int,
+) -> LockInput:
+    """Assemble a per-tuple ``LockInput`` over the given orderings.
+
+    ``labels`` fixes the tuple order, the ``per_tuple_pins`` dict is
+    built in that order, and each pin's wheels are rotated by
+    ``wheel_shift`` so two calls with different orderings exercise the
+    insertion-order paths the emitter must neutralise.
+    """
+    per_tuple_pins: dict[str, dict[str, IndexPin]] = {}
+    for label in labels:
+        version = versions_by_label[label]
+        per_name: dict[str, IndexPin] = {}
+        for name in names:
+            wheels = tuple(_reorder(_multi_wheel(name, version), wheel_shift))
+            per_name[name] = IndexPin(
+                name=name,
+                version=version,
+                index="pypi",
+                wheels=wheels,  # type: ignore[arg-type]
+            )
+        per_tuple_pins[label] = per_name
+    tuple_markers = {label: Marker(markers_by_label[label]) for label in labels}
+    return LockInput(per_tuple_pins=per_tuple_pins, tuple_markers=tuple_markers)
+
+
+class TestQuoteShuffledInputInvariant:
+    """PEP 751, § File Format:
+
+    > "Tools SHOULD write their lock files in a consistent way to
+    > minimize noise in diff output. ... As well, tools SHOULD sort
+    > arrays in consistent order."
+
+    The byte-stability guarantee must survive a reordering of every
+    insertion-ordered input: the package map, the per-tuple map, each
+    pin's wheel list, each wheel's hash pairs, and the OR-marker
+    fragments. Emitting a shuffled-but-equivalent input must produce
+    identical bytes; otherwise a re-resolve that happened to populate
+    its dicts in a different order would churn the lockfile.
+
+    Reference: https://peps.python.org/pep-0751/#file-format
+    """
+
+    def test_shuffled_per_tuple_input_is_byte_equal(self) -> None:
+        """Reordering every input axis yields byte-identical output."""
+        names = ["alpha", "beta", "gamma"]
+        labels = ["py310", "py311", "py312", "py313"]
+        versions_by_label = {
+            "py310": "1.0",
+            "py311": "1.0",
+            "py312": "2.0",
+            "py313": "2.0",
+        }
+        markers_by_label = {
+            "py310": 'python_version == "3.10"',
+            "py311": 'python_version == "3.11"',
+            "py312": 'python_version == "3.12"',
+            "py313": 'python_version == "3.13"',
+        }
+        canonical = write_lock(
+            _per_tuple_input(
+                names=names,
+                labels=labels,
+                versions_by_label=versions_by_label,
+                markers_by_label=markers_by_label,
+                wheel_shift=0,
+            )
+        )
+        shuffled = write_lock(
+            _per_tuple_input(
+                names=list(reversed(names)),
+                labels=list(reversed(labels)),
+                versions_by_label=versions_by_label,
+                markers_by_label=markers_by_label,
+                wheel_shift=1,
+            )
+        )
+        assert shuffled == canonical
+
+
+class TestQuoteMarkerCollisionOrdering:
+    """PEP 751, § ``[[packages]]``:
+
+    > "Packages MAY be listed multiple times with varying data, but
+    > all packages to be installed MUST narrow down to a single entry
+    > at install time."
+
+    Two entries with the same name and version but different markers
+    are a legal per-tuple shape (e.g. one index per environment). The
+    name+version sort key alone cannot separate them, so the emitter
+    must break the tie on the marker string. Both entries must survive
+    and their relative order must not depend on insertion order.
+
+    Reference: https://peps.python.org/pep-0751/#packages
+    """
+
+    def _collision_input(self, *, labels: Sequence[str]) -> LockInput:
+        per_tuple_pins = {
+            "linux": {
+                "foo": IndexPin(
+                    name="foo",
+                    version="1.0",
+                    index="https://linux.example/simple",
+                    wheels=(_wheel("foo", "1.0", "a" * 64),),
+                )
+            },
+            "darwin": {
+                "foo": IndexPin(
+                    name="foo",
+                    version="1.0",
+                    index="https://darwin.example/simple",
+                    wheels=(_wheel("foo", "1.0", "b" * 64),),
+                )
+            },
+        }
+        ordered = {label: per_tuple_pins[label] for label in labels}
+        tuple_markers = {
+            "linux": Marker('sys_platform == "linux"'),
+            "darwin": Marker('sys_platform == "darwin"'),
+        }
+        return LockInput(per_tuple_pins=ordered, tuple_markers=tuple_markers)
+
+    def test_same_name_version_distinct_markers_stable(self) -> None:
+        """A same-name same-version marker pair sorts stably by marker."""
+        forward = write_lock(self._collision_input(labels=["linux", "darwin"]))
+        reverse = write_lock(self._collision_input(labels=["darwin", "linux"]))
+        assert forward == reverse
+        data: Mapping[str, object] = tomllib.loads(forward)
+        packages = data["packages"]
+        assert isinstance(packages, list)
+        assert len(packages) == 2
+        markers = [pkg["marker"] for pkg in packages]
+        assert markers == sorted(markers)
+
+
+class TestQuoteWheelOrdering:
+    """PEP 751, § ``[[packages.wheels]]``:
+
+    > "tools SHOULD sort arrays in consistent order."
+
+    A pin's wheels arrive in whatever order the index listed them.
+    The emitter sorts them by filename so the ``packages.wheels``
+    array is stable across runs and across indexes that list the same
+    files in a different order.
+
+    Reference: https://peps.python.org/pep-0751/#packageswheels
+    """
+
+    def test_wheels_emitted_in_filename_order(self) -> None:
+        """Out-of-order wheels emit filename-ascending."""
+        wheels = (
+            _wheel_named("foo-1.0-cp312-cp312-win_amd64.whl", "f" * 64),
+            _wheel_named("foo-1.0-cp310-cp310-manylinux_2_17_x86_64.whl", "a" * 64),
+            _wheel_named("foo-1.0-cp311-cp311-macosx_11_0_arm64.whl", "c" * 64),
+        )
+        pin = IndexPin(name="foo", version="1.0", index="pypi", wheels=wheels)
+        text = write_lock(LockInput(pins={"foo": pin}))
+        data: Mapping[str, object] = tomllib.loads(text)
+        packages = data["packages"]
+        assert isinstance(packages, list)
+        emitted = [w["name"] for w in packages[0]["wheels"]]
+        assert emitted == sorted(emitted)
+        assert emitted == [
+            "foo-1.0-cp310-cp310-manylinux_2_17_x86_64.whl",
+            "foo-1.0-cp311-cp311-macosx_11_0_arm64.whl",
+            "foo-1.0-cp312-cp312-win_amd64.whl",
+        ]
 
 
 class TestQuoteUniversalPerTuplePackages:


### PR DESCRIPTION
Sort the pylock.toml emitter's output so a fixed resolution serializes byte-identically: a marker tiebreak on the package key, wheels by filename then url or path, hashes by algorithm, OR-marker fragments by string, and per-tuple grouping in sorted label order.

Adds a shuffled-input invariant test; the previous test only re-serialized a single fixed object, so it could not catch insertion-order leaks.

Closes #16.