### PR TITLE
Mark workspace members editable by default

### DIFF
--- a/nab-python/src/nab_python/workspace.py
+++ b/nab-python/src/nab_python/workspace.py
@@ -108,6 +108,10 @@ def read_workspace_members(root_pyproject: Path) -> tuple[LocalSource, ...]:
     :class:`WorkspaceDiscoveryError`.  The returned tuple preserves
     declaration order, which makes ``nab lock`` output stable when the
     list of members is itself stable.
+
+    Members are marked ``editable``; a workspace member installs
+    editably by default, matching uv.  Explicit
+    ``[[tool.nab.local-sources]]`` entries default to non-editable.
     """
     with root_pyproject.open("rb") as f:
         root_data = tomli.load(f)
@@ -168,7 +172,7 @@ def read_workspace_members(root_pyproject: Path) -> tuple[LocalSource, ...]:
             )
             raise WorkspaceDiscoveryError(msg)
         seen[canonical] = entry
-        sources.append(LocalSource(name=name, path=str(member_dir)))
+        sources.append(LocalSource(name=name, path=str(member_dir), editable=True))
     return tuple(sources)
 
 

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -1202,7 +1202,7 @@ class TestWorkspaceDiscoveryIntegration:
         member = self._ws(tmp_path)
         config = read_pyproject_config(member)
         assert config.local_sources == (
-            LocalSource(name="alpha", path=str(member.parent)),
+            LocalSource(name="alpha", path=str(member.parent), editable=True),
         )
         assert config.build_policy is BuildPolicy.BUILD_LOCAL
 

--- a/nab-python/tests/test_workspace.py
+++ b/nab-python/tests/test_workspace.py
@@ -112,9 +112,24 @@ class TestReadWorkspaceMembers:
         )
         sources = read_workspace_members(root)
         assert sources == (
-            LocalSource(name="alpha", path=str(tmp_path / "a")),
-            LocalSource(name="beta", path=str(tmp_path / "sub" / "b")),
+            LocalSource(name="alpha", path=str(tmp_path / "a"), editable=True),
+            LocalSource(name="beta", path=str(tmp_path / "sub" / "b"), editable=True),
         )
+
+    def test_members_default_to_editable(self, tmp_path: Path) -> None:
+        # Workspace members install editably by default, matching uv.
+        root = _write(
+            tmp_path / "pyproject.toml",
+            '[project]\nname = "ws"\nversion = "0"\n'
+            "[tool.nab.workspace]\n"
+            'members = ["a"]\n',
+        )
+        _write(
+            tmp_path / "a" / "pyproject.toml",
+            '[project]\nname = "alpha"\nversion = "0"\n',
+        )
+        (source,) = read_workspace_members(root)
+        assert source.editable is True
 
     def test_dot_member_resolves_to_root_directory(self, tmp_path: Path) -> None:
         # ``.`` as a member entry points at the workspace root itself.
@@ -131,8 +146,12 @@ class TestReadWorkspaceMembers:
         )
         sources = read_workspace_members(root)
         assert sources == (
-            LocalSource(name="apache-airflow", path=str(tmp_path)),
-            LocalSource(name="apache-airflow-core", path=str(tmp_path / "core")),
+            LocalSource(name="apache-airflow", path=str(tmp_path), editable=True),
+            LocalSource(
+                name="apache-airflow-core",
+                path=str(tmp_path / "core"),
+                editable=True,
+            ),
         )
 
     def test_glob_in_members_raises(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Workspace members discovered via `[tool.nab.workspace].members` now get `editable=True` by default, matching uv's behaviour. Explicit `[[tool.nab.local-sources]]` entries are unaffected and remain non-editable by default.