### PR TITLE
Single-entry fast path in _parse_hashes

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -299,16 +299,22 @@ def _parse_files(
 
 
 def _parse_hashes(value: object) -> tuple[tuple[str, str], ...]:
+    # Algo names are a tiny fixed vocabulary, so interning dedups them.
     if not isinstance(value, dict):
         return ()
+
+    # The common case is a single hash; skip the list build.
+    if len(value) == 1:
+        ((algo, digest),) = value.items()
+        if isinstance(algo, str) and isinstance(digest, str):
+            return ((sys.intern(algo), digest),)
+        return ()
+
     out: list[tuple[str, str]] = []
     for algo, digest in value.items():
         if isinstance(algo, str) and isinstance(digest, str):
-            # Hash algo names are drawn from a fixed vocabulary
-            # (``sha256``, ``md5``, ``blake2b``...) but appear once per
-            # file; interning collapses the duplicates into the handful
-            # actually used.
             out.append((sys.intern(algo), digest))
+
     return tuple(out)
 
 

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -242,6 +242,40 @@ class TestZipSdistDropped:
         assert all(isinstance(f, WheelFile) for f in files)
 
 
+class TestParseHashes:
+    def test_single_entry(self) -> None:
+        from nab_index.client import _parse_hashes
+
+        assert _parse_hashes({"sha256": "a" * 64}) == (("sha256", "a" * 64),)
+
+    def test_single_entry_malformed(self) -> None:
+        from nab_index.client import _parse_hashes
+
+        assert _parse_hashes({"sha256": 123}) == ()
+
+    def test_multiple_entries(self) -> None:
+        from nab_index.client import _parse_hashes
+
+        result = _parse_hashes({"sha256": "a" * 64, "md5": "b" * 32})
+        assert result == (("sha256", "a" * 64), ("md5", "b" * 32))
+
+    def test_multiple_entries_skips_malformed(self) -> None:
+        from nab_index.client import _parse_hashes
+
+        result = _parse_hashes({"sha256": "a" * 64, "md5": 123})
+        assert result == (("sha256", "a" * 64),)
+
+    def test_non_dict(self) -> None:
+        from nab_index.client import _parse_hashes
+
+        assert _parse_hashes("sha256:abc") == ()
+
+    def test_empty_dict(self) -> None:
+        from nab_index.client import _parse_hashes
+
+        assert _parse_hashes({}) == ()
+
+
 class TestParseMaxAge:
     def test_default_when_none(self) -> None:
         assert _parse_max_age(None) == 600


### PR DESCRIPTION
Single-entry fast path in _parse_hashes: most files carry exactly one sha256, so return that tuple directly and skip the list build and list-to-tuple copy. The multi-entry path is unchanged.