### PR TITLE
Canonicalize override keys at Provider construction

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -13,7 +13,7 @@ import logging
 import re
 from collections import defaultdict, deque
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 from nab_index.client import SdistFile, WheelFile
 
@@ -70,6 +70,22 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 _EXTRA_RE = re.compile(r"^(?P<base>[^\[]+)\[(?P<extra>[^\]]+)\]$")
+
+_OverrideValue = TypeVar("_OverrideValue")
+
+
+def _canonical_override_map(
+    overrides: Mapping[str, _OverrideValue] | None, label: str
+) -> dict[str, _OverrideValue]:
+    """Return a copy of *overrides* with each key canonicalized; raise on duplicates."""
+    out: dict[str, _OverrideValue] = {}
+    for raw_name, value in (overrides or {}).items():
+        canonical = canonicalize_name(raw_name)
+        if canonical in out:
+            msg = f"duplicate {label} override for {raw_name!r}"
+            raise ValueError(msg)
+        out[canonical] = value
+    return out
 
 
 # PEP 508 ``python_version`` is the ``major.minor`` pair;
@@ -380,7 +396,7 @@ class Provider:
     CONFLICT_THRESHOLD = _priority.CONFLICT_THRESHOLD
     CULPRIT_DEMOTE_THRESHOLD = _priority.CULPRIT_DEMOTE_THRESHOLD
 
-    def __init__(  # noqa: PLR0913, PLR0915, PLR0912, C901 - resolver config is wide; bundling all flags into one bag is worse for callers
+    def __init__(  # noqa: PLR0913, PLR0915, C901 - resolver config is wide; bundling all flags into one bag is worse for callers
         self,
         coordinator: FetchCoordinator,
         python_version: str | None = None,
@@ -406,8 +422,8 @@ class Provider:
         self.coordinator = coordinator
         self.python_version = python_version
         self.uploaded_prior_to = uploaded_prior_to
-        self.uploaded_prior_to_overrides: dict[str, datetime | None] = dict(
-            uploaded_prior_to_overrides or {}
+        self.uploaded_prior_to_overrides = _canonical_override_map(
+            uploaded_prior_to_overrides, "uploaded-prior-to"
         )
 
         # Passed through to the build env when extract_source_metadata
@@ -416,20 +432,16 @@ class Provider:
         self.extras_mode = extras_mode
         self.root_extras = root_extras or set()
         self._dist_policy = dist_policy
-        self._dist_policy_overrides: dict[str, DistPolicy] = dict(
-            dist_policy_overrides or {}
+        self._dist_policy_overrides = _canonical_override_map(
+            dist_policy_overrides, "dist-policy"
         )
         self.build_policy = build_policy
         self._resolution_strategy = resolution_strategy
         self._direct_packages: frozenset[str] = direct_packages or frozenset()
 
-        self._build_policy_overrides: dict[str, BuildPolicy] = {}
-        for raw_name, policy in (build_policy_overrides or {}).items():
-            canonical = canonicalize_name(raw_name)
-            if canonical in self._build_policy_overrides:
-                msg = f"duplicate build-policy override for {raw_name!r}"
-                raise ValueError(msg)
-            self._build_policy_overrides[canonical] = policy
+        self._build_policy_overrides = _canonical_override_map(
+            build_policy_overrides, "build-policy"
+        )
 
         # Backends run on the host, so invoking one under a marker overlay
         # would produce metadata that does not match the impersonated target.

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -2164,6 +2164,31 @@ class TestUploadedPriorToOverrides:
         versions = [v for v, _ in provider.fetch_versions("foo")]
         assert versions == [V("1.0")]
 
+    def test_override_canonicalises_name(self) -> None:
+        """An override declared as ``Foo_Bar`` applies to ``foo-bar``."""
+        wheels = [
+            make_wheel("2.0", upload_time="2024-06-01T00:00:00Z"),
+            make_wheel("1.0", upload_time="2024-01-01T00:00:00Z"),
+        ]
+        coordinator = make_coordinator(wheels, package="foo-bar")
+        package_cutoff = datetime(2024, 3, 1, tzinfo=timezone.utc)
+        provider = Provider(
+            coordinator,
+            uploaded_prior_to=None,
+            uploaded_prior_to_overrides={"Foo_Bar": package_cutoff},
+        )
+        versions = [v for v, _ in provider.fetch_versions("foo-bar")]
+        assert versions == [V("1.0")]
+
+    def test_duplicate_override_raises(self) -> None:
+        coordinator = make_coordinator([], package="foo")
+        cutoff = datetime(2024, 3, 1, tzinfo=timezone.utc)
+        with pytest.raises(ValueError, match="duplicate uploaded-prior-to override"):
+            Provider(
+                coordinator,
+                uploaded_prior_to_overrides={"foo": cutoff, "Foo": None},
+            )
+
 
 def _make_sdist(version: str, package: str = "foo") -> SdistFile:
     """Build a minimal :class:`SdistFile`."""
@@ -2249,6 +2274,26 @@ class TestDistPolicyOverrides:
         )
         assert provider.effective_dist_policy("lxml") is DistPolicy.SDIST_ONLY
         assert provider.effective_dist_policy("foo") is DistPolicy.WHEEL_OR_SDIST
+
+    def test_override_canonicalises_name(self) -> None:
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(
+            coordinator,
+            dist_policy=DistPolicy.WHEEL_OR_SDIST,
+            dist_policy_overrides={"L_XML": DistPolicy.SDIST_ONLY},
+        )
+        assert provider.effective_dist_policy("l-xml") is DistPolicy.SDIST_ONLY
+
+    def test_duplicate_override_raises(self) -> None:
+        coordinator = make_coordinator([], package="foo")
+        with pytest.raises(ValueError, match="duplicate dist-policy override"):
+            Provider(
+                coordinator,
+                dist_policy_overrides={
+                    "lxml": DistPolicy.SDIST_ONLY,
+                    "LXML": DistPolicy.NO_SDIST,
+                },
+            )
 
 
 EXTRA_METADATA = (


### PR DESCRIPTION
Package names in override tables (dist-policy, cooldown, build-policy) were stored as-is, so a key like `Foo_Bar` would never match a lookup for `foo-bar`. This PR canonicalizes all three tables at Provider construction time using `packaging.utils.canonicalize_name`, matching how the config parsers already treat these keys.

Duplicate detection was already in place for build-policy overrides inline. That logic is extracted into `_canonical_override_map` and applied uniformly to all three tables.