### PR TITLE
Handle lockfile-only set markers in dependency markers

### DIFF
--- a/nab-python/src/nab_python/_conflict_kind.py
+++ b/nab-python/src/nab_python/_conflict_kind.py
@@ -8,6 +8,14 @@ cycle.  :class:`nab_python.config.ConflictKind` takes its enum values from
 
 from __future__ import annotations
 
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from ._vendor.packaging.markers import Marker
+
 KIND_EXTRA = "extra"
 KIND_GROUP = "group"
 
@@ -18,3 +26,37 @@ MARKER_VARIABLE_FOR_KIND = {
     KIND_EXTRA: "extras",
     KIND_GROUP: "dependency_groups",
 }
+
+# ``extras`` and ``dependency_groups`` are PEP 685 / PEP 735 set variables that
+# packaging only defines when consuming a lockfile.  At resolve time no
+# conflict-fork member is active as a marker-set member (forks fold their
+# members into requirements, not the environment), so both are empty.  Seeding
+# them keeps a dependency marker that tests one from raising a raw KeyError at
+# evaluation; the membership simply tests False and the dep is dropped.
+EMPTY_MEMBERSHIP_SETS: dict[str, frozenset[str]] = {
+    variable: frozenset() for variable in MARKER_VARIABLE_FOR_KIND.values()
+}
+
+_MEMBERSHIP_SET_PATTERN = re.compile(
+    r"\b(" + "|".join(MARKER_VARIABLE_FOR_KIND.values()) + r")\b"
+)
+
+
+def membership_set_in_marker(marker_text: str) -> str | None:
+    """Return the lockfile-only set variable a marker tests, or ``None``.
+
+    A dependency marker that tests ``extras`` or ``dependency_groups`` is a
+    mistake (usually meant as ``extra ==``): those variables are defined only
+    when consuming a lockfile, so they are empty at resolve time.
+    """
+    match = _MEMBERSHIP_SET_PATTERN.search(marker_text)
+    return match.group(1) if match else None
+
+
+def dependency_marker_holds(marker: Marker, environment: Mapping[str, str]) -> bool:
+    """Evaluate a dependency marker for a resolve-time ``environment``.
+
+    Seeds the empty lockfile-only set variables so a marker that tests one
+    evaluates cleanly to False instead of raising a raw KeyError.
+    """
+    return bool(marker.evaluate({**environment, **EMPTY_MEMBERSHIP_SETS}))

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -16,6 +16,7 @@ from nab_resolver.resolver import (
     Resolver,
 )
 
+from ._conflict_kind import dependency_marker_holds, membership_set_in_marker
 from ._vcs_admission import admit_vcs_url
 from ._vendor.packaging.markers import default_environment
 from ._vendor.packaging.ranges import VersionRange
