### PR TITLE
Add resolver and provider regression-test coverage

### DIFF
--- a/nab-python/tests/test_build_backend.py
+++ b/nab-python/tests/test_build_backend.py
@@ -13,6 +13,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from nab_python._provider.metadata_resolver import (
+    extend_with_extras,
+    parse_pyproject_deps,
+)
 from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.version import Version
 from nab_python.build_backend import (
@@ -20,6 +24,7 @@ from nab_python.build_backend import (
     extract_metadata,
     extract_static_metadata,
 )
+from nab_python.metadata import parse_metadata
 
 
 def _write_pyproject(tmp: Path, body: str) -> Path:
@@ -358,3 +363,85 @@ class TestExtractMetadata:
             pytest.raises(BuildBackendError, match="backend exploded"),
         ):
             extract_metadata(tmp_path, config=MagicMock(name="config"))
+
+
+class TestStaticExtractAugmentParity:
+    """Pin the static extractor against the parallel augment and index paths.
+
+    Guards the two places they could silently diverge: extra-name
+    normalisation and malformed-dependency handling.
+    """
+
+    def test_non_canonical_extra_canonicalized(self, tmp_path: Path) -> None:
+        _write_pyproject(
+            tmp_path,
+            """
+            [project]
+            name = "foo"
+            version = "1.0"
+            [project.optional-dependencies]
+            "My.Extra" = ["click>=8"]
+            """,
+        )
+        meta = extract_static_metadata(tmp_path)
+        assert meta is not None
+        assert meta.provides_extra == ["my-extra"]
+        click = next(r for r in meta.requires_dist if r.name == "click")
+        assert str(click.marker) == 'extra == "my-extra"'
+
+    def test_non_canonical_extra_marker_matches_augment_path(
+        self, tmp_path: Path
+    ) -> None:
+        optional = {"My.Extra": ["click>=8"]}
+        _write_pyproject(
+            tmp_path,
+            """
+            [project]
+            name = "foo"
+            version = "1.0"
+            [project.optional-dependencies]
+            "My.Extra" = ["click>=8"]
+            """,
+        )
+        meta = extract_static_metadata(tmp_path)
+        assert meta is not None
+        bb_click = next(r for r in meta.requires_dist if r.name == "click")
+
+        augment_rd: list = []
+        extend_with_extras(augment_rd, optional)
+        aug_click = next(r for r in augment_rd if r.name == "click")
+
+        assert bb_click.marker is not None
+        assert aug_click.marker is not None
+        assert str(bb_click.marker) == str(aug_click.marker)
+        assert bb_click.marker.evaluate({"extra": "my-extra"})
+        assert aug_click.marker.evaluate({"extra": "my-extra"})
+
+    def test_malformed_static_dep_dropped_like_augment_index_refuses(
+        self, tmp_path: Path
+    ) -> None:
+        deps = ["requests>=2", "this is not a valid !! req"]
+        _write_pyproject(
+            tmp_path,
+            """
+            [project]
+            name = "foo"
+            version = "1.0"
+            dependencies = [
+                "requests>=2",
+                "this is not a valid !! req",
+            ]
+            """,
+        )
+        meta = extract_static_metadata(tmp_path)
+        assert meta is not None
+        bb_names = [r.name for r in meta.requires_dist]
+        aug_names = [r.name for r in parse_pyproject_deps(deps)]
+        assert bb_names == aug_names == ["requests"]
+
+        md = (
+            "Metadata-Version: 2.3\nName: foo\nVersion: 1.0\n"
+            "Requires-Dist: this is not a valid !! req\n"
+        )
+        with pytest.raises(ValueError, match="Expected"):
+            parse_metadata(md)

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -349,6 +349,38 @@ class TestRelativeUrlResolution:
         files = _parse_files(data, "https://pypi.org/simple/", "foo")
         assert files[0].url == urljoin(base, raw) == raw
 
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "https://files.example.com/a/../b/foo-1.0-py3-none-any.whl",
+            "https://files.example.com/foo-1.0-py3-none-any.whl?token=x",
+            "https://files.example.com/foo-1.0-py3-none-any.whl#sha256=abc",
+            "http://files.example.com/foo-1.0-py3-none-any.whl",
+        ],
+    )
+    def test_absolute_url_edge_forms_match_urljoin(self, raw: str) -> None:
+        base = "https://example.com/simple/foo/"
+        data = {"files": [{"filename": "foo-1.0-py3-none-any.whl", "url": raw}]}
+        files = _parse_files(data, "https://example.com/simple/", "foo")
+        assert files[0].url == urljoin(base, raw) == raw
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "//files.example.com/foo-1.0-py3-none-any.whl",
+            "https:foo-1.0-py3-none-any.whl",
+        ],
+    )
+    def test_non_absolute_url_resolves_against_page(self, raw: str) -> None:
+        # The shortcut only fires on an https://-or-http:// prefix; a
+        # protocol-relative or scheme-without-authority URL must fall through
+        # to urljoin, not be used verbatim. A broadened prefix would keep these
+        # unchanged and silently yield a wrong download URL.
+        base = "https://example.com/simple/foo/"
+        data = {"files": [{"filename": "foo-1.0-py3-none-any.whl", "url": raw}]}
+        files = _parse_files(data, "https://example.com/simple/", "foo")
+        assert files[0].url == urljoin(base, raw) != raw
+
 
 class TestParseHashes:
     def test_single_entry(self) -> None:

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -1187,6 +1187,98 @@ class TestMultiIndexCoordinator:
             assert listing is not None
             assert len(listing) == 1
 
