### PR TITLE
Fix CPython marker in multi-impl matrix

### DIFF
--- a/nab-python/src/nab_python/universal/matrix.py
+++ b/nab-python/src/nab_python/universal/matrix.py
@@ -108,6 +108,7 @@ class MatrixTuple:
         default_factory=lambda: PlatformSpec("linux_x86_64"),
     )
     implementation: str = "cpython"
+    multi_implementation: bool = field(default=False, hash=False, compare=False)
 
     @property
     def label(self) -> str:
@@ -127,10 +128,11 @@ class MatrixTuple:
         Combines ``python_version``, ``sys_platform``, and
         ``platform_machine`` into a conjunction.  Universal lockfiles
         attach this to each per-tuple ``Package`` entry so an installer
-        on a matching environment picks the right pin.  A non-CPython
-        tuple also constrains ``implementation_name`` so its entry is
-        distinguishable from the CPython tuple for the same
-        python/platform.
+        on a matching environment picks the right pin.  When the matrix
+        models more than one implementation, every tuple constrains
+        ``implementation_name`` so the CPython and PyPy entries for the
+        same python/platform stay mutually exclusive; a sole-CPython
+        matrix omits the clause.
         """
         env = self.environment
         marker = (
@@ -138,7 +140,7 @@ class MatrixTuple:
             f' and sys_platform == "{env["sys_platform"]}"'
             f' and platform_machine == "{env["platform_machine"]}"'
         )
-        if self.implementation != "cpython":
+        if self.multi_implementation or self.implementation != "cpython":
             marker += f' and implementation_name == "{env["implementation_name"]}"'
         return marker
 
@@ -215,6 +217,7 @@ class Matrix:
         if self.python_order == "desc":
             py_versions.reverse()
         patches = self.python_patches or {}
+        multi_impl = len(self.implementations) > 1
         return [
             MatrixTuple(
                 python_version=py,
@@ -222,6 +225,7 @@ class Matrix:
                 environment=_build_environment(py, spec, impl, patches.get(py)),
                 platform_spec=spec,
                 implementation=impl,
+                multi_implementation=multi_impl,
             )
             for py in py_versions
             for spec in specs

--- a/nab-python/tests/universal/test_matrix.py
+++ b/nab-python/tests/universal/test_matrix.py
@@ -317,6 +317,21 @@ class TestMatrixTuple:
         )
         assert t.marker_string.endswith('and implementation_name == "pypy"')
 
+    def test_multi_implementation_cpython_marker_excludes_pypy(self) -> None:
+        """In a multi-implementation matrix the CPython tuple constrains
+        ``implementation_name`` so it no longer matches a PyPy environment."""
+        matrix = Matrix(
+            python="==3.11",
+            platforms=("linux_x86_64",),
+            implementations=("cpython", "pypy"),
+        )
+        tuples = matrix.expand()
+        cpython = next(t for t in tuples if t.implementation == "cpython")
+        pypy = next(t for t in tuples if t.implementation == "pypy")
+        assert cpython.marker_string.endswith('and implementation_name == "cpython"')
+        assert not Marker(cpython.marker_string).evaluate(pypy.environment)
+        assert not Marker(pypy.marker_string).evaluate(cpython.environment)
+
 
 class TestKnownConstants:
     """Coverage for the module-level lookup tables."""


### PR DESCRIPTION
When a matrix models more than one implementation, CPython and PyPy tuples for the same python/platform must be mutually exclusive. Previously, only non-CPython tuples got an `implementation_name` clause, so the CPython marker matched PyPy environments too.

The fix passes a `multi_implementation` flag through to each `MatrixTuple`. When that flag is set, every tuple (including CPython) includes the `implementation_name` constraint. A sole-CPython matrix is unchanged.