### PR TITLE
Guard vendored packaging with differential property tests

### DIFF
--- a/nab-python/tests/property_python/test_vendor_diff_upstream.py
+++ b/nab-python/tests/property_python/test_vendor_diff_upstream.py
@@ -1,0 +1,112 @@
+"""Differential: vendored range-backed specifiers vs upstream packaging.
+
+The vendored copy rewires ``Specifier``/``SpecifierSet`` contains and
+filter through the ``VersionRange`` machinery; upstream implements the
+same PEP 440 semantics directly, so it is an oracle.  Any divergence on
+contains/filter for valid inputs is a behavioral bug in the range
+machinery (or an intentional upstream fix, to be checked against
+PEP 440).
+"""
+
+from __future__ import annotations
+
+import packaging.specifiers as up_spec
+import pytest
+from hypothesis import given
+
+from nab_python._vendor.packaging import specifiers as nab_spec
+
+from .strategies import DEEP_SETTINGS
+from .vendor_strategies import probe_lists, specifier_set_strings, specifier_strings
+
+pytestmark = pytest.mark.property
+
+POLICIES = (None, True, False)
+
+
+def _build_pair(
+    spec_str: str,
+) -> tuple[up_spec.SpecifierSet | None, nab_spec.SpecifierSet | None]:
+    try:
+        upstream = up_spec.SpecifierSet(spec_str)
+    except up_spec.InvalidSpecifier:
+        upstream = None
+    try:
+        vendored = nab_spec.SpecifierSet(spec_str)
+    except nab_spec.InvalidSpecifier:
+        vendored = None
+    assert (upstream is None) == (vendored is None), (
+        f"validity disagreement for {spec_str!r}: "
+        f"upstream={'rejects' if upstream is None else 'accepts'}"
+    )
+    return upstream, vendored
+
+
+@DEEP_SETTINGS
+@given(spec=specifier_strings(), probes=probe_lists())
+def test_single_specifier_contains_agrees(spec: str, probes: list[str]) -> None:
+    try:
+        upstream = up_spec.Specifier(spec)
+    except up_spec.InvalidSpecifier:
+        upstream = None
+    try:
+        vendored = nab_spec.Specifier(spec)
+    except nab_spec.InvalidSpecifier:
+        vendored = None
+    assert (upstream is None) == (vendored is None), f"validity: {spec!r}"
+    if upstream is None or vendored is None:
+        return
+    assert upstream.prereleases == vendored.prereleases, f"prereleases: {spec!r}"
+    for probe in probes:
+        for policy in POLICIES:
+            up_result = upstream.contains(probe, prereleases=policy)
+            nab_result = vendored.contains(probe, prereleases=policy)
+            assert up_result == nab_result, (
+                f"spec={spec!r} probe={probe!r} prereleases={policy!r}: "
+                f"upstream={up_result} vendored={nab_result}"
+            )
+
+
+@DEEP_SETTINGS
+@given(spec_set=specifier_set_strings(), probes=probe_lists())
+def test_specifier_set_contains_agrees(spec_set: str, probes: list[str]) -> None:
+    upstream, vendored = _build_pair(spec_set)
+    if upstream is None or vendored is None:
+        return
+    assert upstream.prereleases == vendored.prereleases, f"prereleases: {spec_set!r}"
+    for probe in probes:
+        for policy in POLICIES:
+            up_result = upstream.contains(probe, prereleases=policy)
+            nab_result = vendored.contains(probe, prereleases=policy)
+            assert up_result == nab_result, (
+                f"set={spec_set!r} probe={probe!r} prereleases={policy!r}: "
+                f"upstream={up_result} vendored={nab_result}"
+            )
+
+
+@DEEP_SETTINGS
+@given(spec_set=specifier_set_strings(), probes=probe_lists(min_size=6, max_size=12))
+def test_specifier_set_filter_agrees(spec_set: str, probes: list[str]) -> None:
+    upstream, vendored = _build_pair(spec_set)
+    if upstream is None or vendored is None:
+        return
+    for policy in POLICIES:
+        up_result = list(upstream.filter(probes, prereleases=policy))
+        nab_result = list(vendored.filter(probes, prereleases=policy))
+        assert up_result == nab_result, (
+            f"set={spec_set!r} probes={probes!r} prereleases={policy!r}: "
+            f"upstream={up_result} vendored={nab_result}"
+        )
+
+
+@DEEP_SETTINGS
+@given(spec_set=specifier_set_strings(), probes=probe_lists())
+def test_specifier_set_in_operator_agrees(spec_set: str, probes: list[str]) -> None:
+    upstream, vendored = _build_pair(spec_set)
+    if upstream is None or vendored is None:
+        return
+    for probe in probes:
+        assert (probe in upstream) == (probe in vendored), (
+            f"set={spec_set!r} probe={probe!r}: "
+            f"upstream={probe in upstream} vendored={probe in vendored}"
+        )

--- a/nab-python/tests/property_python/test_vendor_homomorphism.py
+++ b/nab-python/tests/property_python/test_vendor_homomorphism.py
@@ -1,0 +1,90 @@
+"""Homomorphism and soundness extras on the vendored range layer.
+
+* ``SpecifierSet`` concatenation must map to range intersection.
+* ``Specifier.filter`` (single-spec path) differential vs upstream.
+* ``is_prerelease_only`` soundness: a range that contains any final
+  version must not claim to be prerelease-only.
+* ``is_unsatisfiable`` soundness: an unsatisfiable set matches nothing.
+"""
+
+from __future__ import annotations
+
+import packaging.specifiers as up_spec
+import pytest
+from hypothesis import given
+
+from nab_python._vendor.packaging import specifiers as nab_spec
+from nab_python._vendor.packaging.version import InvalidVersion, Version
+
+from .strategies import DEEP_SETTINGS
+from .vendor_strategies import probe_lists, specifier_set_strings, specifier_strings
+
+pytestmark = pytest.mark.property
+
+POLICIES = (None, True, False)
+
+
+@DEEP_SETTINGS
+@given(a=specifier_set_strings(), b=specifier_set_strings(), probes=probe_lists())
+def test_intersection_homomorphism(a: str, b: str, probes: list[str]) -> None:
+    combined = nab_spec.SpecifierSet(f"{a},{b}").to_range()
+    folded = nab_spec.SpecifierSet(a).to_range() & nab_spec.SpecifierSet(b).to_range()
+    assert combined == folded, (
+        f"to_range({a!r},{b!r}) != to_range({a!r}) & to_range({b!r}): "
+        f"{combined!r} vs {folded!r}"
+    )
+    for probe in probes:
+        assert combined.contains(probe, prereleases=True) == folded.contains(
+            probe, prereleases=True
+        ), f"membership: a={a!r} b={b!r} probe={probe!r}"
+
+
+@DEEP_SETTINGS
+@given(spec=specifier_strings(), probes=probe_lists(min_size=6, max_size=12))
+def test_single_specifier_filter_agrees_with_upstream(
+    spec: str, probes: list[str]
+) -> None:
+    try:
+        upstream = up_spec.Specifier(spec)
+    except up_spec.InvalidSpecifier:
+        return
+    vendored = nab_spec.Specifier(spec)
+    for policy in POLICIES:
+        up_result = list(upstream.filter(probes, prereleases=policy))
+        nab_result = list(vendored.filter(probes, prereleases=policy))
+        assert up_result == nab_result, (
+            f"spec={spec!r} probes={probes!r} prereleases={policy!r}: "
+            f"upstream={up_result} vendored={nab_result}"
+        )
+
+
+@DEEP_SETTINGS
+@given(spec_set=specifier_set_strings(), probes=probe_lists())
+def test_is_prerelease_only_soundness(spec_set: str, probes: list[str]) -> None:
+    spec = nab_spec.SpecifierSet(spec_set)
+    rng = spec.to_range()
+    if not rng.is_prerelease_only:
+        return
+    for probe in probes:
+        try:
+            parsed = Version(probe)
+        except InvalidVersion:
+            continue
+        if parsed.is_prerelease:
+            continue
+        assert not rng.contains(probe, prereleases=True), (
+            f"is_prerelease_only range contains final {probe!r}: "
+            f"set={spec_set!r} range={rng!r}"
+        )
+
+
+@DEEP_SETTINGS
+@given(spec_set=specifier_set_strings(), probes=probe_lists())
+def test_is_unsatisfiable_soundness(spec_set: str, probes: list[str]) -> None:
+    spec = nab_spec.SpecifierSet(spec_set)
+    if not spec.is_unsatisfiable():
+        return
+    for probe in probes:
+        assert not spec.contains(probe), (
+            f"unsatisfiable set matched {probe!r}: set={spec_set!r}"
+        )

