### PR TITLE
Binary-search the earliest satisfier

### DIFF
--- a/nab-resolver/src/nab_resolver/partial_solution.py
+++ b/nab-resolver/src/nab_resolver/partial_solution.py
@@ -65,6 +65,15 @@ class Assignment(Generic[PackageType, VersionType]):
     positive: bool = True
     """Whether this constrains the package positively or negatively."""
 
+    cum_positive: RangeProtocol[VersionType] | None = None
+    """Latest positive accumulated range for the package as of this entry."""
+
+    cum_negative: RangeProtocol[VersionType] | None = None
+    """Latest negative accumulated range for the package as of this entry."""
+
+    package_index: int = 0
+    """Position in the package's own assignment trail."""
+
 
 class PartialSolution(Generic[PackageType, VersionType]):
     """Tracks the resolver's current partial solution as a decision trail.
@@ -147,6 +156,7 @@ class PartialSolution(Generic[PackageType, VersionType]):
         self._effective_range_cache.pop(package, None)
         self._undecided.discard(package)
 
+        package_entries = self._assignments_by_package[package]
         assignment = Assignment(
             package=package,
             accumulated_range=exact_range,
@@ -155,9 +165,12 @@ class PartialSolution(Generic[PackageType, VersionType]):
             trail_index=len(self._assignments),
             version=version,
             positive=True,
+            cum_positive=exact_range,
+            cum_negative=self._negative_ranges.get(package),
+            package_index=len(package_entries),
         )
         self._assignments.append(assignment)
-        self._assignments_by_package[package].append(assignment)
+        package_entries.append(assignment)
 
     def derive(
         self,
@@ -190,6 +203,7 @@ class PartialSolution(Generic[PackageType, VersionType]):
 
         self._effective_range_cache.pop(package, None)
 
+        package_entries = self._assignments_by_package[package]
         assignment = Assignment(
             package=package,
             accumulated_range=new_range,
@@ -198,9 +212,12 @@ class PartialSolution(Generic[PackageType, VersionType]):
             trail_index=len(self._assignments),
             cause=cause,
             positive=positive,
+            cum_positive=self._positive_ranges.get(package),
+            cum_negative=self._negative_ranges.get(package),
+            package_index=len(package_entries),
         )
         self._assignments.append(assignment)
-        self._assignments_by_package[package].append(assignment)
+        package_entries.append(assignment)
 
     def backtrack(self, target_level: int) -> None:
         """Remove all assignments above target_level.
@@ -325,70 +342,67 @@ class PartialSolution(Generic[PackageType, VersionType]):
         self, stop_at: Assignment[PackageType, VersionType], package: PackageType
     ) -> RangeProtocol[VersionType] | None:
         """Return what earlier trail entries imply about this package."""
-        cumulative_positive: RangeProtocol[VersionType] | None = None
-        cumulative_negative: RangeProtocol[VersionType] | None = None
-
-        # Each accumulated_range is already cumulative, so the latest entry
-        # of each sign is enough; no need to re-intersect.
-        package_entries = self._assignments_by_package.get(package, ())
-        for assignment in package_entries:
-            if assignment is stop_at:
-                break
-            if assignment.is_decision or assignment.positive:
-                cumulative_positive = assignment.accumulated_range
-            else:
-                cumulative_negative = assignment.accumulated_range
-        else:  # pragma: no cover
-            unreachable = f"Bug: stop_at assignment not found in trail for {package!r}"
-            raise RuntimeError(unreachable)
-
-        if cumulative_positive is None and cumulative_negative is None:
+        if stop_at.package_index == 0:
             return None
 
-        if cumulative_positive is not None:
-            effective = cumulative_positive
-            if cumulative_negative is not None:
-                effective = effective & ~cumulative_negative
-            return effective
+        prev = self._assignments_by_package[package][stop_at.package_index - 1]
+        if prev.cum_positive is None:
+            assert prev.cum_negative is not None
+            return ~prev.cum_negative
+        if prev.cum_negative is None:
+            return prev.cum_positive
+        return prev.cum_positive & ~prev.cum_negative
 
