### PR TITLE
read an absent [project].dependencies as an empty dep set

### DIFF
--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -67,15 +67,17 @@ def read_pyproject_dependencies(path: Path) -> list[Requirement]:
     """Read [project].dependencies from a pyproject.toml file.
 
     Returns a list of Requirement objects parsed from the dependency
-    strings.  Raises FileNotFoundError if the file doesn't exist,
-    KeyError if [project] or [project].dependencies is missing, or
-    InvalidProjectRequirementError if a dependency string is malformed.
+    strings.  ``[project].dependencies`` is optional under PEP 621, so an
+    absent key reads as an empty base dependency set.  Raises
+    FileNotFoundError if the file doesn't exist, KeyError if [project] is
+    missing, or InvalidProjectRequirementError if a dependency string is
+    malformed.
     """
     with path.open("rb") as f:
         data = tomli.load(f)
 
     source = "[project].dependencies"
-    dep_strings = _require_string_list(data["project"]["dependencies"], source)
+    dep_strings = _require_string_list(data["project"].get("dependencies", []), source)
     return _parse_requirements(dep_strings, source)
 
 

--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -67,17 +67,28 @@ def read_pyproject_dependencies(path: Path) -> list[Requirement]:
     """Read [project].dependencies from a pyproject.toml file.
 
     Returns a list of Requirement objects parsed from the dependency
-    strings.  ``[project].dependencies`` is optional under PEP 621, so an
-    absent key reads as an empty base dependency set.  Raises
-    FileNotFoundError if the file doesn't exist, KeyError if [project] is
-    missing, or InvalidProjectRequirementError if a dependency string is
-    malformed.
+    strings. The key is optional under PEP 621, so an absent
+    ``dependencies`` reads as an empty list. Raises FileNotFoundError if
+    the file doesn't exist, KeyError if [project] is missing, and
+    InvalidProjectRequirementError if a dependency string is malformed or
+    if ``dependencies`` is declared dynamic. The root-project lock path
+    cannot run the build backend that would compute a dynamic value.
     """
     with path.open("rb") as f:
         data = tomli.load(f)
 
     source = "[project].dependencies"
-    dep_strings = _require_string_list(data["project"].get("dependencies", []), source)
+    project = data["project"]
+    if "dependencies" not in project:
+        dynamic = project.get("dynamic")
+        if isinstance(dynamic, list) and "dependencies" in dynamic:
+            msg = (
+                "[project].dependencies is declared dynamic; computing it"
+                " requires the build backend, which the root-project lock"
+                " path does not support"
+            )
+            raise InvalidProjectRequirementError(msg)
+    dep_strings = _require_string_list(project.get("dependencies", []), source)
     return _parse_requirements(dep_strings, source)
 
 

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -72,11 +72,31 @@ class TestReadPyprojectDependencies:
         p.write_text("[project]\ndependencies = []\n")
         assert read_pyproject_dependencies(p) == []
 
-    def test_dynamic_dependencies_returns_empty(self, tmp_path: object) -> None:
-        """dynamic = ['dependencies'] with no static key reads as empty."""
+    def test_other_dynamic_field_returns_empty(self, tmp_path: object) -> None:
+        """dynamic = ['version'] without a deps key still reads as empty."""
+        p = Path(str(tmp_path)) / "pyproject.toml"
+        p.write_text('[project]\nname = "foo"\ndynamic = ["version"]\n')
+        assert read_pyproject_dependencies(p) == []
+
+    def test_dynamic_dependencies_raises(self, tmp_path: object) -> None:
+        """dynamic = ['dependencies'] is unsupported, not an empty dep set."""
         p = Path(str(tmp_path)) / "pyproject.toml"
         p.write_text('[project]\nname = "foo"\ndynamic = ["dependencies"]\n')
-        assert read_pyproject_dependencies(p) == []
+        with pytest.raises(InvalidProjectRequirementError, match="dynamic"):
+            read_pyproject_dependencies(p)
+
+    def test_static_dependencies_win_over_dynamic_listing(
+        self, tmp_path: object
+    ) -> None:
+        """A present static key is read even if dynamic also lists it."""
+        p = Path(str(tmp_path)) / "pyproject.toml"
+        p.write_text(
+            '[project]\nname = "foo"\n'
+            'dynamic = ["dependencies"]\n'
+            'dependencies = ["requests"]\n'
+        )
+        deps = read_pyproject_dependencies(p)
+        assert [d.name for d in deps] == ["requests"]
 
     def test_malformed_dependency_string_raises(self, tmp_path: object) -> None:
         """A malformed PEP 508 string raises InvalidProjectRequirementError."""

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -48,17 +48,34 @@ class TestReadPyprojectDependencies:
         with pytest.raises(KeyError):
             read_pyproject_dependencies(p)
 
-    def test_missing_dependencies_key_raises(self, tmp_path: object) -> None:
-        """Raise KeyError when dependencies key is missing."""
+    def test_missing_dependencies_key_returns_empty(self, tmp_path: object) -> None:
+        """An absent dependencies key reads as no base deps (PEP 621 optional)."""
         p = Path(str(tmp_path)) / "pyproject.toml"
         p.write_text('[project]\nname = "foo"\n')
-        with pytest.raises(KeyError):
-            read_pyproject_dependencies(p)
+        assert read_pyproject_dependencies(p) == []
+
+    def test_missing_dependencies_key_with_extras_returns_empty(
+        self, tmp_path: object
+    ) -> None:
+        """Deps declared only as an extra leave the base dep set empty."""
+        p = Path(str(tmp_path)) / "pyproject.toml"
+        p.write_text(
+            '[project]\nname = "myproj"\nversion = "1.0"\n'
+            "[project.optional-dependencies]\n"
+            'dev = ["pytest"]\n'
+        )
+        assert read_pyproject_dependencies(p) == []
 
     def test_empty_dependencies(self, tmp_path: object) -> None:
         """Return empty list when dependencies list is empty."""
         p = Path(str(tmp_path)) / "pyproject.toml"
         p.write_text("[project]\ndependencies = []\n")
+        assert read_pyproject_dependencies(p) == []
+
+    def test_dynamic_dependencies_returns_empty(self, tmp_path: object) -> None:
+        """dynamic = ['dependencies'] with no static key reads as empty."""
+        p = Path(str(tmp_path)) / "pyproject.toml"
+        p.write_text('[project]\nname = "foo"\ndynamic = ["dependencies"]\n')
         assert read_pyproject_dependencies(p) == []
 
     def test_malformed_dependency_string_raises(self, tmp_path: object) -> None:


### PR DESCRIPTION
A valid PEP 621 project that leaves out the optional `[project].dependencies` key could not be locked: `read_pyproject_dependencies` indexed the key directly, so a missing key raised a KeyError that surfaced to the user as exit 1 instead of resolving against an empty base dep set.

The key is optional under PEP 621, so an absent `dependencies` now reads as no base dependencies. A project that declares its deps only as optional extras, or only sets `dynamic = ["version"]`, locks cleanly.

One case is still an error rather than empty: `dynamic = ["dependencies"]`. Computing those needs the build backend, which the root-project lock path does not run, so it raises `InvalidProjectRequirementError` with a message saying so. A static `dependencies` key still wins if `dynamic` also lists it.