--- a/nab-python/tests/property_python/test_vendor_marker_differential.py
+++ b/nab-python/tests/property_python/test_vendor_marker_differential.py
@@ -1,0 +1,179 @@
+"""Differential PEP 508 marker semantics: vendored vs upstream packaging.
+
+Generates syntactically plausible marker strings (all comparison ops,
+``in``/``not in``, ``and``/``or`` chains, parens, literal vs variable on
+either side) plus random environments (valid and invalid version
+strings) and asserts both implementations agree on parse acceptance,
+evaluation result, and raised exception class name.
+"""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+import packaging.markers as up_markers
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+import nab_python._vendor.packaging.markers as nb_markers
+
+from .strategies import DEEP_SETTINGS
+
+pytestmark = pytest.mark.property
+
+VERSION_VARS = (
+    "python_version",
+    "python_full_version",
+    "implementation_version",
+    "platform_release",
+)
+STRING_VARS = (
+    "os_name",
+    "sys_platform",
+    "platform_machine",
+    "platform_system",
+    "platform_version",
+    "platform_python_implementation",
+    "implementation_name",
+    "extra",
+)
+ALL_VARS = VERSION_VARS + STRING_VARS
+
+OPS = ("<", "<=", "==", "!=", ">=", ">", "~=", "===", "in", "not in")
+
+VERSIONISH = (
+    "1.0",
+    "2.0.1",
+    "1!1.0",
+    "1.0+abc",
+    "1.0+ubuntu.1",
+    "1.0.dev1",
+    "1.0.post1",
+    "1.0rc1",
+    "1.0a1",
+    "3.*",
+    "1.0.*",
+    "0.dev0",
+    "1.2.3.4.5",
+    "01.0",
+    "v1.0",
+    "3.11",
+    "3.11.0",
+)
+STRINGY = (
+    "linux",
+    "Linux",
+    "",
+    "a b",
+    "extra",
+    "5.15.0-86-generic",
+    "not-a-version",
+    "*",
+    ".",
+    "10",
+)
+VALUES = VERSIONISH + STRINGY
+
+values = st.sampled_from(VALUES)
+variables = st.sampled_from(ALL_VARS)
+ops = st.sampled_from(OPS)
+
+
+@st.composite
+def atoms(draw: st.DrawFn) -> str:
+    op = draw(ops)
+    form = draw(st.integers(0, 2))
+    var = draw(variables)
+    val = draw(values)
+    if form == 0:
+        return f'{var} {op} "{val}"'
+    if form == 1:
+        return f'"{val}" {op} {var}'
+    other = draw(values)
+    return f'"{val}" {op} "{other}"'
+
+
+def _combine(children: st.SearchStrategy[str]) -> st.SearchStrategy[str]:
+    @st.composite
+    def inner(draw: st.DrawFn) -> str:
+        n = draw(st.integers(2, 3))
+        parts = [draw(children) for _ in range(n)]
+        joiners = [draw(st.sampled_from([" and ", " or "])) for _ in range(n - 1)]
+        out = parts[0]
+        for joiner, part in zip(joiners, parts[1:], strict=True):
+            out += joiner + part
+        if draw(st.booleans()):
+            return f"({out})"
+        return out
+
+    return inner()
+
+
+marker_strings = st.recursive(atoms(), _combine, max_leaves=6)
+
+environments = st.dictionaries(st.sampled_from(ALL_VARS), values, max_size=6)
+
+
+def _outcome(mod: ModuleType, text: str, env: dict[str, str]) -> tuple[str, object]:
+    try:
+        marker = mod.Marker(text)
+    except Exception as exc:  # noqa: BLE001
+        return ("parse-error", type(exc).__name__)
+    try:
+        return ("value", marker.evaluate(dict(env)))
+    except Exception as exc:  # noqa: BLE001
+        return ("eval-error", type(exc).__name__)
+
+
+@DEEP_SETTINGS
+@given(text=marker_strings, env=environments)
+def test_vendored_matches_upstream(text: str, env: dict[str, str]) -> None:
+    up = _outcome(up_markers, text, env)
+    nb = _outcome(nb_markers, text, env)
+    assert up == nb, f"marker {text!r} env {env!r}: upstream {up} vendored {nb}"
+
+
+_FREE_CHARS = st.characters(
+    codec="ascii", min_codepoint=32, max_codepoint=126, exclude_characters="\"'\\"
+)
+free_values = st.text(_FREE_CHARS, max_size=12)
+
+
+@st.composite
+def free_atoms(draw: st.DrawFn) -> str:
+    var = draw(variables)
+    op = draw(ops)
+    val = draw(free_values)
+    quote = draw(st.sampled_from(['"', "'"]))
+    if draw(st.booleans()):
+        return f"{var} {op} {quote}{val}{quote}"
+    return f"{quote}{val}{quote} {op} {var}"
+
+
+free_marker_strings = st.recursive(free_atoms(), _combine, max_leaves=4)
+
+
+@DEEP_SETTINGS
+@given(
+    text=free_marker_strings,
+    env=st.dictionaries(variables, free_values, max_size=4),
+)
+def test_free_text_values_match_upstream(text: str, env: dict[str, str]) -> None:
+    up = _outcome(up_markers, text, env)
+    nb = _outcome(nb_markers, text, env)
+    assert up == nb, f"marker {text!r} env {env!r}: upstream {up} vendored {nb}"
+
+
+@DEEP_SETTINGS
+@given(text=marker_strings)
+def test_str_roundtrip_matches_upstream(text: str) -> None:
+    try:
+        up: str | tuple[str, str] = str(up_markers.Marker(text))
+    except Exception as exc:  # noqa: BLE001
+        up = ("parse-error", type(exc).__name__)
+    try:
+        nb: str | tuple[str, str] = str(nb_markers.Marker(text))
+    except Exception as exc:  # noqa: BLE001
+        nb = ("parse-error", type(exc).__name__)
+    assert up == nb, f"marker {text!r}: upstream {up!r} vendored {nb!r}"

