### PR TITLE
Release 0.0.4

### DIFF
--- a/nab-index/pyproject.toml
+++ b/nab-index/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-index"
-version = "0.0.4"
+version = "0.0.5.dev0"
 description = "PyPI Simple-API client and on-disk cache for nab"
 readme = "README.md"
 license = "MIT"

--- a/nab-index/pyproject.toml
+++ b/nab-index/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-index"
-version = "0.0.4.dev0"
+version = "0.0.4"
 description = "PyPI Simple-API client and on-disk cache for nab"
 readme = "README.md"
 license = "MIT"

--- a/nab-python/pyproject.toml
+++ b/nab-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-python"
-version = "0.0.4.dev0"
+version = "0.0.4"
 description = "Index-backed provider, lockfile emitter, and downloader for nab"
 readme = "README.md"
 license = "MIT"
@@ -19,8 +19,8 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "nab-resolver==0.0.4.dev0",
-    "nab-index==0.0.4.dev0",
+    "nab-resolver==0.0.4",
+    "nab-index==0.0.4",
     "tomli>=2.0",
     "tomli_w>=1.2",
     "build>=1.2",

--- a/nab-python/pyproject.toml
+++ b/nab-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-python"
-version = "0.0.4"
+version = "0.0.5.dev0"
 description = "Index-backed provider, lockfile emitter, and downloader for nab"
 readme = "README.md"
 license = "MIT"
@@ -19,8 +19,8 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "nab-resolver==0.0.4",
-    "nab-index==0.0.4",
+    "nab-resolver==0.0.5.dev0",
+    "nab-index==0.0.5.dev0",
     "tomli>=2.0",
     "tomli_w>=1.2",
     "build>=1.2",

--- a/nab-resolver/pyproject.toml
+++ b/nab-resolver/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-resolver"
-version = "0.0.4"
+version = "0.0.5.dev0"
 description = "Generic PubGrub dependency-resolver core"
 readme = "README.md"
 license = "MIT"

--- a/nab-resolver/pyproject.toml
+++ b/nab-resolver/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab-resolver"
-version = "0.0.4.dev0"
+version = "0.0.4"
 description = "Generic PubGrub dependency-resolver core"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab"
-version = "0.0.4"
+version = "0.0.5.dev0"
 description = "PubGrub-based dependency resolver for Python packages"
 readme = "README.md"
 license = "MIT"
@@ -19,14 +19,14 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "nab-resolver==0.0.4",
-    "nab-python==0.0.4",
-    "nab-index==0.0.4",
+    "nab-resolver==0.0.5.dev0",
+    "nab-python==0.0.5.dev0",
+    "nab-index==0.0.5.dev0",
     "tyro>=1.0",
 ]
 
 [project.optional-dependencies]
-httpx = ["nab-index[httpx]==0.0.4"]
+httpx = ["nab-index[httpx]==0.0.5.dev0"]
 
 [project.urls]
 Homepage = "https://github.com/notatallshaw/nab"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nab"
-version = "0.0.4.dev0"
+version = "0.0.4"
 description = "PubGrub-based dependency resolver for Python packages"
 readme = "README.md"
 license = "MIT"
@@ -19,14 +19,14 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "nab-resolver==0.0.4.dev0",
-    "nab-python==0.0.4.dev0",
-    "nab-index==0.0.4.dev0",
+    "nab-resolver==0.0.4",
+    "nab-python==0.0.4",
+    "nab-index==0.0.4",
     "tyro>=1.0",
 ]
 
 [project.optional-dependencies]
-httpx = ["nab-index[httpx]==0.0.4.dev0"]
+httpx = ["nab-index[httpx]==0.0.4"]
 
 [project.urls]
 Homepage = "https://github.com/notatallshaw/nab"


### PR DESCRIPTION
Cuts release 0.0.4. Merge with a merge commit (not squash) so the `Release 0.0.4` commit and the `v0.0.4` tag stay in history. Publishing happens after the GitHub release for `v0.0.4` is published.