@@ -321,7 +322,9 @@ def _group_package_ranges(
     ranges: dict[str, VersionRange] = {}
     sources: dict[str, list[str]] = defaultdict(list)
     for req in requirements:
-        if req.marker is not None and not req.marker.evaluate(environment):
+        if req.marker is not None and not dependency_marker_holds(
+            req.marker, environment
+        ):
             continue
         if req.url is not None:
             continue
@@ -632,6 +635,23 @@ def _walk_no_versions_packages(
     return out
 
 
+def _warn_dropped_root_marker(req: Requirement) -> None:
+    """Warn when a dropped root requirement tests an extra/group membership.
+
+    A root marker testing ``extra``, ``extras``, or ``dependency_groups``
+    evaluates False at resolve time (root activates no extra or group), so the
+    dep would otherwise be dropped silently.
+    """
+    marker_text = str(req.marker)
+    if "extra ==" in marker_text or membership_set_in_marker(marker_text):
+        _logger.warning(
+            "Root requirement %r tests an extra or dependency-group membership "
+            "marker; the dep is dropped because root activates no extra or group "
+            "at resolve time. For an extra, use pkg[extra] (extras-of-package).",
+            str(req),
+        )
+
+
 def _build_resolver_inputs(
     requirements: list[Requirement],
     config: NabProjectConfig,
@@ -649,14 +669,10 @@ def _build_resolver_inputs(
     sources: defaultdict[str, list[str]] = defaultdict(list)
     root_extras: set[tuple[str, str]] = set()
     for req in requirements:
-        if req.marker is not None and not req.marker.evaluate(environment):
-            if "extra ==" in str(req.marker):
-                _logger.warning(
-                    "Root requirement %r uses an extra marker; the dep is "
-                    "dropped because root has no parent extra. Did you mean "
-                    "pkg[extra] (extras-of-package) instead?",
-                    str(req),
-                )
+        if req.marker is not None and not dependency_marker_holds(
+            req.marker, environment
+        ):
+            _warn_dropped_root_marker(req)
             continue
         if req.url is not None:
             admit_vcs_url(req.url, config.vcs)
@@ -942,7 +958,9 @@ def _build_constraints(
         if req.extras:
             msg = f"Constraints cannot have extras: {cstr}"
             raise ConfigError(msg)
-        if req.marker is not None and not req.marker.evaluate(environment):
+        if req.marker is not None and not dependency_marker_holds(
+            req.marker, environment
+        ):
             continue
         if req.url is not None:
             admit_vcs_url(req.url, config.vcs)

--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -19,6 +19,7 @@ from nab_index.urllib3_async_transport import Urllib3AsyncTransport
 from nab_resolver.errors import ResolutionError
 from nab_resolver.resolver import Resolver
 
+from .._conflict_kind import dependency_marker_holds, membership_set_in_marker
 from .._vcs_admission import admit_vcs_url
 from .._vendor.packaging.markers import Marker
 from .._vendor.packaging.ranges import VersionRange
@@ -509,13 +510,13 @@ def _run_pass(  # noqa: PLR0913
 
 
 def _warn_extra_marker_at_root(requirements: list[str]) -> list[str]:
-    """Warn when a root requirement uses an ``extra ==`` marker.
+    """Warn when a root requirement tests an extra/group membership marker.
 
-    Hole 1.6 plug.  ``packaging`` defaults the ``extra`` variable to
-    ``""`` at root, so a marker like ``pkg ; extra == "test"`` evaluates
-    False during root parsing and the dep is silently dropped.  The
-    user almost certainly meant the ``parent[test]`` extra-of-parent
-    syntax, not a self-referential extra marker.
+    Hole 1.6 plug.  ``packaging`` defaults ``extra`` to ``""`` at root and
+    the ``extras`` / ``dependency_groups`` set variables are empty at resolve
+    time, so a marker like ``pkg ; extra == "test"`` or ``pkg ; "test" in
+    extras`` evaluates False during root parsing and the dep is dropped.  The
+    user almost certainly meant the ``parent[test]`` extra-of-parent syntax.
 
     Returns the list of requirement strings that triggered the warning
     so callers can write tests against the diagnostic without parsing
@@ -528,12 +529,17 @@ def _warn_extra_marker_at_root(requirements: list[str]) -> list[str]:
         except InvalidRequirement:  # pragma: no cover - re-raised at resolve time
             continue
         marker_text = str(req.marker or "")
-        if "extra ==" in marker_text or "extra==" in marker_text:
+        if (
+            "extra ==" in marker_text
+            or "extra==" in marker_text
+            or membership_set_in_marker(marker_text)
+        ):
             flagged.append(req_str)
             logger.warning(
-                "Root requirement %r uses an ``extra`` marker; the dep will be "
-                "silently dropped because root has no parent extra.  Did you "
-                "mean ``pkg[extra]`` (extras-of-package) instead?",
+                "Root requirement %r tests an extra or dependency-group "
+                "membership marker; the dep is dropped because root activates "
+                "no extra or group at resolve time. For an extra, use "
+                "``pkg[extra]`` (extras-of-package).",
                 req_str,
             )
     return flagged
@@ -578,7 +584,9 @@ def _parse_requirements(
         if kind == "constraint" and req.extras:
             msg = f"Constraints cannot have extras: {req_str}"
             raise ConfigError(msg)
-        if req.marker is not None and not req.marker.evaluate(environment):
+        if req.marker is not None and not dependency_marker_holds(
+            req.marker, environment
+        ):
             continue
         if req.url is not None:
             admit_vcs_url(req.url, vcs_config or VcsConfig())

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -1768,7 +1768,31 @@ class TestBuildResolverInputs:
                 reqs, NabProjectConfig(), environment={}
             )
         assert "foo" not in resolver_requirements
-        assert any("uses an extra marker" in rec.message for rec in caplog.records)
+        assert any("membership marker" in rec.message for rec in caplog.records)
+
+    def test_root_extras_set_marker_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A root ``"x" in extras`` marker is dropped with a warning, not a crash."""
+        reqs = [Requirement('foo ; "x" in extras')]
+        with caplog.at_level("WARNING", logger="nab_python.resolve"):
+            resolver_requirements, _ = _build_resolver_inputs(
+                reqs, NabProjectConfig(), environment={}
+            )
+        assert "foo" not in resolver_requirements
+        assert any("membership marker" in rec.message for rec in caplog.records)
+
+    def test_root_dependency_groups_marker_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A root ``in dependency_groups`` marker is dropped with a warning."""
+        reqs = [Requirement('foo ; "dev" in dependency_groups')]
+        with caplog.at_level("WARNING", logger="nab_python.resolve"):
+            resolver_requirements, _ = _build_resolver_inputs(
+                reqs, NabProjectConfig(), environment={}
+            )
+        assert "foo" not in resolver_requirements
+        assert any("membership marker" in rec.message for rec in caplog.records)
 
     def test_env_gated_drop_is_silent(self, caplog: pytest.LogCaptureFixture) -> None:
         """A requirement dropped by a plain env marker stays silent."""
@@ -1840,6 +1864,13 @@ class TestBuildConstraints:
                 ),
                 environment={"python_version": "3.12"},
             )
+
+    def test_set_marker_constraint_dropped(self) -> None:
+        """A constraint gated on a lockfile-only set marker drops, not crashes."""
+        out = _build_constraints(
+            NabProjectConfig(constraints=('foo<2.0 ; "x" in extras',)), environment={}
+        )
+        assert "foo" not in out
 
 
 class TestResolvePyprojectConflicts:

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -613,6 +613,16 @@ class TestWarnExtraMarkerAtRoot:
         flagged = _warn_extra_marker_at_root(['pkg ; extra=="test"'])
         assert flagged == ['pkg ; extra=="test"']
 
+    def test_extras_set_marker_is_flagged(self) -> None:
+        """``"test" in extras`` triggers the diagnostic."""
+        flagged = _warn_extra_marker_at_root(['pkg ; "test" in extras'])
+        assert flagged == ['pkg ; "test" in extras']
+
+    def test_dependency_groups_marker_is_flagged(self) -> None:
+        """``"dev" in dependency_groups`` triggers the diagnostic."""
+        flagged = _warn_extra_marker_at_root(['pkg ; "dev" in dependency_groups'])
+        assert flagged == ['pkg ; "dev" in dependency_groups']
+
     def test_clean_requirement_not_flagged(self) -> None:
         """A normal requirement passes silently."""
         flagged = _warn_extra_marker_at_root(
@@ -648,6 +658,12 @@ class TestParseRequirements:
         """A requirement whose marker excludes the env is dropped."""
         env = _linux_311().environment
         out = _parse_requirements(['pkg; sys_platform == "win32"'], env)
+        assert out == {}
+
+    def test_set_marker_drops_without_crash(self) -> None:
+        """A lockfile-only set marker is empty at resolve time, so the dep drops."""
+        env = _linux_311().environment
+        out = _parse_requirements(['pkg ; "x" in extras'], env)
         assert out == {}
 
     def test_extras_get_separate_entries(self) -> None:


### PR DESCRIPTION
A user-input dependency marker that tests a lockfile-only set variable (for example `foo ; "x" in extras` or `foo ; "dev" in dependency_groups`) raised a raw KeyError mid-resolve, because packaging only defines `extras` and `dependency_groups` when consuming a lockfile, so they are absent from the resolve-time environment. This seeds those two set variables as empty when evaluating root requirements, constraints, and grouped package ranges, so such a marker evaluates to False and the dependency is dropped cleanly instead of crashing. A root requirement that tests one of these (or an `extra ==` marker) now emits a warning pointing users at the `pkg[extra]` extras-of-package syntax, since root activates no extra or group at resolve time. This is behavior and correctness only and corpus-inert: no benchmark scenario exercises these malformed markers.
