### PR TITLE
Resolve annotated tag to the commit it points at

### DIFF
--- a/nab-index/src/nab_index/vcs.py
+++ b/nab-index/src/nab_index/vcs.py
@@ -189,7 +189,10 @@ def _resolve_sha(request: VcsRequest, *, require_pin: bool) -> str:
         raise VcsCloneError(msg)
 
     target = request.ref or "HEAD"
-    ls_remote_args = ["git", "ls-remote", request.repo_url, target]
+    # Also request the peeled form: an exact-ref ls-remote omits the
+    # companion refs/tags/<name>^{} line, so without it an annotated tag
+    # would resolve to the tag object rather than the commit it points at.
+    ls_remote_args = ["git", "ls-remote", request.repo_url, target, f"{target}^{{}}"]
     try:
         proc = subprocess.run(  # noqa: S603 - URL admission upstream
             ls_remote_args,

--- a/nab-python/tests/test_vcs.py
+++ b/nab-python/tests/test_vcs.py
@@ -208,6 +208,36 @@ class TestResolveSha:
             _resolve_sha(req, require_pin=False)
 
 
+class TestResolveShaAnnotatedTag:
+    """An annotated tag resolves to its commit, not the tag object.
+
+    ``git ls-remote repo <ref>`` returns only the tag-object line for an
+    exact ref; the peeled ``refs/tags/<ref>^{}`` commit line appears only
+    when the peeled ref is queried too, so ``_resolve_sha`` must ask for
+    it to pin the commit a ``git tag -a`` release points at.
+    """
+
+    def test_annotated_tag_resolves_to_commit_not_tag_object(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        tag_object = "a" * 40
+        commit = "b" * 40
+        queried: list[str] = []
+
+        def fake_run(cmd: list[str], **_kwargs: object) -> object:
+            queried.extend(cmd)
+            lines = [f"{tag_object}\trefs/tags/v1"]
+            if any(arg.endswith("^{}") for arg in cmd):
+                lines.append(f"{commit}\trefs/tags/v1^{{}}")
+            return type("P", (), {"stdout": "\n".join(lines) + "\n"})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        req = VcsRequest("git", "https://x", "v1", "")
+        assert _resolve_sha(req, require_pin=False) == commit
+        assert "v1^{}" in queried
+
+
 class TestPrepareClone:
     def test_idempotent_when_dest_exists(
         self,


### PR DESCRIPTION
When pinning a VCS ref, an exact-ref `git ls-remote repo <ref>` only advertises the tag-object line, so an annotated tag pinned to the tag object SHA instead of the commit it points at. The fix also queries the peeled `<ref>^{}` form so the existing peel-preference logic picks the commit.

Adds a test that an annotated tag resolves to its commit and that the peeled ref is queried.