### PR TITLE
Skip invalid metadata for user-requested extras

### DIFF
--- a/nab-python/src/nab_python/_provider/extras.py
+++ b/nab-python/src/nab_python/_provider/extras.py
@@ -76,11 +76,11 @@ def _pick_in_mode(
 ) -> Version | None:
     """Pick a candidate honoring ``ExtrasMode``.
 
-    User-requested extras short-circuit and return the first
-    candidate. Transitive extras validate the base metadata parses
-    so a malformed PKG-INFO becomes a candidate skip instead of a
-    fatal error during the later dependency fetch. BACKTRACK mode
-    additionally checks ``Provides-Extra``.
+    User-requested extras return the first candidate that does not have
+    known-invalid metadata. Transitive extras additionally validate the
+    base metadata parses, so a malformed PKG-INFO becomes a candidate
+    skip instead of a fatal error during the later dependency fetch.
+    BACKTRACK mode additionally checks ``Provides-Extra``.
 
     Missing-metadata cases (no PEP 658, no sdist) fall through;
     mock test coordinators rely on this.
@@ -92,10 +92,10 @@ def _pick_in_mode(
     is_user = (normalized, extra) in provider.root_extras
     backtrack = provider.extras_mode == ExtrasMode.BACKTRACK
     for version in candidates:
-        if is_user:
-            return version
         if provider.has_invalid_metadata(normalized, version):
             continue
+        if is_user:
+            return version
         # Fetch base metadata so an unparseable PKG-INFO is caught
         # before the extras proxy decides this version. Any
         # MetadataError (parse failure or no metadata source) is a

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -4557,6 +4557,29 @@ class TestExtrasInvalidMetadata:
         version = provider.choose_version("foo[security]", VersionRange.full())
         assert version == V("1.0")
 
+    def test_user_extra_skips_invalid_metadata(self) -> None:
+        """A user-requested extra must not pick a known-invalid version.
+
+        get_dependencies raises MetadataError for a version in
+        _invalid_metadata, so returning 2.0 here crashes when the proxy
+        later fetches its dependencies.
+        """
+        wheels = [make_wheel("2.0"), make_wheel("1.0")]
+        coordinator = make_coordinator(
+            wheels,
+            metadata_by_version={"2.0": EXTRA_METADATA, "1.0": EXTRA_METADATA},
+            package="foo",
+        )
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            extras_mode=ExtrasMode.WARN,
+            root_extras={("foo", "security")},
+        )
+        provider._invalid_metadata[("foo", V("2.0"))] = "stub"
+        version = provider.choose_version("foo[security]", VersionRange.full())
+        assert version == V("1.0")
+
 
 class TestScanBatchNoFirstCandidate:
     """Cover the `first_candidate is None` skip in _scan_batch."""


### PR DESCRIPTION
`_pick_in_mode` short-circuited on the first candidate for a user-requested extra without the `has_invalid_metadata` guard, so a known-invalid highest version was returned and then crashed in `get_dependencies` (which raises `MetadataError` for invalid-metadata entries). Now the guard runs before the user short-circuit.