### PR TITLE
Surface index HTTP errors as clean messages

### DIFF
--- a/nab-index/src/nab_index/httpx_async_transport.py
+++ b/nab-index/src/nab_index/httpx_async_transport.py
@@ -3,25 +3,63 @@
 from __future__ import annotations
 
 import ssl
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import httpx
 import truststore
 
+from .transport import HttpError
+
 if TYPE_CHECKING:
-    from .transport import HttpResponse
+    from collections.abc import Mapping
 
 __all__ = [
     "HttpxAsyncTransport",
 ]
 
 
+class _HttpxResponse:
+    """Adapter that converts httpx's status error to the transport's HttpError.
+
+    httpx.Response already matches the HttpResponse protocol; only
+    raise_for_status needs translating so callers see one error type.
+    """
+
+    __slots__ = ("_response",)
+
+    def __init__(self, response: httpx.Response) -> None:
+        self._response = response
+
+    @property
+    def status_code(self) -> int:
+        return self._response.status_code
+
+    @property
+    def headers(self) -> Mapping[str, str]:
+        return self._response.headers
+
+    @property
+    def content(self) -> bytes:
+        return self._response.content
+
+    @property
+    def text(self) -> str:
+        return self._response.text
+
+    def json(self) -> Any:
+        return self._response.json()
+
+    def raise_for_status(self) -> None:
+        try:
+            self._response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise HttpError(str(exc)) from exc
+
+
 class HttpxAsyncTransport:
     """Async HTTP transport using httpx.
 
     HTTP/2 is enabled by default for connection multiplexing.
-    The httpx.Response type already matches the HttpResponse
-    protocol, so it is returned directly.
     """
 
     def __init__(self, *, http2: bool = True) -> None:
@@ -33,13 +71,14 @@ class HttpxAsyncTransport:
 
     async def get(
         self, url: str, *, headers: dict[str, str] | None = None
-    ) -> HttpResponse:
+    ) -> _HttpxResponse:
         """Send a GET request."""
-        # httpx.Response satisfies the HttpResponse protocol structurally
-        # (headers, status_code, content, text, json, raise_for_status are
-        # all present); the disagreement is only that httpx's headers slot
-        # is its own Headers class rather than a literal Mapping[str, str].
-        return await self._client.get(url, headers=headers)  # type: ignore[return-value]
+        try:
+            response = await self._client.get(url, headers=headers)
+        except httpx.HTTPError as exc:
+            msg = f"GET {url} failed: {exc}"
+            raise HttpError(msg) from exc
+        return _HttpxResponse(response)
 
     async def aclose(self) -> None:
         """Close the underlying client."""

--- a/nab-index/src/nab_index/transport.py
+++ b/nab-index/src/nab_index/transport.py
@@ -14,8 +14,17 @@ if TYPE_CHECKING:
 
 __all__ = [
     "AsyncHttpTransport",
+    "HttpError",
     "HttpResponse",
 ]
+
+
+class HttpError(Exception):
+    """A request failed: a connection/transport error or a 4xx/5xx status.
+
+    Transports raise this from ``get`` and ``raise_for_status`` so callers
+    can handle index failures without importing a specific HTTP backend.
+    """
 
 
 class HttpResponse(Protocol):
@@ -46,7 +55,7 @@ class HttpResponse(Protocol):
         ...
 
     def raise_for_status(self) -> None:
-        """Raise an exception for 4xx/5xx responses."""
+        """Raise :class:`HttpError` for 4xx/5xx responses."""
         ...
 
 
@@ -61,7 +70,10 @@ class AsyncHttpTransport(Protocol):
     async def get(
         self, url: str, *, headers: dict[str, str] | None = None
     ) -> HttpResponse:
-        """Send a GET request and return the response."""
+        """Send a GET request and return the response.
+
+        Raises :class:`HttpError` on a connection or transport failure.
+        """
         ...
 
     async def aclose(self) -> None:

