### PR TITLE
Skip marker-false constraints in _build_constraints

### DIFF
--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -150,7 +150,7 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
     resolver_requirements, root_extras = _build_resolver_inputs(
         requirements, config, environment=marker_environment
     )
-    resolver_constraints = _build_constraints(config)
+    resolver_constraints = _build_constraints(config, environment=marker_environment)
     direct_packages = frozenset(
         name for name in resolver_requirements if split_extra(name)[1] is None
     )
@@ -645,16 +645,22 @@ def _resolve_target_python(specifier: str) -> str:
     return host
 
 
-def _build_constraints(config: NabProjectConfig) -> dict[str, VersionRange]:
+def _build_constraints(
+    config: NabProjectConfig, *, environment: dict[str, str]
+) -> dict[str, VersionRange]:
     """Parse constraint strings from config into resolver-input ranges.
 
-    Repeated package names are intersected into one range; an empty
-    intersection raises :class:`ResolutionError`.
+    Marker-gated constraints whose marker is False in ``environment`` are
+    dropped, matching the universal path and pip. Repeated package names are
+    intersected into one range; an empty intersection raises
+    :class:`ResolutionError`.
     """
     out: dict[str, VersionRange] = {}
     sources: defaultdict[str, list[str]] = defaultdict(list)
     for cstr in config.constraints:
         req = Requirement(cstr)
+        if req.marker is not None and not req.marker.evaluate(environment):
+            continue
         if req.extras:
             msg = f"Constraints cannot have extras: {cstr}"
             raise ConfigError(msg)

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -1000,7 +1000,9 @@ class TestBuildConstraints:
 
     def test_duplicate_constraint_intersects(self) -> None:
         """Two constraint lines for one package combine to their overlap."""
-        out = _build_constraints(NabProjectConfig(constraints=("foo>=2.0", "foo<3.0")))
+        out = _build_constraints(
+            NabProjectConfig(constraints=("foo>=2.0", "foo<3.0")), environment={}
+        )
         assert V("2.5") in out["foo"]
         assert V("1.0") not in out["foo"]
         assert V("5.0") not in out["foo"]
@@ -1008,12 +1010,35 @@ class TestBuildConstraints:
     def test_conflicting_constraints_raise(self) -> None:
         """Pinned-but-different constraint lines for one package raise."""
         with pytest.raises(ResolutionError, match="conflicting constraints"):
-            _build_constraints(NabProjectConfig(constraints=("foo==1.0", "foo==2.0")))
+            _build_constraints(
+                NabProjectConfig(constraints=("foo==1.0", "foo==2.0")), environment={}
+            )
+
+    def test_marker_false_constraint_dropped(self) -> None:
+        """A constraint whose marker is False is not applied."""
+        env = {"python_version": "3.12"}
+        out = _build_constraints(
+            NabProjectConfig(constraints=('foo<2.0 ; python_version < "3.0"',)),
+            environment=env,
+        )
+        assert "foo" not in out
+
+    def test_marker_true_constraint_applied(self) -> None:
+        """A constraint whose marker is True still restricts the range."""
+        env = {"python_version": "3.12"}
+        out = _build_constraints(
+            NabProjectConfig(constraints=('foo<2.0 ; python_version >= "3.0"',)),
+            environment=env,
+        )
+        assert V("1.0") in out["foo"]
+        assert V("5.0") not in out["foo"]
 
     def test_constraint_with_extras_rejected(self) -> None:
         """A constraint carrying extras is rejected, matching pip."""
         with pytest.raises(ConfigError, match="extras"):
-            _build_constraints(NabProjectConfig(constraints=("foo[dev]<2.0",)))
+            _build_constraints(
+                NabProjectConfig(constraints=("foo[dev]<2.0",)), environment={}
+            )
 
 
 class TestResolvePyprojectConflicts:


### PR DESCRIPTION
`_build_constraints` in `resolve.py` was applying every `constraints` entry unconditionally, ignoring any environment marker. A constraint like `foo<2.0 ; python_version < "3.10"` would restrict all resolves, even when the marker evaluated False for the target Python. The universal path and pip both skip such constraints.

The fix passes the existing `marker_environment` into `_build_constraints` and skips any requirement whose marker evaluates False. Marker-less constraints are unaffected.

Closes #38
