### PR TITLE
Fail-fast on listing fetch transport errors

### DIFF
--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -54,9 +54,12 @@ def fetch_versions(provider: Provider, package: str) -> list[tuple[Version, Dist
     if files is None:
         event = provider.coordinator.request_listing(normalized)
         event.wait()
+        error = provider.coordinator.index.get_listing_error(normalized)
+        if error is not None:
+            raise error
         files = provider.coordinator.index.get_listing(normalized)
-    # request_listing always stores at least an empty list on completion;
-    # ``files`` is therefore non-None on the second read.
+    # A successful fetch stores at least an empty list; a failed fetch
+    # stores an error, re-raised above, so ``files`` is non-None here.
     assert files is not None
 
     # Routed through the method (not the module function) so subclass

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -18,7 +18,7 @@ import threading
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from nab_index.cache import CacheBackend, NullCache, OnDiskCache
+from nab_index.cache import CacheBackend, NullCache, OfflineError, OnDiskCache
 from nab_index.cached_client import CachedAsyncSimpleClient
 from nab_index.client import SdistFile, WheelFile
 from nab_index.local_index import LocalIndexClient
@@ -138,6 +138,7 @@ class InMemoryIndex:
         """Create an empty index."""
         self._lock = threading.Lock()
         self._listings: dict[str, list[WheelFile | SdistFile]] = {}
+        self._listing_errors: dict[str, BaseException] = {}
         self._listing_indexes: dict[str, str] = {}
         self._metadata: dict[tuple[str, str], str | None] = {}
         self._sdist_pyproject: dict[tuple[str, str], str | None] = {}
@@ -177,6 +178,26 @@ class InMemoryIndex:
         if pending is not None:
             pending.result = materialised
             pending.event.set()
+
+    def store_listing_error(self, package: str, error: BaseException) -> None:
+        """Record a failed listing fetch and unblock any waiter.
+
+        Distinct from ``store_listing([])``: an empty listing means the
+        index served no files (a 404), while an error means the fetch
+        itself failed. ``fetch_versions`` re-raises the error instead of
+        reporting the package as having no candidates.
+        """
+        key = f"listing:{package}"
+        with self._lock:
+            self._listing_errors[package] = error
+            pending = self._pending.get(key)
+        if pending is not None:
+            pending.event.set()
+
+    def get_listing_error(self, package: str) -> BaseException | None:
+        """Return the recorded listing fetch error for ``package``, or ``None``."""
+        with self._lock:
+            return self._listing_errors.get(package)
 
     def store_listing_index(self, package: str, index_name: str) -> None:
         """Record which configured index served ``package``."""
@@ -749,14 +770,20 @@ class FetchCoordinator:
                     await self._fetch_sdist(client, req)
                 else:
                     await self._fetch_sdist_archive(client, req)
-            except Exception:
+            except Exception as exc:
                 logger.exception("Fetch failed: %s %s", req.kind.value, req.package)
-                # Record an empty result so any waiter unblocks. Without
-                # this, the resolver deadlocks on event.wait() when a
-                # transitive dep 404s or fails any other way.
+                # Record a result so any waiter unblocks; without it the
+                # resolver deadlocks on event.wait().
                 if req.kind is FetchKind.LISTING:
-                    self.index.store_listing(req.package, [])
-                    self._record_serving_index(client, req.package)
+                    # Offline + cold cache is a deliberate empty listing
+                    # (the resolver proceeds with no candidates); any other
+                    # failure is stored as an error so fetch_versions can
+                    # surface it instead of reporting no candidates.
+                    if isinstance(exc, OfflineError):
+                        self.index.store_listing(req.package, [])
+                        self._record_serving_index(client, req.package)
+                    else:
+                        self.index.store_listing_error(req.package, exc)
                 else:
                     assert req.version is not None
                     if req.kind is FetchKind.METADATA:

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -429,6 +429,19 @@ class TestFetchCoordinator:
             assert not coord._crashed
 
     @respx.mock
+    def test_listing_transport_error_not_masked_as_empty(self) -> None:
+        """A 5xx on a listing fetch stores an error, not an empty listing.
+        A genuine 404 (no candidates) is distinct and handled inside get_files.
+        """
+        respx.get("https://pypi.org/simple/bad/").mock(return_value=httpx.Response(500))
+        with _coord() as coord:
+            event = coord.request_listing("bad")
+            event.wait(timeout=5)
+            assert not coord._crashed
+            assert coord.index.get_listing("bad") is None
+            assert coord.index.get_listing_error("bad") is not None
+
+    @respx.mock
     def test_sdist_fetch_failure_records_empty(self) -> None:
         """When sdist extraction errors, store_sdist_metadata(None) unblocks
         any waiter and the coordinator does not crash."""

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -3079,6 +3079,14 @@ class TestFetchVersionsNotInIndex:
         assert result[0][0] == V("1.0")
         coordinator.request_listing.assert_called_with("pkg")
 
+    def test_listing_fetch_error_reraised(self) -> None:
+        """A recorded listing fetch error surfaces, not an empty listing."""
+        coordinator = make_coordinator(package="bad")
+        coordinator.index.store_listing_error("bad", RuntimeError("index 500"))
+        provider = Provider(coordinator)
+        with pytest.raises(RuntimeError, match="index 500"):
+            provider.fetch_versions("bad")
+
 
 class TestSpeculativePrefetchBatchLimit:
     def test_batch_limit_stops_at_prefetch_batch(self) -> None:


### PR DESCRIPTION
When a listing fetch failed with a transport error (e.g. a 5xx from the index), the coordinator stored an empty list, causing the resolver to report the package as having no candidates rather than surfacing the real failure. A transient index outage was silently misdiagnosed as a resolution error.

The fix stores the exception in `InMemoryIndex` instead of an empty list, and `fetch_versions` re-raises it after `event.wait()`. `OfflineError` keeps its existing behavior (empty listing) because a cold-cache offline run intentionally proceeds with no candidates.
