### PR TITLE
Store solution hint snapshots without re-copying

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -1032,16 +1032,20 @@ class Provider:
 
     def receive_partial_solution_hint(
         self,
-        positive_ranges: Mapping[str, RangeProtocol[Version]],
-        decisions: Mapping[str, Version],
+        positive_ranges: dict[str, RangeProtocol[Version]],
+        decisions: dict[str, Version],
     ) -> None:
         """Accept a snapshot of the resolver's positive-range assignments.
 
         Decision-only forward checking is safer than reasoning over
         derivations because backjumping a decision also undoes its derivations.
+
+        The caller hands over fresh snapshots it does not retain or mutate, so
+        we store them directly. We only ever read these maps, never mutate them
+        in place; both are reassigned wholesale on the next hint.
         """
-        self.solution_ranges = dict(positive_ranges)
-        self.solution_decisions = dict(decisions)
+        self.solution_ranges = positive_ranges
+        self.solution_decisions = decisions
 
     def _look_ahead_ok(
         self, package: str, version: Version, *, check_decisions: bool = True

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -1475,6 +1475,16 @@ class TestDecisionLookAhead:
         assert provider.solution_decisions == decisions
         assert provider.solution_ranges == ranges
 
+    def test_hint_stores_snapshots_without_copying(self) -> None:
+        """The caller hands over owned snapshots, so they are stored as-is."""
+        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
+        provider = Provider(coordinator)
+        ranges = {"bar": SpecifierSet(">=1.0").to_range()}
+        decisions = {"bar": V("1.0")}
+        provider.receive_partial_solution_hint(ranges, decisions)
+        assert provider.solution_ranges is ranges
+        assert provider.solution_decisions is decisions
+
     def test_first_candidate_blocked_by_decision_records_clause(self) -> None:
         """When the newest candidate's deps disagree with a decision, a binary
         clause is queued for the resolver to absorb via consume_pending_clauses."""


### PR DESCRIPTION
At the provider boundary, store the caller-owned solution-hint snapshot directly instead of copying it again, dropping one O(packages) copy per decision. Keeps exactly one snapshot copy.