### PR TITLE
Verify PEP 658 metadata hash before use

### DIFF
--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -25,6 +25,7 @@ from .client import (
     WheelFile,
     _extract_sdist_files,
     _parse_files,
+    _verify_metadata_hash,
 )
 
 if TYPE_CHECKING:
@@ -171,12 +172,20 @@ class CachedAsyncSimpleClient:
         return _parse_files(json.loads(body), self._index_url, package)
 
     async def get_metadata_text(
-        self, package: str, version: str, metadata_url: str
+        self,
+        package: str,
+        version: str,
+        metadata_url: str,
+        metadata_hash: tuple[str, str] | None = None,
     ) -> str:
         """Return PEP 658 metadata text for ``(package, version)``.
 
-        Treated as immutable: cached forever, never revalidated.
-        Cache miss + offline raises :class:`OfflineError`.
+        Treated as immutable: cached forever, never revalidated.  A
+        cache hit is returned without re-checking, since it was
+        verified before being stored.  Cache miss + offline raises
+        :class:`OfflineError`.  When ``metadata_hash`` is given, the
+        fetched bytes are verified against it and a mismatch raises
+        :class:`MetadataHashMismatchError` before anything is cached.
         """
         cached = self._cache.get_metadata(package, version)
         if cached is not None:
@@ -188,6 +197,8 @@ class CachedAsyncSimpleClient:
 
         response = await self._transport.get(metadata_url)
         response.raise_for_status()
+        if metadata_hash is not None:
+            _verify_metadata_hash(response.content, metadata_hash)
         text = response.text
         self._cache.put_metadata(package, version, text)
         return text

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -7,6 +7,7 @@ Transport-agnostic: any async HTTP client implementing the
 
 from __future__ import annotations
 
+import hashlib
 import io
 import re
 import sys
@@ -32,10 +33,15 @@ if TYPE_CHECKING:
 __all__ = [
     "DEFAULT_INDEX",
     "AsyncSimpleClient",
+    "MetadataHashMismatchError",
     "SdistFile",
     "WheelFile",
     "extract_sdist_archive",
 ]
+
+
+class MetadataHashMismatchError(Exception):
+    """Fetched PEP 658 metadata did not match its published hash."""
 
 
 # Mirrors packaging.utils._build_tag_regex: PEP 427 build numbers start with a digit.
@@ -147,6 +153,11 @@ class WheelFile:
     index, and ``None`` for one fetched from a remote index.  It lets
     downstream code use the path directly instead of reversing the
     ``file:`` URL, which is lossy across platforms.
