### PR TITLE
Validate matrix.python-patches minor matches key

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -821,6 +821,16 @@ def _parse_python_patches(value: object) -> dict[str, str] | None:
                 f" string -> string, got {k!r}: {v!r}"
             )
             raise ConfigError(msg)
+        try:
+            minor = Version(k)
+            full = Version(v)
+        except InvalidVersion as exc:
+            msg = f"matrix.python-patches expects version strings, got {k!r}: {v!r}"
+            raise ConfigError(msg) from exc
+
+        if full.release[:2] != minor.release[:2]:
+            msg = f"matrix.python-patches value {v!r} is not a patch release of {k!r}"
+            raise ConfigError(msg)
         out[k] = v
     return out
 

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -1155,6 +1155,34 @@ class TestMatrix:
         with pytest.raises(ConfigError, match="python-patches entries must be string"):
             read_pyproject_config(path)
 
+    def test_python_patches_minor_mismatch_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            "[tool.nab.matrix]\n"
+            'python = ">=3.11"\n'
+            'platforms = ["linux_x86_64"]\n'
+            "[tool.nab.matrix.python-patches]\n"
+            '"3.11" = "3.12.1"\n',
+        )
+        with pytest.raises(ConfigError, match="not a patch release of '3.11'"):
+            read_pyproject_config(path)
+
+    def test_python_patches_unparseable_version_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            "[tool.nab.matrix]\n"
+            'python = ">=3.11"\n'
+            'platforms = ["linux_x86_64"]\n'
+            "[tool.nab.matrix.python-patches]\n"
+            '"3.11" = "not-a-version"\n',
+        )
+        with pytest.raises(ConfigError, match="python-patches expects version"):
+            read_pyproject_config(path)
+
 
 class TestBuildPolicyPackage:
     """``[tool.nab.build-policy-package]`` parses into a name -> policy mapping."""


### PR DESCRIPTION
If a `matrix.python-patches` entry maps `"3.11"` to `"3.12.1"`, the patch version silently overrides the wrong Python minor. This adds a validation step that raises `ConfigError` when the value's minor version does not match the key.