### PR TITLE
Add nab lock --check for CI drift detection

### DIFF
--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -8,7 +8,7 @@ the CLI itself carries only runtime knobs.
 
 ```
 nab [--version | -V]
-nab lock     [PATH] [RUNTIME OPTIONS] [--output PATH] [--format pylock|requirements|requirements-without-hashes]
+nab lock     [PATH] [RUNTIME OPTIONS] [--output PATH] [--format pylock|requirements|requirements-without-hashes] [--check]
 nab download [PATH] [RUNTIME OPTIONS] [--output DIR] [--max-concurrency N]
 ```
 
@@ -74,6 +74,32 @@ all three formats:
 Failed tuples render as `# {label}: FAILED` followed by the
 indented error and exit `1`.
 
+### Checking for drift (`--check`)
+
+`--check` resolves in memory and compares the result against the
+existing `pylock.toml` without writing anything. It exits `0`
+when the lockfile is up to date and `1` when it is out of date,
+missing, or unreadable, printing a package-level diff so you can
+see what a re-lock would change:
+
+```
+$ nab lock --check
+pylock.toml is out of date:
+  added:      httpx 0.28.1
+  upgraded:   requests 2.31.0 -> 2.32.0
+  downgraded: urllib3 2.3.0 -> 2.2.0
+  removed:    idna 3.6
+Run `nab lock` to update it.
+```
+
+Run it in CI to fail the build when a committed lockfile no
+longer matches the project's dependencies, without the
+write-then-`git diff` dance. The re-resolve reuses the existing
+lockfile's `created-at` anchor, so the comparison uses the same
+resolve window the file was written with. `--check` is
+single-environment `pylock` only; it rejects the requirements
+formats, `--output -`, and universal mode.
+
 ## `nab download`
 
 Resolve and download every wheel and sdist into a local
@@ -120,7 +146,7 @@ matching extra.
 | Code | Meaning |
 | ---- | ------- |
 | `0`  | Success. |
-| `1`  | Resolution failed, lockfile cannot be written (missing hash), download failed, missing `[project].dependencies`, or invalid `[tool.nab]` configuration. |
+| `1`  | Resolution failed, lockfile cannot be written (missing hash), download failed, missing `[project].dependencies`, invalid `[tool.nab]` configuration, or `--check` found drift. |
 | `130` | Interrupted with Ctrl-C. `nab` prints `Aborted.` and exits. |
 
 [PEP 751]: https://peps.python.org/pep-0751/

--- a/docs/guides/lockfile.md
+++ b/docs/guides/lockfile.md
@@ -143,6 +143,11 @@ identical inputs are byte-for-byte identical. A relative `P<n>D`
 cutoff is anchored to the wall clock, so `created-at` stays the
 run time; `--upgrade` always re-anchors to now.
 
+To verify a committed lockfile in CI without writing to disk, run
+`nab lock --check`: it re-resolves in memory, exits `0` when the
+result matches `pylock.toml` and `1` with a package-level diff
+when it does not. See [the CLI guide](cli.md) for details.
+
 ## `nab download`
 
 `nab download` walks the same pin set, fetches every wheel and

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -76,6 +76,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     no_emit_workspace: bool = False,
     resolution: ResolutionFlag | None = None,
     upgrade: bool = False,
+    check: bool = False,
 ) -> None:
     """Resolve dependencies and emit a lockfile or pin list.
 
@@ -104,12 +105,19 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     ``--resolution`` overrides ``[tool.nab].resolution`` for this run.
     ``--upgrade`` re-anchors the ``P<n>D`` cutoff to ``datetime.now(UTC)``
     instead of reusing the timestamp recorded in any existing lockfile.
+
+    ``--check`` resolves in memory and compares the result against the
+    on-disk lockfile without writing: it exits 0 when they match and
+    prints a package-level diff then exits 1 when they differ, for CI
+    drift detection.  Single-environment ``pylock`` only.
     """
     _validate_pylock_output_name(output=output, format=format)
     anchor = _determine_lock_anchor(path, output=output, format=format, upgrade=upgrade)
     config = _cli._load_config(  # noqa: SLF001
         path, discover_workspace=workspace_discovery, anchor=anchor
     )
