### PR TITLE
Anchor lock to absolute uploaded-prior-to

### DIFF
--- a/docs/guides/lockfile.md
+++ b/docs/guides/lockfile.md
@@ -137,6 +137,12 @@ same `uploaded-prior-to` produces the same pin set, so the
 lockfile is truly reproducible rather than "reproducible until
 upstream re-uploads".
 
+When `uploaded-prior-to` is an absolute timestamp, that timestamp
+also becomes the lockfile's `created-at`, so two locks from
+identical inputs are byte-for-byte identical. A relative `P<n>D`
+cutoff is anchored to the wall clock, so `created-at` stays the
+run time; `--upgrade` always re-anchors to now.
+
 ## `nab download`
 
 `nab download` walks the same pin set, fetches every wheel and

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -400,6 +400,30 @@ def _parse_uploaded_prior_to(value: object, *, anchor: datetime) -> datetime | N
     return dt
 
 
+def read_pyproject_lock_anchor(path: Path) -> datetime | None:
+    """Return the absolute ``uploaded-prior-to`` timestamp, if one is set.
+
+    A ``P<n>D`` duration is anchored to run time, so it is not reproducible
+    and returns ``None``. ``nab lock`` uses an absolute cutoff as the lock
+    anchor so re-locks from identical inputs produce identical bytes.
+    Absent or invalid values return ``None``; the full config parse reports
+    the error, including a missing file.
+    """
+    try:
+        with path.open("rb") as f:
+            data = tomli.load(f)
+    except FileNotFoundError:
+        return None
+    raw = data.get("tool", {}).get("nab", {})
+    value = raw.get("uploaded-prior-to") if isinstance(raw, dict) else None
+    if isinstance(value, str) and _DURATION_PATTERN.match(value):
+        return None
+    try:
+        return _parse_uploaded_prior_to(value, anchor=datetime.now(timezone.utc))
+    except ConfigError:
+        return None
+
+
 def _parse_uploaded_prior_to_package(
     value: object, *, anchor: datetime
 ) -> Mapping[str, datetime | None]:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -13,6 +13,7 @@ from nab_python.config import (
     NabProjectConfig,
     ResolveMode,
     read_pyproject_config,
+    read_pyproject_lock_anchor,
 )
 from nab_python.fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, IndexOverride
 from nab_python.provider import (
@@ -282,6 +283,44 @@ class TestUploadedPriorTo:
             ),
         ):
             read_pyproject_config(path)
