### PR TITLE
Read local find-links artefacts from disk on download

### DIFF
--- a/nab-python/src/nab_python/download.py
+++ b/nab-python/src/nab_python/download.py
@@ -4,6 +4,8 @@ Consumes a :class:`~nab_python.lockfile.LockInput` and writes every
 recorded wheel and sdist into a target directory, verifying the
 recorded hash.  Local and VCS pins are skipped: their contents live
 elsewhere on disk and the lockfile carries no ``sha256`` for them.
+An artefact from a local ``file://`` (find-links) index is copied
+from its on-disk path rather than fetched over HTTP.
 
 Use as a one-shot from the CLI ``nab download`` command, or
 programmatically after :func:`~nab_python.resolve.resolve_pyproject_to_lock`.
@@ -54,6 +56,10 @@ class DownloadEntry:
     ``digest`` is the recorded hex digest under that algorithm.
     The downloader verifies against the first acceptable algorithm the
     index published, preferring sha256 over sha384 over sha512.
+
+    ``local_path`` is set for an artefact from a local ``file://``
+    (find-links) index; its bytes are read from disk instead of fetched
+    over ``url``.
     """
 
     package: str
@@ -62,6 +68,7 @@ class DownloadEntry:
     url: str
     hash_algo: str
     digest: str
+    local_path: Path | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -115,6 +122,7 @@ def _iter_index_pin(canonical: str, pin: IndexPin) -> Iterable[DownloadEntry]:
             url=pin.sdist.url,
             hash_algo=algo,
             digest=digest.lower(),
+            local_path=pin.sdist.local_path,
         )
     for wheel in pin.wheels:
         algo, digest = wheel.primary_digest
@@ -125,6 +133,7 @@ def _iter_index_pin(canonical: str, pin: IndexPin) -> Iterable[DownloadEntry]:
             url=wheel.url,
             hash_algo=algo,
             digest=digest.lower(),
+            local_path=wheel.local_path,
         )
 
 
@@ -168,15 +177,7 @@ async def _run_downloads(
                 skipped.append(target)
                 logger.info("skip %s (%s matches)", entry.filename, entry.hash_algo)
                 return
-            try:
-                data = await client.download(entry.url)
-            except HttpError as exc:
-                msg = (
-                    f"{entry.package}=={entry.version}: failed to fetch"
-                    f" {entry.filename}: {exc}"
-                )
-                raise DownloadError(msg) from exc
-
+            data = await _fetch_bytes(entry, client)
             actual = hashlib.new(entry.hash_algo, data).hexdigest()
             if actual != entry.digest:
                 msg = (
@@ -201,6 +202,26 @@ async def _run_downloads(
     finally:
         await client.aclose()
     return DownloadResult(written=tuple(written), skipped=tuple(skipped))
+
+
+async def _fetch_bytes(entry: DownloadEntry, client: AsyncSimpleClient) -> bytes:
+    """Read a local artefact from disk, else fetch it over HTTP."""
+    if entry.local_path is not None:
+        try:
+            return entry.local_path.read_bytes()
+        except OSError as exc:
+            msg = (
+                f"{entry.package}=={entry.version}: failed to read"
+                f" {entry.filename} from {entry.local_path}: {exc}"
+            )
+            raise DownloadError(msg) from exc
+    try:
+        return await client.download(entry.url)
+    except HttpError as exc:
+        msg = (
+            f"{entry.package}=={entry.version}: failed to fetch {entry.filename}: {exc}"
+        )
+        raise DownloadError(msg) from exc
 
 
 def _already_present(target: Path, algo: str, expected_digest: str) -> bool:

--- a/nab-python/tests/test_download.py
+++ b/nab-python/tests/test_download.py
@@ -373,6 +373,77 @@ class TestDownloadLock:
         assert target.is_dir()
 
 
+class TestLocalIndexArtefacts:
+    """Artefacts resolved from a local file:// (find-links) index."""
+
+    def test_entry_carries_local_path(self, tmp_path: Path) -> None:
+        wheel = WheelArtifact(
+            filename="foo-1.0-py3-none-any.whl",
+            url=(tmp_path / "foo-1.0-py3-none-any.whl").as_uri(),
+            hashes=(("sha256", "a" * 64),),
+            local_path=tmp_path / "foo-1.0-py3-none-any.whl",
+        )
+        pin = IndexPin(name="foo", version="1.0", index="local", wheels=(wheel,))
+        (entry,) = list(iter_artifacts(LockInput(pins={"foo": pin})))
+        assert entry.local_path == tmp_path / "foo-1.0-py3-none-any.whl"
+
+    def test_wheel_and_sdist_copied_from_disk(self, tmp_path: Path) -> None:
+        src = tmp_path / "wheelhouse"
+        src.mkdir()
+        out = tmp_path / "out"
+        wheel_bytes = b"WHEELDATA"
+        sdist_bytes = b"SDISTDATA"
+        wheel_file = src / "foo-1.0-py3-none-any.whl"
+        sdist_file = src / "foo-1.0.tar.gz"
+        wheel_file.write_bytes(wheel_bytes)
+        sdist_file.write_bytes(sdist_bytes)
+        wheel = WheelArtifact(
+            filename="foo-1.0-py3-none-any.whl",
+            url=wheel_file.as_uri(),
+            hashes=(("sha256", hashlib.sha256(wheel_bytes).hexdigest()),),
+            local_path=wheel_file,
+        )
+        sdist = SdistArtifact(
+            filename="foo-1.0.tar.gz",
+            url=sdist_file.as_uri(),
+            hashes=(("sha256", hashlib.sha256(sdist_bytes).hexdigest()),),
+            local_path=sdist_file,
+        )
+        pin = IndexPin(
+            name="foo", version="1.0", index="local", sdist=sdist, wheels=(wheel,)
+        )
+        # The transport would serve the wrong bytes; a local artefact must
+        # never reach it.
+        transport = _FakeTransport(
+            {wheel_file.as_uri(): b"WRONG", sdist_file.as_uri(): b"WRONG"}
+        )
+        result = download_lock(
+            LockInput(pins={"foo": pin}),
+            transport,  # type: ignore[arg-type]
+            out,
+        )
+        assert (out / "foo-1.0-py3-none-any.whl").read_bytes() == wheel_bytes
+        assert (out / "foo-1.0.tar.gz").read_bytes() == sdist_bytes
+        assert len(result.written) == 2
+        assert transport.requested == []
+
+    def test_missing_local_file_raises_download_error(self, tmp_path: Path) -> None:
+        missing = tmp_path / "gone" / "foo-1.0-py3-none-any.whl"
+        wheel = WheelArtifact(
+            filename="foo-1.0-py3-none-any.whl",
+            url=missing.as_uri(),
+            hashes=(("sha256", "a" * 64),),
+            local_path=missing,
+        )
+        pin = IndexPin(name="foo", version="1.0", index="local", wheels=(wheel,))
+        with pytest.raises(DownloadError, match="failed to read foo-1.0-py3-none-any"):
+            download_lock(
+                LockInput(pins={"foo": pin}),
+                _FakeTransport({}),  # type: ignore[arg-type]
+                tmp_path / "out",
+            )
+
+
 def test_download_entry_is_a_dataclass() -> None:
     e = DownloadEntry(
         package="foo",


### PR DESCRIPTION
An artefact resolved from a local file:// (find-links) index was still fetched over HTTP during nab download, which failed because there is no server to answer the request. DownloadEntry now carries each artefact's on-disk local_path and reads those bytes from disk instead, raising DownloadError if the file is missing.

Adds tests covering a wheel and sdist copied from disk and a missing local file.