+
+    ``metadata_hash`` is the published ``(algorithm, hex_digest)`` for
+    the PEP 658/714 sidecar, or ``None`` when the index advertised the
+    sidecar without a hash.  The fetcher verifies the sidecar bytes
+    against it.
     """
 
     filename: str
@@ -158,6 +169,7 @@ class WheelFile:
     hashes: tuple[tuple[str, str], ...] = ()
     size: int | None = None
     local_path: Path | None = None
+    metadata_hash: tuple[str, str] | None = None
 
     @property
     def metadata_url(self) -> str | None:
@@ -289,6 +301,7 @@ def _parse_files(
                     upload_time=file_info.get("upload-time"),
                     hashes=hashes,
                     size=size,
+                    metadata_hash=_metadata_hash(file_info),
                 )
             )
             continue
@@ -353,6 +366,31 @@ def _has_metadata(file_info: dict) -> bool:
         if value is True or isinstance(value, dict):
             return True
     return False
+
+
+def _metadata_hash(file_info: dict) -> tuple[str, str] | None:
+    """Return the sidecar's published ``(algo, hex)`` to verify, or None.
+
+    Only sha256 is checked: it is what PyPI publishes for core metadata
+    and what pip verifies.  A bare ``true`` (sidecar exists, no hash)
+    or a table without sha256 yields None, so no check runs.
+    """
+    for key in ("core-metadata", "data-dist-info-metadata"):
+        value = file_info.get(key)
+        if isinstance(value, dict):
+            digest = value.get("sha256")
+            if isinstance(digest, str):
+                return ("sha256", digest.lower())
+    return None
+
+
+def _verify_metadata_hash(content: bytes, metadata_hash: tuple[str, str]) -> None:
+    """Raise :class:`MetadataHashMismatchError` if ``content`` fails the hash."""
+    algo, expected = metadata_hash
+    actual = hashlib.new(algo, content).hexdigest()
+    if actual != expected:
+        msg = f"metadata {algo} mismatch: expected {expected}, got {actual}"
+        raise MetadataHashMismatchError(msg)
 
 
 def _extract_sdist_files(data: bytes) -> tuple[str | None, str | None]:

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -267,8 +267,13 @@ class LocalIndexClient:
         package: str,  # noqa: ARG002 - matches CachedAsyncSimpleClient signature
         version: str,  # noqa: ARG002
         metadata_url: str,
+        metadata_hash: tuple[str, str] | None = None,  # noqa: ARG002
     ) -> str:
-        """Return PEP 658 metadata text for a wheel sitting on disk."""
+        """Return PEP 658 metadata text for a wheel sitting on disk.
+
+        Local wheels never advertise a sidecar hash, so ``metadata_hash``
+        is accepted only to match the remote client signature.
+        """
         path = _parse_file_url(metadata_url)
         return path.read_text(encoding="utf-8")
 

--- a/nab-index/src/nab_index/multi_index.py
+++ b/nab-index/src/nab_index/multi_index.py
@@ -52,7 +52,11 @@ class IndexClient(Protocol):
         ...
 
     async def get_metadata_text(
-        self, package: str, version: str, metadata_url: str
+        self,
+        package: str,
+        version: str,
+        metadata_url: str,
+        metadata_hash: tuple[str, str] | None = None,
     ) -> str:
         """Return the metadata text for a wheel."""
         ...
@@ -199,10 +203,11 @@ class MultiIndexClient:
         package: str,
         version: str,
         metadata_url: str,
+        metadata_hash: tuple[str, str] | None = None,
     ) -> str:
         """Forward to the routed client; presupposes ``get_files`` was called."""
         return await self._client_for(package).get_metadata_text(
-            package, version, metadata_url
+            package, version, metadata_url, metadata_hash
         )
 
     async def get_sdist_files(

--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -128,7 +128,7 @@ def prefetch_root_batch(
     # Provider in at the top would create an import cycle.
     from ..provider import Provider as _Provider
 
-    items: list[tuple[str, str, str]] = []
+    items: list[tuple[str, str, str, tuple[str, str] | None]] = []
     for version, dist in versions:
         if len(items) >= _Provider.PREFETCH_BATCH:
             break
@@ -137,7 +137,9 @@ def prefetch_root_batch(
         if (normalized, version) in provider.deps_cache:
             continue
         if isinstance(dist, WheelFile) and dist.metadata_url is not None:
-            items.append((normalized, dist.version, dist.metadata_url))
+            items.append(
+                (normalized, dist.version, dist.metadata_url, dist.metadata_hash)
+            )
     if items:
         provider.coordinator.request_metadata_batch(items)
 
@@ -162,7 +164,7 @@ def prefetch_transitive_best(
         and dist.metadata_url is not None
     ):
         provider.coordinator.request_metadata(
-            normalized, dist.version, dist.metadata_url
+            normalized, dist.version, dist.metadata_url, dist.metadata_hash
         )
 
 
@@ -339,7 +341,7 @@ def prefetch_walk_ahead(
         return
     wheel_for_v = _first_wheel_per_version(versions_list)
     coordinator_index = provider.coordinator.index
-    items: list[tuple[str, str, str]] = []
+    items: list[tuple[str, str, str, tuple[str, str] | None]] = []
     seen_versions: set[Version] = set()
     for version, _ in versions_list:
         if version in seen_versions:
@@ -355,7 +357,7 @@ def prefetch_walk_ahead(
         # ``_first_wheel_per_version`` filters out wheels without metadata_url.
         metadata_url = wheel.metadata_url
         assert metadata_url is not None
-        items.append((normalized, wheel.version, metadata_url))
+        items.append((normalized, wheel.version, metadata_url, wheel.metadata_hash))
     if items:
         provider.coordinator.request_metadata_batch(items)
 
@@ -372,14 +374,16 @@ def prefetch_batch(
     as a single queue item and are processed concurrently.
     Returns list of (version, ver_str, event) for submitted requests.
     """
