### PR TITLE
Distrust static version when project marks it dynamic

### DIFF
--- a/nab-python/src/nab_python/build_backend.py
+++ b/nab-python/src/nab_python/build_backend.py
@@ -80,6 +80,11 @@ def _project_to_metadata(project: dict) -> WheelMetadata | None:
     version_raw = project.get("version")
     if not isinstance(name, str) or not isinstance(version_raw, str):
         return None
+    dynamic = project.get("dynamic")
+    if isinstance(dynamic, list) and "version" in dynamic:
+        # A dynamic version is computed by the build backend; a static
+        # value alongside it is a stale placeholder, not authoritative.
+        return None
     try:
         version = Version(version_raw)
     except InvalidVersion:

--- a/nab-python/tests/test_build_backend.py
+++ b/nab-python/tests/test_build_backend.py
@@ -113,6 +113,32 @@ class TestExtractStaticMetadata:
         )
         assert extract_static_metadata(tmp_path) is None
 
+    def test_dynamic_version_placeholder_returns_none(self, tmp_path: Path) -> None:
+        _write_pyproject(
+            tmp_path,
+            """
+            [project]
+            name = "foo"
+            version = "0.0.0"
+            dynamic = ["version"]
+            """,
+        )
+        assert extract_static_metadata(tmp_path) is None
+
+    def test_dynamic_non_version_keeps_static_version(self, tmp_path: Path) -> None:
+        _write_pyproject(
+            tmp_path,
+            """
+            [project]
+            name = "foo"
+            version = "1.0"
+            dynamic = ["readme"]
+            """,
+        )
+        meta = extract_static_metadata(tmp_path)
+        assert meta is not None
+        assert meta.version == Version("1.0")
+
     def test_missing_name_returns_none(self, tmp_path: Path) -> None:
         _write_pyproject(tmp_path, '[project]\nversion = "1.0"\n')
         assert extract_static_metadata(tmp_path) is None


### PR DESCRIPTION
A pyproject [project] table can list version in dynamic while still carrying a stale static version key. Static metadata extraction trusted that placeholder, so resolution used the wrong version instead of letting the build backend compute the real one.

_project_to_metadata now returns None when version is in the dynamic list, falling back to a build. A non-version dynamic entry still keeps the static version. Adds tests for both cases.