### PR TITLE
Add PyPy implementation axis to universal matrix

### DIFF
--- a/docs/guides/universal.md
+++ b/docs/guides/universal.md
@@ -114,6 +114,33 @@ evaluate False on a 3.11 cell, the safe direction (drop the
 gated dep) but a silent failure if your deployed interpreter is
 actually 3.11.4 or later.
 
+## Interpreter implementations
+
+`implementations` selects the interpreter implementations to model.
+It defaults to `["cpython"]`, so leaving it out keeps the matrix and
+its lockfile output unchanged.
+
+```toml
+[tool.nab.matrix]
+python = ">=3.11,<3.14"
+platforms = ["linux_x86_64"]
+implementations = ["cpython", "pypy"]
+```
+
+Each implementation multiplies the tuple count (pythons x platforms x
+implementations). A PyPy tuple sets `platform_python_implementation =
+"PyPy"` / `implementation_name = "pypy"` for marker evaluation and
+accepts `ppXY-pypyXY_pp73` wheel tags instead of `cpXY`. Labels use the
+`pp` interpreter prefix (`pp311-linux_x86_64`).
+
+The CPython tuple's lockfile marker stays unconstrained
+(`python_version`, `sys_platform`, `platform_machine` only) for
+backward compatibility; a non-CPython tuple adds an
+`implementation_name` clause so its entry is distinguishable. PyPy's
+`implementation_version` is modelled as the Python level, not PyPy's
+own release, so the rare marker comparing `implementation_version`
+against a PyPy version misevaluates.
+
 ## Trade-offs versus marker-fork PubGrub
 
 | Property | Matrix (nab) | Marker-fork (uv) |

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -100,6 +100,7 @@ class MatrixConfig:
     platforms: tuple[str, ...]
     python_order: str = "asc"
     python_patches: Mapping[str, str] | None = None
+    implementations: tuple[str, ...] = ("cpython",)
 
 
 @dataclass(frozen=True, slots=True)
@@ -812,7 +813,13 @@ def _parse_matrix(value: object) -> MatrixConfig | None:
     if not isinstance(value, dict):
         msg = f"[tool.nab.matrix] must be a table, got {type(value).__name__}"
         raise ConfigError(msg)
