### PR TITLE
Re-date october-regression sibling scenarios

### DIFF
--- a/nab-python/benchmarks/scenarios/airflow-lowest.toml
+++ b/nab-python/benchmarks/scenarios/airflow-lowest.toml
@@ -215,42 +215,39 @@ requirements = [
     "kubernetes-asyncio",
 ]
 
-[airflow-october-regression-py310-full]
-# https://github.com/pypa/pip/issues/13281#issuecomment-3399373356
-# Adds apache-airflow-core and apache-airflow-task-sdk co-pins to
-# airflow-october-regression (the CI run installs all three).  Fails
-# on 3.10 / 3.11 / 3.13; succeeds on 3.12.
+# apache-airflow 3.1.1 with the full provider-extra fan-out plus
+# apache-airflow-core and apache-airflow-task-sdk co-pins, from
+# https://github.com/pypa/pip/issues/13281#issuecomment-3399373356 (the CI run
+# installs all three). pip's #13281 reports ResolutionTooDeep on 3.10/3.11/3.13;
+# nab resolves every Python. Cutoff is 2025-11-01 (3.1.1 uploaded 2025-10-27).
+
+[airflow-october-regression-py310]
 resolution = "lowest"
 python_version = "3.10"
 platform_system = "Linux"
-datetime = "2025-10-13 23:19:02"
+datetime = "2025-11-01 00:00:00"
 requirements = [
     "apache-airflow[aiobotocore,amazon,async,celery,cncf-kubernetes,common-io,common-messaging,docker,elasticsearch,fab,ftp,git,google,google-auth,graphviz,grpc,hashicorp,http,ldap,microsoft-azure,mysql,odbc,openlineage,pandas,postgres,redis,sendgrid,sftp,slack,snowflake,ssh,statsd,uv]==3.1.1",
     "apache-airflow-core==3.1.1",
     "apache-airflow-task-sdk==1.1.1",
 ]
 
-[airflow-october-regression-py313-full]
-# https://github.com/pypa/pip/issues/13281#issuecomment-3399373356
-# Same as airflow-october-regression-py310-full on Python 3.13.
-resolution = "lowest"
-python_version = "3.13"
-platform_system = "Linux"
-datetime = "2025-10-13 23:19:02"
-requirements = [
-    "apache-airflow[aiobotocore,amazon,async,celery,cncf-kubernetes,common-io,common-messaging,docker,elasticsearch,fab,ftp,git,google,google-auth,graphviz,grpc,hashicorp,http,ldap,microsoft-azure,mysql,odbc,openlineage,pandas,postgres,redis,sendgrid,sftp,slack,snowflake,ssh,statsd,uv]==3.1.1",
-    "apache-airflow-core==3.1.1",
-    "apache-airflow-task-sdk==1.1.1",
-]
-
-[airflow-october-regression-py312-pass]
-# https://github.com/pypa/pip/issues/13281#issuecomment-3399373356
-# 3.12 was reported as the only Python that resolves.  Kept as a
-# passing baseline against airflow-october-regression-py310-full.
+[airflow-october-regression-py312]
 resolution = "lowest"
 python_version = "3.12"
 platform_system = "Linux"
