### PR TITLE
Refuse direct-URL deps in universal mode

### DIFF
--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -19,6 +19,7 @@ from nab_index.urllib3_async_transport import Urllib3AsyncTransport
 from nab_resolver.errors import ResolutionError
 from nab_resolver.resolver import Resolver
 
+from .._vcs_admission import admit_vcs_url
 from .._vendor.packaging.markers import Marker
 from .._vendor.packaging.ranges import VersionRange
 from .._vendor.packaging.requirements import InvalidRequirement, Requirement
@@ -336,7 +337,7 @@ def _run_pass(  # noqa: PLR0913
     def resolve(t: MatrixTuple, current_prefs: dict[str, Version]) -> TupleResult:
         try:
             tuple_requirements, tuple_constraints = _parse_tuple_inputs(
-                requirements, constraints, t.environment
+                requirements, constraints, t.environment, vcs_config or VcsConfig()
             )
         except ResolutionError as exc:
             return TupleResult(
@@ -420,6 +421,7 @@ def _parse_requirements(
     reqs: list[str],
     environment: dict[str, str],
     *,
+    vcs_config: VcsConfig | None = None,
     kind: str = "requirement",
 ) -> dict[str, VersionRange]:
     """Convert PEP 508 strings to resolver requirements for ``environment``.
@@ -428,6 +430,10 @@ def _parse_requirements(
     ``environment`` are dropped.  This matches what
     ``Provider._classify_requirement`` does for transitive deps;
     we just apply the same rule at the root.
+
+    A direct-URL/VCS requirement is refused via :func:`admit_vcs_url`,
+    mirroring the single-environment path; universal resolution of such
+    sources is not implemented.
 
     Repeated package names are intersected into one range; an empty
     intersection raises :class:`ResolutionError`.  ``kind``
@@ -442,6 +448,13 @@ def _parse_requirements(
             raise ConfigError(msg)
         if req.marker is not None and not req.marker.evaluate(environment):
             continue
+        if req.url is not None:
+            admit_vcs_url(req.url, vcs_config or VcsConfig())
+            msg = (
+                f"VCS {kind} admitted by policy but resolver path is not"
+                f" implemented: {req.name} @ {req.url}"
+            )
+            raise NotImplementedError(msg)
         name = canonicalize_name(req.name)
         out[name] = out.get(name, VersionRange.full()) & req.specifier.to_range()
         sources[name].append(req_str)
@@ -471,14 +484,19 @@ def _parse_tuple_inputs(
     requirements: list[str],
     constraints: list[str] | None,
     environment: dict[str, str],
+    vcs_config: VcsConfig,
 ) -> tuple[dict[str, VersionRange], dict[str, VersionRange] | None]:
     """Parse a tuple's root requirements and constraints for its env.
 
     Raises :class:`ResolutionError` if either folds to an empty range.
     """
-    parsed_requirements = _parse_requirements(requirements, environment)
+    parsed_requirements = _parse_requirements(
+        requirements, environment, vcs_config=vcs_config
+    )
     parsed_constraints = (
-        _parse_requirements(constraints, environment, kind="constraint")
+        _parse_requirements(
+            constraints, environment, vcs_config=vcs_config, kind="constraint"
+        )
         if constraints
         else None
     )

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -26,6 +26,7 @@ from nab_python.provider import (
     LocalSource,
     MissingExtraError,
     UnsupportedSdistError,
+    UnsupportedVcsError,
     VcsConfig,
     VcsPolicy,
     VcsSource,
@@ -164,6 +165,9 @@ class TestWarnExtraMarkerAtRoot:
         assert any("extra" in rec.message.lower() for rec in caplog.records)
 
 
+_FORTY_SHA = "0123456789abcdef0123456789abcdef01234567"
+
+
 class TestParseRequirements:
     """``_parse_requirements`` builds the resolver-input dict per env."""
 
@@ -241,6 +245,43 @@ class TestParseRequirements:
         env = _linux_311().environment
         out = _parse_requirements(["pkg[My_Extra]"], env)
         assert "pkg[my-extra]" in out
+
+    def test_plain_url_requirement_refused(self) -> None:
+        """A plain archive URL is refused as an unsupported scheme."""
+        env = _linux_311().environment
+        with pytest.raises(UnsupportedVcsError, match="not a recognized VCS scheme"):
+            _parse_requirements(["pkg @ https://example.com/pkg.whl"], env)
+
+    def test_vcs_url_refused_by_default_policy(self) -> None:
+        """A git+https requirement is refused under the default BLOCK policy."""
+        env = _linux_311().environment
+        with pytest.raises(UnsupportedVcsError, match="VcsPolicy is BLOCK"):
+            _parse_requirements(
+                [f"pkg @ git+https://example.com/pkg.git@{_FORTY_SHA}"], env
+            )
+
+    def test_url_constraint_refused(self) -> None:
+        """A direct-URL constraint is refused the same way as a requirement."""
+        env = _linux_311().environment
+        with pytest.raises(UnsupportedVcsError, match="VcsPolicy is BLOCK"):
+            _parse_requirements(
+                [f"pkg @ git+https://example.com/pkg.git@{_FORTY_SHA}"],
+                env,
+                kind="constraint",
+            )
+
+    def test_admitted_vcs_url_raises_not_implemented(self) -> None:
+        """An admitted VCS requirement still has no universal resolve path."""
+        env = _linux_311().environment
+        vcs_config = VcsConfig(
+            policy=VcsPolicy.ALLOW, allowed_schemes=frozenset({"git+https"})
+        )
+        with pytest.raises(NotImplementedError, match="not implemented"):
+            _parse_requirements(
+                [f"pkg @ git+https://example.com/pkg.git@{_FORTY_SHA}"],
+                env,
+                vcs_config=vcs_config,
+            )
 
 
 class TestRootExtras:
@@ -332,9 +373,6 @@ class TestResolveOneTuple:
         assert tr.error is not None
         assert "MissingSdistError" in tr.error
         assert tr.pins == {"pkg": Version("1.0")}
-
-
-_FORTY_SHA = "0123456789abcdef0123456789abcdef01234567"
 
 
 class TestVcsConfigPlumbing:

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -245,6 +245,9 @@ def _resolve_universal(
     except HttpError as e:
         sys.stderr.write(f"Cannot lock: {e}\n")
         sys.exit(1)
+    except UnsupportedVcsError as e:
+        sys.stderr.write(f"Cannot lock: {e}\n")
+        sys.exit(1)
 
     if not result.success:
         _print_universal_blocks(result)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -585,6 +585,23 @@ class TestLockCommandUniversal:
             lock(pyproject, output=tmp_path / "pylock.toml")
         assert "Cannot lock" in capsys.readouterr().err
 
+    def test_unsupported_vcs_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A direct-URL requirement refused in universal mode exits cleanly."""
+        pyproject = _universal_pyproject(tmp_path)
+        with (
+            patch(
+                "nab.cli.resolve_universal_pyproject",
+                side_effect=UnsupportedVcsError("refusing direct-URL requirement"),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, output=tmp_path / "pylock.toml")
+        err = capsys.readouterr().err
+        assert "Cannot lock" in err
+        assert "refusing direct-URL requirement" in err
+
     def test_per_tuple_pins_to_stdout_by_default(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
When a root requirement or constraint contained a direct URL (plain archive or VCS), the universal resolver silently dropped the URL and resolved only the package name from the index, ignoring the pin the user specified.

The fix calls `admit_vcs_url` on any `req.url` before proceeding. Under the default BLOCK policy this raises `UnsupportedVcsError` immediately. Under an ALLOW policy the URL passes admission but hits a `NotImplementedError` because universal resolution of direct-URL sources is not yet implemented. The `_emit_universal` CLI path now catches `UnsupportedVcsError` and exits with a clean error instead of a traceback.