### PR TITLE
Re-admit yanked versions under exact pins

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -158,6 +158,10 @@ class WheelFile:
     the PEP 658/714 sidecar, or ``None`` when the index advertised the
     sidecar without a hash.  The fetcher verifies the sidecar bytes
     against it.
+
+    ``yanked`` records the PEP 592 yank flag.  Yanked files stay in the
+    listing so the resolver can fall back to one when no non-yanked file
+    satisfies a request; otherwise they are skipped.
     """
 
     filename: str
@@ -170,6 +174,7 @@ class WheelFile:
     size: int | None = None
     local_path: Path | None = None
     metadata_hash: tuple[str, str] | None = None
+    yanked: bool = False
 
     @property
     def metadata_url(self) -> str | None:
@@ -193,6 +198,7 @@ class SdistFile:
     hashes: tuple[tuple[str, str], ...] = ()
     size: int | None = None
     local_path: Path | None = None
+    yanked: bool = False
 
 
 class AsyncSimpleClient:
@@ -259,14 +265,14 @@ def _parse_files(
     name check those leak into the listing as a phantom version, and
     show up in the resolved lockfile as ``cffi==2``.
 
-    PEP 592 ``yanked`` files are dropped unconditionally.
+    PEP 592 ``yanked`` files are kept and flagged so the resolver can
+    re-admit one under an exact pin; see :attr:`WheelFile.yanked`.
     """
     expected = canonicalize_name(package)
     files: list[WheelFile | SdistFile] = []
     for file_info in data.get("files", []):
         # PEP 592: ``true`` or a non-empty reason string means yanked.
-        if file_info.get("yanked"):
-            continue
+        yanked = bool(file_info.get("yanked"))
         filename = file_info["filename"]
 
         file_url = file_info["url"]
@@ -302,6 +308,7 @@ def _parse_files(
                     hashes=hashes,
                     size=size,
                     metadata_hash=_metadata_hash(file_info),
+                    yanked=yanked,
                 )
             )
             continue
@@ -320,6 +327,7 @@ def _parse_files(
                     upload_time=file_info.get("upload-time"),
                     hashes=hashes,
                     size=size,
+                    yanked=yanked,
                 )
             )
 

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -68,14 +68,15 @@ _YANKED_ATTR = "data-yanked"
 class _Pep503Parser(HTMLParser):
     """Collect ``<a href="..." data-requires-python="...">`` entries.
 
-    Anchors carrying ``data-yanked`` (PEP 592) are dropped at parse
-    time so the listing never surfaces them.  Matches the PEP 691
-    behaviour in :func:`nab_index.client._parse_files`.
+    Anchors carrying ``data-yanked`` (PEP 592) are kept and flagged, so
+    the resolver can fall back to one when no non-yanked file satisfies a
+    request.  Matches the PEP 691 behaviour in
+    :func:`nab_index.client._parse_files`.
     """
 
     def __init__(self) -> None:
         super().__init__()
-        self.links: list[tuple[str, str | None]] = []
+        self.links: list[tuple[str, str | None, bool]] = []
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         if tag != "a":
@@ -90,8 +91,8 @@ class _Pep503Parser(HTMLParser):
                 requires_python = value
             elif name == _YANKED_ATTR:
                 yanked = True
-        if href is not None and not yanked:
-            self.links.append((href, requires_python))
+        if href is not None:
+            self.links.append((href, requires_python, yanked))
 
 
 _FLAT_EXTS = re.compile(r"\.(whl|tar\.gz)$", re.IGNORECASE)
