### PR TITLE
Reject wheel-only pins under sdist-install policy

### DIFF
--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -115,13 +115,14 @@ class MissingHashError(ValueError):
 
 
 class MissingSdistError(ValueError):
-    """A version pinned under sdist-install has no source distribution.
+    """A ``sdist-install`` package's pinned version has no sdist.
 
-    ``DistPolicy.SDIST_INSTALL`` drops every wheel from the lock so the
-    installer builds from source.  When the version has no sdist (it was
-    published wheel-only, or its sdist fell outside an ``uploaded-prior-to``
-    cooldown while a wheel survived), emitting the pin would write a package
-    entry with no artefacts, an uninstallable lock.  Surface it loudly.
+    Under :attr:`~nab_python.provider.DistPolicy.SDIST_INSTALL` the
+    resolver may read a wheel's metadata but the lock must pin only the
+    sdist.  When the pinned version publishes wheels but no sdist, the
+    wheels are dropped and nothing is left to pin.  Surface the package
+    and version so the user can pick a version with an sdist or relax
+    the policy, rather than emitting an empty package the spec rejects.
     """
 
 
@@ -299,12 +300,11 @@ def _index_pin_from_listing(
     files = list(provider.dist_files_for(canonical, version))
     if provider.effective_dist_policy(canonical) is DistPolicy.SDIST_INSTALL:
         files = [f for f in files if not isinstance(f, WheelFile)]
-        if not files:
+        if not any(isinstance(f, SdistFile) for f in files):
             msg = (
-                f"{canonical} {version}: dist-policy 'sdist-install' requires a "
-                "source distribution, but none is available for this version "
-                "(it may be wheel-only, or its sdist was excluded by an "
-                "'uploaded-prior-to' cooldown)"
+                f"{canonical}=={version} has no sdist, but its dist-policy is "
+                f"'sdist-install'; pick a version that publishes an sdist or "
+                f"change dist-policy for {canonical}"
             )
             raise MissingSdistError(msg)
 

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -1272,12 +1272,12 @@ class TestBuildLockInputFromProvider:
         assert pin.sdist.hashes == (("sha256", "b" * 64),)
 
     def test_index_pin_sdist_install_without_sdist_raises(self) -> None:
-        """sdist-install with no sdist available raises MissingSdistError."""
+        """A wheel-only version under sdist-install has nothing to pin."""
         provider = _FakeProvider(
             listings={"foo": [(Version("1.0"), _wheel_file())]},
             dist_policy_overrides={"foo": DistPolicy.SDIST_INSTALL},
         )
-        with pytest.raises(MissingSdistError, match="sdist-install"):
+        with pytest.raises(MissingSdistError, match="foo==1.0 has no sdist"):
             build_lock_input_from_provider(provider, {"foo": Version("1.0")})
 
     def test_index_pin_records_serving_index(self) -> None:

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -315,6 +315,23 @@ class TestResolveOneTuple:
         assert "MissingHashError" in tr.error
         assert tr.pins == {"pkg": Version("1.0")}
 
+    def test_sdist_install_without_sdist_reports_failed_tuple(self) -> None:
+        """A wheel-only version under sdist-install fails the tuple."""
+        coordinator = _make_coordinator({"pkg": [_make_wheel("1.0", package="pkg")]})
+        tr = _resolve_one_tuple(
+            coordinator,
+            _linux_311(),
+            requirements={"pkg": VersionRange.full()},
+            constraints=None,
+            uploaded_prior_to=None,
+            dist_policy=DistPolicy.SDIST_INSTALL,
+            build_policy=BuildPolicy.NEVER,
+        )
+        assert not tr.success
+        assert tr.error is not None
+        assert "MissingSdistError" in tr.error
+        assert tr.pins == {"pkg": Version("1.0")}
+
 
 _FORTY_SHA = "0123456789abcdef0123456789abcdef01234567"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,6 +44,7 @@ from nab_python.lockfile import (
     IndexPin,
     LockInput,
     MissingHashError,
+    MissingSdistError,
     SdistArtifact,
     WheelArtifact,
 )
@@ -385,6 +386,21 @@ class TestLockCommandSpecific:
         err = capsys.readouterr().err
         assert "Cannot lock" in err
         assert "503" in err
+
+    def test_missing_sdist_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """MissingSdistError exits 1 with the message instead of a traceback."""
+        pyproject = _make_pyproject(tmp_path)
+        with (
+            patch(
+                "nab.cli.resolve_pyproject",
+                side_effect=MissingSdistError("foo==1.0 has no sdist"),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject)
+        assert "Cannot lock" in capsys.readouterr().err
 
     def test_lookup_error_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
When a package has `dist-policy = "sdist-install"`, the resolver is allowed to read wheel metadata during resolution, but the lockfile must pin only the sdist. If the pinned version publishes wheels but no sdist, the code silently dropped the wheels and wrote an empty file list, which the PEP 751 spec rejects.

This adds `MissingSdistError` and raises it in `_index_pin_from_listing` before the lock entry is written. The error names the package, version, and what to do (pick a version with an sdist or change the policy). Both the specific and universal resolution paths surface it as a clean user-facing error rather than a traceback.