### PR TITLE
Treat Simple-API 404 as empty listing

### DIFF
--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 
 from .cache import CacheBackend, CachePolicy, OfflineError
 from .client import (
+    _HTTP_NOT_FOUND,
     DEFAULT_INDEX,
     SdistFile,
     WheelFile,
@@ -111,6 +112,7 @@ class CachedAsyncSimpleClient:
         Cache hit + offline: cached body is returned regardless of age.
         Cache miss + offline: raises :class:`OfflineError`.
         Cache miss + online: fetches, caches, returns.
+        A 404 from the index yields an empty listing and is not cached.
         """
         cached = self._cache.get_simple(package)
         if cached is not None:
@@ -141,6 +143,8 @@ class CachedAsyncSimpleClient:
             self._cache.refresh_simple_policy(package, new_policy)
             return _parse_files(json.loads(body), self._index_url, package)
 
+        if response.status_code == _HTTP_NOT_FOUND:
+            return []
         response.raise_for_status()
         new_body = response.content
         new_policy = CachePolicy(
@@ -154,6 +158,8 @@ class CachedAsyncSimpleClient:
     async def _fetch_simple(self, package: str) -> list[WheelFile | SdistFile]:
         url = f"{self._index_url}{package}/"
         response = await self._transport.get(url, headers={"Accept": _JSON_ACCEPT})
+        if response.status_code == _HTTP_NOT_FOUND:
+            return []
         response.raise_for_status()
         body = response.content
         policy = CachePolicy(

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -129,6 +129,7 @@ def _parse_sdist_filename(filename: str) -> tuple[NormalizedName, str] | None:
 
 
 _JSON_ACCEPT = "application/vnd.pypi.simple.v1+json"
+_HTTP_NOT_FOUND = 404
 
 DEFAULT_INDEX = "https://pypi.org/simple/"
 
@@ -214,6 +215,8 @@ class AsyncSimpleClient:
         """Fetch all distribution files for a package."""
         url = f"{self._index_url}{package}/"
         response = await self._transport.get(url, headers={"Accept": _JSON_ACCEPT})
+        if response.status_code == _HTTP_NOT_FOUND:
+            return []
         response.raise_for_status()
         return _parse_files(response.json(), self._index_url, package)
 

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -280,15 +280,16 @@ class TestAsyncSimpleClient:
                 raise RuntimeError(msg)
 
     class _FakeTransport:
-        def __init__(self, body: bytes) -> None:
+        def __init__(self, body: bytes, status: int = 200) -> None:
             self._body = body
+            self._status = status
             self.calls: list[tuple[str, dict[str, str] | None]] = []
 
         async def get(
             self, url: str, *, headers: dict[str, str] | None = None
         ) -> TestAsyncSimpleClient._FakeResponse:
             self.calls.append((url, headers))
-            return TestAsyncSimpleClient._FakeResponse(self._body)
+            return TestAsyncSimpleClient._FakeResponse(self._body, self._status)
 
         async def aclose(self) -> None:
             return None
@@ -307,6 +308,15 @@ class TestAsyncSimpleClient:
         assert transport.calls[0][1] == {
             "Accept": "application/vnd.pypi.simple.v1+json"
         }
+
+    def test_get_files_404_returns_empty(self) -> None:
+        transport = self._FakeTransport(b"not found", status=404)
+
+        async def go() -> list:
+            async with AsyncSimpleClient(transport, "https://pypi.org/simple/") as c:
+                return await c.get_files("absent")
+
+        assert asyncio.run(go()) == []
 
     def test_get_metadata_text(self) -> None:
         transport = self._FakeTransport(b"Metadata-Version: 2.1\n")

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -538,6 +538,39 @@ class TestGetFiles:
         with pytest.raises(RuntimeError, match="500"):
             asyncio.run(go())
 
+    def test_cold_cache_404_returns_empty(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport([_FakeResponse(b"not found", status=404)])
+
+        async def go() -> list:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_files("absent")
+            finally:
+                await client.aclose()
+
+        assert asyncio.run(go()) == []
+        # A 404 is not cached, so a later run re-queries the index.
+        assert cache.get_simple("absent") is None
+
+    def test_revalidate_404_returns_empty(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        cache.put_simple(
+            "pkg",
+            LISTING_BYTES,
+            CachePolicy(fetched_at=0, max_age=1, etag="old"),
+        )
+        transport = _FakeTransport([_FakeResponse(b"gone", status=404)])
+
+        async def go() -> list:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_files("pkg")
+            finally:
+                await client.aclose()
+
+        assert asyncio.run(go()) == []
+
     def test_legacy_filename_with_build_tag_is_dropped(self, tmp_path: Path) -> None:
         """Legacy sdists like ``cffi-1.0.2-2.tar.gz`` parse to a different
         canonical name (``cffi-1-0-2``) under packaging's last-dash split.


### PR DESCRIPTION
With two or more indexes configured, a package absent from an earlier index would fail the resolution because `AsyncSimpleClient.get_files` and `CachedAsyncSimpleClient.get_files` called `raise_for_status()` on every non-2xx response, including 404. PEP 503/691 allow a 404 for a package that isn't on a given index, and pip and uv already skip to the next index on a 404.

Both the plain and cached Simple-API clients now return an empty list when the server replies with 404. The 404 is not written to the cache so the index is re-queried on the next run. The multi-index fall-through loop in `MultiIndexClient` is unchanged.