### PR TITLE
Skip tag parse and intern version in wheel parser

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -8,19 +8,20 @@ Transport-agnostic: any async HTTP client implementing the
 from __future__ import annotations
 
 import io
+import re
 import sys
 import tarfile
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from packaging.utils import (
     InvalidSdistFilename,
-    InvalidWheelFilename,
     canonicalize_name,
     parse_sdist_filename,
-    parse_wheel_filename,
 )
+from packaging.version import InvalidVersion, Version
 
 if TYPE_CHECKING:
     from packaging.utils import NormalizedName
@@ -37,6 +38,26 @@ __all__ = [
 ]
 
 
+# Mirrors packaging.utils._build_tag_regex: PEP 427 build numbers start with a digit.
+_BUILD_TAG_RE = re.compile(r"(\d+)(.*)", re.ASCII)
+# Mirrors packaging.utils' PEP 427 project-name check (re.match, not fullmatch).
+_WHEEL_NAME_RE = re.compile(r"^[\w\d._]*$", re.UNICODE)
+# A wheel filename has 4 dashes, or 5 when it carries a build tag.
+_WHEEL_DASHES = (4, 5)
+_WHEEL_DASHES_WITH_BUILD = 5
+
+
+@lru_cache(maxsize=65536)
+def _intern_version(version: str) -> Version:
+    """Construct a :class:`Version`, reusing one object per distinct string.
+
+    Raises :class:`InvalidVersion`; callers map that to a rejected file.
+    The same version recurs across every per-platform wheel of a release,
+    so the PEP 440 parse runs once per distinct string instead of per file.
+    """
+    return Version(version)
+
+
 def _parse_wheel_filename(filename: str) -> tuple[NormalizedName, str] | None:
     """Parse a wheel filename per PEP 427.
 
@@ -47,14 +68,30 @@ def _parse_wheel_filename(filename: str) -> tuple[NormalizedName, str] | None:
     matches what packaging records on the file; e.g. a wheel
     declaring ``2.0.0`` in its filename comes back as ``"2.0.0"``,
     not ``"2"``.
+
+    This reproduces :func:`packaging.utils.parse_wheel_filename`'s
+    name/version validation but skips its ``parse_tag`` call, whose
+    ``frozenset[Tag]`` result nab discards. With ``validate_order=False``
+    (nab's default) ``parse_tag`` never raises, so the accepted filename
+    set is unchanged. A differential test guards against drift.
     """
     if not filename.endswith(".whl"):
         return None
-    try:
-        name, version, _build, _tags = parse_wheel_filename(filename)
-    except InvalidWheelFilename:
+    stem = filename[:-4]
+    dashes = stem.count("-")
+    if dashes not in _WHEEL_DASHES:
         return None
-    return (name, str(version))
+    parts = stem.split("-", dashes - 2)
+    name_part = parts[0]
+    if "__" in name_part or _WHEEL_NAME_RE.match(name_part) is None:
+        return None
+    try:
+        version = _intern_version(parts[1])
+    except InvalidVersion:
+        return None
+    if dashes == _WHEEL_DASHES_WITH_BUILD and _BUILD_TAG_RE.match(parts[2]) is None:
+        return None
+    return (canonicalize_name(name_part), str(version))
 
 
 def _parse_sdist_filename(filename: str) -> tuple[NormalizedName, str] | None:

--- a/nab-python/tests/test_simple_client_filenames.py
+++ b/nab-python/tests/test_simple_client_filenames.py
@@ -1,0 +1,71 @@
+"""Differential tests for nab_index's wheel-filename parser.
+
+``_parse_wheel_filename`` reproduces packaging's name/version validation
+while skipping the discarded tag-set parse and interning the version. These
+tests assert it accepts/rejects exactly what packaging does and shares one
+:class:`Version` per distinct string, so the optimization stays output-invariant
+even if packaging is re-vendored.
+"""
+
+from __future__ import annotations
+
+import pytest
+from packaging.utils import (
+    InvalidWheelFilename,
+    canonicalize_name,
+    parse_wheel_filename,
+)
+
+from nab_index.client import _intern_version, _parse_wheel_filename
+
+CORPUS = [
+    # valid, no build tag
+    "foo-1.0-py3-none-any.whl",
+    "Foo.Bar-2.0.0-py3-none-any.whl",
+    "numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.whl",
+    # compressed tag set (multiple tags in one component)
+    "wheel-0.1-py2.py3-none-any.whl",
+    "pkg-1.0-py3-none-any.whl",
+    # valid, with build tag (5 dashes)
+    "torch-2.0.1-1-cp311-cp311-linux_x86_64.whl",
+    "pkg-1.0-0build-py3-none-any.whl",
+    # rejected: wrong extension
+    "foo-1.0-py3-none-any.tar.gz",
+    "foo-1.0-py3-none-any",
+    # rejected: wrong number of parts
+    "foo-1.0-py3-none.whl",
+    "foo-1.0-1-2-py3-none-any.whl",
+    # rejected: invalid project name
+    "foo__bar-1.0-py3-none-any.whl",
+    "foo bar-1.0-py3-none-any.whl",
+    # rejected: invalid version
+    "foo-notaversion-py3-none-any.whl",
+    # rejected: 5-dash build part not starting with a digit
+    "foo-1.0-build-py3-none-any.whl",
+]
+
+
+def _packaging_result(filename: str) -> tuple[str, str] | None:
+    try:
+        name, version, _build, _tags = parse_wheel_filename(filename)
+    except InvalidWheelFilename:
+        return None
+    return (str(name), str(version))
+
+
+@pytest.mark.parametrize("filename", CORPUS)
+def test_matches_packaging(filename: str) -> None:
+    assert _parse_wheel_filename(filename) == _packaging_result(filename)
+
+
+def test_canonical_form_and_trailing_zeros() -> None:
+    assert _parse_wheel_filename("Foo.Bar-2.0.0-py3-none-any.whl") == (
+        canonicalize_name("Foo.Bar"),
+        "2.0.0",
+    )
+
+
+def test_intern_reuses_version_object() -> None:
+    first = _intern_version("9.99.123")
+    second = _intern_version("9.99.123")
+    assert first is second


### PR DESCRIPTION
_parse_wheel_filename used packaging.utils.parse_wheel_filename, which eagerly expands the compressed tag set into a frozenset[Tag] that nab discards. This replaces it with a name+version parser mirroring packaging's validation minus parse_tag, and routes the per-file Version construction through an lru_cache so each distinct version string is parsed once rather than once per wheel.

Output-invariant by construction: with validate_order=False parse_tag never raises and only builds the tag set we drop, and str(version) is unchanged. A new differential test asserts the parser agrees with parse_wheel_filename (matching name+version, or None where packaging rejects) over a real and adversarial corpus, guarding against drift on a future packaging re-vendor.