### PR TITLE
Account for partial satisfiers in backjump targets

### DIFF
--- a/nab-python/tests/test_resolver_packaging.py
+++ b/nab-python/tests/test_resolver_packaging.py
@@ -14,6 +14,7 @@ from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.version import Version
 from nab_resolver.resolver import ResolutionError, Resolver
+from nab_resolver.types import Term
 
 V = Version
 
@@ -45,6 +46,23 @@ class TestSpecifierToRange:
         """Contradictory specifiers produce an empty range."""
         r = SpecifierSet(">=2.0,<1.0").to_range()
         assert r.is_empty
+
+    def test_term_subset_ignores_arbitrary_flag(self) -> None:
+        """A specifier-built full range satisfies a flag-free full term.
+
+        ``SpecifierSet("")`` produces the full range flagged as also
+        admitting arbitrary ``===`` versions, while range unions built
+        during conflict resolution produce the unflagged full range.
+        The two compare unequal but their difference is empty, and term
+        satisfaction follows the difference: conflict resolution would
+        otherwise loop on a clause it can never resolve away.
+        """
+        flagged_full = SpecifierSet("").to_range()
+        exact = VersionRange.singleton(V("1.0"))
+        plain_full = exact | ~exact
+        assert plain_full != flagged_full
+        assert (flagged_full & ~plain_full).is_empty
+        assert Term("pkg", plain_full).satisfies(flagged_full)
 
     def test_not_equal(self) -> None:
         """Convert !=1.5 to a range excluding only 1.5."""

