### PR TITLE
Keep sdist-only versions available under BuildPolicy.NEVER in universal mode

### DIFF
--- a/nab-python/src/nab_python/universal/provider.py
+++ b/nab-python/src/nab_python/universal/provider.py
@@ -18,7 +18,8 @@ When ``platform_spec`` is supplied, the provider also filters wheel
 candidates by tag compatibility at resolve time (hole 2 in
 ``universal_open_questions.md``).  Versions whose only wheels are
 above the spec's manylinux/musllinux/macOS floor become unavailable
-unless an sdist is present and ``build_policy`` allows building.
+unless an sdist is present, which keeps the version alive at every
+``build_policy`` level (look-ahead rejects an unreadable sdist).
 """
 
 from __future__ import annotations
@@ -210,8 +211,7 @@ class UniversalProvider(Provider):
                 kept.append((version, dist))
                 versions_with_sdist.add(version)
 
-        build_allowed = self.build_policy != BuildPolicy.NEVER
-        usable = versions_with_wheel | (versions_with_sdist if build_allowed else set())
+        usable = versions_with_wheel | versions_with_sdist
         all_versions = {v for v, _ in base}
         self.excluded_versions_no_compatible_wheel += len(all_versions) - len(usable)
         return [pair for pair in kept if pair[0] in usable]

--- a/nab-python/tests/universal/property_universal/test_provider_pep425.py
+++ b/nab-python/tests/universal/property_universal/test_provider_pep425.py
@@ -181,13 +181,9 @@ class TestOnlyCompatibleWheelsKept:
 
 class TestVersionAdmissionPolicy:
     """A version survives the wheel-tag filter iff at least one usable
-    artifact remains.  Under ``BuildPolicy.BUILD_REMOTE`` an sdist
-    (per `PEP 517`_'s build-from-sdist contract) counts as usable;
-    under ``BuildPolicy.NEVER`` only a tag-compatible wheel counts.
-
-    The two parameter combinations correspond to "wheel-only" and
-    "wheel-or-sdist" install modes; the filter must distinguish
-    between them.
+    artifact remains.  A compatible wheel OR an sdist keeps the version
+    alive at every ``BuildPolicy`` level; look-ahead, not this filter,
+    rejects an unreadable sdist under ``BuildPolicy.NEVER``.
 
     .. _PEP 517: https://peps.python.org/pep-0517/
     """
@@ -224,10 +220,12 @@ class TestVersionAdmissionPolicy:
 
     @given(files=listing())
     @PROPERTY_SETTINGS
-    def test_never_policy_drops_sdist_only_versions(
+    def test_never_policy_keeps_sdist_only_versions(
         self, files: list[WheelFile | SdistFile]
     ) -> None:
-        """Under NEVER, a version is admitted iff a compatible wheel exists."""
+        """Under NEVER, a version is admitted if a compatible wheel OR an sdist
+        exists; the look-ahead gate, not filter_distributions, rejects an
+        unbuildable sdist, so sdist-only versions stay available here."""
         spec = PlatformSpec("linux_x86_64")
         provider = UniversalProvider(
             coordinator(files),
@@ -246,5 +244,5 @@ class TestVersionAdmissionPolicy:
             for v, d in super_out
             if isinstance(d, WheelFile)
             and wheel_compatible_with_tuple(d, python_version="3.11", spec=spec)
-        }
+        } | {v for v, d in super_out if isinstance(d, SdistFile)}
         assert out_versions == expected

--- a/nab-python/tests/universal/test_universal_provider.py
+++ b/nab-python/tests/universal/test_universal_provider.py
@@ -383,11 +383,12 @@ class TestWheelTagFiltering:
         # is the incompatible win wheel, so the version disappears.
         assert result == []
 
-    def test_incompatible_wheel_with_sdist_under_never_drops_version(self) -> None:
-        """Incompatible wheel + sdist + NEVER -> version is dropped.
+    def test_incompatible_wheel_with_sdist_under_never_kept_via_sdist(self) -> None:
+        """Incompatible wheel + sdist + NEVER -> version stays alive.
 
-        Exercises the elif=False branch in the version-survival loop:
-        sdists alone cannot save a version when builds are forbidden.
+        An sdist keeps the version alive at every build policy level: a
+        PEP 643 static sdist is read without a backend, so look-ahead,
+        not this filter, rejects the dynamic-no-fallback case.
         """
         files: list[WheelFile | SdistFile] = [
             _platform_wheel("2.0", "cp311-cp311-win_amd64"),
@@ -401,11 +402,10 @@ class TestWheelTagFiltering:
             build_policy=BuildPolicy.NEVER,
         )
         result = provider.filter_distributions("pkg", files)
-        # The win wheel is tag-incompatible; only the sdist is kept by
-        # the first pass.  Since build_policy=NEVER, the version is not
-        # admitted (we'd hit UnsupportedSdistError later anyway).
-        assert result == []
-        assert provider.excluded_versions_no_compatible_wheel == 1
+        kept_kinds = {(v, isinstance(d, WheelFile)) for v, d in result}
+        assert (Version("2.0"), False) in kept_kinds
+        assert (Version("2.0"), True) not in kept_kinds
+        assert provider.excluded_versions_no_compatible_wheel == 0
 
     def test_fetch_versions_applies_wheel_tag_filter(self) -> None:
         """Regression: the resolver path must consult the override.
@@ -419,14 +419,12 @@ class TestWheelTagFiltering:
         """
         files: list[WheelFile | SdistFile] = [
             _platform_wheel("2.0", "cp311-cp311-win_amd64"),
-            _sdist("2.0"),
         ]
         provider = UniversalProvider(
             _index_with_files(files),
             marker_environment=_LINUX_ENV,
             platform_spec=PlatformSpec("linux_x86_64"),
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
-            build_policy=BuildPolicy.NEVER,
         )
         result = provider.fetch_versions("pkg")
         assert result == []


### PR DESCRIPTION
The `filter_distributions` override in `UniversalProvider` was dropping sdist-only versions whenever `build_policy=BuildPolicy.NEVER`. That was wrong: a PEP 643 static sdist is read without invoking a build backend, so metadata extraction succeeds unconditionally. Under NEVER the look-ahead gate, not this filter, is the right place to reject a version whose sdist has dynamic deps and no static fallback.

The fix removes the `build_allowed` guard so sdists contribute to the usable-version set at every build-policy level. The test that previously asserted the version was dropped is updated to assert it stays alive (sdist only, no wheel).