### PR TITLE
Oracle-based property tests for the resolver core

### DIFF
--- a/nab-resolver/tests/property/graph_oracles.py
+++ b/nab-resolver/tests/property/graph_oracles.py
@@ -1,0 +1,252 @@
+"""Graph-level oracles shared by the proof and metamorphic property tests.
+
+``solve`` wraps a :class:`FuzzProvider` resolution and normalizes the
+outcome; ``proof_leaves`` and ``check_leaf_against_universe`` walk an
+unsat proof's derivation DAG and validate every external clause against
+the generating graph.  The strategies here produce graph shapes the
+shared strategies module does not: self-dependencies and non-contiguous
+version sets.
+"""
+
+from __future__ import annotations
+
+from hypothesis import strategies as st
+
+from nab_resolver.ranges import Range
+from nab_resolver.resolver import ResolutionError, Resolver
+from nab_resolver.root import ROOT
+from nab_resolver.types import Incompatibility, IncompatibilityCause
+
+from .providers import FuzzProvider
+from .strategies import PACKAGE_NAMES, non_empty_ranges, version_ranges
+
+Graph = dict[str, dict[int, dict[str, Range[int]]]]
+
+
+def solve(
+    graph: Graph,
+    requirements: dict[str, Range[int]] | None = None,
+    constraints: dict[str, Range[int]] | None = None,
+) -> tuple[dict[str, int] | None, ResolutionError | None]:
+    """Resolve ``graph`` and return ``(solution, error)``.
+
+    Requirements default to the graph's root dependencies, resolved
+    directly (no virtual root pin).  Iteration-limit blowups return
+    ``(None, None)``: they carry no proof to check, so callers treat
+    them as inconclusive.
+    """
+    provider = FuzzProvider(graph)
+    resolver: Resolver[str, int] = Resolver(provider, max_iterations=2000)
+    reqs = requirements if requirements is not None else graph["root"][1]
+    try:
+        return resolver.resolve(reqs, constraints=constraints), None
+    except ResolutionError as error:
+        if "exceeded" in str(error):
+            return None, None
+        return None, error
+
+
+def proof_leaves(
+    incompatibility: Incompatibility[str, int],
+) -> list[Incompatibility[str, int]]:
+    """All non-DERIVED clauses in the derivation DAG."""
+    leaves: list[Incompatibility[str, int]] = []
+    seen: set[int] = set()
+    stack = [incompatibility]
+    while stack:
+        node = stack.pop()
+        if id(node) in seen:
+            continue
+        seen.add(id(node))
+        if node.cause is IncompatibilityCause.DERIVED:
+            assert node.cause_left is not None, "DERIVED node missing cause_left"
+            assert node.cause_right is not None, "DERIVED node missing cause_right"
+            stack.append(node.cause_left)
+            stack.append(node.cause_right)
+        else:
+            leaves.append(node)
+    return leaves
+
+
+def check_leaf_against_universe(
+    leaf: Incompatibility[str, int],
+    graph: Graph,
+    requirements: dict[str, Range[int]],
+    constraints: dict[str, Range[int]] | None = None,
+) -> None:
+    """Assert one external clause of an unsat proof is true in the universe.
+
+    ROOT: matches a stated requirement.
+    DEPENDENCY: for every real version of the parent inside the parent
+    term, the universe dep range is a subset of the clause's dep range.
+    NO_VERSIONS: no real version of the package lies in the claimed range.
+    CONSTRAINT: no real version lies in claimed-range & user-constraint.
+    """
+    constraints = constraints or {}
+    if leaf.cause is IncompatibilityCause.ROOT:
+        non_root = [t for t in leaf.terms if t.package is not ROOT]
+        assert len(non_root) == 1, f"ROOT clause shape unexpected: {leaf!r}"
+        term = non_root[0]
+        assert not term.is_positive(), f"ROOT dep term should be negative: {leaf!r}"
+        assert term.package in requirements, (
+            f"ROOT clause names {term.package!r} which was never required"
+        )
+        assert term.constraint == requirements[term.package], (
+            f"ROOT clause range {term.constraint} != stated "
+            f"requirement {requirements[term.package]}"
+        )
+        return
+
+    if leaf.cause is IncompatibilityCause.DEPENDENCY:
+        assert len(leaf.terms) == 2, f"DEPENDENCY clause shape: {leaf!r}"
+        parent_term, dep_term = leaf.terms
+        assert parent_term.is_positive()
+        assert not dep_term.is_positive()
+        parent = parent_term.package
+        dep = dep_term.package
+        real_versions = [
+            v for v in graph.get(parent, {}) if v in parent_term.constraint
+        ]
+        assert real_versions, (
+            f"DEPENDENCY clause for {parent!r} covers no real version: {leaf!r}"
+        )
+        for v in real_versions:
+            actual = graph[parent][v].get(dep)
+            assert actual is not None, (
+                f"{parent!r}@{v} has no dep on {dep!r} but proof claims it: {leaf!r}"
+            )
+            assert (actual & dep_term.constraint) == actual, (
+                f"{parent!r}@{v} dep range {actual} not a subset of "
+                f"claimed {dep_term.constraint}: {leaf!r}"
+            )
+        return
+
+    if leaf.cause is IncompatibilityCause.NO_VERSIONS:
+        assert len(leaf.terms) == 1, f"NO_VERSIONS clause shape: {leaf!r}"
+        term = leaf.terms[0]
+        assert term.is_positive()
+        in_range = [v for v in graph.get(term.package, {}) if v in term.constraint]
+        assert not in_range, (
+            f"NO_VERSIONS claims no {term.package!r} in {term.constraint} "
+            f"but versions {in_range} exist"
+        )
+        return
+
+    if leaf.cause is IncompatibilityCause.CONSTRAINT:
+        assert len(leaf.terms) == 1, f"CONSTRAINT clause shape: {leaf!r}"
+        term = leaf.terms[0]
+        assert term.is_positive()
+        constraint = constraints.get(term.package)
+        assert constraint is not None, (
+            f"CONSTRAINT clause for unconstrained package {term.package!r}"
+        )
+        narrowed = term.constraint & constraint
+        in_range = [v for v in graph.get(term.package, {}) if v in narrowed]
+        assert not in_range, (
+            f"CONSTRAINT claims no {term.package!r} in "
+            f"{term.constraint} & {constraint} but versions {in_range} exist"
+        )
+        return
+
+    message = f"Unexpected leaf cause {leaf.cause!r} in proof: {leaf!r}"
+    raise AssertionError(message)
+
+
+@st.composite
+def selfdep_graphs(draw: st.DrawFn) -> Graph:
+    """Small graphs where at least one package depends on itself.
+
+    The forced self-dependency's range may be empty, may exclude the
+    carrying version, or may include it.
+    """
+    num_packages = draw(st.integers(min_value=2, max_value=4))
+    packages = PACKAGE_NAMES[:num_packages]
+
+    graph: Graph = {}
+    for package in packages:
+        num_versions = draw(st.integers(min_value=1, max_value=3))
+        package_versions: dict[int, dict[str, Range[int]]] = {}
+        for version in range(1, num_versions + 1):
+            deps: dict[str, Range[int]] = {}
+            num_deps = draw(st.integers(min_value=0, max_value=2))
+            if num_deps:
+                dep_packages = draw(
+                    st.lists(
+                        st.sampled_from(packages),  # self allowed
+                        min_size=num_deps,
+                        max_size=num_deps,
+                        unique=True,
+                    )
+                )
+                for dep_package in dep_packages:
+                    deps[dep_package] = draw(version_ranges())
+            package_versions[version] = deps
+        graph[package] = package_versions
+
+    target = draw(st.sampled_from(packages))
+    target_version = draw(st.sampled_from(sorted(graph[target].keys())))
+    graph[target][target_version][target] = draw(version_ranges())
+
+    root_dep_count = draw(st.integers(min_value=1, max_value=min(2, len(packages))))
+    root_dep_packages = draw(
+        st.lists(
+            st.sampled_from(packages),
+            min_size=root_dep_count,
+            max_size=root_dep_count,
+            unique=True,
+        )
+    )
+    graph["root"] = {1: {p: draw(non_empty_ranges()) for p in root_dep_packages}}
+    return graph
+
+
+@st.composite
+def sparse_version_graphs(draw: st.DrawFn) -> Graph:
+    """Small graphs whose version numbers are non-contiguous (e.g. {2, 7, 15}).
+
+    The shared strategies always use 1..n; sparse sets exercise ranges
+    whose interior contains no actual versions.
+    """
+    num_packages = draw(st.integers(min_value=2, max_value=3))
+    packages = PACKAGE_NAMES[:num_packages]
+
+    graph: Graph = {}
+    for package in packages:
+        versions = draw(
+            st.lists(
+                st.integers(min_value=1, max_value=20),
+                min_size=1,
+                max_size=3,
+                unique=True,
+            )
+        )
+        package_versions: dict[int, dict[str, Range[int]]] = {}
+        for version in sorted(versions):
+            deps: dict[str, Range[int]] = {}
+            num_deps = draw(st.integers(min_value=0, max_value=2))
+            others = [p for p in packages if p != package]
+            if num_deps and others:
+                dep_packages = draw(
+                    st.lists(
+                        st.sampled_from(others),
+                        min_size=min(num_deps, len(others)),
+                        max_size=min(num_deps, len(others)),
+                        unique=True,
+                    )
+                )
+                for dep_package in dep_packages:
+                    deps[dep_package] = draw(version_ranges())
+            package_versions[version] = deps
+        graph[package] = package_versions
+
+    root_dep_count = draw(st.integers(min_value=1, max_value=min(2, len(packages))))
+    root_dep_packages = draw(
+        st.lists(
+            st.sampled_from(packages),
+            min_size=root_dep_count,
+            max_size=root_dep_count,
+            unique=True,
+        )
+    )
+    graph["root"] = {1: {p: draw(version_ranges()) for p in root_dep_packages}}
+    return graph

