### PR TITLE
Add lockfile and universal oracle property tests

### DIFF
--- a/nab-python/tests/property_python/test_conflict_fork_markers.py
+++ b/nab-python/tests/property_python/test_conflict_fork_markers.py
@@ -1,0 +1,249 @@
+"""Semantic property tests for conflict-fork marker emission.
+
+`PEP 751`_ consumers install from the emitted markers alone, so a
+lock built from conflict forks must reproduce each fork's pins
+exactly.  The model here is a universal resolve over 1-2
+environments, each forked over a declared ``at_most_one`` conflict
+between extras ``a`` and ``b``.  Per fork, each package name may be
+pinned; the base (no-member) install set is the names pinned in
+every fork.  Generation keeps the shape nab's builder produces: a
+base name is pinned at the SAME version across an environment's
+forks.
+
+The oracle evaluates the emitted lockfile text per install context:
+
+* extras={m}: exactly fork m's pins fire, at fork m's versions.
+* extras=empty: exactly the base names fire, at the agreed version.
+
+Any extra or missing firing entry is a correctness bug (silent over-
+or under-install).
+
+.. _PEP 751: https://peps.python.org/pep-0751/#packages
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import NamedTuple
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - 3.10 fallback
+    import tomli as tomllib  # type: ignore[no-redef]
+
+from nab_python._vendor.packaging.markers import Marker
+from nab_python._vendor.packaging.pylock import Pylock
+from nab_python.config import (
+    ConflictKind,
+    ConflictMember,
+    ConflictPolicy,
+    ConflictSet,
+)
+from nab_python.lockfile import (
+    IndexPin,
+    LockInput,
+    WheelArtifact,
+    write_lock,
+)
+
+from .strategies import PROPERTY_SETTINGS
+
+pytestmark = pytest.mark.property
+
+MEMBERS = ("a", "b")
+NAMES = ("p1", "p2", "p3")
+VERSIONS = ("1.0", "2.0")
+ENVS = (
+    ("linux", "3.11"),
+    ("win32", "3.11"),
+)
+
+
+class EnvForks(NamedTuple):
+    """One environment's fork pins and base names."""
+
+    platform: str
+    python: str
+    fork_pins: dict[str, dict[str, str]]
+    base_names: frozenset[str]
+
+
+def _pin(name: str, version: str) -> IndexPin:
+    """Build a one-wheel ``IndexPin``."""
+    return IndexPin(
+        name=name,
+        version=version,
+        index="https://pypi.org/simple/",
+        wheels=(
+            WheelArtifact(
+                filename=f"{name}-{version}-py3-none-any.whl",
+                url=f"https://example.com/{name}-{version}-py3-none-any.whl",
+                hashes=(("sha256", "a" * 64),),
+            ),
+        ),
+    )
+
+
+@st.composite
+def fork_cases(draw: st.DrawFn) -> list[EnvForks]:
+    """Generate per-environment fork pins with version-agreeing base names."""
+    n_envs = draw(st.integers(min_value=1, max_value=2))
+    case = []
+    for plat, py in ENVS[:n_envs]:
+        fork_pins: dict[str, dict[str, str]] = {}
+        for member in MEMBERS:
+            names = draw(
+                st.lists(st.sampled_from(NAMES), min_size=0, max_size=3, unique=True)
+            )
+            fork_pins[member] = {n: draw(st.sampled_from(VERSIONS)) for n in names}
+        in_all_forks = set(fork_pins["a"]) & set(fork_pins["b"])
+        base_names = frozenset(
+            draw(
+                st.lists(
+                    st.sampled_from(sorted(in_all_forks)),
+                    unique=True,
+                    max_size=len(in_all_forks),
+                )
+            )
+            if in_all_forks
+            else []
+        )
+        # Well-formedness: a base name agrees on version across forks.
+        for n in base_names:
+            fork_pins["b"][n] = fork_pins["a"][n]
+        case.append(EnvForks(plat, py, fork_pins, base_names))
+    return case
+
+
+def _environment(env_forks: EnvForks) -> dict[str, str]:
+    """Build the marker environment for one generated environment."""
+    return {
+        "python_version": env_forks.python,
+        "python_full_version": f"{env_forks.python}.0",
+        "sys_platform": env_forks.platform,
+    }
+
+
+def _build_input(case: list[EnvForks]) -> LockInput:
+    """Assemble the per-tuple ``LockInput`` for the generated forks."""
+    per_tuple_pins: dict[str, dict[str, IndexPin]] = {}
+    tuple_markers: dict[str, Marker] = {}
+    tuple_env_markers: dict[str, Marker] = {}
+    tuple_environments: dict[str, dict[str, str]] = {}
+    env_base_names: dict[tuple[tuple[str, str], ...], frozenset[str]] = {}
+    for env_forks in case:
+        env = _environment(env_forks)
+        env_marker = (
+            f'python_version == "{env_forks.python}" '
+            f'and sys_platform == "{env_forks.platform}"'
+        )
+        env_base_names[tuple(sorted(env.items()))] = env_forks.base_names
+        for member in MEMBERS:
+            label = f"{env_forks.platform}-{member}"
+            tuple_markers[label] = Marker(f'({env_marker}) and "{member}" in extras')
+            tuple_env_markers[label] = Marker(env_marker)
+            tuple_environments[label] = env
+            per_tuple_pins[label] = {
+                n: _pin(n, v) for n, v in env_forks.fork_pins[member].items()
+            }
+    conflicts = (
+        ConflictSet(
+            members=tuple(
+                ConflictMember(kind=ConflictKind.EXTRA, name=m) for m in MEMBERS
+            ),
+            policy=ConflictPolicy.AT_MOST_ONE,
+        ),
+    )
+    return LockInput(
+        per_tuple_pins=per_tuple_pins,
+        tuple_markers=tuple_markers,
+        tuple_env_markers=tuple_env_markers,
+        tuple_environments=tuple_environments,
+        env_base_names=env_base_names,
+        extras=tuple(MEMBERS),
+        conflicts=conflicts,
+    )
+
+
+class TestQuoteSelectAgreesWithForkPins:
+    """PEP 751, § Installation:
+
+    > "Tools MUST NOT install a package if its ``marker`` evaluates
+    > to false."
+
+    ``packaging.pylock.Pylock.select`` is the spec-reference
+    consumer: selecting with one conflict member active must install
+    exactly that fork's pins, never raise an ambiguity error.
+
+    Reference: https://peps.python.org/pep-0751/#installation
+    """
+
+    @given(case=fork_cases())
+    @PROPERTY_SETTINGS
+    def test_select_agrees_with_fork_pins(self, case: list[EnvForks]) -> None:
+        """``Pylock.select`` per fork returns exactly the fork's pins."""
+        text = write_lock(_build_input(case))
+        pylock = Pylock.from_dict(tomllib.loads(text))
+        for env_forks in case:
+            env = _environment(env_forks)
+            for member in MEMBERS:
+                selected = {
+                    str(pkg.name): str(pkg.version)
+                    for pkg, _artifact in pylock.select(
+                        environment=env,  # type: ignore[arg-type]
+                        extras={member},
+                        dependency_groups=(),
+                    )
+                }
+                assert selected == env_forks.fork_pins[member], (
+                    f"select(env={env_forks.platform}, extras={{{member}!r}}) "
+                    f"-> {selected}, expected {env_forks.fork_pins[member]}\n{text}"
+                )
+
+
+class TestForkAndBaseInstallSets:
+    """Direct marker evaluation per install context: with one member
+    active, exactly that fork's pins fire at the fork's versions;
+    with no member active, exactly the base names fire at the agreed
+    version.  At most one entry may fire per name in any context.
+    """
+
+    @given(case=fork_cases())
+    @PROPERTY_SETTINGS
+    def test_fork_and_base_install_sets(self, case: list[EnvForks]) -> None:
+        """Each extras context fires exactly its expected pin set."""
+        text = write_lock(_build_input(case))
+        pylock = Pylock.from_dict(tomllib.loads(text))
+
+        for env_forks in case:
+            env = _environment(env_forks)
+            contexts: list[tuple[frozenset[str], dict[str, str]]] = [
+                (
+                    frozenset(),
+                    {n: env_forks.fork_pins["a"][n] for n in env_forks.base_names},
+                ),
+                (frozenset({"a"}), dict(env_forks.fork_pins["a"])),
+                (frozenset({"b"}), dict(env_forks.fork_pins["b"])),
+            ]
+            for extras, expected in contexts:
+                ctx: dict[str, object] = dict(env)
+                ctx["extras"] = extras
+                ctx["dependency_groups"] = frozenset()
+                fired: dict[str, list[str]] = {}
+                for p in pylock.packages:
+                    if p.marker is None or p.marker.evaluate(ctx):  # type: ignore[arg-type]
+                        fired.setdefault(str(p.name), []).append(str(p.version))
+                for name, vers in fired.items():
+                    assert len(vers) == 1, (
+                        f"{name}: multiple entries fire under "
+                        f"env={env_forks.platform} extras={set(extras)}: {vers}\n{text}"
+                    )
+                got = {n: v[0] for n, v in fired.items()}
+                assert got == expected, (
+                    f"env={env_forks.platform} extras={set(extras)}: "
+                    f"installed {got}, expected {expected}\n{text}"
+                )

