### PR TITLE
Reject non-table [project] for workspace members

### DIFF
--- a/nab-python/src/nab_python/workspace.py
+++ b/nab-python/src/nab_python/workspace.py
@@ -158,7 +158,14 @@ def read_workspace_members(root_pyproject: Path) -> tuple[LocalSource, ...]:
             raise WorkspaceDiscoveryError(msg)
         with member_pyproject.open("rb") as f:
             member_data = tomli.load(f)
-        name = member_data.get("project", {}).get("name")
+        project_table = member_data.get("project", {})
+        if not isinstance(project_table, dict):
+            msg = (
+                f"{member_pyproject}: workspace member [project] must be a"
+                f" table, got {type(project_table).__name__}"
+            )
+            raise WorkspaceDiscoveryError(msg)
+        name = project_table.get("name")
         if not isinstance(name, str) or not name:
             msg = (
                 f"{member_pyproject}: workspace member must declare"

--- a/nab-python/tests/test_workspace.py
+++ b/nab-python/tests/test_workspace.py
@@ -243,6 +243,24 @@ class TestReadWorkspaceMembers:
         with pytest.raises(WorkspaceDiscoveryError, match=r"\[project\]\.name"):
             read_workspace_members(root)
 
+    def test_member_non_table_project_raises(self, tmp_path: Path) -> None:
+        # ``project = "x"`` (a scalar) is a common slip for ``[project]``;
+        # it must raise a clean WorkspaceDiscoveryError, not AttributeError.
+        root = _write(
+            tmp_path / "pyproject.toml",
+            '[project]\nname = "ws"\nversion = "0"\n'
+            "[tool.nab.workspace]\n"
+            'members = ["pkg"]\n',
+        )
+        _write(
+            tmp_path / "pkg" / "pyproject.toml",
+            'project = "broken"\n',
+        )
+        with pytest.raises(
+            WorkspaceDiscoveryError, match=r"\[project\] must be a table"
+        ):
+            read_workspace_members(root)
+
     def test_duplicate_canonical_name_raises(self, tmp_path: Path) -> None:
         # ``A`` and ``a`` canonicalise to the same name.
         root = _write(


### PR DESCRIPTION
When a workspace member's pyproject.toml declares `project` as a scalar instead of a `[project]` table, read_workspace_members called .get() on a non-dict and crashed with AttributeError. It now checks that the project entry is a table and raises a WorkspaceDiscoveryError with a clear message.

Adds a test for a scalar `project` value.