+    @respx.mock
+    def test_serving_index_recorded_per_package(self) -> None:
+        """Each package records the index that actually served it.
+
+        numpy is served by the first index and torch by the second
+        after a first-index miss, so the recorded serving index differs
+        per package. The lockfile reads this to attribute each pin's
+        ``index`` URL.
+        """
+        respx.get("https://pypi.org/simple/numpy/").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "meta": {"api-version": "1.0"},
+                    "name": "numpy",
+                    "files": [
+                        {
+                            "filename": "numpy-1.0-py3-none-any.whl",
+                            "url": "https://pypi.org/numpy-1.0.whl",
+                        },
+                    ],
+                },
+            )
+        )
+        respx.get("https://pypi.org/simple/torch/").mock(
+            return_value=httpx.Response(
+                200,
+                json={"meta": {"api-version": "1.0"}, "name": "torch", "files": []},
+            )
+        )
+        respx.get("https://torch.example/cpu/torch/").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "meta": {"api-version": "1.0"},
+                    "name": "torch",
+                    "files": [
+                        {
+                            "filename": "torch-2.0-py3-none-any.whl",
+                            "url": "https://torch.example/cpu/torch-2.0.whl",
+                        },
+                    ],
+                },
+            )
+        )
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            _coord(
+                cache_dir=Path(tmp),
+                indexes=[
+                    IndexConfig("pypi", "https://pypi.org/simple/"),
+                    IndexConfig("torch-cpu", "https://torch.example/cpu/"),
+                ],
+            ) as coord,
+        ):
+            for pkg in ("numpy", "torch"):
+                coord.request_listing(pkg).wait(timeout=5)
+            assert coord.index.get_listing_index("numpy") == "pypi"
+            assert coord.index.get_listing_index("torch") == "torch-cpu"
+
+    @respx.mock
+    def test_override_serving_index_recorded(self) -> None:
+        """An overridden package records its override index, not the first."""
+        respx.get("https://torch.example/cpu/torch/").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "meta": {"api-version": "1.0"},
+                    "name": "torch",
+                    "files": [
+                        {
+                            "filename": "torch-2.0-py3-none-any.whl",
+                            "url": "https://torch.example/cpu/torch-2.0.whl",
+                        },
+                    ],
+                },
+            )
+        )
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            _coord(
+                cache_dir=Path(tmp),
+                indexes=[
+                    IndexConfig("pypi", "https://pypi.org/simple/"),
+                    IndexConfig("torch-cpu", "https://torch.example/cpu/"),
+                ],
+                index_overrides=[IndexOverride("torch", "torch-cpu")],
+            ) as coord,
+        ):
+            coord.request_listing("torch").wait(timeout=5)
+            assert coord.index.get_listing_index("torch") == "torch-cpu"
+
     def test_explicit_cache_backend_with_multi_index_raises(self) -> None:
         """cache_backend + multi-index is a config error."""
         with pytest.raises(ValueError, match="more than one"):

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -435,6 +435,75 @@ class TestPerTupleMarkerSimplification:
         # Same VCS commit -> single group -> one package
         assert len(data["packages"]) == 1
 
