### PR TITLE
Seed pins from prior lockfile for stable re-locks

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -417,6 +417,7 @@ class Provider:
         build_config: NabProjectConfig | None = None,
         resolution_strategy: ResolutionStrategy = ResolutionStrategy.HIGHEST,
         direct_packages: frozenset[str] | None = None,
+        preferences: dict[str, Version] | None = None,
     ) -> None:
         """Construct the provider; see the class docstring for parameters."""
         self.coordinator = coordinator
@@ -438,6 +439,13 @@ class Provider:
         self.build_policy = build_policy
         self._resolution_strategy = resolution_strategy
         self._direct_packages: frozenset[str] = direct_packages or frozenset()
+
+        # Seed pins from a prior lock: choose_version returns one of these
+        # when it is still in range, keeping a re-lock stable. Keys are
+        # canonicalized to match the provider's naming.
+        self._preferences: dict[str, Version] = {
+            canonicalize_name(k): v for k, v in (preferences or {}).items()
+        }
 
         self._build_policy_overrides = _canonical_override_map(
             build_policy_overrides, "build-policy"
@@ -685,6 +693,39 @@ class Provider:
         return _listing.pick_best_candidate(self, normalized, versions)
 
     def choose_version(
+        self, package: str, version_range: RangeProtocol[Version]
+    ) -> Version | None:
+        """Pick a version within the allowed range, respecting the strategy.
+
+        A seed preference wins when it is still in range and its metadata
+        is extractable; otherwise the strategy scan in
+        ``_choose_version_core`` decides.
+        """
+        assert isinstance(version_range, VersionRange)
+        if self._preferences:
+            _, extra, normalized = self.split_and_normalize(package)
+            if extra is None:
+                preferred = self._preferred_version(package, normalized, version_range)
+                if preferred is not None:
+                    return preferred
+        return self._choose_version_core(package, version_range)
+
+    def _preferred_version(
+        self, package: str, normalized: str, version_range: VersionRange
+    ) -> Version | None:
+        """Return the seeded version for ``package`` if it is usable here."""
+        preferred = self._preferences.get(normalized)
+        if preferred is None:
+            return None
+        all_versions = self.versions_only(normalized, self.fetch_versions(package))
+        if preferred in set(version_range.filter(all_versions)) and self._look_ahead_ok(
+            normalized, preferred, check_decisions=True
+        ):
+            self._flush_pending_blocks()
+            return preferred
+        return None
+
+    def _choose_version_core(
         self, package: str, version_range: RangeProtocol[Version]
     ) -> Version | None:
         """Pick a version within the allowed range, respecting the strategy."""

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -96,6 +96,7 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
     groups: Sequence[str] = (),
     extras: Sequence[str] = (),
     resolution_strategy: ResolutionStrategy | None = None,
+    seed_pins: dict[str, Version] | None = None,
 ) -> ResolutionResult:
     """Resolve a project's dependencies for a single environment.
 
@@ -107,6 +108,9 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
     ``groups`` and ``extras`` name PEP 735 groups and
     ``[project.optional-dependencies]`` keys to fold in.
     ``resolution_strategy`` overrides ``config.resolution`` when set.
+    ``seed_pins`` maps canonical names to versions preferred from a
+    prior lock, keeping a re-lock stable unless a constraint forces a
+    change.
 
     Use :func:`resolve_universal_pyproject` when
     ``config.mode is ResolveMode.UNIVERSAL``. Returns a
@@ -182,6 +186,7 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
             build_config=config,
             resolution_strategy=effective_strategy,
             direct_packages=direct_packages,
+            preferences=seed_pins,
         )
 
         resolver: Resolver[str, Version] = Resolver(
@@ -515,7 +520,7 @@ def _build_marker_environment(
     return env
 
 
-def resolve_universal_pyproject(
+def resolve_universal_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling into a config object would hide it
     path: Path,
     *,
     config: NabProjectConfig | None = None,
@@ -525,6 +530,7 @@ def resolve_universal_pyproject(
     groups: Sequence[str] = (),
     extras: Sequence[str] = (),
     resolution_strategy: ResolutionStrategy | None = None,
+    seed_pins: dict[str, Version] | None = None,
 ) -> UniversalResult:
     """Run a universal resolve for the project at ``path``.
 
