### PR TITLE
Fix platform spec label clobber in universal matrix

### DIFF
--- a/nab-python/src/nab_python/universal/matrix.py
+++ b/nab-python/src/nab_python/universal/matrix.py
@@ -116,10 +116,12 @@ class MatrixTuple:
 
         Uses the interpreter prefix (``py`` for CPython, ``pp`` for
         PyPy) so tuples that differ only by implementation get distinct
-        labels.
+        labels, and appends the platform spec's floor discriminator so
+        two specs sharing a ``platform_id`` do not collapse.
         """
         prefix = _IMPLEMENTATION_PREFIX[self.implementation]
-        return f"{prefix}{self.python_version.replace('.', '')}-{self.platform_id}"
+        base = f"{prefix}{self.python_version.replace('.', '')}-{self.platform_id}"
+        return base + self.platform_spec.label_suffix()
 
     @property
     def marker_string(self) -> str:

--- a/nab-python/src/nab_python/universal/wheel_selection.py
+++ b/nab-python/src/nab_python/universal/wheel_selection.py
@@ -93,6 +93,26 @@ class PlatformSpec:
         """The architecture suffix used in platform tags."""
         return _PLATFORM_ARCH[self.platform_id]
 
+    def label_suffix(self) -> str:
+        """Return a label discriminator, empty for the platform default.
+
+        Two specs sharing a ``platform_id`` collapse to one matrix-tuple
+        label unless their floors set them apart, which silently merges
+        their per-tuple pins.  The suffix encodes the floors so distinct
+        specs stay distinct; a spec left at the platform default emits no
+        suffix and keeps the plain ``pyXY-platform`` label.
+        """
+        if self == PlatformSpec(self.platform_id):
+            return ""
+        fields = (
+            ("glibc", _floor_tag(self.manylinux_floor)),
+            ("musl", _floor_tag(self.musllinux_floor)),
+            ("macos", _floor_tag(self.macos_min)),
+            ("rel", "_".join(self.platform_release.split())),
+            ("ver", "_".join(self.platform_version.split())),
+        )
+        return "".join(f"-{tag}{value}" for tag, value in fields if value)
+
 
 # Map our matrix platform_ids to (kind, arch).  Kind is one of
 # "linux", "macos", "windows".  Used for tag generation.
@@ -111,6 +131,11 @@ _PLATFORM_KIND: dict[str, str] = {
     "macos_x86_64": "macos",
     "windows_amd64": "windows",
 }
+
+
+def _floor_tag(floor: tuple[int, int] | None) -> str:
+    """Render a ``(major, minor)`` floor as ``major.minor``, or ``""`` if unset."""
+    return f"{floor[0]}.{floor[1]}" if floor is not None else ""
 
 
 def _linux_platform_tags(

--- a/nab-python/tests/universal/test_matrix.py
+++ b/nab-python/tests/universal/test_matrix.py
@@ -290,6 +290,23 @@ class TestMatrixTuple:
         )
         assert t.label == "pp311-linux_x86_64"
 
+    def test_duplicate_platform_id_specs_get_distinct_labels(self) -> None:
+        """Two specs sharing a platform_id but differing in a floor stay distinct.
+
+        The default-floor spec keeps the bare label; a non-default floor
+        gets a discriminator suffix so the tuples do not collapse.
+        """
+        matrix = Matrix(
+            python="==3.11",
+            platforms=(
+                PlatformSpec("linux_x86_64", manylinux_floor=(2, 17)),
+                PlatformSpec("linux_x86_64", manylinux_floor=(2, 34)),
+            ),
+        )
+        labels = [t.label for t in matrix.expand()]
+        assert len(set(labels)) == 2
+        assert "py311-linux_x86_64" in labels
+
     def test_cpython_marker_omits_implementation(self) -> None:
         """The default CPython marker keeps its three-clause form."""
         t = MatrixTuple(

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -44,6 +44,7 @@ from nab_python.universal.resolve import (
     merge_universal_lock_inputs,
     resolve_with_coordinator,
 )
+from nab_python.universal.wheel_selection import PlatformSpec
 from nab_resolver.errors import ResolutionError
 
 if TYPE_CHECKING:
@@ -597,6 +598,48 @@ class TestMergeUniversalLockInputs:
         # Only the linux tuple survives; windows had no lock_input.
         assert set(merged.per_tuple_pins) == {"py311-linux_x86_64"}
         assert set(merged.tuple_markers) == {"py311-linux_x86_64"}
+
+    def test_distinct_platform_specs_do_not_clobber_pins(self) -> None:
+        """Two specs sharing a platform_id keep separate per-tuple pins.
+
+        Both tuples share python_version and platform_id, so before the
+        label gained a spec discriminator they produced the same label
+        and the second tuple's pins overwrote the first in
+        ``per_tuple_pins``, silently dropping a resolved pin.
+        """
+        matrix = Matrix(
+            python="==3.11",
+            platforms=(
+                PlatformSpec("linux_x86_64", manylinux_floor=(2, 17)),
+                PlatformSpec("linux_x86_64", manylinux_floor=(2, 34)),
+            ),
+        )
+        older, newer = matrix.expand()
+        results = [
+            TupleResult(
+                tuple_=older,
+                success=True,
+                pins={"pkg": Version("1.0")},
+                lock_input=LockInput(
+                    pins={"pkg": IndexPin(name="pkg", version="1.0", index="pypi")},
+                ),
+            ),
+            TupleResult(
+                tuple_=newer,
+                success=True,
+                pins={"pkg": Version("2.0")},
+                lock_input=LockInput(
+                    pins={"pkg": IndexPin(name="pkg", version="2.0", index="pypi")},
+                ),
+            ),
+        ]
+        merged = merge_universal_lock_inputs(
+            UniversalResult(matrix=matrix, tuple_results=results)
+        )
+        assert len(merged.per_tuple_pins) == 2
+        assert len(merged.tuple_markers) == 2
+        versions = {pins["pkg"].version for pins in merged.per_tuple_pins.values()}
+        assert versions == {"1.0", "2.0"}
 
 
 class TestResolveWithCoordinator:


### PR DESCRIPTION
Two `PlatformSpec` instances that share a `platform_id` but differ in their floor settings (manylinux glibc, musllinux musl, macOS minimum, or kernel release/version) previously produced identical `MatrixTuple.label` values, so the second tuple's pins silently overwrote the first in `per_tuple_pins` when `merge_universal_lock_inputs` ran.

`PlatformSpec.label_suffix()` now appends a discriminator string encoding each non-default floor. A spec left at the platform default emits no suffix and keeps the plain `pyXY-platform` label for backward compatibility.