--- a/nab-resolver/tests/property/rep_model.py
+++ b/nab-resolver/tests/property/rep_model.py
@@ -1,0 +1,284 @@
+"""Shared model machinery for partial-solution differential tests.
+
+Constraints are modeled as exact finite-or-cofinite sets of integers
+("reps"): a pair ``(frozenset, cofinite_flag)``.  The algebra of finite
+unions of singletons and their complements is closed under union,
+intersection, and complement, so a rep models the corresponding
+``nab_resolver.ranges.Range`` exactly (no finite-pool blind spots) and
+covers cofinite shapes the interval-based strategies never produce.
+
+``ModelPS`` is an independent reimplementation of the documented
+:class:`PartialSolution` semantics: a chronological trail replayed from
+scratch on every query, with no incremental caching.  Differential
+testing against the real class catches stored-field, cache,
+binary-search, and backtrack-rebuild bugs.
+
+Operations are restricted to resolver-reachable states:
+
+- decide only an undecided package with a positive constraint, choosing
+  a version inside the current effective range;
+- derive never targets an already-decided package (a decided package's
+  terms are never UNDETERMINED, so unit propagation cannot derive on it);
+- backtrack targets are at most the current decision level.
+"""
+
+from __future__ import annotations
+
+from hypothesis import strategies as st
+
+from nab_resolver.partial_solution import PartialSolution
+from nab_resolver.ranges import Range
+from nab_resolver.types import Incompatibility, IncompatibilityCause
+
+POOL = tuple(range(1, 7))
+OUTSIDE_PROBES = (0, 100)
+ALL_PROBES = POOL + OUTSIDE_PROBES
+PACKAGES = ("a", "b", "c")
+PROBE_PACKAGES = (*PACKAGES, "z")
+CANDIDATE_VERSIONS = (*POOL, 100)
+
+Rep = tuple[frozenset[int], bool]
+
+EMPTY_REP: Rep = (frozenset(), False)
+
+
+def rep_not(a: Rep) -> Rep:
+    """Complement of a rep."""
+    return (a[0], not a[1])
+
+
+def rep_and(a: Rep, b: Rep) -> Rep:
+    """Intersection of two reps."""
+    sa, ca = a
+    sb, cb = b
+    if not ca and not cb:
+        return (sa & sb, False)
+    if not ca and cb:
+        return (sa - sb, False)
+    if ca and not cb:
+        return (sb - sa, False)
+    return (sa | sb, True)
+
+
+def rep_or(a: Rep, b: Rep) -> Rep:
+    """Union of two reps."""
+    return rep_not(rep_and(rep_not(a), rep_not(b)))
+
+
+def rep_member(v: int, a: Rep) -> bool:
+    """Membership test for a rep."""
+    return (v in a[0]) != a[1]
+
+
+def rep_is_empty(a: Rep) -> bool:
+    """Whether a rep denotes the empty set."""
+    return not a[1] and not a[0]
+
+
+def rep_subset(a: Rep, b: Rep) -> bool:
+    """Whether ``a`` is a subset of ``b``."""
+    return rep_is_empty(rep_and(a, rep_not(b)))
+
+
+def rep_disjoint(a: Rep, b: Rep) -> bool:
+    """Whether ``a`` and ``b`` are disjoint."""
+    return rep_is_empty(rep_and(a, b))
+
+
+def rep_to_range(rep: Rep) -> Range[int]:
+    """Convert a rep to the equivalent ``Range[int]``."""
+    s, cofinite = rep
+    r: Range[int] = Range.empty()
+    for v in sorted(s):
+        r = r | Range.singleton(v)
+    return ~r if cofinite else r
+
+
+@st.composite
+def rep_constraints(draw: st.DrawFn) -> Rep:
+    """Generate a random finite-or-cofinite rep over the version pool."""
+    base = frozenset(draw(st.sets(st.sampled_from(POOL), max_size=4)))
+    cofinite = draw(st.booleans())
+    return (base, cofinite)
+
+
+def root_cause() -> Incompatibility[str, int]:
+    """A throwaway ROOT-cause incompatibility for derive calls."""
+    return Incompatibility([], cause=IncompatibilityCause.ROOT)
+
+
+class ModelPS:
+    """Replay-from-scratch model of the documented PartialSolution."""
+
+    def __init__(self) -> None:
+        self.level = 0
+        # Entries are (package, kind, payload, level) with kind one of
+        # decide, pos, neg.
+        self.trail: list[tuple[str, str, object, int]] = []
+
+    def decide(self, pkg: str, version: int) -> None:
+        """Record a decision, raising the level by one."""
+        self.level += 1
+        self.trail.append((pkg, "decide", version, self.level))
+
+    def derive(self, pkg: str, rep: Rep, *, positive: bool) -> None:
+        """Record a derivation at the current level."""
+        self.trail.append((pkg, "pos" if positive else "neg", rep, self.level))
+
+    def backtrack(self, target: int) -> None:
+        """Drop every trail entry above the target level."""
+        self.trail = [e for e in self.trail if e[3] <= target]
+        self.level = target
+
+    def state(self, pkg: str) -> tuple[Rep | None, Rep, int | None, bool]:
+        """Return (pos, neg, decided_version, neg_recorded) by replay."""
+        pos: Rep | None = None
+        neg: Rep = EMPTY_REP
+        decided: int | None = None
+        neg_recorded = False
+        for p, kind, payload, _ in self.trail:
+            if p != pkg:
+                continue
+            if kind == "decide":
+                assert isinstance(payload, int)
+                pos = (frozenset({payload}), False)
+                decided = payload
+            elif kind == "pos":
+                assert isinstance(payload, tuple)
+                pos = payload if pos is None else rep_and(pos, payload)
+            else:
+                assert isinstance(payload, tuple)
+                neg = rep_or(neg, payload)
+                neg_recorded = True
+        return pos, neg, decided, neg_recorded
+
+    def decided_map(self) -> dict[str, int]:
+        """Return {package: decided version} by replay."""
+        out: dict[str, int] = {}
+        for pkg in PACKAGES:
+            decided = self.state(pkg)[2]
+            if decided is not None:
+                out[pkg] = decided
+        return out
+
+    def undecided(self) -> set[str]:
+        """Packages with a positive constraint but no decision."""
+        out: set[str] = set()
+        for pkg in PACKAGES:
+            pos, _, decided, _ = self.state(pkg)
+            if pos is not None and decided is None:
+                out.add(pkg)
+        return out
+
+    def prefix_states(self, pkg: str) -> list[tuple[Rep | None, Rep, bool]]:
+        """Cumulative (pos, neg, is_decision_entry) after each pkg entry."""
+        out: list[tuple[Rep | None, Rep, bool]] = []
+        pos: Rep | None = None
+        neg: Rep = EMPTY_REP
+        for p, kind, payload, _ in self.trail:
+            if p != pkg:
+                continue
+            if kind == "decide":
+                assert isinstance(payload, int)
+                pos = (frozenset({payload}), False)
+            elif kind == "pos":
+                assert isinstance(payload, tuple)
+                pos = payload if pos is None else rep_and(pos, payload)
+            else:
+                assert isinstance(payload, tuple)
+                neg = rep_or(neg, payload)
+            out.append((pos, neg, kind == "decide"))
+        return out
+
+    @staticmethod
+    def _satisfied_at(pos: Rep | None, neg: Rep, c: Rep, *, positive: bool) -> bool:
+        if positive and pos is None:
+            return False
+        eff = rep_and(pos, rep_not(neg)) if pos is not None else rep_not(neg)
+        return rep_subset(eff, c) if positive else rep_disjoint(eff, c)
+
+    def satisfier_index(self, pkg: str, c: Rep, *, positive: bool) -> int | None:
+        """Index of the earliest pkg entry whose prefix satisfies the term."""
+        for i, (pos, neg, _) in enumerate(self.prefix_states(pkg)):
+            if self._satisfied_at(pos, neg, c, positive=positive):
+                return i
+        return None
+
+    def is_sole(self, pkg: str, index: int, c: Rep, *, positive: bool) -> bool:
+        """Whether the satisfier at ``index`` alone satisfies the term.
+
+        Mirrors ``satisfier_is_sole``: decision entries and trail-initial
+        entries are always sole; otherwise the entry is sole when the
+        strict prefix before it does not already satisfy the term at the
+        range level (ungated, mirroring ``Term.satisfies``).
+        """
+        states = self.prefix_states(pkg)
+        if states[index][2]:
+            return True
+        if index == 0:
+            return True
+        prev_pos, prev_neg, _ = states[index - 1]
+        if prev_pos is None:
+            eff_prev = rep_not(prev_neg)
+        else:
+            eff_prev = rep_and(prev_pos, rep_not(prev_neg))
+        prev_satisfies = (
+            rep_subset(eff_prev, c) if positive else rep_disjoint(eff_prev, c)
+        )
+        return not prev_satisfies
+
+
+_operations = st.one_of(
+    st.tuples(
+        st.just("derive"),
+        st.sampled_from(PACKAGES),
+        rep_constraints(),
+        st.booleans(),
+    ),
+    st.tuples(st.just("decide"), st.sampled_from(PACKAGES)),
+    st.tuples(st.just("backtrack"), st.integers(min_value=0, max_value=10)),
+)
+
+
+def operations() -> st.SearchStrategy[tuple[object, ...]]:
+    """Strategy for derive/decide/backtrack operations."""
+    return _operations
+
+
+def probe_terms() -> st.SearchStrategy[tuple[str, Rep, bool]]:
+    """Strategy for (package, constraint rep, positive) probe terms."""
+    return st.tuples(st.sampled_from(PROBE_PACKAGES), rep_constraints(), st.booleans())
+
+
+def apply_op(
+    ps: PartialSolution[str, int], model: ModelPS, op: tuple[object, ...]
+) -> None:
+    """Apply one generated op to the real PartialSolution and model in lockstep."""
+    kind = op[0]
+    if kind == "derive":
+        _, pkg, rep, positive = op
+        assert isinstance(pkg, str)
+        assert isinstance(rep, tuple)
+        assert isinstance(positive, bool)
+        if model.state(pkg)[2] is not None:
+            return
+        ps.derive(pkg, rep_to_range(rep), positive=positive, cause=root_cause())
+        model.derive(pkg, rep, positive=positive)
+    elif kind == "decide":
+        _, pkg = op
+        assert isinstance(pkg, str)
+        pos, neg, decided, _ = model.state(pkg)
+        if decided is not None or pos is None:
+            return
+        eff = rep_and(pos, rep_not(neg))
+        version = next((v for v in CANDIDATE_VERSIONS if rep_member(v, eff)), None)
+        if version is None:
+            return
+        ps.decide(pkg, version)
+        model.decide(pkg, version)
+    else:
+        _, raw = op
+        assert isinstance(raw, int)
+        target = raw % (model.level + 1)
+        ps.backtrack(target)
+        model.backtrack(target)

