### PR TITLE
reject a non-table [project] in pyproject.toml with a clear error

### DIFF
--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -98,22 +98,44 @@ def _require_string_list(value: object, source: str) -> list[str]:
     return value
 
 
+def _load_project_table(path: Path) -> Mapping[str, object]:
+    """Load a pyproject.toml and return its ``[project]`` table.
+
+    Returns an empty mapping when ``[project]`` is absent (a
+    workspace-root pyproject without its own distribution).  Raises
+    :class:`TypeError` when ``[project]`` is present but not a table, so
+    the readers below fail with a named diagnostic instead of a raw
+    subscript or attribute error.
+    """
+    with path.open("rb") as f:
+        data = tomli.load(f)
+    project = data.get("project", {})
+    if not isinstance(project, dict):
+        msg = f"[project] must be a table, got {type(project).__name__}"
+        raise TypeError(msg)
+    return project
+
+
 def read_pyproject_dependencies(path: Path) -> list[Requirement]:
     """Read [project].dependencies from a pyproject.toml file.
 
     Returns a list of Requirement objects parsed from the dependency
     strings. The key is optional under PEP 621, so an absent
     ``dependencies`` reads as an empty list. Raises FileNotFoundError if
-    the file doesn't exist, KeyError if [project] is missing, and
-    InvalidProjectRequirementError if a dependency string is malformed or
-    if ``dependencies`` is declared dynamic. The root-project lock path
-    cannot run the build backend that would compute a dynamic value.
+    the file doesn't exist, KeyError if [project] is missing, TypeError
+    if [project] is not a table, and InvalidProjectRequirementError if a
+    dependency string is malformed or if ``dependencies`` is declared
+    dynamic. The root-project lock path cannot run the build backend
+    that would compute a dynamic value.
     """
     with path.open("rb") as f:
         data = tomli.load(f)
+    project = data["project"]
+    if not isinstance(project, dict):
+        msg = f"[project] must be a table, got {type(project).__name__}"
+        raise TypeError(msg)
 
     source = "[project].dependencies"
-    project = data["project"]
     if "dependencies" not in project:
         dynamic = project.get("dynamic")
         if isinstance(dynamic, list) and "dependencies" in dynamic:
@@ -134,9 +156,7 @@ def read_pyproject_name(path: Path) -> str | None:
     has no ``[project]`` table or no ``name`` key (a workspace-root
     pyproject without its own distribution).
     """
-    with path.open("rb") as f:
-        data = tomli.load(f)
-    name = data.get("project", {}).get("name")
+    name = _load_project_table(path).get("name")
     return name if isinstance(name, str) else None
 
 
@@ -149,9 +169,7 @@ def read_pyproject_optional_dependencies(
     Returns an empty dict when ``[project.optional-dependencies]``
     is absent.
     """
