### PR TITLE
Error on naive index upload-time instead of coercing

### DIFF
--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -302,6 +302,19 @@ def excluded_by_time(provider: Provider, normalized: str, dist: DistFile) -> boo
     except ValueError:
         provider.stats.excluded_by_time += 1
         return True
+
+    # PEP 700 mandates timezone-aware UTC upload times; refuse to guess.
+    if upload_dt.tzinfo is None:
+        # Imported lazily: provider.py imports this module.
+        from ..provider import InvalidUploadTimeError
+
+        msg = (
+            f"{normalized} {dist.version} has a timezone-naive upload time "
+            f"{dist.upload_time!r}; the Simple API requires "
+            f"timezone-aware (UTC) upload times"
+        )
+        raise InvalidUploadTimeError(msg)
+
     excluded = upload_dt >= cutoff
     if excluded:
         provider.stats.excluded_by_time += 1

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -50,6 +50,7 @@ __all__ = [
     "DistFile",
     "DistPolicy",
     "ExtrasMode",
+    "InvalidUploadTimeError",
     "LocalSource",
     "MetadataError",
     "MissingExtraError",
@@ -289,6 +290,12 @@ class UnsupportedSdistError(MetadataError):
     :meth:`Provider._look_ahead_ok` so the resolver skips the
     version instead of failing.
     """
+
+
+# Deliberately not a MetadataError: _look_ahead_ok catches MetadataError
+# and would silently reject the version; a naive upload-time is a hard error.
+class InvalidUploadTimeError(Exception):
+    """Raised when an index upload-time is not the timezone-aware UTC PEP 700 needs."""
 
 
 def _add_extra_marker(dep_str: str, extra_name: str) -> str:

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -27,6 +27,7 @@ from nab_python.provider import (
     BuildPolicy,
     DistPolicy,
     ExtrasMode,
+    InvalidUploadTimeError,
     LocalSource,
     MetadataError,
     MissingExtraError,
@@ -2090,6 +2091,31 @@ class TestUploadedPriorTo:
         cutoff = datetime(2024, 3, 1, tzinfo=timezone.utc)
         provider = Provider(coordinator, uploaded_prior_to=cutoff)
         assert provider.fetch_versions("foo") == []
+
+    def test_naive_upload_time_raises_when_cutoff_active(self) -> None:
+        """A timezone-naive upload-time violates PEP 700, so it is a hard error."""
+        wheels = [
+            make_wheel("1.0", upload_time="2024-01-01T00:00:00"),
+        ]
+        coordinator = make_coordinator(wheels, package="foo")
+        cutoff = datetime(2024, 3, 1, tzinfo=timezone.utc)
+        provider = Provider(coordinator, uploaded_prior_to=cutoff)
+        with pytest.raises(InvalidUploadTimeError, match="2024-01-01T00:00:00"):
+            provider.fetch_versions("foo")
+
+    def test_naive_upload_time_not_metadata_error(self) -> None:
+        """The error is not a MetadataError, so look-ahead cannot swallow it."""
+        assert not issubclass(InvalidUploadTimeError, MetadataError)
+
+    def test_naive_upload_time_ignored_without_cutoff(self) -> None:
+        """With no cutoff active the naive upload-time is never inspected."""
+        wheels = [
+            make_wheel("1.0", upload_time="2024-01-01T00:00:00"),
+        ]
+        coordinator = make_coordinator(wheels, package="foo")
+        provider = Provider(coordinator)
+        versions = [v for v, _ in provider.fetch_versions("foo")]
+        assert versions == [V("1.0")]
 
 
 class TestUploadedPriorToOverrides:

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -153,7 +153,7 @@ def is_stdout(output: Path | None) -> bool:
     return output is not None and str(output) == "-"
 
 
-def _resolve_specific(  # noqa: PLR0913 - one wrapper per resolve_pyproject kwarg
+def _resolve_specific(  # noqa: PLR0913, C901 - one wrapper per resolve_pyproject kwarg / exit-mapped error
     path: Path,
     *,
     config: NabProjectConfig,

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -36,7 +36,7 @@ from nab_python.lockfile import (
     write_requirements_with_hashes,  # noqa: F401 - re-exported for tests
     write_requirements_without_hashes,  # noqa: F401 - re-exported for tests
 )
-from nab_python.provider import UnsupportedVcsError
+from nab_python.provider import InvalidUploadTimeError, UnsupportedVcsError
 from nab_python.requirements_file import InvalidProjectRequirementError
 from nab_python.resolve import (
     resolve_pyproject,
@@ -181,6 +181,9 @@ def _resolve_specific(  # noqa: PLR0913 - one wrapper per resolve_pyproject kwar
     except UnsupportedVcsError as e:
         sys.stderr.write(f"{failure_prefix}: {e}\n")
         sys.exit(1)
+    except InvalidUploadTimeError as e:
+        sys.stderr.write(f"Error: {e}\n")
+        sys.exit(1)
     except KeyError:
         sys.stderr.write(f"Error: {path} has no [project].dependencies\n")
         sys.exit(1)
@@ -229,6 +232,9 @@ def _resolve_universal(
             extras=extras,
             resolution_strategy=resolution_strategy,
         )
+    except InvalidUploadTimeError as e:
+        sys.stderr.write(f"Error: {e}\n")
+        sys.exit(1)
     except KeyError:
         sys.stderr.write(f"Error: {path} has no [project].dependencies\n")
         sys.exit(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,7 +46,11 @@ from nab_python.lockfile import (
     SdistArtifact,
     WheelArtifact,
 )
-from nab_python.provider import ResolutionStrategy, UnsupportedVcsError
+from nab_python.provider import (
+    InvalidUploadTimeError,
+    ResolutionStrategy,
+    UnsupportedVcsError,
+)
 from nab_python.requirements_file import InvalidProjectRequirementError
 from nab_python.resolve import ResolutionResult
 from nab_python.universal.matrix import Matrix, MatrixTuple
@@ -301,6 +305,21 @@ class TestLockCommandSpecific:
             lock(pyproject)
         assert "refusing direct-URL requirement" in capsys.readouterr().err
 
+    def test_invalid_upload_time_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A naive index upload-time exits 1 with a clean message, not a traceback."""
+        pyproject = _make_pyproject(tmp_path)
+        with (
+            patch(
+                "nab.cli.resolve_pyproject",
+                side_effect=InvalidUploadTimeError("foo 1.0 has a naive upload time"),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject)
+        assert "naive upload time" in capsys.readouterr().err
+
     def test_not_implemented_vcs_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -442,6 +461,22 @@ class TestLockCommandUniversal:
         ):
             lock(pyproject, output=out)
         assert "invalid requirement" in capsys.readouterr().err
+
+    def test_invalid_upload_time_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A naive index upload-time exits 1 with a clean message, not a traceback."""
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with (
+            patch(
+                "nab.cli.resolve_universal_pyproject",
+                side_effect=InvalidUploadTimeError("foo 1.0 has a naive upload time"),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, output=out)
+        assert "naive upload time" in capsys.readouterr().err
 
     def test_pylock_writes_universal_lock(self, tmp_path: Path) -> None:
         """Universal + pylock format runs the real merge + write pipeline."""


### PR DESCRIPTION
When a PyPI Simple API response carries a naive (timezone-free) `upload_time`, comparing it against the aware `uploaded_prior_to` cutoff raised a `TypeError`. PEP 700 mandates timezone-aware UTC upload times, so a naive value is a spec violation we refuse to guess about rather than silently coerce to UTC.

The cooldown filter now raises a dedicated `InvalidUploadTimeError` naming the package, version, and offending value. It deliberately does not subclass `MetadataError`, so the look-ahead cannot turn it into a silent per-version rejection; it is a hard error. Both resolve wrappers surface it as a clean exit 1. The check only runs when a cooldown cutoff is active, so a naive upload-time without a cutoff is never inspected.