--- a/nab-resolver/tests/property/test_incompat_index.py
+++ b/nab-resolver/tests/property/test_incompat_index.py
@@ -1,0 +1,174 @@
+"""Brute-force equivalence for incompat_index clause merging and indexing.
+
+Invariants:
+
+1. Semantic equivalence: the merged clause store forbids exactly the
+   same full assignments (each package absent or pinned to a version)
+   as the raw un-merged clause list.  Merging unions the parent term of
+   matching DEPENDENCY clauses, which must preserve the forbidden set.
+2. Index exactness: ``package_to_incompatibilities[p]`` reaches exactly
+   the clauses a full scan over ``incompatibilities`` would find for p.
+3. ``dependency_index`` validity: every key maps to a live clause whose
+   merge key still equals that key (in-place merges keep keys stable).
+
+The clause generator includes shapes the resolver tests never produce:
+self-dependency clauses (parent == dep package), negative parent terms
+(no-merge path), positive dep terms, non-DEPENDENCY causes mixed in,
+and cofinite ranges.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_resolver.incompat_index import add_incompatibility, dependency_merge_key
+from nab_resolver.resolver import Resolver
+from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
+
+from .providers import FuzzProvider
+from .rep_model import POOL, rep_constraints, rep_to_range
+from .strategies import PROPERTY_SETTINGS
+
+pytestmark = pytest.mark.property
+
+_PKGS = ("p", "q", "r")
+
+
+def _fresh_resolver() -> Resolver[str, int]:
+    """A resolver used only as the clause-store state carrier."""
+    return Resolver(FuzzProvider({}))
+
+
+@st.composite
+def clause_specs(draw: st.DrawFn) -> tuple[object, ...]:
+    """Generate a clause spec; building twice yields independent copies."""
+    cause = draw(
+        st.sampled_from(
+            [IncompatibilityCause.DEPENDENCY] * 4
+            + [IncompatibilityCause.NO_VERSIONS, IncompatibilityCause.DERIVED]
+        )
+    )
+    parent = draw(st.sampled_from(_PKGS))
+    if cause is IncompatibilityCause.NO_VERSIONS:
+        return ("one", cause, parent, draw(rep_constraints()))
+    dep = draw(st.sampled_from(_PKGS))  # parent == dep allowed (self-dep shape)
+    parent_rep = draw(rep_constraints())
+    parent_positive = draw(st.sampled_from([True, True, True, False]))
+    dep_rep = draw(rep_constraints())
+    dep_positive = draw(st.sampled_from([False, False, True]))
+    return (
+        "two",
+        cause,
+        parent,
+        parent_rep,
+        parent_positive,
+        dep,
+        dep_rep,
+        dep_positive,
+    )
+
+
+def _build_clause(spec: tuple[object, ...]) -> Incompatibility[str, int]:
+    """Materialize a clause spec into an Incompatibility."""
+    if spec[0] == "one":
+        _, cause, parent, rep = spec
+        assert isinstance(cause, IncompatibilityCause)
+        assert isinstance(parent, str)
+        assert isinstance(rep, tuple)
+        return Incompatibility(
+            [Term(parent, rep_to_range(rep), positive=True)], cause=cause
+        )
+    _, cause, parent, parent_rep, parent_positive, dep, dep_rep, dep_positive = spec
+    assert isinstance(cause, IncompatibilityCause)
+    assert isinstance(parent, str)
+    assert isinstance(parent_rep, tuple)
+    assert isinstance(parent_positive, bool)
+    assert isinstance(dep, str)
+    assert isinstance(dep_rep, tuple)
+    assert isinstance(dep_positive, bool)
+    return Incompatibility(
+        [
+            Term(parent, rep_to_range(parent_rep), positive=parent_positive),
+            Term(dep, rep_to_range(dep_rep), positive=dep_positive),
+        ],
+        cause=cause,
+    )
+
+
+def _term_true(term: Term[str, int], assignment: dict[str, int | None]) -> bool:
+    """Whether a term holds under a full assignment (None means absent)."""
+    version = assignment[term.package]
+    if term.is_positive():
+        return version is not None and version in term.constraint
+    return version is None or version not in term.constraint
+
+
+def _violated(
+    clauses: list[Incompatibility[str, int]], assignment: dict[str, int | None]
+) -> bool:
+    """Whether any clause has all terms true under the assignment."""
+    return any(
+        all(_term_true(t, assignment) for t in clause.terms) for clause in clauses
+    )
+
+
+@given(specs=st.lists(clause_specs(), min_size=1, max_size=8))
+@PROPERTY_SETTINGS
+def test_merged_store_semantically_equivalent(
+    specs: list[tuple[object, ...]],
+) -> None:
+    """The merged store forbids exactly the assignments the raw list does."""
+    resolver = _fresh_resolver()
+    raw: list[Incompatibility[str, int]] = []
+    for spec in specs:
+        raw.append(_build_clause(spec))  # independent copy for the raw store
+        add_incompatibility(resolver, _build_clause(spec))
+
+    versions: tuple[int | None, ...] = (None, *POOL)
+    for combo in itertools.product(versions, repeat=len(_PKGS)):
+        assignment: dict[str, int | None] = dict(zip(_PKGS, combo, strict=True))
+        assert _violated(raw, assignment) == _violated(
+            resolver.incompatibilities, assignment
+        ), f"forbidden-set divergence at {assignment}"
+
+
+@given(specs=st.lists(clause_specs(), min_size=1, max_size=8))
+@PROPERTY_SETTINGS
+def test_package_index_matches_full_scan(specs: list[tuple[object, ...]]) -> None:
+    """The per-package index reaches exactly the clauses a full scan finds."""
+    resolver = _fresh_resolver()
+    for spec in specs:
+        add_incompatibility(resolver, _build_clause(spec))
+
+    full_scan: dict[str, set[int]] = {pkg: set() for pkg in _PKGS}
+    for i, clause in enumerate(resolver.incompatibilities):
+        for term in clause.terms:
+            full_scan[term.package].add(i)
+
+    for pkg in _PKGS:
+        indexed = set(resolver.package_to_incompatibilities.get(pkg, []))
+        assert indexed == full_scan[pkg], (
+            f"index for {pkg!r}: {sorted(indexed)} != {sorted(full_scan[pkg])}"
+        )
+    for indices in resolver.package_to_incompatibilities.values():
+        assert all(0 <= i < len(resolver.incompatibilities) for i in indices)
+
+
+@given(specs=st.lists(clause_specs(), min_size=1, max_size=8))
+@PROPERTY_SETTINGS
+def test_dependency_index_keys_stay_canonical(
+    specs: list[tuple[object, ...]],
+) -> None:
+    """Every dependency_index key still matches its clause's merge key."""
+    resolver = _fresh_resolver()
+    for spec in specs:
+        add_incompatibility(resolver, _build_clause(spec))
+
+    for key, index in resolver.dependency_index.items():
+        assert 0 <= index < len(resolver.incompatibilities)
+        clause = resolver.incompatibilities[index]
+        assert dependency_merge_key(clause) == key

