### PR TITLE
Require PEP 643 static deps for sdists by default

### DIFF
--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -201,7 +201,7 @@ def get_git_commit() -> str:
     return result.stdout.strip()
 
 
-def run_one(
+def run_one(  # noqa: PLR0913 - one wrapper per scenario knob
     requirements: dict[str, VersionRange],
     python_version: str,
     uploaded_prior_to: datetime | None,
@@ -210,6 +210,8 @@ def run_one(
     indexes: list[IndexConfig] | None = None,
     index_overrides: list[IndexOverride] | None = None,
     build_policy_overrides: Mapping[str, BuildPolicy] | None = None,
+    *,
+    trust_unverified_sdist_deps: bool = False,
 ) -> dict:
     with FetchCoordinator(
         HttpxAsyncTransport(),
@@ -226,6 +228,7 @@ def run_one(
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.NEVER,
             build_policy_overrides=build_policy_overrides,
+            trust_unverified_sdist_deps=trust_unverified_sdist_deps,
             marker_environment=marker_environment,
         )
         resolver = Resolver(
@@ -365,6 +368,9 @@ def median_run(scenario: dict, runs: int) -> tuple[list[dict], dict]:
         else None
     )
     uploaded_prior_to = parse_datetime(datetime_str) if datetime_str else None
+    trust_unverified_sdist_deps = bool(
+        scenario.get("trust_unverified_sdist_deps", False)
+    )
 
     runs_data: list[dict] = [
         run_one(
@@ -376,6 +382,7 @@ def median_run(scenario: dict, runs: int) -> tuple[list[dict], dict]:
             indexes=indexes,
             index_overrides=index_overrides or None,
             build_policy_overrides=build_policy_overrides or None,
+            trust_unverified_sdist_deps=trust_unverified_sdist_deps,
         )
         for _ in range(runs)
     ]

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -215,6 +215,8 @@ def resolve_scenario(  # noqa: PLR0913 - one wrapper per scenario knob
     index_overrides: list[IndexOverride] | None = None,
     build_policy_overrides: Mapping[str, BuildPolicy] | None = None,
     resolution_strategy: ResolutionStrategy = ResolutionStrategy.HIGHEST,
+    *,
+    trust_unverified_sdist_deps: bool = False,
 ) -> dict:
     """Resolve requirements and return stats dict."""
     direct_packages = frozenset(
@@ -235,6 +237,7 @@ def resolve_scenario(  # noqa: PLR0913 - one wrapper per scenario knob
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.NEVER,
             build_policy_overrides=build_policy_overrides,
+            trust_unverified_sdist_deps=trust_unverified_sdist_deps,
             marker_environment=marker_environment,
             resolution_strategy=resolution_strategy,
             direct_packages=direct_packages,
@@ -316,6 +319,8 @@ def _expected_input(  # noqa: PLR0913 - assembling the JSON dump key
     index_overrides: list[IndexOverride],
     build_packages: list[str] | None = None,
     resolution_strategy: ResolutionStrategy = ResolutionStrategy.HIGHEST,
+    *,
+    trust_unverified_sdist_deps: bool = False,
 ) -> dict:
     """Build the JSON-serialisable ``input`` block describing the scenario."""
     expected_input: dict = {
@@ -354,6 +359,8 @@ def _expected_input(  # noqa: PLR0913 - assembling the JSON dump key
         expected_input["build_packages"] = sorted(build_packages)
     if resolution_strategy is not ResolutionStrategy.HIGHEST:
         expected_input["resolution"] = resolution_strategy.value
+    if trust_unverified_sdist_deps:
+        expected_input["trust_unverified_sdist_deps"] = True
     return expected_input
 
 
@@ -536,6 +543,9 @@ def process_scenario(
             f" got {resolution_raw!r}"
         )
         raise ValueError(msg) from exc
+    trust_unverified_sdist_deps: bool = scenario.get(
+        "trust_unverified_sdist_deps", False
+    )
     optional_dependencies: dict[str, list[str]] = scenario.get(
         "optional_dependencies", {}
     )
@@ -573,6 +583,7 @@ def process_scenario(
         index_overrides,
         build_packages=sorted(build_policy_overrides),
         resolution_strategy=resolution_strategy,
+        trust_unverified_sdist_deps=trust_unverified_sdist_deps,
     )
 
     if output_path.exists() and not force:
@@ -607,6 +618,7 @@ def process_scenario(
         index_overrides=index_overrides or None,
         build_policy_overrides=build_policy_overrides or None,
         resolution_strategy=resolution_strategy,
+        trust_unverified_sdist_deps=trust_unverified_sdist_deps,
     )
     data["input"] = expected_input
 

--- a/nab-python/benchmarks/scenarios/ai-stack-lowest-direct.toml
+++ b/nab-python/benchmarks/scenarios/ai-stack-lowest-direct.toml
@@ -565,6 +565,9 @@ resolution = "lowest-direct"
 python_version = "3.11"
 platform_system = "Linux"
 datetime = "2025-06-01 10:00:00"
+# Resolves only by trusting a pre-2.2 sdist's PKG-INFO deps, which the
+# strict PEP 643 default routes to a build (BuildPolicy.NEVER fails).
+trust_unverified_sdist_deps = true
 requirements = [
     "streamlit",
     "langchain",
@@ -586,6 +589,9 @@ resolution = "lowest-direct"
 python_version = "3.10"
 platform_system = "Linux"
 datetime = "2025-01-16 13:37:05"
+# Resolves only by trusting a pre-2.2 sdist's PKG-INFO deps, which the
+# strict PEP 643 default routes to a build (BuildPolicy.NEVER fails).
+trust_unverified_sdist_deps = true
 requirements = [
     "langchain",
     "langchain-community",

--- a/nab-python/benchmarks/scenarios/ai-stack-lowest.toml
+++ b/nab-python/benchmarks/scenarios/ai-stack-lowest.toml
@@ -565,6 +565,9 @@ resolution = "lowest"
 python_version = "3.11"
 platform_system = "Linux"
 datetime = "2025-06-01 10:00:00"
+# Resolves only by trusting a pre-2.2 sdist's PKG-INFO deps, which the
+# strict PEP 643 default routes to a build (BuildPolicy.NEVER fails).
+trust_unverified_sdist_deps = true
 requirements = [
     "streamlit",
     "langchain",
@@ -586,6 +589,9 @@ resolution = "lowest"
 python_version = "3.10"
 platform_system = "Linux"
 datetime = "2025-01-16 13:37:05"
+# Resolves only by trusting a pre-2.2 sdist's PKG-INFO deps, which the
+# strict PEP 643 default routes to a build (BuildPolicy.NEVER fails).
+trust_unverified_sdist_deps = true
 requirements = [
     "langchain",
     "langchain-community",

--- a/nab-python/benchmarks/scenarios/ai-stack.toml
+++ b/nab-python/benchmarks/scenarios/ai-stack.toml
@@ -530,6 +530,9 @@ requirements = ["pyautogen[long-context]", "PyMuPDF"]
 python_version = "3.11"
 platform_system = "Linux"
 datetime = "2025-06-01 10:00:00"
+# Resolves only by trusting a pre-2.2 sdist's PKG-INFO deps, which the
+# strict PEP 643 default routes to a build (BuildPolicy.NEVER fails).
+trust_unverified_sdist_deps = true
 requirements = [
     "streamlit",
     "langchain",
@@ -550,6 +553,9 @@ requirements = [
 python_version = "3.10"
 platform_system = "Linux"
 datetime = "2025-01-16 13:37:05"
+# Resolves only by trusting a pre-2.2 sdist's PKG-INFO deps, which the
+# strict PEP 643 default routes to a build (BuildPolicy.NEVER fails).
+trust_unverified_sdist_deps = true
 requirements = [
     "langchain",
     "langchain-community",

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -15,7 +15,7 @@ from nab_index.client import SdistFile, WheelFile
 from .._vendor.packaging.ranges import VersionRange
 from .._vendor.packaging.requirements import InvalidRequirement, Requirement
 from .._vendor.packaging.utils import canonicalize_name
-from ..metadata import DEPENDENCY_FIELDS, parse_metadata
+from ..metadata import DEPENDENCY_FIELDS, metadata_deps_are_static, parse_metadata
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -131,9 +131,20 @@ def pick_dist_for_metadata(
     return wheel_with_meta or wheel_without_meta or sdist
 
 
-def is_dynamic_deps(metadata: WheelMetadata) -> bool:
-    """Return True when dependency fields are :pep:`643` Dynamic."""
-    return bool(DEPENDENCY_FIELDS & metadata.dynamic)
+def _sdist_deps_need_dynamic(
+    metadata: WheelMetadata, *, trust_unverified: bool
+) -> bool:
+    """Whether an sdist's PKG-INFO deps must route through the dynamic path.
+
+    By default deps are trusted only when :pep:`643` static
+    (Metadata-Version 2.2+, no Dynamic dependency field), so a pre-2.2
+    PKG-INFO routes through the dynamic path. With ``trust_unverified``
+    set (the opt-out) a pre-2.2 PKG-INFO is trusted, so only an explicit
+    Dynamic dependency field forces the dynamic path.
+    """
+    if trust_unverified:
+        return bool(DEPENDENCY_FIELDS & metadata.dynamic)
+    return not metadata_deps_are_static(metadata)
 
 
 def resolve_dynamic_sdist(
@@ -364,10 +375,11 @@ def parse_and_cache_metadata(
     deps and a per-extra mapping so that get_extra_dependencies
     can do a dict lookup instead of re-iterating requires_dist.
 
-    When ``from_sdist`` is set and PKG-INFO marks dependency-related
-    fields as :pep:`643` Dynamic, attempts the ``pyproject.toml``
-    fallback before raising :class:`UnsupportedSdistError` under
-    :class:`BuildPolicy.NEVER`.
+    When ``from_sdist`` is set and the PKG-INFO deps are not trusted as
+    final (not :pep:`643` static, or a Dynamic dependency field under
+    the ``trust-unverified-sdist-deps`` opt-out), attempts the
+    ``pyproject.toml`` fallback before raising
+    :class:`UnsupportedSdistError` under :class:`BuildPolicy.NEVER`.
 
     The parsed :class:`WheelMetadata` is shared via the
     :class:`~nab_python.fetch.InMemoryIndex` so that universal-mode
@@ -388,7 +400,9 @@ def parse_and_cache_metadata(
     if metadata is None:
         metadata = parse_metadata(metadata_text)
         provider.coordinator.index.store_parsed_metadata(package, version_str, metadata)
-    if from_sdist and is_dynamic_deps(metadata):
+    if from_sdist and _sdist_deps_need_dynamic(
+        metadata, trust_unverified=provider.trust_unverified_sdist_deps
+    ):
         metadata = resolve_dynamic_sdist(provider, cache_key, metadata)
     cache_deps_from_metadata(provider, cache_key, metadata)
 

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -65,6 +65,7 @@ _TOP_LEVEL_KEYS = frozenset(
         "dist-policy-package",
         "build-policy",
         "build-policy-package",
+        "trust-unverified-sdist-deps",
         "marker-environment",
         "indexes",
         "index-overrides",
@@ -121,6 +122,7 @@ class NabProjectConfig:
     dist_policy_overrides: Mapping[str, DistPolicy] = field(default_factory=dict)
     build_policy: BuildPolicy = BuildPolicy.BUILD_LOCAL
     build_policy_overrides: Mapping[str, BuildPolicy] = field(default_factory=dict)
+    trust_unverified_sdist_deps: bool = False
     marker_environment: Mapping[str, str] = field(default_factory=dict)
     indexes: tuple[IndexConfig, ...] = (
         IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL),
@@ -284,6 +286,11 @@ def _parse_nab_table(
         ),
         build_policy_overrides=_parse_build_policy_package(
             raw.get("build-policy-package")
+        ),
+        trust_unverified_sdist_deps=_parse_bool(
+            "trust-unverified-sdist-deps",
+            raw.get("trust-unverified-sdist-deps"),
+            default=False,
         ),
         marker_environment=_parse_marker_environment(raw.get("marker-environment", {})),
         indexes=_parse_indexes(raw.get("indexes")),
@@ -555,6 +562,15 @@ def _parse_dist_policy_package(value: object) -> Mapping[str, DistPolicy]:
         seen[canonical] = raw_key
         out[canonical] = policy
     return out
+
+
+def _parse_bool(key: str, value: object, *, default: bool) -> bool:
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        msg = f"{key} must be a boolean, got {type(value).__name__}"
+        raise ConfigError(msg)
+    return value
 
 
 def _parse_enum(

--- a/nab-python/src/nab_python/metadata.py
+++ b/nab-python/src/nab_python/metadata.py
@@ -25,6 +25,7 @@ __all__ = [
     "WheelMetadata",
     "intern_version",
     "load_static_project",
+    "metadata_deps_are_static",
     "parse_metadata",
 ]
 
@@ -63,6 +64,28 @@ def load_static_project(text: str) -> dict[str, Any] | None:
 # Intersect with WheelMetadata.dynamic to detect wheels whose dep
 # declarations may change at build time.
 DEPENDENCY_FIELDS = frozenset({"requires-dist", "provides-extra"})
+
+# Metadata-Version 2.2 introduced PEP 643's Dynamic field. Earlier
+# formats give no static-deps guarantee.
+_MIN_STATIC_METADATA_VERSION = (2, 2)
+
+
+def metadata_deps_are_static(metadata: WheelMetadata) -> bool:
+    """Return True when a distribution's dependency fields are final.
+
+    Per :pep:`643` the values are trustworthy only at Metadata-Version
+    2.2 or later with no dependency field marked ``Dynamic``. Below 2.2
+    an sdist's declared dependencies may change when it is built.
+    """
+    if metadata.metadata_version is None:
+        return False
+    try:
+        major, minor = (int(p) for p in metadata.metadata_version.split(".")[:2])
+    except ValueError:
+        return False
+    if (major, minor) < _MIN_STATIC_METADATA_VERSION:
+        return False
+    return not (DEPENDENCY_FIELDS & metadata.dynamic)
 
 
 @lru_cache(maxsize=16384)

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -417,6 +417,8 @@ class Provider:
         build_config: NabProjectConfig | None = None,
         resolution_strategy: ResolutionStrategy = ResolutionStrategy.HIGHEST,
         direct_packages: frozenset[str] | None = None,
+        *,
+        trust_unverified_sdist_deps: bool = False,
     ) -> None:
         """Construct the provider; see the class docstring for parameters."""
         self.coordinator = coordinator
@@ -436,6 +438,9 @@ class Provider:
             dist_policy_overrides, "dist-policy"
         )
         self.build_policy = build_policy
+        # Opt-out: trust a pre-2.2 sdist's PKG-INFO deps as final instead of
+        # routing through the dynamic path. Off by default (strict PEP 643).
+        self.trust_unverified_sdist_deps = trust_unverified_sdist_deps
         self._resolution_strategy = resolution_strategy
         self._direct_packages: frozenset[str] = direct_packages or frozenset()
 

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -174,6 +174,7 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
             dist_policy_overrides=config.dist_policy_overrides or None,
             build_policy=config.build_policy,
             build_policy_overrides=dict(config.build_policy_overrides) or None,
+            trust_unverified_sdist_deps=config.trust_unverified_sdist_deps,
             vcs_config=config.vcs,
             marker_environment=dict(config.marker_environment) or None,
             local_sources=list(config.local_sources) or None,

--- a/nab-python/src/nab_python/universal/provider.py
+++ b/nab-python/src/nab_python/universal/provider.py
@@ -101,6 +101,11 @@ class UniversalProvider(Provider):
                     f" got {resolution_strategy!r}"
                 )
                 raise ValueError(msg) from exc
+        trust_unverified_sdist_deps = (
+            build_config.trust_unverified_sdist_deps
+            if build_config is not None
+            else False
+        )
         super().__init__(
             coordinator,
             python_version=marker_environment.get("python_version"),
@@ -113,6 +118,7 @@ class UniversalProvider(Provider):
             dist_policy_overrides=dist_policy_overrides,
             build_policy=build_policy,
             build_policy_overrides=build_policy_overrides,
+            trust_unverified_sdist_deps=trust_unverified_sdist_deps,
             vcs_config=vcs_config,
             local_sources=local_sources,
             vcs_sources=vcs_sources,

--- a/nab-python/src/nab_python/universal/validate.py
+++ b/nab-python/src/nab_python/universal/validate.py
@@ -27,7 +27,7 @@ from .._vendor.packaging.requirements import (
     Requirement,
 )
 from .._vendor.packaging.utils import canonicalize_name
-from ..metadata import DEPENDENCY_FIELDS, load_static_project, parse_metadata
+from ..metadata import load_static_project, metadata_deps_are_static, parse_metadata
 from .wheel_selection import select_wheel_for_tuple
 
 if TYPE_CHECKING:
@@ -53,10 +53,6 @@ _ALWAYS_FATAL_STATUSES = frozenset({"no_compatible_wheel", "no_metadata"})
 # from sdist (BuildPolicy.NEVER).  These pins resolve fine if the
 # user has a build toolchain.
 _BUILD_REQUIRED_STATUSES = frozenset({"sdist_only", "no_compatible_wheel_with_sdist"})
-
-# Metadata-Version 2.2 introduced PEP 643's Dynamic field.  Earlier
-# versions have no static-deps guarantee.
-_MIN_STATIC_METADATA_VERSION = (2, 2)
 
 
 @dataclass(frozen=True)
@@ -341,15 +337,7 @@ def _metadata_is_pep643_static(
         metadata = parse_metadata(text)
     except Exception:  # noqa: BLE001
         return False
-    if metadata.metadata_version is None:
-        return False
-    try:
-        major, minor = (int(p) for p in metadata.metadata_version.split(".")[:2])
-    except ValueError:
-        return False
-    if (major, minor) < _MIN_STATIC_METADATA_VERSION:
-        return False
-    return not (DEPENDENCY_FIELDS & metadata.dynamic)
+    return metadata_deps_are_static(metadata)
 
 
 def _pyproject_is_pep621_static(

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -1235,6 +1235,23 @@ class TestBuildPolicyPackage:
         assert "Foo-Bar" not in config.build_policy_overrides
 
 
+class TestTrustUnverifiedSdistDeps:
+    def test_default_is_false(self, tmp_path: Path) -> None:
+        path = write(tmp_path, "[tool.nab]\n")
+        config = read_pyproject_config(path, discover_workspace=False)
+        assert config.trust_unverified_sdist_deps is False
+
+    def test_true_round_trip(self, tmp_path: Path) -> None:
+        path = write(tmp_path, "[tool.nab]\ntrust-unverified-sdist-deps = true\n")
+        config = read_pyproject_config(path, discover_workspace=False)
+        assert config.trust_unverified_sdist_deps is True
+
+    def test_non_bool_rejected(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab]\ntrust-unverified-sdist-deps = "yes"\n')
+        with pytest.raises(ConfigError, match="must be a boolean"):
+            read_pyproject_config(path, discover_workspace=False)
+
+
 class TestWorkspace:
     """``[tool.nab.workspace]`` parses into a typed :class:`WorkspaceConfig`."""
 

--- a/nab-python/tests/test_metadata.py
+++ b/nab-python/tests/test_metadata.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from nab_python._vendor.packaging.version import Version
-from nab_python.metadata import parse_metadata
+from nab_python.metadata import metadata_deps_are_static, parse_metadata
 
 
 def test_parses_minimal_metadata() -> None:
@@ -70,3 +70,36 @@ def test_provides_extra_kept_as_strings() -> None:
     )
     md = parse_metadata(text)
     assert md.provides_extra == ["dev", "docs"]
+
+
+class TestMetadataDepsAreStatic:
+    def test_2_2_without_dynamic_is_static(self) -> None:
+        md = parse_metadata("Metadata-Version: 2.2\nName: foo\nVersion: 1.0\n")
+        assert metadata_deps_are_static(md) is True
+
+    def test_2_3_is_static(self) -> None:
+        md = parse_metadata("Metadata-Version: 2.3\nName: foo\nVersion: 1.0\n")
+        assert metadata_deps_are_static(md) is True
+
+    def test_2_2_with_dynamic_requires_dist_is_not_static(self) -> None:
+        md = parse_metadata(
+            "Metadata-Version: 2.2\nName: foo\nVersion: 1.0\nDynamic: Requires-Dist\n"
+        )
+        assert metadata_deps_are_static(md) is False
+
+    def test_micro_metadata_version_qualifies(self) -> None:
+        md = parse_metadata("Metadata-Version: 2.2.1\nName: foo\nVersion: 1.0\n")
+        assert metadata_deps_are_static(md) is True
+
+    def test_pre_2_2_is_not_static(self) -> None:
+        md = parse_metadata("Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n")
+        assert metadata_deps_are_static(md) is False
+
+    def test_missing_metadata_version_is_not_static(self) -> None:
+        md = parse_metadata("Metadata-Version: 2.2\nName: foo\nVersion: 1.0\n")
+        md.metadata_version = None
+        assert metadata_deps_are_static(md) is False
+
+    def test_unparseable_metadata_version_is_not_static(self) -> None:
+        md = parse_metadata("Metadata-Version: 2.x\nName: foo\nVersion: 1.0\n")
+        assert metadata_deps_are_static(md) is False

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -2868,6 +2868,14 @@ class TestExtras:
 
 
 SDIST_PKG_INFO = (
+    "Metadata-Version: 2.2\n"
+    "Name: pkg\n"
+    "Version: 1.0\n"
+    "Requires-Dist: dep-a>=1.0\n"
+    "Requires-Dist: dep-b\n"
+)
+
+PRE_22_SDIST_PKG_INFO = (
     "Metadata-Version: 2.1\n"
     "Name: pkg\n"
     "Version: 1.0\n"
@@ -2969,6 +2977,61 @@ class TestDistPolicy:
         deps = provider.get_dependencies("pkg", V("1.0"))
         assert "dep-a" in deps
         assert "dep-b" in deps
+
+    def test_pre_22_sdist_deps_not_trusted(self) -> None:
+        """A pre-2.2 sdist PKG-INFO is not PEP 643 static, so under NEVER
+        its Requires-Dist surfaces UnsupportedSdistError instead of
+        resolving against unverified declared deps.
+        """
+        coordinator = make_coordinator(
+            [make_sdist("1.0")],
+            sdist_pkg_info=PRE_22_SDIST_PKG_INFO,
+        )
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            dist_policy=DistPolicy.WHEEL_OR_SDIST,
+            build_policy=BuildPolicy.NEVER,
+        )
+        with pytest.raises(UnsupportedSdistError):
+            provider.get_dependencies("pkg", V("1.0"))
+
+    def test_pre_22_sdist_deps_trusted_with_opt_out(self) -> None:
+        """The trust-unverified opt-out restores trusting a pre-2.2
+        sdist's PKG-INFO Requires-Dist as final.
+        """
+        coordinator = make_coordinator(
+            [make_sdist("1.0")],
+            sdist_pkg_info=PRE_22_SDIST_PKG_INFO,
+        )
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            dist_policy=DistPolicy.WHEEL_OR_SDIST,
+            build_policy=BuildPolicy.NEVER,
+            trust_unverified_sdist_deps=True,
+        )
+        deps = provider.get_dependencies("pkg", V("1.0"))
+        assert "dep-a" in deps
+        assert "dep-b" in deps
+
+    def test_opt_out_still_routes_explicit_dynamic_deps(self) -> None:
+        """Even with the opt-out, an explicit PEP 643 Dynamic dependency
+        field still forces the dynamic path; under NEVER it raises.
+        """
+        coordinator = make_coordinator(
+            [make_sdist("1.0")],
+            sdist_pkg_info=PKG_INFO_DYNAMIC_DEPS,
+        )
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            dist_policy=DistPolicy.WHEEL_OR_SDIST,
+            build_policy=BuildPolicy.NEVER,
+            trust_unverified_sdist_deps=True,
+        )
+        with pytest.raises(UnsupportedSdistError):
+            provider.get_dependencies("pkg", V("1.0"))
 
     def test_sdist_no_pkg_info_raises(self) -> None:
         """Raise MetadataError when PKG-INFO cannot be extracted."""

--- a/nab-python/tests/universal/test_universal_provider.py
+++ b/nab-python/tests/universal/test_universal_provider.py
@@ -18,6 +18,7 @@ from nab_index.client import SdistFile, WheelFile
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.version import Version
+from nab_python.config import NabProjectConfig
 from nab_python.fetch import InMemoryIndex
 from nab_python.provider import (
     BuildPolicy,
@@ -112,6 +113,24 @@ class TestEnvironmentOverlay:
             marker_environment={"sys_platform": "win32"},
         )
         assert provider.env_with_extra["sys_platform"] == "win32"
+
+
+class TestTrustUnverifiedSdistDeps:
+    """The trust-unverified flag is taken from ``build_config``."""
+
+    def test_defaults_false_without_build_config(self) -> None:
+        coordinator = _make_coordinator([])
+        provider = UniversalProvider(coordinator, marker_environment=_LINUX_ENV)
+        assert provider.trust_unverified_sdist_deps is False
+
+    def test_taken_from_build_config(self) -> None:
+        coordinator = _make_coordinator([])
+        provider = UniversalProvider(
+            coordinator,
+            marker_environment=_LINUX_ENV,
+            build_config=NabProjectConfig(trust_unverified_sdist_deps=True),
+        )
+        assert provider.trust_unverified_sdist_deps is True
 
 
 class TestStrategyValidation:


### PR DESCRIPTION
Before this change nab trusted a pre-2.2 sdist's PKG-INFO `Requires-Dist` as final. PEP 643 only guarantees dependency fields are static at Metadata-Version 2.2 or later with no `Dynamic` dependency field, so a pre-2.2 PKG-INFO carries no such guarantee and the declared deps may differ from what the build backend produces.

The fix introduces `metadata_deps_are_static()` in `nab_python.metadata` and wires it into `parse_and_cache_metadata`: by default a pre-2.2 PKG-INFO now routes through the dynamic path (pyproject.toml fallback, then `UnsupportedSdistError` under `BuildPolicy.NEVER`). A new `trust-unverified-sdist-deps` config key and `Provider` flag restore the old lax behaviour for projects that need it.