-    allowed = {"python", "platforms", "python-order", "python-patches"}
+    allowed = {
+        "python",
+        "platforms",
+        "python-order",
+        "python-patches",
+        "implementations",
+    }
     unknown = sorted(set(value) - allowed)
     if unknown:
         msg = (
@@ -837,9 +844,31 @@ def _parse_matrix(value: object) -> MatrixConfig | None:
         msg = f"matrix.python-order must be 'asc' or 'desc', got {python_order!r}"
         raise ConfigError(msg)
     patches = _parse_python_patches(value.get("python-patches"))
+    implementations = _parse_implementations(value.get("implementations"))
     return MatrixConfig(
         python=python,
         platforms=platforms,
         python_order=python_order,
         python_patches=patches,
+        implementations=implementations,
     )
+
+
+_KNOWN_IMPLEMENTATIONS = ("cpython", "pypy")
+
+
+def _parse_implementations(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ("cpython",)
+    impls = _parse_string_list("matrix.implementations", value)
+    if not impls:
+        msg = "matrix.implementations must list at least one implementation"
+        raise ConfigError(msg)
+    unknown = sorted(set(impls) - set(_KNOWN_IMPLEMENTATIONS))
+    if unknown:
+        msg = (
+            f"unknown matrix.implementations: {unknown!r}; "
+            f"expected {list(_KNOWN_IMPLEMENTATIONS)!r}"
+        )
+        raise ConfigError(msg)
+    return impls

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -563,6 +563,7 @@ def resolve_universal_pyproject(
             if config.matrix.python_patches is not None
             else None
         ),
+        implementations=config.matrix.implementations,
     )
     if len(groups) > 1:
         _check_group_disjointness_across_tuples(

--- a/nab-python/src/nab_python/universal/matrix.py
+++ b/nab-python/src/nab_python/universal/matrix.py
@@ -1,10 +1,11 @@
 """Matrix expansion for user-declared universal resolution.
 
-Expands a python version range plus a platform list into a finite
-list of tuples, each a complete PEP 508 marker environment the
-single-environment resolver can run against. Every PEP 508 variable
-appearing in any marker on the dep graph must have a value in every
-tuple. Wheel-tag and ``Requires-Python`` filtering happens elsewhere.
+Expands a python version range, a platform list, and an implementation
+list into a finite list of tuples, each a complete PEP 508 marker
+environment the single-environment resolver can run against. Every PEP
+508 variable appearing in any marker on the dep graph must have a value
+in every tuple. Wheel-tag and ``Requires-Python`` filtering happens
+elsewhere.
 """
 
 from __future__ import annotations
@@ -48,42 +49,50 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, str]] = {
         "platform_system": "Linux",
         "platform_machine": "x86_64",
         "os_name": "posix",
-        "platform_python_implementation": "CPython",
-        "implementation_name": "cpython",
     },
     "linux_aarch64": {
         "sys_platform": "linux",
         "platform_system": "Linux",
         "platform_machine": "aarch64",
         "os_name": "posix",
-        "platform_python_implementation": "CPython",
-        "implementation_name": "cpython",
     },
     "macos_arm64": {
         "sys_platform": "darwin",
         "platform_system": "Darwin",
         "platform_machine": "arm64",
         "os_name": "posix",
-        "platform_python_implementation": "CPython",
-        "implementation_name": "cpython",
     },
     "macos_x86_64": {
         "sys_platform": "darwin",
         "platform_system": "Darwin",
         "platform_machine": "x86_64",
         "os_name": "posix",
-        "platform_python_implementation": "CPython",
-        "implementation_name": "cpython",
     },
     "windows_amd64": {
         "sys_platform": "win32",
         "platform_system": "Windows",
         "platform_machine": "AMD64",
         "os_name": "nt",
+    },
+}
+
+
+# The implementation-axis PEP 508 marker values per known
+# implementation.
+_IMPLEMENTATION_DEFAULTS: dict[str, dict[str, str]] = {
+    "cpython": {
         "platform_python_implementation": "CPython",
         "implementation_name": "cpython",
     },
+    "pypy": {
+        "platform_python_implementation": "PyPy",
+        "implementation_name": "pypy",
+    },
 }
+
+# PEP 425 interpreter short tag per implementation, used in the tuple
+# label so tuples differing only by implementation stay distinct.
+_IMPLEMENTATION_PREFIX: dict[str, str] = {"cpython": "py", "pypy": "pp"}
 
 
 @dataclass(frozen=True)
@@ -98,11 +107,18 @@ class MatrixTuple:
         compare=False,
         default_factory=lambda: PlatformSpec("linux_x86_64"),
     )
+    implementation: str = "cpython"
 
     @property
     def label(self) -> str:
-        """Return a short human-readable id like ``py311-linux_x86_64``."""
-        return f"py{self.python_version.replace('.', '')}-{self.platform_id}"
+        """Return a short human-readable id like ``py311-linux_x86_64``.
+
+        Uses the interpreter prefix (``py`` for CPython, ``pp`` for
+        PyPy) so tuples that differ only by implementation get distinct
+        labels.
+        """
+        prefix = _IMPLEMENTATION_PREFIX[self.implementation]
+        return f"{prefix}{self.python_version.replace('.', '')}-{self.platform_id}"
 
     @property
     def marker_string(self) -> str:
@@ -111,14 +127,20 @@ class MatrixTuple:
         Combines ``python_version``, ``sys_platform``, and
         ``platform_machine`` into a conjunction.  Universal lockfiles
         attach this to each per-tuple ``Package`` entry so an installer
