### PR TITLE
Skip malformed Simple-API file entries on parse

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -282,12 +282,17 @@ def _parse_files(
         # PEP 592: ``true`` or a non-empty reason string means yanked.
         if file_info.get("yanked"):
             continue
-        filename = file_info["filename"]
+        filename = file_info.get("filename")
+        raw_url = file_info.get("url")
+        # PEP 691 requires both keys. Drop a malformed entry that lacks
+        # either and keep the rest of the listing, rather than letting one
+        # bad file abort the whole resolve.
+        if not isinstance(filename, str) or not isinstance(raw_url, str):
+            continue
 
         # PyPI and most indexes emit absolute file URLs; urljoin then re-parses
         # both sides only to return the URL unchanged. Skip it for the common
         # absolute case; relative URLs still resolve against the page below.
-        raw_url = file_info["url"]
         if raw_url.startswith(("https://", "http://")):
             file_url = raw_url
         else:

--- a/nab-python/tests/test_simple_client_malformed.py
+++ b/nab-python/tests/test_simple_client_malformed.py
@@ -1,0 +1,23 @@
+"""Tests that a malformed file entry is skipped, not fatal, in the JSON parser."""
+
+from __future__ import annotations
+
+from nab_index.client import _parse_files
+
+_VALID = {
+    "filename": "foo-1.0-py3-none-any.whl",
+    "url": "https://example.com/foo/foo-1.0-py3-none-any.whl",
+    "hashes": {"sha256": "a" * 64},
+}
+
+
+def test_entry_missing_filename_skipped_keeps_valid() -> None:
+    data = {"files": [{"url": "https://example.com/foo/x.whl"}, _VALID]}
+    files = _parse_files(data, "https://example.com/", "foo")
+    assert [f.filename for f in files] == ["foo-1.0-py3-none-any.whl"]
+
+
+def test_entry_missing_url_skipped_keeps_valid() -> None:
+    data = {"files": [{"filename": "foo-2.0-py3-none-any.whl"}, _VALID]}
+    files = _parse_files(data, "https://example.com/", "foo")
+    assert [f.filename for f in files] == ["foo-1.0-py3-none-any.whl"]


### PR DESCRIPTION
A Simple-API JSON listing with a file entry missing its required `filename` or `url` key raised a KeyError and aborted the whole resolve.

The parser now reads both keys with `.get()` and skips any entry where either is not a string, keeping the rest of the listing.

Adds tests for the missing-filename and missing-url cases.