--- a/nab-index/src/nab_index/urllib3_async_transport.py
+++ b/nab-index/src/nab_index/urllib3_async_transport.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING, Any
 import truststore
 import urllib3
 
+from .transport import HttpError
+
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
@@ -78,7 +80,7 @@ class _Urllib3Response:
         status = self._response.status
         if status >= _HTTP_BAD_REQUEST:
             msg = f"HTTP {status} for {self._response.geturl() or '<unknown>'}"
-            raise urllib3.exceptions.HTTPError(msg)
+            raise HttpError(msg)
 
 
 class Urllib3AsyncTransport:
@@ -131,7 +133,11 @@ class Urllib3AsyncTransport:
         request_headers = {"Accept-Encoding": "gzip"}
         if headers is not None:
             request_headers.update(headers)
-        response = await asyncio.to_thread(self._request, url, request_headers)
+        try:
+            response = await asyncio.to_thread(self._request, url, request_headers)
+        except urllib3.exceptions.HTTPError as exc:
+            msg = f"GET {url} failed: {exc}"
+            raise HttpError(msg) from exc
         return _Urllib3Response(response)
 
     async def aclose(self) -> None:

--- a/nab-python/src/nab_python/download.py
+++ b/nab-python/src/nab_python/download.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from nab_index.client import AsyncSimpleClient
+from nab_index.transport import HttpError
 
 from .lockfile import IndexPin, LockInput
 