--- a/nab-resolver/tests/property/test_metamorphic.py
+++ b/nab-resolver/tests/property/test_metamorphic.py
@@ -1,0 +1,165 @@
+"""Metamorphic resolver properties with exact-equality oracles.
+
+Each property applies a solution-preserving transformation to a graph
+and asserts the resolver's output is unchanged modulo the mapping:
+
+1. Adding an unreferenced package must not change the exact solution.
+2. Order-preserving package renaming must preserve the outcome modulo
+   the rename (tiebreaks compare ``str(package)``, and a common prefix
+   keeps relative lexicographic order).
+3. Strictly monotone version relabeling (``v -> v + offset`` with range
+   bounds shifted identically) must preserve the outcome modulo the
+   shift.
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_resolver.ranges import NEGATIVE_INFINITY, POSITIVE_INFINITY, Range
+
+from .graph_oracles import Graph, solve
+from .providers import verify_solution
+from .strategies import PROPERTY_SETTINGS, small_exhaustive_graphs
+
+pytestmark = pytest.mark.property
+
+METAMORPHIC_TIMEOUT_SECONDS = 120
+
+
+def _shift_range(r: Range[int], offset: int) -> Range[int]:
+    """Shift every finite interval bound by ``offset`` (strictly monotone)."""
+    intervals = []
+    for lower, lower_inc, upper, upper_inc in r._intervals:
+        new_lower = lower if lower is NEGATIVE_INFINITY else lower + offset
+        new_upper = upper if upper is POSITIVE_INFINITY else upper + offset
+        intervals.append((new_lower, lower_inc, new_upper, upper_inc))
+    return Range(tuple(intervals))
+
+
+def _shift_graph(graph: Graph, offset: int) -> Graph:
+    """Apply the version shift to every version key and range bound."""
+    shifted: Graph = {}
+    for package, versions in graph.items():
+        if package == "root":
+            shifted["root"] = {
+                1: {d: _shift_range(r, offset) for d, r in versions[1].items()}
+            }
+            continue
+        shifted[package] = {
+            version + offset: {d: _shift_range(r, offset) for d, r in deps.items()}
+            for version, deps in versions.items()
+        }
+    return shifted
+
+
+def _rename_graph(graph: Graph, prefix: str) -> Graph:
+    """Prefix every package name except the root entry."""
+
+    def rename(name: str) -> str:
+        return name if name == "root" else prefix + name
+
+    return {
+        rename(package): {
+            version: {rename(d): r for d, r in deps.items()}
+            for version, deps in versions.items()
+        }
+        for package, versions in graph.items()
+    }
+
+
+class TestIrrelevantAddition:
+    """Adding a package nothing references changes nothing."""
+
+    @pytest.mark.timeout(METAMORPHIC_TIMEOUT_SECONDS)
+    @given(
+        graph=small_exhaustive_graphs(),
+        extra_versions=st.integers(min_value=1, max_value=3),
+    )
+    @PROPERTY_SETTINGS
+    def test_unreferenced_package_changes_nothing(
+        self, graph: Graph, extra_versions: int
+    ) -> None:
+        """An unreferenced package leaves the exact solution unchanged."""
+        base_solution, base_error = solve(graph)
+        if base_solution is None and base_error is None:
+            return
+
+        extended = dict(graph)
+        referenced = [p for p in graph if p != "root"]
+        extended["zzz-unreferenced"] = {
+            v: {referenced[0]: Range.full()} for v in range(1, extra_versions + 1)
+        }
+        ext_solution, ext_error = solve(extended)
+        if ext_solution is None and ext_error is None:
+            return
+
+        assert (base_solution is None) == (ext_solution is None), (
+            "adding an unreferenced package flipped solvability"
+        )
+        if base_solution is not None:
+            assert base_solution == ext_solution, (
+                f"adding an unreferenced package changed the solution: "
+                f"{base_solution} -> {ext_solution}"
+            )
+
+
+class TestRenaming:
+    """Order-preserving renames preserve the outcome modulo the mapping."""
+
+    @pytest.mark.timeout(METAMORPHIC_TIMEOUT_SECONDS)
+    @given(graph=small_exhaustive_graphs())
+    @PROPERTY_SETTINGS
+    def test_order_preserving_rename(self, graph: Graph) -> None:
+        """Renaming with a common prefix maps the solution one-to-one."""
+        base_solution, base_error = solve(graph)
+        if base_solution is None and base_error is None:
+            return
+        renamed = _rename_graph(graph, "z")
+        renamed_solution, renamed_error = solve(renamed)
+        if renamed_solution is None and renamed_error is None:
+            return
+
+        assert (base_solution is None) == (renamed_solution is None), (
+            "order-preserving rename flipped solvability"
+        )
+        if base_solution is not None:
+            assert renamed_solution == {"z" + p: v for p, v in base_solution.items()}, (
+                f"rename changed solution: {base_solution} vs {renamed_solution}"
+            )
+        if renamed_solution is not None:
+            verify_solution(renamed_solution, renamed["root"][1], renamed)
+
+
+class TestVersionRelabeling:
+    """Strictly monotone version maps preserve the outcome modulo the map."""
+
+    @pytest.mark.timeout(METAMORPHIC_TIMEOUT_SECONDS)
+    @given(
+        graph=small_exhaustive_graphs(), offset=st.integers(min_value=1, max_value=50)
+    )
+    @PROPERTY_SETTINGS
+    def test_version_shift(self, graph: Graph, offset: int) -> None:
+        """Shifting all versions and bounds by an offset maps the solution."""
+        base_solution, base_error = solve(graph)
+        if base_solution is None and base_error is None:
+            return
+        shifted = _shift_graph(graph, offset)
+        shifted_solution, shifted_error = solve(shifted)
+        if shifted_solution is None and shifted_error is None:
+            return
+
+        assert (base_solution is None) == (shifted_solution is None), (
+            f"version shift by {offset} flipped solvability"
+        )
+        if base_solution is not None:
+            assert shifted_solution == {
+                p: v + offset for p, v in base_solution.items()
+            }, (
+                f"shift by {offset} changed solution: "
+                f"{base_solution} vs {shifted_solution}"
+            )
+        if shifted_solution is not None:
+            verify_solution(shifted_solution, shifted["root"][1], shifted)

--- a/nab-resolver/tests/property/test_partial_solution_model.py
+++ b/nab-resolver/tests/property/test_partial_solution_model.py
@@ -1,0 +1,146 @@
+"""Differential tests: PartialSolution vs a replay-from-scratch model.
+
+The single-package satisfier properties elsewhere in this suite cover
+interval-shaped ranges only.  Here random decide/derive/backtrack
+sequences over multiple interleaved packages, with finite and cofinite
+constraint shapes, are applied in lockstep to the real class and to
+:class:`ModelPS`, then every public query is compared:
+
+- trail bookkeeping (levels monotone non-decreasing, decision count
+  equals ``decision_level``, ``trail_index``/``package_index`` match);
+- state queries (``get`` membership, ``decisions``,
+  ``undecided_packages``, ``has_positive_constraint``);
+- the binary-search ``satisfier`` and ``satisfier_is_sole``;
+- backtrack removing exactly the assignments above the target level.
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_resolver.partial_solution import PartialSolution
+from nab_resolver.types import Term
+
+from .rep_model import (
+    ALL_PROBES,
+    PROBE_PACKAGES,
+    ModelPS,
+    Rep,
+    apply_op,
+    operations,
+    probe_terms,
+    rep_and,
+    rep_member,
+    rep_not,
+    rep_to_range,
+)
+from .strategies import PROPERTY_SETTINGS
+
+pytestmark = pytest.mark.property
+
+
+def _check_trail_invariants(ps: PartialSolution[str, int], model: ModelPS) -> None:
+    """Trail levels, indices, and decision counts match the model."""
+    trail = ps._assignments
+    levels = [a.decision_level for a in trail]
+    assert levels == sorted(levels), "trail levels must be non-decreasing"
+    assert all(lv <= model.level for lv in levels)
+    assert ps.decision_level == model.level
+    assert sum(1 for a in trail if a.is_decision) == ps.decision_level, (
+        "decision count must equal decision_level (dense levels)"
+    )
+    for i, a in enumerate(trail):
+        assert a.trail_index == i
+    for pkg in PROBE_PACKAGES:
+        entries = list(ps.assignments_for(pkg))
+        assert entries == [a for a in trail if a.package == pkg]
+        for j, a in enumerate(entries):
+            assert a.package_index == j
+
+
+def _check_state(ps: PartialSolution[str, int], model: ModelPS) -> None:
+    """Every public state query agrees with the replayed model."""
+    for pkg in PROBE_PACKAGES:
+        pos, neg, decided, neg_recorded = model.state(pkg)
+        assert ps.has_positive_constraint(pkg) == (pos is not None)
+        got = ps.get(pkg)
+        if pos is None and not neg_recorded:
+            assert got is None, f"get({pkg!r}) should be None, got {got!r}"
+            continue
+        assert got is not None
+        eff = rep_and(pos, rep_not(neg)) if pos is not None else rep_not(neg)
+        for v in ALL_PROBES:
+            assert (v in got) == rep_member(v, eff), (
+                f"get({pkg!r}) membership mismatch at {v}: impl={got!r}"
+            )
+        if decided is None:
+            assert pkg not in ps.decisions()
+    assert ps.decisions() == model.decided_map()
+    assert ps.undecided_packages() == model.undecided()
+
+
+@given(ops=st.lists(operations(), min_size=1, max_size=18))
+@PROPERTY_SETTINGS
+def test_state_matches_model(ops: list[tuple[object, ...]]) -> None:
+    """Every public state query agrees with replay-from-scratch after each op."""
+    ps: PartialSolution[str, int] = PartialSolution()
+    model = ModelPS()
+    for op in ops:
+        apply_op(ps, model, op)
+        _check_trail_invariants(ps, model)
+        _check_state(ps, model)
+
+
+@given(
+    ops=st.lists(operations(), min_size=1, max_size=18),
+    probes=st.lists(probe_terms(), min_size=1, max_size=4),
+)
+@PROPERTY_SETTINGS
+def test_satisfier_matches_model(
+    ops: list[tuple[object, ...]], probes: list[tuple[str, Rep, bool]]
+) -> None:
+    """Binary-search satisfier and satisfier_is_sole agree with the model."""
+    ps: PartialSolution[str, int] = PartialSolution()
+    model = ModelPS()
+    for op in ops:
+        apply_op(ps, model, op)
+        for pkg, rep, positive in probes:
+            term: Term[str, int] = Term(pkg, rep_to_range(rep), positive=positive)
+            impl = ps.satisfier(term)
+            idx = model.satisfier_index(pkg, rep, positive=positive)
+            entries = ps.assignments_for(pkg)
+            if idx is None:
+                assert impl is None, f"satisfier should be None, got {impl!r}"
+            else:
+                assert impl is not None, (
+                    f"satisfier missing for {term!r}, model index {idx}"
+                )
+                assert impl is entries[idx], (
+                    f"satisfier mismatch for {term!r}: impl index "
+                    f"{impl.package_index}, model index {idx}"
+                )
+                expected_sole = model.is_sole(pkg, idx, rep, positive=positive)
+                assert ps.satisfier_is_sole(impl, term) == expected_sole
+
+
+@given(ops=st.lists(operations(), min_size=1, max_size=18))
+@PROPERTY_SETTINGS
+def test_backtrack_removes_only_above_target(ops: list[tuple[object, ...]]) -> None:
+    """After backtrack(L) the surviving trail is exactly the level<=L prefix."""
+    ps: PartialSolution[str, int] = PartialSolution()
+    model = ModelPS()
+    for op in ops:
+        if op[0] == "backtrack":
+            before = list(ps._assignments)
+            raw = op[1]
+            assert isinstance(raw, int)
+            target = raw % (model.level + 1)
+            expected = [a for a in before if a.decision_level <= target]
+        else:
+            expected = None
+        apply_op(ps, model, op)
+        if expected is not None:
+            assert ps._assignments == expected
+            assert all(a.decision_level <= ps.decision_level for a in ps._assignments)

