### PR TITLE
Render local pin editable and subdirectory in requirements output

### DIFF
--- a/docs/guides/lockfile.md
+++ b/docs/guides/lockfile.md
@@ -114,10 +114,12 @@ first; wheel hashes follow. The continuation backslashes match
 what pip-compile emits.
 
 Local and VCS pins are rendered without hashes, mirroring pip's
-behaviour:
+behaviour. An editable local pin becomes a `-e` line and a
+`subdirectory` a `#subdirectory=` fragment:
 
 ```
 my-fork @ file:///abs/path/to/checkout
+-e file:///abs/path/to/monorepo#subdirectory=packages/foo
 some-pkg @ git+https://github.com/me/x.git@<sha>
 ```
 

--- a/nab-python/src/nab_python/_lockfile/requirements.py
+++ b/nab-python/src/nab_python/_lockfile/requirements.py
@@ -33,8 +33,10 @@ def write_requirements_with_hashes(
     Each line is ``name==version`` followed by one ``--hash=sha256:...``
     per recorded artefact, in the format pip's hash-checking mode
     accepts.  Local and VCS pins are emitted as ``name @ <url>`` lines
-    without hashes (pip does not hash-check those forms).  Returns the
-    text and, when ``output_path`` is provided, atomically writes it.
+    without hashes (pip does not hash-check those forms); an editable
+    local pin renders as ``-e <url>`` and a ``subdirectory`` as a
+    ``#subdirectory=`` fragment.  Returns the text and, when
+    ``output_path`` is provided, atomically writes it.
     """
     return _render_requirements(lock_input, with_hashes=True, output_path=output_path)
 
@@ -45,8 +47,8 @@ def write_requirements_without_hashes(
     """Render ``lock_input`` as a plain ``name==version`` list.
 
     Same shape as :func:`write_requirements_with_hashes` but without
-    the ``--hash=sha256:...`` lines.  Local and VCS pins still render
-    as ``name @ <url>``.  Returns the text and, when ``output_path``
+    the ``--hash=sha256:...`` lines.  Local and VCS pins render the
+    same in both variants.  Returns the text and, when ``output_path``
     is provided, atomically writes it.
     """
     return _render_requirements(lock_input, with_hashes=False, output_path=output_path)
@@ -97,7 +99,13 @@ def _render_pins(pins: Mapping[str, PinShape], *, with_hashes: bool) -> list[str
         if isinstance(pin, IndexPin):
             lines.extend(_render_index_pin(pin, with_hashes=with_hashes))
         elif isinstance(pin, LocalPin):
-            lines.append(f"{pin.name} @ {Path(pin.path).resolve().as_uri()}")
+            url = Path(pin.path).resolve().as_uri()
+            if pin.subdirectory is not None:
+                url += f"#subdirectory={pin.subdirectory}"
+            if pin.editable:
+                lines.append(f"-e {url}")
+            else:
+                lines.append(f"{pin.name} @ {url}")
         elif isinstance(pin, VcsPin):
             lines.append(f"{pin.name} @ {pin.repo_url}")
         else:  # pragma: no cover - exhaustive

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -2900,6 +2900,51 @@ class TestWriteRequirementsWithHashes:
         )
         assert "foo @ file://" in text
 
+    def test_local_pin_editable_renders_dash_e(self, tmp_path: Path) -> None:
+        text = write_requirements_with_hashes(
+            LockInput(
+                pins={
+                    "foo": LocalPin(
+                        name="foo", version="1.0", path=str(tmp_path), editable=True
+                    )
+                }
+            )
+        )
+        assert text.strip() == f"-e {tmp_path.resolve().as_uri()}"
+
+    def test_local_pin_subdirectory_renders_fragment(self, tmp_path: Path) -> None:
+        text = write_requirements_without_hashes(
+            LockInput(
+                pins={
+                    "foo": LocalPin(
+                        name="foo",
+                        version="1.0",
+                        path=str(tmp_path),
+                        subdirectory="packages/foo",
+                    )
+                }
+            )
+        )
+        url = tmp_path.resolve().as_uri()
+        assert text.strip() == f"foo @ {url}#subdirectory=packages/foo"
+
+    def test_local_pin_editable_with_subdirectory(self, tmp_path: Path) -> None:
+        text = write_requirements_with_hashes(
+            LockInput(
+                pins={
+                    "foo": LocalPin(
+                        name="foo",
+                        version="1.0",
+                        path=str(tmp_path),
+                        editable=True,
+                        subdirectory="packages/foo",
+                    )
+                }
+            )
+        )
+        url = tmp_path.resolve().as_uri()
+        assert text.strip() == f"-e {url}#subdirectory=packages/foo"
+
     def test_vcs_pin_round_trips_url(self) -> None:
         text = write_requirements_with_hashes(
             LockInput(


### PR DESCRIPTION
The requirements.txt emitters rendered every `LocalPin` as `name @ file:///path`, dropping the `editable` and `subdirectory` fields that pylock.toml records from `[[tool.nab.local-sources]]`. Installing the exported file then targets the repo root non-editable, which for a monorepo subdirectory is a different project than what was locked.

`_render_pins` now appends the `#subdirectory=` fragment to the file URL and emits a `-e <url>` line for editable pins, both forms pip accepts, matching how `VcsPin.repo_url` already carries its fragment. The lockfile guide example shows the new shape.