### PR TITLE
Intern version string and name in wheel parser

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -49,13 +49,20 @@ _WHEEL_DASHES_WITH_BUILD = 5
 
 @lru_cache(maxsize=65536)
 def _intern_version(version: str) -> Version:
-    """Construct a :class:`Version`, reusing one object per distinct string.
-
-    Raises :class:`InvalidVersion`; callers map that to a rejected file.
-    The same version recurs across every per-platform wheel of a release,
-    so the PEP 440 parse runs once per distinct string instead of per file.
-    """
+    """Construct a cached :class:`Version`."""
     return Version(version)
+
+
+@lru_cache(maxsize=65536)
+def _canonical_version(version: str) -> str:
+    """Return a cached canonical version string."""
+    return str(_intern_version(version))
+
+
+@lru_cache(maxsize=65536)
+def _intern_name(name: str) -> NormalizedName:
+    """Return a cached canonical name."""
+    return canonicalize_name(name)
 
 
 def _parse_wheel_filename(filename: str) -> tuple[NormalizedName, str] | None:
@@ -77,21 +84,26 @@ def _parse_wheel_filename(filename: str) -> tuple[NormalizedName, str] | None:
     """
     if not filename.endswith(".whl"):
         return None
+
     stem = filename[:-4]
     dashes = stem.count("-")
     if dashes not in _WHEEL_DASHES:
         return None
+
     parts = stem.split("-", dashes - 2)
     name_part = parts[0]
     if "__" in name_part or _WHEEL_NAME_RE.match(name_part) is None:
         return None
+
     try:
-        version = _intern_version(parts[1])
+        version = _canonical_version(parts[1])
     except InvalidVersion:
         return None
+
     if dashes == _WHEEL_DASHES_WITH_BUILD and _BUILD_TAG_RE.match(parts[2]) is None:
         return None
-    return (canonicalize_name(name_part), str(version))
+
+    return (_intern_name(name_part), version)
 
 
 def _parse_sdist_filename(filename: str) -> tuple[NormalizedName, str] | None:

--- a/nab-python/tests/test_simple_client_filenames.py
+++ b/nab-python/tests/test_simple_client_filenames.py
@@ -1,10 +1,11 @@
 """Differential tests for nab_index's wheel-filename parser.
 
 ``_parse_wheel_filename`` reproduces packaging's name/version validation
-while skipping the discarded tag-set parse and interning the version. These
-tests assert it accepts/rejects exactly what packaging does and shares one
-:class:`Version` per distinct string, so the optimization stays output-invariant
-even if packaging is re-vendored.
+while skipping the discarded tag-set parse and interning the version, its
+canonical string, and the canonical name. These tests assert it
+accepts/rejects exactly what packaging does and that the interners return
+byte-identical results to the uncached functions, so the optimization stays
+output-invariant even if packaging is re-vendored.
 """
 
 from __future__ import annotations
@@ -15,8 +16,14 @@ from packaging.utils import (
     canonicalize_name,
     parse_wheel_filename,
 )
+from packaging.version import InvalidVersion
 
-from nab_index.client import _intern_version, _parse_wheel_filename
+from nab_index.client import (
+    _canonical_version,
+    _intern_name,
+    _intern_version,
+    _parse_wheel_filename,
+)
 
 CORPUS = [
     # valid, no build tag
@@ -68,4 +75,33 @@ def test_canonical_form_and_trailing_zeros() -> None:
 def test_intern_reuses_version_object() -> None:
     first = _intern_version("9.99.123")
     second = _intern_version("9.99.123")
+    assert first is second
+
+
+@pytest.mark.parametrize("raw", ["1.26.4", "2.0.0", "1.0", "10!2.3.4rc1.post2"])
+def test_canonical_version_matches_str_version(raw: str) -> None:
+    assert _canonical_version(raw) == str(_intern_version(raw))
+
+
+def test_canonical_version_reuses_string() -> None:
+    first = _canonical_version("3.21.0")
+    second = _canonical_version("3.21.0")
+    assert first is second
+
+
+def test_canonical_version_rejects_invalid() -> None:
+    with pytest.raises(InvalidVersion):
+        _canonical_version("notaversion")
+    with pytest.raises(InvalidVersion):
+        _canonical_version("notaversion")
+
+
+@pytest.mark.parametrize("raw", ["Foo.Bar", "foo_bar", "foo-bar", "Tensorflow_CPU"])
+def test_intern_name_matches_canonicalize(raw: str) -> None:
+    assert _intern_name(raw) == canonicalize_name(raw)
+
+
+def test_intern_name_reuses_result() -> None:
+    first = _intern_name("scikit.learn")
+    second = _intern_name("scikit.learn")
     assert first is second


### PR DESCRIPTION
Memoize the canonical version string and lru-cache canonicalize_name on the raw name segment in the wheel filename parser.