### PR TITLE
Add divergent universal benchmark scenarios

### DIFF
--- a/nab-python/benchmarks/scenarios/universal.toml
+++ b/nab-python/benchmarks/scenarios/universal.toml
@@ -333,3 +333,19 @@ platforms = ["linux_x86_64"]
 requirements = ["apache-airflow-providers-amazon", "numpy"]
 datetime = "2024-09-01 00:00:00"
 align_across_tuples = true
+
+[numpy-wide-python-diverge]
+reason = "py-minor version-floor divergence; tests matrix divergence path"
+python = ">=3.9, <3.14"
+platforms = ["linux_x86_64"]
+requirements = ["numpy", "scipy", "pandas"]
+datetime = "2025-06-01 00:00:00"
+align_across_tuples = false
+
+[numpy-wide-python-align]
+reason = "same as numpy-wide-python-diverge with alignment; measures alignment cost"
+python = ">=3.9, <3.14"
+platforms = ["linux_x86_64"]
+requirements = ["numpy", "scipy", "pandas"]
+datetime = "2025-06-01 00:00:00"
+align_across_tuples = true


### PR DESCRIPTION
Adds two universal benchmark scenarios that exercise the cross-tuple version-divergence path: `numpy-wide-python-diverge` (align=false, each Python minor picks its own numpy/scipy/pandas version) and `numpy-wide-python-align` (align=true, all tuples collapse to the py3.9-compatible cut).

numpy 2.1 dropped Python 3.9 support, so across a >=3.9,<3.14 matrix the two strategies produce different version sets. These are the only scenarios in the suite that produce a non-zero `diverging_packages` count, so they cover a code path previously untested by the benchmark suite.