### PR TITLE
Raise on sdist-install pin with no sdist

### DIFF
--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "MissingHashError",
+    "MissingSdistError",
     "MissingVcsCommitError",
     "build_lock_input_from_provider",
     "read_lockfile_anchor",
@@ -109,6 +110,17 @@ class MissingHashError(ValueError):
     spec-compliant entry.  Surface the failure with the offending
     package and filename so the user can either add a hash to their
     local index or exclude the package.
+    """
+
+
+class MissingSdistError(ValueError):
+    """A version pinned under sdist-install has no source distribution.
+
+    ``DistPolicy.SDIST_INSTALL`` drops every wheel from the lock so the
+    installer builds from source.  When the version has no sdist (it was
+    published wheel-only, or its sdist fell outside an ``uploaded-prior-to``
+    cooldown while a wheel survived), emitting the pin would write a package
+    entry with no artefacts, an uninstallable lock.  Surface it loudly.
     """
 
 
@@ -285,6 +297,14 @@ def _index_pin_from_listing(
     files = list(provider.dist_files_for(canonical, version))
     if provider.effective_dist_policy(canonical) is DistPolicy.SDIST_INSTALL:
         files = [f for f in files if not isinstance(f, WheelFile)]
+        if not files:
+            msg = (
+                f"{canonical} {version}: dist-policy 'sdist-install' requires a "
+                "source distribution, but none is available for this version "
+                "(it may be wheel-only, or its sdist was excluded by an "
+                "'uploaded-prior-to' cooldown)"
+            )
+            raise MissingSdistError(msg)
 
     wheels = tuple(
         _build_artifact(canonical, f, WheelArtifact)

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 
 from ._lockfile.builder import (
     MissingHashError,
+    MissingSdistError,
     MissingVcsCommitError,
     build_lock_input_from_provider,
     read_lockfile_anchor,
@@ -46,6 +47,7 @@ __all__ = [
     "LocalPin",
     "LockInput",
     "MissingHashError",
+    "MissingSdistError",
     "MissingVcsCommitError",
     "PinShape",
     "Provenance",

--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -34,6 +34,7 @@ from ..fetch import (
 from ..lockfile import (
     LockInput,
     MissingHashError,
+    MissingSdistError,
     PinShape,
     build_lock_input_from_provider,
 )
@@ -562,12 +563,12 @@ def _resolve_one_tuple(  # noqa: PLR0913
         lock_input = build_lock_input_from_provider(
             provider, pins, indexes=coordinator.indexes
         )
-    except MissingHashError as exc:
+    except (MissingHashError, MissingSdistError) as exc:
         return TupleResult(
             tuple_=t,
             success=False,
             pins=pins,
-            error=f"MissingHashError: {exc}"[:_ERROR_MESSAGE_LIMIT],
+            error=f"{type(exc).__name__}: {exc}"[:_ERROR_MESSAGE_LIMIT],
             wall_time=elapsed,
             rounds=resolver.stats.rounds,
             decisions=resolver.stats.decisions,

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -37,6 +37,7 @@ from nab_python.lockfile import (
     LocalPin,
     LockInput,
     MissingHashError,
+    MissingSdistError,
     MissingVcsCommitError,
     Provenance,
     SdistArtifact,
@@ -1241,6 +1242,15 @@ class TestBuildLockInputFromProvider:
         assert pin.wheels == ()
         assert pin.sdist is not None
         assert pin.sdist.hashes == (("sha256", "b" * 64),)
+
+    def test_index_pin_sdist_install_without_sdist_raises(self) -> None:
+        """sdist-install with no sdist available raises MissingSdistError."""
+        provider = _FakeProvider(
+            listings={"foo": [(Version("1.0"), _wheel_file())]},
+            dist_policy_overrides={"foo": DistPolicy.SDIST_INSTALL},
+        )
+        with pytest.raises(MissingSdistError, match="sdist-install"):
+            build_lock_input_from_provider(provider, {"foo": Version("1.0")})
 
     def test_index_pin_records_serving_index(self) -> None:
         provider = _FakeProvider(

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -30,6 +30,7 @@ from nab_python.config import (
 from nab_python.download import download_lock  # noqa: F401 - re-exported for tests
 from nab_python.lockfile import (
     MissingHashError,
+    MissingSdistError,
     write_lock,  # noqa: F401 - re-exported for tests
     write_requirements_with_hashes,  # noqa: F401 - re-exported for tests
     write_requirements_without_hashes,  # noqa: F401 - re-exported for tests
@@ -180,7 +181,7 @@ def _resolve_specific(  # noqa: PLR0913 - one wrapper per resolve_pyproject kwar
     except LookupError as e:
         sys.stderr.write(f"Error: {e}\n")
         sys.exit(1)
-    except MissingHashError as e:
+    except (MissingHashError, MissingSdistError) as e:
         sys.stderr.write(f"{failure_prefix}: {e}\n")
         sys.exit(1)
 


### PR DESCRIPTION
When `dist-policy = "sdist-install"` is set, the lock builder strips every wheel from the pin so the installer builds from source. If the version has no sdist (wheel-only package, or sdist excluded by an `uploaded-prior-to` cooldown), that left an entry with no artefacts and no error. The installer would later fail on an uninstallable lock with no clear message.

This adds `MissingSdistError` and raises it at lock-build time instead, with a message naming the package and version.