### PR TITLE
Lowercase index hash digests on ingest

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -312,6 +312,8 @@ def _parse_files(
 
 def _parse_hashes(value: object) -> tuple[tuple[str, str], ...]:
     # Algo names are a tiny fixed vocabulary, so interning dedups them.
+    # Hex digests are lowercased to match hashlib.hexdigest() output:
+    # PEP 503/691 don't mandate a case, and pip treats them case-insensitively.
     if not isinstance(value, dict):
         return ()
 
@@ -319,13 +321,13 @@ def _parse_hashes(value: object) -> tuple[tuple[str, str], ...]:
     if len(value) == 1:
         ((algo, digest),) = value.items()
         if isinstance(algo, str) and isinstance(digest, str):
-            return ((sys.intern(algo), digest),)
+            return ((sys.intern(algo), digest.lower()),)
         return ()
 
     out: list[tuple[str, str]] = []
     for algo, digest in value.items():
         if isinstance(algo, str) and isinstance(digest, str):
-            out.append((sys.intern(algo), digest))
+            out.append((sys.intern(algo), digest.lower()))
 
     return tuple(out)
 

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -160,7 +160,7 @@ def _parse_pep503_hash_fragment(fragment: str) -> tuple[tuple[str, str], ...]:
     algo, sep, digest = fragment.partition("=")
     if not sep or not algo or not digest:
         return ()
-    return ((algo, digest),)
+    return ((algo, digest.lower()),)
 
 
 def _scan_flat_wheelhouse(

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -197,6 +197,14 @@ class TestPep503Directory:
         assert len(result) == 1
         assert result[0].hashes == (("sha256", digest),)
 
+    def test_pep503_hash_fragment_lowercased(self, tmp_path: Path) -> None:
+        body = f'<a href="foo-1.0-py3-none-any.whl#sha256={"A" * 64}">foo</a>'
+        package_dir = self._make_index(tmp_path, body)
+        (package_dir / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        result = run(client.get_files("foo"))
+        assert result[0].hashes == (("sha256", "a" * 64),)
+
     def test_pep503_hash_fragment_on_https_href(self, tmp_path: Path) -> None:
         digest = "b" * 64
         body = (

--- a/nab-python/tests/test_simple_client_hashes.py
+++ b/nab-python/tests/test_simple_client_hashes.py
@@ -1,0 +1,25 @@
+"""Tests for hash-digest lowercasing in nab_index's Simple API JSON parser."""
+
+from __future__ import annotations
+
+from nab_index.client import _parse_files
+
+
+def _file(hashes: dict[str, str]) -> dict[str, object]:
+    return {
+        "filename": "foo-1.0-py3-none-any.whl",
+        "url": "https://example.com/foo/foo-1.0-py3-none-any.whl",
+        "hashes": hashes,
+    }
+
+
+def test_single_hash_digest_lowercased() -> None:
+    data = {"files": [_file({"sha256": "A" * 64})]}
+    files = _parse_files(data, "https://example.com/", "foo")
+    assert files[0].hashes == (("sha256", "a" * 64),)
+
+
+def test_multi_hash_digests_lowercased() -> None:
+    data = {"files": [_file({"sha256": "A" * 64, "sha512": "B" * 128})]}
+    files = _parse_files(data, "https://example.com/", "foo")
+    assert dict(files[0].hashes) == {"sha256": "a" * 64, "sha512": "b" * 128}


### PR DESCRIPTION
nab stored index-supplied hex digests verbatim and compared them against hashlib.hexdigest(), which is always lowercase. An index emitting uppercase hex (valid under PEP 503/691, which don't mandate a case) caused a sha256 mismatch on every fetch, even for the correct file, and the idempotency check never matched so a present file was re-fetched every run.

pip lowercases recorded hashes; nab promises --format requirements output compatible with pip install --require-hashes, so it should accept the same range of inputs. The fix lowercases at the ingest points: both branches of _parse_hashes and _parse_pep503_hash_fragment.