### PR TITLE
Skip urljoin for absolute simple-api URLs

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -272,7 +272,14 @@ def _parse_files(
             continue
         filename = file_info["filename"]
 
-        file_url = urljoin(base_url, file_info["url"])
+        # PyPI and most indexes emit absolute file URLs; urljoin then re-parses
+        # both sides only to return the URL unchanged. Skip it for the common
+        # absolute case; relative URLs still resolve against the page below.
+        raw_url = file_info["url"]
+        if raw_url.startswith(("https://", "http://")):
+            file_url = raw_url
+        else:
+            file_url = urljoin(base_url, raw_url)
 
         hashes = _parse_hashes(file_info.get("hashes"))
         size = _parse_size(file_info.get("size"))

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -10,6 +10,7 @@ import tarfile
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
+from urllib.parse import urljoin
 
 import pytest
 
@@ -340,6 +341,13 @@ class TestRelativeUrlResolution:
         }
         files = _parse_files(data, "https://example.com/simple/", "foo")
         assert files[0].url == "https://files.example.com/foo-1.0-py3-none-any.whl"
+
+    def test_absolute_url_matches_urljoin(self) -> None:
+        raw = "https://files.pythonhosted.org/packages/ab/cd/foo-1.0-py3-none-any.whl"
+        base = "https://pypi.org/simple/foo/"
+        data = {"files": [{"filename": "foo-1.0-py3-none-any.whl", "url": raw}]}
+        files = _parse_files(data, "https://pypi.org/simple/", "foo")
+        assert files[0].url == urljoin(base, raw) == raw
 
 
 class TestParseHashes:


### PR DESCRIPTION
PyPI and most indexes emit absolute file URLs, so `urljoin(base, url)` re-parses both sides only to return the URL unchanged. Take the URL as-is for the common absolute (`http`/`https`) case; relative URLs still resolve against the page as before. This runs for every file in every simple-api listing, a warm-resolve hot path.
