### PR TITLE
match VCS allowed-repos on a path-segment boundary instead of a string prefix

### DIFF
--- a/nab-python/src/nab_python/_vcs_admission.py
+++ b/nab-python/src/nab_python/_vcs_admission.py
@@ -115,6 +115,29 @@ def _without_userinfo(url: str) -> str:
     return urlunsplit(parts._replace(netloc=host))
 
 
+_REPO_BOUNDARY_CHARS: frozenset[str] = frozenset({"/", "@", "#"})
+
+
+def _repo_prefix_matches(inner_url: str, prefix: str) -> bool:
+    """Return True if ``inner_url`` names a repo under ``prefix``.
+
+    A bare :meth:`str.startswith` would admit a sibling repo whose URL
+    merely begins with an allowed entry (``.../airflow.git`` would admit
+    ``.../airflow.git.evil``).  The match here requires the prefix to end
+    at a path-segment boundary: the candidate must equal the prefix, the
+    prefix must already end in a separator, or the next candidate
+    character must be ``/`` (path), ``@`` (ref) or ``#`` (fragment).
+    Both URLs have their authority ``user[:pass]@`` / ``git@`` stripped
+    by the caller.
+    """
+    if not inner_url.startswith(prefix):
+        return False
+    rest = inner_url[len(prefix) :]
+    if not rest or not prefix or prefix[-1] in _REPO_BOUNDARY_CHARS:
+        return True
+    return rest[0] in _REPO_BOUNDARY_CHARS
+
+
 def has_full_commit_sha(url: str) -> bool:
     """Return True if the URL pins to a 40-char hex commit hash.
 
@@ -178,7 +201,7 @@ def admit_vcs_url(url: str, config: VcsConfig) -> str:
     # allowed-schemes: under policy = "allow" the user must list at least
     # one repo prefix.
     if not any(
-        _without_userinfo(inner_url).startswith(_without_userinfo(prefix))
+        _repo_prefix_matches(_without_userinfo(inner_url), _without_userinfo(prefix))
         for prefix in config.allowed_repos
     ):
         allowed_str = ", ".join(sorted(config.allowed_repos)) or "<empty>"

--- a/nab-python/src/nab_python/_vcs_admission.py
+++ b/nab-python/src/nab_python/_vcs_admission.py
@@ -123,7 +123,7 @@ def _repo_prefix_matches(inner_url: str, prefix: str) -> bool:
 
     A bare :meth:`str.startswith` would admit a sibling repo whose URL
     merely begins with an allowed entry (``.../airflow.git`` would admit
-    ``.../airflow.git.evil``).  The match here requires the prefix to end
+    ``.../airflow.git.other``).  The match here requires the prefix to end
     at a path-segment boundary: the candidate must equal the prefix, the
     prefix must already end in a separator, or the next candidate
     character must be ``/`` (path), ``@`` (ref) or ``#`` (fragment).

--- a/nab-python/tests/property_python/test_vcs_admission.py
+++ b/nab-python/tests/property_python/test_vcs_admission.py
@@ -138,7 +138,7 @@ def _prefix_under_repo(inner: str, prefix: str) -> bool:
 
     A candidate is under an allowed prefix only when the prefix ends at a
     path-segment boundary, so a sibling repo whose URL merely begins with
-    the prefix (``.../airflow.git`` vs ``.../airflow.git.evil``) is refused.
+    the prefix (``.../airflow.git`` vs ``.../airflow.git.other``) is refused.
     """
     if not inner.startswith(prefix):
         return False

--- a/nab-python/tests/property_python/test_vcs_admission.py
+++ b/nab-python/tests/property_python/test_vcs_admission.py
@@ -89,7 +89,10 @@ def structured_urls(draw: st.DrawFn) -> str:
     user = draw(st.sampled_from(["", "git@", "user@"]))
     host = draw(st.sampled_from(["github.com", "example.org", "h"]))
     segments = draw(
-        st.lists(st.sampled_from(["org", "repo.git", "repo", "a"]), max_size=3)
+        st.lists(
+            st.sampled_from(["org", "orgx", "repo.git", "repo.gitx", "repo", "a"]),
+            max_size=3,
+        )
     )
     ref = draw(
         st.sampled_from(
@@ -130,6 +133,21 @@ def _drop_login(url: str) -> str:
     return urlunsplit(parts._replace(netloc=parts.netloc.rsplit("@", 1)[1]))
 
 
+def _prefix_under_repo(inner: str, prefix: str) -> bool:
+    """Boundary-aware repo-prefix check, transcribed from the documented policy.
+
+    A candidate is under an allowed prefix only when the prefix ends at a
+    path-segment boundary, so a sibling repo whose URL merely begins with
+    the prefix (``.../airflow.git`` vs ``.../airflow.git.evil``) is refused.
+    """
+    if not inner.startswith(prefix):
+        return False
+    rest = inner[len(prefix) :]
+    if not rest or not prefix or prefix[-1] in "/@#":
+        return True
+    return rest[0] in "/@#"
+
+
 def _oracle(url: str, config: VcsConfig) -> str:
     """Decision procedure transcribed from the documented policy."""
     scheme = next((s for s in VALID_SCHEMES if url.startswith(f"{s}://")), None)
@@ -140,7 +158,7 @@ def _oracle(url: str, config: VcsConfig) -> str:
     if scheme not in config.allowed_schemes:
         return "refuse"
     inner = _drop_login(url[len("git+") :])
-    if not any(inner.startswith(_drop_login(p)) for p in config.allowed_repos):
+    if not any(_prefix_under_repo(inner, _drop_login(p)) for p in config.allowed_repos):
         return "refuse"
     if config.require_pin:
         fragmentless = url.split("#", 1)[0]

--- a/nab-python/tests/test_vcs_admission.py
+++ b/nab-python/tests/test_vcs_admission.py
@@ -21,7 +21,7 @@ _FORTY = "0123456789abcdef0123456789abcdef01234567"
 
 
 def _allow_https() -> VcsConfig:
-    # An empty allowed-repos now denies all, so list a permissive prefix
+    # An empty allowed-repos denies all, so list a permissive prefix
     # for the scheme/pin tests that are not about repo filtering.
     return VcsConfig(
         policy=VcsPolicy.ALLOW,

--- a/nab-python/tests/test_vcs_admission.py
+++ b/nab-python/tests/test_vcs_admission.py
@@ -223,7 +223,7 @@ class TestAdmitVcsUrlRepo:
         )
         with pytest.raises(UnsupportedVcsError, match="not in vcs.allowed-repos"):
             admit_vcs_url(
-                f"git+https://github.com/evil/airflow.git@{_FORTY}",
+                f"git+https://github.com/other/airflow.git@{_FORTY}",
                 config,
             )
 
@@ -275,7 +275,7 @@ class TestAdmitVcsUrlRepo:
         )
         with pytest.raises(UnsupportedVcsError, match="not in vcs.allowed-repos"):
             admit_vcs_url(
-                f"git+https://user:pass@github.com/evil/fork.git@{_FORTY}",
+                f"git+https://user:pass@github.com/other/fork.git@{_FORTY}",
                 config,
             )
 
@@ -288,7 +288,7 @@ class TestAdmitVcsUrlRepo:
         )
         with pytest.raises(UnsupportedVcsError, match="not in vcs.allowed-repos"):
             admit_vcs_url(
-                f"git+https://github.com/apache/airflow.git.evil@{_FORTY}",
+                f"git+https://github.com/apache/airflow.git.other@{_FORTY}",
                 config,
             )
 
