### PR TITLE
Seed empty membership sets in lock validation marker eval

### DIFF
--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 from nab_index.client import SdistFile, WheelFile
 
+from .._conflict_kind import EMPTY_MEMBERSHIP_SETS
 from .._vcs_admission import admit_vcs_url
 from .._vendor.packaging.ranges import VersionRange
 from .._vendor.packaging.requirements import InvalidRequirement, Requirement
@@ -316,7 +317,7 @@ def marker_matches_base(provider: Provider, marker: Marker, marker_id: int) -> b
     """Evaluate ``marker`` against the env without ``extra`` set, cached."""
     result = provider.marker_base_cache.get(marker_id)
     if result is None:
-        result = marker.evaluate(provider.environment)
+        result = marker.evaluate({**provider.environment, **EMPTY_MEMBERSHIP_SETS})
         provider.marker_base_cache[marker_id] = result
     return result
 

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, cast
 
 from nab_index.client import SdistFile, WheelFile
 
+from ._conflict_kind import EMPTY_MEMBERSHIP_SETS
 from ._provider import extras as _extras
 from ._provider import listing as _listing
 from ._provider import lookahead as _lookahead
@@ -518,8 +519,13 @@ class Provider:
         self.marker_extra_cache: dict[int, dict[str, bool]] = {}
         # Memoised str(marker) for the cheap "extra" in marker_text gate.
         self.marker_text_cache: dict[int, str] = {}
-        # Reused per-evaluation environment dict (avoids a copy per requirement).
-        self.env_with_extra: dict[str, str] = dict(self.environment)
+        # Reused per-evaluation environment dict (avoids a copy per requirement),
+        # seeded with the empty lockfile-only set variables (see
+        # EMPTY_MEMBERSHIP_SETS) so a marker testing one evaluates False.
+        self.env_with_extra: dict[str, str | frozenset[str]] = {
+            **self.environment,
+            **EMPTY_MEMBERSHIP_SETS,
+        }
 
         # (base, extra, normalized_name) per input package string.
         self._package_parts: dict[str, tuple[str, str | None, str]] = {}

--- a/nab-python/src/nab_python/universal/provider.py
+++ b/nab-python/src/nab_python/universal/provider.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING
 
 from nab_index.client import SdistFile, WheelFile
 
+from .._conflict_kind import EMPTY_MEMBERSHIP_SETS
 from .._vendor.packaging.markers import default_environment
 from .._vendor.packaging.ranges import VersionRange
 from .._vendor.packaging.utils import canonicalize_name
@@ -139,7 +140,7 @@ class UniversalProvider(Provider):
         }
         merged.update(marker_environment)
         self.environment = merged
