### PR TITLE
Warn on dropped root extra marker in single-env mode

### DIFF
--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -470,6 +470,13 @@ def _build_resolver_inputs(
     root_extras: set[tuple[str, str]] = set()
     for req in requirements:
         if req.marker is not None and not req.marker.evaluate(environment):
+            if "extra ==" in str(req.marker):
+                _logger.warning(
+                    "Root requirement %r uses an extra marker; the dep is "
+                    "dropped because root has no parent extra. Did you mean "
+                    "pkg[extra] (extras-of-package) instead?",
+                    str(req),
+                )
             continue
         if req.url is not None:
             admit_vcs_url(req.url, config.vcs)

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -1041,6 +1041,26 @@ class TestBuildResolverInputs:
         with pytest.raises(ResolutionError, match="foo==1.0"):
             _build_resolver_inputs(reqs, NabProjectConfig(), environment={})
 
+    def test_root_extra_marker_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A root requirement gated on ``extra ==`` is dropped with a warning."""
+        reqs = [Requirement('foo ; extra == "test"')]
+        with caplog.at_level("WARNING", logger="nab_python.resolve"):
+            resolver_requirements, _ = _build_resolver_inputs(
+                reqs, NabProjectConfig(), environment={}
+            )
+        assert "foo" not in resolver_requirements
+        assert any("uses an extra marker" in rec.message for rec in caplog.records)
+
+    def test_env_gated_drop_is_silent(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A requirement dropped by a plain env marker stays silent."""
+        reqs = [Requirement('foo ; python_version < "3.0"')]
+        with caplog.at_level("WARNING", logger="nab_python.resolve"):
+            resolver_requirements, _ = _build_resolver_inputs(
+                reqs, NabProjectConfig(), environment={}
+            )
+        assert "foo" not in resolver_requirements
+        assert not caplog.records
+
 
 class TestBuildConstraints:
     """``_build_constraints`` folds duplicate constraint lines."""


### PR DESCRIPTION
When a root requirement carries an `extra ==` marker, `packaging` evaluates it to `False` (root has no parent extra), so the dep is silently dropped. This adds a `WARNING` log message pointing the user toward the `pkg[extra]` syntax they likely intended.

Two tests cover the new branch: one checks the warning fires for an extra-gated dep, and one checks that a plain environment-gated dep stays silent.