### PR TITLE
Fix relock diff counting local/VCS pins as added

### DIFF
--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -27,6 +27,7 @@ from nab_python.config import (
     read_pyproject_lock_anchor,
 )
 from nab_python.lockfile import (
+    IndexPin,
     LockInput,
     Provenance,
     is_valid_pylock_path,
@@ -222,7 +223,15 @@ def _emit_specific(
         # Read the prior pins before write_lock overwrites the file.
         prior = read_lockfile_packages(target)
         _cli.write_lock(lock_input, output_path=target)
-        diff = _diff_summary(prior, emitted_pins)
+        # Only index pins record a version; local and VCS pins emit
+        # version=None, so read_lockfile_packages never returns them.
+        # Diff against the same set or they read as added every relock.
+        versioned = {
+            name: version
+            for name, version in emitted_pins.items()
+            if isinstance(lock_input.pins[name], IndexPin)
+        }
+        diff = _diff_summary(prior, versioned)
     elif format == "requirements":
         _cli.write_requirements_with_hashes(lock_input, output_path=target)
         diff = ""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,7 @@ from nab_python.config import ConfigError
 from nab_python.download import DownloadError
 from nab_python.lockfile import (
     IndexPin,
+    LocalPin,
     LockInput,
     MissingHashError,
     SdistArtifact,
@@ -1176,6 +1177,31 @@ class TestRelockDiffSummary:
                 provenance=None,
             )
         assert capsys.readouterr().err.strip().endswith("(1 packages)")
+
+    def test_relock_unchanged_with_local_pin_prints_plain_line(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A local pin has no recorded version, so an unchanged relock
+        must not count it as added."""
+        out = tmp_path / "pylock.toml"
+        src = tmp_path / "alpha"
+        src.mkdir()
+        lock_input = LockInput(
+            pins={
+                "foo": _foo_index_pin("1.0", "foo"),
+                "alpha": LocalPin(name="alpha", version="0", path=str(src)),
+            }
+        )
+        for _ in range(2):
+            _emit_specific(
+                ResolutionResult(
+                    pins={"foo": V("1.0"), "alpha": V("0")}, lock_input=lock_input
+                ),
+                format="pylock",
+                output=out,
+                provenance=None,
+            )
+        assert capsys.readouterr().err.strip().endswith("(2 packages)")
 
     def test_unparseable_prior_falls_back_to_plain_line(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
When relocking, `read_lockfile_packages` only returns packages that have a recorded version in the pylock file. Local and VCS pins write `version = null` (or omit it), so they are never present in the prior set.

Before this fix, those pins appeared in `emitted_pins` but not in `prior`, so `_diff_summary` counted each of them as added on every relock even when nothing had changed. The fix filters `emitted_pins` down to index-only pins before passing it to `_diff_summary`, matching the set that `read_lockfile_packages` can actually return.