@@ -594,6 +600,7 @@ def resolve_universal_pyproject(
         indexes=list(config.indexes),
         index_overrides=list(config.index_overrides) or None,
         resolution_strategy=effective_strategy.value,
+        preferences=seed_pins,
     )
 
 

--- a/nab-python/src/nab_python/universal/provider.py
+++ b/nab-python/src/nab_python/universal/provider.py
@@ -29,7 +29,6 @@ from nab_index.client import SdistFile, WheelFile
 
 from .._vendor.packaging.markers import default_environment
 from .._vendor.packaging.ranges import VersionRange
-from .._vendor.packaging.utils import canonicalize_name
 from ..provider import (
     BuildPolicy,
     DistPolicy,
@@ -120,6 +119,7 @@ class UniversalProvider(Provider):
             build_config=build_config,
             resolution_strategy=resolution_strategy,
             direct_packages=direct_packages,
+            preferences=preferences,
         )
         merged: dict[str, str] = {
             key: value
@@ -129,11 +129,6 @@ class UniversalProvider(Provider):
         merged.update(marker_environment)
         self.environment = merged
         self.env_with_extra = dict(merged)
-        # Normalize preferences keys so lookup matches the provider's
-        # canonical naming scheme.
-        self._preferences: dict[str, Version] = {
-            canonicalize_name(k): v for k, v in (preferences or {}).items()
-        }
         self._platform_spec = platform_spec
         self._py_minor = marker_environment.get("python_version")
         self._implementation = marker_environment.get("implementation_name", "cpython")
@@ -161,7 +156,7 @@ class UniversalProvider(Provider):
                 self._flush_pending_blocks()
                 return preferred
 
-        return super().choose_version(package, version_range)
+        return super()._choose_version_core(package, version_range)
 
     def filter_distributions(
         self, normalized: str, files: Sequence[WheelFile | SdistFile]

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -326,6 +326,108 @@ class TestChooseVersion:
         assert provider.choose_version("foo", spec.to_range()) is None
 
 
+class TestPreferences:
+    """``choose_version`` honours seed pins from a prior lock."""
+
+    def test_preferred_version_wins_in_range(self) -> None:
+        """A seeded version in range and usable beats the strategy default."""
+        wheels = [make_wheel(v) for v in ("1.0", "2.0", "3.0")]
+        coordinator = make_coordinator(wheels, package="foo", auto_metadata=True)
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            root_requirements={"foo": VersionRange.full()},
+            preferences={"foo": V("1.0")},
+        )
+        assert provider.choose_version("foo", VersionRange.full()) == V("1.0")
+
+    def test_canonicalizes_preference_keys(self) -> None:
+        """A non-canonical preference name still matches the package."""
+        wheels = [make_wheel(v) for v in ("1.0", "2.0")]
+        coordinator = make_coordinator(wheels, package="foo-bar", auto_metadata=True)
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            root_requirements={"foo-bar": VersionRange.full()},
+            preferences={"Foo.Bar": V("1.0")},
+        )
+        assert provider.choose_version("foo-bar", VersionRange.full()) == V("1.0")
+
+    def test_preferred_out_of_range_falls_through(self) -> None:
+        """A seed outside the requested range yields to the strategy."""
+        wheels = [make_wheel(v) for v in ("1.0", "2.0", "3.0")]
+        coordinator = make_coordinator(wheels, package="foo", auto_metadata=True)
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            root_requirements={"foo": SpecifierSet(">=2.0").to_range()},
+            preferences={"foo": V("1.0")},
+        )
+        chosen = provider.choose_version("foo", SpecifierSet(">=2.0").to_range())
+        assert chosen == V("3.0")
+
+    def test_preferred_version_absent_falls_through(self) -> None:
+        """A seed naming a version that no longer exists yields."""
+        wheels = [make_wheel(v) for v in ("1.0", "2.0")]
+        coordinator = make_coordinator(wheels, package="foo", auto_metadata=True)
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            root_requirements={"foo": VersionRange.full()},
+            preferences={"foo": V("9.0")},
+        )
+        assert provider.choose_version("foo", VersionRange.full()) == V("2.0")
+
+    def test_preference_for_other_package_ignored(self) -> None:
+        """A seed for a different package does not steer this one."""
+        wheels = [make_wheel(v) for v in ("1.0", "2.0")]
+        coordinator = make_coordinator(wheels, package="foo", auto_metadata=True)
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            root_requirements={"foo": VersionRange.full()},
+            preferences={"bar": V("1.0")},
+        )
+        assert provider.choose_version("foo", VersionRange.full()) == V("2.0")
+
+    def test_preferred_rejected_by_lookahead_falls_through(self) -> None:
+        """A seed whose deps conflict with a decision yields to the scan."""
+        wheels = [make_wheel("1.0"), make_wheel("2.0")]
+        coordinator = make_coordinator(
+            wheels,
+            package="foo",
+            metadata_by_version={
+                "1.0": (
+                    "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n"
+                    "Requires-Dist: bar>=5.0\n"
+                ),
+                "2.0": "Metadata-Version: 2.1\nName: foo\nVersion: 2.0\n",
+            },
+        )
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            root_requirements={"foo": VersionRange.full()},
+            preferences={"foo": V("1.0")},
+        )
+        provider.solution_decisions["bar"] = V("3.0")
+        assert provider.choose_version("foo", VersionRange.full()) == V("2.0")
+
+    def test_extra_proxy_skips_preference(self) -> None:
+        """An extras proxy never consults the seed map."""
+        wheels = [make_wheel("2.0"), make_wheel("1.0")]
+        coordinator = make_coordinator(
+            wheels, metadata_text=EXTRA_METADATA, package="foo"
+        )
+        provider = Provider(coordinator, preferences={"foo": V("2.0")})
+        provider.receive_partial_solution_hint(
+            {"foo": SpecifierSet("<2.0").to_range()}, {}
+        )
+        assert provider.choose_version(
+            "foo[security]", SpecifierSet("").to_range()
+        ) == V("1.0")
+
+
 class TestResolutionStrategy:
     """``choose_version`` honours ``ResolutionStrategy``."""
 

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -270,6 +270,33 @@ class TestResolvePyproject:
     @patch("nab_python.resolve.Resolver")
     @patch("nab_python.resolve.Provider")
     @patch("nab_python.resolve.FetchCoordinator")