--- a/nab-python/tests/property_python/test_disjointness_differential.py
+++ b/nab-python/tests/property_python/test_disjointness_differential.py
@@ -1,0 +1,293 @@
+"""Differential property tests for :mod:`nab_python._lockfile.disjointness`.
+
+`PEP 751`_ requires that all packages to be installed narrow down to
+a single entry at install time, so ``validate_marker_disjointness``
+must reject any pair of same-name entries whose markers can fire
+together.  The validator prunes the extras/groups powerset via a
+regex over marker strings plus a backtracking enumeration honouring
+exclusive sets.  Each test here re-models one layer as a full
+filtered-powerset brute force and requires exact agreement; a
+divergence in either direction (validator raises but the model finds
+no collision, or vice versa) is a bug.
+
+.. _PEP 751: https://peps.python.org/pep-0751/#packages
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_python._conflict_kind import KIND_EXTRA, KIND_GROUP
+from nab_python._lockfile.disjointness import (
+    DisjointnessError,
+    _enumerate_valid_points,
+    validate_marker_disjointness,
+)
+from nab_python._vendor.packaging.markers import Marker
+from nab_python._vendor.packaging.pylock import Package
+from nab_python._vendor.packaging.utils import canonicalize_name
+from nab_python._vendor.packaging.version import Version
+
+from .strategies import BRUTE_FORCE_SETTINGS
+
+pytestmark = pytest.mark.property
+
+PLATFORMS = ("linux", "win32")
+PYTHONS = ("3.10", "3.11")
+
+EXTRA_DECLS = ("aa", "b-b", "c-c")
+# Unnormalised spellings a marker may carry for each declared extra,
+# plus one undeclared name; same shape for groups.
+EXTRA_SPELLINGS = ("aa", "AA", "b-b", "B.B", "b_b", "c-c", "C_C", "zz")
+GROUP_DECLS = ("dev", "test-g")
+GROUP_SPELLINGS = ("dev", "DEV", "test-g", "Test_G", "qq")
+
+env_atoms = st.one_of(
+    st.sampled_from([f'sys_platform == "{p}"' for p in PLATFORMS]),
+    st.sampled_from([f'python_version == "{v}"' for v in PYTHONS]),
+)
+extra_atoms = st.builds(
+    lambda spelling, negate: f'"{spelling}" {"not in" if negate else "in"} extras',
+    st.sampled_from(EXTRA_SPELLINGS),
+    st.booleans(),
+)
+group_atoms = st.builds(
+    lambda spelling, negate: (
+        f'"{spelling}" {"not in" if negate else "in"} dependency_groups'
+    ),
+    st.sampled_from(GROUP_SPELLINGS),
+    st.booleans(),
+)
+atoms = st.one_of(env_atoms, extra_atoms, group_atoms)
+
+
+@st.composite
+def markers(draw: st.DrawFn) -> Marker:
+    """Generate a 1-3 atom marker mixing env and membership clauses."""
+    n = draw(st.integers(min_value=1, max_value=3))
+    parts = [draw(atoms) for _ in range(n)]
+    joiners = [draw(st.sampled_from([" and ", " or "])) for _ in range(n - 1)]
+    text = parts[0]
+    for joiner, part in zip(joiners, parts[1:], strict=True):
+        text += joiner + part
+    return Marker(text)
+
+
+@st.composite
+def package_entries(draw: st.DrawFn) -> list[Package]:
+    """Generate 2-3 same-name entries, each with an optional marker."""
+    n = draw(st.integers(min_value=2, max_value=3))
+    out = []
+    for i in range(n):
+        marker = None if draw(st.integers(0, 9)) == 0 else draw(markers())
+        out.append(Package(name="pkg", version=Version(f"{i + 1}.0"), marker=marker))
+    return out
+
+
+@st.composite
+def environment_maps(draw: st.DrawFn) -> dict[str, dict[str, str]]:
+    """Generate 1-3 declared environments over the platform/python pools."""
+    combos = draw(
+        st.lists(
+            st.tuples(st.sampled_from(PLATFORMS), st.sampled_from(PYTHONS)),
+            min_size=1,
+            max_size=3,
+            unique=True,
+        )
+    )
+    return {
+        f"env{i}": {
+            "sys_platform": plat,
+            "python_version": py,
+            "python_full_version": f"{py}.0",
+        }
+        for i, (plat, py) in enumerate(combos)
+    }
+
+
+member_items = st.one_of(
+    st.tuples(st.just(KIND_EXTRA), st.sampled_from(EXTRA_SPELLINGS)),
+    st.tuples(st.just(KIND_GROUP), st.sampled_from(GROUP_SPELLINGS)),
+)
+
+exclusive_sets = st.lists(
+    st.frozensets(member_items, min_size=2, max_size=3),
+    min_size=0,
+    max_size=2,
+)
+
+
+def _powerset(items: list[str]) -> list[tuple[str, ...]]:
+    """Return every subset of ``items``, including the empty one."""
+    return list(
+        itertools.chain.from_iterable(
+            itertools.combinations(items, r) for r in range(len(items) + 1)
+        )
+    )
+
+
+def _model_collides(
+    packages: list[Package],
+    environments: dict[str, dict[str, str]],
+    extras: list[str],
+    groups: list[str],
+    exclusive: list[frozenset[tuple[str, str]]],
+) -> bool:
+    """Brute force the full powerset of the declared install-context universe."""
+    canon_sets = [
+        {(kind, canonicalize_name(name)) for kind, name in s} for s in exclusive
+    ]
+    seen_envs: list[dict[str, str]] = []
+    for env in environments.values():
+        if env in seen_envs:
+            continue
+        seen_envs.append(env)
+    for env in seen_envs:
+        for extras_subset in _powerset(extras):
+            for groups_subset in _powerset(groups):
+                active = {(KIND_EXTRA, canonicalize_name(e)) for e in extras_subset} | {
+                    (KIND_GROUP, canonicalize_name(g)) for g in groups_subset
+                }
+                if any(len(s & active) >= 2 for s in canon_sets):
+                    continue
+                ctx: dict[str, object] = dict(env)
+                ctx["extras"] = frozenset(extras_subset)
+                ctx["dependency_groups"] = frozenset(groups_subset)
+                matching = [
+                    p
+                    for p in packages
+                    if p.marker is None or p.marker.evaluate(ctx)  # type: ignore[arg-type]
+                ]
+                if len(matching) >= 2:
+                    return True
+    return False
+
+
+class TestValidatorAgainstPowersetModel:
+    """``validate_marker_disjointness`` prunes which extras/groups
+    subsets it visits (regex relevance filter plus exclusive-set
+    backtracking); the model enumerates the FULL powerset of declared
+    extras x groups per environment, filters subsets activating two
+    or more members of an exclusive set, and evaluates every
+    same-name entry's marker directly.
+
+    The validator must raise exactly when the model finds two entries
+    firing for one install context: a missed collision means a broken
+    lockfile passes validation, a spurious raise rejects a valid one.
+    """
+
+    @given(
+        packages=package_entries(),
+        environments=environment_maps(),
+        extras=st.lists(st.sampled_from(EXTRA_DECLS), unique=True, max_size=3),
+        groups=st.lists(st.sampled_from(GROUP_DECLS), unique=True, max_size=2),
+        exclusive=exclusive_sets,
+    )
+    @BRUTE_FORCE_SETTINGS
+    def test_validator_agrees_with_brute_force(
+        self,
+        packages: list[Package],
+        environments: dict[str, dict[str, str]],
+        extras: list[str],
+        groups: list[str],
+        exclusive: list[frozenset[tuple[str, str]]],
+    ) -> None:
+        """Validator raises iff the full-powerset model finds a collision."""
+        expected = _model_collides(packages, environments, extras, groups, exclusive)
+        raised = False
+        try:
+            validate_marker_disjointness(
+                packages,
+                environments=environments,
+                extras=extras,
+                groups=groups,
+                exclusive_groups=exclusive,
+                declared_groups=exclusive,
+            )
+        except DisjointnessError:
+            raised = True
+        assert raised == expected, (
+            f"validator={'raised' if raised else 'passed'} "
+            f"model={'collision' if expected else 'disjoint'}\n"
+            f"markers={[str(p.marker) for p in packages]}\n"
+            f"envs={environments}\nextras={extras} groups={groups}\n"
+            f"exclusive={exclusive}"
+        )
+
+
+POINT_NAMES = ("A_a", "b-B", "c", "D.d", "e", "F")
+
+
+@st.composite
+def enumeration_cases(
+    draw: st.DrawFn,
+) -> tuple[list[str], list[str], list[frozenset[tuple[str, str]]]]:
+    """Generate (extras, groups, exclusive sets) over mixed-case names."""
+    extras = draw(st.lists(st.sampled_from(POINT_NAMES), unique=True, max_size=4))
+    groups = draw(st.lists(st.sampled_from(POINT_NAMES), unique=True, max_size=3))
+    pool = [(KIND_EXTRA, n) for n in extras] + [(KIND_GROUP, n) for n in groups]
+    exclusive: list[frozenset[tuple[str, str]]] = []
+    for _ in range(draw(st.integers(min_value=0, max_value=3))):
+        if not pool:
+            break
+        members = draw(
+            st.lists(st.sampled_from(pool), min_size=1, max_size=3, unique=True)
+        )
+        # Sometimes use a different surface spelling of the same name.
+        exclusive.append(
+            frozenset(
+                (kind, name.upper() if draw(st.booleans()) else name)
+                for kind, name in members
+            )
+        )
+    return extras, groups, exclusive
+
+
+class TestEnumerationAgainstFilteredPowerset:
+    """``_enumerate_valid_points`` backtracks instead of materialising
+    the ``2^(E+G)`` powerset, skipping any subset that activates two
+    or more members of one exclusive set (canonicalised comparison).
+
+    The model generates the full powerset and filters it; the
+    enumeration must produce exactly the same set of points.  A
+    missing point hides a marker collision from the validator, an
+    extra point makes it over-report.
+    """
+
+    @given(case=enumeration_cases())
+    @BRUTE_FORCE_SETTINGS
+    def test_enumeration_matches_filtered_powerset(
+        self,
+        case: tuple[list[str], list[str], list[frozenset[tuple[str, str]]]],
+    ) -> None:
+        """Enumerated points equal the conflict-filtered full powerset."""
+        extras, groups, exclusive = case
+        got = {
+            (frozenset(extras_subset), frozenset(groups_subset))
+            for extras_subset, groups_subset in _enumerate_valid_points(
+                extras, groups, exclusive
+            )
+        }
+
+        expected = set()
+        for extras_subset in _powerset(sorted(extras)):
+            for groups_subset in _powerset(sorted(groups)):
+                active = {(KIND_EXTRA, canonicalize_name(n)) for n in extras_subset} | {
+                    (KIND_GROUP, canonicalize_name(n)) for n in groups_subset
+                }
+                if any(
+                    sum(
+                        1
+                        for kind, name in members
+                        if (kind, canonicalize_name(name)) in active
+                    )
+                    >= 2
+                    for members in exclusive
+                ):
+                    continue
+                expected.add((frozenset(extras_subset), frozenset(groups_subset)))
+        assert got == expected, (extras, groups, exclusive, got ^ expected)

--- a/nab-python/tests/property_python/test_universal_faithfulness.py
+++ b/nab-python/tests/property_python/test_universal_faithfulness.py
@@ -1,0 +1,259 @@
+"""End-to-end property tests for per-tuple lockfile emission.
+
+`PEP 751`_ says all packages to be installed MUST narrow down to a
+single entry at install time, and recommends consistent output to
+minimize diff noise.  For a universal lock built from per-tuple pins
+that means three end-to-end guarantees:
+
+1. Faithfulness: for every declared tuple and every package name,
+   the emitted ``[[packages]]`` entries select exactly the version
+   that tuple pinned (one matching entry), and zero entries for
+   names the tuple did not pin.  Nothing silently dropped, nothing
+   leaking into other tuples.
+2. Byte-stability: shuffling every insertion-ordered input (tuple
+   order, per-name order, wheel order) yields byte-identical output.
+3. Fixed point: emit -> parse -> emit through the vendored
+   ``packaging.pylock`` round-trip reproduces the same bytes.
+
+.. _PEP 751: https://peps.python.org/pep-0751/#packages
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import NamedTuple
+
+import pytest
+import tomli_w
+from hypothesis import given
+from hypothesis import strategies as st
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - 3.10 fallback
+    import tomli as tomllib  # type: ignore[no-redef]
+
+from nab_python._vendor.packaging.markers import Marker
+from nab_python._vendor.packaging.pylock import Pylock
+from nab_python.lockfile import (
+    IndexPin,
+    LockInput,
+    WheelArtifact,
+    write_lock,
+)
+
+from .strategies import PROPERTY_SETTINGS
+
+pytestmark = pytest.mark.property
+
+PLATFORMS = ("linux", "win32", "darwin")
+PYTHONS = ("3.10", "3.11")
+NAMES = ("aa", "bb", "cc")
+VERSIONS = ("1.0", "2.0", "3.0")
+
+WHEEL_TAGS = (
+    "py3-none-any",
+    "cp310-cp310-manylinux_2_17_x86_64",
+    "cp311-cp311-win_amd64",
+)
+
+
+class UniversalCase(NamedTuple):
+    """One generated universal-lock scenario."""
+
+    labels: list[str]
+    tuple_markers: dict[str, Marker]
+    tuple_environments: dict[str, dict[str, str]]
+    pinned: dict[str, dict[str, str]]
+    n_wheels: int
+
+
+def _wheels(
+    name: str, version: str, tags: tuple[str, ...]
+) -> tuple[WheelArtifact, ...]:
+    """Build one wheel per tag for a pin."""
+    return tuple(
+        WheelArtifact(
+            filename=f"{name}-{version}-{tag}.whl",
+            url=f"https://example.com/{name}-{version}-{tag}.whl",
+            hashes=(("sha256", "a" * 64), ("sha512", "b" * 128)),
+            size=1,
+        )
+        for tag in tags
+    )
+
+
+@st.composite
+def universal_cases(draw: st.DrawFn) -> UniversalCase:
+    """Generate 1-4 tuples, each pinning 1-3 names at random versions."""
+    combos = draw(
+        st.lists(
+            st.tuples(st.sampled_from(PLATFORMS), st.sampled_from(PYTHONS)),
+            min_size=1,
+            max_size=4,
+            unique=True,
+        )
+    )
+    labels = [f"cp{py.replace('.', '')}-{plat}" for plat, py in combos]
+    tuple_markers = {
+        label: Marker(f'python_version == "{py}" and sys_platform == "{plat}"')
+        for label, (plat, py) in zip(labels, combos, strict=True)
+    }
+    tuple_environments = {
+        label: {
+            "python_version": py,
+            "python_full_version": f"{py}.0",
+            "sys_platform": plat,
+        }
+        for label, (plat, py) in zip(labels, combos, strict=True)
+    }
+    pinned: dict[str, dict[str, str]] = {}
+    for label in labels:
+        names = draw(
+            st.lists(st.sampled_from(NAMES), min_size=1, max_size=3, unique=True)
+        )
+        pinned[label] = {name: draw(st.sampled_from(VERSIONS)) for name in names}
+    n_wheels = draw(st.integers(min_value=1, max_value=3))
+    return UniversalCase(labels, tuple_markers, tuple_environments, pinned, n_wheels)
+
+
+def _build_input(
+    case: UniversalCase,
+    *,
+    label_order: list[str] | None = None,
+    name_shift: int = 0,
+    wheel_shift: int = 0,
+) -> LockInput:
+    """Assemble a per-tuple ``LockInput``, optionally rotating each axis."""
+    ordered_labels = label_order if label_order is not None else case.labels
+    per_tuple_pins: dict[str, dict[str, IndexPin]] = {}
+    for label in ordered_labels:
+        names = list(case.pinned[label])
+        shift = name_shift % len(names)
+        names = names[shift:] + names[:shift]
+        per_name: dict[str, IndexPin] = {}
+        for name in names:
+            version = case.pinned[label][name]
+            wheels = list(_wheels(name, version, WHEEL_TAGS[: case.n_wheels]))
+            shift = wheel_shift % len(wheels)
+            wheels = wheels[shift:] + wheels[:shift]
+            per_name[name] = IndexPin(
+                name=name,
+                version=version,
+                index="https://pypi.org/simple/",
+                wheels=tuple(wheels),
+            )
+        per_tuple_pins[label] = per_name
+    return LockInput(
+        per_tuple_pins=per_tuple_pins,
+        tuple_markers={label: case.tuple_markers[label] for label in ordered_labels},
+        tuple_environments={
+            label: case.tuple_environments[label] for label in ordered_labels
+        },
+    )
+
+
+class TestQuotePerTupleFaithfulness:
+    """PEP 751, § ``[[packages]]``:
+
+    > "Packages MAY be listed multiple times with varying data, but
+    > all packages to be installed MUST narrow down to a single entry
+    > at install time."
+
+    Installing under a tuple's environment must select exactly the
+    pins that tuple's resolve produced: one firing entry per pinned
+    name at the pinned version, zero firing entries for unpinned
+    names.  A miss here silently under- or over-installs.
+
+    Reference: https://peps.python.org/pep-0751/#packages
+    """
+
+    @given(case=universal_cases())
+    @PROPERTY_SETTINGS
+    def test_per_tuple_faithfulness(self, case: UniversalCase) -> None:
+        """Each tuple's environment selects exactly that tuple's pins."""
+        text = write_lock(_build_input(case))
+        pylock = Pylock.from_dict(tomllib.loads(text))
+        for label in case.labels:
+            env = case.tuple_environments[label]
+            for name in NAMES:
+                matching = [
+                    p
+                    for p in pylock.packages
+                    if str(p.name) == name
+                    and (
+                        p.marker is None
+                        or p.marker.evaluate(dict(env), context="lock_file")
+                    )
+                ]
+                if name in case.pinned[label]:
+                    assert len(matching) == 1, (
+                        f"{name} under {label}: {len(matching)} entries fire "
+                        f"(want 1)\n{text}"
+                    )
+                    assert str(matching[0].version) == case.pinned[label][name]
+                else:
+                    assert not matching, (
+                        f"{name} not pinned for {label} but "
+                        f"{len(matching)} entries fire\n{text}"
+                    )
+
+
+class TestQuoteByteStabilityUnderShuffle:
+    """PEP 751, § File Format:
+
+    > "Tools SHOULD write their lock files in a consistent way to
+    > minimize noise in diff output. ... As well, tools SHOULD sort
+    > arrays in consistent order."
+
+    Rotating every insertion-ordered input axis (tuple order, the
+    per-name map order, each pin's wheel order) must produce
+    byte-identical output; otherwise a re-resolve that populates its
+    dicts in a different order churns the lockfile.
+
+    Reference: https://peps.python.org/pep-0751/#file-format
+    """
+
+    @given(
+        case=universal_cases(),
+        name_shift=st.integers(min_value=0, max_value=2),
+        wheel_shift=st.integers(min_value=0, max_value=2),
+        reverse_labels=st.booleans(),
+    )
+    @PROPERTY_SETTINGS
+    def test_byte_stability_under_input_shuffle(
+        self,
+        case: UniversalCase,
+        name_shift: int,
+        wheel_shift: int,
+        reverse_labels: bool,
+    ) -> None:
+        """Shuffled-but-equivalent input emits byte-identical output."""
+        canonical = write_lock(_build_input(case))
+        label_order = list(reversed(case.labels)) if reverse_labels else case.labels
+        shuffled = write_lock(
+            _build_input(
+                case,
+                label_order=label_order,
+                name_shift=name_shift,
+                wheel_shift=wheel_shift,
+            )
+        )
+        assert shuffled == canonical
+
+
+class TestEmitParseEmitFixedPoint:
+    """Emitted text parsed back through the vendored
+    ``packaging.pylock`` and re-serialised must reproduce the same
+    bytes.  A drift means the writer and the spec parser disagree
+    about some field's canonical form, so a consumer that round-trips
+    the file (audit tooling, ``nab lock`` re-runs) would churn it.
+    """
+
+    @given(case=universal_cases())
+    @PROPERTY_SETTINGS
+    def test_emit_parse_emit_fixed_point(self, case: UniversalCase) -> None:
+        """``write_lock`` output is a fixed point of parse + re-serialise."""
+        text = write_lock(_build_input(case))
+        reparsed = Pylock.from_dict(tomllib.loads(text))
+        assert tomli_w.dumps(dict(reparsed.to_dict())) == text

