### PR TITLE
Apply python overlay to requires-python wheel filter

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -432,6 +432,16 @@ class Provider:
         """Construct the provider; see the class docstring for parameters."""
         self.coordinator = coordinator
         self.python_version = python_version
+        if marker_environment:
+            # The Requires-Python candidate filter reads self.python_version, so
+            # an impersonated target Python in the overlay must move it too,
+            # keeping the filter aligned with marker evaluation. Mirrors
+            # UniversalProvider.
+            self.python_version = (
+                marker_environment.get("python_full_version")
+                or marker_environment.get("python_version")
+                or python_version
+            )
         self.uploaded_prior_to = uploaded_prior_to
 
         # Passed through to the build env when extract_source_metadata

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -300,6 +300,32 @@ class TestFetchVersions:
         provider = Provider(coordinator, python_version=None)
         assert len(provider.fetch_versions("foo")) == 1
 
+    def test_requires_python_filter_honors_python_overlay(self) -> None:
+        """The Requires-Python filter targets the impersonated Python.
+
+        Under a marker-environment overlay the candidate filter must use
+        the overlaid Python, not the host, so it agrees with how markers
+        are evaluated.
+        """
+        coordinator = make_coordinator(
+            [
+                make_wheel("1.0", requires_python=">=3.8,<3.9"),
+                make_wheel("2.0", requires_python=">=3.12"),
+            ],
+            package="foo",
+        )
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            build_policy=BuildPolicy.NEVER,
+            marker_environment={
+                "python_version": "3.8",
+                "python_full_version": "3.8.0",
+            },
+        )
+        versions = [v for v, _ in provider.fetch_versions("foo")]
+        assert versions == [V("1.0")]
+
     def test_sorted_descending(self) -> None:
         """Results are sorted newest-first."""
         wheels = [make_wheel(v) for v in ("1.0", "3.0", "2.0")]


### PR DESCRIPTION
When a marker-environment overlay impersonates a target Python, the Requires-Python candidate filter kept reading the host `python_version`, so it dropped or kept the wrong wheels relative to how markers were evaluated. The constructor now moves `self.python_version` to the overlaid `python_full_version`/`python_version`, matching UniversalProvider.

Adds a provider test that builds under a 3.8 overlay on a 3.12 host and checks only the 3.8-compatible wheel survives the filter.