### PR TITLE
Drop a version with invalid METADATA Requires-Python

### DIFF
--- a/nab-python/src/nab_python/metadata.py
+++ b/nab-python/src/nab_python/metadata.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any
 import tomli
 
 from ._vendor.packaging.requirements import Requirement
-from ._vendor.packaging.specifiers import SpecifierSet
+from ._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from ._vendor.packaging.version import Version
 
 if TYPE_CHECKING:
@@ -166,7 +166,19 @@ def parse_metadata(data: str | bytes) -> WheelMetadata:
         raise ValueError(err)
 
     requires_python_str = msg.get("Requires-Python")
-    requires_python = SpecifierSet(requires_python_str) if requires_python_str else None
+    requires_python = None
+    if requires_python_str:
+        try:
+            requires_python = SpecifierSet(requires_python_str)
+        except InvalidSpecifier as exc:
+            # A malformed Requires-Python is invalid metadata; raise rather
+            # than silently drop the field, matching the Name/Version checks
+            # above. The resolve boundary turns this into a rejected candidate.
+            err = (
+                f"METADATA for {name}=={version_str} has an invalid "
+                f"Requires-Python: {requires_python_str!r}"
+            )
+            raise ValueError(err) from exc
 
     requires_dist = [
         _parse_requirement_cached(r) for r in msg.get_all("Requires-Dist") or []

--- a/nab-python/tests/test_metadata.py
+++ b/nab-python/tests/test_metadata.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.version import Version
 from nab_python.metadata import metadata_deps_are_static, parse_metadata
 
@@ -39,6 +40,29 @@ def test_missing_version_raises() -> None:
     """Absent ``Version`` is a parser error, not a silent default."""
     text = "Metadata-Version: 2.1\nName: foo\n"
     with pytest.raises(ValueError, match="Version"):
+        parse_metadata(text)
+
+
+def test_valid_requires_python_parsed() -> None:
+    """A well-formed Requires-Python becomes a ``SpecifierSet``."""
+    text = "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\nRequires-Python: >=3.8\n"
+    md = parse_metadata(text)
+    assert md.requires_python == SpecifierSet(">=3.8")
+
+
+def test_malformed_requires_python_raises() -> None:
+    """A malformed Requires-Python is invalid metadata, so parsing raises.
+
+    ``!=3.3*`` is not a valid PEP 440 specifier (the wildcard needs ``.*``).
+    The resolve boundary turns this into a ``MetadataError`` so the candidate
+    is dropped rather than pinned with an unread Python constraint.
+    """
+    text = (
+        "Metadata-Version: 2.1\nName: azure-iot-hub\nVersion: 2.4.0\n"
+        "Requires-Python: >=2.7, !=3.0.*, !=3.3*, <4\n"
+        "Requires-Dist: msrest\n"
+    )
+    with pytest.raises(ValueError, match="invalid Requires-Python"):
         parse_metadata(text)
 
 

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -1070,6 +1070,26 @@ class TestGetDependencies:
         with pytest.raises(MetadataError, match="Invalid metadata"):
             provider.get_dependencies("foo", V("1.0"))
 
+    def test_malformed_requires_python_drops_candidate(self) -> None:
+        """A version whose METADATA Requires-Python is invalid is refused.
+
+        ``!=3.3*`` is not a valid PEP 440 specifier, so the metadata is
+        invalid and ``get_dependencies`` raises ``MetadataError`` instead of
+        pinning the version with the Python constraint silently ignored.
+        """
+        bad_metadata = (
+            "Metadata-Version: 2.1\n"
+            "Name: foo\n"
+            "Version: 1.0\n"
+            "Requires-Python: >=2.7, !=3.3*\n"
+        )
+        coordinator = make_coordinator(
+            [make_wheel("1.0")], metadata_text=bad_metadata, package="foo"
+        )
+        provider = Provider(coordinator, python_version="3.12.0")
+        with pytest.raises(MetadataError, match="invalid Requires-Python"):
+            provider.get_dependencies("foo", V("1.0"))
+
     def test_invalid_metadata_is_negatively_cached(self) -> None:
         """Repeating a parse-failed lookup short-circuits to the cached error.
 


### PR DESCRIPTION
A wheel's METADATA can carry a Requires-Python that is not a valid PEP 440 specifier, for example azure-iot-hub's `!=3.3*` (the wildcard needs `.*`). `parse_metadata` now raises on such a value, the same way it already rejects a missing Name or Version and a malformed Requires-Dist, so `get_dependencies` refuses the version as a candidate (a `MetadataError`, negatively cached) and the resolver moves on to the next one.

Keeping the version and dropping just the Requires-Python would pin a release whose Python constraint nab could not read, which risks a lockfile that is wrong but plausible. Dropping the whole candidate applies the same rule the parser already applies to the rest of the metadata. When every version of a package carries invalid metadata the resolve now fails loudly rather than emitting a lockfile nab cannot stand behind.