### PR TITLE
Reject marker-environment in universal mode

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -645,6 +645,7 @@ def _parse_nab_table(
         anchor=anchor,
         declared_index_names=declared_index_names,
     )
+    marker_environment = _parse_marker_environment(raw.get("marker-environment", {}))
 
     build_policy = _parse_enum(
         "build-policy", raw.get("build-policy"), BuildPolicy, BuildPolicy.BUILD_LOCAL
@@ -656,6 +657,14 @@ def _parse_nab_table(
             package_overrides=package_overrides,
             index_overrides=index_overrides,
         )
+        if marker_environment:
+            msg = (
+                "mode = 'universal' does not support"
+                " [tool.nab.marker-environment]: the matrix defines each"
+                " environment, so a global overlay would conflict with the"
+                " per-tuple values. Drop it or use mode = 'specific'."
+            )
+            raise ConfigError(msg)
 
     default_groups = _parse_string_list("default-groups", raw.get("default-groups", []))
     conflicts = _parse_conflicts(raw.get("conflicts"))
@@ -672,7 +681,7 @@ def _parse_nab_table(
         dist_policy=dist_policy,
         build_policy=build_policy,
         trust_unverified_sdist_deps=trust_unverified,
-        marker_environment=_parse_marker_environment(raw.get("marker-environment", {})),
+        marker_environment=marker_environment,
         indexes=indexes,
         vcs=_parse_vcs(raw.get("vcs", {})),
         local_sources=_parse_local_sources(

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -1036,6 +1036,21 @@ class TestMarkerEnvironment:
         with pytest.raises(ConfigError, match="unknown marker-environment variable"):
             read_pyproject_config(path)
 
+    def test_rejected_in_universal_mode(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab]\nmode = "universal"\n'
+            "[tool.nab.matrix]\n"
+            'python = ">=3.11"\n'
+            'platforms = ["linux_x86_64"]\n'
+            "[tool.nab.marker-environment]\n"
+            'platform_system = "Windows"\n',
+        )
+        with pytest.raises(
+            ConfigError, match="does not support .tool.nab.marker-environment."
+        ):
+            read_pyproject_config(path)
+
 
 class TestIndexes:
     def test_round_trip(self, tmp_path: Path) -> None:


### PR DESCRIPTION
In universal mode a [tool.nab.marker-environment] table was accepted and silently ignored, even though the matrix already defines each tuple's environment and a global overlay would conflict with those per-tuple values. Parse it once and raise a ConfigError when it is set in universal mode, matching the existing rejection of marker-gated index-overrides.

Adds a test that a marker-environment table under mode = "universal" fails to parse.