-        on a matching environment picks the right pin.
+        on a matching environment picks the right pin.  A non-CPython
+        tuple also constrains ``implementation_name`` so its entry is
+        distinguishable from the CPython tuple for the same
+        python/platform.
         """
         env = self.environment
-        return (
+        marker = (
             f'python_version == "{self.python_version}"'
             f' and sys_platform == "{env["sys_platform"]}"'
             f' and platform_machine == "{env["platform_machine"]}"'
         )
+        if self.implementation != "cpython":
+            marker += f' and implementation_name == "{env["implementation_name"]}"'
+        return marker
 
 
 @dataclass
@@ -142,19 +164,26 @@ class Matrix:
     ``python_patches={"3.11": "3.11.4", "3.12": "3.12.1"}``.
     See ``universal_open_questions.md`` section 1.1 for the design
     discussion.
+
+    ``implementations``: the interpreter implementations to model
+    (``"cpython"``, ``"pypy"``).  Defaults to ``("cpython",)``.  Each
+    multiplies the tuple count; markers and wheel tags resolve per
+    implementation.
     """
 
     python: str
     platforms: tuple[str | PlatformSpec, ...]
     python_order: str = "asc"
     python_patches: dict[str, str] | None = None
+    implementations: tuple[str, ...] = ("cpython",)
 
     def expand(self) -> list[MatrixTuple]:
         """Expand the matrix into concrete tuples.
 
-        Validates inputs eagerly: unknown platform ids, an empty
-        python range, or an invalid ``python_order`` each raise a
-        ``ValueError`` before any work happens.
+        Validates inputs eagerly: unknown platform ids, unknown
+        implementations, an empty python range, or an invalid
+        ``python_order`` each raise a ``ValueError`` before any work
+        happens.
 
         ``platforms`` accepts either bare platform-id strings (use
         default tag floors) or :class:`PlatformSpec` instances for
@@ -173,6 +202,12 @@ class Matrix:
         if unknown:
             msg = f"Unknown platform ids: {unknown!r}"
             raise ValueError(msg)
+        unknown_impl = [
+            i for i in self.implementations if i not in _IMPLEMENTATION_DEFAULTS
+        ]
+        if unknown_impl:
+            msg = f"Unknown implementations: {unknown_impl!r}"
+            raise ValueError(msg)
         py_versions = list(_pythons_in_range(self.python))
         if not py_versions:
             msg = f"No known Python versions match {self.python!r}"
@@ -184,35 +219,45 @@ class Matrix:
             MatrixTuple(
                 python_version=py,
                 platform_id=spec.platform_id,
-                environment=_build_environment(py, spec, patches.get(py)),
+                environment=_build_environment(py, spec, impl, patches.get(py)),
                 platform_spec=spec,
+                implementation=impl,
             )
             for py in py_versions
             for spec in specs
+            for impl in self.implementations
         ]
 
 
 def _build_environment(
     python_version: str,
     spec: PlatformSpec,
+    implementation: str,
     python_full_version: str | None = None,
 ) -> dict[str, str]:
     """Build a complete PEP 508 marker environment for one tuple.
 
-    Combines the platform's OS/arch defaults with python-axis values
-    derived from ``python_version``.  ``platform_release`` and
-    ``platform_version`` come from the :class:`PlatformSpec`; both
-    default to ``""`` so kernel-conditioned markers evaluate False
-    unless the user declares a target kernel/OS version.
+    Combines the platform's OS/arch defaults and the implementation's
+    interpreter-identity defaults with python-axis values derived from
+    ``python_version``.  ``platform_release`` and ``platform_version``
+    come from the :class:`PlatformSpec`; both default to ``""`` so
+    kernel-conditioned markers evaluate False unless the user declares a
+    target kernel/OS version.
 
     ``python_full_version`` overrides the default ``{minor}.0`` value.
     Used when the matrix declares ``python_patches`` to make
