### PR TITLE
Carry bare repo URL into PEP 751 vcs.url

### DIFF
--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -425,6 +425,10 @@ def _vcs_pin_from_source(
     not pin the bare SHA).  ``subdirectory`` carries the
     ``#subdirectory=`` fragment so an installer can locate the project
     inside the repo.
+
+    ``bare_repo_url`` comes from ``parsed.repo_url``, which
+    :meth:`VcsRequest.parse` has already separated from the ref and the
+    fragment.
     """
     from nab_index.vcs import VcsRequest
 
@@ -446,6 +450,7 @@ def _vcs_pin_from_source(
         name=canonical,
         version=str(version),
         repo_url=_strip_userinfo(source.url),
+        bare_repo_url=_strip_userinfo(parsed.repo_url),
         commit_id=resolved_sha,
         subdirectory=parsed.subdirectory or None,
         requested_revision=requested_revision,

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -194,13 +194,15 @@ def _pin_to_package(
         )
     if isinstance(pin, VcsPin):
         # PEP 751: omit version for VCS sources for the same reason.
+        # vcs.url is the bare repository URL; the ref and subdirectory
+        # travel in their own fields below.
         return Package(
             name=canonicalize_name(pin.name),
             version=None,
             marker=marker,
             vcs=PackageVcs(
                 type=pin.vcs_type,
-                url=pin.repo_url,
+                url=pin.bare_repo_url,
                 commit_id=pin.commit_id,
                 subdirectory=pin.subdirectory,
                 requested_revision=pin.requested_revision,

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -178,6 +178,12 @@ class LocalPin:
 class VcsPin:
     """A package resolved from a VCS clone.
 
+    ``repo_url`` is the full pip-style installable URL (``git+`` prefix,
+    ``@<ref>``, and ``#subdirectory=`` fragment) the requirements.txt
+    emitter writes verbatim.  ``bare_repo_url`` is the plain repository
+    URL with none of those parts, captured when the source URL is parsed
+    and written to PEP 751 ``packages.vcs.url``.
+
     ``requested_revision`` is the human-readable ref (tag or branch)
     the user pinned, recorded only when it differs from ``commit_id``;
     informational per PEP 751 ``packages.vcs.requested-revision``.
@@ -190,6 +196,7 @@ class VcsPin:
     name: str
     version: str
     repo_url: str
+    bare_repo_url: str
     commit_id: str
     subdirectory: str | None = None
     requested_revision: str | None = None

--- a/nab-python/tests/property_python/test_lockfile_pep751.py
+++ b/nab-python/tests/property_python/test_lockfile_pep751.py
@@ -116,6 +116,7 @@ def vcs_pins(draw: st.DrawFn) -> VcsPin:
         name=name,
         version=draw(versions),
         repo_url=f"https://github.com/example/{name}.git",
+        bare_repo_url=f"https://github.com/example/{name}.git",
         commit_id=sha_hex,
     )
 

--- a/nab-python/tests/test_download.py
+++ b/nab-python/tests/test_download.py
@@ -133,6 +133,7 @@ class TestIterArtifacts:
                             name="foo",
                             version="1.0",
                             repo_url="git+https://x/y.git",
+                            bare_repo_url="https://x/y.git",
                             commit_id="a" * 40,
                         ),
                     },

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -123,6 +123,7 @@ class TestSingleTuple:
                         name="foo",
                         version="1.0",
                         repo_url="https://github.com/x/y.git",
+                        bare_repo_url="https://github.com/x/y.git",
                         commit_id="a" * 40,
                         subdirectory="pkg",
                     ),
@@ -147,6 +148,7 @@ class TestSingleTuple:
                         name="foo",
                         version="1.0",
                         repo_url="https://example.com/x/y",
+                        bare_repo_url="https://example.com/x/y",
                         commit_id="a" * 40,
                         vcs_type="hg",
                     ),
@@ -396,6 +398,7 @@ class TestPerTupleMarkerSimplification:
                     name="foo",
                     version="1.0",
                     repo_url="https://x/y.git",
+                    bare_repo_url="https://x/y.git",
                     commit_id="a" * 40,
                 ),
             },
@@ -404,6 +407,7 @@ class TestPerTupleMarkerSimplification:
                     name="foo",
                     version="1.0",
                     repo_url="https://x/y.git",
+                    bare_repo_url="https://x/y.git",
                     commit_id="a" * 40,
                 ),
             },
@@ -1370,6 +1374,73 @@ class TestBuildLockInputFromProvider:
         assert isinstance(pin, VcsPin)
         assert pin.subdirectory == "pkg/sub"
 
