### PR TITLE
Canonicalize extra names per PEP 685

### DIFF
--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -92,20 +92,34 @@ def read_pyproject_optional_dependencies(
     return raw
 
 
+def _canonicalize_optional_deps(
+    optional_deps: Mapping[str, Sequence[str]],
+) -> dict[str, list[str]]:
+    """Map each extra name to its requirements under PEP 685 normalization."""
+    canonical: dict[str, list[str]] = {}
+    for name, reqs in optional_deps.items():
+        canonical.setdefault(canonicalize_name(name), []).extend(reqs)
+    return canonical
+
+
 def select_optional_dependencies(
     optional_deps: Mapping[str, Sequence[str]],
     selected: Sequence[str],
 ) -> list[Requirement]:
     """Return the union of requirement strings for ``selected`` extras.
 
-    Unknown extra names raise ``LookupError``.  Returns an empty
-    list when ``selected`` is empty.
+    Extra names are compared under PEP 685 normalization, so
+    ``My_Extra`` selects a declared ``my-extra``.  Unknown extra names
+    raise ``LookupError``.  Returns an empty list when ``selected`` is
+    empty.
     """
     if not selected:
         return []
+    canonical_deps = _canonicalize_optional_deps(optional_deps)
     out: list[Requirement] = []
     for name in selected:
-        if name not in optional_deps:
+        canonical = canonicalize_name(name)
+        if canonical not in canonical_deps:
             msg = (
                 f"extra {name!r} is not declared in"
                 f" [project.optional-dependencies]; defined: {sorted(optional_deps)!r}"
@@ -113,7 +127,7 @@ def select_optional_dependencies(
             raise LookupError(msg)
         out.extend(
             _parse_requirements(
-                optional_deps[name],
+                canonical_deps[canonical],
                 f"[project.optional-dependencies] extra {name!r}",
             )
         )
@@ -147,23 +161,28 @@ def expand_self_extras(
     if project_name is None:
         return list(selected)
     canonical_project = canonicalize_name(project_name)
+    canonical_deps = _canonicalize_optional_deps(optional_deps)
     out: list[str] = []
     seen: set[str] = set()
-    worklist: list[str] = list(selected)
+    worklist: list[str] = [canonicalize_name(s) for s in selected]
     while worklist:
         extra = worklist.pop(0)
         if extra in seen:
             continue
         seen.add(extra)
         out.append(extra)
-        for req_str in optional_deps.get(extra, ()):
+        for req_str in canonical_deps.get(extra, ()):
             try:
                 req = Requirement(req_str)
             except (ValueError, TypeError):
                 continue
             if canonicalize_name(req.name) != canonical_project:
                 continue
-            worklist.extend(sub for sub in req.extras if sub not in seen)
+            worklist.extend(
+                canonicalize_name(sub)
+                for sub in req.extras
+                if canonicalize_name(sub) not in seen
+            )
     return out
 
 

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -174,6 +174,17 @@ class TestSelectOptionalDependencies:
         with pytest.raises(InvalidProjectRequirementError, match="gpu"):
             select_optional_dependencies({"gpu": ["torch >= bad junk"]}, ("gpu",))
 
+    def test_selected_extra_name_canonicalized(self) -> None:
+        """PEP 685: a request differing only by case/separator still matches."""
+        opt = {"my-extra": ["requests"]}
+        names = [r.name for r in select_optional_dependencies(opt, ("My_Extra",))]
+        assert names == ["requests"]
+
+    def test_declared_extra_key_canonicalized(self) -> None:
+        opt = {"My_Extra": ["requests"]}
+        names = [r.name for r in select_optional_dependencies(opt, ("my-extra",))]
+        assert names == ["requests"]
+
 
 class TestReadPyprojectName:
     def test_reads_name(self, tmp_path: object) -> None:
@@ -224,6 +235,15 @@ class TestExpandSelfExtras:
         """PEP 503 canonicalisation makes ``my_pkg``/``My.Pkg``/``mypkg`` all match."""
         opt = {"all": ["My.Pkg[a]"], "a": ["depA"]}
         assert expand_self_extras(opt, "my_pkg", ["all"]) == ["all", "a"]
+
+    def test_self_reference_extra_name_canonicalized(self) -> None:
+        """A self-ref naming an extra non-canonically still walks it (PEP 685)."""
+        opt = {
+            "all": ["mypkg[Sub-Extra]"],
+            "sub-extra": ["mypkg[Deep]"],
+            "deep": ["depX"],
+        }
+        assert expand_self_extras(opt, "mypkg", ["all"]) == ["all", "sub-extra", "deep"]
 
     def test_chain_of_self_references(self) -> None:
         opt = {

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -973,6 +973,17 @@ class TestLoadExtraRequirements:
         # the project's own extras-proxy.
         assert "pytest" in names
 
+    def test_selected_extra_name_canonicalized(self, tmp_path: Path) -> None:
+        """A --extra spelling differing only by case/separator still resolves."""
+        path = tmp_path / "pyproject.toml"
+        path.write_text(
+            "[project]\nname = 'x'\n"
+            "[project.optional-dependencies]\n"
+            "my-extra = ['requests']\n"
+        )
+        reqs = _load_extra_requirements(path, ["My_Extra"])
+        assert [r.name for r in reqs] == ["requests"]
+
 
 class TestBuildResolverInputs:
     """``_build_resolver_inputs`` folds duplicate names by intersection."""


### PR DESCRIPTION
Extra names in `[project.optional-dependencies]` can differ by case and separator (e.g. `My_Extra` vs `my-extra`). PEP 685 requires these to be treated as identical, but the old code compared them literally.

Adds `_canonicalize_optional_deps` to normalize all declared extra keys up front, then looks up requests by their canonical form in both `select_optional_dependencies` and `expand_self_extras`.