+
+
+class TestReadLockAnchor:
+    """``read_pyproject_lock_anchor`` returns only absolute cutoffs."""
+
+    def test_iso_string(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path, '[tool.nab]\nuploaded-prior-to = "2026-05-01T00:00:00Z"\n'
+        )
+        assert read_pyproject_lock_anchor(path) == datetime(
+            2026, 5, 1, tzinfo=timezone.utc
+        )
+
+    def test_native_toml_datetime(self, tmp_path: Path) -> None:
+        path = write(tmp_path, "[tool.nab]\nuploaded-prior-to = 2026-05-01T00:00:00Z\n")
+        assert read_pyproject_lock_anchor(path) == datetime(
+            2026, 5, 1, tzinfo=timezone.utc
+        )
+
+    def test_duration_returns_none(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab]\nuploaded-prior-to = "P4D"\n')
+        assert read_pyproject_lock_anchor(path) is None
+
+    def test_absent_returns_none(self, tmp_path: Path) -> None:
+        path = write(tmp_path, "[tool.nab]\n")
+        assert read_pyproject_lock_anchor(path) is None
+
+    def test_invalid_value_returns_none(self, tmp_path: Path) -> None:
+        # The full config parse reports the error; the anchor read stays quiet.
+        path = write(tmp_path, '[tool.nab]\nuploaded-prior-to = "not-a-date"\n')
+        assert read_pyproject_lock_anchor(path) is None
+
+    def test_non_table_tool_nab_returns_none(self, tmp_path: Path) -> None:
+        path = write(tmp_path, 'tool = {nab = "oops"}\n')
+        assert read_pyproject_lock_anchor(path) is None
+
+    def test_missing_file_returns_none(self, tmp_path: Path) -> None:
+        assert read_pyproject_lock_anchor(tmp_path / "missing.toml") is None
 
 
 class TestUploadedPriorToPackage:

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -24,6 +24,7 @@ from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python.config import (
     NabProjectConfig,
     ResolveMode,
+    read_pyproject_lock_anchor,
 )
 from nab_python.lockfile import (
     LockInput,
@@ -104,7 +105,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     instead of reusing the timestamp recorded in any existing lockfile.
     """
     _validate_pylock_output_name(output=output, format=format)
-    anchor = _determine_lock_anchor(output=output, format=format, upgrade=upgrade)
+    anchor = _determine_lock_anchor(path, output=output, format=format, upgrade=upgrade)
     config = _cli._load_config(  # noqa: SLF001
         path, discover_workspace=workspace_discovery, anchor=anchor
     )
@@ -591,6 +592,7 @@ def _build_provenance(
 
 
 def _determine_lock_anchor(
+    path: Path,
     *,
     output: Path | None,
     format: str,  # noqa: A002 - shadows builtin by convention
@@ -598,7 +600,12 @@ def _determine_lock_anchor(
 ) -> datetime:
     """Pick the ``P<n>D`` anchor for ``nab lock``.
 
-    Returns ``datetime.now(UTC)`` (a fresh anchor) when:
+    When the project pins an absolute ``uploaded-prior-to``, that timestamp
+    is the anchor: the resolve window is already fixed, so anchoring there
+    makes ``created-at`` deterministic and two locks from identical inputs
+    produce identical bytes. ``--upgrade`` still re-floats to now.
+
+    Otherwise returns ``datetime.now(UTC)`` (a fresh anchor) when:
 
     - ``--upgrade`` is set: the user is opting into a calendar refresh.
     - Output is stdout (``-``): there is no file to read back later, so
@@ -615,6 +622,9 @@ def _determine_lock_anchor(
     fresh = datetime.now(timezone.utc)
     if upgrade:
         return fresh
+    absolute = read_pyproject_lock_anchor(path)
+    if absolute is not None:
+        return absolute
     if _cli._is_stdout(output):  # noqa: SLF001
         return fresh
     if format != "pylock":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1243,6 +1243,8 @@ class TestDetermineLockAnchor:
 
     _RECORDED = datetime(2024, 1, 1, tzinfo=timezone.utc)
 
+    _ABSOLUTE = datetime(2026, 5, 1, tzinfo=timezone.utc)
+
     def _write_prior(self, target: Path) -> None:
         target.write_text(
             f"[tool.nab]\ncreated-at = {self._RECORDED.isoformat()}\n",
@@ -1252,19 +1254,25 @@ class TestDetermineLockAnchor:
         # Even with a prior pylock present, --upgrade re-anchors.
         target = tmp_path / "pylock.toml"
         self._write_prior(target)
-        anchor = _determine_lock_anchor(output=target, format="pylock", upgrade=True)
+        pyproject = _make_pyproject(tmp_path)
+        anchor = _determine_lock_anchor(
+            pyproject, output=target, format="pylock", upgrade=True
+        )
         assert anchor != self._RECORDED
         assert (datetime.now(timezone.utc) - anchor).total_seconds() < 60
 
-    def test_stdout_returns_fresh(self) -> None:
+    def test_stdout_returns_fresh(self, tmp_path: Path) -> None:
+        pyproject = _make_pyproject(tmp_path)
         anchor = _determine_lock_anchor(
-            output=Path("-"), format="pylock", upgrade=False
+            pyproject, output=Path("-"), format="pylock", upgrade=False
         )
         assert (datetime.now(timezone.utc) - anchor).total_seconds() < 60
 
     def test_non_pylock_returns_fresh(self, tmp_path: Path) -> None:
         # requirements format has no [tool.nab] block to read from.
+        pyproject = _make_pyproject(tmp_path)
         anchor = _determine_lock_anchor(
+            pyproject,
             output=tmp_path / "requirements.txt",
             format="requirements",
             upgrade=False,
@@ -1275,13 +1283,19 @@ class TestDetermineLockAnchor:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.chdir(tmp_path)
-        anchor = _determine_lock_anchor(output=None, format="pylock", upgrade=False)
+        pyproject = _make_pyproject(tmp_path)
+        anchor = _determine_lock_anchor(
+            pyproject, output=None, format="pylock", upgrade=False
+        )
         assert (datetime.now(timezone.utc) - anchor).total_seconds() < 60
 
     def test_existing_lockfile_anchor_is_reused(self, tmp_path: Path) -> None:
         target = tmp_path / "pylock.toml"
         self._write_prior(target)
-        anchor = _determine_lock_anchor(output=target, format="pylock", upgrade=False)
+        pyproject = _make_pyproject(tmp_path)
+        anchor = _determine_lock_anchor(
+            pyproject, output=target, format="pylock", upgrade=False
+        )
         assert anchor == self._RECORDED
 
     def test_default_output_path_used_when_output_is_none(
@@ -1290,7 +1304,48 @@ class TestDetermineLockAnchor:
         # No --output but a pylock.toml in cwd -> reuse.
         monkeypatch.chdir(tmp_path)
         self._write_prior(tmp_path / "pylock.toml")
-        anchor = _determine_lock_anchor(output=None, format="pylock", upgrade=False)
+        pyproject = _make_pyproject(tmp_path)
+        anchor = _determine_lock_anchor(
+            pyproject, output=None, format="pylock", upgrade=False
+        )
+        assert anchor == self._RECORDED
+
+    def test_absolute_uploaded_prior_to_is_the_anchor(self, tmp_path: Path) -> None:
+        # An absolute cutoff pins the anchor regardless of any prior lock.
+        target = tmp_path / "pylock.toml"
+        self._write_prior(target)
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\ndependencies = ["foo"]\n'
+            f'[tool.nab]\nuploaded-prior-to = "{self._ABSOLUTE.isoformat()}"\n',
+        )
+        anchor = _determine_lock_anchor(
+            pyproject, output=target, format="pylock", upgrade=False
+        )
+        assert anchor == self._ABSOLUTE
+
+    def test_absolute_cutoff_ignored_under_upgrade(self, tmp_path: Path) -> None:
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\ndependencies = ["foo"]\n'
+            f'[tool.nab]\nuploaded-prior-to = "{self._ABSOLUTE.isoformat()}"\n',
+        )
+        anchor = _determine_lock_anchor(
+            pyproject, output=None, format="pylock", upgrade=True
+        )
+        assert anchor != self._ABSOLUTE
+        assert (datetime.now(timezone.utc) - anchor).total_seconds() < 60
+
+    def test_relative_cutoff_falls_through_to_prior(self, tmp_path: Path) -> None:
+        target = tmp_path / "pylock.toml"
+        self._write_prior(target)
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\ndependencies = ["foo"]\n[tool.nab]\nuploaded-prior-to = "P4D"\n',
+        )
+        anchor = _determine_lock_anchor(
+            pyproject, output=target, format="pylock", upgrade=False
+        )
         assert anchor == self._RECORDED
 
 
@@ -1334,6 +1389,21 @@ class TestLockAnchorReuse:
         assert new_anchor is not None
         assert new_anchor != self._RECORDED
         assert (datetime.now(timezone.utc) - new_anchor).total_seconds() < 60
+
+    def test_absolute_cutoff_records_itself(self, tmp_path: Path) -> None:
+        # An absolute uploaded-prior-to makes created-at deterministic.
+        absolute = datetime(2026, 5, 1, tzinfo=timezone.utc)
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\ndependencies = ["foo"]\n'
+            f'[tool.nab]\nuploaded-prior-to = "{absolute.isoformat()}"\n',
+        )
+        out = tmp_path / "pylock.toml"
+        with patch("nab.cli.resolve_pyproject", return_value=_stub_resolution_result()):
+            lock(pyproject, output=out)
+        from nab_python.lockfile import read_lockfile_anchor
+
+        assert read_lockfile_anchor(out) == absolute
 
 
 class TestGroupAndExtraSelection:


### PR DESCRIPTION
When `[tool.nab].uploaded-prior-to` is an absolute timestamp, use it as the lock anchor so `created-at` equals that timestamp. Two locks from identical inputs then produce byte-identical output, removing the wall-clock leak from `created-at = now()`.

A relative `P<n>D` cutoff is still anchored to run time, so `created-at` stays non-deterministic as before. `--upgrade` always re-floats to now regardless of the config value.

Adds `config.read_pyproject_lock_anchor` and a `path` argument on `_lock._determine_lock_anchor`.

Closes #23
