### PR TITLE
Honor root extras in universal resolution

### DIFF
--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -43,6 +43,7 @@ from ..provider import (
     LocalSource,
     VcsConfig,
     VcsSource,
+    join_extra,
     split_extra,
 )
 from ..requirements_file import raise_for_unsatisfiable
@@ -444,8 +445,24 @@ def _parse_requirements(
         out[name] = out.get(name, VersionRange.full()) & req.specifier.to_range()
         sources[name].append(req_str)
         for extra in req.extras:
-            out[f"{name}[{extra}]"] = VersionRange.full()
+            out[join_extra(name, extra)] = VersionRange.full()
     raise_for_unsatisfiable(out, sources, kind=kind)
+    return out
+
+
+def _root_extras(requirements: dict[str, VersionRange]) -> set[tuple[str, str]]:
+    """Recover the user's requested extras from the proxy keys.
+
+    ``_parse_requirements`` adds a ``name[extra]`` proxy key for every root
+    extra. Feeding these to the provider as ``root_extras`` matches the
+    single-environment path, so a missing user-requested extra raises
+    ``MissingExtraError`` instead of being silently dropped.
+    """
+    out: set[tuple[str, str]] = set()
+    for key in requirements:
+        base, extra = split_extra(key)
+        if extra is not None:
+            out.add((base, extra))
     return out
 
 
@@ -521,6 +538,7 @@ def _resolve_one_tuple(  # noqa: PLR0913
         coordinator,
         marker_environment=t.environment,
         root_requirements=requirements,
+        root_extras=_root_extras(requirements),
         uploaded_prior_to=uploaded_prior_to,
         uploaded_prior_to_overrides=uploaded_prior_to_overrides,
         dist_policy=dist_policy,

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -24,6 +24,7 @@ from nab_python.provider import (
     BuildPolicy,
     DistPolicy,
     LocalSource,
+    MissingExtraError,
     UnsupportedSdistError,
     VcsConfig,
     VcsPolicy,
@@ -37,6 +38,7 @@ from nab_python.universal.resolve import (
     _direct_package_names,
     _parse_requirements,
     _resolve_one_tuple,
+    _root_extras,
     _run_pass,
     _warn_extra_marker_at_root,
     merge_universal_lock_inputs,
@@ -232,6 +234,24 @@ class TestParseRequirements:
         env = _linux_311().environment
         with pytest.raises(ConfigError, match="extras"):
             _parse_requirements(["pkg[dev]<2.0"], env, kind="constraint")
+
+    def test_extra_proxy_key_normalized(self) -> None:
+        """The proxy key is PEP 685 normalized, matching the single-env path."""
+        env = _linux_311().environment
+        out = _parse_requirements(["pkg[My_Extra]"], env)
+        assert "pkg[my-extra]" in out
+
+
+class TestRootExtras:
+    """``_root_extras`` recovers requested extras from the proxy keys."""
+
+    def test_recovers_and_normalizes_extras(self) -> None:
+        env = _linux_311().environment
+        out = _parse_requirements(["pkg[My_Extra]", "other"], env)
+        assert _root_extras(out) == {("pkg", "my-extra")}
+
+    def test_no_extras_yields_empty(self) -> None:
+        assert _root_extras({"pkg": VersionRange.full()}) == set()
 
 
 class TestResolveOneTuple:
@@ -593,6 +613,18 @@ class TestResolveWithCoordinator:
         )
         assert result.success
         assert result.tuple_results[0].pins == {"pkg": Version("1.0")}
+
+    def test_user_requested_missing_extra_raises(self) -> None:
+        """A user-requested extra a package does not provide raises.
+
+        Matches the single-environment path: with the default
+        ``ExtrasMode.ERROR_USER``, a missing user extra is an error
+        rather than a silent drop.
+        """
+        coordinator = _make_coordinator({"pkg": [_make_wheel("1.0", package="pkg")]})
+        matrix = Matrix(python="==3.11", platforms=("linux_x86_64",))
+        with pytest.raises(MissingExtraError):
+            resolve_with_coordinator(coordinator, matrix, ["pkg[missing]"])
 
     def test_constraints_passed_through(self) -> None:
         """User-supplied constraints reach the resolver."""


### PR DESCRIPTION
Universal resolution was not passing `root_extras` to the provider, so a user-requested extra that a package does not provide was silently dropped instead of raising `MissingExtraError`. This matches the existing single-environment behaviour.

`_parse_requirements` already emits a `name[extra]` proxy key for each root extra; `_root_extras` reads those keys back out and feeds them to the `UniversalProvider` constructor as `root_extras`.