### PR TITLE
Reject built sdist requiring an excluded Python version

### DIFF
--- a/nab-python/src/nab_python/_provider/build_remote.py
+++ b/nab-python/src/nab_python/_provider/build_remote.py
@@ -23,11 +23,11 @@ from typing import TYPE_CHECKING
 from nab_index.client import SdistFile, WheelFile, extract_sdist_archive
 
 from .._vendor.packaging.utils import canonicalize_name
+from .._vendor.packaging.version import Version
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from .._vendor.packaging.version import Version
     from ..metadata import WheelMetadata
     from ..provider import Provider
 
@@ -40,7 +40,10 @@ def build_remote_sdist(
     """Download the sdist for ``(package, version)``, extract, and build.
 
     ``package`` is the canonical package name; ``version`` matches an
-    entry in ``provider.versions_cache``.
+    entry in ``provider.versions_cache``.  A built sdist whose
+    ``Requires-Python`` excludes the resolve target is rejected, since the
+    Simple-API listing filter only sees the listing's own (possibly absent)
+    Requires-Python, not the value the build produces.
     """
     # Late imports: ``provider`` imports this module at module load.
     from .. import build_backend
@@ -75,7 +78,7 @@ def build_remote_sdist(
             msg = f"{package}=={version} sdist archive could not be extracted: {exc}"
             raise UnsupportedSdistError(msg) from exc
         try:
-            return build_backend.extract_metadata(
+            built = build_backend.extract_metadata(
                 source_dir,
                 config=provider.build_config,
                 python_version=provider.python_version,
@@ -83,6 +86,16 @@ def build_remote_sdist(
         except BuildBackendError as exc:
             msg = f"{package}=={version} build-remote backend failed: {exc}"
             raise UnsupportedSdistError(msg) from exc
+
+    target = provider.python_version
+    spec = built.requires_python
+    if spec is not None and target and Version(target) not in spec:
+        msg = (
+            f"{package}=={version} built sdist requires Python {spec} but the"
+            f" resolve targets Python {target}"
+        )
+        raise UnsupportedSdistError(msg)
+    return built
 
 
 def _find_sdist(

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -5467,6 +5467,79 @@ class TestBuildRemoteFailureModes:
         with pytest.raises(UnsupportedSdistError, match="no sdist is available"):
             build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
 
+    def _build_into(self, monkeypatch: pytest.MonkeyPatch, built: object) -> Provider:
+        from nab_python._provider import build_remote
+
+        provider = self._provider(with_sdist=True)
+        provider.versions_cache["pkg"] = [(V("1.0"), make_sdist("1.0"))]
+
+        def _ok_fetch(pkg: str, ver: str, _url: str) -> threading.Event:
+            provider.coordinator.index.store_sdist_archive(pkg, ver, b"data")
+            return _done_event()
+
+        cast(
+            "MagicMock", provider.coordinator
+        ).request_sdist_archive.side_effect = _ok_fetch
+        monkeypatch.setattr(
+            build_remote, "extract_sdist_archive", lambda _d, target: target
+        )
+        monkeypatch.setattr(
+            "nab_python.build_backend.extract_metadata", lambda *_a, **_k: built
+        )
+        return provider
+
+    def test_built_requires_python_excludes_target_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nab_python._provider import build_remote
+        from nab_python.metadata import WheelMetadata as _WheelMetadata
+
+        built = _WheelMetadata(
+            name="pkg",
+            version=V("1.0"),
+            requires_python=SpecifierSet(">=3.13"),
+            requires_dist=[Requirement("dep-a>=1")],
+            provides_extra=[],
+        )
+        provider = self._build_into(monkeypatch, built)
+        with pytest.raises(UnsupportedSdistError, match="requires Python"):
+            build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
+
+    def test_built_requires_python_compatible_accepted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nab_python._provider import build_remote
+        from nab_python.metadata import WheelMetadata as _WheelMetadata
+
+        built = _WheelMetadata(
+            name="pkg",
+            version=V("1.0"),
+            requires_python=SpecifierSet(">=3.10"),
+            requires_dist=[Requirement("dep-a>=1")],
+            provides_extra=[],
+        )
+        provider = self._build_into(monkeypatch, built)
+        result = build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
+        assert result is built
+
+    def test_built_requires_python_no_target_skips_check(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nab_python._provider import build_remote
+        from nab_python.metadata import WheelMetadata as _WheelMetadata
+
+        built = _WheelMetadata(
+            name="pkg",
+            version=V("1.0"),
+            requires_python=SpecifierSet(">=3.13"),
+            requires_dist=[Requirement("dep-a>=1")],
+            provides_extra=[],
+        )
+        provider = self._build_into(monkeypatch, built)
+        provider.python_version = None
+        result = build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
+        assert result is built
+
 
 class TestPublicAccessors:
     """Public read accessors used by lockfile / download tooling."""


### PR DESCRIPTION
The BUILD_REMOTE path trusted whatever a built sdist produced even when its Requires-Python excluded the resolve target. The Simple-API listing filter only sees the listing's own (possibly absent) Requires-Python, not the value the build emits, so an sdist that declares an incompatible Requires-Python in its built metadata slipped through.

The fix re-checks the built wheel metadata's requires_python against provider.python_version after the build and raises UnsupportedSdistError when the target Python is excluded. Added tests cover the excluded, compatible, and no-target cases.