### PR TITLE
Strip whitespace on Provides-Extra in build metadata parse

### DIFF
--- a/nab-python/src/nab_python/_build/runner.py
+++ b/nab-python/src/nab_python/_build/runner.py
@@ -250,9 +250,9 @@ def _parse_metadata(metadata_path: Path) -> WheelMetadata:
 
     provides_extra: list[str] = sorted(
         {
-            canonicalize_name(extra)
+            canonicalize_name(stripped)
             for extra in msg_obj.get_all("Provides-Extra") or ()
-            if extra
+            if (stripped := extra.strip())
         }
     )
 

--- a/nab-python/src/nab_python/metadata.py
+++ b/nab-python/src/nab_python/metadata.py
@@ -172,7 +172,7 @@ def parse_metadata(data: str | bytes) -> WheelMetadata:
         _parse_requirement_cached(r) for r in msg.get_all("Requires-Dist") or []
     ]
 
-    provides_extra = list(msg.get_all("Provides-Extra") or [])
+    provides_extra = [e.strip() for e in msg.get_all("Provides-Extra") or []]
 
     metadata_version = msg.get("Metadata-Version")
     # PEP 643 field names are case-insensitive and, per RFC 822, surrounding

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -510,6 +510,20 @@ class TestParseMetadata:
         names = sorted(r.name for r in meta.requires_dist)
         assert names == ["click"]
 
+    def test_provides_extra_whitespace_stripped(self, tmp_path: Path) -> None:
+        """Surrounding whitespace on a Provides-Extra value is insignificant
+        per RFC 822; canonicalize_name does not strip it, so strip first."""
+        from nab_python._build.runner import _parse_metadata
+
+        path = tmp_path / "METADATA"
+        path.write_text(
+            "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n"
+            "Provides-Extra: security \nProvides-Extra: docs\t\n",
+            encoding="utf-8",
+        )
+        meta = _parse_metadata(path)
+        assert meta.provides_extra == ["docs", "security"]
+
 
 class TestBuildWheelExtraction:
     """``_build_wheel_and_extract`` raises when the built wheel has

--- a/nab-python/tests/test_metadata.py
+++ b/nab-python/tests/test_metadata.py
@@ -104,6 +104,16 @@ def test_provides_extra_kept_as_strings() -> None:
     assert md.provides_extra == ["dev", "docs"]
 
 
+def test_provides_extra_whitespace_stripped() -> None:
+    """Surrounding whitespace on a ``Provides-Extra`` value is insignificant."""
+    text = (
+        "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n"
+        "Provides-Extra: dev \nProvides-Extra: docs\t\n"
+    )
+    md = parse_metadata(text)
+    assert md.provides_extra == ["dev", "docs"]
+
+
 class TestMetadataDepsAreStatic:
     def test_2_2_without_dynamic_is_static(self) -> None:
         md = parse_metadata("Metadata-Version: 2.2\nName: foo\nVersion: 1.0\n")

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -2886,6 +2886,14 @@ NO_EXTRA_METADATA = (
     "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\nRequires-Dist: bar>=1.0\n"
 )
 
+WHITESPACE_EXTRA_METADATA = (
+    "Metadata-Version: 2.1\n"
+    "Name: foo\n"
+    "Version: 1.0\n"
+    "Provides-Extra: security \n"
+    'Requires-Dist: cryptography>=2.0; extra == "security"\n'
+)
+
 
 class TestExtras:
     def test_choose_version_delegates_to_base(self) -> None:
@@ -2925,6 +2933,17 @@ class TestExtras:
         assert "cryptography" in deps
         assert "foo" in deps
         assert "bar" not in deps
+
+    def test_get_dependencies_whitespace_provides_extra_keeps_deps(self) -> None:
+        """A trailing space on Provides-Extra must not drop the extra's deps."""
+        coordinator = make_coordinator(
+            [make_wheel("1.0")],
+            metadata_text=WHITESPACE_EXTRA_METADATA,
+            package="foo",
+        )
+        provider = Provider(coordinator, python_version="3.12.0")
+        deps = provider.get_dependencies("foo[security]", V("1.0"))
+        assert "cryptography" in deps
 
     def test_choose_extra_version_filters_by_base_range(self) -> None:
         """An extras proxy whose base==V is excluded by the base's positive


### PR DESCRIPTION
The dynamic PEP 517 build path canonicalized each `Provides-Extra` value without stripping it first. RFC 822 treats surrounding whitespace as insignificant, but `canonicalize_name` does not strip it, so a backend emitting `Provides-Extra: security ` produced the value `security ` (trailing space). That made the marker `extra == "security"` evaluate False and silently dropped that extra's dependencies.

`_parse_metadata` now strips each value before canonicalizing and keeps the truthiness guard so blank-after-strip values are dropped, matching the wheel path in `metadata.py`. Adds a unit test covering trailing space and tab on `Provides-Extra`.