### PR TITLE
Report malformed pyproject.toml without a traceback

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -413,7 +413,7 @@ def read_pyproject_lock_anchor(path: Path) -> datetime | None:
     try:
         with path.open("rb") as f:
             data = tomli.load(f)
-    except FileNotFoundError:
+    except (FileNotFoundError, tomli.TOMLDecodeError):
         return None
     raw = data.get("tool", {}).get("nab", {})
     value = raw.get("uploaded-prior-to") if isinstance(raw, dict) else None

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -322,6 +322,11 @@ class TestReadLockAnchor:
     def test_missing_file_returns_none(self, tmp_path: Path) -> None:
         assert read_pyproject_lock_anchor(tmp_path / "missing.toml") is None
 
+    def test_malformed_toml_returns_none(self, tmp_path: Path) -> None:
+        # A syntax error is left for the full config parse to report.
+        path = write(tmp_path, '[project]\ndependencies = ["foo"\n')
+        assert read_pyproject_lock_anchor(path) is None
+
 
 class TestUploadedPriorToPackage:
     """``[tool.nab.uploaded-prior-to-package]`` parses into a mapping."""

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -17,6 +17,7 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Literal
 
+import tomli
 import tyro
 from tyro.extras import SubcommandApp
 
@@ -132,6 +133,9 @@ def _load_config(
         return read_pyproject_config(
             path, discover_workspace=discover_workspace, anchor=anchor
         )
+    except tomli.TOMLDecodeError as exc:
+        sys.stderr.write(f"Error: {path} is not valid TOML: {exc}\n")
+        sys.exit(1)
     except ConfigError as exc:
         sys.stderr.write(f"Error in [tool.nab]: {exc}\n")
         sys.exit(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -345,6 +345,16 @@ class TestLockCommandSpecific:
         with pytest.raises(SystemExit, match="1"):
             lock(tmp_path / "missing.toml")
 
+    def test_malformed_toml_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A TOML syntax error reports a clean message, not a traceback."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text('[project]\ndependencies = ["foo"\n')
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, output=Path("-"))
+        assert "is not valid TOML" in capsys.readouterr().err
+
     def test_resolution_flag_threads_to_resolver(self, tmp_path: Path) -> None:
         """``--resolution lowest`` reaches resolve_pyproject as the enum."""
         pyproject = _make_pyproject(tmp_path)


### PR DESCRIPTION
When a pyproject.toml contains a TOML syntax error, `nab` previously let the raw `tomli.TOMLDecodeError` propagate as an unhandled exception, printing a traceback. Now it catches the error in `_load_config` and writes a short message to stderr before exiting with code 1.

The `read_pyproject_lock_anchor` helper also now silently returns `None` on a parse error, since it only reads the anchor timestamp for pre-check purposes; the full config parse later will surface the error properly.