### PR TITLE
Honor SOURCE_DATE_EPOCH for lock anchor

### DIFF
--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -13,6 +13,7 @@ patches keeps working after the per-command split.
 
 from __future__ import annotations
 
+import os
 import sys
 from dataclasses import replace
 from datetime import datetime, timezone
@@ -590,6 +591,17 @@ def _build_provenance(
     )
 
 
+def _source_date_epoch() -> datetime | None:
+    """Return the ``SOURCE_DATE_EPOCH`` anchor, or None if unset or unusable."""
+    raw = os.environ.get("SOURCE_DATE_EPOCH")
+    if raw is None:
+        return None
+    try:
+        return datetime.fromtimestamp(int(raw), tz=timezone.utc)
+    except (ValueError, OverflowError, OSError):
+        return None
+
+
 def _determine_lock_anchor(
     *,
     output: Path | None,
@@ -598,7 +610,11 @@ def _determine_lock_anchor(
 ) -> datetime:
     """Pick the ``P<n>D`` anchor for ``nab lock``.
 
-    Returns ``datetime.now(UTC)`` (a fresh anchor) when:
+    A parseable ``SOURCE_DATE_EPOCH`` wins over everything else: a
+    reproducible-build environment dictates the clock, so the anchor must
+    be that timestamp regardless of ``--upgrade`` or any existing lock.
+
+    Otherwise returns ``datetime.now(UTC)`` (a fresh anchor) when:
 
     - ``--upgrade`` is set: the user is opting into a calendar refresh.
     - Output is stdout (``-``): there is no file to read back later, so
@@ -612,6 +628,9 @@ def _determine_lock_anchor(
     pylock, so a re-lock against the same project produces the same
     cutoff for ``P<n>D`` durations.
     """
+    epoch = _source_date_epoch()
+    if epoch is not None:
+        return epoch
     fresh = datetime.now(timezone.utc)
     if upgrade:
         return fresh

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,7 @@ from nab._lock import (
     _emit_universal_pylock,
     _resolve_extra_selection,
     _resolve_group_selection,
+    _source_date_epoch,
     lock,
 )
 from nab.cli import (
@@ -1278,6 +1279,48 @@ class TestDetermineLockAnchor:
         self._write_prior(tmp_path / "pylock.toml")
         anchor = _determine_lock_anchor(output=None, format="pylock", upgrade=False)
         assert anchor == self._RECORDED
+
+
+class TestSourceDateEpoch:
+    """``SOURCE_DATE_EPOCH`` pins the anchor for reproducible builds."""
+
+    _EPOCH = 1_700_000_000
+    _AS_DATETIME = datetime.fromtimestamp(_EPOCH, tz=timezone.utc)
+    _RECORDED = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    def test_unset_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
+        assert _source_date_epoch() is None
+
+    def test_parseable_value_is_used(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SOURCE_DATE_EPOCH", str(self._EPOCH))
+        assert _source_date_epoch() == self._AS_DATETIME
+
+    def test_unparseable_value_is_ignored(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SOURCE_DATE_EPOCH", "not-a-number")
+        assert _source_date_epoch() is None
+
+    def test_overflowing_value_is_ignored(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SOURCE_DATE_EPOCH", "9" * 30)
+        assert _source_date_epoch() is None
+
+    def test_epoch_wins_over_upgrade(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SOURCE_DATE_EPOCH", str(self._EPOCH))
+        anchor = _determine_lock_anchor(output=Path("-"), format="pylock", upgrade=True)
+        assert anchor == self._AS_DATETIME
+
+    def test_epoch_wins_over_existing_anchor(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("SOURCE_DATE_EPOCH", str(self._EPOCH))
+        target = tmp_path / "pylock.toml"
+        target.write_text(f"[tool.nab]\ncreated-at = {self._RECORDED.isoformat()}\n")
+        anchor = _determine_lock_anchor(output=target, format="pylock", upgrade=False)
+        assert anchor == self._AS_DATETIME
 
 
 class TestLockAnchorReuse:


### PR DESCRIPTION
Closes #23.

`nab lock` now reads `SOURCE_DATE_EPOCH`. A parseable value pins the `created-at` / `P<n>D` anchor, taking precedence over `--upgrade` and any existing-lockfile anchor; unset or unparseable falls through to the current logic. Output-only, so resolution is unaffected.