### PR TITLE
Re-vendor packaging PR #1182

### DIFF
--- a/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
+++ b/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
@@ -9,8 +9,8 @@ from an in-flight pull request, vendored so nab can use the public
 - Upstream repository: https://github.com/pypa/packaging
 - Pull request: https://github.com/pypa/packaging/pull/1182
 - Source branch: `notatallshaw/packaging:public-pep440-version-range`
-- Pinned commit: `82799d02ffec2815769d5889062e54686e7c6863`
-- Snapshot date: 2026-05-23
+- Pinned commit: `5a21dd8dc0d2be554355b0903345acc4164f2e5c`
+- Snapshot date: 2026-05-27
 
 The snapshot is the full `src/packaging/` tree at that commit, plus
 `LICENSE`, `LICENSE.APACHE`, and `LICENSE.BSD` from the repository

--- a/nab-python/src/nab_python/_vendor/packaging/_range_utils.py
+++ b/nab-python/src/nab_python/_vendor/packaging/_range_utils.py
@@ -21,13 +21,11 @@ from typing import (
     Union,
 )
 
-from ._version_utils import coerce_version, trim_release
+from ._version_utils import coerce_version, trim_release, version_cmpkey
 from .version import Version
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator, Sequence
-
-    from .specifiers import Specifier
 
 
 __all__ = [
@@ -43,9 +41,9 @@ __all__ = [
     "bounds_for_spec",
     "filter_by_ranges",
     "intersect_ranges",
-    "intersect_specifier_bounds",
     "matches_bounds_only",
     "range_is_empty",
+    "resolve_prereleases",
     "standard_ranges",
     "wildcard_ranges",
 ]
@@ -57,6 +55,12 @@ def __dir__() -> list[str]:
 
 #: The smallest possible PEP 440 version. No valid version is less than this.
 _MIN_VERSION: Final[Version] = Version("0.dev0")
+
+#: Sorts above any real post number or local label in an ordering key.
+_BOUNDARY_INF: Final[float] = float("inf")
+
+_BoundaryOrderSuffix = tuple[int, int, int, Union[int, float], int, int]
+_BoundaryOrderKey = tuple[int, tuple[int, ...], _BoundaryOrderSuffix, float]
 
 
 def _next_prefix_dev0(version: Version) -> Version:
@@ -99,9 +103,12 @@ class BoundaryVersion:
         "_cached_post",
         "_cached_pre",
         "_cached_trimmed_release",
+        "_order_key",
         "kind",
         "version",
     )
+
+    _order_key: _BoundaryOrderKey
 
     def __init__(self, version: Version, kind: BoundaryKind) -> None:
         self.version = version
@@ -112,13 +119,19 @@ class BoundaryVersion:
         self._cached_post = version.post
         self._cached_dev = version.dev
 
+        # Distinguish AFTER_LOCALS from AFTER_POSTS.
+        epoch, release, raw_suffix = version_cmpkey(version)
+        suffix: _BoundaryOrderSuffix = raw_suffix
+        if kind == BoundaryKind.AFTER_POSTS:
+            suffix = (suffix[0], suffix[1], 1, _BOUNDARY_INF, 1, 0)
+        self._order_key = (epoch, release, suffix, _BOUNDARY_INF)
+
     def _is_family(self, other: Version) -> bool:
         """Is ``other`` a version that this boundary sorts above?"""
         if other.epoch != self._cached_epoch:
             return False
-        # Inline release-trim comparison: other.release matches the
-        # trimmed release iff its leading slice is equal and any extra
-        # components are zero. Avoids trim_release's tuple allocation.
+
+        # Match the trimmed release without allocating a new tuple.
         other_release = other.release
         trimmed_release = self._cached_trimmed_release
         trimmed_length = len(trimmed_release)
@@ -144,9 +157,7 @@ class BoundaryVersion:
 
     def __lt__(self, other: BoundaryVersion | Version) -> bool:
         if isinstance(other, BoundaryVersion):
-            if self.version != other.version:
-                return self.version < other.version
-            return self.kind.value < other.kind.value  # pragma: no cover
+            return self._order_key < other._order_key
         # boundary < other_version iff V < other AND other not in family.
         # The cheap V >= other path short-circuits before the family check.
         if not (self.version < other):
@@ -157,9 +168,7 @@ class BoundaryVersion:
         # Defined directly to bypass functools.total_ordering's
         # NotImplemented round-trip on reflected ``Version < boundary``.
         if isinstance(other, BoundaryVersion):
-            if self.version != other.version:
-                return self.version > other.version
-            return self.kind.value > other.kind.value
+            return self._order_key > other._order_key
         if self.version >= other:
             return True
         return self._is_family(other)
@@ -465,6 +474,28 @@ def range_is_empty(lower: LowerBound, upper: UpperBound) -> bool:
     return lower.version > upper.version
 
 
