### PR TITLE
Write universal failure blocks to stderr

### DIFF
--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -665,7 +665,7 @@ def _validate_pylock_output_name(
 
 
 def _print_universal_blocks(result: UniversalResult) -> None:
-    """Write per-tuple pin blocks (with FAILED markers) to stdout."""
+    """Write per-tuple pin blocks (with FAILED markers) to stderr."""
     blocks: list[str] = []
     for tr in result.tuple_results:
         label = tr.tuple_.label
@@ -675,4 +675,4 @@ def _print_universal_blocks(result: UniversalResult) -> None:
             continue
         blocks.append(f"# {label}")
         blocks.extend(f"{name}=={tr.pins[name]}" for name in sorted(tr.pins))
-    sys.stdout.write("\n".join(blocks) + "\n")
+    sys.stderr.write("\n".join(blocks) + "\n")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -621,9 +621,9 @@ class TestLockCommandUniversal:
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, format="requirements-without-hashes")
-        out = capsys.readouterr().out
-        assert "FAILED" in out
-        assert "#   conflict" in out
+        err = capsys.readouterr().err
+        assert "FAILED" in err
+        assert "#   conflict" in err
 
     def test_failed_tuple_multi_line_error(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -639,10 +639,10 @@ class TestLockCommandUniversal:
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, format="requirements-without-hashes")
-        out = capsys.readouterr().out
-        assert "#   first line" in out
-        assert "#   second line" in out
-        assert "#   third line" in out
+        err = capsys.readouterr().err
+        assert "#   first line" in err
+        assert "#   second line" in err
+        assert "#   third line" in err
 
     def test_failed_tuple_no_error_message(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -657,7 +657,7 @@ class TestLockCommandUniversal:
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, format="requirements-without-hashes")
-        assert "FAILED" in capsys.readouterr().out
+        assert "FAILED" in capsys.readouterr().err
 
     def test_missing_dependencies_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -755,10 +755,10 @@ class TestLockCommandUniversal:
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, format="requirements-without-hashes")
-        out = capsys.readouterr().out
-        assert "# py311-linux_x86_64" in out
-        assert "foo==1.0" in out
-        assert "# py311-windows_amd64: FAILED" in out
+        err = capsys.readouterr().err
+        assert "# py311-linux_x86_64" in err
+        assert "foo==1.0" in err
+        assert "# py311-windows_amd64: FAILED" in err
 
     def test_template_writes_one_file_per_tuple(self, tmp_path: Path) -> None:
         """``{python_version}`` in --output expands to one file per tuple."""


### PR DESCRIPTION
Universal resolution failure blocks were written to stdout, mixing diagnostic output with the lockfile stream. Scripts that capture stdout to process the lock output would receive failure blocks mixed in on a partial failure.

This moves the failure output to stderr, where it belongs alongside other diagnostics.