### PR TITLE
Store sdist pyproject before the event fires

### DIFF
--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -856,9 +856,12 @@ class FetchCoordinator:
         pkg_info, pyproject = await client.get_sdist_files(
             req.package, req.version, req.url
         )
-        self.index.store_sdist_metadata(req.package, req.version, pkg_info)
+        # Store pyproject.toml first: store_sdist_metadata fires the
+        # pending event, and a released waiter reads the pyproject slot
+        # with no further synchronisation.
         if pyproject is not None:
             self.index.store_sdist_pyproject(req.package, req.version, pyproject)
+        self.index.store_sdist_metadata(req.package, req.version, pkg_info)
 
     async def _fetch_sdist_archive(
         self,

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import json
+import tarfile
 import tempfile
 import threading
 from pathlib import Path
@@ -727,6 +729,47 @@ class TestFetchCoordinator:
             )
             event.wait(timeout=5)
             assert coord.index.get_sdist_pyproject("pkg", "1.0") is not None
+
+    @respx.mock
+    def test_request_sdist_pyproject_stored_before_event(self) -> None:
+        """The coupled pyproject.toml is visible before the sdist event fires.
+
+        A waiter released by the sdist event reads the pyproject slot
+        with no further synchronisation, so both artifacts from the one
+        download must be stored before the event is set.
+        """
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            for name, data in (
+                (
+                    "pkg-1.0/PKG-INFO",
+                    b"Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n",
+                ),
+                ("pkg-1.0/pyproject.toml", b'[project]\nname = "pkg"\n'),
+            ):
+                info = tarfile.TarInfo(name=name)
+                info.size = len(data)
+                tar.addfile(info, io.BytesIO(data))
+        respx.get("https://files.example.com/pkg-1.0.tar.gz").mock(
+            return_value=httpx.Response(200, content=buf.getvalue())
+        )
+
+        pyproject_at_event: list[str | None] = []
+
+        class RecordingIndex(InMemoryIndex):
+            def store_sdist_metadata(
+                self, package: str, version: str, data: str | None
+            ) -> None:
+                pyproject_at_event.append(self.get_sdist_pyproject(package, version))
+                super().store_sdist_metadata(package, version, data)
+
+        with _coord() as coord:
+            coord.index = RecordingIndex()
+            event = coord.request_sdist(
+                "pkg", "1.0", "https://files.example.com/pkg-1.0.tar.gz"
+            )
+            event.wait(timeout=5)
+        assert pyproject_at_event == ['[project]\nname = "pkg"\n']
 
     @respx.mock
     def test_request_sdist_deduplicates(self) -> None:


### PR DESCRIPTION
`_fetch_sdist` stored PKG-INFO via `store_sdist_metadata`, which sets the pending sdist event, and only then stored the coupled `pyproject.toml` from the same download. A provider thread released by that event reads the pyproject slot with no further synchronisation, so on the PEP 643 dynamic-deps path it could see `None` for an sdist that does carry a static pyproject, turning a resolvable version into a spurious rejection (or an unnecessary PEP 517 build under `BUILD_REMOTE`).

Store the pyproject first so both coupled artifacts are visible by the time the event releases a waiter. Early pyproject visibility is harmless: `get_sdist_pyproject` has no waiter semantics and readers only consult it after the metadata event.