### PR TITLE
Drop mismatched filenames from local PEP 503 listings

### DIFF
--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -99,6 +99,7 @@ _FLAT_EXTS = re.compile(r"\.(whl|tar\.gz)$", re.IGNORECASE)
 
 def _scan_pep503_directory(
     package_dir: Path,
+    canonical: str,
 ) -> list[WheelFile | SdistFile]:
     """Parse ``<package>/index.html`` and return file records."""
     index_html = package_dir / "index.html"
@@ -111,7 +112,9 @@ def _scan_pep503_directory(
         filename, file_url, local_path, hashes = _resolve_local_link(href, package_dir)
         if filename is None:
             continue
-        record = _make_record(filename, file_url, local_path, requires_python, hashes)
+        record = _make_record(
+            filename, file_url, local_path, requires_python, hashes, canonical
+        )
         if record is not None:
             files.append(record)
     return files
@@ -173,23 +176,10 @@ def _scan_flat_wheelhouse(
             continue
         if _FLAT_EXTS.search(entry.name) is None:
             continue
-        parsed_name = _parsed_dist_name(entry.name)
-        if parsed_name is None or _canonical(parsed_name) != canonical:
-            continue
-        record = _make_record(entry.name, entry.as_uri(), entry, None, ())
+        record = _make_record(entry.name, entry.as_uri(), entry, None, (), canonical)
         if record is not None:
             files.append(record)
     return files
-
-
-def _parsed_dist_name(filename: str) -> str | None:
-    parsed = _parse_wheel_filename(filename)
-    if parsed is not None:
-        return parsed[0]
-    parsed = _parse_sdist_filename(filename)
-    if parsed is not None:
-        return parsed[0]
-    return None
 
 
 def _make_record(
@@ -198,10 +188,19 @@ def _make_record(
     local_path: Path | None,
     requires_python: str | None,
     hashes: tuple[tuple[str, str], ...],
+    expected: str,
 ) -> WheelFile | SdistFile | None:
+    """Build a file record, or ``None`` for unusable filenames.
+
+    Files whose parsed canonical name does not match ``expected`` are
+    dropped; see :func:`nab_index.client._parse_files` for the
+    phantom-version failure this prevents.
+    """
     parsed = _parse_wheel_filename(filename)
     if parsed is not None:
-        _, version = parsed
+        parsed_name, version = parsed
+        if parsed_name != expected:
+            return None
         return WheelFile(
             filename=filename,
             url=file_url,
@@ -214,7 +213,9 @@ def _make_record(
         )
     parsed = _parse_sdist_filename(filename)
     if parsed is not None:
-        _, version = parsed
+        parsed_name, version = parsed
+        if parsed_name != expected:
+            return None
         return SdistFile(
             filename=filename,
             url=file_url,
@@ -256,7 +257,7 @@ class LocalIndexClient:
         canonical = _canonical(package)
         package_dir = self._root / canonical
         if (package_dir / "index.html").is_file():
-            return _scan_pep503_directory(package_dir)
+            return _scan_pep503_directory(package_dir, canonical)
 
         if not self._root.is_dir():
             return []

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -294,6 +294,29 @@ class TestPep503Directory:
         result = run(client.get_files("foo"))
         assert result == []
 
+    def test_pep503_build_tag_sdist_dropped(self, tmp_path: Path) -> None:
+        # cffi-1.0.2-2.tar.gz parses as project cffi-1-0-2 at version 2;
+        # without the name check it surfaces as a phantom cffi==2.
+        package_dir = tmp_path / "cffi"
+        package_dir.mkdir()
+        body = '<a href="cffi-1.0.2-2.tar.gz">cffi-1.0.2-2.tar.gz</a>'
+        (package_dir / "index.html").write_text(body, encoding="utf-8")
+        (package_dir / "cffi-1.0.2-2.tar.gz").write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        assert run(client.get_files("cffi")) == []
+
+    def test_pep503_foreign_wheel_dropped(self, tmp_path: Path) -> None:
+        body = (
+            '<a href="bar-1.0-py3-none-any.whl">bar</a>'
+            '<a href="foo-1.0-py3-none-any.whl">foo</a>'
+        )
+        package_dir = self._make_index(tmp_path, body)
+        (package_dir / "bar-1.0-py3-none-any.whl").write_bytes(b"")
+        (package_dir / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        result = run(client.get_files("foo"))
+        assert [r.filename for r in result] == ["foo-1.0-py3-none-any.whl"]
+
 
 class TestMetadataAndSdist:
     def test_get_metadata_text(self, tmp_path: Path) -> None:
@@ -335,6 +358,7 @@ class TestMakeRecord:
                 Path("/tmp/README.txt"),
                 None,
                 (),
+                "readme",
             )
             is None
         )


### PR DESCRIPTION
The local-index PEP 503 scan built a record for every parseable anchor on a package page without checking the parsed name against the queried package. A legacy build-tag sdist like `cffi-1.0.2-2.tar.gz` parses as project `cffi-1-0-2` at version `2`, so it leaked into the `cffi` listing as a phantom `cffi==2` and, being the highest version, became the preferred candidate; a wheel of an unrelated project linked on the page leaked in the same way. The PEP 691 path (`_parse_files`) and the flat-wheelhouse scan already guard against exactly this.

`_make_record` now takes the queried canonical name and drops files whose parsed name does not match, and the flat-wheelhouse pre-check is folded into it so both local layouts share the one filter.