### PR TITLE
Enforce local/VCS Requires-Python in single-env

### DIFF
--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -230,6 +230,8 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
             _augment_resolution_error(exc, provider)
             raise
         pins = {k: v for k, v in raw.items() if split_extra(k)[1] is None}
+        if config.local_sources or config.vcs_sources:
+            _raise_for_local_vcs_python(provider, pins, Version(effective_python))
         lock_input = build_lock_input_from_provider(
             provider,
             pins,
@@ -691,6 +693,32 @@ def _build_marker_environment(
     env.update(python_axis_environment(python_version))
     env.update(overrides)
     return env
+
+
+def _raise_for_local_vcs_python(
+    provider: Provider,
+    pins: Mapping[str, Version],
+    target: Version,
+) -> None:
+    """Reject a local or VCS pin whose Requires-Python excludes ``target``.
+
+    Index candidates are filtered by Requires-Python while listing; local
+    and VCS sources skip that filter, so a source that rejects the resolve
+    target could otherwise reach the lock. Mirrors the per-tuple check in
+    :mod:`nab_python.universal.resolve`.
+    """
+    managed = provider.local_sources.keys() | provider.vcs_sources.keys()
+    for name, version in pins.items():
+        normalized = canonicalize_name(name)
+        if normalized not in managed:
+            continue
+        spec = provider.metadata_cache[(normalized, version)].requires_python
+        if spec is not None and target not in spec:
+            msg = (
+                f"{normalized} {version} requires Python {spec} but the resolve"
+                f" targets Python {target}"
+            )
+            raise ResolutionError(msg)
 
 
 def resolve_universal_pyproject(

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.version import InvalidVersion, Version
 from nab_python.config import (
@@ -16,7 +17,13 @@ from nab_python.config import (
     NabProjectConfig,
     ResolveMode,
 )
-from nab_python.provider import ResolutionStrategy, UnsupportedVcsError
+from nab_python.provider import (
+    BuildPolicy,
+    LocalSource,
+    Provider,
+    ResolutionStrategy,
+    UnsupportedVcsError,
+)
 from nab_python.resolve import (
     ResolutionResult,
     UnsupportedModeError,
@@ -30,6 +37,7 @@ from nab_python.resolve import (
     _load_extra_requirements,
     _load_group_requirements,
     _load_group_requirements_by_group,
+    _raise_for_local_vcs_python,
     _resolve_target_python,
     _walk_no_versions_packages,
     resolve_pyproject,
@@ -2519,3 +2527,79 @@ class TestResolveUniversalPyprojectGroupConflict:
         mock_universal.return_value = sentinel
         result = resolve_universal_pyproject(pyproject)
         assert result is sentinel
+
+
+class TestLocalVcsRequiresPython:
+    """A local or VCS pin must satisfy the resolve's target Python.
+
+    Index candidates are filtered by Requires-Python while listing;
+    local-path and VCS sources skip that filter, so the single-env
+    resolve checks them after resolving, mirroring the universal path.
+    """
+
+    def _provider_with_local(
+        self, tmp_path: Path, body: str, *, python_version: str = "3.10.0"
+    ) -> Provider:
+        (tmp_path / "pyproject.toml").write_text(body, encoding="utf-8")
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(
+            coordinator,
+            local_sources=[LocalSource("foo", str(tmp_path))],
+            python_version=python_version,
+            build_policy=BuildPolicy.NEVER,
+        )
+        provider.fetch_versions("foo")
+        return provider
+
+    def test_excluding_python_raises(self, tmp_path: Path) -> None:
+        provider = self._provider_with_local(
+            tmp_path,
+            '[project]\nname = "foo"\nversion = "1.0"\nrequires-python = ">=3.12"\n',
+        )
+        with pytest.raises(ResolutionError, match="foo 1.0 requires Python"):
+            _raise_for_local_vcs_python(provider, {"foo": V("1.0")}, V("3.10.0"))
+
+    def test_compatible_python_does_not_raise(self, tmp_path: Path) -> None:
+        provider = self._provider_with_local(
+            tmp_path,
+            '[project]\nname = "foo"\nversion = "1.0"\nrequires-python = ">=3.10"\n',
+        )
+        _raise_for_local_vcs_python(provider, {"foo": V("1.0")}, V("3.10.0"))
+
+    def test_no_requires_python_does_not_raise(self, tmp_path: Path) -> None:
+        provider = self._provider_with_local(
+            tmp_path,
+            '[project]\nname = "foo"\nversion = "1.0"\n',
+        )
+        _raise_for_local_vcs_python(provider, {"foo": V("1.0")}, V("3.10.0"))
+
+    def test_non_managed_pin_is_skipped(self, tmp_path: Path) -> None:
+        provider = self._provider_with_local(
+            tmp_path,
+            '[project]\nname = "foo"\nversion = "1.0"\nrequires-python = ">=3.12"\n',
+        )
+        _raise_for_local_vcs_python(provider, {"bar": V("9.0")}, V("3.10.0"))
+
+    def test_resolve_pyproject_excluding_python_raises(self, tmp_path: Path) -> None:
+        member = tmp_path / "foo"
+        member.mkdir()
+        (member / "pyproject.toml").write_text(
+            '[project]\nname = "foo"\nversion = "1.0"\nrequires-python = ">=3.12"\n',
+            encoding="utf-8",
+        )
+        root = tmp_path / "pyproject.toml"
+        root.write_text(
+            '[project]\nname = "proj"\ndependencies = ["foo"]\n'
+            "[[tool.nab.local-sources]]\n"
+            'name = "foo"\npath = "foo"\n',
+            encoding="utf-8",
+        )
+        fake = make_coordinator([], package="foo")
+        with (
+            patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls,
+            patch("nab_python.resolve.build_lock_input_from_provider"),
+        ):
+            mock_coord_cls.return_value.__enter__ = lambda _self: fake
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            with pytest.raises(ResolutionError, match="foo 1.0 requires Python"):
+                resolve_pyproject(root, _FAKE_TRANSPORT, python_version="3.10.0")


### PR DESCRIPTION
Index candidates are filtered by Requires-Python while listing, but local-path and VCS sources skip that filter, so a single-env resolve could pin a local or VCS source whose Requires-Python excludes the target Python and emit an invalid lock. This adds a post-resolve check, mirroring the per-tuple check already in universal mode, that raises ResolutionError when a managed pin's Requires-Python does not include the resolve target. The change is correctness-only and corpus-inert: no benchmark scenario exercises a local or VCS source with an excluding Requires-Python.
