### PR TITLE
Exit cleanly when --output target is unwritable

### DIFF
--- a/src/nab/_download.py
+++ b/src/nab/_download.py
@@ -110,6 +110,9 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
     except DownloadError as e:
         sys.stderr.write(f"Download failed: {e}\n")
         sys.exit(1)
+    except OSError as e:
+        sys.stderr.write(f"Error: cannot write to output directory {output}: {e}\n")
+        sys.exit(1)
 
     sys.stderr.write(
         f"Downloaded {len(outcome.written)} files,"

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -51,12 +51,21 @@ from .cli import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Callable, Mapping
 
     from nab_index.transport import AsyncHttpTransport
     from nab_python._vendor.packaging.version import Version
     from nab_python.resolve import ResolutionResult
     from nab_python.universal.resolve import TupleResult, UniversalResult
+
+
+def _emit_or_exit(emit: Callable[[], None]) -> None:
+    """Run an emit step, mapping an unwritable ``--output`` to a clean exit."""
+    try:
+        emit()
+    except OSError as e:
+        sys.stderr.write(f"Error: cannot write output: {e}\n")
+        sys.exit(1)
 
 
 @app.command
@@ -131,19 +140,21 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
 
     transport = _cli._make_transport(http_backend)  # noqa: SLF001
     if config.mode is ResolveMode.UNIVERSAL:
-        _emit_universal(
-            path,
-            config=config,
-            cache_dir=effective_cache_dir,
-            transport=transport,
-            offline=offline,
-            output=output,
-            format=format,
-            provenance=provenance,
-            groups=selected_groups,
-            extras=selected_extras,
-            resolution_strategy=strategy_override,
-            workspace_to_drop=workspace_to_drop,
+        _emit_or_exit(
+            lambda: _emit_universal(
+                path,
+                config=config,
+                cache_dir=effective_cache_dir,
+                transport=transport,
+                offline=offline,
+                output=output,
+                format=format,
+                provenance=provenance,
+                groups=selected_groups,
+                extras=selected_extras,
+                resolution_strategy=strategy_override,
+                workspace_to_drop=workspace_to_drop,
+            )
         )
         return
 
@@ -158,12 +169,14 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
         extras=selected_extras,
         resolution_strategy=strategy_override,
     )
-    _emit_specific(
-        result,
-        format=format,
-        output=output,
-        provenance=provenance,
-        workspace_to_drop=workspace_to_drop,
+    _emit_or_exit(
+        lambda: _emit_specific(
+            result,
+            format=format,
+            output=output,
+            provenance=provenance,
+            workspace_to_drop=workspace_to_drop,
+        )
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -459,6 +459,33 @@ class TestLockCommandSpecific:
             lock(pyproject, output=Path("-"))
         assert "is not valid TOML" in capsys.readouterr().err
 
+    def test_output_is_directory_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """--output naming an existing directory exits cleanly, not a traceback."""
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        out.mkdir()
+        with (
+            patch("nab.cli.resolve_pyproject", return_value=_stub_resolution_result()),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, output=out)
+        assert "cannot write output" in capsys.readouterr().err
+
+    def test_output_missing_parent_dir_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """--output under a non-existent directory exits cleanly, not a traceback."""
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "nope" / "pylock.toml"
+        with (
+            patch("nab.cli.resolve_pyproject", return_value=_stub_resolution_result()),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, output=out)
+        assert "cannot write output" in capsys.readouterr().err
+
     def test_resolution_flag_threads_to_resolver(self, tmp_path: Path) -> None:
         """``--resolution lowest`` reaches resolve_pyproject as the enum."""
         pyproject = _make_pyproject(tmp_path)
@@ -2372,6 +2399,20 @@ class TestDownloadCommand:
         ):
             download(pyproject)
         assert "Download failed" in capsys.readouterr().err
+
+    def test_output_is_existing_file_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """--output colliding with an existing file exits cleanly, not a traceback."""
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "wheels"
+        out.write_text("not a directory")
+        with (
+            patch("nab.cli.resolve_pyproject", return_value=_stub_resolution_result()),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            download(pyproject, output=out)
+        assert "cannot write to output directory" in capsys.readouterr().err
 
     def test_extras_flag_forwarded_to_resolver(self, tmp_path: Path) -> None:
         # ``--extras`` is required for ``exactly_one`` / ``at_least_one``


### PR DESCRIPTION
When `nab lock` or `nab download` got an `--output` path that could not be written (an existing directory, a missing parent dir, or a file where the download dir should go), the CLI let the `OSError` escape as a traceback.

The emit and download steps now catch `OSError` and exit 1 with a "cannot write" message naming the path. Adds tests for the directory, missing-parent, and file-collision cases.