-    with path.open("rb") as f:
-        data = tomli.load(f)
-    raw = data.get("project", {}).get("optional-dependencies", {})
+    raw = _load_project_table(path).get("optional-dependencies", {})
     if not isinstance(raw, dict):
         msg = (
             f"[project.optional-dependencies] must be a table, got {type(raw).__name__}"

--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "InvalidProjectRequirementError",
+    "InvalidProjectTableError",
     "expand_extra_requirements",
     "expand_group_includes",
     "expand_self_extras",
@@ -39,6 +40,16 @@ __all__ = [
 
 class InvalidProjectRequirementError(ValueError):
     """A requirement string in pyproject.toml is not valid PEP 508."""
+
+
+class InvalidProjectTableError(TypeError):
+    """A pyproject.toml table such as ``[project]`` is not a table.
+
+    A subclass of :class:`TypeError`, so existing ``except TypeError`` and
+    ``pytest.raises(TypeError)`` sites keep working, but the CLI catches it
+    specifically so an unrelated internal ``TypeError`` is not mislabelled
+    as a user-file error.
+    """
 
 
 def _parse_requirements(strings: Sequence[str], source: str) -> list[Requirement]:
@@ -112,7 +123,7 @@ def _load_project_table(path: Path) -> Mapping[str, object]:
     project = data.get("project", {})
     if not isinstance(project, dict):
         msg = f"[project] must be a table, got {type(project).__name__}"
-        raise TypeError(msg)
+        raise InvalidProjectTableError(msg)
     return project
 
 
@@ -133,7 +144,7 @@ def read_pyproject_dependencies(path: Path) -> list[Requirement]:
     project = data["project"]
     if not isinstance(project, dict):
         msg = f"[project] must be a table, got {type(project).__name__}"
-        raise TypeError(msg)
+        raise InvalidProjectTableError(msg)
 
     source = "[project].dependencies"
     if "dependencies" not in project:
@@ -174,7 +185,7 @@ def read_pyproject_optional_dependencies(
         msg = (
             f"[project.optional-dependencies] must be a table, got {type(raw).__name__}"
         )
-        raise TypeError(msg)
+        raise InvalidProjectTableError(msg)
     return raw
 
 
@@ -420,7 +431,7 @@ def read_pyproject_groups(
     raw = data.get("dependency-groups", {})
     if not isinstance(raw, dict):
         msg = f"[dependency-groups] must be a table, got {type(raw).__name__}"
-        raise TypeError(msg)
+        raise InvalidProjectTableError(msg)
     return raw
 
 

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -155,6 +155,20 @@ class TestReadPyprojectDependencies:
         ):
             read_pyproject_dependencies(p)
 
+    def test_string_project_table_raises(self, tmp_path: object) -> None:
+        """A [project] that is a string is rejected, not subscripted."""
+        p = Path(str(tmp_path)) / "pyproject.toml"
+        p.write_text('project = "hello"\n')
+        with pytest.raises(TypeError, match=r"\[project\] must be a table"):
+            read_pyproject_dependencies(p)
+
+    def test_array_project_table_raises(self, tmp_path: object) -> None:
+        """A [project] that is an array is rejected, not subscripted."""
+        p = Path(str(tmp_path)) / "pyproject.toml"
+        p.write_text('project = ["a", "b"]\n')
+        with pytest.raises(TypeError, match=r"\[project\] must be a table"):
+            read_pyproject_dependencies(p)
+
 
 class TestReadPyprojectGroups:
     def test_reads_groups_table(self, tmp_path: object) -> None:
@@ -260,6 +274,13 @@ class TestReadPyprojectOptionalDependencies:
         with pytest.raises(TypeError, match="must be a table"):
             read_pyproject_optional_dependencies(p)
 
+    def test_string_project_table_raises(self, tmp_path: object) -> None:
+        """A [project] that is a string is rejected before the .get."""
+        p = Path(str(tmp_path)) / "pyproject.toml"
+        p.write_text('project = "hello"\n')
+        with pytest.raises(TypeError, match=r"\[project\] must be a table"):
+            read_pyproject_optional_dependencies(p)
+
 
 class TestSelectOptionalDependencies:
     def test_returns_empty_when_nothing_selected(self) -> None:
@@ -316,6 +337,13 @@ class TestReadPyprojectName:
         p = Path(str(tmp_path)) / "pyproject.toml"
         p.write_text('[project]\nversion = "1.0"\n')
         assert read_pyproject_name(p) is None
+
+    def test_string_project_table_raises(self, tmp_path: object) -> None:
+        """A [project] that is a string is rejected before the .get."""
+        p = Path(str(tmp_path)) / "pyproject.toml"
+        p.write_text('project = "hello"\n')
+        with pytest.raises(TypeError, match=r"\[project\] must be a table"):
+            read_pyproject_name(p)
 
 
 class TestExpandSelfExtras:

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -462,6 +462,9 @@ def _resolve_specific(  # noqa: PLR0913, C901 - one wrapper per resolve_pyprojec
     except KeyError:
         sys.stderr.write(f"Error: {path} has no [project].dependencies\n")
         sys.exit(1)
+    except TypeError as e:
+        sys.stderr.write(f"Error in {path}: {e}\n")
+        sys.exit(1)
     except InvalidProjectRequirementError as e:
         sys.stderr.write(f"Error: {e}\n")
         sys.exit(1)
@@ -482,7 +485,7 @@ def _resolve_specific(  # noqa: PLR0913, C901 - one wrapper per resolve_pyprojec
         sys.exit(1)
 
 
-def _resolve_universal(
+def _resolve_universal(  # noqa: C901 - one except per exit-mapped error
     path: Path,
     *,
     config: NabProjectConfig,
@@ -515,6 +518,9 @@ def _resolve_universal(
         sys.exit(1)
     except KeyError:
         sys.stderr.write(f"Error: {path} has no [project].dependencies\n")
+        sys.exit(1)
+    except TypeError as e:
+        sys.stderr.write(f"Error in {path}: {e}\n")
         sys.exit(1)
     except InvalidProjectRequirementError as e:
         sys.stderr.write(f"Error: {e}\n")

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -59,7 +59,10 @@ from nab_python.lockfile import (
     write_requirements_without_hashes,  # noqa: F401 - re-exported for tests
 )
 from nab_python.provider import InvalidUploadTimeError, UnsupportedVcsError
-from nab_python.requirements_file import InvalidProjectRequirementError
+from nab_python.requirements_file import (
+    InvalidProjectRequirementError,
+    InvalidProjectTableError,
+)
 from nab_python.resolve import (
     resolve_pyproject,
     resolve_universal_pyproject,
@@ -462,7 +465,7 @@ def _resolve_specific(  # noqa: PLR0913, C901 - one wrapper per resolve_pyprojec
     except KeyError:
         sys.stderr.write(f"Error: {path} has no [project].dependencies\n")
         sys.exit(1)
-    except TypeError as e:
+    except InvalidProjectTableError as e:
         sys.stderr.write(f"Error in {path}: {e}\n")
         sys.exit(1)
     except InvalidProjectRequirementError as e:
@@ -519,7 +522,7 @@ def _resolve_universal(  # noqa: C901 - one except per exit-mapped error
     except KeyError:
         sys.stderr.write(f"Error: {path} has no [project].dependencies\n")
         sys.exit(1)
-    except TypeError as e:
+    except InvalidProjectTableError as e:
         sys.stderr.write(f"Error in {path}: {e}\n")
         sys.exit(1)
     except InvalidProjectRequirementError as e:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -949,9 +949,6 @@ class TestLockCommandUniversal:
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, output=tmp_path / "pylock.toml")
-        # The full hint is asserted above; the validator's own hint
-        # text is covered against the real implementation in
-        # nab-python/tests/test_lockfile.py.
         err = capsys.readouterr().err
         assert f"Error: {hint}\n" in err
 
@@ -1350,7 +1347,6 @@ class TestLockCommandUniversal:
         b = tmp_path / "constraints-3.12.txt"
         assert a.read_text().strip() == "foo==1.0"
         assert b.read_text().strip() == "foo==1.0"
-        # The literal templated path is NOT written.
         assert not (tmp_path / "constraints-{python_version}.txt").exists()
 
     def test_template_with_platform_id(self, tmp_path: Path) -> None:
@@ -1568,9 +1564,6 @@ class TestLockCommandUniversal:
             tuple_results=[good_tr, bad_tr],
         )
         out = tmp_path / "constraints-{python_version}.txt"
-        # The lock fails because the matrix has a failure; check the file
-        # for the successful tuple is still printed via the stdout
-        # multi-block path (not via this test).
         with (
             patch("nab.cli.resolve_universal_pyproject", return_value=mixed),
             pytest.raises(SystemExit, match="1"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -442,6 +442,28 @@ class TestLockCommandSpecific:
             lock(pyproject)
         assert "no [project].dependencies" in capsys.readouterr().err
 
+    def test_string_project_table_exits_cleanly(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A non-table [project] exits 1 with a diagnostic, not a traceback."""
+        pyproject = _make_pyproject(tmp_path, 'project = "hello"\n')
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject)
+        err = capsys.readouterr().err
+        assert "[project] must be a table" in err
+        assert "Traceback" not in err
+
+    def test_array_project_table_exits_cleanly(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An array [project] exits 1 with a diagnostic, not a traceback."""
+        pyproject = _make_pyproject(tmp_path, 'project = ["a", "b"]\n')
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject)
+        err = capsys.readouterr().err
+        assert "[project] must be a table" in err
+        assert "Traceback" not in err
+
     def test_missing_hash_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -776,6 +798,25 @@ class TestLockCommandUniversal:
         ):
             lock(pyproject, output=out)
         assert "resolver path is not implemented" in capsys.readouterr().err
+
+    def test_string_project_table_exits_cleanly(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A non-table [project] in universal mode exits 1, not a traceback."""
+        pyproject = _make_pyproject(
+            tmp_path,
+            'project = "hello"\n'
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.11"\n'
+            'platforms = ["linux_x86_64"]\n',
+        )
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, output=tmp_path / "pylock.toml")
+        err = capsys.readouterr().err
+        assert "[project] must be a table" in err
+        assert "Traceback" not in err
 
     def test_pylock_writes_universal_lock(self, tmp_path: Path) -> None:
         """Universal + pylock format runs the real merge + write pipeline."""


### PR DESCRIPTION
Pointing the lock command at a pyproject.toml whose `project` key is a string or an array (anything that is not a table) crashed with a raw `TypeError` or `AttributeError`. The reader subscripted or called `.get()` on the value blindly, so the user saw a traceback instead of being told what was wrong with their file.

The `[project]` readers in `requirements_file.py` now raise a dedicated `InvalidProjectTableError` (a `TypeError` subclass) with a named message (`[project] must be a table, got str`) when the value is not a table. The CLI catches that specific error on both the specific and universal resolve paths, prints `Error in <path>: ...`, and exits 1, so a malformed `[project]` ends in a clear diagnostic. Catching the dedicated subclass rather than a bare `TypeError` keeps an unrelated internal error surfacing as a traceback instead of being mislabelled as a user-file problem.