### PR TITLE
Fix Requires-Python check to use full patch version

### DIFF
--- a/nab-python/src/nab_python/universal/provider.py
+++ b/nab-python/src/nab_python/universal/provider.py
@@ -103,7 +103,13 @@ class UniversalProvider(Provider):
                 raise ValueError(msg) from exc
         super().__init__(
             coordinator,
-            python_version=marker_environment.get("python_version"),
+            # Use the full patch version for Requires-Python evaluation;
+            # python_version only carries major.minor, so patch-level
+            # specifiers (e.g. >=3.13.1) require python_full_version.
+            python_version=(
+                marker_environment.get("python_full_version")
+                or marker_environment.get("python_version")
+            ),
             root_requirements=root_requirements,
             uploaded_prior_to=uploaded_prior_to,
             uploaded_prior_to_overrides=uploaded_prior_to_overrides,

--- a/nab-python/tests/universal/test_universal_provider.py
+++ b/nab-python/tests/universal/test_universal_provider.py
@@ -433,6 +433,29 @@ class TestWheelTagFiltering:
         assert provider.excluded_versions_no_compatible_wheel == 1
 
 
+class TestRequiresPythonPatch:
+    """Requires-Python is evaluated against the tuple's full patch version."""
+
+    def test_dist_kept_when_patch_satisfies_requires_python(self) -> None:
+        """python_full_version 3.13.4 keeps a dist that requires >=3.13.1."""
+        env = {**_LINUX_ENV, "python_version": "3.13", "python_full_version": "3.13.4"}
+        provider = UniversalProvider(
+            _make_coordinator([_make_wheel("1.0", requires_python=">=3.13.1")]),
+            marker_environment=env,
+        )
+        result = provider.fetch_versions("pkg")
+        assert [v for v, _ in result] == [Version("1.0")]
+
+    def test_dist_excluded_when_patch_below_requires_python(self) -> None:
+        """A tuple targeting 3.13.0 excludes a >=3.13.1 dist."""
+        env = {**_LINUX_ENV, "python_version": "3.13", "python_full_version": "3.13.0"}
+        provider = UniversalProvider(
+            _make_coordinator([_make_wheel("1.0", requires_python=">=3.13.1")]),
+            marker_environment=env,
+        )
+        assert provider.fetch_versions("pkg") == []
+
+
 _FORTY_SHA = "0123456789abcdef0123456789abcdef01234567"
 
 


### PR DESCRIPTION
In universal mode, `UniversalProvider.__init__` was passing `python_version` (e.g. `3.13`) to the base `Provider` as the Python version for Requires-Python evaluation. This fails for patch-level specifiers like `>=3.13.1` because `python_version` only carries major.minor.

Fix: prefer `python_full_version` (e.g. `3.13.4`) when it is present in the marker environment, falling back to `python_version` for environments that do not set a patch component. The `_py_minor` field used for wheel tag matching is unchanged.