### PR TITLE
Normalize pylock upload-time to UTC

### DIFF
--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -351,19 +351,23 @@ def _build_artifact(
 
 
 def _parse_upload_time(raw: str | None) -> datetime | None:
-    """Parse an index ``upload-time`` string to a ``datetime``.
+    """Parse an index ``upload-time`` string to a UTC ``datetime``.
 
     Accepts the RFC 3339 form the Simple/JSON API serves (``Z`` or an
-    explicit offset).  Returns ``None`` when the field is absent or
-    unparseable; the timestamp is informational, so a bad value is
-    dropped rather than fatal.
+    explicit offset) and normalizes it to UTC (PEP 751 requires UTC for
+    the emitted field). Returns ``None`` when the field is absent,
+    unparseable, or has no timezone; the timestamp is informational, so
+    a bad value is dropped rather than fatal.
     """
     if raw is None:
         return None
     try:
-        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
     except ValueError:
         return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(timezone.utc)
 
 
 def _filter_acceptable_hashes(

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -1663,6 +1663,42 @@ class TestBuildLockInputFromProvider:
         assert isinstance(pin, IndexPin)
         assert pin.wheels[0].upload_time is None
 
+    def test_upload_time_non_utc_offset_normalized_to_utc(self) -> None:
+        wheel = WheelFile(
+            filename="foo-1.0-py3-none-any.whl",
+            url="https://pypi.org/simple/foo/foo-1.0-py3-none-any.whl",
+            version="1.0",
+            requires_python=">=3.10",
+            has_metadata=False,
+            upload_time="2026-05-01T17:00:00+05:00",
+            hashes=(("sha256", "a" * 64),),
+            size=1234,
+        )
+        provider = _FakeProvider(listings={"foo": [(Version("1.0"), wheel)]})
+        lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0")})
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.wheels[0].upload_time == datetime(
+            2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc
+        )
+
+    def test_upload_time_naive_string_is_dropped(self) -> None:
+        wheel = WheelFile(
+            filename="foo-1.0-py3-none-any.whl",
+            url="https://pypi.org/simple/foo/foo-1.0-py3-none-any.whl",
+            version="1.0",
+            requires_python=">=3.10",
+            has_metadata=False,
+            upload_time="2026-05-01T12:00:00",
+            hashes=(("sha256", "a" * 64),),
+            size=1234,
+        )
+        provider = _FakeProvider(listings={"foo": [(Version("1.0"), wheel)]})
+        lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0")})
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.wheels[0].upload_time is None
+
     def test_missing_acceptable_hash_raises(self) -> None:
         wheel = _wheel_file(sha256=None)
         provider = _FakeProvider(listings={"foo": [(Version("1.0"), wheel)]})


### PR DESCRIPTION
When `_parse_upload_time` received a timestamp with a non-UTC offset (e.g. `+05:00`), it returned the datetime as-is, so the offset was emitted directly into the pylock file. PEP 751 requires the `upload-time` field to be in UTC.

This change normalizes any offset-aware timestamp to UTC via `astimezone(timezone.utc)` and drops naive (no-timezone) timestamps, which cannot be placed in UTC without guessing.