### PR TITLE
Normalize extra/group names in disjointness pruning

### DIFF
--- a/nab-python/src/nab_python/_lockfile/disjointness.py
+++ b/nab-python/src/nab_python/_lockfile/disjointness.py
@@ -16,6 +16,8 @@ import re
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
+from .._vendor.packaging.utils import canonicalize_name
+
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
     from collections.abc import Set as AbstractSet
@@ -177,18 +179,23 @@ def _restrict_to_referenced(
     ``variable`` is the marker token (``"extras"`` or
     ``"dependency_groups"``).  The intersection of declared names
     and regex-matched literals shrinks the powerset axis to what
-    the markers actually depend on.  When the bare token appears
-    in some marker but no literals were extracted (an unusual form
-    the regex did not anticipate), fall back to the full declared
-    list so the validator over-approximates rather than silently
-    misses a collision.
+    the markers actually depend on.  Both sides are normalised with
+    :func:`canonicalize_name` before intersecting, because PEP 685 and
+    PEP 735 compare names under normalisation but :meth:`Marker.__str__`
+    re-emits the membership literal verbatim; a case- or separator-only
+    difference would otherwise drop the name and miss its collision.
+    When the bare token appears in some marker but no literals were
+    extracted (an unusual form the regex did not anticipate), fall back
+    to the full declared list so the validator over-approximates rather
+    than silently misses a collision.
     """
     referenced, has_bare = _referenced_membership_names(markers, variable)
     if not has_bare:
         return ()
     if not referenced:
         return tuple(declared)
-    return tuple(name for name in declared if name in referenced)
+    normalized = {canonicalize_name(name) for name in referenced}
+    return tuple(name for name in declared if canonicalize_name(name) in normalized)
 
 
 def _marker_holds(

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -1024,6 +1024,30 @@ class TestMarkerDisjointness:
             groups=(),
         )
 
+    def test_extras_collision_with_normalization_mismatch(self) -> None:
+        # PEP 685 compares extra names under normalization.  The
+        # declared names and the marker literals here differ only by
+        # case and separator, so the powerset pruning must normalize
+        # both sides; otherwise both extras drop out of the universe
+        # and the {cpu, fast-io} collision is silently missed.
+        envs = {
+            "linux": {
+                "python_version": "3.11",
+                "sys_platform": "linux",
+                "platform_machine": "x86_64",
+            },
+        }
+        with pytest.raises(DisjointnessError, match="extras="):
+            validate_marker_disjointness(
+                [
+                    self._pkg("foo", "1.0", "'CPU' in extras"),
+                    self._pkg("foo", "2.0", "'fast_io' in extras"),
+                ],
+                environments=envs,
+                extras=("cpu", "fast-io"),
+                groups=(),
+            )
+
     def test_powerset_pruned_when_no_marker_uses_groups(self) -> None:
         # Symmetric pruning for ``dependency_groups``: a project with
         # many declared groups whose markers do not reference the


### PR DESCRIPTION
PEP 685 and PEP 735 compare extra and dependency-group names under normalization, but `Marker.__str__` re-emits membership literals verbatim. The disjointness pruning in `_restrict_to_referenced` did a plain `in` check against the raw extracted literals, so a name that differed only by case or separator (e.g. declared `fast-io`, referenced as `fast_io`) would silently drop out of the powerset axis and the collision would be missed.

Fix: normalize both the declared names and the extracted literals with `canonicalize_name` before intersecting.