--- a/nab-python/tests/universal/property_universal/test_matrix_labels.py
+++ b/nab-python/tests/universal/property_universal/test_matrix_labels.py
@@ -1,0 +1,158 @@
+"""Matrix-expansion coverage and label-injectivity property tests.
+
+Tuple labels are used downstream as dict keys for per-tuple pins, so
+two distinct matrix points must never share a label
+(:mod:`nab_python.universal.matrix` docstrings make this claim for
+both selections and platform specs).  A collision silently merges
+two tuples' pins under one key.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+from hypothesis import assume, given
+from hypothesis import strategies as st
+
+from nab_python.universal.matrix import (
+    _IMPLEMENTATION_DEFAULTS,
+    _KNOWN_PYTHON_MINORS,
+    _PLATFORM_DEFAULTS,
+    Matrix,
+)
+from nab_python.universal.wheel_selection import PlatformSpec
+
+from .strategies import PROPERTY_SETTINGS
+
+pytestmark = pytest.mark.property
+
+PLATFORM_IDS = sorted(_PLATFORM_DEFAULTS)
+IMPLS = sorted(_IMPLEMENTATION_DEFAULTS)
+
+python_specs = st.one_of(
+    st.sampled_from(_KNOWN_PYTHON_MINORS).map(lambda v: f"=={v}"),
+    st.sampled_from(_KNOWN_PYTHON_MINORS).map(lambda v: f">={v}"),
+    st.sampled_from(_KNOWN_PYTHON_MINORS).map(lambda v: f"~={v}"),
+    st.tuples(
+        st.sampled_from(_KNOWN_PYTHON_MINORS), st.sampled_from(_KNOWN_PYTHON_MINORS)
+    ).map(lambda t: f">={t[0]}, <={t[1]}"),
+    st.sampled_from(_KNOWN_PYTHON_MINORS).map(lambda v: f"!={v}"),
+)
+
+# No whitespace: label_suffix collapses runs of it into "_", which collides
+# with a literal underscore.
+rel_strings = st.text(alphabet="_-abc0123456789.", min_size=0, max_size=8)
+
+floors = st.tuples(st.integers(0, 3), st.integers(0, 20))
+
+
+def _specs_for(platform_id: str) -> st.SearchStrategy[PlatformSpec]:
+    """Build a ``PlatformSpec`` strategy fixed to one platform id."""
+    return st.builds(
+        PlatformSpec,
+        platform_id=st.just(platform_id),
+        manylinux_floor=floors,
+        musllinux_floor=floors,
+        macos_min=st.none() | st.tuples(st.integers(10, 15), st.integers(0, 3)),
+        platform_release=rel_strings,
+        platform_version=rel_strings,
+    )
+
+
+@st.composite
+def spec_pairs(draw: st.DrawFn) -> tuple[PlatformSpec, PlatformSpec]:
+    """Generate two specs sharing a platform id."""
+    platform_id = draw(st.sampled_from(PLATFORM_IDS))
+    return draw(_specs_for(platform_id)), draw(_specs_for(platform_id))
+
+
+class TestExpansionExactCoverage:
+    """``Matrix.expand()`` must produce exactly the Cartesian product
+    of admitted Python minors, platforms, and implementations, with
+    deterministic per-tuple environments and pairwise-distinct
+    labels, for every supported spec shape and ordering.
+    """
+
+    @given(
+        python=python_specs,
+        platforms=st.lists(
+            st.sampled_from(PLATFORM_IDS), min_size=1, max_size=5, unique=True
+        ),
+        impls=st.lists(st.sampled_from(IMPLS), min_size=1, max_size=2, unique=True),
+        order=st.sampled_from(["asc", "desc"]),
+    )
+    @PROPERTY_SETTINGS
+    def test_expansion_exact_coverage_and_determinism(
+        self, python: str, platforms: list[str], impls: list[str], order: str
+    ) -> None:
+        """Expansion covers the exact cross product, repeatably, with unique labels."""
+        matrix = Matrix(
+            python=python,
+            platforms=tuple(platforms),
+            python_order=order,
+            implementations=tuple(impls),
+        )
+        try:
+            tuples = matrix.expand()
+        except ValueError:
+            return  # empty python range; validated separately
+        pythons = {t.python_version for t in tuples}
+        expected = set(itertools.product(pythons, platforms, impls))
+        got = [(t.python_version, t.platform_id, t.implementation) for t in tuples]
+        assert len(got) == len(expected)
+        assert set(got) == expected
+        again = matrix.expand()
+        assert [(t.label, t.environment) for t in again] == [
+            (t.label, t.environment) for t in tuples
+        ]
+        labels = [t.label for t in tuples]
+        assert len(set(labels)) == len(labels), labels
+
+
+class TestLabelSuffixInjective:
+    """``PlatformSpec.label_suffix`` is the documented disambiguator
+    for specs sharing a ``platform_id``: distinct specs must render
+    distinct suffixes, otherwise their per-tuple pins silently merge
+    under one dict key.
+    """
+
+    @given(pair=spec_pairs())
+    @PROPERTY_SETTINGS
+    def test_label_suffix_injective_for_distinct_specs(
+        self, pair: tuple[PlatformSpec, PlatformSpec]
+    ) -> None:
+        """Two distinct same-platform specs never share a label suffix."""
+        spec_a, spec_b = pair
+        assume(spec_a != spec_b)
+        assert spec_a.label_suffix() != spec_b.label_suffix(), (
+            f"{spec_a!r} and {spec_b!r} collide on suffix {spec_a.label_suffix()!r}"
+        )
+
+
+class TestPythonPatchesEnvironment:
+    """A ``python_patches`` override pins the tuple's full version;
+    ``python_full_version`` and ``implementation_version`` must carry
+    the override while ``python_version`` stays the minor.
+    """
+
+    @given(
+        minor=st.sampled_from(_KNOWN_PYTHON_MINORS),
+        patch=st.integers(0, 20),
+    )
+    @PROPERTY_SETTINGS
+    def test_python_patches_set_full_version_consistently(
+        self, minor: str, patch: int
+    ) -> None:
+        """The patch override flows to every full-version environment key."""
+        full = f"{minor}.{patch}"
+        matrix = Matrix(
+            python=f"=={minor}",
+            platforms=("linux_x86_64",),
+            python_patches={minor: full},
+        )
+        (tup,) = matrix.expand()
+        env = tup.environment
+        assert env["python_full_version"] == full
+        assert env["python_version"] == minor
+        assert env["implementation_version"] == full

--- a/nab-python/tests/universal/property_universal/test_reresolve_fixed_point.py
+++ b/nab-python/tests/universal/property_universal/test_reresolve_fixed_point.py
@@ -1,0 +1,168 @@
+"""End-to-end property tests for :mod:`nab_python.universal.reresolve`.
+
+Universe: an ``app`` whose listing baseline metadata depends on one
+subset of a dependency pool while its chosen wheel's metadata
+depends on another.  ``validate_lock`` must flag the divergence;
+``reresolve_divergent_tuples`` must report exactly the dependency
+swap as its diff; and re-running reresolve against the wheel-aware
+result must be a no-op (fixed point).  A drifting fixed point means
+repeated ``nab lock`` runs never converge.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_index.client import WheelFile
+from nab_python._testing.coordinator_fake import make_coordinator
+from nab_python.provider import BuildPolicy
+from nab_python.universal.matrix import Matrix
+from nab_python.universal.reresolve import (
+    _collect_wheel_metadata_overrides,
+    _override_metadata,
+    reresolve_divergent_tuples,
+)
+from nab_python.universal.resolve import resolve_with_coordinator
+from nab_python.universal.validate import validate_lock
+
+from .strategies import PROPERTY_SETTINGS
+
+pytestmark = pytest.mark.property
+
+DEP_POOL = ("depa", "depb", "depc", "depd")
+
+
+def _wheel(package: str, version: str = "1.0") -> WheelFile:
+    """Build a pure-Python wheel listing entry for ``package``."""
+    fn = f"{package}-{version}-py3-none-any.whl"
+    return WheelFile(
+        filename=fn,
+        url=f"https://example.com/{fn}",
+        version=version,
+        requires_python=None,
+        has_metadata=True,
+        upload_time=None,
+        hashes=(("sha256", "a" * 64),),
+    )
+
+
+def _metadata(name: str, deps: list[str]) -> str:
+    """Build METADATA text for ``name`` 1.0 with the given dependencies."""
+    lines = ["Metadata-Version: 2.1", f"Name: {name}", "Version: 1.0"]
+    lines += [f"Requires-Dist: {d}" for d in deps]
+    return "\n".join(lines) + "\n\n"
+
+
+def _build_universe(baseline_deps: list[str], wheel_deps: list[str]) -> MagicMock:
+    """Build a coordinator whose app baseline and wheel metadata diverge."""
+    listings = {"app": [_wheel("app")]}
+    baseline = {"app": _metadata("app", baseline_deps)}
+    per_wheel = {_wheel("app").filename: _metadata("app", wheel_deps)}
+    for dep in DEP_POOL:
+        listings[dep] = [_wheel(dep)]
+        baseline[dep] = _metadata(dep, [])
+        per_wheel[_wheel(dep).filename] = _metadata(dep, [])
+    return make_coordinator(
+        listings=listings,
+        baseline_metadata=baseline,
+        per_wheel_metadata=per_wheel,
+    )
+
+
+def _matrix() -> Matrix:
+    """Build the single-tuple linux/3.11 matrix used by every test."""
+    return Matrix(python="==3.11", platforms=("linux_x86_64",))
+
+
+deps_sets = st.lists(st.sampled_from(DEP_POOL), unique=True, max_size=3).map(sorted)
+
+
+class TestReresolveDiffIsExactlyTheDepSwap:
+    """The reresolve diff against a divergent pin must report exactly
+    the set difference between the wheel's dependencies and the
+    baseline's: every added dep, every removed dep, no version
+    changes, and an empty diff when the metadata agrees.
+    """
+
+    @given(baseline_deps=deps_sets, wheel_deps=deps_sets)
+    @PROPERTY_SETTINGS
+    def test_reresolve_diff_is_exactly_the_dep_swap(
+        self, baseline_deps: list[str], wheel_deps: list[str]
+    ) -> None:
+        """The divergence diff equals the baseline/wheel dependency swap."""
+        coord = _build_universe(baseline_deps, wheel_deps)
+        result = resolve_with_coordinator(
+            coord, _matrix(), ["app"], build_policy=BuildPolicy.NEVER
+        )
+        assert result.success, [tr.error for tr in result.tuple_results]
+        report = validate_lock(result, coord)
+        diffs = reresolve_divergent_tuples(coord, ["app"], result, report)
+        if baseline_deps == wheel_deps:
+            assert not any(f.status != "ok" for f in report.findings)
+            assert diffs == {}
+            return
+        (diff,) = diffs.values()
+        assert sorted(diff.added) == sorted(set(wheel_deps) - set(baseline_deps))
+        assert sorted(diff.removed) == sorted(set(baseline_deps) - set(wheel_deps))
+        assert diff.version_changed == {}
+
+
+class TestReresolveFixedPoint:
+    """Resolving with the divergent wheels' metadata substituted in
+    must itself validate without a further diff: reresolve is a fixed
+    point after one step on this universe.
+    """
+
+    @given(baseline_deps=deps_sets, wheel_deps=deps_sets)
+    @PROPERTY_SETTINGS
+    def test_reresolve_fixed_point(
+        self, baseline_deps: list[str], wheel_deps: list[str]
+    ) -> None:
+        """Re-running reresolve against the wheel-aware result is a no-op."""
+        coord = _build_universe(baseline_deps, wheel_deps)
+        result = resolve_with_coordinator(
+            coord, _matrix(), ["app"], build_policy=BuildPolicy.NEVER
+        )
+        assert result.success
+        report = validate_lock(result, coord)
+        divergent = [f for f in report.findings if f.status == "divergent"]
+        if not divergent:
+            return
+        overrides = _collect_wheel_metadata_overrides(coord, divergent)
+        with _override_metadata(coord, overrides):
+            wheel_aware = resolve_with_coordinator(
+                coord, _matrix(), ["app"], build_policy=BuildPolicy.NEVER
+            )
+        assert wheel_aware.success
+        report2 = validate_lock(wheel_aware, coord)
+        diffs2 = reresolve_divergent_tuples(coord, ["app"], wheel_aware, report2)
+        for label, diff in diffs2.items():
+            assert diff.added == {}, (label, diff)
+            assert diff.removed == {}, (label, diff)
+            assert diff.version_changed == {}, (label, diff)
+
+
+class TestOverrideMetadataRestoresIndexState:
+    """``_override_metadata`` is a context manager; on exit every
+    metadata slot it touched must hold its original value, otherwise
+    a reresolve poisons later phases of the same run.
+    """
+
+    @given(baseline_deps=deps_sets, wheel_deps=deps_sets)
+    @PROPERTY_SETTINGS
+    def test_override_metadata_restores_index_state(
+        self, baseline_deps: list[str], wheel_deps: list[str]
+    ) -> None:
+        """The override context restores every metadata slot it touched."""
+        coord = _build_universe(baseline_deps, wheel_deps)
+        keys = [("app", "1.0"), *((d, "1.0") for d in DEP_POOL)]
+        before = {k: coord.index.get_metadata(*k) for k in keys}
+        overrides = {("app", "1.0"): _metadata("app", ["depz"])}
+        with _override_metadata(coord, overrides):
+            assert coord.index.get_metadata("app", "1.0") == _metadata("app", ["depz"])
+        after = {k: coord.index.get_metadata(*k) for k in keys}
+        assert before == after

