### PR TITLE
validate python_version marker-environment overrides as PEP 440 at config parse

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -112,6 +112,11 @@ _PEP508_MARKER_VARIABLES = frozenset(
     },
 )
 
+# Marker variables whose values must parse as PEP 440 versions. These feed
+# python_axis_environment and the provider, so a bad value here would crash
+# the resolve with a raw InvalidVersion instead of a ConfigError.
+_VERSION_MARKER_VARIABLES = frozenset({"python_version", "python_full_version"})
+
 
 @dataclass(frozen=True, slots=True)
 class MatrixConfig:
@@ -1066,6 +1071,12 @@ def _parse_marker_environment(value: object) -> dict[str, str]:
                 f" marker variable, one of {valid!r}"
             )
             raise ConfigError(msg)
+        if k in _VERSION_MARKER_VARIABLES:
+            try:
+                Version(v)
+            except InvalidVersion as exc:
+                msg = f"marker-environment.{k} must be a PEP 440 version, got {v!r}"
+                raise ConfigError(msg) from exc
         out[k] = v
     return out
 

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -112,9 +112,7 @@ _PEP508_MARKER_VARIABLES = frozenset(
     },
 )
 
-# Marker variables whose values must parse as PEP 440 versions. These feed
-# python_axis_environment and the provider, so a bad value here would crash
-# the resolve with a raw InvalidVersion instead of a ConfigError.
+# Marker variables whose values must parse as PEP 440 versions.
 _VERSION_MARKER_VARIABLES = frozenset({"python_version", "python_full_version"})
 
 

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -1056,6 +1056,39 @@ class TestMarkerEnvironment:
         with pytest.raises(ConfigError, match="unknown marker-environment variable"):
             read_pyproject_config(path)
 
+    def test_version_value_round_trip(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab.marker-environment]\n"
+            'python_version = "3.12"\n'
+            'python_full_version = "3.12.4"\n',
+        )
+        env = read_pyproject_config(path).marker_environment
+        assert env == {"python_version": "3.12", "python_full_version": "3.12.4"}
+
+    def test_python_version_must_be_pep440(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path, '[tool.nab.marker-environment]\npython_version = "3.x"\n'
+        )
+        with pytest.raises(
+            ConfigError,
+            match=r"marker-environment.python_version must be a PEP 440 version,"
+            r" got '3.x'",
+        ):
+            read_pyproject_config(path)
+
+    def test_python_full_version_must_be_pep440(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab.marker-environment]\npython_full_version = "not-a-version"\n',
+        )
+        with pytest.raises(
+            ConfigError,
+            match=r"marker-environment.python_full_version must be a PEP 440"
+            r" version, got 'not-a-version'",
+        ):
+            read_pyproject_config(path)
+
     def test_rejected_in_universal_mode(self, tmp_path: Path) -> None:
         path = write(
             tmp_path,


### PR DESCRIPTION
A version-shaped `python_version` or `python_full_version` set under `[tool.nab.marker-environment]` passed config validation even when it was not a real version, so a value like `python_version = "3.x"` was accepted at parse time and then failed mid-resolve with a raw `InvalidVersion` traceback once the value reached the Python axis and the provider.

`_parse_marker_environment` only checked that each key was a known PEP 508 marker variable, never that the value of these two version-typed variables parsed. This adds that check: both values are run through `Version()` while reading config, and a bad one raises a `ConfigError` naming the variable and the offending value, the same as the other config errors. A well-formed version still parses unchanged.
