### PR TITLE
Reject duplicate matrix axis entries

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -756,6 +756,15 @@ def _parse_string_list(key: str, value: object) -> tuple[str, ...]:
     return tuple(out)
 
 
+def _reject_duplicates(key: str, items: tuple[str, ...]) -> None:
+    seen: set[str] = set()
+    for item in items:
+        if item in seen:
+            msg = f"{key} has duplicate entry: {item!r}"
+            raise ConfigError(msg)
+        seen.add(item)
+
+
 def _parse_optional_string(key: str, value: object) -> str | None:
     if value is None:
         return None
@@ -1955,6 +1964,7 @@ def _parse_matrix(value: object) -> MatrixConfig | None:
     if not platforms:
         msg = "matrix.platforms must list at least one platform id"
         raise ConfigError(msg)
+    _reject_duplicates("matrix.platforms", platforms)
     python_order = value.get("python-order", "asc")
     if python_order not in {"asc", "desc"}:
         msg = f"matrix.python-order must be 'asc' or 'desc', got {python_order!r}"
@@ -2000,6 +2010,7 @@ def _parse_implementations(value: object) -> tuple[str, ...]:
     if not impls:
         msg = "matrix.implementations must list at least one implementation"
         raise ConfigError(msg)
+    _reject_duplicates("matrix.implementations", impls)
     unknown = sorted(set(impls) - set(_KNOWN_IMPLEMENTATIONS))
     if unknown:
         msg = (

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -2044,6 +2044,14 @@ class TestMatrix:
         with pytest.raises(ConfigError, match="unknown matrix.implementations"):
             read_pyproject_config(write(tmp_path, body))
 
+    def test_duplicate_implementations_rejected(self, tmp_path: Path) -> None:
+        # A duplicate makes len(implementations) > 1, which flips
+        # multi_implementation on and emits a spurious implementation_name
+        # marker a sole-cpython matrix omits.
+        body = self._matrix_body(implementations='["cpython", "cpython"]')
+        with pytest.raises(ConfigError, match="duplicate entry"):
+            read_pyproject_config(write(tmp_path, body))
+
     def test_must_be_table(self, tmp_path: Path) -> None:
         path = write(
             tmp_path,
@@ -2152,6 +2160,14 @@ class TestMatrix:
         body = self._matrix_body()
         body = body.replace('["linux_x86_64", "macos_arm64"]', '["frobnicate"]')
         with pytest.raises(ConfigError, match="Unknown platform ids"):
+            read_pyproject_config(write(tmp_path, body))
+
+    def test_duplicate_platforms_rejected(self, tmp_path: Path) -> None:
+        body = self._matrix_body()
+        body = body.replace(
+            '["linux_x86_64", "macos_arm64"]', '["linux_x86_64", "linux_x86_64"]'
+        )
+        with pytest.raises(ConfigError, match="duplicate entry"):
             read_pyproject_config(write(tmp_path, body))
 
     def test_empty_python_range_rejected(self, tmp_path: Path) -> None:


### PR DESCRIPTION
A matrix config that listed the same axis entry twice was accepted. A duplicated implementation made the list length exceed one, which flipped multi_implementation on and added a spurious implementation_name marker; a duplicated platform was likewise silently kept.

Add a _reject_duplicates helper used for matrix.platforms and matrix.implementations so duplicate entries now raise ConfigError. Tests cover both axes.