--- a/nab-resolver/src/nab_resolver/conflict.py
+++ b/nab-resolver/src/nab_resolver/conflict.py
@@ -340,10 +340,9 @@ def find_most_recent_satisfier(
         raise RuntimeError(unreachable)
     assert most_recent_term is not None
 
-    if not resolver.solution.satisfier_is_sole(most_recent, most_recent_term):
-        previous_level = recompute_previous_level(
-            resolver, most_recent, most_recent_term, previous_level
-        )
+    previous_level = recompute_previous_level(
+        resolver, most_recent, most_recent_term, previous_level
+    )
 
     return most_recent, most_recent_term, previous_level
 
@@ -356,8 +355,10 @@ def recompute_previous_level(
 ) -> int:
     """Refine previous_level when the satisfier is partial.
 
-    Isolates the satisfier's own contribution (from its cause), subtracts
-    it from the term, and folds the remainder's satisfier level in.
+    The satisfier's own assertion (the negated cause term) may cover only
+    part of the term; the trail must then also exclude the difference
+    ``own & ~term``, so the level of the earliest assignment that does is
+    folded in.
     """
     if satisfier.cause is None:
         return current_previous_level
@@ -370,14 +371,15 @@ def recompute_previous_level(
     if cause_term is None:
         return current_previous_level
 
-    individual = cause_term.negate()
-    remainder = satisfier_term.intersect(individual.negate())
-    if remainder is None or remainder.constraint.is_empty:
+    own_term = cause_term.negate()
+    difference = own_term.intersect(satisfier_term.negate())
+    assert difference is not None
+    if difference.constraint.is_empty:
         return current_previous_level
 
-    remainder_satisfier = resolver.solution.satisfier(remainder)
-    if remainder_satisfier is not None:
-        return max(current_previous_level, remainder_satisfier.decision_level)
+    difference_satisfier = resolver.solution.satisfier(difference.negate())
+    if difference_satisfier is not None:
+        return max(current_previous_level, difference_satisfier.decision_level)
     return current_previous_level
 
 

--- a/nab-resolver/src/nab_resolver/partial_solution.py
+++ b/nab-resolver/src/nab_resolver/partial_solution.py
@@ -318,40 +318,6 @@ class PartialSolution(Generic[PackageType, VersionType]):
         """Return a copy of the positive-range map for each package."""
         return dict(self._positive_ranges)
 
-    def satisfier_is_sole(
-        self,
-        satisfier: Assignment[PackageType, VersionType],
-        term: Term[PackageType, VersionType],
-    ) -> bool:
-        """Check whether the satisfier alone satisfies the term.
-
-        Returns True if removing the satisfier would leave the term
-        unsatisfied; False if earlier assignments already satisfied it.
-        """
-        if satisfier.is_decision:
-            return True
-
-        effective = self._effective_range_before(satisfier, term.package)
-        if effective is None:
-            return True
-
-        return not term.satisfies(effective)
-
-    def _effective_range_before(
-        self, stop_at: Assignment[PackageType, VersionType], package: PackageType
-    ) -> RangeProtocol[VersionType] | None:
-        """Return what earlier trail entries imply about this package."""
-        if stop_at.package_index == 0:
-            return None
-
-        prev = self._assignments_by_package[package][stop_at.package_index - 1]
-        if prev.cum_positive is None:
-            assert prev.cum_negative is not None
-            return ~prev.cum_negative
-        if prev.cum_negative is None:
-            return prev.cum_positive
-        return prev.cum_positive & ~prev.cum_negative
-
     def _satisfied_at(
         self,
         assignment: Assignment[PackageType, VersionType],

--- a/nab-resolver/src/nab_resolver/propagate.py
+++ b/nab-resolver/src/nab_resolver/propagate.py
@@ -149,17 +149,21 @@ def classify_intersection(
 ) -> SetRelation:
     """Classify a term against its precomputed assignment intersection.
 
-    Positive term: satisfied when intersection covers the assignment;
-    contradicted when intersection is empty.
-    Negative term: satisfied when intersection is empty; contradicted when
-    the assignment falls entirely inside the forbidden range.
+    Positive term: satisfied when the assignment is a subset of the
+    constraint; contradicted when the intersection is empty.
+    Negative term: satisfied when the intersection is empty; contradicted
+    when the assignment falls entirely inside the forbidden range.
+
+    The subset test is emptiness of ``assignment & ~constraint``, not a
+    range equality, so it agrees with :meth:`Term.satisfies` on flagged
+    range types (see that docstring).
     """
     if term.is_positive():
-        covers = intersection == assignment
+        covers = (assignment & ~term.constraint).is_empty
         empty = intersection.is_empty
     else:
         covers = intersection.is_empty
-        empty = intersection == assignment
+        empty = (assignment & ~term.constraint).is_empty
 
     if covers:
         return SetRelation.SATISFIED

--- a/nab-resolver/src/nab_resolver/report.py
+++ b/nab-resolver/src/nab_resolver/report.py
@@ -103,7 +103,7 @@ def prior_cause(
     """Compute the prior cause by resolving two incompatibilities.
 
     Follows pubgrub-rs's prior_cause: for the shared package, union
-    the terms (and drop if the union is universal). For other shared
+    the terms (and drop if the union is a tautology). For other shared
     packages, intersect the terms. For packages in only one side,
     keep as-is.
 
@@ -118,7 +118,7 @@ def prior_cause(
 
     result: list[Term[PackageType, VersionType]] = []
 
-    # Shared package: union, dropping if the result is universal.
+    # Shared package: union, dropping if the result is a tautology.
     incompat_shared = incompat_terms.pop(shared_package, None)
     cause_shared = cause_terms.pop(shared_package, None)
     if incompat_shared is not None and cause_shared is not None:
@@ -155,14 +155,14 @@ def union_terms(
 ) -> Term[PackageType, VersionType] | None:
     """Union two terms for the same package.
 
-    Returns None when the union is universal (the package is then
-    unconstrained and can be dropped).
+    Returns None when the union is a tautology (the term can be dropped
+    from the resolvent).  Only a negative result can be one: a positive
+    term, even over the full range, still requires the package to be
+    selected, so solutions that omit the package don't satisfy it.
     """
-    # Positive | Positive = Positive(R1 | R2)
+    # Positive | Positive = Positive(R1 | R2); never a tautology.
     if first.is_positive() and second.is_positive():
         merged = first.constraint | second.constraint
-        if (~merged).is_empty:
-            return None
         return Term(first.package, merged, positive=True)
 
     # Negative | Negative = Negative(R1 & R2) by De Morgan.

--- a/nab-resolver/src/nab_resolver/types.py
+++ b/nab-resolver/src/nab_resolver/types.py
@@ -127,11 +127,18 @@ class Term(Generic[PackageType, VersionType]):
 
         Negative: satisfied when assignment doesn't intersect constraint
         (no version in the assignment is in the constraint).
+
+        The subset test is ``(assignment & ~constraint).is_empty`` rather
+        than ``(assignment & constraint) == assignment``: range types may
+        carry flags (the vendored packaging ranges mark specifier-built
+        ranges as also admitting arbitrary ``===`` versions) under which
+        extensionally equal ranges compare unequal.  Emptiness of the
+        difference agrees with the algebra's own complement, which is what
+        PubGrub's conflict-resolution progress argument relies on.
         """
-        intersection = assignment & self.constraint
         if self._positive:
-            return intersection == assignment
-        return intersection.is_empty
+            return (assignment & ~self.constraint).is_empty
+        return (assignment & self.constraint).is_empty
 
     def intersect(
         self, other: Term[PackageType, VersionType]

--- a/nab-resolver/tests/property/rep_model.py
+++ b/nab-resolver/tests/property/rep_model.py
@@ -204,29 +204,6 @@ class ModelPS:
                 return i
         return None
 
-    def is_sole(self, pkg: str, index: int, c: Rep, *, positive: bool) -> bool:
-        """Whether the satisfier at ``index`` alone satisfies the term.
-
-        Mirrors ``satisfier_is_sole``: decision entries and trail-initial
-        entries are always sole; otherwise the entry is sole when the
-        strict prefix before it does not already satisfy the term at the
-        range level (ungated, mirroring ``Term.satisfies``).
-        """
-        states = self.prefix_states(pkg)
-        if states[index][2]:
-            return True
-        if index == 0:
-            return True
-        prev_pos, prev_neg, _ = states[index - 1]
-        if prev_pos is None:
-            eff_prev = rep_not(prev_neg)
-        else:
-            eff_prev = rep_and(prev_pos, rep_not(prev_neg))
-        prev_satisfies = (
-            rep_subset(eff_prev, c) if positive else rep_disjoint(eff_prev, c)
-        )
-        return not prev_satisfies
-
 
 _operations = st.one_of(
     st.tuples(

--- a/nab-resolver/tests/property/test_partial_solution_model.py
+++ b/nab-resolver/tests/property/test_partial_solution_model.py
@@ -10,7 +10,7 @@ constraint shapes, are applied in lockstep to the real class and to
   equals ``decision_level``, ``trail_index``/``package_index`` match);
 - state queries (``get`` membership, ``decisions``,
   ``undecided_packages``, ``has_positive_constraint``);
-- the binary-search ``satisfier`` and ``satisfier_is_sole``;
+- the binary-search ``satisfier``;
 - backtrack removing exactly the assignments above the target level.
 """
 
@@ -101,7 +101,7 @@ def test_state_matches_model(ops: list[tuple[object, ...]]) -> None:
 def test_satisfier_matches_model(
     ops: list[tuple[object, ...]], probes: list[tuple[str, Rep, bool]]
 ) -> None:
-    """Binary-search satisfier and satisfier_is_sole agree with the model."""
+    """Binary-search satisfier agrees with the model."""
     ps: PartialSolution[str, int] = PartialSolution()
     model = ModelPS()
     for op in ops:
@@ -121,8 +121,6 @@ def test_satisfier_matches_model(
                     f"satisfier mismatch for {term!r}: impl index "
                     f"{impl.package_index}, model index {idx}"
                 )
-                expected_sole = model.is_sole(pkg, idx, rep, positive=positive)
-                assert ps.satisfier_is_sole(impl, term) == expected_sole
 
 
 @given(ops=st.lists(operations(), min_size=1, max_size=18))

--- a/nab-resolver/tests/property/test_partial_solution_satisfier.py
+++ b/nab-resolver/tests/property/test_partial_solution_satisfier.py
@@ -5,15 +5,14 @@ satisfies a term with a binary search rather than a linear scan.  The
 search is licensed by one invariant: along a package's chronological
 trail the effective range only narrows (positive derivations intersect,
 negative derivations union), so ``term.satisfies`` is monotone (once
-true at an entry it stays true for every later entry).  The search and
-the prefix lookups read ``cum_positive`` / ``cum_negative`` stored on
-each entry, so a stored-field or backtrack bug would silently return the
-wrong satisfier.
+true at an entry it stays true for every later entry).  The search
+reads ``cum_positive`` / ``cum_negative`` stored on each entry, so a
+stored-field or backtrack bug would silently return the wrong
+satisfier.
 
 These properties drive random decide/derive/backtrack sequences and
-check the invariant directly, that the binary search agrees with an
-independent linear scan, and that the O(1) prefix range agrees with a
-recomputed prefix.
+check the invariant directly and that the binary search agrees with an
+independent linear scan.
 """
 
 from __future__ import annotations
@@ -115,20 +114,6 @@ def _linear_satisfier(
     return None
 
 
-def _effective_before_reference(
-    ps: PartialSolution[str, int], entry: Assignment[str, int]
-) -> RangeProtocol[int] | None:
-    """Effective range of the strict per-package prefix before ``entry``."""
-    cum_pos: RangeProtocol[int] | None = None
-    cum_neg: RangeProtocol[int] | None = None
-    for prior in ps.assignments_for(entry.package)[: entry.package_index]:
-        if prior.is_decision or prior.positive:
-            cum_pos = prior.accumulated_range
-        else:
-            cum_neg = prior.accumulated_range
-    return _effective(cum_pos, cum_neg)
-
-
 @given(
     ops=st.lists(_operations, min_size=1, max_size=14),
     probes=st.lists(terms(), min_size=1, max_size=4),
@@ -162,16 +147,3 @@ def test_satisfier_matches_linear_scan(
         _apply(ps, op)
         for term in probes:
             assert ps.satisfier(term) is _linear_satisfier(ps, term)
-
-
-@given(ops=st.lists(_operations, min_size=1, max_size=14))
-@PROPERTY_SETTINGS
-def test_effective_range_before_matches_prefix(ops: list[Op]) -> None:
-    """The O(1) prefix range equals the recomputed strict prefix."""
-    ps: PartialSolution[str, int] = PartialSolution()
-    for op in ops:
-        _apply(ps, op)
-        for entry in ps.assignments_for(_PKG):
-            assert ps._effective_range_before(
-                entry, _PKG
-            ) == _effective_before_reference(ps, entry)

--- a/nab-resolver/tests/property/test_pubgrub_resolver.py
+++ b/nab-resolver/tests/property/test_pubgrub_resolver.py
@@ -842,9 +842,33 @@ class TestIndependenceOfIrrelevantAlternatives:
 
     @pytest.mark.timeout(RESOLUTION_TIMEOUT_SECONDS * 50)
     @given(graph=dependency_graphs())
+    @example(
+        graph={
+            "root": {1: {"pkg0": Range.full()}},
+            "pkg0": {1: {}, 2: {"pkg1": Range.full()}},
+            "pkg1": {1: {"pkg2": Range.full()}},
+            "pkg2": {
+                1: {
+                    "pkg0": Range.full(),
+                    "pkg1": Range.full(),
+                    "pkg3": Range.full(),
+                }
+            },
+            "pkg3": {
+                1: {"pkg0": Range.singleton(1)},
+                2: {"pkg0": Range.full(), "pkg1": Range.singleton(2)},
+            },
+        }
+    )
     @BRUTE_FORCE_SETTINGS
     def test_removing_unselected_version_cant_break(self, graph: dict) -> None:
-        """Removing an unselected version cannot break a working resolution."""
+        """Removing an unselected version cannot break a working resolution.
+
+        The explicit example pins the case where dropping ``pkg3``@1
+        once made ``union_terms`` collapse two positive terms into a
+        full-range union and discard it as a tautology, deriving an
+        unsound clause and a false unsat.
+        """
         requirements = {"root": Range.singleton(1)}
         provider = FuzzProvider(graph)
         resolver = Resolver(provider, max_iterations=1000)

--- a/nab-resolver/tests/property/test_pubgrub_term.py
+++ b/nab-resolver/tests/property/test_pubgrub_term.py
@@ -337,14 +337,16 @@ class TestQuoteResolutionIdentity:
     def test_resolution_identity_positive_positive(
         self, left: Range[int], right: Range[int]
     ) -> None:
-        """``positive(A) ∪ positive(B)`` agrees with ``A ∪ B``."""
+        """``positive(A) ∪ positive(B)`` agrees with ``A ∪ B``.
+
+        The result is kept even when ``A ∪ B`` is the full range: a
+        positive term still requires the package to be selected, so it
+        is never a tautology and never reduces out of the resolvent.
+        """
         term_left = Term("pkg", left, positive=True)
         term_right = Term("pkg", right, positive=True)
         result = union_terms(term_left, term_right)
         range_union = left | right
-        if range_union == Range.full():
-            assert result is None
-            return
         assert result is not None
         assert result.is_positive()
         for version in VERSION_RANGE:

--- a/nab-resolver/tests/property/test_satisfier_adversarial.py
+++ b/nab-resolver/tests/property/test_satisfier_adversarial.py
@@ -64,7 +64,7 @@ def test_satisfier_with_trail_derived_probes(
     pkg_picks: list[str],
     polarity: bool,
 ) -> None:
-    """Satisfier and soleness agree with the model on trail-derived probes."""
+    """Satisfier agrees with the model on trail-derived probes."""
     ps: PartialSolution[str, int] = PartialSolution()
     model = ModelPS()
     probe_reps = _derived_probe_reps(ops)
@@ -84,5 +84,3 @@ def test_satisfier_with_trail_derived_probes(
                     else:
                         assert impl is not None
                         assert impl is entries[idx]
-                        expected_sole = model.is_sole(pkg, idx, rep, positive=positive)
-                        assert ps.satisfier_is_sole(impl, term) == expected_sole

--- a/nab-resolver/tests/test_partial_solution.py
+++ b/nab-resolver/tests/test_partial_solution.py
@@ -300,62 +300,6 @@ class TestSatisfierBinarySearch:
                 term = Term("foo", Range.at_least(lo), positive=positive)
                 assert ps.satisfier(term) is _linear_satisfier(ps, term)
 
-    def test_effective_range_before_first_entry_is_none(self) -> None:
-        ps = PartialSolution()
-        ps.derive("foo", Range.at_least(1), positive=True, cause=self._root())
-        first = ps._assignments_by_package["foo"][0]
-        assert ps._effective_range_before(first, "foo") is None
-
-    def test_effective_range_before_positive_prefix(self) -> None:
-        ps = PartialSolution()
-        ps.derive("foo", Range.at_least(1), positive=True, cause=self._root())
-        ps.derive("foo", Range.less_than(20), positive=False, cause=self._root())
-        second = ps._assignments_by_package["foo"][1]
-        before = ps._effective_range_before(second, "foo")
-        assert before is not None
-        assert 5 in before
-
-    def test_effective_range_before_negative_prefix(self) -> None:
-        ps = PartialSolution()
-        ps.derive("foo", Range.at_least(50), positive=False, cause=self._root())
-        ps.derive("foo", Range.at_least(60), positive=False, cause=self._root())
-        second = ps._assignments_by_package["foo"][1]
-        before = ps._effective_range_before(second, "foo")
-        assert before is not None
-        assert 10 in before
-        assert 50 not in before
-
-    def test_effective_range_before_mixed_prefix(self) -> None:
-        ps = PartialSolution()
-        ps.derive("foo", Range.at_least(1), positive=True, cause=self._root())
-        ps.derive("foo", Range.at_least(90), positive=False, cause=self._root())
-        ps.derive("foo", Range.at_least(2), positive=True, cause=self._root())
-        third = ps._assignments_by_package["foo"][2]
-        before = ps._effective_range_before(third, "foo")
-        assert before is not None
-        assert 5 in before
-        assert 90 not in before
-
-    def test_satisfier_is_sole_decision(self) -> None:
-        ps = PartialSolution()
-        ps.decide("foo", 5)
-        decision = ps._assignments_by_package["foo"][0]
-        assert ps.satisfier_is_sole(decision, Term("foo", Range.at_least(1)))
-
-    def test_satisfier_is_sole_first_derivation(self) -> None:
-        ps = PartialSolution()
-        ps.derive("foo", Range.at_least(5), positive=True, cause=self._root())
-        first = ps._assignments_by_package["foo"][0]
-        assert ps.satisfier_is_sole(first, Term("foo", Range.at_least(5)))
-
-    def test_satisfier_is_sole_false_when_earlier_satisfies(self) -> None:
-        ps = PartialSolution()
-        ps.derive("foo", Range.at_least(10), positive=True, cause=self._root())
-        ps.derive("foo", Range.at_least(12), positive=True, cause=self._root())
-        second = ps._assignments_by_package["foo"][1]
-        # "foo >= 5" was already satisfied by the first entry.
-        assert not ps.satisfier_is_sole(second, Term("foo", Range.at_least(5)))
-
 
 class TestDecisionMap:
     def test_decisions(self) -> None:

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -12,6 +12,7 @@ from nab_resolver import propagate
 from nab_resolver.conflict import (
     apply_targeted_backtrack,
     conflict_resolution,
+    find_most_recent_satisfier,
     is_terminal_incompatibility,
     recompute_previous_level,
     try_force_resolution_step,
@@ -670,11 +671,19 @@ class TestResolverInternals:
         assert 2 in result.constraint
         assert 1 not in result.constraint
 
-    def testunion_terms_positive_covers_all_returns_none(self) -> None:
-        """Positive union of Range.full() is universal, returns None."""
+    def testunion_terms_positive_full_range_is_kept(self) -> None:
+        """A full-range positive union is not a tautology.
+
+        It still requires the package to be selected, so dropping it
+        from a resolvent would make the clause fire for solutions that
+        omit the package entirely.
+        """
         a = Term("foo", Range.full(), positive=True)
         b = Term("foo", Range.singleton(1), positive=True)
-        assert union_terms(a, b) is None
+        result = union_terms(a, b)
+        assert result is not None
+        assert result.is_positive()
+        assert (~result.constraint).is_empty
 
     def testunion_terms_negative_empty_intersection_returns_none(self) -> None:
         """Negative union where intersection is empty is universal."""
@@ -712,19 +721,28 @@ class TestResolverInternals:
         assert "foo" in packages
         assert "baz" in packages
 
-    def testprior_cause_shared_package_union_drops_universal(self) -> None:
-        """When the shared package's terms union to any(), it's dropped."""
+    def testprior_cause_shared_package_union_drops_tautology(self) -> None:
+        """When the shared package's terms union to a tautology, it's dropped.
+
+        Mixed polarity over the same range is the classic case: the
+        union ``bar >= 2 or not bar >= 2`` holds for every solution.
+        Two positive terms never qualify (their union still requires
+        the package), so only this form reduces.
+        """
         inc1 = Incompatibility(
             [Term("foo", Range.singleton(1)), Term("bar", Range.at_least(2))],
             cause=IncompatibilityCause.DEPENDENCY,
         )
         inc2 = Incompatibility(
-            [Term("bar", Range.less_than(2)), Term("baz", Range.singleton(3))],
+            [
+                Term("bar", Range.at_least(2), positive=False),
+                Term("baz", Range.singleton(3)),
+            ],
             cause=IncompatibilityCause.DEPENDENCY,
         )
         result = prior_cause(inc1, inc2, "bar")
         packages = {t.package for t in result}
-        # bar terms union to any(), so bar is dropped
+        # The bar terms union to a tautology, so bar is dropped.
         assert "bar" not in packages
         assert "foo" in packages
         assert "baz" in packages
@@ -1003,45 +1021,20 @@ class TestResolverInternals:
         result = recompute_previous_level(resolver, assignment, term, 3)
         assert result == 3
 
-    def test_effective_range_before_mixed(self) -> None:
-        """_effective_range_before accumulates multiple positives and a negative."""
-        solution = PartialSolution()
-        cause = Incompatibility(
-            [Term("x", Range.full())], cause=IncompatibilityCause.ROOT
-        )
-        # Two positive derivations: [1,10) then [2,10)
-        solution.derive("x", Range.between(1, 10), positive=True, cause=cause)
-        solution.derive("x", Range.at_least(2), positive=True, cause=cause)
-        # One negative derivation excludes x==5
-        solution.derive("x", Range.singleton(5), positive=False, cause=cause)
-        # Final derivation as the "satisfier"
-        solution.derive("x", Range.less_than(4), positive=True, cause=cause)
-
-        satisfier = solution.assignments_for("x")[-1]
-        # Effective before satisfier: [1,10) & [2,inf) & ~{5} = [2,5) | (5,10)
-        # Use a term that IS satisfied by [2,5) | (5,10): e.g. [2,10) minus {5}
-        term = Term("x", Range.between(2, 5))
-        # [2,5) | (5,10) is a subset of [2,5)? No, (5,10) is outside.
-        # Use a wider term: [2,10)
-        term = Term("x", Range.between(2, 10))
-        # Is [2,5) | (5,10) a subset of [2,10)?
-        # [2,5) is in [2,10). (5,10) is in [2,10). Yes.
-        assert not solution.satisfier_is_sole(satisfier, term)
-
-    def test_recompute_previous_level_no_remainder_satisfier(self) -> None:
-        """If satisfier(remainder) is None, previous_level is unchanged."""
+    def test_recompute_previous_level_no_difference_satisfier(self) -> None:
+        """If satisfier(difference) is None, previous_level is unchanged."""
         resolver = Resolver(DictProvider({}))
         cause = Incompatibility(
             [Term("x", Range.at_least(3), positive=False)],
             cause=IncompatibilityCause.DEPENDENCY,
         )
         solution = PartialSolution()
-        solution.derive("x", Range.less_than(3), positive=True, cause=cause)
+        solution.derive("x", Range.at_least(3), positive=True, cause=cause)
 
         # Force satisfier() to return None to exercise the defensive
         # branch in recompute_previous_level. In normal resolution this
         # branch is unreachable because the partial solution always
-        # contains an assignment that satisfies the remainder.
+        # contains an assignment that excludes the difference.
         solution.satisfier = lambda _term: None  # type: ignore[method-assign]
 
         term = Term("x", Range.between(1, 5))
@@ -1050,42 +1043,124 @@ class TestResolverInternals:
         result = recompute_previous_level(resolver, assignment, term, 7)
         assert result == 7
 
-    def test_recompute_previous_level_with_remainder(self) -> None:
-        """recompute_previous_level finds the remainder satisfier."""
+    def test_recompute_previous_level_partial_positive_satisfier(self) -> None:
+        """The satisfier's own assertion overshoots the term.
+
+        The trail must also exclude the overshoot, so the level of the
+        earlier assignment that does is folded in.
+        """
         resolver = Resolver(DictProvider({}))
-        # Set up a solution where the satisfier's cause contributes
-        # only part of the term's range, leaving a non-empty remainder
-        # that was satisfied by an earlier assignment.
-        cause = Incompatibility(
-            [Term("x", Range.at_least(3), positive=False)],
+        solution = PartialSolution()
+        solution.decide("a", 1)  # level 1
+        narrow_cause = Incompatibility(
+            [Term("x", Range.between(1, 6), positive=False)],
             cause=IncompatibilityCause.DEPENDENCY,
         )
-        solution = PartialSolution()
-        # Level 1: narrow x to [1, 5)
-        root_cause = Incompatibility(
-            [Term("x", Range.full())], cause=IncompatibilityCause.ROOT
+        solution.derive("x", Range.between(1, 6), positive=True, cause=narrow_cause)
+        solution.decide("b", 1)  # level 2
+        cause = Incompatibility(
+            [Term("x", Range.between(3, 9), positive=False)],
+            cause=IncompatibilityCause.DEPENDENCY,
         )
-        solution.derive("x", Range.between(1, 5), positive=True, cause=root_cause)
-        solution.decide("pkg", 1)
-        # Level 2: narrow x further to [1, 3) via cause that says "not x >= 3"
-        solution.derive("x", Range.less_than(3), positive=True, cause=cause)
-        # The satisfier is the level-2 derivation.  Its individual
-        # contribution is less_than(3).  The term is between(1,3).
-        # Remainder = between(1,3) intersect negate(less_than(3)) = between(1,3) & at_least(3) = empty.
-        # Since remainder is empty, previous_level stays unchanged.
-        # But let's use a term where remainder is non-empty:
+        solution.derive("x", Range.between(3, 9), positive=True, cause=cause)
+
+        term = Term("x", Range.between(3, 7))
+        assignment = solution.assignments_for("x")[-1]
+        resolver.solution = solution
+        # The satisfier's own [3,9) leaves [7,9) outside the term; the
+        # level-1 derivation [1,6) is what excludes it.
+        result = recompute_previous_level(resolver, assignment, term, 0)
+        assert result == 1
+
+    def test_recompute_previous_level_partial_negative_satisfier(self) -> None:
+        """A negative satisfier needs the earlier positive range.
+
+        Excluding [5,10) only satisfies x [1,5) together with the
+        level-1 derivation [1,10), so that level is folded in.
+        """
+        resolver = Resolver(DictProvider({}))
+        solution = PartialSolution()
+        solution.decide("a", 1)  # level 1
+        pos_cause = Incompatibility(
+            [Term("x", Range.between(1, 10), positive=False)],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+        solution.derive("x", Range.between(1, 10), positive=True, cause=pos_cause)
+        solution.decide("b", 1)  # level 2
+        neg_cause = Incompatibility(
+            [Term("x", Range.between(5, 10), positive=True)],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+        solution.derive("x", Range.between(5, 10), positive=False, cause=neg_cause)
+
         term = Term("x", Range.between(1, 5))
         assignment = solution.assignments_for("x")[-1]
-        # individual from cause: negate of neg-term for x = pos(at_least(3))
-        # negate of individual = neg(at_least(3))
-        # remainder = term.intersect(neg(at_least(3))) = between(1,5) & less_than(3) = between(1,3)
-        # between(1,3) is non-empty, so it looks for satisfier of between(1,3)
         resolver.solution = solution
-        result = recompute_previous_level(resolver, assignment, term, 1)
-        # The remainder [1,3) was satisfied at level 0 (before the
-        # decision at level 1) by the derivation of [1,5).
-        # max(1, 0) = 1.
+        result = recompute_previous_level(resolver, assignment, term, 0)
         assert result == 1
+
+    def test_recompute_previous_level_sole_satisfier(self) -> None:
+        """No refinement when the satisfier's own assertion covers the term."""
+        resolver = Resolver(DictProvider({}))
+        solution = PartialSolution()
+        solution.decide("a", 1)  # level 1
+        wide_cause = Incompatibility(
+            [Term("x", Range.between(1, 9), positive=False)],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+        solution.derive("x", Range.between(1, 9), positive=True, cause=wide_cause)
+        solution.decide("b", 1)  # level 2
+        cause = Incompatibility(
+            [Term("x", Range.between(3, 5), positive=False)],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+        solution.derive("x", Range.between(3, 5), positive=True, cause=cause)
+
+        # Own assertion [3,5) is a subset of the term [2,6).
+        term = Term("x", Range.between(2, 6))
+        assignment = solution.assignments_for("x")[-1]
+        resolver.solution = solution
+        result = recompute_previous_level(resolver, assignment, term, 0)
+        assert result == 0
+
+    def test_previous_level_includes_partial_satisfier_contribution(self) -> None:
+        """A partial satisfier raises previous_level past the other terms.
+
+        x's satisfier asserts [3,9), which only partially covers the
+        conflicting term x [3,7); the level-2 derivation [1,6) supplies
+        the rest, so the previous satisfier level is 2, not r's level 1.
+        """
+        solution = PartialSolution()
+        solution.decide("r", 1)  # level 1
+        solution.decide("a", 1)  # level 2
+        cause_a = Incompatibility(
+            [
+                Term("a", Range.singleton(1)),
+                Term("x", Range.between(1, 6), positive=False),
+            ],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+        solution.derive("x", Range.between(1, 6), positive=True, cause=cause_a)
+        solution.decide("b", 1)  # level 3
+        cause_b = Incompatibility(
+            [
+                Term("b", Range.singleton(1)),
+                Term("x", Range.between(3, 9), positive=False),
+            ],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+        solution.derive("x", Range.between(3, 9), positive=True, cause=cause_b)
+
+        resolver = Resolver(DictProvider({}))
+        resolver.solution = solution
+        conflict = Incompatibility(
+            [Term("r", Range.singleton(1)), Term("x", Range.between(3, 7))],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+        satisfier, term, previous_level = find_most_recent_satisfier(resolver, conflict)
+        assert satisfier.decision_level == 3
+        assert term.package == "x"
+        assert previous_level == 2
 
 
 class TestBruteForceRegressions:
@@ -1127,6 +1202,44 @@ class TestBruteForceRegressions:
         assert result["pkg0"] in (1, 2)
         assert "pkg1" not in result
         assert "pkg2" not in result
+
+    def test_positive_full_union_term_is_not_dropped(self) -> None:
+        """Resolving two positive terms must keep a full-range union.
+
+        Graph:
+            root -> pkg0 (any)
+            pkg0@1 has no deps          pkg0@2 -> pkg1 (any)
+            pkg1@1 -> pkg2 (any)
+            pkg2@1 -> pkg0 (any), pkg1 (any), pkg3 (any)
+            pkg3@2 -> pkg0 (any), pkg1==2  (no pkg1@2 exists)
+
+        Expected: {root: 1, pkg0: 1}; pkg2 and pkg3 stay unselected.
+
+        Conflict resolution combines "no versions of pkg2 outside 1"
+        with a clause containing "pkg2 == 1"; the union is the positive
+        full range.  Dropping it as a tautology asserted "pkg3 must be
+        2 in every solution" even for solutions without pkg2, deriving
+        a false unsat.
+
+        Found by the removing-unselected-version property test.
+        """
+        provider = DictProvider(
+            {
+                "root": {1: {"pkg0": Range.full()}},
+                "pkg0": {1: {}, 2: {"pkg1": Range.full()}},
+                "pkg1": {1: {"pkg2": Range.full()}},
+                "pkg2": {
+                    1: {
+                        "pkg0": Range.full(),
+                        "pkg1": Range.full(),
+                        "pkg3": Range.full(),
+                    }
+                },
+                "pkg3": {2: {"pkg0": Range.full(), "pkg1": Range.singleton(2)}},
+            }
+        )
+        result = Resolver(provider).resolve({"root": Range.singleton(1)})
+        assert result == {"root": 1, "pkg0": 1}
 
 
 class TestBackjumpToRoot:


### PR DESCRIPTION
When the most recent satisfier only partially satisfied its term, `find_most_recent_satisfier` never raised `previous_satisfier_level`: the `satisfier_is_sole` gate checked the trail before the satisfier, which is unsatisfied by the satisfier's minimality, and `recompute_previous_level` computed the difference in the wrong direction (`term & ~own` instead of `own & ~term`). Conflict resolution backjumped deeper than PubGrub specifies, discarding valid decision levels and skipping resolve-with-cause steps on every partial-satisfier conflict.

`recompute_previous_level` now mirrors dart pub's `satisfier.difference(term)`: it folds in the level of the earliest assignment that excludes `own & ~term`, and an empty difference means the satisfier alone covers the term, replacing the `satisfier_is_sole` gate (removed along with its `_effective_range_before` helper).

The shallower backjumps route more conflicts through resolve-with-cause, which exposed two latent bugs the over-deep backjumps had masked:

- `union_terms` dropped a full-range positive union as a tautology. A positive term still requires the package to be selected, so the learned clause also fired for solutions that omit the package, and satisfiable graphs reported unsat (caught by the removing-unselected-version property test). The union is now kept; only a negative union can be a tautology, matching pubgrub-rs, whose `Term::any()` is the negative-empty term, and dart pub, which adds `difference.inverse` back to the resolvent.
- Term satisfaction tested subsets by range equality (`(assignment & constraint) == assignment`), which disagrees with the complement algebra on flagged ranges: a specifier-built full range admits arbitrary `===` versions and never compares equal to the plain full range such a union produces, so conflict resolution looped forever on a clause it could never resolve away. Subset tests in `Term.satisfies` and `classify_intersection` now check emptiness of `assignment & ~constraint`, the form PubGrub's progress argument relies on.

Backjump depths change on partial-satisfier conflicts, so search paths and learned clauses shift on conflict-heavy scenarios and a benchmark sweep is worth running before merge.