### PR TITLE
Merge self-dependency terms in dependency clauses

### DIFF
--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -392,19 +392,27 @@ class Resolver(Generic[PackageType, VersionType]):
 
         dependencies = self.provider.get_dependencies(next_package, chosen_version)
         for dependency_package, dependency_range in dependencies.items():
+            package_term = Term(
+                next_package,
+                self.range_type.singleton(chosen_version),
+                positive=True,
+            )
+            if dependency_package == next_package:
+                # An incompatibility holds at most one term per package,
+                # so self-dependency terms merge to {v} & ~range: empty
+                # (a vacuous clause) when the range contains the chosen
+                # version, else exactly {v}.
+                if chosen_version in dependency_range:
+                    continue
+                terms = [package_term]
+            else:
+                terms = [
+                    package_term,
+                    Term(dependency_package, dependency_range, positive=False),
+                ]
             incompat_index.add_incompatibility(
                 self,
-                Incompatibility(
-                    [
-                        Term(
-                            next_package,
-                            self.range_type.singleton(chosen_version),
-                            positive=True,
-                        ),
-                        Term(dependency_package, dependency_range, positive=False),
-                    ],
-                    cause=IncompatibilityCause.DEPENDENCY,
-                ),
+                Incompatibility(terms, cause=IncompatibilityCause.DEPENDENCY),
             )
         return next_package
 

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -487,6 +487,43 @@ class TestCircularDependencies:
             resolver.resolve({"root": Range.singleton(1)})
 
 
+class TestSelfDependency:
+    def test_self_dep_excluding_own_version_backtracks(self) -> None:
+        """foo@2 depends on foo==1, contradicting itself; foo@1 is fine.
+
+        The raw dependency clause would carry two terms for the same
+        package, which the unit rule cannot fire on: the resolver
+        re-decides foo@2 after every backjump and never terminates.
+        The terms must be merged so foo@2 is rejected and foo@1 wins.
+        """
+        provider = DictProvider({"foo": {2: {"foo": Range.singleton(1)}, 1: {}}})
+        resolver = Resolver(provider, max_iterations=100)
+        result = resolver.resolve({"foo": Range.full()})
+        assert result == {"foo": 1}
+
+    def test_self_dep_excluding_own_version_unsat(self) -> None:
+        """The only version foo@1 depends on foo==2, which doesn't exist.
+
+        Must fail with an unsat proof, not by hitting max_iterations.
+        """
+        provider = DictProvider({"foo": {1: {"foo": Range.singleton(2)}}})
+        resolver = Resolver(provider, max_iterations=100)
+        with pytest.raises(ResolutionError, match="because"):
+            resolver.resolve({"foo": Range.full()})
+
+    def test_self_dep_containing_own_version_is_vacuous(self) -> None:
+        """foo@1 depends on foo=={1}: satisfied by itself, resolves."""
+        provider = DictProvider({"foo": {1: {"foo": Range.singleton(1)}}})
+        result = Resolver(provider).resolve({"foo": Range.full()})
+        assert result == {"foo": 1}
+
+    def test_self_dep_empty_range_unsat(self) -> None:
+        """foo@1 depends on foo in the empty range: unsatisfiable."""
+        provider = DictProvider({"foo": {1: {"foo": Range.empty()}}})
+        with pytest.raises(ResolutionError, match="because"):
+            Resolver(provider).resolve({"foo": Range.full()})
+
+
 class TestNoExtraPackages:
     def test_backtracked_dependencies_excluded(self) -> None:
         """Packages from a failed branch must not appear in result.


### PR DESCRIPTION
When a version depends on its own package, `_decide_next` built a DEPENDENCY incompatibility with two terms on the same package. PubGrub clauses hold at most one term per package, and `evaluate_incompatibility` treats terms independently, so the unit rule never fired on such a clause: after each backjump both terms went undetermined, the same version was re-decided, and the resolver looped until `max_iterations`. A package whose self-dep excludes its own version (bad metadata like `foo 1.0` requiring `foo>=2.0`) therefore burned 200k rounds and reported an iteration-limit error, even when an older self-consistent version was a valid solution; the truly unsatisfiable variant got the same wrong error instead of an unsat proof.

The fix merges the two terms when building the clause: a self-dep range containing the chosen version is vacuous and skipped, otherwise the clause reduces to the single positive term `{v}`, which propagates and rejects the version normally. Solvable cases now back off to the older version and unsatisfiable ones fail fast with a proof.