### PR TITLE
Reject built sdist with mismatched name or version

### DIFF
--- a/nab-python/src/nab_python/_provider/build_remote.py
+++ b/nab-python/src/nab_python/_provider/build_remote.py
@@ -43,7 +43,9 @@ def build_remote_sdist(
     entry in ``provider.versions_cache``.  A built sdist whose
     ``Requires-Python`` excludes the resolve target is rejected, since the
     Simple-API listing filter only sees the listing's own (possibly absent)
-    Requires-Python, not the value the build produces.
+    Requires-Python, not the value the build produces.  A built sdist whose
+    declared name or version disagrees with the requested candidate is also
+    rejected rather than used for the wrong package.
     """
     # Late imports: ``provider`` imports this module at module load.
     from .. import build_backend
@@ -93,6 +95,13 @@ def build_remote_sdist(
         msg = (
             f"{package}=={version} built sdist requires Python {spec} but the"
             f" resolve targets Python {target}"
+        )
+        raise UnsupportedSdistError(msg)
+    if canonicalize_name(built.name) != canonical or built.version != version:
+        msg = (
+            f"{package}=={version} built sdist declares"
+            f" {built.name}=={built.version}, which does not match the"
+            " requested candidate"
         )
         raise UnsupportedSdistError(msg)
     return built

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -5639,6 +5639,38 @@ class TestBuildRemoteFailureModes:
         result = build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
         assert result is built
 
+    def test_built_name_mismatch_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from nab_python._provider import build_remote
+        from nab_python.metadata import WheelMetadata as _WheelMetadata
+
+        wrong = _WheelMetadata(
+            name="other-pkg",
+            version=V("1.0"),
+            requires_python=None,
+            requires_dist=[Requirement("dep-a>=1")],
+            provides_extra=[],
+        )
+        provider = self._build_into(monkeypatch, wrong)
+        with pytest.raises(UnsupportedSdistError, match="does not match"):
+            build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
+
+    def test_built_version_mismatch_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nab_python._provider import build_remote
+        from nab_python.metadata import WheelMetadata as _WheelMetadata
+
+        wrong = _WheelMetadata(
+            name="pkg",
+            version=V("2.0"),
+            requires_python=None,
+            requires_dist=[Requirement("dep-a>=1")],
+            provides_extra=[],
+        )
+        provider = self._build_into(monkeypatch, wrong)
+        with pytest.raises(UnsupportedSdistError, match="does not match"):
+            build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
+
 
 class TestPublicAccessors:
     """Public read accessors used by lockfile / download tooling."""


### PR DESCRIPTION
build_remote_sdist trusted whatever metadata the built sdist declared, so an archive that built into a different package (wrong name or version) could be used for the requested candidate. The build now compares the built sdist's canonicalized name and version against the requested candidate and raises UnsupportedSdistError on a mismatch.

Tests cover both the name and version mismatch cases.