+    def test_vcs_pin_carries_bare_repo_url(self) -> None:
+        """The bare repo URL is carried through from the parsed source.
+
+        ``repo_url`` keeps the full installable form for the
+        requirements.txt path; ``bare_repo_url`` holds the plain
+        repository URL with no ``git+`` prefix, ``@<ref>``, or
+        ``#subdirectory`` fragment.
+        """
+        sha = "a" * 40
+        provider = _FakeProvider(
+            vcs_sources={
+                "foo": VcsSource(
+                    name="foo",
+                    url="git+https://example.com/r.git@release/1.0#subdirectory=pkg/sub",
+                ),
+            },
+            vcs_pins={"foo": sha},
+        )
+        lock_input = build_lock_input_from_provider(
+            provider, {"foo": Version("0.0.0+vcs")}
+        )
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, VcsPin)
+        full_url = "git+https://example.com/r.git@release/1.0#subdirectory=pkg/sub"
+        assert pin.repo_url == full_url
+        assert pin.bare_repo_url == "https://example.com/r.git"
+
+    def test_vcs_pin_pylock_url_is_bare_repo(self) -> None:
+        """vcs.url is the bare repository URL; ref and subdirectory are separate fields."""
+        sha = "a" * 40
+        provider = _FakeProvider(
+            vcs_sources={
+                "foo": VcsSource(
+                    name="foo",
+                    url="git+https://example.com/r.git@release/1.0#subdirectory=pkg/sub",
+                ),
+            },
+            vcs_pins={"foo": sha},
+        )
+        lock_input = build_lock_input_from_provider(
+            provider, {"foo": Version("0.0.0+vcs")}
+        )
+        vcs = tomllib.loads(write_lock(lock_input))["packages"][0]["vcs"]
+        assert vcs["url"] == "https://example.com/r.git"
+        assert vcs["commit-id"] == sha
+        assert vcs["subdirectory"] == "pkg/sub"
+        assert vcs["requested-revision"] == "release/1.0"
+
+    def test_vcs_pin_bare_repo_url_strips_credentials(self) -> None:
+        """Embedded userinfo is dropped from the bare URL, as for repo_url."""
+        sha = "a" * 40
+        provider = _FakeProvider(
+            vcs_sources={
+                "foo": VcsSource(
+                    name="foo",
+                    url=f"git+https://user:pass@example.com/r.git@{sha}",
+                ),
+            },
+            vcs_pins={"foo": sha},
+        )
+        lock_input = build_lock_input_from_provider(
+            provider, {"foo": Version("0.0.0+vcs")}
+        )
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, VcsPin)
+        assert pin.bare_repo_url == "https://example.com/r.git"
+
     def test_vcs_source_without_resolved_sha_raises(self) -> None:
         """A pinned VCS source with no recorded SHA is an invariant breach.
 
@@ -1792,6 +1863,7 @@ class TestVcsRequestedRevision:
                         name="foo",
                         version="1.0",
                         repo_url="https://github.com/x/y.git",
+                        bare_repo_url="https://github.com/x/y.git",
                         commit_id="a" * 40,
                         requested_revision="v2.1.0",
                     ),
@@ -1809,6 +1881,7 @@ class TestVcsRequestedRevision:
                         name="foo",
                         version="1.0",
                         repo_url="https://github.com/x/y.git",
+                        bare_repo_url="https://github.com/x/y.git",
                         commit_id="a" * 40,
                     ),
                 },
@@ -2039,6 +2112,7 @@ class TestWriteRequirementsWithHashes:
                         name="foo",
                         version="1.0",
                         repo_url="git+https://example.com/r.git@abc",
+                        bare_repo_url="https://example.com/r.git",
                         commit_id="abc",
                     ),
                 },


### PR DESCRIPTION
PEP 751 specifies that `packages.vcs.url` is the bare repository URL, mirroring the `url` field of pip's PEP 610 `direct_url.json`. The pylock emitter was writing `VcsPin.repo_url`, but that field holds the full pip-style installable URL (for example `git+https://example.com/r.git@release/1.0#subdirectory=pkg`) that the requirements.txt emitter needs verbatim, so the lock recorded a malformed `vcs.url` even though commit-id, subdirectory, and requested-revision are already separate fields.

`VcsRequest.parse` already splits the source URL into its parts, so the bare repository URL is available as `parsed.repo_url`. This carries that parsed value through as a new `bare_repo_url` field on `VcsPin`, and the emitter writes it directly to `packages.vcs.url`. It gets the same userinfo strip as `repo_url` so committed lockfiles never carry embedded credentials. `repo_url` and the requirements.txt path are unchanged.
