### PR TITLE
Use deque for unit-propagation queue

### DIFF
--- a/nab-resolver/src/nab_resolver/propagate.py
+++ b/nab-resolver/src/nab_resolver/propagate.py
@@ -10,6 +10,7 @@ Reference: https://github.com/dart-lang/pub/blob/master/doc/solver.md#unit-propa
 
 from __future__ import annotations
 
+from collections import deque
 from typing import TYPE_CHECKING, Any
 
 from .types import IncompatibilityState, SetRelation, Term
@@ -38,15 +39,15 @@ def unit_propagation(
 
     Reference: https://github.com/dart-lang/pub/blob/master/doc/solver.md#unit-propagation
     """
-    propagation_queue: list[Any] = [changed_package]
+    propagation_queue: deque[Any] = deque([changed_package])
     in_queue: set[Any] = {changed_package}
 
     while propagation_queue:
-        package = propagation_queue.pop(0)
+        package = propagation_queue.popleft()
         in_queue.discard(package)
         related_indices = resolver.package_to_incompatibilities.get(package, [])
 
-        for incompatibility_index in list(related_indices):
+        for incompatibility_index in related_indices:
             incompatibility = resolver.incompatibilities[incompatibility_index]
             evaluation = evaluate_incompatibility(resolver, incompatibility)
 


### PR DESCRIPTION
Swap the FIFO list + pop(0) (O(n) dequeue) in unit_propagation for collections.deque + popleft() (O(1)), and drop the per-visit list(related_indices) copy.

FIFO order is byte-for-byte preserved. package_to_incompatibilities is never appended to from inside the propagation loop, so iterating the live list is safe.

Output-invariant: decisions byte-identical on 18/19 canary scenarios (trustllm drift is pre-existing async nondeterminism). Coverage held at 100%.