### PR TITLE
Refuse transitive direct-URL dependencies

### DIFF
--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 from nab_index.client import SdistFile, WheelFile
 
+from .._vcs_admission import admit_vcs_url
 from .._vendor.packaging.ranges import VersionRange
 from .._vendor.packaging.requirements import InvalidRequirement, Requirement
 from .._vendor.packaging.utils import canonicalize_name
@@ -421,6 +422,13 @@ def cache_deps_from_metadata(
         req_extras = classify_requirement(provider, req, provided_extras)
         if req_extras is None:
             continue
+        if req.url is not None:
+            admit_vcs_url(req.url, provider.vcs_config)
+            msg = (
+                f"VCS dependency admitted by policy but resolver path is not"
+                f" implemented: {req.name} @ {req.url}"
+            )
+            raise NotImplementedError(msg)
         add_classified_dep(req, req_extras, base_deps, extra_deps_map)
     provider.deps_cache[cache_key] = base_deps
     provider.extra_deps_map[cache_key] = extra_deps_map

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -1159,6 +1159,9 @@ class Provider:
         except UnsupportedSdistError:
             self._unsupported_sdists.add(cache_key)
             raise
+        except (UnsupportedVcsError, NotImplementedError):
+            # A refused direct-URL dep is a hard error, not a parse skip.
+            raise
         except Exception as exc:
             logger.warning(
                 "Skipping %s==%s: metadata cannot be parsed (%s)."

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -33,6 +33,7 @@ from nab_python.provider import (
     Provider,
     ResolutionStrategy,
     UnsupportedSdistError,
+    UnsupportedVcsError,
     VcsConfig,
     VcsPolicy,
     VcsSource,
@@ -837,6 +838,72 @@ class TestGetDependencies:
         assert "bar" in deps
         assert "custom-build" in deps["bar"]
         assert V("1.0") not in deps["bar"]
+        assert "baz" in deps
+
+
+class TestTransitiveDirectUrlDep:
+    """A direct-URL ``Requires-Dist`` is refused, not silently substituted.
+
+    The root and constraint inputs and the universal per-tuple path already
+    call ``admit_vcs_url`` then raise. Without the same check here a fetched
+    package's ``bar @ https://...`` dep was recorded as a bare ``bar`` and
+    resolved from the index, pinning the wrong artifact silently.
+    """
+
+    @staticmethod
+    def _provider_for(url: str, vcs_config: VcsConfig | None = None) -> Provider:
+        coordinator = make_coordinator(
+            [make_wheel("1.0")],
+            metadata_text=(
+                "Metadata-Version: 2.1\n"
+                "Name: foo\n"
+                "Version: 1.0\n"
+                f"Requires-Dist: bar @ {url}\n"
+            ),
+            package="foo",
+        )
+        return Provider(coordinator, python_version="3.12.0", vcs_config=vcs_config)
+
+    def test_plain_url_dep_refused(self) -> None:
+        """A non-VCS direct-URL dep raises rather than pinning from the index."""
+        provider = self._provider_for("https://example.com/bar-9.9-py3-none-any.whl")
+        with pytest.raises(UnsupportedVcsError, match="not a recognized VCS scheme"):
+            provider.get_dependencies("foo", V("1.0"))
+
+    def test_vcs_url_dep_blocked_by_default(self) -> None:
+        """A VCS dep is refused under the default BLOCK policy."""
+        provider = self._provider_for("git+https://example.com/bar.git@" + "a" * 40)
+        with pytest.raises(UnsupportedVcsError, match="BLOCK"):
+            provider.get_dependencies("foo", V("1.0"))
+
+    def test_admitted_vcs_url_dep_raises_not_implemented(self) -> None:
+        """An admitted VCS dep raises NotImplementedError; support is deferred."""
+        provider = self._provider_for(
+            "git+https://example.com/bar.git@" + "a" * 40,
+            vcs_config=VcsConfig(
+                policy=VcsPolicy.ALLOW, allowed_schemes=frozenset({"git+https"})
+            ),
+        )
+        with pytest.raises(NotImplementedError, match="not implemented"):
+            provider.get_dependencies("foo", V("1.0"))
+
+    def test_marker_gated_url_dep_not_applying_is_skipped(self) -> None:
+        """A url dep gated by a marker that does not apply is skipped, not refused."""
+        coordinator = make_coordinator(
+            [make_wheel("1.0")],
+            metadata_text=(
+                "Metadata-Version: 2.1\n"
+                "Name: foo\n"
+                "Version: 1.0\n"
+                "Requires-Dist: bar @ https://example.com/bar.whl ;"
+                ' python_version < "3.0"\n'
+                "Requires-Dist: baz>=1.0\n"
+            ),
+            package="foo",
+        )
+        provider = Provider(coordinator, python_version="3.12.0")
+        deps = provider.get_dependencies("foo", V("1.0"))
+        assert "bar" not in deps
         assert "baz" in deps
 
 


### PR DESCRIPTION
When a fetched package's metadata carried a Requires-Dist with a direct URL (bar @ https://...), the provider dropped the URL and recorded a bare index dependency, then resolved and pinned the wrong artifact silently. The transitive site now runs the same admit_vcs_url policy check the root, constraint, and universal paths already use, and refuses the dependency (a non-VCS URL raises UnsupportedVcsError, a blocked VCS URL raises under the default BLOCK policy, and an admitted VCS URL raises NotImplementedError since that resolver path is not built yet). The provider re-raises UnsupportedVcsError and NotImplementedError as hard errors instead of letting the broad metadata handler downgrade them to a parse skip. This is correctness-only and corpus-inert; no benchmark scenario carries a transitive direct-URL dependency.
