### PR TITLE
Reject patch-level matrix.python value

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -20,6 +20,7 @@ from nab_index.multi_index import IndexConfig
 
 from ._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from ._vendor.packaging.utils import canonicalize_name
+from ._vendor.packaging.version import InvalidVersion, Version
 from .fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, IndexOverride
 from .provider import (
     BuildPolicy,
@@ -831,6 +832,26 @@ def _parse_workspace(value: object) -> WorkspaceConfig | None:
     return WorkspaceConfig(members=members)
 
 
+_MINOR_RELEASE_PARTS = 2
+
+
+def _matrix_python_patch_clause(spec_set: SpecifierSet) -> str | None:
+    """Return the first clause pinning a patch (micro) version, else None.
+
+    The matrix python axis is minor-granular, so ``>=3.11.5`` would
+    silently exclude 3.11 entirely. A trailing ``.*`` wildcard targets a
+    minor and is allowed.
+    """
+    for clause in spec_set:
+        try:
+            release = Version(clause.version.removesuffix(".*")).release
+        except InvalidVersion:
+            continue
+        if len(release) > _MINOR_RELEASE_PARTS:
+            return str(clause)
+    return None
+
+
 def _parse_matrix(value: object) -> MatrixConfig | None:
     if value is None:
         return None
@@ -858,6 +879,18 @@ def _parse_matrix(value: object) -> MatrixConfig | None:
         raise ConfigError(msg) from None
     if not isinstance(python, str):
         msg = "matrix.python must be a string PEP 440 specifier"
+        raise ConfigError(msg)
+    try:
+        spec_set = SpecifierSet(python)
+    except InvalidSpecifier as exc:
+        msg = f"matrix.python must be a PEP 440 specifier, got {python!r}"
+        raise ConfigError(msg) from exc
+    patched = _matrix_python_patch_clause(spec_set)
+    if patched is not None:
+        msg = (
+            f"matrix.python takes minor (language) versions only, got {patched!r}."
+            " The python axis is minor-granular; use 3.X, not a patch like 3.X.Y."
+        )
         raise ConfigError(msg)
     platforms = _parse_string_list("matrix.platforms", platforms_raw)
     if not platforms:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -1001,6 +1001,51 @@ class TestMatrix:
         with pytest.raises(ConfigError, match="matrix.python must be a string"):
             read_pyproject_config(path)
 
+    def _body_with_python(self, python: str) -> str:
+        return (
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            "[tool.nab.matrix]\n"
+            f"python = {python}\n"
+            'platforms = ["linux_x86_64"]\n'
+        )
+
+    def test_python_patch_level_rejected(self, tmp_path: Path) -> None:
+        body = self._body_with_python('">=3.11.5"')
+        with pytest.raises(ConfigError, match="minor \\(language\\) versions only"):
+            read_pyproject_config(write(tmp_path, body))
+
+    def test_python_exact_patch_rejected(self, tmp_path: Path) -> None:
+        body = self._body_with_python('"==3.11.0"')
+        with pytest.raises(ConfigError, match="minor \\(language\\) versions only"):
+            read_pyproject_config(write(tmp_path, body))
+
+    def test_python_minor_wildcard_allowed(self, tmp_path: Path) -> None:
+        matrix = read_pyproject_config(
+            write(tmp_path, self._body_with_python('"==3.11.*"'))
+        ).matrix
+        assert matrix is not None
+        assert matrix.python == "==3.11.*"
+
+    def test_python_not_a_specifier_rejected(self, tmp_path: Path) -> None:
+        body = self._body_with_python('"3.11"')
+        with pytest.raises(ConfigError, match="matrix.python must be a PEP 440"):
+            read_pyproject_config(write(tmp_path, body))
+
+    def test_python_arbitrary_equality_skipped(self, tmp_path: Path) -> None:
+        matrix = read_pyproject_config(
+            write(tmp_path, self._body_with_python('"===nightly"'))
+        ).matrix
+        assert matrix is not None
+        assert matrix.python == "===nightly"
+
+    def test_python_empty_specifier_allowed(self, tmp_path: Path) -> None:
+        matrix = read_pyproject_config(
+            write(tmp_path, self._body_with_python('""'))
+        ).matrix
+        assert matrix is not None
+        assert matrix.python == ""
+
     def test_empty_platforms(self, tmp_path: Path) -> None:
         path = write(
             tmp_path,


### PR DESCRIPTION
The matrix python axis is minor-granular: nab resolves once per minor version and the python-patches key supplies patch-level refinements. A specifier like `>=3.11.5` would silently exclude all of 3.11 from the matrix, which is almost certainly wrong.

This adds a validation pass over the python specifier set that rejects any clause whose version has three or more release parts. A trailing `.*` wildcard (e.g. `==3.11.*`) is explicitly allowed since it targets a minor, not a patch.