### PR TITLE
Follow redirects in httpx async transport

### DIFF
--- a/nab-index/src/nab_index/httpx_async_transport.py
+++ b/nab-index/src/nab_index/httpx_async_transport.py
@@ -66,6 +66,9 @@ class HttpxAsyncTransport:
         """Create a transport."""
         self._client = httpx.AsyncClient(
             http2=http2,
+            # httpx defaults this off, unlike urllib3 and pip; the Simple
+            # API relies on redirects (canonicalising URLs, mirrors, CDNs).
+            follow_redirects=True,
             verify=truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT),
         )
 

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -93,6 +93,31 @@ class TestHttpxAsyncTransport:
             asyncio.run(go())
 
     @respx.mock
+    def test_get_follows_redirects(self) -> None:
+        """httpx follows a 3xx redirect, like the urllib3 backend and pip/uv."""
+        respx.get("https://example.com/simple/pkg").mock(
+            return_value=httpx.Response(
+                301, headers={"Location": "https://example.com/simple/pkg/"}
+            )
+        )
+        respx.get("https://example.com/simple/pkg/").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        async def go() -> _HttpxResponse:
+            transport = HttpxAsyncTransport(http2=False)
+            try:
+                resp = await transport.get("https://example.com/simple/pkg")
+                resp.raise_for_status()
+                return resp
+            finally:
+                await transport.aclose()
+
+        resp = asyncio.run(go())
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+
+    @respx.mock
     def test_get_wraps_connection_error(self) -> None:
         respx.get("https://example.com/").mock(side_effect=httpx.ConnectError("boom"))
 


### PR DESCRIPTION
The httpx async transport built its AsyncClient without follow_redirects, so a 3xx from the Simple API (URL canonicalisation, mirrors, CDNs) came back unfollowed instead of being resolved the way the urllib3 backend and pip/uv do. Set follow_redirects=True on the client so a redirect is followed to its final response.

Adds a test that a 301 is followed to the 200 at the redirect target.