### PR TITLE
Break wheel selection ties by PEP 427 build tag

### DIFF
--- a/nab-python/src/nab_python/universal/wheel_selection.py
+++ b/nab-python/src/nab_python/universal/wheel_selection.py
@@ -13,6 +13,7 @@ tags share a member with the tuple's compatible-tag set.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from functools import cache, lru_cache
 from typing import TYPE_CHECKING
@@ -38,6 +39,11 @@ __all__ = [
 
 
 _MIN_WHEEL_FILENAME_PARTS = 5
+
+# PEP 427: a build tag adds a sixth dash-separated segment at index 2,
+# and build tags start with a digit (captured here for ordering).
+_WHEEL_PARTS_WITH_BUILD = 6
+_BUILD_TAG_RE = re.compile(r"(\d+)(.*)", re.ASCII)
 
 # Default manylinux floor: glibc 2.17 (the manylinux2014 generation,
 # adopted by every mainstream distro since CentOS 7 / Ubuntu 14.04).
@@ -333,12 +339,13 @@ def select_wheel_for_tuple(
     Implements PEP 425 preference: wheels matching earlier
     (more-specific) tags in ``compatible_tags_for_tuple`` win over
     those matching later (more-generic) tags.  Within the same tag
-    rank, the first wheel in input order wins.
+    rank, the wheel with the highest PEP 427 build tag wins (an absent
+    tag sorts lowest); exact ties keep input order.
     """
     compat_list = list(_tags_in_order(python_version, spec, implementation))
     rank: dict[Tag, int] = {tag: i for i, tag in enumerate(compat_list)}
 
-    best: tuple[int, WheelFile] | None = None
+    best: tuple[int, tuple[int, str], WheelFile] | None = None
     for wheel in wheels:
         wheel_tags = wheel_tag_set(wheel.filename)
         if not wheel_tags:
@@ -347,9 +354,29 @@ def select_wheel_for_tuple(
         wheel_rank = min((rank[t] for t in wheel_tags if t in rank), default=None)
         if wheel_rank is None:
             continue
-        if best is None or wheel_rank < best[0]:
-            best = (wheel_rank, wheel)
-    return best[1] if best is not None else None
+        build_key = _build_tag_sort_key(wheel.filename)
+        if (
+            best is None
+            or wheel_rank < best[0]
+            or (wheel_rank == best[0] and build_key > best[1])
+        ):
+            best = (wheel_rank, build_key, wheel)
+    return best[2] if best is not None else None
+
+
+def _build_tag_sort_key(filename: str) -> tuple[int, str]:
+    """Return a PEP 427 build-tag sort key; an absent tag sorts lowest.
+
+    The build tag is the third dash-separated segment when present.
+    A missing or malformed tag sorts below every real build number.
+    """
+    parts = filename[:-4].split("-")
+    if len(parts) != _WHEEL_PARTS_WITH_BUILD:
+        return (-1, "")
+    match = _BUILD_TAG_RE.match(parts[2])
+    if match is None:
+        return (-1, "")
+    return (int(match.group(1)), match.group(2))
 
 
 def _tags_in_order(

--- a/nab-python/tests/universal/test_wheel_selection.py
+++ b/nab-python/tests/universal/test_wheel_selection.py
@@ -389,6 +389,50 @@ class TestSelectWheelForTuple:
         assert chosen is not None
         assert "manylinux_2_17" in chosen.filename
 
+    def test_higher_build_tag_wins_at_same_rank(self) -> None:
+        """Among same-tag wheels, the higher PEP 427 build tag wins."""
+        spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
+        build1 = _wheel("pkg-1.0-1-cp311-cp311-manylinux_2_17_x86_64.whl")
+        build5 = _wheel("pkg-1.0-5-cp311-cp311-manylinux_2_17_x86_64.whl")
+        chosen = select_wheel_for_tuple(
+            [build1, build5], python_version="3.11", spec=spec
+        )
+        assert chosen is build5
+
+    def test_build_tag_selection_is_order_independent(self) -> None:
+        """The same wheel is chosen regardless of index file order."""
+        spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
+        build1 = _wheel("pkg-1.0-1-cp311-cp311-manylinux_2_17_x86_64.whl")
+        build5 = _wheel("pkg-1.0-5-cp311-cp311-manylinux_2_17_x86_64.whl")
+        forward = select_wheel_for_tuple(
+            [build1, build5], python_version="3.11", spec=spec
+        )
+        reverse = select_wheel_for_tuple(
+            [build5, build1], python_version="3.11", spec=spec
+        )
+        assert forward is build5
+        assert reverse is build5
+
+    def test_build_tagged_wheel_beats_untagged_at_same_rank(self) -> None:
+        """An absent build tag sorts lowest, so a tagged wheel wins."""
+        spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
+        untagged = _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl")
+        build3 = _wheel("pkg-1.0-3-cp311-cp311-manylinux_2_17_x86_64.whl")
+        chosen = select_wheel_for_tuple(
+            [untagged, build3], python_version="3.11", spec=spec
+        )
+        assert chosen is build3
+
+    def test_malformed_build_tag_treated_as_absent(self) -> None:
+        """A build segment without a leading digit sorts lowest."""
+        spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
+        malformed = _wheel("pkg-1.0-x-cp311-cp311-manylinux_2_17_x86_64.whl")
+        build5 = _wheel("pkg-1.0-5-cp311-cp311-manylinux_2_17_x86_64.whl")
+        chosen = select_wheel_for_tuple(
+            [malformed, build5], python_version="3.11", spec=spec
+        )
+        assert chosen is build5
+
 
 class TestUnknownPlatformKindGuard:
     """Explicit guard for the unreachable platform-kind branch."""


### PR DESCRIPTION
When two wheels matched the same PEP 425 tag rank, `select_wheel_for_tuple` kept whichever came first in input order, so the choice depended on index ordering and ignored PEP 427 build tags.

Add a build-tag sort key so the highest build number wins at a given rank; an absent or malformed tag sorts lowest and exact ties keep input order. Tests cover the higher-build win, order independence, tagged-beats-untagged, and the malformed-tag case.