### PR TITLE
keep the prerelease tag in python_full_version for two-component versions

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -89,18 +89,23 @@ def python_axis_environment(python_version: str) -> dict[str, str]:
     if the input is not a version.
     """
     try:
-        release = Version(python_version).release
+        parsed = Version(python_version)
     except InvalidVersion:
         msg = f"python_version {python_version!r} is not a valid version"
         raise InvalidVersion(msg) from None
+    release = parsed.release
     minor = ".".join(str(part) for part in (*release, 0)[:_PYTHON_VERSION_PARTS])
-    full = (
-        python_version
-        if len(release) >= _PYTHON_FULL_VERSION_PARTS
-        else ".".join(
+    if len(release) >= _PYTHON_FULL_VERSION_PARTS:
+        full = python_version
+    else:
+        # Pad the release to three components, keeping the epoch and any
+        # prerelease/post/dev/local tag, which live outside ``release``.
+        epoch = f"{parsed.epoch}!" if parsed.epoch else ""
+        padded = ".".join(
             str(part) for part in (*release, 0, 0)[:_PYTHON_FULL_VERSION_PARTS]
         )
-    )
+        suffix = str(parsed)[len(parsed.base_version) :]
+        full = f"{epoch}{padded}{suffix}"
     return {"python_version": minor, "python_full_version": full}
 
 

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -17,6 +17,7 @@ from nab_python._provider.metadata_resolver import (
     pick_dist_for_metadata,
 )
 from nab_python._testing.coordinator_fake import make_coordinator
+from nab_python._vendor.packaging.markers import Marker
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.specifiers import SpecifierSet
@@ -1586,6 +1587,18 @@ class TestPythonAxisEnvironment:
         """The error names the bad ``python_version`` input."""
         with pytest.raises(InvalidVersion, match="python_version 'not-a-version'"):
             python_axis_environment("not-a-version")
+
+    def test_two_component_prerelease_keeps_tag(self) -> None:
+        """A 2-release-component prerelease keeps its tag in full version."""
+        env = python_axis_environment("3.14a1")
+        assert env["python_version"] == "3.14"
+        assert Version(env["python_full_version"]) == Version("3.14a1")
+
+    def test_two_component_prerelease_not_treated_as_final(self) -> None:
+        """A prerelease target must not satisfy a final-release marker."""
+        env = python_axis_environment("3.14rc1")
+        assert Marker('python_full_version >= "3.14.0"').evaluate(env) is False
+        assert Marker('python_full_version == "3.14.0"').evaluate(env) is False
 
 
 class TestLookAhead:


### PR DESCRIPTION
When a Python version with only two release components carried a prerelease tag, `python_axis_environment` dropped the tag while padding to three components, so `3.14a1` became `python_full_version` of `3.14.0`. A prerelease target then wrongly satisfied final-release markers like `python_full_version >= "3.14.0"` or `== "3.14.0"`.

The padding step only operated on the parsed `release` tuple, which does not include the epoch or the prerelease/post/dev/local tag. The fix pads the release to three components and re-attaches the epoch and the original suffix, so `3.14a1` stays `3.14a1` and a final-release marker no longer matches a prerelease.
