### PR TITLE
Make the conflict path independent of the hash seed

### DIFF
--- a/nab-resolver/src/nab_resolver/conflict.py
+++ b/nab-resolver/src/nab_resolver/conflict.py
@@ -184,12 +184,14 @@ def update_culprit_counts(
     clauses we walk the satisfier's cause chain instead.  When a culprit
     crosses ``CULPRIT_THRESHOLD`` it gets queued for targeted backtrack.
     """
-    culprit_packages: set[Any] = set()
+    # Dict-as-ordered-set: hash-ordered iteration would make the
+    # targeted-backtrack queue order vary across processes.
+    culprit_packages: dict[Any, None] = {}
     for term in incompatibility.terms:
         package = term.package
         if package is ROOT or package == affected_package:
             continue
-        culprit_packages.add(package)
+        culprit_packages[package] = None
 
     # Single-term NO_VERSIONS clauses carry the antecedent decisions only
     # via the satisfier's cause; without this, those decisions go uncredited.
@@ -198,7 +200,7 @@ def update_culprit_counts(
             package = term.package
             if package is ROOT or package == affected_package:
                 continue
-            culprit_packages.add(package)
+            culprit_packages[package] = None
 
     threshold = resolver.CULPRIT_THRESHOLD
     for package in culprit_packages:

--- a/nab-resolver/src/nab_resolver/report.py
+++ b/nab-resolver/src/nab_resolver/report.py
@@ -131,7 +131,9 @@ def prior_cause(
         result.append(cause_shared)
 
     # Remaining packages: intersect when in both sides, else keep as-is.
-    all_packages = set(incompat_terms) | set(cause_terms)
+    # Dict merge keeps insertion order; a set union would iterate in hash
+    # order, making learned-clause term order vary across processes.
+    all_packages = {**incompat_terms, **cause_terms}
     for package in all_packages:
         incompat_term = incompat_terms.get(package)
         cause_term = cause_terms.get(package)

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -15,13 +15,14 @@ from nab_resolver.conflict import (
     is_terminal_incompatibility,
     recompute_previous_level,
     try_force_resolution_step,
+    update_culprit_counts,
 )
 from nab_resolver.incompat_index import (
     add_incompatibility,
     dependency_merge_key,
     maybe_merge_dependency,
 )
-from nab_resolver.partial_solution import PartialSolution
+from nab_resolver.partial_solution import Assignment, PartialSolution
 from nab_resolver.propagate import term_relation
 from nab_resolver.ranges import Range
 from nab_resolver.report import explain_incompatibility, prior_cause, union_terms
@@ -1934,6 +1935,75 @@ class TestRegressions:
         resolver = Resolver(provider)
         with pytest.raises(ResolutionError):
             resolver.resolve({"root": Range.singleton(1)})
+
+
+class _SeededPackage:
+    """Package key with an explicit hash, standing in for one str hash seed."""
+
+    def __init__(self, name: str, hash_value: int) -> None:
+        self.name = name
+        self.hash_value = hash_value
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _SeededPackage) and self.name == other.name
+
+    def __hash__(self) -> int:
+        return self.hash_value
+
+
+class TestHashOrderIndependence:
+    """The conflict path must not depend on the per-process str hash seed."""
+
+    _NAMES = tuple(f"pkg{i}" for i in range(8))
+
+    def _prior_cause_order(self, hashes: list[int]) -> list[str]:
+        packages = [
+            _SeededPackage(n, h) for n, h in zip(self._NAMES, hashes, strict=True)
+        ]
+        shared = _SeededPackage("shared", 100)
+        incompatibility = Incompatibility(
+            [Term(p, Range.singleton(1)) for p in [shared, *packages[:4]]],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+        cause = Incompatibility(
+            [Term(p, Range.singleton(1)) for p in [shared, *packages[4:]]],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+        terms = prior_cause(incompatibility, cause, shared)
+        return [term.package.name for term in terms]
+
+    def test_prior_cause_term_order_ignores_package_hashes(self) -> None:
+        forward = self._prior_cause_order(list(range(8)))
+        backward = self._prior_cause_order(list(range(7, -1, -1)))
+        assert forward == backward
+
+    def _culprit_queue_order(self, hashes: list[int]) -> list[str]:
+        resolver: Resolver[Any, int] = Resolver(DictProvider({}))
+        packages = [
+            _SeededPackage(n, h) for n, h in zip(self._NAMES, hashes, strict=True)
+        ]
+        affected = _SeededPackage("affected", 100)
+        incompatibility = Incompatibility(
+            [Term(p, Range.singleton(1)) for p in [affected, *packages]],
+            cause=IncompatibilityCause.DERIVED,
+        )
+        for package in packages:
+            resolver.stats.package_culprit_counts[package] = (
+                resolver.CULPRIT_THRESHOLD - 1
+            )
+        satisfier = Assignment(
+            package=affected,
+            accumulated_range=Range.singleton(1),
+            decision_level=1,
+            is_decision=True,
+        )
+        update_culprit_counts(resolver, incompatibility, affected, satisfier)
+        return [package.name for package in resolver.pending_targeted_backtrack]
+
+    def test_culprit_queue_order_ignores_package_hashes(self) -> None:
+        forward = self._culprit_queue_order(list(range(8)))
+        backward = self._culprit_queue_order(list(range(7, -1, -1)))
+        assert forward == backward
 
 
 class TestRelationCache:


### PR DESCRIPTION
Two spots on the conflict path iterated over sets of package keys: `prior_cause` built the learned clause's term list from `set(incompat_terms) | set(cause_terms)`, and `update_culprit_counts` collected culprits in a set before appending them to `pending_targeted_backtrack`. Package keys are strings in real resolves, so both iterations followed the per-process str hash seed. The learned-clause term order feeds `changed_package` after a conflict and the culprit order decides targeted-backtrack tie-breaks, so the same scenario could take a different search path, learn different clauses, and print a different derivation in UNSAT reports depending on `PYTHONHASHSEED`.

Both sites now dedup with insertion-ordered dicts instead of sets: `prior_cause` merges the two term dicts and `update_culprit_counts` uses a dict as an ordered set. Identical inputs now resolve identically in every process.