--- a/nab-python/tests/property_python/test_vendor_metadata_email_differential.py
+++ b/nab-python/tests/property_python/test_vendor_metadata_email_differential.py
@@ -1,0 +1,148 @@
+"""Differential METADATA parsing: nab parse_metadata vs upstream packaging.
+
+Oracles:
+
+* field agreement with upstream ``packaging.metadata.parse_email`` raw
+  output
+* metamorphic: header-name recasing, unknown-header interleaving, body
+  isolation
+* bytes/str input equivalence
+"""
+
+from __future__ import annotations
+
+import random
+
+import packaging.metadata as up_meta
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+from packaging.requirements import Requirement as UpReq
+
+from nab_python.metadata import parse_metadata
+
+from .strategies import DEEP_SETTINGS
+
+pytestmark = pytest.mark.property
+
+names = st.from_regex(r"[A-Za-z0-9]([A-Za-z0-9._-]{0,10}[A-Za-z0-9])?", fullmatch=True)
+version_strs = st.sampled_from(
+    ["1.0", "0.1.dev0", "2!1.0rc1", "1.0.post3+local.7", "1.0a1", "10.20.30"]
+)
+req_strs = st.sampled_from(
+    [
+        "numpy>=1.26",
+        'pytest; extra == "test"',
+        "pkg[a,b]~=2.0",
+        'dep===1.0+local; python_version < "3.10" or os_name == "posix"',
+        "url-dep @ https://example.com/x.whl",
+    ]
+)
+extra_strs = st.sampled_from(["test", "Dev_Tools", "docs.x", "ALL"])
+dynamic_strs = st.sampled_from(
+    ["Requires-Dist", "requires-dist", "PROVIDES-EXTRA", "Author", "License-File"]
+)
+rp_strs = st.sampled_from([">=3.9", "<4, >=3.8", "~=3.10", "==3.11.*"])
+
+
+def _recase(upper: bool, s: str) -> str:
+    return s.upper() if upper else s.lower()
+
+
+@st.composite
+def metadata_inputs(draw: st.DrawFn) -> str:
+    lines: list[str] = []
+    cases = st.booleans()
+    lines.append(f"{_recase(draw(cases), 'Metadata-Version')}: 2.2")
+    lines.append(f"{_recase(draw(cases), 'Name')}: {draw(names)}")
+    lines.append(f"{_recase(draw(cases), 'Version')}: {draw(version_strs)}")
+    if draw(st.booleans()):
+        lines.append(f"{_recase(draw(cases), 'Requires-Python')}: {draw(rp_strs)}")
+    for r in draw(st.lists(req_strs, max_size=4)):
+        lines.append(f"{_recase(draw(cases), 'Requires-Dist')}: {r}")
+    for e in draw(st.lists(extra_strs, max_size=3)):
+        lines.append(f"{_recase(draw(cases), 'Provides-Extra')}: {e}")
+    for d in draw(st.lists(dynamic_strs, max_size=3)):
+        lines.append(f"{_recase(draw(cases), 'Dynamic')}: {d}")
+    # unknown headers sprinkled anywhere
+    unknown = st.sampled_from(["Summary: stuff", "Author: A B", "X-Junk: 1"])
+    for u in draw(st.lists(unknown, max_size=3)):
+        lines.insert(draw(st.integers(0, len(lines))), u)
+    text = "\n".join(lines) + "\n"
+    if draw(st.booleans()):
+        text += "\nLong description body...\nRequires-Dist: not-a-header-anymore\n"
+    return text
+
+
+@DEEP_SETTINGS
+@given(text=metadata_inputs())
+def test_fields_agree_with_upstream_raw(text: str) -> None:
+    nab = parse_metadata(text)
+    raw, _unparsed = up_meta.parse_email(text)
+    assert nab.name == raw.get("name"), text
+    assert str(nab.version) == raw.get("version"), text
+    up_rp = raw.get("requires_python")
+    if up_rp is None:
+        assert nab.requires_python is None, text
+    else:
+        assert nab.requires_python is not None, text
+        assert str(nab.requires_python) == str(type(nab.requires_python)(up_rp)), text
+    up_reqs = raw.get("requires_dist") or []
+    assert [str(r) for r in nab.requires_dist] == [str(UpReq(r)) for r in up_reqs], text
+    assert nab.provides_extra == (raw.get("provides_extra") or []), text
+    assert nab.dynamic == frozenset(d.lower() for d in (raw.get("dynamic") or [])), text
+    assert nab.metadata_version == raw.get("metadata_version"), text
+
+
+@DEEP_SETTINGS
+@given(text=metadata_inputs())
+def test_bytes_and_str_inputs_equivalent(text: str) -> None:
+    a = parse_metadata(text)
+    b = parse_metadata(text.encode("utf-8"))
+    assert (a.name, str(a.version), a.provides_extra, a.dynamic) == (
+        b.name,
+        str(b.version),
+        b.provides_extra,
+        b.dynamic,
+    )
+    assert [str(r) for r in a.requires_dist] == [str(r) for r in b.requires_dist]
+
+
+@DEEP_SETTINGS
+@given(text=metadata_inputs(), rng=st.randoms(use_true_random=False))
+def test_header_recasing_is_identity(text: str, rng: random.Random) -> None:
+    headers, sep, body = text.partition("\n\n")
+    recased_lines = []
+    for line in headers.splitlines():
+        key, colon, val = line.partition(":")
+        recased_lines.append(
+            "".join(c.upper() if rng.random() < 0.5 else c.lower() for c in key)
+            + colon
+            + val
+        )
+    recased = "\n".join(recased_lines) + "\n" + sep + body
+    a = parse_metadata(text)
+    b = parse_metadata(recased)
+    assert a.name == b.name
+    assert a.version == b.version
+    assert [str(r) for r in a.requires_dist] == [str(r) for r in b.requires_dist]
+    assert a.provides_extra == b.provides_extra
+    assert a.dynamic == b.dynamic
+    assert (a.requires_python is None) == (b.requires_python is None)
+
+
+@DEEP_SETTINGS
+@given(text=metadata_inputs())
+def test_body_never_contributes_fields(text: str) -> None:
+    headers, _, _ = text.partition("\n\n")
+    if not headers.endswith("\n"):
+        headers += "\n"
+    base = parse_metadata(headers)
+    poisoned = (
+        headers
+        + "\nRequires-Dist: evil-pkg\nDynamic: Requires-Dist\nProvides-Extra: evil\n"
+    )
+    after = parse_metadata(poisoned)
+    assert [str(r) for r in base.requires_dist] == [str(r) for r in after.requires_dist]
+    assert base.dynamic == after.dynamic
+    assert base.provides_extra == after.provides_extra

