### PR TITLE
Tighten benchmark harness fidelity and lock checks

### DIFF
--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -62,26 +62,30 @@ DEFAULT_INDEXES: tuple[IndexConfig, ...] = (
     IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL),
 )
 
+# Each entry pins its TOML variant as ``stem:name``. Most of these names also
+# live in -lowest / -lowest-direct siblings with different counts; the pins
+# record the variant the suite already ran so the numbers are reproducible
+# instead of depending on directory scan order.
 CANARY_SCENARIOS = [
-    "boto3-urllib3-transient",
-    "trustllm",
-    "copick",
-    "promptflow-vectordb",
-    "ultralytics-export",
-    "datacontract-cli",
-    "pandas-aws-boto3-dandi-frenzy",
-    "vllm-transformers-floor",
-    "google-bigquery-soda",
-    "langchain-ml-course",
-    "airflow-3-0-2-awswrangler",
-    "airflow-3-0-3-pandas-sqlalchemy",
-    "airflow-portalocker-qdrant",
-    "airflow-fastapi-121",
-    "so-dbt-core-snowflake-79744735",
-    "uv-issue-16601-xinference",
-    "uv-issue-16601-xinference-fixed",
-    "rag-chroma-langchain",
-    "streamlit-langchain",
+    "uv-lowest:boto3-urllib3-transient",
+    "pip-lowest:trustllm",
+    "pip-lowest:copick",
+    "pip-lowest:promptflow-vectordb",
+    "pip-lowest:ultralytics-export",
+    "pip-lowest:datacontract-cli",
+    "pip-lowest:pandas-aws-boto3-dandi-frenzy",
+    "ai-stack:vllm-transformers-floor",
+    "pip-lowest:google-bigquery-soda",
+    "pip-lowest:langchain-ml-course",
+    "airflow-lowest-direct:airflow-3-0-2-awswrangler",
+    "airflow-lowest-direct:airflow-3-0-3-pandas-sqlalchemy",
+    "airflow-lowest-direct:airflow-portalocker-qdrant",
+    "airflow-lowest-direct:airflow-fastapi-121",
+    "forums-lowest-direct:so-dbt-core-snowflake-79744735",
+    "uv-lowest:uv-issue-16601-xinference",
+    "uv-lowest:uv-issue-16601-xinference-fixed",
+    "ai-stack:rag-chroma-langchain",
+    "ai-stack:streamlit-langchain",
 ]
 
 WALL_TIMEOUT_S = 60
@@ -274,13 +278,39 @@ def run_one(  # noqa: PLR0913 - one wrapper per scenario knob
         }
 
 
-def find_scenario(scenario_name: str) -> dict | None:
-    for toml_file in SCENARIOS_DIR.glob("*.toml"):
+def find_scenario(spec: str) -> dict | None:
+    """Locate a scenario by name, or by ``stem:name`` to pin a specific TOML file.
+
+    Many names live in several variant TOMLs (a ``highest`` file plus
+    ``-lowest`` / ``-lowest-direct`` siblings) with different decision counts.
+    A bare name scans the files in sorted order so the match is reproducible
+    across machines, and warns when the name is ambiguous so an exact-count run
+    can pin the variant with ``stem:name``.
+    """
+    if ":" in spec:
+        toml_stem, name = spec.split(":", 1)
+        toml_path = SCENARIOS_DIR / f"{toml_stem}.toml"
+        if not toml_path.is_file():
+            return None
+        with toml_path.open("rb") as f:
+            return tomllib.load(f).get(name)
+
+    matches: list[tuple[str, dict]] = []
+    for toml_file in sorted(SCENARIOS_DIR.glob("*.toml")):
         with toml_file.open("rb") as f:
             data = tomllib.load(f)
-        if scenario_name in data:
-            return data[scenario_name]
-    return None
+        if spec in data:
+            matches.append((toml_file.stem, data[spec]))
+    if not matches:
+        return None
+    if len(matches) > 1:
+        stems = ", ".join(stem for stem, _ in matches)
+        print(
+            f"  [ambiguous] {spec!r} is in {len(matches)} files ({stems}); "
+            f"using {matches[0][0]}. Pin one with '{matches[0][0]}:{spec}'.",
+            flush=True,
+        )
+    return matches[0][1]
 
 
 def median_run(scenario: dict, runs: int) -> tuple[list[dict], dict]:
