### PR TITLE
Drop malformed Requires-Python before lock emit

### DIFF
--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -21,6 +21,7 @@ from nab_index.client import SdistFile, WheelFile
 
 from .._toml import tool_nab_section
 from .._vendor.packaging.pylock import Pylock, PylockValidationError
+from .._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from .._vendor.packaging.utils import canonicalize_name
 
 if TYPE_CHECKING:
@@ -524,10 +525,20 @@ def _common_requires_python(files: Iterable[WheelFile | SdistFile]) -> str | Non
     An artefact with no Requires-Python is unconstrained, so a single
     such artefact leaves the whole package unconstrained. Otherwise the
     value survives only when every artefact agrees.
+
+    A malformed value counts as unconstrained too, matching
+    ``excluded_by_python``, which admits a dist whose Requires-Python is
+    an unparseable specifier on any Python. So the lock writer always
+    parses a valid specifier or ``None``, and the pin is never
+    over-constrained by an artefact whose floor nab could not read.
     """
     seen: set[str] = set()
     for f in files:
         if f.requires_python is None:
+            return None
+        try:
+            SpecifierSet(f.requires_python)
+        except InvalidSpecifier:
             return None
         seen.add(f.requires_python)
     if len(seen) == 1:

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -16,6 +16,7 @@ else:
 
 from nab_index.client import SdistFile, WheelFile
 from nab_index.multi_index import IndexConfig
+from nab_python._lockfile.builder import _common_requires_python
 from nab_python._lockfile.disjointness import (
     _restrict_to_referenced,
     validate_marker_disjointness,
@@ -2255,6 +2256,37 @@ class TestBuildLockInputFromProvider:
         assert isinstance(pin, IndexPin)
         assert pin.requires_python == ""
         assert "requires-python" not in write_lock(lock_input)
+
+    def test_malformed_requires_python_dropped_and_emittable(self) -> None:
+        """A malformed listing Requires-Python is dropped, so the lock still emits.
+
+        ``excluded_by_python`` admits a dist whose Requires-Python is an invalid
+        PEP 440 specifier, so the pin must not carry it into ``write_lock``,
+        whose ``SpecifierSet`` parse would otherwise crash.
+        """
+        provider = _FakeProvider(
+            listings={"foo": [(Version("1.0"), _wheel_file(requires_python=">=3.6.*"))]}
+        )
+        lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0")})
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.requires_python is None
+        text = write_lock(lock_input)
+        assert ">=3.6.*" not in text
+
+    def test_common_requires_python_malformed_with_valid_stays_unconstrained(
+        self,
+    ) -> None:
+        """A malformed value leaves the pin unconstrained beside a valid one.
+
+        ``excluded_by_python`` admits the malformed artefact on any Python, so
+        emitting the sibling's floor would over-constrain the pin below it.
+        """
+        files = [
+            _wheel_file(requires_python=">=3.6.*"),
+            _wheel_file(requires_python=">=3.7"),
+        ]
+        assert _common_requires_python(files) is None
 
     def test_skip_fetch_override_pins_sdist_without_metadata(self) -> None:
         """A skip-fetch package still produces a complete sdist lock pin.


### PR DESCRIPTION
A dist can list a Requires-Python that is not a valid PEP 440 specifier. `excluded_by_python` already admits such a dist by treating the bad value as no constraint, but `_common_requires_python` carried the raw string into the lock pin, where `write_lock`'s `SpecifierSet` parse then crashed.

`_common_requires_python` now validates each value with `SpecifierSet` and skips the unparseable ones, so the pin holds a valid specifier or `None`. Added a test that locks a dist with a malformed Requires-Python and checks the lock emits without the bad value.