### PR TITLE
Exit cleanly on bad dependency-group include

### DIFF
--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -10,6 +10,7 @@ import tomli
 from nab_resolver.errors import ResolutionError
 
 from ._vendor.packaging.dependency_groups import resolve_dependency_groups
+from ._vendor.packaging.errors import ExceptionGroup
 from ._vendor.packaging.markers import Marker
 from ._vendor.packaging.requirements import InvalidRequirement, Requirement
 from ._vendor.packaging.utils import canonicalize_name
@@ -332,11 +333,10 @@ def resolve_groups_to_requirements(
     """Resolve PEP 735 group includes and return the union of requirements.
 
     ``selected`` names the groups whose requirements should be
-    expanded.  Unknown group names surface as :class:`LookupError`
-    from the vendored resolver and a malformed requirement string as
-    :class:`InvalidProjectRequirementError`; a cyclic include raises the
-    vendored resolver's error.  Returns an empty list when
-    ``selected`` is empty.
+    expanded.  An unknown group name surfaces as :class:`LookupError`;
+    a malformed requirement string, cyclic include, or duplicate group
+    name surfaces as :class:`InvalidProjectRequirementError`.  Returns
+    an empty list when ``selected`` is empty.
     """
     if not selected:
         return []
@@ -345,6 +345,12 @@ def resolve_groups_to_requirements(
     except InvalidRequirement as exc:
         msg = f"invalid requirement in [dependency-groups]: {exc}"
         raise InvalidProjectRequirementError(msg) from exc
+    except ExceptionGroup as group:
+        detail = "; ".join(str(e) for e in group.exceptions)
+        if all(isinstance(e, LookupError) for e in group.exceptions):
+            raise LookupError(detail) from group
+        msg = f"invalid [dependency-groups]: {detail}"
+        raise InvalidProjectRequirementError(msg) from group
     return [Requirement(s) for s in resolved]
 
 

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -115,8 +115,26 @@ class TestResolveGroupsToRequirements:
         assert names == ["pytest", "ruff"]
 
     def test_unknown_group_raises(self) -> None:
-        with pytest.raises(BaseException, match="nope"):
+        with pytest.raises(LookupError, match="nope"):
             resolve_groups_to_requirements({"dev": ["pytest"]}, ("nope",))
+
+    def test_multiple_missing_includes_raise_lookuperror(self) -> None:
+        groups = {"x": [{"include-group": "miss1"}, {"include-group": "miss2"}]}
+        with pytest.raises(LookupError, match="miss1.*miss2"):
+            resolve_groups_to_requirements(groups, ("x",))
+
+    def test_cyclic_include_raises_clean(self) -> None:
+        groups = {
+            "a": [{"include-group": "b"}],
+            "b": [{"include-group": "a"}],
+        }
+        with pytest.raises(InvalidProjectRequirementError, match="Cyclic"):
+            resolve_groups_to_requirements(groups, ("a",))
+
+    def test_duplicate_group_names_raise_clean(self) -> None:
+        groups = {"my-dev": ["pytest"], "my_dev": ["ruff"]}
+        with pytest.raises(InvalidProjectRequirementError, match="Duplicate"):
+            resolve_groups_to_requirements(groups, ("my-dev",))
 
     def test_malformed_requirement_string_raises(self) -> None:
         with pytest.raises(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -297,6 +297,20 @@ class TestLockCommandSpecific:
             lock(pyproject)
         assert "Resolution failed" in capsys.readouterr().err
 
+    def test_unknown_group_exits_cleanly(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A typo'd --group with a present table exits 1, not a raw traceback."""
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "1"\ndependencies = ["foo"]\n'
+            "[dependency-groups]\n"
+            'dev = ["ruff"]\n',
+        )
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, groups=("typo",), offline=True, cache=False)
+        assert "Dependency group 'typo' not found" in capsys.readouterr().err
+
     def test_unsupported_vcs_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
An unknown, cyclic, or duplicate-named PEP 735 dependency group made the vendored resolver raise an ExceptionGroup that escaped as a raw traceback instead of a clean CLI error.

resolve_groups_to_requirements now catches that ExceptionGroup and re-raises it as a LookupError when every cause is a missing group (so the CLI prints "Dependency group '...' not found" and exits 1) or as InvalidProjectRequirementError otherwise.

Adds tests for multiple missing includes, a cyclic include, a duplicate group name, and the CLI exit path for a typo'd --group.