### PR TITLE
Drop non-string upload-time at index parse

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -293,6 +293,11 @@ def _parse_files(
             if isinstance(requires_python_raw, str)
             else requires_python_raw
         )
+        # A non-conformant index may serve a non-string ``upload-time``
+        # (a JSON number or bool); drop it so the downstream datetime
+        # parse never crashes.
+        upload_time_raw = file_info.get("upload-time")
+        upload_time = upload_time_raw if isinstance(upload_time_raw, str) else None
 
         wheel_parsed = _parse_wheel_filename(filename)
         if wheel_parsed is not None:
@@ -306,7 +311,7 @@ def _parse_files(
                     version=version,
                     requires_python=requires_python,
                     has_metadata=_has_metadata(file_info),
-                    upload_time=file_info.get("upload-time"),
+                    upload_time=upload_time,
                     hashes=hashes,
                     size=size,
                     metadata_hash=_metadata_hash(file_info),
@@ -325,7 +330,7 @@ def _parse_files(
                     url=file_url,
                     version=version,
                     requires_python=requires_python,
-                    upload_time=file_info.get("upload-time"),
+                    upload_time=upload_time,
                     hashes=hashes,
                     size=size,
                 )

--- a/nab-python/tests/test_simple_client_upload_time.py
+++ b/nab-python/tests/test_simple_client_upload_time.py
@@ -1,0 +1,33 @@
+"""A non-string upload-time from a non-conformant index must not crash."""
+
+from __future__ import annotations
+
+from nab_index.client import _parse_files
+from nab_python._lockfile.builder import _parse_upload_time
+
+
+def _file(extra: dict[str, object]) -> dict[str, object]:
+    base: dict[str, object] = {
+        "filename": "foo-1.0-py3-none-any.whl",
+        "url": "https://example.com/foo/foo-1.0-py3-none-any.whl",
+    }
+    base.update(extra)
+    return base
+
+
+def test_string_upload_time_preserved() -> None:
+    data = {"files": [_file({"upload-time": "2024-06-21T00:00:00Z"})]}
+    files = _parse_files(data, "https://example.com/", "foo")
+    assert files[0].upload_time == "2024-06-21T00:00:00Z"
+
+
+def test_non_string_upload_time_coerced_to_none() -> None:
+    data = {"files": [_file({"upload-time": 1719000000})]}
+    files = _parse_files(data, "https://example.com/", "foo")
+    assert files[0].upload_time is None
+
+
+def test_non_string_upload_time_does_not_crash_lock_emit() -> None:
+    data = {"files": [_file({"upload-time": 1719000000})]}
+    files = _parse_files(data, "https://example.com/", "foo")
+    assert _parse_upload_time(files[0].upload_time) is None


### PR DESCRIPTION
A non-conformant Simple index could serve a non-string `upload-time` (a JSON number or bool), which violated the str|None type and crashed the downstream datetime parse. Now `_parse_files` drops any non-string `upload-time` to None at the parse boundary.

Adds a test covering a numeric upload-time coerced to None and that lock emit no longer crashes.