+    def test_vcs_pin_per_tuple_diverging_commit(self) -> None:
+        # Diverging commit -> two groups -> two packages
+        per_tuple = {
+            "py310": {
+                "foo": VcsPin(
+                    name="foo",
+                    version="1.0",
+                    repo_url="https://x/y.git",
+                    bare_repo_url="https://x/y.git",
+                    commit_id="a" * 40,
+                ),
+            },
+            "py311": {
+                "foo": VcsPin(
+                    name="foo",
+                    version="1.0",
+                    repo_url="https://x/y.git",
+                    bare_repo_url="https://x/y.git",
+                    commit_id="b" * 40,
+                ),
+            },
+        }
+        tuple_markers = {
+            "py310": Marker('python_version == "3.10"'),
+            "py311": Marker('python_version == "3.11"'),
+        }
+        text = write_lock(
+            LockInput(per_tuple_pins=per_tuple, tuple_markers=tuple_markers)
+        )
+        data = tomllib.loads(text)
+        assert len(data["packages"]) == 2
+        commits = {p["vcs"]["commit-id"] for p in data["packages"]}
+        assert commits == {"a" * 40, "b" * 40}
+
+    def test_discriminator_separates_vcs_commit(self) -> None:
+        one = VcsPin(
+            name="foo",
+            version="1.0",
+            repo_url="https://x/y.git",
+            bare_repo_url="https://x/y.git",
+            commit_id="a" * 40,
+        )
+        other = VcsPin(
+            name="foo",
+            version="1.0",
+            repo_url="https://x/y.git",
+            bare_repo_url="https://x/y.git",
+            commit_id="b" * 40,
+        )
+        assert _pin_discriminator(one) != _pin_discriminator(other)
+
+    def test_discriminator_separates_vcs_subdirectory(self) -> None:
+        plain = VcsPin(
+            name="foo",
+            version="1.0",
+            repo_url="https://x/y.git",
+            bare_repo_url="https://x/y.git",
+            commit_id="a" * 40,
+        )
+        sub = VcsPin(
+            name="foo",
+            version="1.0",
+            repo_url="https://x/y.git",
+            bare_repo_url="https://x/y.git",
+            commit_id="a" * 40,
+            subdirectory="pkg",
+        )
+        assert _pin_discriminator(plain) != _pin_discriminator(sub)
+
     def test_pin_in_both_pins_and_per_tuple_emits_once(self) -> None:
         # When the same package appears in both pins and per_tuple_pins,
         # the per_tuple_pins entry wins (single emission per name).

--- a/nab-python/tests/test_metadata.py
+++ b/nab-python/tests/test_metadata.py
@@ -125,6 +125,16 @@ class TestMetadataDepsAreStatic:
         )
         assert metadata_deps_are_static(md) is False
 
+    def test_2_2_with_dynamic_provides_extra_is_not_static(self) -> None:
+        """Provides-Extra is the other DEPENDENCY_FIELDS member: a dynamic
+        extras set leaves the deps non-final even with a static Requires-Dist.
+        """
+        md = parse_metadata(
+            "Metadata-Version: 2.2\nName: foo\nVersion: 1.0\n"
+            "Requires-Dist: bar\nDynamic: Provides-Extra\n"
+        )
+        assert metadata_deps_are_static(md) is False
+
     def test_micro_metadata_version_qualifies(self) -> None:
         md = parse_metadata("Metadata-Version: 2.2.1\nName: foo\nVersion: 1.0\n")
         assert metadata_deps_are_static(md) is True

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -3330,6 +3330,24 @@ class TestDistPolicy:
         with pytest.raises(UnsupportedSdistError):
             provider.get_dependencies("pkg", V("1.0"))
 
