### PR TITLE
Property-test fetch, build policy, VCS admission, downloads

### DIFF
--- a/nab-python/tests/property_python/test_build_policy_never.py
+++ b/nab-python/tests/property_python/test_build_policy_never.py
@@ -1,0 +1,151 @@
+"""Property test: no sdist build runs unless :attr:`BuildPolicy.BUILD_REMOTE`.
+
+Fuzzes sdist PKG-INFO shapes (Metadata-Version, Dynamic field
+case/content, Requires-Dist lines) and the static-pyproject fallback,
+across BuildPolicy NEVER / BUILD_LOCAL / BUILD_REMOTE.  Oracle is a
+monkeypatched ``build_remote_sdist`` that records invocations.
+
+Invariants:
+
+* ``build_remote_sdist`` is invoked only when the effective policy is
+  BUILD_REMOTE (NEVER and BUILD_LOCAL must not build a remote sdist);
+* under a non-building policy, dynamic deps without a static
+  pyproject fallback raise UnsupportedSdistError (loud refusal, not a
+  silent guess: PEP 643 untrusted deps must not be used);
+* PEP 643-static PKG-INFO (2.2+, no Dynamic dependency field) never
+  triggers a build under any policy: the metadata is authoritative.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_index.client import SdistFile
+from nab_python._provider import build_remote
+from nab_python._testing.coordinator_fake import make_coordinator
+from nab_python._vendor.packaging.version import Version
+from nab_python.metadata import WheelMetadata
+from nab_python.provider import (
+    BuildPolicy,
+    DistPolicy,
+    Provider,
+    UnsupportedSdistError,
+)
+
+from .strategies import PROPERTY_SETTINGS
+
+pytestmark = pytest.mark.property
+
+BUILT = WheelMetadata(
+    name="pkg",
+    version=Version("1.0"),
+    requires_python=None,
+    requires_dist=[],
+    provides_extra=[],
+)
+
+STATIC_PYPROJECT = '[project]\nname = "pkg"\nversion = "1.0"\ndependencies = ["depz"]\n'
+
+
+def _sdist(version: str = "1.0") -> SdistFile:
+    return SdistFile(
+        filename=f"pkg-{version}.tar.gz",
+        url=f"https://example.com/pkg-{version}.tar.gz",
+        version=version,
+        requires_python=None,
+        upload_time=None,
+    )
+
+
+pkg_info_shapes = st.fixed_dictionaries(
+    {
+        "metadata_version": st.sampled_from(["2.1", "2.2", "2.3", "2.4"]),
+        "dynamic": st.sampled_from(
+            [None, "Requires-Dist", "requires-dist", "REQUIRES-DIST", "Provides-Extra"]
+        ),
+        "deps": st.lists(
+            st.sampled_from(["depa", "depb>=1.0", 'depc; python_version >= "3"']),
+            max_size=2,
+        ),
+    }
+)
+
+policies = st.sampled_from(
+    [BuildPolicy.NEVER, BuildPolicy.BUILD_LOCAL, BuildPolicy.BUILD_REMOTE]
+)
+
+
+def _pkg_info(shape: dict) -> str:
+    lines = [
+        f"Metadata-Version: {shape['metadata_version']}",
+        "Name: pkg",
+        "Version: 1.0",
+    ]
+    if shape["dynamic"] is not None:
+        lines.append(f"Dynamic: {shape['dynamic']}")
+    lines.extend(f"Requires-Dist: {d}" for d in shape["deps"])
+    return "\n".join(lines) + "\n"
+
+
+def _deps_are_static(shape: dict) -> bool:
+    """PEP 643: 2.2+ metadata whose dependency fields are not Dynamic."""
+    if shape["metadata_version"] == "2.1":
+        return False
+    dyn = (shape["dynamic"] or "").lower()
+    return dyn not in {"requires-dist", "provides-extra"}
+
+
+@PROPERTY_SETTINGS
+@given(shape=pkg_info_shapes, policy=policies, with_fallback=st.booleans())
+def test_build_only_under_build_remote(
+    shape: dict,
+    policy: BuildPolicy,
+    with_fallback: bool,
+) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def _fake_build(provider: object, package: str, version: object) -> WheelMetadata:
+        calls.append((package, str(version)))
+        return BUILT
+
+    with patch.object(build_remote, "build_remote_sdist", _fake_build):
+        _run_case(shape, policy, with_fallback, calls)
+
+
+def _run_case(
+    shape: dict, policy: BuildPolicy, with_fallback: bool, calls: list[tuple[str, str]]
+) -> None:
+    coordinator = make_coordinator(
+        [_sdist("1.0")],
+        sdist_pkg_info=_pkg_info(shape),
+        sdist_pyproject_toml=STATIC_PYPROJECT if with_fallback else None,
+    )
+    provider = Provider(
+        coordinator,
+        python_version="3.12.0",
+        dist_policy=DistPolicy.WHEEL_OR_SDIST,
+        build_policy=policy,
+    )
+
+    static = _deps_are_static(shape)
+    try:
+        deps = provider.get_dependencies("pkg", Version("1.0"))
+    except UnsupportedSdistError:
+        deps = None
+        assert not static, "static PEP 643 metadata must not be refused"
+        assert policy is not BuildPolicy.BUILD_REMOTE
+        assert not with_fallback, "static pyproject fallback should have applied"
+
+    if policy is not BuildPolicy.BUILD_REMOTE:
+        assert calls == [], f"sdist build ran under {policy}: {calls}"
+    if static:
+        assert calls == [], "PEP 643-static metadata must never trigger a build"
+        assert deps is not None
+    if not static and deps is not None and not with_fallback:
+        # Dynamic deps with no fallback: only a build can have produced deps.
+        assert policy is BuildPolicy.BUILD_REMOTE
+        assert calls == [("pkg", "1.0")]

--- a/nab-python/tests/property_python/test_download_hashes.py
+++ b/nab-python/tests/property_python/test_download_hashes.py
@@ -1,0 +1,123 @@
+"""Property tests for :mod:`nab_python.download` hash verification.
+
+Oracle: hashlib over the served bytes.  Invariants:
+
+* a digest that does not equal the content's hex digest always raises
+  DownloadError and never leaves the bad file in the output dir;
+* the correct digest always verifies, and a second run skips the file
+  (idempotence).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import pytest
+from hypothesis import assume, given
+from hypothesis import strategies as st
+
+from nab_python.download import DownloadError, download_lock
+from nab_python.lockfile import IndexPin, LockInput, WheelArtifact
+
+from .strategies import PROPERTY_SETTINGS
+
+pytestmark = pytest.mark.property
+
+ALGOS = ["sha256", "sha384", "sha512"]
+
+HEX = "0123456789abcdef"
+
+
+@dataclass
+class _FakeResponse:
+    content: bytes
+    status_code: int = 200
+
+    @property
+    def headers(self) -> Mapping[str, str]:
+        return {}
+
+    @property
+    def text(self) -> str:
+        return self.content.decode()
+
+    def json(self) -> object:
+        return None
+
+    def raise_for_status(self) -> None:
+        pass
+
+
+class _FakeTransport:
+    def __init__(self, responses: dict[str, bytes]) -> None:
+        self._responses = responses
+
+    async def get(
+        self, url: str, *, headers: dict[str, str] | None = None
+    ) -> _FakeResponse:
+        return _FakeResponse(content=self._responses[url])
+
+    async def aclose(self) -> None:
+        pass
+
+
+def _lock_input(algo: str, digest: str) -> tuple[LockInput, str]:
+    url = "https://example.invalid/foo-1.0-py3-none-any.whl"
+    wheel = WheelArtifact(
+        filename="foo-1.0-py3-none-any.whl",
+        url=url,
+        hashes=((algo, digest),),
+    )
+    pin = IndexPin(name="foo", version="1.0", index="pypi", sdist=None, wheels=(wheel,))
+    return LockInput(pins={"foo": pin}), url
+
+
+@st.composite
+def content_and_corruption(draw: st.DrawFn) -> tuple[bytes, str, str]:
+    data = draw(st.binary(min_size=0, max_size=64))
+    algo = draw(st.sampled_from(ALGOS))
+    good = hashlib.new(algo, data).hexdigest()
+    mutation = draw(st.sampled_from(["flip", "truncate", "extend", "empty"]))
+    if mutation == "flip":
+        pos = draw(st.integers(0, len(good) - 1))
+        replacement = draw(st.sampled_from(HEX))
+        assume(replacement != good[pos])
+        bad = good[:pos] + replacement + good[pos + 1 :]
+    elif mutation == "truncate":
+        bad = good[:-2]
+    elif mutation == "extend":
+        bad = good + "ab"
+    else:
+        bad = ""
+    return data, algo, bad
+
+
+@PROPERTY_SETTINGS
+@given(payload=content_and_corruption())
+def test_wrong_digest_always_raises(
+    payload: tuple[bytes, str, str], tmp_path_factory: pytest.TempPathFactory
+) -> None:
+    data, algo, bad_digest = payload
+    out = tmp_path_factory.mktemp("dl")
+    lock, url = _lock_input(algo, bad_digest)
+    with pytest.raises(DownloadError):
+        download_lock(lock, _FakeTransport({url: data}), out)
+    assert not (out / "foo-1.0-py3-none-any.whl").exists(), "bad file left on disk"
+
+
+@PROPERTY_SETTINGS
+@given(data=st.binary(min_size=0, max_size=64), algo=st.sampled_from(ALGOS))
+def test_correct_digest_verifies_and_is_idempotent(
+    data: bytes, algo: str, tmp_path_factory: pytest.TempPathFactory
+) -> None:
+    out = tmp_path_factory.mktemp("dl")
+    digest = hashlib.new(algo, data).hexdigest()
+    lock, url = _lock_input(algo, digest)
+    first = download_lock(lock, _FakeTransport({url: data}), out)
+    assert [p.name for p in first.written] == ["foo-1.0-py3-none-any.whl"]
+    assert (out / "foo-1.0-py3-none-any.whl").read_bytes() == data
+    second = download_lock(lock, _FakeTransport({url: data}), out)
+    assert second.written == ()
+    assert [p.name for p in second.skipped] == ["foo-1.0-py3-none-any.whl"]

