### PR TITLE
Standardize config, CLI, and env-var sourcing

### DIFF
--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -1,8 +1,9 @@
 # CLI
 
-`nab` exposes two subcommands: `lock` and `download`. Both read
-project shape from `[tool.nab]` in the project's `pyproject.toml`;
-the CLI itself carries only runtime knobs.
+`nab` exposes three subcommands: `lock`, `download`, and `config`. The
+first two read project shape from `[tool.nab]` in the project's
+`pyproject.toml`; the CLI itself carries only runtime knobs. `config`
+inspects the layered configuration.
 
 ## Synopsis
 
@@ -10,12 +11,16 @@ the CLI itself carries only runtime knobs.
 nab [--version | -V]
 nab lock     [PATH] [RUNTIME OPTIONS] [--output PATH] [--format pylock|requirements|requirements-without-hashes]
 nab download [PATH] [RUNTIME OPTIONS] [--output DIR] [--max-concurrency N]
+nab config   {list | get <key> | explain <key>} [--path PATH]
 ```
 
 `PATH` is positional and defaults to `pyproject.toml` in the
 current directory. Run `nab lock --help` (or `-h`) for the full
 per-command flag list. Boolean flags render as a `--flag` /
-`--no-flag` pair (for example `--cache` / `--no-cache`).
+`--no-flag` pair (for example `--cache` / `--no-cache`). The one
+exception is `--offline`, which is layered and so takes an explicit
+value (`--offline True` / `--offline False`); a bare `--offline` is
+an error.
 
 ## `nab lock`
 
@@ -74,6 +79,25 @@ all three formats:
 Failed tuples render as `# {label}: FAILED` followed by the
 indented error and exit `1`.
 
+A project option can be overridden for one run with a `--project-<key>`
+flag: `--project-resolution`, `--project-mode`, `--project-requires-python`,
+`--project-uploaded-prior-to`, `--project-dist-policy`,
+`--project-build-policy`, and the repeatable `--project-constraint` and
+`--project-default-group`. Each changes the resolved set, so passing one
+prints a reproducibility notice on stderr and records the override in the
+lockfile's `[tool.nab]` block, since the lock no longer derives from the
+committed files alone. `--project-resolution` was previously named
+`--resolution`.
+
+`--locked` re-resolves and checks that the committed `pylock.toml` is
+already up to date, writing nothing. It exits non-zero if the lock would
+change or is missing, so CI can assert the lock is current. It covers
+`pylock` output to a file in single-environment mode.
+
+`--upgrade` re-anchors the `P<n>D` resolve window to the current time
+instead of reusing the timestamp recorded in an existing lockfile, and
+prints a notice naming the cutoff it dropped.
+
 ## `nab download`
 
 Resolve and download every wheel and sdist into a local
@@ -82,10 +106,40 @@ sha256 matches a local file are left alone. Local and VCS pins
 are skipped. Single-environment only.
 
 * `--output` defaults to `wheels/`.
-* `--max-concurrency` controls parallel HTTP fetches (default `8`).
+* `--max-concurrency` controls parallel HTTP fetches (default `8`,
+  minimum `1`). Layered, so it can also be set in an `nab.toml` or
+  `NAB_MAX_CONCURRENCY`.
+
+`--offline`, `--cache-dir`, `--http-backend`, `--max-concurrency` and the
+`--project-*` overrides flow through the same layered config sources `nab
+lock` uses, so a `NAB_*` variable or a system/user/project `nab.toml` is
+read for `nab download` as for `nab lock`.
 
 A summary of how many files were written and how many were
 already present is printed to stderr.
+
+## `nab config`
+
+Inspect the effective layered configuration (read-only). Three
+actions:
+
+* `nab config list` prints every option with its value, scope, and
+  the source it came from.
+* `nab config get <key>` prints one effective value.
+* `nab config explain <key>` prints the full source stack for one
+  key, the winning source marked with a `>`. Array options concatenate
+  every layer instead of one winning, so each source is shown as a
+  contribution and the merged effective value is printed on a trailing
+  `= effective:` line. Add `--include-rejected` to also list sources
+  that tried to set the key but were rejected by the category gate.
+
+The same per-option override flags the run commands accept (the
+`--project-*` overrides and the user knobs `--offline`, `--cache-dir`,
+`--http-backend`, `--max-concurrency`) layer a CLI value on top, so the
+inspector reflects the same effective values a run would see.
+
+See [Configuration](configuration.md) for the source ladder and the
+`NAB_*` environment variables.
 
 ## Runtime flags
 
@@ -95,8 +149,8 @@ Both subcommands accept the same runtime knobs:
 | ---- | ------- | ------ |
 | `--cache-dir PATH` | `~/.cache/nab` | Override the on-disk cache root. |
 | `--no-cache` | off | Disable cache for this run. Combine with `--offline` only if the cache already has every file. |
-| `--offline` | off | Use cache only, never hit the network. |
-| `--http-backend {urllib3,httpx}` | `urllib3` | Pick the async transport for fetches. `httpx` needs its extra (see [installation](installation.md)). |
+| `--offline {True,False}` | unset | Use cache only, never hit the network. Layered, so it takes an explicit value: `--offline True` forces offline, `--offline False` forces network even over a lower `offline = true`. A bare `--offline` is an error. |
+| `--http-backend {urllib3,httpx}` | `urllib3` | Pick the async transport for fetches. Layered, so it can also be set in an `nab.toml` or `NAB_HTTP_BACKEND`. `httpx` needs its extra (see [installation](installation.md)). |
 
 `urllib3` is the only backend pulled in by the base install. The
 others surface a helpful `ImportError` if selected without the
@@ -120,7 +174,7 @@ matching extra.
 | Code | Meaning |
 | ---- | ------- |
 | `0`  | Success. |
-| `1`  | Resolution failed, lockfile cannot be written (missing hash), download failed, missing `[project].dependencies`, or invalid `[tool.nab]` configuration. |
+| `1`  | Resolution failed, lockfile cannot be written (missing hash), download failed, missing `[project].dependencies`, invalid `[tool.nab]` configuration, or `--locked` found the lockfile out of date or missing. |
 | `130` | Interrupted with Ctrl-C. `nab` prints `Aborted.` and exits. |
 
 [PEP 751]: https://peps.python.org/pep-0751/

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -359,13 +359,106 @@ based on whether you want one lock or many.
 
 ```
 nab lock [PATH]
-  --output PATH           # output file (or "-" for stdout)
-  --format FORMAT         # pylock | requirements | requirements-without-hashes
-  --cache-dir PATH        # override on-disk cache location
-  --no-cache              # disable cache for this run
-  --offline               # use cache only, no network
-  --http-backend X        # urllib3 (default) | httpx
+  --output PATH                # output file (or "-" for stdout)
+  --format FORMAT              # pylock | requirements | requirements-without-hashes
+  --cache-dir PATH             # override on-disk cache location
+  --no-cache                   # disable cache for this run
+  --offline True|False         # use cache only, no network (layered value flag)
+  --http-backend X             # urllib3 (default) | httpx (layered)
+  --locked                     # verify the committed pylock is current; write nothing
+  --upgrade                    # re-anchor the P<n>D window to now
+  --project-<key> VALUE        # override a project option for this run
 ```
+
+A project option can be overridden for a single run with a
+`--project-<key>` flag (for example `--project-resolution`,
+`--project-dist-policy`, or the repeatable `--project-constraint`); the
+structured table options stay file-only. A `--project-*` override changes
+the resolved set, so it prints a notice and is recorded in the lockfile.
+`--project-dist-policy` takes a bare policy, so it replaces the whole
+`dist-policy` value and resets `trust-unverified-deps`; set the table form
+in a file to keep that flag.
 
 Anything that defines *what* gets resolved goes in `[tool.nab]`; the
 CLI only carries knobs about *how this run executes*.
