### PR TITLE
Catch UnsupportedVcsError in _resolve_specific

### DIFF
--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -34,6 +34,7 @@ from nab_python.lockfile import (
     write_requirements_with_hashes,  # noqa: F401 - re-exported for tests
     write_requirements_without_hashes,  # noqa: F401 - re-exported for tests
 )
+from nab_python.provider import UnsupportedVcsError
 from nab_python.resolve import (
     resolve_pyproject,
     resolve_universal_pyproject,  # noqa: F401 - re-exported for tests
@@ -169,6 +170,9 @@ def _resolve_specific(  # noqa: PLR0913 - one wrapper per resolve_pyproject kwar
         )
     except ResolutionError as e:
         sys.stderr.write(f"Resolution failed: {e}\n")
+        sys.exit(1)
+    except UnsupportedVcsError as e:
+        sys.stderr.write(f"{failure_prefix}: {e}\n")
         sys.exit(1)
     except KeyError:
         sys.stderr.write(f"Error: {path} has no [project].dependencies\n")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,7 +45,7 @@ from nab_python.lockfile import (
     SdistArtifact,
     WheelArtifact,
 )
-from nab_python.provider import ResolutionStrategy
+from nab_python.provider import ResolutionStrategy, UnsupportedVcsError
 from nab_python.resolve import ResolutionResult
 from nab_python.universal.matrix import Matrix, MatrixTuple
 from nab_python.universal.resolve import TupleResult, UniversalResult
@@ -284,6 +284,20 @@ class TestLockCommandSpecific:
         ):
             lock(pyproject)
         assert "Resolution failed" in capsys.readouterr().err
+
+    def test_unsupported_vcs_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        with (
+            patch(
+                "nab.cli.resolve_pyproject",
+                side_effect=UnsupportedVcsError("refusing direct-URL requirement"),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject)
+        assert "refusing direct-URL requirement" in capsys.readouterr().err
 
     def test_missing_dependencies_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
`_resolve_specific` caught `Resolution`/`Key`/`Lookup`/`MissingHashError` but not `UnsupportedVcsError`, so a refused direct-URL or VCS root requirement escaped as a full traceback on both `nab lock` and `nab download`.

Adds an `except UnsupportedVcsError` clause that writes the failure prefix and the error message to stderr and exits 1, matching the existing `MissingHashError` handling.

Relates to #10.
