### PR TITLE
Skip sdist whose build needs a direct-URL dependency

### DIFF
--- a/nab-python/src/nab_python/_build/env.py
+++ b/nab-python/src/nab_python/_build/env.py
@@ -37,6 +37,7 @@ from installer.destinations import SchemeDictionaryDestination
 from installer.sources import WheelFile
 from nab_index.urllib3_async_transport import Urllib3AsyncTransport
 
+from .._vcs_admission import UnsupportedVcsError
 from ..config import NabProjectConfig
 from ..download import download_lock
 
@@ -277,12 +278,19 @@ class NabBuildEnv:
         # this again for ``get_requires_for_build_wheel`` follow-ups;
         # build a fresh transport each time.
         transport = self._transport_factory()
-        result = resolve_pyproject(
-            synthetic,
-            transport,
-            config=inner_config,
-            python_version=self._python_version,
-        )
+        try:
+            result = resolve_pyproject(
+                synthetic,
+                transport,
+                config=inner_config,
+                python_version=self._python_version,
+            )
+        except (UnsupportedVcsError, NotImplementedError) as exc:
+            # A direct-URL/VCS build requirement means nab cannot build this
+            # sdist. Report it as a build-env failure so the outer resolve
+            # skips the version instead of aborting on the raw error.
+            msg = f"build env resolve failed: {exc}"
+            raise BuildEnvError(msg) from exc
 
         # Reject sdist-only pins early: build deps that ship only an
         # sdist trigger a recursive backend invocation that this

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -756,6 +756,24 @@ class TestResolveAndDownload:
             with pytest.raises(BuildEnvError, match="sdist-only"):
                 env._resolve_and_download(wheel_dir)
 
+    def test_url_build_requirement_wrapped(self, tmp_path: Path) -> None:
+        """A direct-URL build requirement the inner resolve refuses is
+        wrapped as BuildEnvError, so the outer resolve skips the
+        unbuildable sdist instead of aborting on the raw
+        UnsupportedVcsError.
+        """
+        env = NabBuildEnv(
+            requires=["plugin @ https://example.com/plugin-1.0.tar.gz"],
+            config=NabProjectConfig(),
+        )
+        env._tmpdir = MagicMock()  # type: ignore[attr-defined]
+        env._venv_path = tmp_path / "venv"  # type: ignore[attr-defined]
+        env._python_executable = tmp_path / "venv" / "bin" / "python"  # type: ignore[attr-defined]
+        wheel_dir = tmp_path / "wheels"
+        wheel_dir.mkdir()
+        with pytest.raises(BuildEnvError, match="build env resolve"):
+            env._resolve_and_download(wheel_dir)
+
 
 class TestNabBuildEnvLifecycle:
     """Edge cases of the context-manager lifecycle that fall outside


### PR DESCRIPTION
When an sdist's build requirements include a direct-URL or VCS dependency, the inner build-env resolve raised UnsupportedVcsError (or NotImplementedError), which propagated up and aborted the whole resolution.

NabBuildEnv._resolve_and_download now catches those and re-raises them as BuildEnvError, so the outer resolve treats the version as unbuildable and skips it.

Adds a test covering a build requirement pinned to a direct URL.