### PR TITLE
Wrap Requires-Python parse failure as BuildBackendError

### DIFF
--- a/nab-python/src/nab_python/_build/runner.py
+++ b/nab-python/src/nab_python/_build/runner.py
@@ -34,7 +34,7 @@ import pyproject_hooks
 import tomli
 
 from .._vendor.packaging.requirements import Requirement
-from .._vendor.packaging.specifiers import SpecifierSet
+from .._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from .._vendor.packaging.utils import canonicalize_name
 from .._vendor.packaging.version import InvalidVersion, Version
 from ..metadata import WheelMetadata
@@ -228,7 +228,13 @@ def _parse_metadata(metadata_path: Path) -> WheelMetadata:
         raise BuildBackendError(msg) from exc
 
     requires_python_raw = msg_obj.get("Requires-Python")
-    requires_python = SpecifierSet(requires_python_raw) if requires_python_raw else None
+    try:
+        requires_python = (
+            SpecifierSet(requires_python_raw) if requires_python_raw else None
+        )
+    except InvalidSpecifier as exc:
+        msg = f"backend METADATA has invalid Requires-Python {requires_python_raw!r}: {exc}"
+        raise BuildBackendError(msg) from exc
 
     requires_dist: list[Requirement] = []
     for raw in msg_obj.get_all("Requires-Dist") or ():

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -443,6 +443,18 @@ class TestParseMetadata:
         with pytest.raises(BuildBackendError, match="invalid Version"):
             _parse_metadata(path)
 
+    def test_invalid_requires_python_raises(self, tmp_path: Path) -> None:
+        from nab_python._build.runner import _parse_metadata
+
+        path = tmp_path / "METADATA"
+        path.write_text(
+            "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n"
+            "Requires-Python: not-a-specifier\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(BuildBackendError, match="invalid Requires-Python"):
+            _parse_metadata(path)
+
     def test_unparseable_requires_dist_is_skipped(self, tmp_path: Path) -> None:
         """A malformed Requires-Dist line logs and is dropped; well-formed
         siblings still come through."""


### PR DESCRIPTION
When a build backend emits a METADATA file with a malformed `Requires-Python` value, the raw `InvalidSpecifier` exception was leaking through. This wraps it in `BuildBackendError` with the same style of message already used for invalid `Version` fields, so callers get a clean diagnostic instead of a traceback from inside the vendored packaging library.