--- a/nab-python/tests/property_python/test_vendor_metamorphic_canonical.py
+++ b/nab-python/tests/property_python/test_vendor_metamorphic_canonical.py
@@ -1,0 +1,137 @@
+"""Metamorphic and canonical-form properties on the vendored range layer.
+
+* Trailing-zero padding of versions in non-wildcard specifiers must not
+  change the range (PEP 440: release segments compare zero-padded).
+* PEP 440 defines ``~= V`` as ``>= V, == prefix.*``; both spellings
+  must produce the same range.
+* Unsatisfiable sets must equal the canonical empty range.
+* A single ``Specifier`` and the singleton ``SpecifierSet`` must agree.
+* ``==V`` and ``!=V`` must partition the PEP 440 version universe.
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_python._vendor.packaging.ranges import VersionRange
+from nab_python._vendor.packaging.specifiers import Specifier, SpecifierSet
+from nab_python._vendor.packaging.version import InvalidVersion, Version
+
+from .strategies import DEEP_SETTINGS
+from .vendor_strategies import (
+    DEVS,
+    EPOCHS,
+    POSTS,
+    PRES,
+    probe_lists,
+    releases,
+    specifier_strings,
+    version_strings,
+    version_strings_no_local,
+)
+
+pytestmark = pytest.mark.property
+
+PADDABLE_OPS = st.sampled_from(["==", "!=", ">=", "<=", ">", "<"])
+
+
+@DEEP_SETTINGS
+@given(
+    op=PADDABLE_OPS,
+    version=version_strings_no_local(),
+    pad=st.integers(1, 3),
+    probes=probe_lists(),
+)
+def test_trailing_zero_padding_is_identity(
+    op: str, version: str, pad: int, probes: list[str]
+) -> None:
+    # "1.2rc1.post0" -> pad release only; splitting at the first non-digit
+    # non-dot character keeps suffixes intact.
+    head_end = 0
+    while head_end < len(version) and (
+        version[head_end].isdigit() or version[head_end] in ".!"
+    ):
+        head_end += 1
+    head, tail = version[:head_end], version[head_end:]
+    if head.endswith("."):
+        return
+    padded = head + ".0" * pad + tail
+    base_range = SpecifierSet(op + version).to_range()
+    padded_range = SpecifierSet(op + padded).to_range()
+    assert base_range == padded_range, (
+        f"padding changed the range: {op + version!r} vs {op + padded!r}: "
+        f"{base_range!r} vs {padded_range!r}"
+    )
+    for probe in probes:
+        assert base_range.contains(probe, prereleases=True) == padded_range.contains(
+            probe, prereleases=True
+        ), f"padding membership: {op + version!r} vs {op + padded!r} probe={probe!r}"
+
+
+@DEEP_SETTINGS
+@given(
+    epoch=EPOCHS,
+    release=releases(max_segments=3),
+    pre=PRES,
+    post=POSTS,
+    dev=DEVS,
+    probes=probe_lists(),
+)
+def test_compatible_release_equals_pep440_definition(
+    epoch: str, release: str, pre: str, post: str, dev: str, probes: list[str]
+) -> None:
+    if "." not in release:
+        release += ".0"
+    version = epoch + release + pre + post + dev
+    prefix = epoch + release.rsplit(".", 1)[0]
+    tilde = SpecifierSet(f"~={version}").to_range()
+    spelled = SpecifierSet(f">={version},=={prefix}.*").to_range()
+    assert tilde == spelled, (
+        f"~={version} != '>={version},=={prefix}.*': {tilde!r} vs {spelled!r}"
+    )
+    for probe in probes:
+        assert tilde.contains(probe, prereleases=True) == spelled.contains(
+            probe, prereleases=True
+        ), f"~= membership: version={version!r} probe={probe!r}"
+
+
+@DEEP_SETTINGS
+@given(version=version_strings_no_local())
+def test_unsatisfiable_set_is_canonical_empty(version: str) -> None:
+    rng = SpecifierSet(f">{version},<{version}").to_range()
+    assert rng.is_empty
+    assert rng == VersionRange.empty(), (
+        f">{version},<{version} -> {rng!r}, expected canonical empty"
+    )
+
+
+@DEEP_SETTINGS
+@given(spec=specifier_strings())
+def test_specifier_and_singleton_set_agree(spec: str) -> None:
+    single = VersionRange.from_specifier(Specifier(spec))
+    as_set = SpecifierSet(spec).to_range()
+    assert single == as_set, f"{spec!r}: {single!r} vs {as_set!r}"
+
+
+@DEEP_SETTINGS
+@given(version=version_strings(), probes=probe_lists())
+def test_eq_neq_partition(version: str, probes: list[str]) -> None:
+    eq_range = SpecifierSet(f"=={version}").to_range()
+    neq_range = SpecifierSet(f"!={version}").to_range()
+    assert (eq_range & neq_range).is_empty, f"=={version} & !={version} not empty"
+    assert ~eq_range == neq_range, (
+        f"~(=={version}) != (!={version}): {~eq_range!r} vs {neq_range!r}"
+    )
+    union = eq_range | neq_range
+    pep440_full = VersionRange.full(admit_arbitrary=False)
+    for probe in probes:
+        try:
+            Version(probe)
+        except InvalidVersion:
+            continue
+        if pep440_full.contains(probe, prereleases=True):
+            assert union.contains(probe, prereleases=True), (
+                f"== | != must cover every version: version={version!r} probe={probe!r}"
+            )

--- a/nab-python/tests/property_python/test_vendor_pep643_properties.py
+++ b/nab-python/tests/property_python/test_vendor_pep643_properties.py
@@ -1,0 +1,122 @@
+"""PEP 643 staticness properties for ``metadata_deps_are_static``.
+
+* ``Dynamic`` field is case-insensitive end to end (header value casing
+  never matters)
+* version threshold: parsed ``(major, minor) < (2, 2)`` is never static
+* monotonicity: adding ``Dynamic`` entries never makes metadata more
+  trusted
+* arbitrary ``Metadata-Version`` strings never crash; unparseable means
+  untrusted
+* pre-2.2 PKG-INFO deps untrusted by default
+  (``_sdist_deps_need_dynamic``)
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_python._provider.metadata_resolver import _sdist_deps_need_dynamic
+from nab_python._vendor.packaging.version import Version
+from nab_python.metadata import (
+    DEPENDENCY_FIELDS,
+    WheelMetadata,
+    metadata_deps_are_static,
+    parse_metadata,
+)
+
+from .strategies import DEEP_SETTINGS
+
+pytestmark = pytest.mark.property
+
+DEP_FIELDS = sorted(DEPENDENCY_FIELDS)
+NON_DEP_FIELDS = ["author", "license-file", "classifier", "requires-python", "summary"]
+
+
+def _randcase(s: str, mask: int) -> str:
+    return "".join(c.upper() if (mask >> i) & 1 else c.lower() for i, c in enumerate(s))
+
+
+@DEEP_SETTINGS
+@given(
+    field=st.sampled_from(DEP_FIELDS),
+    mask=st.integers(0, 2**16),
+    mv=st.sampled_from(["2.2", "2.3", "2.4", "2.5", "3.0", "12.0"]),
+)
+def test_dynamic_dep_field_any_casing_blocks_static(
+    field: str, mask: int, mv: str
+) -> None:
+    text = (
+        f"Metadata-Version: {mv}\nName: p\nVersion: 1.0\n"
+        f"Dynamic: {_randcase(field, mask)}\n"
+    )
+    md = parse_metadata(text)
+    assert metadata_deps_are_static(md) is False, text
+
+
+@DEEP_SETTINGS
+@given(
+    fields=st.lists(st.sampled_from(NON_DEP_FIELDS), max_size=4),
+    mv=st.sampled_from(["2.2", "2.3", "2.6", "10.0"]),
+)
+def test_non_dep_dynamic_fields_do_not_block_static(fields: list[str], mv: str) -> None:
+    lines = [f"Metadata-Version: {mv}", "Name: p", "Version: 1.0"]
+    lines += [f"Dynamic: {f}" for f in fields]
+    md = parse_metadata("\n".join(lines) + "\n")
+    assert metadata_deps_are_static(md) is True
+
+
+@DEEP_SETTINGS
+@given(major=st.integers(0, 1), minor=st.integers(0, 9))
+def test_below_2_2_never_static(major: int, minor: int) -> None:
+    md = WheelMetadata(
+        name="p", version=Version("1.0"), metadata_version=f"{major}.{minor}"
+    )
+    assert metadata_deps_are_static(md) is False
+    assert _sdist_deps_need_dynamic(md, trust_unverified=False) is True
+
+
+@DEEP_SETTINGS
+@given(mv=st.text(max_size=12))
+def test_arbitrary_metadata_version_never_crashes(mv: str) -> None:
+    md = WheelMetadata(name="p", version=Version("1.0"), metadata_version=mv)
+    result = metadata_deps_are_static(md)
+    assert isinstance(result, bool)
+    parts = mv.split(".")[:2]
+    try:
+        nums = [int(p) for p in parts]
+        parseable = len(nums) == 2
+    except ValueError:
+        parseable = False
+    if not parseable:
+        assert result is False, f"unparseable {mv!r} must be untrusted"
+
+
+@DEEP_SETTINGS
+@given(
+    mv=st.sampled_from(["2.2", "2.5", "9.9"]),
+    base=st.sets(st.sampled_from(DEP_FIELDS + NON_DEP_FIELDS), max_size=5),
+    extra=st.sets(st.sampled_from(DEP_FIELDS + NON_DEP_FIELDS), max_size=3),
+)
+def test_adding_dynamic_fields_is_monotone(
+    mv: str, base: set[str], extra: set[str]
+) -> None:
+    md_small = WheelMetadata(
+        name="p", version=Version("1.0"), metadata_version=mv, dynamic=frozenset(base)
+    )
+    md_big = WheelMetadata(
+        name="p",
+        version=Version("1.0"),
+        metadata_version=mv,
+        dynamic=frozenset(base | extra),
+    )
+    if not metadata_deps_are_static(md_small):
+        assert not metadata_deps_are_static(md_big)
+
+
+@DEEP_SETTINGS
+@given(mv=st.sampled_from(["1.0", "1.1", "1.2", "2.1"]), trust=st.booleans())
+def test_pre_2_2_trust_flag_is_the_only_escape(mv: str, trust: bool) -> None:
+    md = WheelMetadata(name="p", version=Version("1.0"), metadata_version=mv)
+    assert _sdist_deps_need_dynamic(md, trust_unverified=trust) is (not trust)

