### PR TITLE
raise default macos_arm64 ceiling to 12.0 so modern arm64 wheels match

### DIFF
--- a/nab-python/src/nab_python/universal/wheel_selection.py
+++ b/nab-python/src/nab_python/universal/wheel_selection.py
@@ -52,9 +52,13 @@ _BUILD_TAG_RE = re.compile(r"(\d+)(.*)", re.ASCII)
 _DEFAULT_MANYLINUX_FLOOR = (2, 17)
 # Default musllinux floor: musl 1.2 (adopted by Alpine 3.13+, 2021+).
 _DEFAULT_MUSLLINUX_FLOOR = (1, 2)
-# Default macOS minimum: 11 (Big Sur, 2020+).  arm64 was introduced
-# at 11.0; using 10.x for arm64 has no compatible wheels.
-_DEFAULT_MACOS_MIN = (11, 0)
+# The macOS defaults model the deployment-target (system) macOS version.
+# ``mac_platforms`` treats this as a ceiling: a system at macOS V installs
+# wheels built for V and older, never newer, so a higher value accepts more
+# (newer) wheels. Default arm64 target: 12.0 (Monterey). Apple Silicon was
+# introduced at 11.0, but most arm64 wheels published since 2023 target
+# macosx_12_0 or newer, so a value below 12.0 would reject them.
+_DEFAULT_MACOS_MIN = (12, 0)
 # Default macOS minimum for x86_64 builds.  10.13 was the last with
 # wide wheel coverage; newer macOS x86_64 builds rarely declare
 # below 10.13.
@@ -74,8 +78,8 @@ class PlatformSpec:
 
     Users can override the per-platform floors when their
     deployment target requires it.  The defaults are deliberately
-    permissive (manylinux 2.17, musl 1.2, macOS 11) so most real
-    deployments work out of the box.
+    permissive (manylinux 2.17, musl 1.2, macOS 12 arm64 / 10.13
+    x86_64) so most real deployments work out of the box.
 
     ``platform_release`` and ``platform_version`` set the
     corresponding PEP 508 marker values on this platform's tuples

--- a/nab-python/tests/universal/test_wheel_selection.py
+++ b/nab-python/tests/universal/test_wheel_selection.py
@@ -127,14 +127,17 @@ class TestCompatibleTagsForTuple:
         assert "cp311-cp311-musllinux_1_2_x86_64" in tag_strs
         assert "cp311-cp311-musllinux_1_0_x86_64" in tag_strs
 
-    def test_macos_arm64_uses_default_floor(self) -> None:
-        """``macos_arm64`` defaults to macOS 11 (arm64 minimum)."""
+    def test_macos_arm64_default_accepts_modern_wheels(self) -> None:
+        """The default ``macos_arm64`` admits ``macosx_11_0`` and ``macosx_12_0``."""
         spec = PlatformSpec("macos_arm64")
         tag_strs = {
             str(t) for t in compatible_tags_for_tuple(python_version="3.11", spec=spec)
         }
         # mac_platforms yields versions <= the declared one
         assert "cp311-cp311-macosx_11_0_arm64" in tag_strs
+        assert "cp311-cp311-macosx_12_0_arm64" in tag_strs
+        # Still a ceiling: a newer-than-default macOS wheel is excluded.
+        assert "cp311-cp311-macosx_13_0_arm64" not in tag_strs
 
     def test_macos_x86_64_uses_default_floor(self) -> None:
         """``macos_x86_64`` defaults to macOS 10.13 (x86_64-era)."""
@@ -223,6 +226,13 @@ class TestWheelCompatibility:
         assert wheel_compatible_with_tuple(wheel, python_version="3.10", spec=spec)
         assert wheel_compatible_with_tuple(wheel, python_version="3.13", spec=spec)
 
+    def test_default_macos_arm64_accepts_modern_arm64_wheel(self) -> None:
+        """``macosx_11_0`` and ``macosx_12_0`` wheels match the default spec."""
+        spec = PlatformSpec("macos_arm64")
+        for tag in ("macosx_11_0_arm64", "macosx_12_0_arm64"):
+            wheel = _wheel(f"pkg-1.0-cp311-cp311-{tag}.whl")
+            assert wheel_compatible_with_tuple(wheel, python_version="3.11", spec=spec)
+
     def test_garbage_filename(self) -> None:
         """A non-wheel filename is rejected."""
         spec = PlatformSpec("linux_x86_64")
@@ -302,6 +312,25 @@ class TestSelectWheelForTuple:
         spec = PlatformSpec("linux_x86_64")
         wheels = [_wheel("pkg-1.0-cp311-cp311-win_amd64.whl")]
         assert select_wheel_for_tuple(wheels, python_version="3.11", spec=spec) is None
+
+    def test_default_macos_arm64_selects_modern_only_wheel(self) -> None:
+        """A version shipping only a ``macosx_12_0`` arm64 wheel is selectable."""
+        spec = PlatformSpec("macos_arm64")
+        wheels = [_wheel("pkg-2.2.0-cp312-cp312-macosx_12_0_arm64.whl")]
+        chosen = select_wheel_for_tuple(wheels, python_version="3.12", spec=spec)
+        assert chosen is not None
+        assert chosen.filename == "pkg-2.2.0-cp312-cp312-macosx_12_0_arm64.whl"
+
+    def test_default_macos_arm64_prefers_native_over_universal(self) -> None:
+        """A ``macosx_12_0_arm64`` wheel beats the ``py3-none-any`` fallback."""
+        spec = PlatformSpec("macos_arm64")
+        wheels = [
+            _wheel("pkg-2.2.0-py3-none-any.whl"),
+            _wheel("pkg-2.2.0-cp312-cp312-macosx_12_0_arm64.whl"),
+        ]
+        chosen = select_wheel_for_tuple(wheels, python_version="3.12", spec=spec)
+        assert chosen is not None
+        assert chosen.filename == "pkg-2.2.0-cp312-cp312-macosx_12_0_arm64.whl"
 
     def test_specific_beats_universal(self) -> None:
         """A platform-specific wheel beats py3-none-any."""


### PR DESCRIPTION
The default macos_arm64 platform spec set its ceiling to macOS 11.0. `mac_platforms` treats that value as a ceiling, so any wheel built for `macosx_12_0_arm64` or newer was rejected. For a package whose arm64 wheels target 12.0 or later, that meant the version was dropped, or the resolver fell back to the pure-Python `py3-none-any` wheel instead of the native arm64 one.

Apple Silicon shipped at 11.0, but many arm64 wheels now declare `macosx_12_0` or newer. Raise the default arm64 ceiling to 12.0 (Monterey) so those wheels match while still excluding versions newer than the deployment target.