+    def test_seed_pins_passed_to_provider(
+        self,
+        mock_coord_cls: MagicMock,
+        mock_provider_cls: MagicMock,
+        mock_resolver_cls: MagicMock,
+        mock_build_lock: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Seed pins from a prior lock reach the provider as preferences."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text('[project]\ndependencies = ["foo>=1.0"]\n')
+
+        mock_coord_cls.return_value.__enter__ = lambda s: s
+        mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_resolver_cls.return_value.resolve.return_value = {"foo": V("1.0")}
+
+        seed = {"foo": V("1.0")}
+        resolve_pyproject(
+            pyproject, _FAKE_TRANSPORT, python_version="3.12.0", seed_pins=seed
+        )
+
+        assert mock_provider_cls.call_args.kwargs["preferences"] == seed
+
+    @patch("nab_python.resolve.build_lock_input_from_provider")
+    @patch("nab_python.resolve.Resolver")
+    @patch("nab_python.resolve.Provider")
+    @patch("nab_python.resolve.FetchCoordinator")
     def test_extras_create_proxy_packages(
         self,
         mock_coord_cls: MagicMock,

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -101,8 +101,11 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     refuse directory entries because they cannot be hashed.
 
     ``--resolution`` overrides ``[tool.nab].resolution`` for this run.
+    A re-lock seeds the resolver with the prior pylock's pins so the
+    result stays stable unless a requirement forces a change.
     ``--upgrade`` re-anchors the ``P<n>D`` cutoff to ``datetime.now(UTC)``
-    instead of reusing the timestamp recorded in any existing lockfile.
+    instead of reusing the timestamp recorded in any existing lockfile,
+    and drops the seed so every pin re-floats.
     """
     _validate_pylock_output_name(output=output, format=format)
     anchor = _determine_lock_anchor(path, output=output, format=format, upgrade=upgrade)
@@ -127,6 +130,8 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
         config.workspace_member_names if no_emit_workspace else frozenset()
     )
 
+    seed_pins = _seed_pins(output=output, format=format, upgrade=upgrade)
+
     transport = _cli._make_transport(http_backend)  # noqa: SLF001
     if config.mode is ResolveMode.UNIVERSAL:
         _emit_universal(
@@ -142,6 +147,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
             extras=selected_extras,
             resolution_strategy=strategy_override,
             workspace_to_drop=workspace_to_drop,
+            seed_pins=seed_pins,
         )
         return
 
@@ -155,6 +161,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
         groups=selected_groups,
         extras=selected_extras,
         resolution_strategy=strategy_override,
+        seed_pins=seed_pins,
     )
     _emit_specific(
         result,
@@ -163,6 +170,23 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
         provenance=provenance,
         workspace_to_drop=workspace_to_drop,
     )
+
+
+def _seed_pins(
+    *,
+    output: Path | None,
+    format: str,  # noqa: A002 - shadows builtin by convention
+    upgrade: bool,
+) -> dict[str, Version] | None:
+    """Return the prior pylock's pins to seed a stable re-lock.
+
+    Returns ``None`` (no seeding) for ``--upgrade``, a non-pylock
+    format, stdout output, or a missing/unparseable prior file.
+    """
+    if upgrade or format != "pylock" or _cli._is_stdout(output):  # noqa: SLF001
+        return None
+    target = output if output is not None else Path(_cli._DEFAULT_OUTPUT[format])  # noqa: SLF001
+    return read_lockfile_packages(target)
 
 
 def _drop_workspace_pins(
@@ -281,6 +305,7 @@ def _emit_universal(  # noqa: PLR0913 - one wrapper per resolve_universal_pyproj
     extras: tuple[str, ...] = (),
     resolution_strategy: ResolutionStrategy | None = None,
     workspace_to_drop: frozenset[str] = frozenset(),
+    seed_pins: dict[str, Version] | None = None,
 ) -> None:
     """Run the universal resolver and emit the requested artefact."""
     sys.stderr.write(
@@ -297,6 +322,7 @@ def _emit_universal(  # noqa: PLR0913 - one wrapper per resolve_universal_pyproj
         groups=groups,
         extras=extras,
         resolution_strategy=resolution_strategy,
+        seed_pins=seed_pins,
     )
 
     if format == "pylock":

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
     from datetime import datetime
 
     from nab_index.transport import AsyncHttpTransport
+    from nab_python._vendor.packaging.version import Version
     from nab_python.provider import ResolutionStrategy
     from nab_python.resolve import ResolutionResult
     from nab_python.universal.resolve import UniversalResult
@@ -162,6 +163,7 @@ def _resolve_specific(  # noqa: PLR0913 - one wrapper per resolve_pyproject kwar
     groups: tuple[str, ...] = (),
     extras: tuple[str, ...] = (),
     resolution_strategy: ResolutionStrategy | None = None,
+    seed_pins: dict[str, Version] | None = None,
 ) -> ResolutionResult:
     """Run the single-environment resolver and translate errors to exits."""
     try:
@@ -174,6 +176,7 @@ def _resolve_specific(  # noqa: PLR0913 - one wrapper per resolve_pyproject kwar
             groups=groups,
             extras=extras,
             resolution_strategy=resolution_strategy,
+            seed_pins=seed_pins,
         )
     except ResolutionError as e:
         sys.stderr.write(f"Resolution failed: {e}\n")
@@ -201,7 +204,7 @@ def _resolve_specific(  # noqa: PLR0913 - one wrapper per resolve_pyproject kwar
         sys.exit(1)
 
 
-def _resolve_universal(
+def _resolve_universal(  # noqa: PLR0913 - one wrapper per resolve_universal_pyproject kwarg
     path: Path,
     *,
     config: NabProjectConfig,
@@ -211,6 +214,7 @@ def _resolve_universal(
     groups: tuple[str, ...] = (),
     extras: tuple[str, ...] = (),
     resolution_strategy: ResolutionStrategy | None = None,
+    seed_pins: dict[str, Version] | None = None,
 ) -> UniversalResult:
     """Run the universal resolver, translating errors to exits.
 
@@ -228,6 +232,7 @@ def _resolve_universal(
             groups=groups,
             extras=extras,
             resolution_strategy=resolution_strategy,
+            seed_pins=seed_pins,
         )
     except KeyError:
         sys.stderr.write(f"Error: {path} has no [project].dependencies\n")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,7 @@ from nab._lock import (
     _emit_universal_pylock,
     _resolve_extra_selection,
     _resolve_group_selection,
+    _seed_pins,
     lock,
 )
 from nab.cli import (
@@ -45,6 +46,7 @@ from nab_python.lockfile import (
     MissingHashError,
     SdistArtifact,
     WheelArtifact,
+    write_lock,
 )
 from nab_python.provider import ResolutionStrategy, UnsupportedVcsError
 from nab_python.requirements_file import InvalidProjectRequirementError
@@ -1420,6 +1422,93 @@ class TestDetermineLockAnchor:
             pyproject, output=target, format="pylock", upgrade=False
         )
         assert anchor == self._RECORDED
+
+
+class TestSeedPins:
+    """``_seed_pins`` reads prior pins to keep a re-lock stable."""
+
+    def _write_prior(self, target: Path) -> None:
+        write_lock(
+            LockInput(pins={"foo": _foo_index_pin("1.2.3")}),
+            output_path=target,
+        )
+
+    def test_upgrade_drops_seed(self, tmp_path: Path) -> None:
+        target = tmp_path / "pylock.toml"
+        self._write_prior(target)
+        assert _seed_pins(output=target, format="pylock", upgrade=True) is None
+
+    def test_non_pylock_format_drops_seed(self, tmp_path: Path) -> None:
+        assert (
+            _seed_pins(
+                output=tmp_path / "requirements.txt",
+                format="requirements",
+                upgrade=False,
+            )
+            is None
+        )
+
+    def test_stdout_drops_seed(self) -> None:
+        assert _seed_pins(output=Path("-"), format="pylock", upgrade=False) is None
+
+    def test_missing_prior_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        assert _seed_pins(output=None, format="pylock", upgrade=False) is None
+
+    def test_reads_explicit_output(self, tmp_path: Path) -> None:
+        target = tmp_path / "pylock.toml"
+        self._write_prior(target)
+        assert _seed_pins(output=target, format="pylock", upgrade=False) == {
+            "foo": V("1.2.3")
+        }
+
+    def test_reads_default_output(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        self._write_prior(tmp_path / "pylock.toml")
+        assert _seed_pins(output=None, format="pylock", upgrade=False) == {
+            "foo": V("1.2.3")
+        }
+
+
+class TestLockSeedsResolver:
+    """End-to-end: `lock` forwards prior pins to the resolver."""
+
+    def _write_prior(self, target: Path) -> None:
+        write_lock(
+            LockInput(pins={"foo": _foo_index_pin("1.2.3")}),
+            output_path=target,
+        )
+
+    def test_specific_lock_forwards_seed(self, tmp_path: Path) -> None:
+        prior = tmp_path / "pylock.toml"
+        self._write_prior(prior)
+        pyproject = _make_pyproject(tmp_path)
+        resolve = MagicMock(return_value=_stub_resolution_result(version="1.2.3"))
+        with patch("nab.cli.resolve_pyproject", resolve):
+            lock(pyproject, output=prior)
+        assert resolve.call_args.kwargs["seed_pins"] == {"foo": V("1.2.3")}
+
+    def test_upgrade_forwards_no_seed(self, tmp_path: Path) -> None:
+        prior = tmp_path / "pylock.toml"
+        self._write_prior(prior)
+        pyproject = _make_pyproject(tmp_path)
+        resolve = MagicMock(return_value=_stub_resolution_result())
+        with patch("nab.cli.resolve_pyproject", resolve):
+            lock(pyproject, output=prior, upgrade=True)
+        assert resolve.call_args.kwargs["seed_pins"] is None
+
+    def test_universal_lock_forwards_seed(self, tmp_path: Path) -> None:
+        prior = tmp_path / "pylock.toml"
+        self._write_prior(prior)
+        pyproject = _universal_pyproject(tmp_path)
+        resolve = MagicMock(return_value=_universal_result(success=True))
+        with patch("nab.cli.resolve_universal_pyproject", resolve):
+            lock(pyproject, output=prior)
+        assert resolve.call_args.kwargs["seed_pins"] == {"foo": V("1.2.3")}
 
 
 class TestLockAnchorReuse:


### PR DESCRIPTION
On a re-lock, read the prior pylock's pins and seed the resolver via preferences so the result stays stable unless a requirement forces a change. The feature is gated to the pylock format and dropped under `--upgrade`, so a fresh lock or an explicit upgrade is unaffected.

The seed flows through `Provider` (base class), `resolve_pyproject` / `resolve_universal_pyproject`, `cli._resolve_specific`, and `_lock._seed_pins`. `Provider.choose_version` checks `self._preferences` before the strategy scan; `UniversalProvider.choose_version` already had preference logic and now delegates initialization to the base. The `_seed_pins` helper reads the prior file via `read_lockfile_packages` and returns `None` in every no-seed case.

Closes #34
