### PR TITLE
Pin vendored packaging specifier and marker semantics

### DIFF
--- a/nab-python/tests/test_marker_evaluation.py
+++ b/nab-python/tests/test_marker_evaluation.py
@@ -1,0 +1,221 @@
+"""Marker-evaluation semantics the resolver depends on.
+
+The PubGrub provider gates marker-conditioned dependencies on
+``nab_python._vendor.packaging.markers.Marker.evaluate``. The vendored
+snapshot tracks packaging PR #1182 (unreleased), so these tests pin the
+boolean results for realistic markers and the deliberate string-key
+operator semantics, so a future re-vendor cannot silently change which
+dependencies a resolve includes.
+
+Audited differentially against released packaging 24.2/25.0/26.2: every
+realistic marker evaluates identically across all three (and nab matches
+26.2 exactly); the only divergences are pathological forms no real
+package writes. See kb 2026-06-04-marker-eval-operator-audited-clean.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nab_python._vendor.packaging.markers import Marker
+
+LINUX_CP311: dict[str, str] = {
+    "os_name": "posix",
+    "sys_platform": "linux",
+    "platform_machine": "x86_64",
+    "platform_system": "Linux",
+    "platform_release": "6.6.0",
+    "platform_version": "#1 SMP",
+    "platform_python_implementation": "CPython",
+    "implementation_name": "cpython",
+    "python_version": "3.11",
+    "python_full_version": "3.11.2",
+    "implementation_version": "3.11.2",
+    "extra": "",
+}
+
+PYPY_LINUX: dict[str, str] = {
+    **LINUX_CP311,
+    "platform_python_implementation": "PyPy",
+    "implementation_name": "pypy",
+    "python_version": "3.9",
+    "python_full_version": "3.9.18",
+    "implementation_version": "7.3.13",
+}
+
+CP314_PRE: dict[str, str] = {
+    **LINUX_CP311,
+    "python_version": "3.14",
+    "python_full_version": "3.14.0a1",
+    "implementation_version": "3.14.0a1",
+}
+
+
+def _ev(text: str, env: dict[str, str]) -> bool:
+    return Marker(text).evaluate(env)
+
+
+class TestRealisticMarkers:
+    """Version-key comparisons and string-key equality/membership.
+
+    These are the marker forms real packages write; they must match
+    pip/uv (every packaging version agrees) or nab resolves differently.
+    """
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ('python_version >= "3.8"', True),
+            ('python_version < "3.8"', False),
+            ('python_version == "3.11"', True),
+            ('python_version != "3.11"', False),
+            ('python_version == "3.11.0"', True),
+            ('python_full_version >= "3.11.0"', True),
+            ('python_full_version < "3.11.2"', False),
+            ('python_full_version >= "3.12"', False),
+            ('sys_platform == "linux"', True),
+            ('sys_platform == "win32"', False),
+            ('sys_platform != "win32"', True),
+            ('os_name == "posix"', True),
+            ('platform_machine == "x86_64"', True),
+            ('platform_system == "Linux"', True),
+            ('implementation_name == "cpython"', True),
+            ('platform_python_implementation == "CPython"', True),
+            ('"x86" in platform_machine', True),
+            ('"arm" in platform_machine', False),
+            ('"arm" not in platform_machine', True),
+        ],
+    )
+    def test_linux_cpython(self, text: str, expected: bool) -> None:
+        assert _ev(text, LINUX_CP311) is expected
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ('platform_python_implementation == "PyPy"', True),
+            ('implementation_name == "pypy"', True),
+            ('implementation_version >= "7.3"', True),
+            ('python_full_version == "3.9.18"', True),
+        ],
+    )
+    def test_pypy(self, text: str, expected: bool) -> None:
+        assert _ev(text, PYPY_LINUX) is expected
+
+
+class TestPrereleaseBoundaries:
+    """PEP 440 prerelease semantics through the Specifier path."""
+
+    def test_prerelease_matches_own_lower_bound(self) -> None:
+        assert _ev('python_full_version >= "3.14.0a1"', CP314_PRE) is True
+
+    def test_exclusive_upper_excludes_own_prerelease(self) -> None:
+        # <V excludes prereleases of V, so 3.14.0a1 is not < "3.14".
+        assert _ev('python_full_version < "3.14"', CP314_PRE) is False
+
+    def test_minor_version_unaffected_by_prerelease(self) -> None:
+        assert _ev('python_version == "3.14"', CP314_PRE) is True
+
+
+class TestCompound:
+    """and / or / parenthesised grouping."""
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ('python_version >= "3.8" and sys_platform == "linux"', True),
+            ('python_version >= "3.8" and sys_platform == "win32"', False),
+            ('python_version < "3.8" or os_name == "posix"', True),
+            (
+                '(python_version == "3.11" and sys_platform == "linux")'
+                ' or platform_machine == "arm64"',
+                True,
+            ),
+        ],
+    )
+    def test_compound(self, text: str, expected: bool) -> None:
+        assert _ev(text, LINUX_CP311) is expected
+
+
+class TestStringKeyOrderingSemantics:
+    """Deliberate packaging 26.x behavior for ordering on string keys.
+
+    ``<`` and ``>`` are always False and ``<=``/``>=`` reduce to equality
+    for non-version markers. Older packaging compared lexicographically
+    (``implementation_name < "darwin"`` was True); pinning catches a
+    re-vendor that reverts to that.
+    """
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ('sys_platform < "linux"', False),
+            ('sys_platform > "linux"', False),
+            ('sys_platform <= "linux"', True),
+            ('sys_platform >= "linux"', True),
+            ('sys_platform <= "windows"', False),
+            ('implementation_name < "darwin"', False),
+        ],
+    )
+    def test_string_ordering(self, text: str, expected: bool) -> None:
+        assert _ev(text, LINUX_CP311) is expected
+
+
+class TestStringKeyVersionLikeRhsIsRobust:
+    """A version-like rhs on a string key returns a bool, never raises.
+
+    Older packaging raised InvalidVersion here; nab stays robust.
+    """
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            'sys_platform == "0"',
+            'os_name >= "3.8"',
+            'platform_machine != "1.0"',
+        ],
+    )
+    def test_no_raise(self, text: str) -> None:
+        assert isinstance(_ev(text, LINUX_CP311), bool)
+
+
+class TestExtraNormalization:
+    """metadata-context ``extra`` with PEP 685 name normalization."""
+
+    @pytest.mark.parametrize(
+        ("extra_value", "text", "expected"),
+        [
+            ("test", 'extra == "test"', True),
+            ("test", 'extra == "docs"', False),
+            ("dev-tools", 'extra == "dev_tools"', True),
+            ("dev_tools", 'extra == "dev-tools"', True),
+            ("", 'extra == "test"', False),
+        ],
+    )
+    def test_extra(self, extra_value: str, text: str, expected: bool) -> None:
+        assert _ev(text, {**LINUX_CP311, "extra": extra_value}) is expected
+
+
+class TestSetMarkers:
+    """lock_file-context set membership (extras / dependency_groups)."""
+
+    @pytest.mark.parametrize(
+        ("text", "key", "value", "expected"),
+        [
+            ('"test" in extras', "extras", frozenset({"test"}), True),
+            ('"test" not in extras', "extras", frozenset({"docs"}), True),
+            (
+                '"grp" in dependency_groups',
+                "dependency_groups",
+                frozenset({"grp"}),
+                True,
+            ),
+        ],
+    )
+    def test_set_membership(
+        self, text: str, key: str, value: frozenset[str], expected: bool
+    ) -> None:
+        env: dict[str, str | frozenset[str]] = {
+            k: v for k, v in LINUX_CP311.items() if k != "extra"
+        }
+        env[key] = value
+        assert Marker(text).evaluate(env, context="lock_file") is expected

--- a/nab-python/tests/test_resolver_packaging.py
+++ b/nab-python/tests/test_resolver_packaging.py
@@ -181,6 +181,76 @@ class TestSpecifierToRange:
         assert V("1.9.9") in r
         assert V("2.0.dev0") not in r
 
+    def test_wildcard_includes_prerelease(self) -> None:
+        """==1.2.* admits pre-releases in the 1.2 family."""
+        r = SpecifierSet("==1.2.*").to_range()
+        assert V("1.2.0a1") in r
+        assert V("1.2.0") in r
+        assert V("1.2.9") in r
+        assert V("1.3.dev0") not in r
+        assert V("1.1.9") not in r
+
+    def test_compatible_release_post(self) -> None:
+        """~=2.2.post3 drops the last release component for the prefix.
+
+        The compatible bound is ==2.* so the upper edge is 3.dev0; the
+        lower edge keeps the post-release.
+        """
+        r = SpecifierSet("~=2.2.post3").to_range()
+        assert V("2.2.post2") not in r
+        assert V("2.2.post3") in r
+        assert V("2.2.5") in r
+        assert V("2.3") in r
+        assert V("3.0") not in r
+
+    def test_gt_pre_release(self) -> None:
+        """>1.0a1 carves out only 1.0a1 and its own pre/post/local family.
+
+        The specifier is a pre-release, so PEP 440 excludes 1.0a1
+        itself, 1.0a1+local, and 1.0a1.postN.  The final release 1.0 and
+        its post-releases are higher versions and stay in.
+        """
+        r = SpecifierSet(">1.0a1").to_range()
+        assert V("1.0a1") not in r
+        assert V("1.0a1.post1") not in r
+        assert V("1.0a2") in r
+        assert V("1.0") in r
+        assert V("1.0.post1") in r
+        assert V("1.1") in r
+
+    def test_epoch_ordering(self) -> None:
+        """An epoch sorts above every lower-epoch release."""
+        r = SpecifierSet(">=1!1.0").to_range()
+        assert V("1!1.0") in r
+        assert V("1!2.0") in r
+        assert V("1.0") not in r
+        assert V("999") not in r
+
+    def test_epoch_wildcard(self) -> None:
+        """==1!2.* keeps the epoch and stays within the 1!2 family."""
+        r = SpecifierSet("==1!2.*").to_range()
+        assert V("1!2.0") in r
+        assert V("1!2.0.dev0") in r
+        assert V("1!2.9") in r
+        assert V("1!3.0") not in r
+        assert V("2.0") not in r
+
+    def test_epoch_compatible_release(self) -> None:
+        """~=1!2.2 carries the epoch into both bounds."""
+        r = SpecifierSet("~=1!2.2").to_range()
+        assert V("1!2.2") in r
+        assert V("1!2.9") in r
+        assert V("1!3.0") not in r
+        assert V("2.2") not in r
+
+    def test_epoch_not_equal_excludes_local(self) -> None:
+        """!=1!1.5 excludes the local family but keeps post-releases."""
+        r = SpecifierSet("!=1!1.5").to_range()
+        assert V("1!1.4") in r
+        assert V("1!1.5") not in r
+        assert V("1!1.5+local") not in r
+        assert V("1!1.5.post1") in r
+
 
 class TestTrivialResolution:
     """Resolve simple graphs with PEP 440 versions."""

--- a/nab-python/tests/test_resolver_packaging.py
+++ b/nab-python/tests/test_resolver_packaging.py
@@ -519,3 +519,58 @@ class TestBruteForceRegression:
         assert result["pkg0"] in (V("1.0"), V("2.0"))
         assert "pkg1" not in result
         assert "pkg2" not in result
+
+
+class _FilterProvider(PackagingProvider):
+    """PackagingProvider that selects via ``version_range.filter``.
+
+    The real PyPI provider picks with ``Provider.choose_version``, which
+    calls ``version_range.filter(all_versions)`` rather than a plain
+    membership test. ``filter`` is prerelease-aware, so it exposes the
+    constraint prerelease behavior that membership selection hides.
+    """
+
+    def choose_version(
+        self, package: str, version_range: VersionRange
+    ) -> Version | None:
+        return next(iter(version_range.filter(self._get_versions(package))), None)
+
+
+class TestConstraintPrereleases:
+    """A constraint that names a prerelease must enable that prerelease."""
+
+    def test_constraint_capping_at_prerelease_keeps_it(self) -> None:
+        """``foo<=2.0b1`` must pick 2.0b1, not the older 1.5.
+
+        PEP 440 enables prereleases for a specifier that names one. A
+        constraint is injected and read back through a double complement;
+        the old vendored packaging dropped the prerelease policy there, so
+        ``filter`` excluded 2.0b1 and the resolver fell back to 1.5.
+        """
+        provider = _FilterProvider(
+            {
+                "root": {V("1.0"): {"foo": SpecifierSet(">=1.0")}},
+                "foo": {V("2.0b1"): {}, V("1.5"): {}, V("1.0"): {}},
+            },
+        )
+        result = Resolver(provider, range_type=VersionRange, root_version="0").resolve(
+            {"root": VersionRange.singleton(V("1.0"))},
+            constraints={"foo": SpecifierSet("<=2.0b1").to_range()},
+        )
+        assert result["foo"] == V("2.0b1")
+
+
+class TestComplementPrereleases:
+    """``VersionRange.complement`` preserves the prerelease policy."""
+
+    def test_double_complement_keeps_prerelease_filtering(self) -> None:
+        """``~~r`` filters a named prerelease in, just as ``r`` does.
+
+        Resetting the policy on complement made the double complement
+        that constraint injection performs buffer 2.0b1 out under the
+        PEP 440 default.
+        """
+        r = SpecifierSet("<=2.0b1").to_range()
+        versions = [V("2.0b1"), V("1.5"), V("1.0")]
+        assert list(r.filter(versions)) == versions
+        assert list(r.complement().complement().filter(versions)) == versions


### PR DESCRIPTION
Pins the vendored packaging behavior the resolver relies on with regression tests. Covers marker evaluation across realistic and string-key operator forms, specifier-to-range conversion for epoch, post, and wildcard cases, and constraint prerelease handling through the double-complement path. These are test-only changes with no resolver behavior change.
