### PR TITLE
Property-test index parsing, caching, routing, extraction

### DIFF
--- a/nab-python/tests/property_python/test_cached_client_equiv.py
+++ b/nab-python/tests/property_python/test_cached_client_equiv.py
@@ -1,0 +1,319 @@
+"""Observational equivalence: ``CachedAsyncSimpleClient`` vs ``AsyncSimpleClient``.
+
+Over identical scripted responses, the cached client must return the same
+listings as the uncached client; a warm cache must serve identical results
+without any transport call; stale entries revalidated via 304 must equal
+the cached parse, via 200 must equal the new body's parse.  PEP 658
+metadata is immutable once verified; a hash mismatch must raise and must
+not poison the cache.
+
+Also fuzzes ``_parse_files`` over random PEP 691 JSON: drops yanked and
+name-mismatched files, lowercases hex digests, never keeps a negative size.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from typing import TYPE_CHECKING, TypeVar
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_index.cache import CachePolicy
+from nab_index.cached_client import CachedAsyncSimpleClient
+from nab_index.client import (
+    AsyncSimpleClient,
+    MetadataHashMismatchError,
+    _parse_files,
+)
+
+from .strategies import PROPERTY_SETTINGS
+
+if TYPE_CHECKING:
+    from collections.abc import Coroutine
+    from typing import Any
+
+pytestmark = pytest.mark.property
+
+_T = TypeVar("_T")
+
+INDEX = "https://idx.example/simple/"
+
+
+class FakeResponse:
+    """Minimal ``HttpResponse`` stand-in over canned bytes."""
+
+    def __init__(self, status: int, headers: dict[str, str], body: bytes) -> None:
+        self.status_code = status
+        self.headers = headers
+        self.content = body
+
+    @property
+    def text(self) -> str:
+        return self.content.decode("utf-8")
+
+    def json(self) -> Any:
+        return json.loads(self.content)
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            msg = f"HTTP {self.status_code}"
+            raise RuntimeError(msg)
+
+
+class FakeTransport:
+    """URL -> list of scripted (status, headers, body); replays the last forever."""
+
+    def __init__(
+        self, script: dict[str, list[tuple[int, dict[str, str], bytes]]]
+    ) -> None:
+        self.script = script
+        self.calls: list[tuple[str, dict[str, str] | None]] = []
+
+    async def get(
+        self, url: str, *, headers: dict[str, str] | None = None
+    ) -> FakeResponse:
+        self.calls.append((url, headers))
+        responses = self.script[url]
+        entry = responses.pop(0) if len(responses) > 1 else responses[0]
+        return FakeResponse(*entry)
+
+    async def aclose(self) -> None:
+        pass
+
+
+class DictCache:
+    """In-memory ``CacheBackend`` whose state the tests can inspect."""
+
+    def __init__(self) -> None:
+        self.simple: dict[str, tuple[bytes, CachePolicy]] = {}
+        self.metadata: dict[tuple[str, str], str] = {}
+        self.pkginfo: dict[tuple[str, str], str] = {}
+        self.pyproject: dict[tuple[str, str], str] = {}
+
+    def get_simple(self, package: str) -> tuple[bytes, CachePolicy] | None:
+        return self.simple.get(package)
+
+    def put_simple(self, package: str, body: bytes, policy: CachePolicy) -> None:
+        self.simple[package] = (body, policy)
+
+    def refresh_simple_policy(self, package: str, policy: CachePolicy) -> None:
+        body, _ = self.simple[package]
+        self.simple[package] = (body, policy)
+
+    def get_metadata(self, package: str, version: str) -> str | None:
+        return self.metadata.get((package, version))
+
+    def put_metadata(self, package: str, version: str, text: str) -> None:
+        self.metadata[(package, version)] = text
+
+    def get_sdist_pkginfo(self, package: str, version: str) -> str | None:
+        return self.pkginfo.get((package, version))
+
+    def put_sdist_pkginfo(self, package: str, version: str, text: str) -> None:
+        self.pkginfo[(package, version)] = text
+
+    def get_sdist_pyproject(self, package: str, version: str) -> str | None:
+        return self.pyproject.get((package, version))
+
+    def put_sdist_pyproject(self, package: str, version: str, text: str) -> None:
+        self.pyproject[(package, version)] = text
+
+
+def run(coro: Coroutine[Any, Any, _T]) -> _T:
+    """Synchronously run an awaitable inside a property test."""
+    return asyncio.run(coro)
+
+
+pkg_names = st.from_regex(r"[a-z][a-z0-9]{0,5}", fullmatch=True)
+versions = st.sampled_from(["1.0", "2.0.0", "0.1.dev1", "1!1.0", "1.0+local", "3"])
+hex_chars = "0123456789abcdefABCDEF"
+
+
+@st.composite
+def file_entries(draw: st.DrawFn, package: str) -> dict[str, Any]:
+    """One PEP 691 file entry: wheel, sdist, or junk, with optional fields."""
+    kind = draw(st.integers(min_value=0, max_value=4))
+    version = draw(versions)
+    name = package if kind < 3 else draw(pkg_names)
+    if kind in (0, 3):
+        filename = f"{name}-{version}-py3-none-any.whl"
+    elif kind in (1, 4):
+        filename = f"{name}-{version}.tar.gz"
+    else:
+        filename = draw(st.text(max_size=20)) + draw(
+            st.sampled_from([".whl", ".tar.gz", ".txt"])
+        )
+    entry: dict[str, Any] = {
+        "filename": filename,
+        "url": draw(
+            st.sampled_from(
+                [f"https://files.example/{filename}", filename, f"../pool/{filename}"]
+            )
+        ),
+    }
+    if draw(st.booleans()):
+        entry["yanked"] = draw(st.sampled_from([True, False, "reason", ""]))
+    if draw(st.booleans()):
+        entry["hashes"] = {
+            "sha256": draw(st.text(alphabet=hex_chars, min_size=4, max_size=16))
+        }
+    if draw(st.booleans()):
+        entry["requires-python"] = ">=3.9"
+    if draw(st.booleans()):
+        entry["core-metadata"] = draw(st.sampled_from([True, False, {"sha256": "ab"}]))
+    if draw(st.booleans()):
+        entry["size"] = draw(st.integers(min_value=-5, max_value=10**6))
+    return entry
+
+
+@st.composite
+def listings(draw: st.DrawFn) -> tuple[str, bytes]:
+    """A package name plus a PEP 691 project-page body for it."""
+    package = draw(pkg_names)
+    entries = draw(st.lists(file_entries(package), max_size=6))
+    body = json.dumps({"name": package, "files": entries}).encode()
+    return package, body
+
+
+@given(data=listings())
+@PROPERTY_SETTINGS
+def test_cached_equals_uncached_first_call(data: tuple[str, bytes]) -> None:
+    """A cold cached client returns exactly what the plain client returns."""
+    package, body = data
+    url = f"{INDEX}{package}/"
+    headers = {"Cache-Control": "max-age=10000", "ETag": '"e1"'}
+
+    plain = AsyncSimpleClient(FakeTransport({url: [(200, headers, body)]}), INDEX)
+    transport = FakeTransport({url: [(200, headers, body)]})
+    cached = CachedAsyncSimpleClient(transport, DictCache(), INDEX)
+
+    assert run(cached.get_files(package)) == run(plain.get_files(package))
+
+
+@given(data=listings())
+@PROPERTY_SETTINGS
+def test_warm_fresh_cache_serves_identically_without_network(
+    data: tuple[str, bytes],
+) -> None:
+    """A fresh cache entry is served as-is with no transport call."""
+    package, body = data
+    url = f"{INDEX}{package}/"
+    transport = FakeTransport({url: [(200, {"Cache-Control": "max-age=10000"}, body)]})
+    cached = CachedAsyncSimpleClient(transport, DictCache(), INDEX)
+    first = run(cached.get_files(package))
+    n_calls = len(transport.calls)
+    second = run(cached.get_files(package))
+    assert second == first
+    assert len(transport.calls) == n_calls
+
+
+@given(data=listings())
+@PROPERTY_SETTINGS
+def test_stale_304_revalidation_equals_cached_parse(data: tuple[str, bytes]) -> None:
+    """A 304 revalidation reuses the cached body and refreshes the policy."""
+    package, body = data
+    url = f"{INDEX}{package}/"
+    transport = FakeTransport(
+        {
+            url: [
+                (200, {"Cache-Control": "max-age=0", "ETag": '"e1"'}, body),
+                (304, {"Cache-Control": "max-age=10000"}, b""),
+            ]
+        }
+    )
+    cached = CachedAsyncSimpleClient(transport, DictCache(), INDEX)
+    first = run(cached.get_files(package))
+    second = run(cached.get_files(package))
+    assert second == first
+    # Conditional request carried the stored ETag.
+    assert transport.calls[-1][1] is not None
+    assert transport.calls[-1][1].get("If-None-Match") == '"e1"'
+    # 304 refreshed the policy: a third call is served from cache.
+    n_calls = len(transport.calls)
+    third = run(cached.get_files(package))
+    assert third == first
+    assert len(transport.calls) == n_calls
+
+
+@given(data=listings(), data2=listings())
+@PROPERTY_SETTINGS
+def test_stale_200_revalidation_serves_new_body(
+    data: tuple[str, bytes], data2: tuple[str, bytes]
+) -> None:
+    """A 200 revalidation replaces the cached body and re-caches as fresh."""
+    package, body = data
+    _, body2 = data2
+    body2 = json.dumps({**json.loads(body2), "name": package}).encode()
+    url = f"{INDEX}{package}/"
+    transport = FakeTransport(
+        {
+            url: [
+                (200, {"Cache-Control": "max-age=0"}, body),
+                (200, {"Cache-Control": "max-age=10000"}, body2),
+            ]
+        }
+    )
+    cached = CachedAsyncSimpleClient(transport, DictCache(), INDEX)
+    run(cached.get_files(package))
+    second = run(cached.get_files(package))
+    assert second == _parse_files(json.loads(body2), INDEX, package)
+    # New body cached as fresh: third call hits cache and equals it.
+    n_calls = len(transport.calls)
+    assert run(cached.get_files(package)) == second
+    assert len(transport.calls) == n_calls
+
+
+@given(
+    package=pkg_names,
+    version=versions,
+    text=st.text(max_size=50),
+    digest_ok=st.booleans(),
+)
+@PROPERTY_SETTINGS
+def test_metadata_hash_gate_and_immutability(
+    package: str, version: str, text: str, digest_ok: bool
+) -> None:
+    """A verified sidecar is cached forever; a mismatch raises and caches nothing."""
+    body = text.encode()
+    good = hashlib.sha256(body).hexdigest()
+    bad = ("0" * 64) if good[0] != "0" else ("1" * 64)
+    murl = "https://files.example/m.metadata"
+    transport = FakeTransport({murl: [(200, {}, body)]})
+    cache = DictCache()
+    client = CachedAsyncSimpleClient(transport, cache, INDEX)
+
+    if digest_ok:
+        out = run(client.get_metadata_text(package, version, murl, ("sha256", good)))
+        assert out == text
+        # Immutable: second call with a now-different server is cache-served.
+        transport.script[murl] = [(200, {}, b"CHANGED")]
+        assert run(client.get_metadata_text(package, version, murl, None)) == text
+    else:
+        with pytest.raises(MetadataHashMismatchError):
+            run(client.get_metadata_text(package, version, murl, ("sha256", bad)))
+        # Mismatch must not poison the cache.
+        assert cache.get_metadata(package, version) is None
+        out = run(client.get_metadata_text(package, version, murl, ("sha256", good)))
+        assert out == text
+
+
+@given(data=listings())
+@PROPERTY_SETTINGS
+def test_parse_files_postconditions(data: tuple[str, bytes]) -> None:
+    """Yanked and name-mismatched files are dropped; digests and sizes sane."""
+    package, body = data
+    payload = json.loads(body)
+    files = _parse_files(payload, INDEX, package)
+    for f in files:
+        candidates = [e for e in payload["files"] if e["filename"] == f.filename]
+        assert any(not e.get("yanked") for e in candidates), "yanked file leaked"
+        # Name always matches the queried package (pkg_names are canonical).
+        assert f.filename.startswith((package, package.replace("-", "_")))
+        for _algo, digest in f.hashes:
+            assert digest == digest.lower()
+        if f.size is not None:
+            assert f.size >= 0

--- a/nab-python/tests/property_python/test_filename_differential.py
+++ b/nab-python/tests/property_python/test_filename_differential.py
@@ -1,0 +1,183 @@
+"""Differential property tests for :mod:`nab_index.client` filename parsing.
+
+``_parse_wheel_filename`` reimplements
+:func:`packaging.utils.parse_wheel_filename` minus the tag-set parse, and
+its docstring promises the accepted filename set is unchanged.
+``_parse_sdist_filename`` wraps
+:func:`packaging.utils.parse_sdist_filename` but rejects ``.zip`` sdists.
+Upstream packaging is the oracle for both.
+"""
+
+from __future__ import annotations
+
+import string
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+from packaging.utils import (
+    InvalidSdistFilename,
+    InvalidWheelFilename,
+    parse_sdist_filename,
+    parse_wheel_filename,
+)
+
+from nab_index.client import _parse_sdist_filename, _parse_wheel_filename
+
+from .strategies import DEEP_SETTINGS
+
+pytestmark = pytest.mark.property
+
+# Name-ish components: word chars, dots, underscores, unicode word
+# characters, empties.
+name_chars = st.sampled_from(
+    [*string.ascii_letters, *string.digits, ".", "_", "é", "ß", "京"]
+)
+names = st.lists(name_chars, min_size=0, max_size=8).map("".join)
+
+version_bits = st.sampled_from(
+    [
+        "1.0",
+        "2.0.0",
+        "0",
+        "1!2.0",
+        "1.0a1",
+        "1.0.post2",
+        "1.0.dev3",
+        "1.0+local",
+        "1.0+Local.UPPER",
+        "01.02",
+        "1.0rc1",
+        "v1.0",
+        "1.0.*",
+        "",
+        "abc",
+        "1-0",
+        "1_0",
+        "  1.0  ",
+        "1.0\n",
+        "1.0.0.0.0.0",
+        "~1.0",
+        "1.0+abc_def",
+    ]
+)
+
+build_bits = st.sampled_from(["0", "1", "12abc", "build", "1-2", "", "01", "1.2"])
+
+tag_part = st.sampled_from(
+    [
+        "py3",
+        "py2.py3",
+        "cp311",
+        "none",
+        "any",
+        "abi3",
+        "",
+        "manylinux_2_17_x86_64",
+        "PY3",
+        "py3 ",
+    ]
+)
+tags = st.tuples(tag_part, tag_part, tag_part).map("-".join)
+
+extensions = st.sampled_from(
+    [".whl", ".WHL", ".tar.gz", ".zip", "", ".whl ", ".whl.whl"]
+)
+
+
+@st.composite
+def wheelish_filenames(draw: st.DrawFn) -> str:
+    """Structured wheel-shaped filenames, valid and invalid."""
+    name = draw(names)
+    version = draw(version_bits)
+    use_build = draw(st.booleans())
+    tag = draw(tags)
+    parts = [name, version]
+    if use_build:
+        parts.append(draw(build_bits))
+    parts.append(tag)
+    stem = "-".join(parts)
+    # Occasionally perturb: drop or add a dash run.
+    perturb = draw(st.integers(min_value=0, max_value=3))
+    if perturb == 1:
+        stem = stem.replace("-", "", 1)
+    elif perturb == 2:
+        stem = "-" + stem
+    return stem + draw(extensions)
+
+
+def oracle_wheel(filename: str) -> tuple[str, str] | None:
+    """Parse via upstream packaging; ``None`` when it rejects."""
+    try:
+        name, version, _build, _tags = parse_wheel_filename(filename)
+    except InvalidWheelFilename:
+        return None
+    return (str(name), str(version))
+
+
+def oracle_sdist(filename: str) -> tuple[str, str] | None:
+    """Parse via upstream packaging; ``None`` for rejects and ``.zip``."""
+    if filename.endswith(".zip"):
+        return None
+    try:
+        name, version = parse_sdist_filename(filename)
+    except InvalidSdistFilename:
+        return None
+    return (str(name), str(version))
+
+
+@given(filename=wheelish_filenames())
+@DEEP_SETTINGS
+def test_wheel_parse_matches_upstream_structured(filename: str) -> None:
+    """Structured near-miss wheel filenames parse like upstream, or nab rejects.
+
+    nab's parser is intentionally stricter than upstream on malformed
+    filenames (an empty name or an empty tag component), so ``None`` where
+    upstream is lenient is acceptable; when nab does return a result it must
+    agree with upstream.
+    """
+    result = _parse_wheel_filename(filename)
+    if result is not None:
+        assert result == oracle_wheel(filename)
+
+
+@given(filename=st.text(min_size=0, max_size=40))
+@DEEP_SETTINGS
+def test_wheel_parse_matches_upstream_fuzz(filename: str) -> None:
+    """Arbitrary text with a ``.whl`` suffix parses like upstream, or nab rejects."""
+    result = _parse_wheel_filename(filename + ".whl")
+    if result is not None:
+        assert result == oracle_wheel(filename + ".whl")
+
+
+@given(filename=st.text(min_size=0, max_size=40))
+@DEEP_SETTINGS
+def test_wheel_parse_never_crashes(filename: str) -> None:
+    """Malformed input is rejected with ``None``, never an exception."""
+    result = _parse_wheel_filename(filename)
+    assert result is None or isinstance(result, tuple)
+
+
+@st.composite
+def sdistish_filenames(draw: st.DrawFn) -> str:
+    """Sdist-shaped filenames, valid and invalid."""
+    name = draw(names)
+    version = draw(version_bits)
+    sep = draw(st.sampled_from(["-", "_", "", "--"]))
+    ext = draw(st.sampled_from([".tar.gz", ".zip", ".tar.bz2", ".whl", "", ".TAR.GZ"]))
+    return f"{name}{sep}{version}{ext}"
+
+
+@given(filename=sdistish_filenames())
+@DEEP_SETTINGS
+def test_sdist_parse_matches_upstream_structured(filename: str) -> None:
+    """Structured near-miss sdist filenames parse exactly like upstream."""
+    assert _parse_sdist_filename(filename) == oracle_sdist(filename)
+
+
+@given(filename=st.text(min_size=0, max_size=40))
+@DEEP_SETTINGS
+def test_sdist_parse_matches_upstream_fuzz(filename: str) -> None:
+    """Arbitrary text with a ``.tar.gz`` suffix parses exactly like upstream."""
+    fn = filename + ".tar.gz"
+    assert _parse_sdist_filename(fn) == oracle_sdist(fn)

--- a/nab-python/tests/property_python/test_multi_index_contract.py
+++ b/nab-python/tests/property_python/test_multi_index_contract.py
@@ -1,0 +1,180 @@
+"""Property tests for the :mod:`nab_index.multi_index` routing contract.
+
+Contract (module docstring): walk the ordered index list left-to-right,
+stop at the first index whose listing is non-empty; an override pins a
+package to exactly one named index.  Listings from different indexes are
+never mixed.  ``route_for`` reports the serving index after ``get_files``,
+and follow-up metadata calls hit that same index whatever PEP 503
+spelling they use.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, TypeVar
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_index._naming import canonical
+from nab_index.client import SdistFile, WheelFile
+from nab_index.multi_index import MultiIndexClient
+
+from .strategies import PROPERTY_SETTINGS
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Coroutine
+    from typing import Any
+
+pytestmark = pytest.mark.property
+
+_T = TypeVar("_T")
+
+Universe = tuple[MultiIndexClient, "list[Stub]", "dict[str, str]"]
+
+
+def run(coro: Coroutine[Any, Any, _T]) -> _T:
+    """Synchronously run an awaitable inside a property test."""
+    return asyncio.run(coro)
+
+
+def _wheel(name: str, idx: str) -> WheelFile:
+    """Build a wheel whose URL host identifies the serving index."""
+    return WheelFile(
+        filename=f"{name}-1.0-py3-none-any.whl",
+        url=f"https://{idx}.example/{name}-1.0-py3-none-any.whl",
+        version="1.0",
+        requires_python=None,
+        has_metadata=False,
+        upload_time=None,
+    )
+
+
+class Stub:
+    """Index client serving one wheel per hosted package, recording calls."""
+
+    def __init__(self, idx_name: str, has: set[str]) -> None:
+        self.idx_name = idx_name
+        self.has = has
+        self.get_files_calls: list[str] = []
+        self.metadata_calls: list[str] = []
+
+    async def get_files(self, package: str) -> list[WheelFile | SdistFile]:
+        self.get_files_calls.append(package)
+        if canonical(package) in self.has:
+            return [_wheel(canonical(package), self.idx_name)]
+        return []
+
+    async def get_metadata_text(
+        self,
+        package: str,
+        version: str,
+        metadata_url: str,
+        metadata_hash: tuple[str, str] | None = None,
+    ) -> str:
+        del version, metadata_url, metadata_hash
+        self.metadata_calls.append(package)
+        return f"served-by:{self.idx_name}"
+
+    async def get_sdist_files(
+        self, package: str, version: str, sdist_url: str
+    ) -> tuple[str | None, str | None]:
+        del package, version, sdist_url
+        return (None, None)
+
+    async def get_sdist_archive(
+        self, package: str, version: str, sdist_url: str
+    ) -> bytes:
+        del package, version, sdist_url
+        return b""
+
+    async def aclose(self) -> None:
+        pass
+
+
+pkg_names = st.from_regex(r"[a-z]{1,4}", fullmatch=True)
+spellings = st.sampled_from([str.upper, str.title, str, lambda s: s.replace("a", "A")])
+
+
+@st.composite
+def universes(draw: st.DrawFn) -> Universe:
+    """Router over 1-4 stub indexes with random holdings and overrides."""
+    n = draw(st.integers(min_value=1, max_value=4))
+    stubs = [Stub(f"idx{i}", draw(st.sets(pkg_names, max_size=4))) for i in range(n)]
+    clients = {s.idx_name: s for s in stubs}
+    order = [s.idx_name for s in stubs]
+    overrides = draw(st.dictionaries(pkg_names, st.sampled_from(order), max_size=2))
+    return MultiIndexClient(clients, order, overrides), stubs, overrides
+
+
+@given(data=universes(), package=pkg_names)
+@PROPERTY_SETTINGS
+def test_first_nonempty_index_wins_and_no_mixing(data: Universe, package: str) -> None:
+    """The first non-empty index serves the listing; later ones stay unasked."""
+    router, stubs, overrides = data
+    can = canonical(package)
+    files = run(router.get_files(package))
+
+    if can in overrides:
+        target = overrides[can]
+        winner = next(s for s in stubs if s.idx_name == target)
+        expected = [_wheel(can, winner.idx_name)] if can in winner.has else []
+        assert files == expected
+        assert router.route_for(package) == target
+        return
+
+    expected_winner = None
+    for s in stubs:
+        if can in s.has:
+            expected_winner = s
+            break
+
+    if expected_winner is None:
+        assert files == []
+        # All indexes consulted, attribution falls back to the first index.
+        assert all(s.get_files_calls == [package] for s in stubs)
+        assert router.route_for(package) == stubs[0].idx_name
+    else:
+        assert files == [_wheel(can, expected_winner.idx_name)]
+        assert router.route_for(package) == expected_winner.idx_name
+        seen_winner = False
+        for s in stubs:
+            if s is expected_winner:
+                seen_winner = True
+                assert s.get_files_calls == [package]
+            elif not seen_winner:
+                assert s.get_files_calls == [package]
+            else:
+                assert s.get_files_calls == []
+
+    # No mixing: every returned file came from exactly one index.
+    hosts = {f.url.split("/")[2] for f in files}
+    assert len(hosts) <= 1
+
+
+@given(data=universes(), package=pkg_names, respell=spellings)
+@PROPERTY_SETTINGS
+def test_metadata_follows_listing_route(
+    data: Universe, package: str, respell: Callable[[str], str]
+) -> None:
+    """Metadata after ``get_files`` hits the index that served the listing."""
+    router, _stubs, _overrides = data
+    run(router.get_files(package))
+    served = router.route_for(package)
+    text = run(router.get_metadata_text(respell(package), "1.0", "https://x/m"))
+    assert text == f"served-by:{served}"
+
+
+@given(data=universes(), package=pkg_names, respell=spellings)
+@PROPERTY_SETTINGS
+def test_route_stable_across_spellings(
+    data: Universe, package: str, respell: Callable[[str], str]
+) -> None:
+    """A second ``get_files`` under another PEP 503 spelling keeps the route."""
+    router, _stubs, _overrides = data
+    first = run(router.get_files(package))
+    route_first = router.route_for(package)
+    second = run(router.get_files(respell(package)))
+    assert router.route_for(respell(package)) == route_first
+    assert [f.filename for f in second] == [f.filename for f in first]

