### PR TITLE
Re-date llama-index scenarios past pin uploads

### DIFF
--- a/nab-python/benchmarks/scenarios/ai-stack-lowest-direct.toml
+++ b/nab-python/benchmarks/scenarios/ai-stack-lowest-direct.toml
@@ -395,7 +395,7 @@ requirements = [
 resolution = "lowest-direct"
 python_version = "3.11"
 platform_system = "Linux"
-datetime = "2025-08-04 12:00:00"
+datetime = "2025-08-05 20:00:00"
 requirements = [
     "openai==1.99.1",
     "llama-index~=0.12.52",
@@ -473,7 +473,7 @@ requirements = ["llama-index-readers-docling"]
 resolution = "lowest-direct"
 python_version = "3.11"
 platform_system = "Linux"
-datetime = "2025-08-13 06:32:08"
+datetime = "2025-08-13 22:00:00"
 requirements = [
     "llama-index-embeddings-openai-like==0.2.1",
     "llama-index-core>=0.12.0",

--- a/nab-python/benchmarks/scenarios/ai-stack-lowest.toml
+++ b/nab-python/benchmarks/scenarios/ai-stack-lowest.toml
@@ -395,7 +395,7 @@ requirements = [
 resolution = "lowest"
 python_version = "3.11"
 platform_system = "Linux"
-datetime = "2025-08-04 12:00:00"
+datetime = "2025-08-05 20:00:00"
 requirements = [
     "openai==1.99.1",
     "llama-index~=0.12.52",
@@ -473,7 +473,7 @@ requirements = ["llama-index-readers-docling"]
 resolution = "lowest"
 python_version = "3.11"
 platform_system = "Linux"
-datetime = "2025-08-13 06:32:08"
+datetime = "2025-08-13 22:00:00"
 requirements = [
     "llama-index-embeddings-openai-like==0.2.1",
     "llama-index-core>=0.12.0",

--- a/nab-python/benchmarks/scenarios/ai-stack.toml
+++ b/nab-python/benchmarks/scenarios/ai-stack.toml
@@ -373,7 +373,7 @@ requirements = [
 # Same requirements, earlier PyPI snapshot.
 python_version = "3.11"
 platform_system = "Linux"
-datetime = "2025-08-04 12:00:00"
+datetime = "2025-08-05 20:00:00"
 requirements = [
     "openai==1.99.1",
     "llama-index~=0.12.52",
@@ -445,7 +445,7 @@ requirements = ["llama-index-readers-docling"]
 # https://github.com/run-llama/llama_index/issues/19659
 python_version = "3.11"
 platform_system = "Linux"
-datetime = "2025-08-13 06:32:08"
+datetime = "2025-08-13 22:00:00"
 requirements = [
     "llama-index-embeddings-openai-like==0.2.1",
     "llama-index-core>=0.12.0",


### PR DESCRIPTION
Two groups of llama-index scenarios had datetime cutoffs that preceded the PyPI upload of a version they pin, so the resolver saw a missing candidate and failed with an unsat rather than resolving.

The `llama-index-upgrade-older` scenarios (in ai-stack.toml, ai-stack-lowest.toml, ai-stack-lowest-direct.toml) pin `openai==1.99.1`, which was uploaded on 2025-08-05. The cutoff was `2025-08-04 12:00:00`, moved to `2025-08-05 20:00:00`.

The `llama-index-openai-like` scenarios pin `llama-index-embeddings-openai-like==0.2.1`, uploaded later on 2025-08-13. The cutoff was `2025-08-13 06:32:08`, moved to `2025-08-13 22:00:00`.