-    patch-bound markers (``python_full_version >= "3.11.4"``)
-    evaluate against the user's actual deployment patch release.
+    patch-bound markers (``python_full_version >= "3.11.4"``) evaluate
+    against the user's actual deployment patch release.
+
+    ``implementation_version`` is set to the Python version for every
+    implementation; for non-CPython this is the interpreter's Python
+    level, not its own release (PyPy 7.3.x), so the rare
+    ``implementation_version`` marker on PyPy may misevaluate.
     """
     full = python_full_version or f"{python_version}.0"
     return {
         **_PLATFORM_DEFAULTS[spec.platform_id],
+        **_IMPLEMENTATION_DEFAULTS[implementation],
         "python_version": python_version,
         "python_full_version": full,
         "implementation_version": full,

--- a/nab-python/src/nab_python/universal/provider.py
+++ b/nab-python/src/nab_python/universal/provider.py
@@ -136,6 +136,7 @@ class UniversalProvider(Provider):
         }
         self._platform_spec = platform_spec
         self._py_minor = marker_environment.get("python_version")
+        self._implementation = marker_environment.get("implementation_name", "cpython")
         self.excluded_by_wheel_tags = 0
         self.excluded_versions_no_compatible_wheel = 0
 
@@ -191,7 +192,9 @@ class UniversalProvider(Provider):
         # loop and inline the membership check; this loop runs for every
         # wheel of every package on every tuple, so the hoist matters on
         # large workloads.
-        compat = compatible_tags_for_tuple(python_version=py_minor, spec=spec)
+        compat = compatible_tags_for_tuple(
+            python_version=py_minor, spec=spec, implementation=self._implementation
+        )
         kept: list[tuple[Version, DistFile]] = []
         versions_with_wheel: set[Version] = set()
         versions_with_sdist: set[Version] = set()

--- a/nab-python/src/nab_python/universal/reresolve.py
+++ b/nab-python/src/nab_python/universal/reresolve.py
@@ -204,6 +204,7 @@ def _resolve_one_tuple_with_overrides(  # noqa: PLR0913
     one_tuple_matrix = _Matrix(
         python=f"=={tup.python_version}",
         platforms=(tup.platform_spec,),
+        implementations=(tup.implementation,),
     )
     with _override_metadata(coordinator, wheel_metadata):
         result = resolve_with_coordinator(

--- a/nab-python/src/nab_python/universal/validate.py
+++ b/nab-python/src/nab_python/universal/validate.py
@@ -181,6 +181,7 @@ def _validate_pin(  # noqa: PLR0911 - one return per outcome reads cleaner here
         wheels_at_version,
         python_version=tup.python_version,
         spec=tup.platform_spec,
+        implementation=tup.implementation,
     )
     if chosen is None:
         status = (

--- a/nab-python/src/nab_python/universal/wheel_selection.py
+++ b/nab-python/src/nab_python/universal/wheel_selection.py
@@ -1,13 +1,14 @@
-"""Predict which wheel a ``(python_version, platform_id)`` tuple would install.
+"""Predict which wheel a tuple would install.
 
 Universal resolution needs the install-time wheel selection answer
 without a live interpreter, so the tag set is computed from
-:class:`PlatformSpec` directly. CPython tags come from
-``packaging.tags.cpython_tags``, interpreter-agnostic tags from
-``compatible_tags``, macOS from ``mac_platforms``, and manylinux /
-musllinux are expanded from a declared glibc / musl floor. A wheel
-matches the tuple iff its parsed tags share a member with the
-tuple's compatible-tag set.
+:class:`PlatformSpec` and the implementation name directly. CPython
+tags come from ``packaging.tags.cpython_tags``; PyPy tags are emitted
+directly (interpreter ``ppXY``, abi ``pypyXY_pp73``). Both add
+interpreter-agnostic tags from ``compatible_tags``. Platform tags use
+``mac_platforms`` for macOS and expand manylinux / musllinux from the
+declared glibc / musl floor. A wheel matches the tuple iff its parsed
+tags share a member with the tuple's compatible-tag set.
 """
 
 from __future__ import annotations
@@ -181,41 +182,27 @@ def _platform_tags_for_spec(spec: PlatformSpec) -> list[str]:
     raise ValueError(msg)  # pragma: no cover
 
 
+# PyPy 7.3.x soabi, stable across every Python minor PyPy 3 ships
+# (pp36..pp311 all use ``_pp73``); the abi tag is ``pypyXY_pp73``.
+_PYPY_SOABI = "73"
+
+
 @cache
 def compatible_tags_for_tuple(
     *,
     python_version: str,
     spec: PlatformSpec,
+    implementation: str = "cpython",
 ) -> frozenset[Tag]:
-    """Return the full set of tags ``(python_version, spec)`` accepts.
+    """Return the full set of tags ``(python_version, spec, impl)`` accepts.
 