--- a/nab-python/tests/universal/property_universal/test_validate_mutations.py
+++ b/nab-python/tests/universal/property_universal/test_validate_mutations.py
@@ -1,0 +1,184 @@
+"""Mutation-style property tests for :mod:`nab_python.universal.validate`.
+
+Each test builds a small valid universal lock via the coordinator
+fake, corrupts exactly one thing, and requires ``validate_lock`` to
+flag it.  A corruption that yields an "ok" report means the validate
+phase would wave a broken lock through; the unmutated control checks
+the inverse (no false positives).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_index.client import WheelFile
+from nab_python._testing.coordinator_fake import make_coordinator
+from nab_python._vendor.packaging.version import Version
+from nab_python.universal.matrix import Matrix
+from nab_python.universal.resolve import TupleResult, UniversalResult
+from nab_python.universal.validate import validate_lock
+
+from .strategies import PROPERTY_SETTINGS
+
+pytestmark = pytest.mark.property
+
+DEP_POOL = ("requests", "numpy", "click", "attrs", "idna")
+
+
+def _wheel(filename: str) -> WheelFile:
+    """Build a ``WheelFile`` whose version is parsed from the filename."""
+    parts = filename.split("-")
+    return WheelFile(
+        filename=filename,
+        url=f"https://example.com/{filename}",
+        version=parts[1],
+        requires_python=None,
+        has_metadata=True,
+        upload_time=None,
+    )
+
+
+def _matrix() -> Matrix:
+    """Build the single-tuple linux/3.11 matrix used by every test."""
+    return Matrix(python=">=3.11,<3.12", platforms=("linux_x86_64",))
+
+
+def _metadata(deps: list[str], version: str = "1.0") -> str:
+    """Build METADATA text for pkg with the given dependencies."""
+    lines = ["Metadata-Version: 2.1", "Name: pkg", f"Version: {version}"]
+    lines += [f"Requires-Dist: {d}" for d in deps]
+    return "\n".join(lines) + "\n\n"
+
+
+def _result(pins: dict[str, Version]) -> UniversalResult:
+    """Wrap ``pins`` as a successful one-tuple ``UniversalResult``."""
+    matrix = _matrix()
+    return UniversalResult(
+        matrix=matrix,
+        tuple_results=[TupleResult(tuple_=matrix.expand()[0], success=True, pins=pins)],
+    )
+
+
+def _coordinator(deps: list[str], wheel_deps: list[str]) -> MagicMock:
+    """Build a coordinator whose baseline and per-wheel metadata may differ."""
+    fn = "pkg-1.0-py3-none-any.whl"
+    return make_coordinator(
+        wheels=[_wheel(fn)],
+        baseline_metadata={"pkg": _metadata(deps)},
+        per_wheel_metadata={fn: _metadata(wheel_deps)},
+    )
+
+
+class TestUnmutatedLockIsOk:
+    """Control: when the chosen wheel's metadata equals the baseline
+    the resolver saw, the report must be clean.  A false positive
+    here would make every real lock fail validation.
+    """
+
+    @given(deps=st.lists(st.sampled_from(DEP_POOL), unique=True, max_size=4))
+    @PROPERTY_SETTINGS
+    def test_unmutated_lock_is_ok(self, deps: list[str]) -> None:
+        """Identical baseline and wheel metadata validates clean."""
+        coord = _coordinator(deps, deps)
+        report = validate_lock(_result({"pkg": Version("1.0")}), coord)
+        assert report.pins_checked == 1
+        assert report.pins_ok == 1
+        assert not report.fatal_findings(build_allowed=False)
+
+
+class TestDroppedDepInWheelIsFlagged:
+    """Chosen wheel metadata missing one baseline dep must surface as
+    a divergent finding naming the dropped dep; an "ok" report would
+    silently under-install it.
+    """
+
+    @given(
+        deps=st.lists(st.sampled_from(DEP_POOL), unique=True, min_size=1, max_size=4),
+        data=st.data(),
+    )
+    @PROPERTY_SETTINGS
+    def test_dropped_dep_in_wheel_is_flagged(
+        self, deps: list[str], data: st.DataObject
+    ) -> None:
+        """A baseline dep absent from the wheel shows in ``missing_deps``."""
+        drop = data.draw(st.sampled_from(deps))
+        wheel_deps = [d for d in deps if d != drop]
+        coord = _coordinator(deps, wheel_deps)
+        report = validate_lock(_result({"pkg": Version("1.0")}), coord)
+        assert report.pins_ok == 0
+        (finding,) = report.findings
+        assert finding.status == "divergent"
+        assert drop in finding.missing_deps
+
+
+class TestExtraDepInWheelIsFlagged:
+    """Chosen wheel metadata with one dep added must surface as a
+    divergent finding naming the added dep; an "ok" report would
+    silently over-install it.
+    """
+
+    @given(
+        deps=st.lists(st.sampled_from(DEP_POOL), unique=True, max_size=3),
+        extra_dep=st.sampled_from(DEP_POOL),
+    )
+    @PROPERTY_SETTINGS
+    def test_extra_dep_in_wheel_is_flagged(
+        self, deps: list[str], extra_dep: str
+    ) -> None:
+        """A wheel-only dep shows in ``extra_deps``."""
+        if extra_dep in deps:
+            deps = [d for d in deps if d != extra_dep]
+        coord = _coordinator(deps, [*deps, extra_dep])
+        report = validate_lock(_result({"pkg": Version("1.0")}), coord)
+        assert report.pins_ok == 0
+        (finding,) = report.findings
+        assert finding.status == "divergent"
+        assert extra_dep in finding.extra_deps
+
+
+class TestFlippedMarkerInWheelIsFlagged:
+    """Dependency divergence can hide behind markers: a dep the
+    baseline gates on the tuple's platform but the wheel gates on a
+    different one evaluates to a dropped dep for that tuple and must
+    be flagged.
+    """
+
+    @given(dep=st.sampled_from(DEP_POOL))
+    @PROPERTY_SETTINGS
+    def test_flipped_marker_in_wheel_is_flagged(self, dep: str) -> None:
+        """Baseline dep gated on linux; wheel flips the marker to win32."""
+        fn = "pkg-1.0-py3-none-any.whl"
+        base = _metadata([f'{dep}; sys_platform == "linux"'])
+        wheel = _metadata([f'{dep}; sys_platform == "win32"'])
+        coord = make_coordinator(
+            wheels=[_wheel(fn)],
+            baseline_metadata={"pkg": base},
+            per_wheel_metadata={fn: wheel},
+        )
+        report = validate_lock(_result({"pkg": Version("1.0")}), coord)
+        (finding,) = report.findings
+        assert finding.status == "divergent"
+        assert dep in finding.missing_deps
+
+
+class TestWheelForWrongPlatformIsFatal:
+    """A pin whose only artifact targets a different platform cannot
+    install on this tuple; the finding must be fatal even when
+    building is allowed (there is no sdist to fall back to).
+    """
+
+    def test_wheel_for_wrong_platform_is_always_fatal(self) -> None:
+        """Only a win32 wheel exists; the linux tuple pin must be fatal."""
+        fn = "pkg-1.0-cp311-cp311-win_amd64.whl"
+        coord = make_coordinator(
+            wheels=[_wheel(fn)],
+            baseline_metadata={"pkg": _metadata(["requests"])},
+        )
+        report = validate_lock(_result({"pkg": Version("1.0")}), coord)
+        (finding,) = report.findings
+        assert finding.status == "no_compatible_wheel"
+        assert report.fatal_findings(build_allowed=True)

--- a/nab-python/tests/universal/property_universal/test_wheel_selection_differential.py
+++ b/nab-python/tests/universal/property_universal/test_wheel_selection_differential.py
@@ -1,0 +1,316 @@
+"""Differential property tests: nab wheel selection vs upstream ``packaging.tags``.
+
+:mod:`nab_python.universal.wheel_selection` implements `PEP 425`_
+wheel-tag preference on top of the vendored ``packaging.tags``.
+Each test here re-derives one layer with the upstream ``packaging``
+distribution as the oracle and requires agreement:
+
+1. The tag order built by ``_tags_in_order`` must match the same
+   order rebuilt with upstream ``cpython_tags``/``compatible_tags``.
+2. The vendored ``mac_platforms`` must match upstream for identical
+   inputs.
+3. ``parse_tag`` must expand compressed tag sets identically.
+4. ``wheel_tag_set`` must agree with upstream
+   ``parse_wheel_filename`` on every spec-valid filename.
+5. ``select_wheel_for_tuple`` must pick a wheel whose best upstream
+   rank is the minimum over all candidate wheels.
+
+.. _PEP 425: https://peps.python.org/pep-0425/
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import assume, given
+from hypothesis import strategies as st
+from packaging import tags as upstream_tags
+from packaging import utils as upstream_utils
+from packaging.utils import InvalidWheelFilename
+from packaging.version import InvalidVersion
+
+from nab_index.client import WheelFile
+from nab_python._vendor.packaging import tags as vendored_tags
+from nab_python.universal.wheel_selection import (
+    PlatformSpec,
+    _platform_tags_for_spec,
+    _tags_in_order,
+    select_wheel_for_tuple,
+    wheel_tag_set,
+)
+
+from .strategies import PROPERTY_SETTINGS
+
+pytestmark = pytest.mark.property
+
+PY_VERSIONS = ("3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14")
+PLATFORM_IDS = (
+    "linux_x86_64",
+    "linux_aarch64",
+    "macos_arm64",
+    "macos_x86_64",
+    "windows_amd64",
+)
+
+specs = st.builds(
+    PlatformSpec,
+    platform_id=st.sampled_from(PLATFORM_IDS),
+    manylinux_floor=st.tuples(st.just(2), st.integers(0, 35)),
+    musllinux_floor=st.tuples(st.just(1), st.integers(0, 4)),
+    macos_min=st.none() | st.tuples(st.integers(10, 14), st.integers(0, 15)),
+)
+
+
+def _triples(tag_iter: object) -> list[tuple[str, str, str]]:
+    """Flatten an iterable of ``Tag`` into (interpreter, abi, platform) triples."""
+    return [(t.interpreter, t.abi, t.platform) for t in tag_iter]  # type: ignore[attr-defined]
+
+
+def _oracle_tags_in_order(
+    python_version: str, platforms: list[str], implementation: str
+) -> list[tuple[str, str, str]]:
+    """Rebuild ``wheel_selection._tags_in_order`` with upstream ``packaging.tags``."""
+    major, minor = (int(p) for p in python_version.split("."))
+    py = (major, minor)
+    out: list[tuple[str, str, str]] = []
+    if implementation == "pypy":
+        interpreter = f"pp{major}{minor}"
+        abi = f"pypy{major}{minor}_pp73"
+        out += [(interpreter, abi, p) for p in platforms]
+        out += [(interpreter, "none", p) for p in platforms]
+    else:
+        interpreter = f"cp{major}{minor}"
+        out += _triples(
+            upstream_tags.cpython_tags(
+                python_version=py, abis=[interpreter], platforms=platforms
+            )
+        )
+    out += _triples(
+        upstream_tags.compatible_tags(
+            python_version=py, interpreter=interpreter, platforms=platforms
+        )
+    )
+    return out
+
+
+class TestTagOrderMatchesUpstream:
+    """``_tags_in_order`` defines the install-preference ranking every
+    wheel choice hangs off.  Rebuilding the same order with upstream
+    ``cpython_tags``/``compatible_tags`` over the same platform list
+    must agree exactly: a divergence reorders wheel preference.
+    """
+
+    @given(
+        python_version=st.sampled_from(PY_VERSIONS),
+        spec=specs,
+        implementation=st.sampled_from(["cpython", "pypy"]),
+    )
+    @PROPERTY_SETTINGS
+    def test_tag_order_matches_upstream(
+        self, python_version: str, spec: PlatformSpec, implementation: str
+    ) -> None:
+        """Vendored tag order equals the upstream-rebuilt order."""
+        platforms = _platform_tags_for_spec(spec)
+        # An empty platform list falls back to host tags, which drifted upstream after 26.2.
+        assume(platforms)
+        got = _triples(_tags_in_order(python_version, spec, implementation))
+        expected = _oracle_tags_in_order(python_version, platforms, implementation)
+        assert got == expected
+
+
+class TestMacPlatformsMatchesUpstream:
+    """The vendored ``mac_platforms`` drives the macOS platform-tag
+    axis of every matrix tuple; it must yield the same tags in the
+    same order as upstream ``packaging.tags.mac_platforms``.
+    """
+
+    @given(
+        version=st.tuples(st.integers(10, 15), st.integers(0, 16)),
+        arch=st.sampled_from(["x86_64", "arm64"]),
+    )
+    @PROPERTY_SETTINGS
+    def test_mac_platforms_matches_upstream(
+        self, version: tuple[int, int], arch: str
+    ) -> None:
+        """Vendored ``mac_platforms`` equals upstream for identical inputs."""
+        got = list(vendored_tags.mac_platforms(version=version, arch=arch))
+        expected = list(upstream_tags.mac_platforms(version=version, arch=arch))
+        # packaging 26.2 predates the fat32 -> fat3 tag fix the vendored copy carries.
+        expected = [p.replace("fat32", "fat3") for p in expected]
+        assert got == expected
+
+
+tag_part = st.text(alphabet="abcdefgh0123456789_", min_size=1, max_size=8)
+compressed = st.lists(tag_part, min_size=1, max_size=3, unique=True).map(".".join)
+
+
+class TestParseTagMatchesUpstream:
+    """`PEP 425`_ compressed tag sets expand to a cross product;
+    vendored ``parse_tag`` must produce the same set as upstream for
+    any dotted tag string.
+
+    .. _PEP 425: https://peps.python.org/pep-0425/#compressed-tag-sets
+    """
+
+    @given(py=compressed, abi=compressed, plat=compressed)
+    @PROPERTY_SETTINGS
+    def test_parse_tag_matches_upstream(self, py: str, abi: str, plat: str) -> None:
+        """Vendored and upstream ``parse_tag`` expand identically."""
+        s = f"{py}-{abi}-{plat}"
+        got = {(t.interpreter, t.abi, t.platform) for t in vendored_tags.parse_tag(s)}
+        expected = {
+            (t.interpreter, t.abi, t.platform) for t in upstream_tags.parse_tag(s)
+        }
+        assert got == expected
+
+
+name_strategy = st.text(alphabet="abcxyz0123456789_", min_size=1, max_size=8)
+version_strategy = st.sampled_from(
+    ["1.0", "2.1.3", "0.9a1", "1!2.0", "3.0.post1", "1.0+local"]
+)
+build_strategy = st.none() | st.integers(0, 99).map(str)
+
+
+@st.composite
+def wheel_filenames(draw: st.DrawFn) -> str:
+    """Generate a wheel filename with optional build tag and random tag parts."""
+    name = draw(name_strategy)
+    version = draw(version_strategy)
+    build = draw(build_strategy)
+    parts = [name, version]
+    if build is not None:
+        parts.append(build)
+    parts += [draw(compressed), draw(compressed), draw(compressed)]
+    return "-".join(parts) + ".whl"
+
+
+class TestWheelTagSetMatchesUpstream:
+    """``wheel_tag_set`` parses the tag suffix out of wheel filenames;
+    on every filename upstream ``parse_wheel_filename`` accepts, the
+    extracted tag set must agree.  Filenames upstream rejects are out
+    of scope: nab is intentionally permissive there.
+    """
+
+    @given(filename=wheel_filenames())
+    @PROPERTY_SETTINGS
+    def test_wheel_tag_set_matches_upstream_parse_wheel_filename(
+        self, filename: str
+    ) -> None:
+        """``wheel_tag_set`` agrees with upstream on spec-valid filenames."""
+        try:
+            _, _, _, expected = upstream_utils.parse_wheel_filename(filename)
+        except (InvalidWheelFilename, InvalidVersion):
+            return  # upstream rejects; nab is intentionally permissive
+        got = wheel_tag_set(filename)
+        assert got is not None
+        assert {(t.interpreter, t.abi, t.platform) for t in got} == {
+            (t.interpreter, t.abi, t.platform) for t in expected
+        }
+
+
+def _wheel(filename: str) -> WheelFile:
+    """Build a minimal ``WheelFile`` for a literal filename."""
+    return WheelFile(
+        filename=filename,
+        url=f"https://example.com/{filename}",
+        version="1.0",
+        requires_python=None,
+        has_metadata=True,
+        upload_time=None,
+    )
+
+
+KNOWN_PLATS = (
+    "any",
+    "manylinux_2_17_x86_64",
+    "manylinux2014_x86_64",
+    "manylinux_2_28_x86_64",
+    "manylinux1_x86_64",
+    "musllinux_1_2_x86_64",
+    "linux_x86_64",
+    "macosx_11_0_arm64",
+    "macosx_10_13_x86_64",
+    "macosx_10_9_universal2",
+    "win_amd64",
+    "manylinux_2_17_aarch64",
+)
+KNOWN_PYS = (
+    "py3",
+    "py2.py3",
+    "cp38",
+    "cp39",
+    "cp310",
+    "cp311",
+    "cp312",
+    "cp313",
+    "pp310",
+)
+KNOWN_ABIS = ("none", "abi3", "cp310", "cp311", "cp312", "pypy310_pp73")
+
+
+@st.composite
+def realistic_wheels(draw: st.DrawFn) -> WheelFile:
+    """Generate a wheel with realistic interpreter/abi/platform tags."""
+    py = draw(st.sampled_from(KNOWN_PYS))
+    abi = draw(st.sampled_from(KNOWN_ABIS))
+    plat = draw(st.sampled_from(KNOWN_PLATS))
+    return _wheel(f"pkg-1.0-{py}-{abi}-{plat}.whl")
+
+
+class TestSelectWheelMinimizesUpstreamRank:
+    """`PEP 425`_ preference: installers pick the wheel matching the
+    earliest tag in the compatibility order.  The selected wheel's
+    best tag rank, computed entirely with upstream packaging (parse
+    the filename's tags with upstream ``parse_tag``, rank against the
+    tuple's tag order rebuilt with upstream
+    ``cpython_tags``/``compatible_tags``), must equal the minimum
+    over all candidate wheels.
+
+    .. _PEP 425: https://peps.python.org/pep-0425/#use
+    """
+
+    @given(
+        wheels=st.lists(realistic_wheels(), min_size=0, max_size=8),
+        python_version=st.sampled_from(PY_VERSIONS),
+        spec=specs,
+        implementation=st.sampled_from(["cpython", "pypy"]),
+    )
+    @PROPERTY_SETTINGS
+    def test_select_wheel_minimizes_upstream_rank(
+        self,
+        wheels: list[WheelFile],
+        python_version: str,
+        spec: PlatformSpec,
+        implementation: str,
+    ) -> None:
+        """The selected wheel's best upstream rank is the minimum over all wheels."""
+        platforms = _platform_tags_for_spec(spec)
+        # An empty platform list falls back to host tags, which drifted upstream after 26.2.
+        assume(platforms)
+        order = _oracle_tags_in_order(python_version, platforms, implementation)
+        rank = {t: i for i, t in enumerate(order)}
+
+        def best_rank(w: WheelFile) -> int | None:
+            stem = w.filename[:-4]
+            tag_str = "-".join(stem.split("-")[-3:])
+            triples = {
+                (t.interpreter, t.abi, t.platform)
+                for t in upstream_tags.parse_tag(tag_str)
+            }
+            ranks = [rank[t] for t in triples if t in rank]
+            return min(ranks) if ranks else None
+
+        oracle_ranks = [r for w in wheels if (r := best_rank(w)) is not None]
+        chosen = select_wheel_for_tuple(
+            wheels,
+            python_version=python_version,
+            spec=spec,
+            implementation=implementation,
+        )
+        if not oracle_ranks:
+            assert chosen is None
+            return
+        assert chosen is not None
+        assert best_rank(chosen) == min(oracle_ranks), (
+            f"chose {chosen.filename} rank {best_rank(chosen)}; "
+            f"best available {min(oracle_ranks)}"
+        )


### PR DESCRIPTION
Seven new property-test files. Lockfile suite: `validate_marker_disjointness` and `_enumerate_valid_points` checked against full filtered-powerset models, per-tuple emission faithfulness plus byte-stability under input shuffles and an emit/parse/emit fixed point, and conflict-fork marker semantics with `Pylock.select` as the consumer oracle. Universal suite: wheel selection differential against the upstream `packaging` distribution, matrix expansion coverage and label-suffix injectivity, validate-phase mutation flagging, and the reresolve divergence diff and fixed point.

The wheel-selection differential carves out two known post-26.2 upstream drifts: the `fat32` to `fat3` tag spelling and the host-tag fallback for empty platform lists.