### PR TITLE
Fix inaccurate source comments and docstrings

### DIFF
--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -376,11 +376,9 @@ def parse_and_cache_metadata(
     Per-tuple classification (marker evaluation, extras admission)
     still runs locally in :func:`cache_deps_from_metadata`.  The
     sdist-dynamic-deps reconciliation in
-    :func:`resolve_dynamic_sdist` returns a *new* dataclass and is
-    therefore cached only by the (per-provider) ``metadata_cache``;
-    the coordinator-level entry stays the raw parse so subsequent
-    tuples can re-apply their own dynamic-resolution rules without
-    inheriting this tuple's pyproject fallback.
+    :func:`resolve_dynamic_sdist` returns a new dataclass cached in a
+    separate coordinator slot, so it too is reused across tuples while
+    the shared raw parse stays unreconciled.
     """
     package, version = cache_key
     version_str = str(version)

--- a/nab-python/src/nab_python/download.py
+++ b/nab-python/src/nab_python/download.py
@@ -52,8 +52,8 @@ class DownloadEntry:
 
     ``hash_algo`` is one of ``sha256``, ``sha384``, ``sha512`` and
     ``digest`` is the recorded hex digest under that algorithm.
-    The downloader picks the strongest acceptable algorithm the
-    index published; it does not re-hash with a weaker one.
+    The downloader verifies against the first acceptable algorithm the
+    index published, preferring sha256 over sha384 over sha512.
     """
 
     package: str

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -70,6 +70,9 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 LOCK_VERSION = "1.0"
+
+# Verification prefers sha256 (pip's hash-checking baseline), not the strongest;
+# any one published hash verifies the same bytes.
 ACCEPTED_HASH_ALGORITHMS: tuple[str, ...] = ("sha256", "sha384", "sha512")
 
 
@@ -110,7 +113,7 @@ class WheelArtifact:
 
     @property
     def primary_digest(self) -> tuple[str, str]:
-        """Return ``(algo, digest)`` of the strongest acceptable hash."""
+        """Return ``(algo, digest)`` for the first acceptable algorithm present."""
         chosen = _select_primary_digest(self.hashes)
         if chosen is None:
             msg = f"{self.filename} has no acceptable hash"
@@ -135,7 +138,7 @@ class SdistArtifact:
 
     @property
     def primary_digest(self) -> tuple[str, str]:
-        """Return ``(algo, digest)`` of the strongest acceptable hash."""
+        """Return ``(algo, digest)`` for the first acceptable algorithm present."""
         chosen = _select_primary_digest(self.hashes)
         if chosen is None:
             msg = f"{self.filename} has no acceptable hash"

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -502,6 +502,10 @@ class Provider:
         self.root_requirements = root_requirements or {}
         self.versions_cache: dict[str, list[tuple[Version, DistFile]]] = {}
         self.deps_cache: dict[tuple[str, Version], dict[str, VersionRange]] = {}
+        # Unbounded by design and never evicted mid-resolve: it keeps every
+        # parsed Requirement (hence every Marker) alive for the whole resolve,
+        # which is what makes the id(marker)-keyed marker caches below safe
+        # against id reuse. Do not bound it without re-keying those caches.
         self.metadata_cache: dict[tuple[str, Version], WheelMetadata] = {}
         self.extra_deps_map: dict[
             tuple[str, Version], dict[str, dict[str, VersionRange]]
@@ -524,7 +528,9 @@ class Provider:
         self.requires_python_cache: dict[str, bool] = {}
 
         # Marker evaluation caches keyed by id(marker); requirement parsing is
-        # cached upstream so each distinct marker text shares one Marker.
+        # cached upstream so each distinct marker text shares one Marker. The
+        # id keying is safe because metadata_cache keeps every evaluated marker
+        # alive (see its note above).
         self.marker_base_cache: dict[int, bool] = {}
         self.marker_extra_cache: dict[int, dict[str, bool]] = {}
         # Memoised str(marker) for the cheap "extra" in marker_text gate.


### PR DESCRIPTION
This corrects three inaccurate source comments and docstrings in nab-python. The marker-cache note now documents the GC-safety invariant that keeps id(marker)-keyed caches valid (metadata_cache is never evicted). The primary_digest docstrings and DownloadEntry note now state that verification uses the first acceptable algorithm present, preferring sha256 over sha384 over sha512, rather than the strongest. The parse-and-cache docstring now describes the resolved-sdist result as cached in its own coordinator slot. These are comment and docstring changes only, with no resolver behavior change.
