### PR TITLE
Exit cleanly on malformed pyproject requirement strings

### DIFF
--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -9,7 +9,7 @@ import tomli
 from nab_resolver.errors import ResolutionError
 
 from ._vendor.packaging.dependency_groups import resolve_dependency_groups
-from ._vendor.packaging.requirements import Requirement
+from ._vendor.packaging.requirements import InvalidRequirement, Requirement
 from ._vendor.packaging.utils import canonicalize_name
 
 if TYPE_CHECKING:
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from ._vendor.packaging.ranges import VersionRange
 
 __all__ = [
+    "InvalidProjectRequirementError",
     "expand_self_extras",
     "raise_for_unsatisfiable",
     "read_pyproject_dependencies",
@@ -30,18 +31,32 @@ __all__ = [
 ]
 
 
+class InvalidProjectRequirementError(ValueError):
+    """A requirement string in pyproject.toml is not valid PEP 508."""
+
+
+def _parse_requirements(strings: Sequence[str], source: str) -> list[Requirement]:
+    """Parse PEP 508 strings, naming ``source`` if one is malformed."""
+    try:
+        return [Requirement(s) for s in strings]
+    except InvalidRequirement as exc:
+        msg = f"invalid requirement in {source}: {exc}"
+        raise InvalidProjectRequirementError(msg) from exc
+
+
 def read_pyproject_dependencies(path: Path) -> list[Requirement]:
     """Read [project].dependencies from a pyproject.toml file.
 
     Returns a list of Requirement objects parsed from the dependency
-    strings.  Raises FileNotFoundError if the file doesn't exist, or
-    KeyError if [project] or [project].dependencies is missing.
+    strings.  Raises FileNotFoundError if the file doesn't exist,
+    KeyError if [project] or [project].dependencies is missing, or
+    InvalidProjectRequirementError if a dependency string is malformed.
     """
     with path.open("rb") as f:
         data = tomli.load(f)
 
     dep_strings: list[str] = data["project"]["dependencies"]
-    return [Requirement(s) for s in dep_strings]
+    return _parse_requirements(dep_strings, "[project].dependencies")
 
 
 def read_pyproject_name(path: Path) -> str | None:
@@ -96,7 +111,12 @@ def select_optional_dependencies(
                 f" [project.optional-dependencies]; defined: {sorted(optional_deps)!r}"
             )
             raise LookupError(msg)
-        out.extend(Requirement(req_str) for req_str in optional_deps[name])
+        out.extend(
+            _parse_requirements(
+                optional_deps[name],
+                f"[project.optional-dependencies] extra {name!r}",
+            )
+        )
     return out
 
 
@@ -175,13 +195,18 @@ def resolve_groups_to_requirements(
 
     ``selected`` names the groups whose requirements should be
     expanded.  Unknown group names surface as :class:`LookupError`
-    from the vendored resolver.  Cyclic or malformed groups raise
-    the matching packaging error.  Returns an empty list when
+    from the vendored resolver and a malformed requirement string as
+    :class:`InvalidProjectRequirementError`; a cyclic include raises the
+    vendored resolver's error.  Returns an empty list when
     ``selected`` is empty.
     """
     if not selected:
         return []
-    resolved = resolve_dependency_groups(groups, *selected)
+    try:
+        resolved = resolve_dependency_groups(groups, *selected)
+    except InvalidRequirement as exc:
+        msg = f"invalid requirement in [dependency-groups]: {exc}"
+        raise InvalidProjectRequirementError(msg) from exc
     return [Requirement(s) for s in resolved]
 
 

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python.requirements_file import (
+    InvalidProjectRequirementError,
     expand_self_extras,
     raise_for_unsatisfiable,
     read_pyproject_dependencies,
@@ -21,8 +24,6 @@ from nab_resolver.errors import ResolutionError
 class TestReadPyprojectDependencies:
     def test_reads_dependencies(self, tmp_path: object) -> None:
         """Parse [project].dependencies from a valid pyproject.toml."""
-        from pathlib import Path
-
         p = Path(str(tmp_path)) / "pyproject.toml"
         p.write_text(
             '[project]\ndependencies = ["requests>=2.0", "click"]\n',
@@ -34,16 +35,12 @@ class TestReadPyprojectDependencies:
 
     def test_missing_file_raises(self, tmp_path: object) -> None:
         """Raise FileNotFoundError for missing pyproject.toml."""
-        from pathlib import Path
-
         p = Path(str(tmp_path)) / "missing.toml"
         with pytest.raises(FileNotFoundError):
             read_pyproject_dependencies(p)
 
     def test_missing_project_section_raises(self, tmp_path: object) -> None:
         """Raise KeyError when [project] section is missing."""
-        from pathlib import Path
-
         p = Path(str(tmp_path)) / "pyproject.toml"
         p.write_text("[build-system]\n")
         with pytest.raises(KeyError):
@@ -51,8 +48,6 @@ class TestReadPyprojectDependencies:
 
     def test_missing_dependencies_key_raises(self, tmp_path: object) -> None:
         """Raise KeyError when dependencies key is missing."""
-        from pathlib import Path
-
         p = Path(str(tmp_path)) / "pyproject.toml"
         p.write_text('[project]\nname = "foo"\n')
         with pytest.raises(KeyError):
@@ -60,18 +55,23 @@ class TestReadPyprojectDependencies:
 
     def test_empty_dependencies(self, tmp_path: object) -> None:
         """Return empty list when dependencies list is empty."""
-        from pathlib import Path
-
         p = Path(str(tmp_path)) / "pyproject.toml"
         p.write_text("[project]\ndependencies = []\n")
         assert read_pyproject_dependencies(p) == []
+
+    def test_malformed_dependency_string_raises(self, tmp_path: object) -> None:
+        """A malformed PEP 508 string raises InvalidProjectRequirementError."""
+        p = Path(str(tmp_path)) / "pyproject.toml"
+        p.write_text('[project]\ndependencies = ["requests >= 2.0 extra junk"]\n')
+        with pytest.raises(
+            InvalidProjectRequirementError, match=r"\[project\].dependencies"
+        ):
+            read_pyproject_dependencies(p)
 
 
 class TestReadPyprojectGroups:
     def test_reads_groups_table(self, tmp_path: object) -> None:
         """Parse [dependency-groups] from a valid pyproject.toml."""
-        from pathlib import Path
-
         p = Path(str(tmp_path)) / "pyproject.toml"
         p.write_text(
             '[dependency-groups]\ndev = ["pytest", "ruff"]\ndocs = ["sphinx"]\n',
@@ -81,15 +81,11 @@ class TestReadPyprojectGroups:
         assert list(groups["dev"]) == ["pytest", "ruff"]
 
     def test_missing_table_returns_empty(self, tmp_path: object) -> None:
-        from pathlib import Path
-
         p = Path(str(tmp_path)) / "pyproject.toml"
         p.write_text('[project]\ndependencies = ["foo"]\n')
         assert read_pyproject_groups(p) == {}
 
     def test_non_table_value_raises(self, tmp_path: object) -> None:
-        from pathlib import Path
-
         p = Path(str(tmp_path)) / "pyproject.toml"
         p.write_text('dependency-groups = "not-a-table"\n')
         with pytest.raises(TypeError, match="must be a table"):
@@ -120,11 +116,15 @@ class TestResolveGroupsToRequirements:
         with pytest.raises(BaseException, match="nope"):
             resolve_groups_to_requirements({"dev": ["pytest"]}, ("nope",))
 
+    def test_malformed_requirement_string_raises(self) -> None:
+        with pytest.raises(
+            InvalidProjectRequirementError, match=r"\[dependency-groups\]"
+        ):
+            resolve_groups_to_requirements({"dev": ["pytest >= bad junk"]}, ("dev",))
+
 
 class TestReadPyprojectOptionalDependencies:
     def test_reads_optional_dependencies(self, tmp_path: object) -> None:
-        from pathlib import Path
-
         p = Path(str(tmp_path)) / "pyproject.toml"
         p.write_text(
             "[project]\n"
@@ -139,15 +139,11 @@ class TestReadPyprojectOptionalDependencies:
         assert set(opt.keys()) == {"cpu", "gpu"}
 
     def test_missing_table_returns_empty(self, tmp_path: object) -> None:
-        from pathlib import Path
-
         p = Path(str(tmp_path)) / "pyproject.toml"
         p.write_text('[project]\ndependencies = ["foo"]\n')
         assert read_pyproject_optional_dependencies(p) == {}
 
     def test_non_table_value_raises(self, tmp_path: object) -> None:
-        from pathlib import Path
-
         p = Path(str(tmp_path)) / "pyproject.toml"
         p.write_text(
             "[project]\n"
@@ -174,11 +170,13 @@ class TestSelectOptionalDependencies:
         with pytest.raises(LookupError, match="nope"):
             select_optional_dependencies({"cpu": ["torch"]}, ("nope",))
 
+    def test_malformed_requirement_string_raises(self) -> None:
+        with pytest.raises(InvalidProjectRequirementError, match="gpu"):
+            select_optional_dependencies({"gpu": ["torch >= bad junk"]}, ("gpu",))
+
 
 class TestReadPyprojectName:
     def test_reads_name(self, tmp_path: object) -> None:
-        from pathlib import Path
-
         p = Path(str(tmp_path)) / "pyproject.toml"
         p.write_text('[project]\nname = "mypkg"\nversion = "1.0"\n')
         assert read_pyproject_name(p) == "mypkg"
@@ -189,15 +187,11 @@ class TestReadPyprojectName:
         nab still reads ``[tool.nab]`` and friends from such files, so
         the helper has to tolerate the missing project table.
         """
-        from pathlib import Path
-
         p = Path(str(tmp_path)) / "pyproject.toml"
         p.write_text('[tool.nab]\nmode = "specific"\n')
         assert read_pyproject_name(p) is None
 
     def test_returns_none_when_name_missing(self, tmp_path: object) -> None:
-        from pathlib import Path
-
         p = Path(str(tmp_path)) / "pyproject.toml"
         p.write_text('[project]\nversion = "1.0"\n')
         assert read_pyproject_name(p) is None

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -35,6 +35,7 @@ from nab_python.lockfile import (
 )
 from nab_python.provider import ResolutionStrategy
 from nab_python.requirements_file import (
+    InvalidProjectRequirementError,
     read_pyproject_groups,
     read_pyproject_optional_dependencies,
 )
@@ -301,6 +302,9 @@ def _emit_universal(  # noqa: PLR0913 - one wrapper per resolve_universal_pyproj
         )
     except KeyError:
         sys.stderr.write(f"Error: {path} has no [project].dependencies\n")
+        sys.exit(1)
+    except InvalidProjectRequirementError as e:
+        sys.stderr.write(f"Error: {e}\n")
         sys.exit(1)
     except LookupError as e:
         sys.stderr.write(f"Error: {e}\n")

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -35,6 +35,7 @@ from nab_python.lockfile import (
     write_requirements_without_hashes,  # noqa: F401 - re-exported for tests
 )
 from nab_python.provider import UnsupportedVcsError
+from nab_python.requirements_file import InvalidProjectRequirementError
 from nab_python.resolve import (
     resolve_pyproject,
     resolve_universal_pyproject,  # noqa: F401 - re-exported for tests
@@ -176,6 +177,9 @@ def _resolve_specific(  # noqa: PLR0913 - one wrapper per resolve_pyproject kwar
         sys.exit(1)
     except KeyError:
         sys.stderr.write(f"Error: {path} has no [project].dependencies\n")
+        sys.exit(1)
+    except InvalidProjectRequirementError as e:
+        sys.stderr.write(f"Error: {e}\n")
         sys.exit(1)
     except LookupError as e:
         sys.stderr.write(f"Error: {e}\n")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,6 +46,7 @@ from nab_python.lockfile import (
     WheelArtifact,
 )
 from nab_python.provider import ResolutionStrategy, UnsupportedVcsError
+from nab_python.requirements_file import InvalidProjectRequirementError
 from nab_python.resolve import ResolutionResult
 from nab_python.universal.matrix import Matrix, MatrixTuple
 from nab_python.universal.resolve import TupleResult, UniversalResult
@@ -321,6 +322,21 @@ class TestLockCommandSpecific:
             lock(pyproject)
         assert "Cannot lock" in capsys.readouterr().err
 
+    def test_invalid_requirement_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A malformed dependency string exits 1 instead of tracebacking."""
+        pyproject = _make_pyproject(tmp_path)
+        with (
+            patch(
+                "nab.cli.resolve_pyproject",
+                side_effect=InvalidProjectRequirementError("invalid requirement 'x y'"),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject)
+        assert "invalid requirement" in capsys.readouterr().err
+
     def test_lookup_error_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -369,6 +385,22 @@ class TestLockCommandSpecific:
 
 class TestLockCommandUniversal:
     """Tests for `nab lock` in universal mode."""
+
+    def test_invalid_requirement_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A malformed dependency string exits 1 instead of tracebacking."""
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with (
+            patch(
+                "nab.cli.resolve_universal_pyproject",
+                side_effect=InvalidProjectRequirementError("invalid requirement 'x y'"),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, output=out)
+        assert "invalid requirement" in capsys.readouterr().err
 
     def test_pylock_writes_universal_lock(self, tmp_path: Path) -> None:
         """Universal + pylock format runs the real merge + write pipeline."""


### PR DESCRIPTION
When a pyproject.toml contains a dependency string that does not conform to PEP 508, nab was letting the `InvalidRequirement` exception surface as an unhandled traceback. This replaces that with a typed `InvalidProjectRequirementError` (a `ValueError` subclass) raised at the parse site, and catches it in the CLI entry points to print a clean error message and exit 1.

The fix covers all three places that parse requirement strings from pyproject metadata: `[project].dependencies`, `[project.optional-dependencies]`, and `[dependency-groups]`.