### PR TITLE
Sort per-tuple requirements blocks by label

### DIFF
--- a/nab-python/src/nab_python/_lockfile/requirements.py
+++ b/nab-python/src/nab_python/_lockfile/requirements.py
@@ -69,15 +69,16 @@ def _render_requirements(
 
 
 def _render_per_tuple_requirements(lock_input: LockInput, *, with_hashes: bool) -> str:
-    """Emit one ``# label`` block per tuple followed by that tuple's pins.
+    """Emit one ``# label`` block per tuple in sorted label order.
 
-    Pip cannot install a single requirements.txt across multiple
-    ``(python, platform)`` tuples in hash-checking mode, so a multi-
-    tuple resolve serialises as commented sections that callers are
-    expected to extract per environment.
+    Each block is followed by that tuple's pins.  Pip cannot install a
+    single requirements.txt across multiple ``(python, platform)``
+    tuples in hash-checking mode, so a multi-tuple resolve serialises as
+    commented sections that callers are expected to extract per
+    environment.
     """
     blocks: list[str] = []
-    for label in lock_input.per_tuple_pins:
+    for label in sorted(lock_input.per_tuple_pins):
         pins = lock_input.per_tuple_pins[label]
         block = [f"# {label}"]
         block.extend(_render_pins(pins, with_hashes=with_hashes))

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -47,6 +47,7 @@ from nab_python.lockfile import (
     read_lockfile_packages,
     write_lock,
     write_requirements_with_hashes,
+    write_requirements_without_hashes,
 )
 from nab_python.provider import DistPolicy, LocalSource, VcsConfig, VcsPolicy, VcsSource
 
@@ -2132,6 +2133,20 @@ class TestWriteRequirementsWithHashes:
             output_path=out,
         )
         assert out.read_text(encoding="utf-8") == text
+
+
+class TestWriteRequirementsPerTuple:
+    def test_blocks_sorted_by_label(self) -> None:
+        # Blocks must come out in sorted label order regardless of the
+        # per_tuple_pins insertion order, matching the pylock writer so
+        # equivalent matrices declared in a different order render the
+        # same bytes.
+        per_tuple = {
+            "py311-linux": {"foo": _index_pin(version="2.0")},
+            "py310-linux": {"foo": _index_pin(version="1.0")},
+        }
+        text = write_requirements_without_hashes(LockInput(per_tuple_pins=per_tuple))
+        assert text.index("# py310-linux") < text.index("# py311-linux")
 
 
 def test_vcs_config_unused_in_lockfile_path() -> None:


### PR DESCRIPTION
The per-tuple requirements output was ordered by dict insertion order, so the same matrix declared in a different order produced different bytes.

Sort `per_tuple_pins` by label before iterating so output is stable regardless of insertion order, matching the existing sorted behaviour in the pylock writer.