### PR TITLE
Strip whitespace on PEP 643 Dynamic dep fields

### DIFF
--- a/nab-python/src/nab_python/metadata.py
+++ b/nab-python/src/nab_python/metadata.py
@@ -175,9 +175,10 @@ def parse_metadata(data: str | bytes) -> WheelMetadata:
     provides_extra = list(msg.get_all("Provides-Extra") or [])
 
     metadata_version = msg.get("Metadata-Version")
-    # PEP 643 field names are case-insensitive per RFC 822; normalise so
-    # downstream lookups don't depend on the producer's capitalisation.
-    dynamic = frozenset(d.lower() for d in msg.get_all("Dynamic") or [])
+    # PEP 643 field names are case-insensitive and, per RFC 822, surrounding
+    # whitespace is insignificant; normalise both so downstream membership
+    # tests don't depend on the producer's capitalisation or stray spacing.
+    dynamic = frozenset(d.strip().lower() for d in msg.get_all("Dynamic") or [])
 
     return WheelMetadata(
         name=name,

--- a/nab-python/tests/test_metadata.py
+++ b/nab-python/tests/test_metadata.py
@@ -52,6 +52,16 @@ def test_dynamic_field_lowercased() -> None:
     assert md.dynamic == frozenset({"requires-dist", "provides-extra"})
 
 
+def test_dynamic_field_whitespace_stripped() -> None:
+    """Surrounding whitespace on a ``Dynamic`` value is insignificant."""
+    text = (
+        "Metadata-Version: 2.2\nName: foo\nVersion: 1.0\n"
+        "Dynamic: Requires-Dist \nDynamic: Provides-Extra\t\n"
+    )
+    md = parse_metadata(text)
+    assert md.dynamic == frozenset({"requires-dist", "provides-extra"})
+
+
 def test_requires_dist_parsed() -> None:
     """Each ``Requires-Dist`` entry yields a parsed ``Requirement``."""
     text = (
@@ -106,6 +116,12 @@ class TestMetadataDepsAreStatic:
     def test_2_2_with_dynamic_requires_dist_is_not_static(self) -> None:
         md = parse_metadata(
             "Metadata-Version: 2.2\nName: foo\nVersion: 1.0\nDynamic: Requires-Dist\n"
+        )
+        assert metadata_deps_are_static(md) is False
+
+    def test_2_2_with_whitespace_dynamic_requires_dist_is_not_static(self) -> None:
+        md = parse_metadata(
+            "Metadata-Version: 2.2\nName: foo\nVersion: 1.0\nDynamic: Requires-Dist \n"
         )
         assert metadata_deps_are_static(md) is False
 


### PR DESCRIPTION
A PKG-INFO that writes a dependency field as `Dynamic: Requires-Dist ` with trailing whitespace (or a tab) was parsed with that whitespace intact, so the value never matched the lowercased `requires-dist`/`provides-extra` keys used to detect non-static dependencies. The sdist was then wrongly treated as having final, trustworthy dependencies. This strips surrounding whitespace when building the Dynamic set so such a field classifies the distribution as non-static and falls back to building, matching RFC 822 where surrounding whitespace is insignificant. The change is correctness-only and corpus-inert; no benchmark scenario emits a Dynamic value with stray whitespace.