-    Combines:
-
-    1. CPython-specific tags via ``packaging.tags.cpython_tags``
-       (cpXY-cpXY, cpXY-abi3 forward-compat, cpXY-none).
-    2. Interpreter-agnostic tags via ``packaging.tags.compatible_tags``
-       (pyXY-none-any, py3-none-any, etc.).
-
-    The platform list is computed by :func:`_platform_tags_for_spec`.
-    Cached on ``(python_version, spec)``: both inputs are immutable
-    (str, frozen dataclass) and the resulting set is identical across
-    every wheel-compatibility check for the same tuple, so the cache
-    skips rebuilding the same :class:`Tag` set per call.
+    Builds the same ordered tags as :func:`_tags_in_order` and returns
+    them as a frozenset.  Cached on the three immutable inputs (str,
+    frozen dataclass, str): the resulting set is identical across every
+    wheel-compatibility check for the same tuple, so the cache skips
+    rebuilding the same :class:`Tag` set per call.
     """
-    major, minor = (int(p) for p in python_version.split("."))
-    py_version = (major, minor)
-    abi = f"cp{major}{minor}"
-    platforms = _platform_tags_for_spec(spec)
-    out: set[Tag] = set()
-    out.update(
-        ptags.cpython_tags(python_version=py_version, abis=[abi], platforms=platforms)
-    )
-    out.update(
-        ptags.compatible_tags(
-            python_version=py_version, interpreter=abi, platforms=platforms
-        )
-    )
-    return frozenset(out)
+    return frozenset(_tags_in_order(python_version, spec, implementation))
 
 
 @lru_cache(maxsize=4096)
@@ -274,12 +261,15 @@ def wheel_compatible_with_tuple(
     *,
     python_version: str,
     spec: PlatformSpec,
+    implementation: str = "cpython",
 ) -> bool:
     """Return True iff ``wheel`` is a candidate for the given tuple."""
     wheel_tags = wheel_tag_set(wheel.filename)
     if wheel_tags is None:
         return False
-    compat = compatible_tags_for_tuple(python_version=python_version, spec=spec)
+    compat = compatible_tags_for_tuple(
+        python_version=python_version, spec=spec, implementation=implementation
+    )
     # ``frozenset.isdisjoint`` is a C-level builtin that beats the
     # Python ``any(t in compat for t in wheel_tags)`` generator on
     # the per-wheel hot loop.
@@ -291,6 +281,7 @@ def select_wheel_for_tuple(
     *,
     python_version: str,
     spec: PlatformSpec,
+    implementation: str = "cpython",
 ) -> WheelFile | None:
     """Pick the most-specific compatible wheel for the tuple, or None.
 
