### PR TITLE
Use PEP 658 JSON metadata key in nab-index

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -367,9 +367,11 @@ def _has_metadata(file_info: dict) -> bool:
 
     PEP 691 allows either a ``true`` boolean (sidecar exists but no
     hashes published) or a mapping carrying the digest table.  Either
-    flavour means the index will serve ``<file>.metadata``.
+    flavour means the index will serve ``<file>.metadata``.  The legacy
+    JSON key is ``dist-info-metadata`` (PEP 658); ``data-dist-info-metadata``
+    is the HTML attribute name and never appears in the JSON response.
     """
-    for key in ("core-metadata", "data-dist-info-metadata"):
+    for key in ("core-metadata", "dist-info-metadata"):
         value = file_info.get(key)
         if value is True or isinstance(value, dict):
             return True
@@ -383,7 +385,7 @@ def _metadata_hash(file_info: dict) -> tuple[str, str] | None:
     and what pip verifies.  A bare ``true`` (sidecar exists, no hash)
     or a table without sha256 yields None, so no check runs.
     """
-    for key in ("core-metadata", "data-dist-info-metadata"):
+    for key in ("core-metadata", "dist-info-metadata"):
         value = file_info.get(key)
         if isinstance(value, dict):
             digest = value.get("sha256")

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -34,7 +34,7 @@ LISTING_JSON = {
         {
             "filename": "pkg-1.0-py3-none-any.whl",
             "url": "https://files.example.com/pkg-1.0-py3-none-any.whl",
-            "data-dist-info-metadata": {"sha256": "abc"},
+            "dist-info-metadata": {"sha256": "abc"},
         },
     ],
 }

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -99,7 +99,7 @@ def _build_tarball(members: list[tuple[str, bytes]]) -> bytes:
 
 
 class TestHasMetadataFlag:
-    """PEP 691 boolean variants of ``core-metadata`` / ``data-dist-info-metadata``."""
+    """PEP 691 boolean variants of ``core-metadata`` / ``dist-info-metadata``."""
 
     def test_dict_value_advertises_metadata(self) -> None:
         from nab_index.client import _has_metadata
@@ -111,10 +111,10 @@ class TestHasMetadataFlag:
 
         assert _has_metadata({"core-metadata": True})
 
-    def test_legacy_data_dist_info_true(self) -> None:
+    def test_legacy_json_key_true(self) -> None:
         from nab_index.client import _has_metadata
 
-        assert _has_metadata({"data-dist-info-metadata": True})
+        assert _has_metadata({"dist-info-metadata": True})
 
     def test_false_value_does_not_advertise(self) -> None:
         from nab_index.client import _has_metadata
@@ -141,7 +141,7 @@ class TestMetadataHashParsing:
     def test_legacy_key_used(self) -> None:
         from nab_index.client import _metadata_hash
 
-        assert _metadata_hash({"data-dist-info-metadata": {"sha256": "ab"}}) == (
+        assert _metadata_hash({"dist-info-metadata": {"sha256": "ab"}}) == (
             "sha256",
             "ab",
         )

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -191,13 +191,13 @@ LISTING_JSON = {
             "filename": "testpkg-1.0-py3-none-any.whl",
             "url": "https://files.example.com/testpkg-1.0-py3-none-any.whl",
             "requires-python": ">=3.8",
-            "data-dist-info-metadata": {"sha256": "abc"},
+            "dist-info-metadata": {"sha256": "abc"},
         },
         {
             "filename": "testpkg-2.0-py3-none-any.whl",
             "url": "https://files.example.com/testpkg-2.0-py3-none-any.whl",
             "requires-python": ">=3.8",
-            "data-dist-info-metadata": {"sha256": "def"},
+            "dist-info-metadata": {"sha256": "def"},
         },
     ],
 }
@@ -416,17 +416,17 @@ class TestFetchCoordinator:
                 {
                     "filename": "pkg-3.0-py3-none-any.whl",
                     "url": "https://f.com/pkg-3.0-py3-none-any.whl",
-                    "data-dist-info-metadata": {"sha256": "x"},
+                    "dist-info-metadata": {"sha256": "x"},
                 },
                 {
                     "filename": "pkg-2.0-py3-none-any.whl",
                     "url": "https://f.com/pkg-2.0-py3-none-any.whl",
-                    "data-dist-info-metadata": {"sha256": "y"},
+                    "dist-info-metadata": {"sha256": "y"},
                 },
                 {
                     "filename": "pkg-1.0-py3-none-any.whl",
                     "url": "https://f.com/pkg-1.0-py3-none-any.whl",
-                    "data-dist-info-metadata": {"sha256": "z"},
+                    "dist-info-metadata": {"sha256": "z"},
                 },
             ],
         }


### PR DESCRIPTION
The Simple JSON metadata sidecar was detected using the key `data-dist-info-metadata`, which is the HTML attribute name and never appears in the JSON response, so JSON-API indexes serving `dist-info-metadata` were missed and their PEP 658 metadata went unused.

`_has_metadata` and `_metadata_hash` now read the correct PEP 658 JSON key `dist-info-metadata`. Test fixtures and the legacy-key cases are updated to match.