### PR TITLE
Validate python axis and python-patches inputs

### DIFF
--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -271,10 +271,10 @@ def excluded_by_python(provider: Provider, dist: DistFile) -> bool:
         try:
             spec = SpecifierSet(requires_python)
             cached = Version(provider.python_version) not in spec
-        except (InvalidSpecifier, InvalidVersion):
-            # Malformed Requires-Python on the dist or our own
-            # python_version: treat as not-excluded, let downstream
-            # logic decide.
+        except InvalidSpecifier:
+            # Malformed Requires-Python on the dist: treat as
+            # not-excluded, let downstream logic decide.  Our own
+            # python_version is validated at Provider construction.
             cached = False
         provider.requires_python_cache[requires_python] = cached
     if cached:

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -7,7 +7,6 @@ types.  Uses a thread pool with a shared HTTP session to overlap I/O.
 
 from __future__ import annotations
 
-import contextlib
 import enum
 import logging
 import re
@@ -98,16 +97,17 @@ _PYTHON_FULL_VERSION_PARTS = 3
 def python_axis_environment(python_version: str) -> dict[str, str]:
     """Map an explicit Python version to its PEP 508 marker keys.
 
-    ``python_full_version`` is padded to three components so patch-precision
-    markers evaluate the same here as in the universal matrix. Raises
-    ``InvalidVersion`` if the input is not a version.
+    ``python_version`` is padded to two components and
+    ``python_full_version`` to three so patch-precision markers evaluate
+    the same here as in the universal matrix. Raises ``InvalidVersion``
+    if the input is not a version.
     """
-    release = Version(python_version).release
-    minor = (
-        f"{release[0]}.{release[1]}"
-        if len(release) >= _PYTHON_VERSION_PARTS
-        else python_version
-    )
+    try:
+        release = Version(python_version).release
+    except InvalidVersion:
+        msg = f"python_version {python_version!r} is not a valid version"
+        raise InvalidVersion(msg) from None
+    minor = ".".join(str(part) for part in (*release, 0)[:_PYTHON_VERSION_PARTS])
     full = (
         python_version
         if len(release) >= _PYTHON_FULL_VERSION_PARTS
@@ -494,8 +494,7 @@ class Provider:
         }
         self.environment: dict[str, str] = env_init
         if python_version is not None:
-            with contextlib.suppress(InvalidVersion):
-                self.environment.update(python_axis_environment(python_version))
+            self.environment.update(python_axis_environment(python_version))
         if marker_environment:
             for key, value in marker_environment.items():
                 self.environment[key] = value

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import itertools
 import logging
 import sys
@@ -23,7 +22,7 @@ from ._vendor.packaging.ranges import VersionRange
 from ._vendor.packaging.requirements import Requirement
 from ._vendor.packaging.specifiers import SpecifierSet
 from ._vendor.packaging.utils import canonicalize_name
