### PR TITLE
Keep surviving decisions in backtrack rebuild

### DIFF
--- a/nab-resolver/src/nab_resolver/partial_solution.py
+++ b/nab-resolver/src/nab_resolver/partial_solution.py
@@ -260,9 +260,9 @@ class PartialSolution(Generic[PackageType, VersionType]):
         """Recompute positive/negative/decided state for a package.
 
         Each ``Assignment.accumulated_range`` is already cumulative, so the
-        latest entry of each kind is enough to rebuild state.  A later
-        derivation clears the recorded decision, so a backtrack that pops a
-        decision but keeps a derivation does the right thing.
+        latest entry of each kind is enough to rebuild state.  Trail levels
+        never decrease, so popping a decision pops every later entry for the
+        same package; a surviving decision is always the current one.
         """
         last_pos: RangeProtocol[VersionType] | None = None
         last_neg: RangeProtocol[VersionType] | None = None
@@ -274,7 +274,6 @@ class PartialSolution(Generic[PackageType, VersionType]):
                 last_decision_version = assignment.version
             elif assignment.positive:
                 last_pos = assignment.accumulated_range
-                last_decision_version = None
             else:
                 last_neg = assignment.accumulated_range
 

--- a/nab-resolver/tests/test_partial_solution.py
+++ b/nab-resolver/tests/test_partial_solution.py
@@ -167,6 +167,18 @@ class TestMultipleDerivations:
         assert 5 not in r  # still excluded from level 0
         assert 3 in r  # no longer excluded (was level 1)
 
+    def test_backtrack_keeps_decision_with_later_positive_derivation(self) -> None:
+        """A surviving decision stays decided even when a positive
+        derivation on the same package follows it in the trail."""
+        ps = PartialSolution()
+        ps.decide("foo", 3)
+        inc = Incompatibility([], cause=IncompatibilityCause.ROOT)
+        ps.derive("foo", Range.between(1, 10), positive=True, cause=inc)
+        # Removes nothing: every assignment is at the current level.
+        ps.backtrack(ps.decision_level)
+        assert ps.decisions() == {"foo": 3}
+        assert ps.undecided_packages() == set()
+
     def test_satisfier_with_multiple_positive_derivations(self) -> None:
         """satisfier walks through multiple positive derivations."""
         ps = PartialSolution()


### PR DESCRIPTION
After a backtrack, `_update_package_state_after_backtrack` rebuilds each package's state from its surviving trail entries. The positive-derivation branch cleared `last_decision_version`, so any decision followed by a surviving positive derivation on the same package was dropped from `decisions()` and the package wrongly reported as undecided, even when the backtrack removed nothing. The clearing was written for a backtrack that pops a decision but keeps a later same-package derivation, which cannot happen: trail levels never decrease, so popping a decision pops every later entry for that package.

The resolver itself never derives on a decided package, so this only affects direct users of the public `PartialSolution` API. The fix takes the decision from the last `is_decision` entry only and corrects the docstring.