### PR TITLE
Return the empty range from degenerate Range.between

### DIFF
--- a/nab-resolver/src/nab_resolver/ranges.py
+++ b/nab-resolver/src/nab_resolver/ranges.py
@@ -204,7 +204,11 @@ class Range(Generic[VersionType]):
 
     @classmethod
     def between(cls, lower: VersionType, upper: VersionType) -> Range[VersionType]:
-        """Create ``[lower, upper)``."""
+        """Create ``[lower, upper)``, or the empty range if ``lower >= upper``."""
+        if _interval_is_empty(
+            lower, lower_inclusive=True, upper=upper, upper_inclusive=False
+        ):
+            return cls(())
         return cls(((lower, True, upper, False),))
 
     @property

--- a/nab-resolver/tests/test_ranges.py
+++ b/nab-resolver/tests/test_ranges.py
@@ -46,6 +46,18 @@ class TestRangeConstruction:
         assert 5 not in r
         assert 1 not in r
 
+    def test_between_equal_bounds_is_empty(self) -> None:
+        r = Range.between(3, 3)
+        assert r.is_empty
+        assert 3 not in r
+        assert r == Range.empty()
+
+    def test_between_inverted_bounds_is_empty(self) -> None:
+        r = Range.between(5, 3)
+        assert r.is_empty
+        assert r == Range.empty()
+        assert ~~r == r
+
 
 class TestRangeOperations:
     def test_intersection_overlapping(self) -> None:


### PR DESCRIPTION
Range.between(v, v) and Range.between(hi, lo) constructed a range holding a single empty interval. The object claimed to be non-empty (`is_empty` False, truthy) while containing no versions, compared unequal to `Range.empty()`, and its complement produced overlapping intervals, breaking the sorted non-overlapping invariant and identities like `~~r == r`. Nothing in the resolver hits this, but `between` is public API in the published nab-resolver package.

`between` now returns the canonical empty range when `lower >= upper`, matching the other factories and pubgrub-rs `Ranges::between`.