### PR TITLE
Populate PEP 751 packages.dependencies

### DIFF
--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -9,6 +9,7 @@ be read directly without a second fetch.  This module also owns the
 
 from __future__ import annotations
 
+from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, overload
@@ -72,6 +73,12 @@ class LockInputProvider(Protocol):
     exposes that :func:`build_lock_input_from_provider` consumes; tests
     may supply a stub without inheriting the full Provider class.
     """
+
+    deps_cache: Mapping[tuple[str, Version], Mapping[str, object]]
+    """Direct dependencies per ``(canonical name, version)``."""
+
+    extra_deps_map: Mapping[tuple[str, Version], Mapping[str, Mapping[str, object]]]
+    """Per-extra dependencies per ``(canonical name, version)``."""
 
     @property
     def coordinator(self) -> _LockInputCoordinator:
@@ -208,7 +215,7 @@ def _strip_userinfo(url: str) -> str:
     return urlunsplit(parts._replace(netloc=netloc))
 
 
-def build_lock_input_from_provider(
+def build_lock_input_from_provider(  # noqa: PLR0913 - each flag maps to a distinct lockfile field
     provider: LockInputProvider,
     pins: Mapping[str, Version],
     *,
@@ -218,6 +225,7 @@ def build_lock_input_from_provider(
     default_groups: Sequence[str] = (),
     created_by: str = "nab",
     indexes: Sequence[IndexConfig] = (),
+    resolved_keys: Iterable[str] = (),
 ) -> LockInput:
     """Build a :class:`LockInput` from a finished resolve.
 