+    def test_opt_out_still_routes_dynamic_provides_extra(self) -> None:
+        """A Dynamic Provides-Extra also forces the dynamic path under the
+        opt-out: the other DEPENDENCY_FIELDS member, so under NEVER it raises.
+        """
+        coordinator = make_coordinator(
+            [make_sdist("1.0")],
+            sdist_pkg_info=PKG_INFO_DYNAMIC_PROVIDES_EXTRA,
+        )
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            dist_policy=DistPolicy.WHEEL_OR_SDIST,
+            build_policy=BuildPolicy.NEVER,
+            trust_unverified_sdist_deps=True,
+        )
+        with pytest.raises(UnsupportedSdistError):
+            provider.get_dependencies("pkg", V("1.0"))
+
     def test_sdist_no_pkg_info_raises(self) -> None:
         """Raise MetadataError when PKG-INFO cannot be extracted."""
         coordinator = make_coordinator(
@@ -4054,6 +4072,11 @@ PKG_INFO_DYNAMIC_DEPS = (
 
 PKG_INFO_PRE_PEP643_DEPS = (
     "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\nRequires-Dist: hidden-dep\n"
+)
+
+PKG_INFO_DYNAMIC_PROVIDES_EXTRA = (
+    "Metadata-Version: 2.2\nName: pkg\nVersion: 1.0\n"
+    "Requires-Dist: dep-a\nDynamic: Provides-Extra\n"
 )
 
 

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -972,6 +972,34 @@ class TestAddClassifiedDep:
         assert V("1.0") not in extra_map["x"]["bar"]
         assert V("9.0") not in extra_map["x"]["bar"]
 
+    def test_base_multi_extra_splits_into_one_proxy_each(self) -> None:
+        """``bar[a,b]`` as a base dep records ``bar`` plus a proxy per extra."""
+        base: dict[str, VersionRange] = {}
+        extra_map: dict[str, dict[str, VersionRange]] = {}
+        add_classified_dep(Requirement("bar[a,b]>=1.0"), set(), base, extra_map)
+        assert V("2.0") in base["bar"]
+        assert V("0.5") not in base["bar"]
+        assert base["bar[a]"] == VersionRange.full()
+        assert base["bar[b]"] == VersionRange.full()
+
+    def test_extra_gated_multi_extra_splits_into_one_proxy_each(self) -> None:
+        """``bar[a,b]`` under extra ``x`` records both proxies in that bucket."""
+        base: dict[str, VersionRange] = {}
+        extra_map: dict[str, dict[str, VersionRange]] = {"x": {}}
+        add_classified_dep(Requirement("bar[a,b]>=1.0"), {"x"}, base, extra_map)
+        assert V("2.0") in extra_map["x"]["bar"]
+        assert extra_map["x"]["bar[a]"] == VersionRange.full()
+        assert extra_map["x"]["bar[b]"] == VersionRange.full()
+        assert "bar" not in base
+
+    def test_multi_extra_proxy_names_normalized(self) -> None:
+        """Proxy keys for the dep's extras are PEP 685 normalized."""
+        base: dict[str, VersionRange] = {}
+        extra_map: dict[str, dict[str, VersionRange]] = {}
+        add_classified_dep(Requirement("bar[A_x,B.y]"), set(), base, extra_map)
+        assert "bar[a-x]" in base
+        assert "bar[b-y]" in base
+
 
 class TestLocalSources:
     def _write_local(
@@ -2875,6 +2903,46 @@ class TestExtras:
         assert "bar[http]" not in base_deps  # base doesn't have the extra
         extra_deps = provider.get_dependencies("foo[all]", V("1.0"))
         assert "bar[http]" in extra_deps  # extra adds the proxy
+
+    def test_base_multi_extra_dep_creates_all_proxies(self) -> None:
+        """A base ``bar[http,socks]`` dep yields both proxies and the base."""
+        metadata = (
+            "Metadata-Version: 2.1\n"
+            "Name: foo\n"
+            "Version: 1.0\n"
+            "Requires-Dist: bar[http,socks]>=1.0\n"
+        )
+        coordinator = make_coordinator(
+            [make_wheel("1.0")],
+            metadata_text=metadata,
+            package="foo",
+        )
+        provider = Provider(coordinator, python_version="3.12.0")
+        deps = provider.get_dependencies("foo", V("1.0"))
+        assert "bar" in deps
+        assert "bar[http]" in deps
+        assert "bar[socks]" in deps
+
+    def test_extra_gated_multi_extra_dep_creates_all_proxies(self) -> None:
+        """An extra-gated ``bar[http,socks]`` dep yields both proxies."""
+        metadata = (
+            "Metadata-Version: 2.1\n"
+            "Name: foo\n"
+            "Version: 1.0\n"
+            "Provides-Extra: all\n"
+            'Requires-Dist: bar[http,socks]>=1.0; extra == "all"\n'
+        )
+        coordinator = make_coordinator(
+            [make_wheel("1.0")],
+            metadata_text=metadata,
+            package="foo",
+        )
+        provider = Provider(coordinator, python_version="3.12.0")
+        deps = provider.get_dependencies("foo[all]", V("1.0"))
+        assert "bar" in deps
+        assert "bar[http]" in deps
+        assert "bar[socks]" in deps
+        assert "foo" in deps
 
     def test_warn_mode_missing_extra(self) -> None:
         """WARN mode logs and returns only the base pin for missing extra."""

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -434,6 +434,115 @@ class TestResolutionStrategy:
         assert provider.choose_version("foo", VersionRange.full()) == V("2.0")
 
 
+class TestPrereleaseAdmission:
+    """The real Provider applies PEP 440 pre-release admission end to end.
+
+    The toy ``PackagingProvider`` used by the resolver tests picks by plain
+    membership, so it cannot catch a regression in the real provider's
+    ``version_range.filter`` buffering. These exercise that path directly.
+    """
+
+    @staticmethod
+    def _provider(
+        versions: list[str],
+        strategy: ResolutionStrategy = ResolutionStrategy.HIGHEST,
+    ) -> Provider:
+        wheels = [make_wheel(v) for v in versions]
+        coordinator = make_coordinator(wheels, package="foo")
+        return Provider(coordinator, resolution_strategy=strategy)
+
+    def test_final_preferred_over_newer_prerelease(self) -> None:
+        """A bare requirement buffers a newer pre-release behind the final."""
+        provider = self._provider(["1.0", "2.0rc1"])
+        assert provider.choose_version("foo", VersionRange.full()) == V("1.0")
+
+    def test_only_prerelease_admitted(self) -> None:
+        """With no final in range the buffered pre-release is admitted."""
+        provider = self._provider(["2.0rc1"])
+        assert provider.choose_version("foo", VersionRange.full()) == V("2.0rc1")
+
+    def test_dev_release_buffered_then_admitted(self) -> None:
+        """Developmental releases follow the same buffer-unless-only rule."""
+        assert self._provider(["1.0.dev1", "1.0"]).choose_version(
+            "foo", VersionRange.full()
+        ) == V("1.0")
+        assert self._provider(["1.0.dev1"]).choose_version(
+            "foo", VersionRange.full()
+        ) == V("1.0.dev1")
+
+    def test_explicit_prerelease_spec_admits(self) -> None:
+        """A spec naming a pre-release admits it (auto-detected policy)."""
+        provider = self._provider(["1.0", "2.0rc1"])
+        chosen = provider.choose_version("foo", SpecifierSet(">=2.0rc1").to_range())
+        assert chosen == V("2.0rc1")
+
+    def test_prerelease_in_range_but_final_wins(self) -> None:
+        """A higher in-range pre-release stays buffered while finals exist."""
+        provider = self._provider(["1.0", "1.5", "2.0rc1"])
+        chosen = provider.choose_version("foo", SpecifierSet(">=1.0").to_range())
+        assert chosen == V("1.5")
+
+    def test_exact_prerelease_pin(self) -> None:
+        """An exact ``==`` pin to a pre-release selects it."""
+        provider = self._provider(["1.0", "2.0rc1"])
+        chosen = provider.choose_version("foo", SpecifierSet("==2.0rc1").to_range())
+        assert chosen == V("2.0rc1")
+
+    def test_lowest_skips_lower_prerelease(self) -> None:
+        """LOWEST picks the lowest final, not a lower pre-release."""
+        provider = self._provider(["1.0rc1", "1.0", "2.0"], ResolutionStrategy.LOWEST)
+        assert provider.choose_version("foo", VersionRange.full()) == V("1.0")
+
+    def test_lowest_all_prerelease(self) -> None:
+        """With only pre-releases LOWEST picks the lowest pre-release."""
+        provider = self._provider(["1.0rc1", "1.0rc2"], ResolutionStrategy.LOWEST)
+        assert provider.choose_version("foo", VersionRange.full()) == V("1.0rc1")
+
+    def test_dependency_prerelease_admits_via_intersection(self) -> None:
+        """A dep naming a pre-release propagates admission through ``&``."""
+        provider = self._provider(["1.0", "2.0rc1"])
+        accumulated = VersionRange.full() & SpecifierSet(">=2.0rc1").to_range()
+        assert provider.choose_version("foo", accumulated) == V("2.0rc1")
+
+    def test_plain_dependency_constraint_keeps_final(self) -> None:
+        """A plain dep constraint leaves the final-preferring default intact."""
+        provider = self._provider(["1.0", "2.0rc1"])
+        accumulated = VersionRange.full() & SpecifierSet(">=1.0").to_range()
+        assert provider.choose_version("foo", accumulated) == V("1.0")
+
+    def test_only_candidate_in_derived_range_is_prerelease(self) -> None:
+        """A derived range leaving only a pre-release admits it (PEP 440)."""
+        provider = self._provider(["1.0", "2.5rc1"])
+        accumulated = VersionRange.full() & SpecifierSet(">=2.0").to_range()
+        assert provider.choose_version("foo", accumulated) == V("2.5rc1")
+
+    def test_full_resolve_propagates_dependency_prerelease(self) -> None:
+        """End to end: a transitive dep naming a pre-release pins it."""
+        listings = {
+            "foo": [make_wheel("1.0"), make_wheel("2.0rc1")],
+            "bar": [make_wheel("5.0")],
+        }
+        metadata = {
+            "1.0": "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n\n",
+            "2.0rc1": "Metadata-Version: 2.1\nName: foo\nVersion: 2.0rc1\n\n",
+            "5.0": (
+                "Metadata-Version: 2.1\nName: bar\nVersion: 5.0\n"
+                "Requires-Dist: foo>=2.0rc1\n\n"
+            ),
+        }
+        coordinator = make_coordinator(listings=listings, metadata_by_version=metadata)
+        root_reqs = {
+            "foo": VersionRange.full(),
+            "bar": SpecifierSet("==5.0").to_range(),
+        }
+        provider = Provider(
+            coordinator, python_version="3.12.0", root_requirements=root_reqs
+        )
+        resolver = Resolver(provider, range_type=VersionRange, root_version="0")
+        pins = resolver.resolve(root_reqs)
+        assert pins["foo"] == V("2.0rc1")
+
+
 class TestNoVersionsReasons:
     """``_record_no_versions_reason`` captures provider-side hints."""
 

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from nab_index.client import WheelFile
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.version import InvalidVersion, Version
@@ -2633,3 +2634,141 @@ class TestLocalVcsRequiresPython:
             mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
             with pytest.raises(ResolutionError, match="foo 1.0 requires Python"):
                 resolve_pyproject(root, _FAKE_TRANSPORT, python_version="3.10.0")
+
+
+def _index_wheels(name: str, *versions: str) -> list[WheelFile]:
+    """One pure-python wheel per version, dependency-free in minimal METADATA."""
+    return [
+        WheelFile(
+            filename=f"{name}-{v}-py3-none-any.whl",
+            url=f"https://example.com/{name}-{v}-py3-none-any.whl",
+            version=v,
+            requires_python=None,
+            has_metadata=True,
+            upload_time=None,
+        )
+        for v in versions
+    ]
+
+
+class TestLocalSourceExtrasMarkers:
+    """Extras and markers on a local-source package resolve like an index one.
+
+    A local source is materialised into a synthetic single-version listing
+    from its pyproject metadata, then flows through the same extras-proxy and
+    marker machinery as an index package. These end-to-end checks pin that
+    parity, plus the invariant that the single synthetic version is still
+    subject to the requirement's range (no short-circuit past an unsatisfying
+    pin).
+    """
+
+    @staticmethod
+    def _resolve(
+        tmp_path: Path,
+        root_body: str,
+        members: dict[str, str],
+        coordinator: MagicMock,
+        python_version: str,
+    ) -> ResolutionResult:
+        (tmp_path / "pyproject.toml").write_text(root_body, encoding="utf-8")
+        for name, body in members.items():
+            member = tmp_path / name
+            member.mkdir()
+            (member / "pyproject.toml").write_text(body, encoding="utf-8")
+        with (
+            patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls,
+            patch("nab_python.resolve.build_lock_input_from_provider"),
+        ):
+            mock_coord_cls.return_value.__enter__ = lambda _self: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            return resolve_pyproject(
+                tmp_path / "pyproject.toml",
+                _FAKE_TRANSPORT,
+                python_version=python_version,
+            )
+
+    _ROOT_FOO_GPU = (
+        '[project]\nname = "proj"\ndependencies = ["foo[gpu]"]\n'
+        '[[tool.nab.local-sources]]\nname = "foo"\npath = "foo"\n'
+    )
+
+    def test_extra_pulls_its_dependency(self, tmp_path: Path) -> None:
+        coordinator = make_coordinator(
+            listings={"bar": _index_wheels("bar", "2.0", "3.0")},
+            auto_metadata=True,
+        )
+        result = self._resolve(
+            tmp_path,
+            self._ROOT_FOO_GPU,
+            {
+                "foo": '[project]\nname = "foo"\nversion = "1.0"\n'
+                '[project.optional-dependencies]\ngpu = ["bar>=2"]\n',
+            },
+            coordinator,
+            "3.12.0",
+        )
+        assert result.pins == {"foo": V("1.0"), "bar": V("3.0")}
+
+    @pytest.mark.parametrize(
+        ("python_version", "expects_bar"),
+        [("3.12.0", True), ("3.9.0", False)],
+    )
+    def test_extra_dependency_marker_gated_by_target(
+        self, tmp_path: Path, python_version: str, expects_bar: bool
+    ) -> None:
+        coordinator = make_coordinator(
+            listings={"bar": _index_wheels("bar", "2.0")}, auto_metadata=True
+        )
+        result = self._resolve(
+            tmp_path,
+            self._ROOT_FOO_GPU,
+            {
+                "foo": '[project]\nname = "foo"\nversion = "1.0"\n'
+                "[project.optional-dependencies]\n"
+                "gpu = [\"bar ; python_version >= '3.11'\"]\n",
+            },
+            coordinator,
+            python_version,
+        )
+        expected = {"foo": V("1.0")}
+        if expects_bar:
+            expected["bar"] = V("2.0")
+        assert result.pins == expected
+
+    @pytest.mark.parametrize(
+        ("python_version", "expects_bar"),
+        [("3.9.0", True), ("3.12.0", False)],
+    )
+    def test_local_dependency_marker_gated_by_target(
+        self, tmp_path: Path, python_version: str, expects_bar: bool
+    ) -> None:
+        coordinator = make_coordinator(
+            listings={"bar": _index_wheels("bar", "1.0")}, auto_metadata=True
+        )
+        result = self._resolve(
+            tmp_path,
+            '[project]\nname = "proj"\ndependencies = ["foo"]\n'
+            '[[tool.nab.local-sources]]\nname = "foo"\npath = "foo"\n',
+            {
+                "foo": '[project]\nname = "foo"\nversion = "1.0"\n'
+                "dependencies = [\"bar ; python_version < '3.10'\"]\n",
+            },
+            coordinator,
+            python_version,
+        )
+        expected = {"foo": V("1.0")}
+        if expects_bar:
+            expected["bar"] = V("1.0")
+        assert result.pins == expected
+
+    def test_version_mismatch_is_unsat_not_a_wrong_pin(self, tmp_path: Path) -> None:
+        coordinator = make_coordinator(listings={})
+        with pytest.raises(ResolutionError):
+            self._resolve(
+                tmp_path,
+                '[project]\nname = "proj"\ndependencies = ["foo>=2.0"]\n'
+                '[[tool.nab.local-sources]]\nname = "foo"\npath = "foo"\n',
+                {"foo": '[project]\nname = "foo"\nversion = "1.0"\n'},
+                coordinator,
+                "3.12.0",
+            )

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -707,6 +707,29 @@ class TestParseRequirements:
         with pytest.raises(ConfigError, match="extras"):
             _parse_requirements(["pkg[dev]<2.0"], env, kind="constraint")
 
+    def test_marker_false_drops_constraint(self) -> None:
+        """A constraint whose marker excludes the env is dropped.
+
+        The marker is evaluated per env for constraints too, so a
+        constraint gated off this tuple never binds. The sibling
+        single-env path once enforced such constraints unconditionally
+        (issue #38).
+        """
+        env = _linux_311().environment
+        out = _parse_requirements(
+            ['pkg<2.0 ; sys_platform == "win32"'], env, kind="constraint"
+        )
+        assert out == {}
+
+    def test_marker_true_keeps_constraint(self) -> None:
+        """A constraint whose marker matches the env binds its range."""
+        env = _linux_311().environment
+        out = _parse_requirements(
+            ['pkg<2.0 ; sys_platform == "linux"'], env, kind="constraint"
+        )
+        assert Version("1.0") in out["pkg"]
+        assert Version("2.0") not in out["pkg"]
+
     def test_extra_proxy_key_normalized(self) -> None:
         """The proxy key is PEP 685 normalized, matching the single-env path."""
         env = _linux_311().environment
@@ -1072,6 +1095,39 @@ class TestRunPassConflict:
         assert not results[0].success
         assert results[0].error is not None
         assert "ResolutionError" in results[0].error
+
+
+class TestRunPassConstraintMarker:
+    """A constraint's marker gates it per tuple, not across the matrix."""
+
+    def test_marker_gated_constraint_binds_only_matching_tuples(self) -> None:
+        """A win32-gated ``pkg<2.0`` pins 1.0 on Windows, leaves Linux at 2.0.
+
+        Each tuple evaluates the constraint marker against its own
+        environment, so the constraint binds only the Windows tuple.
+        Evaluating it once against a shared env, or skipping it for
+        constraints, would mis-pin a tuple's lock.
+        """
+        wheels = [_make_wheel("1.0", package="pkg"), _make_wheel("2.0", package="pkg")]
+        coordinator = _make_coordinator({"pkg": wheels})
+        results = _run_pass(
+            [_linux_311(), _windows_311()],
+            requirements=["pkg"],
+            constraints=['pkg<2.0 ; sys_platform == "win32"'],
+            coordinator=coordinator,
+            uploaded_prior_to=None,
+            dist_policy=DistPolicy.WHEEL_OR_SDIST,
+            build_policy=BuildPolicy.NEVER,
+            resolution_strategy="highest",
+            direct_packages=frozenset({"pkg"}),
+            preferences={},
+            align_serial=False,
+        )
+        pins = {r.tuple_.platform_id: r.pins["pkg"] for r in results}
+        assert pins == {
+            "linux_x86_64": Version("2.0"),
+            "windows_amd64": Version("1.0"),
+        }
 
 
 class TestUniversalResult:

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -26,7 +26,13 @@ from nab_resolver.incompat_index import (
 from nab_resolver.partial_solution import Assignment, PartialSolution
 from nab_resolver.propagate import term_relation
 from nab_resolver.ranges import Range
-from nab_resolver.report import explain_incompatibility, prior_cause, union_terms
+from nab_resolver.report import (
+    explain_incompatibility,
+    format_error,
+    format_term,
+    prior_cause,
+    union_terms,
+)
 from nab_resolver.resolver import (
     ResolutionError,
     Resolver,
@@ -1772,6 +1778,56 @@ class TestErrorMessages:
         # The error should have a derived incompatibility with causes
         root_inc = exc_info.value.incompatibility
         assert root_inc is not None
+
+    def test_dependency_clause_attributes_parent_to_dependency(self) -> None:
+        """A DEPENDENCY clause reads as parent depends on dependency."""
+        parent = Term("foo", Range.singleton(2), positive=True)
+        dependency = Term("bar", Range.at_least(3), positive=False)
+        clause = Incompatibility(
+            [parent, dependency], cause=IncompatibilityCause.DEPENDENCY
+        )
+        message = format_error(clause)
+        assert message == "because foo 2 depends on bar [3, +inf)"
+
+    def test_root_clause_attributes_to_the_project(self) -> None:
+        """A ROOT clause reads as a project dependency and ignores the root term."""
+        root = Term("root", Range.singleton(0), positive=True)
+        dependency = Term("baz", Range.at_least(1), positive=False)
+        clause = Incompatibility([root, dependency], cause=IncompatibilityCause.ROOT)
+        message = format_error(clause)
+        assert message == "because your project depends on baz [1, +inf)"
+
+    def test_no_versions_clause_reports_availability(self) -> None:
+        """A NO_VERSIONS clause names the unavailable range."""
+        clause = Incompatibility(
+            [Term("qux", Range.at_least(5), positive=True)],
+            cause=IncompatibilityCause.NO_VERSIONS,
+        )
+        message = format_error(clause)
+        assert message == "because no versions of qux [5, +inf) are available"
+
+    def test_derived_clause_chains_children_with_so(self) -> None:
+        """A DERIVED clause renders its child cause first, then a `so` line."""
+        no_versions = Incompatibility(
+            [Term("qux", Range.at_least(5), positive=True)],
+            cause=IncompatibilityCause.NO_VERSIONS,
+        )
+        derived = Incompatibility(
+            [Term("qux", Range.at_least(5), positive=True)],
+            cause=IncompatibilityCause.DERIVED,
+            cause_left=no_versions,
+        )
+        assert format_error(derived).splitlines() == [
+            "because no versions of qux [5, +inf) are available",
+            "so qux [5, +inf)",
+        ]
+
+    def test_format_term_marks_negation(self) -> None:
+        """format_term prefixes a negated term with `not` and leaves positives bare."""
+        positive = format_term(Term("a", Range.at_least(1), positive=True))
+        negative = format_term(Term("a", Range.at_least(1), positive=False))
+        assert positive == "a [1, +inf)"
+        assert negative == "not a [1, +inf)"
 
 
 class TestConstraints:


### PR DESCRIPTION
This bundle adds regression-test coverage for the resolver, provider, fetch coordinator, lockfile, and universal matrix paths. It pins behavior that the current code already gets right but had no guarding test for: error-report rendering, VcsPin discrimination, pre-release admission in the real provider, extras and markers on local sources, multi-extra dependency splitting, per-tuple constraint marker evaluation, build-backend static-extract parity, the simple-index absolute-url shortcut boundary, multi-index serving attribution, and the dynamic Provides-Extra dependency-field guard. These are test-only changes with no resolver behavior change.
