### PR TITLE
Keep SSH login when scrubbing VCS lock URLs

### DIFF
--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -207,17 +207,23 @@ def read_lockfile_packages(path: Path) -> dict[str, Version] | None:
 
 
 def _strip_userinfo(url: str) -> str:
-    """Return ``url`` with any ``user:password@`` userinfo removed.
+    """Return ``url`` with credential userinfo removed.
 
-    Lockfiles are committed to version control, so an index or VCS
-    URL carrying embedded credentials must not be written verbatim.
-    Only the userinfo is dropped: host case and port are preserved
-    and a ``git+`` scheme prefix is left intact.  A no-op for URLs
-    without credentials.
+    Lockfiles are committed to version control, so an index or VCS URL
+    carrying an embedded ``user:password`` must not be written verbatim.
+    An SSH login such as ``git@`` is the protocol login, not a secret,
+    and is required to clone, so it is kept (only an embedded password is
+    dropped); host case and port are preserved.  A no-op for URLs without
+    userinfo.
     """
     parts = urlsplit(url)
-    netloc = parts.netloc.rpartition("@")[2]
-    return urlunsplit(parts._replace(netloc=netloc))
+    userinfo, sep, host = parts.netloc.rpartition("@")
+    if not sep:
+        return url
+    if parts.scheme.endswith("ssh"):
+        login = userinfo.split(":", 1)[0]
+        host = f"{login}@{host}"
+    return urlunsplit(parts._replace(netloc=host))
 
 
 def build_lock_input_from_provider(  # noqa: PLR0913 - each flag maps to a distinct lockfile field

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -2328,6 +2328,49 @@ class TestBuildLockInputFromProvider:
         assert isinstance(pin, VcsPin)
         assert pin.bare_repo_url == "https://example.com/r.git"
 
+    def test_vcs_pin_ssh_keeps_login(self) -> None:
+        """An SSH login (``git@``) is the protocol login, not a credential.
+
+        Stripping it yields a URL the installer cannot clone over SSH, so
+        it must survive into both the bare URL and the pinned repo URL.
+        """
+        sha = "a" * 40
+        provider = _FakeProvider(
+            vcs_sources={
+                "foo": VcsSource(
+                    name="foo",
+                    url=f"git+ssh://git@github.com/foo/bar.git@{sha}",
+                ),
+            },
+            vcs_pins={"foo": sha},
+        )
+        lock_input = build_lock_input_from_provider(
+            provider, {"foo": Version("0.0.0+vcs")}
+        )
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, VcsPin)
+        assert pin.bare_repo_url == "ssh://git@github.com/foo/bar.git"
+        assert pin.repo_url == f"git+ssh://git@github.com/foo/bar.git@{sha}"
+
+    def test_vcs_pin_ssh_drops_embedded_password(self) -> None:
+        """An embedded password in an SSH URL is still dropped; login stays."""
+        sha = "a" * 40
+        provider = _FakeProvider(
+            vcs_sources={
+                "foo": VcsSource(
+                    name="foo",
+                    url=f"git+ssh://git:secret@github.com/foo/bar.git@{sha}",
+                ),
+            },
+            vcs_pins={"foo": sha},
+        )
+        lock_input = build_lock_input_from_provider(
+            provider, {"foo": Version("0.0.0+vcs")}
+        )
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, VcsPin)
+        assert pin.bare_repo_url == "ssh://git@github.com/foo/bar.git"
+
     def test_vcs_source_without_resolved_sha_raises(self) -> None:
         """A pinned VCS source with no recorded SHA is an invariant breach.
 


### PR DESCRIPTION
The lockfile builder's `_strip_userinfo` dropped the entire netloc userinfo from VCS URLs, so an SSH login like `git@` was removed and the resulting `ssh://` URL could no longer be cloned. For `ssh` schemes the fix keeps the login (the part before the colon) while still dropping any embedded password, and returns early for URLs that carry no userinfo.

Adds tests covering an SSH URL with a bare `git@` login and one with a `git:secret@` password.