### PR TITLE
Benchmark: trust pre-2.2 sdist deps by default

### DIFF
--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -368,8 +368,10 @@ def median_run(scenario: dict, runs: int) -> tuple[list[dict], dict]:
         else None
     )
     uploaded_prior_to = parse_datetime(datetime_str) if datetime_str else None
+    # See scenarios.py: trust pre-2.2 sdist PKG-INFO deps by default so the
+    # benchmark measures search, not strict PEP 643 sdist rejection.
     trust_unverified_sdist_deps = bool(
-        scenario.get("trust_unverified_sdist_deps", False)
+        scenario.get("trust_unverified_sdist_deps", True)
     )
 
     runs_data: list[dict] = [

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -543,8 +543,13 @@ def process_scenario(
             f" got {resolution_raw!r}"
         )
         raise ValueError(msg) from exc
+    # Trust a pre-2.2 sdist's PKG-INFO deps by default. The benchmark measures
+    # resolver search, and under BuildPolicy.NEVER the strict PEP 643 product
+    # default rejects every sdist-only pre-2.2 pin (UnsupportedSdistError),
+    # dropping in-window versions uv resolves by building. A scenario sets this
+    # false to exercise strict behavior.
     trust_unverified_sdist_deps: bool = scenario.get(
-        "trust_unverified_sdist_deps", False
+        "trust_unverified_sdist_deps", True
     )
     optional_dependencies: dict[str, list[str]] = scenario.get(
         "optional_dependencies", {}


### PR DESCRIPTION
Defaults `trust_unverified_sdist_deps` to True in the benchmark (scenarios.py, canary.py). Under BuildPolicy.NEVER the strict PEP 643 default rejected every sdist-only pre-2.2 pin (UnsupportedSdistError), dropping in-window versions that uv resolves by building, which masked ~389 standard-suite successes as fails on the 0.0.4 board. No scenario sets the flag False, so no scenario's intent changes. Benchmark-only; the product default is unchanged.
