### PR TITLE
Treat pins with no files at the pinned version as fatal

### DIFF
--- a/nab-python/src/nab_python/universal/validate.py
+++ b/nab-python/src/nab_python/universal/validate.py
@@ -47,7 +47,9 @@ __all__ = [
 
 # Statuses that always fail the lock at install time, regardless of
 # build policy.
-_ALWAYS_FATAL_STATUSES = frozenset({"no_compatible_wheel", "no_metadata"})
+_ALWAYS_FATAL_STATUSES = frozenset(
+    {"version_not_found", "no_compatible_wheel", "no_metadata"}
+)
 
 # Statuses that fail only when the build policy refuses to build
 # from sdist (BuildPolicy.NEVER).  These pins resolve fine if the
@@ -77,8 +79,10 @@ class PinValidation:
 
     - ``ok``: chosen wheel's deps (after marker eval) match the resolver's.
     - ``divergent``: wheel has metadata but deps differ from baseline.
-    - ``sdist_only``: no wheels at all; the user must build from sdist.
-      Fatal under ``BuildPolicy.NEVER``.
+    - ``sdist_only``: an sdist but no wheels; the user must build from
+      sdist. Fatal under ``BuildPolicy.NEVER``.
+    - ``version_not_found``: the index has no files at the pinned
+      version (or no listing for the package). Always fatal.
     - ``no_compatible_wheel``: wheels exist but none match the tuple's
       tags and no buildable sdist exists. Always fatal.
     - ``no_compatible_wheel_with_sdist``: as above but a sdist is
@@ -112,9 +116,10 @@ class ValidationReport:
     def fatal_findings(self, *, build_allowed: bool = False) -> list[PinValidation]:
         """Return findings that would prevent installation.
 
-        Always fatal: ``no_compatible_wheel`` (no installable
-        artifact) and ``no_metadata`` (we can't trust the resolver
-        ran with the right deps).
+        Always fatal: ``version_not_found`` (nothing at the pinned
+        version), ``no_compatible_wheel`` (no installable artifact)
+        and ``no_metadata`` (we can't trust the resolver ran with
+        the right deps).
 
         Fatal under BuildPolicy.NEVER: ``sdist_only`` and
         ``no_compatible_wheel_with_sdist`` (only sdist available).
@@ -165,6 +170,14 @@ def _validate_pin(  # noqa: PLR0911 - one return per outcome reads cleaner here
     files_at_version = [f for f in listing if f.version == str(version)]
     wheels_at_version = [f for f in files_at_version if isinstance(f, WheelFile)]
     has_sdist = any(not isinstance(f, WheelFile) for f in files_at_version)
+    if not files_at_version:
+        return PinValidation(
+            tuple_label=tup.label,
+            package=package,
+            version=str(version),
+            status="version_not_found",
+            detail="index has no files at this version; nothing to install or build",
+        )
     if not wheels_at_version:
         return PinValidation(
             tuple_label=tup.label,

--- a/nab-python/tests/universal/test_validate.py
+++ b/nab-python/tests/universal/test_validate.py
@@ -216,8 +216,8 @@ class TestValidateLock:
         assert "numpy" in win_finding.missing_deps
 
     def test_sdist_only_reported(self) -> None:
-        """A version with no wheels reports ``sdist_only``."""
-        coordinator = _make_coordinator({"pkg": []})  # listing exists but empty
+        """A version with an sdist but no wheels reports ``sdist_only``."""
+        coordinator = _make_coordinator({"pkg": [_sdist("pkg-1.0.tar.gz")]})
         result = UniversalResult(
             matrix=MagicMock(),
             tuple_results=[
@@ -231,6 +231,39 @@ class TestValidateLock:
         report = validate_lock(result, coordinator)
         assert report.pins_checked == 1
         assert report.findings[0].status == "sdist_only"
+
+    def test_version_not_found_when_no_files_at_pinned_version(self) -> None:
+        """A pin at a version with zero files reports ``version_not_found``."""
+        wheel = _wheel("pkg-1.0-py3-none-any.whl")
+        coordinator = _make_coordinator({"pkg": [wheel]})
+        result = UniversalResult(
+            matrix=MagicMock(),
+            tuple_results=[
+                TupleResult(
+                    tuple_=_linux_311(),
+                    success=True,
+                    pins={"pkg": Version("2.0")},
+                ),
+            ],
+        )
+        report = validate_lock(result, coordinator)
+        assert report.findings[0].status == "version_not_found"
+
+    def test_version_not_found_when_package_has_no_listing(self) -> None:
+        """A pin for a package with no listing reports ``version_not_found``."""
+        coordinator = _make_coordinator({})
+        result = UniversalResult(
+            matrix=MagicMock(),
+            tuple_results=[
+                TupleResult(
+                    tuple_=_linux_311(),
+                    success=True,
+                    pins={"pkg": Version("1.0")},
+                ),
+            ],
+        )
+        report = validate_lock(result, coordinator)
+        assert report.findings[0].status == "version_not_found"
 
     def test_no_compatible_wheel(self) -> None:
         """When wheels exist but none compatible, ``no_compatible_wheel``."""
@@ -713,6 +746,18 @@ class TestFatalFindings:
             package="p",
             version="1.0",
             status="no_compatible_wheel",
+        )
+        report = ValidationReport(pins_checked=1, findings=[f])
+        assert report.fatal_findings(build_allowed=False) == [f]
+        assert report.fatal_findings(build_allowed=True) == [f]
+
+    def test_version_not_found_always_fatal(self) -> None:
+        """``version_not_found`` fails regardless of build_allowed."""
+        f = PinValidation(
+            tuple_label="x",
+            package="p",
+            version="1.0",
+            status="version_not_found",
         )
         report = ValidationReport(pins_checked=1, findings=[f])
         assert report.fatal_findings(build_allowed=False) == [f]


### PR DESCRIPTION
`validate_lock` classified a pin whose version had no files in the index listing (or no listing at all) as `sdist_only`, with a detail claiming the install just needs a build from sdist. When builds were allowed, `fatal_findings` returned nothing, so a lock pointing at a version with zero artifacts passed validation silently.

Such pins now get a distinct `version_not_found` status that is always fatal regardless of build policy, and `sdist_only` is reserved for versions that actually ship an sdist.