### PR TITLE
Re-date mis-dated airflow-october-regression scenarios

### DIFF
--- a/nab-python/benchmarks/scenarios/airflow-lowest-direct.toml
+++ b/nab-python/benchmarks/scenarios/airflow-lowest-direct.toml
@@ -215,42 +215,41 @@ requirements = [
     "kubernetes-asyncio",
 ]
 
-[airflow-october-regression-py310-full]
-# https://github.com/pypa/pip/issues/13281#issuecomment-3399373356
-# Adds apache-airflow-core and apache-airflow-task-sdk co-pins to
-# airflow-october-regression (the CI run installs all three).  Fails
-# on 3.10 / 3.11 / 3.13; succeeds on 3.12.
+# apache-airflow 3.1.1 with the full provider-extra fan-out plus the
+# apache-airflow-core and apache-airflow-task-sdk co-pins, from
+# https://github.com/pypa/pip/issues/13281#issuecomment-3399373356 (the CI run
+# installs all three). pip's #13281 reports a per-Python split (ResolutionTooDeep
+# on 3.10/3.11/3.13, only 3.12 resolves); nab resolves every Python, so it does
+# not reproduce that regression. Heavy lowest-direct extras-fanout stress
+# scenarios. The cutoff is 2025-11-01 because 3.1.1 was uploaded 2025-10-27.
+
+[airflow-october-regression-py310]
 resolution = "lowest-direct"
 python_version = "3.10"
 platform_system = "Linux"
-datetime = "2025-10-13 23:19:02"
+datetime = "2025-11-01 00:00:00"
 requirements = [
     "apache-airflow[aiobotocore,amazon,async,celery,cncf-kubernetes,common-io,common-messaging,docker,elasticsearch,fab,ftp,git,google,google-auth,graphviz,grpc,hashicorp,http,ldap,microsoft-azure,mysql,odbc,openlineage,pandas,postgres,redis,sendgrid,sftp,slack,snowflake,ssh,statsd,uv]==3.1.1",
     "apache-airflow-core==3.1.1",
     "apache-airflow-task-sdk==1.1.1",
 ]
 
-[airflow-october-regression-py313-full]
-# https://github.com/pypa/pip/issues/13281#issuecomment-3399373356
-# Same as airflow-october-regression-py310-full on Python 3.13.
-resolution = "lowest-direct"
-python_version = "3.13"
-platform_system = "Linux"
-datetime = "2025-10-13 23:19:02"
-requirements = [
-    "apache-airflow[aiobotocore,amazon,async,celery,cncf-kubernetes,common-io,common-messaging,docker,elasticsearch,fab,ftp,git,google,google-auth,graphviz,grpc,hashicorp,http,ldap,microsoft-azure,mysql,odbc,openlineage,pandas,postgres,redis,sendgrid,sftp,slack,snowflake,ssh,statsd,uv]==3.1.1",
-    "apache-airflow-core==3.1.1",
-    "apache-airflow-task-sdk==1.1.1",
-]
-
-[airflow-october-regression-py312-pass]
-# https://github.com/pypa/pip/issues/13281#issuecomment-3399373356
-# 3.12 was reported as the only Python that resolves.  Kept as a
-# passing baseline against airflow-october-regression-py310-full.
+[airflow-october-regression-py312]
 resolution = "lowest-direct"
 python_version = "3.12"
 platform_system = "Linux"
-datetime = "2025-10-13 23:19:02"
+datetime = "2025-11-01 00:00:00"
+requirements = [
+    "apache-airflow[aiobotocore,amazon,async,celery,cncf-kubernetes,common-io,common-messaging,docker,elasticsearch,fab,ftp,git,google,google-auth,graphviz,grpc,hashicorp,http,ldap,microsoft-azure,mysql,odbc,openlineage,pandas,postgres,redis,sendgrid,sftp,slack,snowflake,ssh,statsd,uv]==3.1.1",
+    "apache-airflow-core==3.1.1",
+    "apache-airflow-task-sdk==1.1.1",
+]
+
+[airflow-october-regression-py313]
+resolution = "lowest-direct"
+python_version = "3.13"
+platform_system = "Linux"
+datetime = "2025-11-01 00:00:00"
 requirements = [
     "apache-airflow[aiobotocore,amazon,async,celery,cncf-kubernetes,common-io,common-messaging,docker,elasticsearch,fab,ftp,git,google,google-auth,graphviz,grpc,hashicorp,http,ldap,microsoft-azure,mysql,odbc,openlineage,pandas,postgres,redis,sendgrid,sftp,slack,snowflake,ssh,statsd,uv]==3.1.1",
     "apache-airflow-core==3.1.1",


### PR DESCRIPTION
The airflow-october-regression scenarios had a cutoff date of 2025-10-13, but apache-airflow 3.1.1 was not uploaded to PyPI until 2025-10-27. The pin was therefore unsatisfiable due to the date, not a resolver failure.

This moves the cutoff to 2025-11-01 (after the upload), renames the scenarios to drop the misleading -full/-pass suffixes, and rewrites the comment to reflect that nab resolves all three Python versions. The old names implied a per-Python pass/fail split matching pip issue #13281, which nab does not reproduce.
