### PR TITLE
Accept merged self-dependency clauses in the proof oracle

### DIFF
--- a/nab-resolver/tests/property/graph_oracles.py
+++ b/nab-resolver/tests/property/graph_oracles.py
@@ -79,6 +79,8 @@ def check_leaf_against_universe(
     ROOT: matches a stated requirement.
     DEPENDENCY: for every real version of the parent inside the parent
     term, the universe dep range is a subset of the clause's dep range.
+    A single-term clause is a merged self-dependency ({v} & ~range);
+    it is true when the version's declared self-range excludes it.
     NO_VERSIONS: no real version of the package lies in the claimed range.
     CONSTRAINT: no real version lies in claimed-range & user-constraint.
     """
@@ -98,6 +100,25 @@ def check_leaf_against_universe(
         return
 
     if leaf.cause is IncompatibilityCause.DEPENDENCY:
+        if len(leaf.terms) == 1:
+            (term,) = leaf.terms
+            assert term.is_positive(), f"self-dep term should be positive: {leaf!r}"
+            parent = term.package
+            real_versions = [v for v in graph.get(parent, {}) if v in term.constraint]
+            assert real_versions, (
+                f"DEPENDENCY clause for {parent!r} covers no real version: {leaf!r}"
+            )
+            for v in real_versions:
+                actual = graph[parent][v].get(parent)
+                assert actual is not None, (
+                    f"{parent!r}@{v} has no self-dep but proof claims it: {leaf!r}"
+                )
+                assert v not in actual, (
+                    f"{parent!r}@{v} self-range {actual} contains {v}, the "
+                    f"clause should have been vacuous: {leaf!r}"
+                )
+            return
+
         assert len(leaf.terms) == 2, f"DEPENDENCY clause shape: {leaf!r}"
         parent_term, dep_term = leaf.terms
         assert parent_term.is_positive()


### PR DESCRIPTION
The proof-leaf checker from #186 asserts every DEPENDENCY clause has two terms, but #170 merges a self-dependency clause to the single positive term `{v}` when the declared self-range excludes the chosen version. Both were green against the pre-merge main; together the `test_selfdep_graphs` property fails on every unsat proof containing a merged clause, which is the current red on main.

The checker now validates the one-term shape directly: for every real version covered by the term, the universe must declare a self-dependency whose range excludes that version, which is exactly the condition under which the resolver emits the merged clause.