### PR TITLE
Seed membership sets in self-extra marker eval

### DIFF
--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -9,6 +9,7 @@ import tomli
 
 from nab_resolver.errors import ResolutionError
 
+from ._conflict_kind import dependency_marker_holds
 from ._vendor.packaging.dependency_groups import resolve_dependency_groups
 from ._vendor.packaging.markers import Marker
 from ._vendor.packaging.requirements import InvalidRequirement, Requirement
@@ -192,7 +193,7 @@ def expand_self_extras(
             if (
                 environment is not None
                 and req.marker is not None
-                and not req.marker.evaluate(environment)
+                and not dependency_marker_holds(req.marker, environment)
             ):
                 continue
             worklist.extend(

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -312,6 +312,15 @@ class TestExpandSelfExtras:
         env = {"python_version": "3.12", "python_full_version": "3.12.0"}
         assert expand_self_extras(opt, "mypkg", ["all"], env) == ["all", "a"]
 
+    def test_self_reference_membership_set_marker_skipped(self) -> None:
+        """A self-ref marker testing a lockfile-only set is False at resolve time."""
+        opt = {
+            "all": ['mypkg[fast]; "x" in extras'],
+            "fast": ["some-dep"],
+        }
+        env = {"python_version": "3.12", "python_full_version": "3.12.0"}
+        assert expand_self_extras(opt, "mypkg", ["all"], env) == ["all"]
+
 
 class TestExpandExtraRequirements:
     def test_empty_selection_returns_empty(self) -> None:


### PR DESCRIPTION
A self-referencing extra requirement whose marker tests a lockfile-only membership set (e.g. `"x" in extras`) raised a raw KeyError during `expand_self_extras`, because those PEP 685/735 set variables are not seeded at resolve time.

Route that marker evaluation through the existing `dependency_marker_holds` helper, same as every other resolve path, so the empty membership sets are seeded and the marker evaluates to False and the dependency is dropped.

Adds a test covering a self-ref extra gated on `"x" in extras`.