### PR TITLE
Make the platform-spec label suffix injective

### DIFF
--- a/nab-python/src/nab_python/universal/wheel_selection.py
+++ b/nab-python/src/nab_python/universal/wheel_selection.py
@@ -108,8 +108,8 @@ class PlatformSpec:
             ("glibc", _floor_tag(self.manylinux_floor)),
             ("musl", _floor_tag(self.musllinux_floor)),
             ("macos", _floor_tag(self.macos_min)),
-            ("rel", "_".join(self.platform_release.split())),
-            ("ver", "_".join(self.platform_version.split())),
+            ("rel", _escape_label_value(self.platform_release)),
+            ("ver", _escape_label_value(self.platform_version)),
         )
         return "".join(f"-{tag}{value}" for tag, value in fields if value)
 
@@ -136,6 +136,26 @@ _PLATFORM_KIND: dict[str, str] = {
 def _floor_tag(floor: tuple[int, int] | None) -> str:
     """Render a ``(major, minor)`` floor as ``major.minor``, or ``""`` if unset."""
     return f"{floor[0]}.{floor[1]}" if floor is not None else ""
+
+
+def _escape_label_value(value: str) -> str:
+    """Escape a free-form marker value for a label suffix field.
+
+    Alphanumerics and ``.`` pass through, ``_`` doubles itself, and any
+    other character becomes ``_<hex codepoint>_``.  This keeps the
+    encoding injective and the output free of ``-``, so a value can
+    never forge a field boundary and collapse two distinct specs onto
+    one label.
+    """
+    out: list[str] = []
+    for ch in value:
+        if ch == "_":
+            out.append("__")
+        elif ch.isalnum() or ch == ".":
+            out.append(ch)
+        else:
+            out.append(f"_{ord(ch):x}_")
+    return "".join(out)
 
 
 def _linux_platform_tags(

--- a/nab-python/tests/universal/test_wheel_selection.py
+++ b/nab-python/tests/universal/test_wheel_selection.py
@@ -54,6 +54,30 @@ class TestPlatformSpec:
         spec = PlatformSpec("macos_arm64")
         assert spec.arch == "arm64"
 
+    def test_label_suffix_distinguishes_space_from_underscore(self) -> None:
+        """Whitespace and ``_`` in ``platform_release`` encode differently.
+
+        Both are legal release characters; if they folded to the same
+        suffix the two specs' matrix tuples would share a label and
+        their per-tuple pins would silently merge.
+        """
+        with_space = PlatformSpec("linux_x86_64", platform_release="a a")
+        with_underscore = PlatformSpec("linux_x86_64", platform_release="a_a")
+        assert with_space.label_suffix() != with_underscore.label_suffix()
+
+    def test_label_suffix_release_cannot_forge_version_field(self) -> None:
+        """A ``-`` in ``platform_release`` cannot fake a ``ver`` field."""
+        release_only = PlatformSpec("linux_x86_64", platform_release="r-ver1")
+        release_and_version = PlatformSpec(
+            "linux_x86_64", platform_release="r", platform_version="1"
+        )
+        assert release_only.label_suffix() != release_and_version.label_suffix()
+
+    def test_label_suffix_escapes_kernel_release(self) -> None:
+        """Pins the escaped suffix shape for a realistic kernel release."""
+        spec = PlatformSpec("linux_x86_64", platform_release="5.15.0-generic")
+        assert spec.label_suffix() == "-glibc2.17-musl1.2-rel5.15.0_2d_generic"
+
 
 class TestCompatibleTagsForTuple:
     """``compatible_tags_for_tuple`` produces the full PEP 425 tag set."""


### PR DESCRIPTION
PlatformSpec.label_suffix folded whitespace in `platform_release` and `platform_version` with `"_".join(value.split())` and passed `-` through verbatim, so distinct specs could emit the same suffix (`"a a"` vs `"a_a"`, or a release containing `-ver` forging the version field). Matrix-tuple labels are dict keys for per-tuple pins, so two colliding specs on one `platform_id` silently merged their pins in the lock, contradicting the docstring claim that distinct specs stay distinct.

The fix escapes these values with an injective per-character encoding: alphanumerics and `.` pass through, `_` doubles itself, and anything else becomes `_<hex codepoint>_`. Encoded values can never contain `-`, so field boundaries cannot be forged. Only matrices that set `platform_release`/`platform_version` through the Python API see different labels; CLI and pyproject matrices cannot produce such specs, so their lockfile labels are unchanged.