### PR TITLE
Support universal mode in nab download

### DIFF
--- a/nab-python/src/nab_python/download.py
+++ b/nab-python/src/nab_python/download.py
@@ -19,13 +19,15 @@ from typing import TYPE_CHECKING
 
 from nab_index.client import AsyncSimpleClient
 
-from .lockfile import IndexPin, LocalPin, LockInput, VcsPin
+from .lockfile import IndexPin, LockInput
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from pathlib import Path
 
     from nab_index.transport import AsyncHttpTransport
+
+    from .lockfile import PinShape
 
 __all__ = [
     "DownloadEntry",
@@ -70,15 +72,29 @@ class DownloadResult:
 
 
 def iter_artifacts(lock_input: LockInput) -> Iterable[DownloadEntry]:
-    """Yield every wheel/sdist artefact referenced by ``lock_input``."""
+    """Yield every wheel/sdist artefact referenced by ``lock_input``.
+
+    A universal lock (``per_tuple_pins`` populated) yields the union of
+    every tuple's artefacts, deduplicated by URL so a wheel shared
+    across platform tuples is downloaded once.
+    """
+    if lock_input.per_tuple_pins:
+        seen: set[str] = set()
+        for label in sorted(lock_input.per_tuple_pins):
+            for canonical, pin in sorted(lock_input.per_tuple_pins[label].items()):
+                for entry in _entries_for_pin(canonical, pin):
+                    if entry.url not in seen:
+                        seen.add(entry.url)
+                        yield entry
+        return
     for canonical, pin in sorted(lock_input.pins.items()):
-        if isinstance(pin, IndexPin):
-            yield from _iter_index_pin(canonical, pin)
-        elif isinstance(pin, (LocalPin, VcsPin)):
-            continue
-        else:  # pragma: no cover - exhaustive
-            msg = f"unknown pin shape: {pin!r}"
-            raise TypeError(msg)
+        yield from _entries_for_pin(canonical, pin)
+
+
+def _entries_for_pin(canonical: str, pin: PinShape) -> Iterable[DownloadEntry]:
+    # Only index pins have downloadable artefacts; local and VCS pins are skipped.
+    if isinstance(pin, IndexPin):
+        yield from _iter_index_pin(canonical, pin)
 
 
 def _iter_index_pin(canonical: str, pin: IndexPin) -> Iterable[DownloadEntry]:

--- a/nab-python/tests/test_download.py
+++ b/nab-python/tests/test_download.py
@@ -147,6 +147,65 @@ class TestIterArtifacts:
         entries = list(iter_artifacts(LockInput(pins={"foo": pin})))
         assert entries == []
 
+    def test_universal_unions_every_tuple(self) -> None:
+        linux = _index_pin(name="foo", version="1.0", wheel_sha="a" * 64)
+        windows = _index_pin(name="bar", version="2.0", wheel_sha="b" * 64)
+        lock = LockInput(
+            per_tuple_pins={
+                "py3.12-linux": {"foo": linux},
+                "py3.12-windows": {"bar": windows},
+            }
+        )
+        assert sorted(e.filename for e in iter_artifacts(lock)) == [
+            "bar-2.0-py3-none-any.whl",
+            "foo-1.0-py3-none-any.whl",
+        ]
+
+    def test_universal_dedups_shared_artefact_by_url(self) -> None:
+        shared = _index_pin(name="foo", version="1.0", wheel_sha="a" * 64)
+        lock = LockInput(
+            per_tuple_pins={
+                "py3.12-linux": {"foo": shared},
+                "py3.12-windows": {"foo": shared},
+            }
+        )
+        assert [e.filename for e in iter_artifacts(lock)] == [
+            "foo-1.0-py3-none-any.whl"
+        ]
+
+    def test_universal_skips_local_and_vcs_pins(self, tmp_path: Path) -> None:
+        lock = LockInput(
+            per_tuple_pins={
+                "py3.12-linux": {
+                    "loc": LocalPin(name="loc", version="1.0", path=str(tmp_path)),
+                    "vcs": VcsPin(
+                        name="vcs",
+                        version="1.0",
+                        repo_url="git+https://x/y.git",
+                        bare_repo_url="https://x/y.git",
+                        commit_id="a" * 40,
+                    ),
+                    "idx": _index_pin(name="idx", version="1.0", wheel_sha="c" * 64),
+                }
+            }
+        )
+        assert [e.filename for e in iter_artifacts(lock)] == [
+            "idx-1.0-py3-none-any.whl"
+        ]
+
+    def test_per_tuple_pins_take_precedence_over_pins(self) -> None:
+        lock = LockInput(
+            pins={"foo": _index_pin(name="foo", version="1.0", wheel_sha="a" * 64)},
+            per_tuple_pins={
+                "py3.12-linux": {
+                    "bar": _index_pin(name="bar", version="2.0", wheel_sha="b" * 64)
+                }
+            },
+        )
+        assert [e.filename for e in iter_artifacts(lock)] == [
+            "bar-2.0-py3-none-any.whl"
+        ]
+
 
 class TestDownloadLock:
     def test_writes_files_and_verifies_hashes(self, tmp_path: Path) -> None:

--- a/src/nab/_download.py
+++ b/src/nab/_download.py
@@ -1,10 +1,11 @@
 """``nab download`` subcommand.
 
-Resolves a project once with the single-environment resolver and
-fetches every wheel and sdist into a local directory.  Universal
-mode is rejected: the per-tuple lock is the install-time contract,
-so a one-environment download would not represent the resolved
-universe.
+Resolves a project and fetches every wheel and sdist into a local
+directory.  Single-environment mode downloads the one resolved
+environment's artefacts; universal mode re-resolves across the
+matrix and downloads the union of every tuple's artefacts,
+deduplicated by URL, to pre-populate a directory for offline
+deployment across platforms.
 
 External callers (the resolver entry point and the download
 helper) are accessed through :mod:`nab.cli` so the test suite's
@@ -53,27 +54,34 @@ def download(
     config = _cli._load_config(  # noqa: SLF001
         path, discover_workspace=workspace_discovery
     )
-    if config.mode is ResolveMode.UNIVERSAL:
-        sys.stderr.write("Error: `nab download` is single-environment only.\n")
-        sys.exit(1)
-
     effective_cache_dir = _cli._resolve_effective_cache_dir(  # noqa: SLF001
         cache_dir, cache=cache
     )
     transport = _cli._make_transport(http_backend)  # noqa: SLF001
-    result = _cli._resolve_specific(  # noqa: SLF001
-        path,
-        config=config,
-        cache_dir=effective_cache_dir,
-        offline=offline,
-        transport=transport,
-        failure_prefix="Cannot download",
-    )
+    if config.mode is ResolveMode.UNIVERSAL:
+        universal = _cli._resolve_universal(  # noqa: SLF001
+            path,
+            config=config,
+            cache_dir=effective_cache_dir,
+            offline=offline,
+            transport=transport,
+        )
+        lock_input = _cli.merge_universal_lock_inputs(universal)
+    else:
+        result = _cli._resolve_specific(  # noqa: SLF001
+            path,
+            config=config,
+            cache_dir=effective_cache_dir,
+            offline=offline,
+            transport=transport,
+            failure_prefix="Cannot download",
+        )
+        lock_input = result.lock_input
 
     download_transport = _cli._make_transport(http_backend)  # noqa: SLF001
     try:
         outcome = _cli.download_lock(
-            result.lock_input,
+            lock_input,
             download_transport,
             output,
             max_concurrency=max_concurrency,

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -35,7 +35,6 @@ from nab_python.lockfile import (
 )
 from nab_python.provider import ResolutionStrategy
 from nab_python.requirements_file import (
-    InvalidProjectRequirementError,
     read_pyproject_groups,
     read_pyproject_optional_dependencies,
 )
@@ -289,33 +288,16 @@ def _emit_universal(  # noqa: PLR0913 - one wrapper per resolve_universal_pyproj
         " change without notice\n"
     )
 
-    try:
-        result = _cli.resolve_universal_pyproject(
-            path,
-            config=config,
-            cache_dir=cache_dir,
-            transport=transport,
-            offline=offline,
-            groups=groups,
-            extras=extras,
-            resolution_strategy=resolution_strategy,
-        )
-    except KeyError:
-        sys.stderr.write(f"Error: {path} has no [project].dependencies\n")
-        sys.exit(1)
-    except InvalidProjectRequirementError as e:
-        sys.stderr.write(f"Error: {e}\n")
-        sys.exit(1)
-    except LookupError as e:
-        sys.stderr.write(f"Error: {e}\n")
-        sys.exit(1)
-
-    if not result.success:
-        # Always print per-tuple blocks on failure so the user sees
-        # which tuple(s) failed and why; the resolved tuples still
-        # appear so partial progress is visible.
-        _print_universal_blocks(result)
-        sys.exit(1)
+    result = _cli._resolve_universal(  # noqa: SLF001
+        path,
+        config=config,
+        cache_dir=cache_dir,
+        offline=offline,
+        transport=transport,
+        groups=groups,
+        extras=extras,
+        resolution_strategy=resolution_strategy,
+    )
 
     if format == "pylock":
         _emit_universal_pylock(
@@ -662,17 +644,3 @@ def _validate_pylock_output_name(
         f" not a hyphen).  Try {suggestion!r}.\n"
     )
     sys.exit(1)
-
-
-def _print_universal_blocks(result: UniversalResult) -> None:
-    """Write per-tuple pin blocks (with FAILED markers) to stdout."""
-    blocks: list[str] = []
-    for tr in result.tuple_results:
-        label = tr.tuple_.label
-        if not tr.success:
-            blocks.append(f"# {label}: FAILED")
-            blocks.extend(f"#   {raw}" for raw in (tr.error or "").splitlines())
-            continue
-        blocks.append(f"# {label}")
-        blocks.extend(f"{name}=={tr.pins[name]}" for name in sorted(tr.pins))
-    sys.stdout.write("\n".join(blocks) + "\n")

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -40,7 +40,7 @@ from nab_python.provider import UnsupportedVcsError
 from nab_python.requirements_file import InvalidProjectRequirementError
 from nab_python.resolve import (
     resolve_pyproject,
-    resolve_universal_pyproject,  # noqa: F401 - re-exported for tests
+    resolve_universal_pyproject,
 )
 from nab_python.universal.resolve import (
     merge_universal_lock_inputs,  # noqa: F401 - re-exported for tests
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
     from nab_index.transport import AsyncHttpTransport
     from nab_python.provider import ResolutionStrategy
     from nab_python.resolve import ResolutionResult
+    from nab_python.universal.resolve import UniversalResult
 
 __all__ = [
     "main",
@@ -198,6 +199,64 @@ def _resolve_specific(  # noqa: PLR0913 - one wrapper per resolve_pyproject kwar
     except ConfigError as e:
         sys.stderr.write(f"Error in [tool.nab]: {e}\n")
         sys.exit(1)
+
+
+def _resolve_universal(
+    path: Path,
+    *,
+    config: NabProjectConfig,
+    cache_dir: Path | None,
+    offline: bool,
+    transport: AsyncHttpTransport,
+    groups: tuple[str, ...] = (),
+    extras: tuple[str, ...] = (),
+    resolution_strategy: ResolutionStrategy | None = None,
+) -> UniversalResult:
+    """Run the universal resolver, translating errors to exits.
+
+    On a partial failure (any tuple unresolved) the per-tuple blocks
+    are printed and the process exits 1, so a returned result is
+    always fully successful.
+    """
+    try:
+        result = resolve_universal_pyproject(
+            path,
+            config=config,
+            cache_dir=cache_dir,
+            transport=transport,
+            offline=offline,
+            groups=groups,
+            extras=extras,
+            resolution_strategy=resolution_strategy,
+        )
+    except KeyError:
+        sys.stderr.write(f"Error: {path} has no [project].dependencies\n")
+        sys.exit(1)
+    except InvalidProjectRequirementError as e:
+        sys.stderr.write(f"Error: {e}\n")
+        sys.exit(1)
+    except LookupError as e:
+        sys.stderr.write(f"Error: {e}\n")
+        sys.exit(1)
+
+    if not result.success:
+        _print_universal_blocks(result)
+        sys.exit(1)
+    return result
+
+
+def _print_universal_blocks(result: UniversalResult) -> None:
+    """Write per-tuple pin blocks (with FAILED markers) to stdout."""
+    blocks: list[str] = []
+    for tr in result.tuple_results:
+        label = tr.tuple_.label
+        if not tr.success:
+            blocks.append(f"# {label}: FAILED")
+            blocks.extend(f"#   {raw}" for raw in (tr.error or "").splitlines())
+            continue
+        blocks.append(f"# {label}")
+        blocks.extend(f"{name}=={tr.pins[name]}" for name in sorted(tr.pins))
+    sys.stdout.write("\n".join(blocks) + "\n")
 
 
 # Side-effect imports: each module's @app.command decorators register the

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1816,10 +1816,24 @@ class TestDownloadCommand:
             download(pyproject, output=out)
         mock_dl.assert_called_once()
 
-    def test_universal_mode_rejected(self, tmp_path: Path) -> None:
+    def test_universal_mode_downloads_all_tuples(self, tmp_path: Path) -> None:
+        """Universal mode re-resolves the matrix and downloads the union."""
         pyproject = _universal_pyproject(tmp_path)
-        with pytest.raises(SystemExit, match="1"):
-            download(pyproject)
+        out = tmp_path / "vendor"
+        download_result = MagicMock(written=(out / "foo.whl",), skipped=())
+        with (
+            patch(
+                "nab.cli.resolve_universal_pyproject",
+                return_value=_multi_tuple_universal_result(),
+            ),
+            patch("nab.cli.download_lock", return_value=download_result) as mock_dl,
+        ):
+            download(pyproject, output=out)
+        lock_input = mock_dl.call_args.args[0]
+        assert set(lock_input.per_tuple_pins) == {
+            "py311-linux_x86_64",
+            "py312-linux_x86_64",
+        }
 
     @pytest.mark.parametrize("bad", [0, -1])
     def test_non_positive_max_concurrency_exits(


### PR DESCRIPTION
Previously `nab download` exited with an error when the project config set `mode = "universal"`, making it impossible to pre-populate a wheels directory from a universal lockfile.

The fix resolves the project across the full matrix (the same path `nab lock` already takes), then downloads the union of every tuple's artefacts, deduplicated by URL so a wheel shared across platform tuples is only fetched once. Local and VCS pins are skipped as before.

Closes #39
