### PR TITLE
Handle non-table [tool] in pyproject/lockfile readers

### DIFF
--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -18,6 +18,7 @@ import tomli
 
 from nab_index.client import SdistFile, WheelFile
 
+from .._toml import tool_nab_section
 from .._vendor.packaging.pylock import Pylock, PylockValidationError
 from .._vendor.packaging.utils import canonicalize_name
 
@@ -156,7 +157,8 @@ def read_lockfile_anchor(path: Path) -> datetime | None:
             data = tomli.load(f)
     except (OSError, tomli.TOMLDecodeError):
         return None
-    raw = data.get("tool", {}).get("nab", {}).get("created-at")
+    nab = tool_nab_section(data)
+    raw = nab.get("created-at") if isinstance(nab, dict) else None
     if isinstance(raw, datetime):
         return raw if raw.tzinfo else raw.replace(tzinfo=timezone.utc)
     if isinstance(raw, str):

--- a/nab-python/src/nab_python/_toml.py
+++ b/nab-python/src/nab_python/_toml.py
@@ -1,0 +1,16 @@
+"""Shared helpers for reading the ``[tool.nab]`` section of a pyproject."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def tool_nab_section(data: dict[str, Any]) -> Any:
+    """Return the raw ``[tool.nab]`` value from parsed TOML ``data``.
+
+    Returns ``{}`` when ``[tool]`` is absent or is not a table, so callers
+    can chain ``.get`` safely. The value may itself be a non-table when
+    ``[tool.nab]`` is malformed; callers that require a table check.
+    """
+    tool = data.get("tool", {})
+    return tool.get("nab", {}) if isinstance(tool, dict) else {}

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -18,6 +18,7 @@ import tomli
 
 from nab_index.multi_index import IndexConfig
 
+from ._toml import tool_nab_section
 from ._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from ._vendor.packaging.utils import canonicalize_name
 from ._vendor.packaging.version import InvalidVersion, Version
@@ -174,7 +175,7 @@ def read_pyproject_config(
         anchor = datetime.now(timezone.utc)
     with path.open("rb") as f:
         data = tomli.load(f)
-    raw = data.get("tool", {}).get("nab", {})
+    raw = tool_nab_section(data)
     if not isinstance(raw, dict):
         msg = f"[tool.nab] must be a table, got {type(raw).__name__}"
         raise ConfigError(msg)
@@ -435,7 +436,7 @@ def read_pyproject_lock_anchor(path: Path) -> datetime | None:
             data = tomli.load(f)
     except (FileNotFoundError, tomli.TOMLDecodeError):
         return None
-    raw = data.get("tool", {}).get("nab", {})
+    raw = tool_nab_section(data)
     value = raw.get("uploaded-prior-to") if isinstance(raw, dict) else None
     if isinstance(value, str) and _DURATION_PATTERN.match(value):
         return None

--- a/nab-python/src/nab_python/workspace.py
+++ b/nab-python/src/nab_python/workspace.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 
 import tomli
 
+from ._toml import tool_nab_section
 from ._vendor.packaging.utils import canonicalize_name
 from .provider import BuildPolicy, LocalSource
 
@@ -89,7 +90,8 @@ def discover_workspace_root(member_pyproject: Path) -> Path | None:
                 data = tomli.load(f)
         except (OSError, tomli.TOMLDecodeError):
             continue
-        if "workspace" in data.get("tool", {}).get("nab", {}):
+        nab = tool_nab_section(data)
+        if isinstance(nab, dict) and "workspace" in nab:
             return candidate
     return None
 

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -53,6 +53,10 @@ class TestDefaults:
         config = read_pyproject_config(path)
         assert config == NabProjectConfig()
 
+    def test_non_table_tool_returns_defaults(self, tmp_path: Path) -> None:
+        path = write(tmp_path, 'tool = "not-a-table"\n')
+        assert read_pyproject_config(path) == NabProjectConfig()
+
 
 class TestMode:
     def test_specific_explicit(self, tmp_path: Path) -> None:
@@ -324,6 +328,10 @@ class TestReadLockAnchor:
 
     def test_non_table_tool_nab_returns_none(self, tmp_path: Path) -> None:
         path = write(tmp_path, 'tool = {nab = "oops"}\n')
+        assert read_pyproject_lock_anchor(path) is None
+
+    def test_non_table_tool_returns_none(self, tmp_path: Path) -> None:
+        path = write(tmp_path, 'tool = "oops"\n')
         assert read_pyproject_lock_anchor(path) is None
 
     def test_missing_file_returns_none(self, tmp_path: Path) -> None:

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -45,6 +45,7 @@ from nab_python.lockfile import (
     WheelArtifact,
     build_lock_input_from_provider,
     build_pylock,
+    read_lockfile_anchor,
     read_lockfile_packages,
     write_lock,
     write_requirements_with_hashes,
@@ -722,33 +723,23 @@ class TestReadLockfileAnchor:
     """``read_lockfile_anchor`` extracts ``[tool.nab].created-at``."""
 
     def test_returns_none_when_file_missing(self, tmp_path: Path) -> None:
-        from nab_python.lockfile import read_lockfile_anchor
-
         assert read_lockfile_anchor(tmp_path / "missing.toml") is None
 
     def test_returns_none_when_file_is_directory(self, tmp_path: Path) -> None:
         # ``is_file`` returns False for directories; the helper skips.
-        from nab_python.lockfile import read_lockfile_anchor
-
         assert read_lockfile_anchor(tmp_path) is None
 
     def test_returns_none_when_toml_invalid(self, tmp_path: Path) -> None:
-        from nab_python.lockfile import read_lockfile_anchor
-
         path = tmp_path / "broken.toml"
         path.write_text("this is not [[[ valid TOML")
         assert read_lockfile_anchor(path) is None
 
     def test_returns_none_when_no_tool_nab(self, tmp_path: Path) -> None:
-        from nab_python.lockfile import read_lockfile_anchor
-
         path = tmp_path / "pylock.toml"
         path.write_text('lock-version = "1.0"\n')
         assert read_lockfile_anchor(path) is None
 
     def test_reads_offset_datetime(self, tmp_path: Path) -> None:
-        from nab_python.lockfile import read_lockfile_anchor
-
         path = tmp_path / "pylock.toml"
         path.write_text(
             "[tool.nab]\ncreated-at = 2026-05-01T00:00:00+00:00\n",
@@ -756,8 +747,6 @@ class TestReadLockfileAnchor:
         assert read_lockfile_anchor(path) == datetime(2026, 5, 1, tzinfo=timezone.utc)
 
     def test_reads_iso_string(self, tmp_path: Path) -> None:
-        from nab_python.lockfile import read_lockfile_anchor
-
         path = tmp_path / "pylock.toml"
         # Some writers may emit the timestamp as a quoted string instead
         # of a TOML offset-date-time; the reader handles both shapes.
@@ -767,8 +756,6 @@ class TestReadLockfileAnchor:
         assert read_lockfile_anchor(path) == datetime(2026, 5, 1, tzinfo=timezone.utc)
 
     def test_naive_datetime_coerced_to_utc(self, tmp_path: Path) -> None:
-        from nab_python.lockfile import read_lockfile_anchor
-
         path = tmp_path / "pylock.toml"
         path.write_text(
             "[tool.nab]\ncreated-at = 2026-05-01T00:00:00\n",
@@ -776,8 +763,6 @@ class TestReadLockfileAnchor:
         assert read_lockfile_anchor(path) == datetime(2026, 5, 1, tzinfo=timezone.utc)
 
     def test_naive_iso_string_coerced_to_utc(self, tmp_path: Path) -> None:
-        from nab_python.lockfile import read_lockfile_anchor
-
         path = tmp_path / "pylock.toml"
         path.write_text(
             '[tool.nab]\ncreated-at = "2026-05-01T00:00:00"\n',
@@ -785,8 +770,6 @@ class TestReadLockfileAnchor:
         assert read_lockfile_anchor(path) == datetime(2026, 5, 1, tzinfo=timezone.utc)
 
     def test_invalid_iso_string_returns_none(self, tmp_path: Path) -> None:
-        from nab_python.lockfile import read_lockfile_anchor
-
         path = tmp_path / "pylock.toml"
         path.write_text(
             '[tool.nab]\ncreated-at = "not-a-date"\n',
@@ -794,10 +777,18 @@ class TestReadLockfileAnchor:
         assert read_lockfile_anchor(path) is None
 
     def test_non_datetime_value_returns_none(self, tmp_path: Path) -> None:
-        from nab_python.lockfile import read_lockfile_anchor
-
         path = tmp_path / "pylock.toml"
         path.write_text("[tool.nab]\ncreated-at = 1234\n")
+        assert read_lockfile_anchor(path) is None
+
+    def test_non_table_tool_returns_none(self, tmp_path: Path) -> None:
+        path = tmp_path / "pylock.toml"
+        path.write_text('tool = "not-a-table"\n')
+        assert read_lockfile_anchor(path) is None
+
+    def test_non_table_tool_nab_returns_none(self, tmp_path: Path) -> None:
+        path = tmp_path / "pylock.toml"
+        path.write_text('tool = {nab = "oops"}\n')
         assert read_lockfile_anchor(path) is None
 
 

--- a/nab-python/tests/test_workspace.py
+++ b/nab-python/tests/test_workspace.py
@@ -93,6 +93,40 @@ class TestDiscoverWorkspaceRoot:
             tmp_path / "outer" / "pyproject.toml"
         )
 
+    def test_walks_past_non_table_tool(self, tmp_path: Path) -> None:
+        # A non-table top-level ``tool`` must be skipped, not crash the walk.
+        _write(
+            tmp_path / "outer" / "pyproject.toml",
+            '[project]\nname = "outer"\nversion = "0"\n'
+            "[tool.nab.workspace]\nmembers = []\n",
+        )
+        _write(tmp_path / "outer" / "inner" / "pyproject.toml", 'tool = "oops"\n')
+        member = _write(
+            tmp_path / "outer" / "inner" / "pkg" / "pyproject.toml",
+            '[project]\nname = "pkg"\nversion = "0"\n',
+        )
+        assert discover_workspace_root(member) == (
+            tmp_path / "outer" / "pyproject.toml"
+        )
+
+    def test_walks_past_non_table_tool_nab(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "outer" / "pyproject.toml",
+            '[project]\nname = "outer"\nversion = "0"\n'
+            "[tool.nab.workspace]\nmembers = []\n",
+        )
+        _write(
+            tmp_path / "outer" / "inner" / "pyproject.toml",
+            '[tool]\nnab = "oops"\n',
+        )
+        member = _write(
+            tmp_path / "outer" / "inner" / "pkg" / "pyproject.toml",
+            '[project]\nname = "pkg"\nversion = "0"\n',
+        )
+        assert discover_workspace_root(member) == (
+            tmp_path / "outer" / "pyproject.toml"
+        )
+
 
 class TestReadWorkspaceMembers:
     def test_literal_members_become_local_sources(self, tmp_path: Path) -> None:


### PR DESCRIPTION
All three pyproject/lockfile readers called `.get("nab", {})` on the raw `[tool]` value without checking whether `[tool]` was actually a table. A pyproject.toml containing `tool = "string"` would raise `AttributeError` instead of being silently skipped.

The fix extracts a shared `tool_nab_section()` helper in `nab_python/_toml.py` that guards the `isinstance(tool, dict)` check in one place. Each reader now calls the helper and the three affected paths (config, workspace walk, lockfile anchor) handle the non-table case as they already handled a missing `[tool]` section.