### PR TITLE
Add materialize-before-order spike flag and A/B harness

### DIFF
--- a/nab-python/benchmarks/materialize_ab.py
+++ b/nab-python/benchmarks/materialize_ab.py
@@ -1,0 +1,119 @@
+"""Targeted A/B for the materialize-before-order spike.
+
+Runs named scenarios from named TOML files (so the per-scenario
+``resolution`` strategy is honoured, unlike canary.py) under the
+NAB_MATERIALIZE_BEFORE_ORDER flag off vs on.
+
+Usage:
+    python nab-python/benchmarks/materialize_ab.py \
+        --target rip-lowest:rip-apache-airflow-all-pinned \
+        --target uv-lowest:uv-issue-3078-airflow-2_8_4 \
+        --runs 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+
+import scenarios as sc
+import tomllib
+
+FLAG = "NAB_MATERIALIZE_BEFORE_ORDER"
+
+
+def load_scenario(toml_stem: str, name: str) -> dict:
+    path = sc.SCENARIOS_DIR / f"{toml_stem}.toml"
+    with path.open("rb") as f:
+        data = tomllib.load(f)
+    return data[name]
+
+
+def build_inputs(name: str, scenario: dict) -> dict:
+    python_version = scenario["python_version"]
+    requirement_strings = list(scenario["requirements"])
+    constraint_strings = scenario.get("constraints", [])
+    marker_environment = sc.parse_marker_environment(name, scenario)
+    indexes = sc.parse_indexes(name, scenario)
+    index_overrides = sc.parse_index_overrides(name, scenario)
+    build_policy_overrides = sc.parse_build_packages(name, scenario)
+    if marker_environment and build_policy_overrides:
+        build_policy_overrides = {}
+    resolution_strategy = sc.ResolutionStrategy(scenario.get("resolution", "highest"))
+    vcs_config = sc.VcsConfig(
+        policy=sc.VcsPolicy(scenario.get("vcs_policy", "block")),
+        allowed_schemes=frozenset(scenario.get("vcs_allowed_schemes", [])),
+        allowed_repos=tuple(scenario.get("vcs_allowed_repos", [])),
+        require_pin=scenario.get("vcs_require_pin", True),
+    )
+
+    if scenario.get("project_name"):
+        requirement_strings += sc.expand_project_extras(
+            scenario["project_name"],
+            scenario.get("project_extras", []),
+            scenario.get("optional_dependencies", {}),
+        )
+
+    marker_env = sc._scenario_marker_env(python_version, marker_environment)
+    requirements = sc.parse_requirements(
+        requirement_strings, vcs_config=vcs_config, marker_environment=marker_env
+    )
+    constraints = (
+        sc.parse_requirements(
+            constraint_strings, vcs_config=vcs_config, marker_environment=marker_env
+        )
+        if constraint_strings
+        else None
+    )
+    datetime_str = scenario.get("datetime")
+    return {
+        "requirements": requirements,
+        "python_version": python_version,
+        "uploaded_prior_to": sc.parse_datetime(datetime_str) if datetime_str else None,
+        "constraints": constraints,
+        "marker_environment": marker_environment or None,
+        "indexes": indexes,
+        "index_overrides": index_overrides or None,
+        "build_policy_overrides": build_policy_overrides or None,
+        "resolution_strategy": resolution_strategy,
+    }
+
+
+def run_target(toml_stem: str, name: str, runs: int) -> None:
+    inputs = build_inputs(name, load_scenario(toml_stem, name))
+    runs_data = [sc.resolve_scenario(**inputs) for _ in range(runs)]
+    decisions = [r["stats"]["decisions"] for r in runs_data]
+    walls = [r["stats"]["wall_time_seconds"] for r in runs_data]
+    successes = sum(1 for r in runs_data if r["result"]["success"])
+    print(
+        f"  {toml_stem}:{name}  success {successes}/{runs}  "
+        f"decisions med {int(statistics.median(decisions))} "
+        f"min {min(decisions)} max {max(decisions)}  "
+        f"wall med {round(statistics.median(walls), 1)}s"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--target", action="append", required=True, help="toml:scenario"
+    )
+    parser.add_argument("--runs", type=int, default=2)
+    parser.add_argument("--materialize", action="store_true")
+    args = parser.parse_args()
+
+    if args.materialize:
+        os.environ[FLAG] = "1"
+    else:
+        os.environ.pop(FLAG, None)
+
+    flag_state = "on" if args.materialize else "off"
+    print(f"=== materialize_ab, flag={flag_state}, runs={args.runs} ===")
+    for target in args.target:
+        toml_stem, name = target.split(":", 1)
+        run_target(toml_stem, name, args.runs)
+
+
+if __name__ == "__main__":
+    main()

--- a/nab-python/src/nab_python/_provider/priority.py
+++ b/nab-python/src/nab_python/_provider/priority.py
@@ -80,12 +80,15 @@ def compute_matching(
         normalized in provider.local_sources or normalized in provider.vcs_sources
     )
     if normalized not in provider.versions_cache and not has_local_source:
-        files = provider.coordinator.index.get_listing(normalized)
-        if files is not None:
-            versions = provider.filter_distributions(normalized, files)
-            provider.versions_cache[normalized] = versions
-            provider.stats.listings_fetched += 1
-            provider.speculative_prefetch(normalized, versions)
+        if provider.materialize_before_order:
+            provider.fetch_versions(normalized)
+        else:
+            files = provider.coordinator.index.get_listing(normalized)
+            if files is not None:
+                versions = provider.filter_distributions(normalized, files)
+                provider.versions_cache[normalized] = versions
+                provider.stats.listings_fetched += 1
+                provider.speculative_prefetch(normalized, versions)
 
     if normalized in provider.versions_cache:
         versions = provider.versions_cache[normalized]

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import contextlib
 import enum
 import logging
+import os
 import re
 from collections import defaultdict, deque
 from dataclasses import dataclass
@@ -489,6 +490,14 @@ class Provider:
                 self.environment[key] = value
 
         self.root_requirements = root_requirements or {}
+
+        # When set, block-loads every undecided listing before ordering so the
+        # MRV count is real rather than the in-flight placeholder, and is_ready
+        # always returns True (dropping the ready_penalty). Off by default.
+        self.materialize_before_order = (
+            os.environ.get("NAB_MATERIALIZE_BEFORE_ORDER") == "1"
+        )
+
         self.versions_cache: dict[str, list[tuple[Version, DistFile]]] = {}
         self.deps_cache: dict[tuple[str, Version], dict[str, VersionRange]] = {}
         self.metadata_cache: dict[tuple[str, Version], WheelMetadata] = {}
@@ -1225,6 +1234,8 @@ class Provider:
         Used by the resolver to prefer packages with cached data,
         letting it make progress while other listings are in flight.
         """
