### PR TITLE
Intern markers by text in metadata parse

### DIFF
--- a/nab-python/src/nab_python/metadata.py
+++ b/nab-python/src/nab_python/metadata.py
@@ -12,13 +12,16 @@ from __future__ import annotations
 import email.parser
 from dataclasses import dataclass, field
 from functools import lru_cache
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import tomli
 
 from ._vendor.packaging.requirements import Requirement
 from ._vendor.packaging.specifiers import SpecifierSet
 from ._vendor.packaging.version import Version
+
+if TYPE_CHECKING:
+    from ._vendor.packaging.markers import Marker
 
 __all__ = [
     "DEPENDENCY_FIELDS",
@@ -88,6 +91,22 @@ def metadata_deps_are_static(metadata: WheelMetadata) -> bool:
     return not (DEPENDENCY_FIELDS & metadata.dynamic)
 
 
+@lru_cache(maxsize=8192)
+def _intern_marker(marker: Marker) -> Marker:
+    """Return a shared :class:`Marker` for an equal marker expression.
+
+    ``Marker`` hashes and compares by its text, so a single marker like
+    ``extra == "test"`` recurs across hundreds of distinct dep strings
+    (``pytest; extra == "test"``, ``coverage; extra == "test"``, ...),
+    each parsing to its own object.  The provider caches marker
+    evaluation by ``id(marker)``, so sharing one object per distinct
+    expression lets that cache hit across every candidate instead of
+    re-evaluating the same expression per dep.  Markers are read-only,
+    so sharing is safe.
+    """
+    return marker
+
+
 @lru_cache(maxsize=16384)
 def _parse_requirement_cached(req_str: str) -> Requirement:
     """Cache ``Requirement(req_str)`` parsing across wheel metadata.
@@ -97,7 +116,10 @@ def _parse_requirement_cached(req_str: str) -> Requirement:
     only read operations (specifier, marker, extras, name) so sharing
     parsed objects is safe.
     """
-    return Requirement(req_str)
+    req = Requirement(req_str)
+    if req.marker is not None:
+        req.marker = _intern_marker(req.marker)
+    return req
 
 
 @lru_cache(maxsize=65536)

--- a/nab-python/tests/test_metadata.py
+++ b/nab-python/tests/test_metadata.py
@@ -62,6 +62,28 @@ def test_requires_dist_parsed() -> None:
     assert [str(r) for r in md.requires_dist] == ["bar>=1.0", "baz<2"]
 
 
+def test_equal_markers_are_interned() -> None:
+    """The same marker text across different dep strings shares one object."""
+    text = (
+        "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n"
+        'Requires-Dist: pytest; extra == "test"\n'
+        'Requires-Dist: coverage; extra == "test"\n'
+        'Requires-Dist: ruff; extra == "lint"\n'
+    )
+    md = parse_metadata(text)
+    pytest_marker, coverage_marker, ruff_marker = (r.marker for r in md.requires_dist)
+    assert pytest_marker is coverage_marker
+    assert ruff_marker is not pytest_marker
+
+
+def test_markerless_requirement_keeps_none_marker() -> None:
+    """A dep without a marker is unaffected by interning."""
+    md = parse_metadata(
+        "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\nRequires-Dist: bar>=1.0\n"
+    )
+    assert md.requires_dist[0].marker is None
+
+
 def test_provides_extra_kept_as_strings() -> None:
     """``Provides-Extra`` values are retained as raw strings."""
     text = (


### PR DESCRIPTION
The same marker expression (`extra == "test"`, etc.) recurs across hundreds of distinct dep strings, each parsing to its own `Marker` object. The provider caches marker evaluation by `id(marker)`, so interning one shared object per distinct expression lets that cache hit across every candidate instead of re-evaluating the same expression per dep.