-datetime = "2025-10-13 23:19:02"
+datetime = "2025-11-01 00:00:00"
+requirements = [
+    "apache-airflow[aiobotocore,amazon,async,celery,cncf-kubernetes,common-io,common-messaging,docker,elasticsearch,fab,ftp,git,google,google-auth,graphviz,grpc,hashicorp,http,ldap,microsoft-azure,mysql,odbc,openlineage,pandas,postgres,redis,sendgrid,sftp,slack,snowflake,ssh,statsd,uv]==3.1.1",
+    "apache-airflow-core==3.1.1",
+    "apache-airflow-task-sdk==1.1.1",
+]
+
+[airflow-october-regression-py313]
+resolution = "lowest"
+python_version = "3.13"
+platform_system = "Linux"
+datetime = "2025-11-01 00:00:00"
 requirements = [
     "apache-airflow[aiobotocore,amazon,async,celery,cncf-kubernetes,common-io,common-messaging,docker,elasticsearch,fab,ftp,git,google,google-auth,graphviz,grpc,hashicorp,http,ldap,microsoft-azure,mysql,odbc,openlineage,pandas,postgres,redis,sendgrid,sftp,slack,snowflake,ssh,statsd,uv]==3.1.1",
     "apache-airflow-core==3.1.1",

--- a/nab-python/benchmarks/scenarios/airflow.toml
+++ b/nab-python/benchmarks/scenarios/airflow.toml
@@ -197,39 +197,36 @@ requirements = [
     "kubernetes-asyncio",
 ]
 
-[airflow-october-regression-py310-full]
-# https://github.com/pypa/pip/issues/13281#issuecomment-3399373356
-# Adds apache-airflow-core and apache-airflow-task-sdk co-pins to
-# airflow-october-regression (the CI run installs all three).  Fails
-# on 3.10 / 3.11 / 3.13; succeeds on 3.12.
+# apache-airflow 3.1.1 with the full provider-extra fan-out plus
+# apache-airflow-core and apache-airflow-task-sdk co-pins, from
+# https://github.com/pypa/pip/issues/13281#issuecomment-3399373356 (the CI run
+# installs all three). pip's #13281 reports ResolutionTooDeep on 3.10/3.11/3.13;
+# nab resolves every Python. Cutoff is 2025-11-01 (3.1.1 uploaded 2025-10-27).
+
+[airflow-october-regression-py310]
 python_version = "3.10"
 platform_system = "Linux"
-datetime = "2025-10-13 23:19:02"
+datetime = "2025-11-01 00:00:00"
 requirements = [
     "apache-airflow[aiobotocore,amazon,async,celery,cncf-kubernetes,common-io,common-messaging,docker,elasticsearch,fab,ftp,git,google,google-auth,graphviz,grpc,hashicorp,http,ldap,microsoft-azure,mysql,odbc,openlineage,pandas,postgres,redis,sendgrid,sftp,slack,snowflake,ssh,statsd,uv]==3.1.1",
     "apache-airflow-core==3.1.1",
     "apache-airflow-task-sdk==1.1.1",
 ]
 
-[airflow-october-regression-py313-full]
-# https://github.com/pypa/pip/issues/13281#issuecomment-3399373356
-# Same as airflow-october-regression-py310-full on Python 3.13.
-python_version = "3.13"
-platform_system = "Linux"
-datetime = "2025-10-13 23:19:02"
-requirements = [
-    "apache-airflow[aiobotocore,amazon,async,celery,cncf-kubernetes,common-io,common-messaging,docker,elasticsearch,fab,ftp,git,google,google-auth,graphviz,grpc,hashicorp,http,ldap,microsoft-azure,mysql,odbc,openlineage,pandas,postgres,redis,sendgrid,sftp,slack,snowflake,ssh,statsd,uv]==3.1.1",
-    "apache-airflow-core==3.1.1",
-    "apache-airflow-task-sdk==1.1.1",
-]
-
-[airflow-october-regression-py312-pass]
-# https://github.com/pypa/pip/issues/13281#issuecomment-3399373356
-# 3.12 was reported as the only Python that resolves.  Kept as a
-# passing baseline against airflow-october-regression-py310-full.
+[airflow-october-regression-py312]
 python_version = "3.12"
 platform_system = "Linux"
-datetime = "2025-10-13 23:19:02"
+datetime = "2025-11-01 00:00:00"
+requirements = [
+    "apache-airflow[aiobotocore,amazon,async,celery,cncf-kubernetes,common-io,common-messaging,docker,elasticsearch,fab,ftp,git,google,google-auth,graphviz,grpc,hashicorp,http,ldap,microsoft-azure,mysql,odbc,openlineage,pandas,postgres,redis,sendgrid,sftp,slack,snowflake,ssh,statsd,uv]==3.1.1",
+    "apache-airflow-core==3.1.1",
+    "apache-airflow-task-sdk==1.1.1",
+]
+
+[airflow-october-regression-py313]
+python_version = "3.13"
+platform_system = "Linux"
+datetime = "2025-11-01 00:00:00"
 requirements = [
     "apache-airflow[aiobotocore,amazon,async,celery,cncf-kubernetes,common-io,common-messaging,docker,elasticsearch,fab,ftp,git,google,google-auth,graphviz,grpc,hashicorp,http,ldap,microsoft-azure,mysql,odbc,openlineage,pandas,postgres,redis,sendgrid,sftp,slack,snowflake,ssh,statsd,uv]==3.1.1",
     "apache-airflow-core==3.1.1",

--- a/nab-python/benchmarks/scenarios/pip-lowest-direct.toml
+++ b/nab-python/benchmarks/scenarios/pip-lowest-direct.toml
@@ -699,12 +699,15 @@ requirements = [
 ]
 
 [airflow-october-regression]
-# https://github.com/pypa/pip/issues/13281#issuecomment-3399373356
-# Airflow 3.1.1 from main: ResolutionTooDeep on 3.10 / 3.11 / 3.13 but not 3.12.
+# apache-airflow 3.1.1 with the full provider-extra fan-out, from
+# https://github.com/pypa/pip/issues/13281#issuecomment-3399373356. pip's #13281
+# reports ResolutionTooDeep on 3.10/3.11/3.13 (only 3.12 resolves); nab resolves
+# py3.11, so it does not reproduce that regression. The cutoff is 2025-11-01
+# because 3.1.1 was uploaded 2025-10-27.
 resolution = "lowest-direct"
 python_version = "3.11"
 platform_system = "Linux"
-datetime = "2025-10-13 23:19:02"
+datetime = "2025-11-01 00:00:00"
 requirements = [
     "apache-airflow[aiobotocore,amazon,async,celery,cncf-kubernetes,common-io,common-messaging,docker,elasticsearch,fab,ftp,git,google,google-auth,graphviz,grpc,hashicorp,http,ldap,microsoft-azure,mysql,odbc,openlineage,pandas,postgres,redis,sendgrid,sftp,slack,snowflake,ssh,statsd,uv]==3.1.1",
 ]

--- a/nab-python/benchmarks/scenarios/pip-lowest.toml
+++ b/nab-python/benchmarks/scenarios/pip-lowest.toml
@@ -699,12 +699,15 @@ requirements = [
 ]
 
 [airflow-october-regression]
-# https://github.com/pypa/pip/issues/13281#issuecomment-3399373356
-# Airflow 3.1.1 from main: ResolutionTooDeep on 3.10 / 3.11 / 3.13 but not 3.12.
+# apache-airflow 3.1.1 with the full provider-extra fan-out, from
+# https://github.com/pypa/pip/issues/13281#issuecomment-3399373356. pip's #13281
+# reports ResolutionTooDeep on 3.10/3.11/3.13 (only 3.12 resolves); nab resolves
+# py3.11, so it does not reproduce that regression. The cutoff is 2025-11-01
+# because 3.1.1 was uploaded 2025-10-27.
 resolution = "lowest"
 python_version = "3.11"
 platform_system = "Linux"
-datetime = "2025-10-13 23:19:02"
+datetime = "2025-11-01 00:00:00"
 requirements = [
     "apache-airflow[aiobotocore,amazon,async,celery,cncf-kubernetes,common-io,common-messaging,docker,elasticsearch,fab,ftp,git,google,google-auth,graphviz,grpc,hashicorp,http,ldap,microsoft-azure,mysql,odbc,openlineage,pandas,postgres,redis,sendgrid,sftp,slack,snowflake,ssh,statsd,uv]==3.1.1",
 ]

--- a/nab-python/benchmarks/scenarios/pip.toml
+++ b/nab-python/benchmarks/scenarios/pip.toml
@@ -663,11 +663,14 @@ requirements = [
 ]
 
 [airflow-october-regression]
-# https://github.com/pypa/pip/issues/13281#issuecomment-3399373356
-# Airflow 3.1.1 from main: ResolutionTooDeep on 3.10 / 3.11 / 3.13 but not 3.12.
+# apache-airflow 3.1.1 with the full provider-extra fan-out, from
+# https://github.com/pypa/pip/issues/13281#issuecomment-3399373356. pip's #13281
+# reports ResolutionTooDeep on 3.10/3.11/3.13 (only 3.12 resolves); nab resolves
+# py3.11, so it does not reproduce that regression. The cutoff is 2025-11-01
+# because 3.1.1 was uploaded 2025-10-27.
 python_version = "3.11"
 platform_system = "Linux"
-datetime = "2025-10-13 23:19:02"
+datetime = "2025-11-01 00:00:00"
 requirements = [
     "apache-airflow[aiobotocore,amazon,async,celery,cncf-kubernetes,common-io,common-messaging,docker,elasticsearch,fab,ftp,git,google,google-auth,graphviz,grpc,hashicorp,http,ldap,microsoft-azure,mysql,odbc,openlineage,pandas,postgres,redis,sendgrid,sftp,slack,snowflake,ssh,statsd,uv]==3.1.1",
 ]


### PR DESCRIPTION
Five benchmark scenarios pinned to apache-airflow 3.1.1 had datetime cutoffs of 2025-10-13, which predates the 3.1.1 upload date of 2025-10-27, causing spurious unsatisfiable results. The cutoffs are moved to 2025-11-01 to put all pinned releases inside the resolution window.

The airflow.toml and airflow-lowest.toml scenarios were also renamed: the -py310-full/-py313-full/-py312-pass suffixes reflected a pip-specific pass/fail split that nab does not reproduce, so the names are simplified to -py310/-py312/-py313. The shared block comment above the three scenarios is condensed to match the file's existing style.
