### PR TITLE
Reject unsafe artefact filenames on download

### DIFF
--- a/nab-python/src/nab_python/download.py
+++ b/nab-python/src/nab_python/download.py
@@ -15,6 +15,7 @@ import asyncio
 import hashlib
 import logging
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from nab_index.client import AsyncSimpleClient
@@ -24,7 +25,6 @@ from .lockfile import IndexPin, LocalPin, LockInput, VcsPin
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-    from pathlib import Path
 
     from nab_index.transport import AsyncHttpTransport
 
@@ -163,6 +163,14 @@ async def _run_downloads(
 
     async def _one(entry: DownloadEntry) -> None:
         async with sem:
+            # The filename is index-controlled; reject anything but a plain
+            # basename so a crafted name cannot escape output_dir on write.
+            if not entry.filename or Path(entry.filename).name != entry.filename:
+                msg = (
+                    f"{entry.package}=={entry.version}:"
+                    f" unsafe artefact filename: {entry.filename!r}"
+                )
+                raise DownloadError(msg)
             target = output_dir / entry.filename
             if _already_present(target, entry.hash_algo, entry.digest):
                 skipped.append(target)

--- a/nab-python/tests/test_download.py
+++ b/nab-python/tests/test_download.py
@@ -372,6 +372,52 @@ class TestDownloadLock:
         )
         assert target.is_dir()
 
+    def test_rejects_parent_escape_filename(self, tmp_path: Path) -> None:
+        payload = b"EVIL"
+        sha = hashlib.sha256(payload).hexdigest()
+        wheel = WheelArtifact(
+            filename="../escaped.whl",
+            url="https://example.com/foo-1.0.whl",
+            hashes=(("sha256", sha),),
+            size=4,
+        )
+        pin = IndexPin(
+            name="foo", version="1.0", index="pypi", sdist=None, wheels=(wheel,)
+        )
+        transport = _FakeTransport({"https://example.com/foo-1.0.whl": payload})
+        output_dir = tmp_path / "wheels"
+        with pytest.raises(DownloadError, match="unsafe"):
+            download_lock(
+                LockInput(pins={"foo": pin}),
+                transport,  # type: ignore[arg-type]
+                output_dir,
+            )
+        assert not (tmp_path / "escaped.whl").exists()
+
+    def test_rejects_index_injectable_traversal_filename(self, tmp_path: Path) -> None:
+        # A malicious index serving "foo" can return this filename: it parses as
+        # name "foo" version "1.0" (so the resolver pins it) while the tail carries
+        # the traversal into the join at the write site.
+        payload = b"EVIL"
+        sha = hashlib.sha256(payload).hexdigest()
+        wheel = WheelArtifact(
+            filename="foo-1.0-py3-none-any/../../../evil.whl",
+            url="https://example.com/foo-1.0.whl",
+            hashes=(("sha256", sha),),
+            size=4,
+        )
+        pin = IndexPin(
+            name="foo", version="1.0", index="pypi", sdist=None, wheels=(wheel,)
+        )
+        transport = _FakeTransport({"https://example.com/foo-1.0.whl": payload})
+        with pytest.raises(DownloadError, match="unsafe"):
+            download_lock(
+                LockInput(pins={"foo": pin}),
+                transport,  # type: ignore[arg-type]
+                tmp_path / "wheels",
+            )
+        assert not (tmp_path.parent / "evil.whl").exists()
+
 
 def test_download_entry_is_a_dataclass() -> None:
     e = DownloadEntry(


### PR DESCRIPTION
A download artefact filename comes from the index and was joined straight onto output_dir, so a crafted name like "../escaped.whl" (or one that parses as a valid package but carries a traversal tail, "foo-1.0-py3-none-any/../../../evil.whl") could write outside the target directory.

Now any filename that is empty or not a plain basename (Path(filename).name != filename) raises DownloadError before the path join. Adds tests for both the parent-escape and index-injectable traversal cases.