### PR TITLE
Validate Requires-Python for local and VCS pins in universal mode

### DIFF
--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -23,6 +23,7 @@ from .._vendor.packaging.markers import Marker
 from .._vendor.packaging.ranges import VersionRange
 from .._vendor.packaging.requirements import InvalidRequirement, Requirement
 from .._vendor.packaging.utils import canonicalize_name
+from .._vendor.packaging.version import Version
 from ..config import ConfigError
 from ..fetch import (
     DEFAULT_INDEX_NAME,
@@ -70,7 +71,6 @@ if TYPE_CHECKING:
 
     from nab_index.transport import AsyncHttpTransport
 
-    from .._vendor.packaging.version import Version
     from ..config import NabProjectConfig
     from .matrix import Matrix, MatrixTuple
 
@@ -467,6 +467,34 @@ def _parse_tuple_inputs(
     return parsed_requirements, parsed_constraints
 
 
+def _raise_for_local_vcs_python(
+    provider: UniversalProvider,
+    t: MatrixTuple,
+    pins: Mapping[str, Version],
+) -> None:
+    """Reject a local or VCS pin whose Requires-Python excludes the tuple.
+
+    Index candidates are filtered by Requires-Python while listing, but
+    local-path and VCS sources skip that filter, so a checkout that
+    rejects this tuple's Python could otherwise reach the lockfile.
+    """
+    managed = provider.local_sources.keys() | provider.vcs_sources.keys()
+    if not managed:
+        return
+    target = Version(t.python_version)
+    for name, version in pins.items():
+        normalized = canonicalize_name(name)
+        if normalized not in managed:
+            continue
+        spec = provider.metadata_cache[(normalized, version)].requires_python
+        if spec is not None and target not in spec:
+            msg = (
+                f"{normalized} {version} requires Python {spec} but tuple "
+                f"{t.label} targets Python {t.python_version}"
+            )
+            raise ResolutionError(msg)
+
+
 def _resolve_one_tuple(  # noqa: PLR0913
     coordinator: FetchCoordinator,
     t: MatrixTuple,
@@ -518,6 +546,8 @@ def _resolve_one_tuple(  # noqa: PLR0913
     start = time.monotonic()
     try:
         raw = resolver.resolve(requirements, constraints=constraints)
+        pins = {k: v for k, v in raw.items() if split_extra(k)[1] is None}
+        _raise_for_local_vcs_python(provider, t, pins)
     except ResolutionError as exc:
         return TupleResult(
             tuple_=t,
@@ -528,7 +558,6 @@ def _resolve_one_tuple(  # noqa: PLR0913
             decisions=resolver.stats.decisions,
         )
     elapsed = time.monotonic() - start
-    pins = {k: v for k, v in raw.items() if split_extra(k)[1] is None}
     try:
         lock_input = build_lock_input_from_provider(
             provider, pins, indexes=coordinator.indexes

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -23,6 +23,7 @@ from nab_python.lockfile import IndexPin, LockInput
 from nab_python.provider import (
     BuildPolicy,
     DistPolicy,
+    LocalSource,
     UnsupportedSdistError,
     VcsConfig,
     VcsPolicy,
@@ -677,3 +678,67 @@ class TestResolveUniversalWrapper:
             )
         # FetchCoordinator received the same list (not the default).
         assert fetch_cls.call_args.kwargs["indexes"] is custom
+
+
+class TestLocalVcsRequiresPython:
+    """A local or VCS pin must satisfy each targeted Python version.
+
+    Index candidates are filtered by Requires-Python while listing;
+    local-path and VCS sources skip that filter, so the universal
+    resolve checks them after resolving.
+    """
+
+    def _write(self, tmp_path: Path, body: str) -> LocalSource:
+        (tmp_path / "pyproject.toml").write_text(body, encoding="utf-8")
+        return LocalSource("foo", str(tmp_path))
+
+    def test_excluding_python_fails_the_tuple(self, tmp_path: Path) -> None:
+        local = self._write(
+            tmp_path,
+            '[project]\nname = "foo"\nversion = "1.0"\nrequires-python = ">=3.12"\n',
+        )
+        coord = make_coordinator([], package="foo")
+        result = resolve_with_coordinator(
+            coord,
+            Matrix(python="==3.10", platforms=("linux_x86_64",)),
+            ["foo"],
+            local_sources=[local],
+        )
+        assert not result.success
+        error = result.tuple_results[0].error
+        assert error is not None
+        assert "foo 1.0 requires Python" in error
+        assert "3.10" in error
+
+    def test_compatible_python_with_index_dep_succeeds(self, tmp_path: Path) -> None:
+        local = self._write(
+            tmp_path,
+            '[project]\nname = "foo"\nversion = "1.0"\n'
+            'requires-python = ">=3.10"\ndependencies = ["bar"]\n',
+        )
+        coord = make_coordinator(
+            listings={"bar": [_make_wheel("2.0", package="bar")]},
+            auto_metadata=True,
+        )
+        result = resolve_with_coordinator(
+            coord,
+            Matrix(python="==3.10", platforms=("linux_x86_64",)),
+            ["foo"],
+            local_sources=[local],
+        )
+        assert result.success
+        pins = result.tuple_results[0].pins
+        assert str(pins["foo"]) == "1.0"
+        assert str(pins["bar"]) == "2.0"
+
+    def test_no_requires_python_is_unconstrained(self, tmp_path: Path) -> None:
+        local = self._write(tmp_path, '[project]\nname = "foo"\nversion = "1.0"\n')
+        coord = make_coordinator([], package="foo")
+        result = resolve_with_coordinator(
+            coord,
+            Matrix(python="==3.10", platforms=("linux_x86_64",)),
+            ["foo"],
+            local_sources=[local],
+        )
+        assert result.success
+        assert str(result.tuple_results[0].pins["foo"]) == "1.0"


### PR DESCRIPTION
In universal mode, index candidates are filtered by Requires-Python while listing, but local-path and VCS sources bypass that filter. A local or VCS checkout whose Requires-Python excludes a tuple's Python could therefore reach the lockfile without this check.

`_raise_for_local_vcs_python` runs after each single-tuple resolve, inspects the resolved pins for any local or VCS package, and raises `ResolutionError` when the pin's Requires-Python excludes that tuple's Python. The tuple fails and no lock is written. Index scenarios are unaffected since the incompatible candidates are already excluded before resolution.

Closes #19
