### PR TITLE
Keep self-ref extra markers in universal flatten

### DIFF
--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -10,6 +10,7 @@ import tomli
 from nab_resolver.errors import ResolutionError
 
 from ._vendor.packaging.dependency_groups import resolve_dependency_groups
+from ._vendor.packaging.markers import Marker
 from ._vendor.packaging.requirements import InvalidRequirement, Requirement
 from ._vendor.packaging.utils import canonicalize_name
 
@@ -21,6 +22,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "InvalidProjectRequirementError",
+    "expand_extra_requirements",
     "expand_group_includes",
     "expand_self_extras",
     "raise_for_unsatisfiable",
@@ -185,6 +187,69 @@ def expand_self_extras(
                 for sub in req.extras
                 if canonicalize_name(sub) not in seen
             )
+    return out
+
+
+def _and_markers(marker: Marker | None, gates: frozenset[str]) -> Marker:
+    """AND a non-empty set of marker strings onto ``marker``."""
+    parts = [str(marker)] if marker is not None else []
+    parts.extend(sorted(gates))
+    return Marker(" and ".join(f"({p})" for p in parts))
+
+
+def expand_extra_requirements(
+    optional_deps: Mapping[str, Sequence[str]],
+    project_name: str | None,
+    selected: Sequence[str],
+) -> list[Requirement]:
+    """Flatten ``selected`` extras to requirements, propagating self-ref markers.
+
+    This is :func:`select_optional_dependencies` over the self-reference
+    closure :func:`expand_self_extras` walks, except a self-reference's
+    PEP 508 marker is carried onto the requirements it pulls in.  With
+    ``all = ["pkg[fast]; python_version < '3.10'"]`` and ``fast =
+    ["dep"]``, selecting ``all`` yields ``dep; python_version < '3.10'``
+    rather than a bare ``dep`` that survives on every environment, so the
+    per-tuple universal parser drops the dep on the tuples it excludes.
+
+    Each activation path is walked separately, so a dep reachable through
+    two markers is required under their disjunction.  Unknown extras
+    raise ``LookupError``.
+    """
+    if not selected:
+        return []
+    canonical_project = (
+        canonicalize_name(project_name) if project_name is not None else None
+    )
+    canonical_deps = _canonicalize_optional_deps(optional_deps)
+    out: list[Requirement] = []
+    visited: set[tuple[str, frozenset[str]]] = set()
+    worklist: list[tuple[str, frozenset[str]]] = [
+        (canonicalize_name(s), frozenset()) for s in selected
+    ]
+    while worklist:
+        extra, gates = worklist.pop(0)
+        if (extra, gates) in visited:
+            continue
+        visited.add((extra, gates))
+        if extra not in canonical_deps:
+            msg = (
+                f"extra {extra!r} is not declared in"
+                f" [project.optional-dependencies]; defined: {sorted(canonical_deps)!r}"
+            )
+            raise LookupError(msg)
+        for req in _parse_requirements(
+            canonical_deps[extra],
+            f"[project.optional-dependencies] extra {extra!r}",
+        ):
+            if canonical_project is not None and (
+                canonicalize_name(req.name) == canonical_project
+            ):
+                edge = gates if req.marker is None else gates | {str(req.marker)}
+                worklist.extend((canonicalize_name(sub), edge) for sub in req.extras)
+            if gates:
+                req.marker = _and_markers(req.marker, gates)
+            out.append(req)
     return out
 
 

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -45,6 +45,7 @@ from .provider import (
     split_extra,
 )
 from .requirements_file import (
+    expand_extra_requirements,
     expand_group_includes,
     expand_self_extras,
     raise_for_unsatisfiable,
@@ -468,8 +469,6 @@ def _extra_requirements_from_table(
     See :func:`_load_extra_requirements` for the self-reference rules;
     ``path`` is used only for the missing-table error message.
     """
-    if not selected:
-        return []
     if not optional:
         msg = (
             "extras requested but [project.optional-dependencies] is"
@@ -538,8 +537,8 @@ def _fork_requirement_strings(
         _group_requirements_from_table(tables.groups, fork.active_groups, path=path)
     )
     requirements.extend(
-        _extra_requirements_from_table(
-            tables.optional, tables.project_name, fork.active_extras, path=path
+        expand_extra_requirements(
+            tables.optional, tables.project_name, fork.active_extras
         )
     )
     return [str(r) for r in requirements]

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -9,6 +9,7 @@ import pytest
 from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python.requirements_file import (
     InvalidProjectRequirementError,
+    expand_extra_requirements,
     expand_group_includes,
     expand_self_extras,
     raise_for_unsatisfiable,
@@ -286,6 +287,112 @@ class TestExpandSelfExtras:
         """Duplicates in the user-supplied selection are deduped."""
         opt = {"a": ["depA"]}
         assert expand_self_extras(opt, "mypkg", ["a", "a", "a"]) == ["a"]
+
+
+class TestExpandExtraRequirements:
+    def test_empty_selection_returns_empty(self) -> None:
+        assert expand_extra_requirements({"a": ["depA"]}, "mypkg", []) == []
+
+    def test_no_project_name_flattens_without_self_ref(self) -> None:
+        """Without a project name a self-ref cannot be walked, so only the
+        selected extra's own requirements come back."""
+        opt = {"all": ["mypkg[fast]", "plain"], "fast": ["some-dep"]}
+        out = expand_extra_requirements(opt, None, ["all"])
+        assert sorted(r.name for r in out) == ["mypkg", "plain"]
+
+    def test_plain_extra_requirements_keep_their_markers(self) -> None:
+        opt = {"cpu": ["torch", "numpy; python_version < '3.10'"]}
+        by_name = {r.name: r for r in expand_extra_requirements(opt, "mypkg", ["cpu"])}
+        assert by_name["torch"].marker is None
+        assert by_name["numpy"].marker is not None
+        assert by_name["numpy"].marker.evaluate({"python_version": "3.9"})
+
+    def test_self_ref_marker_propagates_to_flattened_dep(self) -> None:
+        """The reported bug: a marker-gated self-ref's dep carries the marker."""
+        opt = {
+            "fast": ["some-dep"],
+            "all": ["mypkg[fast]; python_version < '3.10'"],
+        }
+        out = expand_extra_requirements(opt, "mypkg", ["all"])
+        dep = next(r for r in out if r.name == "some-dep")
+        assert dep.marker is not None
+        assert dep.marker.evaluate({"python_version": "3.9"})
+        assert not dep.marker.evaluate({"python_version": "3.11"})
+
+    def test_self_ref_without_marker_leaves_dep_unmarked(self) -> None:
+        opt = {"all": ["mypkg[fast]"], "fast": ["some-dep"]}
+        out = expand_extra_requirements(opt, "mypkg", ["all"])
+        dep = next(r for r in out if r.name == "some-dep")
+        assert dep.marker is None
+
+    def test_dep_own_marker_anded_with_activation(self) -> None:
+        opt = {
+            "fast": ["some-dep; sys_platform == 'linux'"],
+            "all": ["mypkg[fast]; python_version < '3.10'"],
+        }
+        dep = next(
+            r
+            for r in expand_extra_requirements(opt, "mypkg", ["all"])
+            if r.name == "some-dep"
+        )
+        assert dep.marker.evaluate({"sys_platform": "linux", "python_version": "3.9"})
+        assert not dep.marker.evaluate(
+            {"sys_platform": "linux", "python_version": "3.11"}
+        )
+        assert not dep.marker.evaluate(
+            {"sys_platform": "win32", "python_version": "3.9"}
+        )
+
+    def test_chain_of_self_refs_combines_markers(self) -> None:
+        opt = {
+            "all": ["mypkg[mid]; python_version < '3.12'"],
+            "mid": ["mypkg[leaf]; sys_platform == 'linux'"],
+            "leaf": ["dep"],
+        }
+        dep = next(
+            r
+            for r in expand_extra_requirements(opt, "mypkg", ["all"])
+            if r.name == "dep"
+        )
+        assert dep.marker.evaluate({"python_version": "3.11", "sys_platform": "linux"})
+        assert not dep.marker.evaluate(
+            {"python_version": "3.12", "sys_platform": "linux"}
+        )
+        assert not dep.marker.evaluate(
+            {"python_version": "3.11", "sys_platform": "win32"}
+        )
+
+    def test_multi_path_emits_dep_under_each_activation(self) -> None:
+        """A dep reachable through two markers is required under their OR:
+        each activation path is emitted separately."""
+        opt = {
+            "all": [
+                "mypkg[fast]; python_version < '3.10'",
+                "mypkg[fast]; sys_platform == 'win32'",
+            ],
+            "fast": ["some-dep"],
+        }
+        deps = [
+            r
+            for r in expand_extra_requirements(opt, "mypkg", ["all"])
+            if r.name == "some-dep"
+        ]
+        assert len(deps) == 2
+        py_only = {"python_version": "3.9", "sys_platform": "linux"}
+        win_only = {"python_version": "3.11", "sys_platform": "win32"}
+        neither = {"python_version": "3.11", "sys_platform": "linux"}
+        assert any(d.marker.evaluate(py_only) for d in deps)
+        assert any(d.marker.evaluate(win_only) for d in deps)
+        assert not any(d.marker.evaluate(neither) for d in deps)
+
+    def test_unknown_extra_raises(self) -> None:
+        with pytest.raises(LookupError, match="not declared"):
+            expand_extra_requirements({"a": ["depA"]}, "mypkg", ["missing"])
+
+    def test_self_ref_cycle_terminates(self) -> None:
+        opt = {"a": ["mypkg[b]", "depA"], "b": ["mypkg[a]", "depB"]}
+        names = {r.name for r in expand_extra_requirements(opt, "mypkg", ["a"])}
+        assert {"depA", "depB"} <= names
 
 
 class TestExpandGroupIncludes:

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -38,6 +38,12 @@ from nab_python.provider import (
     VcsPolicy,
     VcsSource,
 )
+from nab_python.requirements_file import (
+    expand_extra_requirements,
+    read_pyproject_dependencies,
+    read_pyproject_name,
+    read_pyproject_optional_dependencies,
+)
 from nab_python.universal import resolve as resolve_mod
 from nab_python.universal.matrix import Matrix, MatrixTuple
 from nab_python.universal.resolve import (
@@ -743,6 +749,36 @@ class TestParseRequirements:
                 env,
                 vcs_config=vcs_config,
             )
+
+
+class TestUniversalSelfRefMarker:
+    """The universal flatten must keep a self-ref's marker so the per-tuple
+    parser drops its dep on the tuples the marker excludes."""
+
+    def test_marker_gated_dep_dropped_on_excluded_tuple(self, tmp_path: Path) -> None:
+        path = tmp_path / "pyproject.toml"
+        path.write_text(
+            "[project]\nname = 'x'\ndependencies = []\n"
+            "[project.optional-dependencies]\n"
+            "fast = ['some-dep']\n"
+            "all = [\"x[fast]; python_version < '3.10'\"]\n"
+        )
+        reqs = read_pyproject_dependencies(path)
+        reqs.extend(
+            expand_extra_requirements(
+                read_pyproject_optional_dependencies(path),
+                read_pyproject_name(path),
+                ["all"],
+            )
+        )
+        strings = [str(r) for r in reqs]
+        assert "some-dep" not in _parse_requirements(strings, _linux_311().environment)
+        included = {
+            **_linux_311().environment,
+            "python_version": "3.9",
+            "python_full_version": "3.9.0",
+        }
+        assert "some-dep" in _parse_requirements(strings, included)
 
 
 class TestRootExtras:


### PR DESCRIPTION
In universal resolution a marker-gated self-reference such as `all = ["pkg[fast]; python_version < '3.10'"]` was flattened to a bare `dep` with no marker, so the dep leaked onto every resolution tuple instead of only the ones the marker selects. This adds `expand_extra_requirements`, which walks the self-reference closure per activation path and ANDs each path's marker onto the requirements it pulls in, and wires it into the per-fork requirement build. A dep reached through two different markers is emitted once per path so it ends up required under their disjunction. The change is correctness-only and corpus-inert; no benchmark scenario exercises a marker-gated self-reference.