--- a/nab-resolver/tests/property/test_resolver_oracle.py
+++ b/nab-resolver/tests/property/test_resolver_oracle.py
@@ -1,0 +1,321 @@
+"""End-to-end soundness oracle: closure on success, brute force on failure.
+
+Scenarios are resolved directly from multi-package requirements (no
+virtual root pin) with a constant-priority provider, so the decision
+order differs from the count-prioritizing :class:`FuzzProvider` runs
+elsewhere in this suite.  On success the result must be closed: every
+requirement and every pinned package's dependencies are pinned in
+range.  On failure a brute-force enumeration over all pin subsets must
+agree that no solution exists.
+
+The lookahead variant exercises the pending-clauses and force-backtrack
+provider contract: the provider rejects candidates whose dependencies
+conflict with current decisions, queues the corresponding sound clauses,
+and periodically requests force backtracks, mimicking nab-python's
+look-ahead.  Every queued clause is implied by a dependency fact, so any
+unsoundness flagged here is the resolver's.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import TYPE_CHECKING
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_resolver.ranges import Range
+from nab_resolver.resolver import ResolutionError, Resolver
+from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
+
+from .strategies import DEEP_SETTINGS
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from nab_resolver.types import RangeProtocol
+
+pytestmark = pytest.mark.property
+
+ORACLE_TIMEOUT_SECONDS = 120
+
+Versions = dict[str, list[int]]
+Deps = dict[tuple[str, int], dict[str, Range[int]]]
+Roots = dict[str, Range[int]]
+
+
+@st.composite
+def scenarios(draw: st.DrawFn) -> tuple[Versions, Deps, Roots]:
+    """Generate (versions, deps, roots) over 2-4 packages, 2-3 versions."""
+    n_packages = draw(st.integers(min_value=2, max_value=4))
+    n_versions = draw(st.integers(min_value=2, max_value=3))
+    packages = [f"p{i}" for i in range(n_packages)]
+    versions: Versions = {p: list(range(1, n_versions + 1)) for p in packages}
+
+    deps: Deps = {}
+    for package in packages:
+        others = [q for q in packages if q != package]
+        for version in versions[package]:
+            dep_packages = draw(
+                st.lists(st.sampled_from(others), max_size=2, unique=True)
+            )
+            package_deps: dict[str, Range[int]] = {}
+            for dep in dep_packages:
+                lower = draw(st.integers(min_value=1, max_value=n_versions))
+                upper = min(
+                    n_versions, lower + draw(st.integers(min_value=0, max_value=2))
+                )
+                package_deps[dep] = Range.between(lower, upper + 1)
+            deps[(package, version)] = package_deps
+
+    root_count = draw(st.integers(min_value=1, max_value=min(3, n_packages)))
+    root_packages = draw(
+        st.lists(
+            st.sampled_from(packages),
+            min_size=root_count,
+            max_size=root_count,
+            unique=True,
+        )
+    )
+    roots: Roots = {}
+    for package in root_packages:
+        lower = draw(st.integers(min_value=1, max_value=n_versions))
+        upper = min(
+            n_versions, lower + draw(st.integers(min_value=1, max_value=n_versions))
+        )
+        roots[package] = Range.between(lower, upper + 1)
+    return versions, deps, roots
+
+
+class ConstantPriorityProvider:
+    """Newest-first provider whose priority is constant for every package."""
+
+    def __init__(self, versions: Versions, deps: Deps) -> None:
+        """Create a provider from versions and per-version dependency dicts."""
+        self._versions = versions
+        self._deps = deps
+
+    def choose_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> int | None:
+        """Pick the newest version within the allowed range."""
+        best: int | None = None
+        for version in self._versions.get(package, []):
+            if version in version_range and (best is None or version > best):
+                best = version
+        return best
+
+    def get_dependencies(self, package: str, version: int) -> dict[str, Range[int]]:
+        """Return dependencies for a specific version."""
+        return self._deps.get((package, version), {})
+
+    def prioritize(
+        self,
+        package: str,
+        version_range: RangeProtocol[int],
+        conflict_counts: Mapping[str, int],
+        culprit_counts: Mapping[str, int] | None = None,
+    ) -> int:
+        """Constant priority: decision order is left to the resolver."""
+        del package, version_range, conflict_counts, culprit_counts
+        return 0
+
+    def is_ready(self, package: str) -> bool:
+        """All packages decidable immediately in tests."""
+        del package
+        return True
+
+    def receive_partial_solution_hint(
+        self,
+        positive_ranges: Mapping[str, RangeProtocol[int]],
+        decisions: Mapping[str, int],
+    ) -> None:
+        """No-op: this provider does not use partial solution state."""
+        del positive_ranges, decisions
+
+    def consume_pending_clauses(self) -> list[Incompatibility[str, int]]:
+        """No queued clauses."""
+        return []
+
+    def consume_force_backtrack_targets(self) -> list[str]:
+        """No force-backtrack signal from this provider."""
+        return []
+
+
+class LookaheadProvider:
+    """Provider exercising the pending-clauses and force-backtrack contract.
+
+    When the preferred candidate ``v`` for a package has a dependency
+    whose range excludes that dependency's current decision ``w``, the
+    provider rejects ``v``, queues the clause ``{package==v, dep==w}``,
+    and on every ``force_every``-th blocker requests a force backtrack
+    on the dependency.
+    """
+
+    def __init__(self, versions: Versions, deps: Deps, force_every: int) -> None:
+        """Create a provider that force-backtracks on every nth blocker."""
+        self._versions = versions
+        self._deps = deps
+        self._force_every = force_every
+        self._decisions: dict[str, int] = {}
+        self._pending: list[Incompatibility[str, int]] = []
+        self._force_targets: list[str] = []
+        self._blockers_seen = 0
+
+    def choose_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> int | None:
+        """Pick the newest unblocked version, queueing clauses for blocked ones."""
+        candidates = sorted(
+            (v for v in self._versions.get(package, []) if v in version_range),
+            reverse=True,
+        )
+        for version in candidates:
+            blockers: list[tuple[str, int]] = []
+            for dep, dep_range in self._deps.get((package, version), {}).items():
+                decided = self._decisions.get(dep)
+                if decided is not None and decided not in dep_range:
+                    blockers.append((dep, decided))
+            if not blockers:
+                return version
+            for dep, decided in blockers:
+                self._pending.append(
+                    Incompatibility(
+                        [
+                            Term(package, Range.singleton(version), positive=True),
+                            Term(dep, Range.singleton(decided), positive=True),
+                        ],
+                        cause=IncompatibilityCause.DEPENDENCY,
+                    )
+                )
+                self._blockers_seen += 1
+                if self._blockers_seen % self._force_every == 0:
+                    self._force_targets.append(dep)
+        return None
+
+    def get_dependencies(self, package: str, version: int) -> dict[str, Range[int]]:
+        """Return dependencies for a specific version."""
+        return self._deps.get((package, version), {})
+
+    def prioritize(
+        self,
+        package: str,
+        version_range: RangeProtocol[int],
+        conflict_counts: Mapping[str, int],
+        culprit_counts: Mapping[str, int] | None = None,
+    ) -> int:
+        """Constant priority: decision order is left to the resolver."""
+        del package, version_range, conflict_counts, culprit_counts
+        return 0
+
+    def is_ready(self, package: str) -> bool:
+        """All packages decidable immediately in tests."""
+        del package
+        return True
+
+    def receive_partial_solution_hint(
+        self,
+        positive_ranges: Mapping[str, RangeProtocol[int]],
+        decisions: Mapping[str, int],
+    ) -> None:
+        """Track current decisions for the look-ahead check."""
+        del positive_ranges
+        self._decisions = dict(decisions)
+
+    def consume_pending_clauses(self) -> list[Incompatibility[str, int]]:
+        """Hand over and clear the queued clauses."""
+        clauses = self._pending
+        self._pending = []
+        return clauses
+
+    def consume_force_backtrack_targets(self) -> list[str]:
+        """Hand over and clear the force-backtrack targets."""
+        targets = self._force_targets
+        self._force_targets = []
+        return targets
+
+
+def _assert_closure(result: dict[str, int], deps: Deps, roots: Roots) -> None:
+    """Assert the result satisfies all roots and is dependency-closed."""
+    for package, required_range in roots.items():
+        assert package in result, f"root {package!r} missing from result"
+        assert result[package] in required_range, (
+            f"root {package!r}@{result[package]} not in {required_range}"
+        )
+    for package, version in result.items():
+        for dep, dep_range in deps.get((package, version), {}).items():
+            assert dep in result, (
+                f"dep {dep!r} of {package!r}@{version} missing from result"
+            )
+            assert result[dep] in dep_range, (
+                f"dep {dep!r}@{result[dep]} of {package!r}@{version} not in {dep_range}"
+            )
+
+
+def _brute_force_sat(
+    versions: Versions, deps: Deps, roots: Roots
+) -> dict[str, int] | None:
+    """Return a satisfying pin set (packages may be absent), or None."""
+    packages = sorted(versions)
+    for combo in itertools.product(*[[None, *versions[p]] for p in packages]):
+        pins = {p: v for p, v in zip(packages, combo, strict=True) if v is not None}
+        if any(p not in pins or pins[p] not in r for p, r in roots.items()):
+            continue
+        if all(
+            dep in pins and pins[dep] in dep_range
+            for (p, v) in pins.items()
+            for dep, dep_range in deps.get((p, v), {}).items()
+        ):
+            return pins
+    return None
+
+
+def _check_scenario(
+    resolver: Resolver[str, int],
+    versions: Versions,
+    deps: Deps,
+    roots: Roots,
+) -> None:
+    """Resolve and check closure on success, brute-force unsat on failure."""
+    try:
+        result = resolver.resolve(roots)
+    except ResolutionError as error:
+        if "exceeded" in str(error):
+            return
+        witness = _brute_force_sat(versions, deps, roots)
+        assert witness is None, (
+            f"resolver reported impossible but {witness} works\n"
+            f"roots={roots}\ndeps={deps}"
+        )
+        return
+    _assert_closure(result, deps, roots)
+
+
+class TestClosureSoundAgainstBruteForce:
+    """resolve() output is closed; failures are brute-force verified unsat."""
+
+    @pytest.mark.timeout(ORACLE_TIMEOUT_SECONDS)
+    @given(scenario=scenarios())
+    @DEEP_SETTINGS
+    def test_plain_provider(self, scenario: tuple[Versions, Deps, Roots]) -> None:
+        """Constant-priority provider results are closure-sound."""
+        versions, deps, roots = scenario
+        provider = ConstantPriorityProvider(versions, deps)
+        resolver: Resolver[str, int] = Resolver(provider, max_iterations=5000)
+        _check_scenario(resolver, versions, deps, roots)
+
+    @pytest.mark.timeout(ORACLE_TIMEOUT_SECONDS)
+    @given(
+        scenario=scenarios(),
+        force_every=st.integers(min_value=1, max_value=4),
+    )
+    @DEEP_SETTINGS
+    def test_lookahead_provider(
+        self, scenario: tuple[Versions, Deps, Roots], force_every: int
+    ) -> None:
+        """Pending clauses and force backtracks stay closure-sound."""
+        versions, deps, roots = scenario
+        provider = LookaheadProvider(versions, deps, force_every)
+        resolver: Resolver[str, int] = Resolver(provider, max_iterations=5000)
+        _check_scenario(resolver, versions, deps, roots)

--- a/nab-resolver/tests/property/test_satisfier_adversarial.py
+++ b/nab-resolver/tests/property/test_satisfier_adversarial.py
@@ -1,0 +1,88 @@
+"""Adversarial satisfier probes: terms built from the trail's own constraints.
+
+Random probe constraints rarely flip satisfaction mid-trail.  Here the
+probe terms are algebraic combinations (identity, complement, pairwise
+union and intersection) of the constraint reps used in the operations
+themselves, so the earliest-satisfier boundary lands at interior trail
+entries far more often, stressing the binary search and the stored
+cumulative-range snapshots across backtracks.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_resolver.partial_solution import PartialSolution
+from nab_resolver.types import Term
+
+from .rep_model import (
+    PROBE_PACKAGES,
+    ModelPS,
+    Rep,
+    apply_op,
+    operations,
+    rep_and,
+    rep_not,
+    rep_or,
+    rep_to_range,
+)
+from .strategies import DEEP_SETTINGS
+
+pytestmark = pytest.mark.property
+
+
+def _derived_probe_reps(ops: list[tuple[object, ...]]) -> list[Rep]:
+    """Combine the ops' own constraint reps into adversarial probes."""
+    base: list[Rep] = []
+    for op in ops:
+        if op[0] == "derive":
+            rep = op[2]
+            assert isinstance(rep, tuple)
+            base.append(rep)
+    out: list[Rep] = []
+    for rep in base[:5]:
+        out.append(rep)
+        out.append(rep_not(rep))
+    for left, right in itertools.pairwise(base):
+        out.append(rep_or(left, right))
+        out.append(rep_and(left, rep_not(right)))
+    return out[:10]
+
+
+@given(
+    ops=st.lists(operations(), min_size=2, max_size=30),
+    pkg_picks=st.lists(st.sampled_from(PROBE_PACKAGES), min_size=1, max_size=3),
+    polarity=st.booleans(),
+)
+@DEEP_SETTINGS
+def test_satisfier_with_trail_derived_probes(
+    ops: list[tuple[object, ...]],
+    pkg_picks: list[str],
+    polarity: bool,
+) -> None:
+    """Satisfier and soleness agree with the model on trail-derived probes."""
+    ps: PartialSolution[str, int] = PartialSolution()
+    model = ModelPS()
+    probe_reps = _derived_probe_reps(ops)
+    for op in ops:
+        apply_op(ps, model, op)
+        for pkg in pkg_picks:
+            entries = ps.assignments_for(pkg)
+            for rep in probe_reps:
+                for positive in (polarity, not polarity):
+                    term: Term[str, int] = Term(
+                        pkg, rep_to_range(rep), positive=positive
+                    )
+                    impl = ps.satisfier(term)
+                    idx = model.satisfier_index(pkg, rep, positive=positive)
+                    if idx is None:
+                        assert impl is None
+                    else:
+                        assert impl is not None
+                        assert impl is entries[idx]
+                        expected_sole = model.is_sole(pkg, idx, rep, positive=positive)
+                        assert ps.satisfier_is_sole(impl, term) == expected_sole

