### PR TITLE
Reject non-table dependency-groups/optional-dependencies

### DIFF
--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -513,15 +513,18 @@ def _resolve_group_selection(
     if all_groups and groups:
         sys.stderr.write("Error: --all-groups and --groups are mutually exclusive\n")
         sys.exit(1)
-    if not all_groups:
-        return tuple(dict.fromkeys(groups))
+    if not (all_groups or groups):
+        return ()
 
     try:
         defined = read_pyproject_groups(path)
     except FileNotFoundError:
         sys.stderr.write(f"Error: {path} not found\n")
         sys.exit(1)
-    return tuple(defined.keys())
+    except TypeError as e:
+        sys.stderr.write(f"Error in {path}: {e}\n")
+        sys.exit(1)
+    return tuple(defined.keys()) if all_groups else tuple(dict.fromkeys(groups))
 
 
 def _resolve_extra_selection(
@@ -534,15 +537,18 @@ def _resolve_extra_selection(
     if all_extras and extras:
         sys.stderr.write("Error: --all-extras and --extras are mutually exclusive\n")
         sys.exit(1)
-    if not all_extras:
-        return tuple(dict.fromkeys(extras))
+    if not (all_extras or extras):
+        return ()
 
     try:
         defined = read_pyproject_optional_dependencies(path)
     except FileNotFoundError:
         sys.stderr.write(f"Error: {path} not found\n")
         sys.exit(1)
-    return tuple(defined.keys())
+    except TypeError as e:
+        sys.stderr.write(f"Error in {path}: {e}\n")
+        sys.exit(1)
+    return tuple(defined.keys()) if all_extras else tuple(dict.fromkeys(extras))
 
 
 def _build_provenance(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1555,6 +1555,79 @@ class TestGroupAndExtraSelection:
         result = _resolve_extra_selection(pyproject, extras=(), all_extras=True)
         assert sorted(result) == ["ci", "test"]
 
+    def test_no_group_selection_skips_read(self, tmp_path: Path) -> None:
+        result = _resolve_group_selection(
+            tmp_path / "missing.toml", groups=(), all_groups=False
+        )
+        assert result == ()
+
+    def test_no_extra_selection_skips_read(self, tmp_path: Path) -> None:
+        result = _resolve_extra_selection(
+            tmp_path / "missing.toml", extras=(), all_extras=False
+        )
+        assert result == ()
+
+    def test_explicit_groups_returns_deduplicated(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            "[project]\nname = 'x'\n[dependency-groups]\ndev = []\nlint = []\n",
+        )
+        result = _resolve_group_selection(
+            pyproject, groups=("dev", "lint", "dev"), all_groups=False
+        )
+        assert result == ("dev", "lint")
+
+    def test_explicit_extras_returns_deduplicated(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            "[project]\nname = 'x'\n"
+            "[project.optional-dependencies]\ntest = []\nci = []\n",
+        )
+        result = _resolve_extra_selection(
+            pyproject, extras=("test", "ci", "test"), all_extras=False
+        )
+        assert result == ("test", "ci")
+
+    def test_all_groups_non_table_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("dependency-groups = 'oops'\n[project]\nname = 'x'\n")
+        with pytest.raises(SystemExit, match="1"):
+            _resolve_group_selection(pyproject, groups=(), all_groups=True)
+        assert "[dependency-groups] must be a table" in capsys.readouterr().err
+
+    def test_explicit_groups_non_table_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("dependency-groups = 'oops'\n[project]\nname = 'x'\n")
+        with pytest.raises(SystemExit, match="1"):
+            _resolve_group_selection(pyproject, groups=("dev",), all_groups=False)
+        assert "[dependency-groups] must be a table" in capsys.readouterr().err
+
+    def test_all_extras_non_table_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("[project]\nname = 'x'\noptional-dependencies = 'oops'\n")
+        with pytest.raises(SystemExit, match="1"):
+            _resolve_extra_selection(pyproject, extras=(), all_extras=True)
+        assert "[project.optional-dependencies] must be a table" in (
+            capsys.readouterr().err
+        )
+
+    def test_explicit_extras_non_table_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("[project]\nname = 'x'\noptional-dependencies = 'oops'\n")
+        with pytest.raises(SystemExit, match="1"):
+            _resolve_extra_selection(pyproject, extras=("foo",), all_extras=False)
+        assert "[project.optional-dependencies] must be a table" in (
+            capsys.readouterr().err
+        )
+
 
 class TestEmitHelpers:
     """Helpers accept ``provenance=None``.


### PR DESCRIPTION
When `[dependency-groups]` or `[project.optional-dependencies]` holds a non-table value in pyproject.toml, `nab lock` used to crash with a raw Python traceback. The underlying readers already raise `TypeError` with a descriptive message; the callers just weren't catching it.

This adds `except TypeError` handling in `_resolve_group_selection` and `_resolve_extra_selection` so the error is printed cleanly and the process exits with status 1. The early-return path for the no-selection case is tightened so explicit `--groups`/`--extras` flags also trigger the pyproject read and get the same clean error.