### PR TITLE
Honor markers on single-env self-ref extra activation

### DIFF
--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -140,6 +140,7 @@ def expand_self_extras(
     optional_deps: Mapping[str, Sequence[str]],
     project_name: str | None,
     selected: Sequence[str],
+    environment: dict[str, str] | None = None,
 ) -> list[str]:
     """Return ``selected`` plus every extra reachable through self-references.
 
@@ -151,6 +152,12 @@ def expand_self_extras(
     (graphviz, opentelemetry-api, etc.) out of the resolver's root
     requirements and look-ahead loses the ability to predict
     candidates.
+
+    A self-reference carrying a PEP 508 marker (``{name}[fast];
+    python_version < "3.10"``) activates its extra only when the marker
+    evaluates true under ``environment``.  ``environment`` ``None`` skips
+    that check and walks every self-reference, which is what the
+    universal path wants (it defers marker evaluation to each tuple).
 
     The original ``selected`` order is preserved at the front of the
     result; reachable extras are appended in BFS order without
@@ -179,6 +186,12 @@ def expand_self_extras(
             except (ValueError, TypeError):
                 continue
             if canonicalize_name(req.name) != canonical_project:
+                continue
+            if (
+                environment is not None
+                and req.marker is not None
+                and not req.marker.evaluate(environment)
+            ):
                 continue
             worklist.extend(
                 canonicalize_name(sub)

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -169,13 +169,13 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
         resolution_strategy if resolution_strategy is not None else config.resolution
     )
 
-    requirements = read_pyproject_dependencies(path)
-    requirements.extend(_load_group_requirements(path, effective_groups))
-    requirements.extend(_load_extra_requirements(path, extras))
     marker_environment = _build_marker_environment(
         python_version=effective_python,
         overrides=config.marker_environment,
     )
+    requirements = read_pyproject_dependencies(path)
+    requirements.extend(_load_group_requirements(path, effective_groups))
+    requirements.extend(_load_extra_requirements(path, extras, marker_environment))
     if len(effective_groups) > 1:
         _check_group_disjointness(
             _load_group_requirements_by_group(path, effective_groups),
@@ -438,13 +438,18 @@ def _check_group_disjointness_across_tuples(
     raise ResolutionError("; ".join(clauses))
 
 
-def _load_extra_requirements(path: Path, selected: Sequence[str]) -> list[Requirement]:
+def _load_extra_requirements(
+    path: Path,
+    selected: Sequence[str],
+    environment: dict[str, str] | None = None,
+) -> list[Requirement]:
     """Read [project.optional-dependencies] from ``path`` and expand ``selected``.
 
     Self-references (``{project_name}[a, b]`` inside an extra's
     contents) are expanded transitively so that the third-party deps
     they ultimately reach reach the resolver as root requirements.
-    See :func:`expand_self_extras` for the rationale.
+    A marker-gated self-reference is walked only when its marker holds
+    under ``environment``; see :func:`expand_self_extras`.
     """
     if not selected:
         return []
@@ -453,6 +458,7 @@ def _load_extra_requirements(path: Path, selected: Sequence[str]) -> list[Requir
         read_pyproject_name(path),
         selected,
         path=path,
+        environment=environment,
     )
 
 
@@ -462,6 +468,7 @@ def _extra_requirements_from_table(
     selected: Sequence[str],
     *,
     path: Path,
+    environment: dict[str, str] | None = None,
 ) -> list[Requirement]:
     """Expand ``selected`` extras from an already-read optional-deps table.
 
@@ -476,7 +483,7 @@ def _extra_requirements_from_table(
             f" missing from {path}: {sorted(selected)!r}"
         )
         raise LookupError(msg)
-    expanded = expand_self_extras(optional, project_name, selected)
+    expanded = expand_self_extras(optional, project_name, selected, environment)
     return select_optional_dependencies(optional, expanded)
 
 

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -287,6 +287,30 @@ class TestExpandSelfExtras:
         opt = {"a": ["depA"]}
         assert expand_self_extras(opt, "mypkg", ["a", "a", "a"]) == ["a"]
 
+    def test_self_reference_marker_false_skipped(self) -> None:
+        """A self-ref whose marker is false does not activate its extra."""
+        opt = {
+            "all": ["mypkg[fast]; python_version < '3.10'"],
+            "fast": ["some-dep"],
+        }
+        env = {"python_version": "3.12", "python_full_version": "3.12.0"}
+        assert expand_self_extras(opt, "mypkg", ["all"], env) == ["all"]
+
+    def test_self_reference_marker_true_walked(self) -> None:
+        """A self-ref whose marker is true activates its extra."""
+        opt = {
+            "all": ["mypkg[fast]; python_version < '3.10'"],
+            "fast": ["some-dep"],
+        }
+        env = {"python_version": "3.9", "python_full_version": "3.9.0"}
+        assert expand_self_extras(opt, "mypkg", ["all"], env) == ["all", "fast"]
+
+    def test_self_reference_without_marker_walked_with_environment(self) -> None:
+        """An unconditional self-ref is walked even when an environment is given."""
+        opt = {"all": ["mypkg[a]"], "a": ["depA"]}
+        env = {"python_version": "3.12", "python_full_version": "3.12.0"}
+        assert expand_self_extras(opt, "mypkg", ["all"], env) == ["all", "a"]
+
 
 class TestExpandGroupIncludes:
     def test_no_include_returns_input(self) -> None:

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -1716,6 +1716,21 @@ class TestLoadExtraRequirements:
         reqs = _load_extra_requirements(path, ["My_Extra"])
         assert [r.name for r in reqs] == ["requests"]
 
+    def test_self_ref_marker_excludes_dep_in_wrong_environment(
+        self, tmp_path: Path
+    ) -> None:
+        """A marker-false self-ref does not flatten its extra's deps into roots."""
+        path = tmp_path / "pyproject.toml"
+        path.write_text(
+            "[project]\nname = 'x'\n"
+            "[project.optional-dependencies]\n"
+            "fast = ['some-dep']\n"
+            "all = [\"x[fast]; python_version < '3.10'\"]\n"
+        )
+        env = {"python_version": "3.12", "python_full_version": "3.12.0"}
+        reqs = _load_extra_requirements(path, ["all"], env)
+        assert "some-dep" not in [r.name for r in reqs]
+
 
 class TestBuildResolverInputs:
     """``_build_resolver_inputs`` folds duplicate names by intersection."""


### PR DESCRIPTION
In a single-environment resolve, a self-referential extra such as all = ["mypkg[fast]; python_version < '3.10'"] activated its referenced extra unconditionally, ignoring the PEP 508 marker, so a marker-false self-ref flattened the fast extra's third-party deps into the root requirements on a Python where the marker does not hold. expand_self_extras now takes an optional environment and skips a self-reference whose marker evaluates false under it, and the single-env path threads its marker environment through _load_extra_requirements. The argument defaults to None, which preserves the existing walk-every-self-ref behavior used by the conflict checks and the universal per-tuple path that defers marker evaluation. This is correctness-only and corpus-inert; no benchmark scenario exercises a marker-gated self-referential extra.
