### PR TITLE
Reject directory path on lock and download

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -896,7 +896,7 @@ def read_pyproject_lock_anchor(path: Path) -> datetime | None:
     try:
         with path.open("rb") as f:
             data = tomli.load(f)
-    except (FileNotFoundError, tomli.TOMLDecodeError):
+    except (OSError, tomli.TOMLDecodeError):
         return None
     raw = tool_nab_section(data)
     value = raw.get("uploaded-prior-to") if isinstance(raw, dict) else None

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -803,6 +803,10 @@ class TestReadLockAnchor:
     def test_missing_file_returns_none(self, tmp_path: Path) -> None:
         assert read_pyproject_lock_anchor(tmp_path / "missing.toml") is None
 
+    def test_directory_returns_none(self, tmp_path: Path) -> None:
+        # A directory is left for the full config parse to report, like a missing file.
+        assert read_pyproject_lock_anchor(tmp_path) is None
+
     def test_malformed_toml_returns_none(self, tmp_path: Path) -> None:
         # A syntax error is left for the full config parse to report.
         path = write(tmp_path, '[project]\ndependencies = ["foo"\n')

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -581,8 +581,9 @@ def resolve_group_selection(
 
     try:
         defined = read_pyproject_groups(path)
-    except FileNotFoundError:
-        sys.stderr.write(f"Error: {path} not found\n")
+    except OSError:
+        reason = "is a directory" if path.is_dir() else "not found"
+        sys.stderr.write(f"Error: {path} {reason}\n")
         sys.exit(1)
     except TypeError as e:
         sys.stderr.write(f"Error in {path}: {e}\n")
@@ -605,8 +606,9 @@ def resolve_extra_selection(
 
     try:
         defined = read_pyproject_optional_dependencies(path)
-    except FileNotFoundError:
-        sys.stderr.write(f"Error: {path} not found\n")
+    except OSError:
+        reason = "is a directory" if path.is_dir() else "not found"
+        sys.stderr.write(f"Error: {path} {reason}\n")
         sys.exit(1)
     except TypeError as e:
         sys.stderr.write(f"Error in {path}: {e}\n")

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -130,8 +130,9 @@ def _load_config(
     discover_workspace: bool = True,
     anchor: datetime | None = None,
 ) -> NabProjectConfig:
-    if not path.exists():
-        sys.stderr.write(f"Error: {path} not found\n")
+    if not path.is_file():
+        reason = "is a directory" if path.is_dir() else "not found"
+        sys.stderr.write(f"Error: {path} {reason}\n")
         sys.exit(1)
 
     try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -463,6 +463,14 @@ class TestLockCommandSpecific:
         with pytest.raises(SystemExit, match="1"):
             lock(tmp_path / "missing.toml")
 
+    def test_directory_path_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A directory path exits 1 with a clean message, not a traceback."""
+        with pytest.raises(SystemExit, match="1"):
+            lock(tmp_path)
+        assert "is a directory" in capsys.readouterr().err
+
     def test_malformed_toml_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -2443,6 +2451,31 @@ class TestDownloadCommand:
         ):
             download(pyproject, output=out)
         assert "cannot write to output directory" in capsys.readouterr().err
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {},
+            {"all_groups": True},
+            {"all_extras": True},
+            {"groups": ("g",)},
+            {"extras": ("e",)},
+        ],
+    )
+    def test_directory_path_exits(
+        self,
+        kwargs: dict[str, object],
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A directory path exits 1 with a clean message, not a traceback.
+
+        The group/extra selection flags read the path before the config
+        load, so they must reject a directory just as cleanly.
+        """
+        with pytest.raises(SystemExit, match="1"):
+            download(tmp_path, **kwargs)
+        assert "is a directory" in capsys.readouterr().err
 
     def test_extras_flag_forwarded_to_resolver(self, tmp_path: Path) -> None:
         # ``--extras`` is required for ``exactly_one`` / ``at_least_one``


### PR DESCRIPTION
Passing a directory to `nab lock` or `nab download` crashed with an unhandled `IsADirectoryError`. The group/extra selection helpers and the lock-anchor reader run before the main config load and only caught `FileNotFoundError`, so a directory escaped as a traceback.

Both selection helpers and the anchor reader now catch `OSError` and exit 1 with the same "is a directory" / "not found" message used by `_load_config`. Added a parametrized download test covering the no-flag and `--groups`/`--extras`/`--all-groups`/`--all-extras` paths, plus a directory case for lock.