### PR TITLE
Skip unextractable base versions for user extras

### DIFF
--- a/nab-python/src/nab_python/_provider/extras.py
+++ b/nab-python/src/nab_python/_provider/extras.py
@@ -76,17 +76,23 @@ def _pick_in_mode(
 ) -> Version | None:
     """Pick a candidate honoring ``ExtrasMode``.
 
-    User-requested extras return the first candidate that does not have
-    known-invalid metadata. Transitive extras additionally validate the
-    base metadata parses, so a malformed PKG-INFO becomes a candidate
-    skip instead of a fatal error during the later dependency fetch.
-    BACKTRACK mode additionally checks ``Provides-Extra``.
+    Fetches base metadata so an extraction failure (unparseable
+    PKG-INFO, or an sdist build the policy disallows) becomes a
+    candidate skip instead of a fatal error during the later
+    dependency fetch.  BACKTRACK mode additionally checks
+    ``Provides-Extra`` for transitive extras.
 
-    Missing-metadata cases (no PEP 658, no sdist) fall through;
-    mock test coordinators rely on this.
+    Missing-metadata cases (no PEP 658, no sdist) skip transitive
+    extras but fall through for user-requested ones; mock test
+    coordinators rely on this.
     """
     # Late import: ``pypi`` imports this module at module load.
-    from ..provider import ExtrasMode, MetadataError, _normalize_extra
+    from ..provider import (
+        ExtrasMode,
+        MetadataError,
+        UnsupportedSdistError,
+        _normalize_extra,
+    )
 
     _, _, normalized = provider.split_and_normalize(base)
     is_user = (normalized, extra) in provider.root_extras
@@ -94,17 +100,15 @@ def _pick_in_mode(
     for version in candidates:
         if provider.has_invalid_metadata(normalized, version):
             continue
-        if is_user:
-            return version
-        # Fetch base metadata so an unparseable PKG-INFO is caught
-        # before the extras proxy decides this version. Any
-        # MetadataError (parse failure or no metadata source) is a
-        # candidate skip.
         try:
             provider.get_dependencies(base, version)
-        except MetadataError:
+        except UnsupportedSdistError:
             continue
-        if not backtrack:
+        except MetadataError:
+            if not is_user or provider.has_invalid_metadata(normalized, version):
+                continue
+            return version
+        if is_user or not backtrack:
             return version
         metadata = provider.metadata_cache.get((normalized, version))
         provided = (

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -4748,6 +4748,51 @@ class TestExtrasInvalidMetadata:
         version = provider.choose_version("foo[security]", VersionRange.full())
         assert version == V("1.0")
 
+    def test_user_extra_skips_unsupported_sdist(self) -> None:
+        """A user-requested extra must not pick an unbuildable sdist version.
+
+        2.0 is sdist-only with a pre-2.2 PKG-INFO, so its metadata
+        cannot be extracted under the default BUILD_LOCAL policy.
+        The base package's look-ahead skips it; the user-extra path
+        must skip it too instead of letting the resolver's later
+        dependency fetch raise UnsupportedSdistError.
+        """
+        dists = [make_sdist("2.0"), make_wheel("1.0")]
+        coordinator = make_coordinator(
+            dists,
+            metadata_by_version={"1.0": EXTRA_METADATA},
+            sdist_pkg_info=PRE_22_SDIST_PKG_INFO,
+            package="foo",
+        )
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            root_extras={("foo", "security")},
+        )
+        version = provider.choose_version("foo[security]", VersionRange.full())
+        assert version == V("1.0")
+
+    def test_user_extra_skips_when_get_dependencies_marks_invalid(self) -> None:
+        """A user-requested extra skips metadata rejected mid-loop.
+
+        The invalid metadata for 2.0 is not cached before the pick, so
+        only the fetch inside the candidate loop can reveal it.
+        """
+        wheels = [make_wheel("2.0"), make_wheel("1.0")]
+        coordinator = make_coordinator(
+            wheels,
+            metadata_by_version={"2.0": self.BAD_META, "1.0": EXTRA_METADATA},
+            package="foo",
+        )
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            extras_mode=ExtrasMode.WARN,
+            root_extras={("foo", "security")},
+        )
+        version = provider.choose_version("foo[security]", VersionRange.full())
+        assert version == V("1.0")
+
 
 class TestScanBatchNoFirstCandidate:
     """Cover the `first_candidate is None` skip in _scan_batch."""


### PR DESCRIPTION
The version picker for a user-requested extra returned the first candidate without fetching the base metadata, while transitive extras validate it first. When the latest version of a package is sdist-only with a pre-2.2 PKG-INFO (unextractable under the default `BUILD_LOCAL` policy), resolving `foo[bar]` crashed with a raw `UnsupportedSdistError` even though plain `foo` resolves fine: the extras proxy decides before its base, so the base look-ahead that normally converts the error into a version skip never runs.

`_pick_in_mode` now fetches base metadata for user extras too and treats extraction failures (disallowed sdist builds, unparseable metadata) as candidate skips, matching the base path. Candidates with a genuinely missing metadata source still fall through for user extras, preserving the documented mock-coordinator behavior.