@@ -299,7 +290,7 @@ def select_wheel_for_tuple(
     those matching later (more-generic) tags.  Within the same tag
     rank, the first wheel in input order wins.
     """
-    compat_list = list(_compatible_tags_in_order(python_version, spec))
+    compat_list = list(_tags_in_order(python_version, spec, implementation))
     rank: dict[Tag, int] = {tag: i for i, tag in enumerate(compat_list)}
 
     best: tuple[int, WheelFile] | None = None
@@ -316,15 +307,32 @@ def select_wheel_for_tuple(
     return best[1] if best is not None else None
 
 
-def _compatible_tags_in_order(python_version: str, spec: PlatformSpec) -> Iterable[Tag]:
-    """Yield compatible tags in install preference order."""
+def _tags_in_order(
+    python_version: str, spec: PlatformSpec, implementation: str = "cpython"
+) -> Iterable[Tag]:
+    """Yield the tags a tuple accepts in install preference order.
+
+    CPython tuples use ``packaging.tags.cpython_tags`` (cpXY-cpXY,
+    cpXY-abi3 forward-compat, cpXY-none).  PyPy tuples cannot reuse that
+    (it forces the ``cp`` interpreter and abi3, which PyPy lacks), so
+    their interpreter/abi/none tags are emitted directly.  Both then add
+    the interpreter-agnostic tags (pyXY-none-any, py3-none-any, ...).
+    """
     major, minor = (int(p) for p in python_version.split("."))
     py_version = (major, minor)
-    abi = f"cp{major}{minor}"
     platforms = _platform_tags_for_spec(spec)
-    yield from ptags.cpython_tags(
-        python_version=py_version, abis=[abi], platforms=platforms
-    )
+    if implementation == "pypy":
+        interpreter = f"pp{major}{minor}"
+        abi = f"pypy{major}{minor}_pp{_PYPY_SOABI}"
+        for platform_ in platforms:
+            yield ptags.Tag(interpreter, abi, platform_)
+        for platform_ in platforms:
+            yield ptags.Tag(interpreter, "none", platform_)
+    else:
+        interpreter = f"cp{major}{minor}"
+        yield from ptags.cpython_tags(
+            python_version=py_version, abis=[interpreter], platforms=platforms
+        )
     yield from ptags.compatible_tags(
-        python_version=py_version, interpreter=abi, platforms=platforms
+        python_version=py_version, interpreter=interpreter, platforms=platforms
     )

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -894,6 +894,28 @@ class TestMatrix:
         assert matrix.python_order == "desc"
         assert matrix.python_patches == {"3.11": "3.11.4"}
 
+    def test_implementations_default_is_cpython(self, tmp_path: Path) -> None:
+        path = write(tmp_path, self._matrix_body())
+        matrix = read_pyproject_config(path).matrix
+        assert matrix is not None
+        assert matrix.implementations == ("cpython",)
+
+    def test_implementations_parsed(self, tmp_path: Path) -> None:
+        body = self._matrix_body(implementations='["cpython", "pypy"]')
+        matrix = read_pyproject_config(write(tmp_path, body)).matrix
+        assert matrix is not None
+        assert matrix.implementations == ("cpython", "pypy")
+
+    def test_implementations_empty_rejected(self, tmp_path: Path) -> None:
+        body = self._matrix_body(implementations="[]")
+        with pytest.raises(ConfigError, match="at least one implementation"):
+            read_pyproject_config(write(tmp_path, body))
+
+    def test_implementations_unknown_rejected(self, tmp_path: Path) -> None:
+        body = self._matrix_body(implementations='["jython"]')
+        with pytest.raises(ConfigError, match="unknown matrix.implementations"):
+            read_pyproject_config(write(tmp_path, body))
+
     def test_must_be_table(self, tmp_path: Path) -> None:
         path = write(
             tmp_path,

--- a/nab-python/tests/universal/test_matrix.py
+++ b/nab-python/tests/universal/test_matrix.py
@@ -10,6 +10,7 @@ import pytest
 
 from nab_python._vendor.packaging.markers import Marker
 from nab_python.universal.matrix import (
+    _IMPLEMENTATION_DEFAULTS,
     _KNOWN_PYTHON_MINORS,
     _PLATFORM_DEFAULTS,
     Matrix,
@@ -220,6 +221,53 @@ class TestMatrixExpand:
         assert py_marker.evaluate(linux_env) is True
 
 
+class TestImplementationAxis:
+    """The implementation axis adds PyPy alongside the default CPython."""
+
+    def test_default_is_cpython_only(self) -> None:
+        """Without declaring implementations, every tuple is CPython."""
+        matrix = Matrix(python="==3.11", platforms=("linux_x86_64",))
+        tuples = matrix.expand()
+        assert len(tuples) == 1
+        env = tuples[0].environment
+        assert tuples[0].implementation == "cpython"
+        assert env["implementation_name"] == "cpython"
+        assert env["platform_python_implementation"] == "CPython"
+
+    def test_count_is_pythons_times_platforms_times_implementations(self) -> None:
+        """The implementation axis multiplies the tuple count."""
+        matrix = Matrix(
+            python=">=3.11, <3.13",
+            platforms=("linux_x86_64", "macos_arm64"),
+            implementations=("cpython", "pypy"),
+        )
+        tuples = matrix.expand()
+        assert len(tuples) == 2 * 2 * 2
+
+    def test_pypy_tuple_has_pypy_markers(self) -> None:
+        """A PyPy tuple sets the PyPy interpreter-identity markers."""
+        matrix = Matrix(
+            python="==3.11",
+            platforms=("linux_x86_64",),
+            implementations=("pypy",),
+        )
+        env = matrix.expand()[0].environment
+        assert env["implementation_name"] == "pypy"
+        assert env["platform_python_implementation"] == "PyPy"
+        assert Marker('platform_python_implementation == "PyPy"').evaluate(env)
+        assert not Marker('platform_python_implementation == "CPython"').evaluate(env)
+
+    def test_unknown_implementation_raises(self) -> None:
+        """An unknown implementation is a user error, raised eagerly."""
+        matrix = Matrix(
+            python="==3.11",
+            platforms=("linux_x86_64",),
+            implementations=("jython",),
+        )
+        with pytest.raises(ValueError, match="Unknown implementations"):
+            matrix.expand()
+
+
 class TestMatrixTuple:
     """``MatrixTuple`` is a lightweight value object."""
 
@@ -232,6 +280,43 @@ class TestMatrixTuple:
         )
         assert t.label == "py311-linux_x86_64"
 
+    def test_pypy_label_uses_pp_prefix(self) -> None:
+        """A PyPy tuple's label uses the ``pp`` interpreter prefix."""
+        t = MatrixTuple(
+            python_version="3.11",
+            platform_id="linux_x86_64",
+            environment={},
+            implementation="pypy",
+        )
+        assert t.label == "pp311-linux_x86_64"
+
+    def test_cpython_marker_omits_implementation(self) -> None:
+        """The default CPython marker keeps its three-clause form."""
+        t = MatrixTuple(
+            python_version="3.11",
+            platform_id="linux_x86_64",
+            environment={
+                "sys_platform": "linux",
+                "platform_machine": "x86_64",
+                "implementation_name": "cpython",
+            },
+        )
+        assert "implementation_name" not in t.marker_string
+
+    def test_pypy_marker_constrains_implementation(self) -> None:
+        """A PyPy marker adds an ``implementation_name`` clause."""
+        t = MatrixTuple(
+            python_version="3.11",
+            platform_id="linux_x86_64",
+            environment={
+                "sys_platform": "linux",
+                "platform_machine": "x86_64",
+                "implementation_name": "pypy",
+            },
+            implementation="pypy",
+        )
+        assert t.marker_string.endswith('and implementation_name == "pypy"')
+
 
 class TestKnownConstants:
     """Coverage for the module-level lookup tables."""
@@ -243,6 +328,12 @@ class TestKnownConstants:
         ]
         assert as_versions == sorted(as_versions)
 