@@ -229,6 +237,10 @@ def build_lock_input_from_provider(
     ``dependency_groups`` lists the PEP 735 groups whose requirements
     were folded into this resolve; ``default_groups`` is the subset
     that a default install (no ``--group`` flag) should apply.
+
+    ``resolved_keys`` is the full set of resolver result keys, including
+    ``name[extra]`` proxies; it is read to find which extras activated
+    so their edges join the forward dependency graph.
 
     All wheels and the sdist for each pinned version are recorded so
     the lockfile is portable across architectures of the same Python.
@@ -267,7 +279,51 @@ def build_lock_input_from_provider(
         extras=tuple(extras),
         dependency_groups=tuple(dependency_groups),
         default_groups=tuple(default_groups),
+        dependencies=_forward_dependency_graph(provider, pins, resolved_keys),
     )
+
+
+def _forward_dependency_graph(
+    provider: LockInputProvider,
+    pins: Mapping[str, Version],
+    resolved_keys: Iterable[str],
+) -> dict[str, tuple[str, ...]]:
+    """Build the forward dependency graph among the locked packages.
+
+    Each pinned package maps to the canonical names of its direct
+    dependencies that are themselves pinned.  Base dependencies come
+    from ``deps_cache``; an activated extra (a ``name[extra]`` key in
+    ``resolved_keys``) folds that extra's dependencies in too.  Names
+    not in ``pins`` are dropped so every edge points at a real
+    ``[[packages]]`` entry.
+    """
+    from ..provider import split_extra
+
+    activated_extras: defaultdict[str, set[str]] = defaultdict(set)
+    for key in resolved_keys:
+        base, extra = split_extra(key)
+        if extra is not None:
+            activated_extras[canonicalize_name(base)].add(extra)
+
+    pinned = {canonicalize_name(name) for name in pins}
+    graph: dict[str, tuple[str, ...]] = {}
+    for raw_name, version in pins.items():
+        canonical = canonicalize_name(raw_name)
+        cache_key = (canonical, version)
+        dep_names = {
+            canonicalize_name(split_extra(dep)[0])
+            for dep in provider.deps_cache.get(cache_key, {})
+        }
+        extra_map = provider.extra_deps_map.get(cache_key, {})
+        for extra in activated_extras.get(canonical, ()):
+            dep_names.update(
+                canonicalize_name(split_extra(dep)[0])
+                for dep in extra_map.get(extra, {})
+            )
+        dep_names &= pinned
+        if dep_names:
+            graph[canonical] = tuple(sorted(dep_names))
+    return graph
 
 
 def _index_pin_from_listing(

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -94,7 +94,12 @@ def build_pylock(lock_input: LockInput, *, lock_dir: Path | None = None) -> Pylo
         package_records = _build_per_tuple_packages(lock_input, base)
     else:
         package_records = [
-            _pin_to_package(pin, lock_dir=base) for pin in lock_input.pins.values()
+            _pin_to_package(
+                pin,
+                lock_dir=base,
+                dependencies=_dependency_entries(name, lock_input.dependencies),
+            )
+            for name, pin in lock_input.pins.items()
         ]
     package_records.sort(key=_package_sort_key)
     validate_marker_disjointness(
@@ -157,8 +162,26 @@ def _relativize_path(target: str | os.PathLike[str], lock_dir: Path) -> str:
     return Path(rel).as_posix()
 
 
+def _dependency_entries(
+    name: str, graph: Mapping[str, tuple[str, ...]]
+) -> list[dict[str, str]] | None:
+    """Render a package's forward edges as PEP 751 dependency tables.
+
+    In single-environment mode each locked package name is unique, so
+    ``name`` alone identifies the target ``[[packages]]`` entry.
+    """
+    deps = graph.get(name)
+    if not deps:
+        return None
+    return [{"name": dep} for dep in deps]
+
+
 def _pin_to_package(
-    pin: PinShape, marker: Marker | None = None, *, lock_dir: Path
+    pin: PinShape,
+    marker: Marker | None = None,
+    *,
+    lock_dir: Path,
+    dependencies: list[dict[str, str]] | None = None,
 ) -> Package:
     from ..lockfile import IndexPin, LocalPin, VcsPin
 
@@ -167,6 +190,7 @@ def _pin_to_package(
             name=canonicalize_name(pin.name),
             version=Version(pin.version),
             marker=marker,
+            dependencies=dependencies,
             requires_python=(
                 SpecifierSet(pin.requires_python) if pin.requires_python else None
             ),
@@ -188,6 +212,7 @@ def _pin_to_package(
             name=canonicalize_name(pin.name),
             version=None,
             marker=marker,
+            dependencies=dependencies,
             directory=PackageDirectory(
                 path=_relativize_path(pin.path, lock_dir),
                 editable=pin.editable,
@@ -202,6 +227,7 @@ def _pin_to_package(
             name=canonicalize_name(pin.name),
             version=None,
             marker=marker,
+            dependencies=dependencies,
             vcs=PackageVcs(
                 type=pin.vcs_type,
                 url=pin.bare_repo_url,

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -269,6 +269,12 @@ class LockInput:
     ``provenance`` is optional metadata about the inputs that
     produced this lock.  When present, it lands in the ``[tool.nab]``
     block of the emitted ``pylock.toml``.
+
+    ``dependencies`` is the forward dependency graph, keyed by
+    canonical package name; each value lists the canonical names of
+    that package's direct dependencies that are themselves locked.
+    The writer emits it as PEP 751 ``packages.dependencies``.  Empty
+    in universal mode, which does not track per-tuple edges.
     """
 
     pins: Mapping[str, PinShape] = field(default_factory=dict)
@@ -281,4 +287,5 @@ class LockInput:
     extras: tuple[str, ...] = ()
     dependency_groups: tuple[str, ...] = ()
     default_groups: tuple[str, ...] = ()
+    dependencies: Mapping[str, tuple[str, ...]] = field(default_factory=dict)
     provenance: Provenance | None = None

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -203,6 +203,7 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
             dependency_groups=tuple(groups),
             default_groups=config.default_groups,
             indexes=config.indexes,
+            resolved_keys=raw,
         )
         return ResolutionResult(pins=pins, lock_input=lock_input)
 

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -1160,6 +1160,10 @@ class _FakeProvider:
         vcs_pins: dict[str, str] | None = None,
         listing_indexes: dict[str, str] | None = None,
         dist_policy_overrides: dict[str, DistPolicy] | None = None,
+        deps_cache: dict[tuple[str, Version], dict[str, object]] | None = None,
+        extra_deps_map: (
+            dict[tuple[str, Version], dict[str, dict[str, object]]] | None
+        ) = None,
     ) -> None:
         self._listings = listings or {}
         self._local = local_sources or {}
@@ -1167,6 +1171,8 @@ class _FakeProvider:
         self._vcs_pins = vcs_pins or {}
         self._dist_policy_overrides = dist_policy_overrides or {}
         self.coordinator = _FakeCoordinator(listing_indexes)
+        self.deps_cache = deps_cache or {}
+        self.extra_deps_map = extra_deps_map or {}
 
     def local_source_for(self, canonical: str) -> LocalSource | None:
         return self._local.get(canonical)
@@ -2258,3 +2264,73 @@ def test_vcs_config_unused_in_lockfile_path() -> None:
     """VcsConfig is consumed by the provider; lockfile builder ignores it."""
     cfg = VcsConfig(policy=VcsPolicy.BLOCK)
     assert cfg.policy is VcsPolicy.BLOCK
+
+
+class TestDependencyGraph:
+    def test_base_deps_filtered_to_locked(self) -> None:
+        provider = _FakeProvider(
+            listings={
+                name: [(Version("1.0"), _wheel_file(name))]
+                for name in ("foo", "bar", "baz")
+            },
+            deps_cache={
+                ("foo", Version("1.0")): dict.fromkeys(["bar", "missing"]),
+                ("bar", Version("1.0")): {},
+            },
+        )
+        lock_input = build_lock_input_from_provider(
+            provider,
+            {"foo": Version("1.0"), "bar": Version("1.0"), "baz": Version("1.0")},
+            resolved_keys=("foo", "bar", "baz"),
+        )
+        # ``missing`` is not locked, so it is dropped; bar and baz have no
+        # locked dependencies, so they are absent from the graph.
+        assert lock_input.dependencies == {"foo": ("bar",)}
+
+    def test_activated_extra_edges_join_graph(self) -> None:
+        provider = _FakeProvider(
+            listings={
+                name: [(Version("1.0"), _wheel_file(name))]
+                for name in ("foo", "plugin")
+            },
+            deps_cache={("foo", Version("1.0")): {}},
+            extra_deps_map={
+                ("foo", Version("1.0")): {"cli": dict.fromkeys(["plugin"])}
+            },
+        )
+        lock_input = build_lock_input_from_provider(
+            provider,
+            {"foo": Version("1.0"), "plugin": Version("1.0")},
+            # ``doc`` is activated but has no recorded deps; ``cli`` pulls plugin.
+            resolved_keys=("foo", "foo[cli]", "foo[doc]", "plugin"),
+        )
+        assert lock_input.dependencies == {"foo": ("plugin",)}
+
+    def test_emitted_as_pep751_dependencies(self) -> None:
+        text = write_lock(
+            LockInput(
+                pins={"foo": _index_pin("foo"), "bar": _index_pin("bar")},
+                dependencies={"foo": ("bar",)},
+            )
+        )
+        data = tomllib.loads(text)
+        by_name = {p["name"]: p for p in data["packages"]}
+        assert by_name["foo"]["dependencies"] == [{"name": "bar"}]
+        assert "dependencies" not in by_name["bar"]
+
+    def test_local_pin_carries_dependencies(self, tmp_path: Path) -> None:
+        text = write_lock(
+            LockInput(
+                pins={
+                    "foo": LocalPin(
+                        name="foo", version="1.0", path=str(tmp_path / "foo")
+                    ),
+                    "bar": _index_pin("bar"),
+                },
+                dependencies={"foo": ("bar",)},
+            ),
+            output_path=tmp_path / "pylock.toml",
+        )
+        data = tomllib.loads(text)
+        by_name = {p["name"]: p for p in data["packages"]}
+        assert by_name["foo"]["dependencies"] == [{"name": "bar"}]

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -173,7 +173,9 @@ def _drop_workspace_pins(
 
     ``workspace_to_drop`` holds canonical workspace member names; pin
     keys are already canonical.  An empty set returns ``lock_input``
-    unchanged.  Both ``pins`` and ``per_tuple_pins`` are filtered.
+    unchanged.  ``pins`` and ``per_tuple_pins`` are filtered, and the
+    forward dependency graph is filtered too so no edge points at a
+    dropped member with no ``[[packages]]`` entry.
     """
     if not workspace_to_drop:
         return lock_input
@@ -186,10 +188,16 @@ def _drop_workspace_pins(
         label: {name: pin for name, pin in tuple_pins.items() if keep(name)}
         for label, tuple_pins in lock_input.per_tuple_pins.items()
     }
+    filtered_dependencies = {
+        name: kept
+        for name, deps in lock_input.dependencies.items()
+        if keep(name) and (kept := tuple(dep for dep in deps if keep(dep)))
+    }
     return replace(
         lock_input,
         pins=filtered_pins,
         per_tuple_pins=filtered_per_tuple,
+        dependencies=filtered_dependencies,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,6 +21,7 @@ from nab import _version as nab_version
 from nab._download import download
 from nab._lock import (
     _determine_lock_anchor,
+    _drop_workspace_pins,
     _emit_specific,
     _emit_universal_pylock,
     _resolve_extra_selection,
@@ -1105,6 +1106,45 @@ class TestNoEmitWorkspace:
         text = out.read_text()
         assert 'name = "alpha"' in text
         assert 'name = "foo"' in text
+
+    def test_specific_pylock_drops_dependency_edge_to_workspace(
+        self, tmp_path: Path
+    ) -> None:
+        """A retained package keeps no forward edge to the dropped member."""
+        result = ResolutionResult(
+            pins={"alpha": V("0"), "foo": V("1.0")},
+            lock_input=LockInput(
+                pins={
+                    "alpha": _foo_index_pin("0", "alpha"),
+                    "foo": _foo_index_pin("1.0", "foo"),
+                },
+                dependencies={"foo": ("alpha",)},
+            ),
+        )
+        pyproject = _workspace_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with patch("nab.cli.resolve_pyproject", return_value=result):
+            lock(pyproject, output=out, no_emit_workspace=True)
+        text = out.read_text()
+        assert 'name = "foo"' in text
+        # alpha's [[packages]] row and the dangling forward edge are both gone.
+        assert 'name = "alpha"' not in text
+
+    def test_drop_filters_dependency_graph(self) -> None:
+        """Dropped members vanish as graph keys and as edge targets."""
+        lock_input = LockInput(
+            pins={
+                "foo": _foo_index_pin("1.0", "foo"),
+                "bar": _foo_index_pin("2.0", "bar"),
+            },
+            dependencies={
+                "foo": ("alpha", "bar"),
+                "bar": ("alpha",),
+                "alpha": ("bar",),
+            },
+        )
+        dropped = _drop_workspace_pins(lock_input, frozenset({"alpha"}))
+        assert dropped.dependencies == {"foo": ("bar",)}
 
 
 class TestRelockDiffSummary:


### PR DESCRIPTION
Single-environment `nab lock` now emits each package's direct dependencies as `packages.dependencies` (one `{"name": dep}` entry per edge), built from the resolved dependency graph and filtered to locked packages.

Per PEP 751 this field is informational only (installers MUST NOT use it), so it cannot change resolution or install.

Universal/per-tuple mode still emits no dependencies: a name-to-names graph cannot disambiguate a dependency pinned at different versions across tuples. Deferred.

Closes #21
