### PR TITLE
Pin VCS requirements URL to resolved commit

### DIFF
--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -452,7 +452,10 @@ def _vcs_pin_from_source(
 
     ``bare_repo_url`` comes from ``parsed.repo_url``, which
     :meth:`VcsRequest.parse` has already separated from the ref and the
-    fragment.
+    fragment.  ``repo_url`` re-pins that bare URL to ``commit_id`` (the
+    ``git+`` prefix, ``@<sha>``, and any ``#subdirectory=`` fragment) so
+    the requirements.txt line installs the locked commit, not the ref
+    the user supplied.
     """
     from nab_index.vcs import VcsRequest
 
@@ -467,14 +470,23 @@ def _vcs_pin_from_source(
         )
         raise MissingVcsCommitError(msg)
     parsed = VcsRequest.parse(source.url)
+    # Keep the named ref only when it differs from the SHA (tag or branch case).
     requested_revision = (
         parsed.ref if parsed.ref and parsed.ref != resolved_sha else None
     )
+
+    # Compose a pinned installable URL from the parsed pieces, not from source.url,
+    # so credentials are stripped and the sha replaces any floating ref.
+    bare_repo_url = _strip_userinfo(parsed.repo_url)
+    repo_url = f"{parsed.scheme}+{bare_repo_url}@{resolved_sha}"
+    if parsed.subdirectory:
+        repo_url += f"#subdirectory={parsed.subdirectory}"
+
     return VcsPin(
         name=canonical,
         version=str(version),
-        repo_url=_strip_userinfo(source.url),
-        bare_repo_url=_strip_userinfo(parsed.repo_url),
+        repo_url=repo_url,
+        bare_repo_url=bare_repo_url,
         commit_id=resolved_sha,
         subdirectory=parsed.subdirectory or None,
         requested_revision=requested_revision,

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -180,11 +180,13 @@ class LocalPin:
 class VcsPin:
     """A package resolved from a VCS clone.
 
-    ``repo_url`` is the full pip-style installable URL (``git+`` prefix,
-    ``@<ref>``, and ``#subdirectory=`` fragment) the requirements.txt
-    emitter writes verbatim.  ``bare_repo_url`` is the plain repository
-    URL with none of those parts, captured when the source URL is parsed
-    and written to PEP 751 ``packages.vcs.url``.
+    ``repo_url`` is the reproducible pip-style installable URL: the
+    ``git+`` prefix, the bare repository URL, ``@<commit-id>``, and any
+    ``#subdirectory=`` fragment.  The requirements.txt emitter writes it
+    verbatim, so a branch or tag pin installs the locked commit rather
+    than a moving ref.  ``bare_repo_url`` is the plain repository URL
+    with none of those parts, captured when the source URL is parsed and
+    written to PEP 751 ``packages.vcs.url``.
 
     ``requested_revision`` is the human-readable ref (tag or branch)
     the user pinned, recorded only when it differs from ``commit_id``;

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -1424,10 +1424,9 @@ class TestBuildLockInputFromProvider:
     def test_vcs_pin_carries_bare_repo_url(self) -> None:
         """The bare repo URL is carried through from the parsed source.
 
-        ``repo_url`` keeps the full installable form for the
-        requirements.txt path; ``bare_repo_url`` holds the plain
-        repository URL with no ``git+`` prefix, ``@<ref>``, or
-        ``#subdirectory`` fragment.
+        ``repo_url`` is the installable form re-pinned to ``commit_id``;
+        ``bare_repo_url`` holds the plain repository URL with no ``git+``
+        prefix, ``@<ref>``, or ``#subdirectory`` fragment.
         """
         sha = "a" * 40
         provider = _FakeProvider(
@@ -1444,9 +1443,32 @@ class TestBuildLockInputFromProvider:
         )
         pin = lock_input.pins["foo"]
         assert isinstance(pin, VcsPin)
-        full_url = "git+https://example.com/r.git@release/1.0#subdirectory=pkg/sub"
-        assert pin.repo_url == full_url
+        assert (
+            pin.repo_url == f"git+https://example.com/r.git@{sha}#subdirectory=pkg/sub"
+        )
         assert pin.bare_repo_url == "https://example.com/r.git"
+
+    def test_vcs_requirements_line_pins_to_commit(self) -> None:
+        """A branch/tag-pinned VCS source renders the resolved commit.
+
+        lockfile.md documents the requirements.txt VCS line as
+        ``git+<repo>@<sha>``, and the pylock writer pins to the
+        resolved ``commit-id``.  The requirements emitter must match,
+        not echo the moving ``@<ref>`` the user supplied.
+        """
+        sha = "a" * 40
+        provider = _FakeProvider(
+            vcs_sources={
+                "foo": VcsSource(name="foo", url="git+https://example.com/r.git@main"),
+            },
+            vcs_pins={"foo": sha},
+        )
+        lock_input = build_lock_input_from_provider(
+            provider, {"foo": Version("0.0.0+vcs")}
+        )
+        text = write_requirements_with_hashes(lock_input)
+        assert f"foo @ git+https://example.com/r.git@{sha}" in text
+        assert "@main" not in text
 
     def test_vcs_pin_pylock_url_is_bare_repo(self) -> None:
         """vcs.url is the bare repository URL; ref and subdirectory are separate fields."""
@@ -1538,7 +1560,7 @@ class TestBuildLockInputFromProvider:
         )
         pin = lock_input.pins["foo"]
         assert isinstance(pin, VcsPin)
-        assert pin.repo_url == "git+https://GitHub.com/org/repo.git"
+        assert pin.repo_url == "git+https://GitHub.com/org/repo.git@" + "a" * 40
 
     def test_vcs_source_keeps_url_without_credentials(self) -> None:
         provider = _FakeProvider(
@@ -1552,7 +1574,7 @@ class TestBuildLockInputFromProvider:
         )
         pin = lock_input.pins["foo"]
         assert isinstance(pin, VcsPin)
-        assert pin.repo_url == "git+https://github.com/org/repo.git"
+        assert pin.repo_url == "git+https://github.com/org/repo.git@" + "a" * 40
 
     def test_vcs_source_records_requested_revision_for_floating_ref(self) -> None:
         """A named ``@<ref>`` resolved to a different SHA is recorded."""


### PR DESCRIPTION
When a VCS source was pinned to a branch or tag (e.g. `@main`), the requirements.txt emitter wrote that moving ref rather than the resolved commit SHA. Reinstalling from such a lockfile could silently pick up a different commit.

`_vcs_pin_from_source` now builds `repo_url` as `git+<bare_repo_url>@<commit_sha>[#subdirectory=...]` so the emitter always writes the locked commit. `bare_repo_url` stays as the plain repository URL for the PEP 751 pylock `vcs.url` field.