### PR TITLE
Memoise term_relation to skip redundant range intersections

### DIFF
--- a/nab-resolver/src/nab_resolver/propagate.py
+++ b/nab-resolver/src/nab_resolver/propagate.py
@@ -26,8 +26,7 @@ __all__ = [
     "unit_propagation",
 ]
 
-# Cap on resolver.relation_cache entries before it is cleared, bounding
-# memory on deep-conflict resolutions where distinct relations accumulate.
+# Upper bound on relation_cache size; cleared on overflow to bound memory.
 RELATION_CACHE_MAX = 100_000
 
 

--- a/nab-resolver/src/nab_resolver/propagate.py
+++ b/nab-resolver/src/nab_resolver/propagate.py
@@ -26,6 +26,10 @@ __all__ = [
     "unit_propagation",
 ]
 
+# Cap on resolver.relation_cache entries before it is cleared, bounding
+# memory on deep-conflict resolutions where distinct relations accumulate.
+RELATION_CACHE_MAX = 100_000
+
 
 def unit_propagation(
     resolver: Resolver[Any, Any], changed_package: Any
@@ -119,11 +123,19 @@ def term_relation(resolver: Resolver[Any, Any], term: Term[Any, Any]) -> SetRela
     if assignment is None:
         return SetRelation.UNDETERMINED
 
-    intersection = assignment & term.constraint
-    result = classify_intersection(term, assignment, intersection)
+    positive = term.is_positive()
+    cache = resolver.relation_cache
+    key = (positive, assignment, term.constraint)
+    result = cache.get(key)
+    if result is None:
+        intersection = assignment & term.constraint
+        result = classify_intersection(term, assignment, intersection)
+        if len(cache) >= RELATION_CACHE_MAX:
+            cache.clear()
+        cache[key] = result
 
-    needs_positive = (term.is_positive() and result is SetRelation.SATISFIED) or (
-        not term.is_positive() and result is SetRelation.CONTRADICTED
+    needs_positive = (positive and result is SetRelation.SATISFIED) or (
+        not positive and result is SetRelation.CONTRADICTED
     )
     if needs_positive and not resolver.solution.has_positive_constraint(term.package):
         return SetRelation.UNDETERMINED

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -285,7 +285,7 @@ class Resolver(Generic[PackageType, VersionType]):
         self.tiebreak_cache: dict[PackageType, tuple[int, int, str]] = {}
 
         # Memoises term_relation's pre-adjustment SetRelation, keyed by
-        # (positive, assignment, constraint).  Cleared on overflow.
+        # (positive, assignment, constraint). Cleared on overflow.
         self.relation_cache: dict[
             tuple[bool, RangeProtocol[Any], RangeProtocol[Any]], SetRelation
         ] = {}

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -284,6 +284,12 @@ class Resolver(Generic[PackageType, VersionType]):
         # Memoises the tiebreak tuple in choose_package_to_decide.
         self.tiebreak_cache: dict[PackageType, tuple[int, int, str]] = {}
 
+        # Memoises term_relation's pre-adjustment SetRelation, keyed by
+        # (positive, assignment, constraint).  Cleared on overflow.
+        self.relation_cache: dict[
+            tuple[bool, RangeProtocol[Any], RangeProtocol[Any]], SetRelation
+        ] = {}
+
     def resolve(
         self,
         requirements: Mapping[PackageType, RangeProtocol[VersionType]],
@@ -435,6 +441,7 @@ class Resolver(Generic[PackageType, VersionType]):
         self.root_package_order.clear()
         self.pending_targeted_backtrack.clear()
         self.tiebreak_cache.clear()
+        self.relation_cache.clear()
 
     def _add_root_requirements(
         self, requirements: Mapping[PackageType, RangeProtocol[VersionType]]

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -1897,9 +1897,6 @@ class TestRegressions:
 
 
 class TestRelationCache:
-    """term_relation memoises its pre-adjustment SetRelation, keyed by
-    (positive, assignment, constraint)."""
-
     def test_caches_relation_and_reuses_it(self) -> None:
         resolver: Resolver[str, int] = Resolver(DictProvider({}))
         resolver.solution.decide("foo", 2)
@@ -1913,9 +1910,7 @@ class TestRelationCache:
         assert term_relation(resolver, term) is first
         assert resolver.relation_cache == {key: first}
 
-    def test_clears_cache_on_overflow(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_clears_cache_on_overflow(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(propagate, "RELATION_CACHE_MAX", 1)
         resolver: Resolver[str, int] = Resolver(DictProvider({}))
         resolver.solution.decide("foo", 2)

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 
+from nab_resolver import propagate
 from nab_resolver.conflict import (
     apply_targeted_backtrack,
     conflict_resolution,
@@ -21,6 +22,7 @@ from nab_resolver.incompat_index import (
     maybe_merge_dependency,
 )
 from nab_resolver.partial_solution import PartialSolution
+from nab_resolver.propagate import term_relation
 from nab_resolver.ranges import Range
 from nab_resolver.report import explain_incompatibility, prior_cause, union_terms
 from nab_resolver.resolver import (
@@ -33,6 +35,7 @@ from nab_resolver.types import (
     Incompatibility,
     IncompatibilityCause,
     RangeProtocol,
+    SetRelation,
     Term,
 )
 
@@ -1891,3 +1894,37 @@ class TestRegressions:
         resolver = Resolver(provider)
         with pytest.raises(ResolutionError):
             resolver.resolve({"root": Range.singleton(1)})
+
+
+class TestRelationCache:
+    """term_relation memoises its pre-adjustment SetRelation, keyed by
+    (positive, assignment, constraint)."""
+
+    def test_caches_relation_and_reuses_it(self) -> None:
+        resolver: Resolver[str, int] = Resolver(DictProvider({}))
+        resolver.solution.decide("foo", 2)
+        term = Term("foo", Range.at_least(1), positive=True)
+
+        assert resolver.relation_cache == {}
+        first = term_relation(resolver, term)
+        key = (True, resolver.solution.get("foo"), term.constraint)
+        assert resolver.relation_cache == {key: first}
+
+        assert term_relation(resolver, term) is first
+        assert resolver.relation_cache == {key: first}
+
+    def test_clears_cache_on_overflow(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(propagate, "RELATION_CACHE_MAX", 1)
+        resolver: Resolver[str, int] = Resolver(DictProvider({}))
+        resolver.solution.decide("foo", 2)
+        resolver.relation_cache[(False, Range.full(), Range.full())] = (
+            SetRelation.SATISFIED
+        )
+
+        term = Term("foo", Range.at_least(1), positive=True)
+        result = term_relation(resolver, term)
+
+        key = (True, resolver.solution.get("foo"), term.constraint)
+        assert resolver.relation_cache == {key: result}


### PR DESCRIPTION
During unit propagation, `term_relation` is called once per incompatibility term per propagation step. The dominant cost is `assignment & term.constraint`, a full range intersection, followed by `classify_intersection`. Many calls repeat the same `(positive, assignment, constraint)` triple across multiple incompatibilities in the same propagation pass, doing identical work each time.

This change adds `relation_cache` on `Resolver`, keyed by `(positive, assignment, constraint)`, that stores the raw `SetRelation` before the `needs_positive` guard is applied. The guard itself is cheap (a dict lookup in `solution`), so it stays outside the cache. The cache is cleared whenever it hits `RELATION_CACHE_MAX` (100,000 entries) to bound memory during deep-conflict resolutions.