-        self.env_with_extra = dict(merged)
+        self.env_with_extra = {**merged, **EMPTY_MEMBERSHIP_SETS}
         # Normalize preferences keys so lookup matches the provider's
         # canonical naming scheme.
         self._preferences: dict[str, Version] = {

--- a/nab-python/src/nab_python/universal/validate.py
+++ b/nab-python/src/nab_python/universal/validate.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 
 from nab_index.client import WheelFile
 
+from .._conflict_kind import dependency_marker_holds
 from .._vendor.packaging.requirements import (
     InvalidRequirement,
     Requirement,
@@ -438,11 +439,11 @@ def _evaluate_metadata_deps_by_extra(
             continue
         key = _requirement_key(req)
         marker = req.marker
-        if marker is None or marker.evaluate(base_env):
+        if marker is None or dependency_marker_holds(marker, base_env):
             out[None].add(key)
             continue
         for e in extras:
-            if marker.evaluate({**environment, "extra": e}):
+            if dependency_marker_holds(marker, {**environment, "extra": e}):
                 out[e].add(key)
     return out
 

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -231,6 +231,44 @@ class TestSpeculativePrefetch:
         assert "bar" in deps
 
 
+class TestMembershipSetMarkerInMetadata:
+    """A Requires-Dist marker testing extras/dependency_groups drops only the dep.
+
+    The set variables are empty at resolve time, so the membership tests False
+    and the gated dep is excluded. The candidate version itself must survive,
+    matching the root-requirement handling (test_root_extras_set_marker_warns).
+    """
+
+    def test_extras_membership_marker_keeps_version(self) -> None:
+        meta_text = (
+            "Metadata-Version: 2.3\nName: foo\nVersion: 1.0\n"
+            "Provides-Extra: docs\n"
+            "Requires-Dist: realdep>=1.0\n"
+            'Requires-Dist: somedep; "docs" in extras\n'
+        )
+        coordinator = make_coordinator(
+            [make_wheel("1.0")], metadata_text=meta_text, package="foo"
+        )
+        provider = Provider(coordinator)
+        deps = provider.get_dependencies("foo", V("1.0"))
+        assert "realdep" in deps
+        assert "somedep" not in deps
+
+    def test_dependency_groups_membership_marker_keeps_version(self) -> None:
+        meta_text = (
+            "Metadata-Version: 2.3\nName: foo\nVersion: 1.0\n"
+            "Requires-Dist: realdep>=1.0\n"
+            'Requires-Dist: somedep; "dev" in dependency_groups\n'
+        )
+        coordinator = make_coordinator(
+            [make_wheel("1.0")], metadata_text=meta_text, package="foo"
+        )
+        provider = Provider(coordinator)
+        deps = provider.get_dependencies("foo", V("1.0"))
+        assert "realdep" in deps
+        assert "somedep" not in deps
+
+
 class TestFetchVersions:
     def test_caches_results(self) -> None:
         """Second call returns cached results without re-fetching."""

--- a/nab-python/tests/universal/test_validate.py
+++ b/nab-python/tests/universal/test_validate.py
@@ -23,6 +23,7 @@ from nab_python.universal.resolve import TupleResult, UniversalResult
 from nab_python.universal.validate import (
     PinValidation,
     ValidationReport,
+    _evaluate_metadata_deps_by_extra,
     validate_lock,
 )
 from nab_python.universal.wheel_selection import PlatformSpec
@@ -853,13 +854,32 @@ class TestPerExtraDivergence:
 
     def test_evaluate_metadata_deps_by_extra_groups_correctly(self) -> None:
         """``_evaluate_metadata_deps_by_extra`` returns base + per-extra buckets."""
-        from nab_python.universal.validate import _evaluate_metadata_deps_by_extra
-
         env = _linux_311().environment
         out = _evaluate_metadata_deps_by_extra(_BASE_EXTRA_METADATA, env)
         assert out[None] == {"requests>=2"}
         assert out["redis"] == {"redis>=5"}
         assert out["postgres"] == {"psycopg2>=2.9"}
+
+    def test_membership_set_marker_drops_dep_not_version(self) -> None:
+        """A ``Requires-Dist`` marker testing extras/dependency_groups drops the dep.
+
+        The set variables are empty when validating a lock, so the membership
+        tests False and the gated dep is excluded without raising a KeyError
+        that would crash the whole validation pass.
+        """
+        meta = (
+            "Metadata-Version: 2.3\n"
+            "Name: foo\n"
+            "Version: 1.0\n"
+            "Provides-Extra: docs\n"
+            "Requires-Dist: realdep>=1.0\n"
+            'Requires-Dist: somedep; "docs" in extras\n'
+            'Requires-Dist: devdep; "dev" in dependency_groups\n'
+        )
+        env = _linux_311().environment
+        out = _evaluate_metadata_deps_by_extra(meta, env)
+        assert out[None] == {"realdep>=1"}
+        assert out["docs"] == set()
 
     def test_extras_divergent_status_when_only_extra_differs(self) -> None:
         """Base deps match but the redis extra differs -> ``divergent_in_extra``."""


### PR DESCRIPTION
A wheel's Requires-Dist marker that tests `extras` or `dependency_groups` (e.g. `"docs" in extras`) was evaluated against an unseeded environment in `_evaluate_metadata_deps_by_extra`, raising KeyError and crashing the whole validate_lock() pass on that one wheel.

Both marker evaluations now route through `dependency_marker_holds`, which seeds the empty membership sets so the test evaluates False and only the gated dep is dropped, leaving the candidate version intact. This matches the resolve-path handling. Adds a test covering a metadata marker on extras and dependency_groups.