### PR TITLE
Reject invalid matrix axes at parse time

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -30,6 +30,7 @@ from .provider import (
     VcsPolicy,
     VcsSource,
 )
+from .universal.matrix import Matrix
 from .workspace import (
     WorkspaceConfig,
     auto_promote_build_policy_for_workspace,
@@ -869,13 +870,33 @@ def _parse_matrix(value: object) -> MatrixConfig | None:
         raise ConfigError(msg)
     patches = _parse_python_patches(value.get("python-patches"))
     implementations = _parse_implementations(value.get("implementations"))
-    return MatrixConfig(
+    config = MatrixConfig(
         python=python,
         platforms=platforms,
         python_order=python_order,
         python_patches=patches,
         implementations=implementations,
     )
+    _validate_matrix_axes(config)
+    return config
+
+
+def _validate_matrix_axes(config: MatrixConfig) -> None:
+    """Expand the matrix eagerly to catch bad axes at parse time."""
+    matrix = Matrix(
+        python=config.python,
+        platforms=config.platforms,
+        python_order=config.python_order,
+        python_patches=dict(config.python_patches)
+        if config.python_patches is not None
+        else None,
+        implementations=config.implementations,
+    )
+    try:
+        matrix.expand()
+    except ValueError as exc:
+        msg = f"invalid [tool.nab.matrix]: {exc}"
+        raise ConfigError(msg) from exc
 
 
 _KNOWN_IMPLEMENTATIONS = ("cpython", "pypy")

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -1028,6 +1028,24 @@ class TestMatrix:
         with pytest.raises(ConfigError, match="python-order must be 'asc' or 'desc'"):
             read_pyproject_config(path)
 
+    def test_unknown_platform_rejected(self, tmp_path: Path) -> None:
+        body = self._matrix_body()
+        body = body.replace('["linux_x86_64", "macos_arm64"]', '["frobnicate"]')
+        with pytest.raises(ConfigError, match="Unknown platform ids"):
+            read_pyproject_config(write(tmp_path, body))
+
+    def test_empty_python_range_rejected(self, tmp_path: Path) -> None:
+        body = self._matrix_body()
+        body = body.replace('">=3.11,<3.14"', '"==3.99"')
+        with pytest.raises(ConfigError, match="No known Python versions match"):
+            read_pyproject_config(write(tmp_path, body))
+
+    def test_malformed_python_specifier_rejected(self, tmp_path: Path) -> None:
+        body = self._matrix_body()
+        body = body.replace('">=3.11,<3.14"', '"not a specifier"')
+        with pytest.raises(ConfigError, match="Invalid specifier"):
+            read_pyproject_config(write(tmp_path, body))
+
     def test_python_patches_must_be_table(self, tmp_path: Path) -> None:
         path = write(
             tmp_path,


### PR DESCRIPTION
Previously a bad `[tool.nab.matrix]` axis (unknown platform id, empty python range, or malformed specifier) was only caught when the matrix was first expanded at resolve time, producing a raw `ValueError` with no context.

This change calls `Matrix.expand()` during config parsing so any such error is caught and re-raised as a `ConfigError` with a "invalid [tool.nab.matrix]: ..." prefix.