### PR TITLE
Pad python_full_version to three components

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -7,6 +7,7 @@ types.  Uses a thread pool with a shared HTTP session to overlap I/O.
 
 from __future__ import annotations
 
+import contextlib
 import enum
 import logging
 import re
@@ -61,6 +62,7 @@ __all__ = [
     "VcsPolicy",
     "VcsSource",
     "join_extra",
+    "python_axis_environment",
     "split_extra",
 ]
 
@@ -69,8 +71,34 @@ logger = logging.getLogger(__name__)
 
 _EXTRA_RE = re.compile(r"^(?P<base>[^\[]+)\[(?P<extra>[^\]]+)\]$")
 
-# A PEP 508 ``python_version`` value is the ``major.minor`` pair.
+
+# PEP 508 ``python_version`` is the ``major.minor`` pair;
+# ``python_full_version`` is the full ``major.minor.micro`` release.
 _PYTHON_VERSION_PARTS = 2
+_PYTHON_FULL_VERSION_PARTS = 3
+
+
+def python_axis_environment(python_version: str) -> dict[str, str]:
+    """Map an explicit Python version to its PEP 508 marker keys.
+
+    ``python_full_version`` is padded to three components so patch-precision
+    markers evaluate the same here as in the universal matrix. Raises
+    ``InvalidVersion`` if the input is not a version.
+    """
+    release = Version(python_version).release
+    minor = (
+        f"{release[0]}.{release[1]}"
+        if len(release) >= _PYTHON_VERSION_PARTS
+        else python_version
+    )
+    full = (
+        python_version
+        if len(release) >= _PYTHON_FULL_VERSION_PARTS
+        else ".".join(
+            str(part) for part in (*release, 0, 0)[:_PYTHON_FULL_VERSION_PARTS]
+        )
+    )
+    return {"python_version": minor, "python_full_version": full}
 
 
 def _normalize_extra(extra: str) -> str:
@@ -442,19 +470,8 @@ class Provider:
         }
         self.environment: dict[str, str] = env_init
         if python_version is not None:
-            try:
-                release = Version(python_version).release
-            except InvalidVersion:
-                pass
-            else:
-                # python_version is major.minor (PEP 508);
-                # python_full_version is the full release.
-                self.environment["python_version"] = (
-                    f"{release[0]}.{release[1]}"
-                    if len(release) >= _PYTHON_VERSION_PARTS
-                    else python_version
-                )
-                self.environment["python_full_version"] = python_version
+            with contextlib.suppress(InvalidVersion):
+                self.environment.update(python_axis_environment(python_version))
         if marker_environment:
             for key, value in marker_environment.items():
                 self.environment[key] = value

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import itertools
 import logging
 import sys
@@ -30,6 +31,7 @@ from .provider import (
     Provider,
     ResolutionStrategy,
     join_extra,
+    python_axis_environment,
     split_extra,
 )
 from .requirements_file import (
@@ -490,9 +492,6 @@ def _build_resolver_inputs(
     return resolver_requirements, root_extras
 
 
-_PYTHON_VERSION_PARTS = 2
-
-
 def _build_marker_environment(
     *,
     python_version: str,
@@ -510,17 +509,8 @@ def _build_marker_environment(
         for key, value in default_environment().items()
         if isinstance(value, str)
     }
-    try:
-        release = Version(python_version).release
-    except InvalidVersion:
-        pass
-    else:
-        env["python_version"] = (
-            f"{release[0]}.{release[1]}"
-            if len(release) >= _PYTHON_VERSION_PARTS
-            else python_version
-        )
-        env["python_full_version"] = python_version
+    with contextlib.suppress(InvalidVersion):
+        env.update(python_axis_environment(python_version))
     env.update(overrides)
     return env
 

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -1188,6 +1188,23 @@ class TestMarkerEnvironment:
         )
         assert provider.environment["python_version"] == "3.13"
 
+    def test_two_part_python_version_expands_full_version(self) -> None:
+        """A 2-part python_version yields a 3-part python_full_version."""
+        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
+        provider = Provider(
+            coordinator, python_version="3.10", build_policy=BuildPolicy.NEVER
+        )
+        assert provider.environment["python_version"] == "3.10"
+        assert provider.environment["python_full_version"] == "3.10.0"
+
+    def test_full_python_version_preserved(self) -> None:
+        """A 3-part python_version keeps its patch component."""
+        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
+        provider = Provider(
+            coordinator, python_version="3.11.5", build_policy=BuildPolicy.NEVER
+        )
+        assert provider.environment["python_full_version"] == "3.11.5"
+
     def test_overlay_with_never_override_passes(self) -> None:
         """Overrides at ``NEVER`` skip the guard's offending branch.
 

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -20,6 +20,7 @@ from nab_python.resolve import (
     UnsupportedModeError,
     _augment_resolution_error,
     _build_constraints,
+    _build_marker_environment,
     _build_resolver_inputs,
     _check_group_disjointness,
     _check_group_disjointness_across_tuples,
@@ -1485,6 +1486,18 @@ def _tuple_for_python(python_version: str) -> MatrixTuple:
             "sys_platform": "linux",
         },
     )
+
+
+class TestBuildMarkerEnvironment:
+    def test_two_part_python_version_expands_full_version(self) -> None:
+        """python_full_version pads to three components, matching the matrix."""
+        env = _build_marker_environment(python_version="3.10", overrides={})
+        assert env["python_version"] == "3.10"
+        assert env["python_full_version"] == "3.10.0"
+
+    def test_full_python_version_preserved(self) -> None:
+        env = _build_marker_environment(python_version="3.11.5", overrides={})
+        assert env["python_full_version"] == "3.11.5"
 
 
 class TestCheckGroupDisjointnessAcrossTuples:


### PR DESCRIPTION
PEP 508 defines `python_full_version` as `platform.python_version()`, which is always `major.minor.micro`. When resolving with an explicit `python_version="3.10"`, the non-universal path was setting `python_full_version="3.10"` (two components) while the universal matrix padded to `"3.10.0"`. The two-component value diverges on string-membership markers (`in` / `not in`), where specifier coercion does not apply.

This adds a `python_axis_environment()` helper in `provider.py` that pads to three components and uses it in both `Provider.__init__` and `_build_marker_environment`, so both paths produce consistent marker environments.