### PR TITLE
Reject non-positive download --max-concurrency

### DIFF
--- a/src/nab/_download.py
+++ b/src/nab/_download.py
@@ -46,6 +46,10 @@ def download(
     download is idempotent: files whose sha256 already matches are
     left alone.  Local and VCS pins are skipped.
     """
+    if max_concurrency < 1:
+        sys.stderr.write("Error: --max-concurrency must be at least 1.\n")
+        sys.exit(1)
+
     config = _cli._load_config(  # noqa: SLF001
         path, discover_workspace=workspace_discovery
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1748,6 +1748,15 @@ class TestDownloadCommand:
         with pytest.raises(SystemExit, match="1"):
             download(pyproject)
 
+    @pytest.mark.parametrize("bad", [0, -1])
+    def test_non_positive_max_concurrency_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], bad: int
+    ) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        with pytest.raises(SystemExit, match="1"):
+            download(pyproject, max_concurrency=bad)
+        assert "--max-concurrency must be at least 1" in capsys.readouterr().err
+
     def test_resolution_error_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
Passing 0 or a negative value to `nab download --max-concurrency` would silently produce misbehavior (zero worker threads). This adds an explicit check that exits with a clear error message instead.