### PR TITLE
Percent-encode subdirectory fragment in pin URLs

### DIFF
--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, overload
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import quote, urlsplit, urlunsplit
 
 import tomli
 
@@ -544,7 +544,7 @@ def _vcs_pin_from_source(
     bare_repo_url = _strip_userinfo(parsed.repo_url)
     repo_url = f"{parsed.scheme}+{bare_repo_url}@{resolved_sha}"
     if parsed.subdirectory:
-        repo_url += f"#subdirectory={parsed.subdirectory}"
+        repo_url += f"#subdirectory={quote(parsed.subdirectory, safe='/')}"
 
     return VcsPin(
         name=canonical,

--- a/nab-python/src/nab_python/_lockfile/requirements.py
+++ b/nab-python/src/nab_python/_lockfile/requirements.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING
+from urllib.parse import quote
 
 if TYPE_CHECKING:
     import os
@@ -101,7 +102,7 @@ def _render_pins(pins: Mapping[str, PinShape], *, with_hashes: bool) -> list[str
         elif isinstance(pin, LocalPin):
             url = Path(pin.path).resolve().as_uri()
             if pin.subdirectory is not None:
-                url += f"#subdirectory={pin.subdirectory}"
+                url += f"#subdirectory={quote(pin.subdirectory, safe='/')}"
             if pin.editable:
                 lines.append(f"-e {url}")
             else:

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -2266,6 +2266,32 @@ class TestBuildLockInputFromProvider:
         )
         assert pin.bare_repo_url == "https://example.com/r.git"
 
+    def test_vcs_pin_repo_url_encodes_subdirectory(self) -> None:
+        """A subdirectory with a URL-reserved char is percent-encoded.
+
+        The requirements.txt ``name @ <url>`` line is parsed as PEP 508; an
+        unencoded space terminates the URL token, so ``repo_url`` must carry
+        the fragment encoded to stay installable.
+        """
+        sha = "a" * 40
+        provider = _FakeProvider(
+            vcs_sources={
+                "foo": VcsSource(
+                    name="foo",
+                    url=f"git+https://example.com/r.git@{sha}#subdirectory=my pkg",
+                ),
+            },
+            vcs_pins={"foo": sha},
+        )
+        lock_input = build_lock_input_from_provider(
+            provider, {"foo": Version("0.0.0+vcs")}
+        )
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, VcsPin)
+        assert (
+            pin.repo_url == f"git+https://example.com/r.git@{sha}#subdirectory=my%20pkg"
+        )
+
     def test_vcs_requirements_line_pins_to_commit(self) -> None:
         """A branch/tag-pinned VCS source renders the resolved commit.
 
@@ -3094,6 +3120,27 @@ class TestWriteRequirementsWithHashes:
         )
         url = tmp_path.resolve().as_uri()
         assert text.strip() == f"-e {url}#subdirectory=packages/foo"
+
+    def test_local_pin_subdirectory_encodes_reserved_char(self, tmp_path: Path) -> None:
+        """A subdirectory with a URL-reserved char is percent-encoded.
+
+        An unencoded space terminates the URL token of the PEP 508
+        ``name @ <url>`` line, so the fragment must stay encoded.
+        """
+        text = write_requirements_without_hashes(
+            LockInput(
+                pins={
+                    "foo": LocalPin(
+                        name="foo",
+                        version="1.0",
+                        path=str(tmp_path),
+                        subdirectory="my pkg",
+                    )
+                }
+            )
+        )
+        url = tmp_path.resolve().as_uri()
+        assert text.strip() == f"foo @ {url}#subdirectory=my%20pkg"
 
     def test_vcs_pin_round_trips_url(self) -> None:
         text = write_requirements_with_hashes(


### PR DESCRIPTION
A [tool.nab.local-sources] subdirectory containing a URL-reserved character (for example a space, as in `my pkg`) was written into the file:// fragment verbatim, so the rendered `name @ file:///...#subdirectory=my pkg` line failed to parse as PEP 508: the unencoded space terminates the URL token and packaging/pip raise InvalidRequirement.

requirements.py:_render_pins now applies quote(subdirectory, safe='/') when building the fragment for LocalPin, matching the VCS-pin emitter in builder.py. Adds a test covering a reserved char in a local-pin subdirectory.