### PR TITLE
evaluate self-reference markers in the conflict-exclusion check

### DIFF
--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -146,20 +146,6 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
     # into the active group set alongside the CLI selection.
     effective_groups = tuple(dict.fromkeys((*groups, *config.default_groups)))
 
-    if config.conflicts:
-        # Read each table once and reuse it across the existence check
-        # and the umbrella expansion, so a conflict the selection only
-        # reaches transitively is still caught without re-parsing the
-        # file.
-        optional = read_pyproject_optional_dependencies(path)
-        groups_table = read_pyproject_groups(path)
-        project_name = read_pyproject_name(path)
-        _validate_conflict_members_exist(config.conflicts, optional, groups_table)
-        active_extras = expand_self_extras(optional, project_name, extras)
-        active_groups = expand_group_includes(groups_table, effective_groups)
-        validate_conflict_exclusions(config.conflicts, active_extras, active_groups)
-        validate_conflict_minimums(config.conflicts, active_extras, active_groups)
-
     if python_version is not None:
         effective_python = python_version
     elif config.requires_python is not None:
@@ -168,14 +154,34 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
         vi = sys.version_info
         effective_python = f"{vi.major}.{vi.minor}.{vi.micro}"
 
-    effective_strategy = (
-        resolution_strategy if resolution_strategy is not None else config.resolution
-    )
-
     marker_environment = _build_marker_environment(
         python_version=effective_python,
         overrides=config.marker_environment,
     )
+
+    if config.conflicts:
+        # Read each table once and reuse it across the existence check
+        # and the umbrella expansion, so a conflict the selection only
+        # reaches transitively is still caught without re-parsing the
+        # file.  The expansion takes the target environment so a self
+        # reference gated by a PEP 508 marker counts toward the exclusion
+        # check only when its marker holds here; members reached through
+        # disjoint markers never co-select.
+        optional = read_pyproject_optional_dependencies(path)
+        groups_table = read_pyproject_groups(path)
+        project_name = read_pyproject_name(path)
+        _validate_conflict_members_exist(config.conflicts, optional, groups_table)
+        active_extras = expand_self_extras(
+            optional, project_name, extras, marker_environment
+        )
+        active_groups = expand_group_includes(groups_table, effective_groups)
+        validate_conflict_exclusions(config.conflicts, active_extras, active_groups)
+        validate_conflict_minimums(config.conflicts, active_extras, active_groups)
+
+    effective_strategy = (
+        resolution_strategy if resolution_strategy is not None else config.resolution
+    )
+
     requirements = read_pyproject_dependencies(path)
     requirements.extend(_load_group_requirements(path, effective_groups))
     requirements.extend(_load_extra_requirements(path, extras, marker_environment))

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -288,6 +288,52 @@ class TestSpecificModeConflictValidation:
         # is pulled in through the self-reference.
         assert result.pins["foo"] == V("1.0")
 
+    def test_umbrella_extra_disjoint_markers_resolve(self, tmp_path: Path) -> None:
+        """Self-refs to both members under disjoint markers do not co-select.
+
+        ``all`` reaches cpu only below 3.10 and gpu only at 3.10+, so on
+        Python 3.12 just gpu is active and there is no co-selection. The
+        exclusion check must evaluate the self-reference markers in the
+        target environment rather than walking every self-reference.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\nversion = "0"\n'
+            "dependencies = []\n"
+            "[project.optional-dependencies]\n"
+            'cpu = ["foo==1.0"]\n'
+            'gpu = ["foo==2.0"]\n'
+            "all = [\n"
+            "    \"x[cpu]; python_version < '3.10'\",\n"
+            "    \"x[gpu]; python_version >= '3.10'\",\n"
+            "]\n"
+            "[tool.nab]\n"
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+        )
+        with (
+            patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls,
+            patch("nab_python.resolve.Provider") as mock_provider_cls,
+            patch("nab_python.resolve.build_lock_input_from_provider"),
+        ):
+            mock_coord_cls.return_value.__enter__ = lambda s: s
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            mock_provider = mock_provider_cls.return_value
+            mock_provider.choose_version.return_value = V("2.0")
+            mock_provider.get_dependencies.return_value = {}
+            mock_provider.prioritize.return_value = 1
+            result = resolve_pyproject(
+                pyproject,
+                _FAKE_TRANSPORT,
+                extras=("all",),
+                python_version="3.12.0",
+            )
+        # Only gpu's self-reference marker holds on 3.12, so gpu's pin is
+        # the one that reaches the resolver and cpu's is excluded.
+        root_reqs = mock_provider_cls.call_args.kwargs["root_requirements"]
+        assert V("2.0") in root_reqs["foo"]
+        assert V("1.0") not in root_reqs["foo"]
+        assert result.pins == {"foo": V("2.0")}
+
     def test_specific_mode_exactly_one_with_no_member_raises(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
In specific (non-universal) mode, the conflict-exclusion check expanded self-reference extras without looking at their PEP 508 markers. So an umbrella extra that reaches two conflicting members through disjoint markers, like `all = ["x[cpu]; python_version < '3.10'", "x[gpu]; python_version >= '3.10'"]`, was treated as activating both cpu and gpu at once and raised ConflictSelectionError, even though only one marker can ever hold in a given environment.

The expansion now takes the resolved target marker environment and only follows a self-reference when its marker holds there. Members reached through markers that are false in the environment no longer count toward exclusion. This required computing the marker environment before the conflicts block, so that block moved down to where the environment is available.

The universal path is unchanged: it still passes no environment and walks every self-reference, deferring marker evaluation to each environment tuple.
