### PR TITLE
Carry python_patches into the divergence re-resolve

### DIFF
--- a/nab-python/src/nab_python/universal/reresolve.py
+++ b/nab-python/src/nab_python/universal/reresolve.py
@@ -201,9 +201,12 @@ def _resolve_one_tuple_with_overrides(  # noqa: PLR0913
     resolution_strategy: str,
 ) -> dict[str, str]:
     """Re-resolve ``tup`` with the given metadata overrides; return pins."""
+    # Carry the original tuple's patch release so markers gated on
+    # python_full_version evaluate the same in both passes.
     one_tuple_matrix = _Matrix(
         python=f"=={tup.python_version}",
         platforms=(tup.platform_spec,),
+        python_patches={tup.python_version: tup.environment["python_full_version"]},
         implementations=(tup.implementation,),
     )
     with _override_metadata(coordinator, wheel_metadata):

--- a/nab-python/tests/universal/test_reresolve.py
+++ b/nab-python/tests/universal/test_reresolve.py
@@ -13,10 +13,12 @@ from unittest.mock import MagicMock, patch
 from nab_index.client import WheelFile
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.version import Version
+from nab_python.provider import BuildPolicy, DistPolicy
 from nab_python.universal import reresolve as reresolve_module
 from nab_python.universal.matrix import MatrixTuple
 from nab_python.universal.reresolve import (
     _diff_pins,
+    _resolve_one_tuple_with_overrides,
     reresolve_divergent_tuples,
 )
 from nab_python.universal.resolve import TupleResult, UniversalResult
@@ -49,15 +51,15 @@ def _make_coordinator(
     )
 
 
-def _linux_311() -> MatrixTuple:
+def _linux_311(full_version: str = "3.11.0") -> MatrixTuple:
     return MatrixTuple(
         python_version="3.11",
         platform_id="linux_x86_64",
         environment={
             "python_version": "3.11",
-            "python_full_version": "3.11.0",
+            "python_full_version": full_version,
             "implementation_name": "cpython",
-            "implementation_version": "3.11.0",
+            "implementation_version": full_version,
             "os_name": "posix",
             "platform_machine": "x86_64",
             "platform_python_implementation": "CPython",
@@ -381,6 +383,41 @@ class TestResolveOneTupleWithOverrides:
                 resolution_strategy="highest",
             )
         assert pins == {"pkg": "1.0", "dep": "2.0"}
+
+    def test_one_tuple_matrix_keeps_python_patch_release(self) -> None:
+        """The re-resolve matrix carries the original tuple's patch release.
+
+        A tuple resolved with ``python_patches`` must re-resolve under
+        the same ``python_full_version``, otherwise markers gated on
+        the patch release flip between the two passes and pollute the
+        diff.
+        """
+        tup = _linux_311(full_version="3.11.9")
+        coordinator = _make_coordinator({})
+        ok = UniversalResult(
+            matrix=MagicMock(),
+            tuple_results=[TupleResult(tuple_=tup, success=True, pins={})],
+        )
+        with patch.object(
+            reresolve_module,
+            "resolve_with_coordinator",
+            return_value=ok,
+        ) as inner:
+            _resolve_one_tuple_with_overrides(
+                coordinator,
+                tup,
+                ["pkg"],
+                {("pkg", "1.0"): "Name: pkg\nVersion: 1.0\n\n"},
+                constraints=None,
+                uploaded_prior_to=None,
+                dist_policy=DistPolicy.WHEEL_OR_SDIST,
+                build_policy=BuildPolicy.NEVER,
+                resolution_strategy="highest",
+            )
+        matrix = inner.call_args.args[1]
+        env = matrix.expand()[0].environment
+        assert env["python_full_version"] == "3.11.9"
+        assert env["implementation_version"] == "3.11.9"
 
 
 _DIVERGENT_BASELINE_METADATA = (


### PR DESCRIPTION
The re-resolve pass for divergent wheel findings rebuilds a one-tuple matrix from the original tuple's Python version, platform, and implementation, but dropped the matrix's `python_patches`. The second pass then ran with `python_full_version` at `{minor}.0` instead of the declared patch release, so dependencies gated on markers like `python_full_version >= "3.11.4"` flipped between the two passes and `ReresolveDiff` reported phantom added or removed pins on top of the genuine wheel-divergence effects.

The one-tuple matrix now passes `python_patches` built from the original tuple's `python_full_version`, keeping the re-resolve on the same marker environment the original resolve used. When no patches were declared this is a no-op, since the value is already `{minor}.0`.