### PR TITLE
Reject constraint extras before marker drop

### DIFF
--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -905,11 +905,11 @@ def _build_constraints(
     sources: defaultdict[str, list[str]] = defaultdict(list)
     for cstr in config.constraints:
         req = Requirement(cstr)
-        if req.marker is not None and not req.marker.evaluate(environment):
-            continue
         if req.extras:
             msg = f"Constraints cannot have extras: {cstr}"
             raise ConfigError(msg)
+        if req.marker is not None and not req.marker.evaluate(environment):
+            continue
         if req.url is not None:
             admit_vcs_url(req.url, config.vcs)
             msg = (

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -1803,6 +1803,21 @@ class TestBuildConstraints:
                 NabProjectConfig(constraints=("foo[dev]<2.0",)), environment={}
             )
 
+    def test_constraint_with_extras_rejected_under_false_marker(self) -> None:
+        """Extras on a constraint are rejected even when its marker is False.
+
+        pip rejects constraint extras at parse, before evaluating the marker,
+        and the universal path does the same. The extras guard must run before
+        the marker drop so a marker-false constraint is not silently accepted.
+        """
+        with pytest.raises(ConfigError, match="extras"):
+            _build_constraints(
+                NabProjectConfig(
+                    constraints=('foo[dev]<2.0 ; python_version < "3.0"',)
+                ),
+                environment={"python_version": "3.12"},
+            )
+
 
 class TestResolvePyprojectConflicts:
     """End-to-end: contradictory folded requirements fail loudly."""


### PR DESCRIPTION
A constraint that carries extras together with a marker that evaluates False was silently dropped instead of rejected, because the marker-false `continue` ran before the extras guard in `_build_constraints`. This let an invalid constraint like `foo[dev]<2.0 ; python_version < "3.0"` slip through on a Python where the marker is False, diverging from pip and from the universal resolution path, which both reject constraint extras before evaluating the marker. The fix moves the extras guard above the marker drop so the constraint raises ConfigError regardless of marker outcome. This is behavior and correctness only and no benchmark scenario exercises it.
