### PR TITLE
Strip userinfo before VCS allowed-repos prefix match

### DIFF
--- a/nab-python/src/nab_python/_vcs_admission.py
+++ b/nab-python/src/nab_python/_vcs_admission.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import enum
 from dataclasses import dataclass
+from urllib.parse import urlsplit, urlunsplit
 
 from nab_index.vcs import FULL_GIT_SHA_RE
 
@@ -100,6 +101,20 @@ def split_vcs_scheme(url: str) -> tuple[str | None, str]:
     return (None, url)
 
 
+def _without_userinfo(url: str) -> str:
+    """Drop any authority ``user[:pass]@`` / SSH ``git@`` from ``url``.
+
+    An ``allowed-repos`` prefix names a repo by scheme + host + path, not
+    by credentials, so both the candidate URL and the prefix are stripped
+    before the match. A URL with no userinfo is returned unchanged.
+    """
+    parts = urlsplit(url)
+    if "@" not in parts.netloc:
+        return url
+    host = parts.netloc.rsplit("@", 1)[1]
+    return urlunsplit(parts._replace(netloc=host))
+
+
 def has_full_commit_sha(url: str) -> bool:
     """Return True if the URL pins to a 40-char hex commit hash.
 
@@ -162,7 +177,10 @@ def admit_vcs_url(url: str, config: VcsConfig) -> str:
     # An empty allowed-repos denies every repo (deny-all), matching
     # allowed-schemes: under policy = "allow" the user must list at least
     # one repo prefix.
-    if not any(inner_url.startswith(prefix) for prefix in config.allowed_repos):
+    if not any(
+        _without_userinfo(inner_url).startswith(_without_userinfo(prefix))
+        for prefix in config.allowed_repos
+    ):
         allowed_str = ", ".join(sorted(config.allowed_repos)) or "<empty>"
         msg = (
             "refusing VCS repo\n"

--- a/nab-python/tests/property_python/test_vcs_admission.py
+++ b/nab-python/tests/property_python/test_vcs_admission.py
@@ -21,6 +21,8 @@ Invariants:
 
 from __future__ import annotations
 
+from urllib.parse import urlsplit, urlunsplit
+
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
@@ -120,6 +122,14 @@ def _decision(url: str, config: VcsConfig) -> tuple[str, str]:
         return ("refuse", "")
 
 
+def _drop_login(url: str) -> str:
+    """Strip any authority ``user[:pass]@`` / ``git@`` from ``url``."""
+    parts = urlsplit(url)
+    if "@" not in parts.netloc:
+        return url
+    return urlunsplit(parts._replace(netloc=parts.netloc.rsplit("@", 1)[1]))
+
+
 def _oracle(url: str, config: VcsConfig) -> str:
     """Decision procedure transcribed from the documented policy."""
     scheme = next((s for s in VALID_SCHEMES if url.startswith(f"{s}://")), None)
@@ -129,8 +139,8 @@ def _oracle(url: str, config: VcsConfig) -> str:
         return "refuse"
     if scheme not in config.allowed_schemes:
         return "refuse"
-    inner = url[len("git+") :]
-    if not any(inner.startswith(p) for p in config.allowed_repos):
+    inner = _drop_login(url[len("git+") :])
+    if not any(inner.startswith(_drop_login(p)) for p in config.allowed_repos):
         return "refuse"
     if config.require_pin:
         fragmentless = url.split("#", 1)[0]

--- a/nab-python/tests/test_vcs_admission.py
+++ b/nab-python/tests/test_vcs_admission.py
@@ -240,6 +240,45 @@ class TestAdmitVcsUrlRepo:
         )
         assert scheme == "git+https"
 
+    def test_https_credentials_under_prefix_pass(self) -> None:
+        """A token in the authority does not move the repo out of its org."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com/myorg/",),
+        )
+        scheme = admit_vcs_url(
+            f"git+https://x-access-token:secret@github.com/myorg/fork.git@{_FORTY}",
+            config,
+        )
+        assert scheme == "git+https"
+
+    def test_ssh_login_under_prefix_passes(self) -> None:
+        """The mandatory SSH ``git@`` login does not block a prefix match."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+ssh"}),
+            allowed_repos=("ssh://github.com/myorg/",),
+        )
+        scheme = admit_vcs_url(
+            f"git+ssh://git@github.com/myorg/fork.git@{_FORTY}",
+            config,
+        )
+        assert scheme == "git+ssh"
+
+    def test_credentials_outside_prefix_still_refused(self) -> None:
+        """Stripping credentials does not admit a repo outside the allowlist."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com/myorg/",),
+        )
+        with pytest.raises(UnsupportedVcsError, match="not in vcs.allowed-repos"):
+            admit_vcs_url(
+                f"git+https://user:pass@github.com/evil/fork.git@{_FORTY}",
+                config,
+            )
+
 
 class TestAdmitVcsUrlRequirePin:
     def test_pinned_passes(self) -> None:


### PR DESCRIPTION
VCS allowed-repos matching compared a candidate URL against each prefix with a plain startswith, so any authority credentials (a `token@github.com` login, or the mandatory SSH `git@`) sat between the scheme and host and broke the match. A repo inside an allowed org was wrongly refused whenever the URL carried login info.

The fix drops the userinfo from both the candidate URL and each prefix before comparing, so credentials no longer affect admission. Tests cover an HTTPS token and the SSH `git@` login passing under a prefix, and confirm a repo outside the allowlist is still refused after stripping.