### PR TITLE
honor PEP 714 core-metadata precedence in the JSON index parser

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -368,20 +368,32 @@ def _parse_size(value: object) -> int | None:
     return None
 
 
+_LEGACY_METADATA_KEY = "dist-info-metadata"
+
+
+def _metadata_value(file_info: dict) -> object:
+    """Return the metadata field, applying PEP 714 key precedence.
+
+    When ``core-metadata`` is present it wins and the legacy
+    ``dist-info-metadata`` key is ignored, so ``core-metadata: false``
+    means no sidecar even if a stale legacy entry lingers.  The legacy key
+    applies only when ``core-metadata`` is absent.  ``data-dist-info-metadata``
+    is the HTML attribute name and never appears in the JSON response.
+    """
+    if "core-metadata" in file_info:
+        return file_info.get("core-metadata")
+    return file_info.get(_LEGACY_METADATA_KEY)
+
+
 def _has_metadata(file_info: dict) -> bool:
     """Return True when the file entry advertises a PEP 658/714 sidecar.
 
     PEP 691 allows either a ``true`` boolean (sidecar exists but no
     hashes published) or a mapping carrying the digest table.  Either
-    flavour means the index will serve ``<file>.metadata``.  The legacy
-    JSON key is ``dist-info-metadata`` (PEP 658); ``data-dist-info-metadata``
-    is the HTML attribute name and never appears in the JSON response.
+    flavour means the index will serve ``<file>.metadata``.
     """
-    for key in ("core-metadata", "dist-info-metadata"):
-        value = file_info.get(key)
-        if value is True or isinstance(value, dict):
-            return True
-    return False
+    value = _metadata_value(file_info)
+    return value is True or isinstance(value, dict)
 
 
 def _metadata_hash(file_info: dict) -> tuple[str, str] | None:
@@ -391,12 +403,11 @@ def _metadata_hash(file_info: dict) -> tuple[str, str] | None:
     and what pip verifies.  A bare ``true`` (sidecar exists, no hash)
     or a table without sha256 yields None, so no check runs.
     """
-    for key in ("core-metadata", "dist-info-metadata"):
-        value = file_info.get(key)
-        if isinstance(value, dict):
-            digest = value.get("sha256")
-            if isinstance(digest, str):
-                return ("sha256", digest.lower())
+    value = _metadata_value(file_info)
+    if isinstance(value, dict):
+        digest = value.get("sha256")
+        if isinstance(digest, str):
+            return ("sha256", digest.lower())
     return None
 
 

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -126,6 +126,18 @@ class TestHasMetadataFlag:
 
         assert not _has_metadata({})
 
+    def test_core_metadata_false_suppresses_legacy_key(self) -> None:
+        from nab_index.client import _has_metadata
+
+        assert not _has_metadata(
+            {"core-metadata": False, "dist-info-metadata": {"sha256": "deadbeef"}}
+        )
+
+    def test_core_metadata_true_ignores_legacy_key(self) -> None:
+        from nab_index.client import _has_metadata
+
+        assert _has_metadata({"core-metadata": True, "dist-info-metadata": False})
+
 
 class TestMetadataHashParsing:
     """``_metadata_hash`` carries the published sha256 to verify, or None."""
@@ -160,6 +172,36 @@ class TestMetadataHashParsing:
         from nab_index.client import _metadata_hash
 
         assert _metadata_hash({}) is None
+
+    def test_core_metadata_false_ignores_legacy_hash(self) -> None:
+        from nab_index.client import _metadata_hash
+
+        assert (
+            _metadata_hash(
+                {"core-metadata": False, "dist-info-metadata": {"sha256": "deadbeef"}}
+            )
+            is None
+        )
+
+    def test_core_metadata_true_ignores_legacy_hash(self) -> None:
+        from nab_index.client import _metadata_hash
+
+        assert (
+            _metadata_hash(
+                {"core-metadata": True, "dist-info-metadata": {"sha256": "cafef00d"}}
+            )
+            is None
+        )
+
+    def test_core_metadata_hash_preferred_over_legacy(self) -> None:
+        from nab_index.client import _metadata_hash
+
+        assert _metadata_hash(
+            {
+                "core-metadata": {"sha256": "AAAA"},
+                "dist-info-metadata": {"sha256": "BBBB"},
+            }
+        ) == ("sha256", "aaaa")
 
     def test_parse_files_populates_metadata_hash(self) -> None:
         from nab_index.client import WheelFile, _parse_files


### PR DESCRIPTION
When a JSON Simple-API file entry carried both keys, the parser read whichever appeared first instead of following PEP 714. A present `core-metadata: false` did not suppress a stale legacy `dist-info-metadata` entry, so we would fetch and hash-check a `.metadata` sidecar the index never offered to serve.

PEP 714 says `core-metadata` always wins when present, and the legacy `dist-info-metadata` key applies only when `core-metadata` is absent. Both `_has_metadata` and `_metadata_hash` looped over the two keys and returned on the first truthy match, which broke that ordering.

The fix routes both through a single `_metadata_value` helper that picks the field by precedence: if `core-metadata` is present it is used as-is (including `false`), otherwise the legacy key is consulted. `core-metadata: false` now means no sidecar, and the legacy hash is ignored whenever `core-metadata` is set.
