### PR TITLE
Compare recorded hex digests case-insensitively

### DIFF
--- a/nab-python/src/nab_python/download.py
+++ b/nab-python/src/nab_python/download.py
@@ -104,6 +104,8 @@ def _entries_for_pin(canonical: str, pin: PinShape) -> Iterable[DownloadEntry]:
 
 
 def _iter_index_pin(canonical: str, pin: IndexPin) -> Iterable[DownloadEntry]:
+    # Recorded digests are lowercased to match hashlib.hexdigest() output:
+    # index-fed flows already lowercase, but a caller-built LockInput may not.
     if pin.sdist is not None:
         algo, digest = pin.sdist.primary_digest
         yield DownloadEntry(
@@ -112,7 +114,7 @@ def _iter_index_pin(canonical: str, pin: IndexPin) -> Iterable[DownloadEntry]:
             filename=pin.sdist.filename,
             url=pin.sdist.url,
             hash_algo=algo,
-            digest=digest,
+            digest=digest.lower(),
         )
     for wheel in pin.wheels:
         algo, digest = wheel.primary_digest
@@ -122,7 +124,7 @@ def _iter_index_pin(canonical: str, pin: IndexPin) -> Iterable[DownloadEntry]:
             filename=wheel.filename,
             url=wheel.url,
             hash_algo=algo,
-            digest=digest,
+            digest=digest.lower(),
         )
 
 

--- a/nab-python/tests/test_download.py
+++ b/nab-python/tests/test_download.py
@@ -267,6 +267,36 @@ class TestDownloadLock:
         assert (tmp_path / "foo-1.0-py3-none-any.whl").read_bytes() == wheel_bytes
         assert len(result.written) == 1
 
+    def test_uppercase_recorded_digest_verifies(self, tmp_path: Path) -> None:
+        wheel_bytes = b"WHEELDATA"
+        wheel_sha = hashlib.sha256(wheel_bytes).hexdigest().upper()
+        pin = _index_pin(wheel_sha=wheel_sha)
+        transport = _FakeTransport({"https://example.com/foo-1.0.whl": wheel_bytes})
+        result = download_lock(
+            LockInput(pins={"foo": pin}),
+            transport,
+            tmp_path,  # type: ignore[arg-type]
+        )
+        assert len(result.written) == 1
+        assert (tmp_path / "foo-1.0-py3-none-any.whl").read_bytes() == wheel_bytes
+
+    def test_idempotent_skip_with_uppercase_recorded_digest(
+        self, tmp_path: Path
+    ) -> None:
+        wheel_bytes = b"BYTES"
+        wheel_sha = hashlib.sha256(wheel_bytes).hexdigest().upper()
+        (tmp_path / "foo-1.0-py3-none-any.whl").write_bytes(wheel_bytes)
+        pin = _index_pin(wheel_sha=wheel_sha)
+        transport = _FakeTransport({"https://example.com/foo-1.0.whl": wheel_bytes})
+        result = download_lock(
+            LockInput(pins={"foo": pin}),
+            transport,
+            tmp_path,  # type: ignore[arg-type]
+        )
+        assert result.written == ()
+        assert len(result.skipped) == 1
+        assert transport.requested == []
+
     def test_sha_mismatch_raises(self, tmp_path: Path) -> None:
         wheel_bytes = b"REAL"
         pin = _index_pin(wheel_sha="0" * 64)  # advertised sha is wrong


### PR DESCRIPTION
The downloader compared recorded digests against `hashlib.hexdigest()` output verbatim, so a `LockInput` carrying an uppercase hex digest always failed verification with a `sha256 mismatch` even though the hash value was correct. The same comparison in `_already_present` meant a correct pre-existing file was re-downloaded and then rejected, defeating the documented idempotence. All index-fed flows already lowercase digests at ingress, so this was only reachable through the public `download_lock` API with caller-built artifacts.

The fix lowercases the recorded digest where `DownloadEntry` objects are built in `_iter_index_pin`, the single ingress for both verification sites, matching the lowercase-at-ingress convention in `nab_index.client`.