--- a/nab-python/tests/property_python/test_fetch_coordinator.py
+++ b/nab-python/tests/property_python/test_fetch_coordinator.py
@@ -1,0 +1,262 @@
+"""Property tests for :class:`nab_python.fetch.FetchCoordinator`.
+
+Drives the real coordinator (real thread, real event loop, real queue)
+with a fake async index client that completes requests in randomised
+orders and injects errors.  Invariants:
+
+* every submitted request's event is set within a modest timeout
+  (provider-side waits are infinite ``event.wait()``, so a lost reply
+  is a resolver deadlock);
+* replies route to the right key (values encode pkg/version, no
+  cross-talk);
+* each logical fetch key reaches the client at most once (dedup),
+  including duplicate submissions, batch duplicates, and the
+  listing-triggered metadata prefetch;
+* injected errors surface as replies (None / listing error), never
+  as hangs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections import Counter
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from nab_index.client import SdistFile, WheelFile
+from nab_python.fetch import FetchCoordinator
+
+pytestmark = pytest.mark.property
+
+PKGS = ["alpha", "beta", "gamma"]
+VERSIONS = ["1.0", "2.0", "3.0"]
+DELAYS = [0.0, 0.001, 0.003]
+
+EVENT_TIMEOUT = 15.0
+
+# Each example spins up a real fetcher thread, so the example budget
+# stays small to keep the file fast.
+COORDINATOR_SETTINGS = settings(
+    max_examples=40,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+
+Key = tuple[str, ...]
+Plan = dict[Key, tuple[str, float]]
+
+
+def _wheel(pkg: str, version: str, *, has_metadata: bool) -> WheelFile:
+    return WheelFile(
+        filename=f"{pkg}-{version}-py3-none-any.whl",
+        url=f"https://example.invalid/{pkg}-{version}-py3-none-any.whl",
+        version=version,
+        requires_python=None,
+        has_metadata=has_metadata,
+        upload_time=None,
+    )
+
+
+def _sdist(pkg: str, version: str) -> SdistFile:
+    return SdistFile(
+        filename=f"{pkg}-{version}.tar.gz",
+        url=f"https://example.invalid/{pkg}-{version}.tar.gz",
+        version=version,
+        requires_python=None,
+        upload_time=None,
+    )
+
+
+class FakeClient:
+    """Stands in for the index client inside the fetcher loop."""
+
+    def __init__(self, plan: Plan, listing_has_metadata: dict[str, bool]) -> None:
+        self.plan = plan
+        self.listing_has_metadata = listing_has_metadata
+        self.calls: Counter[Key] = Counter()
+        self.calls_lock = threading.Lock()
+        self.closed = False
+
+    async def _common(self, key: Key) -> None:
+        with self.calls_lock:
+            self.calls[key] += 1
+        mode, delay = self.plan.get(key, ("ok", 0.0))
+        if delay:
+            await asyncio.sleep(delay)
+        if mode == "err":
+            msg = f"boom {key}"
+            raise RuntimeError(msg)
+
+    async def get_files(self, package: str) -> list[WheelFile | SdistFile]:
+        await self._common(("listing", package))
+        has_meta = self.listing_has_metadata.get(package, False)
+        files: list[WheelFile | SdistFile] = [
+            _wheel(package, v, has_metadata=has_meta) for v in VERSIONS
+        ]
+        files.append(_sdist(package, VERSIONS[0]))
+        return files
+
+    async def get_metadata_text(
+        self,
+        package: str,
+        version: str,
+        url: str,
+        metadata_hash: tuple[str, str] | None = None,
+    ) -> str:
+        await self._common(("metadata", package, version))
+        return f"META:{package}:{version}"
+
+    async def get_sdist_files(
+        self, package: str, version: str, url: str
+    ) -> tuple[str, str | None]:
+        await self._common(("sdist", package, version))
+        return (f"PKGINFO:{package}:{version}", f"PYPROJECT:{package}:{version}")
+
+    async def get_sdist_archive(self, package: str, version: str, url: str) -> bytes:
+        await self._common(("sdist-archive", package, version))
+        return f"BYTES:{package}:{version}".encode()
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class FakeClientCoordinator(FetchCoordinator):
+    """Coordinator whose fetcher loop talks to a :class:`FakeClient`."""
+
+    def __init__(self, fake_client: FakeClient) -> None:
+        super().__init__(transport=None)  # type: ignore[arg-type]
+        self._fake_client = fake_client
+
+    def _build_client(self) -> FakeClient:  # type: ignore[override]
+        return self._fake_client
+
+
+# One action = (kind, pkg_idx, ver_idx).
+actions = st.lists(
+    st.tuples(
+        st.sampled_from(
+            ["listing", "metadata", "wheel_meta", "sdist", "sdist_archive", "batch"]
+        ),
+        st.integers(0, len(PKGS) - 1),
+        st.integers(0, len(VERSIONS) - 1),
+    ),
+    min_size=1,
+    max_size=12,
+)
+
+plans = st.dictionaries(
+    st.tuples(
+        st.sampled_from(["listing", "metadata", "sdist", "sdist-archive"]),
+        st.sampled_from(PKGS),
+        st.sampled_from(VERSIONS),
+    ).map(lambda t: t if t[0] != "listing" else ("listing", t[1])),
+    st.tuples(st.sampled_from(["ok", "err"]), st.sampled_from(DELAYS)),
+    max_size=12,
+)
+
+listing_meta_flags = st.fixed_dictionaries({p: st.booleans() for p in PKGS})
+
+
+@COORDINATOR_SETTINGS
+@given(action_list=actions, plan=plans, has_meta=listing_meta_flags)
+def test_every_request_gets_exactly_one_correct_reply(
+    action_list: list[tuple[str, int, int]],
+    plan: Plan,
+    has_meta: dict[str, bool],
+) -> None:
+    client = FakeClient(plan, has_meta)
+    requested: list[tuple[Key, threading.Event]] = []
+
+    with FakeClientCoordinator(client) as coord:
+        for kind, pi, vi in action_list:
+            pkg, ver = PKGS[pi], VERSIONS[vi]
+            if kind == "listing":
+                ev = coord.request_listing(pkg)
+                requested.append((("listing", pkg), ev))
+            elif kind == "metadata":
+                ev = coord.request_metadata(
+                    pkg, ver, f"https://example.invalid/{pkg}-{ver}.whl.metadata"
+                )
+                requested.append((("metadata", pkg, ver), ev))
+            elif kind == "wheel_meta":
+                fname = f"{pkg}-{ver}-py3-none-any.whl"
+                ev = coord.request_wheel_metadata(
+                    pkg, ver, fname, f"https://example.invalid/{fname}.metadata"
+                )
+                requested.append((("metadata", pkg, f"{ver}#{fname}"), ev))
+            elif kind == "sdist":
+                ev = coord.request_sdist(
+                    pkg, ver, f"https://example.invalid/{pkg}-{ver}.tar.gz"
+                )
+                requested.append((("sdist", pkg, ver), ev))
+            elif kind == "sdist_archive":
+                ev = coord.request_sdist_archive(
+                    pkg, ver, f"https://example.invalid/{pkg}-{ver}.tar.gz"
+                )
+                requested.append((("sdist-archive", pkg, ver), ev))
+            else:  # batch: include a duplicate pair on purpose
+                items: list[tuple[str, str, str, tuple[str, str] | None]] = [
+                    (pkg, ver, "https://example.invalid/u.metadata", None),
+                    (pkg, ver, "https://example.invalid/u.metadata", None),
+                ]
+                for bpkg, bver, bev in coord.request_metadata_batch(items):
+                    requested.append((("metadata", bpkg, bver), bev))
+
+        # Liveness: every reply must arrive.
+        for key, ev in requested:
+            assert ev.wait(EVENT_TIMEOUT), f"no reply for {key}"
+
+        index = coord.index
+
+        # Routing + error-as-reply checks per key.
+        meta_keys = {k for k, _ in requested if k[0] == "metadata"}
+        sdist_keys = {k for k, _ in requested if k[0] == "sdist"}
+        for key in meta_keys | sdist_keys:
+            _, pkg, ver = key
+            assert index.has_metadata(pkg, ver), f"no metadata slot for {key}"
+            value = index.get_metadata(pkg, ver)
+            allowed: set[str | None] = set()
+            base_ver = ver.split("#", 1)[0]
+            if ("metadata", pkg, ver) in meta_keys:
+                mode, _ = client.plan.get(("metadata", pkg, ver), ("ok", 0.0))
+                allowed.add(f"META:{pkg}:{ver}" if mode == "ok" else None)
+            # The listing prefetch can also have written META for this slot.
+            if has_meta.get(pkg) and "#" not in ver:
+                mode, _ = client.plan.get(("metadata", pkg, ver), ("ok", 0.0))
+                allowed.add(f"META:{pkg}:{ver}" if mode == "ok" else None)
+            if ("sdist", pkg, ver) in sdist_keys:
+                mode, _ = client.plan.get(("sdist", pkg, base_ver), ("ok", 0.0))
+                allowed.add(f"PKGINFO:{pkg}:{ver}" if mode == "ok" else None)
+            assert value in allowed, f"cross-talk at {key}: {value!r} not in {allowed}"
+
+        for key, _ in requested:
+            if key[0] == "sdist-archive":
+                _, pkg, ver = key
+                mode, _delay = client.plan.get(key, ("ok", 0.0))
+                got = index.get_sdist_archive(pkg, ver)
+                expected = f"BYTES:{pkg}:{ver}".encode() if mode == "ok" else None
+                assert got == expected, f"archive mismatch for {key}"
+
+        for key, _ in requested:
+            if key[0] == "listing":
+                pkg = key[1]
+                mode, _delay = client.plan.get(("listing", pkg), ("ok", 0.0))
+                listing = index.get_listing(pkg)
+                if mode == "ok":
+                    assert listing is not None
+                    assert len(listing) == len(VERSIONS) + 1
+                    assert all(f.filename.startswith(pkg) for f in listing), (
+                        f"listing cross-talk for {pkg}"
+                    )
+                else:
+                    assert listing is None
+                    assert isinstance(index.get_listing_error(pkg), RuntimeError)
+
+    # Dedup: every fetch key reached the client at most once, even with
+    # duplicate submissions, batch duplicates, and prefetch overlap.
+    dupes = {k: c for k, c in client.calls.items() if c > 1}
+    assert not dupes, f"duplicate fetches: {dupes}"
+    assert client.closed

--- a/nab-python/tests/property_python/test_vcs_admission.py
+++ b/nab-python/tests/property_python/test_vcs_admission.py
@@ -1,0 +1,193 @@
+"""Property tests for :mod:`nab_python._vcs_admission` Layer-1 policy.
+
+Invariants:
+
+* total partition: any URL/config either returns a recognised scheme
+  or raises UnsupportedVcsError; no other exception ever escapes
+  (robustness over arbitrary text);
+* determinism: same inputs, same decision;
+* docstring-derived oracle agrees with the implementation;
+* fragment irrelevance: appending a ``#fragment`` never changes the
+  decision (``has_full_commit_sha`` strips fragments; prefix checks
+  are on the head of the URL);
+* pin monotonicity: a URL admitted under ``require_pin=False`` is
+  admitted under ``require_pin=True`` once ``@<40-hex-sha>`` is
+  appended;
+* admission/clone agreement: a URL admitted under
+  ``require_pin=True`` must parse (``VcsRequest.parse``) to a ref
+  that IS a full commit sha, i.e. the admission layer's "pinned"
+  promise holds at clone time.
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_index.vcs import FULL_GIT_SHA_RE, VcsRequest
+from nab_python._vcs_admission import (
+    UnsupportedVcsError,
+    VcsConfig,
+    VcsPolicy,
+    admit_vcs_url,
+)
+
+from .strategies import PROPERTY_SETTINGS
+
+pytestmark = pytest.mark.property
+
+VALID_SCHEMES = ["git+https", "git+ssh", "git+http", "git+file", "git+git"]
+ALL_SCHEMES = [
+    *VALID_SCHEMES,
+    "https",
+    "http",
+    "file",
+    "hg+https",
+    "svn+ssh",
+    "GIT+HTTPS",
+]
+
+SHA = "a" * 39 + "b"
+UPPER_SHA = SHA.upper()
+
+configs = st.builds(
+    VcsConfig,
+    policy=st.sampled_from([VcsPolicy.BLOCK, VcsPolicy.ALLOW]),
+    allowed_schemes=st.frozensets(st.sampled_from(VALID_SCHEMES), max_size=5),
+    allowed_repos=st.lists(
+        st.sampled_from(
+            [
+                "https://github.com/org",
+                "https://example.org/",
+                "ssh://git@github.com/org/repo.git",
+                "",
+            ]
+        ),
+        max_size=2,
+    ).map(tuple),
+    require_pin=st.booleans(),
+)
+
+
+@st.composite
+def structured_urls(draw: st.DrawFn) -> str:
+    scheme = draw(st.sampled_from(ALL_SCHEMES))
+    user = draw(st.sampled_from(["", "git@", "user@"]))
+    host = draw(st.sampled_from(["github.com", "example.org", "h"]))
+    segments = draw(
+        st.lists(st.sampled_from(["org", "repo.git", "repo", "a"]), max_size=3)
+    )
+    ref = draw(
+        st.sampled_from(["", f"@{SHA}", "@main", f"@{UPPER_SHA}", "@release/1.0", "@"])
+    )
+    frag = draw(st.sampled_from(["", "#subdirectory=src", "#egg=foo", "#x@y"]))
+    # Keep any ref in the path component; a ref directly after the
+    # authority is not generated here.
+    if ref and not segments:
+        segments = ["repo"]
+    path = "/" + "/".join(segments) if segments else ""
+    return f"{scheme}://{user}{host}{path}{ref}{frag}"
+
+
+def _decision(url: str, config: VcsConfig) -> tuple[str, str]:
+    try:
+        return ("admit", admit_vcs_url(url, config))
+    except UnsupportedVcsError:
+        return ("refuse", "")
+
+
+def _oracle(url: str, config: VcsConfig) -> str:
+    """Decision procedure transcribed from the documented policy."""
+    scheme = next((s for s in VALID_SCHEMES if url.startswith(f"{s}://")), None)
+    if scheme is None:
+        return "refuse"
+    if config.policy is VcsPolicy.BLOCK:
+        return "refuse"
+    if scheme not in config.allowed_schemes:
+        return "refuse"
+    inner = url[len("git+") :]
+    if config.allowed_repos and not any(
+        inner.startswith(p) for p in config.allowed_repos
+    ):
+        return "refuse"
+    if config.require_pin:
+        fragmentless = url.split("#", 1)[0]
+        after = fragmentless.split("://", 1)[-1]
+        if "@" not in after:
+            return "refuse"
+        if not FULL_GIT_SHA_RE.match(after.rsplit("@", 1)[1]):
+            return "refuse"
+    return "admit"
+
+
+@PROPERTY_SETTINGS
+@given(url=st.text(max_size=80), config=configs)
+def test_total_partition_and_determinism_arbitrary_text(
+    url: str, config: VcsConfig
+) -> None:
+    first = _decision(url, config)
+    second = _decision(url, config)
+    assert first == second
+    if first[0] == "admit":
+        assert first[1] in VALID_SCHEMES
+        assert url.startswith(f"{first[1]}://")
+
+
+@PROPERTY_SETTINGS
+@given(url=structured_urls(), config=configs)
+def test_matches_documented_oracle(url: str, config: VcsConfig) -> None:
+    assert _decision(url, config)[0] == _oracle(url, config)
+
+
+@PROPERTY_SETTINGS
+@given(
+    url=structured_urls(),
+    config=configs,
+    frag=st.sampled_from(["#subdirectory=pkg", "#egg=a@b", "#", "#x#y"]),
+)
+def test_fragment_append_never_changes_decision(
+    url: str, config: VcsConfig, frag: str
+) -> None:
+    if "#" in url:
+        return
+    assert _decision(url, config)[0] == _decision(url + frag, config)[0]
+
+
+@PROPERTY_SETTINGS
+@given(url=structured_urls(), config=configs)
+def test_pin_append_monotonicity(url: str, config: VcsConfig) -> None:
+    if "#" in url:
+        return
+    unpinned_cfg = VcsConfig(
+        policy=config.policy,
+        allowed_schemes=config.allowed_schemes,
+        allowed_repos=config.allowed_repos,
+        require_pin=False,
+    )
+    pinned_cfg = VcsConfig(
+        policy=config.policy,
+        allowed_schemes=config.allowed_schemes,
+        allowed_repos=config.allowed_repos,
+        require_pin=True,
+    )
+    if _decision(url, unpinned_cfg)[0] == "admit":
+        assert _decision(f"{url}@{SHA}", pinned_cfg)[0] == "admit"
+
+
+@PROPERTY_SETTINGS
+@given(url=structured_urls())
+def test_admitted_pin_is_a_real_pin_at_clone_time(url: str) -> None:
+    config = VcsConfig(
+        policy=VcsPolicy.ALLOW,
+        allowed_schemes=frozenset(VALID_SCHEMES),
+        allowed_repos=(),
+        require_pin=True,
+    )
+    kind, _scheme = _decision(url, config)
+    if kind != "admit":
+        return
+    request = VcsRequest.parse(url)
+    assert FULL_GIT_SHA_RE.match(request.ref), (
+        f"admission said pinned, clone parser sees ref={request.ref!r} for {url!r}"
+    )


### PR DESCRIPTION
Four new opt-in property files under `nab-python/tests/property_python/`. `test_fetch_coordinator.py` drives the real `FetchCoordinator` thread bridge with a fake async client and randomised completion orders, checking liveness (every request event is set), reply routing with no cross-talk between keys, at-most-once fetches per logical key including batch and prefetch duplicates, and injected errors surfacing as replies rather than hangs. `test_build_policy_never.py` fuzzes PKG-INFO shapes across build policies and asserts `build_remote_sdist` runs only under `BUILD_REMOTE` and that PEP 643-static metadata never triggers a build.

`test_vcs_admission.py` checks `admit_vcs_url` is total and deterministic over arbitrary text, matches an oracle transcribed from the documented policy on structured URLs, ignores fragments, is monotone under appending a pin, and that an admitted pin parses to a full commit sha via `VcsRequest.parse`. `test_download_hashes.py` verifies a wrong digest always raises `DownloadError` without leaving the file on disk, and that a correct digest verifies then skips on rerun.