### PR TITLE
Track sdist origin of the shared metadata slot

### DIFF
--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -429,6 +429,11 @@ def await_metadata_batch(
             # look-ahead's get_dependencies runs the sdist fallback (or
             # refuses it) rather than pinning it as dependency-free.
             continue
+        if provider.coordinator.index.metadata_from_sdist(package, ver_str):
+            # The shared slot holds sdist PKG-INFO from an earlier
+            # fallback; caching it here would skip the PEP 643 gate
+            # that get_dependencies applies on the from_sdist path.
+            continue
         try:
             provider.parse_and_cache_metadata(cache_key, text)
         except (ValueError, InvalidVersion, InvalidSpecifier):

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -48,11 +48,11 @@ def resolve_metadata(
 
     text = provider.coordinator.index.get_metadata(normalized, ver_str)
     if text is not None:
-        # Decide source from listing: a wheel-with-metadata-url at this
-        # version means the text was wheel METADATA; otherwise sdist
-        # PKG-INFO.  ``_metadata`` and ``_sdist`` write to the same
-        # slot, so we can't tell from the index alone.
-        from_sdist = not has_wheel_metadata_at(versions, version)
+        # Wheel METADATA and sdist PKG-INFO share the slot; the index
+        # records which kind the last write was.  Inferring from the
+        # listing instead would mislabel the text whenever this
+        # provider's view differs from the one that stored it.
+        from_sdist = provider.coordinator.index.metadata_from_sdist(normalized, ver_str)
         return (text, from_sdist)
 
     dist = pick_dist_for_metadata(versions, version)
@@ -83,18 +83,6 @@ def resolve_metadata(
         f"no PEP 658 metadata and no sdist available"
     )
     raise MetadataError(msg)
-
-
-def has_wheel_metadata_at(
-    versions: Sequence[tuple[Version, DistFile]], version: Version
-) -> bool:
-    """Report whether the listing has a wheel with PEP 658 metadata."""
-    for v, d in versions:
-        if v != version:
-            continue
-        if isinstance(d, WheelFile) and d.metadata_url is not None:
-            return True
-    return False
 
 
 def pick_dist_for_metadata(

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -141,6 +141,10 @@ class InMemoryIndex:
         self._listing_errors: dict[str, BaseException] = {}
         self._listing_indexes: dict[str, str] = {}
         self._metadata: dict[tuple[str, str], str | None] = {}
+        # Keys whose ``_metadata`` slot was last written from an sdist
+        # PKG-INFO rather than a wheel METADATA; readers need the
+        # origin because only sdist deps go through the PEP 643 gate.
+        self._metadata_from_sdist: set[tuple[str, str]] = set()
         self._sdist_pyproject: dict[tuple[str, str], str | None] = {}
         self._sdist_archives: dict[tuple[str, str], bytes | None] = {}
         self._pending: dict[str, _Pending] = {}
@@ -227,6 +231,7 @@ class InMemoryIndex:
         key = f"metadata:{package}:{version}"
         with self._lock:
             self._metadata[(package, version)] = data
+            self._metadata_from_sdist.discard((package, version))
             pending = self._pending.get(key)
         if pending is not None:
             pending.result = data
@@ -241,14 +246,26 @@ class InMemoryIndex:
         because PKG-INFO is core-metadata-equivalent. The pending
         keys differ so a sdist request can run in parallel with (or
         after) a failed wheel metadata request.
+        :meth:`metadata_from_sdist` reports which kind the slot holds.
         """
         key = f"sdist:{package}:{version}"
         with self._lock:
             self._metadata[(package, version)] = data
+            self._metadata_from_sdist.add((package, version))
             pending = self._pending.get(key)
         if pending is not None:
             pending.result = data
             pending.event.set()
+
+    def metadata_from_sdist(self, package: str, version: str) -> bool:
+        """Return ``True`` when the metadata slot was last written from an sdist.
+
+        The slot itself cannot distinguish wheel METADATA from sdist
+        PKG-INFO; readers that apply the :pep:`643` dynamic-deps gate
+        only to sdist values ask here for the current text's origin.
+        """
+        with self._lock:
+            return (package, version) in self._metadata_from_sdist
 
     def store_sdist_pyproject(self, package: str, version: str, data: str) -> None:
         """Store sdist-derived pyproject.toml text for static-metadata fallback.

--- a/nab-python/src/nab_python/universal/reresolve.py
+++ b/nab-python/src/nab_python/universal/reresolve.py
@@ -294,17 +294,24 @@ def _override_metadata(
     overridden raw text rather than serving the prior tuple's view.
     """
     text_snapshot: dict[tuple[str, str], str | None] = {}
+    from_sdist_snapshot: dict[tuple[str, str], bool] = {}
     parsed_snapshot: dict[tuple[str, str], object | None] = {}
     for key in overrides:
         text_snapshot[key] = coordinator.index.get_metadata(*key)
+        from_sdist_snapshot[key] = coordinator.index.metadata_from_sdist(*key)
         parsed_snapshot[key] = coordinator.index.pop_parsed_metadata(*key)
     try:
         for key, text in overrides.items():
             coordinator.index.store_metadata(*key, text)
         yield
     finally:
+        # Restore through the matching store call so the slot's sdist
+        # provenance survives the override cycle.
         for key, prior in text_snapshot.items():
-            coordinator.index.store_metadata(*key, prior)
+            if from_sdist_snapshot[key]:
+                coordinator.index.store_sdist_metadata(*key, prior)
+            else:
+                coordinator.index.store_metadata(*key, prior)
         for key, parsed in parsed_snapshot.items():
             coordinator.index.pop_parsed_metadata(*key)
             if parsed is not None:

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -107,6 +107,14 @@ class TestInMemoryIndex:
         assert idx.has_metadata("foo", "1.0")
         assert idx.get_metadata("foo", "1.0") is None
 
+    def test_metadata_from_sdist_tracks_last_write(self) -> None:
+        idx = InMemoryIndex()
+        assert not idx.metadata_from_sdist("foo", "1.0")
+        idx.store_sdist_metadata("foo", "1.0", "PKG-INFO\n")
+        assert idx.metadata_from_sdist("foo", "1.0")
+        idx.store_metadata("foo", "1.0", "METADATA\n")
+        assert not idx.metadata_from_sdist("foo", "1.0")
+
     def test_sdist_archive_pending_event_fires(self) -> None:
         idx = InMemoryIndex()
         pending, _ = idx.get_or_create_pending("sdist-archive:foo:1.0")

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -14,7 +14,6 @@ from nab_index.client import SdistFile, WheelFile
 from nab_python._provider.metadata_resolver import (
     add_classified_dep,
     classify_requirement,
-    has_wheel_metadata_at,
     pick_dist_for_metadata,
 )
 from nab_python._testing.coordinator_fake import make_coordinator
@@ -3510,6 +3509,31 @@ class TestAwaitMetadataBatchEdgeCases:
         assert result == V("1.0")
         assert ("foo", V("2.0")) not in provider.deps_cache
 
+    def test_batch_does_not_parse_sdist_pkg_info_as_wheel_metadata(self) -> None:
+        """Sdist PKG-INFO in the shared slot is not cached by the batch path.
+
+        When a wheel's PEP 658 fetch yields nothing, get_dependencies
+        falls back to the sdist, stores its PKG-INFO in the shared
+        metadata slot, and rejects the version under the strict PEP 643
+        default. A later batch await reads the same slot; caching that
+        text as wheel METADATA would bypass the gate and resurrect the
+        rejected version with unverified deps.
+        """
+        dists = [make_sdist("1.0"), make_wheel("1.0")]
+        coordinator = make_coordinator(dists, sdist_pkg_info=PKG_INFO_PRE_PEP643_DEPS)
+        provider = Provider(coordinator, python_version="3.12.0")
+        with pytest.raises(UnsupportedSdistError):
+            provider.get_dependencies("pkg", V("1.0"))
+
+        version_list = provider.fetch_versions("pkg")
+        wheel_map = provider._wheel_by_version("pkg", version_list)
+        submitted = provider._prefetch_batch("pkg", [V("1.0")], wheel_map)
+        provider._await_metadata_batch("pkg", submitted)
+
+        assert ("pkg", V("1.0")) not in provider.deps_cache
+        with pytest.raises(UnsupportedSdistError):
+            provider.get_dependencies("pkg", V("1.0"))
+
 
 class TestIsReady:
     def test_extras_cached_base(self) -> None:
@@ -3736,6 +3760,10 @@ PKG_INFO_DYNAMIC_DEPS = (
     "Metadata-Version: 2.2\nName: pkg\nVersion: 1.0\nDynamic: Requires-Dist\n"
 )
 
+PKG_INFO_PRE_PEP643_DEPS = (
+    "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\nRequires-Dist: hidden-dep\n"
+)
+
 
 class TestAddExtraMarker:
     def test_no_existing_marker(self) -> None:
@@ -3749,24 +3777,50 @@ class TestAddExtraMarker:
         assert out == ("numpy>=1.0 ; (python_version >= '3.10') and extra == \"foo\"")
 
 
-class TestHasWheelMetadataAt:
-    def test_returns_true_for_wheel_with_metadata(self) -> None:
-        """A wheel with a metadata_url is detected."""
-        versions = [(V("1.0"), make_wheel("1.0"))]
-        assert has_wheel_metadata_at(versions, V("1.0")) is True
+class TestSharedSlotProvenance:
+    def test_pkg_info_stays_gated_for_provider_with_wheel_in_view(self) -> None:
+        """PKG-INFO stored by one provider stays sdist-gated for another.
 
-    def test_returns_false_for_wheel_without_metadata(self) -> None:
-        """A wheel with has_metadata=False is not counted."""
-        versions = [(V("1.0"), make_wheel("1.0", has_metadata=False))]
-        assert has_wheel_metadata_at(versions, V("1.0")) is False
+        Universal mode shares one coordinator index across tuple
+        providers. A tuple whose filtered view is sdist-only stores
+        PKG-INFO in the shared slot; a second tuple with the wheel in
+        view must not relabel that text as wheel METADATA and trust
+        the pre-PEP-643 deps.
+        """
+        coordinator = make_coordinator(None, sdist_pkg_info=PKG_INFO_PRE_PEP643_DEPS)
+        first = Provider(coordinator, python_version="3.12.0")
+        first.versions_cache["pkg"] = [(V("1.0"), make_sdist("1.0"))]
+        with pytest.raises(UnsupportedSdistError):
+            first.get_dependencies("pkg", V("1.0"))
 
-    def test_skips_other_versions(self) -> None:
-        """Other-version wheels with metadata don't count for this version."""
-        versions = [
-            (V("2.0"), make_wheel("2.0")),
+        second = Provider(coordinator, python_version="3.12.0")
+        second.versions_cache["pkg"] = [
+            (V("1.0"), make_wheel("1.0")),
             (V("1.0"), make_sdist("1.0")),
         ]
-        assert has_wheel_metadata_at(versions, V("1.0")) is False
+        with pytest.raises(UnsupportedSdistError):
+            second.get_dependencies("pkg", V("1.0"))
+
+    def test_wheel_metadata_stays_trusted_for_sdist_only_view(self) -> None:
+        """Wheel METADATA in the slot is trusted whatever the reader's view.
+
+        The reverse ordering: a provider with the wheel in view stores
+        METADATA text, then a provider whose view is sdist-only reads
+        it. Inferring the origin from the reader's listing would
+        mislabel the text as PKG-INFO and spuriously reject the
+        version under the PEP 643 gate.
+        """
+        metadata = (
+            "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\nRequires-Dist: dep-a\n"
+        )
+        coordinator = make_coordinator(None, metadata_text=metadata)
+        first = Provider(coordinator, python_version="3.12.0")
+        first.versions_cache["pkg"] = [(V("1.0"), make_wheel("1.0"))]
+        assert "dep-a" in first.get_dependencies("pkg", V("1.0"))
+
+        second = Provider(coordinator, python_version="3.12.0")
+        second.versions_cache["pkg"] = [(V("1.0"), make_sdist("1.0"))]
+        assert "dep-a" in second.get_dependencies("pkg", V("1.0"))
 
 
 class TestPickDistForMetadata:

--- a/nab-python/tests/universal/test_reresolve.py
+++ b/nab-python/tests/universal/test_reresolve.py
@@ -314,6 +314,17 @@ class TestOverrideMetadata:
             coordinator.index.store_parsed_metadata("pkg", "1.0", object())
         assert coordinator.index.get_parsed_metadata("pkg", "1.0") is None
 
+    def test_restore_preserves_sdist_provenance(self) -> None:
+        """An sdist-origin baseline is still sdist-origin after restore."""
+        from nab_python.universal.reresolve import _override_metadata
+
+        coordinator = _make_coordinator({})
+        coordinator.index.store_sdist_metadata("pkg", "1.0", "PKG-INFO")
+        with _override_metadata(coordinator, {("pkg", "1.0"): "OVERRIDE"}):
+            assert not coordinator.index.metadata_from_sdist("pkg", "1.0")
+        assert coordinator.index.get_metadata("pkg", "1.0") == "PKG-INFO"
+        assert coordinator.index.metadata_from_sdist("pkg", "1.0")
+
 
 class TestResolveOneTupleWithOverrides:
     """``_resolve_one_tuple_with_overrides`` builds a one-tuple matrix."""


### PR DESCRIPTION
Wheel METADATA and sdist PKG-INFO land in the same `InMemoryIndex` slot, and readers guessed which kind the text was from their own listing view. The batch prefetch path (`await_metadata_batch`) never guessed at all: it parsed whatever the slot held as wheel METADATA. So when a PEP 658 fetch yielded nothing and `get_dependencies` fell back to the sdist, the stored PKG-INFO was later cached with the PEP 643 gate bypassed, silently resurrecting a version already rejected as an unsupported sdist with its unverified deps trusted. The listing-based guess in `resolve_metadata` had the same problem in both directions under universal resolution, where tuple providers share one index but see differently filtered views.

The index now records at store time whether the slot was last written from an sdist (`metadata_from_sdist`). The batch path leaves sdist-origin text for `get_dependencies`, which applies the gate, `resolve_metadata` reads the recorded origin instead of inferring it from the listing (so `has_wheel_metadata_at` is gone), and the universal re-resolve override restores provenance along with the text.