+        if self.materialize_before_order:
+            return True
         _, extra, normalized = self.split_and_normalize(package)
         if extra is not None:
             return normalized in self.versions_cache

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -4585,6 +4585,42 @@ class TestComputeTier:
         assert tier == TIER_CULPRIT
 
 
+class TestMaterializeBeforeOrder:
+    """Tests for the NAB_MATERIALIZE_BEFORE_ORDER spike flag."""
+
+    def test_flag_defaults_off(self) -> None:
+        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
+        provider = Provider(coordinator, build_policy=BuildPolicy.NEVER)
+        assert provider.materialize_before_order is False
+
+    def test_block_loads_inflight_listing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Under the flag, an in-flight listing is block-loaded so the MRV
+        count is real rather than the ``_NO_LISTING_PRIOR`` placeholder, and
+        ``is_ready`` returns True so ``ready_penalty`` drops out."""
+        from nab_python._provider.priority import _NO_LISTING_PRIOR, compute_matching
+
+        wheels = [make_wheel("2.0"), make_wheel("1.0")]
+        coordinator = make_coordinator(None)
+
+        def _store(pkg: str) -> threading.Event:
+            coordinator.index.store_listing(pkg, wheels)
+            return _done_event()
+
+        coordinator.request_listing.side_effect = _store
+
+        monkeypatch.setenv("NAB_MATERIALIZE_BEFORE_ORDER", "1")
+        provider = Provider(coordinator, build_policy=BuildPolicy.NEVER)
+        assert provider.materialize_before_order is True
+        assert provider.is_ready("foo") is True
+
+        matching = compute_matching(provider, "foo", VersionRange.full())
+        assert matching == 2
+        assert matching != _NO_LISTING_PRIOR
+        assert "foo" in provider.versions_cache
+
+
 class TestExtrasInvalidMetadata:
     """Cover the invalid-metadata skip paths in extras pick mode."""
 


### PR DESCRIPTION
Adds a `NAB_MATERIALIZE_BEFORE_ORDER` env flag to `Provider` that, when set, block-loads every undecided package listing before the prioritization step instead of relying on async arrival. This makes the MRV count real at ordering time (rather than the in-flight placeholder) and short-circuits `is_ready` to always return True, dropping the `ready_penalty` from the sort key entirely.

The intent is to measure whether the tier/MRV key alone reproduces the current ready-first ordering on high-conflict LOWEST scenarios (e.g. the airflow ones that regressed under earlier look-ahead gating). The flag is off by default; no existing behavior changes.

Also adds `nab-python/benchmarks/materialize_ab.py`, a targeted A/B script that runs named scenarios under the flag off vs on to report decision counts and wall time side by side.
