### PR TITLE
Cache contradicted incompatibilities in propagation

### DIFF
--- a/nab-resolver/src/nab_resolver/conflict.py
+++ b/nab-resolver/src/nab_resolver/conflict.py
@@ -135,6 +135,7 @@ def conflict_resolution(
 
             from_level = resolver.solution.decision_level
             resolver.solution.backtrack(backjump_target)
+            resolver.prune_contradicted(backjump_target)
             resolver.stats.backjumps += 1
             resolver.observer.on_backjump(from_level, backjump_target)
 
@@ -420,6 +421,8 @@ def maybe_restart(
     resolver.stats.restarts += 1
     resolver.solution = PartialSolution(range_type=resolver.range_type)
     resolver.solution.decide(ROOT, resolver.root_version)
+    # Restart widens every package, so all cached contradictions are stale.
+    resolver.contradicted_at.clear()
     resolver.pending_targeted_backtrack.clear()
     resolver.stats.targeted_backtracks = 0
 
@@ -487,5 +490,6 @@ def apply_targeted_backtrack(resolver: Resolver[Any, Any]) -> Any | None:
         return None
 
     resolver.solution.backtrack(target_level)
+    resolver.prune_contradicted(target_level)
     resolver.stats.targeted_backtracks += 1
     return triggering_package

--- a/nab-resolver/src/nab_resolver/incompat_index.py
+++ b/nab-resolver/src/nab_resolver/incompat_index.py
@@ -116,4 +116,6 @@ def maybe_merge_dependency(
     # Safe to replace in place: DEPENDENCY clauses have no cause_left/right
     # references that would break.
     resolver.incompatibilities[existing_index] = merged
+    # A widening merge can un-contradict the clause; drop its cached entry.
+    resolver.contradicted_at.pop(existing_index, None)
     return True

--- a/nab-resolver/src/nab_resolver/propagate.py
+++ b/nab-resolver/src/nab_resolver/propagate.py
@@ -41,6 +41,8 @@ def unit_propagation(
     """
     propagation_queue: deque[Any] = deque([changed_package])
     in_queue: set[Any] = {changed_package}
+    # Contradiction holds until a backtrack widens it, so skip cached indices.
+    contradicted_at = resolver.contradicted_at
 
     while propagation_queue:
         package = propagation_queue.popleft()
@@ -48,11 +50,19 @@ def unit_propagation(
         related_indices = resolver.package_to_incompatibilities.get(package, [])
 
         for incompatibility_index in related_indices:
+            if incompatibility_index in contradicted_at:
+                continue
             incompatibility = resolver.incompatibilities[incompatibility_index]
             evaluation = evaluate_incompatibility(resolver, incompatibility)
 
             if evaluation is IncompatibilityState.CONFLICT:
                 return incompatibility
+
+            if evaluation is IncompatibilityState.CONTRADICTED:
+                contradicted_at[incompatibility_index] = (
+                    resolver.solution.decision_level
+                )
+                continue
 
             if isinstance(evaluation, Term):
                 negated_term = evaluation.negate()
@@ -86,8 +96,11 @@ def evaluate_incompatibility(
 
     Returns:
       ``IncompatibilityState.CONFLICT``: all terms satisfied
+      ``IncompatibilityState.CONTRADICTED``: some term is contradicted; the
+        clause is dead until a backtrack and is safe to cache as skippable
       ``Term``: exactly one undetermined term (unit propagation candidate)
-      ``None``: 0 or 2+ undetermined terms (nothing to do yet)
+      ``None``: 2+ undetermined terms (nothing to do yet, not cacheable since
+        an undetermined term becomes determined without a backtrack)
     """
     undetermined_term: Term[Any, Any] | None = None
 
@@ -96,7 +109,7 @@ def evaluate_incompatibility(
         if relation is SetRelation.SATISFIED:
             continue
         if relation is SetRelation.CONTRADICTED:
-            return None
+            return IncompatibilityState.CONTRADICTED
         if undetermined_term is not None:
             return None
         undetermined_term = term

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -267,6 +267,10 @@ class Resolver(Generic[PackageType, VersionType]):
             list
         )
 
+        # Incompatibility index -> decision level it became contradicted at;
+        # pruned on backtrack, cleared on restart.
+        self.contradicted_at: dict[int, int] = {}
+
         # Keyed by (package, dep_package, dep_constraint, dep_positive); used
         # to merge mergeable dependency clauses (pubgrub-rs's merge_dependents).
         self.dependency_index: dict[Any, int] = {}
@@ -419,6 +423,20 @@ class Resolver(Generic[PackageType, VersionType]):
             root_sentinel=ROOT,
         )
 
+    def prune_contradicted(self, target_level: int) -> None:
+        """Drop contradicted-clause cache entries recorded above ``target_level``.
+
+        A backtrack to ``target_level`` pops every assignment above it, so any
+        clause that became contradicted at a higher level may now be live again
+        and must be re-evaluated. Entries at or below the target stay valid
+        because their contradicting assignments survive the backtrack.
+        """
+        self.contradicted_at = {
+            index: level
+            for index, level in self.contradicted_at.items()
+            if level <= target_level
+        }
+
     def _reset(
         self,
         constraints: Mapping[PackageType, RangeProtocol[VersionType]] | None,
@@ -426,6 +444,7 @@ class Resolver(Generic[PackageType, VersionType]):
         """Reset solver state for a new resolution."""
         self.incompatibilities.clear()
         self.package_to_incompatibilities.clear()
+        self.contradicted_at.clear()
         self.dependency_index.clear()
         self.solution = PartialSolution(range_type=self.range_type)
         self.stats = ResolverStats()

--- a/nab-resolver/src/nab_resolver/types.py
+++ b/nab-resolver/src/nab_resolver/types.py
@@ -186,6 +186,7 @@ class IncompatibilityState(enum.Enum):
     """Result of evaluating an incompatibility against the partial solution."""
 
     CONFLICT = enum.auto()
+    CONTRADICTED = enum.auto()
 
 
 class IncompatibilityCause(enum.Enum):

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -21,6 +21,7 @@ from nab_resolver.incompat_index import (
     maybe_merge_dependency,
 )
 from nab_resolver.partial_solution import PartialSolution
+from nab_resolver.propagate import evaluate_incompatibility, unit_propagation
 from nab_resolver.ranges import Range
 from nab_resolver.report import explain_incompatibility, prior_cause, union_terms
 from nab_resolver.resolver import (
@@ -32,6 +33,7 @@ from nab_resolver.root import ROOT
 from nab_resolver.types import (
     Incompatibility,
     IncompatibilityCause,
+    IncompatibilityState,
     RangeProtocol,
     Term,
 )
@@ -1891,3 +1893,96 @@ class TestRegressions:
         resolver = Resolver(provider)
         with pytest.raises(ResolutionError):
             resolver.resolve({"root": Range.singleton(1)})
+
+
+class TestContradictedCache:
+    """The contradicted-incompatibility skip cache (card 026)."""
+
+    def _decided(self, package: str, version: int) -> PartialSolution:
+        solution: PartialSolution = PartialSolution()
+        root = Incompatibility(
+            [Term(package, Range.full())], cause=IncompatibilityCause.ROOT
+        )
+        solution.derive(package, Range.at_least(1), positive=True, cause=root)
+        solution.decide(package, version)
+        return solution
+
+    def test_evaluate_returns_contradicted(self) -> None:
+        """A positive term whose range excludes the decision is contradicted."""
+        resolver = Resolver(DictProvider({}))
+        resolver.solution = self._decided("x", 2)
+        incompatibility = Incompatibility(
+            [Term("x", Range.singleton(5), positive=True)],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+        assert (
+            evaluate_incompatibility(resolver, incompatibility)
+            is IncompatibilityState.CONTRADICTED
+        )
+
+    def test_evaluate_two_undetermined_is_not_cacheable(self) -> None:
+        """Two undetermined terms return None, not the contradicted sentinel."""
+        resolver = Resolver(DictProvider({}))
+        incompatibility = Incompatibility(
+            [
+                Term("a", Range.full(), positive=True),
+                Term("b", Range.full(), positive=True),
+            ],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+        assert evaluate_incompatibility(resolver, incompatibility) is None
+
+    def test_propagation_records_contradicted_index(self) -> None:
+        """Unit propagation caches a contradicted clause at the current level."""
+        resolver = Resolver(DictProvider({}))
+        resolver.solution = self._decided("x", 2)
+        add_incompatibility(
+            resolver,
+            Incompatibility(
+                [Term("x", Range.singleton(5), positive=True)],
+                cause=IncompatibilityCause.DEPENDENCY,
+            ),
+        )
+        assert unit_propagation(resolver, "x") is None
+        assert resolver.contradicted_at == {0: resolver.solution.decision_level}
+
+    def test_propagation_skips_cached_index(self) -> None:
+        """A cached index is skipped even when it would otherwise conflict."""
+        resolver = Resolver(DictProvider({}))
+        resolver.solution = self._decided("x", 2)
+        add_incompatibility(
+            resolver,
+            Incompatibility(
+                [Term("x", Range.singleton(2), positive=True)],
+                cause=IncompatibilityCause.DEPENDENCY,
+            ),
+        )
+        resolver.contradicted_at[0] = 0
+        assert unit_propagation(resolver, "x") is None
+
+    def test_prune_keeps_low_levels_drops_high(self) -> None:
+        resolver = Resolver(DictProvider({}))
+        resolver.contradicted_at = {1: 2, 2: 4, 3: 5}
+        resolver.prune_contradicted(4)
+        assert resolver.contradicted_at == {1: 2, 2: 4}
+
+    def test_merge_evicts_widened_index(self) -> None:
+        """Widening a clause on merge drops its cached contradiction."""
+        resolver = Resolver(DictProvider({}))
+        dep = Term("d", Range.singleton(9), positive=False)
+        add_incompatibility(
+            resolver,
+            Incompatibility(
+                [Term("p", Range.singleton(1), positive=True), dep],
+                cause=IncompatibilityCause.DEPENDENCY,
+            ),
+        )
+        resolver.contradicted_at[0] = 1
+        add_incompatibility(
+            resolver,
+            Incompatibility(
+                [Term("p", Range.singleton(2), positive=True), dep],
+                cause=IncompatibilityCause.DEPENDENCY,
+            ),
+        )
+        assert 0 not in resolver.contradicted_at


### PR DESCRIPTION
Skip re-evaluating already-contradicted incompatibilities in unit_propagation. A contradicted clause stays contradicted until a backtrack pops the assignment that did it, so re-running term_relation on it is wasted work. The contradiction is cached by decision level and pruned at the widening sites (backtrack, restart, dependency-merge).