### PR TITLE
Reject marker-gated index overrides in universal mode

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -243,6 +243,20 @@ def _parse_nab_table(
         )
         raise ConfigError(msg)
 
+    index_overrides = _parse_index_overrides(raw.get("index-overrides", []))
+    if mode is ResolveMode.UNIVERSAL:
+        marker_gated = sorted(o.name for o in index_overrides if o.marker)
+        if marker_gated:
+            joined = ", ".join(marker_gated)
+            msg = (
+                "mode = 'universal' does not support marker-gated"
+                f" [[tool.nab.index-overrides]] ({joined}): a universal lock"
+                " fetches each package once and cannot route it to a"
+                " different index per environment. Drop the marker or use"
+                " mode = 'specific'."
+            )
+            raise ConfigError(msg)
+
     return NabProjectConfig(
         mode=mode,
         constraints=_parse_string_list("constraints", raw.get("constraints", [])),
@@ -273,7 +287,7 @@ def _parse_nab_table(
         ),
         marker_environment=_parse_marker_environment(raw.get("marker-environment", {})),
         indexes=_parse_indexes(raw.get("indexes")),
-        index_overrides=_parse_index_overrides(raw.get("index-overrides", [])),
+        index_overrides=index_overrides,
         vcs=_parse_vcs(raw.get("vcs", {})),
         local_sources=_parse_local_sources(
             raw.get("local-sources", []), pyproject_dir=pyproject_dir

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -737,6 +737,35 @@ class TestIndexOverrides:
         with pytest.raises(ConfigError, match="marker must be a string"):
             read_pyproject_config(path)
 
+    def test_marker_gated_rejected_in_universal_mode(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab]\nmode = "universal"\n'
+            "[tool.nab.matrix]\n"
+            'python = ">=3.11"\n'
+            'platforms = ["linux_x86_64"]\n'
+            "[[tool.nab.index-overrides]]\n"
+            'name = "torch"\n'
+            'index = "torch-cpu"\n'
+            "marker = \"sys_platform == 'linux'\"\n",
+        )
+        with pytest.raises(ConfigError, match="does not support marker-gated"):
+            read_pyproject_config(path)
+
+    def test_unconditional_allowed_in_universal_mode(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab]\nmode = "universal"\n'
+            "[tool.nab.matrix]\n"
+            'python = ">=3.11"\n'
+            'platforms = ["linux_x86_64"]\n'
+            "[[tool.nab.index-overrides]]\n"
+            'name = "torch"\n'
+            'index = "torch-cpu"\n',
+        )
+        ovr = read_pyproject_config(path).index_overrides
+        assert ovr == (IndexOverride(name="torch", index="torch-cpu", marker=None),)
+
 
 class TestVcs:
     def test_full_round_trip(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Universal mode resolves each package exactly once across all environments, so a marker-gated `[[tool.nab.index-overrides]]` entry is incoherent: the index chosen for the first environment would be silently applied to all others.

`_parse_nab_table` now rejects any combination of `mode = "universal"` and a marker-bearing index override, listing the offending package names in the error. Unconditional overrides (no marker) are still permitted.