+    def test_each_implementation_default_has_interpreter_markers(self) -> None:
+        """Every implementation default sets the two interpreter markers."""
+        required = {"platform_python_implementation", "implementation_name"}
+        for impl, env in _IMPLEMENTATION_DEFAULTS.items():
+            assert required == env.keys(), impl
+
     def test_each_platform_default_has_required_keys(self) -> None:
         """Every platform default must define the OS/arch markers."""
         required = {
@@ -250,8 +341,6 @@ class TestKnownConstants:
             "platform_system",
             "platform_machine",
             "os_name",
-            "platform_python_implementation",
-            "implementation_name",
         }
         for platform_id, env in _PLATFORM_DEFAULTS.items():
             missing = required - env.keys()

--- a/nab-python/tests/universal/test_wheel_selection.py
+++ b/nab-python/tests/universal/test_wheel_selection.py
@@ -386,3 +386,76 @@ class TestUnknownPlatformKindGuard:
         finally:
             del _PLATFORM_ARCH["fake_x"]
             del _PLATFORM_KIND["fake_x"]
+
+
+class TestPyPyTags:
+    """The ``implementation="pypy"`` axis matches PyPy wheels, not CPython."""
+
+    SPEC = PlatformSpec("linux_x86_64")
+
+    def test_pypy_wheel_matches_pypy_tuple(self) -> None:
+        """A real ``ppXY-pypyXY_pp73`` wheel matches its PyPy tuple."""
+        wheel = _wheel("numpy-1.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.whl")
+        assert wheel_compatible_with_tuple(
+            wheel, python_version="3.11", spec=self.SPEC, implementation="pypy"
+        )
+
+    def test_pypy_none_wheel_matches_pypy_tuple(self) -> None:
+        """A ``ppXY-none`` interpreter-specific wheel matches too."""
+        wheel = _wheel("foo-1.0-pp311-none-manylinux_2_17_x86_64.whl")
+        assert wheel_compatible_with_tuple(
+            wheel, python_version="3.11", spec=self.SPEC, implementation="pypy"
+        )
+
+    def test_cpython_wheel_rejected_on_pypy_tuple(self) -> None:
+        """A CPython wheel is not a candidate for a PyPy tuple."""
+        wheel = _wheel("numpy-1.0-cp311-cp311-manylinux_2_17_x86_64.whl")
+        assert not wheel_compatible_with_tuple(
+            wheel, python_version="3.11", spec=self.SPEC, implementation="pypy"
+        )
+
+    def test_pypy_wheel_rejected_on_cpython_tuple(self) -> None:
+        """A PyPy wheel is not a candidate for the default CPython tuple."""
+        wheel = _wheel("numpy-1.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.whl")
+        assert not wheel_compatible_with_tuple(
+            wheel, python_version="3.11", spec=self.SPEC, implementation="cpython"
+        )
+
+    def test_pypy_minor_must_match(self) -> None:
+        """A PyPy 3.10 wheel does not match a PyPy 3.11 tuple."""
+        wheel = _wheel("numpy-1.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.whl")
+        assert not wheel_compatible_with_tuple(
+            wheel, python_version="3.11", spec=self.SPEC, implementation="pypy"
+        )
+
+    def test_pure_python_wheel_matches_either(self) -> None:
+        """A ``py3-none-any`` wheel matches both implementations."""
+        wheel = _wheel("foo-1.0-py3-none-any.whl")
+        assert wheel_compatible_with_tuple(
+            wheel, python_version="3.11", spec=self.SPEC, implementation="pypy"
+        )
+
+    def test_select_prefers_pypy_specific_over_pure_python(self) -> None:
+        """The PyPy-specific wheel outranks the pure-Python fallback."""
+        pure = _wheel("numpy-1.0-py3-none-any.whl")
+        native = _wheel("numpy-1.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.whl")
+        chosen = select_wheel_for_tuple(
+            [pure, native],
+            python_version="3.11",
+            spec=self.SPEC,
+            implementation="pypy",
+        )
+        assert chosen is native
+
+    def test_compat_tag_sets_differ_by_implementation(self) -> None:
+        """The CPython and PyPy tuples accept disjoint native-tag sets."""
+        cp = compatible_tags_for_tuple(python_version="3.11", spec=self.SPEC)
+        pp = compatible_tags_for_tuple(
+            python_version="3.11", spec=self.SPEC, implementation="pypy"
+        )
+        cp_native = {t for t in cp if t.abi.startswith("cp")}
+        pp_native = {t for t in pp if t.abi.startswith("pypy")}
+        assert cp_native
+        assert pp_native
+        assert cp_native.isdisjoint(pp)
+        assert pp_native.isdisjoint(cp)


### PR DESCRIPTION
Adds an implementation axis to the universal resolution matrix. `MatrixConfig` gains `implementations` (default `("cpython",)`, validated against the known set), `MatrixTuple` gains `implementation`, and `Matrix.expand()` grows a third loop so tuple count is pythons x platforms x implementations.

PyPy tuples set `platform_python_implementation = "PyPy"` / `implementation_name = "pypy"` for marker evaluation and accept `ppXY-pypyXY_pp73` wheel tags (PyPy 7.3.x soabi) instead of the CPython `cpXY` family. Tuple labels use the `pp` interpreter prefix (`pp311-linux_x86_64`).

The default stays `("cpython",)`, so any matrix that omits `implementations` produces byte-identical lockfile output. One intentional limitation: when both `cpython` and `pypy` are listed for the same python/platform, the CPython entry's lockfile marker stays unconstrained on implementation (no `implementation_name` clause) to keep cpython-only output byte-identical; only the PyPy entry is implementation-constrained. A new doc section in `docs/guides/universal.md` explains this.

Relates to #24