### PR TITLE
Drop non-string requires-python at index parse

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -300,10 +300,12 @@ def _parse_files(
         # wheel.  Interning collapses the duplicates into one shared
         # string per distinct specifier.
         requires_python_raw = file_info.get("requires-python")
+        # PEP 691 mandates a string; a non-conformant index serving a number
+        # would otherwise crash SpecifierSet downstream. Treat it as absent.
         requires_python = (
             sys.intern(requires_python_raw)
             if isinstance(requires_python_raw, str)
-            else requires_python_raw
+            else None
         )
         # A non-conformant index may serve a non-string ``upload-time``
         # (a JSON number or bool); drop it so the downstream datetime

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -15,6 +15,7 @@ from nab_index.client import (
     SdistFile,
     SdistHashMismatchError,
     WheelFile,
+    _parse_files,
 )
 from nab_python._provider import build_remote, metadata_resolver
 from nab_python._provider.metadata_resolver import (
@@ -309,6 +310,28 @@ class TestFetchVersions:
         coordinator = make_coordinator(
             [make_wheel("1.0", requires_python=">>>invalid")], package="foo"
         )
+        provider = Provider(coordinator, python_version="3.12.0")
+        assert len(provider.fetch_versions("foo")) == 1
+
+    def test_non_string_requires_python_admitted_without_crash(self) -> None:
+        """A numeric requires-python from a non-conformant index is dropped.
+
+        PEP 691 mandates a string; a JSON number would reach SpecifierSet and
+        raise an uncaught TypeError that aborts the resolve. The parser coerces
+        it to None, so the wheel is admitted with no Python constraint.
+        """
+        data = {
+            "files": [
+                {
+                    "filename": "foo-1.0-py3-none-any.whl",
+                    "url": "https://example.com/foo/foo-1.0-py3-none-any.whl",
+                    "requires-python": 3.7,
+                }
+            ]
+        }
+        files = _parse_files(data, "https://example.com/", "foo")
+        assert files[0].requires_python is None
+        coordinator = make_coordinator(files, package="foo")
         provider = Provider(coordinator, python_version="3.12.0")
         assert len(provider.fetch_versions("foo")) == 1
 


### PR DESCRIPTION
A non-conformant index can serve a numeric requires-python instead of the string PEP 691 mandates. That value was carried through untouched and later raised an uncaught TypeError from SpecifierSet, aborting the resolve.

The index parser now coerces any non-string requires-python to None, so the file is admitted with no Python constraint. Adds a test feeding a numeric requires-python through the parser and confirming the wheel is still admitted.