### PR TITLE
Follow mirror-layout links in local index

### DIFF
--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -144,12 +144,10 @@ def _resolve_local_link(
         path = _parse_file_url(href_no_frag)
         return (path.name, href_no_frag, path, hashes)
 
-    package_dir_resolved = package_dir.resolve()
-    target = (package_dir_resolved / unquote(href_no_frag)).resolve()
-    try:
-        target.relative_to(package_dir_resolved)
-    except ValueError:
-        return (None, "", None, ())
+    # A relative href resolves against the package page wherever it points;
+    # the standard mirror layout links to a shared ../../packages/ tree, so the
+    # target legitimately sits outside the package directory.
+    target = (package_dir.resolve() / unquote(href_no_frag)).resolve()
     return (target.name, target.as_uri(), target, hashes)
 
 

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -145,6 +145,20 @@ class TestPep503Directory:
             result[0].local_path == package_dir.resolve() / "foo-1.0-py3-none-any.whl"
         )
 
+    def test_relative_href_resolves_outside_package_dir(self, tmp_path: Path) -> None:
+        simple = tmp_path / "simple"
+        package_dir = simple / "foo"
+        package_dir.mkdir(parents=True)
+        body = '<a href="../../packages/ab/cd/foo-1.0-py3-none-any.whl">foo</a>'
+        (package_dir / "index.html").write_text(body, encoding="utf-8")
+        wheel_path = tmp_path / "packages" / "ab" / "cd" / "foo-1.0-py3-none-any.whl"
+        wheel_path.parent.mkdir(parents=True)
+        wheel_path.write_bytes(b"")
+        client = LocalIndexClient(simple.as_uri())
+        result = run(client.get_files("foo"))
+        assert len(result) == 1
+        assert result[0].local_path == wheel_path.resolve()
+
     def test_https_href_pass_through(self, tmp_path: Path) -> None:
         body = '<a href="https://example.com/foo/foo-1.0-py3-none-any.whl">foo</a>'
         self._make_index(tmp_path, body)


### PR DESCRIPTION
The local file:// PEP 503 index silently returned an empty listing for packages on a standard mirror (bandersnatch, devpi, or a directory built with `pip download`).

The root cause was a containment check in `_resolve_local_link`: before resolving a relative href, the code called `target.relative_to(package_dir)` and silently dropped any link whose target resolved outside `<root>/<package>/`. Bandersnatch and similar tools place wheel files under a shared `<root>/packages/<ab>/<cd>/` tree and link to them as `../../packages/...` from each package page, so every artifact was dropped.

The containment check was a misplaced zip-slip guard. That protection is appropriate when extracting archive members onto the filesystem (and nab does apply it in `client.py` at extraction time), but not when following a listing link on a trusted local index. PEP 503 places no constraint on where an index author may put the files; pip and uv both follow the href wherever it points relative to the page. The check is removed and the code now resolves any relative href against the package directory without restricting the target path.
