### PR TITLE
Make benchmark timeout uncatchable

### DIFF
--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -88,8 +88,12 @@ WALL_TIMEOUT_S = 60
 MAX_ITERATIONS = 50_000
 
 
-class _ScenarioTimeoutError(Exception):
-    pass
+class _ScenarioTimeoutError(BaseException):
+    """Raised when a scenario exceeds the per-run wall-clock budget.
+
+    Subclasses BaseException so the resolver's internal ``except Exception``
+    handlers cannot swallow the alarm mid-resolve.
+    """
 
 
 def _alarm_handler(_signum: int, _frame: object) -> None:
@@ -241,7 +245,7 @@ def run_one(
             success = True
             error = None
             packages = len(result)
-        except Exception as exc:
+        except (_ScenarioTimeoutError, Exception) as exc:
             elapsed = time.monotonic() - start
             success = False
             error = f"{type(exc).__name__}: {exc}"

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -189,8 +189,12 @@ def parse_datetime(value: str) -> datetime:
 SCENARIO_WALL_TIMEOUT_SECONDS = 120
 
 
-class _ScenarioTimeoutError(Exception):
-    """Raised when a scenario exceeds the per-run wall-clock budget."""
+class _ScenarioTimeoutError(BaseException):
+    """Raised when a scenario exceeds the per-run wall-clock budget.
+
+    Subclasses BaseException so the resolver's internal ``except Exception``
+    handlers cannot swallow the alarm mid-resolve.
+    """
 
 
 def _alarm_handler(_signum: int, _frame: object) -> None:
@@ -252,7 +256,7 @@ def resolve_scenario(  # noqa: PLR0913 - one wrapper per scenario knob
             success = True
             error = None
             packages_resolved = len(result)
-        except Exception as exc:
+        except (_ScenarioTimeoutError, Exception) as exc:
             elapsed = time.monotonic() - start
             success = False
             error = f"{type(exc).__name__}: {exc}"

--- a/nab-python/benchmarks/strategy_sweep.py
+++ b/nab-python/benchmarks/strategy_sweep.py
@@ -59,8 +59,12 @@ WALL_TIMEOUT_S = 60
 MAX_ITERATIONS = 50_000
 
 
-class _Timeout(Exception):
-    pass
+class _Timeout(BaseException):
+    """Raised when a scenario exceeds the per-run wall-clock budget.
+
+    Subclasses BaseException so the resolver's internal ``except Exception``
+    handlers cannot swallow the alarm mid-resolve.
+    """
 
 
 def _on_alarm(_signum: int, _frame: object) -> None:

--- a/nab-python/benchmarks/universal_scenarios.py
+++ b/nab-python/benchmarks/universal_scenarios.py
@@ -44,8 +44,12 @@ CACHE_DIR = BENCHMARKS_DIR / "cache"
 SCENARIO_WALL_TIMEOUT_SECONDS = 300
 
 
-class _ScenarioTimeoutError(Exception):
-    """Raised when a scenario exceeds the per-run wall-clock budget."""
+class _ScenarioTimeoutError(BaseException):
+    """Raised when a scenario exceeds the per-run wall-clock budget.
+
+    Subclasses BaseException so the resolver's internal ``except Exception``
+    handlers cannot swallow the alarm mid-resolve.
+    """
 
 
 def _alarm_handler(_signum: int, _frame: object) -> None:


### PR DESCRIPTION
Change `_ScenarioTimeoutError` (and `_Timeout` in strategy_sweep) from `Exception` to `BaseException` in all four benchmark scripts so the resolver's internal `except Exception` handlers cannot swallow the alarm mid-resolve.

Also update each catch site to `except (_ScenarioTimeoutError, Exception)` so both timeout and non-timeout failures still route through the single error-recording branch.