### PR TITLE
Keep explicit local-source pin under --no-emit-workspace

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -197,6 +197,7 @@ def _apply_workspace_discovery(
     if not discovered:
         return config
     merged = merge_workspace_local_sources(config.local_sources, discovered)
+    explicit_names = {canonicalize_name(src.name) for src in config.local_sources}
     promoted_policy = auto_promote_build_policy_for_workspace(config.build_policy)
     if promoted_policy is not config.build_policy:
         _logger.info(
@@ -211,7 +212,9 @@ def _apply_workspace_discovery(
         local_sources=merged,
         build_policy=promoted_policy,
         workspace_member_names=frozenset(
-            canonicalize_name(src.name) for src in discovered
+            canonicalize_name(src.name)
+            for src in discovered
+            if canonicalize_name(src.name) not in explicit_names
         ),
     )
 

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -1322,6 +1322,21 @@ class TestWorkspaceDiscoveryIntegration:
         config = read_pyproject_config(member)
         assert config.local_sources == (LocalSource(name="alpha", path=str(explicit)),)
 
+    def test_shadowed_member_excluded_from_workspace_member_names(
+        self, tmp_path: Path
+    ) -> None:
+        member = self._ws(tmp_path)
+        explicit = (tmp_path / "explicit-alpha").resolve()
+        member.write_text(
+            '[project]\nname = "alpha"\nversion = "0"\n'
+            "[tool.nab]\n"
+            "[[tool.nab.local-sources]]\n"
+            'name = "alpha"\n'
+            f'path = "{explicit.as_posix()}"\n',
+        )
+        config = read_pyproject_config(member)
+        assert config.workspace_member_names == frozenset()
+
     def test_workspace_promotes_never_to_build_local_and_logs(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:


### PR DESCRIPTION
When `--no-emit-workspace` is set, `workspace_member_names` is used to drop workspace members from the lockfile output. If the user had already pinned a workspace member via an explicit `[[tool.nab.local-sources]]` entry, that member was still being added to `workspace_member_names` and then silently dropped, losing the explicit source pin.

The fix excludes any discovered workspace member from `workspace_member_names` when the user already has an explicit local-source entry for that name, so the pin survives the `--no-emit-workspace` filter.