### PR TITLE
Drop self-referential extra from project dependencies

### DIFF
--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -109,16 +109,22 @@ def _canonicalize_optional_deps(
 def select_optional_dependencies(
     optional_deps: Mapping[str, Sequence[str]],
     selected: Sequence[str],
+    project_name: str | None = None,
 ) -> list[Requirement]:
     """Return the union of requirement strings for ``selected`` extras.
 
     Extra names are compared under PEP 685 normalization, so
     ``My_Extra`` selects a declared ``my-extra``.  Unknown extra names
     raise ``LookupError``.  Returns an empty list when ``selected`` is
-    empty.
+    empty.  A self-reference (a requirement naming ``project_name``) has
+    its extras reached through the expanded selection, so it is dropped
+    here rather than returned as a dependency on the project itself.
     """
     if not selected:
         return []
+    canonical_project = (
+        canonicalize_name(project_name) if project_name is not None else None
+    )
     canonical_deps = _canonicalize_optional_deps(optional_deps)
     out: list[Requirement] = []
     for name in selected:
@@ -129,12 +135,15 @@ def select_optional_dependencies(
                 f" [project.optional-dependencies]; defined: {sorted(optional_deps)!r}"
             )
             raise LookupError(msg)
-        out.extend(
-            _parse_requirements(
-                canonical_deps[canonical],
-                f"[project.optional-dependencies] extra {name!r}",
-            )
-        )
+        for req in _parse_requirements(
+            canonical_deps[canonical],
+            f"[project.optional-dependencies] extra {name!r}",
+        ):
+            if canonical_project is not None and (
+                canonicalize_name(req.name) == canonical_project
+            ):
+                continue
+            out.append(req)
     return out
 
 
@@ -260,6 +269,7 @@ def expand_extra_requirements(
             ):
                 edge = gates if req.marker is None else gates | {str(req.marker)}
                 worklist.extend((canonicalize_name(sub), edge) for sub in req.extras)
+                continue
             if gates:
                 req.marker = _and_markers(req.marker, gates)
             out.append(req)

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -487,7 +487,7 @@ def _extra_requirements_from_table(
         )
         raise LookupError(msg)
     expanded = expand_self_extras(optional, project_name, selected, environment)
-    return select_optional_dependencies(optional, expanded)
+    return select_optional_dependencies(optional, expanded, project_name)
 
 
 def _validate_conflict_members_exist(

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -349,6 +349,14 @@ class TestExpandExtraRequirements:
         dep = next(r for r in out if r.name == "some-dep")
         assert dep.marker is None
 
+    def test_self_reference_not_emitted_as_requirement(self) -> None:
+        """The self-reference activates its extra but never lands as a
+        requirement of its own; the project is the root, not a dependency."""
+        opt = {"all": ["mypkg[fast]"], "fast": ["some-dep"]}
+        names = {r.name for r in expand_extra_requirements(opt, "mypkg", ["all"])}
+        assert "mypkg" not in names
+        assert "some-dep" in names
+
     def test_dep_own_marker_anded_with_activation(self) -> None:
         opt = {
             "fast": ["some-dep; sys_platform == 'linux'"],

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -1696,6 +1696,8 @@ class TestLoadExtraRequirements:
     def test_returns_requirements_for_selected_extras(self, tmp_path: Path) -> None:
         """Selected extras expand into ``Requirement`` instances, with
         self-references walked transitively to their underlying deps.
+        The self-reference itself does not survive as a requirement: the
+        project is the root, not an index candidate.
         """
         path = tmp_path / "pyproject.toml"
         path.write_text(
@@ -1706,10 +1708,8 @@ class TestLoadExtraRequirements:
         )
         reqs = _load_extra_requirements(path, ["all"])
         names = sorted(r.name for r in reqs)
-        # Self-reference walks to ``pytest`` while keeping the
-        # original ``x[test]`` placeholder so the resolver still sees
-        # the project's own extras-proxy.
         assert "pytest" in names
+        assert "x" not in names
 
     def test_selected_extra_name_canonicalized(self, tmp_path: Path) -> None:
         """A --extra spelling differing only by case/separator still resolves."""


### PR DESCRIPTION
When an extra self-references the project (e.g. `all = ["mypkg[fast]"]`), the resolver emitted the project itself as a dependency instead of only walking through to the extra's real deps. The fix drops the self-reference in both expansion paths so the project stays the root and only the underlying deps survive: `select_optional_dependencies` takes the project name and skips requirements naming it, and `expand_extra_requirements` continues past the self-reference after enqueuing its extras.

Adds a test that selecting an extra whose member is `mypkg[fast]` yields `some-dep` but not `mypkg`.