### PR TITLE
Declare conflicting extras and dependency groups

### DIFF
--- a/docs/guides/conflicts.md
+++ b/docs/guides/conflicts.md
@@ -57,7 +57,7 @@ A single-environment resolve cannot serve two exclusive members at
 once. Selecting both is rejected before any network work:
 
 ```console
-$ nab lock --extras cpu --extras gpu
+$ nab lock --extras cpu gpu
 Error in [tool.nab]: extra 'cpu', extra 'gpu' cannot be selected
 together: declared mutually exclusive (at_most_one) in
 [tool.nab].conflicts
@@ -91,10 +91,27 @@ product across them (one member chosen per set), so `black{22,23,24}`
 crossed with `isort{5,6,7}` is nine forks. Non-conflicting selections
 stay active in every fork.
 
+Forking needs one member per fork. If a single selection forces two
+members of one set together, no fork can separate them, so the resolve
+is refused. This happens when an umbrella extra self-references both
+members (`all = ["proj[cpu]", "proj[gpu]"]`) or an umbrella group
+includes both member groups. Co-selecting the members directly still
+forks; only the all-in-one umbrella, which cannot resolve disjointly,
+is rejected.
+
 The require-one check is not skipped in universal mode. Declaring
 `exactly_one` or `at_least_one` and selecting none of its members still
 raises before the resolve, the same as in specific mode. Only the
 co-selection case differs: universal mode forks instead of rejecting.
+
+A dependency required by every member of a set but not by the base
+keeps its membership marker, so it does not install when no member is
+selected (relevant under `at_most_one`, which permits selecting none).
+A base resolve names the deps that install regardless of the
+selection, which is how the writer tells the two apart. When a single
+dependency is required by every member of two or more engaged sets at
+once, its marker is the conjunction across those sets; this stays
+correct for one set, the common case.
 
 The lockfile stays within PEP 751: the membership markers use the
 standard `extras` and `dependency_groups` variables, and the install

--- a/docs/guides/conflicts.md
+++ b/docs/guides/conflicts.md
@@ -1,0 +1,111 @@
+# Conflicting extras and groups
+
+> [!WARNING]
+> Conflict declarations are tied to universal mode, which is
+> experimental. The lockfile shape may change.
+
+Some optional dependency sets are mutually exclusive: a CPU build and a
+GPU build of the same stack, or testing variants pinned to different
+tool versions. nab cannot put two such sets in one resolution, and a
+universal lock that tried to would fail the emit-time disjointness
+check. Declaring the conflict tells nab to keep them apart.
+
+## Declaring a conflict
+
+Conflicts live in `[tool.nab].conflicts`. Each entry is a set of
+members that are mutually exclusive with each other. A member is an
+extra or a dependency group:
+
+```toml
+[tool.nab]
+conflicts = [
+    [{ extra = "cpu" }, { extra = "gpu" }],
+]
+```
+
+The bare list form means *at most one* of the members may be active, so
+selecting neither is fine (extras are opt-in). A set may mix extras and
+groups, and you can declare several independent sets:
+
+```toml
+[tool.nab]
+conflicts = [
+    [{ group = "black22" }, { group = "black23" }, { group = "black24" }],
+    [{ group = "isort5" }, { group = "isort6" }, { group = "isort7" }],
+]
+```
+
+To require a choice rather than merely forbidding co-selection, name the
+policy explicitly. The three policies mirror Gentoo's `REQUIRED_USE`
+operators:
+
+```toml
+[tool.nab]
+conflicts = [
+    { at_most_one = [{ extra = "cpu" }, { extra = "gpu" }] },   # ?? (default)
+    { exactly_one = [{ extra = "cpu" }, { extra = "gpu" }] },   # ^^
+    { at_least_one = [{ group = "a" }, { group = "b" }] },      # ||
+]
+```
+
+Extra and group names are normalised (PEP 685 / PEP 735), so the
+spelling here does not have to match the table key exactly.
+
+## Specific mode: fail fast
+
+A single-environment resolve cannot serve two exclusive members at
+once. Selecting both is rejected before any network work:
+
+```console
+$ nab lock --extras cpu --extras gpu
+Error in [tool.nab]: extra 'cpu', extra 'gpu' cannot be selected
+together: declared mutually exclusive (at_most_one) in
+[tool.nab].conflicts
+```
+
+`exactly_one` additionally rejects selecting none; `at_least_one`
+rejects selecting none.
+
+## Universal mode: fork the resolve
+
+In universal mode nab does not reject co-selected members: it forks the
+resolve. When the selection activates two or more members of a set (for
+example `nab lock --all-groups` over the `black*` groups above), nab
+resolves each member separately and writes every result into one
+lockfile. Each fork's pins carry a marker selecting that member:
+
+```toml
+[[packages]]
+name = "black"
+version = "22.1.0"
+marker = "... and 'black22' in dependency_groups"
+
+[[packages]]
+name = "black"
+version = "23.12.0"
+marker = "... and 'black23' in dependency_groups"
+```
+
+When several sets are engaged at once, the forks are the cartesian
+product across them (one member chosen per set), so `black{22,23,24}`
+crossed with `isort{5,6,7}` is nine forks. Non-conflicting selections
+stay active in every fork.
+
+The lockfile stays within PEP 751: the membership markers use the
+standard `extras` and `dependency_groups` variables, and the install
+context that would activate two members of one set is pruned by the
+declared conflict, so the two entries never collide for a reader. A
+collision that is *not* covered by a declared conflict still raises a
+`DisjointnessError`, now with a hint pointing at the `conflicts` key.
+
+## Trade-offs
+
+| Property | nab (matrix fork) | uv (conflict markers) |
+| --- | --- | --- |
+| Lockfile encoding | Standard PEP 751 `'x' in extras`. | Bespoke `extra-<n>-<pkg>-<name>` dialect in `uv.lock`. |
+| Mechanism | Each member is a separate resolution under a marker. | Synthetic activation variables fork the single solve. |
+| Cost | Re-resolves a near-identical universe per fork. | Shared until a fork diverges. |
+
+The cost row is the honest price of the matrix model (see
+[universal resolution](universal.md)); the win is a standards-conformant
+lock with no in-band conflict-marker grammar to grow unbounded.

--- a/docs/guides/conflicts.md
+++ b/docs/guides/conflicts.md
@@ -146,17 +146,3 @@ The cost row reflects how the matrix model works (see
 [universal resolution](universal.md)): it re-resolves per fork. In
 return the lock stays within PEP 751, with no custom conflict-marker
 grammar.
-
-## Re-resolving from a previous lock
-
-A conflict-forked lock records, per environment, which deps came from
-the base resolve. That attribution is what tells the writer which
-pins keep their membership marker. If a future re-resolve feeds the
-old lock back as preferences while the member selection changes, the
-recorded attribution becomes stale: a dep that was member-only in the
-old lock may be base-required under the new selection (or vice
-versa), and the membership markers in the new emit would mis-shape.
-nab does not feed lock output back as preferences today, so the trap
-is latent. Any future seed-pins path that does should refuse a
-forked input lock until the attribution is re-derived from the new
-resolve rather than reused.

--- a/docs/guides/conflicts.md
+++ b/docs/guides/conflicts.md
@@ -51,6 +51,12 @@ conflicts = [
 Extra and group names are normalised (PEP 685 / PEP 735), so the
 spelling here does not have to match the table key exactly.
 
+In a workspace, `conflicts` is scoped to the pyproject being locked.
+Declaring conflicts in the workspace root does not propagate to a
+`nab lock packages/<member>/pyproject.toml`; each member declares
+its own. See the [workspaces guide](workspaces.md) for the full list
+of keys that flow vs stay local.
+
 ## Specific mode: fail fast
 
 A single-environment resolve cannot serve two exclusive members at

--- a/docs/guides/conflicts.md
+++ b/docs/guides/conflicts.md
@@ -78,18 +78,23 @@ lockfile. Each fork's pins carry a marker selecting that member:
 [[packages]]
 name = "black"
 version = "22.1.0"
-marker = "... and 'black22' in dependency_groups"
+marker = "... and \"black22\" in dependency_groups"
 
 [[packages]]
 name = "black"
 version = "23.12.0"
-marker = "... and 'black23' in dependency_groups"
+marker = "... and \"black23\" in dependency_groups"
 ```
 
 When several sets are engaged at once, the forks are the cartesian
 product across them (one member chosen per set), so `black{22,23,24}`
 crossed with `isort{5,6,7}` is nine forks. Non-conflicting selections
 stay active in every fork.
+
+The require-one check is not skipped in universal mode. Declaring
+`exactly_one` or `at_least_one` and selecting none of its members still
+raises before the resolve, the same as in specific mode. Only the
+co-selection case differs: universal mode forks instead of rejecting.
 
 The lockfile stays within PEP 751: the membership markers use the
 standard `extras` and `dependency_groups` variables, and the install
@@ -102,10 +107,11 @@ collision that is *not* covered by a declared conflict still raises a
 
 | Property | nab (matrix fork) | uv (conflict markers) |
 | --- | --- | --- |
-| Lockfile encoding | Standard PEP 751 `'x' in extras`. | Bespoke `extra-<n>-<pkg>-<name>` dialect in `uv.lock`. |
+| Lockfile encoding | Standard PEP 751 `"x" in extras`. | Bespoke `extra-<n>-<pkg>-<name>` dialect in `uv.lock`. |
 | Mechanism | Each member is a separate resolution under a marker. | Synthetic activation variables fork the single solve. |
 | Cost | Re-resolves a near-identical universe per fork. | Shared until a fork diverges. |
 
-The cost row is the honest price of the matrix model (see
-[universal resolution](universal.md)); the win is a standards-conformant
-lock with no in-band conflict-marker grammar to grow unbounded.
+The cost row reflects how the matrix model works (see
+[universal resolution](universal.md)): it re-resolves per fork. In
+return the lock stays within PEP 751, with no custom conflict-marker
+grammar.

--- a/docs/guides/conflicts.md
+++ b/docs/guides/conflicts.md
@@ -104,6 +104,14 @@ The require-one check is not skipped in universal mode. Declaring
 raises before the resolve, the same as in specific mode. Only the
 co-selection case differs: universal mode forks instead of rejecting.
 
+Groups named in `[tool.nab].default-groups` count as part of the
+selection for every conflict check. A project with
+`default-groups = ["a"]` and `exactly_one = [{ group = "a" }, { group = "b" }]`
+satisfies the minimum without passing `--groups`, and a `--groups b`
+on top of that default activates two members of an exclusive set,
+which the exclusion check then catches (specific mode) or the
+universal resolver forks into two.
+
 A dependency required by every member of a set but not by the base
 keeps its membership marker, so it does not install when no member is
 selected (relevant under `at_most_one`, which permits selecting none).

--- a/docs/guides/conflicts.md
+++ b/docs/guides/conflicts.md
@@ -146,3 +146,17 @@ The cost row reflects how the matrix model works (see
 [universal resolution](universal.md)): it re-resolves per fork. In
 return the lock stays within PEP 751, with no custom conflict-marker
 grammar.
+
+## Re-resolving from a previous lock
+
+A conflict-forked lock records, per environment, which deps came from
+the base resolve. That attribution is what tells the writer which
+pins keep their membership marker. If a future re-resolve feeds the
+old lock back as preferences while the member selection changes, the
+recorded attribution becomes stale: a dep that was member-only in the
+old lock may be base-required under the new selection (or vice
+versa), and the membership markers in the new emit would mis-shape.
+nab does not feed lock output back as preferences today, so the trap
+is latent. Any future seed-pins path that does should refuse a
+forked input lock until the attribution is re-derived from the new
+resolve rather than reused.

--- a/docs/guides/workspaces.md
+++ b/docs/guides/workspaces.md
@@ -63,6 +63,23 @@ metadata extraction runs even when the user-set policy is stricter.
 A policy that is already `build-local` or `build-remote` is left
 alone.
 
+## Scope of `[tool.nab]` keys
+
+Workspace discovery flows these from the root into the file being
+locked: the member entries from `[tool.nab.workspace].members`
+(merged into `local-sources`), and the build-policy floor described
+above. Everything else under `[tool.nab]` is scoped to the
+pyproject being locked: `conflicts`, `default-groups`, `constraints`,
+`matrix`, `mode`, `requires-python`, `uploaded-prior-to`,
+`build-policy` itself, `dist-policy`, `vcs`, `indexes`, and
+`marker-environment`. Locking a member with `nab lock
+packages/core/pyproject.toml` reads only that file's keys; the
+root's are ignored.
+
+Declare conflicts and default-groups on each member that needs them.
+The same applies to constraints: a root-level constraint table does
+not constrain a member resolve.
+
 ## Example layout
 
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ guides/vcs
 guides/multi-index
 guides/workspaces
 guides/universal
