### PR TITLE
Raise when conflict forks pin a base dependency differently

### DIFF
--- a/docs/guides/conflicts.md
+++ b/docs/guides/conflicts.md
@@ -122,10 +122,14 @@ A dependency required by every member of a set but not by the base
 keeps its membership marker, so it does not install when no member is
 selected (relevant under `at_most_one`, which permits selecting none).
 A base resolve names the deps that install regardless of the
-selection, which is how the writer tells the two apart. When a single
-dependency is required by every member of two or more engaged sets at
-once, its marker is the conjunction across those sets; this stays
-correct for one set, the common case.
+selection, which is how the writer tells the two apart. When the
+forks of one environment pin a base dependency at different versions,
+no single entry can serve the no-member context; the writer raises a
+`DivergentBaseDependencyError` rather than emit a lock that silently
+skips the dependency. When a single dependency is required by every
+member of two or more engaged sets at once, its marker is the
+conjunction across those sets; this stays correct for one set, the
+common case.
 
 The lockfile stays within PEP 751: the membership markers use the
 standard `extras` and `dependency_groups` variables, and the install

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -45,9 +45,24 @@ if TYPE_CHECKING:
 
 
 __all__ = [
+    "DivergentBaseDependencyError",
     "build_pylock",
     "write_lock",
 ]