--- a/nab-python/tests/property_python/test_vendor_range_vs_specset.py
+++ b/nab-python/tests/property_python/test_vendor_range_vs_specset.py
@@ -1,0 +1,131 @@
+"""VersionRange must match its originating SpecifierSet exactly.
+
+Doc anchor (vendored ``packaging/ranges.py`` module docstring):
+"membership and filtering match the originating specifier; and
+conversion back to a SpecifierSet is available where a PEP 440 form
+exists."
+"""
+
+from __future__ import annotations
+
+import pickle
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_python._vendor.packaging.ranges import VersionRange
+from nab_python._vendor.packaging.specifiers import SpecifierSet
+
+from .strategies import DEEP_SETTINGS
+from .vendor_strategies import probe_lists, specifier_set_strings
+
+pytestmark = pytest.mark.property
+
+POLICIES = (None, True, False)
+CONFIGURED = st.sampled_from([None, True, False])
+
+
+@DEEP_SETTINGS
+@given(spec_set=specifier_set_strings(), configured=CONFIGURED, probes=probe_lists())
+def test_range_contains_matches_specifier_set(
+    spec_set: str, configured: bool | None, probes: list[str]
+) -> None:
+    spec = SpecifierSet(spec_set, prereleases=configured)
+    rng = spec.to_range()
+    for probe in probes:
+        for policy in POLICIES:
+            spec_result = spec.contains(probe, prereleases=policy)
+            range_result = rng.contains(probe, prereleases=policy)
+            assert spec_result == range_result, (
+                f"set={spec_set!r} cfg={configured!r} probe={probe!r} "
+                f"prereleases={policy!r}: spec={spec_result} range={range_result}"
+            )
+        assert (probe in spec) == (probe in rng), (
+            f"in-operator: set={spec_set!r} cfg={configured!r} probe={probe!r}"
+        )
+
+
+@DEEP_SETTINGS
+@given(
+    spec_set=specifier_set_strings(),
+    configured=CONFIGURED,
+    probes=probe_lists(min_size=6, max_size=12),
+)
+def test_range_filter_matches_specifier_set(
+    spec_set: str, configured: bool | None, probes: list[str]
+) -> None:
+    spec = SpecifierSet(spec_set, prereleases=configured)
+    rng = spec.to_range()
+    for policy in POLICIES:
+        spec_result = list(spec.filter(probes, prereleases=policy))
+        range_result = list(rng.filter(probes, prereleases=policy))
+        assert spec_result == range_result, (
+            f"set={spec_set!r} cfg={configured!r} prereleases={policy!r}: "
+            f"spec={spec_result} range={range_result}"
+        )
+
+
+@DEEP_SETTINGS
+@given(spec_set=specifier_set_strings(), configured=CONFIGURED, probes=probe_lists())
+def test_to_specifier_sets_round_trip(
+    spec_set: str, configured: bool | None, probes: list[str]
+) -> None:
+    spec = SpecifierSet(spec_set, prereleases=configured)
+    rng = spec.to_range()
+    try:
+        pieces = rng.to_specifier_sets()
+    except AssertionError:
+        # Vendored snapshot bug: <=V.postN.dev0 trips an assertion here; fix pending re-vendor.
+        return
+    if pieces is None:
+        return
+    recovered = VersionRange.empty(prereleases=configured)
+    for piece in pieces:
+        recovered = recovered | VersionRange.from_specifier_set(piece)
+    if configured is not False:
+        # Doc: structurally equal under autodetect or explicit True.
+        assert recovered == rng, (
+            f"set={spec_set!r} cfg={configured!r}: pieces="
+            f"{[str(p) for p in pieces]} recovered={recovered!r} source={rng!r}"
+        )
+    # Either way the recovered range must match the same versions.
+    for probe in probes:
+        assert (probe in recovered) == (probe in rng), (
+            f"membership drift: set={spec_set!r} cfg={configured!r} "
+            f"probe={probe!r} pieces={[str(p) for p in pieces]}"
+        )
+
+
+@DEEP_SETTINGS
+@given(spec_set=specifier_set_strings(), configured=CONFIGURED, probes=probe_lists())
+def test_to_specifier_set_membership_round_trip(
+    spec_set: str, configured: bool | None, probes: list[str]
+) -> None:
+    spec = SpecifierSet(spec_set, prereleases=configured)
+    rng = spec.to_range()
+    try:
+        single = rng.to_specifier_set()
+    except AssertionError:
+        # Vendored snapshot bug: <=V.postN.dev0 trips an assertion here; fix pending re-vendor.
+        return
+    if single is None:
+        return
+    for probe in probes:
+        assert (probe in single) == (probe in rng), (
+            f"set={spec_set!r} cfg={configured!r} probe={probe!r} "
+            f"single={single!r}: in_single={probe in single} in_range={probe in rng}"
+        )
+    # Filter equivalence is promised at the configured policy (default args).
+    assert list(single.filter(probes)) == list(rng.filter(probes)), (
+        f"filter drift: set={spec_set!r} cfg={configured!r} single={single!r}"
+    )
+
+
+@DEEP_SETTINGS
+@given(spec_set=specifier_set_strings(), configured=CONFIGURED)
+def test_pickle_round_trip(spec_set: str, configured: bool | None) -> None:
+    rng = SpecifierSet(spec_set, prereleases=configured).to_range()
+    restored = pickle.loads(pickle.dumps(rng))  # noqa: S301
+    assert restored == rng
+    assert hash(restored) == hash(rng)