+guides/conflicts
 ```
 
 ## Status
@@ -33,3 +34,6 @@ guides/universal
 * Universal resolution across a user-declared `(python, platform)`
   matrix.  Opt-in via `[tool.nab].mode = "universal"`; the API and
   output format are still subject to change.
+* Mutually-exclusive extras and dependency groups via
+  `[tool.nab].conflicts`: fail fast in specific mode, fork the resolve
+  in universal mode.  See [conflicts](guides/conflicts.md).

--- a/nab-python/src/nab_python/_conflict_kind.py
+++ b/nab-python/src/nab_python/_conflict_kind.py
@@ -1,0 +1,20 @@
+"""Conflict-kind constants and PEP 508 marker-variable mapping.
+
+A leaf module that :mod:`nab_python.config`, :mod:`nab_python.universal.matrix`,
+and :mod:`nab_python._lockfile.disjointness` can import without forming a
+cycle.  :class:`nab_python.config.ConflictKind` takes its enum values from
+``KIND_EXTRA`` / ``KIND_GROUP`` so a rename here flows to every consumer.
+"""
+
+from __future__ import annotations
+
+KIND_EXTRA = "extra"
+KIND_GROUP = "group"
+
+# Membership of a conflict-fork member emits ``'name' in <variable>`` on
+# the per-package marker; this mapping is the (kind -> variable) contract
+# the universal matrix and the disjointness validator share.
+MARKER_VARIABLE_FOR_KIND = {
+    KIND_EXTRA: "extras",
+    KIND_GROUP: "dependency_groups",
+}

--- a/nab-python/src/nab_python/_lockfile/disjointness.py
+++ b/nab-python/src/nab_python/_lockfile/disjointness.py
@@ -30,6 +30,10 @@ __all__ = [
     "DisjointnessError",
 ]
 
+# Two or more active members of a conflict set is the illegitimate case
+# the conflict declaration prunes from the install-context universe.
+_MUTUALLY_EXCLUSIVE_LIMIT = 2
+
 
 class DisjointnessError(ValueError):
     """Two same-name ``[[packages]]`` entries can fire under one context.
@@ -50,6 +54,7 @@ def validate_marker_disjointness(
     environments: Mapping[str, Mapping[str, str]],
     extras: Sequence[str],
     groups: Sequence[str],
+    exclusive_groups: Sequence[AbstractSet[tuple[str, str]]] = (),
 ) -> None:
     """Confirm same-name ``[[packages]]`` entries are pairwise disjoint.
 
@@ -76,6 +81,19 @@ def validate_marker_disjointness(
     actually mentions.  When no marker references a variable, that
     powerset collapses to ``{()}`` and the cartesian explosion
     disappears.
+
+    ``exclusive_groups`` declares mutually-exclusive selections from
+    ``[tool.nab].conflicts``: each entry is a set of ``(kind, name)``
+    members (``kind`` is ``"extra"`` or ``"group"``) of which at most
+    one may be active at once.  Install contexts that activate two or
+    more members of any such set cannot legitimately occur, so they
+    are pruned from the universe before the collision check.  This is
+    what lets a universal lock carry one fork per conflicting
+    extra/group under bare ``'name' in extras`` markers: the
+    both-selected point that would otherwise collide is never
+    enumerated.  A collision that survives outside every pruned point
+    still raises, with a hint pointing at the ``conflicts`` key when
+    extras or groups drive the colliding markers.
     """
     if not environments:
         return
@@ -90,30 +108,77 @@ def validate_marker_disjointness(
     relevant_groups = _restrict_to_referenced(
         groups, candidate_markers, "dependency_groups"
     )
-    extras_subsets = list(_powerset(relevant_extras))
-    group_subsets = list(_powerset(relevant_groups))
+    points = [
+        (extra_subset, group_subset)
+        for extra_subset in _powerset(relevant_extras)
+        for group_subset in _powerset(relevant_groups)
+        if not _point_violates_exclusions(extra_subset, group_subset, exclusive_groups)
+    ]
     for entries in same_name_entries:
         name = str(entries[0].name)
         for env_label, env_dict in environments.items():
-            for extra_subset in extras_subsets:
-                for group_subset in group_subsets:
-                    context: dict[str, str | AbstractSet[str]] = dict(env_dict)
-                    context["extras"] = frozenset(extra_subset)
-                    context["dependency_groups"] = frozenset(group_subset)
-                    matching = [
-                        pkg for pkg in entries if _marker_holds(pkg.marker, context)
-                    ]
-                    if len(matching) <= 1:
-                        continue
-                    versions = sorted(
-                        str(p.version) if p.version else "" for p in matching
-                    )
-                    msg = (
-                        f"{name}: {len(matching)} entries fire under"
-                        f" env={env_label!r} extras={sorted(extra_subset)!r}"
-                        f" groups={sorted(group_subset)!r}: versions={versions}"
-                    )
-                    raise DisjointnessError(msg)
+            for extra_subset, group_subset in points:
+                context: dict[str, str | AbstractSet[str]] = dict(env_dict)
+                context["extras"] = frozenset(extra_subset)
+                context["dependency_groups"] = frozenset(group_subset)
+                matching = [
+                    pkg for pkg in entries if _marker_holds(pkg.marker, context)
+                ]
+                if len(matching) <= 1:
+                    continue
+                versions = sorted(str(p.version) if p.version else "" for p in matching)
+                msg = (
+                    f"{name}: {len(matching)} entries fire under"
+                    f" env={env_label!r} extras={sorted(extra_subset)!r}"
+                    f" groups={sorted(group_subset)!r}: versions={versions}"
+                    f"{_conflict_hint([p.marker for p in matching])}"
+                )
+                raise DisjointnessError(msg)
+
+
+def _point_violates_exclusions(
+    extra_subset: Sequence[str],
+    group_subset: Sequence[str],
+    exclusive_groups: Sequence[AbstractSet[tuple[str, str]]],
+) -> bool:
+    """Return True when this context activates 2+ members of a conflict set.
+
+    Members are compared under canonicalisation so a marker literal
+    spelled differently from the declared conflict name still matches.
+    """
+    if not exclusive_groups:
+        return False
+    active_extras = {canonicalize_name(name) for name in extra_subset}
+    active_groups = {canonicalize_name(name) for name in group_subset}
+    for members in exclusive_groups:
+        active = sum(
+            1
+            for kind, name in members
+            if (kind == "extra" and name in active_extras)
+            or (kind == "group" and name in active_groups)
+        )
+        if active >= _MUTUALLY_EXCLUSIVE_LIMIT:
+            return True
+    return False
+
+
+def _conflict_hint(markers: Sequence[Marker | None]) -> str:
+    """Return a one-line hint about declaring a conflict, when relevant.
+
+    Relevant means the colliding markers reference an extra or a
+    dependency group, so declaring the pair mutually exclusive in
+    ``[tool.nab].conflicts`` could prune the offending context.  A
+    purely environment-driven collision (no membership variable) gets
+    no hint because a conflict declaration would not help.
+    """
+    _, has_extras = _referenced_membership_names(markers, "extras")
+    _, has_groups = _referenced_membership_names(markers, "dependency_groups")
+    if not (has_extras or has_groups):
+        return ""
+    return (
+        ". If these are intentionally mutually exclusive, declare them in"
+        " [tool.nab].conflicts so the colliding context is pruned"
+    )
 
 
 @functools.cache

--- a/nab-python/src/nab_python/_lockfile/disjointness.py
+++ b/nab-python/src/nab_python/_lockfile/disjointness.py
@@ -111,9 +111,10 @@ def validate_marker_disjointness(
         for group_subset in _powerset(relevant_groups)
         if not _point_violates_exclusions(extra_subset, group_subset, exclusive_groups)
     ]
+    distinct_environments = _distinct_environments(environments)
     for entries in same_name_entries:
         name = str(entries[0].name)
-        for env_label, env_dict in environments.items():
+        for env_label, env_dict in distinct_environments:
             for extra_subset, group_subset in points:
                 context: dict[str, str | AbstractSet[str]] = dict(env_dict)
                 context["extras"] = frozenset(extra_subset)
@@ -124,13 +125,38 @@ def validate_marker_disjointness(
                 if len(matching) <= 1:
                     continue
                 versions = sorted(str(p.version) if p.version else "" for p in matching)
+                hint = _conflict_hint(
+                    [p.marker for p in matching], extra_subset, group_subset
+                )
                 msg = (
                     f"{name}: {len(matching)} entries fire under"
                     f" env={env_label!r} extras={sorted(extra_subset)!r}"
                     f" groups={sorted(group_subset)!r}: versions={versions}"
-                    f"{_conflict_hint([p.marker for p in matching])}"
+                    f"{hint}"
                 )
                 raise DisjointnessError(msg)
+
+
+def _distinct_environments(
+    environments: Mapping[str, Mapping[str, str]],
+) -> list[tuple[str, Mapping[str, str]]]:
+    """Collapse the environment axis to one label per distinct env dict.
+
+    A conflict-forked universal lock repeats a python/platform under
+    several selection labels, so identical env dicts would otherwise be
+    re-evaluated once per fork with no added coverage.  The first label
+    seen for each signature is kept so the error message matches the
+    pre-dedup iteration order.
+    """
+    seen: set[tuple[tuple[str, str], ...]] = set()
+    distinct: list[tuple[str, Mapping[str, str]]] = []
+    for label, env_dict in environments.items():
+        signature = tuple(sorted(env_dict.items()))
+        if signature in seen:
+            continue
+        seen.add(signature)
+        distinct.append((label, env_dict))
+    return distinct
 
 
 def _point_violates_exclusions(
@@ -159,23 +185,46 @@ def _point_violates_exclusions(
     return False
 
 
-def _conflict_hint(markers: Sequence[Marker | None]) -> str:
+def _conflict_hint(
+    markers: Sequence[Marker | None],
+    extra_subset: Sequence[str],
+    group_subset: Sequence[str],
+) -> str:
     """Return a one-line hint about declaring a conflict, when relevant.
 
-    Relevant means the colliding markers reference an extra or a
-    dependency group, so declaring the pair mutually exclusive in
-    ``[tool.nab].conflicts`` could prune the offending context.  A
-    purely environment-driven collision (no membership variable) gets
-    no hint because a conflict declaration would not help.
+    Relevant means a membership variable actually drives the witness
+    point: a referenced extra or dependency group is active in the
+    colliding context, so declaring the pair mutually exclusive in
+    ``[tool.nab].conflicts`` could prune that point.  A purely
+    environment-driven collision (no membership variable referenced, or
+    the witness selects none of the referenced ones) gets no hint
+    because a conflict declaration would not help.
     """
-    _, has_extras = _referenced_membership_names(markers, "extras")
-    _, has_groups = _referenced_membership_names(markers, "dependency_groups")
-    if not (has_extras or has_groups):
-        return ""
-    return (
-        ". If these are intentionally mutually exclusive, declare them in"
-        " [tool.nab].conflicts so the colliding context is pruned"
-    )
+    if _membership_drives_point(markers, "extras", extra_subset) or (
+        _membership_drives_point(markers, "dependency_groups", group_subset)
+    ):
+        return (
+            ". If these are intentionally mutually exclusive, declare them in"
+            " [tool.nab].conflicts so the colliding context is pruned"
+        )
+    return ""
+
+
+def _membership_drives_point(
+    markers: Sequence[Marker | None], variable: str, subset: Sequence[str]
+) -> bool:
+    """Return True when a referenced ``variable`` literal is active here.
+
+    A membership variable drives the witness only when the witness
+    ``subset`` is non-empty and intersects the literals the colliding
+    markers test for membership in ``variable`` (compared under
+    canonicalisation, matching the powerset axis restriction).
+    """
+    referenced, _ = _referenced_membership_names(markers, variable)
+    if not referenced:
+        return False
+    active = {canonicalize_name(name) for name in subset}
+    return any(canonicalize_name(name) in active for name in referenced)
 
 
 @functools.cache

--- a/nab-python/src/nab_python/_lockfile/disjointness.py
+++ b/nab-python/src/nab_python/_lockfile/disjointness.py
@@ -85,15 +85,12 @@ def validate_marker_disjointness(
     ``exclusive_groups`` declares mutually-exclusive selections from
     ``[tool.nab].conflicts``: each entry is a set of ``(kind, name)``
     members (``kind`` is ``"extra"`` or ``"group"``) of which at most
-    one may be active at once.  Install contexts that activate two or
-    more members of any such set cannot legitimately occur, so they
-    are pruned from the universe before the collision check.  This is
-    what lets a universal lock carry one fork per conflicting
-    extra/group under bare ``'name' in extras`` markers: the
-    both-selected point that would otherwise collide is never
-    enumerated.  A collision that survives outside every pruned point
-    still raises, with a hint pointing at the ``conflicts`` key when
-    extras or groups drive the colliding markers.
+    one may be active.  Contexts activating two or more members of a
+    set are pruned before the collision check, so a universal lock can
+    carry one fork per conflicting extra/group under bare
+    ``'name' in extras`` markers.  A collision outside every pruned
+    point still raises, hinting at the ``conflicts`` key when extras or
+    groups drive the colliding markers.
     """
     if not environments:
         return

--- a/nab-python/src/nab_python/_lockfile/disjointness.py
+++ b/nab-python/src/nab_python/_lockfile/disjointness.py
@@ -18,7 +18,7 @@ import re
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
-from .._conflict_kind import KIND_EXTRA, KIND_GROUP
+from .._conflict_kind import KIND_EXTRA, KIND_GROUP, MARKER_VARIABLE_FOR_KIND
 from .._vendor.packaging.utils import canonicalize_name
 
 if TYPE_CHECKING:
@@ -111,14 +111,17 @@ def validate_marker_disjointness(
     if not same_name_entries:
         return
     candidate_markers = [pkg.marker for entries in same_name_entries for pkg in entries]
-    relevant_extras = _restrict_to_referenced(extras, candidate_markers, "extras")
-    relevant_groups = _restrict_to_referenced(
-        groups, candidate_markers, "dependency_groups"
-    )
+
+    extras_var = MARKER_VARIABLE_FOR_KIND[KIND_EXTRA]
+    groups_var = MARKER_VARIABLE_FOR_KIND[KIND_GROUP]
+
+    relevant_extras = _restrict_to_referenced(extras, candidate_markers, extras_var)
+    relevant_groups = _restrict_to_referenced(groups, candidate_markers, groups_var)
     points = list(
         _enumerate_valid_points(relevant_extras, relevant_groups, exclusive_groups)
     )
     distinct_environments = _distinct_environments(environments)
+
     # Iterate env x point outermost so the install context dict is built
     # once per (env, point) and reused across every same-name entry group.
     # The earlier per-entry-group rebuild scaled M*D*P dicts where M is the
@@ -127,8 +130,8 @@ def validate_marker_disjointness(
     for env_label, env_dict in distinct_environments:
         for extra_subset, group_subset in points:
             context: dict[str, str | AbstractSet[str]] = dict(env_dict)
-            context["extras"] = frozenset(extra_subset)
-            context["dependency_groups"] = frozenset(group_subset)
+            context[extras_var] = frozenset(extra_subset)
+            context[groups_var] = frozenset(group_subset)
             for entries in same_name_entries:
                 matching = [
                     pkg for pkg in entries if _marker_holds(pkg.marker, context)
@@ -266,8 +269,12 @@ def _conflict_hint(
     declaration permits co-selection, so the validator still raises and
     the user has to switch to an exclusive policy to prune the point.
     """
-    extras_driven = _membership_drives_point(markers, "extras", extra_subset)
-    groups_driven = _membership_drives_point(markers, "dependency_groups", group_subset)
+    extras_driven = _membership_drives_point(
+        markers, MARKER_VARIABLE_FOR_KIND[KIND_EXTRA], extra_subset
+    )
+    groups_driven = _membership_drives_point(
+        markers, MARKER_VARIABLE_FOR_KIND[KIND_GROUP], group_subset
+    )
     if not (extras_driven or groups_driven):
         return ""
 

--- a/nab-python/src/nab_python/_lockfile/disjointness.py
+++ b/nab-python/src/nab_python/_lockfile/disjointness.py
@@ -58,6 +58,7 @@ def validate_marker_disjointness(
     extras: Sequence[str],
     groups: Sequence[str],
     exclusive_groups: Sequence[AbstractSet[tuple[str, str]]] = (),
+    declared_groups: Sequence[AbstractSet[tuple[str, str]]] = (),
 ) -> None:
     """Confirm same-name ``[[packages]]`` entries are pairwise disjoint.
 
@@ -95,6 +96,11 @@ def validate_marker_disjointness(
     ``'name' in extras`` markers.  A collision outside every pruned
     point still raises, hinting at the ``conflicts`` key when extras or
     groups drive the colliding markers.
+
+    ``declared_groups`` carries every conflict set regardless of policy
+    so the hint can distinguish an undeclared collision (suggest adding
+    a declaration) from one already declared under ``at_least_one``
+    (suggest tightening to ``at_most_one`` or ``exactly_one``).
     """
     if not environments:
         return
@@ -127,7 +133,10 @@ def validate_marker_disjointness(
                     continue
                 versions = sorted(str(p.version) if p.version else "" for p in matching)
                 hint = _conflict_hint(
-                    [p.marker for p in matching], extra_subset, group_subset
+                    [p.marker for p in matching],
+                    extra_subset,
+                    group_subset,
+                    declared_groups,
                 )
                 msg = (
                     f"{name}: {len(matching)} entries fire under"
@@ -235,6 +244,7 @@ def _conflict_hint(
     markers: Sequence[Marker | None],
     extra_subset: Sequence[str],
     group_subset: Sequence[str],
+    declared_groups: Sequence[AbstractSet[tuple[str, str]]] = (),
 ) -> str:
     """Return a one-line hint about declaring a conflict, when relevant.
 
@@ -245,15 +255,34 @@ def _conflict_hint(
     environment-driven collision (no membership variable referenced, or
     the witness selects none of the referenced ones) gets no hint
     because a conflict declaration would not help.
+
+    When ``declared_groups`` already covers the active members, the
+    hint instead suggests tightening the policy: an ``at_least_one``
+    declaration permits co-selection, so the validator still raises and
+    the user has to switch to an exclusive policy to prune the point.
     """
-    if _membership_drives_point(markers, "extras", extra_subset) or (
-        _membership_drives_point(markers, "dependency_groups", group_subset)
-    ):
+    extras_driven = _membership_drives_point(markers, "extras", extra_subset)
+    groups_driven = _membership_drives_point(markers, "dependency_groups", group_subset)
+    if not (extras_driven or groups_driven):
+        return ""
+
+    active = {(KIND_EXTRA, canonicalize_name(n)) for n in extra_subset} | {
+        (KIND_GROUP, canonicalize_name(n)) for n in group_subset
+    }
+    already_declared = any(
+        sum(1 for kind, name in declared if (kind, name) in active) >= 2  # noqa: PLR2004
+        for declared in declared_groups
+    )
+    if already_declared:
         return (
-            ". If these are intentionally mutually exclusive, declare them in"
-            " [tool.nab].conflicts so the colliding context is pruned"
+            ". These members are declared in [tool.nab].conflicts under a"
+            " policy that permits co-selection; switch to at_most_one or"
+            " exactly_one to prune the colliding context"
         )
-    return ""
+    return (
+        ". If these are intentionally mutually exclusive, declare them in"
+        " [tool.nab].conflicts so the colliding context is pruned"
+    )
 
 
 def _membership_drives_point(

--- a/nab-python/src/nab_python/_lockfile/disjointness.py
+++ b/nab-python/src/nab_python/_lockfile/disjointness.py
@@ -119,18 +119,23 @@ def validate_marker_disjointness(
         _enumerate_valid_points(relevant_extras, relevant_groups, exclusive_groups)
     )
     distinct_environments = _distinct_environments(environments)
-    for entries in same_name_entries:
-        name = str(entries[0].name)
-        for env_label, env_dict in distinct_environments:
-            for extra_subset, group_subset in points:
-                context: dict[str, str | AbstractSet[str]] = dict(env_dict)
-                context["extras"] = frozenset(extra_subset)
-                context["dependency_groups"] = frozenset(group_subset)
+    # Iterate env x point outermost so the install context dict is built
+    # once per (env, point) and reused across every same-name entry group.
+    # The earlier per-entry-group rebuild scaled M*D*P dicts where M is the
+    # same-name package count; conflict-fork locks make M scale with the
+    # universe size.
+    for env_label, env_dict in distinct_environments:
+        for extra_subset, group_subset in points:
+            context: dict[str, str | AbstractSet[str]] = dict(env_dict)
+            context["extras"] = frozenset(extra_subset)
+            context["dependency_groups"] = frozenset(group_subset)
+            for entries in same_name_entries:
                 matching = [
                     pkg for pkg in entries if _marker_holds(pkg.marker, context)
                 ]
                 if len(matching) <= 1:
                     continue
+                name = str(entries[0].name)
                 versions = sorted(str(p.version) if p.version else "" for p in matching)
                 hint = _conflict_hint(
                     [p.marker for p in matching],
@@ -390,4 +395,6 @@ def _marker_holds(
     """Return True when ``marker`` is absent or evaluates True under ``context``."""
     if marker is None:
         return True
-    return bool(marker.evaluate(dict(context)))
+    # ``Marker.evaluate`` treats the environment as read-only, so no
+    # defensive copy is needed here.
+    return bool(marker.evaluate(context))

--- a/nab-python/src/nab_python/_lockfile/disjointness.py
+++ b/nab-python/src/nab_python/_lockfile/disjointness.py
@@ -2,20 +2,23 @@
 
 PEP 751 forbids two ``[[packages]]`` entries with the same name from
 firing under one install context.  This module owns the validator
-that enumerates the install-context universe (environments x extras
-powerset x dependency-groups powerset) and reports any pair that
-collide, plus the bookkeeping helpers that prune the powerset axes
-to the marker variables a same-name candidate actually references.
+that enumerates the install-context universe (environments x valid
+extras/groups combinations) and reports any pair that collide, plus
+the bookkeeping helpers that prune the axes to the marker variables a
+same-name candidate actually references.  Declared conflicts shrink
+the combination space directly: a set with N mutually-exclusive
+members contributes only N+1 outcomes (none, or each member alone),
+not the 2^N raw powerset.
 """
 
 from __future__ import annotations
 
 import functools
-import itertools
 import re
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
+from .._conflict_kind import KIND_EXTRA, KIND_GROUP
 from .._vendor.packaging.utils import canonicalize_name
 
 if TYPE_CHECKING:
@@ -59,11 +62,12 @@ def validate_marker_disjointness(
     """Confirm same-name ``[[packages]]`` entries are pairwise disjoint.
 
     Builds the universe of install contexts as the cartesian product
-    of declared environments, the powerset of declared ``extras``,
-    and the powerset of declared ``dependency_groups``.  For every
-    point in that universe and every package name, evaluates each
-    candidate entry's marker.  When two or more entries hold for the
-    same point, raises :class:`DisjointnessError` with the witness.
+    of declared environments and the conflict-respecting combinations
+    of declared ``extras`` and ``dependency_groups`` (see
+    :func:`_enumerate_valid_points`).  For every point in that
+    universe and every package name, evaluates each candidate entry's
+    marker.  When two or more entries hold for the same point, raises
+    :class:`DisjointnessError` with the witness.
 
     The empty-environments path skips validation: a producer that
     does not declare a universe cannot specify what "all envs" means
@@ -105,12 +109,9 @@ def validate_marker_disjointness(
     relevant_groups = _restrict_to_referenced(
         groups, candidate_markers, "dependency_groups"
     )
-    points = [
-        (extra_subset, group_subset)
-        for extra_subset in _powerset(relevant_extras)
-        for group_subset in _powerset(relevant_groups)
-        if not _point_violates_exclusions(extra_subset, group_subset, exclusive_groups)
-    ]
+    points = list(
+        _enumerate_valid_points(relevant_extras, relevant_groups, exclusive_groups)
+    )
     distinct_environments = _distinct_environments(environments)
     for entries in same_name_entries:
         name = str(entries[0].name)
@@ -159,30 +160,75 @@ def _distinct_environments(
     return distinct
 
 
-def _point_violates_exclusions(
-    extra_subset: Sequence[str],
-    group_subset: Sequence[str],
+def _enumerate_valid_points(
+    relevant_extras: Sequence[str],
+    relevant_groups: Sequence[str],
     exclusive_groups: Sequence[AbstractSet[tuple[str, str]]],
-) -> bool:
-    """Return True when this context activates 2+ members of a conflict set.
+) -> Iterable[tuple[tuple[str, ...], tuple[str, ...]]]:
+    """Yield every (extras_subset, groups_subset) the conflicts allow.
 
-    Members are compared under canonicalisation so a marker literal
-    spelled differently from the declared conflict name still matches.
+    The full powerset is ``2^(E+G)`` and overwhelmingly dominated by
+    points a declared conflict already forbids (any subset that picks
+    two members of one mutually-exclusive set).  Generating then
+    filtering wastes the exponent: a set with N members keeps only
+    N+1 of its 2^N subsets.  This enumerates by backtracking: at each
+    item, the include branch is skipped as soon as one of its
+    exclusion sets already has an active member, so the search visits
+    exactly the surviving subsets.
+
+    Names are compared under :func:`canonicalize_name` against the
+    declared conflict members; subsets are emitted as sorted tuples
+    drawn from the input order so the downstream collision check sees
+    them in a stable shape.
     """
-    if not exclusive_groups:
-        return False
-    active_extras = {canonicalize_name(name) for name in extra_subset}
-    active_groups = {canonicalize_name(name) for name in group_subset}
-    for members in exclusive_groups:
-        active = sum(
-            1
-            for kind, name in members
-            if (kind == "extra" and name in active_extras)
-            or (kind == "group" and name in active_groups)
-        )
-        if active >= _MUTUALLY_EXCLUSIVE_LIMIT:
-            return True
-    return False
+    extras = sorted(set(relevant_extras))
+    groups = sorted(set(relevant_groups))
+    items: list[tuple[str, str]] = [(KIND_EXTRA, e) for e in extras] + [
+        (KIND_GROUP, g) for g in groups
+    ]
+
+    # Per item, the indices of every exclusion set whose membership it
+    # belongs to.  Names compare canonicalised on both sides.
+    item_sets: list[list[int]] = []
+    for kind, name in items:
+        canonical = canonicalize_name(name)
+        sets_for_item: list[int] = []
+        for i, members in enumerate(exclusive_groups):
+            for member_kind, member_name in members:
+                if member_kind == kind and canonicalize_name(member_name) == canonical:
+                    sets_for_item.append(i)
+                    break
+        item_sets.append(sets_for_item)
+
+    active_per_set = [0] * len(exclusive_groups)
+    extras_buf: list[str] = []
+    groups_buf: list[str] = []
+
+    def recurse(idx: int) -> Iterable[tuple[tuple[str, ...], tuple[str, ...]]]:
+        if idx == len(items):
+            yield (tuple(extras_buf), tuple(groups_buf))
+            return
+
+        # Exclude branch is always valid.
+        yield from recurse(idx + 1)
+
+        # Include branch is pruned as soon as a set has its single
+        # allowed member already active.
+        if any(
+            active_per_set[i] >= _MUTUALLY_EXCLUSIVE_LIMIT - 1 for i in item_sets[idx]
+        ):
+            return
+        kind, name = items[idx]
+        target = extras_buf if kind == KIND_EXTRA else groups_buf
+        target.append(name)
+        for i in item_sets[idx]:
+            active_per_set[i] += 1
+        yield from recurse(idx + 1)
+        for i in item_sets[idx]:
+            active_per_set[i] -= 1
+        target.pop()
+
+    yield from recurse(0)
 
 
 def _conflict_hint(
@@ -316,10 +362,3 @@ def _marker_holds(
     if marker is None:
         return True
     return bool(marker.evaluate(dict(context)))
-
-
-def _powerset(items: Sequence[str]) -> Iterable[tuple[str, ...]]:
-    """Yield every subset of ``items`` as a sorted tuple, including ``()``."""
-    seen = sorted(set(items))
-    for r in range(len(seen) + 1):
-        yield from itertools.combinations(seen, r)

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -30,6 +30,7 @@ from .._vendor.packaging.pylock import (
 from .._vendor.packaging.specifiers import SpecifierSet
 from .._vendor.packaging.utils import canonicalize_name
 from .._vendor.packaging.version import Version
+from ..config import conflict_exclusion_groups
 from .disjointness import validate_marker_disjointness
 
 if TYPE_CHECKING:
@@ -102,6 +103,7 @@ def build_pylock(lock_input: LockInput, *, lock_dir: Path | None = None) -> Pylo
         environments=lock_input.tuple_environments,
         extras=lock_input.extras,
         groups=lock_input.dependency_groups,
+        exclusive_groups=conflict_exclusion_groups(lock_input.conflicts),
     )
     tool: dict[str, Any] | None = (
         {"nab": lock_input.provenance.to_block()}

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -435,23 +435,22 @@ def _build_marker(
 ) -> Marker | None:
     """Return the marker selecting ``tuple_labels``, or ``None`` if unconditional.
 
-    The package is unconditional when ``tuple_labels`` covers every
-    declared tuple in ``tuple_markers``.  Otherwise the marker is the
-    OR of one contribution per environment the package appears in:
-    when the package is present in every fork of an environment it
-    contributes that environment's membership-free env-only marker, and
-    when present in only some forks it contributes the OR of the
-    membership-carrying per-fork markers.  When ``tuple_markers`` is
-    empty the caller has not declared a tuple universe and we omit the
-    marker.
+    For each environment the package appears in, the contribution is
+    the membership-free env-only marker when the package is present in
+    every fork of that env AND ``env_base_names`` lists it as a base
+    dep there; otherwise the contribution is the OR of the per-fork
+    membership-carrying markers.  The result is the OR of those
+    contributions, or ``None`` when the package covers every declared
+    tuple AND every env collapsed to its env-only marker.  An empty
+    ``tuple_markers`` means the caller has not declared a tuple
+    universe and the marker is omitted.
 
-    Dropping the membership clause is gated on ``env_base_names``: only
-    a package the base (no-member) resolve produced for that environment
-    may collapse to the env-only marker.  A dep required by every member
-    but not the base is absent from that set, so it keeps the membership
-    OR and does not install when no member is selected.  When an
-    environment has no base-name set (no conflict fork ran) the gate is
-    open, so the no-conflict path emits markers byte for byte as before.
+    A dep required by every member of an ``at_most_one`` set but not
+    by the base is absent from ``env_base_names``, so it keeps the
+    membership OR and does not install when no member is selected.
+    An environment with no base-name set (no conflict fork ran) leaves
+    the gate open, so the no-conflict path emits markers byte for byte
+    as before.
     """
     if total_tuples == 0:
         return None

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -284,7 +284,11 @@ def _build_per_tuple_packages(lock_input: LockInput, lock_dir: Path) -> list[Pac
     A base dependency present in every fork of an environment must
     install regardless of which member is selected, so for that
     environment it contributes the membership-free env-only marker
-    rather than the OR of the per-fork membership markers.
+    rather than the OR of the per-fork membership markers.  A package
+    is recognised as a base dependency through
+    ``lock_input.env_base_names``: a dep required by every member but
+    not by the base is absent from that set, so it keeps the
+    membership clause and does not install when no member is selected.
     """
     out: list[Package] = []
     by_name = _group_by_name(lock_input.per_tuple_pins)
@@ -295,15 +299,17 @@ def _build_per_tuple_packages(lock_input: LockInput, lock_dir: Path) -> list[Pac
     env_fork_counts = _count(
         env_signatures[label] for label in lock_input.tuple_markers
     )
-    for per_tuple in by_name.values():
+    for canonical_name, per_tuple in by_name.items():
         groups = _group_pins_by_pin(per_tuple)
         for pins, tuple_labels in groups:
             marker = _build_marker(
+                canonical_name,
                 tuple_labels,
                 lock_input.tuple_markers,
                 lock_input.tuple_env_markers,
                 env_signatures,
                 env_fork_counts,
+                lock_input.env_base_names,
                 total_tuples,
             )
             out.append(
@@ -418,11 +424,13 @@ def _merge_pins_in_group(pins: list[PinShape]) -> PinShape:
 
 
 def _build_marker(
+    name: str,
     tuple_labels: Sequence[str],
     tuple_markers: Mapping[str, Marker],
     tuple_env_markers: Mapping[str, Marker],
     env_signatures: Mapping[str, tuple[tuple[str, str], ...]],
     env_fork_counts: Mapping[tuple[tuple[str, str], ...], int],
+    env_base_names: Mapping[tuple[tuple[str, str], ...], frozenset[str]],
     total_tuples: int,
 ) -> Marker | None:
     """Return the marker selecting ``tuple_labels``, or ``None`` if unconditional.
@@ -437,12 +445,15 @@ def _build_marker(
     empty the caller has not declared a tuple universe and we omit the
     marker.
 
-    With no conflict forks there is one fork per environment, so a
-    present package always covers its whole environment and the env-only
-    marker equals the per-tuple marker: the emitted markers match the
-    no-conflict path byte for byte.
+    Dropping the membership clause is gated on ``env_base_names``: only
+    a package the base (no-member) resolve produced for that environment
+    may collapse to the env-only marker.  A dep required by every member
+    but not the base is absent from that set, so it keeps the membership
+    OR and does not install when no member is selected.  When an
+    environment has no base-name set (no conflict fork ran) the gate is
+    open, so the no-conflict path emits markers byte for byte as before.
     """
-    if total_tuples == 0 or len(tuple_labels) >= total_tuples:
+    if total_tuples == 0:
         return None
     present = [label for label in tuple_labels if label in tuple_markers]
     if not present:
@@ -450,14 +461,26 @@ def _build_marker(
     by_env: defaultdict[tuple[tuple[str, str], ...], list[str]] = defaultdict(list)
     for label in present:
         by_env[env_signatures[label]].append(label)
+
+    # The package is unconditional only when it covers every declared
+    # tuple AND every environment collapsed to its env-only marker. A
+    # member-only dep present in all forks of an env keeps the
+    # membership OR, so it is not unconditional even at full coverage.
     contributions: list[Marker] = []
+    unconditional = len(present) >= total_tuples
     for signature, labels in by_env.items():
-        if len(labels) >= env_fork_counts[signature]:
+        base_names = env_base_names.get(signature)
+        is_base = base_names is None or name in base_names
+        if len(labels) >= env_fork_counts[signature] and is_base:
             contributions.append(
                 tuple_env_markers.get(labels[0], tuple_markers[labels[0]])
             )
         else:
             contributions.extend(tuple_markers[label] for label in labels)
+            unconditional = False
+
+    if unconditional:
+        return None
     return _or_markers(contributions)
 
 

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -290,6 +290,8 @@ def _build_per_tuple_packages(lock_input: LockInput, lock_dir: Path) -> list[Pac
     ``lock_input.env_base_names``: a dep required by every member but
     not by the base is absent from that set, so it keeps the
     membership clause and does not install when no member is selected.
+    See :class:`LockInput.env_base_names` for the missing-signature
+    contract.
     """
     out: list[Package] = []
     by_name = _group_by_name(lock_input.per_tuple_pins)
@@ -470,7 +472,16 @@ def _build_marker(
     unconditional = len(present) >= total_tuples
     for signature, labels in by_env.items():
         base_names = env_base_names.get(signature)
-        is_base = base_names is None or name in base_names
+
+        # When no base pass ran for an env (``base_names is None``),
+        # treat the dep as base only if no fork ran either; with forks
+        # but no base attribution, base status is unknowable and the
+        # safe answer is to keep the membership OR.
+        is_base = (
+            (name in base_names)
+            if base_names is not None
+            else (env_fork_counts[signature] == 1)
+        )
         if len(labels) >= env_fork_counts[signature] and is_base:
             contributions.append(
                 tuple_env_markers.get(labels[0], tuple_markers[labels[0]])

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -30,7 +30,7 @@ from .._vendor.packaging.pylock import (
 from .._vendor.packaging.specifiers import SpecifierSet
 from .._vendor.packaging.utils import canonicalize_name
 from .._vendor.packaging.version import Version
-from ..config import conflict_exclusion_groups
+from ..config import conflict_exclusion_groups, conflict_member_groups
 from .disjointness import validate_marker_disjointness
 
 if TYPE_CHECKING:
@@ -104,6 +104,7 @@ def build_pylock(lock_input: LockInput, *, lock_dir: Path | None = None) -> Pylo
         extras=lock_input.extras,
         groups=lock_input.dependency_groups,
         exclusive_groups=conflict_exclusion_groups(lock_input.conflicts),
+        declared_groups=conflict_member_groups(lock_input.conflicts),
     )
     tool: dict[str, Any] | None = (
         {"nab": lock_input.provenance.to_block()}

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -34,7 +34,7 @@ from ..config import conflict_exclusion_groups
 from .disjointness import validate_marker_disjointness
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Iterable, Mapping, Sequence
 
     from ..lockfile import (
         LockInput,
@@ -278,14 +278,34 @@ def _build_per_tuple_packages(lock_input: LockInput, lock_dir: Path) -> list[Pac
 
     The emitted marker is the raw OR of the per-tuple marker
     expressions; no Boolean minimisation runs.
+
+    A conflict fork injects a membership clause into every tuple's
+    ``tuple_markers`` entry, including the forks' base dependencies.
+    A base dependency present in every fork of an environment must
+    install regardless of which member is selected, so for that
+    environment it contributes the membership-free env-only marker
+    rather than the OR of the per-fork membership markers.
     """
     out: list[Package] = []
     by_name = _group_by_name(lock_input.per_tuple_pins)
     total_tuples = len(lock_input.tuple_markers)
+    env_signatures = _env_signatures(
+        lock_input.tuple_markers, lock_input.tuple_environments
+    )
+    env_fork_counts = _count(
+        env_signatures[label] for label in lock_input.tuple_markers
+    )
     for per_tuple in by_name.values():
         groups = _group_pins_by_pin(per_tuple)
         for pins, tuple_labels in groups:
-            marker = _build_marker(tuple_labels, lock_input.tuple_markers, total_tuples)
+            marker = _build_marker(
+                tuple_labels,
+                lock_input.tuple_markers,
+                lock_input.tuple_env_markers,
+                env_signatures,
+                env_fork_counts,
+                total_tuples,
+            )
             out.append(
                 _pin_to_package(_merge_pins_in_group(pins), marker, lock_dir=lock_dir)
             )
@@ -400,21 +420,77 @@ def _merge_pins_in_group(pins: list[PinShape]) -> PinShape:
 def _build_marker(
     tuple_labels: Sequence[str],
     tuple_markers: Mapping[str, Marker],
+    tuple_env_markers: Mapping[str, Marker],
+    env_signatures: Mapping[str, tuple[tuple[str, str], ...]],
+    env_fork_counts: Mapping[tuple[tuple[str, str], ...], int],
     total_tuples: int,
 ) -> Marker | None:
     """Return the marker selecting ``tuple_labels``, or ``None`` if unconditional.
 
     The package is unconditional when ``tuple_labels`` covers every
     declared tuple in ``tuple_markers``.  Otherwise the marker is the
-    OR of the per-tuple markers.  When ``tuple_markers`` is empty the
-    caller has not declared a tuple universe and we omit the marker.
+    OR of one contribution per environment the package appears in:
+    when the package is present in every fork of an environment it
+    contributes that environment's membership-free env-only marker, and
+    when present in only some forks it contributes the OR of the
+    membership-carrying per-fork markers.  When ``tuple_markers`` is
+    empty the caller has not declared a tuple universe and we omit the
+    marker.
+
+    With no conflict forks there is one fork per environment, so a
+    present package always covers its whole environment and the env-only
+    marker equals the per-tuple marker: the emitted markers match the
+    no-conflict path byte for byte.
     """
     if total_tuples == 0 or len(tuple_labels) >= total_tuples:
         return None
-    markers = [tuple_markers[label] for label in tuple_labels if label in tuple_markers]
-    if not markers:
+    present = [label for label in tuple_labels if label in tuple_markers]
+    if not present:
         return None
-    return _or_markers(markers)
+    by_env: defaultdict[tuple[tuple[str, str], ...], list[str]] = defaultdict(list)
+    for label in present:
+        by_env[env_signatures[label]].append(label)
+    contributions: list[Marker] = []
+    for signature, labels in by_env.items():
+        if len(labels) >= env_fork_counts[signature]:
+            contributions.append(
+                tuple_env_markers.get(labels[0], tuple_markers[labels[0]])
+            )
+        else:
+            contributions.extend(tuple_markers[label] for label in labels)
+    return _or_markers(contributions)
+
+
+def _env_signatures(
+    tuple_markers: Mapping[str, Marker],
+    tuple_environments: Mapping[str, Mapping[str, str]],
+) -> dict[str, tuple[tuple[str, str], ...]]:
+    """Map each tuple label to a hashable signature of its environment.
+
+    Two labels share an environment (differ only by conflict-fork
+    selection) when their environment dicts are equal, so the sorted
+    items form a stable, hashable key.  A label without a declared
+    environment falls back to a signature unique to itself, so it
+    never groups with another label: the env-only marker collapses to
+    the per-tuple marker and the no-conflict behaviour is preserved.
+    """
+    signatures: dict[str, tuple[tuple[str, str], ...]] = {}
+    for label in tuple_markers:
+        env = tuple_environments.get(label)
+        signatures[label] = (
+            tuple(sorted(env.items())) if env is not None else (("__label__", label),)
+        )
+    return signatures
+
+
+def _count(
+    signatures: Iterable[tuple[tuple[str, str], ...]],
+) -> dict[tuple[tuple[str, str], ...], int]:
+    """Count how many forks each environment signature spans."""
+    counts: defaultdict[tuple[tuple[str, str], ...], int] = defaultdict(int)
+    for signature in signatures:
+        counts[signature] += 1
+    return counts
 
 
 def _or_markers(markers: Sequence[Marker]) -> Marker:

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -62,6 +62,7 @@ __all__ = [
     "ResolveMode",
     "conflict_exclusion_groups",
     "conflict_forks",
+    "conflict_member_groups",
     "read_pyproject_config",
     "validate_conflict_exclusions",
     "validate_conflict_minimums",
@@ -197,6 +198,22 @@ def conflict_exclusion_groups(
         frozenset((m.kind.value, m.name) for m in cs.members)
         for cs in conflicts
         if cs.policy is not ConflictPolicy.AT_LEAST_ONE
+    )
+
+
+def conflict_member_groups(
+    conflicts: Sequence[ConflictSet],
+) -> tuple[frozenset[tuple[str, str]], ...]:
+    """Project every conflict set (any policy) to ``(kind, name)`` member sets.
+
+    Distinct from :func:`conflict_exclusion_groups`, which drops
+    :attr:`ConflictPolicy.AT_LEAST_ONE` because that policy permits
+    co-selection.  The disjointness validator uses this projection to
+    tell already-declared collisions from undeclared ones when shaping
+    the hint.
+    """
+    return tuple(
+        frozenset((m.kind.value, m.name) for m in cs.members) for cs in conflicts
     )
 
 
@@ -367,12 +384,19 @@ def validate_conflict_minimums(
         )
         if any_active:
             continue
-        if conflict_set.policy is ConflictPolicy.EXACTLY_ONE:
-            msg = f"exactly one of {conflict_set} must be selected"
-            raise ConflictSelectionError(msg)
-        if conflict_set.policy is ConflictPolicy.AT_LEAST_ONE:
-            msg = f"at least one of {conflict_set} must be selected"
-            raise ConflictSelectionError(msg)
+        if conflict_set.policy is ConflictPolicy.AT_MOST_ONE:
+            continue
+        members = ", ".join(str(m) for m in conflict_set.members)
+        quantifier = (
+            "exactly one"
+            if conflict_set.policy is ConflictPolicy.EXACTLY_ONE
+            else "at least one"
+        )
+        msg = (
+            f"{quantifier} of {members} must be selected: declared"
+            f" {conflict_set.policy.value} in [tool.nab].conflicts"
+        )
+        raise ConflictSelectionError(msg)
 
 
 def validate_conflict_exclusions(

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -41,15 +41,22 @@ from .workspace import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Sequence
     from pathlib import Path
 
 __all__ = [
     "ConfigError",
+    "ConflictKind",
+    "ConflictMember",
+    "ConflictPolicy",
+    "ConflictSelectionError",
+    "ConflictSet",
     "MatrixConfig",
     "NabProjectConfig",
     "ResolveMode",
+    "conflict_exclusion_groups",
     "read_pyproject_config",
+    "validate_conflict_selection",
 ]
 
 
@@ -74,6 +81,7 @@ _TOP_LEVEL_KEYS = frozenset(
         "matrix",
         "resolution",
         "workspace",
+        "conflicts",
     },
 )
 
@@ -105,6 +113,81 @@ class MatrixConfig:
     implementations: tuple[str, ...] = ("cpython",)
 
 
+class ConflictPolicy(enum.Enum):
+    """How exclusive the members of a :class:`ConflictSet` are.
+
+    Mirrors Gentoo's ``REQUIRED_USE`` group operators.  ``AT_MOST_ONE``
+    (``??``) is the default for a bare uv-style set: the members are
+    mutually exclusive but selecting none is fine, which suits opt-in
+    extras.  ``EXACTLY_ONE`` (``^^``) additionally requires one to be
+    chosen.  ``AT_LEAST_ONE`` (``||``) only forbids the empty
+    selection; it is rarely useful for extras and is included for
+    completeness.
+    """
+
+    AT_MOST_ONE = "at_most_one"
+    EXACTLY_ONE = "exactly_one"
+    AT_LEAST_ONE = "at_least_one"
+
+
+class ConflictKind(enum.Enum):
+    """Whether a :class:`ConflictMember` names an extra or a group."""
+
+    EXTRA = "extra"
+    GROUP = "group"
+
+
+@dataclass(frozen=True, slots=True)
+class ConflictMember:
+    """One side of a conflict: a named extra or dependency group.
+
+    ``name`` is stored canonicalised (PEP 685 for extras, PEP 735 for
+    groups) so a selection compares equal regardless of how the user
+    spelled it.  An extra and a group sharing a name are distinct
+    members, matching uv's package-qualified model.
+    """
+
+    kind: ConflictKind
+    name: str
+
+    def __str__(self) -> str:
+        """Render as ``extra 'cpu'`` / ``group 'black22'`` for messages."""
+        return f"{self.kind.value} {self.name!r}"
+
+
+@dataclass(frozen=True, slots=True)
+class ConflictSet:
+    """A set of mutually-exclusive members with an exclusivity policy."""
+
+    members: tuple[ConflictMember, ...]
+    policy: ConflictPolicy = ConflictPolicy.AT_MOST_ONE
+
+    def __str__(self) -> str:
+        """Render as ``at_most_one (extra 'cpu', extra 'gpu')`` for messages."""
+        joined = ", ".join(str(m) for m in self.members)
+        return f"{self.policy.value} ({joined})"
+
+
+def conflict_exclusion_groups(
+    conflicts: Sequence[ConflictSet],
+) -> tuple[frozenset[tuple[str, str]], ...]:
+    """Project conflict sets to the neutral exclusion form the lockfile uses.
+
+    The disjointness validator consumes a sequence of member sets, of
+    which at most one member may be active in any install context.
+    Only :attr:`ConflictPolicy.AT_MOST_ONE` and
+    :attr:`ConflictPolicy.EXACTLY_ONE` forbid co-selection, so only
+    those contribute; :attr:`ConflictPolicy.AT_LEAST_ONE` constrains the
+    empty selection, not co-selection, and is omitted.  Each member
+    becomes a ``(kind, canonical_name)`` pair.
+    """
+    return tuple(
+        frozenset((m.kind.value, m.name) for m in cs.members)
+        for cs in conflicts
+        if cs.policy is not ConflictPolicy.AT_LEAST_ONE
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class NabProjectConfig:
     """Everything ``[tool.nab]`` says about how to resolve this project."""
@@ -132,6 +215,7 @@ class NabProjectConfig:
     matrix: MatrixConfig | None = None
     resolution: ResolutionStrategy = ResolutionStrategy.HIGHEST
     workspace: WorkspaceConfig | None = None
+    conflicts: tuple[ConflictSet, ...] = ()
     # Canonical names of workspace members. Populated by
     # _apply_workspace_discovery; empty otherwise. Distinct from
     # ``local_sources``, which also carries explicit
@@ -141,6 +225,64 @@ class NabProjectConfig:
 
 class ConfigError(ValueError):
     """Raised when ``[tool.nab]`` is structurally invalid."""
+
+
+class ConflictSelectionError(ConfigError):
+    """A requested extra/group selection violates a declared conflict.
+
+    Raised on the single-environment path, where one resolution cannot
+    serve two mutually-exclusive members at once.  Universal mode forks
+    the resolve instead of raising.
+    """
+
+
+def _member_active(
+    member: ConflictMember,
+    active_extras: set[str],
+    active_groups: set[str],
+) -> bool:
+    if member.kind is ConflictKind.EXTRA:
+        return member.name in active_extras
+    return member.name in active_groups
+
+
+def validate_conflict_selection(
+    conflicts: Sequence[ConflictSet],
+    selected_extras: Sequence[str],
+    selected_groups: Sequence[str],
+) -> None:
+    """Raise when a selection breaks a declared conflict's policy.
+
+    For a single-environment resolve, two members of an at-most-one or
+    exactly-one set cannot both be active, an exactly-one set must have
+    one active member, and an at-least-one set must have at least one.
+    Names compare under canonicalisation.  Universal mode does not call
+    this for the co-selection case: it forks the matrix so each member
+    resolves on its own.
+    """
+    active_extras = {canonicalize_name(e) for e in selected_extras}
+    active_groups = {canonicalize_name(g) for g in selected_groups}
+    for conflict_set in conflicts:
+        active = [
+            m
+            for m in conflict_set.members
+            if _member_active(m, active_extras, active_groups)
+        ]
+        policy = conflict_set.policy
+        exclusive = {ConflictPolicy.AT_MOST_ONE, ConflictPolicy.EXACTLY_ONE}
+        if len(active) > 1 and policy in exclusive:
+            chosen = ", ".join(str(m) for m in active)
+            msg = (
+                f"{chosen} cannot be selected together: declared mutually"
+                f" exclusive ({policy.value}) in [tool.nab].conflicts"
+            )
+            raise ConflictSelectionError(msg)
+        if not active and policy is ConflictPolicy.EXACTLY_ONE:
+            msg = f"exactly one of {conflict_set} must be selected"
+            raise ConflictSelectionError(msg)
+        if not active and policy is ConflictPolicy.AT_LEAST_ONE:
+            msg = f"at least one of {conflict_set} must be selected"
+            raise ConflictSelectionError(msg)
 
 
 def read_pyproject_config(
@@ -301,6 +443,7 @@ def _parse_nab_table(
             ResolutionStrategy.HIGHEST,
         ),
         workspace=_parse_workspace(raw.get("workspace")),
+        conflicts=_parse_conflicts(raw.get("conflicts")),
     )
 
 
@@ -849,6 +992,108 @@ def _parse_workspace(value: object) -> WorkspaceConfig | None:
         raise ConfigError(msg)
     members = _parse_string_list("workspace.members", value.get("members", []))
     return WorkspaceConfig(members=members)
+
+
+_MIN_CONFLICT_MEMBERS = 2
+_CONFLICT_POLICY_KEYS = {p.value: p for p in ConflictPolicy}
+
+
+def _parse_conflicts(value: object) -> tuple[ConflictSet, ...]:
+    """Parse the optional ``[tool.nab].conflicts`` array.
+
+    Each item is either a bare array of members (uv-compatible; the
+    members are mutually exclusive under the default at-most-one
+    policy) or a single-key table naming the policy
+    (``at_most_one``/``exactly_one``/``at_least_one``) whose value is
+    the member array.  A member is ``{ extra = "NAME" }`` or
+    ``{ group = "NAME" }``.  Reference validation (the extra or group
+    actually exists) happens at resolve time, where the project tables
+    are read.
+    """
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        msg = f"conflicts must be an array of conflict sets, got {type(value).__name__}"
+        raise ConfigError(msg)
+    return tuple(_parse_conflict_set(item, i) for i, item in enumerate(value))
+
+
+def _parse_conflict_set(item: object, index: int) -> ConflictSet:
+    where = f"conflicts[{index}]"
+    if isinstance(item, list):
+        return ConflictSet(
+            members=_parse_conflict_members(item, where),
+            policy=ConflictPolicy.AT_MOST_ONE,
+        )
+    if isinstance(item, dict):
+        keys = set(item)
+        unknown = sorted(keys - _CONFLICT_POLICY_KEYS.keys())
+        if unknown:
+            msg = (
+                f"{where}: unknown conflict-set key(s) {unknown!r}; expected a"
+                f" policy table with one of {sorted(_CONFLICT_POLICY_KEYS)!r}"
+                " or a bare array of members"
+            )
+            raise ConfigError(msg)
+        if len(keys) != 1:
+            msg = (
+                f"{where}: a policy conflict set must name exactly one policy"
+                f" of {sorted(_CONFLICT_POLICY_KEYS)!r}, got {sorted(keys)!r}"
+            )
+            raise ConfigError(msg)
+        policy_key = next(iter(keys))
+        return ConflictSet(
+            members=_parse_conflict_members(item[policy_key], f"{where}.{policy_key}"),
+            policy=_CONFLICT_POLICY_KEYS[policy_key],
+        )
+    msg = (
+        f"{where} must be an array of members or a policy table, got"
+        f" {type(item).__name__}"
+    )
+    raise ConfigError(msg)
+
+
+def _parse_conflict_members(value: object, where: str) -> tuple[ConflictMember, ...]:
+    if not isinstance(value, list):
+        msg = f"{where} must be an array of members, got {type(value).__name__}"
+        raise ConfigError(msg)
+    members = tuple(
+        _parse_conflict_member(item, f"{where}[{i}]") for i, item in enumerate(value)
+    )
+    if len(members) < _MIN_CONFLICT_MEMBERS:
+        msg = (
+            f"{where} must list at least {_MIN_CONFLICT_MEMBERS} members to be"
+            f" a conflict; got {len(members)}"
+        )
+        raise ConfigError(msg)
+    if len(set(members)) != len(members):
+        msg = f"{where} lists a member more than once"
+        raise ConfigError(msg)
+    return members
+
+
+def _parse_conflict_member(item: object, where: str) -> ConflictMember:
+    if not isinstance(item, dict):
+        msg = (
+            f"{where} must be a table {{ extra = ... }} or {{ group = ... }},"
+            f" got {type(item).__name__}"
+        )
+        raise ConfigError(msg)
+    kinds = {k.value for k in ConflictKind}
+    unknown = sorted(set(item) - kinds)
+    if unknown:
+        msg = f"{where}: unknown member key(s) {unknown!r}; expected {sorted(kinds)!r}"
+        raise ConfigError(msg)
+    present = sorted(set(item) & kinds)
+    if len(present) != 1:
+        msg = f"{where} must name exactly one of {sorted(kinds)!r}, got {present!r}"
+        raise ConfigError(msg)
+    kind = ConflictKind(present[0])
+    name = item[present[0]]
+    if not isinstance(name, str) or not name:
+        msg = f"{where}.{kind.value} must be a non-empty string, got {name!r}"
+        raise ConfigError(msg)
+    return ConflictMember(kind=kind, name=canonicalize_name(name))
 
 
 _MINOR_RELEASE_PARTS = 2

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -16,6 +16,7 @@ from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
 import tomli
+from typing_extensions import override
 
 from nab_index.multi_index import IndexConfig
 
@@ -43,6 +44,7 @@ from .workspace import (
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
+    from collections.abc import Set as AbstractSet
     from pathlib import Path
 
 __all__ = [
@@ -59,6 +61,7 @@ __all__ = [
     "conflict_exclusion_groups",
     "conflict_forks",
     "read_pyproject_config",
+    "validate_conflict_minimums",
     "validate_conflict_selection",
 ]
 
@@ -153,6 +156,7 @@ class ConflictMember:
     kind: ConflictKind
     name: str
 
+    @override
     def __str__(self) -> str:
         """Render as ``extra 'cpu'`` / ``group 'black22'`` for messages."""
         return f"{self.kind.value} {self.name!r}"
@@ -165,6 +169,7 @@ class ConflictSet:
     members: tuple[ConflictMember, ...]
     policy: ConflictPolicy = ConflictPolicy.AT_MOST_ONE
 
+    @override
     def __str__(self) -> str:
         """Render as ``at_most_one (extra 'cpu', extra 'gpu')`` for messages."""
         joined = ", ".join(str(m) for m in self.members)
@@ -323,13 +328,43 @@ class ConflictSelectionError(ConfigError):
 
 def _member_active(
     member: ConflictMember,
-    active_extras: set[str],
-    active_groups: set[str],
+    active_extras: AbstractSet[str],
+    active_groups: AbstractSet[str],
 ) -> bool:
     """Return True when ``member`` is in the selected extras/groups."""
     if member.kind is ConflictKind.EXTRA:
         return member.name in active_extras
     return member.name in active_groups
+
+
+def validate_conflict_minimums(
+    conflicts: Sequence[ConflictSet],
+    selected_extras: Sequence[str],
+    selected_groups: Sequence[str],
+) -> None:
+    """Raise when a require-one set has no active member.
+
+    Enforces only the "must select one" policies: an exactly-one set
+    and an at-least-one set each require at least one active member.
+    Names compare under canonicalisation.  Universal mode calls this to
+    apply the minimums without the co-selection rejection, which it
+    handles by forking instead.
+    """
+    active_extras = {canonicalize_name(e) for e in selected_extras}
+    active_groups = {canonicalize_name(g) for g in selected_groups}
+    for conflict_set in conflicts:
+        any_active = any(
+            _member_active(m, active_extras, active_groups)
+            for m in conflict_set.members
+        )
+        if any_active:
+            continue
+        if conflict_set.policy is ConflictPolicy.EXACTLY_ONE:
+            msg = f"exactly one of {conflict_set} must be selected"
+            raise ConflictSelectionError(msg)
+        if conflict_set.policy is ConflictPolicy.AT_LEAST_ONE:
+            msg = f"at least one of {conflict_set} must be selected"
+            raise ConflictSelectionError(msg)
 
 
 def validate_conflict_selection(
@@ -348,27 +383,21 @@ def validate_conflict_selection(
     """
     active_extras = {canonicalize_name(e) for e in selected_extras}
     active_groups = {canonicalize_name(g) for g in selected_groups}
+    exclusive = {ConflictPolicy.AT_MOST_ONE, ConflictPolicy.EXACTLY_ONE}
     for conflict_set in conflicts:
         active = [
             m
             for m in conflict_set.members
             if _member_active(m, active_extras, active_groups)
         ]
-        policy = conflict_set.policy
-        exclusive = {ConflictPolicy.AT_MOST_ONE, ConflictPolicy.EXACTLY_ONE}
-        if len(active) > 1 and policy in exclusive:
+        if len(active) > 1 and conflict_set.policy in exclusive:
             chosen = ", ".join(str(m) for m in active)
             msg = (
                 f"{chosen} cannot be selected together: declared mutually"
-                f" exclusive ({policy.value}) in [tool.nab].conflicts"
+                f" exclusive ({conflict_set.policy.value}) in [tool.nab].conflicts"
             )
             raise ConflictSelectionError(msg)
-        if not active and policy is ConflictPolicy.EXACTLY_ONE:
-            msg = f"exactly one of {conflict_set} must be selected"
-            raise ConflictSelectionError(msg)
-        if not active and policy is ConflictPolicy.AT_LEAST_ONE:
-            msg = f"at least one of {conflict_set} must be selected"
-            raise ConflictSelectionError(msg)
+    validate_conflict_minimums(conflicts, selected_extras, selected_groups)
 
 
 def read_pyproject_config(
@@ -485,12 +514,14 @@ def _parse_nab_table(
             )
             raise ConfigError(msg)
 
+    default_groups = _parse_string_list("default-groups", raw.get("default-groups", []))
+    conflicts = _parse_conflicts(raw.get("conflicts"))
+    _validate_default_groups_against_conflicts(default_groups, conflicts)
+
     return NabProjectConfig(
         mode=mode,
         constraints=_parse_string_list("constraints", raw.get("constraints", [])),
-        default_groups=_parse_string_list(
-            "default-groups", raw.get("default-groups", [])
-        ),
+        default_groups=default_groups,
         requires_python=_parse_requires_python(raw.get("requires-python")),
         uploaded_prior_to=_parse_uploaded_prior_to(
             raw.get("uploaded-prior-to"), anchor=anchor
@@ -529,7 +560,7 @@ def _parse_nab_table(
             ResolutionStrategy.HIGHEST,
         ),
         workspace=_parse_workspace(raw.get("workspace")),
-        conflicts=_parse_conflicts(raw.get("conflicts")),
+        conflicts=conflicts,
     )
 
 
@@ -1082,6 +1113,7 @@ def _parse_workspace(value: object) -> WorkspaceConfig | None:
 
 _MIN_CONFLICT_MEMBERS = 2
 _CONFLICT_POLICY_KEYS = {p.value: p for p in ConflictPolicy}
+_CANONICAL_NAME_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
 
 
 def _parse_conflicts(value: object) -> tuple[ConflictSet, ...]:
@@ -1099,7 +1131,45 @@ def _parse_conflicts(value: object) -> tuple[ConflictSet, ...]:
     if not isinstance(value, list):
         msg = f"conflicts must be an array of conflict sets, got {type(value).__name__}"
         raise ConfigError(msg)
-    return tuple(_parse_conflict_set(item, i) for i, item in enumerate(value))
+    sets = tuple(_parse_conflict_set(item, i) for i, item in enumerate(value))
+    seen: set[ConflictMember] = set()
+    for conflict_set in sets:
+        for member in conflict_set.members:
+            if member in seen:
+                msg = (
+                    f"conflicts declares {member} in more than one set;"
+                    " a member may belong to at most one conflict set"
+                )
+                raise ConfigError(msg)
+            seen.add(member)
+    return sets
+
+
+def _validate_default_groups_against_conflicts(
+    default_groups: Sequence[str],
+    conflicts: Sequence[ConflictSet],
+) -> None:
+    """Reject default-groups that co-activate an exclusive conflict set.
+
+    A default install activates every default group with no user
+    selection, so the emit-time disjointness validator never sees them.
+    Two default groups in the same at-most-one or exactly-one set would
+    silently violate the declared conflict; catch it at parse time.
+    """
+    active = {canonicalize_name(g) for g in default_groups}
+    for group in conflict_exclusion_groups(conflicts):
+        co_active = sorted(
+            name
+            for kind, name in group
+            if kind == ConflictKind.GROUP.value and name in active
+        )
+        if len(co_active) >= _MIN_CONFLICT_MEMBERS:
+            joined = ", ".join(repr(name) for name in co_active)
+            msg = (
+                f"default-groups activates {joined}, which are declared"
+                " mutually exclusive in [tool.nab].conflicts"
+            )
+            raise ConfigError(msg)
 
 
 def _parse_conflict_set(item: object, index: int) -> ConflictSet:
@@ -1177,7 +1247,14 @@ def _parse_conflict_member(item: object, where: str) -> ConflictMember:
     if not isinstance(name, str) or not name:
         msg = f"{where}.{kind.value} must be a non-empty string, got {name!r}"
         raise ConfigError(msg)
-    return ConflictMember(kind=kind, name=canonicalize_name(name))
+    canonical = canonicalize_name(name)
+    if _CANONICAL_NAME_PATTERN.match(canonical) is None:
+        msg = (
+            f"{where}.{kind.value} is not a valid extra/group name: {name!r}"
+            f" (canonicalises to {canonical!r})"
+        )
+        raise ConfigError(msg)
+    return ConflictMember(kind=kind, name=canonical)
 
 
 _MINOR_RELEASE_PARTS = 2

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -66,7 +66,6 @@ __all__ = [
     "read_pyproject_config",
     "validate_conflict_exclusions",
     "validate_conflict_minimums",
-    "validate_conflict_selection",
 ]
 
 
@@ -428,24 +427,6 @@ def validate_conflict_exclusions(
                 f" exclusive ({conflict_set.policy.value}) in [tool.nab].conflicts"
             )
             raise ConflictSelectionError(msg)
-
-
-def validate_conflict_selection(
-    conflicts: Sequence[ConflictSet],
-    selected_extras: Sequence[str],
-    selected_groups: Sequence[str],
-) -> None:
-    """Raise when a selection breaks a declared conflict's policy.
-
-    For a single-environment resolve, two members of an at-most-one or
-    exactly-one set cannot both be active, an exactly-one set must have
-    one active member, and an at-least-one set must have at least one.
-    Names compare under canonicalisation.  Universal mode does not call
-    this for the co-selection case: it forks the matrix so each member
-    resolves on its own.
-    """
-    validate_conflict_exclusions(conflicts, selected_extras, selected_groups)
-    validate_conflict_minimums(conflicts, selected_extras, selected_groups)
 
 
 def read_pyproject_config(
@@ -1240,7 +1221,7 @@ def _validate_default_groups_against_conflicts(
             for kind, name in group
             if kind == ConflictKind.GROUP.value and name in active
         )
-        if len(co_active) >= _MIN_CONFLICT_MEMBERS:
+        if len(co_active) >= _MIN_ENGAGED_MEMBERS:
             joined = ", ".join(repr(name) for name in co_active)
             msg = (
                 f"default-groups activates {joined}, which are declared"

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -20,9 +20,10 @@ from typing_extensions import override
 
 from nab_index.multi_index import IndexConfig
 
+from ._conflict_kind import KIND_EXTRA, KIND_GROUP
 from ._toml import tool_nab_section
 from ._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
-from ._vendor.packaging.utils import canonicalize_name
+from ._vendor.packaging.utils import InvalidName, canonicalize_name
 from ._vendor.packaging.version import InvalidVersion, Version
 from .fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, IndexOverride
 from .provider import (
@@ -62,6 +63,7 @@ __all__ = [
     "conflict_exclusion_groups",
     "conflict_forks",
     "read_pyproject_config",
+    "validate_conflict_exclusions",
     "validate_conflict_minimums",
     "validate_conflict_selection",
 ]
@@ -141,8 +143,8 @@ class ConflictPolicy(enum.Enum):
 class ConflictKind(enum.Enum):
     """Whether a :class:`ConflictMember` names an extra or a group."""
 
-    EXTRA = "extra"
-    GROUP = "group"
+    EXTRA = KIND_EXTRA
+    GROUP = KIND_GROUP
 
 
 @dataclass(frozen=True, slots=True)
@@ -214,6 +216,9 @@ class ConflictFork:
     active_groups: tuple[str, ...]
 
 
+# Two active selections engage the set's exclusivity, forcing a fork.
+# Distinct from ``_MIN_CONFLICT_MEMBERS`` (a structural check on the
+# declaration), which happens to be the same number for unrelated reasons.
 _MIN_ENGAGED_MEMBERS = 2
 
 
@@ -370,19 +375,18 @@ def validate_conflict_minimums(
             raise ConflictSelectionError(msg)
 
 
-def validate_conflict_selection(
+def validate_conflict_exclusions(
     conflicts: Sequence[ConflictSet],
     selected_extras: Sequence[str],
     selected_groups: Sequence[str],
 ) -> None:
-    """Raise when a selection breaks a declared conflict's policy.
+    """Raise when a selection co-activates two members of an exclusive set.
 
-    For a single-environment resolve, two members of an at-most-one or
-    exactly-one set cannot both be active, an exactly-one set must have
-    one active member, and an at-least-one set must have at least one.
-    Names compare under canonicalisation.  Universal mode does not call
-    this for the co-selection case: it forks the matrix so each member
-    resolves on its own.
+    An at-most-one or exactly-one set cannot have two active members at
+    once.  Names compare under canonicalisation.  Universal mode applies
+    this per fork, against the self-reference- and include-expanded
+    active set, to catch members an umbrella selection reaches only
+    transitively (one fork cannot serve two of them disjointly).
     """
     active_extras = {canonicalize_name(e) for e in selected_extras}
     active_groups = {canonicalize_name(g) for g in selected_groups}
@@ -400,6 +404,23 @@ def validate_conflict_selection(
                 f" exclusive ({conflict_set.policy.value}) in [tool.nab].conflicts"
             )
             raise ConflictSelectionError(msg)
+
+
+def validate_conflict_selection(
+    conflicts: Sequence[ConflictSet],
+    selected_extras: Sequence[str],
+    selected_groups: Sequence[str],
+) -> None:
+    """Raise when a selection breaks a declared conflict's policy.
+
+    For a single-environment resolve, two members of an at-most-one or
+    exactly-one set cannot both be active, an exactly-one set must have
+    one active member, and an at-least-one set must have at least one.
+    Names compare under canonicalisation.  Universal mode does not call
+    this for the co-selection case: it forks the matrix so each member
+    resolves on its own.
+    """
+    validate_conflict_exclusions(conflicts, selected_extras, selected_groups)
     validate_conflict_minimums(conflicts, selected_extras, selected_groups)
 
 
@@ -1141,9 +1162,11 @@ def _parse_workspace(value: object) -> WorkspaceConfig | None:
     return WorkspaceConfig(members=members)
 
 
+# A declared conflict set must list at least this many members to mean
+# anything.  Distinct from ``_MIN_ENGAGED_MEMBERS`` (a runtime engagement
+# threshold), which happens to be the same number for unrelated reasons.
 _MIN_CONFLICT_MEMBERS = 2
 _CONFLICT_POLICY_KEYS = {p.value: p for p in ConflictPolicy}
-_CANONICAL_NAME_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
 
 
 def _parse_conflicts(value: object) -> tuple[ConflictSet, ...]:
@@ -1277,13 +1300,15 @@ def _parse_conflict_member(item: object, where: str) -> ConflictMember:
     if not isinstance(name, str) or not name:
         msg = f"{where}.{kind.value} must be a non-empty string, got {name!r}"
         raise ConfigError(msg)
-    canonical = canonicalize_name(name)
-    if _CANONICAL_NAME_PATTERN.match(canonical) is None:
+    try:
+        canonical = canonicalize_name(name, validate=True)
+    except InvalidName:
+        canonical = canonicalize_name(name)
         msg = (
             f"{where}.{kind.value} is not a valid extra/group name: {name!r}"
             f" (canonicalises to {canonical!r})"
         )
-        raise ConfigError(msg)
+        raise ConfigError(msg) from None
     return ConflictMember(kind=kind, name=canonical)
 
 

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -8,6 +8,7 @@ lives on the CLI.  This module owns the project side.
 from __future__ import annotations
 
 import enum
+import itertools
 import logging
 import re
 from dataclasses import dataclass, field, replace
@@ -46,6 +47,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "ConfigError",
+    "ConflictFork",
     "ConflictKind",
     "ConflictMember",
     "ConflictPolicy",
@@ -55,6 +57,7 @@ __all__ = [
     "NabProjectConfig",
     "ResolveMode",
     "conflict_exclusion_groups",
+    "conflict_forks",
     "read_pyproject_config",
     "validate_conflict_selection",
 ]
@@ -189,6 +192,88 @@ def conflict_exclusion_groups(
 
 
 @dataclass(frozen=True, slots=True)
+class ConflictFork:
+    """One fork of a conflict-driven universal resolve.
+
+    ``selection`` is the active conflicting members as ``(kind, name)``
+    pairs.  ``active_extras`` and ``active_groups`` are the full extra
+    and group selections this fork resolves with: the non-conflicting
+    selections plus this fork's chosen members.  An unforked resolve is
+    a single fork with an empty ``selection``.
+    """
+
+    selection: tuple[tuple[str, str], ...]
+    active_extras: tuple[str, ...]
+    active_groups: tuple[str, ...]
+
+
+_MIN_ENGAGED_MEMBERS = 2
+
+
+def conflict_forks(
+    selected_extras: Sequence[str],
+    selected_groups: Sequence[str],
+    conflicts: Sequence[ConflictSet],
+) -> list[ConflictFork]:
+    """Split a selection into one fork per mutually-exclusive combination.
+
+    A conflict set is *engaged* when the selection activates two or more
+    of its members under an exclusivity policy (at-most-one or
+    exactly-one); only an engaged set forces a fork.  Each engaged set
+    contributes one chosen member per fork, and the forks are the
+    cartesian product across engaged sets.  Members of engaged sets are
+    dropped from the shared base; non-conflicting selections stay active
+    in every fork.  With no engaged set the result is a single unforked
+    fork carrying the whole selection.
+
+    Names compare and emit canonicalised; the extra and group loaders
+    normalise on lookup, so a canonical active set resolves the same
+    requirements the user's spelling would.
+    """
+    base_extras = [canonicalize_name(e) for e in selected_extras]
+    base_groups = [canonicalize_name(g) for g in selected_groups]
+    extra_set = set(base_extras)
+    group_set = set(base_groups)
+
+    # Collect the engaged sets (2+ selected members) and the members to
+    # drop from the shared base; each engaged set becomes a fork axis.
+    engaged: list[list[ConflictMember]] = []
+    drop_extras: set[str] = set()
+    drop_groups: set[str] = set()
+    for conflict_set in conflicts:
+        if conflict_set.policy is ConflictPolicy.AT_LEAST_ONE:
+            continue
+        members = [
+            m for m in conflict_set.members if _member_active(m, extra_set, group_set)
+        ]
+        if len(members) < _MIN_ENGAGED_MEMBERS:
+            continue
+        engaged.append(members)
+        for member in members:
+            target = drop_extras if member.kind is ConflictKind.EXTRA else drop_groups
+            target.add(member.name)
+
+    if not engaged:
+        return [ConflictFork((), tuple(base_extras), tuple(base_groups))]
+
+    # One fork per choice of a single member from each engaged set.
+    rest_extras = [e for e in base_extras if e not in drop_extras]
+    rest_groups = [g for g in base_groups if g not in drop_groups]
+    forks: list[ConflictFork] = []
+    for combo in itertools.product(*engaged):
+        chosen_extras = [m.name for m in combo if m.kind is ConflictKind.EXTRA]
+        chosen_groups = [m.name for m in combo if m.kind is ConflictKind.GROUP]
+        forks.append(
+            ConflictFork(
+                selection=tuple(sorted((m.kind.value, m.name) for m in combo)),
+                active_extras=tuple(rest_extras + chosen_extras),
+                active_groups=tuple(rest_groups + chosen_groups),
+            )
+        )
+    return forks
+
+
+@dataclass(frozen=True, slots=True)
 class NabProjectConfig:
     """Everything ``[tool.nab]`` says about how to resolve this project."""
 
@@ -241,6 +326,7 @@ def _member_active(
     active_extras: set[str],
     active_groups: set[str],
 ) -> bool:
+    """Return True when ``member`` is in the selected extras/groups."""
     if member.kind is ConflictKind.EXTRA:
         return member.name in active_extras
     return member.name in active_groups
@@ -1006,9 +1092,7 @@ def _parse_conflicts(value: object) -> tuple[ConflictSet, ...]:
     policy) or a single-key table naming the policy
     (``at_most_one``/``exactly_one``/``at_least_one``) whose value is
     the member array.  A member is ``{ extra = "NAME" }`` or
-    ``{ group = "NAME" }``.  Reference validation (the extra or group
-    actually exists) happens at resolve time, where the project tables
-    are read.
+    ``{ group = "NAME" }``.
     """
     if value is None:
         return ()

--- a/nab-python/src/nab_python/download.py
+++ b/nab-python/src/nab_python/download.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING
 
 from nab_index.client import AsyncSimpleClient
 
-from .lockfile import IndexPin, LockInput
+from .lockfile import IndexPin, LocalPin, LockInput, VcsPin
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -95,6 +95,11 @@ def _entries_for_pin(canonical: str, pin: PinShape) -> Iterable[DownloadEntry]:
     # Only index pins have downloadable artefacts; local and VCS pins are skipped.
     if isinstance(pin, IndexPin):
         yield from _iter_index_pin(canonical, pin)
+    elif isinstance(pin, (LocalPin, VcsPin)):
+        return
+    else:  # pragma: no cover - exhaustive
+        msg = f"unknown pin shape: {pin!r}"
+        raise TypeError(msg)
 
 
 def _iter_index_pin(canonical: str, pin: IndexPin) -> Iterable[DownloadEntry]:

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from ._vendor.packaging.markers import Marker
+    from .config import ConflictSet
 
 
 __all__ = [
@@ -282,3 +283,7 @@ class LockInput:
     dependency_groups: tuple[str, ...] = ()
     default_groups: tuple[str, ...] = ()
     provenance: Provenance | None = None
+    conflicts: tuple[ConflictSet, ...] = ()
+    """Declared ``[tool.nab].conflicts``.  Prunes the disjointness
+    validator's install-context universe so a per-fork lock (one entry
+    per mutually-exclusive extra/group) validates."""

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -263,6 +263,12 @@ class LockInput:
     ``per_tuple_pins``) to the PEP 508 marker that selects that
     tuple.  The writer uses these to build per-package markers.
 
+    ``tuple_env_markers`` maps each tuple label to its
+    environment-only marker (no conflict-fork membership clause).
+    A base dependency present in every fork of an environment emits
+    this marker so it installs even when no conflicting member is
+    selected; with no conflict forks it equals ``tuple_markers``.
+
     ``environments`` is the lockfile-level set of permitted
     environments (PEP 751 ``environments``).  Independent from
     ``tuple_markers``; intended for declaring the universe.
@@ -275,6 +281,7 @@ class LockInput:
     pins: Mapping[str, PinShape] = field(default_factory=dict)
     per_tuple_pins: Mapping[str, Mapping[str, PinShape]] = field(default_factory=dict)
     tuple_markers: Mapping[str, Marker] = field(default_factory=dict)
+    tuple_env_markers: Mapping[str, Marker] = field(default_factory=dict)
     tuple_environments: Mapping[str, Mapping[str, str]] = field(default_factory=dict)
     environments: list[Marker] = field(default_factory=list)
     requires_python: str | None = None

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -271,6 +271,15 @@ class LockInput:
     this marker so it installs even when no conflicting member is
     selected; with no conflict forks it equals ``tuple_markers``.
 
+    ``env_base_names`` maps an environment signature
+    (``tuple(sorted(env.items()))``) to the canonical names that the
+    base (no-member) resolve produced for that environment.  A package
+    present in every conflict fork only counts as a base dependency
+    (and so drops its membership clause) when its name is listed here;
+    a dependency required by every member but not by the base keeps the
+    membership clause, so it does not install when no member is
+    selected.  Empty when no conflict fork ran.
+
     ``environments`` is the lockfile-level set of permitted
     environments (PEP 751 ``environments``).  Independent from
     ``tuple_markers``; intended for declaring the universe.
@@ -285,6 +294,9 @@ class LockInput:
     tuple_markers: Mapping[str, Marker] = field(default_factory=dict)
     tuple_env_markers: Mapping[str, Marker] = field(default_factory=dict)
     tuple_environments: Mapping[str, Mapping[str, str]] = field(default_factory=dict)
+    env_base_names: Mapping[tuple[tuple[str, str], ...], frozenset[str]] = field(
+        default_factory=dict
+    )
     environments: list[Marker] = field(default_factory=list)
     requires_python: str | None = None
     created_by: str = "nab"

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -278,7 +278,14 @@ class LockInput:
     (and so drops its membership clause) when its name is listed here;
     a dependency required by every member but not by the base keeps the
     membership clause, so it does not install when no member is
-    selected.  Empty when no conflict fork ran.
+    selected.
+
+    The missing-key vs empty-frozenset distinction is load-bearing:
+    a missing signature means no base pass ran for that env (with no
+    forks: the no-conflict path; with forks: base status unknowable,
+    so the membership OR is kept).  An empty frozenset means the base
+    pass ran and produced zero pins, so every dep is member-only.
+    Empty when no conflict fork ran.
 
     ``environments`` is the lockfile-level set of permitted
     environments (PEP 751 ``environments``).  Independent from

--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 import tomli
@@ -13,13 +14,14 @@ from ._vendor.packaging.requirements import InvalidRequirement, Requirement
 from ._vendor.packaging.utils import canonicalize_name
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Sequence
     from pathlib import Path
 
     from ._vendor.packaging.ranges import VersionRange
 
 __all__ = [
     "InvalidProjectRequirementError",
+    "expand_group_includes",
     "expand_self_extras",
     "raise_for_unsatisfiable",
     "read_pyproject_dependencies",
@@ -183,6 +185,45 @@ def expand_self_extras(
                 for sub in req.extras
                 if canonicalize_name(sub) not in seen
             )
+    return out
+
+
+def expand_group_includes(
+    groups: Mapping[str, Sequence[str | Mapping[str, str]]],
+    selected: Sequence[str],
+) -> list[str]:
+    """Return ``selected`` plus every group reached through ``include-group``.
+
+    PEP 735 lets one group pull in another with
+    ``{include-group = "other"}``.  A conflict declared on a group must
+    see the groups an umbrella group includes, so the membership test
+    runs over the transitive closure rather than the literal selection.
+    Group names compare canonicalised (PEP 503), matching the loaders.
+
+    Unknown or cyclic includes are tolerated here;
+    :func:`resolve_groups_to_requirements` raises on them when the
+    requirements themselves are loaded.
+    """
+    canonical_groups: dict[str, list[str | Mapping[str, str]]] = {}
+    for name, entries in groups.items():
+        canonical_groups.setdefault(canonicalize_name(name), []).extend(entries)
+
+    out: list[str] = []
+    seen: set[str] = set()
+    worklist = [canonicalize_name(s) for s in selected]
+    while worklist:
+        group = worklist.pop(0)
+        if group in seen:
+            continue
+        seen.add(group)
+        out.append(group)
+        for entry in canonical_groups.get(group, ()):
+            if isinstance(entry, Mapping):
+                include = entry.get("include-group")
+                # A malformed (non-string) include is left for the group
+                # loader to report when the requirements are read.
+                if isinstance(include, str):
+                    worklist.append(canonicalize_name(include))
     return out
 
 

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -33,6 +33,7 @@ from .config import (
     ResolveMode,
     conflict_forks,
     read_pyproject_config,
+    validate_conflict_exclusions,
     validate_conflict_minimums,
     validate_conflict_selection,
 )
@@ -46,6 +47,7 @@ from .provider import (
     split_extra,
 )
 from .requirements_file import (
+    expand_group_includes,
     expand_self_extras,
     raise_for_unsatisfiable,
     read_pyproject_dependencies,
@@ -138,8 +140,18 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
         )
         raise UnsupportedModeError(msg)
 
-    _validate_conflict_members_exist(path, config.conflicts)
-    validate_conflict_selection(config.conflicts, extras, groups)
+    if config.conflicts:
+        # Read each table once and reuse it across the existence check
+        # and the umbrella expansion, so a conflict the selection only
+        # reaches transitively is still caught without re-parsing the
+        # file.
+        optional = read_pyproject_optional_dependencies(path)
+        groups_table = read_pyproject_groups(path)
+        project_name = read_pyproject_name(path)
+        _validate_conflict_members_exist(config.conflicts, optional, groups_table)
+        active_extras = expand_self_extras(optional, project_name, extras)
+        active_groups = expand_group_includes(groups_table, groups)
+        validate_conflict_selection(config.conflicts, active_extras, active_groups)
 
     if python_version is not None:
         effective_python = python_version
@@ -464,21 +476,20 @@ def _extra_requirements_from_table(
 
 
 def _validate_conflict_members_exist(
-    path: Path, conflicts: Sequence[ConflictSet]
+    conflicts: Sequence[ConflictSet],
+    optional: Mapping[str, Sequence[str]],
+    groups: Mapping[str, Sequence[str | Mapping[str, str]]],
 ) -> None:
     """Raise when a declared conflict names an extra/group the project lacks.
 
     A member naming an undeclared extra or group can never match, so
     the conflict would be silently inert.  Names compare under
-    canonicalisation, matching the loaders.  A no-op when no conflicts
-    are declared.
+    canonicalisation, matching the loaders.  The caller passes the
+    already-read ``optional`` and ``groups`` tables so this does not
+    re-parse pyproject.toml.
     """
-    if not conflicts:
-        return
-    known_extras = {
-        canonicalize_name(name) for name in read_pyproject_optional_dependencies(path)
-    }
-    known_groups = {canonicalize_name(name) for name in read_pyproject_groups(path)}
+    known_extras = {canonicalize_name(name) for name in optional}
+    known_groups = {canonicalize_name(name) for name in groups}
     unknown: list[str] = []
     for conflict_set in conflicts:
         for member in conflict_set.members:
@@ -527,6 +538,30 @@ def _fork_requirement_strings(
         )
     )
     return [str(r) for r in requirements]
+
+
+def _base_fork(reference: ConflictFork) -> ConflictFork:
+    """Return the no-member fork: a reference fork minus its chosen members.
+
+    Every fork shares the same non-conflicting base selection, so any
+    fork's active sets with its own chosen members removed recover that
+    base.  Resolving it names the deps that install regardless of which
+    member is selected.
+    """
+    chosen = set(reference.selection)
+    rest_extras = tuple(
+        e
+        for e in reference.active_extras
+        if (ConflictKind.EXTRA.value, e) not in chosen
+    )
+    rest_groups = tuple(
+        g
+        for g in reference.active_groups
+        if (ConflictKind.GROUP.value, g) not in chosen
+    )
+    return ConflictFork(
+        selection=(), active_extras=rest_extras, active_groups=rest_groups
+    )
 
 
 def _augment_resolution_error(exc: ResolutionError, provider: Provider) -> None:
@@ -682,9 +717,6 @@ def resolve_universal_pyproject(
         msg = "mode = 'universal' requires a [tool.nab.matrix] table"
         raise UnsupportedModeError(msg)
 
-    _validate_conflict_members_exist(path, config.conflicts)
-    validate_conflict_minimums(config.conflicts, extras, groups)
-
     base_dependencies = read_pyproject_dependencies(path)
     matrix = Matrix(
         python=config.matrix.python,
@@ -704,9 +736,43 @@ def resolve_universal_pyproject(
         optional=read_pyproject_optional_dependencies(path),
         project_name=read_pyproject_name(path),
     )
+
+    if config.conflicts:
+        # Reuse the already-read tables for every conflict check, and
+        # expand the selection so an umbrella extra or include-group
+        # counts toward both the existence and the require-one checks.
+        _validate_conflict_members_exist(
+            config.conflicts, tables.optional, tables.groups
+        )
+        validate_conflict_minimums(
+            config.conflicts,
+            expand_self_extras(tables.optional, tables.project_name, extras),
+            expand_group_includes(tables.groups, groups),
+        )
+
+    conflict_fork_list = conflict_forks(extras, groups, config.conflicts)
     forks: list[ResolveFork] = []
-    for fork in conflict_forks(extras, groups, config.conflicts):
-        if len(fork.active_groups) > 1:
+    # Forks of an extra-based conflict share the same group selection,
+    # so dedupe to skip the (group, group)->tuple scan once it has run
+    # for an active_groups tuple.
+    seen_group_selections: set[tuple[str, ...]] = set()
+    for fork in conflict_fork_list:
+        if config.conflicts:
+            # A fork that still reaches two members of one exclusive set
+            # (for example through an umbrella extra) has no disjoint
+            # resolution, so refuse rather than silently merge them.
+            validate_conflict_exclusions(
+                config.conflicts,
+                expand_self_extras(
+                    tables.optional, tables.project_name, fork.active_extras
+                ),
+                expand_group_includes(tables.groups, fork.active_groups),
+            )
+        if (
+            len(fork.active_groups) > 1
+            and fork.active_groups not in seen_group_selections
+        ):
+            seen_group_selections.add(fork.active_groups)
             _check_group_disjointness_across_tuples(
                 _group_requirements_by_group_from_table(
                     group_table, fork.active_groups, path=path
@@ -721,12 +787,23 @@ def resolve_universal_pyproject(
                 ),
             )
         )
+
+    # With more than one fork the lock writer needs to tell a base
+    # dependency from one required by every member, so resolve the
+    # no-member requirements too.
+    base_requirements = None
+    if len(conflict_fork_list) > 1:
+        base_requirements = _fork_requirement_strings(
+            path, base_dependencies, _base_fork(conflict_fork_list[0]), tables
+        )
+
     effective_strategy = (
         resolution_strategy if resolution_strategy is not None else config.resolution
     )
     return resolve_universal(
         matrix=matrix,
         forks=forks,
+        base_requirements=base_requirements,
         transport=transport,
         offline=offline,
         constraints=list(config.constraints) or None,

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -35,7 +35,6 @@ from .config import (
     read_pyproject_config,
     validate_conflict_exclusions,
     validate_conflict_minimums,
-    validate_conflict_selection,
 )
 from .fetch import FetchCoordinator
 from .lockfile import LockInput, build_lock_input_from_provider
@@ -156,7 +155,8 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
         _validate_conflict_members_exist(config.conflicts, optional, groups_table)
         active_extras = expand_self_extras(optional, project_name, extras)
         active_groups = expand_group_includes(groups_table, effective_groups)
-        validate_conflict_selection(config.conflicts, active_extras, active_groups)
+        validate_conflict_exclusions(config.conflicts, active_extras, active_groups)
+        validate_conflict_minimums(config.conflicts, active_extras, active_groups)
 
     if python_version is not None:
         effective_python = python_version

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -27,10 +27,13 @@ from ._vendor.packaging.version import InvalidVersion, Version
 from .config import (
     ConfigError,
     ConflictFork,
+    ConflictKind,
+    ConflictSet,
     NabProjectConfig,
     ResolveMode,
     conflict_forks,
     read_pyproject_config,
+    validate_conflict_minimums,
     validate_conflict_selection,
 )
 from .fetch import FetchCoordinator
@@ -135,6 +138,7 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
         )
         raise UnsupportedModeError(msg)
 
+    _validate_conflict_members_exist(path, config.conflicts)
     validate_conflict_selection(config.conflicts, extras, groups)
 
     if python_version is not None:
@@ -225,7 +229,23 @@ def _load_group_requirements(path: Path, selected: Sequence[str]) -> list[Requir
     """Read [dependency-groups] from ``path`` and expand ``selected``."""
     if not selected:
         return []
-    groups = read_pyproject_groups(path)
+    return _group_requirements_from_table(
+        read_pyproject_groups(path), selected, path=path
+    )
+
+
+def _group_requirements_from_table(
+    groups: Mapping[str, Sequence[str | Mapping[str, str]]],
+    selected: Sequence[str],
+    *,
+    path: Path,
+) -> list[Requirement]:
+    """Expand ``selected`` from an already-read group table.
+
+    ``path`` is used only for the missing-table error message.
+    """
+    if not selected:
+        return []
     if not groups:
         msg = (
             "groups requested but [dependency-groups] is missing from"
@@ -243,9 +263,20 @@ def _load_group_requirements_by_group(
     Like :func:`_load_group_requirements`, but keeps each group's
     requirements separate so a caller can name the source group.
     """
+    return _group_requirements_by_group_from_table(
+        read_pyproject_groups(path), selected, path=path
+    )
+
+
+def _group_requirements_by_group_from_table(
+    groups: Mapping[str, Sequence[str | Mapping[str, str]]],
+    selected: Sequence[str],
+    *,
+    path: Path,
+) -> dict[str, list[Requirement]]:
+    """Per-group expansion from an already-read group table."""
     if not selected:
         return {}
-    groups = read_pyproject_groups(path)
     if not groups:
         msg = (
             "groups requested but [dependency-groups] is missing from"
@@ -399,32 +430,101 @@ def _load_extra_requirements(path: Path, selected: Sequence[str]) -> list[Requir
     """
     if not selected:
         return []
-    optional = read_pyproject_optional_dependencies(path)
+    return _extra_requirements_from_table(
+        read_pyproject_optional_dependencies(path),
+        read_pyproject_name(path),
+        selected,
+        path=path,
+    )
+
+
+def _extra_requirements_from_table(
+    optional: Mapping[str, Sequence[str]],
+    project_name: str | None,
+    selected: Sequence[str],
+    *,
+    path: Path,
+) -> list[Requirement]:
+    """Expand ``selected`` extras from an already-read optional-deps table.
+
+    See :func:`_load_extra_requirements` for the self-reference rules;
+    ``path`` is used only for the missing-table error message.
+    """
+    if not selected:
+        return []
     if not optional:
         msg = (
             "extras requested but [project.optional-dependencies] is"
             f" missing from {path}: {sorted(selected)!r}"
         )
         raise LookupError(msg)
-    project_name = read_pyproject_name(path)
     expanded = expand_self_extras(optional, project_name, selected)
     return select_optional_dependencies(optional, expanded)
+
+
+def _validate_conflict_members_exist(
+    path: Path, conflicts: Sequence[ConflictSet]
+) -> None:
+    """Raise when a declared conflict names an extra/group the project lacks.
+
+    A member naming an undeclared extra or group can never match, so
+    the conflict would be silently inert.  Names compare under
+    canonicalisation, matching the loaders.  A no-op when no conflicts
+    are declared.
+    """
+    if not conflicts:
+        return
+    known_extras = {
+        canonicalize_name(name) for name in read_pyproject_optional_dependencies(path)
+    }
+    known_groups = {canonicalize_name(name) for name in read_pyproject_groups(path)}
+    unknown: list[str] = []
+    for conflict_set in conflicts:
+        for member in conflict_set.members:
+            known = known_extras if member.kind is ConflictKind.EXTRA else known_groups
+            if member.name not in known:
+                unknown.append(str(member))
+    if unknown:
+        joined = ", ".join(unknown)
+        msg = (
+            f"[tool.nab].conflicts names {joined}, which the project does not"
+            " declare in [project.optional-dependencies] or [dependency-groups]"
+        )
+        raise ConfigError(msg)
+
+
+@dataclass(frozen=True, slots=True)
+class _ForkTables:
+    """Pyproject tables read once and reused across every conflict fork."""
+
+    groups: Mapping[str, Sequence[str | Mapping[str, str]]]
+    optional: Mapping[str, Sequence[str]]
+    project_name: str | None
 
 
 def _fork_requirement_strings(
     path: Path,
     base_dependencies: Sequence[Requirement],
     fork: ConflictFork,
+    tables: _ForkTables,
 ) -> list[str]:
     """Fold one conflict fork's active groups and extras onto the base deps.
 
     Each fork resolves a different slice of the selection (one member
     per engaged conflict set), so its requirement list is built
-    separately rather than shared across forks.
+    separately rather than shared across forks.  ``tables`` carries the
+    group and optional-dependency tables read once for the whole
+    resolve, so the per-fork loop does not re-read the file.
     """
     requirements = list(base_dependencies)
-    requirements.extend(_load_group_requirements(path, fork.active_groups))
-    requirements.extend(_load_extra_requirements(path, fork.active_extras))
+    requirements.extend(
+        _group_requirements_from_table(tables.groups, fork.active_groups, path=path)
+    )
+    requirements.extend(
+        _extra_requirements_from_table(
+            tables.optional, tables.project_name, fork.active_extras, path=path
+        )
+    )
     return [str(r) for r in requirements]
 
 
@@ -581,6 +681,9 @@ def resolve_universal_pyproject(
         msg = "mode = 'universal' requires a [tool.nab.matrix] table"
         raise UnsupportedModeError(msg)
 
+    _validate_conflict_members_exist(path, config.conflicts)
+    validate_conflict_minimums(config.conflicts, extras, groups)
+
     base_dependencies = read_pyproject_dependencies(path)
     matrix = Matrix(
         python=config.matrix.python,
@@ -593,17 +696,28 @@ def resolve_universal_pyproject(
         ),
         implementations=config.matrix.implementations,
     )
+    expanded_tuples = matrix.expand()
+    group_table = read_pyproject_groups(path)
+    tables = _ForkTables(
+        groups=group_table,
+        optional=read_pyproject_optional_dependencies(path),
+        project_name=read_pyproject_name(path),
+    )
     forks: list[ResolveFork] = []
     for fork in conflict_forks(extras, groups, config.conflicts):
         if len(fork.active_groups) > 1:
             _check_group_disjointness_across_tuples(
-                _load_group_requirements_by_group(path, fork.active_groups),
-                matrix.expand(),
+                _group_requirements_by_group_from_table(
+                    group_table, fork.active_groups, path=path
+                ),
+                expanded_tuples,
             )
         forks.append(
             ResolveFork(
                 selection=fork.selection,
-                requirements=_fork_requirement_strings(path, base_dependencies, fork),
+                requirements=_fork_requirement_strings(
+                    path, base_dependencies, fork, tables
+                ),
             )
         )
     effective_strategy = (

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -26,8 +26,10 @@ from ._vendor.packaging.utils import canonicalize_name
 from ._vendor.packaging.version import InvalidVersion, Version
 from .config import (
     ConfigError,
+    ConflictFork,
     NabProjectConfig,
     ResolveMode,
+    conflict_forks,
     read_pyproject_config,
     validate_conflict_selection,
 )
@@ -52,10 +54,8 @@ from .requirements_file import (
 )
 from .universal.matrix import Matrix
 from .universal.resolve import (
+    ResolveFork,
     UniversalResult,
-    _conflict_forks,
-    _ConflictFork,
-    _ResolveFork,
     resolve_universal,
 )
 
@@ -414,7 +414,7 @@ def _load_extra_requirements(path: Path, selected: Sequence[str]) -> list[Requir
 def _fork_requirement_strings(
     path: Path,
     base_dependencies: Sequence[Requirement],
-    fork: _ConflictFork,
+    fork: ConflictFork,
 ) -> list[str]:
     """Fold one conflict fork's active groups and extras onto the base deps.
 
@@ -593,15 +593,15 @@ def resolve_universal_pyproject(
         ),
         implementations=config.matrix.implementations,
     )
-    forks: list[_ResolveFork] = []
-    for fork in _conflict_forks(extras, groups, config.conflicts):
+    forks: list[ResolveFork] = []
+    for fork in conflict_forks(extras, groups, config.conflicts):
         if len(fork.active_groups) > 1:
             _check_group_disjointness_across_tuples(
                 _load_group_requirements_by_group(path, fork.active_groups),
                 matrix.expand(),
             )
         forks.append(
-            _ResolveFork(
+            ResolveFork(
                 selection=fork.selection,
                 requirements=_fork_requirement_strings(path, base_dependencies, fork),
             )
@@ -611,7 +611,6 @@ def resolve_universal_pyproject(
     )
     return resolve_universal(
         matrix=matrix,
-        requirements=forks[0].requirements,
         forks=forks,
         transport=transport,
         offline=offline,

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -24,7 +24,13 @@ from ._vendor.packaging.requirements import Requirement
 from ._vendor.packaging.specifiers import SpecifierSet
 from ._vendor.packaging.utils import canonicalize_name
 from ._vendor.packaging.version import InvalidVersion, Version
-from .config import ConfigError, NabProjectConfig, ResolveMode, read_pyproject_config
+from .config import (
+    ConfigError,
+    NabProjectConfig,
+    ResolveMode,
+    read_pyproject_config,
+    validate_conflict_selection,
+)
 from .fetch import FetchCoordinator
 from .lockfile import LockInput, build_lock_input_from_provider
 from .provider import (
@@ -45,7 +51,13 @@ from .requirements_file import (
     select_optional_dependencies,
 )
 from .universal.matrix import Matrix
-from .universal.resolve import UniversalResult, resolve_universal
+from .universal.resolve import (
+    UniversalResult,
+    _conflict_forks,
+    _ConflictFork,
+    _ResolveFork,
+    resolve_universal,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -122,6 +134,8 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
             " mode = 'universal'."
         )
         raise UnsupportedModeError(msg)
+
+    validate_conflict_selection(config.conflicts, extras, groups)
 
     if python_version is not None:
         effective_python = python_version
@@ -397,6 +411,23 @@ def _load_extra_requirements(path: Path, selected: Sequence[str]) -> list[Requir
     return select_optional_dependencies(optional, expanded)
 
 
+def _fork_requirement_strings(
+    path: Path,
+    base_dependencies: Sequence[Requirement],
+    fork: _ConflictFork,
+) -> list[str]:
+    """Fold one conflict fork's active groups and extras onto the base deps.
+
+    Each fork resolves a different slice of the selection (one member
+    per engaged conflict set), so its requirement list is built
+    separately rather than shared across forks.
+    """
+    requirements = list(base_dependencies)
+    requirements.extend(_load_group_requirements(path, fork.active_groups))
+    requirements.extend(_load_extra_requirements(path, fork.active_extras))
+    return [str(r) for r in requirements]
+
+
 def _augment_resolution_error(exc: ResolutionError, provider: Provider) -> None:
     """Append per-package NO_VERSIONS diagnostics to ``exc`` in-place.
 
@@ -550,10 +581,7 @@ def resolve_universal_pyproject(
         msg = "mode = 'universal' requires a [tool.nab.matrix] table"
         raise UnsupportedModeError(msg)
 
-    requirements = read_pyproject_dependencies(path)
-    requirements.extend(_load_group_requirements(path, groups))
-    requirements.extend(_load_extra_requirements(path, extras))
-    requirement_strings = [str(r) for r in requirements]
+    base_dependencies = read_pyproject_dependencies(path)
     matrix = Matrix(
         python=config.matrix.python,
         platforms=config.matrix.platforms,
@@ -565,17 +593,26 @@ def resolve_universal_pyproject(
         ),
         implementations=config.matrix.implementations,
     )
-    if len(groups) > 1:
-        _check_group_disjointness_across_tuples(
-            _load_group_requirements_by_group(path, groups),
-            matrix.expand(),
+    forks: list[_ResolveFork] = []
+    for fork in _conflict_forks(extras, groups, config.conflicts):
+        if len(fork.active_groups) > 1:
+            _check_group_disjointness_across_tuples(
+                _load_group_requirements_by_group(path, fork.active_groups),
+                matrix.expand(),
+            )
+        forks.append(
+            _ResolveFork(
+                selection=fork.selection,
+                requirements=_fork_requirement_strings(path, base_dependencies, fork),
+            )
         )
     effective_strategy = (
         resolution_strategy if resolution_strategy is not None else config.resolution
     )
     return resolve_universal(
         matrix=matrix,
-        requirements=requirement_strings,
+        requirements=forks[0].requirements,
+        forks=forks,
         transport=transport,
         offline=offline,
         constraints=list(config.constraints) or None,

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -140,6 +140,11 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
         )
         raise UnsupportedModeError(msg)
 
+    # ``default-groups`` is project policy: every default install
+    # activates them, so the conflict checks and the resolve fold them
+    # into the active group set alongside the CLI selection.
+    effective_groups = tuple(dict.fromkeys((*groups, *config.default_groups)))
+
     if config.conflicts:
         # Read each table once and reuse it across the existence check
         # and the umbrella expansion, so a conflict the selection only
@@ -150,7 +155,7 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
         project_name = read_pyproject_name(path)
         _validate_conflict_members_exist(config.conflicts, optional, groups_table)
         active_extras = expand_self_extras(optional, project_name, extras)
-        active_groups = expand_group_includes(groups_table, groups)
+        active_groups = expand_group_includes(groups_table, effective_groups)
         validate_conflict_selection(config.conflicts, active_extras, active_groups)
 
     if python_version is not None:
@@ -166,15 +171,15 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
     )
 
     requirements = read_pyproject_dependencies(path)
-    requirements.extend(_load_group_requirements(path, groups))
+    requirements.extend(_load_group_requirements(path, effective_groups))
     requirements.extend(_load_extra_requirements(path, extras))
     marker_environment = _build_marker_environment(
         python_version=effective_python,
         overrides=config.marker_environment,
     )
-    if len(groups) > 1:
+    if len(effective_groups) > 1:
         _check_group_disjointness(
-            _load_group_requirements_by_group(path, groups),
+            _load_group_requirements_by_group(path, effective_groups),
             environment=marker_environment,
         )
     resolver_requirements, root_extras = _build_resolver_inputs(
@@ -737,6 +742,12 @@ def resolve_universal_pyproject(
         project_name=read_pyproject_name(path),
     )
 
+    # ``default-groups`` is project policy: every default install
+    # activates them, so the conflict checks, the fork plan, and the
+    # per-fork resolves all fold them into the active group set
+    # alongside the CLI selection.
+    effective_groups = tuple(dict.fromkeys((*groups, *config.default_groups)))
+
     if config.conflicts:
         # Reuse the already-read tables for every conflict check, and
         # expand the selection so an umbrella extra or include-group
@@ -747,10 +758,10 @@ def resolve_universal_pyproject(
         validate_conflict_minimums(
             config.conflicts,
             expand_self_extras(tables.optional, tables.project_name, extras),
-            expand_group_includes(tables.groups, groups),
+            expand_group_includes(tables.groups, effective_groups),
         )
 
-    conflict_fork_list = conflict_forks(extras, groups, config.conflicts)
+    conflict_fork_list = conflict_forks(extras, effective_groups, config.conflicts)
     forks: list[ResolveFork] = []
     # Forks of an extra-based conflict share the same group selection,
     # so dedupe to skip the (group, group)->tuple scan once it has run

--- a/nab-python/src/nab_python/universal/matrix.py
+++ b/nab-python/src/nab_python/universal/matrix.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from .._conflict_kind import MARKER_VARIABLE_FOR_KIND
 from .._vendor.packaging.specifiers import SpecifierSet
 from .._vendor.packaging.version import Version
 from .wheel_selection import PlatformSpec
@@ -187,7 +188,7 @@ class MatrixTuple:
         """
         marker = self.environment_marker_string
         for kind, name in sorted(self.selection):
-            variable = "extras" if kind == "extra" else "dependency_groups"
+            variable = MARKER_VARIABLE_FOR_KIND[kind]
             marker += f' and "{name}" in {variable}'
         return marker
 

--- a/nab-python/src/nab_python/universal/matrix.py
+++ b/nab-python/src/nab_python/universal/matrix.py
@@ -97,7 +97,16 @@ _IMPLEMENTATION_PREFIX: dict[str, str] = {"cpython": "py", "pypy": "pp"}
 
 @dataclass(frozen=True)
 class MatrixTuple:
-    """A single point in the universal-resolution matrix."""
+    """A single point in the universal-resolution matrix.
+
+    ``selection`` records the conflict-fork this tuple belongs to: a
+    tuple of ``(kind, name)`` members (``kind`` is ``"extra"`` or
+    ``"group"``) that are active in this fork's resolve.  It is empty
+    for an unforked resolve.  When set, it both disambiguates the
+    label and adds an ``'name' in extras`` / ``'name' in
+    dependency_groups`` clause to the marker so the lockfile entry
+    fires only when the user selects that member.
+    """
 
     python_version: str
     platform_id: str
@@ -109,6 +118,7 @@ class MatrixTuple:
     )
     implementation: str = "cpython"
     multi_implementation: bool = field(default=False, hash=False, compare=False)
+    selection: tuple[tuple[str, str], ...] = ()
 
     @property
     def label(self) -> str:
@@ -116,10 +126,16 @@ class MatrixTuple:
 
         Uses the interpreter prefix (``py`` for CPython, ``pp`` for
         PyPy) so tuples that differ only by implementation get distinct
-        labels.
+        labels.  A conflict-fork ``selection`` appends each active
+        member name (sorted) so the forks of one python/platform stay
+        distinct, e.g. ``py311-linux_x86_64-black22``.
         """
         prefix = _IMPLEMENTATION_PREFIX[self.implementation]
-        return f"{prefix}{self.python_version.replace('.', '')}-{self.platform_id}"
+        base = f"{prefix}{self.python_version.replace('.', '')}-{self.platform_id}"
+        if not self.selection:
+            return base
+        suffix = "-".join(name for _kind, name in sorted(self.selection))
+        return f"{base}-{suffix}"
 
     @property
     def marker_string(self) -> str:
@@ -133,6 +149,13 @@ class MatrixTuple:
         ``implementation_name`` so the CPython and PyPy entries for the
         same python/platform stay mutually exclusive; a sole-CPython
         matrix omits the clause.
+
+        A conflict-fork ``selection`` adds a bare membership clause per
+        active member (``'name' in extras`` for an extra, ``'name' in
+        dependency_groups`` for a group).  The emit-time disjointness
+        validator prunes the install contexts that activate two members
+        of one declared conflict, so the bare clause is enough; no
+        ``not in`` negation against the other members is required.
         """
         env = self.environment
         marker = (
@@ -142,6 +165,9 @@ class MatrixTuple:
         )
         if self.multi_implementation or self.implementation != "cpython":
             marker += f' and implementation_name == "{env["implementation_name"]}"'
+        for kind, name in sorted(self.selection):
+            variable = "extras" if kind == "extra" else "dependency_groups"
+            marker += f' and "{name}" in {variable}'
         return marker
 
 

--- a/nab-python/src/nab_python/universal/matrix.py
+++ b/nab-python/src/nab_python/universal/matrix.py
@@ -127,14 +127,22 @@ class MatrixTuple:
         Uses the interpreter prefix (``py`` for CPython, ``pp`` for
         PyPy) so tuples that differ only by implementation get distinct
         labels.  A conflict-fork ``selection`` appends each active
-        member name (sorted) so the forks of one python/platform stay
-        distinct, e.g. ``py311-linux_x86_64-black22``.
+        member as ``kind-name``, joined by ``.``, in sorted order so the
+        forks of one python/platform stay distinct, e.g.
+        ``py311-linux_x86_64-group-black22.group-isort5``.  The ``.``
+        separator and the ``kind`` prefix keep the label unambiguous:
+        canonical member names are ``[a-z0-9-]`` only, so a name can
+        never introduce a ``.``, and two selections that differ only in
+        how their names split on ``-`` (or an extra versus a group of
+        the same name) cannot collide into one label and silently
+        overwrite each other's pins when the label is used as a dict
+        key.
         """
         prefix = _IMPLEMENTATION_PREFIX[self.implementation]
         base = f"{prefix}{self.python_version.replace('.', '')}-{self.platform_id}"
         if not self.selection:
             return base
-        suffix = "-".join(name for _kind, name in sorted(self.selection))
+        suffix = ".".join(f"{kind}-{name}" for kind, name in sorted(self.selection))
         return f"{base}-{suffix}"
 
     @property

--- a/nab-python/src/nab_python/universal/matrix.py
+++ b/nab-python/src/nab_python/universal/matrix.py
@@ -138,24 +138,18 @@ class MatrixTuple:
         return f"{base}-{suffix}"
 
     @property
-    def marker_string(self) -> str:
-        """Return a PEP 508 marker that selects this tuple.
+    def environment_marker_string(self) -> str:
+        """Return the PEP 508 marker for this tuple's environment only.
 
         Combines ``python_version``, ``sys_platform``, and
-        ``platform_machine`` into a conjunction.  Universal lockfiles
-        attach this to each per-tuple ``Package`` entry so an installer
-        on a matching environment picks the right pin.  When the matrix
-        models more than one implementation, every tuple constrains
-        ``implementation_name`` so the CPython and PyPy entries for the
-        same python/platform stay mutually exclusive; a sole-CPython
-        matrix omits the clause.
+        ``platform_machine``.  In a multi-implementation matrix every
+        tuple also constrains ``implementation_name`` so the CPython and
+        PyPy entries for the same python/platform stay mutually
+        exclusive; a sole-CPython matrix omits the clause.
 
-        A conflict-fork ``selection`` adds a bare membership clause per
-        active member (``'name' in extras`` for an extra, ``'name' in
-        dependency_groups`` for a group).  The emit-time disjointness
-        validator prunes the install contexts that activate two members
-        of one declared conflict, so the bare clause is enough; no
-        ``not in`` negation against the other members is required.
+        This carries no conflict-fork ``selection``, so it is what the
+        lockfile's top-level ``environments`` list declares: the
+        platform/Python universe, not which extras or groups are active.
         """
         env = self.environment
         marker = (
@@ -165,6 +159,20 @@ class MatrixTuple:
         )
         if self.multi_implementation or self.implementation != "cpython":
             marker += f' and implementation_name == "{env["implementation_name"]}"'
+        return marker
+
+    @property
+    def marker_string(self) -> str:
+        """Return the per-package PEP 508 marker that selects this tuple.
+
+        This is :attr:`environment_marker_string` plus a bare membership
+        clause per active conflict-fork member (``'name' in extras`` for
+        an extra, ``'name' in dependency_groups`` for a group).  The
+        emit-time disjointness validator prunes the install contexts
+        that activate two members of one declared conflict, so the bare
+        clause needs no ``not in`` negation against the other members.
+        """
+        marker = self.environment_marker_string
         for kind, name in sorted(self.selection):
             variable = "extras" if kind == "extra" else "dependency_groups"
             marker += f' and "{name}" in {variable}'

--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -8,10 +8,11 @@ pin applies.
 
 from __future__ import annotations
 
+import itertools
 import logging
 import time
 from collections import defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING
 
 from nab_index.multi_index import IndexConfig
@@ -24,7 +25,7 @@ from .._vendor.packaging.ranges import VersionRange
 from .._vendor.packaging.requirements import InvalidRequirement, Requirement
 from .._vendor.packaging.utils import canonicalize_name
 from .._vendor.packaging.version import Version
-from ..config import ConfigError
+from ..config import ConfigError, ConflictKind, ConflictPolicy
 from ..fetch import (
     DEFAULT_INDEX_NAME,
     DEFAULT_INDEX_URL,
@@ -73,7 +74,7 @@ if TYPE_CHECKING:
 
     from nab_index.transport import AsyncHttpTransport
 
-    from ..config import NabProjectConfig
+    from ..config import ConflictMember, ConflictSet, NabProjectConfig
     from .matrix import Matrix, MatrixTuple
 
 
@@ -118,6 +119,106 @@ class UniversalResult:
         return out
 
 
+@dataclass(frozen=True, slots=True)
+class _ConflictFork:
+    """One fork of a conflict-driven universal resolve.
+
+    ``selection`` is the active conflicting members as ``(kind, name)``
+    pairs; it drives the per-tuple label suffix and the ``in extras`` /
+    ``in dependency_groups`` marker clause.  ``active_extras`` and
+    ``active_groups`` are the full extra and group selections this fork
+    resolves with: the non-conflicting selections plus this fork's
+    chosen members.  An unforked resolve is a single fork with an empty
+    ``selection``.
+    """
+
+    selection: tuple[tuple[str, str], ...]
+    active_extras: tuple[str, ...]
+    active_groups: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _ResolveFork:
+    """A fork's resolver input: a marker selection plus folded requirements.
+
+    ``selection`` is the active conflicting members; ``requirements``
+    are the fully folded requirement strings to resolve under it.  The
+    pyproject layer builds these (it owns reading groups/extras);
+    :func:`resolve_with_coordinator` runs the matrix once per fork,
+    injecting ``selection`` into every tuple so the pins land under a
+    distinct label and marker.
+    """
+
+    selection: tuple[tuple[str, str], ...]
+    requirements: list[str]
+
+
+_MIN_ENGAGED_MEMBERS = 2
+
+
+def _conflict_forks(
+    selected_extras: Sequence[str],
+    selected_groups: Sequence[str],
+    conflicts: Sequence[ConflictSet],
+) -> list[_ConflictFork]:
+    """Split a selection into one fork per mutually-exclusive combination.
+
+    A conflict set is *engaged* when the selection activates two or
+    more of its members under an exclusivity policy (at-most-one or
+    exactly-one); only an engaged set forces a fork.  Each engaged set
+    contributes one chosen member per fork, and the forks are the
+    cartesian product across engaged sets.  Members of engaged sets are
+    dropped from the shared base; non-conflicting selections (and the
+    sole selected member of a non-engaged set) stay active in every
+    fork.  With no engaged set the result is a single unforked fork
+    carrying the whole selection, so the caller's non-conflict path is
+    unchanged.
+
+    Names are compared and emitted canonicalised; the extra and group
+    loaders normalise on lookup, so a canonical active set resolves the
+    same requirements the user's spelling would.
+    """
+    base_extras = [canonicalize_name(e) for e in selected_extras]
+    base_groups = [canonicalize_name(g) for g in selected_groups]
+    extra_set = set(base_extras)
+    group_set = set(base_groups)
+
+    def is_selected(member: ConflictMember) -> bool:
+        if member.kind is ConflictKind.EXTRA:
+            return member.name in extra_set
+        return member.name in group_set
+
+    engaged: list[list[ConflictMember]] = []
+    drop_extras: set[str] = set()
+    drop_groups: set[str] = set()
+    for conflict_set in conflicts:
+        if conflict_set.policy is ConflictPolicy.AT_LEAST_ONE:
+            continue
+        members = [m for m in conflict_set.members if is_selected(m)]
+        if len(members) < _MIN_ENGAGED_MEMBERS:
+            continue
+        engaged.append(members)
+        for member in members:
+            target = drop_extras if member.kind is ConflictKind.EXTRA else drop_groups
+            target.add(member.name)
+    if not engaged:
+        return [_ConflictFork((), tuple(base_extras), tuple(base_groups))]
+    rest_extras = [e for e in base_extras if e not in drop_extras]
+    rest_groups = [g for g in base_groups if g not in drop_groups]
+    forks: list[_ConflictFork] = []
+    for combo in itertools.product(*engaged):
+        chosen_extras = [m.name for m in combo if m.kind is ConflictKind.EXTRA]
+        chosen_groups = [m.name for m in combo if m.kind is ConflictKind.GROUP]
+        forks.append(
+            _ConflictFork(
+                selection=tuple(sorted((m.kind.value, m.name) for m in combo)),
+                active_extras=tuple(rest_extras + chosen_extras),
+                active_groups=tuple(rest_groups + chosen_groups),
+            )
+        )
+    return forks
+
+
 def merge_universal_lock_inputs(
     result: UniversalResult,
     *,
@@ -126,6 +227,7 @@ def merge_universal_lock_inputs(
     extras: Sequence[str] = (),
     dependency_groups: Sequence[str] = (),
     default_groups: Sequence[str] = (),
+    conflicts: Sequence[ConflictSet] = (),
 ) -> LockInput:
     """Merge per-tuple :class:`LockInput` objects into one universal lock.
 
@@ -169,6 +271,7 @@ def merge_universal_lock_inputs(
         extras=tuple(extras),
         dependency_groups=tuple(dependency_groups),
         default_groups=tuple(default_groups),
+        conflicts=tuple(conflicts),
     )
 
 
@@ -196,11 +299,13 @@ def resolve_universal(  # noqa: PLR0913 - surface area mirrors uv's resolution k
     resolution_strategy: str = "highest",
     align_across_tuples: bool = True,
     preferences: dict[str, Version] | None = None,
+    forks: Sequence[_ResolveFork] | None = None,
 ) -> UniversalResult:
     """Run a universal resolve for ``matrix``.
 
     Returns a :class:`UniversalResult` with one :class:`TupleResult`
-    per (python_version, platform) combination.
+    per (python_version, platform) combination, times the number of
+    conflict ``forks``.
 
     ``resolution_strategy``: ``"highest"`` (default), ``"lowest"``, or
     ``"lowest-direct"``.  Mirrors uv's ``--resolution`` flag.
@@ -210,6 +315,12 @@ def resolve_universal(  # noqa: PLR0913 - surface area mirrors uv's resolution k
 
     ``preferences``: a starting set of preferred ``{name: Version}``,
     e.g. read from a previous lock.
+
+    ``forks``: per-conflict-fork resolver inputs.  When ``None`` the
+    resolve runs once with ``requirements`` and no marker selection;
+    when supplied, the matrix runs once per fork and ``requirements``
+    is ignored (the pyproject layer folds each fork's own
+    requirements).
     """
     if indexes is None:
         indexes = [IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL)]
@@ -242,6 +353,7 @@ def resolve_universal(  # noqa: PLR0913 - surface area mirrors uv's resolution k
             resolution_strategy=resolution_strategy,
             align_across_tuples=align_across_tuples,
             preferences=preferences,
+            forks=forks,
         )
 
 
@@ -265,6 +377,7 @@ def resolve_with_coordinator(  # noqa: PLR0913 - mirrors resolve_universal's sur
     resolution_strategy: str = "highest",
     align_across_tuples: bool = True,
     preferences: dict[str, Version] | None = None,
+    forks: Sequence[_ResolveFork] | None = None,
 ) -> UniversalResult:
     """Run a universal resolve against an already-open coordinator.
 
@@ -272,17 +385,28 @@ def resolve_with_coordinator(  # noqa: PLR0913 - mirrors resolve_universal's sur
     :class:`FetchCoordinator` across multiple resolves and avoids
     transport setup in unit tests.  See :func:`resolve_universal` for
     the full parameter documentation.
-    """
-    tuples = matrix.expand()
-    _warn_extra_marker_at_root(requirements)
-    direct_packages = frozenset(_direct_package_names(requirements))
-    initial_preferences: dict[str, Version] = dict(preferences or {})
 
-    return UniversalResult(
-        matrix=matrix,
-        tuple_results=_run_pass(
+    When ``forks`` is supplied the matrix runs once per fork against
+    that fork's own requirements, with the fork's marker ``selection``
+    injected into every tuple; the per-fork results are concatenated.
+    Pins flow forward across forks too (when ``align_across_tuples``),
+    so a package shared by several forks tends to land on one version.
+    """
+    base_tuples = matrix.expand()
+    fork_list = list(forks) if forks is not None else [_ResolveFork((), requirements)]
+    accumulated: dict[str, Version] = dict(preferences or {})
+    out: list[TupleResult] = []
+    for fork in fork_list:
+        _warn_extra_marker_at_root(fork.requirements)
+        tuples = (
+            base_tuples
+            if not fork.selection
+            else [replace(t, selection=fork.selection) for t in base_tuples]
+        )
+        direct_packages = frozenset(_direct_package_names(fork.requirements))
+        results = _run_pass(
             tuples,
-            requirements,
+            fork.requirements,
             constraints,
             coordinator=coordinator,
             uploaded_prior_to=uploaded_prior_to,
@@ -298,10 +422,15 @@ def resolve_with_coordinator(  # noqa: PLR0913 - mirrors resolve_universal's sur
             build_config=build_config,
             resolution_strategy=resolution_strategy,
             direct_packages=direct_packages,
-            preferences=initial_preferences,
+            preferences=accumulated,
             align_serial=align_across_tuples,
-        ),
-    )
+        )
+        out.extend(results)
+        if align_across_tuples:
+            for tr in results:
+                if tr.success:
+                    accumulated.update(tr.pins)
+    return UniversalResult(matrix=matrix, tuple_results=out)
 
 
 def _run_pass(  # noqa: PLR0913

--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -168,6 +168,7 @@ def merge_universal_lock_inputs(
     """
     per_tuple_pins: dict[str, dict[str, PinShape]] = {}
     tuple_markers: dict[str, Marker] = {}
+    tuple_env_markers: dict[str, Marker] = {}
     tuple_environments: dict[str, dict[str, str]] = {}
 
     # The top-level ``environments`` declares the platform/Python
@@ -185,12 +186,14 @@ def merge_universal_lock_inputs(
         tuple_environments[label] = dict(tr.tuple_.environment)
 
         env_marker = tr.tuple_.environment_marker_string
+        tuple_env_markers[label] = Marker(env_marker)
         if env_marker not in seen_env_markers:
             seen_env_markers.add(env_marker)
             environments.append(Marker(env_marker))
     return LockInput(
         per_tuple_pins=per_tuple_pins,
         tuple_markers=tuple_markers,
+        tuple_env_markers=tuple_env_markers,
         tuple_environments=tuple_environments,
         environments=environments,
         requires_python=requires_python,

--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -8,7 +8,6 @@ pin applies.
 
 from __future__ import annotations
 
-import itertools
 import logging
 import time
 from collections import defaultdict
@@ -25,7 +24,7 @@ from .._vendor.packaging.ranges import VersionRange
 from .._vendor.packaging.requirements import InvalidRequirement, Requirement
 from .._vendor.packaging.utils import canonicalize_name
 from .._vendor.packaging.version import Version
-from ..config import ConfigError, ConflictKind, ConflictPolicy
+from ..config import ConfigError
 from ..fetch import (
     DEFAULT_INDEX_NAME,
     DEFAULT_INDEX_URL,
@@ -52,6 +51,7 @@ from ..requirements_file import raise_for_unsatisfiable
 from .provider import UniversalProvider
 
 __all__ = [
+    "ResolveFork",
     "TupleResult",
     "UniversalResult",
     "merge_universal_lock_inputs",
@@ -74,7 +74,7 @@ if TYPE_CHECKING:
 
     from nab_index.transport import AsyncHttpTransport
 
-    from ..config import ConflictMember, ConflictSet, NabProjectConfig
+    from ..config import ConflictSet, NabProjectConfig
     from .matrix import Matrix, MatrixTuple
 
 
@@ -120,25 +120,7 @@ class UniversalResult:
 
 
 @dataclass(frozen=True, slots=True)
-class _ConflictFork:
-    """One fork of a conflict-driven universal resolve.
-
-    ``selection`` is the active conflicting members as ``(kind, name)``
-    pairs; it drives the per-tuple label suffix and the ``in extras`` /
-    ``in dependency_groups`` marker clause.  ``active_extras`` and
-    ``active_groups`` are the full extra and group selections this fork
-    resolves with: the non-conflicting selections plus this fork's
-    chosen members.  An unforked resolve is a single fork with an empty
-    ``selection``.
-    """
-
-    selection: tuple[tuple[str, str], ...]
-    active_extras: tuple[str, ...]
-    active_groups: tuple[str, ...]
-
-
-@dataclass(frozen=True, slots=True)
-class _ResolveFork:
+class ResolveFork:
     """A fork's resolver input: a marker selection plus folded requirements.
 
     ``selection`` is the active conflicting members; ``requirements``
@@ -151,72 +133,6 @@ class _ResolveFork:
 
     selection: tuple[tuple[str, str], ...]
     requirements: list[str]
-
-
-_MIN_ENGAGED_MEMBERS = 2
-
-
-def _conflict_forks(
-    selected_extras: Sequence[str],
-    selected_groups: Sequence[str],
-    conflicts: Sequence[ConflictSet],
-) -> list[_ConflictFork]:
-    """Split a selection into one fork per mutually-exclusive combination.
-
-    A conflict set is *engaged* when the selection activates two or
-    more of its members under an exclusivity policy (at-most-one or
-    exactly-one); only an engaged set forces a fork.  Each engaged set
-    contributes one chosen member per fork, and the forks are the
-    cartesian product across engaged sets.  Members of engaged sets are
-    dropped from the shared base; non-conflicting selections (and the
-    sole selected member of a non-engaged set) stay active in every
-    fork.  With no engaged set the result is a single unforked fork
-    carrying the whole selection, so the caller's non-conflict path is
-    unchanged.
-
-    Names are compared and emitted canonicalised; the extra and group
-    loaders normalise on lookup, so a canonical active set resolves the
-    same requirements the user's spelling would.
-    """
-    base_extras = [canonicalize_name(e) for e in selected_extras]
-    base_groups = [canonicalize_name(g) for g in selected_groups]
-    extra_set = set(base_extras)
-    group_set = set(base_groups)
-
-    def is_selected(member: ConflictMember) -> bool:
-        if member.kind is ConflictKind.EXTRA:
-            return member.name in extra_set
-        return member.name in group_set
-
-    engaged: list[list[ConflictMember]] = []
-    drop_extras: set[str] = set()
-    drop_groups: set[str] = set()
-    for conflict_set in conflicts:
-        if conflict_set.policy is ConflictPolicy.AT_LEAST_ONE:
-            continue
-        members = [m for m in conflict_set.members if is_selected(m)]
-        if len(members) < _MIN_ENGAGED_MEMBERS:
-            continue
-        engaged.append(members)
-        for member in members:
-            target = drop_extras if member.kind is ConflictKind.EXTRA else drop_groups
-            target.add(member.name)
-    if not engaged:
-        return [_ConflictFork((), tuple(base_extras), tuple(base_groups))]
-    rest_extras = [e for e in base_extras if e not in drop_extras]
-    rest_groups = [g for g in base_groups if g not in drop_groups]
-    forks: list[_ConflictFork] = []
-    for combo in itertools.product(*engaged):
-        chosen_extras = [m.name for m in combo if m.kind is ConflictKind.EXTRA]
-        chosen_groups = [m.name for m in combo if m.kind is ConflictKind.GROUP]
-        forks.append(
-            _ConflictFork(
-                selection=tuple(sorted((m.kind.value, m.name) for m in combo)),
-                active_extras=tuple(rest_extras + chosen_extras),
-                active_groups=tuple(rest_groups + chosen_groups),
-            )
-        )
-    return forks
 
 
 def merge_universal_lock_inputs(
@@ -244,23 +160,34 @@ def merge_universal_lock_inputs(
     before calling.
 
     ``dependency_groups`` and ``default_groups`` are recorded at the
-    lockfile top level for PEP 735 multi-use locks.  Per-package
-    group attribution (markers gated by
-    ``'group-x' in dependency_groups``) is not emitted.
+    lockfile top level for PEP 735 multi-use locks.  ``conflicts`` rides
+    along on the :class:`LockInput` so the emit-time disjointness check
+    can prune the install contexts a declared conflict forbids; a
+    conflict fork's membership clause reaches each package through its
+    tuple's ``marker_string``.
     """
     per_tuple_pins: dict[str, dict[str, PinShape]] = {}
     tuple_markers: dict[str, Marker] = {}
     tuple_environments: dict[str, dict[str, str]] = {}
+
+    # The top-level ``environments`` declares the platform/Python
+    # universe, so it carries the env-only marker (no conflict-fork
+    # membership clause) and is deduplicated: conflict forks repeat a
+    # (python, platform) under different selections.
     environments: list[Marker] = []
+    seen_env_markers: set[str] = set()
     for tr in result.tuple_results:
         if not tr.success or tr.lock_input is None:
             continue
         label = tr.tuple_.label
         per_tuple_pins[label] = dict(tr.lock_input.pins)
-        marker = Marker(tr.tuple_.marker_string)
-        tuple_markers[label] = marker
+        tuple_markers[label] = Marker(tr.tuple_.marker_string)
         tuple_environments[label] = dict(tr.tuple_.environment)
-        environments.append(marker)
+
+        env_marker = tr.tuple_.environment_marker_string
+        if env_marker not in seen_env_markers:
+            seen_env_markers.add(env_marker)
+            environments.append(Marker(env_marker))
     return LockInput(
         per_tuple_pins=per_tuple_pins,
         tuple_markers=tuple_markers,
@@ -277,7 +204,7 @@ def merge_universal_lock_inputs(
 
 def resolve_universal(  # noqa: PLR0913 - surface area mirrors uv's resolution knobs; bundling all flags into a config object hides the call-site documentation
     matrix: Matrix,
-    requirements: list[str],
+    requirements: Sequence[str] = (),
     *,
     transport: AsyncHttpTransport | None = None,
     offline: bool = False,
@@ -299,7 +226,7 @@ def resolve_universal(  # noqa: PLR0913 - surface area mirrors uv's resolution k
     resolution_strategy: str = "highest",
     align_across_tuples: bool = True,
     preferences: dict[str, Version] | None = None,
-    forks: Sequence[_ResolveFork] | None = None,
+    forks: Sequence[ResolveFork] | None = None,
 ) -> UniversalResult:
     """Run a universal resolve for ``matrix``.
 
@@ -316,11 +243,10 @@ def resolve_universal(  # noqa: PLR0913 - surface area mirrors uv's resolution k
     ``preferences``: a starting set of preferred ``{name: Version}``,
     e.g. read from a previous lock.
 
-    ``forks``: per-conflict-fork resolver inputs.  When ``None`` the
-    resolve runs once with ``requirements`` and no marker selection;
-    when supplied, the matrix runs once per fork and ``requirements``
-    is ignored (the pyproject layer folds each fork's own
-    requirements).
+    ``forks``: per-conflict-fork resolver inputs from the pyproject
+    layer.  When ``None`` the resolve runs once with ``requirements``
+    and no marker selection; otherwise the matrix runs once per fork,
+    each folding its own requirements.
     """
     if indexes is None:
         indexes = [IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL)]
@@ -360,7 +286,7 @@ def resolve_universal(  # noqa: PLR0913 - surface area mirrors uv's resolution k
 def resolve_with_coordinator(  # noqa: PLR0913 - mirrors resolve_universal's surface
     coordinator: FetchCoordinator,
     matrix: Matrix,
-    requirements: list[str],
+    requirements: Sequence[str] = (),
     *,
     constraints: list[str] | None = None,
     uploaded_prior_to: datetime | None = None,
@@ -377,7 +303,7 @@ def resolve_with_coordinator(  # noqa: PLR0913 - mirrors resolve_universal's sur
     resolution_strategy: str = "highest",
     align_across_tuples: bool = True,
     preferences: dict[str, Version] | None = None,
-    forks: Sequence[_ResolveFork] | None = None,
+    forks: Sequence[ResolveFork] | None = None,
 ) -> UniversalResult:
     """Run a universal resolve against an already-open coordinator.
 
@@ -386,18 +312,26 @@ def resolve_with_coordinator(  # noqa: PLR0913 - mirrors resolve_universal's sur
     transport setup in unit tests.  See :func:`resolve_universal` for
     the full parameter documentation.
 
-    When ``forks`` is supplied the matrix runs once per fork against
-    that fork's own requirements, with the fork's marker ``selection``
-    injected into every tuple; the per-fork results are concatenated.
-    Pins flow forward across forks too (when ``align_across_tuples``),
-    so a package shared by several forks tends to land on one version.
+    With ``forks`` the matrix runs once per fork, each fork's marker
+    ``selection`` injected into every tuple and its results
+    concatenated; ``requirements`` is used only for the single unforked
+    resolve.  Pins flow forward across forks, aligning a shared
+    package's version where possible.
     """
     base_tuples = matrix.expand()
-    fork_list = list(forks) if forks is not None else [_ResolveFork((), requirements)]
+    fork_list = (
+        list(forks) if forks is not None else [ResolveFork((), list(requirements))]
+    )
+
+    # Warn once across all forks: forks share the base dependencies, so
+    # a root ``extra ==`` marker would otherwise be flagged per fork.
+    _warn_extra_marker_at_root(
+        sorted({r for fork in fork_list for r in fork.requirements})
+    )
+
     accumulated: dict[str, Version] = dict(preferences or {})
     out: list[TupleResult] = []
     for fork in fork_list:
-        _warn_extra_marker_at_root(fork.requirements)
         tuples = (
             base_tuples
             if not fork.selection

--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -99,6 +99,14 @@ class UniversalResult:
 
     matrix: Matrix
     tuple_results: list[TupleResult] = field(default_factory=list)
+    # Per environment signature (``tuple(sorted(env.items()))``), the
+    # canonical names a base (no-member) resolve produced.  Populated
+    # only when conflict forks ran; lets the lock writer tell a base
+    # dependency from one required by every member, so a member-only
+    # dep keeps its membership clause.
+    env_base_names: dict[tuple[tuple[str, str], ...], frozenset[str]] = field(
+        default_factory=dict
+    )
 
     @property
     def success(self) -> bool:
@@ -196,6 +204,7 @@ def merge_universal_lock_inputs(
         tuple_markers=tuple_markers,
         tuple_env_markers=tuple_env_markers,
         tuple_environments=tuple_environments,
+        env_base_names=dict(result.env_base_names),
         environments=environments,
         requires_python=requires_python,
         created_by=created_by,
@@ -231,6 +240,7 @@ def resolve_universal(  # noqa: PLR0913 - surface area mirrors uv's resolution k
     align_across_tuples: bool = True,
     preferences: dict[str, Version] | None = None,
     forks: Sequence[ResolveFork] | None = None,
+    base_requirements: Sequence[str] | None = None,
 ) -> UniversalResult:
     """Run a universal resolve for ``matrix``.
 
@@ -284,6 +294,7 @@ def resolve_universal(  # noqa: PLR0913 - surface area mirrors uv's resolution k
             align_across_tuples=align_across_tuples,
             preferences=preferences,
             forks=forks,
+            base_requirements=base_requirements,
         )
 
 
@@ -308,6 +319,7 @@ def resolve_with_coordinator(  # noqa: PLR0913 - mirrors resolve_universal's sur
     align_across_tuples: bool = True,
     preferences: dict[str, Version] | None = None,
     forks: Sequence[ResolveFork] | None = None,
+    base_requirements: Sequence[str] | None = None,
 ) -> UniversalResult:
     """Run a universal resolve against an already-open coordinator.
 
@@ -321,6 +333,12 @@ def resolve_with_coordinator(  # noqa: PLR0913 - mirrors resolve_universal's sur
     concatenated; ``requirements`` is used only for the single unforked
     resolve.  Pins flow forward across forks, aligning a shared
     package's version where possible.
+
+    ``base_requirements`` are the no-member requirements (the project
+    deps plus any non-conflicting selection).  When given, a final
+    base pass resolves them per environment so the lock writer can tell
+    a true base dependency from one required by every member; pass it
+    only when conflict forks ran.
     """
     base_tuples = matrix.expand()
     fork_list = (
@@ -333,18 +351,14 @@ def resolve_with_coordinator(  # noqa: PLR0913 - mirrors resolve_universal's sur
         sorted({r for fork in fork_list for r in fork.requirements})
     )
 
-    accumulated: dict[str, Version] = dict(preferences or {})
-    out: list[TupleResult] = []
-    for fork in fork_list:
-        tuples = (
-            base_tuples
-            if not fork.selection
-            else [replace(t, selection=fork.selection) for t in base_tuples]
-        )
-        direct_packages = frozenset(_direct_package_names(fork.requirements))
-        results = _run_pass(
+    def run_pass(
+        reqs: list[str],
+        tuples: list[MatrixTuple],
+        prefs: dict[str, Version],
+    ) -> list[TupleResult]:
+        return _run_pass(
             tuples,
-            fork.requirements,
+            reqs,
             constraints,
             coordinator=coordinator,
             uploaded_prior_to=uploaded_prior_to,
@@ -359,16 +373,44 @@ def resolve_with_coordinator(  # noqa: PLR0913 - mirrors resolve_universal's sur
             vcs_cache_dir=vcs_cache_dir,
             build_config=build_config,
             resolution_strategy=resolution_strategy,
-            direct_packages=direct_packages,
-            preferences=accumulated,
+            direct_packages=frozenset(_direct_package_names(reqs)),
+            preferences=prefs,
             align_serial=align_across_tuples,
         )
+
+    accumulated: dict[str, Version] = dict(preferences or {})
+    out: list[TupleResult] = []
+    for fork in fork_list:
+        tuples = (
+            base_tuples
+            if not fork.selection
+            else [replace(t, selection=fork.selection) for t in base_tuples]
+        )
+        results = run_pass(list(fork.requirements), tuples, accumulated)
         out.extend(results)
         if align_across_tuples:
             for tr in results:
                 if tr.success:
                     accumulated.update(tr.pins)
-    return UniversalResult(matrix=matrix, tuple_results=out)
+
+    # A base (no-member) pass names the deps that install regardless of
+    # which member is chosen, so the writer keeps the membership clause
+    # on a dep required only by members.
+    env_base_names: dict[tuple[tuple[str, str], ...], frozenset[str]] = {}
+    if base_requirements is not None:
+        base_results = run_pass(
+            list(base_requirements), base_tuples, dict(preferences or {})
+        )
+        for tr in base_results:
+            if tr.success:
+                signature = tuple(sorted(tr.tuple_.environment.items()))
+                env_base_names[signature] = frozenset(
+                    canonicalize_name(name) for name in tr.pins
+                )
+
+    return UniversalResult(
+        matrix=matrix, tuple_results=out, env_base_names=env_base_names
+    )
 
 
 def _run_pass(  # noqa: PLR0913

--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -193,7 +193,7 @@ def merge_universal_lock_inputs(
     # membership clause) and is deduplicated: conflict forks repeat a
     # (python, platform) under different selections.
     environments: list[Marker] = []
-    seen_env_markers: set[str] = set()
+    env_marker_cache: dict[str, Marker] = {}
     for tr in result.tuple_results:
         if not tr.success or tr.lock_input is None:
             continue
@@ -203,10 +203,12 @@ def merge_universal_lock_inputs(
         tuple_environments[label] = dict(tr.tuple_.environment)
 
         env_marker = tr.tuple_.environment_marker_string
-        tuple_env_markers[label] = Marker(env_marker)
-        if env_marker not in seen_env_markers:
-            seen_env_markers.add(env_marker)
-            environments.append(Marker(env_marker))
+        parsed = env_marker_cache.get(env_marker)
+        if parsed is None:
+            parsed = Marker(env_marker)
+            env_marker_cache[env_marker] = parsed
+            environments.append(parsed)
+        tuple_env_markers[label] = parsed
     return LockInput(
         per_tuple_pins=per_tuple_pins,
         tuple_markers=tuple_markers,

--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -107,11 +107,19 @@ class UniversalResult:
     env_base_names: dict[tuple[tuple[str, str], ...], frozenset[str]] = field(
         default_factory=dict
     )
+    # One :class:`TupleResult` per environment from the base
+    # (no-member) pass when conflict forks ran with ``base_requirements``.
+    # A failed base pass yields an incomplete ``env_base_names``, so
+    # ``success`` covers these too: the lock writer cannot tell base
+    # deps from member-only deps without them.
+    base_results: list[TupleResult] = field(default_factory=list)
 
     @property
     def success(self) -> bool:
-        """Return True iff every tuple resolved successfully."""
-        return all(tr.success for tr in self.tuple_results)
+        """Return True iff every tuple and every base pass succeeded."""
+        if not all(tr.success for tr in self.tuple_results):
+            return False
+        return all(br.success for br in self.base_results)
 
     def merged_lock(self) -> dict[str, list[tuple[str, str]]]:
         """Collapse per-tuple pins into ``{package: [(version, label), ...]}``.
@@ -397,6 +405,7 @@ def resolve_with_coordinator(  # noqa: PLR0913 - mirrors resolve_universal's sur
     # which member is chosen, so the writer keeps the membership clause
     # on a dep required only by members.
     env_base_names: dict[tuple[tuple[str, str], ...], frozenset[str]] = {}
+    base_results: list[TupleResult] = []
     if base_requirements is not None:
         base_results = run_pass(
             list(base_requirements), base_tuples, dict(preferences or {})
@@ -407,9 +416,18 @@ def resolve_with_coordinator(  # noqa: PLR0913 - mirrors resolve_universal's sur
                 env_base_names[signature] = frozenset(
                     canonicalize_name(name) for name in tr.pins
                 )
+            else:
+                logger.warning(
+                    "Base attribution skipped for tuple %s: %s",
+                    tr.tuple_.label,
+                    tr.error,
+                )
 
     return UniversalResult(
-        matrix=matrix, tuple_results=out, env_base_names=env_base_names
+        matrix=matrix,
+        tuple_results=out,
+        env_base_names=env_base_names,
+        base_results=base_results,
     )
 
 

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -417,6 +417,28 @@ class TestValidateConflictMinimums:
             (),
         )
 
+    def test_at_least_one_message_lists_members_not_policy(self) -> None:
+        # The message renders the members and cites the policy and key
+        # once; no duplicate ``at_least_one`` prefix from ConflictSet.__str__.
+        with pytest.raises(ConflictSelectionError) as info:
+            validate_conflict_minimums(
+                (self._set(ConflictPolicy.AT_LEAST_ONE, "cpu", "gpu"),), (), ()
+            )
+        message = str(info.value)
+        assert "at least one of extra 'cpu', extra 'gpu' must be selected" in message
+        assert "declared at_least_one in [tool.nab].conflicts" in message
+        # No double policy word.
+        assert message.count("at_least_one") == 1
+
+    def test_exactly_one_message_lists_members_not_policy(self) -> None:
+        with pytest.raises(ConflictSelectionError) as info:
+            validate_conflict_minimums(
+                (self._set(ConflictPolicy.EXACTLY_ONE, "cpu", "gpu"),), (), ()
+            )
+        message = str(info.value)
+        assert "exactly one of extra 'cpu', extra 'gpu' must be selected" in message
+        assert "declared exactly_one in [tool.nab].conflicts" in message
+
 
 class TestValidateConflictSelection:
     def _set(self, policy: ConflictPolicy, *names: str) -> ConflictSet:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -1850,3 +1850,29 @@ class TestWorkspaceDiscoveryIntegration:
         config = read_pyproject_config(member)
         assert config.local_sources == ()
         assert config.build_policy is BuildPolicy.BUILD_LOCAL
+
+    def test_root_conflicts_and_defaults_do_not_flow_to_member(
+        self, tmp_path: Path
+    ) -> None:
+        # Per the documented scope, only workspace members and the
+        # build-policy floor cross the root/member boundary; conflicts,
+        # default-groups, and constraints stay scoped to the file being
+        # locked.
+        ws_pyproject = tmp_path / "pyproject.toml"
+        ws_pyproject.write_text(
+            '[project]\nname = "ws"\nversion = "0"\n'
+            "[tool.nab]\n"
+            'default-groups = ["dev"]\n'
+            'constraints = ["foo<2"]\n'
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+            "[tool.nab.workspace]\n"
+            'members = ["pkg"]\n',
+        )
+        member_dir = tmp_path / "pkg"
+        member_dir.mkdir()
+        member = member_dir / "pyproject.toml"
+        member.write_text('[project]\nname = "alpha"\nversion = "0"\n')
+        config = read_pyproject_config(member)
+        assert config.default_groups == ()
+        assert config.constraints == ()
+        assert config.conflicts == ()

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -108,9 +108,35 @@ class TestTopLevelKeys:
             read_pyproject_config(path)
 
 
+class TestConflictRendering:
+    """The ``__str__`` formats are codified in the conflicts guide."""
+
+    def test_member_renders_kind_then_quoted_name(self) -> None:
+        member = ConflictMember(ConflictKind.EXTRA, "cpu")
+        assert str(member) == "extra 'cpu'"
+
+    def test_group_member_renders_kind_then_quoted_name(self) -> None:
+        member = ConflictMember(ConflictKind.GROUP, "black22")
+        assert str(member) == "group 'black22'"
+
+    def test_set_renders_policy_then_parenthesised_members(self) -> None:
+        s = ConflictSet(
+            members=(
+                ConflictMember(ConflictKind.EXTRA, "cpu"),
+                ConflictMember(ConflictKind.EXTRA, "gpu"),
+            ),
+            policy=ConflictPolicy.AT_MOST_ONE,
+        )
+        assert str(s) == "at_most_one (extra 'cpu', extra 'gpu')"
+
+
 class TestConflicts:
     def test_default_is_empty(self, tmp_path: Path) -> None:
         path = write(tmp_path, "[tool.nab]\n")
+        assert read_pyproject_config(path).conflicts == ()
+
+    def test_explicit_empty_list_is_empty(self, tmp_path: Path) -> None:
+        path = write(tmp_path, "[tool.nab]\nconflicts = []\n")
         assert read_pyproject_config(path).conflicts == ()
 
     def test_bare_set_defaults_to_at_most_one(self, tmp_path: Path) -> None:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -17,8 +17,11 @@ from nab_python.config import (
     MatrixConfig,
     NabProjectConfig,
     ResolveMode,
+    conflict_exclusion_groups,
+    conflict_forks,
     read_pyproject_config,
     read_pyproject_lock_anchor,
+    validate_conflict_minimums,
     validate_conflict_selection,
 )
 from nab_python.fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, IndexOverride
@@ -262,6 +265,154 @@ class TestConflicts:
         with pytest.raises(ConfigError, match="must be an array of members"):
             read_pyproject_config(path)
 
+    def test_member_in_two_sets_rejected(self, tmp_path: Path) -> None:
+        # An overlapping member has no well-defined fork; the cartesian
+        # product would otherwise produce a degenerate (cpu, cpu) combo.
+        path = write(
+            tmp_path,
+            "[tool.nab]\nconflicts = [\n"
+            '  [{ extra = "cpu" }, { extra = "gpu" }],\n'
+            '  [{ extra = "cpu" }, { extra = "tpu" }],\n'
+            "]\n",
+        )
+        with pytest.raises(ConfigError, match="more than one set"):
+            read_pyproject_config(path)
+
+    def test_same_name_extra_and_group_in_two_sets_allowed(
+        self, tmp_path: Path
+    ) -> None:
+        # An extra and a group sharing a name are distinct members.
+        path = write(
+            tmp_path,
+            "[tool.nab]\nconflicts = [\n"
+            '  [{ extra = "cpu" }, { extra = "gpu" }],\n'
+            '  [{ group = "cpu" }, { group = "tpu" }],\n'
+            "]\n",
+        )
+        assert len(read_pyproject_config(path).conflicts) == 2
+
+    def test_malformed_member_name_rejected(self, tmp_path: Path) -> None:
+        # ``...`` canonicalises to ``-``, which is not a valid name.
+        path = write(
+            tmp_path,
+            '[tool.nab]\nconflicts = [[{ extra = "..." }, { extra = "gpu" }]]\n',
+        )
+        with pytest.raises(ConfigError, match="not a valid extra/group name"):
+            read_pyproject_config(path)
+
+    def test_default_groups_conflict_with_at_most_one_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab]\n"
+            'default-groups = ["black22", "black23"]\n'
+            'conflicts = [[{ group = "black22" }, { group = "black23" }]]\n',
+        )
+        with pytest.raises(ConfigError, match="declared mutually exclusive"):
+            read_pyproject_config(path, discover_workspace=False)
+
+    def test_default_groups_conflict_with_exactly_one_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab]\n"
+            'default-groups = ["black22", "black23"]\n'
+            "conflicts = [{ exactly_one = "
+            '[{ group = "black22" }, { group = "black23" }] }]\n',
+        )
+        with pytest.raises(ConfigError, match="declared mutually exclusive"):
+            read_pyproject_config(path, discover_workspace=False)
+
+    def test_default_groups_one_member_allowed(self, tmp_path: Path) -> None:
+        # A single default group in an exclusive set is fine.
+        path = write(
+            tmp_path,
+            "[tool.nab]\n"
+            'default-groups = ["black22"]\n'
+            'conflicts = [[{ group = "black22" }, { group = "black23" }]]\n',
+        )
+        config = read_pyproject_config(path, discover_workspace=False)
+        assert config.default_groups == ("black22",)
+
+    def test_default_groups_skip_at_least_one(self, tmp_path: Path) -> None:
+        # at-least-one does not forbid co-selection, so two default
+        # groups in such a set are allowed.
+        path = write(
+            tmp_path,
+            "[tool.nab]\n"
+            'default-groups = ["a", "b"]\n'
+            'conflicts = [{ at_least_one = [{ group = "a" }, { group = "b" }] }]\n',
+        )
+        config = read_pyproject_config(path, discover_workspace=False)
+        assert config.default_groups == ("a", "b")
+
+
+class TestConflictExclusionGroups:
+    def _set(self, policy: ConflictPolicy, *names: str) -> ConflictSet:
+        return ConflictSet(
+            members=tuple(ConflictMember(ConflictKind.EXTRA, n) for n in names),
+            policy=policy,
+        )
+
+    def test_drops_at_least_one_keeps_others(self) -> None:
+        groups = conflict_exclusion_groups(
+            (
+                self._set(ConflictPolicy.AT_MOST_ONE, "a", "b"),
+                self._set(ConflictPolicy.AT_LEAST_ONE, "c", "d"),
+                self._set(ConflictPolicy.EXACTLY_ONE, "e", "f"),
+            )
+        )
+        assert groups == (
+            frozenset({("extra", "a"), ("extra", "b")}),
+            frozenset({("extra", "e"), ("extra", "f")}),
+        )
+        flat = {member for group in groups for member in group}
+        assert ("extra", "c") not in flat
+        assert ("extra", "d") not in flat
+
+
+class TestValidateConflictMinimums:
+    def _set(self, policy: ConflictPolicy, *names: str) -> ConflictSet:
+        return ConflictSet(
+            members=tuple(ConflictMember(ConflictKind.EXTRA, n) for n in names),
+            policy=policy,
+        )
+
+    def test_exactly_one_empty_raises(self) -> None:
+        with pytest.raises(ConflictSelectionError, match="exactly one"):
+            validate_conflict_minimums(
+                (self._set(ConflictPolicy.EXACTLY_ONE, "cpu", "gpu"),), (), ()
+            )
+
+    def test_at_least_one_empty_raises(self) -> None:
+        with pytest.raises(ConflictSelectionError, match="at least one"):
+            validate_conflict_minimums(
+                (self._set(ConflictPolicy.AT_LEAST_ONE, "cpu", "gpu"),), (), ()
+            )
+
+    def test_at_most_one_empty_does_not_raise(self) -> None:
+        validate_conflict_minimums(
+            (self._set(ConflictPolicy.AT_MOST_ONE, "cpu", "gpu"),), (), ()
+        )
+
+    def test_does_not_reject_co_selection(self) -> None:
+        # The minimum check never forbids two active members.
+        validate_conflict_minimums(
+            (self._set(ConflictPolicy.EXACTLY_ONE, "cpu", "gpu"),),
+            ("cpu", "gpu"),
+            (),
+        )
+
+    def test_selection_canonicalised(self) -> None:
+        # An active member spelled differently still satisfies the minimum.
+        validate_conflict_minimums(
+            (self._set(ConflictPolicy.EXACTLY_ONE, "fast-io", "gpu"),),
+            ("Fast_IO",),
+            (),
+        )
+
 
 class TestValidateConflictSelection:
     def _set(self, policy: ConflictPolicy, *names: str) -> ConflictSet:
@@ -337,6 +488,23 @@ class TestValidateConflictSelection:
                 ("CPU", "fast_io"),
                 (),
             )
+
+
+class TestConflictForks:
+    def test_exactly_one_co_selection_forks_per_member(self) -> None:
+        cs = ConflictSet(
+            members=(
+                ConflictMember(ConflictKind.EXTRA, "cpu"),
+                ConflictMember(ConflictKind.EXTRA, "gpu"),
+            ),
+            policy=ConflictPolicy.EXACTLY_ONE,
+        )
+        forks = conflict_forks(("cpu", "gpu"), (), (cs,))
+        assert [f.selection for f in forks] == [
+            (("extra", "cpu"),),
+            (("extra", "gpu"),),
+        ]
+        assert [f.active_extras for f in forks] == [("cpu",), ("gpu",)]
 
 
 class TestConstraints:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -9,11 +9,17 @@ import pytest
 
 from nab_python.config import (
     ConfigError,
+    ConflictKind,
+    ConflictMember,
+    ConflictPolicy,
+    ConflictSelectionError,
+    ConflictSet,
     MatrixConfig,
     NabProjectConfig,
     ResolveMode,
     read_pyproject_config,
     read_pyproject_lock_anchor,
+    validate_conflict_selection,
 )
 from nab_python.fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, IndexOverride
 from nab_python.provider import (
@@ -93,6 +99,244 @@ class TestTopLevelKeys:
         path = write(tmp_path, '[tool]\nnab = "a string, not a table"\n')
         with pytest.raises(ConfigError, match="\\[tool.nab\\] must be a table"):
             read_pyproject_config(path)
+
+
+class TestConflicts:
+    def test_default_is_empty(self, tmp_path: Path) -> None:
+        path = write(tmp_path, "[tool.nab]\n")
+        assert read_pyproject_config(path).conflicts == ()
+
+    def test_bare_set_defaults_to_at_most_one(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab]\nconflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n',
+        )
+        conflicts = read_pyproject_config(path).conflicts
+        assert conflicts == (
+            ConflictSet(
+                members=(
+                    ConflictMember(ConflictKind.EXTRA, "cpu"),
+                    ConflictMember(ConflictKind.EXTRA, "gpu"),
+                ),
+                policy=ConflictPolicy.AT_MOST_ONE,
+            ),
+        )
+
+    def test_group_members(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab]\nconflicts = ["
+            '[{ group = "black22" }, { group = "black23" }, { group = "black24" }]]\n',
+        )
+        (conflict_set,) = read_pyproject_config(path).conflicts
+        assert conflict_set.members == (
+            ConflictMember(ConflictKind.GROUP, "black22"),
+            ConflictMember(ConflictKind.GROUP, "black23"),
+            ConflictMember(ConflictKind.GROUP, "black24"),
+        )
+
+    def test_mixed_extra_and_group_in_one_set(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab]\nconflicts = [[{ extra = "cpu" }, { group = "gpu" }]]\n',
+        )
+        (conflict_set,) = read_pyproject_config(path).conflicts
+        assert conflict_set.members == (
+            ConflictMember(ConflictKind.EXTRA, "cpu"),
+            ConflictMember(ConflictKind.GROUP, "gpu"),
+        )
+
+    def test_names_are_canonicalised(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab]\nconflicts = [[{ extra = "My_Extra" }, { extra = "other" }]]\n',
+        )
+        (conflict_set,) = read_pyproject_config(path).conflicts
+        assert conflict_set.members[0] == ConflictMember(ConflictKind.EXTRA, "my-extra")
+
+    def test_policy_table_forms(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab]\nconflicts = [\n"
+            '  { exactly_one = [{ extra = "cpu" }, { extra = "gpu" }] },\n'
+            '  { at_least_one = [{ group = "a" }, { group = "b" }] },\n'
+            "]\n",
+        )
+        conflicts = read_pyproject_config(path).conflicts
+        assert [c.policy for c in conflicts] == [
+            ConflictPolicy.EXACTLY_ONE,
+            ConflictPolicy.AT_LEAST_ONE,
+        ]
+
+    def test_multiple_independent_sets(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab]\nconflicts = [\n"
+            '  [{ extra = "a" }, { extra = "b" }],\n'
+            '  [{ group = "x" }, { group = "y" }],\n'
+            "]\n",
+        )
+        assert len(read_pyproject_config(path).conflicts) == 2
+
+    def test_must_be_array(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab]\nconflicts = "cpu"\n')
+        with pytest.raises(ConfigError, match="conflicts must be an array"):
+            read_pyproject_config(path)
+
+    def test_set_must_be_array_or_table(self, tmp_path: Path) -> None:
+        path = write(tmp_path, "[tool.nab]\nconflicts = [1]\n")
+        with pytest.raises(ConfigError, match=r"conflicts\[0\] must be an array"):
+            read_pyproject_config(path)
+
+    def test_fewer_than_two_members_rejected(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab]\nconflicts = [[{ extra = "cpu" }]]\n')
+        with pytest.raises(ConfigError, match="at least 2 members"):
+            read_pyproject_config(path)
+
+    def test_duplicate_member_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab]\nconflicts = [[{ extra = "cpu" }, { extra = "cpu" }]]\n',
+        )
+        with pytest.raises(ConfigError, match="more than once"):
+            read_pyproject_config(path)
+
+    def test_unknown_policy_key_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab]\nconflicts = [{ any_two = [{ extra = "a" }, { extra = "b" }] }]\n',
+        )
+        with pytest.raises(ConfigError, match="unknown conflict-set key"):
+            read_pyproject_config(path)
+
+    def test_two_policy_keys_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab]\nconflicts = [{ at_most_one = [{ extra = "
+            '"a" }, { extra = "b" }], exactly_one = [{ extra = "c" }, '
+            '{ extra = "d" }] }]\n',
+        )
+        with pytest.raises(ConfigError, match="exactly one policy"):
+            read_pyproject_config(path)
+
+    def test_member_must_be_table(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab]\nconflicts = [["cpu", "gpu"]]\n')
+        with pytest.raises(ConfigError, match="must be a table"):
+            read_pyproject_config(path)
+
+    def test_member_unknown_key_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab]\nconflicts = [[{ feature = "cpu" }, { extra = "gpu" }]]\n',
+        )
+        with pytest.raises(ConfigError, match="unknown member key"):
+            read_pyproject_config(path)
+
+    def test_member_must_name_exactly_one_kind(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab]\nconflicts = [[{ extra = "cpu", group = "g" }, '
+            '{ extra = "gpu" }]]\n',
+        )
+        with pytest.raises(ConfigError, match="exactly one of"):
+            read_pyproject_config(path)
+
+    def test_member_name_must_be_nonempty_string(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab]\nconflicts = [[{ extra = "" }, { extra = "gpu" }]]\n',
+        )
+        with pytest.raises(ConfigError, match="non-empty string"):
+            read_pyproject_config(path)
+
+    def test_member_name_must_be_string(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab]\nconflicts = [[{ extra = 1 }, { extra = 2 }]]\n",
+        )
+        with pytest.raises(ConfigError, match="non-empty string"):
+            read_pyproject_config(path)
+
+    def test_policy_members_must_be_array(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab]\nconflicts = [{ at_most_one = "cpu" }]\n')
+        with pytest.raises(ConfigError, match="must be an array of members"):
+            read_pyproject_config(path)
+
+
+class TestValidateConflictSelection:
+    def _set(self, policy: ConflictPolicy, *names: str) -> ConflictSet:
+        return ConflictSet(
+            members=tuple(ConflictMember(ConflictKind.EXTRA, n) for n in names),
+            policy=policy,
+        )
+
+    def test_no_conflicts_passes(self) -> None:
+        validate_conflict_selection((), ("cpu", "gpu"), ())
+
+    def test_single_member_selected_passes(self) -> None:
+        validate_conflict_selection(
+            (self._set(ConflictPolicy.AT_MOST_ONE, "cpu", "gpu"),), ("cpu",), ()
+        )
+
+    def test_at_most_one_co_selection_raises(self) -> None:
+        with pytest.raises(ConflictSelectionError, match="cannot be selected together"):
+            validate_conflict_selection(
+                (self._set(ConflictPolicy.AT_MOST_ONE, "cpu", "gpu"),),
+                ("cpu", "gpu"),
+                (),
+            )
+
+    def test_at_most_one_none_selected_passes(self) -> None:
+        validate_conflict_selection(
+            (self._set(ConflictPolicy.AT_MOST_ONE, "cpu", "gpu"),), (), ()
+        )
+
+    def test_exactly_one_co_selection_raises(self) -> None:
+        with pytest.raises(ConflictSelectionError, match="cannot be selected together"):
+            validate_conflict_selection(
+                (self._set(ConflictPolicy.EXACTLY_ONE, "cpu", "gpu"),),
+                ("cpu", "gpu"),
+                (),
+            )
+
+    def test_exactly_one_none_selected_raises(self) -> None:
+        with pytest.raises(ConflictSelectionError, match="exactly one"):
+            validate_conflict_selection(
+                (self._set(ConflictPolicy.EXACTLY_ONE, "cpu", "gpu"),), (), ()
+            )
+
+    def test_at_least_one_none_selected_raises(self) -> None:
+        with pytest.raises(ConflictSelectionError, match="at least one"):
+            validate_conflict_selection(
+                (self._set(ConflictPolicy.AT_LEAST_ONE, "cpu", "gpu"),), (), ()
+            )
+
+    def test_at_least_one_co_selection_allowed(self) -> None:
+        # at-least-one does not forbid co-selection.
+        validate_conflict_selection(
+            (self._set(ConflictPolicy.AT_LEAST_ONE, "cpu", "gpu"),),
+            ("cpu", "gpu"),
+            (),
+        )
+
+    def test_group_members_checked_against_selected_groups(self) -> None:
+        cs = ConflictSet(
+            members=(
+                ConflictMember(ConflictKind.GROUP, "black22"),
+                ConflictMember(ConflictKind.GROUP, "black23"),
+            ),
+            policy=ConflictPolicy.AT_MOST_ONE,
+        )
+        with pytest.raises(ConflictSelectionError, match="black"):
+            validate_conflict_selection((cs,), (), ("black22", "black23"))
+
+    def test_selection_canonicalised(self) -> None:
+        with pytest.raises(ConflictSelectionError):
+            validate_conflict_selection(
+                (self._set(ConflictPolicy.AT_MOST_ONE, "cpu", "fast-io"),),
+                ("CPU", "fast_io"),
+                (),
+            )
 
 
 class TestConstraints:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -233,6 +233,19 @@ class TestConflicts:
         with pytest.raises(ConfigError, match="more than once"):
             read_pyproject_config(path)
 
+    def test_duplicate_member_after_canonicalisation_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        """``{extra="CPU"}`` and ``{extra="cpu"}`` canonicalise to one name,
+        so the dedup check relies on :class:`ConflictMember` comparing under
+        canonical form rather than raw text."""
+        path = write(
+            tmp_path,
+            '[tool.nab]\nconflicts = [[{ extra = "CPU" }, { extra = "cpu" }]]\n',
+        )
+        with pytest.raises(ConfigError, match="more than once"):
+            read_pyproject_config(path)
+
     def test_unknown_policy_key_rejected(self, tmp_path: Path) -> None:
         path = write(
             tmp_path,

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -22,7 +22,6 @@ from nab_python.config import (
     read_pyproject_config,
     read_pyproject_lock_anchor,
     validate_conflict_minimums,
-    validate_conflict_selection,
 )
 from nab_python.fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, IndexOverride
 from nab_python.provider import (
@@ -379,19 +378,21 @@ class TestConflicts:
         assert config.default_groups == ("a", "b")
 
 
-class TestConflictExclusionGroups:
-    def _set(self, policy: ConflictPolicy, *names: str) -> ConflictSet:
-        return ConflictSet(
-            members=tuple(ConflictMember(ConflictKind.EXTRA, n) for n in names),
-            policy=policy,
-        )
+def _extras_set(policy: ConflictPolicy, *names: str) -> ConflictSet:
+    """Build an extras-only ConflictSet for tests."""
+    return ConflictSet(
+        members=tuple(ConflictMember(ConflictKind.EXTRA, n) for n in names),
+        policy=policy,
+    )
 
+
+class TestConflictExclusionGroups:
     def test_drops_at_least_one_keeps_others(self) -> None:
         groups = conflict_exclusion_groups(
             (
-                self._set(ConflictPolicy.AT_MOST_ONE, "a", "b"),
-                self._set(ConflictPolicy.AT_LEAST_ONE, "c", "d"),
-                self._set(ConflictPolicy.EXACTLY_ONE, "e", "f"),
+                _extras_set(ConflictPolicy.AT_MOST_ONE, "a", "b"),
+                _extras_set(ConflictPolicy.AT_LEAST_ONE, "c", "d"),
+                _extras_set(ConflictPolicy.EXACTLY_ONE, "e", "f"),
             )
         )
         assert groups == (
@@ -404,11 +405,7 @@ class TestConflictExclusionGroups:
 
 
 class TestValidateConflictMinimums:
-    def _set(self, policy: ConflictPolicy, *names: str) -> ConflictSet:
-        return ConflictSet(
-            members=tuple(ConflictMember(ConflictKind.EXTRA, n) for n in names),
-            policy=policy,
-        )
+    _set = staticmethod(_extras_set)
 
     def test_exactly_one_empty_raises(self) -> None:
         with pytest.raises(ConflictSelectionError, match="exactly one"):
@@ -464,82 +461,6 @@ class TestValidateConflictMinimums:
         message = str(info.value)
         assert "exactly one of extra 'cpu', extra 'gpu' must be selected" in message
         assert "declared exactly_one in [tool.nab].conflicts" in message
-
-
-class TestValidateConflictSelection:
-    def _set(self, policy: ConflictPolicy, *names: str) -> ConflictSet:
-        return ConflictSet(
-            members=tuple(ConflictMember(ConflictKind.EXTRA, n) for n in names),
-            policy=policy,
-        )
-
-    def test_no_conflicts_passes(self) -> None:
-        validate_conflict_selection((), ("cpu", "gpu"), ())
-
-    def test_single_member_selected_passes(self) -> None:
-        validate_conflict_selection(
-            (self._set(ConflictPolicy.AT_MOST_ONE, "cpu", "gpu"),), ("cpu",), ()
-        )
-
-    def test_at_most_one_co_selection_raises(self) -> None:
-        with pytest.raises(ConflictSelectionError, match="cannot be selected together"):
-            validate_conflict_selection(
-                (self._set(ConflictPolicy.AT_MOST_ONE, "cpu", "gpu"),),
-                ("cpu", "gpu"),
-                (),
-            )
-
-    def test_at_most_one_none_selected_passes(self) -> None:
-        validate_conflict_selection(
-            (self._set(ConflictPolicy.AT_MOST_ONE, "cpu", "gpu"),), (), ()
-        )
-
-    def test_exactly_one_co_selection_raises(self) -> None:
-        with pytest.raises(ConflictSelectionError, match="cannot be selected together"):
-            validate_conflict_selection(
-                (self._set(ConflictPolicy.EXACTLY_ONE, "cpu", "gpu"),),
-                ("cpu", "gpu"),
-                (),
-            )
-
-    def test_exactly_one_none_selected_raises(self) -> None:
-        with pytest.raises(ConflictSelectionError, match="exactly one"):
-            validate_conflict_selection(
-                (self._set(ConflictPolicy.EXACTLY_ONE, "cpu", "gpu"),), (), ()
-            )
-
-    def test_at_least_one_none_selected_raises(self) -> None:
-        with pytest.raises(ConflictSelectionError, match="at least one"):
-            validate_conflict_selection(
-                (self._set(ConflictPolicy.AT_LEAST_ONE, "cpu", "gpu"),), (), ()
-            )
-
-    def test_at_least_one_co_selection_allowed(self) -> None:
-        # at-least-one does not forbid co-selection.
-        validate_conflict_selection(
-            (self._set(ConflictPolicy.AT_LEAST_ONE, "cpu", "gpu"),),
-            ("cpu", "gpu"),
-            (),
-        )
-
-    def test_group_members_checked_against_selected_groups(self) -> None:
-        cs = ConflictSet(
-            members=(
-                ConflictMember(ConflictKind.GROUP, "black22"),
-                ConflictMember(ConflictKind.GROUP, "black23"),
-            ),
-            policy=ConflictPolicy.AT_MOST_ONE,
-        )
-        with pytest.raises(ConflictSelectionError, match="black"):
-            validate_conflict_selection((cs,), (), ("black22", "black23"))
-
-    def test_selection_canonicalised(self) -> None:
-        with pytest.raises(ConflictSelectionError):
-            validate_conflict_selection(
-                (self._set(ConflictPolicy.AT_MOST_ONE, "cpu", "fast-io"),),
-                ("CPU", "fast_io"),
-                (),
-            )
 
 
 class TestConflictForks:

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -30,6 +30,13 @@ from nab_python._vendor.packaging.markers import Marker
 from nab_python._vendor.packaging.pylock import Package, PackageWheel, Pylock
 from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python._vendor.packaging.version import Version
+from nab_python.config import (
+    ConflictKind,
+    ConflictMember,
+    ConflictPolicy,
+    ConflictSet,
+    conflict_exclusion_groups,
+)
 from nab_python.lockfile import (
     LOCK_VERSION,
     DisjointnessError,
@@ -599,6 +606,110 @@ class TestPerTupleMarkerSimplification:
         assert 'python_version == "3.11"' in v2_marker
         assert 'python_version == "3.12"' in v2_marker
         assert 'python_version == "3.13"' not in v2_marker
+
+
+class TestConflictForkBaseDepMarkers:
+    """A base dep present in every fork of an environment drops the
+    conflict-fork membership clause, so it installs even when no member
+    is selected (the env-conditional-base-dep regression)."""
+
+    _LINUX_ENV: ClassVar[dict[str, str]] = {
+        "sys_platform": "linux",
+        "platform_machine": "x86_64",
+    }
+    _WIN_ENV: ClassVar[dict[str, str]] = {
+        "sys_platform": "win32",
+        "platform_machine": "AMD64",
+    }
+
+    def _lock_input(self) -> LockInput:
+        linux_env_marker = Marker('sys_platform == "linux"')
+        win_env_marker = Marker('sys_platform == "win32"')
+        per_tuple = {
+            "linux-cpu": {
+                "basepkg": _index_pin(name="basepkg", version="1.0"),
+                "torch": _index_pin(name="torch", version="2.0+cpu"),
+                "universal": _index_pin(name="universal", version="9.0"),
+            },
+            "linux-gpu": {
+                "basepkg": _index_pin(name="basepkg", version="1.0"),
+                "torch": _index_pin(name="torch", version="2.0+gpu"),
+                "universal": _index_pin(name="universal", version="9.0"),
+            },
+            "win-cpu": {
+                "torch": _index_pin(name="torch", version="2.0+cpu"),
+                "universal": _index_pin(name="universal", version="9.0"),
+            },
+            "win-gpu": {
+                "torch": _index_pin(name="torch", version="2.0+gpu"),
+                "universal": _index_pin(name="universal", version="9.0"),
+            },
+        }
+        tuple_markers = {
+            "linux-cpu": Marker('sys_platform == "linux" and "cpu" in extras'),
+            "linux-gpu": Marker('sys_platform == "linux" and "gpu" in extras'),
+            "win-cpu": Marker('sys_platform == "win32" and "cpu" in extras'),
+            "win-gpu": Marker('sys_platform == "win32" and "gpu" in extras'),
+        }
+        tuple_env_markers = {
+            "linux-cpu": linux_env_marker,
+            "linux-gpu": linux_env_marker,
+            "win-cpu": win_env_marker,
+            "win-gpu": win_env_marker,
+        }
+        tuple_environments = {
+            "linux-cpu": self._LINUX_ENV,
+            "linux-gpu": self._LINUX_ENV,
+            "win-cpu": self._WIN_ENV,
+            "win-gpu": self._WIN_ENV,
+        }
+        conflicts = (
+            ConflictSet(
+                members=(
+                    ConflictMember(ConflictKind.EXTRA, "cpu"),
+                    ConflictMember(ConflictKind.EXTRA, "gpu"),
+                ),
+                policy=ConflictPolicy.AT_MOST_ONE,
+            ),
+        )
+        return LockInput(
+            per_tuple_pins=per_tuple,
+            tuple_markers=tuple_markers,
+            tuple_env_markers=tuple_env_markers,
+            tuple_environments=tuple_environments,
+            extras=("cpu", "gpu"),
+            conflicts=conflicts,
+        )
+
+    def test_base_dep_drops_membership_clause(self) -> None:
+        pylock = build_pylock(self._lock_input())
+        by_name = {str(p.name): p for p in pylock.packages}
+
+        base_marker = by_name["basepkg"].marker
+        assert base_marker is not None
+        # The bug ORs the per-fork membership markers, which is False on
+        # linux with no extras.  The fix emits the env-only marker.
+        assert base_marker.evaluate({"sys_platform": "linux", "extras": frozenset()})
+        assert not base_marker.evaluate(
+            {"sys_platform": "win32", "extras": frozenset()}
+        )
+        assert "in extras" not in str(base_marker)
+
+    def test_conflicting_dep_keeps_membership_markers(self) -> None:
+        pylock = build_pylock(self._lock_input())
+        torch = sorted(
+            (p for p in pylock.packages if str(p.name) == "torch"),
+            key=lambda p: str(p.version),
+        )
+        cpu = next(p for p in torch if str(p.version) == "2.0+cpu")
+        gpu = next(p for p in torch if str(p.version) == "2.0+gpu")
+        assert '"cpu" in extras' in str(cpu.marker)
+        assert '"gpu" in extras' in str(gpu.marker)
+
+    def test_fully_universal_dep_has_no_marker(self) -> None:
+        pylock = build_pylock(self._lock_input())
+        universal = next(p for p in pylock.packages if str(p.name) == "universal")
+        assert universal.marker is None
 
 
 class TestBuildPylockReturnsValidPylock:
@@ -1232,6 +1343,183 @@ class TestMarkerDisjointness:
             extras=("cpu", "fast-io"),
             groups=(),
             exclusive_groups=[frozenset({("extra", "cpu"), ("extra", "fast-io")})],
+        )
+
+    def test_group_membership_drives_conflict_hint(self) -> None:
+        # The collision fires at a witness where a referenced group is
+        # active (extras play no part), so the groups branch of the hint
+        # gate must trigger.
+        with pytest.raises(DisjointnessError, match=r"\[tool.nab\].conflicts"):
+            validate_marker_disjointness(
+                [
+                    self._pkg("black", "22.1", "'black22' in dependency_groups"),
+                    self._pkg("black", "23.12", "'black23' in dependency_groups"),
+                ],
+                environments=self._LINUX,
+                extras=(),
+                groups=("black22", "black23"),
+            )
+
+    def test_env_collision_with_membership_marker_has_no_hint(self) -> None:
+        # One marker mentions an extra, but the collision fires at the
+        # empty-extras witness driven purely by the environment.  A
+        # conflict declaration cannot prune that point, so no hint.
+        with pytest.raises(DisjointnessError) as excinfo:
+            validate_marker_disjointness(
+                [
+                    self._pkg("foo", "1.0", "sys_platform == 'linux'"),
+                    self._pkg(
+                        "foo", "2.0", "sys_platform == 'linux' or 'cpu' in extras"
+                    ),
+                ],
+                environments=self._LINUX,
+                extras=("cpu",),
+                groups=(),
+            )
+        assert "[tool.nab].conflicts" not in str(excinfo.value)
+
+    def test_at_least_one_does_not_prune_collision(self) -> None:
+        # conflict_exclusion_groups DROPS at_least_one, so the projection
+        # passed for an at_least_one-only declaration is empty: the
+        # colliding context survives and the validator still raises.
+        conflicts = [
+            ConflictSet(
+                members=(
+                    ConflictMember(kind=ConflictKind.GROUP, name="a"),
+                    ConflictMember(kind=ConflictKind.GROUP, name="b"),
+                ),
+                policy=ConflictPolicy.AT_LEAST_ONE,
+            )
+        ]
+        with pytest.raises(DisjointnessError, match="black"):
+            validate_marker_disjointness(
+                [
+                    self._pkg("black", "1.0", "'a' in dependency_groups"),
+                    self._pkg("black", "2.0", "'b' in dependency_groups"),
+                ],
+                environments=self._LINUX,
+                extras=(),
+                groups=("a", "b"),
+                exclusive_groups=conflict_exclusion_groups(conflicts),
+            )
+
+    def test_at_most_one_prunes_same_collision(self) -> None:
+        # The same collision under an at_most_one exclusion is pruned.
+        conflicts = [
+            ConflictSet(
+                members=(
+                    ConflictMember(kind=ConflictKind.GROUP, name="a"),
+                    ConflictMember(kind=ConflictKind.GROUP, name="b"),
+                ),
+                policy=ConflictPolicy.AT_MOST_ONE,
+            )
+        ]
+        validate_marker_disjointness(
+            [
+                self._pkg("black", "1.0", "'a' in dependency_groups"),
+                self._pkg("black", "2.0", "'b' in dependency_groups"),
+            ],
+            environments=self._LINUX,
+            extras=(),
+            groups=("a", "b"),
+            exclusive_groups=conflict_exclusion_groups(conflicts),
+        )
+
+    def test_exactly_one_prunes_collision(self) -> None:
+        # exactly_one forbids co-selection like at_most_one, so its
+        # member set is projected as an exclusive group and the colliding
+        # context is pruned.
+        conflicts = [
+            ConflictSet(
+                members=(
+                    ConflictMember(kind=ConflictKind.GROUP, name="a"),
+                    ConflictMember(kind=ConflictKind.GROUP, name="b"),
+                ),
+                policy=ConflictPolicy.EXACTLY_ONE,
+            )
+        ]
+        validate_marker_disjointness(
+            [
+                self._pkg("black", "1.0", "'a' in dependency_groups"),
+                self._pkg("black", "2.0", "'b' in dependency_groups"),
+            ],
+            environments=self._LINUX,
+            extras=(),
+            groups=("a", "b"),
+            exclusive_groups=conflict_exclusion_groups(conflicts),
+        )
+
+    def test_two_exclusion_sets_second_prunes_point(self) -> None:
+        # Two independent exclusive sets: the {cpu, gpu} extras set does
+        # not cover this point, so the exclusion check must iterate past
+        # it to the {black22, black23} groups set that does prune it.
+        validate_marker_disjointness(
+            [
+                self._pkg("black", "22.1", "'black22' in dependency_groups"),
+                self._pkg("black", "23.12", "'black23' in dependency_groups"),
+            ],
+            environments=self._LINUX,
+            extras=("cpu", "gpu"),
+            groups=("black22", "black23"),
+            exclusive_groups=[
+                frozenset({("extra", "cpu"), ("extra", "gpu")}),
+                frozenset({("group", "black22"), ("group", "black23")}),
+            ],
+        )
+
+    def test_two_exclusion_sets_point_outside_both_raises(self) -> None:
+        # A collision outside both exclusive sets still raises even when
+        # two independent sets are declared.
+        with pytest.raises(DisjointnessError, match="black"):
+            validate_marker_disjointness(
+                [
+                    self._pkg("black", "1.0", "'black22' in dependency_groups"),
+                    self._pkg(
+                        "black",
+                        "2.0",
+                        "'black22' in dependency_groups"
+                        " or 'black23' in dependency_groups",
+                    ),
+                ],
+                environments=self._LINUX,
+                extras=("cpu", "gpu"),
+                groups=("black22", "black23"),
+                exclusive_groups=[
+                    frozenset({("extra", "cpu"), ("extra", "gpu")}),
+                    frozenset({("group", "black22"), ("group", "black23")}),
+                ],
+            )
+
+    def test_repeated_environments_still_raise_on_collision(self) -> None:
+        # A conflict-forked lock repeats one physical env under several
+        # selection labels.  Dedup must not hide a genuine collision.
+        envs = {
+            "linux-cpu": dict(self._LINUX["linux"]),
+            "linux-gpu": dict(self._LINUX["linux"]),
+        }
+        with pytest.raises(DisjointnessError):
+            validate_marker_disjointness(
+                [self._pkg("foo", "1.0"), self._pkg("foo", "2.0")],
+                environments=envs,
+                extras=(),
+                groups=(),
+            )
+
+    def test_repeated_environments_pass_when_disjoint(self) -> None:
+        # The same repeated-env lock passes when the entries partition
+        # the install context, matching the pre-dedup behaviour.
+        envs = {
+            "linux-cpu": dict(self._LINUX["linux"]),
+            "linux-gpu": dict(self._LINUX["linux"]),
+        }
+        validate_marker_disjointness(
+            [
+                self._pkg("foo", "1.0", "'cpu' in extras"),
+                self._pkg("foo", "2.0", "'cpu' not in extras"),
+            ],
+            environments=envs,
+            extras=("cpu",),
+            groups=(),
         )
 
 

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -627,14 +627,22 @@ class TestConflictForkBaseDepMarkers:
     def _lock_input(self) -> LockInput:
         linux_env_marker = Marker('sys_platform == "linux"')
         win_env_marker = Marker('sys_platform == "win32"')
+
+        # ``tensorrt`` is a member-only dep: required by every fork but
+        # absent from the base resolve, so its membership clause must
+        # survive even though it appears in both linux forks at the same
+        # version.  Without ``env_base_names`` the writer cannot tell
+        # this case apart from a true base dep.
         per_tuple = {
             "linux-cpu": {
                 "basepkg": _index_pin(name="basepkg", version="1.0"),
+                "tensorrt": _index_pin(name="tensorrt", version="1.0"),
                 "torch": _index_pin(name="torch", version="2.0+cpu"),
                 "universal": _index_pin(name="universal", version="9.0"),
             },
             "linux-gpu": {
                 "basepkg": _index_pin(name="basepkg", version="1.0"),
+                "tensorrt": _index_pin(name="tensorrt", version="1.0"),
                 "torch": _index_pin(name="torch", version="2.0+gpu"),
                 "universal": _index_pin(name="universal", version="9.0"),
             },
@@ -665,6 +673,17 @@ class TestConflictForkBaseDepMarkers:
             "win-cpu": self._WIN_ENV,
             "win-gpu": self._WIN_ENV,
         }
+
+        # Mirror the resolver shape: a base pass ran for both envs and
+        # told the writer which deps install regardless of which member
+        # is selected.  ``tensorrt`` is intentionally absent.
+        linux_sig = tuple(sorted(self._LINUX_ENV.items()))
+        win_sig = tuple(sorted(self._WIN_ENV.items()))
+        env_base_names = {
+            linux_sig: frozenset({"basepkg", "universal"}),
+            win_sig: frozenset({"universal"}),
+        }
+
         conflicts = (
             ConflictSet(
                 members=(
@@ -679,6 +698,7 @@ class TestConflictForkBaseDepMarkers:
             tuple_markers=tuple_markers,
             tuple_env_markers=tuple_env_markers,
             tuple_environments=tuple_environments,
+            env_base_names=env_base_names,
             extras=("cpu", "gpu"),
             conflicts=conflicts,
         )
@@ -708,10 +728,185 @@ class TestConflictForkBaseDepMarkers:
         assert '"cpu" in extras' in str(cpu.marker)
         assert '"gpu" in extras' in str(gpu.marker)
 
+    def test_member_only_dep_present_in_every_fork_keeps_membership(self) -> None:
+        """A dep required by every fork but absent from the base resolve
+        keeps its membership OR, so it does not install when no member
+        is selected (at_most_one permits zero)."""
+        pylock = build_pylock(self._lock_input())
+        tensorrt = next(p for p in pylock.packages if str(p.name) == "tensorrt")
+        marker = tensorrt.marker
+        assert marker is not None
+        assert '"cpu" in extras' in str(marker)
+        assert '"gpu" in extras' in str(marker)
+        assert not marker.evaluate({"sys_platform": "linux", "extras": frozenset()})
+        assert marker.evaluate({"sys_platform": "linux", "extras": frozenset({"cpu"})})
+
     def test_fully_universal_dep_has_no_marker(self) -> None:
         pylock = build_pylock(self._lock_input())
         universal = next(p for p in pylock.packages if str(p.name) == "universal")
         assert universal.marker is None
+
+
+class TestConflictForksWithoutBaseAttribution:
+    """When conflict forks ran but the caller did not supply base
+    requirements, ``env_base_names`` is empty.  Base status is unknowable,
+    so a dep present in every fork at the same version must keep its
+    membership OR rather than collapse to an env-only marker."""
+
+    _ENV: ClassVar[dict[str, str]] = {"sys_platform": "linux"}
+
+    def _lock_input(self) -> LockInput:
+        per_tuple = {
+            "cpu": {"shared": _index_pin(name="shared", version="1.0")},
+            "gpu": {"shared": _index_pin(name="shared", version="1.0")},
+        }
+        env_marker = Marker('sys_platform == "linux"')
+        tuple_markers = {
+            "cpu": Marker('sys_platform == "linux" and "cpu" in extras'),
+            "gpu": Marker('sys_platform == "linux" and "gpu" in extras'),
+        }
+        conflicts = (
+            ConflictSet(
+                members=(
+                    ConflictMember(ConflictKind.EXTRA, "cpu"),
+                    ConflictMember(ConflictKind.EXTRA, "gpu"),
+                ),
+                policy=ConflictPolicy.AT_MOST_ONE,
+            ),
+        )
+        return LockInput(
+            per_tuple_pins=per_tuple,
+            tuple_markers=tuple_markers,
+            tuple_env_markers={"cpu": env_marker, "gpu": env_marker},
+            tuple_environments={"cpu": self._ENV, "gpu": self._ENV},
+            extras=("cpu", "gpu"),
+            conflicts=conflicts,
+        )
+
+    def test_shared_pin_keeps_membership_or(self) -> None:
+        pylock = build_pylock(self._lock_input())
+        shared = next(p for p in pylock.packages if str(p.name) == "shared")
+        marker = shared.marker
+        assert marker is not None
+        assert '"cpu" in extras' in str(marker)
+        assert '"gpu" in extras' in str(marker)
+        assert not marker.evaluate({"sys_platform": "linux", "extras": frozenset()})
+
+
+class TestConflictForkRequiresPythonMerge:
+    """Same-(name, version, index) pins from different conflict forks
+    collapse to one entry; ``requires_python`` survives only when every
+    fork agreed, matching :func:`_common_requires_python`'s rule."""
+
+    _ENV: ClassVar[dict[str, str]] = {"sys_platform": "linux"}
+
+    @staticmethod
+    def _pin(requires_python: str | None) -> IndexPin:
+        return IndexPin(
+            name="foo",
+            version="1.0",
+            index="pypi",
+            sdist=_sdist("foo", "1.0"),
+            wheels=(_wheel("foo", "1.0"),),
+            requires_python=requires_python,
+        )
+
+    def _build(self, cpu_req: str | None, gpu_req: str | None) -> LockInput:
+        return LockInput(
+            per_tuple_pins={
+                "cpu": {"foo": self._pin(cpu_req)},
+                "gpu": {"foo": self._pin(gpu_req)},
+            },
+            tuple_markers={
+                "cpu": Marker('"cpu" in extras'),
+                "gpu": Marker('"gpu" in extras'),
+            },
+            tuple_environments={"cpu": self._ENV, "gpu": self._ENV},
+            extras=("cpu", "gpu"),
+            conflicts=(
+                ConflictSet(
+                    members=(
+                        ConflictMember(ConflictKind.EXTRA, "cpu"),
+                        ConflictMember(ConflictKind.EXTRA, "gpu"),
+                    ),
+                    policy=ConflictPolicy.AT_MOST_ONE,
+                ),
+            ),
+        )
+
+    def test_disagreeing_requires_python_drops_to_none(self) -> None:
+        pylock = build_pylock(self._build(">=3.10", ">=3.11"))
+        foo = next(p for p in pylock.packages if str(p.name) == "foo")
+        assert foo.requires_python is None
+
+    def test_agreeing_requires_python_survives_the_merge(self) -> None:
+        pylock = build_pylock(self._build(">=3.10", ">=3.10"))
+        foo = next(p for p in pylock.packages if str(p.name) == "foo")
+        assert foo.requires_python is not None
+        assert str(foo.requires_python) == ">=3.10"
+
+
+class TestConflictForkByteStability:
+    """``write_lock`` is deterministic across multiple conflict forks.
+
+    Every per-tuple grouping, marker disjunction, and wheel listing must
+    pivot through sorted iteration so two calls on the same
+    :class:`LockInput` produce byte-identical TOML.  Without this, a
+    re-resolve that only re-orders dict insertion would write a
+    spurious diff."""
+
+    _LINUX: ClassVar[dict[str, str]] = {
+        "sys_platform": "linux",
+        "platform_machine": "x86_64",
+    }
+    _DARWIN: ClassVar[dict[str, str]] = {
+        "sys_platform": "darwin",
+        "platform_machine": "arm64",
+    }
+
+    def _two_by_two(self) -> LockInput:
+        # Two pythons (linux, darwin) x two conflict members (cpu, gpu).
+        per_tuple: dict[str, dict[str, IndexPin]] = {}
+        tuple_markers: dict[str, Marker] = {}
+        tuple_env_markers: dict[str, Marker] = {}
+        tuple_environments: dict[str, dict[str, str]] = {}
+        env_marker = {
+            "linux": Marker('sys_platform == "linux"'),
+            "darwin": Marker('sys_platform == "darwin"'),
+        }
+        env_dict = {"linux": self._LINUX, "darwin": self._DARWIN}
+        for sys_plat in ("darwin", "linux"):
+            for member in ("gpu", "cpu"):
+                label = f"{sys_plat}-{member}"
+                per_tuple[label] = {
+                    "torch": _index_pin(name="torch", version=f"2.0+{member}"),
+                    "universal": _index_pin(name="universal", version="9.0"),
+                }
+                tuple_markers[label] = Marker(
+                    f'sys_platform == "{sys_plat}" and "{member}" in extras'
+                )
+                tuple_env_markers[label] = env_marker[sys_plat]
+                tuple_environments[label] = env_dict[sys_plat]
+        return LockInput(
+            per_tuple_pins=per_tuple,
+            tuple_markers=tuple_markers,
+            tuple_env_markers=tuple_env_markers,
+            tuple_environments=tuple_environments,
+            extras=("cpu", "gpu"),
+            conflicts=(
+                ConflictSet(
+                    members=(
+                        ConflictMember(ConflictKind.EXTRA, "cpu"),
+                        ConflictMember(ConflictKind.EXTRA, "gpu"),
+                    ),
+                    policy=ConflictPolicy.AT_MOST_ONE,
+                ),
+            ),
+        )
+
+    def test_pylock_byte_stable_across_two_writes(self) -> None:
+        lock_input = self._two_by_two()
+        assert write_lock(lock_input) == write_lock(lock_input)
 
 
 class TestBuildPylockReturnsValidPylock:
@@ -1322,6 +1517,35 @@ class TestMarkerDisjointness:
                 groups=(),
             )
         assert "[tool.nab].conflicts" not in str(excinfo.value)
+
+    def test_membership_markers_do_not_collide_at_empty_extras(self) -> None:
+        """``'cpu' in frozenset()`` must evaluate False through
+        :class:`Marker`, so the empty-extras point in
+        :func:`_enumerate_valid_points` never makes two membership-gated
+        entries collide.  Asserts the marker-eval primitive in isolation
+        so a later switch to a different Marker library cannot regress
+        this without breaking a focused test."""
+        empty_context = {
+            "sys_platform": "linux",
+            "extras": frozenset(),
+            "dependency_groups": frozenset(),
+        }
+        assert not Marker("'cpu' in extras").evaluate(empty_context)
+        assert not Marker("'gpu' in extras").evaluate(empty_context)
+
+        # End-to-end: two membership-gated entries are not a collision at
+        # the empty-extras witness even without a declared conflict, so
+        # the validator stays silent on that point.
+        validate_marker_disjointness(
+            [
+                self._pkg("foo", "1.0", "'cpu' in extras"),
+                self._pkg("foo", "2.0", "'gpu' in extras"),
+            ],
+            environments=self._LINUX,
+            extras=("cpu", "gpu"),
+            groups=(),
+            exclusive_groups=[frozenset({("extra", "cpu"), ("extra", "gpu")})],
+        )
 
     def test_conflict_member_normalization_prunes_collision(self) -> None:
         # The declared member name and the marker literal differ by

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -1483,12 +1483,13 @@ class TestMarkerDisjointness:
 
     def test_repeated_environments_still_raise_on_collision(self) -> None:
         # A conflict-forked lock repeats one physical env under several
-        # selection labels.  Dedup must not hide a genuine collision.
+        # selection labels.  Dedup must not hide a genuine collision and
+        # must keep the first-seen label so the message stays stable.
         envs = {
             "linux-cpu": dict(self._LINUX["linux"]),
             "linux-gpu": dict(self._LINUX["linux"]),
         }
-        with pytest.raises(DisjointnessError):
+        with pytest.raises(DisjointnessError, match="linux-cpu"):
             validate_marker_disjointness(
                 [self._pkg("foo", "1.0"), self._pkg("foo", "2.0")],
                 environments=envs,
@@ -1512,6 +1513,31 @@ class TestMarkerDisjointness:
             extras=("cpu",),
             groups=(),
         )
+
+    def test_distinct_environments_kept_when_collision_only_in_second(
+        self,
+    ) -> None:
+        # Dedup collapses identical env dicts only; two genuinely
+        # different envs must each get evaluated.  Collision shows
+        # under darwin only, and the error must name darwin.
+        envs = {
+            "linux": dict(self._LINUX["linux"]),
+            "darwin": {
+                "python_version": "3.11",
+                "sys_platform": "darwin",
+                "platform_machine": "arm64",
+            },
+        }
+        with pytest.raises(DisjointnessError, match="darwin"):
+            validate_marker_disjointness(
+                [
+                    self._pkg("foo", "1.0", "sys_platform == 'darwin'"),
+                    self._pkg("foo", "2.0", "sys_platform == 'darwin'"),
+                ],
+                environments=envs,
+                extras=(),
+                groups=(),
+            )
 
 
 class _FakeIndex:

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -36,6 +36,7 @@ from nab_python.config import (
     ConflictPolicy,
     ConflictSet,
     conflict_exclusion_groups,
+    conflict_member_groups,
 )
 from nab_python.lockfile import (
     LOCK_VERSION,
@@ -1393,6 +1394,35 @@ class TestMarkerDisjointness:
                 groups=("a", "b"),
                 exclusive_groups=conflict_exclusion_groups(conflicts),
             )
+
+    def test_already_declared_at_least_one_hint_recommends_tightening(self) -> None:
+        # The colliding members are already declared, just under a policy
+        # that permits co-selection; the hint must point at tightening
+        # rather than suggesting the user declare them again.
+        conflicts = [
+            ConflictSet(
+                members=(
+                    ConflictMember(kind=ConflictKind.GROUP, name="a"),
+                    ConflictMember(kind=ConflictKind.GROUP, name="b"),
+                ),
+                policy=ConflictPolicy.AT_LEAST_ONE,
+            )
+        ]
+        with pytest.raises(DisjointnessError) as info:
+            validate_marker_disjointness(
+                [
+                    self._pkg("black", "1.0", "'a' in dependency_groups"),
+                    self._pkg("black", "2.0", "'b' in dependency_groups"),
+                ],
+                environments=self._LINUX,
+                extras=(),
+                groups=("a", "b"),
+                exclusive_groups=conflict_exclusion_groups(conflicts),
+                declared_groups=conflict_member_groups(conflicts),
+            )
+        message = str(info.value)
+        assert "switch to at_most_one or exactly_one" in message
+        assert "If these are intentionally mutually exclusive" not in message
 
     def test_at_most_one_prunes_same_collision(self) -> None:
         # The same collision under an at_most_one exclusion is pruned.

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import cast
+from typing import ClassVar, cast
 
 import pytest
 
@@ -1130,6 +1130,109 @@ class TestMarkerDisjointness:
                 extras=many_extras,
                 groups=(),
             )
+
+    _LINUX: ClassVar[dict[str, dict[str, str]]] = {
+        "linux": {
+            "python_version": "3.11",
+            "sys_platform": "linux",
+            "platform_machine": "x86_64",
+        },
+    }
+
+    def test_declared_extra_conflict_prunes_collision(self) -> None:
+        # The bare-marker case that collides without a declaration now
+        # passes once cpu and gpu are declared mutually exclusive: the
+        # {cpu, gpu} point is pruned from the universe.
+        validate_marker_disjointness(
+            [
+                self._pkg("foo", "1.0", "'cpu' in extras"),
+                self._pkg("foo", "2.0", "'gpu' in extras"),
+            ],
+            environments=self._LINUX,
+            extras=("cpu", "gpu"),
+            groups=(),
+            exclusive_groups=[frozenset({("extra", "cpu"), ("extra", "gpu")})],
+        )
+
+    def test_declared_group_conflict_prunes_collision(self) -> None:
+        # The datamodel-code-generator case: mutually-exclusive
+        # dependency groups gated by bare ``in dependency_groups``
+        # markers validate once the groups are declared exclusive.
+        validate_marker_disjointness(
+            [
+                self._pkg("black", "22.1", "'black22' in dependency_groups"),
+                self._pkg("black", "23.12", "'black23' in dependency_groups"),
+                self._pkg("black", "24.1", "'black24' in dependency_groups"),
+            ],
+            environments=self._LINUX,
+            extras=(),
+            groups=("black22", "black23", "black24"),
+            exclusive_groups=[
+                frozenset(
+                    {
+                        ("group", "black22"),
+                        ("group", "black23"),
+                        ("group", "black24"),
+                    }
+                )
+            ],
+        )
+
+    def test_conflict_does_not_prune_unrelated_collision(self) -> None:
+        # A collision outside the pruned subspace still raises: cpu/gpu
+        # are declared exclusive, but these two entries collide on the
+        # cpu point itself (both fire when cpu is selected).
+        with pytest.raises(DisjointnessError, match="foo"):
+            validate_marker_disjointness(
+                [
+                    self._pkg("foo", "1.0", "'cpu' in extras"),
+                    self._pkg("foo", "2.0", "'cpu' in extras or 'gpu' in extras"),
+                ],
+                environments=self._LINUX,
+                extras=("cpu", "gpu"),
+                groups=(),
+                exclusive_groups=[frozenset({("extra", "cpu"), ("extra", "gpu")})],
+            )
+
+    def test_collision_hint_points_at_conflicts_key(self) -> None:
+        # A membership-driven collision with no declaration surfaces a
+        # hint pointing at the conflicts key.
+        with pytest.raises(DisjointnessError, match=r"\[tool.nab\].conflicts"):
+            validate_marker_disjointness(
+                [
+                    self._pkg("foo", "1.0", "'cpu' in extras"),
+                    self._pkg("foo", "2.0", "'gpu' in extras"),
+                ],
+                environments=self._LINUX,
+                extras=("cpu", "gpu"),
+                groups=(),
+            )
+
+    def test_environment_only_collision_has_no_conflict_hint(self) -> None:
+        # An environment-driven collision is not helped by a conflict
+        # declaration, so no hint is appended.
+        with pytest.raises(DisjointnessError) as excinfo:
+            validate_marker_disjointness(
+                [self._pkg("foo", "1.0"), self._pkg("foo", "2.0")],
+                environments=self._LINUX,
+                extras=(),
+                groups=(),
+            )
+        assert "[tool.nab].conflicts" not in str(excinfo.value)
+
+    def test_conflict_member_normalization_prunes_collision(self) -> None:
+        # The declared member name and the marker literal differ by
+        # case/separator; canonicalisation must still prune the point.
+        validate_marker_disjointness(
+            [
+                self._pkg("foo", "1.0", "'CPU' in extras"),
+                self._pkg("foo", "2.0", "'fast_io' in extras"),
+            ],
+            environments=self._LINUX,
+            extras=("cpu", "fast-io"),
+            groups=(),
+            exclusive_groups=[frozenset({("extra", "cpu"), ("extra", "fast-io")})],
+        )
 
 
 class _FakeIndex:

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -9,6 +9,7 @@ import pytest
 from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python.requirements_file import (
     InvalidProjectRequirementError,
+    expand_group_includes,
     expand_self_extras,
     raise_for_unsatisfiable,
     read_pyproject_dependencies,
@@ -285,6 +286,78 @@ class TestExpandSelfExtras:
         """Duplicates in the user-supplied selection are deduped."""
         opt = {"a": ["depA"]}
         assert expand_self_extras(opt, "mypkg", ["a", "a", "a"]) == ["a"]
+
+
+class TestExpandGroupIncludes:
+    def test_no_include_returns_input(self) -> None:
+        groups = {"a": ["depA"], "b": ["depB"]}
+        assert expand_group_includes(groups, ["a"]) == ["a"]
+
+    def test_include_group_expanded(self) -> None:
+        groups = {
+            "all-tools": [{"include-group": "b22"}, {"include-group": "b23"}],
+            "b22": ["black==22.0"],
+            "b23": ["black==23.0"],
+        }
+        assert expand_group_includes(groups, ["all-tools"]) == [
+            "all-tools",
+            "b22",
+            "b23",
+        ]
+
+    def test_chain_of_includes(self) -> None:
+        groups = {
+            "all": [{"include-group": "mid"}],
+            "mid": [{"include-group": "leaf"}],
+            "leaf": ["depA"],
+        }
+        assert expand_group_includes(groups, ["all"]) == ["all", "mid", "leaf"]
+
+    def test_diamond_include_visited_once(self) -> None:
+        """A group reached through two paths is emitted a single time."""
+        groups = {
+            "all": [{"include-group": "left"}, {"include-group": "right"}],
+            "left": [{"include-group": "shared"}],
+            "right": [{"include-group": "shared"}],
+            "shared": ["depShared"],
+        }
+        assert expand_group_includes(groups, ["all"]) == [
+            "all",
+            "left",
+            "right",
+            "shared",
+        ]
+
+    def test_include_name_canonicalized(self) -> None:
+        """An include naming a group non-canonically still walks it."""
+        groups = {"all": [{"include-group": "Sub_Group"}], "sub-group": ["depA"]}
+        assert expand_group_includes(groups, ["all"]) == ["all", "sub-group"]
+
+    def test_table_entry_without_include_group_ignored(self) -> None:
+        """A table entry that is not an include record is skipped."""
+        groups = {"a": [{"not-an-include": "x"}, "depA"]}
+        assert expand_group_includes(groups, ["a"]) == ["a"]
+
+    def test_non_string_include_tolerated(self) -> None:
+        """A malformed (non-string) include is skipped, not crashed on."""
+        groups = {"a": [{"include-group": 123}]}
+        assert expand_group_includes(groups, ["a"]) == ["a"]
+
+    def test_cycle_terminates(self) -> None:
+        groups = {
+            "a": [{"include-group": "b"}],
+            "b": [{"include-group": "a"}],
+        }
+        assert sorted(expand_group_includes(groups, ["a"])) == ["a", "b"]
+
+    def test_unknown_include_tolerated(self) -> None:
+        """An include naming a missing group does not raise here."""
+        groups = {"a": [{"include-group": "missing"}]}
+        assert expand_group_includes(groups, ["a"]) == ["a", "missing"]
+
+    def test_duplicate_input_groups_collapsed(self) -> None:
+        groups = {"a": ["depA"]}
+        assert expand_group_includes(groups, ["a", "a"]) == ["a"]
 
 
 class TestRaiseForUnsatisfiable:

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -11,6 +11,7 @@ from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.version import Version
 from nab_python.config import (
     ConfigError,
+    ConflictSelectionError,
     MatrixConfig,
     NabProjectConfig,
     ResolveMode,
@@ -50,6 +51,58 @@ V = Version
 _FAKE_TRANSPORT = MagicMock(name="FakeTransport")
 
 _FORTY = "0123456789abcdef0123456789abcdef01234567"
+
+
+class TestSpecificModeConflictValidation:
+    """A declared conflict fails fast in specific mode, before any network."""
+
+    def test_co_selecting_conflicting_extras_raises(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\nversion = "0"\n'
+            "dependencies = []\n"
+            "[project.optional-dependencies]\n"
+            'cpu = ["numpy==2.1.2"]\n'
+            'gpu = ["numpy==2.0.0"]\n'
+            "[tool.nab]\n"
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+        )
+        # No FetchCoordinator patch: the validation must raise before any
+        # network work is attempted.
+        with pytest.raises(ConflictSelectionError, match="cannot be selected together"):
+            resolve_pyproject(
+                pyproject,
+                _FAKE_TRANSPORT,
+                extras=("cpu", "gpu"),
+                python_version="3.12.0",
+            )
+
+    def test_single_extra_under_conflict_resolves(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\nversion = "0"\n'
+            "dependencies = []\n"
+            "[project.optional-dependencies]\n"
+            'cpu = ["foo==1.0"]\n'
+            'gpu = ["foo==2.0"]\n'
+            "[tool.nab]\n"
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+        )
+        with (
+            patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls,
+            patch("nab_python.resolve.Provider") as mock_provider_cls,
+            patch("nab_python.resolve.build_lock_input_from_provider"),
+        ):
+            mock_coord_cls.return_value.__enter__ = lambda s: s
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            mock_provider = mock_provider_cls.return_value
+            mock_provider.choose_version.return_value = V("1.0")
+            mock_provider.get_dependencies.return_value = {}
+            mock_provider.prioritize.return_value = 1
+            result = resolve_pyproject(
+                pyproject, _FAKE_TRANSPORT, extras=("cpu",), python_version="3.12.0"
+            )
+        assert result.pins == {"foo": V("1.0")}
 
 
 class TestResolvePyproject:

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -772,7 +772,10 @@ class TestResolveUniversalPyproject:
         kwargs = mock_resolve_universal.call_args.kwargs
         assert kwargs["matrix"].python == ">=3.11,<3.13"
         assert kwargs["matrix"].platforms == ("linux_x86_64", "macos_arm64")
-        assert kwargs["requirements"] == ["foo"]
+        # No conflicts: a single unforked fork carrying the base deps.
+        (fork,) = kwargs["forks"]
+        assert fork.selection == ()
+        assert fork.requirements == ["foo"]
 
     @patch("nab_python.resolve.resolve_universal")
     def test_passes_python_patches_when_set(

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -191,6 +191,60 @@ class TestSpecificModeConflictValidation:
                 python_version="3.12.0",
             )
 
+    def test_umbrella_extra_transitively_co_selecting_conflict_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """A two-hop umbrella reaches both members through an intermediate
+        extra.  ``expand_self_extras`` walks the closure, so the
+        co-selection check must trip even though ``all`` does not
+        directly name cpu or gpu."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\nversion = "0"\n'
+            "dependencies = []\n"
+            "[project.optional-dependencies]\n"
+            'cpu = ["numpy==2.1.2"]\n'
+            'gpu = ["numpy==2.0.0"]\n'
+            'middle = ["x[cpu]", "x[gpu]"]\n'
+            'all = ["x[middle]"]\n'
+            "[tool.nab]\n"
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+        )
+        with pytest.raises(ConflictSelectionError, match="cannot be selected together"):
+            resolve_pyproject(
+                pyproject,
+                _FAKE_TRANSPORT,
+                extras=("all",),
+                python_version="3.12.0",
+            )
+
+    def test_umbrella_group_transitively_co_selecting_conflict_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """A two-hop ``include-group`` chain reaches both members.
+        ``expand_group_includes`` must follow the chain so the
+        co-selection check fires for the umbrella alone."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\nversion = "0"\n'
+            "dependencies = []\n"
+            "[dependency-groups]\n"
+            'b22 = ["black==22.0"]\n'
+            'b23 = ["black==23.0"]\n'
+            'middle = [{ include-group = "b22" },'
+            ' { include-group = "b23" }]\n'
+            'all-tools = [{ include-group = "middle" }]\n'
+            "[tool.nab]\n"
+            'conflicts = [[{ group = "b22" }, { group = "b23" }]]\n'
+        )
+        with pytest.raises(ConflictSelectionError, match="cannot be selected together"):
+            resolve_pyproject(
+                pyproject,
+                _FAKE_TRANSPORT,
+                groups=("all-tools",),
+                python_version="3.12.0",
+            )
+
     def test_umbrella_extra_reaching_one_member_resolves(self, tmp_path: Path) -> None:
         """An umbrella reaching only one member stays satisfiable."""
         pyproject = tmp_path / "pyproject.toml"
@@ -1290,6 +1344,34 @@ class TestResolveUniversalPyproject:
             pytest.raises(ConflictSelectionError, match="cannot be selected together"),
         ):
             resolve_universal_pyproject(pyproject, groups=["all-tools"])
+        mock_universal.assert_not_called()
+
+    def test_universal_umbrella_extra_transitively_co_selects_conflict_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """The two-hop transitive case in universal mode.  No fork can
+        separate cpu and gpu when both flow from one umbrella, so the
+        resolve is refused before any tuple runs."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = ["base"]\n'
+            "[project.optional-dependencies]\n"
+            'cpu = ["torch==2.0+cpu"]\n'
+            'gpu = ["torch==2.0+gpu"]\n'
+            'middle = ["x[cpu]", "x[gpu]"]\n'
+            'all = ["x[middle]"]\n'
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.11"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+        with (
+            patch("nab_python.resolve.resolve_universal") as mock_universal,
+            pytest.raises(ConflictSelectionError, match="cannot be selected together"),
+        ):
+            resolve_universal_pyproject(pyproject, extras=["all"])
         mock_universal.assert_not_called()
 
     @patch("nab_python.resolve.resolve_universal")

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -142,6 +142,83 @@ class TestSpecificModeConflictValidation:
                 python_version="3.12.0",
             )
 
+    def test_umbrella_extra_co_selecting_conflict_raises(self, tmp_path: Path) -> None:
+        """An umbrella extra self-referencing both members fails fast."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\nversion = "0"\n'
+            "dependencies = []\n"
+            "[project.optional-dependencies]\n"
+            'cpu = ["numpy==2.1.2"]\n'
+            'gpu = ["numpy==2.0.0"]\n'
+            'all = ["x[cpu]", "x[gpu]"]\n'
+            "[tool.nab]\n"
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+        )
+        with pytest.raises(ConflictSelectionError, match="cannot be selected together"):
+            resolve_pyproject(
+                pyproject,
+                _FAKE_TRANSPORT,
+                extras=("all",),
+                python_version="3.12.0",
+            )
+
+    def test_umbrella_group_co_selecting_conflict_raises(self, tmp_path: Path) -> None:
+        """A group whose include-group reaches both members fails fast."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\nversion = "0"\n'
+            "dependencies = []\n"
+            "[dependency-groups]\n"
+            'b22 = ["black==22.0"]\n'
+            'b23 = ["black==23.0"]\n'
+            'all-tools = [{ include-group = "b22" },'
+            ' { include-group = "b23" }]\n'
+            "[tool.nab]\n"
+            'conflicts = [[{ group = "b22" }, { group = "b23" }]]\n'
+        )
+        with pytest.raises(ConflictSelectionError, match="cannot be selected together"):
+            resolve_pyproject(
+                pyproject,
+                _FAKE_TRANSPORT,
+                groups=("all-tools",),
+                python_version="3.12.0",
+            )
+
+    def test_umbrella_extra_reaching_one_member_resolves(self, tmp_path: Path) -> None:
+        """An umbrella reaching only one member stays satisfiable."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\nversion = "0"\n'
+            "dependencies = []\n"
+            "[project.optional-dependencies]\n"
+            'cpu = ["foo==1.0"]\n'
+            'gpu = ["foo==2.0"]\n'
+            'accel = ["x[cpu]"]\n'
+            "[tool.nab]\n"
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+        )
+        with (
+            patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls,
+            patch("nab_python.resolve.Provider") as mock_provider_cls,
+            patch("nab_python.resolve.build_lock_input_from_provider"),
+        ):
+            mock_coord_cls.return_value.__enter__ = lambda s: s
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            mock_provider = mock_provider_cls.return_value
+            mock_provider.choose_version.return_value = V("1.0")
+            mock_provider.get_dependencies.return_value = {}
+            mock_provider.prioritize.return_value = 1
+            result = resolve_pyproject(
+                pyproject,
+                _FAKE_TRANSPORT,
+                extras=("accel",),
+                python_version="3.12.0",
+            )
+        # Reaching here means the conflict check did not raise; cpu's dep
+        # is pulled in through the self-reference.
+        assert result.pins["foo"] == V("1.0")
+
 
 class TestResolvePyproject:
     def test_resolves_simple_project(self, tmp_path: Path) -> None:
@@ -978,6 +1055,109 @@ class TestResolveUniversalPyproject:
         resolve_universal_pyproject(pyproject, extras=["cpu", "gpu"])
         forks = mock_resolve_universal.call_args.kwargs["forks"]
         assert len(forks) == 2
+
+    @patch("nab_python.resolve.resolve_universal")
+    @patch("nab_python.resolve._check_group_disjointness_across_tuples")
+    def test_repeated_active_groups_check_once(
+        self,
+        mock_check: MagicMock,
+        mock_resolve_universal: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Forks sharing the same multi-group active set check disjointness once."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = ["base"]\n'
+            "[project.optional-dependencies]\n"
+            'cpu = ["torch==2.0+cpu"]\n'
+            'gpu = ["torch==2.0+gpu"]\n'
+            "[dependency-groups]\n"
+            'dev = ["pytest"]\n'
+            'lint = ["ruff"]\n'
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.11"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+        resolve_universal_pyproject(
+            pyproject, extras=["cpu", "gpu"], groups=["dev", "lint"]
+        )
+        # Two forks, both with active_groups=("dev", "lint"): scan once.
+        assert mock_check.call_count == 1
+
+    def test_umbrella_extra_co_selecting_conflict_raises(self, tmp_path: Path) -> None:
+        """An umbrella extra forcing both members cannot fork, so it raises."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = ["base"]\n'
+            "[project.optional-dependencies]\n"
+            'cpu = ["torch==2.0+cpu"]\n'
+            'gpu = ["torch==2.0+gpu"]\n'
+            'all = ["x[cpu]", "x[gpu]"]\n'
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.11"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+        with (
+            patch("nab_python.resolve.resolve_universal") as mock_universal,
+            pytest.raises(ConflictSelectionError, match="cannot be selected together"),
+        ):
+            resolve_universal_pyproject(pyproject, extras=["all"])
+        mock_universal.assert_not_called()
+
+    def test_umbrella_group_co_selecting_conflict_raises(self, tmp_path: Path) -> None:
+        """A group whose includes force both members raises, never forks."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = ["base"]\n'
+            "[dependency-groups]\n"
+            'b22 = ["black==22.0"]\n'
+            'b23 = ["black==23.0"]\n'
+            'all-tools = [{ include-group = "b22" },'
+            ' { include-group = "b23" }]\n'
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'conflicts = [[{ group = "b22" }, { group = "b23" }]]\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.11"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+        with (
+            patch("nab_python.resolve.resolve_universal") as mock_universal,
+            pytest.raises(ConflictSelectionError, match="cannot be selected together"),
+        ):
+            resolve_universal_pyproject(pyproject, groups=["all-tools"])
+        mock_universal.assert_not_called()
+
+    @patch("nab_python.resolve.resolve_universal")
+    def test_umbrella_extra_reaching_one_member_single_fork(
+        self, mock_resolve_universal: MagicMock, tmp_path: Path
+    ) -> None:
+        """An umbrella reaching one member yields one fork with its deps."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = ["base"]\n'
+            "[project.optional-dependencies]\n"
+            'cpu = ["torch==2.0+cpu"]\n'
+            'gpu = ["torch==2.0+gpu"]\n'
+            'accel = ["x[cpu]"]\n'
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.11"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+        resolve_universal_pyproject(pyproject, extras=["accel"])
+        (fork,) = mock_resolve_universal.call_args.kwargs["forks"]
+        assert fork.selection == ()
+        assert "torch==2.0+cpu" in fork.requirements
+        assert "torch==2.0+gpu" not in fork.requirements
 
     def test_unknown_conflict_member_raises(self, tmp_path: Path) -> None:
         """A conflict member naming an undeclared extra raises ConfigError."""

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -102,6 +102,12 @@ class TestSpecificModeConflictValidation:
             result = resolve_pyproject(
                 pyproject, _FAKE_TRANSPORT, extras=("cpu",), python_version="3.12.0"
             )
+        # The selected extra's pin reached the Provider as a root
+        # requirement; the unselected extra's contradictory pin did not.
+        root_reqs = mock_provider_cls.call_args.kwargs["root_requirements"]
+        assert "foo" in root_reqs
+        assert V("1.0") in root_reqs["foo"]
+        assert V("2.0") not in root_reqs["foo"]
         assert result.pins == {"foo": V("1.0")}
 
     def test_unknown_conflict_member_raises(self, tmp_path: Path) -> None:
@@ -218,6 +224,78 @@ class TestSpecificModeConflictValidation:
         # Reaching here means the conflict check did not raise; cpu's dep
         # is pulled in through the self-reference.
         assert result.pins["foo"] == V("1.0")
+
+    def test_specific_mode_exactly_one_with_no_member_raises(
+        self, tmp_path: Path
+    ) -> None:
+        # ``exactly_one`` requires at least one member active; with no
+        # ``--extras`` flag the resolve fails fast before any network work.
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\nversion = "0"\n'
+            "dependencies = []\n"
+            "[project.optional-dependencies]\n"
+            "cpu = []\n"
+            "gpu = []\n"
+            "[tool.nab]\n"
+            "conflicts = ["
+            '{ exactly_one = [{ extra = "cpu" }, { extra = "gpu" }] }'
+            "]\n"
+        )
+        with pytest.raises(ConflictSelectionError, match="exactly one"):
+            resolve_pyproject(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
+
+    def test_specific_mode_at_least_one_with_no_member_raises(
+        self, tmp_path: Path
+    ) -> None:
+        # ``at_least_one`` requires at least one member active; with no
+        # ``--extras`` flag the resolve fails fast before any network work.
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\nversion = "0"\n'
+            "dependencies = []\n"
+            "[project.optional-dependencies]\n"
+            "cpu = []\n"
+            "gpu = []\n"
+            "[tool.nab]\n"
+            "conflicts = ["
+            '{ at_least_one = [{ extra = "cpu" }, { extra = "gpu" }] }'
+            "]\n"
+        )
+        with pytest.raises(ConflictSelectionError, match="at least one"):
+            resolve_pyproject(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
+
+    def test_specific_mode_exactly_one_with_one_member_resolves(
+        self, tmp_path: Path
+    ) -> None:
+        # The happy path for exactly_one: one member selected, resolve runs.
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\nversion = "0"\n'
+            "dependencies = []\n"
+            "[project.optional-dependencies]\n"
+            'cpu = ["foo==1.0"]\n'
+            'gpu = ["foo==2.0"]\n'
+            "[tool.nab]\n"
+            "conflicts = ["
+            '{ exactly_one = [{ extra = "cpu" }, { extra = "gpu" }] }'
+            "]\n"
+        )
+        with (
+            patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls,
+            patch("nab_python.resolve.Provider") as mock_provider_cls,
+            patch("nab_python.resolve.build_lock_input_from_provider"),
+        ):
+            mock_coord_cls.return_value.__enter__ = lambda s: s
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            mock_provider = mock_provider_cls.return_value
+            mock_provider.choose_version.return_value = V("1.0")
+            mock_provider.get_dependencies.return_value = {}
+            mock_provider.prioritize.return_value = 1
+            result = resolve_pyproject(
+                pyproject, _FAKE_TRANSPORT, extras=("cpu",), python_version="3.12.0"
+            )
+        assert result.pins == {"foo": V("1.0")}
 
     def test_default_groups_satisfy_exactly_one(self, tmp_path: Path) -> None:
         # ``default-groups`` activates ``a`` on every default install, so

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -219,6 +219,86 @@ class TestSpecificModeConflictValidation:
         # is pulled in through the self-reference.
         assert result.pins["foo"] == V("1.0")
 
+    def test_default_groups_satisfy_exactly_one(self, tmp_path: Path) -> None:
+        # ``default-groups`` activates ``a`` on every default install, so
+        # the exactly-one minimum is met without any ``--groups`` flag.
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\nversion = "0"\n'
+            "dependencies = []\n"
+            "[dependency-groups]\n"
+            'a = ["foo==1.0"]\n'
+            "b = []\n"
+            "[tool.nab]\n"
+            'default-groups = ["a"]\n'
+            "conflicts = ["
+            '{ exactly_one = [{ group = "a" }, { group = "b" }] }'
+            "]\n"
+        )
+        with (
+            patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls,
+            patch("nab_python.resolve.Provider") as mock_provider_cls,
+            patch("nab_python.resolve.build_lock_input_from_provider"),
+        ):
+            mock_coord_cls.return_value.__enter__ = lambda s: s
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            mock_provider = mock_provider_cls.return_value
+            mock_provider.choose_version.return_value = V("1.0")
+            mock_provider.get_dependencies.return_value = {}
+            mock_provider.prioritize.return_value = 1
+            result = resolve_pyproject(
+                pyproject, _FAKE_TRANSPORT, python_version="3.12.0"
+            )
+        assert result.pins == {"foo": V("1.0")}
+
+    def test_default_groups_deps_are_loaded(self, tmp_path: Path) -> None:
+        # ``default-groups`` deps reach the resolver even without ``--groups``.
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\nversion = "0"\n'
+            "dependencies = []\n"
+            "[dependency-groups]\n"
+            'dev = ["bar==2.0"]\n'
+            "[tool.nab]\n"
+            'default-groups = ["dev"]\n'
+        )
+        with (
+            patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls,
+            patch("nab_python.resolve.Provider") as mock_provider_cls,
+            patch("nab_python.resolve.build_lock_input_from_provider"),
+        ):
+            mock_coord_cls.return_value.__enter__ = lambda s: s
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            mock_provider = mock_provider_cls.return_value
+            mock_provider.choose_version.return_value = V("2.0")
+            mock_provider.get_dependencies.return_value = {}
+            mock_provider.prioritize.return_value = 1
+            resolve_pyproject(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
+        root_reqs = mock_provider_cls.call_args.kwargs["root_requirements"]
+        assert "bar" in root_reqs
+
+    def test_default_groups_plus_cli_violate_exclusion(self, tmp_path: Path) -> None:
+        # ``default-groups = ["a"]`` plus ``--groups b`` activates both
+        # members of an at-most-one set, so the exclusion check trips.
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\nversion = "0"\n'
+            "dependencies = []\n"
+            "[dependency-groups]\n"
+            "a = []\n"
+            "b = []\n"
+            "[tool.nab]\n"
+            'default-groups = ["a"]\n'
+            'conflicts = [[{ group = "a" }, { group = "b" }]]\n'
+        )
+        with pytest.raises(ConflictSelectionError, match="cannot be selected together"):
+            resolve_pyproject(
+                pyproject,
+                _FAKE_TRANSPORT,
+                groups=("b",),
+                python_version="3.12.0",
+            )
+
 
 class TestResolvePyproject:
     def test_resolves_simple_project(self, tmp_path: Path) -> None:
@@ -1179,6 +1259,61 @@ class TestResolveUniversalPyproject:
         ):
             resolve_universal_pyproject(pyproject)
         mock_universal.assert_not_called()
+
+    @patch("nab_python.resolve.resolve_universal")
+    def test_default_groups_satisfy_exactly_one(
+        self, mock_resolve_universal: MagicMock, tmp_path: Path
+    ) -> None:
+        # ``default-groups`` activates ``a`` on every default install, so
+        # ``nab lock`` without ``--groups`` clears the exactly-one minimum.
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = ["base"]\n'
+            "[dependency-groups]\n"
+            'a = ["foo==1.0"]\n'
+            "b = []\n"
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'default-groups = ["a"]\n'
+            "conflicts = ["
+            '{ exactly_one = [{ group = "a" }, { group = "b" }] }'
+            "]\n"
+            "[tool.nab.matrix]\n"
+            'python = "==3.11"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+        resolve_universal_pyproject(pyproject)
+        (fork,) = mock_resolve_universal.call_args.kwargs["forks"]
+        assert "foo==1.0" in fork.requirements
+
+    @patch("nab_python.resolve.resolve_universal")
+    def test_default_groups_drive_forking_with_cli_groups(
+        self, mock_resolve_universal: MagicMock, tmp_path: Path
+    ) -> None:
+        # ``default-groups = ["b22"]`` plus ``--groups b23`` activates two
+        # members of an at-most-one set: each fork carries one member.
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = ["base"]\n'
+            "[dependency-groups]\n"
+            'b22 = ["black==22.0"]\n'
+            'b23 = ["black==23.0"]\n'
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'default-groups = ["b22"]\n'
+            'conflicts = [[{ group = "b22" }, { group = "b23" }]]\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.11"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+        resolve_universal_pyproject(pyproject, groups=["b23"])
+        forks = mock_resolve_universal.call_args.kwargs["forks"]
+        assert len(forks) == 2
+        selections = {f.selection for f in forks}
+        assert selections == {
+            (("group", "b22"),),
+            (("group", "b23"),),
+        }
 
 
 class TestResolvePyprojectVcs:

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -104,6 +104,44 @@ class TestSpecificModeConflictValidation:
             )
         assert result.pins == {"foo": V("1.0")}
 
+    def test_unknown_conflict_member_raises(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\nversion = "0"\n'
+            "dependencies = []\n"
+            "[project.optional-dependencies]\n"
+            'cpu = ["foo==1.0"]\n'
+            "[tool.nab]\n"
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpuu" }]]\n'
+        )
+        # No FetchCoordinator patch: the existence check raises before
+        # any network work is attempted.
+        with pytest.raises(ConfigError, match="gpuu"):
+            resolve_pyproject(
+                pyproject,
+                _FAKE_TRANSPORT,
+                extras=("cpu",),
+                python_version="3.12.0",
+            )
+
+    def test_unknown_group_member_raises(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\nversion = "0"\n'
+            "dependencies = []\n"
+            "[dependency-groups]\n"
+            'a = ["foo==1.0"]\n'
+            "[tool.nab]\n"
+            'conflicts = [[{ group = "a" }, { group = "missing" }]]\n'
+        )
+        with pytest.raises(ConfigError, match="missing"):
+            resolve_pyproject(
+                pyproject,
+                _FAKE_TRANSPORT,
+                groups=("a",),
+                python_version="3.12.0",
+            )
+
 
 class TestResolvePyproject:
     def test_resolves_simple_project(self, tmp_path: Path) -> None:
@@ -821,6 +859,146 @@ class TestResolveUniversalPyproject:
         pyproject.write_text('[project]\ndependencies = ["foo"]\n')
         with pytest.raises(UnsupportedModeError, match="requires mode = 'universal'"):
             resolve_universal_pyproject(pyproject)
+
+    @patch("nab_python.resolve.resolve_universal")
+    def test_co_selected_members_build_multiple_forks(
+        self, mock_resolve_universal: MagicMock, tmp_path: Path
+    ) -> None:
+        """Two co-selected conflicting extras fork into two resolves."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = ["base"]\n'
+            "[project.optional-dependencies]\n"
+            'cpu = ["torch==2.0+cpu"]\n'
+            'gpu = ["torch==2.0+gpu"]\n'
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.11"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+        resolve_universal_pyproject(pyproject, extras=["cpu", "gpu"])
+        forks = mock_resolve_universal.call_args.kwargs["forks"]
+        assert {f.selection for f in forks} == {
+            (("extra", "cpu"),),
+            (("extra", "gpu"),),
+        }
+        by_selection = {f.selection: f.requirements for f in forks}
+        assert by_selection[(("extra", "cpu"),)] == ["base", "torch==2.0+cpu"]
+        assert by_selection[(("extra", "gpu"),)] == ["base", "torch==2.0+gpu"]
+
+    def test_exactly_one_with_no_member_raises(self, tmp_path: Path) -> None:
+        """A universal exactly-one set with no active member raises."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = ["base"]\n'
+            "[project.optional-dependencies]\n"
+            'cpu = ["torch==2.0+cpu"]\n'
+            'gpu = ["torch==2.0+gpu"]\n'
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'conflicts = [{ exactly_one = [{ extra = "cpu" },'
+            ' { extra = "gpu" }] }]\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.11"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+        with (
+            patch("nab_python.resolve.resolve_universal") as mock_universal,
+            pytest.raises(ConflictSelectionError, match="exactly one"),
+        ):
+            resolve_universal_pyproject(pyproject)
+        mock_universal.assert_not_called()
+
+    def test_at_least_one_with_no_member_raises(self, tmp_path: Path) -> None:
+        """A universal at-least-one set with no active member raises."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = ["base"]\n'
+            "[project.optional-dependencies]\n"
+            'cpu = ["torch==2.0+cpu"]\n'
+            'gpu = ["torch==2.0+gpu"]\n'
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'conflicts = [{ at_least_one = [{ extra = "cpu" },'
+            ' { extra = "gpu" }] }]\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.11"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+        with (
+            patch("nab_python.resolve.resolve_universal") as mock_universal,
+            pytest.raises(ConflictSelectionError, match="at least one"),
+        ):
+            resolve_universal_pyproject(pyproject)
+        mock_universal.assert_not_called()
+
+    @patch("nab_python.resolve.resolve_universal")
+    def test_at_most_one_empty_does_not_raise(
+        self, mock_resolve_universal: MagicMock, tmp_path: Path
+    ) -> None:
+        """An at-most-one set with no member selected is fine."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = ["base"]\n'
+            "[project.optional-dependencies]\n"
+            'cpu = ["torch==2.0+cpu"]\n'
+            'gpu = ["torch==2.0+gpu"]\n'
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.11"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+        resolve_universal_pyproject(pyproject)
+        (fork,) = mock_resolve_universal.call_args.kwargs["forks"]
+        assert fork.selection == ()
+
+    @patch("nab_python.resolve.resolve_universal")
+    def test_co_selection_does_not_raise_minimum(
+        self, mock_resolve_universal: MagicMock, tmp_path: Path
+    ) -> None:
+        """Co-selecting an exactly-one set forks rather than raising."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = ["base"]\n'
+            "[project.optional-dependencies]\n"
+            'cpu = ["torch==2.0+cpu"]\n'
+            'gpu = ["torch==2.0+gpu"]\n'
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'conflicts = [{ exactly_one = [{ extra = "cpu" },'
+            ' { extra = "gpu" }] }]\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.11"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+        resolve_universal_pyproject(pyproject, extras=["cpu", "gpu"])
+        forks = mock_resolve_universal.call_args.kwargs["forks"]
+        assert len(forks) == 2
+
+    def test_unknown_conflict_member_raises(self, tmp_path: Path) -> None:
+        """A conflict member naming an undeclared extra raises ConfigError."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = ["base"]\n'
+            "[project.optional-dependencies]\n"
+            'cpu = ["torch==2.0+cpu"]\n'
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpuu" }]]\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.11"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+        with (
+            patch("nab_python.resolve.resolve_universal") as mock_universal,
+            pytest.raises(ConfigError, match="gpuu"),
+        ):
+            resolve_universal_pyproject(pyproject)
+        mock_universal.assert_not_called()
 
 
 class TestResolvePyprojectVcs:

--- a/nab-python/tests/universal/test_matrix.py
+++ b/nab-python/tests/universal/test_matrix.py
@@ -300,6 +300,21 @@ class TestMatrixTuple:
         )
         assert t.label == "py311-linux_x86_64-group-black22.group-isort5"
 
+    def test_mixed_extra_and_group_selection_label_format(self) -> None:
+        """Mixed selections sort ``extra-`` before ``group-`` lexically.
+
+        Pins the exact byte-stable label shape so renaming
+        :data:`KIND_EXTRA` / :data:`KIND_GROUP` cannot silently flip the
+        sort order and rewrite every label dict key.
+        """
+        t = MatrixTuple(
+            python_version="3.11",
+            platform_id="linux_x86_64",
+            environment={},
+            selection=(("group", "isort5"), ("extra", "cpu")),
+        )
+        assert t.label == "py311-linux_x86_64-extra-cpu.group-isort5"
+
     def test_label_distinguishes_selections_that_split_on_hyphen(self) -> None:
         """Names containing ``-`` cannot collide two selections into one label.
 

--- a/nab-python/tests/universal/test_matrix.py
+++ b/nab-python/tests/universal/test_matrix.py
@@ -345,6 +345,23 @@ class TestMatrixTuple:
             'and "cpu" in extras and "isort5" in dependency_groups'
         )
 
+    def test_environment_marker_string_omits_selection(self) -> None:
+        """The env-only marker drops the conflict membership clause."""
+        t = MatrixTuple(
+            python_version="3.11",
+            platform_id="linux_x86_64",
+            environment={
+                "sys_platform": "linux",
+                "platform_machine": "x86_64",
+                "implementation_name": "cpython",
+            },
+            selection=(("group", "black22"),),
+        )
+        assert "in dependency_groups" not in t.environment_marker_string
+        assert t.environment_marker_string.endswith('platform_machine == "x86_64"')
+        # The full per-package marker still carries the membership clause.
+        assert '"black22" in dependency_groups' in t.marker_string
+
     def test_empty_selection_leaves_marker_and_label_unchanged(self) -> None:
         """The default empty selection is a no-op (back-compat)."""
         t = MatrixTuple(

--- a/nab-python/tests/universal/test_matrix.py
+++ b/nab-python/tests/universal/test_matrix.py
@@ -290,6 +290,76 @@ class TestMatrixTuple:
         )
         assert t.label == "pp311-linux_x86_64"
 
+    def test_selection_appends_member_suffix_to_label(self) -> None:
+        """A conflict-fork selection appends sorted member names."""
+        t = MatrixTuple(
+            python_version="3.11",
+            platform_id="linux_x86_64",
+            environment={},
+            selection=(("group", "isort5"), ("group", "black22")),
+        )
+        assert t.label == "py311-linux_x86_64-black22-isort5"
+
+    def test_extra_selection_adds_extras_marker_clause(self) -> None:
+        """An extra member adds a bare ``in extras`` clause to the marker."""
+        t = MatrixTuple(
+            python_version="3.11",
+            platform_id="linux_x86_64",
+            environment={
+                "sys_platform": "linux",
+                "platform_machine": "x86_64",
+                "implementation_name": "cpython",
+            },
+            selection=(("extra", "cpu"),),
+        )
+        assert t.marker_string.endswith('and "cpu" in extras')
+
+    def test_group_selection_adds_dependency_groups_clause(self) -> None:
+        """A group member adds a bare ``in dependency_groups`` clause."""
+        t = MatrixTuple(
+            python_version="3.11",
+            platform_id="linux_x86_64",
+            environment={
+                "sys_platform": "linux",
+                "platform_machine": "x86_64",
+                "implementation_name": "cpython",
+            },
+            selection=(("group", "black22"),),
+        )
+        assert t.marker_string.endswith('and "black22" in dependency_groups')
+
+    def test_selection_clauses_are_sorted(self) -> None:
+        """Selection clauses emit in sorted order for byte-stable output."""
+        t = MatrixTuple(
+            python_version="3.11",
+            platform_id="linux_x86_64",
+            environment={
+                "sys_platform": "linux",
+                "platform_machine": "x86_64",
+                "implementation_name": "cpython",
+            },
+            selection=(("group", "isort5"), ("extra", "cpu")),
+        )
+        # sorted by (kind, name): ("extra", "cpu") < ("group", "isort5")
+        assert t.marker_string.endswith(
+            'and "cpu" in extras and "isort5" in dependency_groups'
+        )
+
+    def test_empty_selection_leaves_marker_and_label_unchanged(self) -> None:
+        """The default empty selection is a no-op (back-compat)."""
+        t = MatrixTuple(
+            python_version="3.11",
+            platform_id="linux_x86_64",
+            environment={
+                "sys_platform": "linux",
+                "platform_machine": "x86_64",
+                "implementation_name": "cpython",
+            },
+        )
+        assert t.label == "py311-linux_x86_64"
+        assert "in extras" not in t.marker_string
+        assert "in dependency_groups" not in t.marker_string
+
     def test_cpython_marker_omits_implementation(self) -> None:
         """The default CPython marker keeps its three-clause form."""
         t = MatrixTuple(

--- a/nab-python/tests/universal/test_matrix.py
+++ b/nab-python/tests/universal/test_matrix.py
@@ -291,14 +291,52 @@ class TestMatrixTuple:
         assert t.label == "pp311-linux_x86_64"
 
     def test_selection_appends_member_suffix_to_label(self) -> None:
-        """A conflict-fork selection appends sorted member names."""
+        """A conflict-fork selection appends sorted ``kind-name`` members."""
         t = MatrixTuple(
             python_version="3.11",
             platform_id="linux_x86_64",
             environment={},
             selection=(("group", "isort5"), ("group", "black22")),
         )
-        assert t.label == "py311-linux_x86_64-black22-isort5"
+        assert t.label == "py311-linux_x86_64-group-black22.group-isort5"
+
+    def test_label_distinguishes_selections_that_split_on_hyphen(self) -> None:
+        """Names containing ``-`` cannot collide two selections into one label.
+
+        Canonical names collapse ``[-_.]`` runs to a single ``-``, so a
+        ``-`` joiner is ambiguous: ``a-b`` plus ``c`` and ``a`` plus
+        ``b-c`` would both read as ``a-b-c``.  The ``.`` separator keeps
+        the two selections on distinct labels.
+        """
+        first = MatrixTuple(
+            python_version="3.11",
+            platform_id="linux_x86_64",
+            environment={},
+            selection=(("extra", "a-b"), ("extra", "c")),
+        )
+        second = MatrixTuple(
+            python_version="3.11",
+            platform_id="linux_x86_64",
+            environment={},
+            selection=(("extra", "a"), ("extra", "b-c")),
+        )
+        assert first.label != second.label
+
+    def test_label_distinguishes_extra_from_group_of_same_name(self) -> None:
+        """An extra and a group of the same name get distinct labels."""
+        as_extra = MatrixTuple(
+            python_version="3.11",
+            platform_id="linux_x86_64",
+            environment={},
+            selection=(("extra", "cpu"),),
+        )
+        as_group = MatrixTuple(
+            python_version="3.11",
+            platform_id="linux_x86_64",
+            environment={},
+            selection=(("group", "cpu"),),
+        )
+        assert as_extra.label != as_group.label
 
     def test_extra_selection_adds_extras_marker_clause(self) -> None:
         """An extra member adds a bare ``in extras`` clause to the marker."""

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -451,10 +451,10 @@ class TestConflictForkBaseNames:
         base = by_name["base"]
         assert base.marker is None or base.marker.evaluate(neither)
 
-    def test_base_pass_failure_leaves_env_base_names_empty(self) -> None:
-        # The base requirement cannot resolve (no such version), so its
-        # environment contributes no base names and the lock falls back
-        # to the present-in-all collapse for that environment.
+    def test_base_pass_failure_fails_the_result(self) -> None:
+        # The base requirement cannot resolve (no such version), so the
+        # writer would lack the data to tell a base dep from a
+        # member-only dep.  Surface the failure on ``result.success``.
         result = resolve_with_coordinator(
             self._coordinator(),
             self._matrix(),
@@ -462,8 +462,25 @@ class TestConflictForkBaseNames:
             base_requirements=["base==9.9"],
             build_policy=BuildPolicy.NEVER,
         )
-        assert result.success
+        assert not result.success
         assert result.env_base_names == {}
+        assert result.base_results
+        assert all(not br.success for br in result.base_results)
+
+    def test_base_pass_failure_logs_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Each failed base pass is announced on the module logger so a
+        # caller that ignores ``result.success`` still gets a signal.
+        with caplog.at_level(logging.WARNING, logger="nab_python.universal.resolve"):
+            resolve_with_coordinator(
+                self._coordinator(),
+                self._matrix(),
+                forks=self._forks(),
+                base_requirements=["base==9.9"],
+                build_policy=BuildPolicy.NEVER,
+            )
+        assert any("Base attribution skipped" in rec.message for rec in caplog.records)
 
 
 class TestDirectPackageNames:

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -18,8 +18,14 @@ from nab_index.client import WheelFile
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.version import Version
-from nab_python.config import ConfigError
-from nab_python.lockfile import IndexPin, LockInput
+from nab_python.config import (
+    ConfigError,
+    ConflictKind,
+    ConflictMember,
+    ConflictPolicy,
+    ConflictSet,
+)
+from nab_python.lockfile import DisjointnessError, IndexPin, LockInput, build_pylock
 from nab_python.provider import (
     BuildPolicy,
     DistPolicy,
@@ -35,9 +41,11 @@ from nab_python.universal.matrix import Matrix, MatrixTuple
 from nab_python.universal.resolve import (
     TupleResult,
     UniversalResult,
+    _conflict_forks,
     _direct_package_names,
     _parse_requirements,
     _resolve_one_tuple,
+    _ResolveFork,
     _root_extras,
     _run_pass,
     _warn_extra_marker_at_root,
@@ -110,6 +118,222 @@ def _windows_311() -> MatrixTuple:
             "sys_platform": "win32",
         },
     )
+
+
+def _extra_set(*names: str) -> ConflictSet:
+    return ConflictSet(
+        members=tuple(ConflictMember(ConflictKind.EXTRA, n) for n in names),
+        policy=ConflictPolicy.AT_MOST_ONE,
+    )
+
+
+def _group_set(*names: str) -> ConflictSet:
+    return ConflictSet(
+        members=tuple(ConflictMember(ConflictKind.GROUP, n) for n in names),
+        policy=ConflictPolicy.AT_MOST_ONE,
+    )
+
+
+class TestConflictForks:
+    """``_conflict_forks`` splits a selection into per-fork resolves."""
+
+    def test_no_conflicts_is_one_unforked_fork(self) -> None:
+        forks = _conflict_forks(("docs",), ("dev",), ())
+        assert len(forks) == 1
+        assert forks[0].selection == ()
+        assert forks[0].active_extras == ("docs",)
+        assert forks[0].active_groups == ("dev",)
+
+    def test_single_selected_member_does_not_engage(self) -> None:
+        # Only cpu selected, gpu absent: no conflict, no fork.
+        forks = _conflict_forks(("cpu",), (), (_extra_set("cpu", "gpu"),))
+        assert len(forks) == 1
+        assert forks[0].selection == ()
+        assert forks[0].active_extras == ("cpu",)
+
+    def test_two_selected_extras_fork_into_two(self) -> None:
+        forks = _conflict_forks(("cpu", "gpu"), (), (_extra_set("cpu", "gpu"),))
+        assert [f.selection for f in forks] == [
+            (("extra", "cpu"),),
+            (("extra", "gpu"),),
+        ]
+        assert [f.active_extras for f in forks] == [("cpu",), ("gpu",)]
+
+    def test_three_selected_groups_fork_into_three(self) -> None:
+        forks = _conflict_forks(
+            (),
+            ("black22", "black23", "black24"),
+            (_group_set("black22", "black23", "black24"),),
+        )
+        assert [f.selection for f in forks] == [
+            (("group", "black22"),),
+            (("group", "black23"),),
+            (("group", "black24"),),
+        ]
+
+    def test_two_engaged_sets_cartesian_product(self) -> None:
+        # datamodel-code-generator: black {22,23,24} x isort {5,6} = 6 forks.
+        forks = _conflict_forks(
+            (),
+            ("black22", "black23", "black24", "isort5", "isort6"),
+            (
+                _group_set("black22", "black23", "black24"),
+                _group_set("isort5", "isort6"),
+            ),
+        )
+        assert len(forks) == 6
+        # Each fork picks exactly one black and one isort.
+        for fork in forks:
+            chosen = {name for _kind, name in fork.selection}
+            assert len(chosen & {"black22", "black23", "black24"}) == 1
+            assert len(chosen & {"isort5", "isort6"}) == 1
+        # Selections are sorted and unique across forks.
+        selections = [f.selection for f in forks]
+        assert len(set(selections)) == 6
+        assert all(list(s) == sorted(s) for s in selections)
+
+    def test_non_conflicting_selection_present_in_every_fork(self) -> None:
+        forks = _conflict_forks(
+            ("docs", "cpu", "gpu"), ("dev",), (_extra_set("cpu", "gpu"),)
+        )
+        assert len(forks) == 2
+        for fork in forks:
+            assert "docs" in fork.active_extras
+            assert fork.active_groups == ("dev",)
+            # exactly one of cpu/gpu active per fork
+            assert len({"cpu", "gpu"} & set(fork.active_extras)) == 1
+
+    def test_mixed_extra_and_group_set(self) -> None:
+        members = (
+            ConflictMember(ConflictKind.EXTRA, "cpu"),
+            ConflictMember(ConflictKind.GROUP, "gpu"),
+        )
+        cs = ConflictSet(members=members, policy=ConflictPolicy.AT_MOST_ONE)
+        forks = _conflict_forks(("cpu",), ("gpu",), (cs,))
+        assert [f.selection for f in forks] == [
+            (("extra", "cpu"),),
+            (("group", "gpu"),),
+        ]
+        assert forks[0].active_extras == ("cpu",)
+        assert forks[0].active_groups == ()
+        assert forks[1].active_extras == ()
+        assert forks[1].active_groups == ("gpu",)
+
+    def test_at_least_one_policy_never_forks(self) -> None:
+        cs = ConflictSet(
+            members=(
+                ConflictMember(ConflictKind.EXTRA, "a"),
+                ConflictMember(ConflictKind.EXTRA, "b"),
+            ),
+            policy=ConflictPolicy.AT_LEAST_ONE,
+        )
+        forks = _conflict_forks(("a", "b"), (), (cs,))
+        assert len(forks) == 1
+        assert forks[0].selection == ()
+        assert forks[0].active_extras == ("a", "b")
+
+    def test_names_canonicalised_before_engagement(self) -> None:
+        # Selection spelled differently still engages the conflict.
+        forks = _conflict_forks(("CPU", "Gpu"), (), (_extra_set("cpu", "gpu"),))
+        assert len(forks) == 2
+        assert {m for f in forks for _k, m in f.selection} == {"cpu", "gpu"}
+
+
+class TestConflictForkResolve:
+    """End-to-end: forked resolves produce a lock that validates only
+    once the conflict is declared (the datamodel-code-generator shape)."""
+
+    def _black_coordinator(self) -> MagicMock:
+        return _make_coordinator(
+            {
+                "black": [
+                    _make_wheel("22.1", package="black"),
+                    _make_wheel("23.12", package="black"),
+                ],
+            }
+        )
+
+    def _one_tuple_matrix(self) -> Matrix:
+        return Matrix(python="==3.11", platforms=("linux_x86_64",))
+
+    def _black_forks(self) -> list:
+        return [
+            _ResolveFork((("group", "black22"),), ["black==22.1"]),
+            _ResolveFork((("group", "black23"),), ["black==23.12"]),
+        ]
+
+    def test_forks_produce_separate_per_label_pins(self) -> None:
+        result = resolve_with_coordinator(
+            self._black_coordinator(),
+            self._one_tuple_matrix(),
+            [],
+            forks=self._black_forks(),
+            build_policy=BuildPolicy.NEVER,
+        )
+        assert result.success
+        by_label = {tr.tuple_.label: tr.pins for tr in result.tuple_results}
+        assert by_label == {
+            "py311-linux_x86_64-black22": {"black": Version("22.1")},
+            "py311-linux_x86_64-black23": {"black": Version("23.12")},
+        }
+
+    def test_declared_conflict_lock_validates_and_marks_forks(self) -> None:
+        result = resolve_with_coordinator(
+            self._black_coordinator(),
+            self._one_tuple_matrix(),
+            [],
+            forks=self._black_forks(),
+            build_policy=BuildPolicy.NEVER,
+        )
+        lock_input = merge_universal_lock_inputs(
+            result,
+            dependency_groups=("black22", "black23"),
+            conflicts=(_group_set("black22", "black23"),),
+        )
+        # Must not raise DisjointnessError: the conflict prunes the
+        # both-groups-selected context where the two entries collide.
+        pylock = build_pylock(lock_input)
+        black = sorted(
+            (p for p in pylock.packages if str(p.name) == "black"),
+            key=lambda p: str(p.version),
+        )
+        assert [str(p.version) for p in black] == ["22.1", "23.12"]
+        assert '"black22" in dependency_groups' in str(black[0].marker)
+        assert '"black23" in dependency_groups' in str(black[1].marker)
+
+    def test_same_lock_without_conflict_declaration_is_ambiguous(self) -> None:
+        # Identical fork pins, but no conflict declared: the installer
+        # could select both groups, so the two black entries collide.
+        result = resolve_with_coordinator(
+            self._black_coordinator(),
+            self._one_tuple_matrix(),
+            [],
+            forks=self._black_forks(),
+            build_policy=BuildPolicy.NEVER,
+        )
+        lock_input = merge_universal_lock_inputs(
+            result,
+            dependency_groups=("black22", "black23"),
+        )
+        with pytest.raises(DisjointnessError, match="black"):
+            build_pylock(lock_input)
+
+    def test_align_across_tuples_false_still_resolves(self) -> None:
+        # With alignment off, pins are not threaded forward, but each
+        # fork still resolves; covers the no-accumulation branch.
+        result = resolve_with_coordinator(
+            self._black_coordinator(),
+            self._one_tuple_matrix(),
+            [],
+            forks=self._black_forks(),
+            build_policy=BuildPolicy.NEVER,
+            align_across_tuples=False,
+        )
+        assert result.success
+        assert {tr.tuple_.label for tr in result.tuple_results} == {
+            "py311-linux_x86_64-black22",
+            "py311-linux_x86_64-black23",
+        }
 
 
 class TestDirectPackageNames:

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -194,6 +194,31 @@ class TestConflictForks:
         assert len(set(selections)) == 6
         assert all(list(s) == sorted(s) for s in selections)
 
+    def test_three_by_three_cartesian_product_is_nine(self) -> None:
+        """Three sets-of-three is the headline conflicts.md example: nine forks
+        with one member chosen from each set."""
+        forks = conflict_forks(
+            (),
+            (
+                "black22",
+                "black23",
+                "black24",
+                "isort5",
+                "isort6",
+                "isort7",
+            ),
+            (
+                _group_set("black22", "black23", "black24"),
+                _group_set("isort5", "isort6", "isort7"),
+            ),
+        )
+        assert len(forks) == 9
+        for fork in forks:
+            chosen = {name for _kind, name in fork.selection}
+            assert len(chosen & {"black22", "black23", "black24"}) == 1
+            assert len(chosen & {"isort5", "isort6", "isort7"}) == 1
+        assert len({f.selection for f in forks}) == 9
+
     def test_non_conflicting_selection_present_in_every_fork(self) -> None:
         forks = conflict_forks(
             ("docs", "cpu", "gpu"), ("dev",), (_extra_set("cpu", "gpu"),)
@@ -450,6 +475,73 @@ class TestConflictForkBaseNames:
         # ``base`` is a true base dep, so it installs unconditionally.
         base = by_name["base"]
         assert base.marker is None or base.marker.evaluate(neither)
+
+    def test_member_only_dep_across_two_sets_keeps_membership_or(self) -> None:
+        """Two engaged sets x one member-only dep present in all four forks.
+
+        Tests the conflicts.md claim that "When a single dependency is
+        required by every member of two or more engaged sets at once, its
+        marker is the conjunction across those sets" by checking the
+        emitted marker references every one of the four memberships.
+        """
+        coordinator = _make_coordinator(
+            {
+                "base": [_make_wheel("1.0", package="base")],
+                "crossdep": [_make_wheel("5.0", package="crossdep")],
+            }
+        )
+
+        # cpu x mon, cpu x debug, gpu x mon, gpu x debug = 4 forks, each
+        # pulling crossdep; base is the only true base-pass dep.
+        forks = [
+            ResolveFork((("extra", "cpu"), ("group", "mon")), ["base", "crossdep"]),
+            ResolveFork((("extra", "cpu"), ("group", "debug")), ["base", "crossdep"]),
+            ResolveFork((("extra", "gpu"), ("group", "mon")), ["base", "crossdep"]),
+            ResolveFork((("extra", "gpu"), ("group", "debug")), ["base", "crossdep"]),
+        ]
+        result = resolve_with_coordinator(
+            coordinator,
+            self._matrix(),
+            forks=forks,
+            base_requirements=["base"],
+            build_policy=BuildPolicy.NEVER,
+        )
+        assert result.success
+
+        lock_input = merge_universal_lock_inputs(
+            result,
+            extras=("cpu", "gpu"),
+            dependency_groups=("mon", "debug"),
+            conflicts=(
+                _extra_set("cpu", "gpu"),
+                _group_set("mon", "debug"),
+            ),
+        )
+        pylock = build_pylock(lock_input)
+        crossdep = next(p for p in pylock.packages if str(p.name) == "crossdep")
+
+        # The marker must reference every membership clause; the empty
+        # selection must not install, but any single (extra, group) pair
+        # in the cartesian product must.
+        marker_text = str(crossdep.marker)
+        for clause in (
+            '"cpu" in extras',
+            '"gpu" in extras',
+            '"mon" in dependency_groups',
+            '"debug" in dependency_groups',
+        ):
+            assert clause in marker_text
+
+        env = dict(result.tuple_results[0].tuple_.environment)
+        none = {**env, "extras": frozenset(), "dependency_groups": frozenset()}
+        assert crossdep.marker is not None
+        assert not crossdep.marker.evaluate(none)
+        for extras, groups in (
+            (frozenset({"cpu"}), frozenset({"mon"})),
+            (frozenset({"gpu"}), frozenset({"debug"})),
+        ):
+            ctx = {**env, "extras": extras, "dependency_groups": groups}
+            assert crossdep.marker.evaluate(ctx)
 
     def test_base_pass_failure_fails_the_result(self) -> None:
         # The base requirement cannot resolve (no such version), so the

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -273,8 +273,8 @@ class TestConflictForkResolve:
         assert result.success
         by_label = {tr.tuple_.label: tr.pins for tr in result.tuple_results}
         assert by_label == {
-            "py311-linux_x86_64-black22": {"black": Version("22.1")},
-            "py311-linux_x86_64-black23": {"black": Version("23.12")},
+            "py311-linux_x86_64-group-black22": {"black": Version("22.1")},
+            "py311-linux_x86_64-group-black23": {"black": Version("23.12")},
         }
 
     def test_declared_conflict_lock_validates_and_marks_forks(self) -> None:
@@ -338,22 +338,51 @@ class TestConflictForkResolve:
         assert "in dependency_groups" not in env_str
         assert "in extras" not in env_str
 
-    def test_align_across_tuples_false_still_resolves(self) -> None:
-        # With alignment off, pins are not threaded forward, but each
-        # fork still resolves; covers the no-accumulation branch.
-        result = resolve_with_coordinator(
-            self._black_coordinator(),
-            self._one_tuple_matrix(),
-            [],
-            forks=self._black_forks(),
-            build_policy=BuildPolicy.NEVER,
-            align_across_tuples=False,
-        )
+    def _per_fork_preferences(
+        self, *, align_across_tuples: bool
+    ) -> list[dict[str, Version]]:
+        """Run the two black forks, recording each fork's preferences.
+
+        Wraps ``_run_pass`` to snapshot the ``preferences`` dict handed
+        to each fork.  Cross-fork accumulation lives in
+        ``resolve_with_coordinator``, so the second fork's snapshot
+        reveals whether the first fork's pins were threaded forward.
+        """
+        seen: list[dict[str, Version]] = []
+        real_run_pass = resolve_mod._run_pass
+
+        def spy(*args: object, **kwargs: object) -> object:
+            seen.append(dict(kwargs["preferences"]))  # type: ignore[arg-type]
+            return real_run_pass(*args, **kwargs)  # type: ignore[arg-type]
+
+        with patch.object(resolve_mod, "_run_pass", spy):
+            result = resolve_with_coordinator(
+                self._black_coordinator(),
+                self._one_tuple_matrix(),
+                [],
+                forks=self._black_forks(),
+                build_policy=BuildPolicy.NEVER,
+                align_across_tuples=align_across_tuples,
+            )
         assert result.success
-        assert {tr.tuple_.label for tr in result.tuple_results} == {
-            "py311-linux_x86_64-black22",
-            "py311-linux_x86_64-black23",
-        }
+        return seen
+
+    def test_align_across_tuples_false_does_not_thread_pins(self) -> None:
+        # With alignment off, the second fork's preferences must not
+        # carry the first fork's black pin: each fork resolves alone.
+        seen = self._per_fork_preferences(align_across_tuples=False)
+        assert len(seen) == 2
+        assert "black" not in seen[0]
+        assert "black" not in seen[1]
+
+    def test_align_across_tuples_true_threads_pins(self) -> None:
+        # The companion case: with alignment on, the first fork's black
+        # pin is accumulated into the second fork's preferences, so the
+        # assertion above genuinely distinguishes the two modes.
+        seen = self._per_fork_preferences(align_across_tuples=True)
+        assert len(seen) == 2
+        assert "black" not in seen[0]
+        assert seen[1].get("black") == Version("22.1")
 
 
 class TestDirectPackageNames:

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -387,6 +387,85 @@ class TestConflictForkResolve:
         assert seen[1].get("black") == Version("22.1")
 
 
+class TestConflictForkBaseNames:
+    """A base (no-member) pass names the deps that install unconditionally,
+    so a dep required by every member but not the base keeps its
+    membership marker (the at_most_one over-install fix)."""
+
+    def _coordinator(self) -> MagicMock:
+        return _make_coordinator(
+            {
+                "base": [_make_wheel("1.0", package="base")],
+                "accel": [_make_wheel("5.0", package="accel")],
+            }
+        )
+
+    def _matrix(self) -> Matrix:
+        return Matrix(python="==3.11", platforms=("linux_x86_64",))
+
+    def _forks(self) -> list[ResolveFork]:
+        # cpu and gpu both pull in accel; the base has only ``base``.
+        return [
+            ResolveFork((("extra", "cpu"),), ["base", "accel"]),
+            ResolveFork((("extra", "gpu"),), ["base", "accel"]),
+        ]
+
+    def test_env_base_names_excludes_member_only_dep(self) -> None:
+        result = resolve_with_coordinator(
+            self._coordinator(),
+            self._matrix(),
+            forks=self._forks(),
+            base_requirements=["base"],
+            build_policy=BuildPolicy.NEVER,
+        )
+        assert result.success
+        (names,) = result.env_base_names.values()
+        assert "base" in names
+        assert "accel" not in names
+
+    def test_member_only_dep_keeps_membership_marker(self) -> None:
+        result = resolve_with_coordinator(
+            self._coordinator(),
+            self._matrix(),
+            forks=self._forks(),
+            base_requirements=["base"],
+            build_policy=BuildPolicy.NEVER,
+        )
+        lock_input = merge_universal_lock_inputs(
+            result,
+            extras=("cpu", "gpu"),
+            conflicts=(_extra_set("cpu", "gpu"),),
+        )
+        pylock = build_pylock(lock_input)
+        by_name = {str(p.name): p for p in pylock.packages}
+        env = dict(result.tuple_results[0].tuple_.environment)
+        neither = {**env, "extras": frozenset()}
+        cpu = {**env, "extras": frozenset({"cpu"})}
+
+        accel = by_name["accel"]
+        assert accel.marker is not None
+        assert not accel.marker.evaluate(neither)
+        assert accel.marker.evaluate(cpu)
+
+        # ``base`` is a true base dep, so it installs unconditionally.
+        base = by_name["base"]
+        assert base.marker is None or base.marker.evaluate(neither)
+
+    def test_base_pass_failure_leaves_env_base_names_empty(self) -> None:
+        # The base requirement cannot resolve (no such version), so its
+        # environment contributes no base names and the lock falls back
+        # to the present-in-all collapse for that environment.
+        result = resolve_with_coordinator(
+            self._coordinator(),
+            self._matrix(),
+            forks=self._forks(),
+            base_requirements=["base==9.9"],
+            build_policy=BuildPolicy.NEVER,
+        )
+        assert result.success
+        assert result.env_base_names == {}
+
+
 class TestDirectPackageNames:
     """``_direct_package_names`` extracts canonical names from req strings."""
 

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -24,6 +24,7 @@ from nab_python.config import (
     ConflictMember,
     ConflictPolicy,
     ConflictSet,
+    conflict_forks,
 )
 from nab_python.lockfile import DisjointnessError, IndexPin, LockInput, build_pylock
 from nab_python.provider import (
@@ -39,13 +40,12 @@ from nab_python.provider import (
 from nab_python.universal import resolve as resolve_mod
 from nab_python.universal.matrix import Matrix, MatrixTuple
 from nab_python.universal.resolve import (
+    ResolveFork,
     TupleResult,
     UniversalResult,
-    _conflict_forks,
     _direct_package_names,
     _parse_requirements,
     _resolve_one_tuple,
-    _ResolveFork,
     _root_extras,
     _run_pass,
     _warn_extra_marker_at_root,
@@ -135,10 +135,10 @@ def _group_set(*names: str) -> ConflictSet:
 
 
 class TestConflictForks:
-    """``_conflict_forks`` splits a selection into per-fork resolves."""
+    """``conflict_forks`` splits a selection into per-fork resolves."""
 
     def test_no_conflicts_is_one_unforked_fork(self) -> None:
-        forks = _conflict_forks(("docs",), ("dev",), ())
+        forks = conflict_forks(("docs",), ("dev",), ())
         assert len(forks) == 1
         assert forks[0].selection == ()
         assert forks[0].active_extras == ("docs",)
@@ -146,13 +146,13 @@ class TestConflictForks:
 
     def test_single_selected_member_does_not_engage(self) -> None:
         # Only cpu selected, gpu absent: no conflict, no fork.
-        forks = _conflict_forks(("cpu",), (), (_extra_set("cpu", "gpu"),))
+        forks = conflict_forks(("cpu",), (), (_extra_set("cpu", "gpu"),))
         assert len(forks) == 1
         assert forks[0].selection == ()
         assert forks[0].active_extras == ("cpu",)
 
     def test_two_selected_extras_fork_into_two(self) -> None:
-        forks = _conflict_forks(("cpu", "gpu"), (), (_extra_set("cpu", "gpu"),))
+        forks = conflict_forks(("cpu", "gpu"), (), (_extra_set("cpu", "gpu"),))
         assert [f.selection for f in forks] == [
             (("extra", "cpu"),),
             (("extra", "gpu"),),
@@ -160,7 +160,7 @@ class TestConflictForks:
         assert [f.active_extras for f in forks] == [("cpu",), ("gpu",)]
 
     def test_three_selected_groups_fork_into_three(self) -> None:
-        forks = _conflict_forks(
+        forks = conflict_forks(
             (),
             ("black22", "black23", "black24"),
             (_group_set("black22", "black23", "black24"),),
@@ -173,7 +173,7 @@ class TestConflictForks:
 
     def test_two_engaged_sets_cartesian_product(self) -> None:
         # datamodel-code-generator: black {22,23,24} x isort {5,6} = 6 forks.
-        forks = _conflict_forks(
+        forks = conflict_forks(
             (),
             ("black22", "black23", "black24", "isort5", "isort6"),
             (
@@ -193,7 +193,7 @@ class TestConflictForks:
         assert all(list(s) == sorted(s) for s in selections)
 
     def test_non_conflicting_selection_present_in_every_fork(self) -> None:
-        forks = _conflict_forks(
+        forks = conflict_forks(
             ("docs", "cpu", "gpu"), ("dev",), (_extra_set("cpu", "gpu"),)
         )
         assert len(forks) == 2
@@ -209,7 +209,7 @@ class TestConflictForks:
             ConflictMember(ConflictKind.GROUP, "gpu"),
         )
         cs = ConflictSet(members=members, policy=ConflictPolicy.AT_MOST_ONE)
-        forks = _conflict_forks(("cpu",), ("gpu",), (cs,))
+        forks = conflict_forks(("cpu",), ("gpu",), (cs,))
         assert [f.selection for f in forks] == [
             (("extra", "cpu"),),
             (("group", "gpu"),),
@@ -227,14 +227,14 @@ class TestConflictForks:
             ),
             policy=ConflictPolicy.AT_LEAST_ONE,
         )
-        forks = _conflict_forks(("a", "b"), (), (cs,))
+        forks = conflict_forks(("a", "b"), (), (cs,))
         assert len(forks) == 1
         assert forks[0].selection == ()
         assert forks[0].active_extras == ("a", "b")
 
     def test_names_canonicalised_before_engagement(self) -> None:
         # Selection spelled differently still engages the conflict.
-        forks = _conflict_forks(("CPU", "Gpu"), (), (_extra_set("cpu", "gpu"),))
+        forks = conflict_forks(("CPU", "Gpu"), (), (_extra_set("cpu", "gpu"),))
         assert len(forks) == 2
         assert {m for f in forks for _k, m in f.selection} == {"cpu", "gpu"}
 
@@ -258,8 +258,8 @@ class TestConflictForkResolve:
 
     def _black_forks(self) -> list:
         return [
-            _ResolveFork((("group", "black22"),), ["black==22.1"]),
-            _ResolveFork((("group", "black23"),), ["black==23.12"]),
+            ResolveFork((("group", "black22"),), ["black==22.1"]),
+            ResolveFork((("group", "black23"),), ["black==23.12"]),
         ]
 
     def test_forks_produce_separate_per_label_pins(self) -> None:
@@ -317,6 +317,26 @@ class TestConflictForkResolve:
         )
         with pytest.raises(DisjointnessError, match="black"):
             build_pylock(lock_input)
+
+    def test_top_level_environments_drop_membership_and_dedupe(self) -> None:
+        # Two forks of the one (python, platform) tuple must collapse to
+        # a single top-level environment with no membership clause: that
+        # field declares the platform universe, not the group selection.
+        result = resolve_with_coordinator(
+            self._black_coordinator(),
+            self._one_tuple_matrix(),
+            forks=self._black_forks(),
+            build_policy=BuildPolicy.NEVER,
+        )
+        lock_input = merge_universal_lock_inputs(
+            result,
+            dependency_groups=("black22", "black23"),
+            conflicts=(_group_set("black22", "black23"),),
+        )
+        assert len(lock_input.environments) == 1
+        env_str = str(lock_input.environments[0])
+        assert "in dependency_groups" not in env_str
+        assert "in extras" not in env_str
 
     def test_align_across_tuples_false_still_resolves(self) -> None:
         # With alignment off, pins are not threaded forward, but each

--- a/src/nab/_download.py
+++ b/src/nab/_download.py
@@ -22,6 +22,7 @@ from nab_python.config import ResolveMode
 from nab_python.download import DownloadError
 
 from . import cli as _cli
+from ._lock import resolve_extra_selection, resolve_group_selection
 from .cli import (
     HttpBackend,
     PathArg,
@@ -30,7 +31,7 @@ from .cli import (
 
 
 @app.command
-def download(
+def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config object would hide the user-facing surface
     path: PathArg = Path("pyproject.toml"),
     *,
     output: Path = Path("wheels"),
@@ -40,16 +41,32 @@ def download(
     offline: bool = False,
     max_concurrency: int = 8,
     workspace_discovery: bool = True,
+    groups: tuple[str, ...] = (),
+    all_groups: bool = False,
+    extras: tuple[str, ...] = (),
+    all_extras: bool = False,
 ) -> None:
     """Resolve and download every wheel/sdist into a local directory.
 
     Output files are named after the recorded artefact filename.  The
     download is idempotent: files whose sha256 already matches are
     left alone.  Local and VCS pins are skipped.
+
+    ``--groups`` / ``--all-groups`` and ``--extras`` / ``--all-extras``
+    mirror ``nab lock``: a project declaring an ``exactly_one`` or
+    ``at_least_one`` conflict needs at least one member selected for
+    the resolve to start, so these flags also gate the download.
     """
     if max_concurrency < 1:
         sys.stderr.write("Error: --max-concurrency must be at least 1.\n")
         sys.exit(1)
+
+    selected_groups = resolve_group_selection(
+        path, groups=groups, all_groups=all_groups
+    )
+    selected_extras = resolve_extra_selection(
+        path, extras=extras, all_extras=all_extras
+    )
 
     config = _cli._load_config(  # noqa: SLF001
         path, discover_workspace=workspace_discovery
@@ -65,6 +82,8 @@ def download(
             cache_dir=effective_cache_dir,
             offline=offline,
             transport=transport,
+            groups=selected_groups,
+            extras=selected_extras,
         )
         lock_input = _cli.merge_universal_lock_inputs(universal)
     else:
@@ -75,6 +94,8 @@ def download(
             offline=offline,
             transport=transport,
             failure_prefix="Cannot download",
+            groups=selected_groups,
+            extras=selected_extras,
         )
         lock_input = result.lock_input
 

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -115,10 +115,10 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
         cache_dir, cache=cache
     )
     provenance = _build_provenance(path, config=config, anchor=anchor)
-    selected_groups = _resolve_group_selection(
+    selected_groups = resolve_group_selection(
         path, groups=groups, all_groups=all_groups
     )
-    selected_extras = _resolve_extra_selection(
+    selected_extras = resolve_extra_selection(
         path, extras=extras, all_extras=all_extras
     )
     strategy_override = (
@@ -537,7 +537,7 @@ def _write_one_tuple_requirements(
     )
 
 
-def _resolve_group_selection(
+def resolve_group_selection(
     path: Path,
     *,
     groups: tuple[str, ...],
@@ -569,7 +569,7 @@ def _resolve_group_selection(
     return tuple(defined.keys()) if all_groups else tuple(dict.fromkeys(groups))
 
 
-def _resolve_extra_selection(
+def resolve_extra_selection(
     path: Path,
     *,
     extras: tuple[str, ...],

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -361,6 +361,9 @@ def _emit_universal_pylock(
     except _cli.MissingHashError as e:
         sys.stderr.write(f"Cannot lock: {e}\n")
         sys.exit(1)
+    except _cli.DisjointnessError as e:
+        sys.stderr.write(f"Error: {e}\n")
+        sys.exit(1)
 
     if target is None:
         sys.stdout.write(text)

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -336,11 +336,13 @@ def _emit_universal_pylock(
     policy rather than this run's request.
     """
     default_groups = config.default_groups if config is not None else ()
+    conflicts = config.conflicts if config is not None else ()
     lock_input = _cli.merge_universal_lock_inputs(
         result,
         extras=extras,
         dependency_groups=groups,
         default_groups=default_groups,
+        conflicts=conflicts,
     )
     lock_input = _drop_workspace_pins(lock_input, workspace_to_drop)
     if provenance is not None:

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -270,6 +270,15 @@ def _print_universal_blocks(result: UniversalResult) -> None:
             continue
         blocks.append(f"# {label}")
         blocks.extend(f"{name}=={tr.pins[name]}" for name in sorted(tr.pins))
+
+    # Surface base-pass failures so a successful tuple set does not
+    # mask a missing base attribution.
+    for br in result.base_results:
+        if br.success:
+            continue
+        blocks.append(f"# base/{br.tuple_.label}: FAILED")
+        blocks.extend(f"#   {raw}" for raw in (br.error or "").splitlines())
+
     sys.stdout.write("\n".join(blocks) + "\n")
 
 

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -30,6 +30,7 @@ from nab_python.config import (
 )
 from nab_python.download import download_lock  # noqa: F401 - re-exported for tests
 from nab_python.lockfile import (
+    DisjointnessError,  # noqa: F401 - referenced as _cli.DisjointnessError in _lock
     MissingHashError,
     MissingSdistError,
     write_lock,  # noqa: F401 - re-exported for tests

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -243,6 +243,9 @@ def _resolve_universal(
     except LookupError as e:
         sys.stderr.write(f"Error: {e}\n")
         sys.exit(1)
+    except ConfigError as e:
+        sys.stderr.write(f"Error in [tool.nab]: {e}\n")
+        sys.exit(1)
     except HttpError as e:
         sys.stderr.write(f"Cannot lock: {e}\n")
         sys.exit(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -880,6 +880,65 @@ class TestLockCommandUniversal:
         assert "foo==1.0" in out
         assert "# py311-windows_amd64: FAILED" in out
 
+    def test_print_blocks_surfaces_base_pass_failure(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # All per-tuple pins succeeded, the first env's base pass
+        # succeeded, and the second env's base pass failed: only the
+        # failed one renders a ``base/<label>: FAILED`` block.  One
+        # tuple has to fail so ``_print_universal_blocks`` runs at all.
+        pyproject = _universal_pyproject(tmp_path)
+        env_a = MatrixTuple(
+            python_version="3.11",
+            platform_id="linux_x86_64",
+            environment=dict(_LINUX_311_ENV),
+            platform_spec=PlatformSpec("linux_x86_64"),
+        )
+        env_b = MatrixTuple(
+            python_version="3.12",
+            platform_id="linux_x86_64",
+            environment={**_LINUX_311_ENV, "python_version": "3.12"},
+            platform_spec=PlatformSpec("linux_x86_64"),
+        )
+        bad_tr = TupleResult(
+            tuple_=env_b,
+            success=False,
+            pins={},
+            error="conflict",
+            lock_input=None,
+        )
+        ok_tr = TupleResult(
+            tuple_=env_a,
+            success=True,
+            pins={"foo": V("1.0")},
+            lock_input=LockInput(pins={"foo": _foo_index_pin()}),
+        )
+        ok_base = TupleResult(tuple_=env_a, success=True, pins={"foo": V("1.0")})
+        bad_base = TupleResult(
+            tuple_=env_b,
+            success=False,
+            pins={},
+            error="ResolutionError: base unresolvable\nDiagnostics: missing",
+        )
+        mixed = UniversalResult(
+            matrix=Matrix(python=">=3.11,<3.13", platforms=("linux_x86_64",)),
+            tuple_results=[ok_tr, bad_tr],
+            base_results=[ok_base, bad_base],
+        )
+        with (
+            patch("nab.cli.resolve_universal_pyproject", return_value=mixed),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, format="requirements-without-hashes")
+        out = capsys.readouterr().out
+        assert "foo==1.0" in out
+        # The succeeded base pass contributes no block: only the failed
+        # one renders, and the per-tuple labels stay distinct.
+        assert "# base/py311-linux_x86_64: FAILED" not in out
+        assert "# base/py312-linux_x86_64: FAILED" in out
+        assert "#   ResolutionError: base unresolvable" in out
+        assert "#   Diagnostics: missing" in out
+
     def test_template_writes_one_file_per_tuple(self, tmp_path: Path) -> None:
         """``{python_version}`` in --output expands to one file per tuple."""
         pyproject = _universal_pyproject(tmp_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,7 @@ from nab_python._vendor.packaging.version import Version
 from nab_python.config import ConfigError
 from nab_python.download import DownloadError
 from nab_python.lockfile import (
+    DisjointnessError,
     IndexPin,
     LockInput,
     MissingHashError,
@@ -550,6 +551,33 @@ class TestLockCommandUniversal:
         ):
             lock(pyproject, output=tmp_path / "pylock.toml")
         assert "Cannot lock" in capsys.readouterr().err
+
+    def test_pylock_disjointness_error_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A DisjointnessError during universal pylock surfaces as exit 1.
+
+        The conflict hint carried by the error reaches the user as a
+        clean ``Error: ...`` line instead of a traceback.
+        """
+        pyproject = _universal_pyproject(tmp_path)
+        hint = (
+            "foo: 2 entries fire under env='py311-linux_x86_64'. If these are"
+            " intentionally mutually exclusive, declare them in"
+            " [tool.nab].conflicts so the colliding context is pruned"
+        )
+        with (
+            patch(
+                "nab.cli.resolve_universal_pyproject",
+                return_value=_universal_result(success=True),
+            ),
+            patch("nab.cli.write_lock", side_effect=DisjointnessError(hint)),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, output=tmp_path / "pylock.toml")
+        err = capsys.readouterr().err
+        assert f"Error: {hint}\n" in err
+        assert "[tool.nab].conflicts" in err
 
     def test_per_tuple_pins_to_stdout_by_default(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -637,6 +637,61 @@ class TestLockCommandUniversal:
         err = capsys.readouterr().err
         assert f"Error: {hint}\n" in err
 
+    def test_universal_lock_collision_without_conflict_shows_hint(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """End-to-end: two conflict-fork pins for the same package with no
+        ``[tool.nab].conflicts`` declared.  The real validator fires
+        :class:`DisjointnessError` and the hint reaches stderr, so a
+        rename of the hint text breaks this test."""
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "0"\ndependencies = []\n'
+            "[project.optional-dependencies]\n"
+            'cpu = ["foo==1.0"]\n'
+            'gpu = ["foo==2.0"]\n'
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.11"\n'
+            'platforms = ["linux_x86_64"]\n',
+        )
+
+        matrix = Matrix(python="==3.11", platforms=("linux_x86_64",))
+        results: list[TupleResult] = []
+        for member, version in (("cpu", "1.0"), ("gpu", "2.0")):
+            tup = MatrixTuple(
+                python_version="3.11",
+                platform_id="linux_x86_64",
+                environment=dict(_LINUX_311_ENV),
+                platform_spec=PlatformSpec("linux_x86_64"),
+                selection=(("extra", member),),
+            )
+            results.append(
+                TupleResult(
+                    tuple_=tup,
+                    success=True,
+                    pins={"foo": V(version)},
+                    error=None,
+                    lock_input=LockInput(pins={"foo": _foo_index_pin(version)}),
+                )
+            )
+        result = UniversalResult(matrix=matrix, tuple_results=results)
+
+        with (
+            patch("nab.cli.resolve_universal_pyproject", return_value=result),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(
+                pyproject,
+                output=tmp_path / "pylock.toml",
+                extras=("cpu", "gpu"),
+            )
+        err = capsys.readouterr().err
+        assert "Error:" in err
+        assert "foo" in err
+        assert "[tool.nab].conflicts" in err
+
     def test_unsupported_vcs_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,9 +23,9 @@ from nab._lock import (
     _determine_lock_anchor,
     _emit_specific,
     _emit_universal_pylock,
-    _resolve_extra_selection,
-    _resolve_group_selection,
     lock,
+    resolve_extra_selection,
+    resolve_group_selection,
 )
 from nab.cli import (
     _default_cache_dir,
@@ -1692,7 +1692,7 @@ class TestGroupAndExtraSelection:
         the inner read; the helper guards against the race.
         """
         with pytest.raises(SystemExit, match="1"):
-            _resolve_group_selection(
+            resolve_group_selection(
                 tmp_path / "missing.toml", groups=(), all_groups=True
             )
         assert "not found" in capsys.readouterr().err
@@ -1702,7 +1702,7 @@ class TestGroupAndExtraSelection:
     ) -> None:
         """Symmetric guard for ``--all-extras``."""
         with pytest.raises(SystemExit, match="1"):
-            _resolve_extra_selection(
+            resolve_extra_selection(
                 tmp_path / "missing.toml", extras=(), all_extras=True
             )
         assert "not found" in capsys.readouterr().err
@@ -1717,7 +1717,7 @@ class TestGroupAndExtraSelection:
         pyproject.write_text(
             "[project]\nname = 'x'\n[dependency-groups]\ndev = []\nlint = []\n",
         )
-        result = _resolve_group_selection(pyproject, groups=(), all_groups=True)
+        result = resolve_group_selection(pyproject, groups=(), all_groups=True)
         assert sorted(result) == ["dev", "lint"]
 
     def test_all_extras_reads_defined_extras(self, tmp_path: Path) -> None:
@@ -1731,17 +1731,17 @@ class TestGroupAndExtraSelection:
             "[project]\nname = 'x'\n"
             "[project.optional-dependencies]\ntest = []\nci = []\n",
         )
-        result = _resolve_extra_selection(pyproject, extras=(), all_extras=True)
+        result = resolve_extra_selection(pyproject, extras=(), all_extras=True)
         assert sorted(result) == ["ci", "test"]
 
     def test_no_group_selection_skips_read(self, tmp_path: Path) -> None:
-        result = _resolve_group_selection(
+        result = resolve_group_selection(
             tmp_path / "missing.toml", groups=(), all_groups=False
         )
         assert result == ()
 
     def test_no_extra_selection_skips_read(self, tmp_path: Path) -> None:
-        result = _resolve_extra_selection(
+        result = resolve_extra_selection(
             tmp_path / "missing.toml", extras=(), all_extras=False
         )
         assert result == ()
@@ -1751,7 +1751,7 @@ class TestGroupAndExtraSelection:
         pyproject.write_text(
             "[project]\nname = 'x'\n[dependency-groups]\ndev = []\nlint = []\n",
         )
-        result = _resolve_group_selection(
+        result = resolve_group_selection(
             pyproject, groups=("dev", "lint", "dev"), all_groups=False
         )
         assert result == ("dev", "lint")
@@ -1762,7 +1762,7 @@ class TestGroupAndExtraSelection:
             "[project]\nname = 'x'\n"
             "[project.optional-dependencies]\ntest = []\nci = []\n",
         )
-        result = _resolve_extra_selection(
+        result = resolve_extra_selection(
             pyproject, extras=("test", "ci", "test"), all_extras=False
         )
         assert result == ("test", "ci")
@@ -1773,7 +1773,7 @@ class TestGroupAndExtraSelection:
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text("dependency-groups = 'oops'\n[project]\nname = 'x'\n")
         with pytest.raises(SystemExit, match="1"):
-            _resolve_group_selection(pyproject, groups=(), all_groups=True)
+            resolve_group_selection(pyproject, groups=(), all_groups=True)
         assert "[dependency-groups] must be a table" in capsys.readouterr().err
 
     def test_explicit_groups_non_table_exits(
@@ -1782,7 +1782,7 @@ class TestGroupAndExtraSelection:
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text("dependency-groups = 'oops'\n[project]\nname = 'x'\n")
         with pytest.raises(SystemExit, match="1"):
-            _resolve_group_selection(pyproject, groups=("dev",), all_groups=False)
+            resolve_group_selection(pyproject, groups=("dev",), all_groups=False)
         assert "[dependency-groups] must be a table" in capsys.readouterr().err
 
     def test_all_extras_non_table_exits(
@@ -1791,7 +1791,7 @@ class TestGroupAndExtraSelection:
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text("[project]\nname = 'x'\noptional-dependencies = 'oops'\n")
         with pytest.raises(SystemExit, match="1"):
-            _resolve_extra_selection(pyproject, extras=(), all_extras=True)
+            resolve_extra_selection(pyproject, extras=(), all_extras=True)
         assert "[project.optional-dependencies] must be a table" in (
             capsys.readouterr().err
         )
@@ -1802,7 +1802,7 @@ class TestGroupAndExtraSelection:
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text("[project]\nname = 'x'\noptional-dependencies = 'oops'\n")
         with pytest.raises(SystemExit, match="1"):
-            _resolve_extra_selection(pyproject, extras=("foo",), all_extras=False)
+            resolve_extra_selection(pyproject, extras=("foo",), all_extras=False)
         assert "[project.optional-dependencies] must be a table" in (
             capsys.readouterr().err
         )
@@ -2159,3 +2159,82 @@ class TestDownloadCommand:
         ):
             download(pyproject)
         assert "Download failed" in capsys.readouterr().err
+
+    def test_extras_flag_forwarded_to_resolver(self, tmp_path: Path) -> None:
+        # ``--extras`` is required for ``exactly_one`` / ``at_least_one``
+        # conflict projects; the resolver must see the selected names.
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "0"\ndependencies = ["foo"]\n'
+            "[project.optional-dependencies]\ncpu = []\ngpu = []\n",
+        )
+        download_result = MagicMock(written=(), skipped=())
+        with (
+            patch(
+                "nab.cli.resolve_pyproject", return_value=_stub_resolution_result()
+            ) as mock_resolve,
+            patch("nab.cli.download_lock", return_value=download_result),
+        ):
+            download(pyproject, extras=("cpu",))
+        assert mock_resolve.call_args.kwargs["extras"] == ("cpu",)
+
+    def test_groups_flag_forwarded_to_resolver(self, tmp_path: Path) -> None:
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "0"\ndependencies = ["foo"]\n'
+            "[dependency-groups]\ndev = []\n",
+        )
+        download_result = MagicMock(written=(), skipped=())
+        with (
+            patch(
+                "nab.cli.resolve_pyproject", return_value=_stub_resolution_result()
+            ) as mock_resolve,
+            patch("nab.cli.download_lock", return_value=download_result),
+        ):
+            download(pyproject, groups=("dev",))
+        assert mock_resolve.call_args.kwargs["groups"] == ("dev",)
+
+    def test_all_extras_expands_to_every_extra(self, tmp_path: Path) -> None:
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "0"\ndependencies = ["foo"]\n'
+            "[project.optional-dependencies]\ncpu = []\ngpu = []\n",
+        )
+        download_result = MagicMock(written=(), skipped=())
+        with (
+            patch(
+                "nab.cli.resolve_pyproject", return_value=_stub_resolution_result()
+            ) as mock_resolve,
+            patch("nab.cli.download_lock", return_value=download_result),
+        ):
+            download(pyproject, all_extras=True)
+        assert set(mock_resolve.call_args.kwargs["extras"]) == {"cpu", "gpu"}
+
+    def test_all_groups_expands_to_every_group(self, tmp_path: Path) -> None:
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "0"\ndependencies = ["foo"]\n'
+            "[dependency-groups]\ndev = []\ntest = []\n",
+        )
+        download_result = MagicMock(written=(), skipped=())
+        with (
+            patch(
+                "nab.cli.resolve_pyproject", return_value=_stub_resolution_result()
+            ) as mock_resolve,
+            patch("nab.cli.download_lock", return_value=download_result),
+        ):
+            download(pyproject, all_groups=True)
+        assert set(mock_resolve.call_args.kwargs["groups"]) == {"dev", "test"}
+
+    def test_universal_forwards_selection(self, tmp_path: Path) -> None:
+        pyproject = _universal_pyproject(tmp_path)
+        download_result = MagicMock(written=(), skipped=())
+        with (
+            patch(
+                "nab.cli.resolve_universal_pyproject",
+                return_value=_multi_tuple_universal_result(),
+            ) as mock_resolve,
+            patch("nab.cli.download_lock", return_value=download_result),
+        ):
+            download(pyproject, extras=("docs",))
+        assert mock_resolve.call_args.kwargs["extras"] == ("docs",)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -479,6 +479,27 @@ class TestLockCommandUniversal:
             lock(pyproject, output=out)
         assert "invalid requirement" in capsys.readouterr().err
 
+    def test_config_error_during_resolve_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A ConfigError raised by the universal resolve exits 1 cleanly."""
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with (
+            patch(
+                "nab.cli.resolve_universal_pyproject",
+                side_effect=ConfigError(
+                    "[tool.nab].conflicts names extra 'gpuu', which the project"
+                    " does not declare in [project.optional-dependencies]"
+                ),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, output=out)
+        err = capsys.readouterr().err
+        assert "Error in [tool.nab]:" in err
+        assert "gpuu" in err
+
     def test_pylock_writes_universal_lock(self, tmp_path: Path) -> None:
         """Universal + pylock format runs the real merge + write pipeline."""
         pyproject = _universal_pyproject(tmp_path)
@@ -610,9 +631,11 @@ class TestLockCommandUniversal:
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, output=tmp_path / "pylock.toml")
+        # The full hint is asserted above; the validator's own hint
+        # text is covered against the real implementation in
+        # nab-python/tests/test_lockfile.py.
         err = capsys.readouterr().err
         assert f"Error: {hint}\n" in err
-        assert "[tool.nab].conflicts" in err
 
     def test_unsupported_vcs_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -2063,6 +2086,25 @@ class TestDownloadCommand:
             "py311-linux_x86_64",
             "py312-linux_x86_64",
         }
+
+    def test_universal_config_error_during_resolve_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A ConfigError out of the universal download path exits 1 cleanly."""
+        pyproject = _universal_pyproject(tmp_path)
+        with (
+            patch(
+                "nab.cli.resolve_universal_pyproject",
+                side_effect=ConfigError(
+                    "exactly one of [extra 'cpu', extra 'gpu'] must be selected"
+                ),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            download(pyproject)
+        err = capsys.readouterr().err
+        assert "Error in [tool.nab]:" in err
+        assert "exactly one" in err
 
     @pytest.mark.parametrize("bad", [0, -1])
     def test_non_positive_max_concurrency_exits(


### PR DESCRIPTION
Adds `[tool.nab].conflicts` to declare that certain extras or PEP 735 dependency groups are mutually exclusive, like datamodel-code-generator's black22/23/24 and isort5/6/7 test variants. Previously `nab lock --all-groups` over those groups resolved them together and failed, with no way to mark the collision as intended.

Specific mode now fails fast when two members of a set are selected, naming the set. Universal mode forks instead: each member resolves on its own and its pins are written under a `'name' in dependency_groups` / `'name' in extras` marker, so one lockfile serves every variant, and the disjointness check prunes the contexts a conflict forbids. The surface follows uv's `conflicts = [[{group = "a"}, {group = "b"}]]`, plus optional `at_most_one`/`exactly_one`/`at_least_one` policies; see `docs/guides/conflicts.md`.

Closes #20