### PR TITLE
Fix local/VCS Requires-Python patch comparison in universal mode

### DIFF
--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -499,7 +499,7 @@ def _raise_for_local_vcs_python(
     managed = provider.local_sources.keys() | provider.vcs_sources.keys()
     if not managed:
         return
-    target = Version(t.python_version)
+    target = Version(t.environment["python_full_version"])
     for name, version in pins.items():
         normalized = canonicalize_name(name)
         if normalized not in managed:
@@ -508,7 +508,7 @@ def _raise_for_local_vcs_python(
         if spec is not None and target not in spec:
             msg = (
                 f"{normalized} {version} requires Python {spec} but tuple "
-                f"{t.label} targets Python {t.python_version}"
+                f"{t.label} targets Python {target}"
             )
             raise ResolutionError(msg)
 

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -774,3 +774,43 @@ class TestLocalVcsRequiresPython:
         )
         assert result.success
         assert str(result.tuple_results[0].pins["foo"]) == "1.0"
+
+    def test_patch_satisfies_local_requires_python(self, tmp_path: Path) -> None:
+        local = self._write(
+            tmp_path,
+            '[project]\nname = "foo"\nversion = "1.0"\nrequires-python = ">=3.13.1"\n',
+        )
+        coord = make_coordinator([], package="foo")
+        result = resolve_with_coordinator(
+            coord,
+            Matrix(
+                python="==3.13",
+                platforms=("linux_x86_64",),
+                python_patches={"3.13": "3.13.4"},
+            ),
+            ["foo"],
+            local_sources=[local],
+        )
+        assert result.success
+        assert str(result.tuple_results[0].pins["foo"]) == "1.0"
+
+    def test_patch_below_local_requires_python_fails(self, tmp_path: Path) -> None:
+        local = self._write(
+            tmp_path,
+            '[project]\nname = "foo"\nversion = "1.0"\nrequires-python = ">=3.13.5"\n',
+        )
+        coord = make_coordinator([], package="foo")
+        result = resolve_with_coordinator(
+            coord,
+            Matrix(
+                python="==3.13",
+                platforms=("linux_x86_64",),
+                python_patches={"3.13": "3.13.4"},
+            ),
+            ["foo"],
+            local_sources=[local],
+        )
+        assert not result.success
+        error = result.tuple_results[0].error
+        assert error is not None
+        assert "foo 1.0 requires Python" in error


### PR DESCRIPTION
When checking a local or VCS pin's Requires-Python in universal mode, the code was comparing against `t.python_version` (the minor-only string like "3.13") rather than the full patch version from the tuple's marker environment. This meant a package requiring `>=3.13.1` would incorrectly fail against a tuple where the patch is 3.13.4, and a package requiring `>=3.13.5` would incorrectly pass against a tuple where the patch is 3.13.2.

The fix mirrors the same correction already applied to index-sourced dependencies: use `t.environment["python_full_version"]` to construct the comparison target so patch-level specifiers are evaluated correctly.