### PR TITLE
Emit live resolve progress to stderr

### DIFF
--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -32,6 +32,8 @@ if TYPE_CHECKING:
 
     from typing_extensions import Self
 
+    from .progress import ProgressReporter
+
 __all__ = [
     "DEFAULT_INDEX_NAME",
     "DEFAULT_INDEX_URL",
@@ -350,7 +352,7 @@ class FetchCoordinator:
 
     PREFETCH_METADATA_COUNT = 10
 
-    def __init__(
+    def __init__(  # noqa: PLR0913 - independent fetch/cache/index config knobs
         self,
         transport: AsyncHttpTransport,
         *,
@@ -361,6 +363,7 @@ class FetchCoordinator:
         offline: bool = False,
         index_overrides: list[IndexOverride] | None = None,
         marker_environment: dict[str, str] | None = None,
+        progress: ProgressReporter | None = None,
     ) -> None:
         """Create a coordinator that wraps ``transport``.
 
@@ -411,6 +414,7 @@ class FetchCoordinator:
         self._marker_environment = (
             dict(marker_environment) if marker_environment is not None else None
         )
+        self._progress = progress
         self.index = InMemoryIndex()
         self._thread: threading.Thread | None = None
         self._started = False
@@ -772,6 +776,8 @@ class FetchCoordinator:
         req: FetchRequest,
     ) -> None:
         files = await client.get_files(req.package)
+        if self._progress is not None:
+            self._progress.listing_fetched(req.package)
         self.index.store_listing(req.package, files)
         self._record_serving_index(client, req.package)
 

--- a/nab-python/src/nab_python/progress.py
+++ b/nab-python/src/nab_python/progress.py
@@ -1,0 +1,45 @@
+"""Progress signals emitted during resolution."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from nab_resolver.resolver import ResolverObserver
+
+from ._vendor.packaging.version import Version
+from .provider import split_extra
+
+
+class ProgressReporter(Protocol):
+    """Receives resolution progress events as they happen."""
+
+    def listing_fetched(self, package: str) -> None:
+        """Note that ``package``'s index listing finished fetching."""
+        ...
+
+    def package_pinned(self, package: str) -> None:
+        """Note that the resolver decided a version for ``package``."""
+        ...
+
+
+class PinObserver(ResolverObserver[str, Version]):
+    """Forward base-package pins from the solver to a progress reporter.
+
+    Extras-proxy decisions (``name[extra]``) share their base package's
+    version, so only base-package pins are reported, matching the pins
+    that reach the lockfile.
+    """
+
+    def __init__(self, progress: ProgressReporter) -> None:
+        """Record the ``progress`` reporter to forward pins to."""
+        self._progress = progress
+
+    def on_decision(
+        self,
+        package: str,
+        version: Version,  # noqa: ARG002
+        level: int,  # noqa: ARG002
+    ) -> None:
+        """Report ``package`` as pinned unless it is an extras proxy."""
+        if split_extra(package)[1] is None:
+            self._progress.package_pinned(package)

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -27,6 +27,7 @@ from ._vendor.packaging.version import InvalidVersion, Version
 from .config import ConfigError, NabProjectConfig, ResolveMode, read_pyproject_config
 from .fetch import FetchCoordinator
 from .lockfile import LockInput, build_lock_input_from_provider
+from .progress import PinObserver
 from .provider import (
     Provider,
     ResolutionStrategy,
@@ -53,6 +54,7 @@ if TYPE_CHECKING:
 
     from nab_index.transport import AsyncHttpTransport
 
+    from .progress import ProgressReporter
     from .universal.matrix import MatrixTuple
 
 
@@ -96,6 +98,7 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
     groups: Sequence[str] = (),
     extras: Sequence[str] = (),
     resolution_strategy: ResolutionStrategy | None = None,
+    progress: ProgressReporter | None = None,
 ) -> ResolutionResult:
     """Resolve a project's dependencies for a single environment.
 
@@ -107,6 +110,9 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
     ``groups`` and ``extras`` name PEP 735 groups and
     ``[project.optional-dependencies]`` keys to fold in.
     ``resolution_strategy`` overrides ``config.resolution`` when set.
+
+    ``progress`` receives a listing-fetched event per package fetched
+    and a pin event per base package decided, for a live status line.
 
     Use :func:`resolve_universal_pyproject` when
     ``config.mode is ResolveMode.UNIVERSAL``. Returns a
@@ -162,6 +168,7 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
         offline=offline,
         index_overrides=list(config.index_overrides),
         marker_environment=marker_environment,
+        progress=progress,
     ) as coordinator:
         provider = Provider(
             coordinator,
@@ -185,7 +192,10 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
         )
 
         resolver: Resolver[str, Version] = Resolver(
-            provider, range_type=VersionRange, root_version="0"
+            provider,
+            observer=PinObserver(progress) if progress is not None else None,
+            range_type=VersionRange,
+            root_version="0",
         )
         try:
             raw = resolver.resolve(
@@ -515,7 +525,7 @@ def _build_marker_environment(
     return env
 
 
-def resolve_universal_pyproject(
+def resolve_universal_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling into a config object would hide it
     path: Path,
     *,
     config: NabProjectConfig | None = None,
@@ -525,6 +535,7 @@ def resolve_universal_pyproject(
     groups: Sequence[str] = (),
     extras: Sequence[str] = (),
     resolution_strategy: ResolutionStrategy | None = None,
+    progress: ProgressReporter | None = None,
 ) -> UniversalResult:
     """Run a universal resolve for the project at ``path``.
 
@@ -537,6 +548,10 @@ def resolve_universal_pyproject(
     folded into every per-tuple resolve.  The CLI passes the
     selections through to ``merge_universal_lock_inputs`` so the
     lockfile records what produced the pin set.
+
+    ``progress`` receives an aggregate listing-fetched event per
+    package (the coordinator is shared across tuples) and a pin event
+    per base package decided in each tuple, for a live status line.
     """
     if config is None:
         config = read_pyproject_config(path)
@@ -594,6 +609,7 @@ def resolve_universal_pyproject(
         indexes=list(config.indexes),
         index_overrides=list(config.index_overrides) or None,
         resolution_strategy=effective_strategy.value,
+        progress=progress,
     )
 
 

--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -38,6 +38,7 @@ from ..lockfile import (
     PinShape,
     build_lock_input_from_provider,
 )
+from ..progress import PinObserver
 from ..provider import (
     BuildPolicy,
     DistPolicy,
@@ -74,6 +75,7 @@ if TYPE_CHECKING:
     from nab_index.transport import AsyncHttpTransport
 
     from ..config import NabProjectConfig
+    from ..progress import ProgressReporter
     from .matrix import Matrix, MatrixTuple
 
 
@@ -196,6 +198,7 @@ def resolve_universal(  # noqa: PLR0913 - surface area mirrors uv's resolution k
     resolution_strategy: str = "highest",
     align_across_tuples: bool = True,
     preferences: dict[str, Version] | None = None,
+    progress: ProgressReporter | None = None,
 ) -> UniversalResult:
     """Run a universal resolve for ``matrix``.
 
@@ -210,6 +213,10 @@ def resolve_universal(  # noqa: PLR0913 - surface area mirrors uv's resolution k
 
     ``preferences``: a starting set of preferred ``{name: Version}``,
     e.g. read from a previous lock.
+
+    ``progress`` receives fetch and pin events for a live status line;
+    the single shared coordinator makes fetch counts aggregate across
+    tuples.
     """
     if indexes is None:
         indexes = [IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL)]
@@ -222,6 +229,7 @@ def resolve_universal(  # noqa: PLR0913 - surface area mirrors uv's resolution k
         cache_dir=cache_dir,
         offline=offline,
         index_overrides=index_overrides,
+        progress=progress,
     ) as coordinator:
         return resolve_with_coordinator(
             coordinator,
@@ -242,6 +250,7 @@ def resolve_universal(  # noqa: PLR0913 - surface area mirrors uv's resolution k
             resolution_strategy=resolution_strategy,
             align_across_tuples=align_across_tuples,
             preferences=preferences,
+            progress=progress,
         )
 
 
@@ -265,6 +274,7 @@ def resolve_with_coordinator(  # noqa: PLR0913 - mirrors resolve_universal's sur
     resolution_strategy: str = "highest",
     align_across_tuples: bool = True,
     preferences: dict[str, Version] | None = None,
+    progress: ProgressReporter | None = None,
 ) -> UniversalResult:
     """Run a universal resolve against an already-open coordinator.
 
@@ -300,6 +310,7 @@ def resolve_with_coordinator(  # noqa: PLR0913 - mirrors resolve_universal's sur
             direct_packages=direct_packages,
             preferences=initial_preferences,
             align_serial=align_across_tuples,
+            progress=progress,
         ),
     )
 
@@ -325,6 +336,7 @@ def _run_pass(  # noqa: PLR0913
     direct_packages: frozenset[str],
     preferences: dict[str, Version],
     align_serial: bool,
+    progress: ProgressReporter | None = None,
 ) -> list[TupleResult]:
     """Run one serial pass of resolution across ``tuples``.
 
@@ -363,6 +375,7 @@ def _run_pass(  # noqa: PLR0913
             resolution_strategy=resolution_strategy,
             preferences=dict(current_prefs),
             direct_packages=direct_packages,
+            progress=progress,
         )
 
     out: list[TupleResult] = []
@@ -533,6 +546,7 @@ def _resolve_one_tuple(  # noqa: PLR0913
     resolution_strategy: str = "highest",
     preferences: dict[str, Version] | None = None,
     direct_packages: frozenset[str] = frozenset(),
+    progress: ProgressReporter | None = None,
 ) -> TupleResult:
     """Run one single-environment resolve for ``t``."""
     provider = UniversalProvider(
@@ -558,6 +572,7 @@ def _resolve_one_tuple(  # noqa: PLR0913
     )
     resolver: Resolver[str, Version] = Resolver(
         provider,
+        observer=PinObserver(progress) if progress is not None else None,
         range_type=VersionRange,
         root_version="0",
         max_iterations=50_000,

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -45,6 +45,16 @@ def _make_wheel(name: str = "foo", version: str = "1.0") -> WheelFile:
     )
 
 
+class _RecordingProgress:
+    """Records the package name of every reported listing fetch."""
+
+    def __init__(self) -> None:
+        self.fetched: list[str] = []
+
+    def listing_fetched(self, package: str) -> None:
+        self.fetched.append(package)
+
+
 class TestInMemoryIndex:
     def test_listing_roundtrip(self) -> None:
         idx = InMemoryIndex()
@@ -218,6 +228,16 @@ class TestFetchCoordinator:
             listing = coord.index.get_listing("testpkg")
             assert listing is not None
             assert len(listing) >= 2
+
+    @respx.mock
+    def test_listing_fetch_reports_progress(self) -> None:
+        respx.get("https://pypi.org/simple/testpkg/").mock(
+            return_value=httpx.Response(200, json=LISTING_JSON)
+        )
+        progress = _RecordingProgress()
+        with _coord(progress=progress) as coord:
+            coord.request_listing("testpkg").wait(timeout=5)
+        assert progress.fetched == ["testpkg"]
 
     @respx.mock
     def test_request_listing_cached(self) -> None:

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -15,6 +15,7 @@ from nab_python.config import (
     NabProjectConfig,
     ResolveMode,
 )
+from nab_python.progress import PinObserver
 from nab_python.provider import ResolutionStrategy, UnsupportedVcsError
 from nab_python.resolve import (
     ResolutionResult,
@@ -50,6 +51,61 @@ V = Version
 _FAKE_TRANSPORT = MagicMock(name="FakeTransport")
 
 _FORTY = "0123456789abcdef0123456789abcdef01234567"
+
+
+class _RecordingProgress:
+    """Records every progress event for assertions."""
+
+    def __init__(self) -> None:
+        self.fetched: list[str] = []
+        self.pinned: list[str] = []
+
+    def listing_fetched(self, package: str) -> None:
+        self.fetched.append(package)
+
+    def package_pinned(self, package: str) -> None:
+        self.pinned.append(package)
+
+
+class TestProgressReporting:
+    def test_observer_reports_base_packages_only(self) -> None:
+        """The bridge skips extras-proxy keys and reports base pins."""
+        progress = _RecordingProgress()
+        observer = PinObserver(progress)
+
+        observer.on_decision("foo", V("1.0"), 1)
+        observer.on_decision("foo[async]", V("1.0"), 2)
+
+        assert progress.pinned == ["foo"]
+
+    def test_progress_threaded_through_resolve(self, tmp_path: Path) -> None:
+        """resolve_pyproject hands progress to the coordinator and observer."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text('[project]\ndependencies = ["foo>=1.0"]\n')
+        progress = _RecordingProgress()
+
+        with (
+            patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls,
+            patch("nab_python.resolve.Provider") as mock_provider_cls,
+            patch("nab_python.resolve.build_lock_input_from_provider"),
+        ):
+            mock_coord_cls.return_value.__enter__ = lambda s: s
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            mock_provider = mock_provider_cls.return_value
+            mock_provider.choose_version.return_value = V("2.0")
+            mock_provider.get_dependencies.return_value = {}
+            mock_provider.prioritize.return_value = 1
+
+            result = resolve_pyproject(
+                pyproject,
+                _FAKE_TRANSPORT,
+                python_version="3.12.0",
+                progress=progress,
+            )
+
+        assert result.pins == {"foo": V("2.0")}
+        assert progress.pinned == ["foo"]
+        assert mock_coord_cls.call_args.kwargs["progress"] is progress
 
 
 class TestResolvePyproject:
@@ -741,6 +797,26 @@ class TestResolveUniversalPyproject:
         resolve_universal_pyproject(pyproject)
         kwargs = mock_resolve_universal.call_args.kwargs
         assert kwargs["matrix"].python_patches == {"3.11": "3.11.4"}
+
+    @patch("nab_python.resolve.resolve_universal")
+    def test_progress_forwarded_to_universal_resolver(
+        self,
+        mock_resolve_universal: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """A progress reporter reaches resolve_universal unchanged."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\ndependencies = ["foo"]\n'
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.11"\n'
+            'platforms = ["linux_x86_64"]\n',
+        )
+        progress = _RecordingProgress()
+        resolve_universal_pyproject(pyproject, progress=progress)
+        assert mock_resolve_universal.call_args.kwargs["progress"] is progress
 
     @patch("nab_python.resolve.resolve_universal")
     def test_explicit_config_arg(

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -72,6 +72,20 @@ def _make_coordinator(listings: dict[str, list[WheelFile]]) -> MagicMock:
     return make_coordinator(listings=listings, auto_metadata=True)
 
 
+class _RecordingProgress:
+    """Records every progress event for assertions."""
+
+    def __init__(self) -> None:
+        self.fetched: list[str] = []
+        self.pinned: list[str] = []
+
+    def listing_fetched(self, package: str) -> None:
+        self.fetched.append(package)
+
+    def package_pinned(self, package: str) -> None:
+        self.pinned.append(package)
+
+
 def _linux_311() -> MatrixTuple:
     return MatrixTuple(
         python_version="3.11",
@@ -646,6 +660,17 @@ class TestResolveWithCoordinator:
         assert result.success
         assert result.tuple_results[0].pins == {"pkg": Version("1.0")}
 
+    def test_progress_observes_per_tuple_pins(self) -> None:
+        """A progress reporter sees each tuple's base-package pins."""
+        coordinator = _make_coordinator({"pkg": [_make_wheel("1.0", package="pkg")]})
+        matrix = Matrix(python="==3.11", platforms=("linux_x86_64",))
+        progress = _RecordingProgress()
+        result = resolve_with_coordinator(
+            coordinator, matrix, ["pkg"], progress=progress
+        )
+        assert result.success
+        assert "pkg" in progress.pinned
+
 
 class TestResolveUniversalWrapper:
     """``resolve_universal`` wraps ``resolve_with_coordinator`` with a transport."""
@@ -710,6 +735,30 @@ class TestResolveUniversalWrapper:
             )
         # FetchCoordinator received the same list (not the default).
         assert fetch_cls.call_args.kwargs["indexes"] is custom
+
+    def test_progress_passed_to_coordinator(self) -> None:
+        """The shared coordinator receives the progress reporter."""
+        progress = _RecordingProgress()
+        sentinel = MagicMock()
+        sentinel.success = True
+        sentinel.tuple_results = []
+        with (
+            patch.object(resolve_mod, "FetchCoordinator") as fetch_cls,
+            patch.object(
+                resolve_mod, "Urllib3AsyncTransport", return_value=MagicMock()
+            ),
+            patch.object(
+                resolve_mod, "resolve_with_coordinator", return_value=sentinel
+            ),
+        ):
+            fetch_cls.return_value.__enter__.return_value = "COORD"
+            fetch_cls.return_value.__exit__.return_value = False
+            resolve_mod.resolve_universal(
+                matrix=Matrix(python="==3.11", platforms=("linux_x86_64",)),
+                requirements=["pkg"],
+                progress=progress,
+            )
+        assert fetch_cls.call_args.kwargs["progress"] is progress
 
 
 class TestLocalVcsRequiresPython:

--- a/src/nab/_download.py
+++ b/src/nab/_download.py
@@ -21,6 +21,7 @@ from nab_python.config import ResolveMode
 from nab_python.download import DownloadError
 
 from . import cli as _cli
+from ._progress import StderrProgressReporter
 from .cli import (
     HttpBackend,
     PathArg,
@@ -68,6 +69,7 @@ def download(
         offline=offline,
         transport=transport,
         failure_prefix="Cannot download",
+        progress=StderrProgressReporter(),
     )
 
     download_transport = _cli._make_transport(http_backend)  # noqa: SLF001

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -41,6 +41,7 @@ from nab_python.requirements_file import (
 )
 
 from . import cli as _cli
+from ._progress import StderrProgressReporter
 from .cli import (
     HttpBackend,
     LockFormat,
@@ -129,6 +130,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     )
 
     transport = _cli._make_transport(http_backend)  # noqa: SLF001
+    progress = StderrProgressReporter()
     if config.mode is ResolveMode.UNIVERSAL:
         _emit_universal(
             path,
@@ -143,6 +145,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
             extras=selected_extras,
             resolution_strategy=strategy_override,
             workspace_to_drop=workspace_to_drop,
+            progress=progress,
         )
         return
 
@@ -156,6 +159,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
         groups=selected_groups,
         extras=selected_extras,
         resolution_strategy=strategy_override,
+        progress=progress,
     )
     _emit_specific(
         result,
@@ -282,6 +286,7 @@ def _emit_universal(  # noqa: PLR0913 - one wrapper per resolve_universal_pyproj
     extras: tuple[str, ...] = (),
     resolution_strategy: ResolutionStrategy | None = None,
     workspace_to_drop: frozenset[str] = frozenset(),
+    progress: StderrProgressReporter,
 ) -> None:
     """Run the universal resolver and emit the requested artefact."""
     sys.stderr.write(
@@ -290,16 +295,20 @@ def _emit_universal(  # noqa: PLR0913 - one wrapper per resolve_universal_pyproj
     )
 
     try:
-        result = _cli.resolve_universal_pyproject(
-            path,
-            config=config,
-            cache_dir=cache_dir,
-            transport=transport,
-            offline=offline,
-            groups=groups,
-            extras=extras,
-            resolution_strategy=resolution_strategy,
-        )
+        try:
+            result = _cli.resolve_universal_pyproject(
+                path,
+                config=config,
+                cache_dir=cache_dir,
+                transport=transport,
+                offline=offline,
+                groups=groups,
+                extras=extras,
+                resolution_strategy=resolution_strategy,
+                progress=progress,
+            )
+        finally:
+            progress.finish()
     except KeyError:
         sys.stderr.write(f"Error: {path} has no [project].dependencies\n")
         sys.exit(1)

--- a/src/nab/_progress.py
+++ b/src/nab/_progress.py
@@ -1,0 +1,49 @@
+"""Live resolve status line for ``nab lock`` / ``nab download``."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import TextIO
+
+
+class StderrProgressReporter:
+    """Render a running resolve status line on a TTY stderr.
+
+    Counts distinct fetched and pinned packages and rewrites one
+    ``Resolving... N fetched, M pinned`` line with a carriage return.
+    Every method is a no-op when the stream is not a TTY, so redirected
+    or piped stderr stays free of carriage-return noise.
+    """
+
+    def __init__(self, stream: TextIO | None = None) -> None:
+        self._stream = stream if stream is not None else sys.stderr
+        self._enabled = self._stream.isatty()
+        self._fetched: set[str] = set()
+        self._pinned: set[str] = set()
+        self._last_len = 0
+
+    def listing_fetched(self, package: str) -> None:
+        self._fetched.add(package)
+        self._render()
+
+    def package_pinned(self, package: str) -> None:
+        self._pinned.add(package)
+        self._render()
+
+    def finish(self) -> None:
+        """Erase the status line so the next stderr write starts clean."""
+        if self._enabled and self._last_len:
+            self._stream.write("\r" + " " * self._last_len + "\r")
+            self._stream.flush()
+            self._last_len = 0
+
+    def _render(self) -> None:
+        if not self._enabled:
+            return
+        line = f"Resolving... {len(self._fetched)} fetched, {len(self._pinned)} pinned"
+        self._stream.write("\r" + line)
+        self._stream.flush()
+        self._last_len = len(line)

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -51,6 +51,7 @@ from nab_resolver.resolver import ResolutionError
 if TYPE_CHECKING:
     from datetime import datetime
 
+    from nab._progress import StderrProgressReporter
     from nab_index.transport import AsyncHttpTransport
     from nab_python.provider import ResolutionStrategy
     from nab_python.resolve import ResolutionResult
@@ -161,19 +162,24 @@ def _resolve_specific(  # noqa: PLR0913 - one wrapper per resolve_pyproject kwar
     groups: tuple[str, ...] = (),
     extras: tuple[str, ...] = (),
     resolution_strategy: ResolutionStrategy | None = None,
+    progress: StderrProgressReporter,
 ) -> ResolutionResult:
     """Run the single-environment resolver and translate errors to exits."""
     try:
-        return resolve_pyproject(
-            path,
-            transport,
-            config=config,
-            cache_dir=cache_dir,
-            offline=offline,
-            groups=groups,
-            extras=extras,
-            resolution_strategy=resolution_strategy,
-        )
+        try:
+            return resolve_pyproject(
+                path,
+                transport,
+                config=config,
+                cache_dir=cache_dir,
+                offline=offline,
+                groups=groups,
+                extras=extras,
+                resolution_strategy=resolution_strategy,
+                progress=progress,
+            )
+        finally:
+            progress.finish()
     except ResolutionError as e:
         sys.stderr.write(f"Resolution failed: {e}\n")
         sys.exit(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,6 +27,7 @@ from nab._lock import (
     _resolve_group_selection,
     lock,
 )
+from nab._progress import StderrProgressReporter
 from nab.cli import (
     _default_cache_dir,
     _make_transport,
@@ -1874,3 +1875,36 @@ class TestDownloadCommand:
         ):
             download(pyproject)
         assert "Download failed" in capsys.readouterr().err
+
+
+class TestProgressWiring:
+    """Each resolve path hands a progress reporter to the resolver."""
+
+    def test_lock_specific_threads_reporter(self, tmp_path: Path) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        with patch(
+            "nab.cli.resolve_pyproject", return_value=_stub_resolution_result()
+        ) as mock:
+            lock(pyproject, output=tmp_path / "pylock.toml")
+        assert isinstance(mock.call_args.kwargs["progress"], StderrProgressReporter)
+
+    def test_download_threads_reporter(self, tmp_path: Path) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        download_result = MagicMock(written=(), skipped=())
+        with (
+            patch(
+                "nab.cli.resolve_pyproject", return_value=_stub_resolution_result()
+            ) as mock,
+            patch("nab.cli.download_lock", return_value=download_result),
+        ):
+            download(pyproject, output=tmp_path / "vendor")
+        assert isinstance(mock.call_args.kwargs["progress"], StderrProgressReporter)
+
+    def test_lock_universal_threads_reporter(self, tmp_path: Path) -> None:
+        pyproject = _universal_pyproject(tmp_path)
+        with patch(
+            "nab.cli.resolve_universal_pyproject",
+            return_value=_universal_result(success=True),
+        ) as mock:
+            lock(pyproject, output=tmp_path / "pylock.toml")
+        assert isinstance(mock.call_args.kwargs["progress"], StderrProgressReporter)

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,75 @@
+"""Tests for the TTY status line reporter."""
+
+from __future__ import annotations
+
+import sys
+
+from nab._progress import StderrProgressReporter
+
+
+class _FakeStream:
+    """A writable stream whose TTY-ness is fixed at construction."""
+
+    def __init__(self, *, tty: bool) -> None:
+        self._tty = tty
+        self.writes: list[str] = []
+
+    def isatty(self) -> bool:
+        return self._tty
+
+    def write(self, text: str) -> int:
+        self.writes.append(text)
+        return len(text)
+
+    def flush(self) -> None:
+        pass
+
+
+class TestStderrProgressReporter:
+    def test_renders_distinct_counts_on_tty(self) -> None:
+        """Repeated names count once; the line shows both totals."""
+        stream = _FakeStream(tty=True)
+        reporter = StderrProgressReporter(stream)
+
+        reporter.listing_fetched("a")
+        reporter.listing_fetched("a")
+        reporter.package_pinned("b")
+
+        assert stream.writes[-1] == "\rResolving... 1 fetched, 1 pinned"
+
+    def test_finish_clears_the_line(self) -> None:
+        """finish() erases the rendered line and is idempotent."""
+        stream = _FakeStream(tty=True)
+        reporter = StderrProgressReporter(stream)
+        reporter.listing_fetched("a")
+
+        reporter.finish()
+        cleared = stream.writes[-1]
+        assert cleared.startswith("\r")
+        assert cleared.endswith("\r")
+        assert cleared.strip() == ""
+
+        before = len(stream.writes)
+        reporter.finish()
+        assert len(stream.writes) == before
+
+    def test_no_op_when_not_a_tty(self) -> None:
+        """A non-TTY stream gets no carriage-return noise."""
+        stream = _FakeStream(tty=False)
+        reporter = StderrProgressReporter(stream)
+
+        reporter.listing_fetched("a")
+        reporter.package_pinned("b")
+        reporter.finish()
+
+        assert stream.writes == []
+
+    def test_finish_without_render_is_silent(self) -> None:
+        """finish() with nothing rendered writes nothing, even on a TTY."""
+        stream = _FakeStream(tty=True)
+        StderrProgressReporter(stream).finish()
+        assert stream.writes == []
+
+    def test_defaults_to_stderr(self) -> None:
+        """No stream argument targets sys.stderr."""
+        assert StderrProgressReporter()._stream is sys.stderr


### PR DESCRIPTION
Running `nab lock` on large projects could sit silent for 30+ seconds with no indication of progress. This adds a live `Resolving... N fetched, M pinned` status line on TTY stderr, updated as packages are fetched and pinned during resolution.

A new `ProgressReporter` protocol in `nab-python` carries fetch and pin events. `FetchCoordinator` calls `listing_fetched` after each index listing completes; a `PinObserver` (a `ResolverObserver` adapter) calls `package_pinned` for each base-package decision, skipping extras-proxy keys. The CLI wires a `StderrProgressReporter` into every `lock` and `download` resolve path and clears the line before the final summary is written. On non-TTY stderr the reporter is a no-op.

Closes #35
