### PR TITLE
Carry VCS type on VcsPin instead of hardcoding git

### DIFF
--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -449,4 +449,5 @@ def _vcs_pin_from_source(
         commit_id=resolved_sha,
         subdirectory=parsed.subdirectory or None,
         requested_revision=requested_revision,
+        vcs_type=parsed.scheme,
     )

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -199,7 +199,7 @@ def _pin_to_package(
             version=None,
             marker=marker,
             vcs=PackageVcs(
-                type="git",
+                type=pin.vcs_type,
                 url=pin.repo_url,
                 commit_id=pin.commit_id,
                 subdirectory=pin.subdirectory,
@@ -341,7 +341,13 @@ def _pin_discriminator(pin: PinShape) -> tuple:
     if isinstance(pin, VcsPin):
         # requested_revision is informational; it does not affect the
         # checkout, so it is intentionally left out of the discriminator.
-        return ("vcs", pin.commit_id, pin.repo_url, pin.subdirectory or "")
+        return (
+            "vcs",
+            pin.vcs_type,
+            pin.commit_id,
+            pin.repo_url,
+            pin.subdirectory or "",
+        )
     msg = f"unknown pin shape: {pin!r}"
     raise TypeError(msg)
 

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -181,6 +181,10 @@ class VcsPin:
     ``requested_revision`` is the human-readable ref (tag or branch)
     the user pinned, recorded only when it differs from ``commit_id``;
     informational per PEP 751 ``packages.vcs.requested-revision``.
+
+    ``vcs_type`` is the PEP 751 ``packages.vcs.type`` backend
+    (``git``/``hg``/``svn``/``bzr``), taken from the URL's ``<vcs>+``
+    scheme.
     """
 
     name: str
@@ -189,6 +193,7 @@ class VcsPin:
     commit_id: str
     subdirectory: str | None = None
     requested_revision: str | None = None
+    vcs_type: str = "git"
 
 
 PinShape = IndexPin | LocalPin | VcsPin

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -139,6 +139,23 @@ class TestSingleTuple:
         # PEP 751: version omitted for VCS sources (not deterministic).
         assert "version" not in package
 
+    def test_vcs_pin_non_git_type(self) -> None:
+        text = write_lock(
+            LockInput(
+                pins={
+                    "foo": VcsPin(
+                        name="foo",
+                        version="1.0",
+                        repo_url="https://example.com/x/y",
+                        commit_id="a" * 40,
+                        vcs_type="hg",
+                    ),
+                },
+            )
+        )
+        data = tomllib.loads(text)
+        assert data["packages"][0]["vcs"]["type"] == "hg"
+
     def test_multiple_packages_sorted_by_name(self) -> None:
         text = write_lock(
             LockInput(


### PR DESCRIPTION
VcsPin previously had no field for the VCS type and the pylock emitter hardcoded `"git"`. This adds a `vcs_type` field to `VcsPin`, threads it through builder and emitter, and includes it in the pin discriminator.

VCS admission today only yields git (hg/svn/bzr are refused at the admission gate), so the hardcode was not wrong in practice. This is latent defensive plumbing: when a future non-git VCS is admitted, the type will propagate correctly without any further changes to the lockfile layer. The default value of `"git"` keeps existing call sites that don't pass `vcs_type` working.

Relates to #4