@@ -160,7 +161,15 @@ async def _run_downloads(
                 skipped.append(target)
                 logger.info("skip %s (%s matches)", entry.filename, entry.hash_algo)
                 return
-            data = await client.download(entry.url)
+            try:
+                data = await client.download(entry.url)
+            except HttpError as exc:
+                msg = (
+                    f"{entry.package}=={entry.version}: failed to fetch"
+                    f" {entry.filename}: {exc}"
+                )
+                raise DownloadError(msg) from exc
+
             actual = hashlib.new(entry.hash_algo, data).hexdigest()
             if actual != entry.digest:
                 msg = (

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -18,7 +18,8 @@ import truststore
 import urllib3
 
 from nab_index.client import AsyncSimpleClient, _extract_sdist_files
-from nab_index.httpx_async_transport import HttpxAsyncTransport
+from nab_index.httpx_async_transport import HttpxAsyncTransport, _HttpxResponse
+from nab_index.transport import HttpError
 from nab_index.urllib3_async_transport import (
     Urllib3AsyncTransport,
     _SSLContext,
@@ -54,21 +55,56 @@ class TestFetchCoordinatorTransport:
 
 class TestHttpxAsyncTransport:
     @respx.mock
-    def test_get_returns_httpx_response(self) -> None:
+    def test_get_returns_response_adapter(self) -> None:
         respx.get("https://example.com/").mock(
-            return_value=httpx.Response(200, text="hello")
+            return_value=httpx.Response(200, json={"a": 1}, headers={"etag": "abc"})
         )
 
-        async def go() -> str:
+        async def go() -> _HttpxResponse:
             transport = HttpxAsyncTransport(http2=False)
             try:
                 resp = await transport.get("https://example.com/")
                 resp.raise_for_status()
-                return resp.text
+                return resp
             finally:
                 await transport.aclose()
 
-        assert asyncio.run(go()) == "hello"
+        resp = asyncio.run(go())
+        assert isinstance(resp, _HttpxResponse)
+        assert resp.status_code == 200
+        assert resp.headers["etag"] == "abc"
+        assert resp.json() == {"a": 1}
+        assert resp.content == b'{"a":1}'
+        assert resp.text == '{"a":1}'
+
+    @respx.mock
+    def test_raise_for_status_converts_status_error(self) -> None:
+        respx.get("https://example.com/missing").mock(return_value=httpx.Response(404))
+
+        async def go() -> None:
+            transport = HttpxAsyncTransport(http2=False)
+            try:
+                resp = await transport.get("https://example.com/missing")
+                resp.raise_for_status()
+            finally:
+                await transport.aclose()
+
+        with pytest.raises(HttpError):
+            asyncio.run(go())
+
+    @respx.mock
+    def test_get_wraps_connection_error(self) -> None:
+        respx.get("https://example.com/").mock(side_effect=httpx.ConnectError("boom"))
+
+        async def go() -> None:
+            transport = HttpxAsyncTransport(http2=False)
+            try:
+                await transport.get("https://example.com/")
+            finally:
+                await transport.aclose()
+
+        with pytest.raises(HttpError, match="GET https://example.com/ failed"):
+            asyncio.run(go())
 
     def test_uses_truststore_ssl_context(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """AsyncClient gets a truststore SSLContext via verify=."""
@@ -114,6 +150,25 @@ class TestUrllib3AsyncTransport:
             "GET", "https://example.com/", headers={"Accept-Encoding": "gzip", "k": "v"}
         )
         pool.clear.assert_called_once()
+
+    def test_get_wraps_connection_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A urllib3 transport error surfaces as the transport-contract HttpError."""
+        pool = MagicMock(spec=urllib3.PoolManager)
+        pool.request.side_effect = urllib3.exceptions.MaxRetryError(pool, "https://x/")
+        monkeypatch.setattr(
+            "nab_index.urllib3_async_transport.urllib3.PoolManager",
+            lambda **kw: pool,
+        )
+
+        async def go() -> None:
+            transport = Urllib3AsyncTransport()
+            try:
+                await transport.get("https://x/")
+            finally:
+                await transport.aclose()
+
+        with pytest.raises(HttpError, match="GET https://x/ failed"):
+            asyncio.run(go())
 
     def test_get_requests_gzip_without_caller_headers(
         self, monkeypatch: pytest.MonkeyPatch
@@ -177,7 +232,7 @@ class TestUrllib3AsyncTransport:
         fake.data = b""
         fake.status = 404
         fake.geturl.return_value = "https://example.com/missing"
-        with pytest.raises(urllib3.exceptions.HTTPError, match="404"):
+        with pytest.raises(HttpError, match="404"):
             _Urllib3Response(fake).raise_for_status()
 
     def test_response_raise_for_status_no_url(self) -> None:
@@ -186,7 +241,7 @@ class TestUrllib3AsyncTransport:
         fake.data = b""
         fake.status = 500
         fake.geturl.return_value = None
-        with pytest.raises(urllib3.exceptions.HTTPError, match="<unknown>"):
+        with pytest.raises(HttpError, match="<unknown>"):
             _Urllib3Response(fake).raise_for_status()
 
     def test_response_raise_for_status_ok(self) -> None:

--- a/nab-python/tests/test_download.py
+++ b/nab-python/tests/test_download.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from nab_index.transport import HttpError
 from nab_python.download import (
     DownloadEntry,
     DownloadError,
@@ -82,13 +83,15 @@ class _FakeResponse:
         return None
 
     def raise_for_status(self) -> None:
-        if self.status_code >= 400:  # pragma: no cover - happy path only
-            raise RuntimeError("HTTP error")
+        if self.status_code >= 400:
+            msg = f"HTTP {self.status_code}"
+            raise HttpError(msg)
 
 
 class _FakeTransport:
-    def __init__(self, responses: dict[str, bytes]) -> None:
+    def __init__(self, responses: dict[str, bytes], *, status_code: int = 200) -> None:
         self._responses = responses
+        self._status_code = status_code
         self.requested: list[str] = []
         self.closed = False
 
@@ -97,7 +100,9 @@ class _FakeTransport:
     ) -> _FakeResponse:
         del headers
         self.requested.append(url)
-        return _FakeResponse(content=self._responses[url])
+        return _FakeResponse(
+            content=self._responses[url], status_code=self._status_code
+        )
 
     async def aclose(self) -> None:
         self.closed = True
@@ -267,6 +272,18 @@ class TestDownloadLock:
         pin = _index_pin(wheel_sha="0" * 64)  # advertised sha is wrong
         transport = _FakeTransport({"https://example.com/foo-1.0.whl": wheel_bytes})
         with pytest.raises(DownloadError, match="sha256 mismatch"):
+            download_lock(
+                LockInput(pins={"foo": pin}),
+                transport,  # type: ignore[arg-type]
+                tmp_path,
+            )
+
+    def test_http_error_becomes_download_error(self, tmp_path: Path) -> None:
+        pin = _index_pin(wheel_sha="a" * 64)
+        transport = _FakeTransport(
+            {"https://example.com/foo-1.0.whl": b"x"}, status_code=503
+        )
+        with pytest.raises(DownloadError, match="failed to fetch foo-1.0-py3-none-any"):
             download_lock(
                 LockInput(pins={"foo": pin}),
                 transport,  # type: ignore[arg-type]

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -22,6 +22,7 @@ import tyro
 from tyro.extras import SubcommandApp
 
 from nab._version import __version__
+from nab_index.transport import HttpError
 from nab_index.urllib3_async_transport import Urllib3AsyncTransport
 from nab_python.config import (
     ConfigError,
@@ -199,6 +200,9 @@ def _resolve_specific(  # noqa: PLR0913 - one wrapper per resolve_pyproject kwar
     except ConfigError as e:
         sys.stderr.write(f"Error in [tool.nab]: {e}\n")
         sys.exit(1)
+    except HttpError as e:
+        sys.stderr.write(f"{failure_prefix}: {e}\n")
+        sys.exit(1)
 
 
 def _resolve_universal(
@@ -237,6 +241,9 @@ def _resolve_universal(
         sys.exit(1)
     except LookupError as e:
         sys.stderr.write(f"Error: {e}\n")
+        sys.exit(1)
+    except HttpError as e:
+        sys.stderr.write(f"Cannot lock: {e}\n")
         sys.exit(1)
 
     if not result.success:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,6 +34,7 @@ from nab.cli import (
     main,
 )
 from nab_index.httpx_async_transport import HttpxAsyncTransport
+from nab_index.transport import HttpError
 from nab_index.urllib3_async_transport import Urllib3AsyncTransport
 from nab_python._vendor.packaging.pylock import Pylock
 from nab_python._vendor.packaging.version import Version
@@ -368,6 +369,23 @@ class TestLockCommandSpecific:
             lock(pyproject)
         assert "invalid requirement" in capsys.readouterr().err
 
+    def test_http_error_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An index HTTP failure during resolve exits 1, not a traceback."""
+        pyproject = _make_pyproject(tmp_path)
+        with (
+            patch(
+                "nab.cli.resolve_pyproject",
+                side_effect=HttpError("GET https://pypi.org/simple/foo/ failed: 503"),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject)
+        err = capsys.readouterr().err
+        assert "Cannot lock" in err
+        assert "503" in err
+
     def test_lookup_error_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -688,6 +706,23 @@ class TestLockCommandUniversal:
         ):
             lock(pyproject, format="requirements-without-hashes")
         assert "unknown group" in capsys.readouterr().err
+
+    def test_http_error_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An index HTTP failure during a tuple resolve exits 1, not a traceback."""
+        pyproject = _universal_pyproject(tmp_path)
+        with (
+            patch(
+                "nab.cli.resolve_universal_pyproject",
+                side_effect=HttpError("GET https://pypi.org/simple/foo/ failed: 503"),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, format="requirements-without-hashes")
+        err = capsys.readouterr().err
+        assert "Cannot lock" in err
+        assert "503" in err
 
     def test_requirements_missing_hash_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
When an index HTTP request fails (a connection error or a 4xx/5xx response), nab previously let the raw exception traceback bubble up to the terminal. This adds an `HttpError` type to the transport contract, has both transport implementations wrap their library errors into it, and has the lock and resolve CLI handlers catch it and print a one-line message before exiting 1.
