### PR TITLE
Fix coordinator marker env missing python_version

### DIFF
--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -161,7 +161,7 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
         cache_dir=cache_dir,
         offline=offline,
         index_overrides=list(config.index_overrides),
-        marker_environment=dict(config.marker_environment) or None,
+        marker_environment=marker_environment,
     ) as coordinator:
         provider = Provider(
             coordinator,

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -143,6 +143,42 @@ class TestResolvePyproject:
         assert forwarded[0].name == "private"
         assert forwarded[0].url == "https://custom.index/simple/"
 
+    def test_coordinator_marker_env_includes_python_version(
+        self, tmp_path: Path
+    ) -> None:
+        """An index-override marker referencing python_version must evaluate.
+
+        The coordinator evaluates index-override markers, so it needs the
+        full environment (defaults plus the effective python), not just the
+        user's [tool.nab.marker-environment] overrides.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\ndependencies = ["baz"]\n'
+            "[[tool.nab.index-overrides]]\n"
+            'name = "baz"\n'
+            'index = "private"\n'
+            "marker = \"python_version >= '3.12'\"\n",
+        )
+
+        with (
+            patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls,
+            patch("nab_python.resolve.Provider") as mock_provider_cls,
+            patch("nab_python.resolve.build_lock_input_from_provider"),
+        ):
+            mock_coord_cls.return_value.__enter__ = lambda s: s
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            mock_provider = mock_provider_cls.return_value
+            mock_provider.choose_version.return_value = V("1.0")
+            mock_provider.get_dependencies.return_value = {}
+            mock_provider.prioritize.return_value = 1
+
+            resolve_pyproject(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
+
+        env = mock_coord_cls.call_args.kwargs["marker_environment"]
+        assert env is not None
+        assert env.get("python_version") == "3.12"
+
     def test_arbitrary_equality_dep_passed_through(self, tmp_path: Path) -> None:
         """``===`` deps reach the resolver as literal-only ranges.
 


### PR DESCRIPTION
The coordinator evaluates index-override markers at fetch time, so it needs the full marker environment (system defaults merged with the effective Python version), not just the raw `[tool.nab.marker-environment]` user overrides.

The earlier fix on `bug/index-override-marker-env` passed `dict(config.marker_environment) or None`, which omitted `python_version`, `python_full_version`, `os_name`, and all other default keys. A marker like `python_version >= '3.12'` would silently fail to route to the correct index.

This commit passes `marker_environment` instead, which is already built by `_build_marker_environment()` earlier in the same function with the full merged environment.