### PR TITLE
Accept micro Metadata-Version in PEP 643 static check

### DIFF
--- a/nab-python/src/nab_python/universal/validate.py
+++ b/nab-python/src/nab_python/universal/validate.py
@@ -344,7 +344,7 @@ def _metadata_is_pep643_static(
     if metadata.metadata_version is None:
         return False
     try:
-        major, minor = (int(p) for p in metadata.metadata_version.split(".", 1))
+        major, minor = (int(p) for p in metadata.metadata_version.split(".")[:2])
     except ValueError:
         return False
     if (major, minor) < _MIN_STATIC_METADATA_VERSION:

--- a/nab-python/tests/universal/test_validate.py
+++ b/nab-python/tests/universal/test_validate.py
@@ -68,6 +68,12 @@ _STATIC_DEPS_METADATA = (
     "\n"
 )
 
+# Same as above but with a micro component on Metadata-Version.
+# 2.2.1 is still >= 2.2, so it qualifies for the static fast path.
+_STATIC_DEPS_METADATA_MICRO = _STATIC_DEPS_METADATA.replace(
+    "Metadata-Version: 2.2", "Metadata-Version: 2.2.1"
+)
+
 
 def _wheel(filename: str) -> WheelFile:
     parts = filename.split("-")
@@ -442,6 +448,15 @@ class TestStaticSdistAuthoritative:
         report = validate_lock(result, coordinator)
         # 2.1 metadata cannot use the fast path.
         assert report.findings[0].status == "ok"
+
+    def test_micro_metadata_version_qualifies(self) -> None:
+        """A Metadata-Version with a micro part (2.2.1) is still >= 2.2."""
+        from nab_python.universal.validate import _baseline_has_static_deps
+
+        wheel = _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl")
+        coordinator = _make_coordinator({"pkg": [wheel]})
+        coordinator.index.store_metadata("pkg", "1.0", _STATIC_DEPS_METADATA_MICRO)
+        assert _baseline_has_static_deps(coordinator, "pkg", Version("1.0")) is True
 
     def test_malformed_metadata_falls_through(self) -> None:
         """Garbage metadata never enters the fast path."""


### PR DESCRIPTION
The PEP 643 static-metadata check in `_metadata_is_pep643_static` used `split(".", 1)` to parse `Metadata-Version`, which splits `"2.2.1"` into `["2", "2.1"]`. Calling `int("2.1")` then raises `ValueError`, causing the check to fall through and treat valid static metadata as non-static.

Fix: use `split(".")[:2]` instead, so `"2.2.1"` yields `["2", "2"]` and is correctly evaluated as `>= 2.2`.