### PR TITLE
Reject constraints with extras

### DIFF
--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -23,7 +23,7 @@ from ._vendor.packaging.requirements import Requirement
 from ._vendor.packaging.specifiers import SpecifierSet
 from ._vendor.packaging.utils import canonicalize_name
 from ._vendor.packaging.version import InvalidVersion, Version
-from .config import NabProjectConfig, ResolveMode, read_pyproject_config
+from .config import ConfigError, NabProjectConfig, ResolveMode, read_pyproject_config
 from .fetch import FetchCoordinator
 from .lockfile import LockInput, build_lock_input_from_provider
 from .provider import (
@@ -665,6 +665,9 @@ def _build_constraints(config: NabProjectConfig) -> dict[str, VersionRange]:
     sources: defaultdict[str, list[str]] = defaultdict(list)
     for cstr in config.constraints:
         req = Requirement(cstr)
+        if req.extras:
+            msg = f"Constraints cannot have extras: {cstr}"
+            raise ConfigError(msg)
         if req.url is not None:
             admit_vcs_url(req.url, config.vcs)
             msg = (

--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -23,6 +23,7 @@ from .._vendor.packaging.markers import Marker
 from .._vendor.packaging.ranges import VersionRange
 from .._vendor.packaging.requirements import InvalidRequirement, Requirement
 from .._vendor.packaging.utils import canonicalize_name
+from ..config import ConfigError
 from ..fetch import (
     DEFAULT_INDEX_NAME,
     DEFAULT_INDEX_URL,
@@ -434,6 +435,9 @@ def _parse_requirements(
     sources: defaultdict[str, list[str]] = defaultdict(list)
     for req_str in reqs:
         req = Requirement(req_str)
+        if kind == "constraint" and req.extras:
+            msg = f"Constraints cannot have extras: {req_str}"
+            raise ConfigError(msg)
         if req.marker is not None and not req.marker.evaluate(environment):
             continue
         name = canonicalize_name(req.name)

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -10,6 +10,7 @@ import pytest
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.version import Version
 from nab_python.config import (
+    ConfigError,
     MatrixConfig,
     NabProjectConfig,
     ResolveMode,
@@ -1007,6 +1008,11 @@ class TestBuildConstraints:
         """Pinned-but-different constraint lines for one package raise."""
         with pytest.raises(ResolutionError, match="conflicting constraints"):
             _build_constraints(NabProjectConfig(constraints=("foo==1.0", "foo==2.0")))
+
+    def test_constraint_with_extras_rejected(self) -> None:
+        """A constraint carrying extras is rejected, matching pip."""
+        with pytest.raises(ConfigError, match="extras"):
+            _build_constraints(NabProjectConfig(constraints=("foo[dev]<2.0",)))
 
 
 class TestResolvePyprojectConflicts:

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -18,6 +18,7 @@ from nab_index.client import WheelFile
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.version import Version
+from nab_python.config import ConfigError
 from nab_python.lockfile import IndexPin, LockInput
 from nab_python.provider import (
     BuildPolicy,
@@ -224,6 +225,12 @@ class TestParseRequirements:
         env = _linux_311().environment
         with pytest.raises(ResolutionError, match="pkg==1.0"):
             _parse_requirements(["pkg==1.0", "pkg==2.0"], env)
+
+    def test_constraint_extras_rejected(self) -> None:
+        """A constraint carrying extras is rejected, matching pip."""
+        env = _linux_311().environment
+        with pytest.raises(ConfigError, match="extras"):
+            _parse_requirements(["pkg[dev]<2.0"], env, kind="constraint")
 
 
 class TestResolveOneTuple:


### PR DESCRIPTION
pip rejects constraints carrying extras with "Constraints cannot have extras". nab accepted them silently and the two resolve paths disagreed: the non-universal path dropped the extras and applied only the version specifier, while the universal path treated each extra as a proxy entry.

Both paths now raise ConfigError before any range or proxy handling when a constraint specifier includes extras, so nab matches pip's behavior and the two paths agree.