### PR TITLE
Add --platform/--python-version matrix override to nab lock

### DIFF
--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -76,6 +76,8 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     no_emit_workspace: bool = False,
     resolution: ResolutionFlag | None = None,
     upgrade: bool = False,
+    platform: tuple[str, ...] = (),
+    python_version: str | None = None,
 ) -> None:
     """Resolve dependencies and emit a lockfile or pin list.
 
@@ -104,11 +106,18 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     ``--resolution`` overrides ``[tool.nab].resolution`` for this run.
     ``--upgrade`` re-anchors the ``P<n>D`` cutoff to ``datetime.now(UTC)``
     instead of reusing the timestamp recorded in any existing lockfile.
+
+    ``--platform`` (repeatable) and ``--python-version`` (a PEP 440
+    specifier) override the ``[tool.nab.matrix]`` axes for this run only.
+    They require universal mode and are rejected otherwise.
     """
     _validate_pylock_output_name(output=output, format=format)
     anchor = _determine_lock_anchor(path, output=output, format=format, upgrade=upgrade)
     config = _cli._load_config(  # noqa: SLF001
         path, discover_workspace=workspace_discovery, anchor=anchor
+    )
+    config = _apply_matrix_overrides(
+        config, platforms=platform, python_version=python_version
     )
     effective_cache_dir = _cli._resolve_effective_cache_dir(  # noqa: SLF001
         cache_dir, cache=cache
@@ -561,6 +570,36 @@ def _resolve_extra_selection(
         sys.stderr.write(f"Error: {path} not found\n")
         sys.exit(1)
     return tuple(defined.keys())
+
+
+def _apply_matrix_overrides(
+    config: NabProjectConfig,
+    *,
+    platforms: tuple[str, ...],
+    python_version: str | None,
+) -> NabProjectConfig:
+    """Replace the matrix axes from ``--platform`` / ``--python-version``.
+
+    Returns ``config`` unchanged when neither flag is given.  The flags
+    require universal mode (a ``[tool.nab.matrix]`` table); in specific
+    mode ``config.matrix`` is ``None`` and the run exits with an error.
+    Unset axes keep their configured value; unknown platform ids and
+    empty python ranges are validated later by ``Matrix.expand``.
+    """
+    if not platforms and python_version is None:
+        return config
+    if config.matrix is None:
+        sys.stderr.write(
+            "Error: --platform / --python-version require mode = 'universal'"
+            " with a [tool.nab.matrix] table\n"
+        )
+        sys.exit(1)
+    matrix = replace(
+        config.matrix,
+        python=config.matrix.python if python_version is None else python_version,
+        platforms=platforms or config.matrix.platforms,
+    )
+    return replace(config, matrix=matrix)
 
 
 def _build_provenance(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -937,6 +937,59 @@ class TestLockCommandUniversal:
         assert not (tmp_path / "constraints-3.12.txt").exists()
 
 
+class TestMatrixOverrides:
+    """``--platform`` / ``--python-version`` override the matrix axes."""
+
+    def test_python_version_override_reaches_resolve(self, tmp_path: Path) -> None:
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with patch(
+            "nab.cli.resolve_universal_pyproject",
+            return_value=_universal_result(success=True),
+        ) as mock_resolve:
+            lock(pyproject, output=out, python_version=">=3.12,<3.14")
+        matrix = mock_resolve.call_args.kwargs["config"].matrix
+        assert matrix.python == ">=3.12,<3.14"
+        assert matrix.platforms == ("linux_x86_64",)
+
+    def test_platform_override_reaches_resolve(self, tmp_path: Path) -> None:
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with patch(
+            "nab.cli.resolve_universal_pyproject",
+            return_value=_universal_result(success=True),
+        ) as mock_resolve:
+            lock(pyproject, output=out, platform=("macos_arm64", "windows_amd64"))
+        matrix = mock_resolve.call_args.kwargs["config"].matrix
+        assert matrix.python == "==3.11"
+        assert matrix.platforms == ("macos_arm64", "windows_amd64")
+
+    def test_override_recorded_in_provenance(self, tmp_path: Path) -> None:
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with patch(
+            "nab.cli.resolve_universal_pyproject",
+            return_value=_universal_result(success=True),
+        ):
+            lock(
+                pyproject,
+                output=out,
+                platform=("macos_arm64",),
+                python_version="==3.12",
+            )
+        text = out.read_text()
+        assert "macos_arm64" in text
+        assert "==3.12" in text
+
+    def test_override_rejected_in_specific_mode(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, platform=("linux_x86_64",))
+        assert "require mode = 'universal'" in capsys.readouterr().err
+
+
 class TestNoEmitWorkspace:
     """``--no-emit-workspace`` drops workspace pins from the lockfile."""
 


### PR DESCRIPTION
`nab lock` gains `--platform` (repeatable platform id) and `--python-version` (PEP 440 specifier) flags that override the `[tool.nab.matrix]` axes for a one-off universal lock without editing `pyproject.toml`. Unset axes keep their configured value. Both flags require universal mode and exit 1 in specific mode.

The overrides are applied after config load and before provenance recording, so the lockfile reflects the effective matrix. Invalid platform ids and python specifiers are caught by the existing `Matrix.expand` validation.

Closes #30
