### PR TITLE
Fix constraint-driven false UNSAT in resolver

### DIFF
--- a/nab-resolver/src/nab_resolver/decide.py
+++ b/nab-resolver/src/nab_resolver/decide.py
@@ -21,7 +21,6 @@ __all__ = [
     "absorb_pending_clauses",
     "choose_package_to_decide",
     "choose_version",
-    "inject_constraint",
     "record_no_versions",
 ]
 
@@ -65,35 +64,17 @@ def choose_package_to_decide(resolver: Resolver[Any, Any]) -> Any | None:
     return min(undecided, key=sort_key)
 
 
-def inject_constraint(resolver: Resolver[Any, Any], package: Any) -> bool:
-    """Inject a CONSTRAINT incompatibility for a package, if applicable.
-
-    Lazy: only fires the first time the package is about to be decided.
-    Returns True if an incompatibility was injected (caller re-propagates).
-    """
-    if package not in resolver.constraints:
-        return False
-    if package in resolver.injected_constraints:
-        return False
-
-    resolver.injected_constraints.add(package)
-    complement = ~resolver.constraints[package]
-    if complement.is_empty:
-        return False
-
-    add_incompatibility(
-        resolver,
-        Incompatibility(
-            [Term(package, complement, positive=True)],
-            cause=IncompatibilityCause.CONSTRAINT,
-        ),
-    )
-    return True
-
-
 def choose_version(resolver: Resolver[Any, Any], package: Any) -> Any | None:
-    """Ask the provider to pick a version within the allowed range."""
+    """Ask the provider to pick a version within the allowed range.
+
+    A user constraint narrows the acceptable range here rather than acting
+    as an incompatibility: it restricts which version is picked but never
+    forces the package into the solution.
+    """
     current_range = resolver.solution.get(package) or resolver.range_type.full()
