### PR TITLE
Only treat a path @<sha> as a VCS pin

### DIFF
--- a/nab-python/src/nab_python/_vcs_admission.py
+++ b/nab-python/src/nab_python/_vcs_admission.py
@@ -103,15 +103,16 @@ def split_vcs_scheme(url: str) -> tuple[str | None, str]:
 def has_full_commit_sha(url: str) -> bool:
     """Return True if the URL pins to a 40-char hex commit hash.
 
-    Looks for ``@<sha>`` after the scheme://host portion; ignores any
-    ``#`` fragment.  Tolerates ``user@host`` syntax by taking the last
-    ``@`` in the path/ref portion.
+    Looks for ``@<sha>`` in the path component (after the authority);
+    ignores any ``#`` fragment.  A ``user@host`` in the authority is
+    left alone, matching the ref parsing in :mod:`nab_index.vcs`.
     """
     fragmentless = url.split("#", 1)[0]
-    after_authority = fragmentless.split("://", 1)[-1]
-    if "@" not in after_authority:
+    after_scheme = fragmentless.split("://", 1)[-1]
+    path = after_scheme.partition("/")[2]
+    if "@" not in path:
         return False
-    ref = after_authority.rsplit("@", 1)[1]
+    ref = path.rsplit("@", 1)[1]
     return bool(FULL_GIT_SHA_RE.match(ref))
 
 

--- a/nab-python/tests/test_vcs_admission.py
+++ b/nab-python/tests/test_vcs_admission.py
@@ -109,6 +109,15 @@ class TestHasFullCommitSha:
         url = f"git+https://github.com/foo/bar.git@{upper}"
         assert not has_full_commit_sha(url)
 
+    def test_sha_in_authority_without_path_rejected(self) -> None:
+        """An ``@<sha>`` in the authority is userinfo, not a ref."""
+        url = f"git+https://github.com@{_FORTY}"
+        assert not has_full_commit_sha(url)
+
+    def test_sha_as_userinfo_with_unpinned_path_rejected(self) -> None:
+        url = f"git+https://{_FORTY}@github.com/foo/bar.git"
+        assert not has_full_commit_sha(url)
+
 
 class TestAdmitVcsUrlBlock:
     def test_block_default_refuses_vcs(self) -> None:
@@ -225,6 +234,14 @@ class TestAdmitVcsUrlRequirePin:
         with pytest.raises(UnsupportedVcsError, match="vcs_require_pin"):
             admit_vcs_url(
                 "git+https://github.com/foo/bar.git@v1.0",
+                _allow_https(),
+            )
+
+    def test_sha_in_authority_refused_when_pin_required(self) -> None:
+        """The clone parser sees no ref here, so admission must refuse."""
+        with pytest.raises(UnsupportedVcsError, match="vcs_require_pin"):
+            admit_vcs_url(
+                f"git+https://github.com@{_FORTY}",
                 _allow_https(),
             )
 


### PR DESCRIPTION
`has_full_commit_sha` searched everything after the scheme for an `@<sha>`, including the URL authority, while the clone-layer parser in `nab_index.vcs` only reads refs from the path component. A degenerate URL like `git+https://github.com@<40-hex>` (sha in the authority, no path) was therefore admitted as pinned under `vcs_require_pin=True`, then failed later at clone time with a confusing floating-ref error instead of the eager unpinned-VCS diagnostic.

The pin check now skips the authority and searches only the path component, matching both its own docstring and the clone parser, so these URLs are refused at ingestion.