### PR TITLE
Lowercase hash algorithm names on index ingest

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -336,8 +336,9 @@ def _parse_files(
 
 def _parse_hashes(value: object) -> tuple[tuple[str, str], ...]:
     # Algo names are a tiny fixed vocabulary, so interning dedups them.
-    # Hex digests are lowercased to match hashlib.hexdigest() output:
-    # PEP 503/691 don't mandate a case, and pip treats them case-insensitively.
+    # Both halves are lowercased: PEP 503/691 don't mandate a case, pip
+    # treats them case-insensitively, and the acceptable-algorithm filter
+    # and hashlib.hexdigest() both expect the lowercase form.
     if not isinstance(value, dict):
         return ()
 
@@ -345,13 +346,13 @@ def _parse_hashes(value: object) -> tuple[tuple[str, str], ...]:
     if len(value) == 1:
         ((algo, digest),) = value.items()
         if isinstance(algo, str) and isinstance(digest, str):
-            return ((sys.intern(algo), digest.lower()),)
+            return ((sys.intern(algo.lower()), digest.lower()),)
         return ()
 
     out: list[tuple[str, str]] = []
     for algo, digest in value.items():
         if isinstance(algo, str) and isinstance(digest, str):
-            out.append((sys.intern(algo), digest.lower()))
+            out.append((sys.intern(algo.lower()), digest.lower()))
 
     return tuple(out)
 

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -161,7 +161,7 @@ def _parse_pep503_hash_fragment(fragment: str) -> tuple[tuple[str, str], ...]:
     algo, sep, digest = fragment.partition("=")
     if not sep or not algo or not digest:
         return ()
-    return ((algo, digest.lower()),)
+    return ((algo.lower(), digest.lower()),)
 
 
 def _scan_flat_wheelhouse(

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -219,6 +219,14 @@ class TestPep503Directory:
         result = run(client.get_files("foo"))
         assert result[0].hashes == (("sha256", "a" * 64),)
 
+    def test_pep503_hash_fragment_algorithm_lowercased(self, tmp_path: Path) -> None:
+        body = f'<a href="foo-1.0-py3-none-any.whl#SHA256={"a" * 64}">foo</a>'
+        package_dir = self._make_index(tmp_path, body)
+        (package_dir / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        result = run(client.get_files("foo"))
+        assert result[0].hashes == (("sha256", "a" * 64),)
+
     def test_pep503_hash_fragment_on_https_href(self, tmp_path: Path) -> None:
         digest = "b" * 64
         body = (

--- a/nab-python/tests/test_simple_client_hashes.py
+++ b/nab-python/tests/test_simple_client_hashes.py
@@ -23,3 +23,15 @@ def test_multi_hash_digests_lowercased() -> None:
     data = {"files": [_file({"sha256": "A" * 64, "sha512": "B" * 128})]}
     files = _parse_files(data, "https://example.com/", "foo")
     assert dict(files[0].hashes) == {"sha256": "a" * 64, "sha512": "b" * 128}
+
+
+def test_single_hash_algorithm_lowercased() -> None:
+    data = {"files": [_file({"SHA256": "a" * 64})]}
+    files = _parse_files(data, "https://example.com/", "foo")
+    assert files[0].hashes == (("sha256", "a" * 64),)
+
+
+def test_multi_hash_algorithms_lowercased() -> None:
+    data = {"files": [_file({"SHA256": "a" * 64, "Sha512": "b" * 128})]}
+    files = _parse_files(data, "https://example.com/", "foo")
+    assert dict(files[0].hashes) == {"sha256": "a" * 64, "sha512": "b" * 128}


### PR DESCRIPTION
Index entries that spell the algorithm with mixed case, like `SHA256=...` or a `{"SHA256": ...}` key, kept that casing. The acceptable-algorithm filter and `hashlib.hexdigest()` both expect lowercase, so those entries were dropped or never matched.

Lowercase the algorithm name alongside the digest in the JSON client and the PEP 503 HTML fragment parser. Adds tests for the uppercase single- and multi-hash JSON cases and the uppercased fragment.