+
+## Layered configuration sources
+
+A few options can be set from more than one place. Each option has a
+scope that fixes where it may come from:
+
+* Project-scope options describe the resolve itself, so they live with
+  the project. Every `[tool.nab]` key is project-scope (`mode`,
+  `indexes`, `constraints`, `vcs`, `workspace`, `dist-policy`,
+  `build-policy`, `marker-environment`, `conflicts`, `matrix`,
+  `packages`, `resolution`, and the rest), and each may be set in
+  either `pyproject.toml`'s `[tool.nab]` or a project-directory
+  `nab.toml`. They are never read from a user/system file or an
+  environment variable. Each project option with a scalar or list form
+  also takes a CLI override under a `--project-` prefix (for example
+  `--project-resolution`); the structured table options stay file-only.
+* User-scope options (`offline`, `cache-dir`, `http-backend`,
+  `max-concurrency`) describe how a run executes on this machine, so they
+  may come from a system, user, or project `nab.toml`, a `NAB_*`
+  environment variable, or the CLI. They are rejected in
+  `pyproject.toml`'s `[tool.nab]`, which is project-scope only.
+
+Sources are consulted low to high; a higher source wins:
+
+1. built-in default
+2. system `nab.toml` (`/etc/nab/nab.toml`)
+3. user `nab.toml` (`$XDG_CONFIG_HOME/nab/nab.toml`, else
+   `~/.config/nab/nab.toml`)
+4. `pyproject.toml` `[tool.nab]` and the project-directory `nab.toml`
+   (same precedence; setting one key to conflicting values across the two
+   files is a hard error, identical values are fine, and array options
+   from both files concatenate)
+5. `NAB_*` environment variables
+6. the CLI flag
+
+The standalone `nab.toml` files use the same key names as
+`[tool.nab]`, but at the top level (no `[tool.nab]` table):
+
+```toml
+# ~/.config/nab/nab.toml
+offline = true
+cache-dir = "/fast/disk/nab-cache"
+```
+
+A project-directory `nab.toml` may set any project-scope key the same
+way, so it can drive the resolve without touching `pyproject.toml`:
+
+```toml
+# nab.toml next to pyproject.toml
+mode = "universal"
+constraints = ["urllib3<2"]
+
+[[indexes]]
+name = "internal"
+url = "https://pypi.example.com/simple/"
+```
+
+Project-directory discovery is the directory of the `pyproject.toml`
+only; there is no walk-up.
+
+`nab config` reports the *configured* value for each key. Two keys take
+a value derived from other config at resolve time, so the resolved
+value can differ from what `nab config` shows: `build-policy` floors to
+`never` under `mode = "universal"` (and promotes workspace members to
+`build-local`), and `local-sources` gains the workspace members found
+by discovery. `nab config` shows the value as written, like
+`git config` reporting configured rather than derived state.
+
+### Environment variables
+
+| Variable | Option | Effect |
+| -------- | ------ | ------ |
+| `NAB_OFFLINE` | `offline` | `1`/`0`/`true`/`false`. |
+| `NAB_CACHE_DIR` | `cache-dir` | Cache root path. |
+| `NAB_HTTP_BACKEND` | `http-backend` | `urllib3` or `httpx`. |
+| `NAB_MAX_CONCURRENCY` | `max-concurrency` | Parallel HTTP fetches for `nab download` (at least `1`). |
+
+A `NAB_*` name that is not one of these (a typo, or `NAB_RESOLUTION`
+for a project-scope option) is an error rather than being silently
+ignored. Run `nab config list` to see every effective value and where
+it came from.

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -82,14 +82,25 @@ def write_lock(
     machines (PEP 751 records those paths relative to the lock file).
     With no ``output_path`` the current directory is the base.
     """
-    require_artifact_hashes(lock_input)
     lock_dir = Path(output_path).parent if output_path is not None else None
-    pylock = build_pylock(lock_input, lock_dir=lock_dir)
-    pylock.validate()
-    text = tomli_w.dumps(dict(pylock.to_dict()))
+    text = render_lock(lock_input, lock_dir=lock_dir)
     if output_path is not None:
         Path(output_path).write_text(text, encoding="utf-8")
     return text
+
+
+def render_lock(lock_input: LockInput, *, lock_dir: Path | None = None) -> str:
+    """Serialise ``lock_input`` to PEP 751 TOML text without writing a file.
+
+    ``lock_dir`` is the directory the lock will live in; directory, wheel
+    and sdist paths are emitted relative to it so the lock stays portable.
+    Defaults to the current directory.  Used by ``write_lock`` and by
+    ``nab lock --locked`` to render the would-be lock for comparison.
+    """
+    require_artifact_hashes(lock_input)
+    pylock = build_pylock(lock_input, lock_dir=lock_dir)
+    pylock.validate()
+    return tomli_w.dumps(dict(pylock.to_dict()))
 
 
 def build_pylock(lock_input: LockInput, *, lock_dir: Path | None = None) -> Pylock:

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -27,12 +27,26 @@ from ._vendor.packaging.requirements import InvalidRequirement, Requirement
 from ._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from ._vendor.packaging.utils import InvalidName, canonicalize_name
 from ._vendor.packaging.version import InvalidVersion, Version
+from .config_sources import (
+    ConfigError,
+    EffectiveValue,
+    SourceKind,
+    SourceRoots,
+    build_cli_layer,
+    discover_layers,
+    pyproject_registry_keys,
+    read_env_layer,
+    reject_user_keys_in_pyproject,
+    resolve_anchor,
+    resolve_config,
+)
 from .fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, IndexRoute
 from .provider import (
     BuildPolicy,
     DistPolicy,
     LocalSource,
     ResolutionStrategy,
+    ResolveMode,
     VcsConfig,
     VcsPolicy,
     VcsSource,
@@ -77,30 +91,6 @@ __all__ = [
 ]
 
 
-_TOP_LEVEL_KEYS = frozenset(
-    {
-        "mode",
-        "constraints",
-        "default-groups",
-        "requires-python",
-        "uploaded-prior-to",
-        "dist-policy",
-        "build-policy",
-        "marker-environment",
-        "indexes",
-        "vcs",
-        "local-sources",
-        "vcs-sources",
-        "matrix",
-        "resolution",
-        "workspace",
-        "conflicts",
-        "packages",
-        "package-rules",
-        "index",
-    },
-)
-
 _DURATION_PATTERN = re.compile(r"^P(\d+)D$")
 
 # PEP 508 environment-marker variables; reject a misspelled
@@ -120,20 +110,6 @@ _PEP508_MARKER_VARIABLES = frozenset(
         "implementation_version",
     },
 )
-
-
-class ResolveMode(enum.Enum):
-    """How the resolver interprets the project.
-
-    ``SPECIFIC`` runs the single-environment resolver against one
-    marker environment (host or impersonated).  ``UNIVERSAL`` runs the
-    matrix-based per-tuple resolver and is *experimental*: users
-    must opt in by setting ``[tool.nab].mode = "universal"`` and
-    declaring ``[tool.nab.matrix]``.
-    """
-
-    SPECIFIC = "specific"
-    UNIVERSAL = "universal"
 
 
 @dataclass(frozen=True, slots=True)
@@ -284,6 +260,11 @@ class PackageOverride:
     uploaded_prior_to: datetime | None = None
     uploaded_prior_to_disabled: bool = False
     index: str | None = None
+    # The config surface this entry was declared on (e.g. "packages.'numpy'"
+    # or "package-rules[0]").  Only used to name the source in an error that
+    # is raised after the two project files merge, so it is excluded from
+    # equality.
+    source_label: str = field(default="", compare=False)
 
 
 @dataclass(frozen=True, slots=True)
@@ -415,10 +396,6 @@ class NabProjectConfig:
     workspace_member_names: frozenset[str] = field(default_factory=frozenset)
 
 
-class ConfigError(ValueError):
-    """Raised when ``[tool.nab]`` is structurally invalid."""
-
-
 class ConflictSelectionError(ConfigError):
     """A requested extra/group selection violates a declared conflict.
 
@@ -523,6 +500,7 @@ def read_pyproject_config(
     *,
     discover_workspace: bool = True,
     anchor: datetime | None = None,
+    cli_overrides: Mapping[str, Any] | None = None,
 ) -> NabProjectConfig:
     """Parse ``[tool.nab]`` from ``path`` into :class:`NabProjectConfig`.
 
@@ -541,28 +519,195 @@ def read_pyproject_config(
     to skip the walk; useful for tests or for callers that layer their
     own workspace logic on top of a base config.
 
+    The ``[tool.nab]``-config portion is sourced from the registry merged
+    ladder (pyproject ``[tool.nab]`` plus a project-dir ``nab.toml``,
+    merged by :func:`config_sources.resolve_config` with its per-key merge,
+    cross-file conflict check, and category gate), so a project-dir
+    ``nab.toml`` value configures the resolve exactly as the inspector
+    reports it.  The
+    cross-field transforms (mode/matrix, build-policy floors,
+    universal marker-environment ban, source-name uniqueness, declared
+    index references) then run on the merged config; workspace discovery
+    runs last.
+
     ``anchor`` is the timestamp ``P<n>D`` durations resolve against.
     Defaults to ``datetime.now(UTC)`` when not supplied, which gives
     fresh-resolve semantics.  The ``nab lock`` CLI passes the anchor
     captured in any existing lockfile so re-locks reproduce the same
     cutoff for relative durations.
+
+    ``cli_overrides`` carries the ``--project-*`` overrides for the
+    PROJECT options that take a CLI flag, keyed by registry key.  They
+    layer as the highest-precedence source, so a flag wins over both
+    project files and an array flag appends after them.  ``None`` (the
+    default) is a file-only resolve, byte-identical to before.
     """
     if anchor is None:
         anchor = datetime.now(timezone.utc)
-    try:
-        with path.open("rb") as f:
-            data = tomli.load(f)
-    except tomli.TOMLDecodeError as exc:
-        msg = f"{path} is not valid TOML: {exc}"
-        raise ConfigError(msg) from exc
-    raw = tool_nab_section(data)
-    if not isinstance(raw, dict):
-        msg = f"[tool.nab] must be a table, got {type(raw).__name__}"
-        raise ConfigError(msg)
-    config = _parse_nab_table(raw, anchor=anchor, pyproject_dir=path.parent.resolve())
+    pyproject_dir = path.parent.resolve()
+    _reject_unknown_pyproject_keys(path)
+    # Point the pyproject root at ``pyproject_dir / path.name`` (not
+    # ``path.resolve()``) so the registry's declaring directory is the
+    # symlink's own directory, matching the historical local-sources base
+    # and the project-dir nab.toml lookup.  ``open`` still follows the
+    # symlink, so the same file is read.
+    roots = SourceRoots(project_dir=pyproject_dir, pyproject=pyproject_dir / path.name)
+    # Bind the lock anchor so the registry resolves ``P<n>D`` durations
+    # (top-level and override-body) against it, exactly as the old direct
+    # parse did.  System/user nab.toml and env/CLI carry no PROJECT key, so
+    # they are excluded here: this is the file-only project config.
+    with resolve_anchor(anchor):
+        layers = discover_layers(roots)
+        cli_layer = build_cli_layer(cli_overrides or {})
+        effective = resolve_config(layers, read_env_layer({}), cli_layer)
+    config = _config_from_effective(
+        effective, anchor=anchor, pyproject_dir=pyproject_dir
+    )
     if discover_workspace:
         config = _apply_workspace_discovery(path, config)
     return config
+
+
+def _config_from_effective(
+    effective: Mapping[str, EffectiveValue],
+    *,
+    anchor: datetime,
+    pyproject_dir: Path,
+) -> NabProjectConfig:
+    """Assemble :class:`NabProjectConfig` from the registry merged ladder.
+
+    Each ``[tool.nab]`` config key is taken from its effective (merged)
+    value; the registry has already applied the per-key merge, the
+    cross-file conflict rule, and the category gate.  The cross-field
+    transforms the single-key rows deliberately defer (mode/matrix mutual
+    requirement, declared-index references for routing and per-index
+    overrides, the cross-surface package-override overlap, universal
+    build-policy enforcement and the marker-environment ban, the
+    default-groups-vs-conflicts check, and source-name uniqueness) then run
+    here over the merged whole.  Workspace discovery is applied by the
+    caller afterwards.
+    """
+    del anchor  # P<n>D durations are already anchored in the effective map.
+    mode: ResolveMode = effective["mode"].value
+    matrix: MatrixConfig | None = effective["matrix"].value
+    if mode is ResolveMode.UNIVERSAL and matrix is None:
+        msg = (
+            "mode = 'universal' requires a [tool.nab.matrix] table"
+            " declaring python and platforms"
+        )
+        raise ConfigError(msg)
+    if mode is ResolveMode.SPECIFIC and matrix is not None:
+        msg = (
+            "[tool.nab.matrix] is set but mode is 'specific'; set"
+            " mode = 'universal' to opt in to the experimental"
+            " matrix-based resolver"
+        )
+        raise ConfigError(msg)
+
+    dist_policy, trust_unverified = effective["dist-policy"].value
+    indexes: tuple[IndexConfig, ...] = effective["indexes"].value
+    declared_index_names = frozenset(i.name for i in indexes)
+
+    package_overrides = (
+        *effective["packages"].value,
+        *effective["package-rules"].value,
+    )
+    _check_package_override_overlap(package_overrides)
+    _validate_routes_declared(package_overrides, declared_index_names)
+
+    index_overrides: Mapping[str, IndexOverride] = effective["index"].value
+    _validate_index_overrides_declared(index_overrides, declared_index_names)
+
+    marker_environment = effective["marker-environment"].value
+    build_policy: BuildPolicy = effective["build-policy"].value
+    if mode is ResolveMode.UNIVERSAL:
+        build_policy = _enforce_universal_build_policy(
+            build_policy_set=effective["build-policy"].origin.kind
+            is not SourceKind.DEFAULT,
+            build_policy=build_policy,
+            package_overrides=package_overrides,
+            index_overrides=index_overrides,
+        )
+        if marker_environment:
+            msg = (
+                "mode = 'universal' does not support"
+                " [tool.nab.marker-environment]: the matrix defines each"
+                " environment, so a global overlay would conflict with the"
+                " per-tuple values. Drop it or use mode = 'specific'."
+            )
+            raise ConfigError(msg)
+
+    default_groups = effective["default-groups"].value
+    conflicts = effective["conflicts"].value
+    _validate_default_groups_against_conflicts(default_groups, conflicts)
+
+    local_sources = effective["local-sources"].value
+    vcs_sources = effective["vcs-sources"].value
+    _reject_duplicate_source_names(local_sources, vcs_sources)
+
+    del pyproject_dir  # paths were resolved per-layer by the registry.
+    return NabProjectConfig(
+        mode=mode,
+        constraints=effective["constraints"].value,
+        default_groups=default_groups,
+        requires_python=effective["requires-python"].value,
+        uploaded_prior_to=effective["uploaded-prior-to"].value,
+        dist_policy=dist_policy,
+        build_policy=build_policy,
+        trust_unverified_sdist_deps=trust_unverified,
+        marker_environment=marker_environment,
+        indexes=indexes,
+        vcs=effective["vcs"].value,
+        local_sources=local_sources,
+        vcs_sources=vcs_sources,
+        matrix=matrix,
+        resolution=effective["resolution"].value,
+        workspace=effective["workspace"].value,
+        conflicts=conflicts,
+        package_overrides=package_overrides,
+        index_overrides=index_overrides,
+    )
+
+
+def _validate_routes_declared(
+    package_overrides: tuple[PackageOverride, ...],
+    declared_index_names: frozenset[str],
+) -> None:
+    """Reject a routing override that names an index not in ``indexes``.
+
+    A per-package surface is parsed without the declared index set, so the
+    route-points-at-a-real-index check runs here, after the index list is
+    known.  The error names the surface the route was declared on
+    (``packages.'<name>'`` or ``package-rules[N]``).
+    """
+    for pkg_override in package_overrides:
+        route = pkg_override.index
+        if route is not None and route not in declared_index_names:
+            valid = sorted(declared_index_names)
+            msg = (
+                f"{pkg_override.source_label}.index routes to undeclared index"
+                f" {route!r}; declared indexes are {valid!r}"
+            )
+            raise ConfigError(msg)
+
+
+def _validate_index_overrides_declared(
+    index_overrides: Mapping[str, IndexOverride],
+    declared_index_names: frozenset[str],
+) -> None:
+    """Reject a ``[tool.nab.index.<name>]`` key naming an undeclared index.
+
+    The registry parses this surface with ``declared_index_names=None``, so
+    the cross-key check runs post-merge with the single-file message.
+    """
+    for name in index_overrides:
+        if name not in declared_index_names:
+            valid = sorted(declared_index_names)
+            msg = (
+                f"index.{name} names undeclared index {name!r};"
+                f" declared indexes are {valid!r}"
+            )
+            raise ConfigError(msg)
 
 
 _logger = logging.getLogger(__name__)
@@ -604,106 +749,37 @@ def _apply_workspace_discovery(
     )
 
 
-def _parse_nab_table(
-    raw: dict[str, Any], *, anchor: datetime, pyproject_dir: Path
-) -> NabProjectConfig:
-    unknown = sorted(set(raw) - _TOP_LEVEL_KEYS)
+def _reject_unknown_pyproject_keys(path: Path) -> None:
+    """Reject a USER-scope or unknown key in pyproject ``[tool.nab]``.
+
+    Run before the registry merge so the resolve reports a typo'd
+    ``[tool.nab]`` key and a USER-scope key set in pyproject with the
+    established messages.  A USER-scope option (``offline``, ``cache-dir``)
+    surfaces the category error; an unknown key fails loud rather than being
+    silently dropped.  Reads the pyproject raw directly; the registry merge
+    reads the same file again, and this keeps the unknown-key error a
+    ``ConfigError`` on the pyproject surface for everything that is a known
+    key.
+    """
+    try:
+        with path.open("rb") as f:
+            data = tomli.load(f)
+    except tomli.TOMLDecodeError as exc:
+        msg = f"{path} is not valid TOML: {exc}"
+        raise ConfigError(msg) from exc
+    raw = tool_nab_section(data)
+    if not isinstance(raw, dict):
+        msg = f"[tool.nab] must be a table, got {type(raw).__name__}"
+        raise ConfigError(msg)
+    # Parser fold: a USER-scope registry option in pyproject [tool.nab]
+    # surfaces the registry category error before the generic unknown-key
+    # error below.
+    reject_user_keys_in_pyproject(raw)
+    known = pyproject_registry_keys()
+    unknown = sorted(set(raw) - known)
     if unknown:
-        msg = (
-            f"unknown [tool.nab] keys: {unknown!r}; expected one of"
-            f" {sorted(_TOP_LEVEL_KEYS)!r}"
-        )
+        msg = f"unknown [tool.nab] keys: {unknown!r}; expected one of {sorted(known)!r}"
         raise ConfigError(msg)
-
-    mode = _parse_mode(raw.get("mode"))
-    matrix = _parse_matrix(raw.get("matrix"))
-    if mode is ResolveMode.UNIVERSAL and matrix is None:
-        msg = (
-            "mode = 'universal' requires a [tool.nab.matrix] table"
-            " declaring python and platforms"
-        )
-        raise ConfigError(msg)
-    if mode is ResolveMode.SPECIFIC and matrix is not None:
-        msg = (
-            "[tool.nab.matrix] is set but mode is 'specific'; set"
-            " mode = 'universal' to opt in to the experimental"
-            " matrix-based resolver"
-        )
-        raise ConfigError(msg)
-
-    dist_policy, trust_unverified = _parse_dist_policy_global(raw.get("dist-policy"))
-    indexes = _parse_indexes(raw.get("indexes"))
-    declared_index_names = frozenset(i.name for i in indexes)
-    package_overrides = _parse_package_overrides(
-        raw.get("packages"),
-        raw.get("package-rules"),
-        anchor=anchor,
-        declared_index_names=declared_index_names,
-    )
-    index_overrides = _parse_index_overrides(
-        raw.get("index"),
-        anchor=anchor,
-        declared_index_names=declared_index_names,
-    )
-    marker_environment = _parse_marker_environment(raw.get("marker-environment", {}))
-
-    build_policy = _parse_enum(
-        "build-policy", raw.get("build-policy"), BuildPolicy, BuildPolicy.BUILD_LOCAL
-    )
-    if mode is ResolveMode.UNIVERSAL:
-        build_policy = _enforce_universal_build_policy(
-            build_policy_set="build-policy" in raw,
-            build_policy=build_policy,
-            package_overrides=package_overrides,
-            index_overrides=index_overrides,
-        )
-        if marker_environment:
-            msg = (
-                "mode = 'universal' does not support"
-                " [tool.nab.marker-environment]: the matrix defines each"
-                " environment, so a global overlay would conflict with the"
-                " per-tuple values. Drop it or use mode = 'specific'."
-            )
-            raise ConfigError(msg)
-
-    default_groups = _parse_string_list("default-groups", raw.get("default-groups", []))
-    conflicts = _parse_conflicts(raw.get("conflicts"))
-    _validate_default_groups_against_conflicts(default_groups, conflicts)
-
-    local_sources = _parse_local_sources(
-        raw.get("local-sources", []), pyproject_dir=pyproject_dir
-    )
-    vcs_sources = _parse_vcs_sources(raw.get("vcs-sources", []))
-    _reject_duplicate_source_names(local_sources, vcs_sources)
-
-    return NabProjectConfig(
-        mode=mode,
-        constraints=_parse_constraints(raw.get("constraints", [])),
-        default_groups=default_groups,
-        requires_python=_parse_requires_python(raw.get("requires-python")),
-        uploaded_prior_to=_parse_uploaded_prior_to(
-            raw.get("uploaded-prior-to"), anchor=anchor
-        ),
-        dist_policy=dist_policy,
-        build_policy=build_policy,
-        trust_unverified_sdist_deps=trust_unverified,
-        marker_environment=marker_environment,
-        indexes=indexes,
-        vcs=_parse_vcs(raw.get("vcs", {})),
-        local_sources=local_sources,
-        vcs_sources=vcs_sources,
-        matrix=matrix,
-        resolution=_parse_enum(
-            "resolution",
-            raw.get("resolution"),
-            ResolutionStrategy,
-            ResolutionStrategy.HIGHEST,
-        ),
-        workspace=_parse_workspace(raw.get("workspace")),
-        conflicts=conflicts,
-        package_overrides=package_overrides,
-        index_overrides=index_overrides,
-    )
 
 
 def _enforce_universal_build_policy(
@@ -743,8 +819,6 @@ def _enforce_universal_build_policy(
 
 
 def _parse_mode(value: object) -> ResolveMode:
-    if value is None:
-        return ResolveMode.SPECIFIC
     if not isinstance(value, str):
         msg = f"mode must be a string, got {type(value).__name__}"
         raise ConfigError(msg)
@@ -793,9 +867,7 @@ def _reject_duplicates(key: str, items: tuple[str, ...]) -> None:
         seen.add(item)
 
 
-def _parse_optional_string(key: str, value: object) -> str | None:
-    if value is None:
-        return None
+def _parse_string_value(key: str, value: object) -> str:
     if not isinstance(value, str):
         msg = f"{key} must be a string, got {type(value).__name__}"
         raise ConfigError(msg)
@@ -812,9 +884,7 @@ def _parse_requires_python(value: object) -> str | None:
     well-meaning bare versions like ``"3.13"``; those are not valid
     specifiers and must be written ``"==3.13"`` or ``">=3.13,<3.14"``.
     """
-    raw = _parse_optional_string("requires-python", value)
-    if raw is None:
-        return None
+    raw = _parse_string_value("requires-python", value)
     try:
         SpecifierSet(raw)
     except InvalidSpecifier as exc:
@@ -842,16 +912,14 @@ def index_routes_from_config(config: NabProjectConfig) -> list[IndexRoute]:
     ]
 
 
-def _parse_uploaded_prior_to(value: object, *, anchor: datetime) -> datetime | None:
+def _parse_uploaded_prior_to(value: object, *, anchor: datetime) -> datetime:
     """Parse ``uploaded-prior-to`` (ISO datetime, TOML datetime, or ``P<n>D``).
 
     Naive datetimes are rejected so lockfiles read identically across
     timezones. ``P<n>D`` (a nab extension) is resolved against
-    ``anchor`` so re-locks reproduce the same cutoff.
+    ``anchor`` so re-locks reproduce the same cutoff.  Callers only reach
+    here with a present value (the absent case is handled upstream).
     """
-    if value is None:
-        return None
-
     if isinstance(value, datetime):
         if value.tzinfo is None:
             msg = (
@@ -899,30 +967,6 @@ def _parse_uploaded_prior_to(value: object, *, anchor: datetime) -> datetime | N
     return dt
 
 
-def read_pyproject_lock_anchor(path: Path) -> datetime | None:
-    """Return the absolute ``uploaded-prior-to`` timestamp, if one is set.
-
-    A ``P<n>D`` duration is anchored to run time, so it is not reproducible
-    and returns ``None``. ``nab lock`` uses an absolute cutoff as the lock
-    anchor so re-locks from identical inputs produce identical bytes.
-    Absent or invalid values return ``None``; the full config parse reports
-    the error, including a missing file.
-    """
-    try:
-        with path.open("rb") as f:
-            data = tomli.load(f)
-    except (OSError, tomli.TOMLDecodeError):
-        return None
-    raw = tool_nab_section(data)
-    value = raw.get("uploaded-prior-to") if isinstance(raw, dict) else None
-    if isinstance(value, str) and _DURATION_PATTERN.match(value):
-        return None
-    try:
-        return _parse_uploaded_prior_to(value, anchor=datetime.now(timezone.utc))
-    except ConfigError:
-        return None
-
-
 _DIST_POLICY_TABLE_KEYS = frozenset({"policy", "trust-unverified-deps"})
 
 
@@ -933,8 +977,6 @@ def _parse_dist_policy_global(value: object) -> tuple[DistPolicy, bool]:
     folds the sdist-trust flag into the dist body.  Returns
     ``(policy, trust_unverified)``.
     """
-    if value is None:
-        return (DistPolicy.WHEEL_OR_SDIST, False)
     if not isinstance(value, dict):
         return (
             _parse_enum("dist-policy", value, DistPolicy, DistPolicy.WHEEL_OR_SDIST),
@@ -1018,9 +1060,6 @@ _INDEX_KEYS = frozenset({"name", "url"})
 
 
 def _parse_indexes(value: object) -> tuple[IndexConfig, ...]:
-    if value is None:
-        return (IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL),)
-
     if not isinstance(value, list):
         msg = f"indexes must be an array of tables, got {type(value).__name__}"
         raise ConfigError(msg)
@@ -1030,7 +1069,6 @@ def _parse_indexes(value: object) -> tuple[IndexConfig, ...]:
         raise ConfigError(msg)
 
     out: list[IndexConfig] = []
-    seen: set[str] = set()
     for i, entry in enumerate(value):
         if not isinstance(entry, dict):
             msg = f"indexes[{i}] must be a table, got {type(entry).__name__}"
@@ -1051,12 +1089,24 @@ def _parse_indexes(value: object) -> tuple[IndexConfig, ...]:
         if not isinstance(name, str) or not isinstance(url, str):
             msg = f"indexes[{i}] name and url must be strings"
             raise ConfigError(msg)
-        if name in seen:
-            msg = f"duplicate index name: {name!r}"
-            raise ConfigError(msg)
-        seen.add(name)
         out.append(IndexConfig(name=name, url=url))
+    _check_index_name_uniqueness(out)
     return tuple(out)
+
+
+def _check_index_name_uniqueness(indexes: Sequence[IndexConfig]) -> None:
+    """Reject two indexes declared with the same name.
+
+    Shared by the single-file parse and the registry's across-file merge
+    re-validation (config_sources): a name may appear at most once, whether
+    the duplicate is in one file or split across the two project files.
+    """
+    seen: set[str] = set()
+    for index in indexes:
+        if index.name in seen:
+            msg = f"duplicate index name: {index.name!r}"
+            raise ConfigError(msg)
+        seen.add(index.name)
 
 
 _PACKAGE_OVERRIDE_BODY_KEYS = frozenset(
@@ -1082,43 +1132,10 @@ _PACKAGE_POLICY_FIELDS = (
 )
 
 
-def _parse_package_overrides(
-    packages: object,
-    rules: object,
-    *,
-    anchor: datetime,
-    declared_index_names: frozenset[str],
-) -> tuple[PackageOverride, ...]:
-    """Parse the per-package surfaces into one list of requirement-keyed overrides.
-
-    Two surfaces feed it: ``[tool.nab.packages.<name>]`` (a table keyed by
-    package name, the sugar form) and ``[[tool.nab.package-rules]]`` (an
-    array of tables whose ``match`` selector lists requirements, so one
-    body can cover several).  Both desugar into :class:`PackageOverride`
-    entries; the combined list is checked so no two entries set the same
-    policy field for one package over overlapping version ranges.
-    """
-    out: list[PackageOverride] = []
-    out.extend(
-        _parse_packages_sugar(
-            packages, anchor=anchor, declared_index_names=declared_index_names
-        )
-    )
-    out.extend(
-        _parse_package_rules(
-            rules, anchor=anchor, declared_index_names=declared_index_names
-        )
-    )
-    overrides = tuple(out)
-    _check_package_override_overlap(overrides)
-    return overrides
-
-
 def _parse_packages_sugar(
     value: object,
     *,
     anchor: datetime,
-    declared_index_names: frozenset[str],
 ) -> list[PackageOverride]:
     """Parse ``[tool.nab.packages.<name>]`` into per-package overrides.
 
@@ -1127,8 +1144,6 @@ def _parse_packages_sugar(
     sub-table is the override body.  The key is the whole selector, so the
     sugar form carries no inner selector key.
     """
-    if value is None:
-        return []
     if isinstance(value, list):
         msg = (
             "[tool.nab.packages] is the name-keyed table form"
@@ -1163,7 +1178,6 @@ def _parse_packages_sugar(
                 body,
                 where,
                 anchor=anchor,
-                declared_index_names=declared_index_names,
             )
         )
     return out
@@ -1173,7 +1187,6 @@ def _parse_package_rules(
     value: object,
     *,
     anchor: datetime,
-    declared_index_names: frozenset[str],
 ) -> list[PackageOverride]:
     """Parse ``[[tool.nab.package-rules]]`` into per-package overrides.
 
@@ -1182,8 +1195,6 @@ def _parse_package_rules(
     single rule can cover many packages (e.g. routing a namespace to one
     index).
     """
-    if value is None:
-        return []
     if not isinstance(value, list):
         msg = (
             "[tool.nab.package-rules] must be an array of tables"
@@ -1193,11 +1204,7 @@ def _parse_package_rules(
         raise ConfigError(msg)
     out: list[PackageOverride] = []
     for i, entry in enumerate(value):
-        out.extend(
-            _parse_package_rule_entry(
-                entry, i, anchor=anchor, declared_index_names=declared_index_names
-            )
-        )
+        out.extend(_parse_package_rule_entry(entry, i, anchor=anchor))
     return out
 
 
@@ -1206,7 +1213,6 @@ def _parse_package_rule_entry(
     index: int,
     *,
     anchor: datetime,
-    declared_index_names: frozenset[str],
 ) -> list[PackageOverride]:
     where = f"package-rules[{index}]"
     if not isinstance(entry, dict):
@@ -1228,13 +1234,7 @@ def _parse_package_rule_entry(
         )
         raise ConfigError(msg)
     body = {key: val for key, val in entry.items() if key != "match"}
-    return _build_package_overrides(
-        requirements,
-        body,
-        where,
-        anchor=anchor,
-        declared_index_names=declared_index_names,
-    )
+    return _build_package_overrides(requirements, body, where, anchor=anchor)
 
 
 def _build_package_overrides(
@@ -1243,7 +1243,6 @@ def _build_package_overrides(
     where: str,
     *,
     anchor: datetime,
-    declared_index_names: frozenset[str],
 ) -> list[PackageOverride]:
     """Turn a validated selector and body into one override per requirement."""
     dist_policy, dist_trust = _parse_override_dist(body.get("dist-policy"), where)
@@ -1263,7 +1262,7 @@ def _build_package_overrides(
         anchor=anchor,
         present="uploaded-prior-to" in body,
     )
-    route = _parse_override_index(body, where, declared_index_names)
+    route = _parse_override_index(body, where)
     has_body = (
         dist_policy is not None
         or dist_trust is not None
@@ -1300,6 +1299,7 @@ def _build_package_overrides(
             uploaded_prior_to=uploaded_prior_to,
             uploaded_prior_to_disabled=uploaded_disabled,
             index=route,
+            source_label=where,
         )
         for requirement in requirements
     ]
@@ -1385,16 +1385,17 @@ def _parse_index_overrides(
     value: object,
     *,
     anchor: datetime,
-    declared_index_names: frozenset[str],
 ) -> dict[str, IndexOverride]:
     """Parse ``[tool.nab.index.<name>]`` into a name-keyed policy map.
 
-    Each key must name a declared ``[[tool.nab.indexes]]`` entry.  The
-    body sets policy fields only (no routing, no version scope); the
-    override applies to every package served from that index.
+    Each key must name a declared ``[[tool.nab.indexes]]`` entry; that
+    cross-key check is a resolve-path concern run post-merge by
+    :func:`_validate_index_overrides_declared` (the surface is parsed in
+    isolation from the ``indexes`` row, so this parser does not see the
+    declared set).  The body sets policy fields only (no routing, no
+    version scope); the override applies to every package served from that
+    index.
     """
-    if value is None:
-        return {}
     if not isinstance(value, dict):
         msg = (
             "[tool.nab.index] must be a table keyed by index name, got"
@@ -1404,13 +1405,6 @@ def _parse_index_overrides(
     out: dict[str, IndexOverride] = {}
     for name, body in value.items():
         where = f"index.{name}"
-        if name not in declared_index_names:
-            valid = sorted(declared_index_names)
-            msg = (
-                f"{where} names undeclared index {name!r};"
-                f" declared indexes are {valid!r}"
-            )
-            raise ConfigError(msg)
         out[name] = _parse_index_override_body(body, where, anchor=anchor)
     return out
 
@@ -1551,26 +1545,21 @@ def _parse_override_uploaded_prior_to(
     return (cutoff, False)
 
 
-def _parse_override_index(
-    entry: dict[str, Any], where: str, declared_index_names: frozenset[str]
-) -> str | None:
+def _parse_override_index(entry: dict[str, Any], where: str) -> str | None:
     """Parse the routing ``index`` body and validate its ``strict`` flag.
 
     The route is always a strict pin to one index, so ``strict`` only
     accepts ``true``.  ``strict = false`` is rejected: fallthrough on a
     miss is not cleanly wireable through the single-index-pin router this
     release ships.
+
+    The route-names-a-declared-index check is a resolve-path concern run
+    post-merge by :func:`_validate_routes_declared`, since this parser sees
+    the override surface in isolation from the ``indexes`` row.
     """
     route = entry.get("index")
     if route is not None and not isinstance(route, str):
         msg = f"{where}.index must be a string, got {type(route).__name__}"
-        raise ConfigError(msg)
-    if route is not None and route not in declared_index_names:
-        valid = sorted(declared_index_names)
-        msg = (
-            f"{where}.index routes to undeclared index {route!r};"
-            f" declared indexes are {valid!r}"
-        )
         raise ConfigError(msg)
     if "strict" not in entry:
         return route
@@ -1763,8 +1752,6 @@ def _parse_workspace(value: object) -> WorkspaceConfig | None:
     validates the table shape so typos like ``member = ...`` (missing
     the ``s``) fail loud at config-parse time.
     """
-    if value is None:
-        return None
     if not isinstance(value, dict):
         msg = f"[tool.nab.workspace] must be a table, got {type(value).__name__}"
         raise ConfigError(msg)
@@ -1798,12 +1785,22 @@ def _parse_conflicts(value: object) -> tuple[ConflictSet, ...]:
     ``at-least-one``.  A member is ``{ extra = "NAME" }`` or
     ``{ group = "NAME" }``.
     """
-    if value is None:
-        return ()
     if not isinstance(value, list):
         msg = f"conflicts must be an array of conflict sets, got {type(value).__name__}"
         raise ConfigError(msg)
     sets = tuple(_parse_conflict_set(item, i) for i, item in enumerate(value))
+    _check_conflict_member_uniqueness(sets)
+    return sets
+
+
+def _check_conflict_member_uniqueness(sets: Sequence[ConflictSet]) -> None:
+    """Reject a member declared in more than one conflict set.
+
+    Shared by the single-file parse and the registry's across-file merge
+    re-validation (config_sources): a member may belong to at most one
+    conflict set, whether the duplicate is in one file or split across the
+    two project files.
+    """
     seen: set[ConflictMember] = set()
     for conflict_set in sets:
         for member in conflict_set.members:
@@ -1814,7 +1811,6 @@ def _parse_conflicts(value: object) -> tuple[ConflictSet, ...]:
                 )
                 raise ConfigError(msg)
             seen.add(member)
-    return sets
 
 
 def _validate_default_groups_against_conflicts(
@@ -1982,8 +1978,6 @@ def _validate_matrix_python(spec: str) -> None:
 
 
 def _parse_matrix(value: object) -> MatrixConfig | None:
-    if value is None:
-        return None
     if not isinstance(value, dict):
         msg = f"[tool.nab.matrix] must be a table, got {type(value).__name__}"
         raise ConfigError(msg)

--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -1,0 +1,1799 @@
+"""Registry of layered nab options and the helpers that read them.
+
+Every layered option is one :class:`OptionSpec` row in :data:`OPTIONS`.
+A row names the option, its scope (``PROJECT`` or ``USER``), its value
+type, its default, the env var (or ``None``), the CLI flag spelling,
+and (via the scope) the set of source kinds it is allowed to come
+from.
+
+Everything else is derived by iterating :data:`OPTIONS`:
+
+* :func:`discover_layers` reads each ``nab.toml`` / ``[tool.nab]``
+  table against the registry, raising on any key that names an option
+  not allowed in that source kind (the category gate).
+* :func:`read_env_layer` reads ``NAB_*`` for the rows that declare an
+  env var, and rejects a ``NAB_<KEY>`` that names a PROJECT option.
+* :func:`resolve_config` merges the discovered layers low-to-high and
+  attaches ``(scope, origin)`` provenance to each effective value.
+* :func:`render_list` / :func:`render_get` / :func:`render_explain`
+  back ``nab config``.
+
+Adding an option is one new row in :data:`OPTIONS` plus, for the
+CLI, one tyro flag.  A conformance test asserts the tyro surface matches
+the registry so the one place the CLI surface is not registry-derived
+(tyro reads flags from a function signature) cannot silently drift.
+"""
+
+from __future__ import annotations
+
+import enum
+import types
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import tomli
+
+from nab_index.multi_index import IndexConfig
+
+from .fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL
+from .provider import (
+    BuildPolicy,
+    DistPolicy,
+    LocalSource,
+    ResolutionStrategy,
+    ResolveMode,
+    VcsConfig,
+    VcsSource,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+
+__all__ = [
+    "OPTIONS",
+    "ConfigError",
+    "EffectiveValue",
+    "Layer",
+    "OptionSpec",
+    "Origin",
+    "RejectedLayer",
+    "Scope",
+    "SourceConfigError",
+    "SourceKind",
+    "SourceRoots",
+    "build_cli_layer",
+    "build_cli_overrides",
+    "discover_layers",
+    "inspector_anchor",
+    "orphan_rejections",
+    "project_cli_override_notice",
+    "project_cli_override_records",
+    "pyproject_registry_keys",
+    "read_env_layer",
+    "reject_user_keys_in_pyproject",
+    "render_explain",
+    "render_get",
+    "render_list",
+    "resolve_anchor",
+    "resolve_config",
+]
+
+
+# The anchor that ``P<n>D`` relative durations resolve against during a
+# real resolve.  ``nab config`` (the inspector) leaves it unset, so the
+# display anchors a relative duration at the current time; the resolve
+# path (``config.read_pyproject_config``) sets it to the lockfile-captured
+# anchor for the duration of the merge so re-locks reproduce the same
+# cutoff.  Carried on a ContextVar rather than threaded through every
+# fixed-arity parse hook.
+_RESOLVE_ANCHOR: ContextVar[datetime | None] = ContextVar(
+    "_RESOLVE_ANCHOR", default=None
+)
+
+# The directory of the TOML file currently being parsed.  Relative
+# ``local-sources`` paths resolve against the declaring file's directory;
+# carried structurally on a ContextVar (set by :func:`_load_toml_layer`)
+# rather than re-derived by splitting a human-facing ``where`` label.
+_DECLARING_DIR: ContextVar[Path | None] = ContextVar("_DECLARING_DIR", default=None)
+
+# A single ``now`` for one inspector pass, so override-body ``P<n>D``
+# durations in the two project files anchor against the same instant.
+# Unlike the top-level ``uploaded-prior-to`` row (which keeps a relative
+# duration as its raw string when the resolve anchor is unset), an override
+# body is resolved eagerly to an absolute datetime, so two identical
+# durations across pyproject and the project nab.toml would otherwise anchor
+# microseconds apart and read as conflicting values.  Bound by
+# :func:`inspector_anchor` around the inspector's discover+merge.  The
+# resolve path leaves it unset and uses :data:`_RESOLVE_ANCHOR` instead.
+_INSPECTOR_ANCHOR: ContextVar[datetime | None] = ContextVar(
+    "_INSPECTOR_ANCHOR", default=None
+)
+
+
+def _current_anchor() -> datetime:
+    """Return the active ``P<n>D`` anchor: the resolve anchor or ``now``.
+
+    The resolve path sets :data:`_RESOLVE_ANCHOR` so relative durations
+    resolve against the lockfile anchor; the inspector leaves it unset and
+    anchors at the current time (display only).
+    """
+    anchor = _RESOLVE_ANCHOR.get()
+    return anchor if anchor is not None else datetime.now(timezone.utc)
+
+
+@contextmanager
+def resolve_anchor(anchor: datetime | None) -> Iterator[None]:
+    """Bind the ``P<n>D`` resolve anchor for the duration of a merge.
+
+    The resolve path wraps its :func:`resolve_config` call in this so the
+    effective override / ``uploaded-prior-to`` values it consumes resolve
+    relative durations against the lockfile anchor.  A ``None`` anchor is a
+    no-op (the inspector's current-time behaviour).
+    """
+    token = _RESOLVE_ANCHOR.set(anchor)
+    try:
+        yield
+    finally:
+        _RESOLVE_ANCHOR.reset(token)
+
+
+@contextmanager
+def inspector_anchor() -> Iterator[None]:
+    """Pin one ``now`` for an inspector discover+merge pass.
+
+    The inspector (``nab config``) leaves :data:`_RESOLVE_ANCHOR` unset, so
+    each override-body ``P<n>D`` duration would otherwise anchor against a
+    fresh :func:`datetime.now` per layer.  Binding a single instant here
+    makes an identical relative duration in pyproject ``[tool.nab]`` and the
+    project ``nab.toml`` resolve to the same datetime, so the cross-file
+    equality check does not see a spurious conflict.  A no-op on the resolve
+    path (the resolve anchor takes precedence).
+    """
+    token = _INSPECTOR_ANCHOR.set(datetime.now(timezone.utc))
+    try:
+        yield
+    finally:
+        _INSPECTOR_ANCHOR.reset(token)
+
+
+class ConfigError(ValueError):
+    """Raised when ``[tool.nab]`` configuration is invalid.
+
+    The base for every config-parse error.  Lives here (the lowest config
+    layer) so :class:`SourceConfigError` can subclass it without an import
+    cycle; :mod:`nab_python.config` re-exports it as its public name and
+    hangs its own subclasses (``ConflictSelectionError``,
+    ``OverrideConflictError``) off it.
+    """
+
+
+class SourceConfigError(ConfigError):
+    """A layered source set a value it is not allowed to set.
+
+    Raised by the category gate: e.g. a PROJECT option appearing in a
+    user ``nab.toml`` or env var, or a USER option appearing in
+    ``pyproject.toml`` ``[tool.nab]``.  A subclass of :class:`ConfigError`
+    so a caller catching the broad config error also catches a layered
+    gate or cross-file conflict failure, while ``except SourceConfigError``
+    still narrows to the layered cases.
+    """
+
+
+class Scope(enum.Enum):
+    """Whether an option configures the project or the user/environment."""
+
+    PROJECT = "project"
+    USER = "user"
+
+
+class SourceKind(enum.Enum):
+    """One discoverable configuration source, low precedence to high.
+
+    The two project-level TOML sources (``PYPROJECT`` and
+    ``PROJECT_TOML``) share a precedence rank; the rest are totally
+    ordered by :data:`_PRECEDENCE`.
+    """
+
+    DEFAULT = "default"
+    SYSTEM_TOML = "system"
+    USER_TOML = "user"
+    PYPROJECT = "pyproject"
+    PROJECT_TOML = "project"
+    ENV = "env"
+    CLI = "cli"
+
+
+# Precedence rank, low -> high.  PYPROJECT and PROJECT_TOML share rank 3:
+# they are the same (project) precedence level, and on a tie PROJECT_TOML
+# (the project-dir nab.toml) sorts last (wins).
+_PRECEDENCE: dict[SourceKind, int] = {
+    SourceKind.DEFAULT: 0,
+    SourceKind.SYSTEM_TOML: 1,
+    SourceKind.USER_TOML: 2,
+    SourceKind.PYPROJECT: 3,
+    SourceKind.PROJECT_TOML: 3,
+    SourceKind.ENV: 4,
+    SourceKind.CLI: 5,
+}
+
+# The category gate, derived once: for each option scope, the TOML
+# sources that may set it.  A PROJECT option lives in the two
+# project-level files (pyproject + project-dir nab.toml).  A USER option
+# lives in the three nab.toml files (system/user/project) but not in
+# pyproject, which is project-scope only.  The project-dir nab.toml is
+# the shared file both scopes accept.
+_ALLOWED_TOML_SOURCES: dict[Scope, frozenset[SourceKind]] = {
+    Scope.PROJECT: frozenset({SourceKind.PYPROJECT, SourceKind.PROJECT_TOML}),
+    Scope.USER: frozenset(
+        {SourceKind.SYSTEM_TOML, SourceKind.USER_TOML, SourceKind.PROJECT_TOML}
+    ),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class OptionSpec:
+    """One row of the registry: the full definition of a layered option.
+
+    ``key`` is the TOML/`nab config` key.  ``scope`` gates which sources
+    may set it.  ``parse`` turns a raw TOML/string value into the typed
+    value (and raises :class:`SourceConfigError` on a bad value).
+    ``env_var`` is the ``NAB_*`` name or ``None`` (not env-settable).
+    ``cli_flag`` is the tyro flag spelling the conformance test checks,
+    or ``None`` for a file-only row (a structured PROJECT table with no
+    bare CLI flag, e.g. ``vcs``/``workspace``/``marker-environment``);
+    ``cli_param`` is the tyro function-parameter name backing the flag,
+    also ``None`` for a file-only row.  ``type_label`` is shown by
+    ``nab config``.
+    """
+
+    key: str
+    scope: Scope
+    type_label: str
+    default: Any
+    env_var: str | None
+    cli_flag: str | None
+    cli_param: str | None
+    parse: Callable[[Any, str], Any]
+    render: Callable[[Any], str]
+    # How bindings from different sources combine.  The default is scalar
+    # last-wins: the highest-precedence source's value is the effective one,
+    # and the same key set to different values in the two project files is a
+    # conflict error.
+    #
+    # ``is_array`` concatenates every binding's items low-to-high into one
+    # value, so the two project files contribute additively rather than
+    # conflicting; the concatenated whole is then re-validated (see
+    # ``merge_check``).
+    is_array: bool = False
+    # ``is_mapping`` is a name-keyed table (``index``, ``marker-environment``)
+    # whose sub-keys merge across sources, folded low-to-high, so the two
+    # project files contribute disjoint sub-keys additively and only the same
+    # sub-key set differently is a conflict.  Mutually exclusive with
+    # ``is_array``.
+    is_mapping: bool = False
+    # For an ``is_array`` row whose items are already-built objects (not
+    # plain strings), the check to run over the concatenated whole; it
+    # returns the validated tuple.  A plain-string array leaves this ``None``
+    # and is re-validated by re-running ``parse`` over the concatenation.
+    merge_check: Callable[[Sequence[Any]], tuple[Any, ...]] | None = None
+
+    def allowed_in_toml(self, kind: SourceKind) -> bool:
+        """Whether a TOML source of ``kind`` may set this option.
+
+        The category gate.  ``kind`` is always one of the four TOML
+        source kinds; env (``NAB_*``) gating is the ``env_var`` field and
+        is handled in :func:`read_env_layer`, CLI is always allowed.
+        """
+        return kind in _ALLOWED_TOML_SOURCES[self.scope]
+
+
+def _parse_bool(value: Any, where: str) -> bool:
+    """Parse a TOML/env boolean.
+
+    Accepts a real bool (TOML) or one of ``1/0/true/false`` (env,
+    case-insensitive).
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true"}:
+            return True
+        if lowered in {"0", "false"}:
+            return False
+        msg = f"{where} must be one of 1/0/true/false, got {value!r}"
+        raise SourceConfigError(msg)
+    msg = f"{where} must be a boolean, got {type(value).__name__}"
+    raise SourceConfigError(msg)
+
+
+def _parse_path(value: Any, where: str) -> Path:
+    # A CLI layer already supplies a Path; TOML/env supply a string.
+    if isinstance(value, Path):
+        return value
+    if not isinstance(value, str):
+        msg = f"{where} must be a string path, got {type(value).__name__}"
+        raise SourceConfigError(msg)
+    if not value.strip():
+        # An empty NAB_CACHE_DIR would resolve Path("") to the cwd; reject
+        # it instead.
+        msg = f"{where} must be a non-empty path"
+        raise SourceConfigError(msg)
+    return Path(value)
+
+
+def _parse_resolution(value: Any, where: str) -> ResolutionStrategy:
+    # TOML/env supply a string; the CLI layer also passes the string spelling.
+    if not isinstance(value, str):
+        msg = f"{where} must be a string, got {type(value).__name__}"
+        raise SourceConfigError(msg)
+    try:
+        return ResolutionStrategy(value)
+    except ValueError as exc:
+        valid = sorted(s.value for s in ResolutionStrategy)
+        msg = f"{where} must be one of {valid!r}, got {value!r}"
+        raise SourceConfigError(msg) from exc
+
+
+_HTTP_BACKENDS = ("httpx", "urllib3")
+
+
+def _parse_http_backend(value: Any, where: str) -> str:
+    if not isinstance(value, str):
+        msg = f"{where} must be a string, got {type(value).__name__}"
+        raise SourceConfigError(msg)
+    lowered = value.strip()
+    if lowered not in _HTTP_BACKENDS:
+        msg = f"{where} must be one of {list(_HTTP_BACKENDS)!r}, got {value!r}"
+        raise SourceConfigError(msg)
+    return lowered
+
+
+def _parse_max_concurrency(value: Any, where: str) -> int:
+    # TOML supplies an int; env/CLI supply a string.  bool is an int
+    # subclass, so reject it explicitly rather than read True as 1.
+    if isinstance(value, bool):
+        msg = f"{where} must be an integer, got {type(value).__name__}"
+        raise SourceConfigError(msg)
+    if isinstance(value, int):
+        result = value
+    elif isinstance(value, str):
+        try:
+            result = int(value)
+        except ValueError as exc:
+            msg = f"{where} must be an integer, got {value!r}"
+            raise SourceConfigError(msg) from exc
+    else:
+        msg = f"{where} must be an integer, got {type(value).__name__}"
+        raise SourceConfigError(msg)
+    if result < 1:
+        msg = f"{where} must be at least 1, got {result}"
+        raise SourceConfigError(msg)
+    return result
+
+
+def _delegate(call: Callable[[], Any]) -> Any:
+    """Run a ``config.py`` parse helper, re-typing its error for the registry.
+
+    The registry rows reuse the single-environment parsers in
+    :mod:`nab_python.config` verbatim, so the value and every validation
+    message are identical to the pyproject parse path.  Those helpers raise
+    :class:`config.ConfigError`; the registry contract is
+    :class:`SourceConfigError`, and the CLI and loader catch only the latter.
+    Re-raise with the same message so behaviour is preserved and the error is
+    caught by the ladder.
+    """
+    try:
+        return call()
+    except ConfigError as exc:
+        raise SourceConfigError(str(exc)) from exc
+
+
+def _parse_mode(value: Any, where: str) -> Any:
+    # Delegates to config._parse_mode (enum specific|universal).  ``where``
+    # is unused: the helper owns the (config-keyed) message wording, kept
+    # identical to the pyproject path.
+    del where
+    from .config import _parse_mode as _impl  # noqa: PLC0415 (config import cycle)
+
+    return _delegate(lambda: _impl(value))
+
+
+def _parse_requires_python(value: Any, where: str) -> str | None:
+    del where
+    from .config import (  # noqa: PLC0415 (config import cycle)
+        _parse_requires_python as _impl,
+    )
+
+    return _delegate(lambda: _impl(value))
+
+
+def _parse_dist_policy(value: Any, where: str) -> tuple[DistPolicy, bool]:
+    # The scalar-or-table dist-policy folds the sdist-trust bool, so the
+    # registry value is the (policy, trust) pair the global parser returns.
+    del where
+    from .config import (  # noqa: PLC0415 (config import cycle)
+        _parse_dist_policy_global as _impl,
+    )
+
+    return _delegate(lambda: _impl(value))
+
+
+def _parse_build_policy(value: Any, where: str) -> BuildPolicy:
+    # The plain scalar last-wins value only.  The universal and workspace
+    # floors are post-merge transforms applied over the merged config, not
+    # this row.
+    del where
+    from .config import _parse_enum as _impl  # noqa: PLC0415 (config import cycle)
+
+    return _delegate(
+        lambda: _impl("build-policy", value, BuildPolicy, BuildPolicy.BUILD_LOCAL)
+    )
+
+
+def _parse_uploaded_prior_to(value: Any, where: str) -> Any:
+    """Parse ``uploaded-prior-to`` without re-anchoring relative durations.
+
+    A ``P<n>D`` duration anchors to the lock at resolve time
+    (config._parse_uploaded_prior_to threads the lockfile anchor); the
+    registry merely gates/displays the key and must not silently
+    re-anchor it to ``now``.  So a relative duration is carried as its
+    raw string (the cross-file conflict check compares the raw strings, so
+    identical durations match and different ones conflict), and only an
+    absolute datetime is normalised through the shared parser.  The real
+    resolve still parses the value with the proper anchor via
+    ``read_pyproject_config``.
+    """
+    del where
+    from .config import _DURATION_PATTERN  # noqa: PLC0415 (config import cycle)
+    from .config import (  # noqa: PLC0415 (config import cycle)
+        _parse_uploaded_prior_to as _impl,
+    )
+
+    if isinstance(value, str) and _DURATION_PATTERN.match(value):
+        # On the resolve path the active anchor is set, so resolve the
+        # relative duration to its absolute cutoff now; the inspector
+        # leaves the anchor unset and carries the raw string for display
+        # (its now-anchor would be misleading in a stored value).
+        if _RESOLVE_ANCHOR.get() is not None:
+            return _delegate(lambda: _impl(value, anchor=_current_anchor()))
+        return value
+    # Absolute datetime / TOML offset-datetime: anchor is irrelevant, but
+    # the helper requires one, so pass a placeholder it never reads.
+    return _delegate(lambda: _impl(value, anchor=_current_anchor()))
+
+
+def _parse_marker_environment(value: Any, where: str) -> Mapping[str, str]:
+    # Name-keyed table (PEP 508 marker var -> str).  Delegates to the
+    # single-environment parser so validation (string->string, known
+    # marker vars) is identical to the pyproject path.
+    del where
+    from .config import (  # noqa: PLC0415 (config import cycle)
+        _parse_marker_environment as _impl,
+    )
+
+    return _delegate(lambda: _impl(value))
+
+
+def _parse_vcs(value: Any, where: str) -> Any:
+    # Nested table (policy, allowed-schemes, allowed-repos, require-pin).
+    # Delegates to config._parse_vcs, returning the frozen VcsConfig.
+    del where
+    from .config import _parse_vcs as _impl  # noqa: PLC0415 (config import cycle)
+
+    return _delegate(lambda: _impl(value))
+
+
+def _parse_workspace(value: Any, where: str) -> Any:
+    # Nested table (members).  Delegates to config._parse_workspace,
+    # returning a WorkspaceConfig or None.  The discovery walk-up is a
+    # post-merge transform applied by read_pyproject_config, never this
+    # row, so the registry only folds the declared table.
+    del where
+    from .config import _parse_workspace as _impl  # noqa: PLC0415 (config import cycle)
+
+    return _delegate(lambda: _impl(value))
+
+
+def _parse_constraints(value: Any, where: str) -> tuple[str, ...]:
+    # Array of PEP 508 strings.  Delegates to config._parse_constraints so
+    # the list-of-strings shape check and the per-item PEP 508 validation
+    # (and their messages) are identical to the pyproject parse path.  Runs
+    # both per-layer (each file's own list) and again over the concatenated
+    # whole (the array merge re-validates the result), which is why the
+    # delegate must accept any tuple as well as a list.
+    del where
+    from .config import (  # noqa: PLC0415 (config import cycle)
+        _parse_constraints as _impl,
+    )
+
+    return _delegate(lambda: _impl(value))
+
+
+def _parse_default_groups(value: Any, where: str) -> tuple[str, ...]:
+    # Array of group names.  Delegates to config._parse_string_list so the
+    # list-of-strings shape check and message match the pyproject path.
+    # The default-groups-vs-conflicts cross-check stays in the single
+    # environment parser (it needs both merged values), so this row only
+    # folds the list itself.
+    del where
+    from .config import (  # noqa: PLC0415 (config import cycle)
+        _parse_string_list as _impl,
+    )
+
+    return _delegate(lambda: _impl("default-groups", value))
+
+
+def _parse_indexes(value: Any, where: str) -> tuple[IndexConfig, ...]:
+    # One file's array-of-tables (name, url): config._parse_indexes validates
+    # shape, keys, and the within-file same-name check into IndexConfig
+    # entries.  The across-file same-name check runs over the concatenation
+    # via merge_check (_revalidate_index_names).
+    del where
+    from .config import _parse_indexes as _impl  # noqa: PLC0415 (config import cycle)
+
+    return _delegate(lambda: _impl(value))
+
+
+def _revalidate_index_names(indexes: Sequence[Any]) -> tuple[IndexConfig, ...]:
+    # Re-run the same-name check over the concatenated indexes, re-typing the
+    # error so its message matches the single-file path.
+    from .config import (  # noqa: PLC0415 (config import cycle)
+        _check_index_name_uniqueness as _impl,
+    )
+
+    merged = tuple(indexes)
+    _delegate(lambda: _impl(merged))
+    return merged
+
+
+def _parse_local_sources(value: Any, where: str) -> tuple[LocalSource, ...]:
+    # One file's array-of-tables (name, path, editable, subdirectory).  Paths
+    # resolve relative to the declaring file's directory (both legal sources
+    # share the project dir).  There is no within-key duplicate check (the
+    # cross-source local/vcs name check is a whole-config pass on the resolve
+    # path), so the concatenation passes through unchanged (merge_check=tuple).
+    del where
+    from .config import (  # noqa: PLC0415 (config import cycle)
+        _parse_local_sources as _impl,
+    )
+
+    base_dir = _declaring_dir()
+    return _delegate(lambda: _impl(value, pyproject_dir=base_dir))
+
+
+def _declaring_dir() -> Path:
+    # local-sources is a file-only row (no CLI/env), so its per-layer parse
+    # is only ever reached from a TOML layer, which sets _DECLARING_DIR to
+    # the file's directory.  Paths in the file resolve relative to it.
+    base = _DECLARING_DIR.get()
+    if base is None:  # pragma: no cover - per-layer parse always sets it
+        msg = "local-sources parsed without a declaring directory"
+        raise SourceConfigError(msg)
+    return base
+
+
+def _parse_vcs_sources(value: Any, where: str) -> tuple[VcsSource, ...]:
+    # One file's array-of-tables (name, url).  Like local-sources there is no
+    # within-key duplicate check, so the concatenation passes through
+    # (merge_check=tuple).
+    del where
+    from .config import (  # noqa: PLC0415 (config import cycle)
+        _parse_vcs_sources as _impl,
+    )
+
+    return _delegate(lambda: _impl(value))
+
+
+def _override_anchor() -> datetime:
+    # An override body may carry an ``uploaded-prior-to`` whose ``P<n>D`` form
+    # resolves against an anchor at parse time.  The resolve path binds the
+    # lockfile anchor, so the duration anchors reproducibly.  The inspector
+    # leaves it unset and, unlike the top-level uploaded-prior-to row, cannot
+    # defer to a raw string (the body is an opaque object), so it anchors at
+    # the inspector pass's single ``now`` (bound by inspector_anchor) rather
+    # than a fresh now per layer, so an identical duration in both project
+    # files compares equal.
+    resolve = _RESOLVE_ANCHOR.get()
+    if resolve is not None:
+        return resolve
+    inspector = _INSPECTOR_ANCHOR.get()
+    if inspector is not None:
+        return inspector
+    return datetime.now(timezone.utc)
+
+
+# ``packages`` (name-keyed sugar) and ``package-rules`` (array-of-tables) are
+# two rows that both desugar into one PackageOverride tuple, so each parses
+# only its own surface and config validates the body and the within-surface
+# same-field overlap.  The across-file overlap runs over the concatenation
+# via merge_check (_revalidate_override_overlap).  The cross-surface
+# packages-vs-package-rules overlap and the route-names-a-declared-index
+# check both need the merged whole, so they run on the resolve path in
+# config._config_from_effective, not here.
+def _parse_packages(value: Any, where: str) -> tuple[Any, ...]:
+    del where
+    from .config import (  # noqa: PLC0415 (config import cycle)
+        _parse_packages_sugar as _impl,
+    )
+
+    return _delegate(lambda: tuple(_impl(value, anchor=_override_anchor())))
+
+
+def _parse_package_rules(value: Any, where: str) -> tuple[Any, ...]:
+    del where
+    from .config import (  # noqa: PLC0415 (config import cycle)
+        _parse_package_rules as _impl,
+    )
+
+    return _delegate(lambda: tuple(_impl(value, anchor=_override_anchor())))
+
+
+def _revalidate_override_overlap(overrides: Sequence[Any]) -> tuple[Any, ...]:
+    # Re-run the per-package same-field overlap check over the concatenation,
+    # re-typing the error to the registry's SourceConfigError.
+    from .config import (  # noqa: PLC0415 (config import cycle)
+        _check_package_override_overlap as _impl,
+    )
+
+    merged = tuple(overrides)
+    _delegate(lambda: _impl(merged))
+    return merged
+
+
+def _parse_index_overrides(value: Any, where: str) -> Mapping[str, Any]:
+    # Name-keyed table (``[tool.nab.index.<name>]``).  The body (policy
+    # fields) is validated as on the pyproject path; the
+    # key-names-a-declared-index check needs the merged indexes and so runs on
+    # the resolve path.  As a mapping row the two project files contribute
+    # disjoint index names additively, and only the same index name set
+    # differently across them is a conflict.
+    del where
+    from .config import (  # noqa: PLC0415 (config import cycle)
+        _parse_index_overrides as _impl,
+    )
+
+    return _delegate(lambda: _impl(value, anchor=_override_anchor()))
+
+
+def _parse_conflicts(value: Any, where: str) -> tuple[Any, ...]:
+    # One file's array-of-tables (member list/table + policy): config validates
+    # shape, members, and policy and runs the within-file member-uniqueness
+    # check.  The across-file member-uniqueness check runs over the
+    # concatenation via merge_check (_revalidate_conflict_members).  The
+    # default-groups-vs-conflicts check needs both merged values, so it runs
+    # on the resolve path.
+    del where
+    from .config import _parse_conflicts as _impl  # noqa: PLC0415 (config import cycle)
+
+    return _delegate(lambda: _impl(value))
+
+
+def _revalidate_conflict_members(conflicts: Sequence[Any]) -> tuple[Any, ...]:
+    # Re-run the member-uniqueness check over the concatenation, re-typing the
+    # error so its message matches the single-file path.
+    from .config import (  # noqa: PLC0415 (config import cycle)
+        _check_conflict_member_uniqueness as _impl,
+    )
+
+    merged = tuple(conflicts)
+    _delegate(lambda: _impl(merged))
+    return merged
+
+
+def _parse_matrix(value: Any, where: str) -> Any:
+    # Nested table (python, platforms, python-order, python-patches,
+    # implementations).  Scalar last-wins, compared by value (a frozen
+    # MatrixConfig or None).  Delegates to config._parse_matrix so axis
+    # validation and eager expansion are identical to the pyproject path.
+    # The mode/matrix mutual-requirement check needs both merged values, so
+    # it runs over the merged config rather than in this row.
+    del where
+    from .config import _parse_matrix as _impl  # noqa: PLC0415 (config import cycle)
+
+    return _delegate(lambda: _impl(value))
+
+
+def _render_conflicts(value: Sequence[Any]) -> str:
+    if not value:
+        return "<none>"
+    return "; ".join(str(cs) for cs in value)
+
+
+def _render_matrix(value: Any) -> str:
+    if value is None:
+        return "<none>"
+    return f"python={value.python}, platforms={list(value.platforms)}"
+
+
+def _render_package_overrides(value: Sequence[Any]) -> str:
+    if not value:
+        return "<none>"
+    return ", ".join(str(o.requirement) for o in value)
+
+
+def _render_index_overrides(value: Mapping[str, Any]) -> str:
+    if not value:
+        return "<none>"
+    return ", ".join(sorted(value))
+
+
+def _render_index_list(value: Sequence[IndexConfig]) -> str:
+    if not value:
+        return "<none>"
+    return ", ".join(f"{i.name}={i.url}" for i in value)
+
+
+def _render_local_sources(value: Sequence[LocalSource]) -> str:
+    if not value:
+        return "<none>"
+    return ", ".join(f"{s.name}@{s.path}" for s in value)
+
+
+def _render_vcs_sources(value: Sequence[VcsSource]) -> str:
+    if not value:
+        return "<none>"
+    return ", ".join(f"{s.name}@{s.url}" for s in value)
+
+
+def _render_string_tuple(value: Sequence[str]) -> str:
+    return "<none>" if not value else ", ".join(value)
+
+
+def _render_marker_environment(value: Mapping[str, str]) -> str:
+    if not value:
+        return "<none>"
+    return ", ".join(f"{k}={v}" for k, v in sorted(value.items()))
+
+
+def _render_vcs(value: Any) -> str:
+    parts = [f"policy={value.policy.value}"]
+    if value.allowed_schemes:
+        parts.append(f"allowed-schemes={sorted(value.allowed_schemes)}")
+    if value.allowed_repos:
+        parts.append(f"allowed-repos={list(value.allowed_repos)}")
+    if not value.require_pin:
+        parts.append("require-pin=false")
+    return ", ".join(parts)
+
+
+def _render_workspace(value: Any) -> str:
+    if value is None:
+        return "<none>"
+    return f"members={list(value.members)}"
+
+
+def _render_uploaded_prior_to(value: Any) -> str:
+    return "<none>" if value is None else str(value)
+
+
+def _render_dist_policy(value: Any) -> str:
+    # value is the (policy, trust_unverified_deps) pair the global parser
+    # returns; show the trust flag only when it diverges from the default.
+    policy, trust = value
+    return f"{policy.value} (trust-unverified-deps)" if trust else policy.value
+
+
+# Immutable empty-mapping default shared by table rows, so an unset
+# value never aliases (or lets a downstream mutation corrupt) the
+# registry default for later resolves in the same process.
+_EMPTY_MAPPING: Mapping[str, Any] = types.MappingProxyType({})
+
+# The registry.  One row per layered option.
+OPTIONS: tuple[OptionSpec, ...] = (
+    OptionSpec(
+        key="resolution",
+        scope=Scope.PROJECT,
+        type_label=f"enum({'|'.join(s.value for s in ResolutionStrategy)})",
+        default=ResolutionStrategy.HIGHEST,
+        env_var=None,
+        cli_flag="--project-resolution",
+        cli_param="project_resolution",
+        parse=_parse_resolution,
+        render=lambda v: v.value,
+    ),
+    OptionSpec(
+        key="mode",
+        scope=Scope.PROJECT,
+        type_label=f"enum({'|'.join(m.value for m in ResolveMode)})",
+        default=ResolveMode.SPECIFIC,
+        env_var=None,
+        cli_flag="--project-mode",
+        cli_param="project_mode",
+        parse=_parse_mode,
+        render=lambda v: v.value,
+    ),
+    OptionSpec(
+        key="constraints",
+        scope=Scope.PROJECT,
+        type_label="list(requirement)",
+        default=(),
+        env_var=None,
+        cli_flag="--project-constraint",
+        cli_param="project_constraint",
+        parse=_parse_constraints,
+        render=_render_string_tuple,
+        is_array=True,
+    ),
+    OptionSpec(
+        key="default-groups",
+        scope=Scope.PROJECT,
+        type_label="list(group)",
+        default=(),
+        env_var=None,
+        cli_flag="--project-default-group",
+        cli_param="project_default_group",
+        parse=_parse_default_groups,
+        render=_render_string_tuple,
+        is_array=True,
+    ),
+    OptionSpec(
+        key="requires-python",
+        scope=Scope.PROJECT,
+        type_label="specifier",
+        default=None,
+        env_var=None,
+        cli_flag="--project-requires-python",
+        cli_param="project_requires_python",
+        parse=_parse_requires_python,
+        render=lambda v: "<none>" if v is None else v,
+    ),
+    OptionSpec(
+        key="uploaded-prior-to",
+        scope=Scope.PROJECT,
+        type_label="datetime|PnD",
+        default=None,
+        env_var=None,
+        cli_flag="--project-uploaded-prior-to",
+        cli_param="project_uploaded_prior_to",
+        parse=_parse_uploaded_prior_to,
+        render=_render_uploaded_prior_to,
+    ),
+    OptionSpec(
+        key="dist-policy",
+        scope=Scope.PROJECT,
+        type_label=f"enum({'|'.join(p.value for p in DistPolicy)})",
+        default=(DistPolicy.WHEEL_OR_SDIST, False),
+        env_var=None,
+        cli_flag="--project-dist-policy",
+        cli_param="project_dist_policy",
+        parse=_parse_dist_policy,
+        render=_render_dist_policy,
+    ),
+    OptionSpec(
+        key="build-policy",
+        scope=Scope.PROJECT,
+        type_label=f"enum({'|'.join(p.value for p in BuildPolicy)})",
+        default=BuildPolicy.BUILD_LOCAL,
+        env_var=None,
+        cli_flag="--project-build-policy",
+        cli_param="project_build_policy",
+        parse=_parse_build_policy,
+        render=lambda v: v.value,
+    ),
+    OptionSpec(
+        key="marker-environment",
+        scope=Scope.PROJECT,
+        type_label="table(marker-var=str)",
+        default=_EMPTY_MAPPING,
+        env_var=None,
+        cli_flag=None,
+        cli_param=None,
+        parse=_parse_marker_environment,
+        render=_render_marker_environment,
+        is_mapping=True,
+    ),
+    OptionSpec(
+        key="vcs",
+        scope=Scope.PROJECT,
+        type_label="table(vcs-policy)",
+        default=VcsConfig(),
+        env_var=None,
+        cli_flag=None,
+        cli_param=None,
+        parse=_parse_vcs,
+        render=_render_vcs,
+    ),
+    OptionSpec(
+        key="workspace",
+        scope=Scope.PROJECT,
+        type_label="table(members)",
+        default=None,
+        env_var=None,
+        cli_flag=None,
+        cli_param=None,
+        parse=_parse_workspace,
+        render=_render_workspace,
+    ),
+    OptionSpec(
+        key="indexes",
+        scope=Scope.PROJECT,
+        type_label="array-of-tables(name,url)",
+        default=(IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL),),
+        env_var=None,
+        cli_flag=None,
+        cli_param=None,
+        parse=_parse_indexes,
+        render=_render_index_list,
+        is_array=True,
+        merge_check=_revalidate_index_names,
+    ),
+    OptionSpec(
+        key="local-sources",
+        scope=Scope.PROJECT,
+        type_label="array-of-tables(name,path)",
+        default=(),
+        env_var=None,
+        cli_flag=None,
+        cli_param=None,
+        parse=_parse_local_sources,
+        render=_render_local_sources,
+        is_array=True,
+        merge_check=tuple,
+    ),
+    OptionSpec(
+        key="vcs-sources",
+        scope=Scope.PROJECT,
+        type_label="array-of-tables(name,url)",
+        default=(),
+        env_var=None,
+        cli_flag=None,
+        cli_param=None,
+        parse=_parse_vcs_sources,
+        render=_render_vcs_sources,
+        is_array=True,
+        merge_check=tuple,
+    ),
+    OptionSpec(
+        key="packages",
+        scope=Scope.PROJECT,
+        type_label="table(package-override)",
+        default=(),
+        env_var=None,
+        cli_flag=None,
+        cli_param=None,
+        parse=_parse_packages,
+        render=_render_package_overrides,
+        is_array=True,
+        merge_check=_revalidate_override_overlap,
+    ),
+    OptionSpec(
+        key="package-rules",
+        scope=Scope.PROJECT,
+        type_label="array-of-tables(match,policy)",
+        default=(),
+        env_var=None,
+        cli_flag=None,
+        cli_param=None,
+        parse=_parse_package_rules,
+        render=_render_package_overrides,
+        is_array=True,
+        merge_check=_revalidate_override_overlap,
+    ),
+    OptionSpec(
+        key="index",
+        scope=Scope.PROJECT,
+        type_label="table(index-override)",
+        default=_EMPTY_MAPPING,
+        env_var=None,
+        cli_flag=None,
+        cli_param=None,
+        parse=_parse_index_overrides,
+        render=_render_index_overrides,
+        is_mapping=True,
+    ),
+    OptionSpec(
+        key="conflicts",
+        scope=Scope.PROJECT,
+        type_label="array-of-tables(members,policy)",
+        default=(),
+        env_var=None,
+        cli_flag=None,
+        cli_param=None,
+        parse=_parse_conflicts,
+        render=_render_conflicts,
+        is_array=True,
+        merge_check=_revalidate_conflict_members,
+    ),
+    OptionSpec(
+        key="matrix",
+        scope=Scope.PROJECT,
+        type_label="table(python,platforms)",
+        default=None,
+        env_var=None,
+        cli_flag=None,
+        cli_param=None,
+        parse=_parse_matrix,
+        render=_render_matrix,
+    ),
+    OptionSpec(
+        key="offline",
+        scope=Scope.USER,
+        type_label="bool",
+        default=False,
+        env_var="NAB_OFFLINE",
+        cli_flag="--offline",
+        cli_param="offline",
+        parse=_parse_bool,
+        render=lambda v: "true" if v else "false",
+    ),
+    OptionSpec(
+        key="cache-dir",
+        scope=Scope.USER,
+        type_label="path",
+        default=None,
+        env_var="NAB_CACHE_DIR",
+        cli_flag="--cache-dir",
+        cli_param="cache_dir",
+        parse=_parse_path,
+        render=lambda v: "<computed>" if v is None else str(v),
+    ),
+    OptionSpec(
+        key="http-backend",
+        scope=Scope.USER,
+        type_label=f"enum({'|'.join(_HTTP_BACKENDS)})",
+        default="urllib3",
+        env_var="NAB_HTTP_BACKEND",
+        cli_flag="--http-backend",
+        cli_param="http_backend",
+        parse=_parse_http_backend,
+        render=str,
+    ),
+    OptionSpec(
+        key="max-concurrency",
+        scope=Scope.USER,
+        type_label="int",
+        default=8,
+        env_var="NAB_MAX_CONCURRENCY",
+        cli_flag="--max-concurrency",
+        cli_param="max_concurrency",
+        parse=_parse_max_concurrency,
+        render=str,
+    ),
+)
+
+_BY_KEY: dict[str, OptionSpec] = {spec.key: spec for spec in OPTIONS}
+
+
+def pyproject_registry_keys() -> frozenset[str]:
+    """Registry keys a pyproject ``[tool.nab]`` table may legitimately carry.
+
+    Only PROJECT-scope registry options are allowed in pyproject; the
+    single-environment parser (:mod:`nab_python.config`) folds this set
+    into its own known-keys so a registry key is not double-reported as
+    an unknown ``[tool.nab]`` key.
+    """
+    return frozenset(
+        spec.key for spec in OPTIONS if spec.allowed_in_toml(SourceKind.PYPROJECT)
+    )
+
+
+def reject_user_keys_in_pyproject(raw: Mapping[str, Any]) -> None:
+    """Raise the category error for any USER registry key in ``[tool.nab]``.
+
+    The parser fold: a USER-scope option (e.g. ``offline``,
+    ``cache-dir``) set in pyproject ``[tool.nab]`` must surface the
+    registry category error (``pyproject [tool.nab]`` is project-scope
+    only) rather than the generic unknown-key error the pyproject
+    parser would otherwise raise.  PROJECT keys and keys the registry
+    does not own are left for the pyproject parser to handle.
+
+    The message carries no ``[tool.nab]:`` prefix: the only caller is the
+    pyproject parser, whose ``Error in [tool.nab]:`` wrapper already
+    supplies it, so prefixing here would double it.
+    """
+    for key in raw:
+        spec = _BY_KEY.get(key)
+        if spec is None:
+            continue
+        if not spec.allowed_in_toml(SourceKind.PYPROJECT):
+            reason = _gate_reason(spec, SourceKind.PYPROJECT)
+            msg = f"{key}: {reason}"
+            raise SourceConfigError(msg)
+
+
+@dataclass(frozen=True, slots=True)
+class Origin:
+    """Where a value came from: a source kind plus a display label."""
+
+    kind: SourceKind
+    label: str
+
+    @property
+    def scope(self) -> str:
+        """The provenance scope name shown by ``nab config``.
+
+        Mirrors the source kind's value for every kind except
+        ``PYPROJECT``, which reports "project" (it sits at the project
+        precedence level alongside the project-dir nab.toml).
+        """
+        return _scope_label(self.kind)
+
+
+def _scope_label(kind: SourceKind) -> str:
+    """Return the scope name ``nab config`` reports for a source kind.
+
+    Distinct from Scope (PROJECT/USER, the gate axis): provenance reports
+    the source, so a project nab.toml reports "project", env reports
+    "env", etc.  Every kind reports its own value except PYPROJECT, which
+    shares the project precedence level and so reports "project".
+    """
+    return "project" if kind is SourceKind.PYPROJECT else kind.value
+
+
+@dataclass(frozen=True, slots=True)
+class Layer:
+    """A set of (key -> value) bindings discovered from one source."""
+
+    origin: Origin
+    values: Mapping[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class RejectedLayer:
+    """A source that tried to set a key it is not allowed to set.
+
+    Captured (not raised) by :func:`discover_layers` only when the caller
+    asks to collect rejections for ``nab config explain
+    --include-rejected``.  The normal load path raises a
+    :class:`SourceConfigError` instead.
+    """
+
+    origin: Origin
+    key: str
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class EffectiveValue:
+    """One option's winning value plus its full shadowed stack."""
+
+    spec: OptionSpec
+    value: Any
+    origin: Origin
+    # Every binding for this key in precedence order (low -> high),
+    # the last of which is the winner.
+    stack: tuple[tuple[Origin, Any], ...]
+    rejected: tuple[RejectedLayer, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class SourceRoots:
+    """Injectable search roots so config discovery is hermetic in tests.
+
+    ``system_toml`` and ``user_toml`` point at the system/user
+    ``nab.toml`` files.  ``project_dir`` is the directory holding the
+    pyproject; the project ``nab.toml`` is looked up beside it.
+    ``pyproject`` names the pyproject file itself when the user pointed at
+    a non-default name; left ``None`` it defaults to
+    ``project_dir / "pyproject.toml"`` so the registry reads the same file
+    the rest of nab does.  Any field may be ``None`` to skip that source.
+    There is no walk-up: the project source is the directory of the
+    pyproject only.
+    """
+
+    system_toml: Path | None = None
+    user_toml: Path | None = None
+    project_dir: Path | None = None
+    pyproject: Path | None = None
+
+
+def _load_toml_layer(
+    path: Path,
+    kind: SourceKind,
+    *,
+    rejections: list[RejectedLayer] | None = None,
+) -> Layer:
+    """Read one TOML source into a :class:`Layer`, gating by category.
+
+    ``kind`` selects how the file is read: a ``PYPROJECT`` source reads
+    ``[tool.nab]``; the standalone ``nab.toml`` sources read top-level
+    keys.  Every registry key is parsed by its row.  A key that names an
+    option not allowed in ``kind`` (the category gate) raises
+    :class:`SourceConfigError`, unless ``rejections`` is supplied, in
+    which case it is appended there and skipped (for explain).
+    """
+    raw = _read_raw_table(path, kind)
+    origin = Origin(kind, str(path))
+    values: dict[str, Any] = {}
+    # Carry the declaring file's directory structurally so relative
+    # local-source paths resolve against it (see _declaring_dir).
+    token = _DECLARING_DIR.set(path.parent)
+    try:
+        for key, value in raw.items():
+            spec = _BY_KEY.get(key)
+            if spec is None:
+                # An unknown key (a typo) crashes naming the file rather than
+                # being dropped, the same way an unknown NAB_* var does.  On
+                # the resolve path config.read_pyproject_config rejects an
+                # unknown pyproject [tool.nab] key before this loader runs;
+                # the inspector reaches here, so it reports the typo too
+                # instead of silently ignoring it.
+                valid = sorted(_BY_KEY)
+                msg = (
+                    f"{path}: {key!r} is not a valid nab setting; the known"
+                    f" keys are {valid!r}."
+                )
+                if rejections is not None:
+                    rejections.append(RejectedLayer(origin, key, msg))
+                    continue
+                raise SourceConfigError(msg)
+            where = f"{path}: {key}"
+            if not spec.allowed_in_toml(kind):
+                reason = _gate_reason(spec, kind)
+                if rejections is not None:
+                    rejections.append(RejectedLayer(origin, key, reason))
+                    continue
+                msg = f"{where}: {reason}"
+                raise SourceConfigError(msg)
+            values[key] = spec.parse(value, where)
+    finally:
+        _DECLARING_DIR.reset(token)
+    return Layer(origin, values)
+
+
+def _gate_reason(spec: OptionSpec, kind: SourceKind) -> str:
+    if kind is SourceKind.PYPROJECT:
+        where = "pyproject [tool.nab] (project-scope only)"
+    else:
+        where = f"a {_scope_label(kind)} nab.toml"
+    return (
+        f"{spec.key!r} is a {spec.scope.value}-scope option and cannot be set"
+        f" in {where}"
+    )
+
+
+def _read_raw_table(path: Path, kind: SourceKind) -> Mapping[str, Any]:
+    try:
+        with path.open("rb") as f:
+            data = tomli.load(f)
+    except tomli.TOMLDecodeError as exc:
+        msg = f"{path} is not valid TOML: {exc}"
+        raise SourceConfigError(msg) from exc
+    if kind is SourceKind.PYPROJECT:
+        tool = data.get("tool", {})
+        section = tool.get("nab", {}) if isinstance(tool, dict) else {}
+        return section if isinstance(section, dict) else {}
+    return data
+
+
+def read_env_layer(
+    environ: Mapping[str, str],
+    *,
+    rejections: list[RejectedLayer] | None = None,
+) -> Layer:
+    """Read ``NAB_*`` for every registry row that declares an env var.
+
+    PROJECT options never declare an env var, so the env layer carries
+    USER options only.  A ``NAB_<KEY>`` naming a PROJECT option (e.g.
+    ``NAB_RESOLUTION``) is a hard error caught by
+    :func:`_reject_renamed_env`; any other unknown ``NAB_*`` name (e.g. a
+    typo) is rejected by :func:`_reject_unknown_env`.  When ``rejections``
+    is supplied (``nab config explain --include-rejected``) those env
+    casualties are recorded there and skipped instead of raised, mirroring
+    the TOML loader.
+    """
+    _reject_renamed_env(environ, rejections=rejections)
+    _reject_unknown_env(environ, rejections=rejections)
+    values: dict[str, Any] = {}
+    for spec in OPTIONS:
+        if spec.env_var is None:
+            continue
+        if spec.env_var not in environ:
+            continue
+        where = f"env:{spec.env_var}"
+        values[spec.key] = spec.parse(environ[spec.env_var], where)
+    return Layer(Origin(SourceKind.ENV, "env"), values)
+
+
+def _reject_unknown_env(
+    environ: Mapping[str, str],
+    *,
+    rejections: list[RejectedLayer] | None = None,
+) -> None:
+    """Reject any ``NAB_*`` var that is neither a known nor renamed name.
+
+    The env half of the category gate: a typo'd or made-up
+    ``NAB_<KEY>`` (e.g. ``NAB_OFLINE``) must crash naming the variable
+    rather than being silently dropped.  Renamed PROJECT names are left
+    for :func:`_reject_renamed_env`, which gives the more specific
+    not-env-settable message.  When ``rejections`` is supplied the var is
+    recorded there and skipped instead of raised.
+    """
+    known = {spec.env_var for spec in OPTIONS if spec.env_var is not None}
+    renamed = set(_renamed_env_names())
+    for name in environ:
+        if not name.startswith("NAB_") or name in known or name in renamed:
+            continue
+        valid = sorted(known)
+        msg = (
+            f"{name} is not a valid nab setting; the known NAB_* variables"
+            f" are {valid!r}."
+        )
+        if rejections is not None:
+            rejections.append(RejectedLayer(Origin(SourceKind.ENV, name), name, msg))
+            continue
+        raise SourceConfigError(msg)
+
+
+def _renamed_env_names() -> dict[str, OptionSpec]:
+    """Map every PROJECT row's would-be ``NAB_<KEY>`` name to its spec."""
+    names: dict[str, OptionSpec] = {}
+    for spec in OPTIONS:
+        if spec.scope is Scope.PROJECT:
+            env_name = "NAB_" + spec.key.upper().replace("-", "_")
+            names[env_name] = spec
+    return names
+
+
+def _reject_renamed_env(
+    environ: Mapping[str, str],
+    *,
+    rejections: list[RejectedLayer] | None = None,
+) -> None:
+    """Reject a ``NAB_<KEY>`` that names a PROJECT (non-env-settable) option.
+
+    When ``rejections`` is supplied the var is recorded there under the
+    spec's key (so ``explain <key> --include-rejected`` lists it) and
+    skipped instead of raised.
+    """
+    for env_name, spec in _renamed_env_names().items():
+        if env_name in environ:
+            # A file-only row (cli_flag is None) carries no per-run flag,
+            # so the message names only the two project files for it.
+            override = (
+                ""
+                if spec.cli_flag is None
+                else f", or override per-run with {spec.cli_flag}"
+            )
+            msg = (
+                f"{env_name} is not a valid nab setting: {spec.key!r} is a"
+                f" {spec.scope.value}-scope option and is not env-settable."
+                f"  Set it in pyproject [tool.nab].{spec.key} or a project-dir"
+                f" nab.toml{override}."
+            )
+            if rejections is not None:
+                rejections.append(
+                    RejectedLayer(Origin(SourceKind.ENV, env_name), spec.key, msg)
+                )
+                continue
+            raise SourceConfigError(msg)
+
+
+def discover_layers(
+    roots: SourceRoots,
+    *,
+    rejections: list[RejectedLayer] | None = None,
+) -> list[Layer]:
+    """Read every present TOML source into ordered layers (low -> high).
+
+    Reads system, user, pyproject, and project-dir ``nab.toml`` in
+    precedence order, skipping any root that is ``None`` or whose file is
+    absent.  Hermetic: the caller supplies the roots, so nothing touches
+    the real ``~/.config``.  There is no walk-up: the project source is
+    the pyproject directory only.
+    """
+    if roots.project_dir is None:
+        pyproject_path = None
+    elif roots.pyproject is not None:
+        pyproject_path = roots.pyproject
+    else:
+        pyproject_path = roots.project_dir / "pyproject.toml"
+    layers: list[Layer] = []
+    plan: list[tuple[Path | None, SourceKind]] = [
+        (roots.system_toml, SourceKind.SYSTEM_TOML),
+        (roots.user_toml, SourceKind.USER_TOML),
+        (pyproject_path, SourceKind.PYPROJECT),
+        (
+            None if roots.project_dir is None else roots.project_dir / "nab.toml",
+            SourceKind.PROJECT_TOML,
+        ),
+    ]
+    for path, kind in plan:
+        if path is None or not path.exists():
+            continue
+        if not path.is_file():
+            # A genuinely-absent file is skipped above; a path that exists
+            # but is not a regular file (e.g. an accidental `mkdir
+            # nab.toml`) would be silently ignored by an is_file() filter,
+            # so crash naming it rather than dropping the config source.
+            msg = f"{path} exists but is not a regular file"
+            raise SourceConfigError(msg)
+        layers.append(_load_toml_layer(path, kind, rejections=rejections))
+    return layers
+
+
+def resolve_config(
+    layers: Sequence[Layer],
+    env_layer: Layer,
+    cli_layer: Layer,
+    *,
+    rejected: Sequence[RejectedLayer] = (),
+) -> dict[str, EffectiveValue]:
+    """Merge all layers into one effective value per registry option.
+
+    ``layers`` are the discovered TOML layers (any order; ranked by
+    :data:`_PRECEDENCE`).  ``env_layer`` and ``cli_layer`` are the env
+    and CLI bindings.  Returns a ``key -> EffectiveValue`` map covering
+    every registry row, each carrying its winner ``(scope, origin)`` and
+    the full shadowed stack.  ``rejected`` (category-gate casualties) is
+    attached per key for ``explain --include-rejected``.
+    """
+    all_layers = [*layers, env_layer, cli_layer]
+    out: dict[str, EffectiveValue] = {}
+    for spec in OPTIONS:
+        stack = _stack_for(spec, all_layers)
+        rejected_for_key = tuple(r for r in rejected if r.key == spec.key)
+        if not stack:
+            origin, value = Origin(SourceKind.DEFAULT, "builtin-default"), spec.default
+        elif spec.is_array:
+            origin, value = stack[-1][0], _merge_array(spec, stack)
+        elif spec.is_mapping:
+            origin, value = stack[-1][0], _merge_mapping(stack)
+        else:
+            origin, value = stack[-1]
+        out[spec.key] = EffectiveValue(
+            spec=spec,
+            value=value,
+            origin=origin,
+            stack=tuple(stack) if stack else ((origin, value),),
+            rejected=rejected_for_key,
+        )
+    return out
+
+
+def _stack_for(
+    spec: OptionSpec, all_layers: Iterable[Layer]
+) -> list[tuple[Origin, Any]]:
+    """Bindings for one option across layers, sorted low -> high.
+
+    Sorted by source precedence; the pyproject/project-dir tie is broken
+    so the project-dir nab.toml sorts last (wins).  Co-presence in both
+    project files with conflicting values is a hard error; identical
+    values pass.
+    """
+    found = [
+        (layer.origin, layer.values[spec.key])
+        for layer in all_layers
+        if spec.key in layer.values
+    ]
+    # Sort by precedence; break the pyproject/project-dir rank-3 tie so
+    # the project-dir nab.toml (False < True) sorts last and wins.
+    found.sort(
+        key=lambda item: (
+            _PRECEDENCE[item[0].kind],
+            item[0].kind is SourceKind.PROJECT_TOML,
+        )
+    )
+    _check_project_file_conflict(spec, found)
+    return found
+
+
+def _merge_array(
+    spec: OptionSpec, stack: Sequence[tuple[Origin, Any]]
+) -> tuple[Any, ...]:
+    """Concatenate an array option's bindings low-to-high, then re-validate.
+
+    Bindings concatenate in precedence order, so the two project files
+    contribute additively and a higher source appends rather than replaces.
+    A row whose items are already-built objects re-validates the whole
+    through ``merge_check`` (the index-name, override-overlap, and
+    conflict-member checks); a plain-string row re-runs ``parse`` over the
+    concatenation, so ``constraints`` is re-checked as PEP 508 as a whole.
+    """
+    merged: list[Any] = []
+    for _origin, value in stack:
+        merged.extend(value)
+    if spec.merge_check is not None:
+        return spec.merge_check(merged)
+    return spec.parse(merged, f"config {spec.key!r}")
+
+
+def _merge_mapping(stack: Sequence[tuple[Origin, Any]]) -> Mapping[str, Any]:
+    """Fold a name-keyed table's bindings sub-key by sub-key, low-to-high.
+
+    Each layer in ``stack`` already holds a per-layer-validated mapping (its
+    own file's ``[tool.nab.index.<name>]`` / ``[marker-environment]`` table
+    parsed by the row).  The two project files contribute disjoint sub-keys
+    additively; a sub-key present in more than one layer takes the
+    highest-precedence binding (and across the two same-rung project files a
+    differing sub-key is already an error, caught by
+    :func:`_check_project_file_conflict`).  Returned as a plain dict; the
+    per-entry body is already validated, and the check that an index name is
+    declared runs over the merged config.
+    """
+    merged: dict[str, Any] = {}
+    for _origin, value in stack:
+        merged.update(value)
+    return merged
+
+
+def _check_project_file_conflict(
+    spec: OptionSpec, found: Sequence[tuple[Origin, Any]]
+) -> None:
+    """Reject one key set differently in pyproject and the project nab.toml.
+
+    Co-presence is allowed; setting the same key to different values
+    across the two same-precedence project files is a hard
+    :class:`SourceConfigError`, not a silent last-wins.  Identical values
+    are fine.
+
+    An array option (``is_array``) is exempt: its two project-file
+    bindings concatenate additively, so differing lists are a merge, not a
+    conflict.  The concat is order-stable (pyproject before project-dir
+    nab.toml) so the result is deterministic.
+
+    A name-keyed table (``is_mapping``) merges sub-key by sub-key, so the
+    two project files contribute disjoint sub-keys additively; only the
+    same sub-key set to different values across them is a conflict
+    (handled below), mirroring the additive array exemption.
+    """
+    if spec.is_array:
+        return
+    by_kind = {origin.kind: value for origin, value in found}
+    if SourceKind.PYPROJECT not in by_kind or SourceKind.PROJECT_TOML not in by_kind:
+        return
+    pyproject_value = by_kind[SourceKind.PYPROJECT]
+    project_value = by_kind[SourceKind.PROJECT_TOML]
+    if spec.is_mapping:
+        _check_mapping_subkey_conflict(spec, pyproject_value, project_value)
+        return
+    if pyproject_value == project_value:
+        return
+    msg = (
+        f"config {spec.key!r} is set to conflicting values in pyproject"
+        f" [tool.nab] ({spec.render(pyproject_value)!r}) and project-dir"
+        f" nab.toml ({spec.render(project_value)!r}).  Both files sit at the"
+        " same precedence level; set the key in only one, or set them to the"
+        " same value."
+    )
+    raise SourceConfigError(msg)
+
+
+def _check_mapping_subkey_conflict(
+    spec: OptionSpec,
+    pyproject_value: Mapping[str, Any],
+    project_value: Mapping[str, Any],
+) -> None:
+    """For a name-keyed table, only a shared sub-key set differently errors.
+
+    Disjoint sub-keys across the two project files merge (additive, like an
+    array row); a sub-key present in both with a differing value is the hard
+    conflict.  Sorted so the message is deterministic.
+    """
+    for sub_key in sorted(set(pyproject_value) & set(project_value)):
+        if pyproject_value[sub_key] != project_value[sub_key]:
+            msg = (
+                f"config {spec.key!r}.{sub_key} is set to conflicting values in"
+                " pyproject [tool.nab] and project-dir nab.toml.  Both files sit"
+                " at the same precedence level; set the sub-key in only one, or"
+                " set them to the same value."
+            )
+            raise SourceConfigError(msg)
+
+
+# ----- nab config renderers (all derived from the effective map) -----
+
+
+def _ordered(effective: Mapping[str, EffectiveValue]) -> list[EffectiveValue]:
+    return [effective[spec.key] for spec in OPTIONS]
+
+
+# Column widths for the ``nab config list`` table, shared by the header
+# and every row so the two cannot drift.  The trailing ``origin`` column
+# is unpadded (last field).
+_LIST_KEY_W = 20
+_LIST_VALUE_W = 20
+_LIST_SCOPE_W = 9
+# Status column width for ``nab config explain`` (winner/shadowed/rejected).
+_EXPLAIN_STATUS_W = 9
+
+
+def orphan_rejections(
+    rejected: Iterable[RejectedLayer],
+) -> tuple[RejectedLayer, ...]:
+    """Rejections that name no registry option, so attach to no key.
+
+    An unknown standalone ``nab.toml`` key or an unknown ``NAB_*`` var is
+    recorded with ``key`` set to the offending name, which matches no
+    registry key, so :func:`resolve_config` attaches it to no
+    :class:`EffectiveValue` and no ``explain <key>`` reaches it.  These
+    orphans are surfaced by :func:`render_list` instead.
+    """
+    return tuple(rej for rej in rejected if rej.key not in _BY_KEY)
+
+
+def render_list(
+    effective: Mapping[str, EffectiveValue],
+    *,
+    rejected: Iterable[RejectedLayer] = (),
+) -> str:
+    """Render every effective option: value, scope, origin.
+
+    ``rejected`` (when collecting for ``--include-rejected``) adds a
+    trailing section listing every rejected source: a key set outside its
+    scope, and an unknown key or ``NAB_*`` var.  ``explain`` reaches the
+    former (it attaches to the named option) but not the latter (it names
+    no option), so ``list`` is the one place that shows both together.
+    """
+    header = (
+        f"{'key':<{_LIST_KEY_W}} {'value':<{_LIST_VALUE_W}}"
+        f" {'scope':<{_LIST_SCOPE_W}} origin"
+    )
+    lines = [header]
+    for ev in _ordered(effective):
+        rendered = ev.spec.render(ev.value)
+        lines.append(
+            f"{ev.spec.key:<{_LIST_KEY_W}} {rendered:<{_LIST_VALUE_W}}"
+            f" {ev.origin.scope:<{_LIST_SCOPE_W}} {ev.origin.label}"
+        )
+    rejected = tuple(rejected)
+    if rejected:
+        lines.append("")
+        lines.append("rejected:")
+        lines.extend(
+            f"  {rej.origin.scope:<{_LIST_SCOPE_W}} {rej.origin.label}"
+            f"  {rej.key}: {rej.reason}"
+            for rej in rejected
+        )
+    return "\n".join(lines) + "\n"
+
+
+def render_get(effective: Mapping[str, EffectiveValue], key: str) -> str:
+    """Render only the effective value of ``key``."""
+    ev = _require_key(effective, key)
+    return ev.spec.render(ev.value) + "\n"
+
+
+def render_explain(
+    effective: Mapping[str, EffectiveValue],
+    key: str,
+    *,
+    include_rejected: bool = False,
+) -> str:
+    """Render the full shadowed stack for ``key``.
+
+    The winner is marked with a ``>`` gutter, every other source is
+    ``shadowed``.  With ``include_rejected`` the category-rejected
+    sources (a source that tried to set ``key`` but was not allowed) are
+    listed too, labelled ``rejected``.
+    """
+    ev = _require_key(effective, key)
+    lines = [f"{key} ({ev.spec.scope.value}, {ev.spec.type_label})"]
+    winner_index = len(ev.stack) - 1
+    merged = ev.spec.is_array or ev.spec.is_mapping
+    for i, (origin, value) in enumerate(ev.stack):
+        # Array / name-keyed-table options merge every layer low-to-high
+        # (concat for arrays, sub-key union for mappings), so no single
+        # layer's binding is the effective value; the per-layer rows are
+        # contributions and the merged value is rendered separately below.
+        if merged:
+            gutter, status = " ", "contributes"
+        else:
+            gutter = ">" if i == winner_index else " "
+            status = "winner" if i == winner_index else "shadowed"
+        rendered = ev.spec.render(value)
+        lines.append(
+            f"{gutter} {origin.scope:<{_LIST_SCOPE_W}} {rendered:<{_LIST_VALUE_W}}"
+            f" {status:<{_EXPLAIN_STATUS_W}} {origin.label}"
+        )
+    if merged:
+        lines.append(f"= effective: {ev.spec.render(ev.value)}")
+    if include_rejected:
+        lines.extend(
+            f"  {rej.origin.scope:<{_LIST_SCOPE_W}} {'-':<{_LIST_VALUE_W}}"
+            f" {'rejected':<{_EXPLAIN_STATUS_W}} {rej.origin.label} ({rej.reason})"
+            for rej in ev.rejected
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _require_key(effective: Mapping[str, EffectiveValue], key: str) -> EffectiveValue:
+    ev = effective.get(key)
+    if ev is None:
+        valid = sorted(_BY_KEY)
+        msg = f"unknown config key {key!r}; known keys are {valid!r}"
+        raise SourceConfigError(msg)
+    return ev
+
+
+def build_cli_overrides(locals_by_param: Mapping[str, Any]) -> dict[str, Any]:
+    """Map ``{cli_param: value}`` to a registry-keyed override dict.
+
+    Iterates :data:`OPTIONS`, reads each row's ``cli_param`` out of
+    ``locals_by_param``, and keeps only the keys the user actually set.
+    An unset scalar flag is ``None`` and an unset array flag is an empty
+    tuple (the append-action default); both are omitted so they do not
+    shadow the file ladder.  A file-only row (``cli_param`` is ``None``)
+    has no CLI flag, so it is skipped entirely.  Both the run subcommands
+    and ``nab config`` build their override dict through this single
+    helper, keyed off the registry rather than a per-option if-chain.
+    """
+    out: dict[str, Any] = {}
+    for spec in OPTIONS:
+        if spec.cli_param is None:
+            continue
+        value = locals_by_param[spec.cli_param]
+        if value is None or (isinstance(value, tuple) and not value):
+            continue
+        out[spec.key] = value
+    return out
+
+
+def build_cli_layer(values: Mapping[str, Any]) -> Layer:
+    """Build the CLI layer from a ``{key: value}`` map of set overrides.
+
+    ``values`` holds only keys the user actually set on the CLI (an
+    unset flag is omitted, so it does not shadow lower layers).  Each
+    value is normalised through its registry row so the effective value
+    carries the typed form regardless of how the flag was spelled.
+    """
+    parsed: dict[str, Any] = {}
+    for key, value in values.items():
+        spec = _BY_KEY[key]
+        # An array flag arrives as a tuple from tyro's append action; the
+        # parse hooks expect a TOML list, so normalise it here.
+        raw = list(value) if spec.is_array and isinstance(value, tuple) else value
+        parsed[key] = spec.parse(raw, f"cli:{spec.cli_flag}")
+    return Layer(Origin(SourceKind.CLI, "cli"), parsed)
+
+
+def project_cli_override_records(
+    effective: Mapping[str, EffectiveValue],
+) -> tuple[tuple[str, str], ...]:
+    """Return the ``(flag, value)`` pairs for PROJECT options set on the CLI.
+
+    A PROJECT option changes the resolved set, so a CLI override means the
+    result no longer derives from the committed files alone.  These pairs
+    drive both the reproducibility notice and the auditable record written
+    into the lockfile provenance.  A file-only row (``cli_flag`` is ``None``)
+    is never CLI-settable, so it cannot appear.
+    """
+    records: list[tuple[str, str]] = []
+    for spec in OPTIONS:
+        if spec.scope is not Scope.PROJECT:
+            continue
+        ev = effective[spec.key]
+        if ev.origin.kind is not SourceKind.CLI or spec.cli_flag is None:
+            continue
+        records.append((spec.cli_flag, spec.render(ev.value)))
+    return tuple(records)
+
+
+def project_cli_override_notice(
+    effective: Mapping[str, EffectiveValue],
+    *,
+    produces_lock: bool = True,
+) -> str | None:
+    """Reproducibility notice for any PROJECT option set on the CLI.
+
+    Returns a notice listing every PROJECT override that came from the CLI
+    rung; ``None`` when no PROJECT option was set on the CLI.
+
+    ``produces_lock`` tailors the wording: ``nab lock`` produces a lock, so
+    the notice warns the lock will not derive from the committed files; the
+    read-only ``nab config`` inspector produces no lock, so it warns only
+    that the displayed values reflect a CLI override.
+    """
+    records = project_cli_override_records(effective)
+    if not records:
+        return None
+    if produces_lock:
+        header = (
+            "notice: project-scope overrides were applied from the CLI; the lock"
+            " they produce does not derive from the committed pyproject/nab.toml"
+            " alone:"
+        )
+    else:
+        header = (
+            "notice: project-scope overrides were applied from the CLI; the"
+            " values below reflect that override, not the committed"
+            " pyproject/nab.toml alone:"
+        )
+    lines = [header]
+    lines.extend(f"  {flag} -> {rendered}" for flag, rendered in records)
+    return "\n".join(lines) + "\n"

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -24,7 +24,12 @@ from ._lockfile.builder import (
     read_lockfile_packages,
 )
 from ._lockfile.disjointness import DisjointnessError
-from ._lockfile.pylock import DivergentBaseDependencyError, build_pylock, write_lock
+from ._lockfile.pylock import (
+    DivergentBaseDependencyError,
+    build_pylock,
+    render_lock,
+    write_lock,
+)
 from ._lockfile.requirements import (
     write_requirements_with_hashes,
     write_requirements_without_hashes,
@@ -61,6 +66,7 @@ __all__ = [
     "is_valid_pylock_path",
     "read_lockfile_anchor",
     "read_lockfile_packages",
+    "render_lock",
     "write_lock",
     "write_requirements_with_hashes",
     "write_requirements_without_hashes",
@@ -235,6 +241,10 @@ class Provenance:
     mode: str
     python_specifier: str | None = None
     platforms: tuple[str, ...] = ()
+    # The --project-* CLI overrides that shaped this lock, as
+    # ``(flag, rendered value)`` pairs.  Recorded so a reader can see the
+    # lock did not derive from the committed files alone.
+    cli_project_overrides: tuple[tuple[str, str], ...] = ()
 
     def to_block(self) -> dict[str, Any]:
         """Render to the dict the TOML writer drops under ``[tool.nab]``."""
@@ -249,6 +259,10 @@ class Provenance:
             block["python-specifier"] = self.python_specifier
         if self.platforms:
             block["platforms"] = list(self.platforms)
+        if self.cli_project_overrides:
+            block["cli-project-overrides"] = [
+                f"{flag}={value}" for flag, value in self.cli_project_overrides
+            ]
         return block
 
 

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -150,6 +150,20 @@ class ExtrasMode(enum.Enum):
     """Error for user-provided, backtrack for transitive."""
 
 
+class ResolveMode(enum.Enum):
+    """How the resolver interprets the project.
+
+    ``SPECIFIC`` runs the single-environment resolver against one
+    marker environment (host or impersonated).  ``UNIVERSAL`` runs the
+    matrix-based per-tuple resolver and is *experimental*: users
+    must opt in by setting ``[tool.nab].mode = "universal"`` and
+    declaring ``[tool.nab.matrix]``.
+    """
+
+    SPECIFIC = "specific"
+    UNIVERSAL = "universal"
+
+
 class DistPolicy(enum.Enum):
     """How to admit wheels and sdists during resolution."""
 

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -22,8 +22,17 @@ from nab_python.config import (
     conflict_forks,
     index_routes_from_config,
     read_pyproject_config,
-    read_pyproject_lock_anchor,
     validate_conflict_minimums,
+)
+from nab_python.config_sources import (
+    SourceConfigError,
+    SourceRoots,
+    build_cli_layer,
+    discover_layers,
+    read_env_layer,
+    render_explain,
+    render_get,
+    resolve_config,
 )
 from nab_python.fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, IndexRoute
 from nab_python.provider import (
@@ -42,6 +51,39 @@ def write(tmp_path: Path, body: str) -> Path:
     p = tmp_path / "pyproject.toml"
     p.write_text(body)
     return p
+
+
+class TestCliOverridesFold:
+    """``--project-*`` overrides fold into the resolved config."""
+
+    def test_cli_override_beats_file_scalar(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab]\ndist-policy = "wheel-or-sdist"\n')
+        config = read_pyproject_config(
+            path, discover_workspace=False, cli_overrides={"dist-policy": "sdist-only"}
+        )
+        assert config.dist_policy is DistPolicy.SDIST_ONLY
+
+    def test_cli_overrides_none_matches_no_overrides(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab]\ndist-policy = "sdist-only"\n')
+        plain = read_pyproject_config(path, discover_workspace=False)
+        explicit_none = read_pyproject_config(
+            path, discover_workspace=False, cli_overrides=None
+        )
+        assert plain == explicit_none
+
+    def test_cli_array_appends_after_files(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab]\nconstraints = ["a<1"]\n')
+        config = read_pyproject_config(
+            path, discover_workspace=False, cli_overrides={"constraints": ["b<2"]}
+        )
+        assert config.constraints == ("a<1", "b<2")
+
+    def test_cli_mode_universal_requires_matrix(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[project]\nname = "x"\nversion = "0"\n')
+        with pytest.raises(ConfigError, match=r"requires a \[tool.nab.matrix\]"):
+            read_pyproject_config(
+                path, discover_workspace=False, cli_overrides={"mode": "universal"}
+            )
 
 
 class TestDefaults:
@@ -118,6 +160,21 @@ class TestTopLevelKeys:
             '[tool.nab.packages.foo]\ndist-policy = "wheel-only"\n',
         )
         with pytest.raises(ConfigError, match="not valid TOML"):
+            read_pyproject_config(path)
+
+    @pytest.mark.parametrize("user_key", ["offline = true", 'cache-dir = "x"'])
+    def test_user_scope_key_in_pyproject_rejected(
+        self, tmp_path: Path, user_key: str
+    ) -> None:
+        # A USER-scope registry option in pyproject [tool.nab] surfaces the
+        # registry category error (single parse path), not the generic
+        # unknown-key error.  This pins the reject_user_keys_in_pyproject
+        # call ahead of the unknown-key check inside _parse_nab_table.
+        path = write(tmp_path, f"[tool.nab]\n{user_key}\n")
+        with pytest.raises(
+            SourceConfigError,
+            match="user-scope option and cannot be set in pyproject",
+        ):
             read_pyproject_config(path)
 
     @pytest.mark.parametrize(
@@ -772,57 +829,6 @@ class TestUploadedPriorTo:
             read_pyproject_config(path)
 
 
-class TestReadLockAnchor:
-    """``read_pyproject_lock_anchor`` returns only absolute cutoffs."""
-
-    def test_iso_string(self, tmp_path: Path) -> None:
-        path = write(
-            tmp_path, '[tool.nab]\nuploaded-prior-to = "2026-05-01T00:00:00Z"\n'
-        )
-        assert read_pyproject_lock_anchor(path) == datetime(
-            2026, 5, 1, tzinfo=timezone.utc
-        )
-
-    def test_native_toml_datetime(self, tmp_path: Path) -> None:
-        path = write(tmp_path, "[tool.nab]\nuploaded-prior-to = 2026-05-01T00:00:00Z\n")
-        assert read_pyproject_lock_anchor(path) == datetime(
-            2026, 5, 1, tzinfo=timezone.utc
-        )
-
-    def test_duration_returns_none(self, tmp_path: Path) -> None:
-        path = write(tmp_path, '[tool.nab]\nuploaded-prior-to = "P4D"\n')
-        assert read_pyproject_lock_anchor(path) is None
-
-    def test_absent_returns_none(self, tmp_path: Path) -> None:
-        path = write(tmp_path, "[tool.nab]\n")
-        assert read_pyproject_lock_anchor(path) is None
-
-    def test_invalid_value_returns_none(self, tmp_path: Path) -> None:
-        # The full config parse reports the error; the anchor read stays quiet.
-        path = write(tmp_path, '[tool.nab]\nuploaded-prior-to = "not-a-date"\n')
-        assert read_pyproject_lock_anchor(path) is None
-
-    def test_non_table_tool_nab_returns_none(self, tmp_path: Path) -> None:
-        path = write(tmp_path, 'tool = {nab = "oops"}\n')
-        assert read_pyproject_lock_anchor(path) is None
-
-    def test_non_table_tool_returns_none(self, tmp_path: Path) -> None:
-        path = write(tmp_path, 'tool = "oops"\n')
-        assert read_pyproject_lock_anchor(path) is None
-
-    def test_missing_file_returns_none(self, tmp_path: Path) -> None:
-        assert read_pyproject_lock_anchor(tmp_path / "missing.toml") is None
-
-    def test_directory_returns_none(self, tmp_path: Path) -> None:
-        # A directory is left for the full config parse to report, like a missing file.
-        assert read_pyproject_lock_anchor(tmp_path) is None
-
-    def test_malformed_toml_returns_none(self, tmp_path: Path) -> None:
-        # A syntax error is left for the full config parse to report.
-        path = write(tmp_path, '[project]\ndependencies = ["foo"\n')
-        assert read_pyproject_lock_anchor(path) is None
-
-
 class TestPolicies:
     def test_sdist_and_build_round_trip(self, tmp_path: Path) -> None:
         path = write(
@@ -1182,6 +1188,26 @@ class TestLocalSources:
         srcs = read_pyproject_config(path).local_sources
         assert srcs == (LocalSource(name="my-fork", path=str(sibling.resolve())),)
 
+    def test_relative_path_base_is_symlink_dir(self, tmp_path: Path) -> None:
+        # A relative local-sources path resolves against the symlink's own
+        # directory, not the symlink target's directory.
+        target_dir = tmp_path / "real"
+        target_dir.mkdir()
+        link_dir = tmp_path / "link_dir"
+        link_dir.mkdir()
+        real_pyproject = target_dir / "pyproject.toml"
+        real_pyproject.write_text(
+            '[[tool.nab.local-sources]]\nname = "foo"\npath = "./libs/foo"\n'
+        )
+        link_pyproject = link_dir / "pyproject.toml"
+        link_pyproject.symlink_to(real_pyproject)
+        srcs = read_pyproject_config(
+            link_pyproject, discover_workspace=False
+        ).local_sources
+        assert srcs == (
+            LocalSource(name="foo", path=str((link_dir / "libs" / "foo").resolve())),
+        )
+
     def test_absolute_path_unchanged(self, tmp_path: Path) -> None:
         abs_dir = tmp_path / "abs-fork"
         abs_dir.mkdir()
@@ -1478,7 +1504,22 @@ class TestPackageSugar:
 
     def test_routing_unknown_index_rejected(self, tmp_path: Path) -> None:
         path = write(tmp_path, '[tool.nab.packages.foo]\nindex = "nope"\n')
-        with pytest.raises(ConfigError, match="routes to undeclared index"):
+        with pytest.raises(
+            ConfigError, match=r"packages\.'foo'\.index routes to undeclared index"
+        ):
+            read_pyproject_config(path, discover_workspace=False)
+
+    def test_routing_unknown_index_via_package_rules_names_that_surface(
+        self, tmp_path: Path
+    ) -> None:
+        path = write(
+            tmp_path,
+            '[[tool.nab.package-rules]]\nmatch = ["foo"]\nindex = "nope"\n',
+        )
+        with pytest.raises(
+            ConfigError,
+            match=r"package-rules\[0\]\.index routes to undeclared index",
+        ):
             read_pyproject_config(path, discover_workspace=False)
 
     def test_index_must_be_string(self, tmp_path: Path) -> None:
@@ -2512,3 +2553,221 @@ class TestWorkspaceDiscoveryIntegration:
         assert config.default_groups == ()
         assert config.constraints == ()
         assert config.conflicts == ()
+
+
+def _inspect(path: Path, key: str) -> str:
+    """Render ``nab config get <key>`` the way the inspector would.
+
+    Discovers the same project-dir ladder ``read_pyproject_config`` reads
+    (pyproject + project-dir ``nab.toml``) and renders the effective value,
+    so a test can assert the inspector reports exactly what the resolve
+    consumes.
+    """
+    roots = SourceRoots(project_dir=path.parent.resolve(), pyproject=path.resolve())
+    layers = discover_layers(roots)
+    effective = resolve_config(layers, read_env_layer({}), build_cli_layer({}))
+    return render_get(effective, key).strip()
+
+
+def _explain(path: Path, key: str) -> str:
+    roots = SourceRoots(project_dir=path.parent.resolve(), pyproject=path.resolve())
+    layers = discover_layers(roots)
+    effective = resolve_config(layers, read_env_layer({}), build_cli_layer({}))
+    return render_explain(effective, key)
+
+
+class TestProjectNabTomlConfiguresResolve:
+    """A project-dir ``nab.toml`` functionally configures every PROJECT key.
+
+    Each test sets a value ONLY in a project-dir ``nab.toml`` (never in
+    pyproject) and asserts (a) ``read_pyproject_config`` (what the resolve
+    consumes) reflects it and (b) ``nab config get/explain`` (the
+    inspector) agrees, one representative key per structural type.
+    """
+
+    def _write(self, tmp_path: Path, pyproject: str, nab_toml: str) -> Path:
+        path = tmp_path / "pyproject.toml"
+        path.write_text(pyproject)
+        (tmp_path / "nab.toml").write_text(nab_toml)
+        return path
+
+    def test_scalar_build_policy(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "0"\n',
+            'build-policy = "never"\n',
+        )
+        config = read_pyproject_config(path, discover_workspace=False)
+        assert config.build_policy is BuildPolicy.NEVER
+        assert _inspect(path, "build-policy") == "never"
+        assert "project" in _explain(path, "build-policy")
+
+    def test_scalar_dist_policy_folds_trust(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "0"\n',
+            '[dist-policy]\npolicy = "wheel-only"\ntrust-unverified-deps = true\n',
+        )
+        config = read_pyproject_config(path, discover_workspace=False)
+        assert config.dist_policy is DistPolicy.WHEEL_ONLY
+        assert config.trust_unverified_sdist_deps is True
+        assert "wheel-only" in _inspect(path, "dist-policy")
+
+    def test_table_vcs(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "0"\n',
+            '[vcs]\npolicy = "allow"\nallowed-schemes = ["https"]\n',
+        )
+        config = read_pyproject_config(path, discover_workspace=False)
+        assert config.vcs.policy is VcsPolicy.ALLOW
+        assert config.vcs.allowed_schemes == frozenset({"https"})
+        assert "policy=allow" in _inspect(path, "vcs")
+
+    def test_table_marker_environment(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "0"\n',
+            '[marker-environment]\nsys_platform = "linux"\n',
+        )
+        config = read_pyproject_config(path, discover_workspace=False)
+        assert config.marker_environment == {"sys_platform": "linux"}
+        assert "sys_platform=linux" in _inspect(path, "marker-environment")
+
+    def test_list_constraints(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "0"\n',
+            'constraints = ["foo<2"]\n',
+        )
+        config = read_pyproject_config(path, discover_workspace=False)
+        assert config.constraints == ("foo<2",)
+        assert _inspect(path, "constraints") == "foo<2"
+
+    def test_list_constraints_concat_across_files(self, tmp_path: Path) -> None:
+        # Array concat: a pyproject list and a project-nab.toml list merge
+        # additively, they do not conflict.
+        path = self._write(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "0"\n'
+            '[tool.nab]\nconstraints = ["foo<2"]\n',
+            'constraints = ["bar<3"]\n',
+        )
+        config = read_pyproject_config(path, discover_workspace=False)
+        assert config.constraints == ("foo<2", "bar<3")
+        assert _inspect(path, "constraints") == "foo<2, bar<3"
+
+    def test_array_of_tables_indexes(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "0"\n',
+            "[[indexes]]\n"
+            'name = "internal"\n'
+            'url = "https://pkgs.example.com/simple/"\n',
+        )
+        config = read_pyproject_config(path, discover_workspace=False)
+        assert [i.name for i in config.indexes] == ["internal"]
+        assert "internal=https://pkgs.example.com/simple/" in _inspect(path, "indexes")
+
+    def test_override_table_packages(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "0"\n',
+            '[packages.numpy]\nbuild-policy = "never"\n',
+        )
+        (override,) = read_pyproject_config(
+            path, discover_workspace=False
+        ).package_overrides
+        assert override.name == "numpy"
+        assert override.build_policy is BuildPolicy.NEVER
+        assert "numpy" in _inspect(path, "packages")
+
+    def test_override_table_index(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "0"\n',
+            "[[indexes]]\n"
+            'name = "internal"\n'
+            'url = "https://pkgs.example.com/simple/"\n'
+            '[index.internal]\ndist-policy = "wheel-only"\n',
+        )
+        config = read_pyproject_config(path, discover_workspace=False)
+        assert config.index_overrides["internal"].dist_policy is DistPolicy.WHEEL_ONLY
+        assert "internal" in _inspect(path, "index")
+
+    def test_cross_field_matrix_and_mode(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "0"\n',
+            'mode = "universal"\n'
+            "[matrix]\n"
+            'python = ">=3.11,<3.13"\n'
+            'platforms = ["linux_x86_64"]\n',
+        )
+        config = read_pyproject_config(path, discover_workspace=False)
+        assert config.mode is ResolveMode.UNIVERSAL
+        assert config.matrix is not None
+        assert config.matrix.platforms == ("linux_x86_64",)
+        # Universal mode forces the build-policy floor to never even though
+        # the project-nab.toml set no build-policy.
+        assert config.build_policy is BuildPolicy.NEVER
+        assert _inspect(path, "mode") == "universal"
+
+    def test_uploaded_prior_to_duration_anchored(self, tmp_path: Path) -> None:
+        # A P<n>D duration set in the project nab.toml anchors against the
+        # lock anchor the resolve threads, not a fresh now().
+        path = self._write(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "0"\n',
+            'uploaded-prior-to = "P4D"\n',
+        )
+        anchor = datetime(2024, 1, 5, tzinfo=timezone.utc)
+        config = read_pyproject_config(path, discover_workspace=False, anchor=anchor)
+        assert config.uploaded_prior_to == datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+
+class TestProjectNabTomlGateAndConflict:
+    """The category gate and the cross-file conflict fire on the resolve path."""
+
+    def test_user_key_in_pyproject_still_rejected(self, tmp_path: Path) -> None:
+        # A USER-scope key in pyproject [tool.nab] is the category gate; it
+        # must still error when a project nab.toml is present.
+        path = tmp_path / "pyproject.toml"
+        path.write_text(
+            '[project]\nname = "x"\nversion = "0"\n[tool.nab]\noffline = true\n'
+        )
+        (tmp_path / "nab.toml").write_text('resolution = "lowest"\n')
+        with pytest.raises(
+            SourceConfigError,
+            match="user-scope option and cannot be set in pyproject",
+        ):
+            read_pyproject_config(path, discover_workspace=False)
+
+    def test_conflict_across_project_files_rejected(self, tmp_path: Path) -> None:
+        # The same scalar key set to different values in pyproject and the
+        # project nab.toml is a hard error on the resolve path.
+        path = tmp_path / "pyproject.toml"
+        path.write_text(
+            '[project]\nname = "x"\nversion = "0"\n'
+            '[tool.nab]\nbuild-policy = "build-local"\n'
+        )
+        (tmp_path / "nab.toml").write_text('build-policy = "never"\n')
+        with pytest.raises(SourceConfigError, match="conflicting values"):
+            read_pyproject_config(path, discover_workspace=False)
+
+    def test_override_overlap_across_project_files_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        # The per-package same-field overlap composes with the cross-file
+        # rule: an override in pyproject and an overlapping one in the project
+        # nab.toml is the hard overlap error, not a silent last-win.
+        path = tmp_path / "pyproject.toml"
+        path.write_text(
+            '[project]\nname = "x"\nversion = "0"\n'
+            '[tool.nab.packages.numpy]\nbuild-policy = "never"\n'
+        )
+        (tmp_path / "nab.toml").write_text(
+            '[packages.numpy]\nbuild-policy = "build-local"\n'
+        )
+        with pytest.raises(SourceConfigError, match="overlapping versions"):
+            read_pyproject_config(path, discover_workspace=False)

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -1,0 +1,2330 @@
+"""Tests for the layered config registry (:mod:`nab_python.config_sources`).
+
+The registry drives the toml loader, env reader, merge, category gate,
+and the ``nab config`` renderers.  These tests exercise the full
+precedence ladder for each option, every category-gate error, the
+pyproject-vs-project-nab.toml conflict rule, the NAB_ env layer and the
+renamed-env gate, the parser-fold helpers, and the list/get/explain
+renderers.  Search roots are injected so nothing reads the real
+``~/.config``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nab_python.config import (
+    ConflictKind,
+    ConflictMember,
+    ConflictPolicy,
+    ConflictSet,
+    MatrixConfig,
+)
+from nab_python.config_sources import (
+    OPTIONS,
+    EffectiveValue,
+    Layer,
+    Origin,
+    RejectedLayer,
+    Scope,
+    SourceConfigError,
+    SourceKind,
+    SourceRoots,
+    _load_toml_layer,
+    build_cli_layer,
+    build_cli_overrides,
+    discover_layers,
+    inspector_anchor,
+    orphan_rejections,
+    project_cli_override_notice,
+    project_cli_override_records,
+    pyproject_registry_keys,
+    read_env_layer,
+    reject_user_keys_in_pyproject,
+    render_explain,
+    render_get,
+    render_list,
+    resolve_config,
+)
+from nab_python.provider import (
+    BuildPolicy,
+    DistPolicy,
+    ResolutionStrategy,
+    ResolveMode,
+    VcsConfig,
+    VcsPolicy,
+    VcsSource,
+)
+from nab_python.workspace import WorkspaceConfig
+
+
+def _write(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    return path
+
+
+def _resolve_collect(
+    roots: SourceRoots,
+    *,
+    environ: dict[str, str] | None = None,
+    cli: dict[str, object] | None = None,
+    collect_rejected: bool = False,
+) -> tuple[dict[str, EffectiveValue], list[RejectedLayer]]:
+    rejected: list[RejectedLayer] = []
+    sink = rejected if collect_rejected else None
+    layers = discover_layers(roots, rejections=sink)
+    env_layer = read_env_layer(environ or {}, rejections=sink)
+    cli_layer = build_cli_layer(cli or {})
+    return resolve_config(layers, env_layer, cli_layer, rejected=rejected), rejected
+
+
+def _resolve(
+    roots: SourceRoots,
+    *,
+    environ: dict[str, str] | None = None,
+    cli: dict[str, object] | None = None,
+    collect_rejected: bool = False,
+) -> dict[str, EffectiveValue]:
+    eff, _ = _resolve_collect(
+        roots, environ=environ, cli=cli, collect_rejected=collect_rejected
+    )
+    return eff
+
+
+def _project(tmp_path: Path, tool_nab: str = "") -> Path:
+    body = '[project]\nname = "x"\nversion = "0"\ndependencies = []\n'
+    if tool_nab:
+        body += f"[tool.nab]\n{tool_nab}"
+    return _write(tmp_path / "pyproject.toml", body)
+
+
+class TestDefaults:
+    def test_all_defaults(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["resolution"].value is ResolutionStrategy.HIGHEST
+        assert eff["offline"].value is False
+        assert eff["cache-dir"].value is None
+        for ev in eff.values():
+            assert ev.origin.kind is SourceKind.DEFAULT
+            assert ev.origin.scope == "default"
+
+
+class TestResolutionLadder:
+    def test_pyproject_sets_resolution(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'resolution = "lowest"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["resolution"].value is ResolutionStrategy.LOWEST
+        assert eff["resolution"].origin.kind is SourceKind.PYPROJECT
+
+    def test_project_nab_toml_sets_resolution(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        _write(tmp_path / "nab.toml", 'resolution = "lowest-direct"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["resolution"].value is ResolutionStrategy.LOWEST_DIRECT
+        assert eff["resolution"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_cli_project_resolution_wins(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'resolution = "lowest"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path), cli={"resolution": "highest"})
+        assert eff["resolution"].value is ResolutionStrategy.HIGHEST
+        assert eff["resolution"].origin.kind is SourceKind.CLI
+
+    def test_resolution_in_user_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(tmp_path / "usr" / "nab" / "nab.toml", 'resolution = "lowest"\n')
+        roots = SourceRoots(user_toml=user, project_dir=tmp_path)
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(roots)
+
+    def test_resolution_in_system_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        sys_toml = _write(tmp_path / "etc" / "nab.toml", 'resolution = "lowest"\n')
+        roots = SourceRoots(system_toml=sys_toml, project_dir=tmp_path)
+        with pytest.raises(SourceConfigError, match="cannot be set in a system"):
+            _resolve(roots)
+
+    def test_nab_resolution_env_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        with pytest.raises(SourceConfigError, match="NAB_RESOLUTION is not a valid"):
+            _resolve(
+                SourceRoots(project_dir=tmp_path),
+                environ={"NAB_RESOLUTION": "lowest"},
+            )
+
+    def test_bad_resolution_value_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'resolution = "sideways"\n')
+        with pytest.raises(SourceConfigError, match="must be one of"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_resolution_non_string_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path, "resolution = 3\n")
+        with pytest.raises(SourceConfigError, match="must be a string"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+
+class TestOfflineLadder:
+    def test_system_then_user_then_project(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        sys_toml = _write(tmp_path / "etc" / "nab.toml", "offline = true\n")
+        user = _write(tmp_path / "usr" / "nab" / "nab.toml", "offline = false\n")
+        roots = SourceRoots(system_toml=sys_toml, user_toml=user, project_dir=tmp_path)
+        eff = _resolve(roots)
+        # user shadows system
+        assert eff["offline"].value is False
+        assert eff["offline"].origin.kind is SourceKind.USER_TOML
+
+    def test_project_nab_toml_sets_offline(self, tmp_path: Path) -> None:
+        # offline is USER-scope but the project-dir nab.toml accepts both
+        # scopes, so a USER key there is allowed.
+        _project(tmp_path)
+        _write(tmp_path / "nab.toml", "offline = true\n")
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["offline"].value is True
+        assert eff["offline"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_env_overrides_toml(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(tmp_path / "usr" / "nab" / "nab.toml", "offline = false\n")
+        eff = _resolve(
+            SourceRoots(user_toml=user, project_dir=tmp_path),
+            environ={"NAB_OFFLINE": "1"},
+        )
+        assert eff["offline"].value is True
+        assert eff["offline"].origin.kind is SourceKind.ENV
+
+    def test_cli_overrides_env(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(
+            SourceRoots(project_dir=tmp_path),
+            environ={"NAB_OFFLINE": "true"},
+            cli={"offline": False},
+        )
+        assert eff["offline"].value is False
+        assert eff["offline"].origin.kind is SourceKind.CLI
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [("1", True), ("0", False), ("true", True), ("FALSE", False)],
+    )
+    def test_env_bool_forms(self, tmp_path: Path, raw: str, expected: bool) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path), environ={"NAB_OFFLINE": raw})
+        assert eff["offline"].value is expected
+
+    def test_env_bad_bool_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        with pytest.raises(SourceConfigError, match="1/0/true/false"):
+            _resolve(
+                SourceRoots(project_dir=tmp_path),
+                environ={"NAB_OFFLINE": "maybe"},
+            )
+
+    def test_unknown_nab_env_var_errors(self, tmp_path: Path) -> None:
+        # A typo'd NAB_* var (e.g. NAB_OFLINE) must crash, not be dropped.
+        _project(tmp_path)
+        with pytest.raises(SourceConfigError, match="NAB_OFLINE is not a valid"):
+            _resolve(
+                SourceRoots(project_dir=tmp_path),
+                environ={"NAB_OFLINE": "true"},
+            )
+
+    def test_offline_in_pyproject_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path, "offline = true\n")
+        with pytest.raises(SourceConfigError, match="project-scope only"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_offline_non_bool_in_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(tmp_path / "usr" / "nab" / "nab.toml", 'offline = "yes"\n')
+        with pytest.raises(SourceConfigError, match="1/0/true/false"):
+            _resolve(SourceRoots(user_toml=user, project_dir=tmp_path))
+
+    def test_offline_wrong_type_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(tmp_path / "usr" / "nab" / "nab.toml", "offline = 3\n")
+        with pytest.raises(SourceConfigError, match="must be a boolean"):
+            _resolve(SourceRoots(user_toml=user, project_dir=tmp_path))
+
+
+class TestCacheDirLadder:
+    def test_user_nab_toml_sets_cache_dir(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(tmp_path / "usr" / "nab" / "nab.toml", 'cache-dir = "/c/user"\n')
+        eff = _resolve(SourceRoots(user_toml=user, project_dir=tmp_path))
+        assert eff["cache-dir"].value == Path("/c/user")
+        assert eff["cache-dir"].origin.kind is SourceKind.USER_TOML
+
+    def test_env_then_cli(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(
+            SourceRoots(project_dir=tmp_path),
+            environ={"NAB_CACHE_DIR": "/c/env"},
+            cli={"cache-dir": Path("/c/cli")},
+        )
+        assert eff["cache-dir"].value == Path("/c/cli")
+        assert eff["cache-dir"].origin.kind is SourceKind.CLI
+
+    def test_env_sets_cache_dir(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(
+            SourceRoots(project_dir=tmp_path),
+            environ={"NAB_CACHE_DIR": "/c/env"},
+        )
+        assert eff["cache-dir"].value == Path("/c/env")
+        assert eff["cache-dir"].origin.kind is SourceKind.ENV
+
+    def test_cache_dir_in_pyproject_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'cache-dir = "/x"\n')
+        with pytest.raises(SourceConfigError, match="project-scope only"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_cache_dir_non_string_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(tmp_path / "usr" / "nab" / "nab.toml", "cache-dir = 3\n")
+        with pytest.raises(SourceConfigError, match="must be a string path"):
+            _resolve(SourceRoots(user_toml=user, project_dir=tmp_path))
+
+    def test_empty_env_cache_dir_errors(self, tmp_path: Path) -> None:
+        # An exported-but-blank NAB_CACHE_DIR resolves Path("") to the cwd;
+        # reject it instead of silently caching into ".".
+        _project(tmp_path)
+        with pytest.raises(SourceConfigError, match="must be a non-empty path"):
+            _resolve(
+                SourceRoots(project_dir=tmp_path),
+                environ={"NAB_CACHE_DIR": ""},
+            )
+
+
+class TestHttpBackendLadder:
+    def test_default(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["http-backend"].value == "urllib3"
+        assert eff["http-backend"].origin.kind is SourceKind.DEFAULT
+
+    def test_user_nab_toml_then_env_then_cli(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(tmp_path / "usr" / "nab.toml", 'http-backend = "httpx"\n')
+        eff = _resolve(SourceRoots(user_toml=user, project_dir=tmp_path))
+        assert eff["http-backend"].value == "httpx"
+        assert eff["http-backend"].origin.kind is SourceKind.USER_TOML
+        eff = _resolve(
+            SourceRoots(user_toml=user, project_dir=tmp_path),
+            environ={"NAB_HTTP_BACKEND": "urllib3"},
+        )
+        assert eff["http-backend"].value == "urllib3"
+        assert eff["http-backend"].origin.kind is SourceKind.ENV
+        eff = _resolve(
+            SourceRoots(user_toml=user, project_dir=tmp_path),
+            environ={"NAB_HTTP_BACKEND": "urllib3"},
+            cli={"http-backend": "httpx"},
+        )
+        assert eff["http-backend"].value == "httpx"
+        assert eff["http-backend"].origin.kind is SourceKind.CLI
+
+    def test_unknown_value_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(tmp_path / "usr" / "nab.toml", 'http-backend = "curl"\n')
+        with pytest.raises(SourceConfigError, match="must be one of"):
+            _resolve(SourceRoots(user_toml=user, project_dir=tmp_path))
+
+    def test_non_string_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(tmp_path / "usr" / "nab.toml", "http-backend = 3\n")
+        with pytest.raises(SourceConfigError, match="must be a string"):
+            _resolve(SourceRoots(user_toml=user, project_dir=tmp_path))
+
+    def test_in_pyproject_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'http-backend = "httpx"\n')
+        with pytest.raises(SourceConfigError, match="project-scope only"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+
+class TestMaxConcurrencyLadder:
+    def test_default(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["max-concurrency"].value == 8
+        assert eff["max-concurrency"].origin.kind is SourceKind.DEFAULT
+
+    def test_toml_int_then_env_string_then_cli(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(tmp_path / "usr" / "nab.toml", "max-concurrency = 4\n")
+        eff = _resolve(SourceRoots(user_toml=user, project_dir=tmp_path))
+        assert eff["max-concurrency"].value == 4
+        eff = _resolve(
+            SourceRoots(user_toml=user, project_dir=tmp_path),
+            environ={"NAB_MAX_CONCURRENCY": "2"},
+        )
+        assert eff["max-concurrency"].value == 2
+        assert eff["max-concurrency"].origin.kind is SourceKind.ENV
+        eff = _resolve(
+            SourceRoots(user_toml=user, project_dir=tmp_path),
+            environ={"NAB_MAX_CONCURRENCY": "2"},
+            cli={"max-concurrency": 16},
+        )
+        assert eff["max-concurrency"].value == 16
+        assert eff["max-concurrency"].origin.kind is SourceKind.CLI
+
+    def test_bool_rejected(self, tmp_path: Path) -> None:
+        # bool is an int subclass; a TOML ``true`` must not read as 1.
+        _project(tmp_path)
+        user = _write(tmp_path / "usr" / "nab.toml", "max-concurrency = true\n")
+        with pytest.raises(SourceConfigError, match="must be an integer"):
+            _resolve(SourceRoots(user_toml=user, project_dir=tmp_path))
+
+    def test_non_numeric_string_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        with pytest.raises(SourceConfigError, match="must be an integer"):
+            _resolve(
+                SourceRoots(project_dir=tmp_path),
+                environ={"NAB_MAX_CONCURRENCY": "lots"},
+            )
+
+    def test_non_int_type_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(tmp_path / "usr" / "nab.toml", "max-concurrency = 1.5\n")
+        with pytest.raises(SourceConfigError, match="must be an integer"):
+            _resolve(SourceRoots(user_toml=user, project_dir=tmp_path))
+
+    def test_below_one_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(tmp_path / "usr" / "nab.toml", "max-concurrency = 0\n")
+        with pytest.raises(SourceConfigError, match="must be at least 1"):
+            _resolve(SourceRoots(user_toml=user, project_dir=tmp_path))
+
+
+class TestProjectFileScalarConflict:
+    """Same PROJECT key, conflicting values in both files, is an error."""
+
+    def test_conflicting_values_error(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'resolution = "highest"\n')
+        _write(tmp_path / "nab.toml", 'resolution = "lowest"\n')
+        with pytest.raises(SourceConfigError, match="conflicting values"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_identical_values_ok(self, tmp_path: Path) -> None:
+        # Co-presence with the same value is fine; the project-dir nab.toml
+        # is reported as the winner (it sorts last on the tie).
+        _project(tmp_path, 'resolution = "lowest"\n')
+        _write(tmp_path / "nab.toml", 'resolution = "lowest"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["resolution"].value is ResolutionStrategy.LOWEST
+        assert eff["resolution"].origin.kind is SourceKind.PROJECT_TOML
+        stack_kinds = [origin.kind for origin, _ in eff["resolution"].stack]
+        assert stack_kinds == [SourceKind.PYPROJECT, SourceKind.PROJECT_TOML]
+
+    def test_different_keys_merge(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'resolution = "lowest"\n')
+        _write(tmp_path / "nab.toml", "offline = true\n")
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["resolution"].value is ResolutionStrategy.LOWEST
+        assert eff["offline"].value is True
+
+    def test_only_pyproject_no_conflict(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'resolution = "lowest"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["resolution"].origin.kind is SourceKind.PYPROJECT
+
+
+class TestPyprojectRoot:
+    """The pyproject layer reads the named file, not a fixed name."""
+
+    def test_custom_pyproject_name_is_read(self, tmp_path: Path) -> None:
+        custom = _write(
+            tmp_path / "app.toml",
+            '[project]\nname = "x"\n[tool.nab]\nresolution = "lowest"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path, pyproject=custom))
+        assert eff["resolution"].value is ResolutionStrategy.LOWEST
+        assert eff["resolution"].origin.kind is SourceKind.PYPROJECT
+
+    def test_default_pyproject_name_used_when_unset(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'resolution = "lowest"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["resolution"].value is ResolutionStrategy.LOWEST
+
+
+class TestRejectedCollection:
+    def test_include_rejected_captures_gate_casualty(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'resolution = "lowest"\n')
+        user = _write(tmp_path / "usr" / "nab" / "nab.toml", 'resolution = "highest"\n')
+        eff = _resolve(
+            SourceRoots(user_toml=user, project_dir=tmp_path),
+            collect_rejected=True,
+        )
+        rejected = eff["resolution"].rejected
+        assert len(rejected) == 1
+        assert rejected[0].origin.kind is SourceKind.USER_TOML
+        assert "project-scope" in rejected[0].reason
+
+    def test_include_rejected_captures_renamed_env(self, tmp_path: Path) -> None:
+        # A real run raises on NAB_RESOLUTION; collecting records it under
+        # the resolution key instead, so explain --include-rejected lists it.
+        _project(tmp_path, 'resolution = "lowest"\n')
+        eff = _resolve(
+            SourceRoots(project_dir=tmp_path),
+            environ={"NAB_RESOLUTION": "highest"},
+            collect_rejected=True,
+        )
+        rejected = eff["resolution"].rejected
+        assert len(rejected) == 1
+        assert rejected[0].origin.kind is SourceKind.ENV
+        assert rejected[0].origin.label == "NAB_RESOLUTION"
+        assert "not env-settable" in rejected[0].reason
+
+    def test_include_rejected_captures_unknown_env(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff, rejected = _resolve_collect(
+            SourceRoots(project_dir=tmp_path),
+            environ={"NAB_OFLINE": "1"},
+            collect_rejected=True,
+        )
+        # The unknown var does not crash; it is recorded as an orphan
+        # (its key names no option) so render_list can surface it.
+        assert eff["offline"].value is False
+        orphans = orphan_rejections(rejected)
+        assert len(orphans) == 1
+        assert orphans[0].origin.label == "NAB_OFLINE"
+
+    def test_include_rejected_captures_unknown_toml_key(self, tmp_path: Path) -> None:
+        # An unknown standalone nab.toml key crashes a real run but, when a
+        # rejections sink is supplied (explain --include-rejected), is
+        # recorded as an orphan instead of crashing the inspector.
+        _project(tmp_path)
+        user = _write(tmp_path / "usr" / "nab" / "nab.toml", "typoo = 1\n")
+        eff, rejected = _resolve_collect(
+            SourceRoots(user_toml=user, project_dir=tmp_path),
+            collect_rejected=True,
+        )
+        assert eff["offline"].value is False
+        orphans = orphan_rejections(rejected)
+        assert len(orphans) == 1
+        assert orphans[0].key == "typoo"
+        assert orphans[0].origin.kind is SourceKind.USER_TOML
+
+
+class TestLoadTomlLayerDirect:
+    def test_unknown_key_in_nab_toml_errors(self, tmp_path: Path) -> None:
+        # A standalone nab.toml has no other parser, so a typo'd top-level
+        # key must crash naming the file, the same way an unknown NAB_*
+        # env var does, rather than be silently dropped.
+        path = _write(tmp_path / "nab.toml", 'resolutionn = "lowest"\n')
+        with pytest.raises(SourceConfigError, match="resolutionn.*not a valid"):
+            _load_toml_layer(path, SourceKind.USER_TOML)
+
+    def test_unknown_key_in_pyproject_errors(self, tmp_path: Path) -> None:
+        # A typo'd [tool.nab] key is rejected by the loader too, so the
+        # inspector reports it rather than silently dropping it (the resolve
+        # path rejects it earlier, in read_pyproject_config).
+        path = _write(
+            tmp_path / "pyproject.toml",
+            '[tool.nab]\nresolutionn = "lowest"\n',
+        )
+        with pytest.raises(SourceConfigError, match="resolutionn.*not a valid"):
+            _load_toml_layer(path, SourceKind.PYPROJECT)
+
+    def test_unknown_key_in_pyproject_recorded_when_collecting(
+        self, tmp_path: Path
+    ) -> None:
+        # With a rejections sink (explain/list --include-rejected) the typo
+        # is recorded and the valid keys still parse.
+        path = _write(
+            tmp_path / "pyproject.toml",
+            '[tool.nab]\nresolutionn = "lowest"\nresolution = "lowest"\n',
+        )
+        rejections: list[RejectedLayer] = []
+        layer = _load_toml_layer(path, SourceKind.PYPROJECT, rejections=rejections)
+        assert layer.values == {"resolution": ResolutionStrategy.LOWEST}
+        assert [r.key for r in rejections] == ["resolutionn"]
+
+    def test_malformed_toml_errors(self, tmp_path: Path) -> None:
+        path = _write(tmp_path / "nab.toml", "offline = \n")
+        with pytest.raises(SourceConfigError, match="not valid TOML"):
+            _load_toml_layer(path, SourceKind.USER_TOML)
+
+    def test_pyproject_without_tool_nab_is_empty(self, tmp_path: Path) -> None:
+        path = _write(tmp_path / "pyproject.toml", '[project]\nname = "x"\n')
+        layer = _load_toml_layer(path, SourceKind.PYPROJECT)
+        assert layer.values == {}
+
+    def test_pyproject_tool_not_table(self, tmp_path: Path) -> None:
+        path = _write(tmp_path / "pyproject.toml", "tool = 3\n")
+        layer = _load_toml_layer(path, SourceKind.PYPROJECT)
+        assert layer.values == {}
+
+    def test_pyproject_tool_nab_not_table(self, tmp_path: Path) -> None:
+        path = _write(tmp_path / "pyproject.toml", "[tool]\nnab = 3\n")
+        layer = _load_toml_layer(path, SourceKind.PYPROJECT)
+        assert layer.values == {}
+
+
+class TestDiscoverAndMissing:
+    def test_missing_files_skipped(self, tmp_path: Path) -> None:
+        roots = SourceRoots(
+            system_toml=tmp_path / "nope-sys.toml",
+            user_toml=tmp_path / "nope-user.toml",
+            project_dir=tmp_path / "nope-dir",
+        )
+        layers = discover_layers(roots)
+        assert layers == []
+
+    def test_none_roots_skipped(self, tmp_path: Path) -> None:
+        eff = _resolve(SourceRoots())
+        assert eff["offline"].value is False
+
+    def test_directory_named_config_errors(self, tmp_path: Path) -> None:
+        # A nab.toml that exists as a directory (an accidental `mkdir`)
+        # must crash naming it, not be silently dropped by an is_file()
+        # filter.
+        _project(tmp_path)
+        (tmp_path / "nab.toml").mkdir()
+        with pytest.raises(SourceConfigError, match="not a regular file"):
+            discover_layers(SourceRoots(project_dir=tmp_path))
+
+
+class TestRenderers:
+    def test_render_list(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'resolution = "lowest"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        out = render_list(eff)
+        assert "resolution" in out
+        assert "lowest" in out
+        assert "offline" in out
+        assert "cache-dir" in out
+        assert "<computed>" in out  # cache-dir default render
+
+    def test_render_list_surfaces_orphan_rejection(self, tmp_path: Path) -> None:
+        # An unknown NAB_* var attaches to no option, so it is unreachable
+        # from explain; render_list surfaces it in a trailing section.
+        _project(tmp_path)
+        eff, rejected = _resolve_collect(
+            SourceRoots(project_dir=tmp_path),
+            environ={"NAB_OFLINE": "1"},
+            collect_rejected=True,
+        )
+        out = render_list(eff, rejected=rejected)
+        assert "rejected:" in out
+        assert "NAB_OFLINE" in out
+
+    def test_render_list_surfaces_known_key_gate_rejection(
+        self, tmp_path: Path
+    ) -> None:
+        # A PROJECT key set in a user nab.toml attaches to its option, so it
+        # is reachable from explain; render_list also lists it (it was
+        # previously shown only by explain, not by list).
+        _project(tmp_path)
+        user_toml = tmp_path / "user.toml"
+        user_toml.write_text('resolution = "lowest"\n', encoding="utf-8")
+        eff, rejected = _resolve_collect(
+            SourceRoots(project_dir=tmp_path, user_toml=user_toml),
+            collect_rejected=True,
+        )
+        out = render_list(eff, rejected=rejected)
+        assert "rejected:" in out
+        assert "resolution" in out
+        assert str(user_toml) in out
+
+    def test_render_list_no_rejected_section_when_clean(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        out = render_list(eff)
+        assert "rejected:" not in out
+
+    def test_render_get(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert render_get(eff, "offline") == "false\n"
+
+    def test_render_get_true(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path), cli={"offline": True})
+        assert render_get(eff, "offline") == "true\n"
+
+    def test_render_get_cache_dir_set(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(
+            SourceRoots(project_dir=tmp_path), cli={"cache-dir": Path("/c/cli")}
+        )
+        assert render_get(eff, "cache-dir") == "/c/cli\n"
+
+    def test_render_get_unknown_key(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        with pytest.raises(SourceConfigError, match="unknown config key"):
+            render_get(eff, "bogus")
+
+    def test_render_explain_winner_and_shadowed(self, tmp_path: Path) -> None:
+        # A scalar shadow across two precedence levels (pyproject then a
+        # CLI override) shows winner/shadowed.
+        _project(tmp_path, 'resolution = "lowest"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path), cli={"resolution": "highest"})
+        out = render_explain(eff, "resolution")
+        lines = out.splitlines()
+        assert lines[0].startswith("resolution (project,")
+        assert any(line.startswith(">") and "winner" in line for line in lines)
+        assert any("shadowed" in line for line in lines)
+
+    def test_render_explain_default_only(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        out = render_explain(eff, "cache-dir")
+        assert "builtin-default" in out
+        assert "> " in out
+
+    def test_render_explain_unknown_key(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        with pytest.raises(SourceConfigError, match="unknown config key"):
+            render_explain(eff, "bogus")
+
+    def test_render_explain_include_rejected(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'resolution = "lowest"\n')
+        user = _write(tmp_path / "usr" / "nab" / "nab.toml", 'resolution = "highest"\n')
+        eff = _resolve(
+            SourceRoots(user_toml=user, project_dir=tmp_path),
+            collect_rejected=True,
+        )
+        out = render_explain(eff, "resolution", include_rejected=True)
+        assert "rejected" in out
+        assert "project-scope" in out
+
+
+class TestReproducibilityNotice:
+    """A CLI PROJECT override is never silent; the lock can be reproduced."""
+
+    def test_notice_lists_cli_project_overrides(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path), cli={"resolution": "lowest"})
+        notice = project_cli_override_notice(eff)
+        assert notice is not None
+        assert "does not derive from the committed" in notice
+        assert "--project-resolution -> lowest" in notice
+
+    def test_notice_inspection_wording(self, tmp_path: Path) -> None:
+        # produces_lock=False (the nab config inspector) makes no lock claim.
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path), cli={"resolution": "lowest"})
+        notice = project_cli_override_notice(eff, produces_lock=False)
+        assert notice is not None
+        assert "the lock they produce" not in notice
+        assert "reflect that override" in notice
+        assert "--project-resolution -> lowest" in notice
+
+    def test_no_notice_without_cli_project_override(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'resolution = "lowest"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert project_cli_override_notice(eff) is None
+
+    def test_records_lists_cli_project_override_pairs(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path), cli={"resolution": "lowest"})
+        assert project_cli_override_records(eff) == (
+            ("--project-resolution", "lowest"),
+        )
+
+    def test_records_empty_without_cli_project_override(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path), cli={"offline": True})
+        assert project_cli_override_records(eff) == ()
+
+    def test_user_cli_override_does_not_trigger_notice(self, tmp_path: Path) -> None:
+        # offline is a USER option; setting it on the CLI never changes the
+        # resolved set, so it is not a reproducibility hazard.
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path), cli={"offline": True})
+        assert project_cli_override_notice(eff) is None
+
+    def test_build_cli_overrides_keyed_by_registry(self, tmp_path: Path) -> None:
+        # build_cli_overrides maps cli_param locals to registry keys, drops
+        # the unset scalars (None) and the unset arrays (empty tuple), and
+        # keeps a non-empty array.
+        overrides = build_cli_overrides(
+            {
+                "project_resolution": "lowest",
+                "offline": None,
+                "cache_dir": Path("/c"),
+                "http_backend": None,
+                "max_concurrency": 16,
+                "project_mode": None,
+                "project_requires_python": None,
+                "project_uploaded_prior_to": None,
+                "project_dist_policy": "sdist-only",
+                "project_build_policy": None,
+                "project_constraint": (),
+                "project_default_group": ("dev",),
+            }
+        )
+        assert overrides == {
+            "resolution": "lowest",
+            "cache-dir": Path("/c"),
+            "max-concurrency": 16,
+            "dist-policy": "sdist-only",
+            "default-groups": ("dev",),
+        }
+
+
+class TestParserFoldHelpers:
+    def test_pyproject_registry_keys_are_project_scope(self) -> None:
+        # Every PROJECT-scope row is legitimate in pyproject [tool.nab];
+        # the USER rows (offline, cache-dir) are not.
+        assert pyproject_registry_keys() == frozenset(
+            {
+                "resolution",
+                "mode",
+                "constraints",
+                "default-groups",
+                "requires-python",
+                "uploaded-prior-to",
+                "dist-policy",
+                "build-policy",
+                "marker-environment",
+                "vcs",
+                "workspace",
+                "indexes",
+                "local-sources",
+                "vcs-sources",
+                "packages",
+                "package-rules",
+                "index",
+                "conflicts",
+                "matrix",
+            }
+        )
+
+    def test_reject_user_key_offline(self) -> None:
+        with pytest.raises(SourceConfigError, match="project-scope only"):
+            reject_user_keys_in_pyproject({"offline": True})
+
+    def test_reject_user_key_cache_dir(self) -> None:
+        with pytest.raises(SourceConfigError, match="project-scope only"):
+            reject_user_keys_in_pyproject({"cache-dir": "/x"})
+
+    def test_project_key_allowed(self) -> None:
+        # resolution is PROJECT-scope, so it is legitimate in pyproject.
+        reject_user_keys_in_pyproject({"resolution": "lowest"})
+
+    def test_unknown_key_ignored(self) -> None:
+        # A PROJECT-scope registry key (mode) is legitimate in pyproject,
+        # so the USER-key gate leaves it for the pyproject parser.
+        reject_user_keys_in_pyproject({"mode": "universal"})
+
+    def test_unowned_key_ignored(self) -> None:
+        # A key the registry does not own is left to the pyproject parser.
+        reject_user_keys_in_pyproject({"trust-unverified-sdist-deps": True})
+
+
+class TestRegistryShape:
+    """The registry rows themselves: invariants the conformance gate relies on."""
+
+    def test_keys_unique(self) -> None:
+        keys = [spec.key for spec in OPTIONS]
+        assert len(keys) == len(set(keys))
+
+    def test_project_options_have_no_env_var(self) -> None:
+        for spec in OPTIONS:
+            if spec.scope is Scope.PROJECT:
+                assert spec.env_var is None
+
+    def test_user_options_have_env_var(self) -> None:
+        for spec in OPTIONS:
+            if spec.scope is Scope.USER:
+                assert spec.env_var is not None
+
+    def test_user_run_knobs_registered(self) -> None:
+        by_key = {spec.key: spec for spec in OPTIONS}
+        for key, env in (
+            ("http-backend", "NAB_HTTP_BACKEND"),
+            ("max-concurrency", "NAB_MAX_CONCURRENCY"),
+        ):
+            assert by_key[key].scope is Scope.USER
+            assert by_key[key].env_var == env
+
+    def test_origin_scope_for_every_kind(self) -> None:
+        for kind in SourceKind:
+            origin = Origin(kind, "x")
+            assert isinstance(origin.scope, str)
+
+    def test_layer_dataclass_roundtrip(self) -> None:
+        layer = Layer(Origin(SourceKind.CLI, "cli"), {"offline": True})
+        assert layer.values["offline"] is True
+
+    def test_allowed_in_toml_project(self) -> None:
+        spec = next(s for s in OPTIONS if s.key == "resolution")
+        assert spec.allowed_in_toml(SourceKind.PYPROJECT)
+        assert spec.allowed_in_toml(SourceKind.PROJECT_TOML)
+        assert not spec.allowed_in_toml(SourceKind.USER_TOML)
+
+    def test_allowed_in_toml_user(self) -> None:
+        spec = next(s for s in OPTIONS if s.key == "offline")
+        assert not spec.allowed_in_toml(SourceKind.PYPROJECT)
+        assert spec.allowed_in_toml(SourceKind.USER_TOML)
+        assert spec.allowed_in_toml(SourceKind.SYSTEM_TOML)
+        assert spec.allowed_in_toml(SourceKind.PROJECT_TOML)
+
+
+class TestScalarProjectOptions:
+    """The scalar PROJECT options: mode, requires-python, uploaded-prior-to,
+    dist-policy, build-policy.  Each reuses the single-environment parser,
+    so the value and validation messages match the pyproject path; the new
+    surface is the project-dir nab.toml home, the category gate, the
+    cross-file conflict check, and nab config visibility.
+    """
+
+    def test_mode_from_pyproject(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'mode = "universal"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["mode"].value is ResolveMode.UNIVERSAL
+        assert eff["mode"].origin.kind is SourceKind.PYPROJECT
+
+    def test_mode_from_project_nab_toml(self, tmp_path: Path) -> None:
+        # New capability: a PROJECT scalar set in the project-dir nab.toml.
+        _project(tmp_path)
+        _write(tmp_path / "nab.toml", 'mode = "universal"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["mode"].value is ResolveMode.UNIVERSAL
+        assert eff["mode"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_mode_in_user_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(tmp_path / "usr" / "nab" / "nab.toml", 'mode = "universal"\n')
+        roots = SourceRoots(user_toml=user, project_dir=tmp_path)
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(roots)
+
+    def test_mode_in_system_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        sys_toml = _write(tmp_path / "etc" / "nab.toml", 'mode = "universal"\n')
+        roots = SourceRoots(system_toml=sys_toml, project_dir=tmp_path)
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(roots)
+
+    def test_nab_mode_env_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        with pytest.raises(SourceConfigError, match="not env-settable"):
+            _resolve(
+                SourceRoots(project_dir=tmp_path), environ={"NAB_MODE": "universal"}
+            )
+
+    def test_mode_bad_value_keeps_existing_message(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'mode = "sideways"\n')
+        with pytest.raises(SourceConfigError, match="mode must be one of"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_mode_cross_file_conflict(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'mode = "universal"\n')
+        _write(tmp_path / "nab.toml", 'mode = "specific"\n')
+        with pytest.raises(SourceConfigError, match="conflicting values"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_mode_identical_across_files_ok(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'mode = "universal"\n')
+        _write(tmp_path / "nab.toml", 'mode = "universal"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["mode"].value is ResolveMode.UNIVERSAL
+
+    def test_requires_python_from_project_nab_toml(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        _write(tmp_path / "nab.toml", 'requires-python = ">=3.11"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["requires-python"].value == ">=3.11"
+        assert eff["requires-python"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_requires_python_in_user_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(
+            tmp_path / "usr" / "nab" / "nab.toml", 'requires-python = ">=3.11"\n'
+        )
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(SourceRoots(user_toml=user, project_dir=tmp_path))
+
+    def test_requires_python_bad_specifier_keeps_message(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'requires-python = "3.11"\n')
+        with pytest.raises(SourceConfigError, match="PEP 440 specifier"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_dist_policy_scalar_from_pyproject(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'dist-policy = "sdist-only"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["dist-policy"].value == (DistPolicy.SDIST_ONLY, False)
+
+    def test_dist_policy_table_folds_trust(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            "[tool.nab.dist-policy]\n"
+            'policy = "sdist-only"\n'
+            "trust-unverified-deps = true\n",
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["dist-policy"].value == (DistPolicy.SDIST_ONLY, True)
+
+    def test_dist_policy_in_user_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(
+            tmp_path / "usr" / "nab" / "nab.toml", 'dist-policy = "sdist-only"\n'
+        )
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(SourceRoots(user_toml=user, project_dir=tmp_path))
+
+    def test_dist_policy_bad_value_keeps_message(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'dist-policy = "nonsense"\n')
+        with pytest.raises(SourceConfigError, match="dist-policy must be one of"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_build_policy_from_project_nab_toml(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        _write(tmp_path / "nab.toml", 'build-policy = "never"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["build-policy"].value is BuildPolicy.NEVER
+
+    def test_build_policy_in_user_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(tmp_path / "usr" / "nab" / "nab.toml", 'build-policy = "never"\n')
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(SourceRoots(user_toml=user, project_dir=tmp_path))
+
+    def test_build_policy_bad_value_keeps_message(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'build-policy = "nonsense"\n')
+        with pytest.raises(SourceConfigError, match="build-policy must be one of"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_uploaded_prior_to_absolute_normalised(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'uploaded-prior-to = "2026-05-01T00:00:00Z"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert str(eff["uploaded-prior-to"].value) == "2026-05-01 00:00:00+00:00"
+
+    def test_uploaded_prior_to_duration_carried_raw(self, tmp_path: Path) -> None:
+        # Hazard: a P<n>D duration must not re-anchor to now in the registry
+        # path, so it is carried as its raw string (anchor-free).
+        _project(tmp_path, 'uploaded-prior-to = "P4D"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["uploaded-prior-to"].value == "P4D"
+
+    def test_uploaded_prior_to_duration_identical_across_files_ok(
+        self, tmp_path: Path
+    ) -> None:
+        # Two identical raw durations across the project files must not read
+        # as conflicting (they would if each re-anchored to now).
+        _project(tmp_path, 'uploaded-prior-to = "P4D"\n')
+        _write(tmp_path / "nab.toml", 'uploaded-prior-to = "P4D"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["uploaded-prior-to"].value == "P4D"
+
+    def test_uploaded_prior_to_duration_cross_file_conflict(
+        self, tmp_path: Path
+    ) -> None:
+        _project(tmp_path, 'uploaded-prior-to = "P4D"\n')
+        _write(tmp_path / "nab.toml", 'uploaded-prior-to = "P9D"\n')
+        with pytest.raises(SourceConfigError, match="conflicting values"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_uploaded_prior_to_in_user_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(
+            tmp_path / "usr" / "nab" / "nab.toml", 'uploaded-prior-to = "P4D"\n'
+        )
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(SourceRoots(user_toml=user, project_dir=tmp_path))
+
+    def test_uploaded_prior_to_bad_value_keeps_message(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'uploaded-prior-to = "not-a-date"\n')
+        with pytest.raises(SourceConfigError, match="ISO 8601 datetime"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_scalar_keys_visible_in_list(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            'mode = "universal"\n'
+            'requires-python = ">=3.11"\n'
+            'build-policy = "never"\n'
+            'dist-policy = "sdist-only"\n'
+            'uploaded-prior-to = "P4D"\n'
+            "[tool.nab.matrix]\n"
+            'python = ">=3.11"\n'
+            'platforms = ["linux_x86_64"]\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        out = render_list(eff)
+        for key in (
+            "mode",
+            "requires-python",
+            "uploaded-prior-to",
+            "dist-policy",
+            "build-policy",
+        ):
+            assert key in out
+
+    def test_dist_policy_default_render(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["dist-policy"].spec.render(eff["dist-policy"].value) == (
+            "wheel-or-sdist"
+        )
+
+    def test_uploaded_prior_to_default_render(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["uploaded-prior-to"].spec.render(None) == "<none>"
+
+    def test_requires_python_default_render(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["requires-python"].spec.render(None) == "<none>"
+
+
+class TestTableProjectOptions:
+    """The PROJECT table options: marker-environment, vcs, workspace.
+
+    Each is a file-only PROJECT row (no CLI flag): settable from
+    pyproject [tool.nab] or a project-dir nab.toml, gated out of
+    user/system files and NAB_*, subject to the cross-file conflict check,
+    and visible in ``nab config``.  Each reuses the single-environment
+    parser so the parsed value and every validation message match the
+    pyproject path.
+    """
+
+    def test_marker_environment_from_pyproject(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            '[tool.nab.marker-environment]\nplatform_system = "Linux"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["marker-environment"].value == {"platform_system": "Linux"}
+        assert eff["marker-environment"].origin.kind is SourceKind.PYPROJECT
+
+    def test_marker_environment_from_project_nab_toml(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        _write(
+            tmp_path / "nab.toml",
+            '[marker-environment]\nplatform_system = "Darwin"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["marker-environment"].value == {"platform_system": "Darwin"}
+        assert eff["marker-environment"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_marker_environment_in_user_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(
+            tmp_path / "usr" / "nab.toml",
+            '[marker-environment]\nplatform_system = "Linux"\n',
+        )
+        roots = SourceRoots(user_toml=user, project_dir=tmp_path)
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(roots)
+
+    def test_nab_marker_environment_env_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        with pytest.raises(SourceConfigError, match="not env-settable"):
+            _resolve(
+                SourceRoots(project_dir=tmp_path),
+                environ={"NAB_MARKER_ENVIRONMENT": "x"},
+            )
+
+    def test_marker_environment_bad_value_keeps_message(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            '[tool.nab.marker-environment]\nnonsense_var = "x"\n',
+        )
+        with pytest.raises(SourceConfigError, match="unknown marker-environment"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_marker_environment_cross_file_conflict(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            '[tool.nab.marker-environment]\nplatform_system = "Linux"\n',
+        )
+        _write(
+            tmp_path / "nab.toml",
+            '[marker-environment]\nplatform_system = "Darwin"\n',
+        )
+        with pytest.raises(SourceConfigError, match="conflicting values"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_marker_environment_identical_across_files_ok(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            '[tool.nab.marker-environment]\nplatform_system = "Linux"\n',
+        )
+        _write(
+            tmp_path / "nab.toml",
+            '[marker-environment]\nplatform_system = "Linux"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["marker-environment"].value == {"platform_system": "Linux"}
+        assert eff["marker-environment"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_marker_environment_disjoint_vars_merge(self, tmp_path: Path) -> None:
+        # Different sub-keys merge: disjoint marker vars across the two
+        # project files merge instead of raising a spurious conflict.
+        _project(
+            tmp_path,
+            '[tool.nab.marker-environment]\nplatform_system = "Linux"\n',
+        )
+        _write(
+            tmp_path / "nab.toml",
+            '[marker-environment]\nsys_platform = "linux"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["marker-environment"].value == {
+            "platform_system": "Linux",
+            "sys_platform": "linux",
+        }
+
+    def test_marker_environment_explain_shows_merged(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            '[tool.nab.marker-environment]\nplatform_system = "Linux"\n',
+        )
+        _write(
+            tmp_path / "nab.toml",
+            '[marker-environment]\nsys_platform = "linux"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        explained = render_explain(eff, "marker-environment")
+        assert "contributes" in explained
+        assert "= effective: platform_system=Linux, sys_platform=linux" in explained
+
+    def test_marker_environment_default_render(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["marker-environment"].spec.render({}) == "<none>"
+
+    def test_marker_environment_render_sorted(self) -> None:
+        spec = next(s for s in OPTIONS if s.key == "marker-environment")
+        rendered = spec.render({"sys_platform": "linux", "platform_system": "Linux"})
+        assert rendered == "platform_system=Linux, sys_platform=linux"
+
+    def test_vcs_from_pyproject(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            '[tool.nab.vcs]\npolicy = "allow"\nallowed-schemes = ["git+https"]\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        value = eff["vcs"].value
+        assert value.policy is VcsPolicy.ALLOW
+        assert value.allowed_schemes == frozenset({"git+https"})
+        assert eff["vcs"].origin.kind is SourceKind.PYPROJECT
+
+    def test_vcs_from_project_nab_toml(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        _write(tmp_path / "nab.toml", '[vcs]\npolicy = "allow"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["vcs"].value.policy is VcsPolicy.ALLOW
+        assert eff["vcs"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_vcs_in_system_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        sys_toml = _write(tmp_path / "etc" / "nab.toml", '[vcs]\npolicy = "allow"\n')
+        roots = SourceRoots(system_toml=sys_toml, project_dir=tmp_path)
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(roots)
+
+    def test_nab_vcs_env_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        with pytest.raises(SourceConfigError, match="not env-settable"):
+            _resolve(SourceRoots(project_dir=tmp_path), environ={"NAB_VCS": "x"})
+
+    def test_vcs_bad_value_keeps_message(self, tmp_path: Path) -> None:
+        _project(tmp_path, '[tool.nab.vcs]\npolicy = "sometimes"\n')
+        with pytest.raises(SourceConfigError, match="vcs.policy must be one of"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_vcs_cross_file_conflict(self, tmp_path: Path) -> None:
+        _project(tmp_path, '[tool.nab.vcs]\npolicy = "allow"\n')
+        _write(tmp_path / "nab.toml", '[vcs]\npolicy = "block"\n')
+        with pytest.raises(SourceConfigError, match="conflicting values"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_vcs_identical_across_files_ok(self, tmp_path: Path) -> None:
+        _project(tmp_path, '[tool.nab.vcs]\npolicy = "allow"\n')
+        _write(tmp_path / "nab.toml", '[vcs]\npolicy = "allow"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["vcs"].value.policy is VcsPolicy.ALLOW
+        assert eff["vcs"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_vcs_default_render(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["vcs"].spec.render(VcsConfig()) == "policy=block"
+
+    def test_vcs_render_full(self) -> None:
+        spec = next(s for s in OPTIONS if s.key == "vcs")
+        rendered = spec.render(
+            VcsConfig(
+                policy=VcsPolicy.ALLOW,
+                allowed_schemes=frozenset({"git+https"}),
+                allowed_repos=("https://example.test/repo",),
+                require_pin=False,
+            )
+        )
+        assert "policy=allow" in rendered
+        assert "allowed-schemes=['git+https']" in rendered
+        assert "allowed-repos=['https://example.test/repo']" in rendered
+        assert "require-pin=false" in rendered
+
+    def test_workspace_from_pyproject(self, tmp_path: Path) -> None:
+        _project(tmp_path, '[tool.nab.workspace]\nmembers = ["pkgs/a"]\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["workspace"].value == WorkspaceConfig(members=("pkgs/a",))
+        assert eff["workspace"].origin.kind is SourceKind.PYPROJECT
+
+    def test_workspace_from_project_nab_toml(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        _write(tmp_path / "nab.toml", '[workspace]\nmembers = ["pkgs/b"]\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["workspace"].value == WorkspaceConfig(members=("pkgs/b",))
+        assert eff["workspace"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_workspace_in_user_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(
+            tmp_path / "usr" / "nab.toml", '[workspace]\nmembers = ["pkgs/a"]\n'
+        )
+        roots = SourceRoots(user_toml=user, project_dir=tmp_path)
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(roots)
+
+    def test_nab_workspace_env_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        with pytest.raises(SourceConfigError, match="not env-settable"):
+            _resolve(SourceRoots(project_dir=tmp_path), environ={"NAB_WORKSPACE": "x"})
+
+    def test_workspace_bad_value_keeps_message(self, tmp_path: Path) -> None:
+        _project(tmp_path, '[tool.nab.workspace]\nmember = ["pkgs/a"]\n')
+        with pytest.raises(SourceConfigError, match="unknown .tool.nab.workspace"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_workspace_cross_file_conflict(self, tmp_path: Path) -> None:
+        _project(tmp_path, '[tool.nab.workspace]\nmembers = ["pkgs/a"]\n')
+        _write(tmp_path / "nab.toml", '[workspace]\nmembers = ["pkgs/b"]\n')
+        with pytest.raises(SourceConfigError, match="conflicting values"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_workspace_identical_across_files_ok(self, tmp_path: Path) -> None:
+        _project(tmp_path, '[tool.nab.workspace]\nmembers = ["pkgs/a"]\n')
+        _write(tmp_path / "nab.toml", '[workspace]\nmembers = ["pkgs/a"]\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["workspace"].value == WorkspaceConfig(members=("pkgs/a",))
+        assert eff["workspace"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_workspace_default_render(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["workspace"].value is None
+        assert eff["workspace"].spec.render(None) == "<none>"
+
+    def test_workspace_render_members(self) -> None:
+        spec = next(s for s in OPTIONS if s.key == "workspace")
+        assert spec.render(WorkspaceConfig(members=("a", "b"))) == "members=['a', 'b']"
+
+    def test_table_keys_visible_in_config(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            '[tool.nab.marker-environment]\nplatform_system = "Linux"\n'
+            "[tool.nab.vcs]\n"
+            'policy = "allow"\n'
+            "[tool.nab.workspace]\n"
+            'members = ["pkgs/a"]\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        out = render_list(eff)
+        for key in ("marker-environment", "vcs", "workspace"):
+            assert key in out
+        assert render_get(eff, "vcs").strip().startswith("policy=allow")
+        explained = render_explain(eff, "workspace")
+        assert "members=['pkgs/a']" in explained
+
+    def test_table_rows_are_file_only(self) -> None:
+        for key in ("marker-environment", "vcs", "workspace"):
+            spec = next(s for s in OPTIONS if s.key == key)
+            assert spec.cli_flag is None
+            assert spec.cli_param is None
+
+
+class TestArrayProjectOptions:
+    """The PROJECT array options: constraints, default-groups.
+
+    Each reuses the single-environment list parser, is gated PROJECT-only,
+    is visible in ``nab config``, and (unlike the scalar/table rows)
+    concatenates additively across the ladder, so the two project files
+    merge rather than conflict.
+    """
+
+    def test_constraints_from_pyproject(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'constraints = ["urllib3<2"]\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["constraints"].value == ("urllib3<2",)
+        assert eff["constraints"].origin.kind is SourceKind.PYPROJECT
+
+    def test_constraints_from_project_nab_toml(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        _write(tmp_path / "nab.toml", 'constraints = ["certifi>=2024"]\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["constraints"].value == ("certifi>=2024",)
+        assert eff["constraints"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_constraints_in_user_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(tmp_path / "usr" / "nab.toml", 'constraints = ["urllib3<2"]\n')
+        roots = SourceRoots(user_toml=user, project_dir=tmp_path)
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(roots)
+
+    def test_constraints_in_system_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        sys_toml = _write(tmp_path / "etc" / "nab.toml", 'constraints = ["a"]\n')
+        roots = SourceRoots(system_toml=sys_toml, project_dir=tmp_path)
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(roots)
+
+    def test_nab_constraints_env_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        with pytest.raises(SourceConfigError, match="not env-settable"):
+            _resolve(
+                SourceRoots(project_dir=tmp_path), environ={"NAB_CONSTRAINTS": "x"}
+            )
+
+    def test_constraints_bad_pep508_keeps_message(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'constraints = ["not a valid !! req"]\n')
+        with pytest.raises(SourceConfigError, match="is not a valid requirement"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_constraints_non_list_keeps_message(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'constraints = "urllib3<2"\n')
+        with pytest.raises(SourceConfigError, match="must be a list of strings"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_constraints_concat_across_project_files(self, tmp_path: Path) -> None:
+        # Arrays are exempt from the conflict check: the two same-rung project
+        # files contribute additively, so differing lists merge (pyproject
+        # first, then the project-dir nab.toml) rather than raise a conflict.
+        _project(tmp_path, 'constraints = ["urllib3<2"]\n')
+        _write(tmp_path / "nab.toml", 'constraints = ["certifi>=2024"]\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["constraints"].value == ("urllib3<2", "certifi>=2024")
+        assert eff["constraints"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_constraints_concat_revalidates_whole(self, tmp_path: Path) -> None:
+        # The concatenated whole is re-validated as PEP 508: a per-file
+        # list can be individually fine yet the merge re-runs the check.
+        _project(tmp_path, 'constraints = ["urllib3<2"]\n')
+        _write(tmp_path / "nab.toml", 'constraints = ["bad !! req"]\n')
+        with pytest.raises(SourceConfigError, match="is not a valid requirement"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_constraints_identical_lists_concat(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'constraints = ["urllib3<2"]\n')
+        _write(tmp_path / "nab.toml", 'constraints = ["urllib3<2"]\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["constraints"].value == ("urllib3<2", "urllib3<2")
+
+    def test_default_groups_from_pyproject(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'default-groups = ["dev"]\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["default-groups"].value == ("dev",)
+        assert eff["default-groups"].origin.kind is SourceKind.PYPROJECT
+
+    def test_default_groups_from_project_nab_toml(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        _write(tmp_path / "nab.toml", 'default-groups = ["docs"]\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["default-groups"].value == ("docs",)
+        assert eff["default-groups"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_default_groups_in_user_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(tmp_path / "usr" / "nab.toml", 'default-groups = ["dev"]\n')
+        roots = SourceRoots(user_toml=user, project_dir=tmp_path)
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(roots)
+
+    def test_nab_default_groups_env_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        with pytest.raises(SourceConfigError, match="not env-settable"):
+            _resolve(
+                SourceRoots(project_dir=tmp_path),
+                environ={"NAB_DEFAULT_GROUPS": "x"},
+            )
+
+    def test_default_groups_non_string_item_keeps_message(self, tmp_path: Path) -> None:
+        _project(tmp_path, "default-groups = [1]\n")
+        with pytest.raises(SourceConfigError, match="must be a string"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_default_groups_concat_across_project_files(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'default-groups = ["dev"]\n')
+        _write(tmp_path / "nab.toml", 'default-groups = ["docs"]\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["default-groups"].value == ("dev", "docs")
+
+    def test_array_defaults_empty(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["constraints"].value == ()
+        assert eff["constraints"].origin.kind is SourceKind.DEFAULT
+        assert eff["default-groups"].value == ()
+
+    def test_array_default_render(self) -> None:
+        spec = next(s for s in OPTIONS if s.key == "constraints")
+        assert spec.render(()) == "<none>"
+        assert spec.render(("a", "b")) == "a, b"
+
+    def test_array_keys_visible_in_config(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            'constraints = ["urllib3<2"]\ndefault-groups = ["dev"]\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        out = render_list(eff)
+        for key in ("constraints", "default-groups"):
+            assert key in out
+        assert render_get(eff, "constraints").strip() == "urllib3<2"
+        explained = render_explain(eff, "default-groups")
+        assert "dev" in explained
+
+    def test_array_explain_shows_both_project_files(self, tmp_path: Path) -> None:
+        # Both project-file bindings show in the explain stack (the array
+        # merge keeps the full shadowed stack, ordered low -> high).
+        _project(tmp_path, 'constraints = ["urllib3<2"]\n')
+        _write(tmp_path / "nab.toml", 'constraints = ["certifi>=2024"]\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        stack_kinds = [origin.kind for origin, _ in eff["constraints"].stack]
+        assert stack_kinds == [SourceKind.PYPROJECT, SourceKind.PROJECT_TOML]
+
+    def test_array_explain_shows_merged_effective(self, tmp_path: Path) -> None:
+        # An array option has no single winning layer: every layer
+        # "contributes" and the concatenated effective value is rendered on
+        # its own line, so explain and get cannot diverge on the effective
+        # value.
+        _project(tmp_path, 'constraints = ["urllib3<2"]\n')
+        _write(tmp_path / "nab.toml", 'constraints = ["certifi>=2024"]\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        explained = render_explain(eff, "constraints")
+        assert "winner" not in explained
+        assert explained.count("contributes") == 2
+        merged = render_get(eff, "constraints").strip()
+        assert f"= effective: {merged}" in explained
+
+    def test_array_project_rows_have_append_cli_flags(self) -> None:
+        for key, flag in (
+            ("constraints", "--project-constraint"),
+            ("default-groups", "--project-default-group"),
+        ):
+            spec = next(s for s in OPTIONS if s.key == key)
+            assert spec.cli_flag == flag
+            assert spec.is_array is True
+
+
+class TestArrayOfTablesSources:
+    """The array-of-tables PROJECT sources: indexes, local-sources,
+    vcs-sources.  Each reuses the single-environment parser per layer
+    (shape/key/dup messages match the pyproject path), is gated
+    PROJECT-only and file-only, concatenates additively across the two
+    project files, and is visible in ``nab config``.  indexes re-runs its
+    same-name dup check over the merged whole; local/vcs-sources carry no
+    intra-key dup check (the cross-key local/vcs check stays on the resolve
+    path), so their merge is a plain concat.
+    """
+
+    def test_indexes_from_pyproject(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            '[[tool.nab.indexes]]\nname = "pypi"\nurl = "https://pypi.org/simple/"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        value = eff["indexes"].value
+        assert [i.name for i in value] == ["pypi"]
+        assert eff["indexes"].origin.kind is SourceKind.PYPROJECT
+
+    def test_indexes_from_project_nab_toml(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        _write(
+            tmp_path / "nab.toml",
+            '[[indexes]]\nname = "extra"\nurl = "https://extra/simple/"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert [i.name for i in eff["indexes"].value] == ["extra"]
+        assert eff["indexes"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_indexes_default_is_pypi(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        value = eff["indexes"].value
+        assert [i.name for i in value] == ["pypi"]
+        assert eff["indexes"].origin.kind is SourceKind.DEFAULT
+
+    def test_indexes_in_user_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(
+            tmp_path / "usr" / "nab.toml",
+            '[[indexes]]\nname = "pypi"\nurl = "https://pypi.org/simple/"\n',
+        )
+        roots = SourceRoots(user_toml=user, project_dir=tmp_path)
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(roots)
+
+    def test_indexes_in_system_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        sys_toml = _write(
+            tmp_path / "etc" / "nab.toml",
+            '[[indexes]]\nname = "pypi"\nurl = "https://pypi.org/simple/"\n',
+        )
+        roots = SourceRoots(system_toml=sys_toml, project_dir=tmp_path)
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(roots)
+
+    def test_nab_indexes_env_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        with pytest.raises(SourceConfigError, match="not env-settable"):
+            _resolve(SourceRoots(project_dir=tmp_path), environ={"NAB_INDEXES": "x"})
+
+    def test_indexes_bad_shape_keeps_message(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'indexes = "pypi"\n')
+        with pytest.raises(SourceConfigError, match="must be an array of tables"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_indexes_unknown_key_keeps_message(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            '[[tool.nab.indexes]]\nname = "x"\nurl = "u"\nbogus = "y"\n',
+        )
+        with pytest.raises(SourceConfigError, match="unknown indexes"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_indexes_concat_across_project_files(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            '[[tool.nab.indexes]]\nname = "pypi"\nurl = "https://pypi.org/simple/"\n',
+        )
+        _write(
+            tmp_path / "nab.toml",
+            '[[indexes]]\nname = "extra"\nurl = "https://extra/simple/"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert [i.name for i in eff["indexes"].value] == ["pypi", "extra"]
+        assert eff["indexes"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_indexes_merge_rejects_duplicate_name(self, tmp_path: Path) -> None:
+        # The merged-whole re-check: the same index name in both project
+        # files conflicts, with the same message the single-file dup check
+        # raises.
+        _project(
+            tmp_path,
+            '[[tool.nab.indexes]]\nname = "pypi"\nurl = "https://pypi.org/simple/"\n',
+        )
+        _write(
+            tmp_path / "nab.toml",
+            '[[indexes]]\nname = "pypi"\nurl = "https://other/simple/"\n',
+        )
+        with pytest.raises(SourceConfigError, match="duplicate index name"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_indexes_per_file_duplicate_name(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            '[[tool.nab.indexes]]\nname = "dup"\nurl = "u1"\n'
+            '[[tool.nab.indexes]]\nname = "dup"\nurl = "u2"\n',
+        )
+        with pytest.raises(SourceConfigError, match="duplicate index name"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_indexes_render(self) -> None:
+        spec = next(s for s in OPTIONS if s.key == "indexes")
+        assert spec.render(()) == "<none>"
+        rendered = spec.render(spec.default)
+        assert rendered == "pypi=https://pypi.org/simple/"
+
+    def test_local_sources_from_pyproject(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            '[[tool.nab.local-sources]]\nname = "pkg"\npath = "./libs/pkg"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        value = eff["local-sources"].value
+        assert [s.name for s in value] == ["pkg"]
+        # Path resolves relative to the declaring file's directory.
+        assert value[0].path == str((tmp_path / "libs" / "pkg").resolve())
+        assert eff["local-sources"].origin.kind is SourceKind.PYPROJECT
+
+    def test_local_sources_from_project_nab_toml(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        _write(
+            tmp_path / "nab.toml",
+            '[[local-sources]]\nname = "pkg"\npath = "./pkg"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        value = eff["local-sources"].value
+        assert value[0].path == str((tmp_path / "pkg").resolve())
+        assert eff["local-sources"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_local_sources_in_user_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(
+            tmp_path / "usr" / "nab.toml",
+            '[[local-sources]]\nname = "pkg"\npath = "./pkg"\n',
+        )
+        roots = SourceRoots(user_toml=user, project_dir=tmp_path)
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(roots)
+
+    def test_nab_local_sources_env_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        with pytest.raises(SourceConfigError, match="not env-settable"):
+            _resolve(
+                SourceRoots(project_dir=tmp_path),
+                environ={"NAB_LOCAL_SOURCES": "x"},
+            )
+
+    def test_local_sources_bad_shape_keeps_message(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'local-sources = "pkg"\n')
+        with pytest.raises(SourceConfigError, match="must be an array of tables"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_local_sources_concat_across_project_files(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            '[[tool.nab.local-sources]]\nname = "a"\npath = "./a"\n',
+        )
+        _write(
+            tmp_path / "nab.toml",
+            '[[local-sources]]\nname = "b"\npath = "./b"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert [s.name for s in eff["local-sources"].value] == ["a", "b"]
+
+    def test_local_sources_render(self, tmp_path: Path) -> None:
+        spec = next(s for s in OPTIONS if s.key == "local-sources")
+        assert spec.render(()) == "<none>"
+        _project(
+            tmp_path,
+            '[[tool.nab.local-sources]]\nname = "pkg"\npath = "./pkg"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        out = render_get(eff, "local-sources")
+        assert out.startswith("pkg@")
+
+    def test_vcs_sources_from_pyproject(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            '[[tool.nab.vcs-sources]]\nname = "pkg"\n'
+            'url = "git+https://example/pkg.git@deadbeef"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert [s.name for s in eff["vcs-sources"].value] == ["pkg"]
+        assert eff["vcs-sources"].origin.kind is SourceKind.PYPROJECT
+
+    def test_vcs_sources_from_project_nab_toml(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        _write(
+            tmp_path / "nab.toml",
+            '[[vcs-sources]]\nname = "pkg"\nurl = "git+https://example/pkg.git@abc"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert [s.name for s in eff["vcs-sources"].value] == ["pkg"]
+        assert eff["vcs-sources"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_vcs_sources_in_system_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        sys_toml = _write(
+            tmp_path / "etc" / "nab.toml",
+            '[[vcs-sources]]\nname = "pkg"\nurl = "git+https://e/p.git@a"\n',
+        )
+        roots = SourceRoots(system_toml=sys_toml, project_dir=tmp_path)
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(roots)
+
+    def test_nab_vcs_sources_env_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        with pytest.raises(SourceConfigError, match="not env-settable"):
+            _resolve(
+                SourceRoots(project_dir=tmp_path),
+                environ={"NAB_VCS_SOURCES": "x"},
+            )
+
+    def test_vcs_sources_bad_shape_keeps_message(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'vcs-sources = "pkg"\n')
+        with pytest.raises(SourceConfigError, match="must be an array of tables"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_vcs_sources_concat_across_project_files(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            '[[tool.nab.vcs-sources]]\nname = "a"\nurl = "git+https://e/a.git@1"\n',
+        )
+        _write(
+            tmp_path / "nab.toml",
+            '[[vcs-sources]]\nname = "b"\nurl = "git+https://e/b.git@2"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert [s.name for s in eff["vcs-sources"].value] == ["a", "b"]
+
+    def test_vcs_sources_render(self) -> None:
+        spec = next(s for s in OPTIONS if s.key == "vcs-sources")
+        assert spec.render(()) == "<none>"
+        rendered = spec.render((VcsSource(name="pkg", url="git+https://e/p.git@a"),))
+        assert rendered == "pkg@git+https://e/p.git@a"
+
+    def test_array_of_tables_rows_are_file_only_arrays(self) -> None:
+        for key in ("indexes", "local-sources", "vcs-sources"):
+            spec = next(s for s in OPTIONS if s.key == key)
+            assert spec.cli_flag is None
+            assert spec.cli_param is None
+            assert spec.is_array is True
+
+    def test_array_of_tables_keys_visible_in_config(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            '[[tool.nab.indexes]]\nname = "pypi"\nurl = "https://pypi.org/simple/"\n'
+            '[[tool.nab.local-sources]]\nname = "pkg"\npath = "./pkg"\n'
+            '[[tool.nab.vcs-sources]]\nname = "v"\nurl = "git+https://e/v.git@a"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        out = render_list(eff)
+        for key in ("indexes", "local-sources", "vcs-sources"):
+            assert key in out
+
+
+class TestOverrideTables:
+    """The per-package override tables: packages, package-rules, index.
+
+    ``packages`` (name-keyed sugar) and ``package-rules`` (array of tables)
+    both desugar into the same ``PackageOverride`` tuple; each is its own
+    file-only PROJECT array row, concatenating additively across the two
+    project files and re-running the same-field overlap check over the
+    merged whole.  ``index`` is a name-keyed table that merges sub-key by
+    sub-key like marker-environment.  Each reuses the single-environment
+    parser per layer so shape/key/body/overlap messages match the pyproject
+    path; the cross-key checks (packages-vs-package-rules overlap, route or
+    key names a declared index) run over the merged config instead.
+    """
+
+    def test_packages_from_pyproject(self, tmp_path: Path) -> None:
+        _project(tmp_path, '[tool.nab.packages.lxml]\ndist-policy = "sdist-only"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        value = eff["packages"].value
+        assert [o.name for o in value] == ["lxml"]
+        assert eff["packages"].origin.kind is SourceKind.PYPROJECT
+
+    def test_packages_from_project_nab_toml(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        _write(
+            tmp_path / "nab.toml",
+            '[packages.lxml]\ndist-policy = "sdist-only"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert [o.name for o in eff["packages"].value] == ["lxml"]
+        assert eff["packages"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_packages_in_user_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(
+            tmp_path / "usr" / "nab.toml",
+            '[packages.lxml]\ndist-policy = "sdist-only"\n',
+        )
+        roots = SourceRoots(user_toml=user, project_dir=tmp_path)
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(roots)
+
+    def test_nab_packages_env_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        with pytest.raises(SourceConfigError, match="not env-settable"):
+            _resolve(SourceRoots(project_dir=tmp_path), environ={"NAB_PACKAGES": "x"})
+
+    def test_packages_bad_shape_keeps_message(self, tmp_path: Path) -> None:
+        _project(tmp_path, '[[tool.nab.packages]]\nmatch = ["foo"]\n')
+        with pytest.raises(SourceConfigError, match="name-keyed table form"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_packages_intra_file_overlap_keeps_message(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            '[tool.nab.packages.foo]\ndist-policy = "sdist-only"\n'
+            '[tool.nab.packages."Foo"]\nbuild-policy = "build-remote"\n'
+            '[tool.nab.packages."FOO"]\ndist-policy = "wheel-only"\n',
+        )
+        with pytest.raises(SourceConfigError, match="overlapping versions"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_packages_concat_across_project_files(self, tmp_path: Path) -> None:
+        _project(tmp_path, '[tool.nab.packages.lxml]\ndist-policy = "sdist-only"\n')
+        _write(
+            tmp_path / "nab.toml",
+            '[packages.numpy]\ndist-policy = "wheel-only"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert sorted(o.name for o in eff["packages"].value) == ["lxml", "numpy"]
+        assert eff["packages"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_packages_merge_overlap_across_project_files(self, tmp_path: Path) -> None:
+        # The same field for one package over overlapping ranges in both
+        # project files raises the same-field overlap error over the merged
+        # whole, not a silent last-win.
+        _project(tmp_path, '[tool.nab.packages.lxml]\ndist-policy = "sdist-only"\n')
+        _write(
+            tmp_path / "nab.toml",
+            '[packages.lxml]\ndist-policy = "wheel-only"\n',
+        )
+        with pytest.raises(SourceConfigError, match="overlapping versions"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_packages_identical_overlap_still_errors(self, tmp_path: Path) -> None:
+        # Two entries setting one field for one package always overlap, so
+        # even identical bodies in the two project files conflict: arrays
+        # skip the cross-file equality check (they concat) and the overlap
+        # check then fires over the merged tuple, as it would within one file.
+        _project(tmp_path, '[tool.nab.packages.lxml]\ndist-policy = "sdist-only"\n')
+        _write(
+            tmp_path / "nab.toml",
+            '[packages.lxml]\ndist-policy = "sdist-only"\n',
+        )
+        with pytest.raises(SourceConfigError, match="overlapping versions"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_packages_disjoint_ranges_across_files_ok(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path, '[tool.nab.packages."lxml <= 2"]\ndist-policy = "sdist-only"\n'
+        )
+        _write(
+            tmp_path / "nab.toml",
+            '[packages."lxml > 2"]\ndist-policy = "wheel-only"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert [o.name for o in eff["packages"].value] == ["lxml", "lxml"]
+
+    def test_packages_index_route_no_declared_check(self, tmp_path: Path) -> None:
+        # The route-names-a-declared-index cross-key check stays on the
+        # resolve path, so the registry accepts a route to an index it
+        # cannot see from the per-row hook.
+        _project(tmp_path, '[tool.nab.packages.foo]\nindex = "internal"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        (override,) = eff["packages"].value
+        assert override.index == "internal"
+
+    def test_package_rules_from_pyproject(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            "[[tool.nab.package-rules]]\n"
+            'match = ["lxml", "xmlsec"]\n'
+            'dist-policy = "sdist-only"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert sorted(o.name for o in eff["package-rules"].value) == ["lxml", "xmlsec"]
+        assert eff["package-rules"].origin.kind is SourceKind.PYPROJECT
+
+    def test_package_rules_from_project_nab_toml(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        _write(
+            tmp_path / "nab.toml",
+            '[[package-rules]]\nmatch = ["lxml"]\ndist-policy = "sdist-only"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert [o.name for o in eff["package-rules"].value] == ["lxml"]
+        assert eff["package-rules"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_package_rules_in_system_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        sys_toml = _write(
+            tmp_path / "etc" / "nab.toml",
+            '[[package-rules]]\nmatch = ["lxml"]\ndist-policy = "sdist-only"\n',
+        )
+        roots = SourceRoots(system_toml=sys_toml, project_dir=tmp_path)
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(roots)
+
+    def test_nab_package_rules_env_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        with pytest.raises(SourceConfigError, match="not env-settable"):
+            _resolve(
+                SourceRoots(project_dir=tmp_path),
+                environ={"NAB_PACKAGE_RULES": "x"},
+            )
+
+    def test_package_rules_bad_shape_keeps_message(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'package-rules = ["x"]\n')
+        with pytest.raises(SourceConfigError, match=r"package-rules\[0\] must be"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_package_rules_concat_across_project_files(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            '[[tool.nab.package-rules]]\nmatch = ["a"]\ndist-policy = "sdist-only"\n',
+        )
+        _write(
+            tmp_path / "nab.toml",
+            '[[package-rules]]\nmatch = ["b"]\ndist-policy = "wheel-only"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert [o.name for o in eff["package-rules"].value] == ["a", "b"]
+
+    def test_index_from_pyproject(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            '[[tool.nab.indexes]]\nname = "internal"\nurl = "https://i/simple/"\n'
+            '[tool.nab.index.internal]\ndist-policy = "wheel-only"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert set(eff["index"].value) == {"internal"}
+        assert eff["index"].origin.kind is SourceKind.PYPROJECT
+
+    def test_index_from_project_nab_toml(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        _write(
+            tmp_path / "nab.toml",
+            '[index.internal]\ndist-policy = "wheel-only"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert set(eff["index"].value) == {"internal"}
+        assert eff["index"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_index_in_user_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(
+            tmp_path / "usr" / "nab.toml",
+            '[index.pypi]\ndist-policy = "wheel-only"\n',
+        )
+        roots = SourceRoots(user_toml=user, project_dir=tmp_path)
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(roots)
+
+    def test_nab_index_env_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        with pytest.raises(SourceConfigError, match="not env-settable"):
+            _resolve(SourceRoots(project_dir=tmp_path), environ={"NAB_INDEX": "x"})
+
+    def test_index_bad_shape_keeps_message(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'index = "pypi"\n')
+        with pytest.raises(SourceConfigError, match="must be a table keyed by index"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_index_no_declared_check(self, tmp_path: Path) -> None:
+        # The key-names-a-declared-index cross-key check stays on the
+        # resolve path; the registry accepts an undeclared name here.
+        _project(tmp_path, '[tool.nab.index.notdeclared]\ndist-policy = "wheel-only"\n')
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert set(eff["index"].value) == {"notdeclared"}
+
+    def test_index_cross_file_conflict(self, tmp_path: Path) -> None:
+        _project(tmp_path, '[tool.nab.index.pypi]\ndist-policy = "wheel-only"\n')
+        _write(
+            tmp_path / "nab.toml",
+            '[index.pypi]\ndist-policy = "sdist-only"\n',
+        )
+        with pytest.raises(SourceConfigError, match="conflicting values"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_index_identical_across_files_ok(self, tmp_path: Path) -> None:
+        _project(tmp_path, '[tool.nab.index.pypi]\ndist-policy = "wheel-only"\n')
+        _write(
+            tmp_path / "nab.toml",
+            '[index.pypi]\ndist-policy = "wheel-only"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert set(eff["index"].value) == {"pypi"}
+
+    def test_index_disjoint_names_merge(self, tmp_path: Path) -> None:
+        # Different sub-keys merge: disjoint index names across the two
+        # project files merge by sub-key rather than tripping a conflict.
+        _project(tmp_path, '[tool.nab.index.pypi]\ndist-policy = "wheel-only"\n')
+        _write(
+            tmp_path / "nab.toml",
+            '[index.internal]\ndist-policy = "sdist-only"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert set(eff["index"].value) == {"pypi", "internal"}
+
+    def test_index_identical_duration_across_files_ok(self, tmp_path: Path) -> None:
+        # An identical relative P<n>D in an index override body across both
+        # project files must not read as conflicting: the inspector pins one
+        # ``now`` so both layers anchor the duration identically.
+        _project(
+            tmp_path,
+            '[tool.nab.index.pypi]\nuploaded-prior-to = "P4D"\n',
+        )
+        _write(
+            tmp_path / "nab.toml",
+            '[index.pypi]\nuploaded-prior-to = "P4D"\n',
+        )
+        with inspector_anchor():
+            eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert set(eff["index"].value) == {"pypi"}
+
+    def test_packages_identical_duration_across_files_ok(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            '[tool.nab.packages.lxml]\nuploaded-prior-to = "P4D"\n',
+        )
+        _write(
+            tmp_path / "nab.toml",
+            '[packages.numpy]\nuploaded-prior-to = "P4D"\n',
+        )
+        with inspector_anchor():
+            eff = _resolve(SourceRoots(project_dir=tmp_path))
+        names = {str(o.requirement) for o in eff["packages"].value}
+        assert names == {"lxml", "numpy"}
+
+    def test_override_defaults_empty(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["packages"].value == ()
+        assert eff["package-rules"].value == ()
+        assert eff["index"].value == {}
+
+    def test_override_default_render(self) -> None:
+        packages = next(s for s in OPTIONS if s.key == "packages")
+        index = next(s for s in OPTIONS if s.key == "index")
+        assert packages.render(()) == "<none>"
+        assert index.render({}) == "<none>"
+
+    def test_packages_render_lists_requirements(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path, '[tool.nab.packages."lxml <= 2"]\ndist-policy = "sdist-only"\n'
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        out = render_get(eff, "packages")
+        assert "lxml" in out
+
+    def test_index_render_lists_names(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            '[tool.nab.index.a]\ndist-policy = "wheel-only"\n'
+            '[tool.nab.index.b]\ndist-policy = "sdist-only"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert render_get(eff, "index").strip() == "a, b"
+
+    def test_override_rows_shape(self) -> None:
+        for key in ("packages", "package-rules"):
+            spec = next(s for s in OPTIONS if s.key == key)
+            assert spec.cli_flag is None
+            assert spec.cli_param is None
+            assert spec.is_array is True
+        index = next(s for s in OPTIONS if s.key == "index")
+        assert index.cli_flag is None
+        assert index.cli_param is None
+        assert index.is_array is False
+
+    def test_override_keys_visible_in_config(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            '[tool.nab.packages.lxml]\ndist-policy = "sdist-only"\n'
+            "[[tool.nab.package-rules]]\n"
+            'match = ["numpy"]\ndist-policy = "wheel-only"\n'
+            '[tool.nab.index.pypi]\ndist-policy = "wheel-only"\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        out = render_list(eff)
+        for key in ("packages", "package-rules", "index"):
+            assert key in out
+
+
+_CONFLICTS_PYPROJECT = 'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+_MATRIX_PYPROJECT = (
+    '[tool.nab.matrix]\npython = ">=3.11,<3.12"\nplatforms = ["linux_x86_64"]\n'
+)
+_MATRIX_PROJECT_TOML = (
+    '[matrix]\npython = ">=3.11,<3.12"\nplatforms = ["linux_x86_64"]\n'
+)
+
+
+class TestCrossFieldProjectOptions:
+    """The cross-field PROJECT keys: conflicts, matrix.
+
+    Each reuses the single-environment parser, is gated PROJECT-only and
+    file-only, and is visible in ``nab config``.  ``conflicts`` is an array
+    that concatenates additively across the two project files and re-runs
+    its member-uniqueness check over the merged whole; ``matrix`` is a
+    nested table that is scalar last-wins.  The cross-field rules they take
+    part in (mode/matrix, default-groups-vs-conflicts,
+    marker-environment-under-universal, the build-policy floors) run as
+    whole-config transforms over the merged config, not registry rows.
+    """
+
+    def test_conflicts_from_pyproject(self, tmp_path: Path) -> None:
+        _project(tmp_path, _CONFLICTS_PYPROJECT)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        value = eff["conflicts"].value
+        assert value == (
+            ConflictSet(
+                members=(
+                    ConflictMember(ConflictKind.EXTRA, "cpu"),
+                    ConflictMember(ConflictKind.EXTRA, "gpu"),
+                ),
+                policy=ConflictPolicy.AT_MOST_ONE,
+            ),
+        )
+        assert eff["conflicts"].origin.kind is SourceKind.PYPROJECT
+
+    def test_conflicts_from_project_nab_toml(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        _write(tmp_path / "nab.toml", _CONFLICTS_PYPROJECT)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["conflicts"].origin.kind is SourceKind.PROJECT_TOML
+        assert len(eff["conflicts"].value) == 1
+
+    def test_conflicts_in_user_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(tmp_path / "usr" / "nab.toml", _CONFLICTS_PYPROJECT)
+        roots = SourceRoots(user_toml=user, project_dir=tmp_path)
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(roots)
+
+    def test_conflicts_in_system_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        sys_toml = _write(tmp_path / "etc" / "nab.toml", _CONFLICTS_PYPROJECT)
+        roots = SourceRoots(system_toml=sys_toml, project_dir=tmp_path)
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(roots)
+
+    def test_nab_conflicts_env_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        with pytest.raises(SourceConfigError, match="not env-settable"):
+            _resolve(SourceRoots(project_dir=tmp_path), environ={"NAB_CONFLICTS": "x"})
+
+    def test_conflicts_bad_shape_keeps_message(self, tmp_path: Path) -> None:
+        _project(tmp_path, 'conflicts = "cpu"\n')
+        with pytest.raises(
+            SourceConfigError, match="must be an array of conflict sets"
+        ):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_conflicts_concat_across_project_files(self, tmp_path: Path) -> None:
+        # Arrays skip the conflict check: the two same-rung project files
+        # contribute additively.
+        _project(tmp_path, _CONFLICTS_PYPROJECT)
+        _write(
+            tmp_path / "nab.toml",
+            'conflicts = [[{ group = "test" }, { group = "docs" }]]\n',
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert len(eff["conflicts"].value) == 2
+        assert eff["conflicts"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_conflicts_merge_rejects_duplicate_member(self, tmp_path: Path) -> None:
+        # The merged-whole re-check: a member declared in both project files
+        # is the existing hard error, the same message the single-file
+        # uniqueness check raises.
+        _project(tmp_path, _CONFLICTS_PYPROJECT)
+        _write(
+            tmp_path / "nab.toml",
+            'conflicts = [[{ extra = "cpu" }, { extra = "tpu" }]]\n',
+        )
+        with pytest.raises(SourceConfigError, match="in more than one set"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_conflicts_per_file_duplicate_member(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }],'
+            ' [{ extra = "cpu" }, { extra = "tpu" }]]\n',
+        )
+        with pytest.raises(SourceConfigError, match="in more than one set"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_conflicts_default_render(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["conflicts"].value == ()
+        assert eff["conflicts"].spec.render(()) == "<none>"
+
+    def test_conflicts_render_lists_sets(self, tmp_path: Path) -> None:
+        _project(tmp_path, _CONFLICTS_PYPROJECT)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        out = render_get(eff, "conflicts")
+        assert "at-most-one" in out
+        assert "cpu" in out
+
+    def test_matrix_from_pyproject(self, tmp_path: Path) -> None:
+        _project(tmp_path, _MATRIX_PYPROJECT)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        value = eff["matrix"].value
+        assert value == MatrixConfig(python=">=3.11,<3.12", platforms=("linux_x86_64",))
+        assert eff["matrix"].origin.kind is SourceKind.PYPROJECT
+
+    def test_matrix_from_project_nab_toml(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        _write(tmp_path / "nab.toml", _MATRIX_PROJECT_TOML)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["matrix"].value == MatrixConfig(
+            python=">=3.11,<3.12", platforms=("linux_x86_64",)
+        )
+        assert eff["matrix"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_matrix_in_user_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        user = _write(tmp_path / "usr" / "nab.toml", _MATRIX_PROJECT_TOML)
+        roots = SourceRoots(user_toml=user, project_dir=tmp_path)
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(roots)
+
+    def test_matrix_in_system_nab_toml_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        sys_toml = _write(tmp_path / "etc" / "nab.toml", _MATRIX_PROJECT_TOML)
+        roots = SourceRoots(system_toml=sys_toml, project_dir=tmp_path)
+        with pytest.raises(SourceConfigError, match="project-scope option"):
+            _resolve(roots)
+
+    def test_nab_matrix_env_errors(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        with pytest.raises(SourceConfigError, match="not env-settable"):
+            _resolve(SourceRoots(project_dir=tmp_path), environ={"NAB_MATRIX": "x"})
+
+    def test_matrix_bad_shape_keeps_message(self, tmp_path: Path) -> None:
+        _project(tmp_path, "matrix = 3\n")
+        with pytest.raises(
+            SourceConfigError, match=r"\[tool.nab.matrix\] must be a table"
+        ):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_matrix_cross_file_conflict(self, tmp_path: Path) -> None:
+        _project(tmp_path, _MATRIX_PYPROJECT)
+        _write(
+            tmp_path / "nab.toml",
+            '[matrix]\npython = ">=3.12,<3.13"\nplatforms = ["linux_x86_64"]\n',
+        )
+        with pytest.raises(SourceConfigError, match="conflicting values"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_matrix_identical_across_files_ok(self, tmp_path: Path) -> None:
+        _project(tmp_path, _MATRIX_PYPROJECT)
+        _write(tmp_path / "nab.toml", _MATRIX_PROJECT_TOML)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["matrix"].value == MatrixConfig(
+            python=">=3.11,<3.12", platforms=("linux_x86_64",)
+        )
+        assert eff["matrix"].origin.kind is SourceKind.PROJECT_TOML
+
+    def test_matrix_default_render(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert eff["matrix"].value is None
+        assert eff["matrix"].spec.render(None) == "<none>"
+
+    def test_matrix_render_axes(self) -> None:
+        spec = next(s for s in OPTIONS if s.key == "matrix")
+        rendered = spec.render(
+            MatrixConfig(python=">=3.11", platforms=("linux_x86_64", "macos_arm64"))
+        )
+        assert rendered == "python=>=3.11, platforms=['linux_x86_64', 'macos_arm64']"
+
+    def test_cross_field_rows_shape(self) -> None:
+        conflicts = next(s for s in OPTIONS if s.key == "conflicts")
+        assert conflicts.cli_flag is None
+        assert conflicts.cli_param is None
+        assert conflicts.is_array is True
+        matrix = next(s for s in OPTIONS if s.key == "matrix")
+        assert matrix.cli_flag is None
+        assert matrix.cli_param is None
+        assert matrix.is_array is False
+
+    def test_cross_field_keys_visible_in_config(self, tmp_path: Path) -> None:
+        _project(tmp_path, _CONFLICTS_PYPROJECT + _MATRIX_PYPROJECT)
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        out = render_list(eff)
+        for key in ("conflicts", "matrix"):
+            assert key in out
+        explained = render_explain(eff, "matrix")
+        assert "linux_x86_64" in explained

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -1147,6 +1147,26 @@ class TestProvenance:
         ]
         assert "python-specifier" not in data["tool"]["nab"]
         assert "platforms" not in data["tool"]["nab"]
+        assert "cli-project-overrides" not in data["tool"]["nab"]
+
+    def test_emits_cli_project_overrides(self) -> None:
+        prov = Provenance(
+            nab_version="9.9.9",
+            created_at=datetime(2026, 5, 7, 12, 0, 0, tzinfo=timezone.utc),
+            command_line=("nab", "lock"),
+            input_path="pyproject.toml",
+            mode="specific",
+            cli_project_overrides=(
+                ("--project-resolution", "lowest"),
+                ("--project-constraint", "urllib3<2"),
+            ),
+        )
+        text = write_lock(LockInput(pins={"foo": _index_pin()}, provenance=prov))
+        data = tomllib.loads(text)
+        assert data["tool"]["nab"]["cli-project-overrides"] == [
+            "--project-resolution=lowest",
+            "--project-constraint=urllib3<2",
+        ]
 
     def test_emits_universal_matrix_fields(self) -> None:
         prov = Provenance(

--- a/src/nab/_config_cmd.py
+++ b/src/nab/_config_cmd.py
@@ -1,0 +1,148 @@
+"""``nab config`` subcommand: inspect the layered config registry.
+
+Read-only v1.  ``list`` shows every effective option with its value,
+scope and origin; ``get`` prints one effective value; ``explain`` prints
+the full shadowed stack for one key, the winner marked with a ``>``
+gutter.  All three are derived from the registry in
+:mod:`nab_python.config_sources`; this module only discovers the
+layers and prints what the renderers return.  There is no set/unset/edit:
+v1 never writes config.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Annotated
+
+import tyro
+
+from nab_python.config_sources import (
+    RejectedLayer,
+    SourceConfigError,
+    project_cli_override_notice,
+    render_explain,
+    render_get,
+    render_list,
+)
+
+from .cli import (
+    BuildPolicyFlag,
+    DistPolicyFlag,
+    HttpBackend,
+    ModeFlag,
+    ResolutionFlag,
+    _cli_overrides,
+    _fail_config,
+    _require_pyproject_file,
+    app,
+    effective_config,
+)
+
+ActionArg = Annotated[str, tyro.conf.Positional]
+KeyArg = Annotated[str, tyro.conf.Positional]
+
+
+@app.command(name="config")
+def config_command(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag
+    action: ActionArg,
+    key: KeyArg = "",
+    *,
+    path: Path = Path("pyproject.toml"),
+    project_resolution: ResolutionFlag | None = None,
+    offline: bool | None = None,
+    cache_dir: Path | None = None,
+    http_backend: HttpBackend | None = None,
+    max_concurrency: int | None = None,
+    project_mode: ModeFlag | None = None,
+    project_requires_python: str | None = None,
+    project_uploaded_prior_to: str | None = None,
+    project_dist_policy: DistPolicyFlag | None = None,
+    project_build_policy: BuildPolicyFlag | None = None,
+    project_constraint: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
+    project_default_group: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
+    include_rejected: bool = False,
+) -> None:
+    """Inspect the effective layered configuration.
+
+    ``nab config list`` lists every option with value/scope/origin.
+    ``nab config get <key>`` prints one effective value.  ``nab config
+    explain <key>`` prints the full shadowed source stack;
+    ``--include-rejected`` also lists category-rejected sources.
+
+    The same per-option flags the run commands accept (the USER
+    ``--offline`` / ``--cache-dir`` / ``--http-backend`` /
+    ``--max-concurrency`` and the ``--project-*`` PROJECT overrides) layer a
+    CLI value on top, so the inspector reflects the same effective values a
+    run would see.
+    """
+    # Registry-derived: the shared _cli_overrides helper maps each row's
+    # cli_param to the same-named local, so the override dict comes from
+    # iterating OPTIONS in one place, not from an if per option.  A new row
+    # needs only its tyro param above.
+    # Validate the pyproject path the same way the run commands do: a
+    # missing or directory --path is a hard error, not a silently-skipped
+    # source that prints all-built-in defaults.
+    _require_pyproject_file(path)
+
+    cli_overrides = _cli_overrides(
+        cli_resolution=project_resolution,
+        cli_offline=offline,
+        cli_cache_dir=cache_dir,
+        cli_http_backend=http_backend,
+        cli_max_concurrency=max_concurrency,
+        cli_mode=project_mode,
+        cli_requires_python=project_requires_python,
+        cli_uploaded_prior_to=project_uploaded_prior_to,
+        cli_dist_policy=project_dist_policy,
+        cli_build_policy=project_build_policy,
+        cli_constraint=project_constraint,
+        cli_default_group=project_default_group,
+    )
+
+    rejected: list[RejectedLayer] = []
+    try:
+        effective = effective_config(
+            path,
+            cli_overrides=cli_overrides,
+            collect_rejected=include_rejected,
+            rejected_out=rejected,
+        )
+    except SourceConfigError as exc:
+        _fail_config(exc)
+
+    # Reproducibility: a PROJECT option set on the CLI changes the
+    # resolved set, so it is never silent.  This inspector produces no
+    # lock, so the notice is worded for inspection (produces_lock=False).
+    notice = project_cli_override_notice(effective, produces_lock=False)
+    if notice is not None:
+        sys.stderr.write(notice)
+
+    if action == "list":
+        sys.stdout.write(render_list(effective, rejected=rejected))
+        return
+    if action in {"get", "explain"}:
+        _require_key_arg(key, action)
+        try:
+            if action == "get":
+                rendered = render_get(effective, key)
+            else:
+                rendered = render_explain(
+                    effective, key, include_rejected=include_rejected
+                )
+        except SourceConfigError as exc:
+            _fail_config(exc)
+        sys.stdout.write(rendered)
+        return
+
+    sys.stderr.write(
+        f"Error: unknown config action {action!r};"
+        " expected one of 'list', 'get', 'explain'\n"
+    )
+    sys.exit(1)
+
+
+def _require_key_arg(key: str, action: str) -> None:
+    if not key:
+        sys.stderr.write(f"Error: `nab config {action}` requires a <key>\n")
+        sys.exit(1)

--- a/src/nab/_download.py
+++ b/src/nab/_download.py
@@ -17,6 +17,9 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Annotated
+
+import tyro
 
 from nab_python.config import ResolveMode
 from nab_python.download import DownloadError
@@ -24,8 +27,12 @@ from nab_python.download import DownloadError
 from . import cli as _cli
 from ._lock import resolve_extra_selection, resolve_group_selection
 from .cli import (
+    BuildPolicyFlag,
+    DistPolicyFlag,
     HttpBackend,
+    ModeFlag,
     PathArg,
+    ResolutionFlag,
     app,
 )
 
@@ -35,16 +42,24 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
     path: PathArg = Path("pyproject.toml"),
     *,
     output: Path = Path("wheels"),
-    http_backend: HttpBackend = "urllib3",
+    http_backend: HttpBackend | None = None,
     cache_dir: Path | None = None,
     cache: bool = True,
-    offline: bool = False,
-    max_concurrency: int = 8,
+    offline: bool | None = None,
+    max_concurrency: int | None = None,
     workspace_discovery: bool = True,
     groups: tuple[str, ...] = (),
     all_groups: bool = False,
     extras: tuple[str, ...] = (),
     all_extras: bool = False,
+    project_resolution: ResolutionFlag | None = None,
+    project_mode: ModeFlag | None = None,
+    project_requires_python: str | None = None,
+    project_uploaded_prior_to: str | None = None,
+    project_dist_policy: DistPolicyFlag | None = None,
+    project_build_policy: BuildPolicyFlag | None = None,
+    project_constraint: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
+    project_default_group: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
 ) -> None:
     """Resolve and download every wheel/sdist into a local directory.
 
@@ -56,11 +71,13 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
     mirror ``nab lock``: a project declaring an ``exactly-one`` or
     ``at-least-one`` conflict needs at least one member selected for
     the resolve to start, so these flags also gate the download.
-    """
-    if max_concurrency < 1:
-        sys.stderr.write("Error: --max-concurrency must be at least 1.\n")
-        sys.exit(1)
 
+    ``--offline``, ``--cache-dir``, ``--http-backend``,
+    ``--max-concurrency`` and ``--project-resolution`` flow through the
+    same config sources ``nab lock`` uses, so a ``NAB_*`` env var or a
+    system/user/project ``nab.toml`` is read for ``nab download`` as for
+    ``nab lock``.
+    """
     selected_groups = resolve_group_selection(
         path, groups=groups, all_groups=all_groups
     )
@@ -68,22 +85,42 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
         path, extras=extras, all_extras=all_extras
     )
 
+    overrides = _cli._cli_overrides(  # noqa: SLF001
+        cli_resolution=project_resolution,
+        cli_offline=offline,
+        cli_cache_dir=cache_dir,
+        cli_http_backend=http_backend,
+        cli_max_concurrency=max_concurrency,
+        cli_mode=project_mode,
+        cli_requires_python=project_requires_python,
+        cli_uploaded_prior_to=project_uploaded_prior_to,
+        cli_dist_policy=project_dist_policy,
+        cli_build_policy=project_build_policy,
+        cli_constraint=project_constraint,
+        cli_default_group=project_default_group,
+    )
     config = _cli._load_config(  # noqa: SLF001
-        path, discover_workspace=workspace_discovery
+        path,
+        discover_workspace=workspace_discovery,
+        cli_overrides=_cli.project_config_overrides(overrides),
+    )
+    settings = _cli._layered_run_settings_or_exit(  # noqa: SLF001
+        path, overrides, produces_lock=False
     )
     effective_cache_dir = _cli._resolve_effective_cache_dir(  # noqa: SLF001
-        cache_dir, cache=cache
+        settings.cache_dir, cache=cache
     )
-    transport = _cli._make_transport(http_backend)  # noqa: SLF001
+    transport = _cli._make_transport(settings.http_backend)  # noqa: SLF001
     if config.mode is ResolveMode.UNIVERSAL:
         universal = _cli._resolve_universal(  # noqa: SLF001
             path,
             config=config,
             cache_dir=effective_cache_dir,
-            offline=offline,
+            offline=settings.offline,
             transport=transport,
             groups=selected_groups,
             extras=selected_extras,
+            resolution_strategy=settings.resolution,
         )
         lock_input = _cli.merge_universal_lock_inputs(universal)
     else:
@@ -91,21 +128,22 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
             path,
             config=config,
             cache_dir=effective_cache_dir,
-            offline=offline,
+            offline=settings.offline,
             transport=transport,
             failure_prefix="Cannot download",
             groups=selected_groups,
             extras=selected_extras,
+            resolution_strategy=settings.resolution,
         )
         lock_input = result.lock_input
 
-    download_transport = _cli._make_transport(http_backend)  # noqa: SLF001
+    download_transport = _cli._make_transport(settings.http_backend)  # noqa: SLF001
     try:
         outcome = _cli.download_lock(
             lock_input,
             download_transport,
             output,
-            max_concurrency=max_concurrency,
+            max_concurrency=settings.max_concurrency,
         )
     except DownloadError as e:
         sys.stderr.write(f"Download failed: {e}\n")

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -18,14 +18,17 @@ from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 from string import Formatter
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
+
+import tomli
+import tomli_w
+import tyro
 
 from nab._version import __version__
 from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python.config import (
     NabProjectConfig,
     ResolveMode,
-    read_pyproject_lock_anchor,
 )
 from nab_python.lockfile import (
     IndexPin,
@@ -35,7 +38,6 @@ from nab_python.lockfile import (
     read_lockfile_anchor,
     read_lockfile_packages,
 )
-from nab_python.provider import ResolutionStrategy
 from nab_python.requirements_file import (
     read_pyproject_groups,
     read_pyproject_optional_dependencies,
@@ -43,8 +45,11 @@ from nab_python.requirements_file import (
 
 from . import cli as _cli
 from .cli import (
+    BuildPolicyFlag,
+    DistPolicyFlag,
     HttpBackend,
     LockFormat,
+    ModeFlag,
     PathArg,
     ResolutionFlag,
     app,
@@ -55,6 +60,7 @@ if TYPE_CHECKING:
 
     from nab_index.transport import AsyncHttpTransport
     from nab_python._vendor.packaging.version import Version
+    from nab_python.provider import ResolutionStrategy
     from nab_python.resolve import ResolutionResult
     from nab_python.universal.resolve import TupleResult, UniversalResult
 
@@ -74,18 +80,26 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     *,
     output: Path | None = None,
     format: LockFormat = "pylock",  # noqa: A002 - shadows builtin by convention
-    http_backend: HttpBackend = "urllib3",
+    http_backend: HttpBackend | None = None,
     cache_dir: Path | None = None,
     cache: bool = True,
-    offline: bool = False,
+    offline: bool | None = None,
     groups: tuple[str, ...] = (),
     all_groups: bool = False,
     extras: tuple[str, ...] = (),
     all_extras: bool = False,
     workspace_discovery: bool = True,
     no_emit_workspace: bool = False,
-    resolution: ResolutionFlag | None = None,
+    project_resolution: ResolutionFlag | None = None,
+    project_mode: ModeFlag | None = None,
+    project_requires_python: str | None = None,
+    project_uploaded_prior_to: str | None = None,
+    project_dist_policy: DistPolicyFlag | None = None,
+    project_build_policy: BuildPolicyFlag | None = None,
+    project_constraint: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
+    project_default_group: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
     upgrade: bool = False,
+    locked: bool = False,
 ) -> None:
     """Resolve dependencies and emit a lockfile or pin list.
 
@@ -111,34 +125,76 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     lockfile via pip's PEP 751 install or ``--require-hashes``: both
     refuse directory entries because they cannot be hashed.
 
-    ``--resolution`` overrides ``[tool.nab].resolution`` for this run.
-    ``--upgrade`` re-anchors the ``P<n>D`` cutoff to ``datetime.now(UTC)``
-    instead of reusing the timestamp recorded in any existing lockfile.
+    ``--project-resolution`` overrides ``[tool.nab].resolution`` for this
+    run (a PROJECT-scope override, so it is layered through the config
+    sources; see Configuration).  ``--http-backend`` is a USER option, so
+    it too is read from the config sources (``NAB_HTTP_BACKEND`` or an
+    ``nab.toml``) when the flag is not passed.  ``--upgrade`` re-anchors the
+    ``P<n>D`` cutoff to ``datetime.now(UTC)`` instead of reusing the
+    timestamp recorded in any existing lockfile.
+
+    ``--locked`` re-resolves and verifies the committed pylock is already
+    up to date, writing nothing and exiting non-zero if it would change.
+    It is for pylock output to a file, single-environment mode only.
     """
     _validate_pylock_output_name(output=output, format=format)
-    anchor = _determine_lock_anchor(path, output=output, format=format, upgrade=upgrade)
+    if locked and (format != "pylock" or _cli.is_stdout(output)):
+        sys.stderr.write(
+            "Error: --locked is only supported for pylock output to a file.\n"
+        )
+        sys.exit(1)
+    overrides = _cli._cli_overrides(  # noqa: SLF001
+        cli_resolution=project_resolution,
+        cli_offline=offline,
+        cli_cache_dir=cache_dir,
+        cli_http_backend=http_backend,
+        cli_mode=project_mode,
+        cli_requires_python=project_requires_python,
+        cli_uploaded_prior_to=project_uploaded_prior_to,
+        cli_dist_policy=project_dist_policy,
+        cli_build_policy=project_build_policy,
+        cli_constraint=project_constraint,
+        cli_default_group=project_default_group,
+    )
+    project_overrides = _cli.project_config_overrides(overrides)
+    anchor = _determine_lock_anchor(
+        path,
+        output=output,
+        format=format,
+        upgrade=upgrade,
+        cli_overrides=project_overrides,
+    )
     config = _cli._load_config(  # noqa: SLF001
-        path, discover_workspace=workspace_discovery, anchor=anchor
+        path,
+        discover_workspace=workspace_discovery,
+        anchor=anchor,
+        cli_overrides=project_overrides,
     )
+    if locked and config.mode is ResolveMode.UNIVERSAL:
+        sys.stderr.write("Error: --locked is not supported in universal mode.\n")
+        sys.exit(1)
+    settings = _cli._layered_run_settings_or_exit(path, overrides)  # noqa: SLF001
     effective_cache_dir = _cli._resolve_effective_cache_dir(  # noqa: SLF001
-        cache_dir, cache=cache
+        settings.cache_dir, cache=cache
     )
-    provenance = _build_provenance(path, config=config, anchor=anchor)
+    provenance = _build_provenance(
+        path,
+        config=config,
+        anchor=anchor,
+        cli_project_overrides=settings.cli_project_overrides,
+    )
     selected_groups = resolve_group_selection(
         path, groups=groups, all_groups=all_groups
     )
     selected_extras = resolve_extra_selection(
         path, extras=extras, all_extras=all_extras
     )
-    strategy_override = (
-        ResolutionStrategy(resolution) if resolution is not None else None
-    )
 
     workspace_to_drop = (
         config.workspace_member_names if no_emit_workspace else frozenset()
     )
 
-    transport = _cli._make_transport(http_backend)  # noqa: SLF001
+    transport = _cli._make_transport(settings.http_backend)  # noqa: SLF001
     if config.mode is ResolveMode.UNIVERSAL:
         _emit_or_exit(
             lambda: _emit_universal(
@@ -146,13 +202,13 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
                 config=config,
                 cache_dir=effective_cache_dir,
                 transport=transport,
-                offline=offline,
+                offline=settings.offline,
                 output=output,
                 format=format,
                 provenance=provenance,
                 groups=selected_groups,
                 extras=selected_extras,
-                resolution_strategy=strategy_override,
+                resolution_strategy=settings.resolution,
                 workspace_to_drop=workspace_to_drop,
             )
         )
@@ -162,13 +218,16 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
         path,
         config=config,
         cache_dir=effective_cache_dir,
-        offline=offline,
+        offline=settings.offline,
         transport=transport,
         failure_prefix="Cannot lock",
         groups=selected_groups,
         extras=selected_extras,
-        resolution_strategy=strategy_override,
+        resolution_strategy=settings.resolution,
     )
+    if locked:
+        _check_locked(result, output=output, workspace_to_drop=workspace_to_drop)
+        return
     _emit_or_exit(
         lambda: _emit_specific(
             result,
@@ -233,6 +292,55 @@ def _emit_specific(
     except _cli.MissingHashError as e:
         sys.stderr.write(f"Cannot lock: {e}\n")
         sys.exit(1)
+
+
+def _packages_only(text: str) -> str:
+    """Re-render lock TOML without the volatile ``[tool.nab]`` block.
+
+    Drops the provenance block (its command line and timestamp change every
+    run) so two locks compare equal whenever their packages, environments,
+    and metadata match.
+    """
+    data = tomli.loads(text)
+    data.pop("tool", None)
+    return tomli_w.dumps(data)
+
+
+def _check_locked(
+    result: ResolutionResult,
+    *,
+    output: Path | None,
+    workspace_to_drop: frozenset[str],
+) -> None:
+    """Verify the committed pylock matches a fresh resolve, writing nothing.
+
+    The resolve has already run; this renders the lock it would produce and
+    compares it to the committed file with the provenance block dropped from
+    both, so only a real change to the locked packages fails.  The committed
+    lock is never read back into the resolve.
+    """
+    lock_input = _drop_workspace_pins(result.lock_input, workspace_to_drop)
+    target = output if output is not None else Path(_cli._DEFAULT_OUTPUT["pylock"])  # noqa: SLF001
+    if not target.exists():
+        sys.stderr.write(
+            f"Error: --locked: no lockfile at {target} to check;"
+            " run `nab lock` first.\n"
+        )
+        sys.exit(1)
+    try:
+        new_text = _cli.render_lock(lock_input, lock_dir=target.parent)
+    except _cli.MissingHashError as e:
+        sys.stderr.write(f"Cannot lock: {e}\n")
+        sys.exit(1)
+    committed = _packages_only(target.read_text(encoding="utf-8"))
+    if _packages_only(new_text) == committed:
+        sys.stderr.write(f"Lockfile {target} is up to date.\n")
+        return
+    sys.stderr.write(
+        f"Error: --locked: lockfile {target} is out of date;"
+        " re-run `nab lock` to update it.\n"
+    )
+    sys.exit(1)
 
 
 def _write_specific(
@@ -632,7 +740,11 @@ def resolve_extra_selection(
 
 
 def _build_provenance(
-    path: Path, *, config: NabProjectConfig, anchor: datetime
+    path: Path,
+    *,
+    config: NabProjectConfig,
+    anchor: datetime,
+    cli_project_overrides: tuple[tuple[str, str], ...] = (),
 ) -> Provenance:
     """Capture the inputs that produced this run for the lockfile.
 
@@ -641,7 +753,8 @@ def _build_provenance(
     ``anchor`` is the timestamp used as ``now`` when resolving relative
     ``P<n>D`` durations on this run.  Recording it as ``created-at``
     lets the next ``nab lock`` reuse the same anchor and reproduce the
-    same cutoff.
+    same cutoff.  ``cli_project_overrides`` records the ``--project-*``
+    overrides passed on this run so the lock is auditable.
     """
     python_specifier: str | None
     platforms: tuple[str, ...]
@@ -660,7 +773,36 @@ def _build_provenance(
         mode=config.mode.value,
         python_specifier=python_specifier,
         platforms=platforms,
+        cli_project_overrides=cli_project_overrides,
     )
+
+
+def _reused_lock_anchor(
+    path: Path,
+    *,
+    output: Path | None,
+    format: str,  # noqa: A002 - shadows builtin by convention
+    cli_overrides: Mapping[str, object] | None = None,
+) -> tuple[datetime | None, datetime | None]:
+    """Return ``(absolute_cutoff, prior_lock_anchor)`` for the re-lock anchor.
+
+    An absolute ``uploaded-prior-to`` fixes the resolve window, so it is the
+    anchor regardless of ``--upgrade``, and two locks from identical inputs
+    produce identical bytes.  ``cli_overrides`` carries a
+    ``--project-uploaded-prior-to`` override so the anchor it produces matches
+    the resolve window.  When there is no absolute cutoff, a ``pylock`` written
+    to a file reuses the ``created-at`` from the existing lock so re-locks
+    reproduce the same cutoff; that recorded timestamp is the only anchor
+    ``--upgrade`` actually drops.  Stdout, the requirements formats, and a
+    first lock have nothing to reuse.
+    """
+    absolute = _cli.lock_anchor(path, cli_overrides)
+    if absolute is not None:
+        return absolute, None
+    if _cli.is_stdout(output) or format != "pylock":
+        return None, None
+    target = output if output is not None else Path(_cli._DEFAULT_OUTPUT[format])  # noqa: SLF001
+    return None, read_lockfile_anchor(target)
 
 
 def _determine_lock_anchor(
@@ -669,41 +811,32 @@ def _determine_lock_anchor(
     output: Path | None,
     format: str,  # noqa: A002 - shadows builtin by convention
     upgrade: bool,
+    cli_overrides: Mapping[str, object] | None = None,
 ) -> datetime:
     """Pick the ``P<n>D`` anchor for ``nab lock``.
 
-    When the project pins an absolute ``uploaded-prior-to``, that timestamp
-    is the anchor: the resolve window is already fixed, so anchoring there
-    makes ``created-at`` deterministic and two locks from identical inputs
-    produce identical bytes. ``--upgrade`` still re-floats to now.
-
-    Otherwise returns ``datetime.now(UTC)`` (a fresh anchor) when:
-
-    - ``--upgrade`` is set: the user is opting into a calendar refresh.
-    - Output is stdout (``-``): there is no file to read back later, so
-      no point preserving an anchor that nothing will reuse.
-    - Format is not ``pylock``: requirements files do not carry the
-      ``[tool.nab]`` block we read the anchor from.
-    - The expected pylock does not exist or has no recorded anchor:
-      first lock or a damaged file.
-
-    Otherwise returns the ``[tool.nab].created-at`` from the existing
-    pylock, so a re-lock against the same project produces the same
-    cutoff for ``P<n>D`` durations.
+    Without ``--upgrade`` the anchor is the cutoff a re-lock reuses: an
+    absolute ``uploaded-prior-to`` cutoff, or the ``created-at`` from an
+    existing pylock, falling back to ``datetime.now(UTC)``.  ``cli_overrides``
+    is forwarded so a ``--project-uploaded-prior-to`` flag pins the anchor.
+    ``--upgrade`` re-anchors to now.  It changes the resolve only when it drops
+    a reused lockfile ``created-at`` (an absolute cutoff still governs the
+    resolve either way), so the notice fires only in that case.
     """
-    fresh = datetime.now(timezone.utc)
+    absolute, prior = _reused_lock_anchor(
+        path, output=output, format=format, cli_overrides=cli_overrides
+    )
     if upgrade:
+        fresh = datetime.now(timezone.utc)
+        if prior is not None:
+            sys.stderr.write(
+                "notice: --upgrade re-anchored the resolve window to"
+                f" {fresh.isoformat()}, dropping the cutoff {prior.isoformat()}"
+                " recorded in the existing lockfile.\n"
+            )
         return fresh
-    absolute = read_pyproject_lock_anchor(path)
-    if absolute is not None:
-        return absolute
-    if _cli.is_stdout(output):
-        return fresh
-    if format != "pylock":
-        return fresh
-    target = output if output is not None else Path(_cli._DEFAULT_OUTPUT[format])  # noqa: SLF001
-    prior = read_lockfile_anchor(target)
-    return prior if prior is not None else fresh
+    reused = absolute if absolute is not None else prior
+    return reused if reused is not None else datetime.now(timezone.utc)
 
 
 def _validate_pylock_output_name(

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -14,8 +14,10 @@ from __future__ import annotations
 
 import os
 import sys
+from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Literal
+from typing import TYPE_CHECKING, Annotated, Literal, NoReturn
 
 import tyro
 from tyro.extras import SubcommandApp
@@ -28,12 +30,30 @@ from nab_python.config import (
     NabProjectConfig,
     read_pyproject_config,
 )
+from nab_python.config_sources import (
+    OPTIONS,
+    EffectiveValue,
+    RejectedLayer,
+    Scope,
+    SourceConfigError,
+    SourceKind,
+    SourceRoots,
+    build_cli_layer,
+    build_cli_overrides,
+    discover_layers,
+    inspector_anchor,
+    project_cli_override_notice,
+    project_cli_override_records,
+    read_env_layer,
+    resolve_config,
+)
 from nab_python.download import download_lock  # noqa: F401 - re-exported for tests
 from nab_python.lockfile import (
     DisjointnessError,  # noqa: F401 - referenced as _cli.DisjointnessError in _lock
     DivergentBaseDependencyError,  # noqa: F401 - referenced via _cli in _lock
     MissingHashError,
     MissingSdistError,
+    render_lock,  # noqa: F401 - referenced as _cli.render_lock in _lock
     write_lock,  # noqa: F401 - re-exported for tests
     write_requirements_with_hashes,  # noqa: F401 - re-exported for tests
     write_requirements_without_hashes,  # noqa: F401 - re-exported for tests
@@ -51,7 +71,7 @@ from nab_python.workspace import WorkspaceDiscoveryError
 from nab_resolver.resolver import ResolutionError
 
 if TYPE_CHECKING:
-    from datetime import datetime
+    from collections.abc import Mapping
 
     from nab_index.transport import AsyncHttpTransport
     from nab_python.provider import ResolutionStrategy
@@ -71,6 +91,11 @@ PathArg = Annotated[Path, tyro.conf.Positional]
 HttpBackend = Literal["urllib3", "httpx"]
 LockFormat = Literal["pylock", "requirements", "requirements-without-hashes"]
 ResolutionFlag = Literal["highest", "lowest", "lowest-direct"]
+ModeFlag = Literal["specific", "universal"]
+DistPolicyFlag = Literal[
+    "wheel-only", "prefer-wheel", "wheel-or-sdist", "sdist-only", "sdist-install"
+]
+BuildPolicyFlag = Literal["never", "build-local", "build-remote"]
 
 _DEFAULT_OUTPUT: dict[str, str] = {
     "pylock": "pylock.toml",
@@ -124,20 +149,258 @@ def _resolve_effective_cache_dir(cache_dir: Path | None, *, cache: bool) -> Path
     return _default_cache_dir()
 
 
-def _load_config(
+def _config_search_roots(pyproject: Path) -> SourceRoots:
+    """Locate the system/user/project config roots for ``pyproject``.
+
+    Uses the same XDG roots as cache-dir: the user ``nab.toml`` lives at
+    ``$XDG_CONFIG_HOME/nab/nab.toml`` or ``~/.config/nab/nab.toml``; the
+    system file at ``/etc/nab/nab.toml``.  Tests inject roots by
+    monkeypatching this function, so the real ``~/.config`` is never
+    touched in the suite.  Discovery is project-dir only.  There is no
+    walk-up.
+
+    ``pyproject`` is the project file the user pointed at, threaded
+    through so the registry's pyproject layer reads that exact file even
+    when its name is not ``pyproject.toml``; the project-dir ``nab.toml``
+    is looked up beside it.  The pyproject root keeps the file's own
+    directory (resolved) rather than resolving the file itself, so a
+    relative ``local-sources`` path resolves against the symlink's
+    directory, matching the resolve path; ``open`` still follows the
+    symlink to read it.
+    """
+    base = os.environ.get("XDG_CONFIG_HOME")
+    user_dir = Path(base) if base else Path.home() / ".config"
+    project_dir = pyproject.parent.resolve()
+    return SourceRoots(
+        system_toml=Path("/etc/nab/nab.toml"),
+        user_toml=user_dir / "nab" / "nab.toml",
+        project_dir=project_dir,
+        pyproject=project_dir / pyproject.name,
+    )
+
+
+def effective_config(
     path: Path,
     *,
-    discover_workspace: bool = True,
-    anchor: datetime | None = None,
-) -> NabProjectConfig:
+    cli_overrides: Mapping[str, object] | None = None,
+    collect_rejected: bool = False,
+    rejected_out: list[RejectedLayer] | None = None,
+) -> dict[str, EffectiveValue]:
+    """Resolve the full layered config for the pyproject at ``path``.
+
+    Discovers the system/user/project TOML layers (roots from
+    :func:`_config_search_roots`), reads the ``NAB_*`` env layer, builds
+    the CLI layer from ``cli_overrides`` (only keys the user set), and
+    merges them through the registry.  Returns the effective map; when
+    ``collect_rejected`` is set the category-rejections are attached per
+    key (``EffectiveValue.rejected``) for ``explain --include-rejected``.
+    ``rejected_out``, when supplied, is filled with the full rejection
+    list so the caller can also surface the orphan rejections (an unknown
+    key or ``NAB_*`` var that names no registry option, and so attaches to
+    no key) that ``nab config list`` reports.
+    """
+    roots = _config_search_roots(path)
+    rejected: list[RejectedLayer] = []
+    sink = rejected if collect_rejected else None
+    # Pin one ``now`` for the pass so identical relative ``P<n>D`` override
+    # durations across the two project files are not read as conflicting
+    # values (the resolve path uses its lockfile anchor instead).
+    with inspector_anchor():
+        layers = discover_layers(roots, rejections=sink)
+        env_layer = read_env_layer(os.environ, rejections=sink)
+        cli_layer = build_cli_layer(cli_overrides or {})
+        if rejected_out is not None:
+            rejected_out.extend(rejected)
+        return resolve_config(layers, env_layer, cli_layer, rejected=rejected)
+
+
+def lock_anchor(
+    path: Path, cli_overrides: Mapping[str, object] | None = None
+) -> datetime | None:
+    """Return the absolute ``uploaded-prior-to`` cutoff for ``nab lock``.
+
+    Sources the cutoff through the same registry ladder the resolve uses
+    (so a value set in the project-dir ``nab.toml`` is honoured exactly
+    like one in pyproject ``[tool.nab]``).  ``cli_overrides`` lets a
+    ``--project-uploaded-prior-to`` flag set the cutoff too, so the lock
+    anchor matches the resolve window the override produces.  An absolute
+    datetime is the lock anchor: the resolve window is already fixed, so
+    anchoring there makes ``created-at`` deterministic and two locks from
+    identical inputs produce identical bytes.  A relative ``P<n>D``
+    duration anchors to run time, so it is not reproducible and returns
+    ``None``; an unset value returns ``None`` too.  Config errors are
+    swallowed here (the full resolve parse reports them) so this
+    best-effort read never crashes.
+    """
+    try:
+        effective = effective_config(path, cli_overrides=cli_overrides)
+    except SourceConfigError:
+        return None
+    value = effective["uploaded-prior-to"].value
+    return value if isinstance(value, datetime) else None
+
+
+@dataclass(frozen=True, slots=True)
+class RunSettings:
+    """The run knobs a subcommand reads from the layered config for one run."""
+
+    resolution: ResolutionStrategy | None
+    offline: bool
+    cache_dir: Path | None
+    http_backend: HttpBackend
+    max_concurrency: int
+    # The (flag, rendered value) pairs for any --project-* override set on
+    # the CLI, recorded into the lockfile provenance so the lock is auditable.
+    cli_project_overrides: tuple[tuple[str, str], ...]
+
+
+def _cli_overrides(  # noqa: PLR0913 - one keyword per CLI flag it maps to a registry key
+    *,
+    cli_resolution: str | None,
+    cli_offline: bool | None,
+    cli_cache_dir: Path | None,
+    cli_http_backend: str | None = None,
+    cli_max_concurrency: int | None = None,
+    cli_mode: str | None = None,
+    cli_requires_python: str | None = None,
+    cli_uploaded_prior_to: str | None = None,
+    cli_dist_policy: str | None = None,
+    cli_build_policy: str | None = None,
+    cli_constraint: tuple[str, ...] = (),
+    cli_default_group: tuple[str, ...] = (),
+) -> dict[str, object]:
+    """Build the registry-keyed CLI override dict from the named flags.
+
+    The one place the ``cli_param`` -> value mapping is written: the run
+    subcommands and ``nab config`` route their flag values through here so
+    the literal lives once.  ``build_cli_overrides`` then keeps only the
+    keys the user actually set.  USER options and the ``--project-*``
+    overrides for the scalar and array PROJECT options pass through; the
+    structured PROJECT tables stay file-only.
+    """
+    return build_cli_overrides(
+        {
+            "project_resolution": cli_resolution,
+            "offline": cli_offline,
+            "cache_dir": cli_cache_dir,
+            "http_backend": cli_http_backend,
+            "max_concurrency": cli_max_concurrency,
+            "project_mode": cli_mode,
+            "project_requires_python": cli_requires_python,
+            "project_uploaded_prior_to": cli_uploaded_prior_to,
+            "project_dist_policy": cli_dist_policy,
+            "project_build_policy": cli_build_policy,
+            "project_constraint": cli_constraint,
+            "project_default_group": cli_default_group,
+        }
+    )
+
+
+def project_config_overrides(
+    cli_overrides: Mapping[str, object],
+) -> dict[str, object]:
+    """Return the PROJECT-scope CLI overrides that belong in the config.
+
+    ``resolution`` is excluded: it keeps its own ``resolution_strategy``
+    path into the resolver, so it must not also enter the merged config.
+    USER options are excluded too (they configure the run, not the project).
+    The rest are the ``--project-*`` overrides the resolve folds in through
+    :func:`config.read_pyproject_config`.
+    """
+    project_keys = {
+        spec.key
+        for spec in OPTIONS
+        if spec.scope is Scope.PROJECT and spec.key != "resolution"
+    }
+    return {key: value for key, value in cli_overrides.items() if key in project_keys}
+
+
+def _layered_run_settings(
+    path: Path, cli_overrides: Mapping[str, object]
+) -> tuple[RunSettings, Mapping[str, EffectiveValue]]:
+    """Fold the layered registry values into a subcommand's run knobs.
+
+    Returns the :class:`RunSettings` reflecting the full ladder, plus the
+    effective map so the caller can emit the reproducibility notice for a
+    CLI PROJECT override.  ``resolution`` stays ``None`` (config wins
+    downstream) when no source above the default set it, preserving the
+    contract that the resolver falls back to ``config.resolution``.
+    """
+    effective = effective_config(path, cli_overrides=cli_overrides)
+    res_ev = effective["resolution"]
+    resolution = res_ev.value if res_ev.origin.kind is not SourceKind.DEFAULT else None
+    settings = RunSettings(
+        resolution=resolution,
+        offline=effective["offline"].value,
+        cache_dir=effective["cache-dir"].value,
+        http_backend=effective["http-backend"].value,
+        max_concurrency=effective["max-concurrency"].value,
+        cli_project_overrides=project_cli_override_records(effective),
+    )
+    return settings, effective
+
+
+def _layered_run_settings_or_exit(
+    path: Path,
+    cli_overrides: Mapping[str, object],
+    *,
+    produces_lock: bool = True,
+) -> RunSettings:
+    """Fold the layered run settings, exiting on a category error.
+
+    Wraps :func:`_layered_run_settings` with the single
+    ``SourceConfigError`` -> ``Config error: ...`` -> ``exit(1)`` mapping
+    shared by ``nab lock`` and ``nab download``.  On success it also emits
+    the reproducibility notice when a PROJECT option was set on the CLI,
+    so a result-shaping override is never silent.  ``produces_lock`` picks
+    the wording: ``nab lock`` warns about the lock it produces while ``nab
+    download`` (which writes no lock) warns only that the resolved set
+    reflects the override.
+    """
+    try:
+        settings, effective = _layered_run_settings(path, cli_overrides)
+    except SourceConfigError as exc:
+        _fail_config(exc)
+    notice = project_cli_override_notice(effective, produces_lock=produces_lock)
+    if notice is not None:
+        sys.stderr.write(notice)
+    return settings
+
+
+def _fail_config(exc: SourceConfigError) -> NoReturn:
+    """Map a layered config error to the shared ``Config error:`` exit."""
+    sys.stderr.write(f"Config error: {exc}\n")
+    sys.exit(1)
+
+
+def _require_pyproject_file(path: Path) -> None:
+    """Exit 1 if ``path`` is not a readable pyproject file.
+
+    Shared by ``_load_config`` (the run path) and ``nab config`` so the
+    not-found/directory wording lives in one place.  A missing or
+    directory ``--path`` is a hard error, not a silently-skipped source.
+    """
     if not path.is_file():
         reason = "is a directory" if path.is_dir() else "not found"
         sys.stderr.write(f"Error: {path} {reason}\n")
         sys.exit(1)
 
+
+def _load_config(
+    path: Path,
+    *,
+    discover_workspace: bool = True,
+    anchor: datetime | None = None,
+    cli_overrides: Mapping[str, object] | None = None,
+) -> NabProjectConfig:
+    _require_pyproject_file(path)
+
     try:
         return read_pyproject_config(
-            path, discover_workspace=discover_workspace, anchor=anchor
+            path,
+            discover_workspace=discover_workspace,
+            anchor=anchor,
+            cli_overrides=cli_overrides,
         )
     except ConfigError as exc:
         sys.stderr.write(f"Error in [tool.nab]: {exc}\n")
@@ -292,6 +555,7 @@ def _print_universal_blocks(result: UniversalResult) -> None:
 # Side-effect imports: each module's @app.command decorators register the
 # subcommand.  Placed at the bottom so helpers above bind before
 # nab._lock / nab._download import back from this module.
+from . import _config_cmd as _config_module  # noqa: E402, F401 - side-effect
 from . import _download as _download_module  # noqa: E402, F401 - side-effect
 from . import _lock as _lock_module  # noqa: E402, F401 - side-effect
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,7 @@ from nab_index.urllib3_async_transport import Urllib3AsyncTransport
 from nab_python._vendor.packaging.pylock import Pylock
 from nab_python._vendor.packaging.version import Version
 from nab_python.config import ConfigError
+from nab_python.config_sources import SourceRoots
 from nab_python.download import DownloadError
 from nab_python.lockfile import (
     DisjointnessError,
@@ -568,18 +569,18 @@ class TestLockCommandSpecific:
         assert "cannot write output" in capsys.readouterr().err
 
     def test_resolution_flag_threads_to_resolver(self, tmp_path: Path) -> None:
-        """``--resolution lowest`` reaches resolve_pyproject as the enum."""
+        """``--project-resolution lowest`` reaches resolve_pyproject as the enum."""
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "pylock.toml"
         with patch(
             "nab.cli.resolve_pyproject", return_value=_stub_resolution_result()
         ) as mock_resolve:
-            lock(pyproject, output=out, resolution="lowest")
+            lock(pyproject, output=out, project_resolution="lowest")
         kwargs = mock_resolve.call_args.kwargs
         assert kwargs["resolution_strategy"] is ResolutionStrategy.LOWEST
 
     def test_resolution_flag_default_none(self, tmp_path: Path) -> None:
-        """No --resolution: resolve_pyproject sees ``None`` (config wins)."""
+        """No --project-resolution: resolve_pyproject sees ``None`` (config wins)."""
         pyproject = _make_pyproject(tmp_path)
         out = tmp_path / "pylock.toml"
         with patch(
@@ -587,6 +588,120 @@ class TestLockCommandSpecific:
         ) as mock_resolve:
             lock(pyproject, output=out)
         assert mock_resolve.call_args.kwargs["resolution_strategy"] is None
+
+    def test_cli_project_override_prints_notice(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A CLI PROJECT override on ``nab lock`` is surfaced on stderr."""
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        monkeypatch.setattr(
+            "nab.cli._config_search_roots",
+            lambda p: SourceRoots(project_dir=p.parent, pyproject=p),
+        )
+        with patch("nab.cli.resolve_pyproject", return_value=_stub_resolution_result()):
+            lock(pyproject, output=out, project_resolution="lowest")
+        err = capsys.readouterr().err
+        assert "does not derive from the committed" in err
+        assert "--project-resolution -> lowest" in err
+
+    def test_no_cli_project_override_prints_no_notice(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """No CLI PROJECT override: no reproducibility notice."""
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        monkeypatch.setattr(
+            "nab.cli._config_search_roots",
+            lambda p: SourceRoots(project_dir=p.parent, pyproject=p),
+        )
+        with patch("nab.cli.resolve_pyproject", return_value=_stub_resolution_result()):
+            lock(pyproject, output=out)
+        assert "does not derive from the committed" not in capsys.readouterr().err
+
+    def test_config_layer_error_exits(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A cross-file conflict exits 1 via the shared [tool.nab] map."""
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\ndependencies = ["foo"]\n[tool.nab]\nresolution = "highest"\n',
+        )
+        (tmp_path / "nab.toml").write_text('resolution = "lowest"\n')
+        out = tmp_path / "pylock.toml"
+        monkeypatch.setattr(
+            "nab.cli._config_search_roots",
+            lambda p: SourceRoots(project_dir=p.parent, pyproject=p),
+        )
+        with (
+            patch("nab.cli.resolve_pyproject", return_value=_stub_resolution_result()),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, output=out)
+        # The merged config now sources every PROJECT key from the registry
+        # ladder, so a cross-file conflict surfaces while loading the config
+        # (the shared [tool.nab] error map) rather than later in the
+        # run-settings fold.
+        err = capsys.readouterr().err
+        assert "Error in [tool.nab]:" in err
+        assert "conflicting values" in err
+
+    def test_standalone_nab_toml_malformed_exits(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A malformed standalone user nab.toml exits 1, not a traceback."""
+        pyproject = _make_pyproject(tmp_path)
+        user = tmp_path / "usr" / "nab" / "nab.toml"
+        user.parent.mkdir(parents=True)
+        user.write_text("offline = \n")
+        out = tmp_path / "pylock.toml"
+        monkeypatch.setattr(
+            "nab.cli._config_search_roots",
+            lambda p: SourceRoots(user_toml=user, project_dir=p.parent, pyproject=p),
+        )
+        with (
+            patch("nab.cli.resolve_pyproject", return_value=_stub_resolution_result()),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, output=out)
+        assert "Config error:" in capsys.readouterr().err
+
+    def test_standalone_nab_toml_unknown_key_exits(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An unknown key in a standalone user nab.toml exits 1, not a traceback."""
+        pyproject = _make_pyproject(tmp_path)
+        user = tmp_path / "usr" / "nab" / "nab.toml"
+        user.parent.mkdir(parents=True)
+        user.write_text("typoo = 1\n")
+        out = tmp_path / "pylock.toml"
+        monkeypatch.setattr(
+            "nab.cli._config_search_roots",
+            lambda p: SourceRoots(user_toml=user, project_dir=p.parent, pyproject=p),
+        )
+        with (
+            patch("nab.cli.resolve_pyproject", return_value=_stub_resolution_result()),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, output=out)
+        err = capsys.readouterr().err
+        assert "Config error:" in err
+        assert "typoo" in err
 
 
 class TestLockCommandUniversal:
@@ -1852,6 +1967,52 @@ class TestDetermineLockAnchor:
         assert anchor != self._RECORDED
         assert (datetime.now(timezone.utc) - anchor).total_seconds() < 60
 
+    def test_upgrade_notices_when_it_drops_a_cutoff(self, tmp_path: Path) -> None:
+        # Re-anchoring over a reusable cutoff changes the resolve window, so
+        # --upgrade names the cutoff it dropped instead of doing it silently.
+        target = tmp_path / "pylock.toml"
+        self._write_prior(target)
+        pyproject = _make_pyproject(tmp_path)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            _determine_lock_anchor(
+                pyproject, output=target, format="pylock", upgrade=True
+            )
+        notice = err.getvalue()
+        assert "--upgrade re-anchored" in notice
+        assert self._RECORDED.isoformat() in notice
+
+    def test_upgrade_silent_on_fresh_lock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # With nothing to reuse, --upgrade has no window to drop, so no notice.
+        monkeypatch.chdir(tmp_path)
+        pyproject = _make_pyproject(tmp_path)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            _determine_lock_anchor(
+                pyproject, output=None, format="pylock", upgrade=True
+            )
+        assert err.getvalue() == ""
+
+    def test_upgrade_silent_for_absolute_cutoff(self, tmp_path: Path) -> None:
+        # An absolute uploaded-prior-to governs the resolve regardless of
+        # --upgrade, so --upgrade does not drop it and prints no notice.
+        target = tmp_path / "pylock.toml"
+        self._write_prior(target)
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\ndependencies = ["foo"]\n'
+            f'[tool.nab]\nuploaded-prior-to = "{self._ABSOLUTE.isoformat()}"\n',
+        )
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            anchor = _determine_lock_anchor(
+                pyproject, output=target, format="pylock", upgrade=True
+            )
+        assert err.getvalue() == ""
+        assert (datetime.now(timezone.utc) - anchor).total_seconds() < 60
+
     def test_stdout_returns_fresh(self, tmp_path: Path) -> None:
         pyproject = _make_pyproject(tmp_path)
         anchor = _determine_lock_anchor(
@@ -1914,6 +2075,49 @@ class TestDetermineLockAnchor:
             pyproject, output=target, format="pylock", upgrade=False
         )
         assert anchor == self._ABSOLUTE
+
+    def test_absolute_cutoff_from_project_nab_toml_is_the_anchor(
+        self, tmp_path: Path
+    ) -> None:
+        # An absolute cutoff set in the project-dir nab.toml (not pyproject)
+        # must pin the anchor too: the resolve honours it, so the lock must.
+        target = tmp_path / "pylock.toml"
+        self._write_prior(target)
+        pyproject = _make_pyproject(tmp_path)
+        (tmp_path / "nab.toml").write_text(
+            f'uploaded-prior-to = "{self._ABSOLUTE.isoformat()}"\n'
+        )
+        anchor = _determine_lock_anchor(
+            pyproject, output=target, format="pylock", upgrade=False
+        )
+        assert anchor == self._ABSOLUTE
+
+    def test_invalid_config_falls_through_to_prior(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A category-gated value (uploaded-prior-to in a USER source) makes
+        # the best-effort anchor read raise SourceConfigError; it is
+        # swallowed so the full resolve parse reports it, and the anchor
+        # falls through to the prior lock.
+        target = tmp_path / "pylock.toml"
+        self._write_prior(target)
+        pyproject = _make_pyproject(tmp_path)
+        user_toml = tmp_path / "user.toml"
+        user_toml.write_text(f'uploaded-prior-to = "{self._ABSOLUTE.isoformat()}"\n')
+
+        def fake_roots(p: Path) -> SourceRoots:
+            return SourceRoots(
+                system_toml=None,
+                user_toml=user_toml,
+                project_dir=p.parent.resolve(),
+                pyproject=p.resolve(),
+            )
+
+        monkeypatch.setattr("nab.cli._config_search_roots", fake_roots)
+        anchor = _determine_lock_anchor(
+            pyproject, output=target, format="pylock", upgrade=False
+        )
+        assert anchor == self._RECORDED
 
     def test_absolute_cutoff_ignored_under_upgrade(self, tmp_path: Path) -> None:
         pyproject = _make_pyproject(
@@ -1993,6 +2197,234 @@ class TestLockAnchorReuse:
         from nab_python.lockfile import read_lockfile_anchor
 
         assert read_lockfile_anchor(out) == absolute
+
+
+def _hashed_pin(version: str, name: str, *, sha: str) -> IndexPin:
+    """Like ``_foo_index_pin`` but with caller-chosen artifact hashes."""
+    return IndexPin(
+        name=name,
+        version=version,
+        index="pypi",
+        sdist=SdistArtifact(
+            filename=f"{name}-{version}.tar.gz",
+            url=f"https://example.com/{name}-{version}.tar.gz",
+            hashes=(("sha256", sha),),
+        ),
+        wheels=(
+            WheelArtifact(
+                filename=f"{name}-{version}-py3-none-any.whl",
+                url=f"https://example.com/{name}-{version}-py3-none-any.whl",
+                hashes=(("sha256", sha),),
+            ),
+        ),
+    )
+
+
+class TestLockedFlag:
+    """``nab lock --locked`` re-resolves and verifies the committed pylock."""
+
+    def _write_lock(self, pyproject: Path, out: Path, result: ResolutionResult) -> None:
+        with patch("nab.cli.resolve_pyproject", return_value=result):
+            app.cli(args=["lock", str(pyproject), "--output", str(out)], prog="nab")
+
+    def _run_locked(self, pyproject: Path, out: Path, result: ResolutionResult) -> None:
+        with patch("nab.cli.resolve_pyproject", return_value=result):
+            app.cli(
+                args=["lock", str(pyproject), "--output", str(out), "--locked"],
+                prog="nab",
+            )
+
+    def test_up_to_date_exits_zero_without_writing(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        self._write_lock(
+            pyproject, out, _stub_resolution_result(pins={"foo": V("1.0")})
+        )
+        capsys.readouterr()
+        before = out.read_bytes()
+        self._run_locked(
+            pyproject, out, _stub_resolution_result(pins={"foo": V("1.0")})
+        )
+        assert "is up to date" in capsys.readouterr().err
+        assert out.read_bytes() == before
+
+    def test_out_of_date_version_exits_one_without_writing(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        self._write_lock(
+            pyproject, out, _stub_resolution_result(pins={"foo": V("1.0")})
+        )
+        capsys.readouterr()
+        before = out.read_bytes()
+        with pytest.raises(SystemExit) as exc:
+            self._run_locked(
+                pyproject, out, _stub_resolution_result(pins={"foo": V("2.0")})
+            )
+        assert exc.value.code == 1
+        assert "out of date" in capsys.readouterr().err
+        assert out.read_bytes() == before
+
+    def test_out_of_date_hash_change_exits_one(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Same version, different artifact hash: the compare looks past the
+        # version, so a re-upload is still caught.
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        first = ResolutionResult(
+            pins={"foo": V("1.0")},
+            lock_input=LockInput(pins={"foo": _hashed_pin("1.0", "foo", sha="a" * 64)}),
+        )
+        self._write_lock(pyproject, out, first)
+        capsys.readouterr()
+        changed = ResolutionResult(
+            pins={"foo": V("1.0")},
+            lock_input=LockInput(pins={"foo": _hashed_pin("1.0", "foo", sha="c" * 64)}),
+        )
+        with pytest.raises(SystemExit) as exc:
+            self._run_locked(pyproject, out, changed)
+        assert exc.value.code == 1
+        assert "out of date" in capsys.readouterr().err
+
+    def test_missing_lockfile_exits_one(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with pytest.raises(SystemExit) as exc:
+            self._run_locked(pyproject, out, _stub_resolution_result())
+        assert exc.value.code == 1
+        assert "no lockfile" in capsys.readouterr().err
+
+    def test_unhashable_pin_during_render_exits_one(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # A pin that cannot be hashed makes the render fail; --locked reports
+        # it and exits without touching the committed lock, like a normal lock.
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        self._write_lock(
+            pyproject, out, _stub_resolution_result(pins={"foo": V("1.0")})
+        )
+        capsys.readouterr()
+        before = out.read_bytes()
+        with (
+            patch(
+                "nab.cli.resolve_pyproject",
+                return_value=_stub_resolution_result(pins={"foo": V("1.0")}),
+            ),
+            patch("nab.cli.render_lock", side_effect=MissingHashError("no hash")),
+            pytest.raises(SystemExit) as exc,
+        ):
+            app.cli(
+                args=["lock", str(pyproject), "--output", str(out), "--locked"],
+                prog="nab",
+            )
+        assert exc.value.code == 1
+        assert "Cannot lock" in capsys.readouterr().err
+        assert out.read_bytes() == before
+
+    def test_requirements_format_unsupported(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "requirements.txt"
+        with pytest.raises(SystemExit) as exc:
+            app.cli(
+                args=[
+                    "lock",
+                    str(pyproject),
+                    "--output",
+                    str(out),
+                    "--format",
+                    "requirements",
+                    "--locked",
+                ],
+                prog="nab",
+            )
+        assert exc.value.code == 1
+        assert "only supported for pylock" in capsys.readouterr().err
+        assert not out.exists()
+
+    def test_stdout_unsupported(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        with pytest.raises(SystemExit) as exc:
+            app.cli(
+                args=["lock", str(pyproject), "--output", "-", "--locked"], prog="nab"
+            )
+        assert exc.value.code == 1
+        assert "only supported for pylock" in capsys.readouterr().err
+
+    def test_universal_unsupported(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with pytest.raises(SystemExit) as exc:
+            app.cli(
+                args=["lock", str(pyproject), "--output", str(out), "--locked"],
+                prog="nab",
+            )
+        assert exc.value.code == 1
+        assert "not supported in universal mode" in capsys.readouterr().err
+        assert not out.exists()
+
+    def test_local_source_paths_do_not_false_mismatch(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # A relative local-source path is emitted relative to the lock dir on
+        # both passes, so an unchanged project stays up to date.
+        (tmp_path / "vendor").mkdir()
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\ndependencies = ["foo"]\n'
+            "[[tool.nab.local-sources]]\n"
+            'name = "foo"\npath = "vendor"\n',
+        )
+        out = tmp_path / "pylock.toml"
+        result = _stub_resolution_result(pins={"foo": V("1.0")})
+        self._write_lock(pyproject, out, result)
+        capsys.readouterr()
+        self._run_locked(
+            pyproject, out, _stub_resolution_result(pins={"foo": V("1.0")})
+        )
+        assert "is up to date" in capsys.readouterr().err
+
+
+class TestLockProvenanceCliOverrides:
+    """A --project-* CLI override is recorded in the lockfile provenance."""
+
+    def test_cli_override_recorded_in_pylock(self, tmp_path: Path) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with patch("nab.cli.resolve_pyproject", return_value=_stub_resolution_result()):
+            app.cli(
+                args=[
+                    "lock",
+                    str(pyproject),
+                    "--output",
+                    str(out),
+                    "--project-resolution",
+                    "lowest",
+                ],
+                prog="nab",
+            )
+        block = tomli.loads(out.read_text())["tool"]["nab"]
+        assert block["cli-project-overrides"] == ["--project-resolution=lowest"]
+
+    def test_no_cli_override_omits_key(self, tmp_path: Path) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with patch("nab.cli.resolve_pyproject", return_value=_stub_resolution_result()):
+            app.cli(args=["lock", str(pyproject), "--output", str(out)], prog="nab")
+        block = tomli.loads(out.read_text())["tool"]["nab"]
+        assert "cli-project-overrides" not in block
 
 
 class TestGroupAndExtraSelection:
@@ -2277,6 +2709,112 @@ class TestHelpText:
         assert "--no-cache" in help_text
 
 
+class TestOfflineFlagContract:
+    """Pin the tyro argv contract for the tri-state ``--offline`` flag.
+
+    ``offline`` is layered (env / nab.toml may set it) and the CLI is the
+    top rung, so the flag has to distinguish ``--offline True`` /
+    ``--offline False`` from being absent (``None``, let the lower layers
+    decide).  tyro renders that tri-state as a value-taking choice rather
+    than an ``--offline`` / ``--no-offline`` pair; these tests lock that
+    surface so it cannot drift unnoticed.
+    """
+
+    def test_offline_renders_as_tristate_choice(self) -> None:
+        help_text = _command_help("lock")
+        assert "--offline {None,True,False}" in help_text
+
+    def _run_offline_argv(self, tmp_path: Path, value: str) -> object:
+        pyproject = _make_pyproject(tmp_path)
+        with (
+            patch(
+                "nab.cli.resolve_pyproject",
+                return_value=_stub_resolution_result(pins={}),
+            ) as mock_resolve,
+            patch("nab.cli.write_lock"),
+        ):
+            app.cli(
+                args=[
+                    "lock",
+                    str(pyproject),
+                    "--offline",
+                    value,
+                    "--output",
+                    str(tmp_path / "pylock.toml"),
+                ],
+                prog="nab",
+            )
+        return mock_resolve.call_args.kwargs["offline"]
+
+    def test_offline_true_parses(self, tmp_path: Path) -> None:
+        assert self._run_offline_argv(tmp_path, "True") is True
+
+    def test_offline_false_parses(self, tmp_path: Path) -> None:
+        assert self._run_offline_argv(tmp_path, "False") is False
+
+    def test_bare_offline_without_value_exits_2(self, tmp_path: Path) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        with (
+            contextlib.redirect_stderr(io.StringIO()),
+            pytest.raises(SystemExit) as exc,
+        ):
+            app.cli(args=["lock", str(pyproject), "--offline"], prog="nab")
+        assert exc.value.code == 2
+
+
+class TestLayeredRunKnobFlagContract:
+    """Pin the tyro argv contract for the layered USER run knobs.
+
+    ``http-backend`` and ``max-concurrency`` are layered (env / nab.toml may
+    set them), so each CLI flag is tri-state: a value distinguishes an
+    explicit override from being absent (``None``, let the lower layers
+    decide).  These tests lock how tyro renders that so it cannot drift.
+    """
+
+    def test_http_backend_renders_as_tristate_choice(self) -> None:
+        for command in ("lock", "download", "config"):
+            assert "--http-backend {None,urllib3,httpx}" in _command_help(command)
+
+    def test_max_concurrency_renders_as_tristate_value(self) -> None:
+        for command in ("download", "config"):
+            assert "--max-concurrency {None}|INT" in _command_help(command)
+
+    def test_project_scalar_override_renders_choices(self) -> None:
+        for command in ("lock", "download", "config"):
+            help_text = _command_help(command)
+            assert "--project-mode {None,specific,universal}" in help_text
+            assert "--project-build-policy {None,never,build-local,build-remote}" in (
+                help_text
+            )
+
+    def test_project_array_override_is_repeatable_single_value(self) -> None:
+        for command in ("lock", "download", "config"):
+            assert "--project-constraint STR" in _command_help(command)
+
+    def test_http_backend_value_reaches_transport(self, tmp_path: Path) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        with (
+            patch(
+                "nab.cli.resolve_pyproject",
+                return_value=_stub_resolution_result(pins={}),
+            ),
+            patch("nab.cli.write_lock"),
+            patch("nab.cli._make_transport") as mock_transport,
+        ):
+            app.cli(
+                args=[
+                    "lock",
+                    str(pyproject),
+                    "--http-backend",
+                    "httpx",
+                    "--output",
+                    str(tmp_path / "pylock.toml"),
+                ],
+                prog="nab",
+            )
+        assert mock_transport.call_args.args[0] == "httpx"
+
+
 class TestPackageVersion:
     """Tests for nab._version.__version__ and the python -m nab entry point."""
 
@@ -2404,6 +2942,30 @@ class TestDownloadCommand:
         ):
             download(pyproject, output=out)
         mock_dl.assert_called_once()
+
+    def test_project_override_uses_download_wording(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A CLI PROJECT override on ``nab download`` uses the no-lock wording."""
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "vendor"
+        download_result = MagicMock(written=(out / "x.whl",), skipped=())
+        monkeypatch.setattr(
+            "nab.cli._config_search_roots",
+            lambda p: SourceRoots(project_dir=p.parent, pyproject=p),
+        )
+        with (
+            patch("nab.cli.resolve_pyproject", return_value=_stub_resolution_result()),
+            patch("nab.cli.download_lock", return_value=download_result),
+        ):
+            download(pyproject, output=out, project_resolution="lowest")
+        err = capsys.readouterr().err
+        assert "the values below reflect that override" in err
+        assert "the lock they produce" not in err
+        assert "--project-resolution -> lowest" in err
 
     def test_universal_mode_downloads_all_tuples(self, tmp_path: Path) -> None:
         """Universal mode re-resolves the matrix and downloads the union."""

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -1,0 +1,940 @@
+"""Tests for the ``nab config`` subcommand and the tyro conformance gate.
+
+The config command is the read-only inspector over the layered registry.
+These tests drive it through tyro's ``app.cli`` (so the real flag surface
+is exercised) with injected search roots, and assert the tyro CLI surface
+matches the registry one-for-one (the conformance test that guards the
+one place the CLI surface is not registry-derived: tyro deriving flags
+from a function signature).  They also pin
+the ``--resolution`` -> ``--project-resolution`` rename, the lock-ladder
+config-error exit, and a byte-identical no-op lock at defaults.
+"""
+
+from __future__ import annotations
+
+import inspect
+import io
+from collections.abc import Mapping
+from contextlib import redirect_stderr, redirect_stdout, suppress
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import nab._config_cmd as config_cmd
+from nab import cli as nab_cli
+from nab._config_cmd import config_command
+from nab._download import download
+from nab._lock import lock
+from nab.cli import app, effective_config
+from nab_python._vendor.packaging.version import Version
+from nab_python.config import NabProjectConfig
+from nab_python.config_sources import OPTIONS, SourceRoots
+from nab_python.lockfile import (
+    IndexPin,
+    LockInput,
+    SdistArtifact,
+    WheelArtifact,
+    read_lockfile_anchor,
+)
+from nab_python.provider import DistPolicy, ResolutionStrategy
+from nab_python.resolve import ResolutionResult
+
+
+def _write(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    return path
+
+
+def _project(tmp_path: Path, tool_nab: str = "") -> Path:
+    body = '[project]\nname = "x"\nversion = "0"\ndependencies = []\n'
+    if tool_nab:
+        body += f"[tool.nab]\n{tool_nab}"
+    return _write(tmp_path / "pyproject.toml", body)
+
+
+def _stub_resolution_result() -> ResolutionResult:
+    pin = IndexPin(
+        name="foo",
+        version="1.0",
+        index="pypi",
+        sdist=SdistArtifact(
+            filename="foo-1.0.tar.gz",
+            url="https://example.com/foo-1.0.tar.gz",
+            hashes=(("sha256", "b" * 64),),
+        ),
+        wheels=(
+            WheelArtifact(
+                filename="foo-1.0-py3-none-any.whl",
+                url="https://example.com/foo-1.0-py3-none-any.whl",
+                hashes=(("sha256", "a" * 64),),
+            ),
+        ),
+    )
+    return ResolutionResult(
+        pins={"foo": Version("1.0")}, lock_input=LockInput(pins={"foo": pin})
+    )
+
+
+@pytest.fixture
+def hermetic_roots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point config discovery at a tmp system/user/project tree.
+
+    Returns the project dir.  The system/user files live elsewhere under
+    tmp so a test can write them; nothing reads the real ~/.config.
+    """
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+
+    def fake_roots(_: Path) -> SourceRoots:
+        return SourceRoots(
+            system_toml=tmp_path / "sys" / "nab.toml",
+            user_toml=tmp_path / "usr" / "nab.toml",
+            project_dir=project_dir,
+        )
+
+    monkeypatch.setattr(nab_cli, "_config_search_roots", fake_roots)
+    monkeypatch.delenv("NAB_OFFLINE", raising=False)
+    monkeypatch.delenv("NAB_CACHE_DIR", raising=False)
+    monkeypatch.delenv("NAB_RESOLUTION", raising=False)
+    return project_dir
+
+
+def _run_config(args: list[str]) -> str:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        app.cli(args=["config", *args], prog="nab")
+    return buf.getvalue()
+
+
+def test_config_search_roots_uses_symlink_dir_not_target(tmp_path: Path) -> None:
+    # A symlinked pyproject keeps the symlink's own directory as the
+    # local-sources base, matching the resolve path (not the target's dir).
+    real = tmp_path / "real"
+    real.mkdir()
+    (real / "pyproject.toml").write_text('[project]\nname = "x"\n')
+    link_dir = tmp_path / "link"
+    link_dir.mkdir()
+    link = link_dir / "pyproject.toml"
+    try:
+        link.symlink_to(real / "pyproject.toml")
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform")
+    roots = nab_cli._config_search_roots(link)
+    assert roots.project_dir == link_dir.resolve()
+    assert roots.pyproject == link_dir.resolve() / "pyproject.toml"
+
+
+class TestConfigList:
+    def test_list_shows_all_options(self, hermetic_roots: Path) -> None:
+        _project(hermetic_roots, 'resolution = "lowest"\n')
+        out = _run_config(["list", "--path", str(hermetic_roots / "pyproject.toml")])
+        assert "resolution" in out
+        assert "lowest" in out
+        assert "offline" in out
+        assert "cache-dir" in out
+
+
+class TestConfigGet:
+    def test_get_value(self, hermetic_roots: Path) -> None:
+        _project(hermetic_roots)
+        out = _run_config(
+            ["get", "offline", "--path", str(hermetic_roots / "pyproject.toml")]
+        )
+        assert out == "false\n"
+
+    def test_get_http_backend_and_max_concurrency_defaults(
+        self, hermetic_roots: Path
+    ) -> None:
+        _project(hermetic_roots)
+        base = ["--path", str(hermetic_roots / "pyproject.toml")]
+        assert _run_config(["get", "http-backend", *base]) == "urllib3\n"
+        assert _run_config(["get", "max-concurrency", *base]) == "8\n"
+
+    def test_get_reads_new_user_env_vars(
+        self, hermetic_roots: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _project(hermetic_roots)
+        monkeypatch.setenv("NAB_HTTP_BACKEND", "httpx")
+        monkeypatch.setenv("NAB_MAX_CONCURRENCY", "5")
+        base = ["--path", str(hermetic_roots / "pyproject.toml")]
+        assert _run_config(["get", "http-backend", *base]) == "httpx\n"
+        assert _run_config(["get", "max-concurrency", *base]) == "5\n"
+
+    def test_list_shows_new_user_knobs(self, hermetic_roots: Path) -> None:
+        _project(hermetic_roots)
+        out = _run_config(["list", "--path", str(hermetic_roots / "pyproject.toml")])
+        assert "http-backend" in out
+        assert "max-concurrency" in out
+
+    def test_get_requires_key(self, hermetic_roots: Path) -> None:
+        _project(hermetic_roots)
+        with pytest.raises(SystemExit):
+            _run_config(["get", "--path", str(hermetic_roots / "pyproject.toml")])
+
+    def test_get_unknown_key_exits(
+        self, hermetic_roots: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _project(hermetic_roots)
+        with pytest.raises(SystemExit):
+            config_command("get", "bogus", path=hermetic_roots / "pyproject.toml")
+        assert "unknown config key" in capsys.readouterr().err
+
+
+class TestConfigExplain:
+    def test_explain_resolution_stack(self, hermetic_roots: Path) -> None:
+        _project(hermetic_roots, 'resolution = "lowest"\n')
+        out = _run_config(
+            [
+                "explain",
+                "resolution",
+                "--path",
+                str(hermetic_roots / "pyproject.toml"),
+                "--project-resolution",
+                "highest",
+            ]
+        )
+        assert out.splitlines()[0].startswith("resolution (project,")
+        assert any(line.startswith(">") for line in out.splitlines())
+        assert "shadowed" in out
+
+    def test_explain_requires_key(self, hermetic_roots: Path) -> None:
+        _project(hermetic_roots)
+        with pytest.raises(SystemExit):
+            _run_config(["explain", "--path", str(hermetic_roots / "pyproject.toml")])
+
+    def test_explain_include_rejected(
+        self, hermetic_roots: Path, tmp_path: Path
+    ) -> None:
+        _project(hermetic_roots, 'resolution = "lowest"\n')
+        _write(tmp_path / "usr" / "nab.toml", 'resolution = "highest"\n')
+        out = _run_config(
+            [
+                "explain",
+                "resolution",
+                "--include-rejected",
+                "--path",
+                str(hermetic_roots / "pyproject.toml"),
+            ]
+        )
+        assert "rejected" in out
+
+    def test_explain_include_rejected_records_renamed_env(
+        self, hermetic_roots: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # NAB_RESOLUTION (a renamed PROJECT name) crashes a real run, but
+        # explain --include-rejected records the env layer instead.
+        _project(hermetic_roots, 'resolution = "lowest"\n')
+        monkeypatch.setenv("NAB_RESOLUTION", "highest")
+        out = _run_config(
+            [
+                "explain",
+                "resolution",
+                "--include-rejected",
+                "--path",
+                str(hermetic_roots / "pyproject.toml"),
+            ]
+        )
+        assert "rejected" in out
+        assert "NAB_RESOLUTION" in out
+
+    def test_explain_include_rejected_records_unknown_env(
+        self, hermetic_roots: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _project(hermetic_roots)
+        monkeypatch.setenv("NAB_OFLINE", "1")
+        out = _run_config(
+            [
+                "explain",
+                "offline",
+                "--include-rejected",
+                "--path",
+                str(hermetic_roots / "pyproject.toml"),
+            ]
+        )
+        # An unknown NAB_* var no longer crashes the inspector.
+        assert "offline (user" in out
+
+    def test_list_include_rejected_surfaces_unknown_env(
+        self, hermetic_roots: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # An unknown NAB_* var attaches to no option, so explain cannot
+        # reach it; `nab config list --include-rejected` surfaces it.
+        _project(hermetic_roots)
+        monkeypatch.setenv("NAB_OFLINE", "1")
+        out = _run_config(
+            [
+                "list",
+                "--include-rejected",
+                "--path",
+                str(hermetic_roots / "pyproject.toml"),
+            ]
+        )
+        assert "rejected:" in out
+        assert "NAB_OFLINE" in out
+
+    def test_list_include_rejected_surfaces_known_key_gate(
+        self, hermetic_roots: Path
+    ) -> None:
+        # A PROJECT key set in a user nab.toml attaches to its option, so it
+        # is reachable from explain; `list --include-rejected` lists it too.
+        _project(hermetic_roots)
+        _write(hermetic_roots.parent / "usr" / "nab.toml", 'resolution = "lowest"\n')
+        out = _run_config(
+            [
+                "list",
+                "--include-rejected",
+                "--path",
+                str(hermetic_roots / "pyproject.toml"),
+            ]
+        )
+        assert "rejected:" in out
+        assert "resolution" in out
+
+    def test_list_reports_unknown_pyproject_key(self, hermetic_roots: Path) -> None:
+        # The inspector reports a typo'd [tool.nab] key the resolve would
+        # reject, rather than silently accepting it.
+        _project(hermetic_roots, 'resolutionn = "lowest"\n')
+        err = io.StringIO()
+        with redirect_stderr(err), pytest.raises(SystemExit) as exc:
+            _run_config(["list", "--path", str(hermetic_roots / "pyproject.toml")])
+        assert exc.value.code == 1
+        assert "not a valid nab setting" in err.getvalue()
+
+    def test_explain_unknown_key_exits(
+        self, hermetic_roots: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _project(hermetic_roots)
+        with pytest.raises(SystemExit):
+            config_command("explain", "bogus", path=hermetic_roots / "pyproject.toml")
+        assert "unknown config key" in capsys.readouterr().err
+
+
+class TestConfigErrors:
+    def test_unknown_action_exits(
+        self, hermetic_roots: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _project(hermetic_roots)
+        with pytest.raises(SystemExit):
+            config_command("frobnicate", path=hermetic_roots / "pyproject.toml")
+        assert "unknown config action" in capsys.readouterr().err
+
+    def test_missing_path_exits(
+        self, hermetic_roots: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # A typo'd --path must fail like nab lock, not print all-defaults.
+        missing = hermetic_roots / "nope" / "pyproject.toml"
+        with pytest.raises(SystemExit):
+            config_command("list", path=missing)
+        err = capsys.readouterr().err
+        assert "not found" in err
+        assert str(missing) in err
+
+    def test_directory_path_exits(
+        self, hermetic_roots: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with pytest.raises(SystemExit):
+            config_command("list", path=hermetic_roots)
+        err = capsys.readouterr().err
+        assert "is a directory" in err
+
+    def test_gate_error_exits(
+        self, hermetic_roots: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # offline in pyproject [tool.nab] is a category error.
+        _project(hermetic_roots, "offline = true\n")
+        with pytest.raises(SystemExit):
+            config_command("list", path=hermetic_roots / "pyproject.toml")
+        assert "project-scope only" in capsys.readouterr().err
+
+    def test_cli_offline_override_layer(self, hermetic_roots: Path) -> None:
+        _project(hermetic_roots)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            config_command(
+                "get",
+                "offline",
+                path=hermetic_roots / "pyproject.toml",
+                offline=True,
+            )
+        assert buf.getvalue() == "true\n"
+
+    def test_cli_resolution_and_cache_dir_overrides(
+        self, hermetic_roots: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _project(hermetic_roots)
+        config_command(
+            "get",
+            "cache-dir",
+            path=hermetic_roots / "pyproject.toml",
+            project_resolution="lowest",
+            cache_dir=Path("/c/cli"),
+        )
+        captured = capsys.readouterr()
+        assert captured.out == "/c/cli\n"
+        # The PROJECT resolution override emits the reproducibility notice.
+        # The inspector produces no lock, so it makes no lock claim.
+        assert "the lock they produce" not in captured.err
+        assert "reflect that override" in captured.err
+        assert "--project-resolution -> lowest" in captured.err
+
+
+class TestConfigProjectFileConflict:
+    """The cross-file conflict surfaced through the config command."""
+
+    def test_conflicting_project_files_exit(
+        self, hermetic_roots: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _project(hermetic_roots, 'resolution = "highest"\n')
+        _write(hermetic_roots / "nab.toml", 'resolution = "lowest"\n')
+        with pytest.raises(SystemExit):
+            config_command("list", path=hermetic_roots / "pyproject.toml")
+        assert "conflicting values" in capsys.readouterr().err
+
+
+class TestTyroConformance:
+    """The tyro CLI surface must match the registry one-for-one.
+
+    tyro derives flags from the ``config`` function signature, which the
+    registry cannot generate.  This test pins them together: every
+    registry CLI flag must appear in the rendered ``config`` help and the
+    backing parameter names must match the rows.
+    """
+
+    def _config_help(self) -> str:
+        buf = io.StringIO()
+        with redirect_stdout(buf), suppress(SystemExit):
+            app.cli(args=["config", "--help"], prog="nab")
+        return buf.getvalue()
+
+    def test_every_registry_flag_present_in_help(self) -> None:
+        help_text = self._config_help()
+        for spec in OPTIONS:
+            if spec.cli_flag is None:
+                # File-only rows (vcs/workspace/marker-environment) carry
+                # no CLI flag, so there is nothing to assert in the help.
+                continue
+            assert spec.cli_flag in help_text, (
+                f"registry flag {spec.cli_flag} missing from `nab config` help"
+            )
+
+    def test_every_registry_param_present(self) -> None:
+        sig = inspect.signature(config_command)
+        params = set(sig.parameters)
+        for spec in OPTIONS:
+            if spec.cli_param is None:
+                continue
+            assert spec.cli_param in params
+
+    def test_param_types_match_registry(self) -> None:
+        sig = inspect.signature(config_command)
+        assert "bool" in str(sig.parameters["offline"].annotation)
+        assert "Path" in str(sig.parameters["cache_dir"].annotation)
+        # project_resolution carries the same constrained ResolutionFlag
+        # type as lock/download, so tyro rejects a bad choice identically
+        # across subcommands.
+        assert "ResolutionFlag" in str(sig.parameters["project_resolution"].annotation)
+
+    def test_lock_exposes_project_resolution_not_bare(self) -> None:
+        # The hard rename: lock carries --project-resolution and the bare
+        # resolution parameter no longer exists.
+        sig = inspect.signature(lock)
+        assert "project_resolution" in sig.parameters
+        assert "resolution" not in sig.parameters
+
+    def test_lock_help_has_project_resolution_flag(self) -> None:
+        buf = io.StringIO()
+        with redirect_stdout(buf), suppress(SystemExit):
+            app.cli(args=["lock", "--help"], prog="nab")
+        help_text = buf.getvalue()
+        assert "--project-resolution" in help_text
+
+    def test_every_cli_param_present_on_run_commands(self) -> None:
+        # Every registry option with a CLI flag is exposed on lock, download,
+        # and config, driven from OPTIONS so the run surface cannot silently
+        # drift from the registry. The one deliberate omission is
+        # max-concurrency, a download-only knob (lock has no parallel-fetch
+        # step to bound); the allowlist asserts it stays absent from lock so
+        # the carve-out is intentional, not accidental drift.
+        omitted = {"lock": {"max_concurrency"}}
+        cli_params = [s.cli_param for s in OPTIONS if s.cli_param is not None]
+        for command in (lock, download, config_command):
+            params = set(inspect.signature(command).parameters)
+            allowed_missing = omitted.get(command.__name__, set())
+            for cli_param in cli_params:
+                if cli_param in allowed_missing:
+                    assert cli_param not in params, (command.__name__, cli_param)
+                else:
+                    assert cli_param in params, (command.__name__, cli_param)
+
+    def test_conformance_catches_a_deliberate_mismatch(self) -> None:
+        """Prove the gate is real: a registry flag with no CLI param fails."""
+        from nab_python.config_sources import OptionSpec, Scope, _parse_bool
+
+        bogus = OptionSpec(
+            key="made-up",
+            scope=Scope.USER,
+            type_label="bool",
+            default=False,
+            env_var=None,
+            cli_flag="--made-up",
+            cli_param="made_up",
+            parse=_parse_bool,
+            render=str,
+        )
+        patched = (*OPTIONS, bogus)
+        sig = inspect.signature(config_command)
+        params = set(sig.parameters)
+        help_text = self._config_help()
+
+        def check_params() -> None:
+            for spec in patched:
+                if spec.cli_param is None:
+                    continue
+                assert spec.cli_param in params, spec.cli_flag
+
+        def check_flags() -> None:
+            for spec in patched:
+                if spec.cli_flag is None:
+                    continue
+                assert spec.cli_flag in help_text, spec.cli_flag
+
+        with pytest.raises(AssertionError):
+            check_params()
+        with pytest.raises(AssertionError):
+            check_flags()
+
+
+class TestEffectiveConfigBridge:
+    def test_effective_config_default_roots_callable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Exercise the real _config_search_roots (no monkeypatch) but with a
+        # project that has no nab.toml, so only defaults/pyproject apply.
+        proj = _project(tmp_path)
+        monkeypatch.delenv("NAB_OFFLINE", raising=False)
+        monkeypatch.delenv("NAB_CACHE_DIR", raising=False)
+        monkeypatch.delenv("NAB_RESOLUTION", raising=False)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+        effective = effective_config(proj)
+        assert "resolution" in effective
+        assert effective["resolution"].rejected == ()
+
+    def test_layered_run_settings_defaults_noop(self, tmp_path: Path) -> None:
+        proj = _project(tmp_path)
+        settings, _effective = nab_cli._layered_run_settings(
+            proj,
+            nab_cli._cli_overrides(
+                cli_resolution=None, cli_offline=None, cli_cache_dir=None
+            ),
+        )
+        assert settings.resolution is None
+        assert settings.offline is False
+        assert settings.cache_dir is None
+        assert settings.http_backend == "urllib3"
+        assert settings.max_concurrency == 8
+
+    def test_layered_run_settings_reads_project_toml(
+        self, hermetic_roots: Path
+    ) -> None:
+        _project(hermetic_roots, 'resolution = "lowest"\n')
+        settings, _effective = nab_cli._layered_run_settings(
+            hermetic_roots / "pyproject.toml",
+            nab_cli._cli_overrides(
+                cli_resolution=None, cli_offline=None, cli_cache_dir=None
+            ),
+        )
+        assert settings.resolution is ResolutionStrategy.LOWEST
+
+    def test_layered_run_settings_cli_offline_set(self, hermetic_roots: Path) -> None:
+        _project(hermetic_roots)
+        settings, _effective = nab_cli._layered_run_settings(
+            hermetic_roots / "pyproject.toml",
+            nab_cli._cli_overrides(
+                cli_resolution=None, cli_offline=True, cli_cache_dir=None
+            ),
+        )
+        assert settings.offline is True
+
+    def test_cli_no_offline_beats_env(
+        self, hermetic_roots: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # CLI is the highest rung: --no-offline (offline=False) must override
+        # a lower NAB_OFFLINE=1 env value.
+        _project(hermetic_roots)
+        monkeypatch.setenv("NAB_OFFLINE", "1")
+        settings, _effective = nab_cli._layered_run_settings(
+            hermetic_roots / "pyproject.toml",
+            nab_cli._cli_overrides(
+                cli_resolution=None, cli_offline=False, cli_cache_dir=None
+            ),
+        )
+        assert settings.offline is False
+
+    def test_cli_no_offline_beats_project_toml(self, hermetic_roots: Path) -> None:
+        _project(hermetic_roots)
+        _write(hermetic_roots / "nab.toml", "offline = true\n")
+        settings, _effective = nab_cli._layered_run_settings(
+            hermetic_roots / "pyproject.toml",
+            nab_cli._cli_overrides(
+                cli_resolution=None, cli_offline=False, cli_cache_dir=None
+            ),
+        )
+        assert settings.offline is False
+
+    def test_layered_run_settings_cli_cache_dir(self, hermetic_roots: Path) -> None:
+        _project(hermetic_roots)
+        settings, _effective = nab_cli._layered_run_settings(
+            hermetic_roots / "pyproject.toml",
+            nab_cli._cli_overrides(
+                cli_resolution=None, cli_offline=None, cli_cache_dir=Path("/c/cli")
+            ),
+        )
+        assert settings.cache_dir == Path("/c/cli")
+
+    def test_layered_run_settings_http_backend_and_max_concurrency(
+        self, hermetic_roots: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Both new USER knobs layer from env and from a CLI override.
+        _project(hermetic_roots)
+        monkeypatch.setenv("NAB_HTTP_BACKEND", "httpx")
+        monkeypatch.setenv("NAB_MAX_CONCURRENCY", "3")
+        settings, _effective = nab_cli._layered_run_settings(
+            hermetic_roots / "pyproject.toml",
+            nab_cli._cli_overrides(
+                cli_resolution=None, cli_offline=None, cli_cache_dir=None
+            ),
+        )
+        assert settings.http_backend == "httpx"
+        assert settings.max_concurrency == 3
+        cli_settings, _ = nab_cli._layered_run_settings(
+            hermetic_roots / "pyproject.toml",
+            nab_cli._cli_overrides(
+                cli_resolution=None,
+                cli_offline=None,
+                cli_cache_dir=None,
+                cli_http_backend="urllib3",
+                cli_max_concurrency=16,
+            ),
+        )
+        assert cli_settings.http_backend == "urllib3"
+        assert cli_settings.max_concurrency == 16
+
+
+def test_default_config_search_roots_xdg(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    pyproject = tmp_path / "pyproject.toml"
+    roots = nab_cli._config_search_roots(pyproject)
+    assert roots.user_toml == tmp_path / "xdg" / "nab" / "nab.toml"
+    assert roots.system_toml == Path("/etc/nab/nab.toml")
+    assert roots.project_dir == tmp_path.resolve()
+    assert roots.pyproject == pyproject.resolve()
+
+
+def test_config_search_roots_threads_custom_pyproject_name(tmp_path: Path) -> None:
+    # A non-default pyproject name is threaded through so the registry's
+    # pyproject layer reads the file the user actually pointed at.
+    custom = tmp_path / "app.toml"
+    roots = nab_cli._config_search_roots(custom)
+    assert roots.pyproject == custom.resolve()
+    assert roots.project_dir == tmp_path.resolve()
+
+
+def test_default_config_search_roots_no_xdg(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.setattr(nab_cli.Path, "home", lambda: tmp_path)
+    roots = nab_cli._config_search_roots(tmp_path / "pyproject.toml")
+    assert roots.user_toml == tmp_path / ".config" / "nab" / "nab.toml"
+
+
+def test_config_module_imports_cleanly() -> None:
+    assert config_cmd.config_command is not None
+
+
+def test_lock_exits_cleanly_on_layered_config_error(
+    hermetic_roots: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A category-gate error reached via the lock ladder exits 1, not traceback."""
+    # A user nab.toml setting the PROJECT resolution key is a category
+    # error the pyproject parser never sees, so it surfaces through the
+    # lock ladder's SourceConfigError handler.
+    _project(hermetic_roots)
+    _write(tmp_path / "usr" / "nab.toml", 'resolution = "lowest"\n')
+    with pytest.raises(SystemExit):
+        lock(hermetic_roots / "pyproject.toml", output=hermetic_roots / "pylock.toml")
+    assert "Config error" in capsys.readouterr().err
+
+
+def test_lock_exits_on_pyproject_user_key_via_fold(
+    hermetic_roots: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The parser fold: a USER key in pyproject [tool.nab] exits 1 with the
+    registry category message, not the old unknown-key error."""
+    _project(hermetic_roots, "offline = true\n")
+    with pytest.raises(SystemExit):
+        lock(hermetic_roots / "pyproject.toml", output=hermetic_roots / "pylock.toml")
+    err = capsys.readouterr().err
+    assert "Error in [tool.nab]" in err
+    assert "user-scope option" in err
+
+
+class TestNoOpLock:
+    """A representative `nab lock` at defaults is byte-identical pre/post the
+    config layer: the layered ladder is a pure no-op at defaults."""
+
+    def _lock_bytes(self, proj: Path, out: Path) -> bytes:
+        with patch(
+            "nab.cli.resolve_pyproject", return_value=_stub_resolution_result()
+        ) as mock_resolve:
+            lock(proj, output=out, cache=False)
+        # The config layer must not perturb the resolve knobs at defaults.
+        kwargs = mock_resolve.call_args.kwargs
+        assert kwargs["offline"] is False
+        assert kwargs["resolution_strategy"] is None
+        return out.read_bytes()
+
+    def test_lock_output_byte_identical_at_defaults(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("NAB_OFFLINE", raising=False)
+        monkeypatch.delenv("NAB_CACHE_DIR", raising=False)
+        monkeypatch.delenv("NAB_RESOLUTION", raising=False)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-empty"))
+        # Inject hermetic roots so the no-op guarantee does not depend on
+        # the host's /etc/nab/nab.toml (which the real roots would read).
+        sys_root = tmp_path / "sys" / "nab.toml"
+        usr_root = tmp_path / "usr" / "nab.toml"
+        monkeypatch.setattr(
+            nab_cli,
+            "_config_search_roots",
+            lambda pyproject: SourceRoots(
+                system_toml=sys_root,
+                user_toml=usr_root,
+                project_dir=pyproject.parent,
+                pyproject=pyproject,
+            ),
+        )
+        # A fixed uploaded-prior-to pins the lock anchor so created-at is
+        # deterministic; the remaining run-to-run stability is then purely
+        # the config layer's no-op-ness.
+        proj = _project(tmp_path, 'uploaded-prior-to = "2024-01-01T00:00:00Z"\n')
+        # Same project, locked twice: the layered config ladder is a pure
+        # no-op at defaults, so the output is byte-identical run to run.
+        first = self._lock_bytes(proj, tmp_path / "pylock.first.toml")
+        second = self._lock_bytes(proj, tmp_path / "pylock.second.toml")
+        assert first == second
+        # The lock carries the resolved pin: the config layer is a no-op,
+        # not a no-output.
+        assert b"foo" in first
+        assert b"1.0" in first
+
+
+class TestProjectCliOverrides:
+    """``--project-*`` overrides flow through ``nab lock`` into the resolve."""
+
+    def _lock_config(
+        self, proj: Path, out: Path, extra: list[str]
+    ) -> tuple[NabProjectConfig, Path]:
+        with (
+            patch(
+                "nab.cli.resolve_pyproject", return_value=_stub_resolution_result()
+            ) as mock_resolve,
+            patch("nab.cli.write_lock"),
+        ):
+            app.cli(
+                args=["lock", str(proj), "--no-cache", "--output", str(out), *extra],
+                prog="nab",
+            )
+        call = mock_resolve.call_args
+        return call.kwargs["config"], call.args[0]
+
+    def test_project_dist_policy_reaches_resolve(self, hermetic_roots: Path) -> None:
+        proj = _project(hermetic_roots)
+        config, _ = self._lock_config(
+            proj,
+            hermetic_roots / "pylock.toml",
+            ["--project-dist-policy", "sdist-only"],
+        )
+        assert config.dist_policy is DistPolicy.SDIST_ONLY
+
+    def test_project_dist_policy_override_replaces_trust(
+        self, hermetic_roots: Path
+    ) -> None:
+        # The CLI dist-policy flag is a bare policy, so it replaces the whole
+        # policy and resets the sdist-trust flag a lower layer set.
+        proj = _project(
+            hermetic_roots,
+            'dist-policy = { policy = "wheel-or-sdist",'
+            " trust-unverified-deps = true }\n",
+        )
+        config, _ = self._lock_config(
+            proj,
+            hermetic_roots / "pylock.toml",
+            ["--project-dist-policy", "sdist-only"],
+        )
+        assert config.dist_policy is DistPolicy.SDIST_ONLY
+        assert config.trust_unverified_sdist_deps is False
+
+    def test_project_constraint_appends_across_repeats(
+        self, hermetic_roots: Path
+    ) -> None:
+        proj = _project(hermetic_roots, 'constraints = ["a<1"]\n')
+        config, _ = self._lock_config(
+            proj,
+            hermetic_roots / "pylock.toml",
+            ["--project-constraint", "b<2", "--project-constraint", "c<3"],
+        )
+        assert config.constraints == ("a<1", "b<2", "c<3")
+
+    def test_append_flag_does_not_swallow_positional_path(
+        self, hermetic_roots: Path
+    ) -> None:
+        # An append flag on either side of the PATH must not consume it.
+        proj = _project(hermetic_roots)
+        out = hermetic_roots / "pylock.toml"
+        with (
+            patch(
+                "nab.cli.resolve_pyproject", return_value=_stub_resolution_result()
+            ) as mock_resolve,
+            patch("nab.cli.write_lock"),
+        ):
+            app.cli(
+                args=[
+                    "lock",
+                    "--project-constraint",
+                    "a<1",
+                    str(proj),
+                    "--project-constraint",
+                    "b<2",
+                    "--no-cache",
+                    "--output",
+                    str(out),
+                ],
+                prog="nab",
+            )
+        call = mock_resolve.call_args
+        assert call.args[0] == proj
+        assert call.kwargs["config"].constraints == ("a<1", "b<2")
+
+    def test_project_override_prints_reproducibility_notice(
+        self, hermetic_roots: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        proj = _project(hermetic_roots)
+        self._lock_config(
+            proj,
+            hermetic_roots / "pylock.toml",
+            ["--project-dist-policy", "sdist-only"],
+        )
+        assert "--project-dist-policy -> sdist-only" in capsys.readouterr().err
+
+    def test_absolute_uploaded_prior_to_override_keeps_anchor_in_sync(
+        self, hermetic_roots: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # An absolute --project-uploaded-prior-to sets the resolve window and
+        # becomes the lock anchor, so the written created-at matches the
+        # cutoff the resolve used.
+        proj = _project(hermetic_roots)
+        out = hermetic_roots / "pylock.toml"
+        with patch(
+            "nab.cli.resolve_pyproject", return_value=_stub_resolution_result()
+        ) as mock_resolve:
+            app.cli(
+                args=[
+                    "lock",
+                    str(proj),
+                    "--no-cache",
+                    "--output",
+                    str(out),
+                    "--project-uploaded-prior-to",
+                    "2024-06-01T00:00:00Z",
+                ],
+                prog="nab",
+            )
+        expected = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        assert mock_resolve.call_args.kwargs["config"].uploaded_prior_to == expected
+        assert read_lockfile_anchor(out) == expected
+        assert "--project-uploaded-prior-to -> 2024-06-01" in capsys.readouterr().err
+
+    def test_lock_anchor_honors_absolute_cli_override(
+        self, hermetic_roots: Path
+    ) -> None:
+        proj = _project(hermetic_roots)
+        anchor = nab_cli.lock_anchor(
+            proj, {"uploaded-prior-to": "2024-06-01T00:00:00Z"}
+        )
+        assert anchor == datetime(2024, 6, 1, tzinfo=timezone.utc)
+
+    def test_relative_uploaded_prior_to_override_pins_no_anchor(
+        self, hermetic_roots: Path
+    ) -> None:
+        # A P<n>D override sets the resolve window relative to the run but is
+        # not a reusable absolute cutoff, so it pins no lock anchor.
+        proj = _project(hermetic_roots)
+        assert nab_cli.lock_anchor(proj, {"uploaded-prior-to": "P7D"}) is None
+
+
+class TestDownloadLadder:
+    """``nab download`` shares ``nab lock``'s config ladder, not raw flags."""
+
+    def _resolve_kwargs(
+        self, proj: Path, out: Path, *, offline: bool | None = None
+    ) -> Mapping[str, object]:
+        download_result = MagicMock(written=(), skipped=())
+        with (
+            patch(
+                "nab.cli.resolve_pyproject", return_value=_stub_resolution_result()
+            ) as mock_resolve,
+            patch("nab.cli.download_lock", return_value=download_result),
+        ):
+            download(proj / "pyproject.toml", output=out, cache=False, offline=offline)
+        return mock_resolve.call_args.kwargs
+
+    def test_project_toml_offline_honored(self, hermetic_roots: Path) -> None:
+        # A project-dir nab.toml offline reaches the download resolve.
+        _project(hermetic_roots)
+        _write(hermetic_roots / "nab.toml", "offline = true\n")
+        kwargs = self._resolve_kwargs(hermetic_roots, hermetic_roots / "out")
+        assert kwargs["offline"] is True
+
+    def test_env_offline_honored(
+        self, hermetic_roots: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # NAB_OFFLINE reaches the download resolve.
+        _project(hermetic_roots)
+        monkeypatch.setenv("NAB_OFFLINE", "1")
+        kwargs = self._resolve_kwargs(hermetic_roots, hermetic_roots / "out")
+        assert kwargs["offline"] is True
+
+    def test_project_toml_resolution_honored(self, hermetic_roots: Path) -> None:
+        # A project-dir nab.toml resolution reaches the download resolve.
+        _project(hermetic_roots, 'resolution = "lowest"\n')
+        kwargs = self._resolve_kwargs(hermetic_roots, hermetic_roots / "out")
+        assert kwargs["resolution_strategy"] is ResolutionStrategy.LOWEST
+
+    def test_cli_offline_false_beats_env(
+        self, hermetic_roots: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # CLI is the highest rung: --offline False overrides NAB_OFFLINE=1.
+        _project(hermetic_roots)
+        monkeypatch.setenv("NAB_OFFLINE", "1")
+        kwargs = self._resolve_kwargs(
+            hermetic_roots, hermetic_roots / "out", offline=False
+        )
+        assert kwargs["offline"] is False
+
+    def test_layered_config_error_exits(
+        self, hermetic_roots: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # A category-gate error reached via the download ladder exits 1.
+        _project(hermetic_roots)
+        # The fixture's user_toml lives at <tmp>/usr; project_dir is <tmp>/proj.
+        _write(hermetic_roots.parent / "usr" / "nab.toml", 'resolution = "lowest"\n')
+        with pytest.raises(SystemExit):
+            download(hermetic_roots / "pyproject.toml", output=hermetic_roots / "out")
+        assert "Config error" in capsys.readouterr().err


### PR DESCRIPTION
Closes #207.

nab's configuration was ad-hoc: a single source (`[tool.nab]` in `pyproject.toml`), no `nab.toml`, no `NAB_*` scheme, and one global CLI flag. As the option count grows this drifts, and for a resolver a disagreement over where an option comes from is a correctness bug, not a cosmetic one. This gives every option one definition and one precedence policy.

Every option is one row in a registry (`nab_python.config_sources`) naming its scope, type, default, env var, and CLI flag. The loader, env reader, merge, category gate, and `nab config` are all derived from that registry, and the existing `[tool.nab]` parser now sources its values from it, so each option has a single parse path.

Scope splits options into two categories:

- PROJECT options change the resolved set, so they come only from `pyproject.toml` `[tool.nab]` or a project-directory `nab.toml`, plus an optional `--project-<key>` CLI override.
- USER options (`offline`, `cache-dir`, `http-backend`, `max-concurrency`) describe how a run executes on this machine, so they come from a system, user, or project `nab.toml`, a `NAB_*` env var, or a plain CLI flag. They are rejected in `[tool.nab]`.

Layers merge low to high: defaults, system `nab.toml`, user `nab.toml`, the two project files (same rank), `NAB_*`, then the CLI. Conflicting values for one key across the two project files are an error, identical values are fine, and a source that sets an option outside its scope is a named error rather than a silent drop. Each effective value carries its source.

### Included

- The registry and the discover/merge/provenance engine, with every `[tool.nab]` option sourced through it, so a project-directory `nab.toml` configures the resolve the same way `pyproject.toml` does.
- `NAB_*` reading for the USER options; an unknown or project-scope `NAB_*` name is rejected.
- `--project-<key>` overrides for the scalar and array PROJECT options (`resolution`, `mode`, `requires-python`, `uploaded-prior-to`, `dist-policy`, `build-policy`, and the repeatable `--project-constraint` / `--project-default-group`). A CLI project override prints a reproducibility notice and is recorded in the lockfile, since the lock no longer derives from the committed files alone. `--resolution` is renamed `--project-resolution`.
- A read-only `nab config` subcommand: `list`, `get <key>`, and `explain <key>` (with `--include-rejected`).
- `nab lock --locked` re-resolves and verifies the committed `pylock.toml` is current, writing nothing and failing if it would change.
- `--upgrade` now prints a notice naming the cutoff it drops when it re-anchors the resolve window.

### Deferred to a follow-up

Writing config (`nab config set` / `unset` / `edit`). The registry already exposes what a writer needs (value validation, the category gate, scope-to-file resolution), so it layers on cleanly later.