--- a/nab-python/tests/property_python/test_sdist_archive_safety.py
+++ b/nab-python/tests/property_python/test_sdist_archive_safety.py
@@ -1,0 +1,197 @@
+"""Property tests for :mod:`nab_index` sdist archive handling and file URLs.
+
+``_extract_sdist_files`` never raises on arbitrary bytes; for well-formed
+sdists it returns PKG-INFO and pyproject.toml contents exactly when they
+sit at depth <= 1.  ``extract_sdist_archive`` must never write outside the
+target directory, whatever the member names are (``..``, absolute,
+backslash, ``./.`` prefixes, symlink members); it either raises or
+extracts safely.  ``_parse_file_url`` round-trips ``Path.as_uri()`` for
+spacey and unicode paths.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import tarfile
+import tempfile
+from pathlib import Path
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_index.client import _extract_sdist_files, extract_sdist_archive
+from nab_index.local_index import _parse_file_url
+
+from .strategies import PROPERTY_SETTINGS
+
+pytestmark = pytest.mark.property
+
+
+def make_targz(members: list[tuple[str, bytes | None]]) -> bytes:
+    """Build a .tar.gz; value ``None`` makes a directory, bytes a regular file."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, content in members:
+            info = tarfile.TarInfo(name=name)
+            if content is None:
+                info.type = tarfile.DIRTYPE
+                tar.addfile(info)
+            else:
+                info.size = len(content)
+                tar.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
+
+
+texts = st.text(min_size=0, max_size=30)
+depths = st.integers(min_value=0, max_value=3)
+
+
+@st.composite
+def benign_archives(draw: st.DrawFn) -> tuple[bytes, str | None, str | None]:
+    """Archive plus the expected (pkg_info, pyproject) extraction result."""
+    members: list[tuple[str, bytes | None]] = [("pkg-1.0", None)]
+    expected_pkginfo: str | None = None
+    expected_pyproject: str | None = None
+
+    pkginfo_depth = draw(depths)
+    if draw(st.booleans()):
+        content = draw(texts)
+        path = (
+            "/".join(["pkg-1.0"] * pkginfo_depth + ["PKG-INFO"])
+            if pkginfo_depth
+            else "PKG-INFO"
+        )
+        members.append((path, content.encode()))
+        if pkginfo_depth <= 1:
+            expected_pkginfo = content
+
+    pyproject_depth = draw(depths)
+    if draw(st.booleans()):
+        content = draw(texts)
+        path = (
+            "/".join(["pkg-1.0"] * pyproject_depth + ["pyproject.toml"])
+            if pyproject_depth
+            else "pyproject.toml"
+        )
+        members.append((path, content.encode()))
+        if pyproject_depth <= 1:
+            expected_pyproject = content
+
+    # Decoys deeper in the tree must be ignored.
+    if draw(st.booleans()):
+        members.append(("pkg-1.0/sub/dir/PKG-INFO", b"DECOY"))
+        members.append(("pkg-1.0/sub/dir/pyproject.toml", b"DECOY"))
+
+    return make_targz(members), expected_pkginfo, expected_pyproject
+
+
+@given(data=benign_archives())
+@PROPERTY_SETTINGS
+def test_extract_sdist_files_depth_rule(
+    data: tuple[bytes, str | None, str | None],
+) -> None:
+    """PKG-INFO and pyproject.toml are picked up at depth <= 1 only."""
+    archive, expected_pkginfo, expected_pyproject = data
+    pkg_info, pyproject = _extract_sdist_files(archive)
+    assert pkg_info == expected_pkginfo
+    assert pyproject == expected_pyproject
+
+
+@given(blob=st.binary(max_size=200))
+@PROPERTY_SETTINGS
+def test_extract_sdist_files_never_raises_on_garbage(blob: bytes) -> None:
+    """Arbitrary bytes yield ``(None, None)``, never an exception."""
+    assert _extract_sdist_files(blob) == (None, None)
+
+
+hostile_names = st.sampled_from(
+    [
+        "../evil.txt",
+        "/abs.txt",
+        "./.hidden",
+        "a\\b.txt",
+        "pkg-1.0/../../evil.txt",
+        "..",
+        "pkg-1.0/./../up.txt",
+        "./../up2.txt",
+        "ok/inner/../../../esc.txt",
+    ]
+)
+benign_names = st.sampled_from(
+    [
+        "pkg-1.0/setup.py",
+        "pkg-1.0/PKG-INFO",
+        "README",
+        "pkg-1.0/sub/x.txt",
+        "./pkg-1.0/y",
+    ]
+)
+
+
+@st.composite
+def mixed_archives(draw: st.DrawFn) -> bytes:
+    """Archives mixing benign members with traversal attempts."""
+    n = draw(st.integers(min_value=1, max_value=5))
+    members: list[tuple[str, bytes | None]] = []
+    for _ in range(n):
+        hostile = draw(st.booleans())
+        name = draw(hostile_names) if hostile else draw(benign_names)
+        members.append((name, b"x"))
+    return make_targz(members)
+
+
+@given(archive=mixed_archives())
+@PROPERTY_SETTINGS
+def test_extract_sdist_archive_never_escapes_target(archive: bytes) -> None:
+    """No member, hostile or not, may create a path outside the target."""
+    with tempfile.TemporaryDirectory() as td:
+        parent = Path(td)
+        target = parent / "t"
+        target.mkdir()
+        before = set(parent.rglob("*"))
+        with contextlib.suppress(ValueError, OSError, tarfile.TarError):
+            extract_sdist_archive(archive, target)
+        new = set(parent.rglob("*")) - before
+        for p in new:
+            assert target in p.parents, f"escaped target: {p}"
+
+
+@given(symlink_target=st.sampled_from(["/etc/passwd", "../../outside", "ok.txt"]))
+@PROPERTY_SETTINGS
+def test_extract_sdist_archive_symlinks_cannot_escape(symlink_target: str) -> None:
+    """Writing through a symlink member cannot land outside the target."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        info = tarfile.TarInfo(name="pkg-1.0/link")
+        info.type = tarfile.SYMTYPE
+        info.linkname = symlink_target
+        tar.addfile(info)
+        info2 = tarfile.TarInfo(name="pkg-1.0/link/inner.txt")
+        info2.size = 1
+        tar.addfile(info2, io.BytesIO(b"x"))
+    archive = buf.getvalue()
+    with tempfile.TemporaryDirectory() as td:
+        parent = Path(td)
+        target = parent / "t"
+        target.mkdir()
+        with contextlib.suppress(ValueError, OSError, tarfile.TarError):
+            extract_sdist_archive(archive, target)
+        outside = [
+            p for p in parent.rglob("*") if p != target and target not in p.parents
+        ]
+        assert outside == []
+
+
+path_segments = st.from_regex(r"[A-Za-z0-9 _.é京-]{1,12}", fullmatch=True).filter(
+    lambda s: s not in (".", "..") and not s.endswith(" ") and not s.startswith(" ")
+)
+
+
+@given(segments=st.lists(path_segments, min_size=1, max_size=4))
+@PROPERTY_SETTINGS
+def test_parse_file_url_roundtrips_as_uri(segments: list[str]) -> None:
+    """``_parse_file_url`` inverts ``Path.as_uri`` for odd but legal paths."""
+    path = Path("/", *segments)
+    assert _parse_file_url(path.as_uri()) == path


### PR DESCRIPTION
Four new property-test files under `nab-python/tests/property_python/`, all offline over in-process fakes. `test_filename_differential.py` checks `_parse_wheel_filename` and `_parse_sdist_filename` against upstream `packaging.utils` as a differential oracle, over structured near-miss filenames and raw fuzz. `test_cached_client_equiv.py` checks `CachedAsyncSimpleClient` is observationally equivalent to `AsyncSimpleClient` over scripted responses: warm-cache hits make no transport call, 304 revalidation reuses the cached body and refreshes the policy, 200 revalidation replaces it, and a PEP 658 hash mismatch raises without poisoning the cache.

`test_multi_index_contract.py` checks the multi-index routing contract: first non-empty index wins, later indexes stay unconsulted, overrides pin to one index, listings never mix, and `route_for` attribution holds across PEP 503 respellings. `test_sdist_archive_safety.py` checks `_extract_sdist_files` honours the depth rule and never raises on garbage, `extract_sdist_archive` cannot write outside the target directory for traversal and symlink members, and `_parse_file_url` inverts `Path.as_uri`.