### PR TITLE
Reject non-array pyproject dependency values

### DIFF
--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -48,6 +48,19 @@ def _parse_requirements(strings: Sequence[str], source: str) -> list[Requirement
         raise InvalidProjectRequirementError(msg) from exc
 
 
+def _require_string_list(value: object, source: str) -> list[str]:
+    """Validate that a PEP 621 dependency value is an array of strings.
+
+    A bare string passes the type checker as ``Sequence[str]`` but
+    iterates character by character, so ``dependencies = "requests"``
+    would parse as eight single-character requirements rather than fail.
+    """
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        msg = f"{source} must be an array of strings"
+        raise InvalidProjectRequirementError(msg)
+    return value
+
+
 def read_pyproject_dependencies(path: Path) -> list[Requirement]:
     """Read [project].dependencies from a pyproject.toml file.
 
@@ -59,8 +72,9 @@ def read_pyproject_dependencies(path: Path) -> list[Requirement]:
     with path.open("rb") as f:
         data = tomli.load(f)
 
-    dep_strings: list[str] = data["project"]["dependencies"]
-    return _parse_requirements(dep_strings, "[project].dependencies")
+    source = "[project].dependencies"
+    dep_strings = _require_string_list(data["project"]["dependencies"], source)
+    return _parse_requirements(dep_strings, source)
 
 
 def read_pyproject_name(path: Path) -> str | None:
@@ -102,7 +116,10 @@ def _canonicalize_optional_deps(
     """Map each extra name to its requirements under PEP 685 normalization."""
     canonical: dict[str, list[str]] = {}
     for name, reqs in optional_deps.items():
-        canonical.setdefault(canonicalize_name(name), []).extend(reqs)
+        source = f"[project.optional-dependencies] extra {name!r}"
+        canonical.setdefault(canonicalize_name(name), []).extend(
+            _require_string_list(reqs, source)
+        )
     return canonical
 
 

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -70,6 +70,24 @@ class TestReadPyprojectDependencies:
         ):
             read_pyproject_dependencies(p)
 
+    def test_string_dependencies_value_raises(self, tmp_path: object) -> None:
+        """A bare string is rejected, not iterated character by character."""
+        p = Path(str(tmp_path)) / "pyproject.toml"
+        p.write_text('[project]\ndependencies = "requests"\n')
+        with pytest.raises(
+            InvalidProjectRequirementError, match=r"\[project\].dependencies"
+        ):
+            read_pyproject_dependencies(p)
+
+    def test_non_string_dependency_element_raises(self, tmp_path: object) -> None:
+        """A non-string array element raises rather than crashing on parse."""
+        p = Path(str(tmp_path)) / "pyproject.toml"
+        p.write_text("[project]\ndependencies = [123]\n")
+        with pytest.raises(
+            InvalidProjectRequirementError, match=r"\[project\].dependencies"
+        ):
+            read_pyproject_dependencies(p)
+
 
 class TestReadPyprojectGroups:
     def test_reads_groups_table(self, tmp_path: object) -> None:
@@ -175,6 +193,11 @@ class TestSelectOptionalDependencies:
     def test_malformed_requirement_string_raises(self) -> None:
         with pytest.raises(InvalidProjectRequirementError, match="gpu"):
             select_optional_dependencies({"gpu": ["torch >= bad junk"]}, ("gpu",))
+
+    def test_string_extra_value_raises(self) -> None:
+        """An extra whose value is a bare string is rejected, not char-iterated."""
+        with pytest.raises(InvalidProjectRequirementError, match="gpu"):
+            select_optional_dependencies({"gpu": "torch"}, ("gpu",))
 
     def test_selected_extra_name_canonicalized(self) -> None:
         """PEP 685: a request differing only by case/separator still matches."""


### PR DESCRIPTION
A bare string in `[project].dependencies` or an optional-dependencies extra value satisfies the `Sequence[str]` annotation but iterates character by character, so `dependencies = "requests"` parsed as eight single-character requirements instead of failing.

A new `_require_string_list` helper raises `InvalidProjectRequirementError` unless the value is a list of strings, applied in both `read_pyproject_dependencies` and `_canonicalize_optional_deps`.

Tests cover a bare-string dependencies value, a non-string array element, and a bare-string extra value.