### PR TITLE
Rank legacy manylinux aliases at their glibc

### DIFF
--- a/nab-python/src/nab_python/universal/wheel_selection.py
+++ b/nab-python/src/nab_python/universal/wheel_selection.py
@@ -53,6 +53,13 @@ _DEFAULT_MACOS_MIN = (11, 0)
 # below 10.13.
 _DEFAULT_MACOS_X86_64_MIN = (10, 13)
 
+# Legacy manylinux aliases (PEPs 513/571/599) keyed by their glibc floor.
+_LEGACY_MANYLINUX: dict[tuple[int, int], str] = {
+    (2, 17): "manylinux2014",
+    (2, 12): "manylinux2010",
+    (2, 5): "manylinux1",
+}
+
 
 @dataclass(frozen=True)
 class PlatformSpec:
@@ -126,21 +133,16 @@ def _linux_platform_tags(
     # manylinux_X_Y: PEP 600 form.  We accept any minor at or below
     # the floor (a wheel built for glibc 2.5 runs on a system with
     # glibc 2.17; a wheel built for glibc 2.34 does not).  Iterate
-    # high-to-low for preference order.
+    # high-to-low for preference order, emitting each legacy alias
+    # right after its equivalent PEP 600 tag so a legacy-named wheel
+    # ranks at its own glibc, matching packaging.tags.
     major, minor = manylinux_floor
-    out = [f"manylinux_{major}_{m}_{arch}" for m in range(minor, -1, -1)]
-    # Legacy aliases (PEPs 513/571/599).  These map to specific
-    # glibc versions: manylinux1=2.5, manylinux2010=2.12,
-    # manylinux2014=2.17.  Listed highest-glibc first so the output
-    # stays in install-preference order alongside the PEP 600 forms.
-    legacy_aliases = [
-        ("manylinux2014", (2, 17)),
-        ("manylinux2010", (2, 12)),
-        ("manylinux1", (2, 5)),
-    ]
-    out.extend(
-        f"{name}_{arch}" for name, lver in legacy_aliases if lver <= manylinux_floor
-    )
+    out: list[str] = []
+    for m in range(minor, -1, -1):
+        out.append(f"manylinux_{major}_{m}_{arch}")
+        legacy = _LEGACY_MANYLINUX.get((major, m))
+        if legacy is not None:
+            out.append(f"{legacy}_{arch}")
     # musllinux_X_Y: PEP 656 form.  Same accept-at-or-below rule.
     mu_major, mu_minor = musllinux_floor
     out.extend(f"musllinux_{mu_major}_{m}_{arch}" for m in range(mu_minor, -1, -1))

--- a/nab-python/tests/universal/test_wheel_selection.py
+++ b/nab-python/tests/universal/test_wheel_selection.py
@@ -332,6 +332,23 @@ class TestSelectWheelForTuple:
         assert chosen is not None
         assert "manylinux_2_17" in chosen.filename
 
+    def test_legacy_alias_ranks_with_its_glibc(self) -> None:
+        """A legacy alias ranks at its glibc, not after all PEP 600 tags.
+
+        manylinux2014 means glibc 2.17, so it must beat a glibc-2.5
+        wheel.  packaging.tags interleaves each legacy alias right after
+        its equivalent manylinux_X_Y tag, so manylinux2014 outranks
+        manylinux_2_5.
+        """
+        spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
+        wheels = [
+            _wheel("pkg-1.0-cp311-cp311-manylinux_2_5_x86_64.whl"),
+            _wheel("pkg-1.0-cp311-cp311-manylinux2014_x86_64.whl"),
+        ]
+        chosen = select_wheel_for_tuple(wheels, python_version="3.11", spec=spec)
+        assert chosen is not None
+        assert "manylinux2014" in chosen.filename
+
     def test_skips_worse_candidate_after_best_set(self) -> None:
         """A later, worse-ranked wheel does not displace an earlier best.
 


### PR DESCRIPTION
In universal wheel selection, legacy manylinux aliases (manylinux1/2010/2014) were all listed after the full PEP 600 tag range, so a `manylinux2014` wheel (glibc 2.17) could lose to a `manylinux_2_5` wheel. Emit each legacy alias right after its equivalent `manylinux_X_Y` tag, matching `packaging.tags` ordering.