@@ -301,7 +301,7 @@ class TestAdmitVcsUrlRepo:
         )
         with pytest.raises(UnsupportedVcsError, match="not in vcs.allowed-repos"):
             admit_vcs_url(
-                f"git+https://github.com/apache-evil/airflow.git@{_FORTY}",
+                f"git+https://github.com/apache-other/airflow.git@{_FORTY}",
                 config,
             )
 

--- a/nab-python/tests/test_vcs_admission.py
+++ b/nab-python/tests/test_vcs_admission.py
@@ -279,6 +279,85 @@ class TestAdmitVcsUrlRepo:
                 config,
             )
 
+    def test_sibling_repo_extending_full_repo_prefix_refused(self) -> None:
+        """A repo whose path extends an allowed full-repo URL is refused."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com/apache/airflow.git",),
+        )
+        with pytest.raises(UnsupportedVcsError, match="not in vcs.allowed-repos"):
+            admit_vcs_url(
+                f"git+https://github.com/apache/airflow.git.evil@{_FORTY}",
+                config,
+            )
+
+    def test_sibling_org_extending_org_name_refused(self) -> None:
+        """An org whose name extends an allowed org (no slash) is refused."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com/apache",),
+        )
+        with pytest.raises(UnsupportedVcsError, match="not in vcs.allowed-repos"):
+            admit_vcs_url(
+                f"git+https://github.com/apache-evil/airflow.git@{_FORTY}",
+                config,
+            )
+
+    def test_full_repo_prefix_with_ref_passes(self) -> None:
+        """An exact full-repo URL followed by an ``@<sha>`` ref is admitted."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com/apache/airflow.git",),
+        )
+        scheme = admit_vcs_url(
+            f"git+https://github.com/apache/airflow.git@{_FORTY}",
+            config,
+        )
+        assert scheme == "git+https"
+
+    def test_full_repo_prefix_with_subdir_under_repo_passes(self) -> None:
+        """A subdirectory path under an allowed full-repo URL stays in-repo."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com/apache/airflow",),
+        )
+        scheme = admit_vcs_url(
+            f"git+https://github.com/apache/airflow/sub.git@{_FORTY}",
+            config,
+        )
+        assert scheme == "git+https"
+
+    def test_org_without_trailing_slash_matches_repo_under_org(self) -> None:
+        """An org prefix with no trailing slash admits a repo at a ``/``."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com/apache",),
+        )
+        scheme = admit_vcs_url(
+            f"git+https://github.com/apache/airflow.git@{_FORTY}",
+            config,
+        )
+        assert scheme == "git+https"
+
+    def test_full_repo_prefix_with_fragment_passes(self) -> None:
+        """A fragment directly after an allowed full-repo URL stays in-repo."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com/apache/airflow.git",),
+            require_pin=False,
+        )
+        scheme = admit_vcs_url(
+            "git+https://github.com/apache/airflow.git#subdirectory=sub",
+            config,
+        )
+        assert scheme == "git+https"
+
 
 class TestAdmitVcsUrlRequirePin:
     def test_pinned_passes(self) -> None:


### PR DESCRIPTION
The vcs.allowed-repos check admitted any inner URL that started with an allowed entry, so a sibling repo whose URL string merely begins with an allowed prefix slipped through. With `https://github.com/apache/airflow.git` on the allowlist, `git+https://github.com/apache/airflow.git.evil@<sha>` was admitted, and with the org `https://github.com/apache` allowed, `apache-evil/airflow.git` was admitted too.

The match now requires the prefix to land on a path-segment boundary: the candidate equals the prefix, the prefix already ends in a separator, or the next character is `/`, `@`, or `#`. Userinfo is still stripped from both sides first. A real path under the repo, a ref, or a fragment immediately after the allowed prefix still passes; a longer sibling name does not.
