### PR TITLE
Reject unknown index-overrides config keys

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -935,6 +935,9 @@ def _parse_indexes(value: object) -> tuple[IndexConfig, ...]:
     return tuple(out)
 
 
+_INDEX_OVERRIDE_KEYS = frozenset({"name", "index", "marker"})
+
+
 def _parse_index_overrides(value: object) -> tuple[IndexOverride, ...]:
     if not isinstance(value, list):
         msg = f"index-overrides must be an array of tables, got {type(value).__name__}"
@@ -943,6 +946,13 @@ def _parse_index_overrides(value: object) -> tuple[IndexOverride, ...]:
     for i, entry in enumerate(value):
         if not isinstance(entry, dict):
             msg = f"index-overrides[{i}] must be a table, got {type(entry).__name__}"
+            raise ConfigError(msg)
+        unknown = sorted(set(entry) - _INDEX_OVERRIDE_KEYS)
+        if unknown:
+            msg = (
+                f"unknown index-overrides[{i}] keys: {unknown!r};"
+                f" expected {sorted(_INDEX_OVERRIDE_KEYS)!r}"
+            )
             raise ConfigError(msg)
         try:
             name = entry["name"]

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -1139,6 +1139,17 @@ class TestIndexOverrides:
         with pytest.raises(ConfigError, match="marker must be a string"):
             read_pyproject_config(path)
 
+    def test_unknown_key_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[[tool.nab.index-overrides]]\n"
+            'name = "torch"\n'
+            'index = "x"\n'
+            "markers = \"platform_machine == 'aarch64'\"\n",
+        )
+        with pytest.raises(ConfigError, match="unknown index-overrides\\[0\\] keys"):
+            read_pyproject_config(path)
+
     def test_marker_gated_rejected_in_universal_mode(self, tmp_path: Path) -> None:
         path = write(
             tmp_path,


### PR DESCRIPTION
`_parse_index_overrides` dropped any unrecognized key in a `[[tool.nab.index-overrides]]` table, so a typo such as `markers` instead of `marker` was silently ignored and the override never took effect. Each entry's keys are now checked against `{name, index, marker}` and a ConfigError lists the unknown keys, matching the local-sources validation.

Adds a test for a misspelled key raising ConfigError.