### PR TITLE
Reset loop state and settle in-flight fetches on shutdown

### DIFF
--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -470,6 +470,11 @@ class FetchCoordinator:
         self._thread.join(timeout=_COORDINATOR_JOIN_TIMEOUT_SECONDS)
         self._thread = None
         self._started = False
+        # Drop the dead loop so a later start() waits for the fresh one
+        # instead of submitting to a closed loop.
+        self._loop = None
+        self._async_q = None
+        self._queue_ready.clear()
 
     def _submit(self, item: _QueueItem) -> None:
         """Schedule ``item`` on the fetcher loop's queue from any thread."""
@@ -711,7 +716,8 @@ class FetchCoordinator:
 
         client = self._build_client()
         try:
-            while True:
+            stopping = False
+            while not stopping:
                 item = await queue.get()
                 if item is None:
                     break
@@ -725,10 +731,11 @@ class FetchCoordinator:
                     except asyncio.QueueEmpty:
                         break
                     if extra is None:
-                        for t in tasks:
-                            t.cancel()
-                        await asyncio.gather(*tasks, return_exceptions=True)
-                        return
+                        # Fall through to the gather below instead of
+                        # cancelling: a cancelled _handle never records a
+                        # result, leaving its waiter's event unset forever.
+                        stopping = True
+                        break
                     self._dispatch(extra, client, sem, tasks)
 
             if tasks:

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import tempfile
 import threading
+import time
 from pathlib import Path
 
 import httpx
@@ -206,6 +207,26 @@ class TestFetchCoordinator:
         coord.start()
         assert coord._thread is thread1
         coord.shutdown()
+
+    @respx.mock
+    def test_restart_after_shutdown_serves_requests(self) -> None:
+        """A coordinator restarted after shutdown serves new requests."""
+
+        class ReusableTransport(HttpxAsyncTransport):
+            """Survives the per-run client aclose so both runs can fetch."""
+
+            async def aclose(self) -> None:
+                pass
+
+        respx.get(url__regex=r".*").mock(return_value=httpx.Response(200, text="ok"))
+        coord = FetchCoordinator(transport=ReusableTransport())  # type: ignore[arg-type]
+        with coord:
+            event = coord.request_metadata("first", "1.0", "https://f.com/first")
+            assert event.wait(timeout=5)
+        with coord:
+            event = coord.request_metadata("second", "1.0", "https://f.com/second")
+            assert event.wait(timeout=5)
+        assert coord.index.get_metadata("second", "1.0") == "ok"
 
     @respx.mock
     def test_request_listing(self) -> None:
@@ -517,6 +538,15 @@ class TestFetchCoordinator:
         coord.shutdown()
         assert coord._thread is None
 
+    def test_shutdown_resets_loop_state(self) -> None:
+        """shutdown() drops the closed loop so a later start() rewires it."""
+        coord = _coord()
+        coord.start()
+        coord.shutdown()
+        assert coord._loop is None
+        assert coord._async_q is None
+        assert not coord._queue_ready.is_set()
+
     def test_run_loop_exception_sets_crashed(self) -> None:
         """If _async_fetcher raises, _run_loop catches it and sets _crashed."""
         coord = _coord()
@@ -609,11 +639,11 @@ class TestFetchCoordinator:
 
     @respx.mock
     def test_shutdown_during_drain(self) -> None:
-        """None sentinel found during drain loop cancels tasks and returns."""
+        """None sentinel found during drain loop settles in-flight tasks and returns."""
         import asyncio as _asyncio
 
         async def slow_response(request: httpx.Request) -> httpx.Response:
-            await _asyncio.sleep(10)
+            await _asyncio.sleep(0.2)
             return httpx.Response(200, text="slow")
 
         respx.get(url__regex=r".*").mock(side_effect=slow_response)
@@ -666,6 +696,29 @@ class TestFetchCoordinator:
         coord._thread = None
         coord._started = False
         assert not coord._crashed
+        assert coord.index.get_metadata("first", "1.0") == "slow"
+        assert coord.index.get_metadata("drain", "1.0") == "slow"
+
+    @respx.mock
+    def test_drain_shutdown_replies_to_inflight_requests(self) -> None:
+        """A request batched with the shutdown sentinel still gets a reply."""
+
+        async def slow_response(request: httpx.Request) -> httpx.Response:
+            await asyncio.sleep(0.5)
+            return httpx.Response(200, text="slow")
+
+        respx.get(url__regex=r".*").mock(side_effect=slow_response)
+        coord = _coord()
+        coord.start()
+        loop = coord._loop
+        assert loop is not None
+        # Block the loop so the request and the sentinel arrive in one
+        # batch and the sentinel is found during the drain.
+        loop.call_soon_threadsafe(time.sleep, 0.3)
+        event = coord.request_metadata("pkg", "1.0", "https://f.com/pkg")
+        coord.shutdown()
+        assert event.wait(timeout=2)
+        assert coord.index.get_metadata("pkg", "1.0") == "slow"
 
     @respx.mock
     def test_request_metadata_deduplicates(self) -> None:


### PR DESCRIPTION
FetchCoordinator.shutdown() left `_loop` and `_async_q` pointing at the closed event loop and `_queue_ready` set, so a second `start()` returned immediately with stale wiring and the next request raised `RuntimeError: Event loop is closed` (or, when the new fetcher thread won the race, stranded the pending it had already created). `shutdown()` now resets that state, so a restarted coordinator waits for the fresh loop to be wired before accepting requests.

Separately, a shutdown sentinel found during the non-blocking drain cancelled in-flight fetches instead of gathering them like the main shutdown path does. A cancelled `_handle` skips the result-recording except branch, so the waiter's event never fires and an untimed `event.wait()` on it hangs forever. The drain path now falls through to the same gather, so every dispatched request records a reply.