### PR TITLE
Normalize extras inside parenthesized marker groups

### DIFF
--- a/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
+++ b/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
@@ -14,9 +14,21 @@ from an in-flight pull request, vendored so nab can use the public
 
 The snapshot is the full `src/packaging/` tree at that commit, plus
 `LICENSE`, `LICENSE.APACHE`, and `LICENSE.BSD` from the repository
-root. No code changes were made; relative imports inside `packaging`
-(`from .version import Version`, etc.) keep working when the package
-is loaded as `nab_python._vendor.packaging`.
+root. Relative imports inside `packaging` (`from .version import
+Version`, etc.) keep working when the package is loaded as
+`nab_python._vendor.packaging`.
+
+## Local patches
+
+Changes on top of the pinned commit. Carry these forward (or confirm
+they landed on the source branch) when updating the snapshot.
+
+- `markers.py`: `_normalize_extras` recurses into nested
+  `MarkerList`s so extra values inside parenthesized marker groups
+  are PEP 685-normalized. Without this, `(extra == "My_Extra")`
+  evaluates differently from the unparenthesized form and deps are
+  silently dropped from the extra. Also present in upstream
+  `packaging` 26.2; not yet fixed there.
 
 ## License
 

--- a/nab-python/src/nab_python/_vendor/packaging/markers.py
+++ b/nab-python/src/nab_python/_vendor/packaging/markers.py
@@ -172,9 +172,15 @@ def _normalize_extras(
 def _normalize_extra_values(results: MarkerList) -> MarkerList:
     """
     Normalize extra values.
+
+    Parenthesized groups parse to nested MarkerLists; recurse so extra
+    values at any depth are normalized.
     """
 
-    return [_normalize_extras(r) for r in results]
+    return [
+        _normalize_extra_values(r) if isinstance(r, list) else _normalize_extras(r)
+        for r in results
+    ]
 
 
 def _format_marker(

--- a/nab-python/tests/test_metadata.py
+++ b/nab-python/tests/test_metadata.py
@@ -76,6 +76,20 @@ def test_equal_markers_are_interned() -> None:
     assert ruff_marker is not pytest_marker
 
 
+def test_extra_normalized_inside_parenthesized_marker_group() -> None:
+    """Extra values inside parenthesized marker groups are PEP 685-normalized."""
+    text = (
+        "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n"
+        "Provides-Extra: My_Extra\n"
+        'Requires-Dist: bar; python_version >= "3.8" and (extra == "My_Extra")\n'
+    )
+    md = parse_metadata(text)
+    marker = md.requires_dist[0].marker
+    assert marker is not None
+    assert 'extra == "my-extra"' in str(marker)
+    assert marker.evaluate({"python_version": "3.12", "extra": "my-extra"})
+
+
 def test_markerless_requirement_keeps_none_marker() -> None:
     """A dep without a marker is unaffected by interning."""
     md = parse_metadata(

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -2574,6 +2574,26 @@ class TestExtras:
         assert "cryptography" not in base_deps
         assert "cryptography" not in sec_deps
 
+    def test_extra_dep_in_parenthesized_marker_group(self) -> None:
+        """A dep gated by ``(extra == ...)`` with legacy spelling stays in the extra."""
+        metadata = (
+            "Metadata-Version: 2.1\n"
+            "Name: foo\n"
+            "Version: 1.0\n"
+            "Provides-Extra: My_Extra\n"
+            "Provides-Extra: other\n"
+            "Requires-Dist: cryptography; "
+            'python_version >= "3.8" and (extra == "My_Extra" or extra == "other")\n'
+        )
+        coordinator = make_coordinator(
+            [make_wheel("1.0")],
+            metadata_text=metadata,
+            package="foo",
+        )
+        provider = Provider(coordinator, python_version="3.12.0")
+        deps = provider.get_dependencies("foo[my-extra]", V("1.0"))
+        assert "cryptography" in deps
+
     def test_multiple_extras_same_package(self) -> None:
         """Different extras on the same package get separate deps."""
         metadata = (


### PR DESCRIPTION
The vendored packaging's `_normalize_extra_values` only walked top-level marker atoms, so extra values inside parenthesized groups (nested `MarkerList`s) kept their raw spelling. A marker like `(extra == "My_Extra")` then evaluated False against the PEP 685-normalized extra name, while the unparenthesized form evaluated True, and `str()` was not a parse round-trip fixed point. The user-visible effect: a metadata line like `Requires-Dist: foo; python_version >= "3.8" and (extra == "My_Extra" or extra == "other")` (the shape poetry-core emits for a dep shared by extras) silently dropped `foo` from the legacy-spelled extra during resolve and lock.

The fix makes `_normalize_extra_values` recurse into nested lists so extra atoms at any depth are canonicalized at parse time. The same bug exists in upstream packaging 26.2 and the pinned PR 1182 snapshot, so this is a local patch on the vendored tree, recorded in `PROVENANCE.md` to carry forward on the next re-vendor; it should also land on the `public-pep440-version-range` fork branch and upstream.