### PR TITLE
sync python_full_version when a marker overlay sets only python_version

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -63,6 +63,7 @@ __all__ = [
     "VcsConfig",
     "VcsPolicy",
     "VcsSource",
+    "apply_python_axis_overlay",
     "join_extra",
     "python_axis_environment",
     "split_extra",
@@ -107,6 +108,25 @@ def python_axis_environment(python_version: str) -> dict[str, str]:
         suffix = str(parsed)[len(parsed.base_version) :]
         full = f"{epoch}{padded}{suffix}"
     return {"python_version": minor, "python_full_version": full}
+
+
+def apply_python_axis_overlay(
+    environment: dict[str, str], overlay: Mapping[str, str]
+) -> None:
+    """Merge ``overlay`` into ``environment``, keeping the python axis in sync.
+
+    When the overlay moves only ``python_version`` (or only
+    ``python_full_version``) the untouched key would keep the host patch
+    level and the two would describe different interpreters. Re-derive both
+    from whichever axis key the overlay supplies (``python_full_version``
+    wins when both are present), so an overlay of ``python_version`` ``3.8``
+    yields ``python_full_version`` ``3.8.0`` like the universal matrix. Keys
+    the overlay sets explicitly are kept verbatim.
+    """
+    source = overlay.get("python_full_version") or overlay.get("python_version")
+    if source is not None:
+        environment.update(python_axis_environment(source))
+    environment.update(overlay)
 
 
 def _normalize_extra(extra: str) -> str:
@@ -442,13 +462,17 @@ class Provider:
         if marker_environment:
             # The Requires-Python candidate filter reads self.python_version, so
             # an impersonated target Python in the overlay must move it too,
-            # keeping the filter aligned with marker evaluation. Mirrors
-            # UniversalProvider.
-            self.python_version = (
-                marker_environment.get("python_full_version")
-                or marker_environment.get("python_version")
-                or python_version
-            )
+            # keeping the filter aligned with marker evaluation. It parses a
+            # full Version, so pad to the full release like the environment does
+            # (overlay python_version "3.8" gives "3.8.0", not the host patch
+            # level). Mirrors UniversalProvider.
+            overlay_python = marker_environment.get(
+                "python_full_version"
+            ) or marker_environment.get("python_version")
+            if overlay_python is not None:
+                self.python_version = python_axis_environment(overlay_python)[
+                    "python_full_version"
+                ]
         self.uploaded_prior_to = uploaded_prior_to
 
         # Passed through to the build env when extract_source_metadata
@@ -496,8 +520,7 @@ class Provider:
         if python_version is not None:
             self.environment.update(python_axis_environment(python_version))
         if marker_environment:
-            for key, value in marker_environment.items():
-                self.environment[key] = value
+            apply_python_axis_overlay(self.environment, marker_environment)
 
         self.root_requirements = root_requirements or {}
         self.versions_cache: dict[str, list[tuple[Version, DistFile]]] = {}

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -43,6 +43,7 @@ from .lockfile import LockInput, build_lock_input_from_provider
 from .provider import (
     Provider,
     ResolutionStrategy,
+    apply_python_axis_overlay,
     join_extra,
     python_axis_environment,
     split_extra,
@@ -713,7 +714,8 @@ def _build_marker_environment(
     Mirrors :class:`Provider`: defaults from
     :func:`default_environment`, then ``python_version`` /
     ``python_full_version`` rewritten from the effective Python, then
-    user overrides.
+    user overrides. An overlay touching one python-axis key re-derives the
+    other through :func:`apply_python_axis_overlay` so they stay in sync.
     """
     env: dict[str, str] = {
         key: value
@@ -721,7 +723,7 @@ def _build_marker_environment(
         if isinstance(value, str)
     }
     env.update(python_axis_environment(python_version))
-    env.update(overrides)
+    apply_python_axis_overlay(env, overrides)
     return env
 
 

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -434,6 +434,32 @@ class TestFetchVersions:
         versions = [v for v, _ in provider.filter_distributions("foo", records)]
         assert versions == [V("1.0")]
 
+    def test_python_version_only_overlay_syncs_full_version(self) -> None:
+        """An overlay with python_version alone syncs the whole axis.
+
+        Overlaying ``python_version = "3.8"`` moves ``python_full_version``
+        off the host patch level and sets the Requires-Python filter target
+        to the impersonated full release.
+        """
+        coordinator = make_coordinator(
+            [
+                make_wheel("1.0", requires_python=">=3.8,<3.9"),
+                make_wheel("2.0", requires_python=">=3.12"),
+            ],
+            package="foo",
+        )
+        provider = Provider(
+            coordinator,
+            python_version="3.12.3",
+            build_policy=BuildPolicy.NEVER,
+            marker_environment={"python_version": "3.8"},
+        )
+        assert provider.environment["python_version"] == "3.8"
+        assert provider.environment["python_full_version"] == "3.8.0"
+        assert provider.python_version == "3.8.0"
+        versions = [v for v, _ in provider.fetch_versions("foo")]
+        assert versions == [V("1.0")]
+
     def test_sorted_descending(self) -> None:
         """Results are sorted newest-first."""
         wheels = [make_wheel(v) for v in ("1.0", "3.0", "2.0")]

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -763,6 +763,47 @@ class TestResolvePyproject:
     @patch("nab_python.resolve.Resolver")
     @patch("nab_python.resolve.Provider")
     @patch("nab_python.resolve.FetchCoordinator")
+    def test_python_version_overlay_keeps_full_version_gated_dep(
+        self,
+        mock_coord_cls: MagicMock,
+        mock_provider_cls: MagicMock,
+        mock_resolver_cls: MagicMock,
+        mock_build_lock: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """A python_full_version-gated dep follows the impersonated Python.
+
+        Overlaying only ``python_version = "3.8"`` on a 3.12 host must keep
+        ``legacy; python_full_version < '3.10'``: the user is impersonating
+        Python 3.8, so the marker holds. The host patch level must not leak
+        in through ``python_full_version``.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            "[project]\n"
+            "dependencies = ["
+            '"foo", "legacy; python_full_version < \'3.10\'"]\n'
+            '[tool.nab]\nbuild-policy = "never"\n'
+            "[tool.nab.marker-environment]\n"
+            'python_version = "3.8"\n',
+        )
+        mock_coord_cls.return_value.__enter__ = lambda s: s
+        mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_resolver_cls.return_value.resolve.return_value = {
+            "foo": V("1.0"),
+            "legacy": V("1.0"),
+        }
+
+        resolve_pyproject(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
+
+        requirements = mock_resolver_cls.return_value.resolve.call_args.args[0]
+        assert "foo" in requirements
+        assert "legacy" in requirements
+
+    @patch("nab_python.resolve.build_lock_input_from_provider")
+    @patch("nab_python.resolve.Resolver")
+    @patch("nab_python.resolve.Provider")
+    @patch("nab_python.resolve.FetchCoordinator")
     def test_root_marker_true_keeps_requirement(
         self,
         mock_coord_cls: MagicMock,
@@ -2519,6 +2560,46 @@ class TestBuildMarkerEnvironment:
     def test_full_python_version_preserved(self) -> None:
         env = _build_marker_environment(python_version="3.11.5", overrides={})
         assert env["python_full_version"] == "3.11.5"
+
+    def test_overlay_python_version_alone_syncs_full_version(self) -> None:
+        """An overlay python_version drives python_full_version too.
+
+        Setting only ``python_version`` moves ``python_full_version`` off
+        the host patch level to ``{minor}.0``, so a
+        ``python_full_version``-gated marker no longer reads the host
+        interpreter.
+        """
+        env = _build_marker_environment(
+            python_version="3.12.3", overrides={"python_version": "3.8"}
+        )
+        assert env["python_version"] == "3.8"
+        assert env["python_full_version"] == "3.8.0"
+
+    def test_overlay_full_version_alone_syncs_minor(self) -> None:
+        """An overlay python_full_version drives python_version too."""
+        env = _build_marker_environment(
+            python_version="3.12.3", overrides={"python_full_version": "3.8.7"}
+        )
+        assert env["python_version"] == "3.8"
+        assert env["python_full_version"] == "3.8.7"
+
+    def test_overlay_both_axis_values_respected(self) -> None:
+        """When the overlay sets both axis keys, both win verbatim."""
+        env = _build_marker_environment(
+            python_version="3.12.3",
+            overrides={"python_version": "3.8", "python_full_version": "3.8.7"},
+        )
+        assert env["python_version"] == "3.8"
+        assert env["python_full_version"] == "3.8.7"
+
+    def test_overlay_without_python_keeps_host_axis(self) -> None:
+        """A non-python overlay leaves both python-axis values alone."""
+        env = _build_marker_environment(
+            python_version="3.12.3", overrides={"sys_platform": "win32"}
+        )
+        assert env["python_version"] == "3.12"
+        assert env["python_full_version"] == "3.12.3"
+        assert env["sys_platform"] == "win32"
 
 
 class TestCheckGroupDisjointnessAcrossTuples:


### PR DESCRIPTION
A single-env marker-environment overlay that sets only `python_version` (say `3.8`) on a 3.12 host left `python_full_version` pinned to the host patch level (`3.12.3`). The two keys then described different interpreters, so a `python_full_version`-gated dependency like `legacy; python_full_version < '3.10'` was evaluated against the host instead of the impersonated Python and got dropped.

The overlay now re-derives the whole python axis from whichever key it supplies, padding to the full release (`python_version` `3.8` gives `python_full_version` `3.8.0`), the same as the universal matrix. `python_full_version` wins when the overlay sets both, and an overlay that sets neither leaves the host axis alone. The Requires-Python filter target on the provider is padded the same way so candidate filtering stays aligned with marker evaluation.
