### PR TITLE
Make profiler runner faithful to scenario config

### DIFF
--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -1,119 +1,138 @@
-"""Single-scenario profiling runner.
-
-Loads one scenario from the benchmark TOML files and runs the resolver
-once.  Designed to be wrapped by ``python -m profiling.sampling run``.
+r"""Single-scenario profiling runner.
 
 Usage:
-    .venv-3.15/bin/python -m profiling.sampling run -r 5khz \
-        --flamegraph -o profile.html \
-        nab-python/benchmarks/_profile_runner.py <scenario>
+    # sampling profiler (requires .venv-3.15)
+    .venv-3.15/bin/python -m profiling.sampling run -r 5khz --flamegraph \
+        -o profile.html nab-python/benchmarks/_profile_runner.py <scenario>
+
+    # cProfile (any venv)
+    python nab-python/benchmarks/_profile_runner.py <scenario> --cprofile
+
+<scenario> is a bare name (first TOML match wins) or ``toml_stem:name``,
+e.g. ``pip-lowest:cburroughs-v3``.
 """
 
 from __future__ import annotations
 
+import argparse
+import cProfile
+import pstats
 import sys
-import time
-from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
 
 if sys.version_info >= (3, 11):
     import tomllib
 else:
-    import tomli as tomllib
+    import tomli as tomllib  # type: ignore[no-redef]
 
-from nab_index.httpx_async_transport import HttpxAsyncTransport
-from nab_index.multi_index import IndexConfig
-from nab_python._vendor.packaging.ranges import VersionRange
-from nab_python._vendor.packaging.requirements import Requirement
-from nab_python._vendor.packaging.utils import canonicalize_name
-from nab_python.fetch import (
-    DEFAULT_INDEX_NAME,
-    DEFAULT_INDEX_URL,
-    FetchCoordinator,
-)
-from nab_python.provider import DistPolicy, Provider
-from nab_resolver.resolver import Resolver
+sys.path.insert(0, str(Path(__file__).parent))
 
-if TYPE_CHECKING:
-    from collections.abc import Iterable
-
-BENCHMARKS_DIR = Path(__file__).parent
-SCENARIOS_DIR = BENCHMARKS_DIR / "scenarios"
-CACHE_DIR = BENCHMARKS_DIR / "cache"
-DEFAULT_INDEXES = (IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL),)
+import scenarios as sc
 
 
-def parse_requirements(strs: Iterable[str]) -> dict[str, VersionRange]:
-    out: dict[str, VersionRange] = {}
-    for r in strs:
-        req = Requirement(r)
-        name = canonicalize_name(req.name)
-        vi = req.specifier.to_range()
-        if vi is not None:
-            out[name] = vi
-        for ex in req.extras:
-            out[f"{name}[{ex}]"] = VersionRange.full()
-    return out
-
-
-def find_scenario(name: str) -> dict[str, Any] | None:
-    for p in SCENARIOS_DIR.glob("*.toml"):
-        with p.open("rb") as f:
+def find_scenario(spec: str) -> tuple[str, dict]:
+    if ":" in spec:
+        toml_stem, name = spec.split(":", 1)
+        toml_path = sc.SCENARIOS_DIR / f"{toml_stem}.toml"
+        try:
+            with toml_path.open("rb") as f:
+                data = tomllib.load(f)
+        except FileNotFoundError:
+            sys.exit(f"no TOML file for stem {toml_stem!r}")
+        if name not in data:
+            sys.exit(f"scenario {name!r} not found in {toml_stem}.toml")
+        return name, data[name]
+    for path in sorted(sc.SCENARIOS_DIR.glob("*.toml")):
+        with path.open("rb") as f:
             data = tomllib.load(f)
-        if name in data:
-            return data[name]
-    return None
+        if spec in data:
+            return spec, data[spec]
+    sys.exit(f"scenario {spec!r} not found")
+
+
+def build_inputs(name: str, scenario: dict) -> dict:
+    python_version = scenario["python_version"]
+    requirement_strings = list(scenario["requirements"])
+    constraint_strings = scenario.get("constraints", [])
+    marker_environment = sc.parse_marker_environment(name, scenario)
+    build_policy_overrides = sc.parse_build_packages(name, scenario)
+
+    # BUILD_REMOTE + marker_environment overlay is unsupported; drop overrides.
+    if marker_environment and build_policy_overrides:
+        build_policy_overrides = {}
+
+    resolution_strategy = sc.ResolutionStrategy(scenario.get("resolution", "highest"))
+    vcs_config = sc.VcsConfig(
+        policy=sc.VcsPolicy(scenario.get("vcs_policy", "block")),
+        allowed_schemes=frozenset(scenario.get("vcs_allowed_schemes", [])),
+        allowed_repos=tuple(scenario.get("vcs_allowed_repos", [])),
+        require_pin=scenario.get("vcs_require_pin", True),
+    )
+
+    if scenario.get("project_name"):
+        requirement_strings += sc.expand_project_extras(
+            scenario["project_name"],
+            scenario.get("project_extras", []),
+            scenario.get("optional_dependencies", {}),
+        )
+
+    marker_env = sc.scenario_marker_env(python_version, marker_environment)
+    requirements = sc.parse_requirements(
+        requirement_strings, vcs_config=vcs_config, marker_environment=marker_env
+    )
+    constraints = (
+        sc.parse_requirements(
+            constraint_strings, vcs_config=vcs_config, marker_environment=marker_env
+        )
+        if constraint_strings
+        else None
+    )
+
+    datetime_str = scenario.get("datetime")
+    return {
+        "requirements": requirements,
+        "python_version": python_version,
+        "uploaded_prior_to": sc.parse_datetime(datetime_str) if datetime_str else None,
+        "constraints": constraints,
+        "marker_environment": marker_environment or None,
+        "indexes": sc.parse_indexes(name, scenario),
+        "index_overrides": sc.parse_index_overrides(name, scenario) or None,
+        "build_policy_overrides": build_policy_overrides or None,
+        "resolution_strategy": resolution_strategy,
+    }
+
+
+def report(name: str, data: dict) -> None:
+    stats = data["stats"]
+    state = "OK" if data["result"]["success"] else f"FAIL {data['result']['error']}"
+    print(
+        f"{name}: {state} in {stats['wall_time_seconds']}s, "
+        f"{stats['decisions']} decisions, {stats['conflicts']} conflicts"
+    )
 
 
 def main() -> None:
-    name = sys.argv[1]
-    scn = find_scenario(name)
-    if scn is None:
-        print(f"scenario {name!r} not found", file=sys.stderr)
-        sys.exit(2)
-    reqs = parse_requirements(scn["requirements"])
-    constraints = (
-        parse_requirements(scn.get("constraints", []))
-        if scn.get("constraints")
-        else None
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("scenario", help="bare name or toml_stem:name")
+    parser.add_argument(
+        "--cprofile",
+        action="store_true",
+        help="profile in-process and print the top functions by self time",
     )
-    py = scn["python_version"]
-    dt = scn.get("datetime")
-    upload = datetime.fromisoformat(dt).replace(tzinfo=timezone.utc) if dt else None
-    with FetchCoordinator(
-        HttpxAsyncTransport(),
-        indexes=list(DEFAULT_INDEXES),
-        cache_dir=CACHE_DIR,
-    ) as coord:
-        provider = Provider(
-            coord,
-            python_version=py,
-            root_requirements=reqs,
-            uploaded_prior_to=upload,
-            dist_policy=DistPolicy.PREFER_BINARY,
-        )
-        resolver = Resolver(
-            provider,
-            range_type=VersionRange,
-            root_version="0",
-            max_iterations=200_000,
-        )
-        t0 = time.monotonic()
-        try:
-            resolver.resolve(reqs, constraints=constraints)
-            elapsed = time.monotonic() - t0
-            print(
-                f"{name}: OK in {elapsed:.2f}s, "
-                f"{resolver.stats.decisions} decisions, "
-                f"{resolver.stats.conflicts} conflicts"
-            )
-        except Exception as exc:
-            elapsed = time.monotonic() - t0
-            print(
-                f"{name}: FAILED ({type(exc).__name__}) in {elapsed:.2f}s, "
-                f"{resolver.stats.decisions} decisions"
-            )
+    parser.add_argument("--limit", type=int, default=30)
+    args = parser.parse_args()
+
+    name, scenario = find_scenario(args.scenario)
+    inputs = build_inputs(name, scenario)
+
+    if not args.cprofile:
+        report(name, sc.resolve_scenario(**inputs))
+        return
+
+    profiler = cProfile.Profile()
+    data = profiler.runcall(sc.resolve_scenario, **inputs)
+    report(name, data)
+    pstats.Stats(profiler).sort_stats("tottime").print_stats(args.limit)
 
 
 if __name__ == "__main__":

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -156,7 +156,7 @@ def _full_marker_environment(
 _PYTHON_VERSION_PARTS = 2
 
 
-def _scenario_marker_env(
+def scenario_marker_env(
     python_version: str,
     overlay: dict[str, str],
 ) -> dict[str, str]:
@@ -582,7 +582,7 @@ def process_scenario(
 
     print(f"  {scenario_name} ", end="", flush=True)
 
-    requirement_marker_env = _scenario_marker_env(python_version, marker_environment)
+    requirement_marker_env = scenario_marker_env(python_version, marker_environment)
     requirements = parse_requirements(
         requirement_strings,
         vcs_config=vcs_config,

--- a/nab-python/benchmarks/strategy_sweep.py
+++ b/nab-python/benchmarks/strategy_sweep.py
@@ -188,7 +188,7 @@ def _scenario_inputs(scenario: dict) -> dict | None:
     uploaded_prior_to = (
         _scenarios.parse_datetime(datetime_str) if datetime_str else None
     )
-    requirement_marker_env = _scenarios._scenario_marker_env(python_version, marker_env)
+    requirement_marker_env = _scenarios.scenario_marker_env(python_version, marker_env)
     requirements = _scenarios.parse_requirements(
         requirement_strings,
         vcs_config=vcs_config,


### PR DESCRIPTION
The profiler runner now delegates scenario parsing to `scenarios.py`'s `resolve_scenario` instead of reimplementing it, so the resolution strategy, dist/build policy, marker environment, VCS config, and constraints all match what a scoreboard run uses.

The practical fix is LOWEST WALL-mode scenarios: the old runner defaulted to HIGHEST, so profiling `cburroughs-v3` (a lowest-mode scenario) would profile the wrong resolution path entirely.

A `--cprofile` flag is added for in-process profiling without the 3.15 sampling venv, and the scenario spec now accepts `toml_stem:name` to pick a strategy variant directly.