-from ._vendor.packaging.version import InvalidVersion, Version
+from ._vendor.packaging.version import Version
 from .config import (
     ConfigError,
     ConflictFork,
@@ -689,8 +688,7 @@ def _build_marker_environment(
         for key, value in default_environment().items()
         if isinstance(value, str)
     }
-    with contextlib.suppress(InvalidVersion):
-        env.update(python_axis_environment(python_version))
+    env.update(python_axis_environment(python_version))
     env.update(overrides)
     return env
 

--- a/nab-python/src/nab_python/universal/matrix.py
+++ b/nab-python/src/nab_python/universal/matrix.py
@@ -231,9 +231,9 @@ class Matrix:
         """Expand the matrix into concrete tuples.
 
         Validates inputs eagerly: unknown platform ids, unknown
-        implementations, an empty python range, or an invalid
-        ``python_order`` each raise a ``ValueError`` before any work
-        happens.
+        implementations, ``python_patches`` keys that are not known
+        minors, an empty python range, or an invalid ``python_order``
+        each raise a ``ValueError`` before any work happens.
 
         ``platforms`` accepts either bare platform-id strings (use
         default tag floors) or :class:`PlatformSpec` instances for
@@ -258,13 +258,20 @@ class Matrix:
         if unknown_impl:
             msg = f"Unknown implementations: {unknown_impl!r}"
             raise ValueError(msg)
+        patches = self.python_patches or {}
+        unknown_patches = [m for m in patches if m not in _KNOWN_PYTHON_MINORS]
+        if unknown_patches:
+            msg = (
+                f"Unknown python_patches minors: {unknown_patches!r};"
+                " keys must be major.minor like '3.11'"
+            )
+            raise ValueError(msg)
         py_versions = list(_pythons_in_range(self.python))
         if not py_versions:
             msg = f"No known Python versions match {self.python!r}"
             raise ValueError(msg)
         if self.python_order == "desc":
             py_versions.reverse()
-        patches = self.python_patches or {}
         multi_impl = len(self.implementations) > 1
         return [
             MatrixTuple(

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -1575,6 +1575,20 @@ class TestMatrix:
         with pytest.raises(ConfigError, match="python-patches expects version"):
             read_pyproject_config(path)
 
+    def test_python_patches_non_minor_key_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            "[tool.nab.matrix]\n"
+            'python = ">=3.11"\n'
+            'platforms = ["linux_x86_64"]\n'
+            "[tool.nab.matrix.python-patches]\n"
+            '"3.11.0" = "3.11.9"\n',
+        )
+        with pytest.raises(ConfigError, match="python_patches"):
+            read_pyproject_config(path)
+
 
 class TestBuildPolicyPackage:
     """``[tool.nab.build-policy-package]`` parses into a name -> policy mapping."""

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -21,7 +21,7 @@ from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.specifiers import SpecifierSet
-from nab_python._vendor.packaging.version import Version
+from nab_python._vendor.packaging.version import InvalidVersion, Version
 from nab_python.fetch import InMemoryIndex
 from nab_python.provider import (
     BuildPolicy,
@@ -38,6 +38,7 @@ from nab_python.provider import (
     VcsPolicy,
     VcsSource,
     _add_extra_marker,
+    python_axis_environment,
 )
 from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
 
@@ -804,14 +805,13 @@ class TestGetDependencies:
         assert "only313" not in deps
         assert "only311" in deps
 
-    def test_invalid_python_version_falls_back_to_host(self) -> None:
-        """A malformed ``python_version`` is silently ignored; markers
-        evaluate against the host environment instead.
+    def test_invalid_python_version_raises(self) -> None:
+        """A malformed ``python_version`` raises instead of silently
+        evaluating markers against the host environment.
         """
         coordinator = make_coordinator([make_wheel("1.0")], package="foo")
-        # Should not raise; environment keeps the host values.
-        provider = Provider(coordinator, python_version="not-a-version")
-        assert "python_version" in provider.environment
+        with pytest.raises(InvalidVersion, match="'not-a-version'"):
+            Provider(coordinator, python_version="not-a-version")
 
     def test_arbitrary_equality_dep_is_literal_range(self) -> None:
         """``===`` deps round-trip as a literal-only range.
@@ -1271,6 +1271,18 @@ class TestMarkerEnvironment:
             marker_environment={},
         )
         assert provider.build_policy is BuildPolicy.BUILD_REMOTE
+
+
+class TestPythonAxisEnvironment:
+    def test_single_component_version_pads_python_version(self) -> None:
+        """``python_version`` is padded to major.minor like full to three."""
+        env = python_axis_environment("3")
+        assert env == {"python_version": "3.0", "python_full_version": "3.0.0"}
+
+    def test_unparseable_version_raises_named_error(self) -> None:
+        """The error names the bad ``python_version`` input."""
+        with pytest.raises(InvalidVersion, match="python_version 'not-a-version'"):
+            python_axis_environment("not-a-version")
 
 
 class TestLookAhead:

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from nab_python._vendor.packaging.requirements import Requirement
-from nab_python._vendor.packaging.version import Version
+from nab_python._vendor.packaging.version import InvalidVersion, Version
 from nab_python.config import (
     ConfigError,
     ConflictSelectionError,
@@ -767,31 +767,18 @@ class TestResolvePyproject:
         requirements = mock_resolver_cls.return_value.resolve.call_args.args[0]
         assert "newer" not in requirements
 
-    @patch("nab_python.resolve.build_lock_input_from_provider")
-    @patch("nab_python.resolve.Resolver")
-    @patch("nab_python.resolve.Provider")
-    @patch("nab_python.resolve.FetchCoordinator")
-    def test_root_marker_with_unparseable_python_version(
-        self,
-        mock_coord_cls: MagicMock,
-        mock_provider_cls: MagicMock,
-        mock_resolver_cls: MagicMock,
-        mock_build_lock: MagicMock,
-        tmp_path: Path,
-    ) -> None:
-        """Garbled ``python_version`` arg falls back to default environment."""
+    def test_unparseable_python_version_raises(self, tmp_path: Path) -> None:
+        """Garbled ``python_version`` arg raises instead of silently
+        resolving against the host interpreter.
+        """
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text(
             '[project]\ndependencies = ["foo"]\n',
         )
-        mock_coord_cls.return_value.__enter__ = lambda s: s
-        mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
-        mock_resolver_cls.return_value.resolve.return_value = {"foo": V("1.0")}
-
-        resolve_pyproject(pyproject, _FAKE_TRANSPORT, python_version="not-a-version")
-
-        requirements = mock_resolver_cls.return_value.resolve.call_args.args[0]
-        assert "foo" in requirements
+        with pytest.raises(InvalidVersion, match="'not-a-version'"):
+            resolve_pyproject(
+                pyproject, _FAKE_TRANSPORT, python_version="not-a-version"
+            )
 
     @patch("nab_python.resolve.build_lock_input_from_provider")
     @patch("nab_python.resolve.Resolver")

--- a/nab-python/tests/universal/test_matrix.py
+++ b/nab-python/tests/universal/test_matrix.py
@@ -160,6 +160,16 @@ class TestMatrixExpand:
         assert py311.environment["python_full_version"] == "3.11.4"
         assert py312.environment["python_full_version"] == "3.12.0"
 
+    def test_python_patches_unknown_minor_key_raises(self) -> None:
+        """A patches key that is not a known ``major.minor`` is a user error."""
+        matrix = Matrix(
+            python="==3.11",
+            platforms=("linux_x86_64",),
+            python_patches={"3.11.0": "3.11.9"},
+        )
+        with pytest.raises(ValueError, match="python_patches"):
+            matrix.expand()
+
     def test_patch_level_marker_evaluation(self) -> None:
         """Patch-bound markers evaluate against the declared full version."""
         from nab_python._vendor.packaging.markers import Marker


### PR DESCRIPTION
Three silent failure modes in marker environment construction now fail loudly or produce consistent values. An unparseable `python_version` override (e.g. a specifier passed where a version belongs) was swallowed by `contextlib.suppress(InvalidVersion)` in `resolve_pyproject` and `Provider`, so the resolve quietly targeted whatever Python the host runs; it now raises `InvalidVersion` naming the bad input. A `[tool.nab.matrix.python-patches]` key spelled non-canonically (`"3.11.0"`, `"v3.11"`) passed config validation but `Matrix.expand` looks patches up by the canonical `M.N` string, so the declared patch never applied and patch-bound markers kept mis-evaluating; `expand` now rejects keys outside the known minors, which `_validate_matrix_axes` surfaces as a `ConfigError` at parse time.

Also, `python_axis_environment("3")` returned `python_version = "3"` next to a padded `python_full_version = "3.0.0"`; the minor is now padded the same way so `python_version` is always the `major.minor` of `python_full_version`.