### PR TITLE
Resolve relative Simple-API file URLs against the page

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING
+from urllib.parse import urljoin
 
 from packaging.utils import (
     InvalidSdistFilename,
@@ -262,6 +263,8 @@ def _parse_files(
     PEP 592 ``yanked`` files are dropped unconditionally.
     """
     expected = canonicalize_name(package)
+    # PEP 691: relative URLs resolve against the package page, not the index root.
+    base_url = f"{index_url}{package}/"
     files: list[WheelFile | SdistFile] = []
     for file_info in data.get("files", []):
         # PEP 592: ``true`` or a non-empty reason string means yanked.
@@ -269,9 +272,7 @@ def _parse_files(
             continue
         filename = file_info["filename"]
 
-        file_url = file_info["url"]
-        if not file_url.startswith("http"):
-            file_url = index_url + file_url
+        file_url = urljoin(base_url, file_info["url"])
 
         hashes = _parse_hashes(file_info.get("hashes"))
         size = _parse_size(file_info.get("size"))

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -300,6 +300,48 @@ class TestZipSdistDropped:
         assert all(isinstance(f, WheelFile) for f in files)
 
 
+class TestRelativeUrlResolution:
+    """PEP 691: relative file URLs resolve against the package page."""
+
+    def test_relative_filename_resolves_against_package_page(self) -> None:
+        data = {
+            "files": [
+                {
+                    "filename": "foo-1.0-py3-none-any.whl",
+                    "url": "foo-1.0-py3-none-any.whl",
+                },
+            ],
+        }
+        files = _parse_files(data, "https://example.com/simple/", "foo")
+        expected = "https://example.com/simple/foo/foo-1.0-py3-none-any.whl"
+        assert files[0].url == expected
+
+    def test_dot_dot_relative_url_is_normalised(self) -> None:
+        data = {
+            "files": [
+                {
+                    "filename": "foo-1.0-py3-none-any.whl",
+                    "url": "../../packages/foo/foo-1.0-py3-none-any.whl",
+                },
+            ],
+        }
+        files = _parse_files(data, "https://example.com/simple/", "foo")
+        expected = "https://example.com/packages/foo/foo-1.0-py3-none-any.whl"
+        assert files[0].url == expected
+
+    def test_absolute_url_unchanged(self) -> None:
+        data = {
+            "files": [
+                {
+                    "filename": "foo-1.0-py3-none-any.whl",
+                    "url": "https://files.example.com/foo-1.0-py3-none-any.whl",
+                },
+            ],
+        }
+        files = _parse_files(data, "https://example.com/simple/", "foo")
+        assert files[0].url == "https://files.example.com/foo-1.0-py3-none-any.whl"
+
+
 class TestParseHashes:
     def test_single_entry(self) -> None:
         from nab_index.client import _parse_hashes


### PR DESCRIPTION
PEP 691 says a relative file URL is relative to the page that contains it. `_parse_files` resolved them by concatenating against the index root (`index_url + url`), which joined against `<index>/` instead of the fetched package page `<index>/<package>/` (dropping the `<package>/` segment) and left `../` and absolute-path forms malformed.

Now resolves every file URL with `urllib.parse.urljoin(base_url, url)` where `base_url` is the package page; urljoin leaves absolute URLs unchanged and normalises relative forms. Any index emitting relative file URLs previously produced wrong download URLs; PyPI emits absolute URLs, so the default corpus never surfaced it.