+def resolve_prereleases(
+    explicit: bool | None,
+    configured: bool | None,
+    autodetected: bool | None,
+) -> bool | None:
+    """Resolve the effective pre-release policy for filtering / membership.
+
+    Shared by specifier filtering and :class:`~packaging.ranges.VersionRange`
+    construction so both agree on the default. The caller's ``explicit``
+    argument wins; then the constructor ``configured`` value; otherwise an
+    autodetected ``True`` propagates, while an autodetected ``False`` / ``None``
+    falls back to the PEP 440 default (``None``).
+    """
+    if explicit is not None:
+        return explicit
+    if configured is not None:
+        return configured
+    if autodetected:
+        return True
+    return None
+
+
 def intersect_ranges(
     left: Sequence[Interval],
     right: Sequence[Interval],
@@ -741,33 +772,3 @@ def bounds_for_spec(operator: str, version_str: str) -> tuple[Interval, ...]:
     return standard_ranges(
         operator=operator, version=version, has_local="+" in version_str
     )
-
-
-def intersect_specifier_bounds(specs: Iterable[Specifier]) -> tuple[Interval, ...]:
-    """Intersect bounds of every spec in ``specs``.
-
-    Each :class:`~packaging.specifiers.Specifier` contributes its cached
-    :meth:`~packaging.specifiers.Specifier._to_ranges` bounds, which reuse
-    the per-spec parsed-version cache rather than re-parsing the version
-    string.
-
-    ``===`` contributes the empty list, which collapses the intersection
-    to empty; callers that need ``===`` literal handling must filter
-    such specs out beforehand.
-    """
-    result_bounds: Sequence[Interval] | None = None
-    for s in specs:
-        sub_bounds = s._to_ranges()
-        if result_bounds is None:
-            result_bounds = sub_bounds
-        elif not result_bounds:
-            break
-        else:
-            result_bounds = intersect_ranges(result_bounds, sub_bounds)
-
-    if result_bounds is None:
-        # Every caller guards on a non-empty spec list; an empty
-        # intersection would mean the unbounded full range.
-        return FULL_RANGE  # pragma: no cover
-
-    return tuple(result_bounds)

--- a/nab-python/src/nab_python/_vendor/packaging/_version_utils.py
+++ b/nab-python/src/nab_python/_vendor/packaging/_version_utils.py
@@ -12,7 +12,10 @@ from __future__ import annotations
 
 from .version import InvalidVersion, Version
 
-__all__ = ["coerce_version", "trim_release"]
+__all__ = ["coerce_version", "trim_release", "version_cmpkey"]
+
+_VersionCmpSuffix = tuple[int, int, int, int, int, int]
+_VersionCmpKey = tuple[int, tuple[int, ...], _VersionCmpSuffix]
 
 
 def __dir__() -> list[str]:
@@ -25,6 +28,44 @@ def trim_release(release: tuple[int, ...]) -> tuple[int, ...]:
     while end > 1 and release[end - 1] == 0:
         end -= 1
     return release if end == len(release) else release[:end]
+
+
+def version_cmpkey(
+    version: Version,
+) -> _VersionCmpKey:
+    """Return the leading comparison key tuple used by Version._key."""
+    release = trim_release(version.release)
+
+    if version.pre is None and version.post is None and version.dev is None:
+        # 3 = no pre-release, 0/0/0 = no post/dev, 1 = no-dev sorts after dev.
+        suffix = (3, 0, 0, 0, 1, 0)
+    elif version.pre is None and version.post is None and version.dev is not None:
+        # -1 = dev-only, so it sorts before a/b/rc; the trailing 0s are
+        # the missing post/dev counters.
+        suffix = (-1, 0, 0, 0, 0, version.dev)
+    elif version.pre is None:
+        # 3 = no pre-release; post/dev are encoded in the last four slots.
+        suffix = (
+            3,
+            0,
+            1,
+            version.post or 0,
+            1 if version.dev is None else 0,
+            version.dev or 0,
+        )
+    else:
+        # 0/1/2 = a/b/rc, 1 = no post-release, 0 = has dev, 1/0 = dev counter.
+        pre_rank = {"a": 0, "b": 1, "rc": 2}[version.pre[0]]
+        suffix = (
+            pre_rank,
+            version.pre[1],
+            1 if version.post is not None else 0,
+            version.post or 0,
+            1 if version.dev is None else 0,
+            version.dev or 0,
+        )
+
+    return version.epoch, release, suffix
 
 
 def coerce_version(version: Version | str) -> Version | None:

--- a/nab-python/src/nab_python/_vendor/packaging/metadata.py
+++ b/nab-python/src/nab_python/_vendor/packaging/metadata.py
@@ -22,6 +22,7 @@ from .errors import ExceptionGroup, _ErrorCollector
 
 if typing.TYPE_CHECKING:
     from .licenses import NormalizedLicenseExpression
+    from .version import Version
 
 T = typing.TypeVar("T")
 
@@ -130,6 +131,8 @@ class RawMetadata(TypedDict, total=False):
     # Metadata 2.5 - PEP 794
     import_names: list[str]
     import_namespaces: list[str]
+
+    # Metadata 2.6 - PEP 808 (no new fields, behavior change for Dynamic)
 
 
 # 'keywords' is special as it's a string in the core metadata spec, but we
@@ -511,8 +514,20 @@ _NOT_FOUND = object()
 
 
 # Keep the two values in sync.
-_VALID_METADATA_VERSIONS = ["1.0", "1.1", "1.2", "2.1", "2.2", "2.3", "2.4", "2.5"]
-_MetadataVersion = Literal["1.0", "1.1", "1.2", "2.1", "2.2", "2.3", "2.4", "2.5"]
+_VALID_METADATA_VERSIONS = [
+    "1.0",
+    "1.1",
+    "1.2",
+    "2.1",
+    "2.2",
+    "2.3",
+    "2.4",
+    "2.5",
+    "2.6",
+]
+_MetadataVersion = Literal[
+    "1.0", "1.1", "1.2", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6"
+]
 
 _REQUIRED_ATTRS = frozenset(["metadata_version", "name", "version"])
 
@@ -597,7 +612,7 @@ class _Validator(Generic[T]):
         else:
             return value
 
-    def _process_version(self, value: str) -> version_module.Version:
+    def _process_version(self, value: str) -> Version:
         if not value:
             raise self._invalid_metadata("{field} is a required field")
         try:
@@ -853,7 +868,7 @@ class Metadata:
     """:external:ref:`core-metadata-name`
     (required; validated using :func:`~packaging.utils.canonicalize_name` and its
     *validate* parameter)"""
-    version: _Validator[version_module.Version] = _Validator()
+    version: _Validator[Version] = _Validator()
     """:external:ref:`core-metadata-version` (required)"""
     dynamic: _Validator[list[str] | None] = _Validator(
         added="2.2",

--- a/nab-python/src/nab_python/_vendor/packaging/ranges.py
+++ b/nab-python/src/nab_python/_vendor/packaging/ranges.py
@@ -8,7 +8,8 @@ versions accepted by a :class:`~packaging.specifiers.Specifier` or
 :class:`~packaging.specifiers.SpecifierSet`. Bound primitives, range
 algebra, and the spec-to-bounds dispatch live in
 :mod:`packaging._range_utils`; this module composes them into the
-public class plus the :meth:`VersionRange.to_specifier_set` encoders,
+public class plus the
+:meth:`~packaging.ranges.VersionRange.to_specifier_set` encoders,
 ``__repr__``, and pickle helpers that only :class:`VersionRange`
 itself uses.
 
@@ -41,9 +42,9 @@ from ._range_utils import (
     bounds_for_spec,
     filter_by_ranges,
     intersect_ranges,
-    intersect_specifier_bounds,
     matches_bounds_only,
     range_is_empty,
+    resolve_prereleases,
 )
 from ._version_utils import coerce_version
 from .version import InvalidVersion, Version
@@ -206,6 +207,24 @@ def _ranges_are_prerelease_only(ranges: Sequence[Interval]) -> bool:
     return True
 
 
+def _combine_prereleases(left: bool | None, right: bool | None) -> bool | None:
+    """Combine two ranges' pre-release tags for :meth:`intersection` /
+    :meth:`union`.
+
+    A ``True`` from either side wins, then an explicit ``False``, otherwise
+    ``None`` (the PEP 440 buffering default). ``None`` is the identity, so
+    ``r & VersionRange.full()`` keeps ``r``'s tag and composition stays
+    faithful to the originating specifiers. ``True`` against ``False`` (which
+    :meth:`SpecifierSet.__and__` rejects) resolves to ``True`` here, since
+    set algebra on ranges is total.
+    """
+    if left is True or right is True:
+        return True
+    if left is False or right is False:
+        return False
+    return None
+
+
 def _format_lower(bound: LowerBound) -> str:
     if bound.version is None:
         return "(-inf"
@@ -259,6 +278,7 @@ def _restore_version_range(
     arbitrary: str | None = None,
     admit: tuple[str, ...] | None = None,
     reject: tuple[str, ...] | None = None,
+    prereleases: bool | None = None,
 ) -> VersionRange:
     """Pickle restorer; bypasses the ``__new__`` guard via ``_build``.
 
@@ -274,20 +294,22 @@ def _restore_version_range(
         for lower, upper in packed_bounds
     )
     if admit is not None or reject is not None:
-        return VersionRange._build(
-            bounds,
-            admit=frozenset(admit or ()),
-            reject=frozenset(reject or ()),
+        result = VersionRange._build(
+            bounds, admit=frozenset(admit or ()), reject=frozenset(reject or ())
         )
-    if arbitrary is None:
-        return VersionRange._build(bounds)
-    # Legacy ``arbitrary`` matched ``{arbitrary}`` if the literal was
-    # in bounds, empty otherwise.
-    literal_lower = arbitrary.lower()
-    legacy_range = VersionRange._build(bounds)
-    if literal_lower in legacy_range:
-        return VersionRange._build((), admit=frozenset({literal_lower}))
-    return VersionRange._build(())
+    elif arbitrary is None:
+        result = VersionRange._build(bounds)
+    else:
+        # Legacy ``arbitrary`` matched ``{arbitrary}`` if the literal was
+        # in bounds, empty otherwise.
+        literal_lower = arbitrary.lower()
+        if literal_lower in VersionRange._build(bounds):
+            result = VersionRange._build((), admit=frozenset({literal_lower}))
+        else:
+            result = VersionRange._build(())
+
+    result._prereleases = prereleases
+    return result
 
 
 # VersionRange to SpecifierSet conversion is partial: not every range
@@ -402,17 +424,33 @@ def _detect_not_equal(
     left_upper: UpperBound,
     right_lower: LowerBound,
 ) -> Version | None:
-    """If ``[..., V (excl)] [AFTER_LOCALS(V) (excl), ...]`` matches, return V.
+    """If the gap between two intervals is an ``!=V`` exclusion, return V.
 
-    The gap shape ``!=V`` produces when intersected with surrounding
-    bounds. Only ``!=V`` pattern that can appear inside a multi-interval
-    range.
+    Two gap shapes encode as ``!=V``:
+
+    - ``[..., V (excl)] [AFTER_LOCALS(V) (excl), ...]`` -- ``!=V`` for a
+      *V* with no local segment; the gap spans V and its whole local
+      family, exactly what ``==V`` (and thus ``!=V``) covers.
+    - ``[..., V+local (excl)] [V+local (excl), ...]`` -- ``!=V+local``;
+      the gap is the single point ``V+local``, which ``==V+local``
+      matches verbatim. A no-local single point (a strict singleton's
+      complement) has no ``!=`` form, so *V* must carry a local segment.
     """
     if isinstance(left_upper.version, BoundaryVersion):
         return None
     if left_upper.version is None or left_upper.inclusive:
         return None
     if not isinstance(right_lower.version, BoundaryVersion):
+        # Single-point ``!=V+local`` gap: same exclusive bound on both
+        # sides, and V carries a local. An inclusive right lower would
+        # leave no gap; a no-local point has no ``!=`` form.
+        if (
+            right_lower.version is not None
+            and not right_lower.inclusive
+            and right_lower.version == left_upper.version
+            and left_upper.version.local is not None
+        ):
+            return left_upper.version
         return None
     if right_lower.version.kind != BoundaryKind.AFTER_LOCALS:
         return None
@@ -466,12 +504,49 @@ def _detect_not_equal_wildcard(
     return left_upper_v.__replace__(dev=None)
 
 
+def _encode_grouped(bounds: list[Interval]) -> list[list[str]] | None:
+    """Split *bounds* into disjoint groups, encoding each as fragments.
+
+    Consecutive intervals whose gap is an ``!=V`` / ``!=V+local`` /
+    ``!=V.*`` exclusion stay in one group, with that exclusion recorded
+    as an ``!=`` fragment; any other gap starts a new group. Each group
+    encodes as ``_encode_interval`` of its outer bounds plus its ``!=``
+    fragments. Returns one fragment list per group, or ``None`` if any
+    group's outer interval has no PEP 440 form.
+    """
+    groups: list[list[str]] = []
+    group_lower, group_upper = bounds[0]
+    exclusions: list[str] = []
+    for next_lower, next_upper in bounds[1:]:
+        not_equal = _detect_not_equal(group_upper, next_lower)
+        not_equal_wildcard = _detect_not_equal_wildcard(group_upper, next_lower)
+        if not_equal is not None:
+            exclusions.append(f"!={not_equal}")
+        elif not_equal_wildcard is not None:
+            exclusions.append(f"!={not_equal_wildcard}.*")
+        else:
+            # A non-``!=`` gap closes the current group and opens a new one.
+            outer = _encode_interval(group_lower, group_upper)
+            if outer is None:
+                return None
+            groups.append(outer + exclusions)
+            group_lower, exclusions = next_lower, []
+        group_upper = next_upper
+
+    outer = _encode_interval(group_lower, group_upper)
+    if outer is None:
+        return None
+    groups.append(outer + exclusions)
+    return groups
+
+
 class VersionRange:
     """A set of :class:`~packaging.version.Version` values, expressed as
     a union of disjoint intervals on the PEP 440 version ordering.
 
     Construct with :meth:`from_specifier` / :meth:`from_specifier_set`,
-    or via :meth:`Specifier.to_range` / :meth:`SpecifierSet.to_range`.
+    or via :meth:`~packaging.specifiers.Specifier.to_range` /
+    :meth:`~packaging.specifiers.SpecifierSet.to_range`.
     Compose with :meth:`intersection`, :meth:`union`, :meth:`complement`
     (and the ``&`` / ``|`` / ``~`` operator aliases).
 
@@ -484,14 +559,16 @@ class VersionRange:
     False
 
     PEP 440's ``===`` operator matches a candidate string verbatim
-    (case-insensitive) rather than a set of :class:`Version` values.
+    (case-insensitive) rather than a set of
+    :class:`~packaging.version.Version` values.
     Ranges built from ``===`` specifiers still support membership,
-    set operations, and conversion back to a :class:`SpecifierSet`;
+    set operations, and conversion back to a
+    :class:`~packaging.specifiers.SpecifierSet`;
     matching follows the literal-equality rule instead of the
     version-ordering rule.
     """
 
-    __slots__ = ("_admit", "_bounds", "_is_simple", "_reject")
+    __slots__ = ("_admit", "_bounds", "_is_simple", "_prereleases", "_reject")
     _bounds: tuple[Interval, ...]
     #: Whether :meth:`filter` can dispatch straight to the bounds-only
     #: filter: no admit/reject literals and bounds aren't the full range.
@@ -503,6 +580,16 @@ class VersionRange:
     #: ``_bounds``. Populated by :meth:`complement` of a range whose
     #: ``_admit`` was non-empty.
     _reject: frozenset[str]
+    #: Pre-release policy stamped from the originating specifier by the
+    #: ``from_*`` factories (see
+    #: :func:`packaging._range_utils.resolve_prereleases`): ``True`` admits
+    #: pre-releases, ``False`` excludes them, ``None`` uses the PEP 440
+    #: default. :meth:`intersection` / :meth:`union` combine the two tags
+    #: (``True`` wins, then ``False``, then ``None``); :meth:`complement`
+    #: resets to ``None``. Read by :meth:`filter` only when its
+    #: ``prereleases`` argument is ``None``; not part of equality,
+    #: membership, or hashing.
+    _prereleases: bool | None
 
     def __new__(cls, *args: object, **kwargs: object) -> VersionRange:  # noqa: PYI034
         raise TypeError(
@@ -523,7 +610,8 @@ class VersionRange:
 
         Drops admit literals already covered by bounds and reject
         literals already outside bounds. Reject wins over admit on
-        overlap.
+        overlap. ``_prereleases`` defaults to ``None``; the ``from_*``
+        factories stamp the spec's resolved value.
         """
         if admit and reject:
             admit = admit - reject
@@ -535,6 +623,7 @@ class VersionRange:
         instance._bounds = bounds
         instance._admit = admit
         instance._reject = reject
+        instance._prereleases = None
         # Pure-bound range: filter can skip the admission dispatch.
         instance._is_simple = not admit and not reject and bounds != FULL_RANGE
         return instance
@@ -551,6 +640,7 @@ class VersionRange:
         instance._bounds = bounds
         instance._admit = _EMPTY_FROZENSET
         instance._reject = _EMPTY_FROZENSET
+        instance._prereleases = None
         instance._is_simple = bounds != FULL_RANGE
         return instance
 
@@ -609,9 +699,14 @@ class VersionRange:
         True
         """
         if not self._has_literals() and not other._has_literals():
-            return self._build(tuple(intersect_ranges(self._bounds, other._bounds)))
-        new_bounds = tuple(intersect_ranges(self._bounds, other._bounds))
-        return self._combine_literals(other, new_bounds, intersect=True)
+            result = self._build(tuple(intersect_ranges(self._bounds, other._bounds)))
+        else:
+            new_bounds = tuple(intersect_ranges(self._bounds, other._bounds))
+            result = self._combine_literals(other, new_bounds, intersect=True)
+        result._prereleases = _combine_prereleases(
+            self._prereleases, other._prereleases
+        )
+        return result
 
     def union(self, other: VersionRange) -> VersionRange:
         """Range containing every version in *self* or *other*.
@@ -624,9 +719,14 @@ class VersionRange:
         False
         """
         if not self._has_literals() and not other._has_literals():
-            return self._build(tuple(_union_ranges(self._bounds, other._bounds)))
-        new_bounds = tuple(_union_ranges(self._bounds, other._bounds))
-        return self._combine_literals(other, new_bounds, intersect=False)
+            result = self._build(tuple(_union_ranges(self._bounds, other._bounds)))
+        else:
+            new_bounds = tuple(_union_ranges(self._bounds, other._bounds))
+            result = self._combine_literals(other, new_bounds, intersect=False)
+        result._prereleases = _combine_prereleases(
+            self._prereleases, other._prereleases
+        )
+        return result
 
     def complement(self) -> VersionRange:
         """Range containing every version *not* in *self*.
@@ -715,15 +815,19 @@ class VersionRange:
         pre-releases are buffered and only emitted if no final release
         in *iterable* is in range.
 
-        Filtering matches :class:`SpecifierSet.filter` for the same
-        :class:`Specifier` / :class:`SpecifierSet`, including
-        :class:`SpecifierSet("")`'s admission of unparsable strings
+        Filtering matches
+        :meth:`~packaging.specifiers.SpecifierSet.filter` for the same
+        :class:`~packaging.specifiers.Specifier` /
+        :class:`~packaging.specifiers.SpecifierSet`, including the
+        admission of unparsable strings for the empty ``SpecifierSet("")``
         and the case-insensitive literal match for ``===``.
 
         >>> r = VersionRange.from_specifier_set(SpecifierSet(">=1.0,<2.0"))
         >>> list(r.filter(["0.9", "1.5", "2.0"]))
         ['1.5']
         """
+        if prereleases is None:
+            prereleases = self._prereleases
         if self._is_simple:
             return filter_by_ranges(self._bounds, iterable, key, prereleases)
         return self._filter_with_admission(iterable, key, prereleases)
@@ -813,19 +917,31 @@ class VersionRange:
         op = specifier.operator
         ver = specifier.version
         if op == "===":
-            return cls._build(bounds=(), admit=frozenset({ver.lower()}))
-
-        return cls._build_simple(bounds=bounds_for_spec(op, ver))
+            result = cls._build(bounds=(), admit=frozenset({ver.lower()}))
+        else:
+            result = cls._build_simple(bounds=bounds_for_spec(op, ver))
+        # Tag the range with the pre-release policy filter() uses by
+        # default, so it mirrors the specifier. ``_prereleases`` is the one
+        # specifier private we read: the public ``prereleases`` property
+        # collapses an auto-detected ``False`` (``>=1.0``, the PEP 440
+        # default) and an explicit ``prereleases=False`` (pre-releases
+        # excluded) to the same value, so the raw flag is needed and has no
+        # public accessor.
+        result._prereleases = resolve_prereleases(
+            None, specifier._prereleases, specifier.prereleases
+        )
+        return result
 
     @classmethod
     def from_specifier_set(cls, specifier_set: SpecifierSet) -> VersionRange:
         """Return the :class:`VersionRange` accepted by *specifier_set*.
 
         The intersection of every specifier in the set. An empty
-        :class:`SpecifierSet` yields the unbounded range; an
-        unsatisfiable set yields an empty :class:`VersionRange`. To reuse
-        the result, call :meth:`SpecifierSet.to_range`, which caches it
-        on the instance.
+        :class:`~packaging.specifiers.SpecifierSet` yields the
+        unbounded range; an unsatisfiable set yields an empty
+        :class:`VersionRange`. To reuse the result, call
+        :meth:`~packaging.specifiers.SpecifierSet.to_range`, which
+        caches it on the instance.
 
         >>> isinstance(
         ...     VersionRange.from_specifier_set(SpecifierSet(">=1.0,<2.0")),
@@ -835,57 +951,36 @@ class VersionRange:
         >>> VersionRange.from_specifier_set(SpecifierSet(">=2.0,<1.0")).is_empty
         True
         """
-        specs = []
-        arbitrary_specs = []
+        # Intersect every specifier through the public API. ``&`` and
+        # :meth:`from_specifier` already handle ``===`` literals via the
+        # admit set, so the fold needs no operator-specific special
+        # cases. An empty set leaves the unbounded ``full()``.
+        result = cls.full()
         for spec in specifier_set:
-            specs.append(spec)
-            if spec.operator == "===":
-                arbitrary_specs.append(spec)
+            result = result.intersection(cls.from_specifier(spec))
 
-        if not specs:
-            return cls._build(bounds=FULL_RANGE)
-
-        if not arbitrary_specs:
-            # Common case: no ``===`` literals. Intersect raw bound
-            # tuples; one wrapper allocation for the result.
-            return cls._build_simple(intersect_specifier_bounds(specs))
-
-        # ``===`` literals need separate handling: the rangelike specs
-        # build the bounds, and a single literal is admitted only if
-        # it also satisfies those bounds.
-        rangelike_specs = [s for s in specs if s.operator != "==="]
-        if not rangelike_specs:
-            rangelike_result: VersionRange = cls._build(bounds=FULL_RANGE)
-        else:
-            rangelike_result = cls._build_simple(
-                intersect_specifier_bounds(rangelike_specs)
-            )
-
-        # Each ``===L_i`` requires the candidate's string to equal L_i.
-        # Distinct literals can never all match, so the result is empty.
-        literals_lower = {s.version.lower() for s in arbitrary_specs}
-        if len(literals_lower) > 1:
-            return cls._build(bounds=())
-
-        (literal_lower,) = literals_lower
-        if literal_lower in rangelike_result:
-            return cls._build(bounds=(), admit=frozenset({literal_lower}))
-
-        return cls._build(bounds=())
+        # Tag the range with the set's pre-release policy. Unlike a single
+        # specifier, a set's public ``prereleases`` never reports an
+        # auto-detected ``False``, so it already equals the resolved value
+        # and no private access is needed here.
+        result._prereleases = specifier_set.prereleases
+        return result
 
     def to_specifier_set(self) -> SpecifierSet | None:
-        """Return a single :class:`SpecifierSet` whose
+        """Return a single
+        :class:`~packaging.specifiers.SpecifierSet` whose
         :meth:`from_specifier_set` yields *self*, or ``None`` if no
         such set exists.
 
-        :class:`SpecifierSet` cannot express every range. PEP 440's
+        :class:`~packaging.specifiers.SpecifierSet` cannot express every
+        range. PEP 440's
         operator set has no syntax for the strict singleton ``{V}`` or
         for the bounds produced by complementing ``>V``; for those
         ranges the result is ``None``. Use :meth:`to_specifier_sets`
         when a tuple of specifier sets is acceptable. The empty range
-        maps to ``SpecifierSet("<0")`` (``<0`` excludes ``0.dev0``,
-        the smallest PEP 440 version); the full range maps to
-        ``SpecifierSet("")``.
+        maps to the range ``SpecifierSet("<0")`` (``<0`` excludes
+        ``0.dev0``, the smallest PEP 440 version); the full range maps
+        to the empty ``SpecifierSet("")``.
 
         >>> r = VersionRange.from_specifier_set(SpecifierSet(">=1.0,<2.0"))
         >>> str(r.to_specifier_set())
@@ -909,38 +1004,25 @@ class VersionRange:
         if self._bounds == FULL_RANGE:
             return SpecifierSet("")
 
-        # Walk left-to-right, merging adjacent intervals whose gap is
-        # a ``!=V`` or ``!=V.*`` exclusion. The merged outer bounds
-        # plus the chain of ``!=`` fragments form a single SpecifierSet.
-        bounds = list(self._bounds)
-        outer_lower = bounds[0][0]
-        outer_upper = bounds[0][1]
-        exclusions: list[str] = []
-        for next_lower, next_upper in bounds[1:]:
-            not_equal = _detect_not_equal(outer_upper, next_lower)
-            not_equal_wildcard = _detect_not_equal_wildcard(outer_upper, next_lower)
-            if not_equal is not None:
-                exclusions.append(f"!={not_equal}")
-            elif not_equal_wildcard is not None:
-                exclusions.append(f"!={not_equal_wildcard}.*")
-            else:
-                return None
-            outer_upper = next_upper
-
-        outer_parts = _encode_interval(outer_lower, outer_upper)
-        if outer_parts is None:
+        # A single SpecifierSet exists only when every interval joins
+        # into one ``!=``-connected group; a genuine disjoint gap (more
+        # than one group) has no single-set form.
+        groups = _encode_grouped(list(self._bounds))
+        if groups is None or len(groups) != 1:
             return None
-        return SpecifierSet(",".join(outer_parts + exclusions))
+        return SpecifierSet(",".join(groups[0]))
 
     def to_specifier_sets(self) -> tuple[SpecifierSet, ...] | None:
-        """Return a tuple of :class:`SpecifierSet` whose union equals
+        """Return a tuple of
+        :class:`~packaging.specifiers.SpecifierSet` whose union equals
         *self*, or ``None`` if no such tuple exists.
 
-        Looser than :meth:`to_specifier_set`: a range that fits a
-        single :class:`SpecifierSet` returns a one-tuple, otherwise
-        each interval encodes separately. ``None`` only for ranges
-        whose individual intervals still have no PEP 440 specifier
-        (for example the singleton produced by :meth:`singleton`).
+        Looser than :meth:`to_specifier_set`: each maximal run of
+        intervals joined by ``!=V`` / ``!=V.*`` gaps becomes one
+        :class:`~packaging.specifiers.SpecifierSet`, and genuinely
+        disjoint runs become separate ones. ``None`` only when some
+        run's outer interval has no PEP 440 form (for example the
+        strict singleton produced by :meth:`singleton`).
 
         >>> r = (
         ...     VersionRange.from_specifier_set(SpecifierSet(">=1.0,<2.0"))
@@ -965,20 +1047,12 @@ class VersionRange:
         if self._bounds == FULL_RANGE:
             return (SpecifierSet(""),)
 
-        # Prefer the single-set form when it exists; that catches
-        # multi-interval ``!=V`` / ``!=V.*`` patterns the per-interval
-        # encoder rejects.
-        single = self.to_specifier_set()
-        if single is not None:
-            return (single,)
-
-        out: list[SpecifierSet] = []
-        for lower, upper in self._bounds:
-            parts = _encode_interval(lower, upper)
-            if parts is None:
-                return None
-            out.append(SpecifierSet(",".join(parts)))
-        return tuple(out)
+        # One SpecifierSet per disjoint group; ``!=`` gaps stay merged
+        # inside their group.
+        groups = _encode_grouped(list(self._bounds))
+        if groups is None:
+            return None
+        return tuple(SpecifierSet(",".join(group)) for group in groups)
 
     def _admit_to_specifier_set(self) -> SpecifierSet | None:
         """Encode a single ``===L`` range as ``SpecifierSet("===L")``.
@@ -1007,6 +1081,7 @@ class VersionRange:
                 None,
                 tuple(sorted(self._admit)),
                 tuple(sorted(self._reject)),
+                self._prereleases,
             ),
         )
 
@@ -1025,7 +1100,9 @@ class VersionRange:
     def is_prerelease_only(self) -> bool:
         """``True`` when every match is a PEP 440 pre-release.
 
-        Used by :meth:`SpecifierSet.is_unsatisfiable` to detect sets
+        Used by
+        :meth:`~packaging.specifiers.SpecifierSet.is_unsatisfiable` to
+        detect sets
         that admit no candidate under the default ``prereleases=False``
         reading. Returns ``False`` for the empty range.
 
@@ -1060,10 +1137,10 @@ class VersionRange:
     def __contains__(self, item: Version | str) -> bool:
         """Return whether *item* is contained in this range.
 
-        Unparsable strings do not match, except where
-        :class:`SpecifierSet` would also match: the full range admits
-        any string, and a ``===`` range admits items whose string
-        equals the literal case-insensitively.
+        Unparsable strings do not match, except where the full
+        ``SpecifierSet`` would also match: the full range admits any
+        string, and a ``===`` range admits items whose string equals
+        the literal case-insensitively.
 
         >>> r = VersionRange.from_specifier_set(SpecifierSet(">=1.0,<2.0"))
         >>> "1.5" in r

--- a/nab-python/src/nab_python/_vendor/packaging/specifiers.py
+++ b/nab-python/src/nab_python/_vendor/packaging/specifiers.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import abc
 import re
-import sys
 import typing
 from typing import (
     TYPE_CHECKING,
@@ -26,7 +25,7 @@ from typing import (
 
 from ._range_utils import (
     filter_by_ranges,
-    intersect_specifier_bounds,
+    intersect_ranges,
     matches_bounds_only,
     standard_ranges,
     wildcard_ranges,
@@ -36,14 +35,14 @@ from .ranges import VersionRange
 from .utils import canonicalize_version
 from .version import Version
 
-if sys.version_info >= (3, 10):
-    from typing import TypeGuard  # pragma: no cover
-elif TYPE_CHECKING:
-    from typing_extensions import TypeGuard
-
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator
+    import sys
+    from collections.abc import Iterable, Iterator, Sequence
 
+    if sys.version_info >= (3, 10):
+        from typing import TypeGuard
+    else:
+        from typing_extensions import TypeGuard
 
 __all__ = [
     "BaseSpecifier",
@@ -210,9 +209,11 @@ class Specifier(BaseSpecifier):
 
     .. tip::
 
-        It is generally not required to instantiate this manually. You should instead
-        prefer to work with :class:`SpecifierSet` instead, which can parse
-        comma-separated version specifiers (which is what package metadata contains).
+        It is generally not required to instantiate this manually. You
+        should instead prefer to work with
+        :class:`~packaging.specifiers.SpecifierSet` instead, which can
+        parse comma-separated version specifiers (which is what package
+        metadata contains).
 
     Instances are safe to serialize with :mod:`pickle`. They use a stable
     format so the same pickle can be loaded in future packaging releases.
@@ -469,6 +470,9 @@ class Specifier(BaseSpecifier):
     @prereleases.setter
     def prereleases(self, value: bool | None) -> None:
         self._prereleases = value
+        # The range carries the resolved prereleases value, so drop the
+        # cache; the bounds-only ``_ranges`` cache is unaffected.
+        self._range_cache = None
 
     def __getstate__(self) -> tuple[tuple[str, str], bool | None]:
         # Return state as a 2-item tuple for compactness:
@@ -628,7 +632,7 @@ class Specifier(BaseSpecifier):
 
         :param item:
             The item to check for, which can be a version string or a
-            :class:`Version` instance.
+            :class:`~packaging.version.Version` instance.
         :param prereleases:
             Whether or not to match prereleases with this Specifier. If set to
             ``None`` (the default), it will follow the recommendation from
@@ -673,11 +677,13 @@ class Specifier(BaseSpecifier):
         return bool(list(self.filter([parsed], prereleases=prereleases)))
 
     def to_range(self) -> VersionRange:
-        """The :class:`VersionRange` accepted by this specifier.
+        """The :class:`~packaging.ranges.VersionRange` accepted by this
+        specifier.
 
         For ``===`` the returned range matches the literal string
-        case-insensitively; no PEP 440 :class:`Version` other than the
-        literal itself is contained.
+        case-insensitively; no PEP 440
+        :class:`~packaging.version.Version` other than the literal
+        itself is contained.
 
         >>> isinstance(Specifier(">=1.0").to_range(), VersionRange)
         True
@@ -716,16 +722,17 @@ class Specifier(BaseSpecifier):
         """Filter items in the given iterable, that match the specifier.
 
         :param iterable:
-            An iterable that can contain version strings and :class:`Version` instances.
-            The items in the iterable will be filtered according to the specifier.
+            An iterable that can contain version strings and
+            :class:`~packaging.version.Version` instances. The items in the
+            iterable will be filtered according to the specifier.
         :param prereleases:
             Whether or not to allow prereleases in the returned iterator. If set to
             ``None`` (the default), it will follow the recommendation from :pep:`440`
             and match prereleases if there are no other versions.
         :param key:
             A callable that takes a single argument (an item from the iterable) and
-            returns a version string or :class:`Version` instance to be used for
-            filtering.
+            returns a version string or :class:`~packaging.version.Version`
+            instance to be used for filtering.
 
         >>> list(Specifier(">=1.2.3").filter(["1.2", "1.3", "1.5a1"]))
         ['1.3']
@@ -742,7 +749,8 @@ class Specifier(BaseSpecifier):
         ... key=lambda x: x["ver"]))
         [{'ver': '1.3'}]
         """
-        # Inlined ``_resolve_prereleases`` for hot-path performance.
+        # Inlined ``resolve_prereleases`` (skips the ``self.prereleases``
+        # lookup unless it is needed).
         if prereleases is None:
             if self._prereleases is not None:
                 prereleases = self._prereleases
@@ -762,22 +770,6 @@ class Specifier(BaseSpecifier):
             )
 
         return self.to_range().filter(iterable, key=key, prereleases=prereleases)
-
-    def _resolve_prereleases(self, prereleases: bool | None) -> bool | None:
-        """Resolve ``prereleases`` for :meth:`filter` / :meth:`contains`.
-
-        Explicit caller argument wins; otherwise the constructor value
-        ``self._prereleases``; otherwise auto-detected ``self.prereleases``
-        only when True (an auto-detected False does not propagate, so
-        non-pre specifiers keep PEP 440 default behaviour).
-        """
-        if prereleases is not None:
-            return prereleases
-        if self._prereleases is not None:
-            return self._prereleases
-        if self.prereleases:
-            return True
-        return None
 
 
 class SpecifierSet(BaseSpecifier):
@@ -846,7 +838,7 @@ class SpecifierSet(BaseSpecifier):
         self._is_unsatisfiable: bool | None = None
         self._range_cache: VersionRange | None = None
         # Internal bounds cache for the hot filter/contains path
-        # (populated by :func:`packaging._range_utils.intersect_specifier_bounds`).
+        # (populated by :meth:`_intersect_bounds`).
         self._ranges: tuple[Any, ...] | None = None
         self._prereleases = prereleases
 
@@ -1096,13 +1088,15 @@ class SpecifierSet(BaseSpecifier):
         return result
 
     def to_range(self) -> VersionRange:
-        """The :class:`VersionRange` accepted by this specifier set.
+        """The :class:`~packaging.ranges.VersionRange` accepted by this
+        specifier set.
 
         The intersection of every specifier in the set. An empty
-        :class:`SpecifierSet` yields the unbounded range; an
-        unsatisfiable set yields an empty :class:`VersionRange`. Sets
-        containing ``===`` produce a range whose only matching items
-        are the literal strings (case-insensitive) that satisfy every
+        :class:`~packaging.specifiers.SpecifierSet` yields the
+        unbounded range; an unsatisfiable set yields an empty
+        :class:`~packaging.ranges.VersionRange`. Sets containing
+        ``===`` produce a range whose only matching items are the
+        literal strings (case-insensitive) that satisfy every
         rangelike specifier in the set as well.
 
         >>> isinstance(SpecifierSet(">=1.0,<2.0").to_range(), VersionRange)
@@ -1120,6 +1114,28 @@ class SpecifierSet(BaseSpecifier):
             self._range_cache = cache
 
         return cache
+
+    def _intersect_bounds(self) -> tuple[Any, ...]:
+        """Intersect every specifier's bounds into a single range.
+
+        Reuses each :class:`Specifier`'s per-instance bounds cache rather
+        than re-parsing version strings. Callers must exclude ``===``
+        specifiers (which have no bound form) and guard against the empty
+        set; the result feeds the cold path of :meth:`__contains__` and
+        :meth:`filter`.
+        """
+        result: Sequence[Any] | None = None
+        for spec in self._specs:
+            sub = spec._to_ranges()
+            if result is None:
+                result = sub
+            elif not result:
+                break
+            else:
+                result = intersect_ranges(result, sub)
+        if result is None:  # pragma: no cover - callers guard non-empty specs
+            raise RuntimeError("intersection over an empty SpecifierSet")
+        return tuple(result)
 
     def __contains__(self, item: UnparsedVersion) -> bool:
         """Return whether or not the item is contained in this specifier.
@@ -1152,7 +1168,7 @@ class SpecifierSet(BaseSpecifier):
 
         :param item:
             The item to check for, which can be a version string or a
-            :class:`Version` instance.
+            :class:`~packaging.version.Version` instance.
         :param prereleases:
             Whether or not to match prereleases with this SpecifierSet. If set to
             ``None`` (the default), it will follow the recommendation from :pep:`440`
@@ -1218,21 +1234,12 @@ class SpecifierSet(BaseSpecifier):
             # interval form; build it once and reuse via ``_ranges``.
             bounds = self._ranges
             if bounds is None:
-                bounds = intersect_specifier_bounds(self._specs)
+                bounds = self._intersect_bounds()
                 self._ranges = bounds
 
             return matches_bounds_only(bounds, version)
 
         return bool(list(self.filter([check_item], prereleases=prereleases)))
-
-    def _resolve_prereleases(self, prereleases: bool | None) -> bool | None:
-        """Resolve ``prereleases`` for :meth:`filter` / :meth:`contains`.
-
-        Explicit caller argument wins; otherwise ``self.prereleases``.
-        """
-        if prereleases is not None:
-            return prereleases
-        return self.prereleases
 
     @typing.overload
     def filter(
@@ -1259,16 +1266,17 @@ class SpecifierSet(BaseSpecifier):
         """Filter items in the given iterable, that match the specifiers in this set.
 
         :param iterable:
-            An iterable that can contain version strings and :class:`Version` instances.
-            The items in the iterable will be filtered according to the specifier.
+            An iterable that can contain version strings and
+            :class:`~packaging.version.Version` instances. The items in the
+            iterable will be filtered according to the specifier.
         :param prereleases:
             Whether or not to allow prereleases in the returned iterator. If set to
             ``None`` (the default), it will follow the recommendation from :pep:`440`
             and match prereleases if there are no other versions.
         :param key:
             A callable that takes a single argument (an item from the iterable) and
-            returns a version string or :class:`Version` instance to be used for
-            filtering.
+            returns a version string or :class:`~packaging.version.Version`
+            instance to be used for filtering.
 
         >>> list(SpecifierSet(">=1.2.3").filter(["1.2", "1.3", "1.5a1"]))
         ['1.3']
@@ -1297,8 +1305,8 @@ class SpecifierSet(BaseSpecifier):
         >>> list(SpecifierSet("").filter(["1.3", "1.5a1"], prereleases=True))
         ['1.3', '1.5a1']
         """
-        # Inlined ``_resolve_prereleases`` for hot-path performance.
-        # ``self.prereleases`` scans every spec, so resolve it once.
+        # Inlined ``resolve_prereleases``: ``self.prereleases`` scans every
+        # spec, so resolve it once and skip it when not needed.
         if prereleases is None:
             resolved = self.prereleases
             if resolved is not None:
@@ -1311,7 +1319,7 @@ class SpecifierSet(BaseSpecifier):
         if not self._has_arbitrary and self._specs:
             bounds = self._ranges
             if bounds is None:
-                bounds = intersect_specifier_bounds(self._specs)
+                bounds = self._intersect_bounds()
                 self._ranges = bounds
 
             return filter_by_ranges(


### PR DESCRIPTION
Bumps the vendored `packaging` snapshot to the current PR #1182 head (5a21dd8): the public VersionRange API plus the prerelease range-filter and set-algebra fixes. Closes #31.