--- a/nab-python/tests/property_python/test_vendor_requirement_differential.py
+++ b/nab-python/tests/property_python/test_vendor_requirement_differential.py
@@ -1,0 +1,216 @@
+"""Differential PEP 508 requirement parsing: vendored vs upstream.
+
+Oracles:
+
+* outcome agreement on valid-by-construction and corrupted strings:
+  either both parsers raise the same exception class or both accept
+  with equal attributes (name, extras, specifier, marker, url)
+* ``str()`` round-trip fixed point on both parsers
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+from packaging.requirements import Requirement as UpReq
+
+from nab_python._vendor.packaging.requirements import Requirement as NabReq
+
+from .strategies import DEEP_SETTINGS
+
+pytestmark = pytest.mark.property
+
+ws = st.text(alphabet=" \t", max_size=2)
+
+names = st.from_regex(r"[A-Za-z0-9]([A-Za-z0-9._-]{0,10}[A-Za-z0-9])?", fullmatch=True)
+
+extra_names = st.from_regex(
+    r"[A-Za-z0-9]([A-Za-z0-9._-]{0,6}[A-Za-z0-9])?", fullmatch=True
+)
+
+
+@st.composite
+def versions(draw: st.DrawFn) -> str:
+    epoch = draw(st.one_of(st.none(), st.integers(0, 3)))
+    release = ".".join(
+        str(draw(st.integers(0, 100))) for _ in range(draw(st.integers(1, 4)))
+    )
+    pre = draw(st.one_of(st.none(), st.sampled_from(["a1", "b2", "rc3", ".alpha4"])))
+    post = draw(st.one_of(st.none(), st.sampled_from([".post1", "-1", "post2"])))
+    dev = draw(st.one_of(st.none(), st.sampled_from([".dev0", "dev3"])))
+    local = draw(st.one_of(st.none(), st.sampled_from(["+local", "+abc.123", "+1-2"])))
+    v = release
+    if epoch is not None:
+        v = f"{epoch}!{v}"
+    if pre is not None:
+        v += pre
+    if post is not None:
+        v += post
+    if dev is not None:
+        v += dev
+    if local is not None:
+        v += local
+    return v
+
+
+@st.composite
+def specifiers(draw: st.DrawFn) -> str:
+    n = draw(st.integers(1, 3))
+    clauses = []
+    for _ in range(n):
+        op = draw(st.sampled_from(["==", "!=", ">=", "<=", ">", "<", "~=", "==="]))
+        v = draw(versions())
+        if op == "~=" and "!" not in v and v.count(".") == 0:
+            v += ".0"  # ~= needs at least two release segments
+        if op in ("==", "!=") and draw(st.booleans()) and "+" not in v:
+            v += ".*"
+        clauses.append(op + draw(ws) + v)
+    return (draw(ws) + ",").join(clauses)
+
+
+MARKER_VARS = [
+    "python_version",
+    "python_full_version",
+    "os_name",
+    "sys_platform",
+    "platform_machine",
+    "platform_python_implementation",
+    "implementation_name",
+    "extra",
+]
+
+
+@st.composite
+def marker_atoms(draw: st.DrawFn) -> str:
+    var = draw(st.sampled_from(MARKER_VARS))
+    op = draw(st.sampled_from(["==", "!=", ">=", "<=", ">", "<", "~=", "in", "not in"]))
+    if var == "extra":
+        # Both parsers skip PEP 685 normalization for parenthesized extra atoms, breaking the str fixed point; only canonical values here.
+        val = draw(st.sampled_from(["linux", "win32", "x86-64", "cpython"]))
+    else:
+        val = draw(
+            st.sampled_from(
+                [
+                    "3.8",
+                    "3.10.1",
+                    "linux",
+                    "win32",
+                    "x86_64",
+                    "cpython",
+                    "spam eggs",
+                    "",
+                ]
+            )
+        )
+    quote = draw(st.sampled_from(['"', "'"]))
+    flip = draw(st.booleans())
+    lhs, rhs = (f"{quote}{val}{quote}", var) if flip else (var, f"{quote}{val}{quote}")
+    return f"{lhs} {op} {rhs}"
+
+
+@st.composite
+def markers(draw: st.DrawFn) -> str:
+    n = draw(st.integers(1, 3))
+    parts = [draw(marker_atoms())]
+    for _ in range(n - 1):
+        joiner = draw(st.sampled_from([" and ", " or "]))
+        atom = draw(marker_atoms())
+        if draw(st.booleans()):
+            atom = f"({atom})"
+        parts.append(joiner + atom)
+    return "".join(parts)
+
+
+URLS = [
+    "https://example.com/pkg-1.0-py3-none-any.whl",
+    "file:///tmp/pkg-1.0.tar.gz",
+    "git+https://github.com/o/r@deadbeef#egg=pkg",
+    "https://example.com/x.whl#sha256=0123abcd",
+]
+
+
+@st.composite
+def requirement_strings(draw: st.DrawFn) -> str:
+    s = draw(names)
+    if draw(st.booleans()):
+        extras = draw(st.lists(extra_names, min_size=1, max_size=3))
+        s += draw(ws) + "[" + (draw(ws) + ",").join(extras) + draw(ws) + "]"
+    use_url = draw(st.booleans())
+    if use_url:
+        s += draw(ws) + "@ " + draw(st.sampled_from(URLS))
+        if draw(st.booleans()):
+            s += " ; " + draw(markers())  # URL reqs need whitespace before ;
+        return s
+    if draw(st.booleans()):
+        spec = draw(specifiers())
+        if draw(st.booleans()):
+            spec = "(" + spec + ")"
+        s += draw(ws) + spec
+    if draw(st.booleans()):
+        s += draw(ws) + ";" + draw(ws) + draw(markers())
+    return s
+
+
+def _outcome(req_cls: type, s: str) -> tuple[str, object]:
+    try:
+        req = req_cls(s)
+    except Exception as exc:  # noqa: BLE001
+        return ("error", type(exc).__name__)
+    marker = str(req.marker) if req.marker is not None else None
+    return (
+        "value",
+        (req.name, sorted(req.extras), str(req.specifier), marker, req.url, str(req)),
+    )
+
+
+@DEEP_SETTINGS
+@given(s=requirement_strings())
+def test_acceptance_and_attributes_match_upstream(s: str) -> None:
+    up = _outcome(UpReq, s)
+    nb = _outcome(NabReq, s)
+    assert up == nb, f"requirement {s!r}: upstream {up} vendored {nb}"
+
+
+@DEEP_SETTINGS
+@given(s=requirement_strings())
+def test_str_is_fixed_point_both_parsers(s: str) -> None:
+    try:
+        nab = NabReq(s)
+        up = UpReq(s)
+    except Exception:  # noqa: BLE001
+        return
+    once = str(nab)
+    assert str(NabReq(once)) == once, s
+    up_once = str(up)
+    assert str(UpReq(up_once)) == up_once, s
+
+
+@st.composite
+def corrupted(draw: st.DrawFn) -> str:
+    s = draw(requirement_strings())
+    kind = draw(st.integers(0, 6))
+    if not s:
+        return s
+    i = draw(st.integers(0, len(s) - 1))
+    if kind == 0:
+        return s[:i] + "\n" + s[i:]
+    if kind == 1:
+        return s[:i] + s[i + 1 :]
+    if kind == 2:
+        return s[:i] + draw(st.sampled_from(",;[]()@<>=!~ ")) + s[i:]
+    if kind == 3:
+        return s[:i] + s[i] + s[i:]
+    if kind == 4:
+        return s.upper()
+    if kind == 5:
+        return s + draw(st.sampled_from([",", ";", "[", "]", "==", "@"]))
+    return draw(st.sampled_from([",", ";", " ", ""])) + s
+
+
+@DEEP_SETTINGS
+@given(s=corrupted())
+def test_corrupted_acceptance_agreement(s: str) -> None:
+    up = _outcome(UpReq, s)
+    nb = _outcome(NabReq, s)
+    assert up == nb, f"corrupted {s!r}: upstream {up} vendored {nb}"

--- a/nab-python/tests/property_python/test_vendor_specifier_differential.py
+++ b/nab-python/tests/property_python/test_vendor_specifier_differential.py
@@ -1,0 +1,253 @@
+"""Differential Specifier/SpecifierSet semantics: vendored vs upstream.
+
+The vendored ``specifiers.py`` is rewritten on top of the
+``VersionRange`` machinery, so parse acceptance, containment,
+filtering, intersection, and version comparison must stay identical to
+upstream across exotic PEP 440 shapes (epoch, local, dev, post, pre,
+wildcards, ``~=``, ``===``, prereleases flag).  Outcomes compare
+raised exception class names too, so error behavior cannot drift
+silently.  Inputs mix a curated pool of awkward literals with
+generated version shapes.
+"""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+import packaging.specifiers as up_specifiers
+import packaging.version as up_version
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+import nab_python._vendor.packaging.specifiers as nb_specifiers
+import nab_python._vendor.packaging.version as nb_version
+
+from .strategies import DEEP_SETTINGS
+
+pytestmark = pytest.mark.property
+
+OPS = ("<", "<=", "==", "!=", ">=", ">", "~=", "===")
+
+CURATED_VERSIONS = (
+    "1.0",
+    "1",
+    "2.0.1",
+    "1!1.0",
+    "2!1",
+    "1.0+abc",
+    "1.0+abc.2",
+    "1.0+ubuntu-1",
+    "1.0.dev1",
+    "1.0.dev0",
+    "1.0.post1",
+    "1.0.post0.dev1",
+    "1.0rc1",
+    "1.0a1",
+    "1.0b2.post345.dev456",
+    "0.dev0",
+    "1.2.3.4.5",
+    "01.0",
+    "v1.0",
+    "3.11",
+    "3.11.0",
+    "1.1.0",
+    "1.0.0",
+)
+CURATED_SPEC_VERSIONS = (
+    *CURATED_VERSIONS,
+    "3.*",
+    "1.0.*",
+    "1.*",
+    "1.0a1.*",
+    "1.0.post1.*",
+    "*",
+)
+
+prerelease_flags = st.sampled_from([None, True, False])
+
+
+@st.composite
+def generated_version_strings(draw: st.DrawFn) -> str:
+    epoch = draw(st.one_of(st.none(), st.integers(0, 2)))
+    release = ".".join(
+        str(draw(st.integers(0, 20))) for _ in range(draw(st.integers(1, 4)))
+    )
+    pre = draw(
+        st.one_of(st.none(), st.sampled_from(["a0", "b1", "rc2", ".preview3", "-c4"]))
+    )
+    post = draw(st.one_of(st.none(), st.sampled_from([".post0", "-2", "r3"])))
+    dev = draw(st.one_of(st.none(), st.sampled_from([".dev0", "dev1"])))
+    local = draw(
+        st.one_of(st.none(), st.sampled_from(["+l", "+abc.7", "+0", "+a-b_c.1"]))
+    )
+    v = release
+    if epoch is not None:
+        v = f"{epoch}!{v}"
+    if pre is not None:
+        v += pre
+    if post is not None:
+        v += post
+    if dev is not None:
+        v += dev
+    if local is not None:
+        v += local
+    return v
+
+
+version_strings = st.one_of(
+    st.sampled_from(CURATED_VERSIONS), generated_version_strings()
+)
+
+
+@st.composite
+def curated_spec_strings(draw: st.DrawFn) -> str:
+    op = draw(st.sampled_from(OPS))
+    ver = draw(st.sampled_from(CURATED_SPEC_VERSIONS))
+    # Upstream 26.2 bug: ~= with a v prefix matches nothing; the vendored copy follows PEP 440.
+    if op == "~=" and ver.startswith("v"):
+        return f"~={ver[1:]}"
+    space = draw(st.sampled_from(["", " "]))
+    return f"{op}{space}{ver}"
+
+
+@st.composite
+def generated_spec_strings(draw: st.DrawFn) -> str:
+    op = draw(st.sampled_from(OPS))
+    v = draw(generated_version_strings())
+    if op == "~=":
+        v = v.split("+")[0]  # ~= forbids local
+        if "!" in v:
+            head, _, tail = v.partition("!")
+            if tail.count(".") == 0:
+                v = f"{head}!{tail}.0"
+        elif v.count(".") == 0:
+            v += ".0"
+    if op in ("==", "!=") and draw(st.booleans()):
+        base = v.split("+")[0]
+        # wildcard only after a release segment
+        if base.replace(".", "").isdigit() or "!" in base:
+            v = base + ".*"
+    return op + v
+
+
+spec_strings = st.one_of(curated_spec_strings(), generated_spec_strings())
+
+
+@st.composite
+def spec_set_strings(draw: st.DrawFn) -> str:
+    n = draw(st.integers(0, 3))
+    return ",".join(draw(spec_strings) for _ in range(n))
+
+
+def _contains_outcome(
+    mod: ModuleType, spec: str, item: str, flag: bool | None
+) -> tuple[str, object]:
+    try:
+        specifier = mod.Specifier(spec)
+    except Exception as exc:  # noqa: BLE001
+        return ("parse-error", type(exc).__name__)
+    try:
+        return ("value", specifier.contains(item, prereleases=flag))
+    except Exception as exc:  # noqa: BLE001
+        return ("contains-error", type(exc).__name__)
+
+
+def _set_contains_outcome(
+    mod: ModuleType, spec: str, item: str, flag: bool | None
+) -> tuple[str, object]:
+    try:
+        spec_set = mod.SpecifierSet(spec)
+    except Exception as exc:  # noqa: BLE001
+        return ("parse-error", type(exc).__name__)
+    try:
+        return ("value", spec_set.contains(item, prereleases=flag))
+    except Exception as exc:  # noqa: BLE001
+        return ("contains-error", type(exc).__name__)
+
+
+def _filter_outcome(
+    mod: ModuleType, spec: str, items: list[str], flag: bool | None
+) -> tuple[str, object]:
+    try:
+        spec_set = mod.SpecifierSet(spec)
+    except Exception as exc:  # noqa: BLE001
+        return ("parse-error", type(exc).__name__)
+    try:
+        return (
+            "value",
+            [str(v) for v in spec_set.filter(items, prereleases=flag)],
+        )
+    except Exception as exc:  # noqa: BLE001
+        return ("filter-error", type(exc).__name__)
+
+
+def _intersection_outcome(mod: ModuleType, a: str, b: str) -> tuple[str, object]:
+    try:
+        return ("value", str(mod.SpecifierSet(a) & mod.SpecifierSet(b)))
+    except Exception as exc:  # noqa: BLE001
+        return ("error", type(exc).__name__)
+
+
+@DEEP_SETTINGS
+@given(spec=spec_strings, item=version_strings, flag=prerelease_flags)
+def test_specifier_contains_matches_upstream(
+    spec: str, item: str, flag: bool | None
+) -> None:
+    up = _contains_outcome(up_specifiers, spec, item, flag)
+    nb = _contains_outcome(nb_specifiers, spec, item, flag)
+    assert up == nb, f"Specifier({spec!r}).contains({item!r}, prereleases={flag})"
+
+
+@DEEP_SETTINGS
+@given(spec=spec_set_strings(), item=version_strings, flag=prerelease_flags)
+def test_specifier_set_contains_matches_upstream(
+    spec: str, item: str, flag: bool | None
+) -> None:
+    up = _set_contains_outcome(up_specifiers, spec, item, flag)
+    nb = _set_contains_outcome(nb_specifiers, spec, item, flag)
+    assert up == nb, f"SpecifierSet({spec!r}).contains({item!r}, prereleases={flag})"
+
+
+@DEEP_SETTINGS
+@given(
+    spec=spec_set_strings(),
+    items=st.lists(version_strings, min_size=0, max_size=6),
+    flag=prerelease_flags,
+)
+def test_specifier_set_filter_matches_upstream(
+    spec: str, items: list[str], flag: bool | None
+) -> None:
+    up = _filter_outcome(up_specifiers, spec, items, flag)
+    nb = _filter_outcome(nb_specifiers, spec, items, flag)
+    assert up == nb, f"SpecifierSet({spec!r}).filter({items!r}, prereleases={flag})"
+
+
+@DEEP_SETTINGS
+@given(a=spec_set_strings(), b=spec_set_strings())
+def test_specifier_set_intersection_matches_upstream(a: str, b: str) -> None:
+    up = _intersection_outcome(up_specifiers, a, b)
+    nb = _intersection_outcome(nb_specifiers, a, b)
+    assert up == nb, f"({a!r}) & ({b!r})"
+
+
+@DEEP_SETTINGS
+@given(left=version_strings, right=version_strings)
+def test_version_compare_matches_upstream(left: str, right: str) -> None:
+    try:
+        upl, upr = up_version.Version(left), up_version.Version(right)
+        up: tuple[str, object] = (
+            "value",
+            (upl < upr, upl == upr, str(upl), upl.release),
+        )
+    except Exception as exc:  # noqa: BLE001
+        up = ("error", type(exc).__name__)
+    try:
+        nbl, nbr = nb_version.Version(left), nb_version.Version(right)
+        nb: tuple[str, object] = (
+            "value",
+            (nbl < nbr, nbl == nbr, str(nbl), nbl.release),
+        )
+    except Exception as exc:  # noqa: BLE001
+        nb = ("error", type(exc).__name__)
+    assert up == nb, f"Version compare {left!r} vs {right!r}"

--- a/nab-python/tests/property_python/vendor_strategies.py
+++ b/nab-python/tests/property_python/vendor_strategies.py
@@ -1,0 +1,102 @@
+"""Shared Hypothesis strategies for the vendored-packaging guard tests.
+
+These generate the PEP 440 shapes the differential suites exercise:
+epochs, pre/post/dev segments, local versions, zero padding, long
+releases, wildcards, ``~=``, and ``===``, plus probe lists that mix
+valid and invalid version strings.
+"""
+
+from __future__ import annotations
+
+from hypothesis import strategies as st
+
+EPOCHS = st.sampled_from(["", "1!", "3!"])
+PRES = st.sampled_from(["", "a1", "b2", "rc1", "a0", ".rc1", "-c3"])
+POSTS = st.sampled_from(["", ".post0", ".post1", ".post2", "-1", ".rev2"])
+DEVS = st.sampled_from(["", ".dev0", ".dev1", ".dev3"])
+LOCALS = st.sampled_from(["", "+abc", "+abc.1", "+0.zz", "+ubuntu-1"])
+
+PROBE_EXTRAS = st.sampled_from(
+    ["0", "0.dev0", "0a0.dev0", "not-a-version", "1.0.0", "1!0", "9999"]
+)
+
+
+@st.composite
+def releases(draw: st.DrawFn, max_segments: int = 4) -> str:
+    """Generate a release segment, occasionally zero-padded.
+
+    A padded segment like ``01`` parses and normalizes to ``1``, so the
+    canonical-form properties can treat padding as an identity.
+    """
+    segments = draw(st.lists(st.integers(0, 12), min_size=1, max_size=max_segments))
+    parts = [str(value) for value in segments]
+    if draw(st.booleans()) and draw(st.booleans()):
+        index = draw(st.integers(0, len(parts) - 1))
+        parts[index] = "0" + parts[index]
+    return ".".join(parts)
+
+
+@st.composite
+def version_strings(draw: st.DrawFn) -> str:
+    """Generate a full PEP 440 version string, local segment included."""
+    return (
+        draw(EPOCHS)
+        + draw(releases())
+        + draw(PRES)
+        + draw(POSTS)
+        + draw(DEVS)
+        + draw(LOCALS)
+    )
+
+
+@st.composite
+def version_strings_no_local(draw: st.DrawFn) -> str:
+    """Generate a PEP 440 version string without a local segment."""
+    return draw(EPOCHS) + draw(releases()) + draw(PRES) + draw(POSTS) + draw(DEVS)
+
+
+@st.composite
+def specifier_strings(draw: st.DrawFn) -> str:
+    """Generate a single PEP 440 specifier across every operator kind."""
+    kind = draw(
+        st.sampled_from(
+            ["cmp", "cmp", "cmp", "eq", "eq", "wildcard", "compatible", "arbitrary"]
+        )
+    )
+    if kind == "cmp":
+        op = draw(st.sampled_from([">=", "<=", ">", "<"]))
+        return op + draw(version_strings_no_local())
+    if kind == "eq":
+        op = draw(st.sampled_from(["==", "!="]))
+        return op + draw(version_strings())
+    if kind == "wildcard":
+        op = draw(st.sampled_from(["==", "!="]))
+        return op + draw(EPOCHS) + draw(releases()) + ".*"
+    if kind == "compatible":
+        release = draw(releases(max_segments=3))
+        if "." not in release:
+            release += ".0"
+        return "~=" + draw(EPOCHS) + release + draw(PRES) + draw(POSTS) + draw(DEVS)
+    literal = draw(
+        st.one_of(version_strings(), st.sampled_from(["wat", "1.0.foo", "WAT"]))
+    )
+    return "===" + literal
+
+
+@st.composite
+def specifier_set_strings(draw: st.DrawFn, max_specs: int = 3) -> str:
+    """Generate a comma-joined specifier set string."""
+    specs = draw(st.lists(specifier_strings(), min_size=1, max_size=max_specs))
+    return ",".join(specs)
+
+
+@st.composite
+def probe_lists(draw: st.DrawFn, min_size: int = 4, max_size: int = 10) -> list[str]:
+    """Generate probe version strings, mixing valid and invalid shapes."""
+    return draw(
+        st.lists(
+            st.one_of(version_strings(), PROBE_EXTRAS),
+            min_size=min_size,
+            max_size=max_size,
+        )
+    )


### PR DESCRIPTION
Adds nine property modules under `nab-python/tests/property_python/` that pin the vendored `nab_python._vendor.packaging` to the installed upstream `packaging` as an oracle: `Specifier`/`SpecifierSet` contains, filter, intersection, and acceptance; `Requirement` parsing outcomes and `str()` fixed points; `Marker` parse, evaluation, and round-trip; `parse_metadata` against `parse_email`; plus `VersionRange` consistency (range vs originating set, intersection homomorphism, canonical forms, PEP 643 staticness). Outcome comparisons include raised exception class names, so error behavior cannot drift silently across re-vendors. A shared `vendor_strategies.py` generates the awkward PEP 440 shapes (epochs, local, pre/post/dev, zero padding, wildcards, `~=`, `===`).

Three knowns are carved out with a one-line comment at each site: the upstream 26.2 `~=` v-prefix bug, the vendored `to_specifier_set` assertion on `<=V.postN.dev0` pending re-vendor, and the shared parser quirk where parenthesized extra atoms skip PEP 685 normalization.