### PR TITLE
raise ConfigError for invalid PEP 508 constraints in [tool.nab]

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -678,7 +678,7 @@ def _parse_nab_table(
 
     return NabProjectConfig(
         mode=mode,
-        constraints=_parse_string_list("constraints", raw.get("constraints", [])),
+        constraints=_parse_constraints(raw.get("constraints", [])),
         default_groups=default_groups,
         requires_python=_parse_requires_python(raw.get("requires-python")),
         uploaded_prior_to=_parse_uploaded_prior_to(
@@ -767,6 +767,21 @@ def _parse_string_list(key: str, value: object) -> tuple[str, ...]:
             raise ConfigError(msg)
         out.append(item)
     return tuple(out)
+
+
+def _require_pep508(key: str, item: str) -> None:
+    try:
+        Requirement(item)
+    except InvalidRequirement as exc:
+        msg = f"{key} is not a valid requirement: {exc}"
+        raise ConfigError(msg) from exc
+
+
+def _parse_constraints(value: object) -> tuple[str, ...]:
+    items = _parse_string_list("constraints", value)
+    for i, item in enumerate(items):
+        _require_pep508(f"constraints[{i}]", item)
+    return items
 
 
 def _reject_duplicates(key: str, items: tuple[str, ...]) -> None:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -581,6 +581,16 @@ class TestConstraints:
         with pytest.raises(ConfigError, match="constraints\\[0\\] must be a string"):
             read_pyproject_config(path)
 
+    def test_constraints_entries_must_be_valid_pep508(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab]\nconstraints = ["urllib3 (((not valid pep508"]\n',
+        )
+        with pytest.raises(
+            ConfigError, match="constraints\\[0\\] is not a valid requirement"
+        ):
+            read_pyproject_config(path)
+
 
 class TestDefaultGroups:
     def test_default_is_empty(self, tmp_path: Path) -> None:


### PR DESCRIPTION
A malformed entry in `[tool.nab].constraints`, such as `"urllib3 (((not valid pep508"`, leaked a raw `InvalidRequirement` from packaging instead of the clean `ConfigError` we report for every other bad config value.

Each constraint is now parsed as a PEP 508 requirement while reading the config, and an unparseable one raises `ConfigError` naming the offending index, for example `constraints[0] is not a valid requirement: ...`.