@@ -107,11 +108,13 @@ def _scan_pep503_directory(
     parser = _Pep503Parser()
     parser.feed(index_html.read_text(encoding="utf-8"))
     files: list[WheelFile | SdistFile] = []
-    for href, requires_python in parser.links:
+    for href, requires_python, yanked in parser.links:
         filename, file_url, local_path, hashes = _resolve_local_link(href, package_dir)
         if filename is None:
             continue
-        record = _make_record(filename, file_url, local_path, requires_python, hashes)
+        record = _make_record(
+            filename, file_url, local_path, requires_python, hashes, yanked=yanked
+        )
         if record is not None:
             files.append(record)
     return files
@@ -198,6 +201,8 @@ def _make_record(
     local_path: Path | None,
     requires_python: str | None,
     hashes: tuple[tuple[str, str], ...],
+    *,
+    yanked: bool = False,
 ) -> WheelFile | SdistFile | None:
     parsed = _parse_wheel_filename(filename)
     if parsed is not None:
@@ -211,6 +216,7 @@ def _make_record(
             upload_time=None,
             hashes=hashes,
             local_path=local_path,
+            yanked=yanked,
         )
     parsed = _parse_sdist_filename(filename)
     if parsed is not None:
@@ -223,6 +229,7 @@ def _make_record(
             upload_time=None,
             hashes=hashes,
             local_path=local_path,
+            yanked=yanked,
         )
     return None
 

--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -97,6 +97,27 @@ def wheel_by_version(
     return cached
 
 
+def yanked_versions(
+    provider: Provider,
+    normalized: str,
+    version_list: list[tuple[Version, DistFile]],
+) -> frozenset[Version]:
+    """Versions whose every distribution file is yanked (PEP 592).
+
+    Such a version is ranked below every non-yanked one and chosen only
+    when no non-yanked version satisfies the request. A version keeping
+    any non-yanked file stays selectable as normal.
+    """
+    cached = provider.yanked_versions_cache.get(normalized)
+    if cached is None:
+        all_yanked: dict[Version, bool] = {}
+        for version, dist in version_list:
+            all_yanked[version] = all_yanked.get(version, True) and dist.yanked
+        cached = frozenset(v for v, yanked in all_yanked.items() if yanked)
+        provider.yanked_versions_cache[normalized] = cached
+    return cached
+
+
 def speculative_prefetch(
     provider: Provider,
     normalized: str,

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -534,6 +534,7 @@ class Provider:
         # Derived views of versions_cache, built lazily alongside the listing.
         self.versions_only_cache: dict[str, list[Version]] = {}
         self.wheel_by_version_cache: dict[str, dict[Version, DistFile]] = {}
+        self.yanked_versions_cache: dict[str, frozenset[Version]] = {}
 
         self.solution_ranges: dict[str, RangeProtocol[Version]] = {}
         self.solution_decisions: dict[str, Version] = {}
@@ -658,6 +659,14 @@ class Provider:
         """See :func:`nab_python._provider.listing.wheel_by_version`."""
         return _listing.wheel_by_version(self, normalized, version_list)
 
+    def _yanked_versions(
+        self,
+        normalized: str,
+        version_list: list[tuple[Version, DistFile]],
+    ) -> frozenset[Version]:
+        """See :func:`nab_python._provider.listing.yanked_versions`."""
+        return _listing.yanked_versions(self, normalized, version_list)
+
     def speculative_prefetch(
         self,
         normalized: str,
@@ -698,6 +707,15 @@ class Provider:
         version_list = self.fetch_versions(package)
         all_versions = self.versions_only(normalized, version_list)
         candidates = list(version_range.filter(all_versions))
+
+        # PEP 592: rank fully-yanked versions below every non-yanked one, so a
+        # yanked release is chosen only when no non-yanked candidate satisfies
+        # the request. That keeps an existing pin to a since-yanked version
+        # resolving while a normal range ignores it.
+        yanked = self._yanked_versions(normalized, version_list)
+        if yanked:
+            live = [c for c in candidates if c not in yanked]
+            candidates = live or candidates
 
         # VersionRange.filter yields newest-first; reverse for LOWEST so
         # look-ahead walks oldest -> newest.
@@ -1270,12 +1288,19 @@ class Provider:
         return self.vcs_pins.get(canonicalize_name(canonical_name))
 
     def dist_files_for(self, canonical_name: str, version: Version) -> list[DistFile]:
-        """Return every distribution file the resolver saw at ``version``.
+        """Return the distribution files the resolver saw at ``version``.
 
         Drawn from the cached listing populated during the resolve, so
         callers do not pay another fetch.  When the package was never
         listed (synthetic / not asked for), returns an empty list.
+
+        Yanked files are dropped when the version keeps any non-yanked
+        file; a fully-yanked version (chosen only when nothing else
+        satisfied the request) returns its yanked files so it stays
+        installable.
         """
         normalized = canonicalize_name(canonical_name)
         listing = self.versions_cache.get(normalized, [])
-        return [dist for v, dist in listing if v == version]
+        at_version = [dist for v, dist in listing if v == version]
+        live = [dist for dist in at_version if not dist.yanked]
+        return live or at_version

--- a/nab-python/src/nab_python/universal/validate.py
+++ b/nab-python/src/nab_python/universal/validate.py
@@ -166,7 +166,10 @@ def _validate_pin(  # noqa: PLR0911 - one return per outcome reads cleaner here
     """Run the per-pin checks; emit a PinValidation outcome."""
     normalized = canonicalize_name(package)
     listing = coordinator.index.get_listing(normalized) or []
-    files_at_version = [f for f in listing if f.version == str(version)]
+    at_version = [f for f in listing if f.version == str(version)]
+    # PEP 592: ignore yanked files unless every file at the pin is yanked.
+    live = [f for f in at_version if not f.yanked]
+    files_at_version = live or at_version
     wheels_at_version = [f for f in files_at_version if isinstance(f, WheelFile)]
     has_sdist = any(not isinstance(f, WheelFile) for f in files_at_version)
     if not wheels_at_version:

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -178,9 +178,9 @@ class TestMetadataHashParsing:
 
 
 class TestYankedFiltering:
-    """PEP 592 ``yanked`` files are dropped from the listing."""
+    """PEP 592 ``yanked`` files stay in the listing with the flag set."""
 
-    def test_yanked_true_excluded(self) -> None:
+    def test_yanked_true_flagged(self) -> None:
         from nab_index.client import _parse_files
 
         data = {
@@ -197,9 +197,12 @@ class TestYankedFiltering:
             ],
         }
         files = _parse_files(data, "https://example.com/", "foo")
-        assert [f.filename for f in files] == ["foo-2.0-py3-none-any.whl"]
+        assert {f.filename: f.yanked for f in files} == {
+            "foo-1.0-py3-none-any.whl": True,
+            "foo-2.0-py3-none-any.whl": False,
+        }
 
-    def test_yanked_reason_string_excluded(self) -> None:
+    def test_yanked_reason_string_flagged(self) -> None:
         from nab_index.client import _parse_files
 
         data = {
@@ -212,9 +215,9 @@ class TestYankedFiltering:
             ],
         }
         files = _parse_files(data, "https://example.com/", "foo")
-        assert files == []
+        assert [f.yanked for f in files] == [True]
 
-    def test_yanked_false_kept(self) -> None:
+    def test_yanked_false_not_flagged(self) -> None:
         from nab_index.client import _parse_files
 
         data = {
@@ -227,9 +230,9 @@ class TestYankedFiltering:
             ],
         }
         files = _parse_files(data, "https://example.com/", "foo")
-        assert len(files) == 1
+        assert [f.yanked for f in files] == [False]
 
-    def test_yanked_empty_string_kept(self) -> None:
+    def test_yanked_empty_string_not_flagged(self) -> None:
         from nab_index.client import _parse_files
 
         data = {
@@ -242,7 +245,7 @@ class TestYankedFiltering:
             ],
         }
         files = _parse_files(data, "https://example.com/", "foo")
-        assert len(files) == 1
+        assert [f.yanked for f in files] == [False]
 
 
 class TestZipSdistDropped:

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -274,7 +274,7 @@ class TestPep503Directory:
         assert [r.filename for r in result] == ["foo-1.0.tar.gz"]
         assert isinstance(result[0], SdistFile)
 
-    def test_pep503_yanked_link_excluded(self, tmp_path: Path) -> None:
+    def test_pep503_yanked_link_flagged(self, tmp_path: Path) -> None:
         body = (
             '<a href="foo-1.0-py3-none-any.whl" data-yanked="security">yanked</a>'
             '<a href="foo-2.0-py3-none-any.whl">live</a>'
@@ -284,15 +284,15 @@ class TestPep503Directory:
         (package_dir / "foo-2.0-py3-none-any.whl").write_bytes(b"")
         client = LocalIndexClient(tmp_path.as_uri())
         result = run(client.get_files("foo"))
-        assert [r.version for r in result] == ["2.0"]
+        assert {r.version: r.yanked for r in result} == {"1.0": True, "2.0": False}
 
-    def test_pep503_yanked_with_empty_attr_excluded(self, tmp_path: Path) -> None:
+    def test_pep503_yanked_with_empty_attr_flagged(self, tmp_path: Path) -> None:
         body = '<a href="foo-1.0-py3-none-any.whl" data-yanked>foo</a>'
         package_dir = self._make_index(tmp_path, body)
         (package_dir / "foo-1.0-py3-none-any.whl").write_bytes(b"")
         client = LocalIndexClient(tmp_path.as_uri())
         result = run(client.get_files("foo"))
-        assert result == []
+        assert [r.yanked for r in result] == [True]
 
 
 class TestMetadataAndSdist:

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -48,6 +48,7 @@ def make_wheel(
     requires_python: str | None = None,
     has_metadata: bool = True,
     upload_time: str | None = None,
+    yanked: bool = False,
 ) -> WheelFile:
     """Build a WheelFile for testing."""
     return WheelFile(
@@ -57,6 +58,7 @@ def make_wheel(
         requires_python=requires_python,
         has_metadata=has_metadata,
         upload_time=upload_time,
+        yanked=yanked,
     )
 
 
@@ -64,6 +66,7 @@ def make_sdist(
     version: str = "1.0",
     requires_python: str | None = None,
     upload_time: str | None = None,
+    yanked: bool = False,
 ) -> SdistFile:
     """Build a SdistFile for testing."""
     return SdistFile(
@@ -72,6 +75,7 @@ def make_sdist(
         version=version,
         requires_python=requires_python,
         upload_time=upload_time,
+        yanked=yanked,
     )
 
 
@@ -324,6 +328,52 @@ class TestChooseVersion:
         provider = Provider(coordinator)
         spec = SpecifierSet("")
         assert provider.choose_version("foo", spec.to_range()) is None
+
+
+class TestYankedReadmission:
+    """PEP 592: a fully-yanked version resolves only under an exact pin."""
+
+    def test_range_skips_fully_yanked_version(self) -> None:
+        wheels = [make_wheel("1.0"), make_wheel("2.0", yanked=True)]
+        coordinator = make_coordinator(wheels, package="foo")
+        provider = Provider(coordinator)
+        chosen = provider.choose_version("foo", SpecifierSet(">=1.0").to_range())
+        assert chosen == V("1.0")
+
+    def test_pin_to_yanked_version_readmits_it(self) -> None:
+        wheels = [make_wheel("1.0"), make_wheel("2.0", yanked=True)]
+        coordinator = make_coordinator(wheels, package="foo")
+        provider = Provider(coordinator)
+        chosen = provider.choose_version("foo", SpecifierSet("==2.0").to_range())
+        assert chosen == V("2.0")
+
+    def test_sole_yanked_version_readmitted(self) -> None:
+        coordinator = make_coordinator([make_wheel("1.0", yanked=True)], package="foo")
+        provider = Provider(coordinator)
+        chosen = provider.choose_version("foo", SpecifierSet(">=1.0").to_range())
+        assert chosen == V("1.0")
+
+    def test_version_with_one_live_file_stays_selectable(self) -> None:
+        files = [make_wheel("1.0", yanked=True), make_sdist("1.0")]
+        coordinator = make_coordinator(files, package="foo")
+        provider = Provider(coordinator)
+        chosen = provider.choose_version("foo", SpecifierSet(">=1.0").to_range())
+        assert chosen == V("1.0")
+
+    def test_dist_files_for_drops_yanked_when_live_exists(self) -> None:
+        files = [make_wheel("1.0", yanked=True), make_sdist("1.0")]
+        coordinator = make_coordinator(files, package="foo")
+        provider = Provider(coordinator)
+        provider.fetch_versions("foo")
+        kept = provider.dist_files_for("foo", V("1.0"))
+        assert [f.yanked for f in kept] == [False]
+
+    def test_dist_files_for_keeps_yanked_when_all_yanked(self) -> None:
+        coordinator = make_coordinator([make_wheel("1.0", yanked=True)], package="foo")
+        provider = Provider(coordinator)
+        provider.fetch_versions("foo")
+        kept = provider.dist_files_for("foo", V("1.0"))
+        assert [f.yanked for f in kept] == [True]
 
 
 class TestResolutionStrategy:

--- a/nab-python/tests/universal/test_validate.py
+++ b/nab-python/tests/universal/test_validate.py
@@ -75,7 +75,7 @@ _STATIC_DEPS_METADATA_MICRO = _STATIC_DEPS_METADATA.replace(
 )
 
 
-def _wheel(filename: str) -> WheelFile:
+def _wheel(filename: str, *, yanked: bool = False) -> WheelFile:
     parts = filename.split("-")
     return WheelFile(
         filename=filename,
@@ -84,6 +84,7 @@ def _wheel(filename: str) -> WheelFile:
         requires_python=None,
         has_metadata=True,
         upload_time=None,
+        yanked=yanked,
     )
 
 
@@ -175,6 +176,28 @@ class TestValidateLock:
         )
         report = validate_lock(result, coordinator)
         assert report.pins_checked == 1
+        assert report.pins_ok == 1
+        assert all(f.status == "ok" for f in report.findings)
+
+    def test_yanked_only_pin_validates_against_yanked_wheel(self) -> None:
+        """A pin whose only file is yanked still validates against it."""
+        wheel = _wheel("pkg-1.0-cp311-cp311-linux_x86_64.whl", yanked=True)
+        coordinator = _make_coordinator(
+            {"pkg": [wheel]},
+            baseline_metadata={"pkg": _BASE_METADATA},
+            per_wheel_metadata={wheel.filename: _BASE_METADATA},
+        )
+        result = UniversalResult(
+            matrix=MagicMock(),
+            tuple_results=[
+                TupleResult(
+                    tuple_=_linux_311(),
+                    success=True,
+                    pins={"pkg": Version("1.0")},
+                ),
+            ],
+        )
+        report = validate_lock(result, coordinator)
         assert report.pins_ok == 1
         assert all(f.status == "ok" for f in report.findings)
 


### PR DESCRIPTION
Previously, PEP 592 yanked files were dropped from the listing on parse, so any exact pin to a since-yanked version would fail to resolve.

Now yanked files stay in the listing with a `yanked` flag. The resolver ranks fully-yanked versions below every live candidate, so normal range constraints still skip them. When nothing live satisfies the request (e.g. `==1.0` where 1.0 is yanked), the yanked version is readmitted and the resolve succeeds.

`dist_files_for` and the universal validator apply the same rule: prefer live files, but fall back to yanked ones when the version carries only yanked distributions.