+    constraint = resolver.constraints.get(package)
+    if constraint is not None:
+        current_range = current_range & constraint
     resolver.provider.receive_partial_solution_hint(
         resolver.solution.positive_ranges(),
         resolver.solution.decisions(),
@@ -129,10 +110,23 @@ def record_no_versions(
 
     current_range = resolver.solution.get(package) or resolver.range_type.full()
     resolver.observer.on_no_versions(package, current_range)
+
+    # When a constraint narrowed the searched range it is the reason no
+    # acceptable version was found, so attribute the clause to it.
+    constraint = resolver.constraints.get(package)
+    constrained = (
+        constraint is not None and (current_range & constraint) != current_range
+    )
+    cause = (
+        IncompatibilityCause.CONSTRAINT
+        if constrained
+        else IncompatibilityCause.NO_VERSIONS
+    )
+
     add_incompatibility(
         resolver,
         Incompatibility(
             [Term(package, current_range, positive=True)],
-            cause=IncompatibilityCause.NO_VERSIONS,
+            cause=cause,
         ),
     )

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -277,7 +277,6 @@ class Resolver(Generic[PackageType, VersionType]):
         self.stats: ResolverStats[PackageType] = ResolverStats()
 
         self.constraints: Mapping[PackageType, RangeProtocol[VersionType]] = {}
-        self.injected_constraints: set[PackageType] = set()
         self.root_package_order: dict[PackageType, tuple[int, int, str]] = {}
         self.pending_targeted_backtrack: list[PackageType] = []
 
@@ -369,9 +368,6 @@ class Resolver(Generic[PackageType, VersionType]):
 
     def _decide_next(self, next_package: Any) -> Any:
         """Run the decision phase for ``next_package``. Return next changed package."""
-        if decide.inject_constraint(self, next_package):
-            return next_package
-
         chosen_version = decide.choose_version(self, next_package)
         had_pending = decide.absorb_pending_clauses(self)
 
@@ -437,7 +433,6 @@ class Resolver(Generic[PackageType, VersionType]):
         self.stats = ResolverStats()
 
         self.constraints = constraints or {}
-        self.injected_constraints.clear()
         self.root_package_order.clear()
         self.pending_targeted_backtrack.clear()
         self.tiebreak_cache.clear()

--- a/nab-resolver/tests/property/providers.py
+++ b/nab-resolver/tests/property/providers.py
@@ -275,13 +275,20 @@ MAX_BRUTE_FORCE_COMBINATIONS = 10_000
 def brute_force_has_solution(
     graph: dict[str, dict[int, dict[str, Range[int]]]],
     requirements: dict[str, Range[int]],
+    constraints: dict[str, Range[int]] | None = None,
 ) -> bool | None:
     """Check whether any version selection satisfies all constraints.
 
     Tries every (package, version) combination over the reachable
     sub-graph.  Returns ``True``/``False``, or ``None`` when the
     search space exceeds :data:`MAX_BRUTE_FORCE_COMBINATIONS`.
+
+    A user constraint restricts the version of a package only when that
+    package is reachable from the root: a constrained package that is
+    never pulled in leaves its constraint vacuous, mirroring the
+    resolver's own constraint semantics.
     """
+    constraints = constraints or {}
     all_packages = sorted(p for p in graph if p != "root" and graph[p])
 
     total_combinations = 1
@@ -324,6 +331,12 @@ def brute_force_has_solution(
                     queue.append(dep_pkg)
             if not valid:
                 break
+
+        if valid and any(
+            pkg in reachable and selection[pkg] not in crange
+            for pkg, crange in constraints.items()
+        ):
+            valid = False
 
         if valid:
             return True

--- a/nab-resolver/tests/property/strategies.py
+++ b/nab-resolver/tests/property/strategies.py
@@ -367,6 +367,39 @@ def small_exhaustive_graphs(
 
 
 @st.composite
+def graph_and_constraints(
+    draw: st.DrawFn,
+) -> tuple[dict[str, dict[int, dict[str, Range[int]]]], dict[str, Range[int]]]:
+    """Draw a small graph together with constraints over its packages.
+
+    Constraints lean toward singletons because pinning a package to one
+    version is what forces it to drag in a conflicting dependency, the
+    shape that exposes constraint-driven completeness bugs.
+    """
+    graph = draw(small_exhaustive_graphs())
+    packages = [p for p in graph if p != "root"]
+    num_constraints = draw(st.integers(min_value=0, max_value=min(2, len(packages))))
+    constrained = (
+        draw(
+            st.lists(
+                st.sampled_from(packages),
+                min_size=num_constraints,
+                max_size=num_constraints,
+                unique=True,
+            )
+        )
+        if num_constraints
+        else []
+    )
+    constraint_range = st.one_of(
+        st.builds(Range.singleton, st.integers(min_value=1, max_value=3)),
+        dependency_ranges(),
+    )
+    constraints = {pkg: draw(constraint_range) for pkg in constrained}
+    return graph, constraints
+
+
+@st.composite
 def empty_dep_graphs(
     draw: st.DrawFn,
 ) -> dict[str, dict[int, dict[str, Range[int]]]]:

--- a/nab-resolver/tests/property/test_pubgrub_resolver.py
+++ b/nab-resolver/tests/property/test_pubgrub_resolver.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
-from hypothesis import given
+from hypothesis import example, given
 from hypothesis import strategies as st
 
 from nab_resolver.ranges import Range
@@ -41,6 +41,7 @@ from .strategies import (
     dependency_graphs,
     dependency_ranges,
     empty_dep_graphs,
+    graph_and_constraints,
     guaranteed_solvable_graphs,
     mutual_back_edge_graphs,
     mutual_dep_exhaustive_graphs,
@@ -649,6 +650,56 @@ class TestAgreesWithBruteForce:
                 f"Graph: {graph}\nSolution: {solution}"
             )
             verify_solution(solution, requirements, graph)
+
+    @pytest.mark.timeout(RESOLUTION_TIMEOUT_SECONDS * 200)
+    @given(case=graph_and_constraints())
+    @example(
+        (
+            {
+                "root": {1: {"foo": Range.at_most(7)}},
+                "foo": {7: {"bar": Range.at_least(1)}, 4: {}},
+                "bar": {8: {"foo": Range.less_than(2)}},
+            },
+            {"bar": Range.singleton(8)},
+        )
+    )
+    @BRUTE_FORCE_SETTINGS
+    def test_agrees_with_brute_force_under_constraints(
+        self, case: tuple[dict, dict]
+    ) -> None:
+        """Resolver agrees with constrained brute force for small graphs.
+
+        Constraints restrict but never force a package, so a constraint
+        on a package that a solution never selects is vacuous. Reporting
+        impossible because of such a constraint is a completeness bug.
+        """
+        graph, constraints = case
+        requirements = {"root": Range.singleton(1)}
+        brute_force_sat = brute_force_has_solution(graph, requirements, constraints)
+        if brute_force_sat is None:
+            return
+
+        for provider in (FuzzProvider(graph), PromotingFuzzProvider(graph, 1)):
+            resolver = Resolver(provider, max_iterations=1000)
+            try:
+                solution = resolver.resolve(requirements, constraints=constraints)
+            except ResolutionError as error:
+                if "exceeded" in str(error):
+                    continue
+                assert not brute_force_sat, (
+                    f"Resolver reported impossible but brute-force found a "
+                    f"solution.\nGraph: {graph}\nConstraints: {constraints}"
+                )
+                continue
+
+            assert brute_force_sat, (
+                f"Resolver found a solution but brute-force says impossible.\n"
+                f"Graph: {graph}\nConstraints: {constraints}\nSolution: {solution}"
+            )
+            verify_solution(solution, requirements, graph)
+            for package, constraint_range in constraints.items():
+                if package in solution:
+                    assert solution[package] in constraint_range
 
     @pytest.mark.timeout(RESOLUTION_TIMEOUT_SECONDS * 200)
     @given(

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -1773,6 +1773,46 @@ class TestConstraints:
         )
         assert result["B"] == 2
 
+    def test_constraint_does_not_cause_false_unsat(self) -> None:
+        """A constraint must not block a solution that never uses the package.
+
+        root needs foo<=7. foo==7 pulls in bar; bar's only version needs
+        foo<2, so the foo==7 branch conflicts. foo==4 has no deps, so bar
+        is never used and its constraint is vacuous. The resolver must
+        find {foo: 4} rather than reporting UNSAT.
+        """
+        provider = DictProvider(
+            {
+                "root": {1: {"foo": Range.at_most(7)}},
+                "foo": {7: {"bar": Range.at_least(1)}, 4: {}},
+                "bar": {8: {"foo": Range.less_than(2)}},
+            }
+        )
+        resolver = Resolver(provider)
+        result = resolver.resolve(
+            {"root": Range.singleton(1)},
+            constraints={"bar": Range.singleton(8)},
+        )
+        assert result["foo"] == 4
+        assert "bar" not in result
+
+    def test_no_versions_in_range_is_not_attributed_to_constraint(self) -> None:
+        """A no-versions failure keeps its own provenance when the
+        constraint does not narrow the searched range."""
+        provider = DictProvider(
+            {
+                "root": {1: {"foo": Range.at_least(5)}},
+                "foo": {3: {}, 2: {}},
+            }
+        )
+        resolver = Resolver(provider)
+        with pytest.raises(ResolutionError) as exc_info:
+            resolver.resolve(
+                {"root": Range.singleton(1)},
+                constraints={"foo": Range.at_least(1)},
+            )
+        assert "the user constrained" not in str(exc_info.value)
+
 
 class TestForceResolutionStep:
     """Direct unit tests for ``try_force_resolution_step``.


### PR DESCRIPTION
When a user constraint was passed to the resolver it was injected as a standalone CONSTRAINT incompatibility at decision time. That incompatibility had no requirement antecedent, so conflict analysis could union its constrained term up to universal and discard it, producing a learned clause that excluded a valid solution where the constrained package is never selected.

The fix models a user constraint as a candidate-range filter in `choose_version` instead. The constraint narrows which version the provider sees, but it never forces the package into the solution. The `record_no_versions` path attributes the cause to `CONSTRAINT` only when the constraint actually narrowed the searched range.

A new property test (`test_agrees_with_brute_force_under_constraints`) and two unit tests cover the fix and the correct attribution.