### PR TITLE
Drop non-standard .zip sdists

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -58,16 +58,20 @@ def _parse_wheel_filename(filename: str) -> tuple[NormalizedName, str] | None:
 
 
 def _parse_sdist_filename(filename: str) -> tuple[NormalizedName, str] | None:
-    """Parse an sdist filename.  Supports ``.tar.gz`` and ``.zip``.
+    """Parse a ``.tar.gz`` sdist filename to ``(canonical_name, version)``.
 
-    Returns ``(canonical_name, version_string)`` or ``None`` for any
-    filename packaging rejects.  Note that legacy filenames with
-    embedded build tags (e.g. ``cffi-1.0.2-2.tar.gz``) parse to a
-    surprising ``(name="cffi-1-0-2", version="2")`` tuple per
-    :func:`packaging.utils.parse_sdist_filename`'s last-dash split;
-    callers MUST drop files whose canonical name does not match the
-    package they queried.  See :func:`_parse_files`.
+    Returns ``None`` for anything packaging rejects and for ``.zip``
+    sdists, which nab does not support (gzip-tar only, and not part of
+    the PEP 625 standard).
+
+    Legacy filenames with embedded build tags (e.g. ``cffi-1.0.2-2.tar.gz``)
+    parse to a surprising ``(name="cffi-1-0-2", version="2")``, so callers
+    MUST drop files whose canonical name does not match the queried
+    package.  See :func:`_parse_files`.
     """
+    if filename.endswith(".zip"):
+        return None
+
     try:
         name, version = parse_sdist_filename(filename)
     except InvalidSdistFilename:

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -7,10 +7,11 @@ Two flavours, both keyed off a ``file://`` URL pointing at a directory:
   :class:`~nab_index.client.WheelFile` /
   :class:`~nab_index.client.SdistFile` records mirror what an HTTPS
   Simple API returns.
-* Flat wheelhouse: a directory containing ``.whl`` and ``.tar.gz`` /
-  ``.zip`` files at the top level (pip's ``--find-links ./wheels``
-  shape). On-disk filenames are parsed for ``(name, version)`` and
-  every distribution for a package is returned by ``get_files``.
+* Flat wheelhouse: a directory containing ``.whl`` and ``.tar.gz``
+  files at the top level (pip's ``--find-links ./wheels`` shape).
+  On-disk filenames are parsed for ``(name, version)`` and every
+  distribution for a package is returned by ``get_files``.  ``.zip``
+  sdists are ignored, matching the remote-index behaviour.
 
 Reads run synchronously off the filesystem; the filesystem is the
 cache. The async surface is a thin shim over the sync helpers so the
@@ -93,7 +94,7 @@ class _Pep503Parser(HTMLParser):
             self.links.append((href, requires_python))
 
 
-_FLAT_EXTS = re.compile(r"\.(whl|tar\.gz|zip)$", re.IGNORECASE)
+_FLAT_EXTS = re.compile(r"\.(whl|tar\.gz)$", re.IGNORECASE)
 
 
 def _scan_pep503_directory(

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -18,6 +18,7 @@ from nab_index.cached_client import (
     _header,
     _parse_max_age,
 )
+from nab_index.client import SdistFile, WheelFile, _parse_files, _parse_sdist_filename
 
 LISTING = {
     "meta": {"api-version": "1.0"},
@@ -184,6 +185,61 @@ class TestYankedFiltering:
         }
         files = _parse_files(data, "https://example.com/", "foo")
         assert len(files) == 1
+
+
+class TestZipSdistDropped:
+    """nab admits only .tar.gz sdists; .zip is dropped at parse time."""
+
+    def test_parse_sdist_filename_rejects_zip(self) -> None:
+        assert _parse_sdist_filename("foo-1.0.zip") is None
+
+    def test_parse_sdist_filename_accepts_tar_gz(self) -> None:
+        assert _parse_sdist_filename("foo-1.0.tar.gz") == ("foo", "1.0")
+
+    def test_zip_alongside_tar_gz_keeps_only_tar_gz(self) -> None:
+        data = {
+            "files": [
+                {
+                    "filename": "foo-1.0.tar.gz",
+                    "url": "https://example.com/foo-1.0.tar.gz",
+                },
+                {
+                    "filename": "foo-1.0.zip",
+                    "url": "https://example.com/foo-1.0.zip",
+                },
+            ],
+        }
+        files = _parse_files(data, "https://example.com/", "foo")
+        assert [f.filename for f in files] == ["foo-1.0.tar.gz"]
+        assert all(isinstance(f, SdistFile) for f in files)
+
+    def test_zip_only_release_yields_no_sdist(self) -> None:
+        data = {
+            "files": [
+                {
+                    "filename": "foo-1.0.zip",
+                    "url": "https://example.com/foo-1.0.zip",
+                },
+            ],
+        }
+        assert _parse_files(data, "https://example.com/", "foo") == []
+
+    def test_zip_dropped_wheel_kept(self) -> None:
+        data = {
+            "files": [
+                {
+                    "filename": "foo-1.0-py3-none-any.whl",
+                    "url": "https://example.com/foo-1.0-py3-none-any.whl",
+                },
+                {
+                    "filename": "foo-1.0.zip",
+                    "url": "https://example.com/foo-1.0.zip",
+                },
+            ],
+        }
+        files = _parse_files(data, "https://example.com/", "foo")
+        assert [f.filename for f in files] == ["foo-1.0-py3-none-any.whl"]
+        assert all(isinstance(f, WheelFile) for f in files)
 
 
 class TestParseMaxAge:

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -67,12 +67,10 @@ class TestFlatWheelhouse:
         assert isinstance(files[0], SdistFile)
         assert files[0].version == "1.0"
 
-    def test_finds_sdist_zip(self, tmp_path: Path) -> None:
+    def test_ignores_sdist_zip(self, tmp_path: Path) -> None:
         (tmp_path / "foo-1.0.zip").write_bytes(b"")
         client = LocalIndexClient(tmp_path.as_uri())
-        files = run(client.get_files("foo"))
-        assert len(files) == 1
-        assert isinstance(files[0], SdistFile)
+        assert run(client.get_files("foo")) == []
 
     def test_filters_other_packages(self, tmp_path: Path) -> None:
         (tmp_path / "foo-1.0-py3-none-any.whl").write_bytes(b"")
@@ -243,6 +241,16 @@ class TestPep503Directory:
         result = run(client.get_files("foo"))
         assert len(result) == 1
         assert result[0].hashes == (("sha256", digest),)
+
+    def test_pep503_zip_sdist_dropped(self, tmp_path: Path) -> None:
+        body = '<a href="foo-1.0.zip">foo-zip</a><a href="foo-1.0.tar.gz">foo-sdist</a>'
+        package_dir = self._make_index(tmp_path, body)
+        (package_dir / "foo-1.0.zip").write_bytes(b"")
+        (package_dir / "foo-1.0.tar.gz").write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        result = run(client.get_files("foo"))
+        assert [r.filename for r in result] == ["foo-1.0.tar.gz"]
+        assert isinstance(result[0], SdistFile)
 
     def test_pep503_yanked_link_excluded(self, tmp_path: Path) -> None:
         body = (


### PR DESCRIPTION
nab can only read and build gzip-tar sdists, and `.zip` is not part of the PEP 625 source-distribution standard, but `.zip` sdists still entered listings and could be recorded in the lockfile nondeterministically when an index served both formats (issue #17). This drops `.zip` sdists at parse time, in both the Simple-API client (`_parse_sdist_filename`) and the local find-links index, so they never become candidates and never reach the lockfile.

A release whose only sdist is a `.zip` is then simply unavailable, which is correct since nab could not build it anyway.

Closes #17.