### PR TITLE
Reject matrix.python axis finer than minor

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -854,21 +854,39 @@ def _parse_workspace(value: object) -> WorkspaceConfig | None:
 _MINOR_RELEASE_PARTS = 2
 
 
-def _matrix_python_patch_clause(spec_set: SpecifierSet) -> str | None:
-    """Return the first clause pinning a patch (micro) version, else None.
+def _validate_matrix_python(spec: str) -> None:
+    """Reject a matrix.python axis finer than major.minor.
 
-    The matrix python axis is minor-granular, so ``>=3.11.5`` would
-    silently exclude 3.11 entirely. A trailing ``.*`` wildcard targets a
-    minor and is allowed.
+    The axis lists language (minor) Python versions; patch pins belong in
+    [tool.nab.matrix.python-patches].
     """
-    for clause in spec_set:
+    try:
+        specifier_set = SpecifierSet(spec)
+    except InvalidSpecifier as exc:
+        msg = f"matrix.python must be a PEP 440 specifier, got {spec!r}"
+        raise ConfigError(msg) from exc
+    for clause in specifier_set:
         try:
-            release = Version(clause.version.removesuffix(".*")).release
-        except InvalidVersion:
-            continue
-        if len(release) > _MINOR_RELEASE_PARTS:
-            return str(clause)
-    return None
+            version = Version(clause.version.removesuffix(".*"))
+        except InvalidVersion as exc:
+            msg = f"matrix.python clause {clause} is not a valid version"
+            raise ConfigError(msg) from exc
+
+        # Reject pre/post/dev/local qualifiers and patch-level release tuples.
+        finer = (
+            version.epoch != 0,
+            version.pre is not None,
+            version.post is not None,
+            version.dev is not None,
+            version.local is not None,
+        )
+        if len(version.release) > _MINOR_RELEASE_PARTS or any(finer):
+            msg = (
+                "matrix.python axis is a language (minor) version only; "
+                f"{clause} is finer than major.minor. Put patch versions in "
+                "[tool.nab.matrix.python-patches]."
+            )
+            raise ConfigError(msg)
 
 
 def _parse_matrix(value: object) -> MatrixConfig | None:
@@ -899,18 +917,7 @@ def _parse_matrix(value: object) -> MatrixConfig | None:
     if not isinstance(python, str):
         msg = "matrix.python must be a string PEP 440 specifier"
         raise ConfigError(msg)
-    try:
-        spec_set = SpecifierSet(python)
-    except InvalidSpecifier as exc:
-        msg = f"matrix.python must be a PEP 440 specifier, got {python!r}"
-        raise ConfigError(msg) from exc
-    patched = _matrix_python_patch_clause(spec_set)
-    if patched is not None:
-        msg = (
-            f"matrix.python takes minor (language) versions only, got {patched!r}."
-            " The python axis is minor-granular; use 3.X, not a patch like 3.X.Y."
-        )
-        raise ConfigError(msg)
+    _validate_matrix_python(python)
     platforms = _parse_string_list("matrix.platforms", platforms_raw)
     if not platforms:
         msg = "matrix.platforms must list at least one platform id"

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -1037,51 +1037,41 @@ class TestMatrix:
         with pytest.raises(ConfigError, match="matrix.python must be a string"):
             read_pyproject_config(path)
 
-    def _body_with_python(self, python: str) -> str:
+    def _python_axis_body(self, python: str) -> str:
         return (
             "[tool.nab]\n"
             'mode = "universal"\n'
             "[tool.nab.matrix]\n"
-            f"python = {python}\n"
+            f"python = {python!r}\n"
             'platforms = ["linux_x86_64"]\n'
         )
 
-    def test_python_patch_level_rejected(self, tmp_path: Path) -> None:
-        body = self._body_with_python('">=3.11.5"')
-        with pytest.raises(ConfigError, match="minor \\(language\\) versions only"):
-            read_pyproject_config(write(tmp_path, body))
-
-    def test_python_exact_patch_rejected(self, tmp_path: Path) -> None:
-        body = self._body_with_python('"==3.11.0"')
-        with pytest.raises(ConfigError, match="minor \\(language\\) versions only"):
-            read_pyproject_config(write(tmp_path, body))
-
-    def test_python_minor_wildcard_allowed(self, tmp_path: Path) -> None:
-        matrix = read_pyproject_config(
-            write(tmp_path, self._body_with_python('"==3.11.*"'))
-        ).matrix
+    @pytest.mark.parametrize(
+        "python",
+        [">=3.11", "==3.12", "<3.13", "~=3.11", ">=3.11,<3.14", "==3.11.*", ">=3", ""],
+    )
+    def test_python_minor_axis_accepted(self, tmp_path: Path, python: str) -> None:
+        path = write(tmp_path, self._python_axis_body(python))
+        matrix = read_pyproject_config(path).matrix
         assert matrix is not None
-        assert matrix.python == "==3.11.*"
+        assert matrix.python == python
 
-    def test_python_not_a_specifier_rejected(self, tmp_path: Path) -> None:
-        body = self._body_with_python('"3.11"')
-        with pytest.raises(ConfigError, match="matrix.python must be a PEP 440"):
-            read_pyproject_config(write(tmp_path, body))
+    @pytest.mark.parametrize(
+        "python",
+        [">=3.11.5", "==3.10.2", "~=3.11.5", "==3.11.0", "==3.11a1", "!=3.11.5"],
+    )
+    def test_python_finer_than_minor_rejected(
+        self, tmp_path: Path, python: str
+    ) -> None:
+        path = write(tmp_path, self._python_axis_body(python))
+        with pytest.raises(ConfigError, match=r"language \(minor\) version"):
+            read_pyproject_config(path)
 
-    def test_python_arbitrary_equality_rejected(self, tmp_path: Path) -> None:
-        # An arbitrary-equality pin like ===nightly parses as a specifier but
-        # matches no known Python, so the eager matrix expansion rejects it.
-        with pytest.raises(ConfigError, match="No known Python versions match"):
-            read_pyproject_config(
-                write(tmp_path, self._body_with_python('"===nightly"'))
-            )
-
-    def test_python_empty_specifier_allowed(self, tmp_path: Path) -> None:
-        matrix = read_pyproject_config(
-            write(tmp_path, self._body_with_python('""'))
-        ).matrix
-        assert matrix is not None
-        assert matrix.python == ""
+    @pytest.mark.parametrize("python", ["3.11", "garbage", "===foo"])
+    def test_python_unparseable_rejected(self, tmp_path: Path, python: str) -> None:
+        path = write(tmp_path, self._python_axis_body(python))
+        with pytest.raises(ConfigError):
+            read_pyproject_config(path)
 
     def test_empty_platforms(self, tmp_path: Path) -> None:
         path = write(


### PR DESCRIPTION
The old `_matrix_python_patch_clause` helper only caught patch-level release segments. Version components like pre-releases (`==3.11a1`), post-releases, dev releases, local labels, and non-zero epochs also produce an axis that is finer than major.minor, but the old code silently accepted them.

This replaces `_matrix_python_patch_clause` with `_validate_matrix_python`, which takes the raw specifier string, parses it once, and rejects any clause whose version has more than two release segments or any pre/post/dev/local/epoch component. The specifier-level `InvalidSpecifier` and version-level `InvalidVersion` error paths are now raised with explicit messages rather than being silently skipped.

The tests are replaced with parametrized forms covering accepted minor-version specifiers, rejected finer-than-minor specifiers, and unparseable inputs.