+    if check:
+        _validate_check_supported(format=format, output=output, mode=config.mode)
     effective_cache_dir = _cli._resolve_effective_cache_dir(  # noqa: SLF001
         cache_dir, cache=cache
     )
@@ -157,6 +165,9 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
         extras=selected_extras,
         resolution_strategy=strategy_override,
     )
+    if check:
+        _check_specific(result, output=output, workspace_to_drop=workspace_to_drop)
+        return
     _emit_specific(
         result,
         format=format,
@@ -266,6 +277,99 @@ def _diff_summary(
         if count
     ]
     return f": {', '.join(parts)}" if parts else ""
+
+
+def _validate_check_supported(
+    *,
+    format: str,  # noqa: A002 - shadows builtin by convention
+    output: Path | None,
+    mode: ResolveMode,
+) -> None:
+    """Reject ``--check`` combinations that have no on-disk lockfile to read.
+
+    Only single-environment ``pylock`` is supported: the requirements
+    formats and the universal merged lock have no ``name -> version``
+    reader to diff against, and stdout has no file at all.
+    """
+    if format != "pylock":
+        sys.stderr.write("Error: --check is only supported for the pylock format\n")
+        sys.exit(1)
+    if _cli._is_stdout(output):  # noqa: SLF001
+        sys.stderr.write("Error: --check cannot be combined with --output -\n")
+        sys.exit(1)
+    if mode is ResolveMode.UNIVERSAL:
+        sys.stderr.write("Error: --check is not yet supported for universal mode\n")
+        sys.exit(1)
+
+
+def _check_specific(
+    result: ResolutionResult,
+    *,
+    output: Path | None,
+    workspace_to_drop: frozenset[str] = frozenset(),
+) -> None:
+    """Compare a resolve against the on-disk pylock without writing.
+
+    Exits 0 when the emitted pins match the lockfile and 1 when they
+    differ or the lockfile is missing or unreadable.
+    """
+    lock_input = _drop_workspace_pins(result.lock_input, workspace_to_drop)
+    emitted_pins = {name: result.pins[name] for name in lock_input.pins}
+    target = output if output is not None else Path(_cli._DEFAULT_OUTPUT["pylock"])  # noqa: SLF001
+
+    if not target.exists():
+        sys.stderr.write(
+            f"Error: {target} does not exist; run `nab lock` to create it\n"
+        )
+        sys.exit(1)
+    prior = read_lockfile_packages(target)
+    if prior is None:
+        sys.stderr.write(
+            f"Error: {target} is not a valid pylock lockfile;"
+            " run `nab lock` to recreate it\n"
+        )
+        sys.exit(1)
+
+    report = _check_diff_report(prior, emitted_pins)
+    if report is None:
+        sys.stderr.write(f"{target} is up to date\n")
+        return
+    sys.stderr.write(
+        f"{target} is out of date:\n{report}\nRun `nab lock` to update it.\n"
+    )
+    sys.exit(1)
+
+
+def _check_diff_report(
+    prior: Mapping[str, Version], current: Mapping[str, Version]
+) -> str | None:
+    """Render the per-package drift between ``prior`` and ``current``.
+
+    Returns ``None`` when the pin sets are identical, otherwise an
+    aligned block of ``added`` / ``upgraded`` / ``downgraded`` /
+    ``removed`` lines.
+    """
+    added = sorted(name for name in current if name not in prior)
+    removed = sorted(name for name in prior if name not in current)
+    upgraded: list[str] = []
+    downgraded: list[str] = []
+    for name in sorted(current):
+        old = prior.get(name)
+        if old is None or old == current[name]:
+            continue
+        (upgraded if current[name] > old else downgraded).append(name)
+
+    lines = [f"  {'added:':<11} {name} {current[name]}" for name in added]
+    lines += [
+        f"  {'upgraded:':<11} {name} {prior[name]} -> {current[name]}"
+        for name in upgraded
+    ]
+    lines += [
+        f"  {'downgraded:':<11} {name} {prior[name]} -> {current[name]}"
+        for name in downgraded
+    ]
+    lines += [f"  {'removed:':<11} {name} {prior[name]}" for name in removed]
+    return "\n".join(lines) if lines else None
 
 
 def _emit_universal(  # noqa: PLR0913 - one wrapper per resolve_universal_pyproject kwarg

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1216,6 +1216,128 @@ class TestRelockDiffSummary:
         assert capsys.readouterr().err.strip().endswith("(1 packages)")
 
 
+class TestCheckMode:
+    """``nab lock --check`` verifies the lockfile without writing."""
+
+    def _seed(self, pyproject: Path, out: Path, pins: dict[str, Version]) -> None:
+        with patch(
+            "nab.cli.resolve_pyproject",
+            return_value=_stub_resolution_result(pins=pins),
+        ):
+            lock(pyproject, output=out)
+
+    def test_up_to_date_exits_zero(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        self._seed(pyproject, out, {"foo": V("1.0")})
+        before = out.read_bytes()
+        capsys.readouterr()
+        with patch(
+            "nab.cli.resolve_pyproject",
+            return_value=_stub_resolution_result(pins={"foo": V("1.0")}),
+        ):
+            lock(pyproject, output=out, check=True)
+        assert "up to date" in capsys.readouterr().err
+        assert out.read_bytes() == before
+
+    def test_out_of_date_reports_every_change(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        self._seed(
+            pyproject,
+            out,
+            {"foo": V("2.0"), "bar": V("1.0"), "gone": V("1.0"), "same": V("1.0")},
+        )
+        before = out.read_bytes()
+        capsys.readouterr()
+        new_pins = {
+            "foo": V("1.0"),
+            "bar": V("2.0"),
+            "new": V("1.0"),
+            "same": V("1.0"),
+        }
+        with (
+            patch(
+                "nab.cli.resolve_pyproject",
+                return_value=_stub_resolution_result(pins=new_pins),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, output=out, check=True)
+        err = capsys.readouterr().err
+        assert "out of date" in err
+        assert "added:      new 1.0" in err
+        assert "upgraded:   bar 1.0 -> 2.0" in err
+        assert "downgraded: foo 2.0 -> 1.0" in err
+        assert "removed:    gone 1.0" in err
+        assert "same" not in err
+        assert "Run `nab lock` to update it." in err
+        assert out.read_bytes() == before
+
+    def test_missing_file_exits(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        pyproject = _make_pyproject(tmp_path)
+        with (
+            patch(
+                "nab.cli.resolve_pyproject",
+                return_value=_stub_resolution_result(pins={"foo": V("1.0")}),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, check=True)
+        assert "does not exist" in capsys.readouterr().err
+
+    def test_unparseable_file_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        out.write_text("not valid toml === {[\n")
+        with (
+            patch(
+                "nab.cli.resolve_pyproject",
+                return_value=_stub_resolution_result(pins={"foo": V("1.0")}),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, output=out, check=True)
+        assert "not a valid" in capsys.readouterr().err
+
+    def test_requirements_format_rejected(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, format="requirements", check=True)
+        assert "only supported for the pylock" in capsys.readouterr().err
+
+    def test_stdout_output_rejected(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, output=Path("-"), check=True)
+        assert "--output -" in capsys.readouterr().err
+
+    def test_universal_mode_rejected(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, output=out, check=True)
+        assert "universal" in capsys.readouterr().err
+
+
 class TestPylockOutputNameValidation:
     """``--output`` is validated against the PEP 751 file-name rule."""
 


### PR DESCRIPTION
Adds `--check` to `nab lock`. It resolves in memory and compares the result against the on-disk `pylock.toml` without writing anything. Exits 0 when the lockfile is up to date, exits 1 with a package-level diff (added, upgraded, downgraded, removed) when it is not. Unsupported combinations (requirements formats, `--output -`, universal mode) are rejected with a clear error.

The flag is intended for CI pipelines that need to verify a committed lockfile is still current, replacing the write-then-`git diff` workaround.

Closes #18