--- a/nab-resolver/tests/property/test_term_relation_oracle.py
+++ b/nab-resolver/tests/property/test_term_relation_oracle.py
@@ -1,0 +1,115 @@
+"""Scenario-semantics oracle for ``term_relation``.
+
+A partial solution constrains a package to either be present with a
+version in pos minus neg (when it has a positive constraint), or be
+absent or present with any version not in neg (negative-only).  Per
+solver.md a term is SATISFIED if true in every consistent scenario,
+CONTRADICTED if false in every one, else UNDETERMINED.
+``term_relation``'s docstring adds a documented downgrade: without a
+positive constraint a positive term is never SATISFIED and a negative
+term never CONTRADICTED (the package may be absent), so those corners
+accept UNDETERMINED.
+
+The finite/cofinite rep algebra makes the oracle exact over all
+integers, covering cofinite shapes (e.g. everything except {2, 5}) that
+the interval-based strategies never produce.
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_resolver.propagate import term_relation
+from nab_resolver.resolver import Resolver
+from nab_resolver.types import SetRelation, Term
+
+from .providers import FuzzProvider
+from .rep_model import (
+    ModelPS,
+    Rep,
+    apply_op,
+    operations,
+    probe_terms,
+    rep_and,
+    rep_disjoint,
+    rep_is_empty,
+    rep_not,
+    rep_subset,
+    rep_to_range,
+)
+from .strategies import PROPERTY_SETTINGS
+
+pytestmark = pytest.mark.property
+
+
+def _fresh_resolver() -> Resolver[str, int]:
+    """A resolver used only as the term_relation state carrier."""
+    return Resolver(FuzzProvider({}))
+
+
+def _oracle_acceptable(
+    pos: Rep | None, neg: Rep, *, neg_recorded: bool, c: Rep, positive: bool
+) -> set[SetRelation]:
+    """Acceptable results per scenario semantics plus documented downgrades."""
+    if pos is None and not neg_recorded:
+        # No assignment at all: documented UNDETERMINED.
+        return {SetRelation.UNDETERMINED}
+
+    can_be_absent = pos is None
+    present = rep_and(pos, rep_not(neg)) if pos is not None else rep_not(neg)
+
+    if rep_is_empty(present) and not can_be_absent:
+        # No consistent scenario: vacuously both; only UNDETERMINED is wrong.
+        return {SetRelation.SATISFIED, SetRelation.CONTRADICTED}
+
+    if positive:
+        all_true = (not can_be_absent) and rep_subset(present, c)
+        all_false = rep_disjoint(present, c)
+    else:
+        all_true = rep_disjoint(present, c)
+        all_false = (not can_be_absent) and rep_subset(present, c)
+
+    if all_true:
+        return {SetRelation.SATISFIED}
+    if all_false:
+        if can_be_absent and rep_is_empty(present):
+            # Only the absent scenario exists.  classify_intersection's
+            # covers-before-empty tie-break reports SATISFIED, which the
+            # needs_positive gate downgrades to UNDETERMINED, so the
+            # truthful CONTRADICTED is unreachable here.  Sound but lossy.
+            return {SetRelation.CONTRADICTED, SetRelation.UNDETERMINED}
+        return {SetRelation.CONTRADICTED}
+    return {SetRelation.UNDETERMINED}
+
+
+@given(
+    ops=st.lists(operations(), min_size=1, max_size=15),
+    probes=st.lists(probe_terms(), min_size=1, max_size=4),
+)
+@PROPERTY_SETTINGS
+def test_term_relation_matches_scenario_semantics(
+    ops: list[tuple[object, ...]], probes: list[tuple[str, Rep, bool]]
+) -> None:
+    """term_relation returns a scenario-semantics-acceptable relation."""
+    resolver = _fresh_resolver()
+    model = ModelPS()
+    for op in ops:
+        apply_op(resolver.solution, model, op)
+        for pkg, rep, positive in probes:
+            term: Term[str, int] = Term(pkg, rep_to_range(rep), positive=positive)
+            result = term_relation(resolver, term)
+            pos, neg, _, neg_recorded = model.state(pkg)
+            acceptable = _oracle_acceptable(
+                pos, neg, neg_recorded=neg_recorded, c=rep, positive=positive
+            )
+            assert result in acceptable, (
+                f"term_relation({term!r}) = {result} not in {acceptable}; "
+                f"pos={pos}, neg={neg}, neg_recorded={neg_recorded}"
+            )
+            # Warm- and cold-cache results must agree.
+            assert term_relation(resolver, term) is result
+            fresh = _fresh_resolver()
+            fresh.solution = resolver.solution
+            assert term_relation(fresh, term) is result

--- a/nab-resolver/tests/property/test_unsat_proof.py
+++ b/nab-resolver/tests/property/test_unsat_proof.py
@@ -1,0 +1,137 @@
+"""Property tests for unsat-proof soundness.
+
+When resolution fails, ``error.incompatibility`` is the root of a
+derivation DAG whose external (non-DERIVED) clauses must each be a true
+fact of the generating universe.  The resolver tests elsewhere only
+check that the proof exists; here every leaf is validated against the
+graph: ROOT clauses match stated requirements, DEPENDENCY clauses cover
+real versions whose actual dep ranges are subsets of the claimed range,
+and NO_VERSIONS / CONSTRAINT clauses name ranges containing no real
+version.
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_resolver.ranges import Range
+
+from .graph_oracles import (
+    Graph,
+    check_leaf_against_universe,
+    proof_leaves,
+    selfdep_graphs,
+    solve,
+    sparse_version_graphs,
+)
+from .strategies import (
+    PROPERTY_SETTINGS,
+    empty_dep_graphs,
+    graph_and_constraints,
+    small_exhaustive_graphs,
+)
+
+pytestmark = pytest.mark.property
+
+PROOF_TIMEOUT_SECONDS = 120
+
+
+def _check_proof(
+    graph: Graph,
+    requirements: dict[str, Range[int]],
+    constraints: dict[str, Range[int]] | None = None,
+) -> None:
+    """Resolve and, on failure, validate every proof leaf."""
+    _, error = solve(graph, requirements=requirements, constraints=constraints)
+    if error is None:
+        return
+    assert error.incompatibility is not None
+    leaves = proof_leaves(error.incompatibility)
+    assert leaves, "unsat proof has no external clauses"
+    for leaf in leaves:
+        check_leaf_against_universe(leaf, graph, requirements, constraints)
+
+
+class TestProofLeavesAreTrueFacts:
+    """Every external clause in an unsat proof is true in the universe."""
+
+    @pytest.mark.timeout(PROOF_TIMEOUT_SECONDS)
+    @given(graph=small_exhaustive_graphs())
+    @PROPERTY_SETTINGS
+    def test_plain_graphs(self, graph: Graph) -> None:
+        """Plain small graphs yield sound proofs."""
+        _check_proof(graph, graph["root"][1])
+
+    @pytest.mark.timeout(PROOF_TIMEOUT_SECONDS)
+    @given(graph=empty_dep_graphs())
+    @PROPERTY_SETTINGS
+    def test_empty_dep_graphs(self, graph: Graph) -> None:
+        """Graphs with empty-range dependencies yield sound proofs."""
+        _check_proof(graph, graph["root"][1])
+
+    @pytest.mark.timeout(PROOF_TIMEOUT_SECONDS)
+    @given(graph=selfdep_graphs())
+    @PROPERTY_SETTINGS
+    def test_selfdep_graphs(self, graph: Graph) -> None:
+        """Graphs with self-dependencies yield sound proofs when they fail."""
+        _check_proof(graph, graph["root"][1])
+
+    @pytest.mark.timeout(PROOF_TIMEOUT_SECONDS)
+    @given(graph=sparse_version_graphs())
+    @PROPERTY_SETTINGS
+    def test_sparse_graphs(self, graph: Graph) -> None:
+        """Graphs with non-contiguous version numbers yield sound proofs."""
+        _check_proof(graph, graph["root"][1])
+
+    @pytest.mark.timeout(PROOF_TIMEOUT_SECONDS)
+    @given(case=graph_and_constraints())
+    @PROPERTY_SETTINGS
+    def test_constrained_graphs(
+        self, case: tuple[Graph, dict[str, Range[int]]]
+    ) -> None:
+        """Constraint-driven failures carry sound CONSTRAINT leaves."""
+        graph, constraints = case
+        _check_proof(graph, graph["root"][1], constraints)
+
+
+class TestDegenerateRequirements:
+    """Degenerate requirements fail with a proof whose leaves are sound."""
+
+    @pytest.mark.timeout(PROOF_TIMEOUT_SECONDS)
+    @given(graph=small_exhaustive_graphs())
+    @PROPERTY_SETTINGS
+    def test_unknown_package_requirement(self, graph: Graph) -> None:
+        """Requiring a nonexistent package fails with a sound proof."""
+        requirements = dict(graph["root"][1])
+        requirements["ghost-package"] = Range.full()
+        solution, error = solve(graph, requirements=requirements)
+        if solution is None and error is None:
+            return
+        assert solution is None, "resolved despite requiring a nonexistent package"
+        assert error is not None
+        assert error.incompatibility is not None
+        for leaf in proof_leaves(error.incompatibility):
+            check_leaf_against_universe(leaf, graph, requirements)
+
+    @pytest.mark.timeout(PROOF_TIMEOUT_SECONDS)
+    @given(
+        graph=small_exhaustive_graphs(),
+        pkg_index=st.integers(min_value=0, max_value=3),
+    )
+    @PROPERTY_SETTINGS
+    def test_empty_range_requirement(self, graph: Graph, pkg_index: int) -> None:
+        """An empty-range requirement fails with a sound proof."""
+        packages = sorted(p for p in graph if p != "root")
+        target = packages[pkg_index % len(packages)]
+        requirements = dict(graph["root"][1])
+        requirements[target] = Range.empty()
+        solution, error = solve(graph, requirements=requirements)
+        if solution is None and error is None:
+            return
+        assert solution is None, "resolved despite an empty-range requirement"
+        assert error is not None
+        assert error.incompatibility is not None
+        for leaf in proof_leaves(error.incompatibility):
+            check_leaf_against_universe(leaf, graph, requirements)


### PR DESCRIPTION
Adds property tests under `nab-resolver/tests/property/` that check the resolver against independent oracles rather than self-consistency alone. `test_unsat_proof.py` walks every failed resolution's derivation DAG and validates each external clause (ROOT, DEPENDENCY, NO_VERSIONS, CONSTRAINT) as a true fact of the generating graph, including self-dependency and sparse-version shapes. `test_metamorphic.py` asserts exact solution equality under solution-preserving transformations: unreferenced-package addition, order-preserving rename, and monotone version shift. `test_resolver_oracle.py` resolves multi-requirement scenarios through a constant-priority provider and a look-ahead provider exercising the pending-clauses and force-backtrack contract, checking closure on success and brute-force-verified unsat on failure.

The partial-solution side is differential: `rep_model.py` models constraints as exact finite/cofinite integer sets and replays the documented trail semantics from scratch on every query, so multi-package interleaved trails with cofinite shapes are compared field-for-field against the real class. This covers the binary-search `satisfier` and `satisfier_is_sole`, backtrack state rebuilds, `get`/`decisions`/`undecided_packages`, `term_relation` scenario semantics, and `incompat_index` merge and index equivalence.