### PR TITLE
Refuse trust-unverified-sdist deps in universal

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -430,6 +430,20 @@ class OverrideConflictError(ConfigError):
     """
 
 
+def reject_universal_trust_unverified(*, trust_unverified_sdist_deps: bool) -> None:
+    """Refuse trusting unverified sdist deps under universal mode."""
+    if not trust_unverified_sdist_deps:
+        return
+    msg = (
+        "mode = 'universal' does not support dist-policy.trust-unverified-deps"
+        " = true: a universal lock filters wheels per target environment, so a"
+        " version whose wheels are all filtered out leaves only its sdist, and"
+        " trusting that sdist's unverified dependencies can omit real ones and"
+        " produce an invalid lock. Use mode = 'specific' to trust them."
+    )
+    raise ConfigError(msg)
+
+
 def _member_active(
     member: ConflictMember,
     active_extras: AbstractSet[str],
@@ -650,6 +664,7 @@ def _config_from_effective(
                 " per-tuple values. Drop it or use mode = 'specific'."
             )
             raise ConfigError(msg)
+        reject_universal_trust_unverified(trust_unverified_sdist_deps=trust_unverified)
 
     default_groups = effective["default-groups"].value
     conflicts = effective["conflicts"].value

--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -26,7 +26,12 @@ from .._vendor.packaging.ranges import VersionRange
 from .._vendor.packaging.requirements import InvalidRequirement, Requirement
 from .._vendor.packaging.utils import canonicalize_name
 from .._vendor.packaging.version import Version
-from ..config import ConfigError, IndexOverride, PackageOverride
+from ..config import (
+    ConfigError,
+    IndexOverride,
+    PackageOverride,
+    reject_universal_trust_unverified,
+)
 from ..fetch import (
     DEFAULT_INDEX_NAME,
     DEFAULT_INDEX_URL,
@@ -351,6 +356,11 @@ def resolve_with_coordinator(  # noqa: PLR0913 - mirrors resolve_universal's sur
     a true base dependency from one required by every member; pass it
     only when conflict forks ran.
     """
+    if build_config is not None:
+        reject_universal_trust_unverified(
+            trust_unverified_sdist_deps=build_config.trust_unverified_sdist_deps
+        )
+
     base_tuples = matrix.expand()
     fork_list = (
         list(forks) if forks is not None else [ResolveFork((), list(requirements))]

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -2646,6 +2646,32 @@ class TestMatrix:
             read_pyproject_config(path)
 
 
+class TestTrustUnverifiedSdistDeps:
+    def test_rejected_in_universal_mode(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab]\nmode = "universal"\n'
+            'dist-policy = { policy = "wheel-or-sdist", trust-unverified-deps = true }\n'
+            "[tool.nab.matrix]\n"
+            'python = ">=3.11"\n'
+            'platforms = ["linux_x86_64"]\n',
+        )
+        with pytest.raises(
+            ConfigError, match="does not support dist-policy.trust-unverified-deps"
+        ):
+            read_pyproject_config(path)
+
+    def test_default_allowed_in_universal_mode(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab]\nmode = "universal"\n'
+            "[tool.nab.matrix]\n"
+            'python = ">=3.11"\n'
+            'platforms = ["linux_x86_64"]\n',
+        )
+        assert read_pyproject_config(path).trust_unverified_sdist_deps is False
+
+
 class TestWorkspace:
     """``[tool.nab.workspace]`` parses into a typed :class:`WorkspaceConfig`."""
 

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -24,6 +24,7 @@ from nab_python.config import (
     ConflictMember,
     ConflictPolicy,
     ConflictSet,
+    NabProjectConfig,
     conflict_forks,
 )
 from nab_python.lockfile import (
@@ -1498,3 +1499,24 @@ class TestLocalVcsRequiresPython:
         error = result.tuple_results[0].error
         assert error is not None
         assert "foo 1.0 requires Python" in error
+
+
+class TestRejectTrustUnverifiedInUniversal:
+    """A universal resolve refuses to trust unverified sdist deps.
+
+    The per-tuple wheel-tag filter can drop every wheel for a version,
+    leaving only its sdist; trusting that sdist's unverified deps can omit
+    real ones and produce an invalid lock.
+    """
+
+    def test_build_config_trust_rejected(self) -> None:
+        coordinator = _make_coordinator({"pkg": [_make_wheel("1.0", package="pkg")]})
+        with pytest.raises(
+            ConfigError, match="does not support dist-policy.trust-unverified-deps"
+        ):
+            resolve_with_coordinator(
+                coordinator,
+                Matrix(python="==3.11", platforms=("linux_x86_64",)),
+                ["pkg"],
+                build_config=NabProjectConfig(trust_unverified_sdist_deps=True),
+            )


### PR DESCRIPTION
A universal lock filters wheels per target environment, so a version whose wheels are all filtered out leaves only its sdist. With trust-unverified-sdist-deps set, that sdist's unverified PKG-INFO dependencies would be trusted across tuples, which can omit real dependencies and write an invalid lock. This change refuses the combination at both entry points: the pyproject parse path raises a ConfigError when mode is universal and the flag is true, and resolve_with_coordinator raises the same error before any tuple runs so a directly constructed config cannot slip past. Users who want to trust unverified sdist deps must use mode = 'specific'. This is a correctness-only behavior change and no benchmark scenario sets the flag under universal mode, so it is corpus-inert.