-        assert cumulative_negative is not None
-        return ~cumulative_negative
+    def _satisfied_at(
+        self,
+        assignment: Assignment[PackageType, VersionType],
+        term: Term[PackageType, VersionType],
+        *,
+        is_positive: bool,
+    ) -> bool:
+        """Whether the trail up to and including ``assignment`` satisfies term.
+
+        Positive terms need a positive assignment first; negatives alone
+        only exclude versions.
+        """
+        cum_positive = assignment.cum_positive
+        if is_positive and cum_positive is None:
+            return False
+
+        if cum_positive is None:
+            assert assignment.cum_negative is not None
+            effective = ~assignment.cum_negative
+        elif assignment.cum_negative is None:
+            effective = cum_positive
+        else:
+            effective = cum_positive & ~assignment.cum_negative
+
+        return term.satisfies(effective)
 
     def satisfier(
         self, term: Term[PackageType, VersionType]
     ) -> Assignment[PackageType, VersionType] | None:
         """Find the earliest assignment that causes the term to be satisfied.
 
-        Used during conflict resolution to identify which assignment caused
-        each term in an incompatibility to become satisfied.
+        The effective range only narrows along the trail, so ``term.satisfies``
+        is monotonic: once an entry satisfies the term, every later one does
+        too.  That lets a binary search replace the linear scan.
         See: https://github.com/dart-lang/pub/blob/master/doc/solver.md#conflict-resolution
         """
-        cumulative_positive: RangeProtocol[VersionType] | None = None
-        cumulative_negative: RangeProtocol[VersionType] | None = None
+        entries = self._assignments_by_package.get(term.package, ())
+        count = len(entries)
+        if count == 0:
+            return None
+
         is_positive = term.is_positive()
+        if not self._satisfied_at(entries[count - 1], term, is_positive=is_positive):
+            return None
 
-        package_entries = self._assignments_by_package.get(term.package, ())
-        for assignment in package_entries:
-            if assignment.is_decision or assignment.positive:
-                cumulative_positive = assignment.accumulated_range
+        low, high = 0, count - 1
+        while low < high:
+            mid = (low + high) // 2
+            if self._satisfied_at(entries[mid], term, is_positive=is_positive):
+                high = mid
             else:
-                cumulative_negative = assignment.accumulated_range
-
-            if cumulative_positive is not None:
-                effective_range = (
-                    cumulative_positive
-                    if cumulative_negative is None
-                    else cumulative_positive & ~cumulative_negative
-                )
-            else:
-                assert cumulative_negative is not None
-                effective_range = ~cumulative_negative
-
-            # Positive terms need a positive assignment before they can
-            # be satisfied; negatives alone only exclude versions.
-            if (not is_positive or cumulative_positive is not None) and term.satisfies(
-                effective_range
-            ):
-                return assignment
-
-        return None
+                low = mid + 1
+        return entries[low]

