### PR TITLE
Normalize group names on pylock emit

### DIFF
--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -122,12 +122,14 @@ def build_pylock(lock_input: LockInput, *, lock_dir: Path | None = None) -> Pylo
             else None
         ),
         dependency_groups=(
-            tuple(lock_input.dependency_groups)
+            tuple(canonicalize_name(g) for g in lock_input.dependency_groups)
             if lock_input.dependency_groups
             else None
         ),
         default_groups=(
-            tuple(lock_input.default_groups) if lock_input.default_groups else None
+            tuple(canonicalize_name(g) for g in lock_input.default_groups)
+            if lock_input.default_groups
+            else None
         ),
         created_by=lock_input.created_by,
         packages=package_records,

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -866,6 +866,18 @@ class TestDependencyGroups:
         assert "dependency-groups" not in data
         assert "default-groups" not in data
 
+    def test_group_names_normalized(self) -> None:
+        text = write_lock(
+            LockInput(
+                pins={"foo": _index_pin()},
+                dependency_groups=("Dev_Group", "Doc.s"),
+                default_groups=("Dev_Group",),
+            )
+        )
+        data = tomllib.loads(text)
+        assert data["dependency-groups"] == ["dev-group", "doc-s"]
+        assert data["default-groups"] == ["dev-group"]
+
 
 class TestMarkerDisjointness:
     def _pkg(self, name: str, version: str, marker: str | None = None) -> Package:


### PR DESCRIPTION
PEP 508 names are case-insensitive and normalise underscores, dots, and runs of separators to a single hyphen. Dependency-group names follow the same convention, but `build_pylock` was emitting them verbatim from `LockInput`, so a group named `Dev_Group` would appear as `Dev_Group` in the lock rather than `dev-group`.

Apply `canonicalize_name` to each entry in `dependency_groups` and `default_groups` at emit time, consistent with how package names, extras, and other name-like fields are already handled in the same function.