### PR TITLE
Exit cleanly on admitted VCS in universal lock

### DIFF
--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -255,6 +255,9 @@ def _resolve_universal(
     except UnsupportedVcsError as e:
         sys.stderr.write(f"Cannot lock: {e}\n")
         sys.exit(1)
+    except NotImplementedError as e:
+        sys.stderr.write(f"Cannot lock: {e}\n")
+        sys.exit(1)
 
     if not result.success:
         _print_universal_blocks(result)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -537,6 +537,22 @@ class TestLockCommandUniversal:
         assert "Error in [tool.nab]:" in err
         assert "gpuu" in err
 
+    def test_not_implemented_vcs_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An admitted VCS dep hits the unimplemented universal path and exits 1, not a traceback."""
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with (
+            patch(
+                "nab.cli.resolve_universal_pyproject",
+                side_effect=NotImplementedError("resolver path is not implemented"),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, output=out)
+        assert "resolver path is not implemented" in capsys.readouterr().err
+
     def test_pylock_writes_universal_lock(self, tmp_path: Path) -> None:
         """Universal + pylock format runs the real merge + write pipeline."""
         pyproject = _universal_pyproject(tmp_path)


### PR DESCRIPTION
A universal lock that admits a VCS dependency reaches an unimplemented resolver path, where resolve_universal_pyproject raised a bare NotImplementedError that escaped to the user as a traceback.

_resolve_universal now catches NotImplementedError and exits 1 with a "Cannot lock: ..." message, matching the adjacent UnsupportedVcsError and HttpError handlers. Adds a test that patches the resolver to raise NotImplementedError and checks the clean exit.