+
+
+class DivergentBaseDependencyError(ValueError):
+    """An environment's conflict forks disagree on a base dependency's pin.
+
+    A base dependency present in every fork of an environment drops its
+    membership clause so it installs even when no conflicting member is
+    selected, which requires the forks to agree on one (version, source).
+    When they diverge, every candidate entry keeps a membership clause,
+    so nothing would fire in the no-member install context and the
+    dependency would silently not install.  Surface the divergence with
+    the offending package and per-fork pins so the producer can
+    reconcile the forks rather than commit an incomplete lock.
+    """
 
 
 def write_lock(
@@ -317,7 +332,9 @@ def _build_per_tuple_packages(lock_input: LockInput, lock_dir: Path) -> list[Pac
     not by the base is absent from that set, so it keeps the
     membership clause and does not install when no member is selected.
     See :class:`LockInput.env_base_names` for the missing-signature
-    contract.
+    contract.  Forks of one environment that disagree on a base
+    dependency's pin raise :class:`DivergentBaseDependencyError`
+    instead of emitting a lock whose no-member context misses it.
     """
     out: list[Package] = []
     by_name = _group_by_name(lock_input.per_tuple_pins)
@@ -330,6 +347,14 @@ def _build_per_tuple_packages(lock_input: LockInput, lock_dir: Path) -> list[Pac
     )
     for canonical_name, per_tuple in by_name.items():
         groups = _group_pins_by_pin(per_tuple)
+        _check_base_fork_agreement(
+            canonical_name,
+            per_tuple,
+            groups,
+            env_signatures,
+            env_fork_counts,
+            lock_input.env_base_names,
+        )
         for pins, tuple_labels in groups:
             marker = _build_marker(
                 canonical_name,
@@ -450,6 +475,46 @@ def _merge_pins_in_group(pins: list[PinShape]) -> PinShape:
         wheels=tuple(sorted(seen_wheels.values(), key=_wheel_sort_key)),
         requires_python=requires_python,
     )
+
+
+def _check_base_fork_agreement(
+    name: str,
+    per_tuple: Mapping[str, PinShape],
+    groups: list[tuple[list[PinShape], list[str]]],
+    env_signatures: Mapping[str, tuple[tuple[str, str], ...]],
+    env_fork_counts: Mapping[tuple[tuple[str, str], ...], int],
+    env_base_names: Mapping[tuple[tuple[str, str], ...], frozenset[str]],
+) -> None:
+    """Reject a base dep whose forks within one env pin it differently.
+
+    The env-only collapse in :func:`_build_marker` needs a single
+    (version, source) group spanning every fork of the environment.
+    Divergent pins split the forks across groups, so every entry would
+    keep its membership clause and none would fire when no member is
+    selected: the base dependency would silently not install.
+    """
+    by_env: defaultdict[tuple[tuple[str, str], ...], list[str]] = defaultdict(list)
+    for label in sorted(per_tuple.keys() & env_signatures.keys()):
+        by_env[env_signatures[label]].append(label)
+    for signature, labels in by_env.items():
+        if len(labels) < env_fork_counts[signature]:
+            continue
+        if name not in env_base_names.get(signature, frozenset()):
+            continue
+        in_env = set(labels)
+        widest = max(
+            sum(1 for label in group_labels if label in in_env)
+            for _, group_labels in groups
+        )
+        if widest >= env_fork_counts[signature]:
+            continue
+        forks = ", ".join(f"{label} -> {per_tuple[label].version}" for label in labels)
+        msg = (
+            f"{name}: the conflict forks of one environment pin this base"
+            f" dependency differently ({forks}); no lockfile entry would"
+            " install it when no conflicting member is selected"
+        )
+        raise DivergentBaseDependencyError(msg)
 
 
 def _build_marker(

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -24,7 +24,7 @@ from ._lockfile.builder import (
     read_lockfile_packages,
 )
 from ._lockfile.disjointness import DisjointnessError
-from ._lockfile.pylock import build_pylock, write_lock
+from ._lockfile.pylock import DivergentBaseDependencyError, build_pylock, write_lock
 from ._lockfile.requirements import (
     write_requirements_with_hashes,
     write_requirements_without_hashes,
@@ -44,6 +44,7 @@ __all__ = [
     "ACCEPTED_HASH_ALGORITHMS",
     "LOCK_VERSION",
     "DisjointnessError",
+    "DivergentBaseDependencyError",
     "IndexPin",
     "LocalPin",
     "LockInput",

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -41,6 +41,7 @@ from nab_python.config import (
 from nab_python.lockfile import (
     LOCK_VERSION,
     DisjointnessError,
+    DivergentBaseDependencyError,
     IndexPin,
     LocalPin,
     LockInput,
@@ -745,6 +746,84 @@ class TestConflictForkBaseDepMarkers:
         pylock = build_pylock(self._lock_input())
         universal = next(p for p in pylock.packages if str(p.name) == "universal")
         assert universal.marker is None
+
+
+class TestConflictForkBaseDepDivergence:
+    """A base dep pinned differently across the conflict forks of one
+    environment cannot drop the membership clause on any entry, so no
+    entry would fire when no member is selected (at_most_one permits
+    zero).  The writer raises instead of emitting a lock that silently
+    skips the dependency."""
+
+    _ENV: ClassVar[dict[str, str]] = {"sys_platform": "linux"}
+
+    def _lock_input(
+        self,
+        *,
+        base_names: frozenset[str] = frozenset({"shared"}),
+        gpu_has_shared: bool = True,
+    ) -> LockInput:
+        env_marker = Marker('sys_platform == "linux"')
+        per_tuple: dict[str, dict[str, IndexPin]] = {
+            "cpu": {"shared": _index_pin(name="shared", version="1.0")},
+            "gpu": {"shared": _index_pin(name="shared", version="2.0")},
+        }
+        if not gpu_has_shared:
+            del per_tuple["gpu"]["shared"]
+        return LockInput(
+            per_tuple_pins=per_tuple,
+            tuple_markers={
+                "cpu": Marker('sys_platform == "linux" and "cpu" in extras'),
+                "gpu": Marker('sys_platform == "linux" and "gpu" in extras'),
+            },
+            tuple_env_markers={"cpu": env_marker, "gpu": env_marker},
+            tuple_environments={"cpu": self._ENV, "gpu": self._ENV},
+            env_base_names={tuple(sorted(self._ENV.items())): base_names},
+            extras=("cpu", "gpu"),
+            conflicts=(
+                ConflictSet(
+                    members=(
+                        ConflictMember(ConflictKind.EXTRA, "cpu"),
+                        ConflictMember(ConflictKind.EXTRA, "gpu"),
+                    ),
+                    policy=ConflictPolicy.AT_MOST_ONE,
+                ),
+            ),
+        )
+
+    def test_divergent_base_dep_raises_with_per_fork_pins(self) -> None:
+        with pytest.raises(DivergentBaseDependencyError) as info:
+            build_pylock(self._lock_input())
+        message = str(info.value)
+        assert "shared" in message
+        assert "cpu -> 1.0" in message
+        assert "gpu -> 2.0" in message
+
+    def test_write_lock_raises_and_writes_nothing(self, tmp_path: Path) -> None:
+        target = tmp_path / "pylock.toml"
+        with pytest.raises(DivergentBaseDependencyError):
+            write_lock(self._lock_input(), output_path=target)
+        assert not target.exists()
+
+    def test_divergent_member_only_dep_keeps_membership_entries(self) -> None:
+        """The same divergence on a dep the base pass did not pin is
+        representable: each entry keeps its membership clause and the
+        no-member context correctly installs neither."""
+        pylock = build_pylock(self._lock_input(base_names=frozenset()))
+        markers = sorted(
+            str(p.marker) for p in pylock.packages if str(p.name) == "shared"
+        )
+        assert len(markers) == 2
+        assert '"cpu" in extras' in markers[0]
+        assert '"gpu" in extras' in markers[1]
+
+    def test_base_dep_missing_from_one_fork_keeps_membership(self) -> None:
+        """A base dep absent from one fork is outside the env-only
+        collapse (it needs presence in every fork), so the present
+        fork's entry keeps its membership clause and nothing raises."""
+        pylock = build_pylock(self._lock_input(gpu_has_shared=False))
+        shared = next(p for p in pylock.packages if str(p.name) == "shared")
+        assert '"cpu" in extras' in str(shared.marker)
 
 
 class TestConflictForksWithoutBaseAttribution:

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -379,7 +379,7 @@ def _emit_universal_pylock(
     except _cli.MissingHashError as e:
         sys.stderr.write(f"Cannot lock: {e}\n")
         sys.exit(1)
-    except _cli.DisjointnessError as e:
+    except (_cli.DisjointnessError, _cli.DivergentBaseDependencyError) as e:
         sys.stderr.write(f"Error: {e}\n")
         sys.exit(1)
 

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -32,6 +32,7 @@ from nab_python.config import (
 from nab_python.download import download_lock  # noqa: F401 - re-exported for tests
 from nab_python.lockfile import (
     DisjointnessError,  # noqa: F401 - referenced as _cli.DisjointnessError in _lock
+    DivergentBaseDependencyError,  # noqa: F401 - referenced via _cli in _lock
     MissingHashError,
     MissingSdistError,
     write_lock,  # noqa: F401 - re-exported for tests

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,6 +43,7 @@ from nab_python.config import ConfigError
 from nab_python.download import DownloadError
 from nab_python.lockfile import (
     DisjointnessError,
+    DivergentBaseDependencyError,
     IndexPin,
     LocalPin,
     LockInput,
@@ -672,6 +673,31 @@ class TestLockCommandUniversal:
         # nab-python/tests/test_lockfile.py.
         err = capsys.readouterr().err
         assert f"Error: {hint}\n" in err
+
+    def test_pylock_divergent_base_dep_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A DivergentBaseDependencyError during universal pylock
+        surfaces as exit 1 with a clean ``Error: ...`` line instead of
+        a traceback."""
+        pyproject = _universal_pyproject(tmp_path)
+        message = (
+            "shared: the conflict forks of one environment pin this base"
+            " dependency differently (cpu -> 1.0, gpu -> 2.0)"
+        )
+        with (
+            patch(
+                "nab.cli.resolve_universal_pyproject",
+                return_value=_universal_result(success=True),
+            ),
+            patch(
+                "nab.cli.write_lock",
+                side_effect=DivergentBaseDependencyError(message),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, output=tmp_path / "pylock.toml")
+        assert f"Error: {message}\n" in capsys.readouterr().err
 
     def test_universal_lock_collision_without_conflict_shows_hint(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
When the conflict forks of one environment pinned a base dependency at different versions (the torch cpu/gpu pattern), the pylock writer emitted only membership-guarded entries for it. Since `at_most_one` permits selecting no member, no entry fired in the no-member install context: a committed lockfile silently installed nothing for a dependency the project requires, and `validate()` could not notice the gap because disjointness only detects over-coverage.

`build_pylock` now rejects a base dependency whose per-fork pins split across (version, source) groups within one environment, raising `DivergentBaseDependencyError` with the package and per-fork pins instead of writing an incomplete lock; `nab lock` surfaces it as a clean `Error:` line. Agreeing forks still collapse to the env-only marker and member-only deps keep their membership clauses, unchanged.