### PR TITLE
Reject oversized uploaded-prior-to duration

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -379,7 +379,11 @@ def _parse_uploaded_prior_to(value: object, *, anchor: datetime) -> datetime | N
     duration_match = _DURATION_PATTERN.match(value)
     if duration_match is not None:
         days = int(duration_match.group(1))
-        return anchor - timedelta(days=days)
+        try:
+            return anchor - timedelta(days=days)
+        except OverflowError:
+            msg = f"uploaded-prior-to duration is too large: {value!r}"
+            raise ConfigError(msg) from None
     # Python 3.10's fromisoformat rejects a trailing 'Z'; 3.11+ accept it.
     iso_value = f"{value[:-1]}+00:00" if value.endswith("Z") else value
     try:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -254,6 +254,13 @@ class TestUploadedPriorTo:
         with pytest.raises(ConfigError, match="must be an ISO 8601 datetime"):
             read_pyproject_config(path)
 
+    def test_duration_overflow_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path, '[tool.nab]\nuploaded-prior-to = "P99999999999999999999D"\n'
+        )
+        with pytest.raises(ConfigError, match="duration is too large"):
+            read_pyproject_config(path)
+
     def test_invalid_string_rejected(self, tmp_path: Path) -> None:
         path = write(tmp_path, '[tool.nab]\nuploaded-prior-to = "not-a-date"\n')
         with pytest.raises(ConfigError, match="must be an ISO 8601 datetime"):


### PR DESCRIPTION
A very large `PnD` value (e.g. `P99999999999999999999D`) caused an unhandled `OverflowError` in `timedelta` when computing the cutoff date. This converts that crash into a `ConfigError` with a clear message.