### PR TITLE
Stop index override marker crash on lockfile-only sets

### DIFF
--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -24,6 +24,7 @@ from nab_index.client import SdistFile, WheelFile
 from nab_index.local_index import LocalIndexClient
 from nab_index.multi_index import IndexConfig, MultiIndexClient
 
+from ._conflict_kind import dependency_marker_holds
 from ._vendor.packaging.markers import Marker
 from ._vendor.packaging.utils import canonicalize_name
 
@@ -106,7 +107,7 @@ def _resolve_overrides(
             continue
         if marker_environment is None:
             continue
-        if Marker(entry.marker).evaluate(marker_environment):
+        if dependency_marker_holds(Marker(entry.marker), marker_environment):
             out[canonical] = entry.index
     return out
 

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -1098,6 +1098,30 @@ class TestResolveOverrides:
         )
         assert result == {}
 
+    def test_membership_set_marker_drops_without_crash(self) -> None:
+        result = _resolve_overrides(
+            [IndexOverride("torch", "alt", marker='"gpu" in extras')],
+            {"platform_system": "Linux"},
+        )
+        assert result == {}
+
+    def test_dependency_groups_marker_drops_without_crash(self) -> None:
+        result = _resolve_overrides(
+            [IndexOverride("torch", "alt", marker='"dev" in dependency_groups')],
+            {"platform_system": "Linux"},
+        )
+        assert result == {}
+
+    def test_membership_set_marker_does_not_block_other_override(self) -> None:
+        result = _resolve_overrides(
+            [
+                IndexOverride("torch", "alt", marker='"gpu" in extras'),
+                IndexOverride("numpy", "numpy-nightly"),
+            ],
+            {"platform_system": "Linux"},
+        )
+        assert result == {"numpy": "numpy-nightly"}
+
 
 class TestMultiIndexCoordinator:
     """Tests for FetchCoordinator with multiple indexes + overrides."""


### PR DESCRIPTION
An index override whose marker tested a lockfile-only membership set (extras or dependency_groups) raised a KeyError in _resolve_overrides at resolve time, since those variables are empty until a lockfile is consumed.

Route the override marker through dependency_marker_holds, which seeds those sets empty so the marker evaluates to False and the override is dropped rather than crashing.

Adds tests covering the extras and dependency_groups cases, including one confirming an unrelated override still applies.