--- a/nab-resolver/tests/property/test_partial_solution_satisfier.py
+++ b/nab-resolver/tests/property/test_partial_solution_satisfier.py
@@ -1,0 +1,177 @@
+"""Property tests for the earliest-satisfier binary search.
+
+``PartialSolution.satisfier`` finds the earliest trail entry that
+satisfies a term with a binary search rather than a linear scan.  The
+search is licensed by one invariant: along a package's chronological
+trail the effective range only narrows (positive derivations intersect,
+negative derivations union), so ``term.satisfies`` is monotone (once
+true at an entry it stays true for every later entry).  The search and
+the prefix lookups read ``cum_positive`` / ``cum_negative`` stored on
+each entry, so a stored-field or backtrack bug would silently return the
+wrong satisfier.
+
+These properties drive random decide/derive/backtrack sequences and
+check the invariant directly, that the binary search agrees with an
+independent linear scan, and that the O(1) prefix range agrees with a
+recomputed prefix.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_resolver.partial_solution import PartialSolution
+from nab_resolver.ranges import Range
+from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
+
+from .strategies import PROPERTY_SETTINGS, terms, version_ranges
+
+if TYPE_CHECKING:
+    from nab_resolver.partial_solution import Assignment
+    from nab_resolver.types import RangeProtocol
+
+pytestmark = pytest.mark.property
+
+_PKG = "pkg"
+_VERSIONS = range(1, 21)
+
+Op = tuple[str, "Range[int] | int"]
+
+
+def _root() -> Incompatibility[str, int]:
+    return Incompatibility([], cause=IncompatibilityCause.ROOT)
+
+
+_operations = st.one_of(
+    st.tuples(st.just("pos"), version_ranges()),
+    st.tuples(st.just("neg"), version_ranges()),
+    st.tuples(st.just("decide"), st.integers(min_value=1, max_value=20)),
+    st.tuples(st.just("backtrack"), st.integers(min_value=0, max_value=8)),
+)
+
+
+def _member(rng: RangeProtocol[int]) -> int | None:
+    """First version in the pool that ``rng`` admits, or None."""
+    return next((v for v in _VERSIONS if v in rng), None)
+
+
+def _apply(ps: PartialSolution[str, int], op: Op) -> None:
+    """Apply one generated operation, staying within reachable states.
+
+    The resolver only decides an undecided package that already carries a
+    positive constraint, choosing a version inside its current range, so a
+    decision never widens the effective range and monotonicity holds.
+    """
+    kind, payload = op
+    if kind == "pos" and isinstance(payload, Range):
+        ps.derive(_PKG, payload, positive=True, cause=_root())
+    elif kind == "neg" and isinstance(payload, Range):
+        ps.derive(_PKG, payload, positive=False, cause=_root())
+    elif kind == "decide" and isinstance(payload, int):
+        if _PKG in ps.decisions() or not ps.has_positive_constraint(_PKG):
+            return
+        effective = ps.get(_PKG)
+        assert effective is not None
+        chosen = payload if payload in effective else _member(effective)
+        if chosen is not None:
+            ps.decide(_PKG, chosen)
+    elif kind == "backtrack" and isinstance(payload, int):
+        ps.backtrack(payload % (ps.decision_level + 1))
+
+
+def _effective(
+    cum_pos: RangeProtocol[int] | None, cum_neg: RangeProtocol[int] | None
+) -> RangeProtocol[int] | None:
+    """Combine accumulated positive and negative ranges, as ``get`` does."""
+    if cum_pos is None and cum_neg is None:
+        return None
+    if cum_pos is None:
+        assert cum_neg is not None
+        return ~cum_neg
+    return cum_pos if cum_neg is None else cum_pos & ~cum_neg
+
+
+def _linear_satisfier(
+    ps: PartialSolution[str, int], term: Term[str, int]
+) -> Assignment[str, int] | None:
+    """Earliest satisfying entry by a plain scan, independent of stored fields."""
+    cum_pos: RangeProtocol[int] | None = None
+    cum_neg: RangeProtocol[int] | None = None
+    is_positive = term.is_positive()
+    for entry in ps.assignments_for(term.package):
+        if entry.is_decision or entry.positive:
+            cum_pos = entry.accumulated_range
+        else:
+            cum_neg = entry.accumulated_range
+        effective = _effective(cum_pos, cum_neg)
+        if not is_positive or cum_pos is not None:
+            assert effective is not None
+            if term.satisfies(effective):
+                return entry
+    return None
+
+
+def _effective_before_reference(
+    ps: PartialSolution[str, int], entry: Assignment[str, int]
+) -> RangeProtocol[int] | None:
+    """Effective range of the strict per-package prefix before ``entry``."""
+    cum_pos: RangeProtocol[int] | None = None
+    cum_neg: RangeProtocol[int] | None = None
+    for prior in ps.assignments_for(entry.package)[: entry.package_index]:
+        if prior.is_decision or prior.positive:
+            cum_pos = prior.accumulated_range
+        else:
+            cum_neg = prior.accumulated_range
+    return _effective(cum_pos, cum_neg)
+
+
+@given(
+    ops=st.lists(_operations, min_size=1, max_size=14),
+    probes=st.lists(terms(), min_size=1, max_size=4),
+)
+@PROPERTY_SETTINGS
+def test_satisfied_at_is_monotone(ops: list[Op], probes: list[Term[str, int]]) -> None:
+    """``_satisfied_at`` never flips back to false later in the trail."""
+    ps: PartialSolution[str, int] = PartialSolution()
+    for op in ops:
+        _apply(ps, op)
+        for term in probes:
+            is_positive = term.is_positive()
+            flags = [
+                ps._satisfied_at(entry, term, is_positive=is_positive)
+                for entry in ps.assignments_for(term.package)
+            ]
+            assert all(flags[i] <= flags[i + 1] for i in range(len(flags) - 1))
+
+
+@given(
+    ops=st.lists(_operations, min_size=1, max_size=14),
+    probes=st.lists(terms(), min_size=1, max_size=4),
+)
+@PROPERTY_SETTINGS
+def test_satisfier_matches_linear_scan(
+    ops: list[Op], probes: list[Term[str, int]]
+) -> None:
+    """The binary search returns the same entry as a linear scan."""
+    ps: PartialSolution[str, int] = PartialSolution()
+    for op in ops:
+        _apply(ps, op)
+        for term in probes:
+            assert ps.satisfier(term) is _linear_satisfier(ps, term)
+
+
+@given(ops=st.lists(_operations, min_size=1, max_size=14))
+@PROPERTY_SETTINGS
+def test_effective_range_before_matches_prefix(ops: list[Op]) -> None:
+    """The O(1) prefix range equals the recomputed strict prefix."""
+    ps: PartialSolution[str, int] = PartialSolution()
+    for op in ops:
+        _apply(ps, op)
+        for entry in ps.assignments_for(_PKG):
+            assert ps._effective_range_before(
+                entry, _PKG
+            ) == _effective_before_reference(ps, entry)

--- a/nab-resolver/tests/test_partial_solution.py
+++ b/nab-resolver/tests/test_partial_solution.py
@@ -207,6 +207,144 @@ class TestMultipleDerivations:
         assert s is not None
 
 
+def _linear_satisfier(ps: PartialSolution, term: Term) -> object:
+    """Reference linear scan, independent of the binary-search satisfier."""
+    cum_pos = cum_neg = None
+    is_positive = term.is_positive()
+    for a in ps._assignments_by_package.get(term.package, ()):
+        if a.is_decision or a.positive:
+            cum_pos = a.accumulated_range
+        else:
+            cum_neg = a.accumulated_range
+        if cum_pos is not None:
+            eff = cum_pos if cum_neg is None else cum_pos & ~cum_neg
+        else:
+            assert cum_neg is not None
+            eff = ~cum_neg
+        if (not is_positive or cum_pos is not None) and term.satisfies(eff):
+            return a
+    return None
+
+
+class TestSatisfierBinarySearch:
+    """The earliest-satisfier search and its O(1) effective-range support."""
+
+    def _root(self) -> Incompatibility:
+        return Incompatibility([], cause=IncompatibilityCause.ROOT)
+
+    def test_satisfier_unknown_package(self) -> None:
+        ps = PartialSolution()
+        assert ps.satisfier(Term("missing", Range.full())) is None
+
+    def test_satisfier_positive_only_trail(self) -> None:
+        ps = PartialSolution()
+        for upper in (100, 50, 20, 10):
+            ps.derive("foo", Range.less_than(upper), positive=True, cause=self._root())
+        # foo is now [.., 10); "foo < 30" first holds once it narrows under 30.
+        s = ps.satisfier(Term("foo", Range.less_than(30)))
+        assert s is not None
+        assert s is _linear_satisfier(ps, Term("foo", Range.less_than(30)))
+
+    def test_satisfier_negative_only_trail(self) -> None:
+        ps = PartialSolution()
+        ps.derive("foo", Range.at_least(5), positive=False, cause=self._root())
+        ps.derive("foo", Range.at_least(3), positive=False, cause=self._root())
+        term = Term("foo", Range.at_least(3), positive=False)
+        s = ps.satisfier(term)
+        assert s is not None
+        assert s is _linear_satisfier(ps, term)
+
+    def test_satisfier_positive_term_negative_only_trail_is_none(self) -> None:
+        ps = PartialSolution()
+        ps.derive("foo", Range.at_least(5), positive=False, cause=self._root())
+        assert ps.satisfier(Term("foo", Range.less_than(5))) is None
+
+    def test_satisfier_mixed_trail(self) -> None:
+        ps = PartialSolution()
+        ps.derive("foo", Range.at_least(1), positive=True, cause=self._root())
+        ps.derive("foo", Range.less_than(100), positive=True, cause=self._root())
+        ps.derive("foo", Range.less_than(10), positive=False, cause=self._root())
+        term = Term("foo", Range.at_least(10))
+        s = ps.satisfier(term)
+        assert s is not None
+        assert s is _linear_satisfier(ps, term)
+
+    def test_satisfier_matches_linear_over_mixed_trail(self) -> None:
+        ps = PartialSolution()
+        ps.decide("foo", 50)
+        ps.backtrack(0)
+        for kind, version in [
+            (True, 1),
+            (False, 5),
+            (True, 2),
+            (False, 90),
+            (True, 3),
+            (False, 40),
+        ]:
+            rng = Range.at_least(version) if kind else Range.greater_than(version)
+            ps.derive("foo", rng, positive=kind, cause=self._root())
+        for lo in range(0, 95, 7):
+            for positive in (True, False):
+                term = Term("foo", Range.at_least(lo), positive=positive)
+                assert ps.satisfier(term) is _linear_satisfier(ps, term)
+
+    def test_effective_range_before_first_entry_is_none(self) -> None:
+        ps = PartialSolution()
+        ps.derive("foo", Range.at_least(1), positive=True, cause=self._root())
+        first = ps._assignments_by_package["foo"][0]
+        assert ps._effective_range_before(first, "foo") is None
+
+    def test_effective_range_before_positive_prefix(self) -> None:
+        ps = PartialSolution()
+        ps.derive("foo", Range.at_least(1), positive=True, cause=self._root())
+        ps.derive("foo", Range.less_than(20), positive=False, cause=self._root())
+        second = ps._assignments_by_package["foo"][1]
+        before = ps._effective_range_before(second, "foo")
+        assert before is not None
+        assert 5 in before
+
+    def test_effective_range_before_negative_prefix(self) -> None:
+        ps = PartialSolution()
+        ps.derive("foo", Range.at_least(50), positive=False, cause=self._root())
+        ps.derive("foo", Range.at_least(60), positive=False, cause=self._root())
+        second = ps._assignments_by_package["foo"][1]
+        before = ps._effective_range_before(second, "foo")
+        assert before is not None
+        assert 10 in before
+        assert 50 not in before
+
+    def test_effective_range_before_mixed_prefix(self) -> None:
+        ps = PartialSolution()
+        ps.derive("foo", Range.at_least(1), positive=True, cause=self._root())
+        ps.derive("foo", Range.at_least(90), positive=False, cause=self._root())
+        ps.derive("foo", Range.at_least(2), positive=True, cause=self._root())
+        third = ps._assignments_by_package["foo"][2]
+        before = ps._effective_range_before(third, "foo")
+        assert before is not None
+        assert 5 in before
+        assert 90 not in before
+
+    def test_satisfier_is_sole_decision(self) -> None:
+        ps = PartialSolution()
+        ps.decide("foo", 5)
+        decision = ps._assignments_by_package["foo"][0]
+        assert ps.satisfier_is_sole(decision, Term("foo", Range.at_least(1)))
+
+    def test_satisfier_is_sole_first_derivation(self) -> None:
+        ps = PartialSolution()
+        ps.derive("foo", Range.at_least(5), positive=True, cause=self._root())
+        first = ps._assignments_by_package["foo"][0]
+        assert ps.satisfier_is_sole(first, Term("foo", Range.at_least(5)))
+
+    def test_satisfier_is_sole_false_when_earlier_satisfies(self) -> None:
+        ps = PartialSolution()
+        ps.derive("foo", Range.at_least(10), positive=True, cause=self._root())
+        ps.derive("foo", Range.at_least(12), positive=True, cause=self._root())
+        second = ps._assignments_by_package["foo"][1]
+        # "foo >= 5" was already satisfied by the first entry.
+        assert not ps.satisfier_is_sole(second, Term("foo", Range.at_least(5)))
+
+
 class TestDecisionMap:
     def test_decisions(self) -> None:
         ps = PartialSolution()


### PR DESCRIPTION
`PartialSolution.satisfier` is on the conflict-resolution path and scanned a package's whole assignment trail from the start, rebuilding the effective range at every entry. The effective range only narrows along the trail (positive derivations intersect, negatives union), so `term.satisfies` is monotone and the earliest satisfier is the first-true index of a monotone predicate.

This stores `cum_positive`, `cum_negative`, and the per-package index on each `Assignment` at append time, turns `satisfier` into a binary search, and makes `_effective_range_before` an O(1) read of the preceding entry. Backtrack only tail-pops each per-package list, so the stored fields stay valid with no recompute. The satisfier returned is unchanged.