@@ -444,18 +474,19 @@ def main() -> None:
     summary_all: dict[str, dict] = {}
     for name in scenarios_to_run:
         scenario = find_scenario(name)
+        label = name.split(":", 1)[-1]
         if scenario is None:
-            print(f"{name:<45} NOT FOUND")
+            print(f"{label:<45} NOT FOUND")
             continue
         runs_data, summary = median_run(scenario, args.runs)
-        summary_all[name] = {"runs": runs_data, "summary": summary}
+        summary_all[label] = {"runs": runs_data, "summary": summary}
 
         if "skipped" in summary:
-            print(f"{name:<45} SKIPPED: {summary['skipped']}")
+            print(f"{label:<45} SKIPPED: {summary['skipped']}")
             continue
 
         print(
-            f"{name:<45} "
+            f"{label:<45} "
             f"{summary['success_runs']:>9} "
             f"{summary['median_decisions']:>8} "
             f"{summary['median_wall']:>10} "

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -1,9 +1,9 @@
 """Quick canary benchmark for fast iteration.
 
 Runs a curated subset of scenarios (canaries + hard cases) N times each
-and reports median decisions, conflicts, and wall time. The set is
-small enough to finish in a few minutes so it can be re-run after each
-algorithm change.
+and reports median decisions, distributions seen (search breadth), and
+wall time. The set is small enough to finish in a few minutes so it can
+be re-run after each algorithm change.
 
 Usage:
     python nab-python/benchmarks/canary.py [--commit LABEL] [--runs N]
@@ -272,6 +272,7 @@ def run_one(  # noqa: PLR0913 - one wrapper per scenario knob
             "restarts": rs.restarts,
             "incompatibilities_learned": rs.incompatibilities_learned,
             "metadata_fetched": ps.metadata_fetched,
+            "distributions_seen": ps.distributions_seen,
             "look_ahead_rejections": ps.look_ahead_rejections,
             "packages": packages,
             "wall_time_seconds": round(elapsed, 3),
@@ -427,6 +428,9 @@ def median_run(scenario: dict, runs: int) -> tuple[list[dict], dict]:
     summary = {
         "success_runs": f"{successes}/{len(runs_data)}",
         "median_decisions": int(med("decisions")),
+        "median_distributions_seen": int(med("distributions_seen")),
+        "median_metadata_fetched": int(med("metadata_fetched")),
+        "median_packages": int(med("packages")),
         "median_conflicts": int(med("conflicts")),
         "median_backjumps": int(med("backjumps")),
         "median_wall": round(med("wall_time_seconds"), 2),
@@ -465,11 +469,12 @@ def main() -> None:
         f"{'scenario':<45} "
         f"{'success':>9} "
         f"{'med_dec':>8} "
+        f"{'med_dist':>10} "
         f"{'med_wall':>10} "
         f"{'min_dec':>8} "
         f"{'max_dec':>8}"
     )
-    print("-" * 100)
+    print("-" * 110)
 
     summary_all: dict[str, dict] = {}
     for name in scenarios_to_run:
@@ -489,6 +494,7 @@ def main() -> None:
             f"{label:<45} "
             f"{summary['success_runs']:>9} "
             f"{summary['median_decisions']:>8} "
+            f"{summary['median_distributions_seen']:>10} "
             f"{summary['median_wall']:>10} "
             f"{summary['min_decisions']:>8} "
             f"{summary['max_decisions']:>8}"

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -150,7 +150,7 @@ def parse_requirements(
             )
             raise NotImplementedError(msg)
         name = canonicalize_name(req.name)
-        reqs[name] = req.specifier.to_range()
+        reqs[name] = reqs.get(name, VersionRange.full()) & req.specifier.to_range()
         for extra in req.extras:
             reqs[f"{name}[{extra}]"] = VersionRange.full()
     return reqs

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -137,7 +137,7 @@ def parse_requirements(
             )
             raise NotImplementedError(msg)
         name = canonicalize_name(req.name)
-        reqs[name] = req.specifier.to_range()
+        reqs[name] = reqs.get(name, VersionRange.full()) & req.specifier.to_range()
         for extra in req.extras:
             reqs[f"{name}[{extra}]"] = VersionRange.full()
     return reqs

--- a/nab-python/benchmarks/universal_scenarios.py
+++ b/nab-python/benchmarks/universal_scenarios.py
@@ -150,6 +150,10 @@ def process_scenario(
                 "error": tr.error,
                 "decisions": tr.decisions,
                 "rounds": tr.rounds,
+                "conflicts": tr.conflicts,
+                "backjumps": tr.backjumps,
+                "metadata_fetched": tr.metadata_fetched,
+                "distributions_seen": tr.distributions_seen,
                 "wall_time_seconds": round(tr.wall_time, 3),
                 "package_count": len(tr.pins),
             }
@@ -178,6 +182,10 @@ def process_scenario(
                 "error": f"{type(exc).__name__}: {exc}"[:200],
                 "decisions": 0,
                 "rounds": 0,
+                "conflicts": 0,
+                "backjumps": 0,
+                "metadata_fetched": 0,
+                "distributions_seen": 0,
                 "wall_time_seconds": 0.0,
                 "package_count": 0,
             }
@@ -206,6 +214,10 @@ def process_scenario(
             "diverging_packages": diverging_packages,
             "decisions_total": sum(t["decisions"] for t in per_tuple),
             "rounds_total": sum(t["rounds"] for t in per_tuple),
+            "conflicts_total": sum(t["conflicts"] for t in per_tuple),
+            "backjumps_total": sum(t["backjumps"] for t in per_tuple),
+            "metadata_fetched_total": sum(t["metadata_fetched"] for t in per_tuple),
+            "distributions_seen_total": sum(t["distributions_seen"] for t in per_tuple),
         },
         "per_tuple": per_tuple,
     }

--- a/nab-python/benchmarks/universal_scenarios.py
+++ b/nab-python/benchmarks/universal_scenarios.py
@@ -31,8 +31,14 @@ else:
     # nab pins py>=3.10 but the import fallback matches scenarios.py
     import tomli as tomllib  # type: ignore[no-redef] # pragma: no cover
 
+from nab_python._lockfile.pylock import build_pylock
+from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python.universal.matrix import Matrix
-from nab_python.universal.resolve import resolve_universal
+from nab_python.universal.resolve import (
+    UniversalResult,
+    merge_universal_lock_inputs,
+    resolve_universal,
+)
 
 BENCHMARKS_DIR = Path(__file__).parent
 SCENARIOS_DIR = BENCHMARKS_DIR / "scenarios"
@@ -78,6 +84,53 @@ def parse_datetime(value: str) -> datetime:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
     return dt
+
+
+def check_lock_consistency(result: UniversalResult) -> tuple[bool, list[str]]:
+    """Verify the marker-gated lock reproduces each tuple's solution.
+
+    Builds the real PEP 751 lock and, for each tuple, projects every
+    package marker onto that tuple's environment. The packages whose
+    markers admit the environment must be exactly that tuple's pins; a
+    missing one is an under-firing marker (a silently dropped dep), an
+    extra one an over-firing marker. The corpus declares no conflict
+    forks, so the markers are pure environment markers and the
+    projection is a plain ``marker.evaluate``.
+
+    Call only when ``result.success`` so the lock covers every tuple.
+    """
+    lock_input = merge_universal_lock_inputs(result)
+    try:
+        pylock = build_pylock(lock_input)
+    except Exception as exc:
+        return False, [f"build_pylock raised {type(exc).__name__}: {exc}"[:200]]
+
+    problems: list[str] = []
+    for tr in result.tuple_results:
+        expected = {canonicalize_name(n): str(v) for n, v in tr.pins.items()}
+        selected: dict[str, str | None] = {}
+        duplicates: set[str] = set()
+        for pkg in pylock.packages:
+            marker = pkg.marker
+            if marker is not None and not marker.evaluate(tr.tuple_.environment):
+                continue
+            name = canonicalize_name(str(pkg.name))
+            if name in selected:
+                duplicates.add(name)
+            selected[name] = str(pkg.version) if pkg.version is not None else None
+        if selected != expected or duplicates:
+            missing = sorted(expected.keys() - selected.keys())
+            extra = sorted(selected.keys() - expected.keys())
+            mismatch = sorted(
+                k
+                for k in expected.keys() & selected.keys()
+                if expected[k] != selected[k]
+            )
+            problems.append(
+                f"{tr.tuple_.label}: missing={missing} extra={extra} "
+                f"mismatch={mismatch} duplicate={sorted(duplicates)}"
+            )
+    return not problems, problems
 
 
 def process_scenario(
@@ -164,6 +217,10 @@ def process_scenario(
             1 for pins in merged.values() if len({version for version, _ in pins}) > 1
         )
         success = result.success
+        if success:
+            lock_consistent, lock_inconsistencies = check_lock_consistency(result)
+        else:
+            lock_consistent, lock_inconsistencies = None, []
     except _ScenarioTimeoutError:
         elapsed = time.monotonic() - start
         timed_out = True
@@ -171,6 +228,7 @@ def process_scenario(
         merged = {}
         diverging_packages = 0
         success = False
+        lock_consistent, lock_inconsistencies = None, []
     except Exception as exc:
         elapsed = time.monotonic() - start
         per_tuple = [
@@ -193,6 +251,7 @@ def process_scenario(
         merged = {}
         diverging_packages = 0
         success = False
+        lock_consistent, lock_inconsistencies = None, []
     finally:
         signal.alarm(0)
         signal.signal(signal.SIGALRM, previous_handler)
@@ -204,6 +263,8 @@ def process_scenario(
             "success": success,
             "timed_out": timed_out,
             "skip_on_fail": skip_on_fail,
+            "lock_consistent": lock_consistent,
+            "lock_inconsistencies": lock_inconsistencies,
         },
         "stats": {
             "wall_time_seconds": round(elapsed, 3),
@@ -229,12 +290,13 @@ def process_scenario(
     if timed_out:
         print(f"TIMEOUT after {elapsed:.1f}s ({stats['tuples_total']} tuples)")
     elif success:
+        lock_note = "" if lock_consistent else " LOCK-INCONSISTENT"
         print(
             f"ok ({stats['tuples_total']} tuples, "
             f"{stats['merged_packages']} pkgs, "
             f"{stats['diverging_packages']} diverging, "
             f"{stats['decisions_total']} decisions, "
-            f"{stats['wall_time_seconds']}s)"
+            f"{stats['wall_time_seconds']}s){lock_note}"
         )
     else:
         failures = [t for t in per_tuple if not t["success"]]

--- a/nab-python/benchmarks/universal_summary.py
+++ b/nab-python/benchmarks/universal_summary.py
@@ -23,8 +23,13 @@ def main() -> int:
             return 1
         target_dir = candidates[-1]
     print(f"Results from {target_dir.relative_to(RESULTS_DIR.parent)}\n")
-    print("| Scenario | Tuples | OK | Pkgs | Diverge | Decisions | Wall (s) | Reason |")
-    print("|---|---:|---:|---:|---:|---:|---:|---|")
+    print(
+        "| Scenario | Tuples | OK | Pkgs | Diverge | Lock"
+        " | Decisions | Wall (s) | Reason |"
+    )
+    print("|---|---:|---:|---:|---:|:---:|---:|---:|---|")
+    checked = 0
+    inconsistent = 0
     for path in sorted(target_dir.glob("*.json")):
         data = json.loads(path.read_text())
         s = data["stats"]
@@ -32,17 +37,32 @@ def main() -> int:
         timed_out = data["result"].get("timed_out", False)
         success = data["result"]["success"]
         suffix = " (TIMEOUT)" if timed_out else "" if success else " (FAIL)"
+        lock_consistent = data["result"].get("lock_consistent")
+        if lock_consistent is None:
+            lock_cell = "-"
+        elif lock_consistent:
+            lock_cell = "ok"
+            checked += 1
+        else:
+            lock_cell = "BAD"
+            checked += 1
+            inconsistent += 1
         print(
             f"| {path.stem}{suffix}"
             f" | {s['tuples_total']}"
             f" | {s['tuples_ok']}"
             f" | {s['merged_packages']}"
             f" | {s['diverging_packages']}"
+            f" | {lock_cell}"
             f" | {s['decisions_total']}"
             f" | {s['wall_time_seconds']:.2f}"
             f" | {reason} |"
         )
-    return 0
+    print(
+        f"\nlock consistency: {checked - inconsistent}/{checked} successful locks "
+        f"reproduce every tuple's solution"
+    )
+    return 1 if inconsistent else 0
 
 
 if __name__ == "__main__":

--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -89,6 +89,10 @@ class TupleResult:
     error: str | None = None
     decisions: int = 0
     rounds: int = 0
+    conflicts: int = 0
+    backjumps: int = 0
+    metadata_fetched: int = 0
+    distributions_seen: int = 0
     wall_time: float = 0.0
     lock_input: LockInput | None = None
 
@@ -659,6 +663,20 @@ def _raise_for_local_vcs_python(
             raise ResolutionError(msg)
 
 
+def _tuple_stats(
+    resolver: Resolver[str, Version], provider: UniversalProvider
+) -> dict[str, int]:
+    """Return the resolver and provider counters for a TupleResult."""
+    return {
+        "rounds": resolver.stats.rounds,
+        "decisions": resolver.stats.decisions,
+        "conflicts": resolver.stats.conflicts,
+        "backjumps": resolver.stats.backjumps,
+        "metadata_fetched": provider.stats.metadata_fetched,
+        "distributions_seen": provider.stats.distributions_seen,
+    }
+
+
 def _resolve_one_tuple(  # noqa: PLR0913
     coordinator: FetchCoordinator,
     t: MatrixTuple,
@@ -719,8 +737,7 @@ def _resolve_one_tuple(  # noqa: PLR0913
             success=False,
             error=f"{type(exc).__name__}: {exc}"[:_ERROR_MESSAGE_LIMIT],
             wall_time=time.monotonic() - start,
-            rounds=resolver.stats.rounds,
-            decisions=resolver.stats.decisions,
+            **_tuple_stats(resolver, provider),
         )
     elapsed = time.monotonic() - start
     try:
@@ -734,15 +751,13 @@ def _resolve_one_tuple(  # noqa: PLR0913
             pins=pins,
             error=f"{type(exc).__name__}: {exc}"[:_ERROR_MESSAGE_LIMIT],
             wall_time=elapsed,
-            rounds=resolver.stats.rounds,
-            decisions=resolver.stats.decisions,
+            **_tuple_stats(resolver, provider),
         )
     return TupleResult(
         tuple_=t,
         success=True,
         pins=pins,
         wall_time=elapsed,
-        rounds=resolver.stats.rounds,
-        decisions=resolver.stats.decisions,
+        **_tuple_stats(resolver, provider),
         lock_input=lock_input,
     )

--- a/nab-python/tests/test_benchmark_parse_requirements.py
+++ b/nab-python/tests/test_benchmark_parse_requirements.py
@@ -1,0 +1,41 @@
+"""The benchmark harness intersects repeated same-name requirements.
+
+A scenario may list a package both pinned and with a bare extra, e.g.
+``inmanta-core==6.0.0`` followed by ``inmanta-core[pytest-inmanta-extensions]``.
+The harness must keep the pin (as pip and uv do), not let the later bare
+requirement widen the range back to any version.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from nab_python._vendor.packaging.ranges import VersionRange
+from nab_python._vendor.packaging.version import Version
+
+_BENCH = Path(__file__).resolve().parents[1] / "benchmarks"
+
+
+def _harness(name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        f"_bench_{name}", _BENCH / f"{name}.py"
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize("harness", ["scenarios", "canary"])
+def test_repeated_name_keeps_pin(harness: str) -> None:
+    reqs = _harness(harness).parse_requirements(
+        ["inmanta-core==6.0.0", "inmanta-core[pytest-inmanta-extensions]"]
+    )
+    assert Version("6.0.0") in reqs["inmanta-core"]
+    assert Version("4.0.0") not in reqs["inmanta-core"]
+    assert reqs["inmanta-core[pytest-inmanta-extensions]"] == VersionRange.full()

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -776,6 +776,10 @@ class TestResolveOneTuple:
         assert tr.pins == {"pkg": Version("1.0")}
         assert tr.tuple_.python_version == "3.11"
         assert tr.tuple_.platform_id == "linux_x86_64"
+        assert tr.conflicts == 0
+        assert tr.backjumps == 0
+        assert tr.metadata_fetched >= 0
+        assert tr.distributions_seen >= 0
 
     def test_failure_returns_error(self) -> None:
         """A resolve with no candidate version reports failure."""


### PR DESCRIPTION
This bundle sharpens the benchmark and test harnesses so they report the resolver's work and lock outputs more faithfully. The standard and canary harnesses now intersect repeated same-name requirements instead of clobbering the range, the canary set is pinned to its TOML scenario variant, the canary reports a distributions-seen breadth metric, the universal benchmark emits conflict and fetch counters per tuple, and the universal benchmark checks that the marker-gated lock reproduces each tuple's solution.

These changes are confined to the benchmark scripts and tests, plus a small observe-only passthrough of existing resolver and provider counters into the universal tuple result. There is no change to resolver behavior or resolution outcomes.
