### PR TITLE
Keep URL extra deps with a semicolon in the URL

### DIFF
--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -247,9 +247,10 @@ def extend_with_extras(requires_dist: list[Requirement], optional: dict) -> list
         for dep_str in extra_deps:
             if not isinstance(dep_str, str):
                 continue
-            with_marker = _add_extra_marker(dep_str, extra_name)
             try:
-                requires_dist.append(Requirement(with_marker))
+                requires_dist.append(
+                    Requirement(_add_extra_marker(dep_str, extra_name))
+                )
             except InvalidRequirement:
                 continue
     return provides_extra

--- a/nab-python/src/nab_python/build_backend.py
+++ b/nab-python/src/nab_python/build_backend.py
@@ -129,8 +129,8 @@ def _extend_with_dep_strings(
     for dep in raw:
         if not isinstance(dep, str):
             continue
-        text = _add_extra_marker(dep, extra) if extra is not None else dep
         try:
+            text = _add_extra_marker(dep, extra) if extra is not None else dep
             out.append(Requirement(text))
         except (ValueError, TypeError):
             logger.warning("skipping unparseable requirement: %s", dep)

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -29,6 +29,7 @@ from ._vcs_admission import (
 )
 from ._vendor.packaging.markers import default_environment
 from ._vendor.packaging.ranges import VersionRange
+from ._vendor.packaging.requirements import Requirement
 from ._vendor.packaging.utils import canonicalize_name
 from ._vendor.packaging.version import InvalidVersion, Version
 
@@ -285,14 +286,18 @@ class InvalidUploadTimeError(Exception):
 def _add_extra_marker(dep_str: str, extra_name: str) -> str:
     """Append ``extra == "name"`` to a :pep:`508` dep string.
 
-    Combines an existing marker with ``and`` so a dep like
-    ``numpy ; python_version >= '3.10'`` becomes
-    ``numpy ; (python_version >= '3.10') and extra == "foo"``.
+    Parses with :class:`Requirement` rather than splitting on the first
+    ``;`` so a semicolon inside a direct-reference URL is not mistaken
+    for the marker separator; an existing marker is combined with ``and``.
     """
-    base, sep, marker = dep_str.partition(";")
-    if sep:
-        return f'{base.strip()} ; ({marker.strip()}) and extra == "{extra_name}"'
-    return f'{dep_str} ; extra == "{extra_name}"'
+    req = Requirement(dep_str)
+    extra_marker = f'extra == "{extra_name}"'
+    if req.marker is not None:
+        marker = f"({req.marker}) and {extra_marker}"
+    else:
+        marker = extra_marker
+    req.marker = None
+    return f"{req} ; {marker}"
 
 
 @dataclass

--- a/nab-python/tests/test_build_backend.py
+++ b/nab-python/tests/test_build_backend.py
@@ -417,6 +417,16 @@ class TestStaticExtractAugmentParity:
         assert bb_click.marker.evaluate({"extra": "my-extra"})
         assert aug_click.marker.evaluate({"extra": "my-extra"})
 
+    def test_semicolon_in_extra_url_dep_not_dropped(self) -> None:
+        """A direct-URL extra dep with a ``;`` survives instead of being dropped."""
+        augment_rd: list = []
+        extend_with_extras(augment_rd, {"net": ["bar @ https://h/a;b/p.tar.gz"]})
+
+        bar = next((r for r in augment_rd if r.name == "bar"), None)
+        assert bar is not None
+        assert bar.url == "https://h/a;b/p.tar.gz"
+        assert str(bar.marker) == 'extra == "net"'
+
     def test_malformed_static_dep_dropped_like_augment_index_refuses(
         self, tmp_path: Path
     ) -> None:

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -4551,7 +4551,23 @@ class TestAddExtraMarker:
     def test_with_existing_marker(self) -> None:
         """An existing marker is wrapped and combined with ``and``."""
         out = _add_extra_marker("numpy>=1.0 ; python_version >= '3.10'", "foo")
-        assert out == ("numpy>=1.0 ; (python_version >= '3.10') and extra == \"foo\"")
+        assert out == 'numpy>=1.0 ; (python_version >= "3.10") and extra == "foo"'
+
+    def test_semicolon_in_direct_url_kept(self) -> None:
+        """A ``;`` in a direct-URL is part of the URL, not the marker."""
+        out = _add_extra_marker("foo @ https://h/a;b/p.tar.gz", "bar")
+        req = Requirement(out)
+        assert req.url == "https://h/a;b/p.tar.gz"
+        assert str(req.marker) == 'extra == "bar"'
+
+    def test_semicolon_in_direct_url_with_marker_kept(self) -> None:
+        """The URL ``;`` survives and the existing marker is kept with extra."""
+        out = _add_extra_marker(
+            "foo @ https://h/a;b/p.tar.gz ; python_version >= '3.10'", "bar"
+        )
+        req = Requirement(out)
+        assert req.url == "https://h/a;b/p.tar.gz"
+        assert str(req.marker) == 'python_version >= "3.10" and extra == "bar"'
 
 
 class TestSharedSlotProvenance:


### PR DESCRIPTION
`_add_extra_marker` split a dep string on the first semicolon to find its marker, but a direct-reference URL can legally hold a semicolon (e.g. `foo @ https://h/a;b/p.tar.gz`). The URL got truncated and the dep was dropped as unparseable.

Parse the dep with `Requirement` and rebuild the marker from `req.marker` so the URL is preserved and any existing marker still gets combined with `extra == "name"`.

Adds tests for a URL with a semicolon, with and without an existing marker.