-    items: list[tuple[str, str, str]] = []
+    items: list[tuple[str, str, str, tuple[str, str] | None]] = []
     version_map: list[tuple[Version, str]] = []
     for v in versions:
         if (package, v) in provider.deps_cache or v not in wheel_by_version_map:
             continue
         wheel = wheel_by_version_map[v]
         if isinstance(wheel, WheelFile) and wheel.metadata_url is not None:
-            items.append((package, wheel.version, wheel.metadata_url))
+            items.append(
+                (package, wheel.version, wheel.metadata_url, wheel.metadata_hash)
+            )
             version_map.append((v, wheel.version))
 
     if not items:

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -62,7 +62,7 @@ def resolve_metadata(
 
     if isinstance(dist, WheelFile) and dist.metadata_url is not None:
         event = provider.coordinator.request_metadata(
-            normalized, ver_str, dist.metadata_url
+            normalized, ver_str, dist.metadata_url, dist.metadata_hash
         )
         event.wait()
         metadata_text = provider.coordinator.index.get_metadata(normalized, ver_str)

--- a/nab-python/src/nab_python/_testing/coordinator_fake.py
+++ b/nab-python/src/nab_python/_testing/coordinator_fake.py
@@ -108,17 +108,19 @@ def _wire_metadata_side_effects(
     def _request_listing(_pkg: str) -> threading.Event:
         return _done_event()
 
-    def _request_metadata(pkg: str, ver: str, _url: str) -> threading.Event:
+    def _request_metadata(
+        pkg: str, ver: str, _url: str, _hash: tuple[str, str] | None = None
+    ) -> threading.Event:
         text = resolve_metadata(pkg, ver)
         if text is not None:
             index.store_metadata(pkg, ver, text)
         return _done_event()
 
     def _request_metadata_batch(
-        items: list[tuple[str, str, str]],
+        items: list[tuple[str, str, str, tuple[str, str] | None]],
     ) -> list[tuple[str, str, threading.Event]]:
         results: list[tuple[str, str, threading.Event]] = []
-        for pkg, ver, _url in items:
+        for pkg, ver, _url, _hash in items:
             text = resolve_metadata(pkg, ver)
             if text is not None:
                 index.store_metadata(pkg, ver, text)
@@ -150,7 +152,11 @@ def _wire_sdist_side_effects(
         return _done_event()
 
     def _request_wheel_metadata(
-        pkg: str, ver: str, filename: str, _url: str
+        pkg: str,
+        ver: str,
+        filename: str,
+        _url: str,
+        _hash: tuple[str, str] | None = None,
     ) -> threading.Event:
         if filename in failures:
             index.store_metadata(pkg, f"{ver}#{filename}", None)

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -119,6 +119,7 @@ class FetchRequest:
     package: str
     version: str | None = None
     url: str | None = None
+    metadata_hash: tuple[str, str] | None = None
 
 
 @dataclass
@@ -475,7 +476,13 @@ class FetchCoordinator:
             self._submit(FetchRequest(kind=FetchKind.LISTING, package=package))
         return pending.event
 
-    def request_metadata(self, package: str, version: str, url: str) -> threading.Event:
+    def request_metadata(
+        self,
+        package: str,
+        version: str,
+        url: str,
+        metadata_hash: tuple[str, str] | None = None,
+    ) -> threading.Event:
         """Request a wheel-metadata fetch for ``(package, version)``."""
         self._check_alive()
         if self.index.has_metadata(package, version):
@@ -491,12 +498,18 @@ class FetchCoordinator:
                     package=package,
                     version=version,
                     url=url,
+                    metadata_hash=metadata_hash,
                 )
             )
         return pending.event
 
     def request_wheel_metadata(
-        self, package: str, version: str, wheel_filename: str, url: str
+        self,
+        package: str,
+        version: str,
+        wheel_filename: str,
+        url: str,
+        metadata_hash: tuple[str, str] | None = None,
     ) -> threading.Event:
         """Request metadata for one specific wheel of ``(package, version)``.
 
@@ -522,6 +535,7 @@ class FetchCoordinator:
                     package=package,
                     version=sentinel_version,
                     url=url,
+                    metadata_hash=metadata_hash,
                 )
             )
         return pending.event
@@ -572,17 +586,18 @@ class FetchCoordinator:
         return pending.event
 
     def request_metadata_batch(
-        self, items: list[tuple[str, str, str]]
+        self, items: list[tuple[str, str, str, tuple[str, str] | None]]
     ) -> list[tuple[str, str, threading.Event]]:
         """Submit a batch of metadata requests as a single queue item.
 
-        All requests in the batch reach the fetcher together so they
-        are processed concurrently.
+        Each item is ``(package, version, url, metadata_hash)``.  All
+        requests in the batch reach the fetcher together so they are
+        processed concurrently.
         """
         self._check_alive()
         results: list[tuple[str, str, threading.Event]] = []
         batch: list[FetchRequest] = []
-        for package, version, url in items:
+        for package, version, url, metadata_hash in items:
             if self.index.has_metadata(package, version):
                 done = threading.Event()
                 done.set()
@@ -597,6 +612,7 @@ class FetchCoordinator:
                         package=package,
                         version=version,
                         url=url,
+                        metadata_hash=metadata_hash,
                     )
                 )
             results.append((package, version, pending.event))
@@ -766,7 +782,7 @@ class FetchCoordinator:
             if isinstance(f, WheelFile) and f.metadata_url is not None
         ]
         for w, metadata_url in wheels_with_meta[-self.PREFETCH_METADATA_COUNT :]:
-            self.request_metadata(req.package, w.version, metadata_url)
+            self.request_metadata(req.package, w.version, metadata_url, w.metadata_hash)
 
     def _record_serving_index(
         self,
@@ -798,7 +814,9 @@ class FetchCoordinator:
         if req.url is None:
             self.index.store_metadata(req.package, req.version, None)
             return
-        text = await client.get_metadata_text(req.package, req.version, req.url)
+        text = await client.get_metadata_text(
+            req.package, req.version, req.url, req.metadata_hash
+        )
         self.index.store_metadata(req.package, req.version, text)
 
     async def _fetch_sdist(

--- a/nab-python/src/nab_python/universal/validate.py
+++ b/nab-python/src/nab_python/universal/validate.py
@@ -399,7 +399,11 @@ def _fetch_wheel_metadata(
     if wheel.metadata_url is None:
         return None
     event = coordinator.request_wheel_metadata(
-        normalized, str(version), wheel.filename, wheel.metadata_url
+        normalized,
+        str(version),
+        wheel.filename,
+        wheel.metadata_url,
+        wheel.metadata_hash,
     )
     event.wait()
     return coordinator.index.get_metadata(normalized, f"{version}#{wheel.filename}")

--- a/nab-python/tests/property_python/test_multi_index_pep503.py
+++ b/nab-python/tests/property_python/test_multi_index_pep503.py
@@ -73,9 +73,13 @@ class _Stub:
         return []
 
     async def get_metadata_text(
-        self, package: str, version: str, metadata_url: str
+        self,
+        package: str,
+        version: str,
+        metadata_url: str,
+        metadata_hash: tuple[str, str] | None = None,
     ) -> str:
-        del package, version, metadata_url
+        del package, version, metadata_url, metadata_hash
         return ""
 
     async def get_sdist_files(

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import io
 import json
 import tarfile
@@ -18,7 +19,13 @@ from nab_index.cached_client import (
     _header,
     _parse_max_age,
 )
-from nab_index.client import SdistFile, WheelFile, _parse_files, _parse_sdist_filename
+from nab_index.client import (
+    MetadataHashMismatchError,
+    SdistFile,
+    WheelFile,
+    _parse_files,
+    _parse_sdist_filename,
+)
 
 LISTING = {
     "meta": {"api-version": "1.0"},
@@ -117,6 +124,57 @@ class TestHasMetadataFlag:
         from nab_index.client import _has_metadata
 
         assert not _has_metadata({})
+
+
+class TestMetadataHashParsing:
+    """``_metadata_hash`` carries the published sha256 to verify, or None."""
+
+    def test_sha256_lowercased(self) -> None:
+        from nab_index.client import _metadata_hash
+
+        assert _metadata_hash({"core-metadata": {"sha256": "ABCD"}}) == (
+            "sha256",
+            "abcd",
+        )
+
+    def test_legacy_key_used(self) -> None:
+        from nab_index.client import _metadata_hash
+
+        assert _metadata_hash({"data-dist-info-metadata": {"sha256": "ab"}}) == (
+            "sha256",
+            "ab",
+        )
+
+    def test_true_value_yields_none(self) -> None:
+        from nab_index.client import _metadata_hash
+
+        assert _metadata_hash({"core-metadata": True}) is None
+
+    def test_other_algo_only_yields_none(self) -> None:
+        from nab_index.client import _metadata_hash
+
+        assert _metadata_hash({"core-metadata": {"blake2b": "ab"}}) is None
+
+    def test_missing_field_yields_none(self) -> None:
+        from nab_index.client import _metadata_hash
+
+        assert _metadata_hash({}) is None
+
+    def test_parse_files_populates_metadata_hash(self) -> None:
+        from nab_index.client import WheelFile, _parse_files
+
+        data = {
+            "files": [
+                {
+                    "filename": "foo-1.0-py3-none-any.whl",
+                    "url": "https://example.com/foo-1.0-py3-none-any.whl",
+                    "core-metadata": {"sha256": "DEAD"},
+                },
+            ],
+        }
+        (wheel,) = _parse_files(data, "https://example.com/", "foo")
+        assert isinstance(wheel, WheelFile)
+        assert wheel.metadata_hash == ("sha256", "dead")
 
 
 class TestYankedFiltering:
@@ -699,6 +757,44 @@ class TestGetMetadataText:
 
         with pytest.raises(OfflineError, match="pkg==1.0"):
             asyncio.run(go())
+
+    def test_matching_hash_returns_and_caches(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        body = b"Metadata-Version: 2.1\nName: pkg\n"
+        digest = hashlib.sha256(body).hexdigest()
+        transport = _FakeTransport([_FakeResponse(body)])
+
+        async def go() -> str:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_metadata_text(
+                    "pkg", "1.0", "https://x/pkg.metadata", ("sha256", digest)
+                )
+            finally:
+                await client.aclose()
+
+        text = asyncio.run(go())
+        assert text == body.decode()
+        assert cache.get_metadata("pkg", "1.0") == text
+
+    def test_mismatching_hash_raises_and_skips_cache(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        digest = hashlib.sha256(b"Metadata-Version: 2.1\nName: pkg\n").hexdigest()
+        tampered = _FakeResponse(b"Metadata-Version: 2.1\nName: evil\n")
+        transport = _FakeTransport([tampered])
+
+        async def go() -> str:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_metadata_text(
+                    "pkg", "1.0", "https://x/pkg.metadata", ("sha256", digest)
+                )
+            finally:
+                await client.aclose()
+
+        with pytest.raises(MetadataHashMismatchError):
+            asyncio.run(go())
+        assert cache.get_metadata("pkg", "1.0") is None
 
 
 class TestGetSdistFiles:

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -352,8 +352,8 @@ class TestFetchCoordinator:
         with _coord() as coord:
             results = coord.request_metadata_batch(
                 [
-                    ("pkg-a", "1.0", "https://f.com/a.metadata"),
-                    ("pkg-b", "2.0", "https://f.com/b.metadata"),
+                    ("pkg-a", "1.0", "https://f.com/a.metadata", None),
+                    ("pkg-b", "2.0", "https://f.com/b.metadata", None),
                 ]
             )
             assert len(results) == 2
@@ -368,7 +368,7 @@ class TestFetchCoordinator:
             coord.index.store_metadata("cached", "1.0", "already")
             results = coord.request_metadata_batch(
                 [
-                    ("cached", "1.0", "https://f.com/c.metadata"),
+                    ("cached", "1.0", "https://f.com/c.metadata", None),
                 ]
             )
             assert len(results) == 1
@@ -473,8 +473,8 @@ class TestFetchCoordinator:
             e1 = coord.request_metadata("a", "1", "https://f.com/a")
             results = coord.request_metadata_batch(
                 [
-                    ("b", "1", "https://f.com/b"),
-                    ("c", "1", "https://f.com/c"),
+                    ("b", "1", "https://f.com/b", None),
+                    ("c", "1", "https://f.com/c", None),
                 ]
             )
             e1.wait(timeout=5)
@@ -810,8 +810,8 @@ class TestFetchCoordinator:
             coord.index.get_or_create_pending("metadata:a:1.0")
             results = coord.request_metadata_batch(
                 [
-                    ("a", "1.0", "https://f.com/a"),
-                    ("b", "1.0", "https://f.com/b"),
+                    ("a", "1.0", "https://f.com/a", None),
+                    ("b", "1.0", "https://f.com/b", None),
                 ]
             )
             for _, _, ev in results:

--- a/nab-python/tests/test_multi_index.py
+++ b/nab-python/tests/test_multi_index.py
@@ -48,7 +48,11 @@ class FakeClient:
         return list(self.listing.get(_normalise_name(package), []))
 
     async def get_metadata_text(
-        self, package: str, version: str, metadata_url: str
+        self,
+        package: str,
+        version: str,
+        metadata_url: str,
+        metadata_hash: tuple[str, str] | None = None,
     ) -> str:
         self.metadata_calls.append((package, version, metadata_url))
         return f"meta:{package}:{version}"

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -1413,7 +1413,9 @@ class TestLookAhead:
 
         call_count = [0]
 
-        def _request_metadata(pkg: str, ver: str, url: str) -> threading.Event:
+        def _request_metadata(
+            pkg: str, ver: str, url: str, metadata_hash: tuple[str, str] | None = None
+        ) -> threading.Event:
             call_count[0] += 1
             text = (
                 f"Metadata-Version: 2.1\nName: foo\nVersion: {ver}\n"
@@ -1427,10 +1429,10 @@ class TestLookAhead:
         coordinator.request_metadata.side_effect = _request_metadata
 
         def _request_metadata_batch(
-            items: list[tuple[str, str, str]],
+            items: list[tuple[str, str, str, tuple[str, str] | None]],
         ) -> list[tuple[str, str, threading.Event]]:
             results: list[tuple[str, str, threading.Event]] = []
-            for pkg, ver, url in items:
+            for pkg, ver, url, _hash in items:
                 call_count[0] += 1
                 # On second batch call, inject cache for v1.0
                 if call_count[0] == 2:
@@ -3021,9 +3023,9 @@ class TestFetchVersionsNotInIndex:
             return _done_event()
 
         coordinator.request_listing.side_effect = _request_listing
-        coordinator.request_metadata.side_effect = lambda p, v, u: _done_event()
+        coordinator.request_metadata.side_effect = lambda p, v, u, h=None: _done_event()
         coordinator.request_metadata_batch.side_effect = lambda items: [
-            (p, v, _done_event()) for p, v, u in items
+            (p, v, _done_event()) for p, v, u, h in items
         ]
 
         provider = Provider(coordinator)
@@ -3074,7 +3076,7 @@ class TestSpeculativePrefetchBatchLimit:
         call_args = coordinator.request_metadata_batch.call_args
         assert call_args is not None
         items = call_args[0][0]
-        assert all(ver == "1.0" for _, ver, _ in items)
+        assert all(ver == "1.0" for _, ver, _, _ in items)
 
 
 class TestPrefetchWalkAhead:
@@ -3114,7 +3116,7 @@ class TestPrefetchWalkAhead:
         coordinator.reset_mock()
         provider.prefetch_walk_ahead("foo")
         items = coordinator.request_metadata_batch.call_args[0][0]
-        versions = [ver for _, ver, _ in items]
+        versions = [ver for _, ver, _, _ in items]
         assert "2.0" not in versions
         assert "3.0" in versions
         assert "1.0" in versions
@@ -3132,7 +3134,7 @@ class TestPrefetchWalkAhead:
         coordinator.reset_mock()
         provider.prefetch_walk_ahead("foo")
         items = coordinator.request_metadata_batch.call_args[0][0]
-        versions = [ver for _, ver, _ in items]
+        versions = [ver for _, ver, _, _ in items]
         assert versions == ["3.0", "2.0"]
 
     def test_picks_wheel_when_both_present(self) -> None:
@@ -3148,7 +3150,7 @@ class TestPrefetchWalkAhead:
         provider.prefetch_walk_ahead("foo")
         items = coordinator.request_metadata_batch.call_args[0][0]
         assert any(
-            ver == "1.0" and url.endswith(".whl.metadata") for _, ver, url in items
+            ver == "1.0" and url.endswith(".whl.metadata") for _, ver, url, _ in items
         )
 
     def test_skips_sdist_only_versions(self) -> None:
@@ -3163,7 +3165,7 @@ class TestPrefetchWalkAhead:
         coordinator.reset_mock()
         provider.prefetch_walk_ahead("foo")
         items = coordinator.request_metadata_batch.call_args[0][0]
-        versions = [ver for _, ver, _ in items]
+        versions = [ver for _, ver, _, _ in items]
         assert versions == ["2.0"]
 
     def test_skips_wheels_without_metadata_url(self) -> None:
@@ -3178,7 +3180,7 @@ class TestPrefetchWalkAhead:
         coordinator.reset_mock()
         provider.prefetch_walk_ahead("foo")
         items = coordinator.request_metadata_batch.call_args[0][0]
-        versions = [ver for _, ver, _ in items]
+        versions = [ver for _, ver, _, _ in items]
         assert versions == ["1.0"]
 
     def test_no_batch_when_all_filtered(self) -> None:
@@ -3416,7 +3418,7 @@ class TestSpeculativePrefetchSkipsNonWheelDists:
         # Batch should only contain the wheel v1.0, not the sdist v2.0.
         if coordinator.request_metadata_batch.called:
             items = coordinator.request_metadata_batch.call_args[0][0]
-            for _, ver, _ in items:
+            for _, ver, _, _ in items:
                 assert ver != "2.0"
 
 


### PR DESCRIPTION
When an index advertises a PEP 658/714 sidecar with a sha256 hash, nab now verifies the fetched bytes against that hash before caching or using the metadata. A mismatch raises `MetadataHashMismatchError` and nothing is written to the cache.

The `metadata_hash` field is parsed from the index response in `_metadata_hash()` (prefer `core-metadata`, fall back to `data-dist-info-metadata`; only sha256 is checked, matching what PyPI publishes and pip verifies). It flows through `WheelFile`, `FetchRequest`, `FetchCoordinator`, and all three client implementations (`CachedAsyncSimpleClient`, `LocalIndexClient`, `MultiIndexClient`).