### PR TITLE
Recompute matching priority once a listing arrives

### DIFF
--- a/nab-python/src/nab_python/_provider/priority.py
+++ b/nab-python/src/nab_python/_provider/priority.py
@@ -93,7 +93,9 @@ def compute_matching(
     elif has_local_source:
         matching = 1
     else:
-        matching = _NO_LISTING_PRIOR
+        # Not cached, so the next call re-checks the index and the
+        # listing-arrival side effect above can still fire.
+        return _NO_LISTING_PRIOR
 
     if per_pkg is None:
         per_pkg = provider.matching_cache[normalized] = {}

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -3786,6 +3786,26 @@ class TestPrioritizeMatchingFromIndex:
         result = provider.prioritize("foo", spec.to_range(), {})
         assert result == (Provider.TIER_NORMAL, 1000, True)
 
+    def test_matching_recomputed_after_listing_arrives(self) -> None:
+        """The in-flight placeholder is not cached; arrival recomputes."""
+        coordinator = make_coordinator(None, package="foo")
+        provider = Provider(coordinator)
+        rng = SpecifierSet(">=1.0").to_range()
+        assert provider.prioritize("foo", rng, {}) == (
+            Provider.TIER_NORMAL,
+            1000,
+            True,
+        )
+        wheels = [make_wheel(v) for v in ("1.0", "2.0", "3.0")]
+        # Store directly into the index, as the fetcher thread would.
+        coordinator.index.store_listing("foo", wheels)
+        assert provider.prioritize("foo", rng, {}) == (
+            Provider.TIER_NORMAL,
+            3,
+            True,
+        )
+        assert "foo" in provider.versions_cache
+
     def test_prioritize_uses_versions_cache(self) -> None:
         """prioritize skips index check when versions cache is populated."""
         wheels = [make_wheel(v) for v in ("1.0", "2.0", "3.0")]


### PR DESCRIPTION
compute_matching stored the in-flight placeholder (1000) in `matching_cache`, so once a package's listing arrived the cached entry made the listing-arrival branch unreachable for that (package, range). The matching count stayed pinned at the prior for the rest of the resolve, inverting the most-constrained-first ordering for that package, and the arrival side effects (`versions_cache` fill plus speculative metadata prefetch) never fired. The adjacent guard in `prioritize` already refuses to cache the placeholder in `priority_cache` for exactly this reason.

The fix returns the placeholder without caching it, so the next `prioritize` call re-checks the coordinator index and computes the real count once the listing is there. Heuristic ordering and prefetch only; pins were never affected.