### PR TITLE
raise on structurally-malformed [project] dependencies instead of dropping them

### DIFF
--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -8,6 +8,7 @@ each ``Requires-Dist`` entry into base deps vs per-extra deps.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from nab_index.client import SdistFile, WheelFile
@@ -24,6 +25,7 @@ from ..metadata import (
     metadata_deps_are_static,
     parse_metadata,
 )
+from ..requirements_file import InvalidProjectRequirementError, _require_string_list
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -31,6 +33,9 @@ if TYPE_CHECKING:
     from .._vendor.packaging.markers import Marker
     from .._vendor.packaging.version import Version
     from ..provider import DistFile, Provider
+
+
+logger = logging.getLogger(__name__)
 
 
 def resolve_metadata(
@@ -210,8 +215,15 @@ def augment_from_pyproject(
     """Replace dynamic deps with statically-declared pyproject deps.
 
     Returns the augmented metadata, or ``None`` if pyproject.toml
-    is missing, malformed, or itself marks deps dynamic via
+    is missing, unparseable, or itself marks deps dynamic via
     ``[project].dynamic``.
+
+    Raises :class:`InvalidProjectRequirementError` when ``dependencies``
+    or ``optional-dependencies`` is present but structurally wrong (not
+    an array of strings / not a table), rather than silently dropping the
+    declared dependencies.  ``get_dependencies`` catches it and rejects the
+    candidate version.  A well-typed entry that is not valid PEP 508 is
+    dropped with a warning.
     """
     # Late import keeps the resolver-time path off ``WheelMetadata``
     # construction unless the dynamic-deps pyproject fallback fires.
@@ -223,15 +235,16 @@ def augment_from_pyproject(
     if project is None:
         return None
 
-    deps_field = project.get("dependencies")
-    if deps_field is not None and not isinstance(deps_field, list):
-        return None
-    optional = project.get("optional-dependencies")
-    if optional is not None and not isinstance(optional, dict):
-        return None
+    deps = _require_string_list(
+        project.get("dependencies", []), "[project].dependencies"
+    )
+    optional = project.get("optional-dependencies", {})
+    if not isinstance(optional, dict):
+        msg = "[project].optional-dependencies must be a table"
+        raise InvalidProjectRequirementError(msg)
 
-    requires_dist = list(parse_pyproject_deps(deps_field or []))
-    provides_extra = extend_with_extras(requires_dist, optional or {})
+    requires_dist = list(parse_pyproject_deps(deps))
+    provides_extra = extend_with_extras(requires_dist, optional)
 
     provider.stats.sdist_pyproject_fallbacks += 1
     return _WheelMetadata(
@@ -246,38 +259,52 @@ def augment_from_pyproject(
 
 
 def extend_with_extras(requires_dist: list[Requirement], optional: dict) -> list[str]:
-    """Append extras-gated requirements and return Provides-Extra names."""
-    # Late import: ``pypi`` imports this module at module load.
-    from ..provider import _add_extra_marker
+    """Append extras-gated requirements and return Provides-Extra names.
 
+    A per-extra value that is not an array of strings raises
+    :class:`InvalidProjectRequirementError`; a well-typed entry that is
+    not valid PEP 508 is dropped with a warning.
+    """
     provides_extra: list[str] = []
     for extra_name, extra_deps in optional.items():
-        if not isinstance(extra_deps, list):
-            continue
+        source = f"[project].optional-dependencies extra {extra_name!r}"
         provides_extra.append(extra_name)
-        for dep_str in extra_deps:
-            if not isinstance(dep_str, str):
-                continue
-            try:
-                requires_dist.append(
-                    Requirement(_add_extra_marker(dep_str, extra_name))
-                )
-            except InvalidRequirement:
-                continue
+        for dep_str in _require_string_list(extra_deps, source):
+            req = _parse_dep(dep_str, extra_name)
+            if req is not None:
+                requires_dist.append(req)
     return provides_extra
 
 
 def parse_pyproject_deps(deps: list) -> list[Requirement]:
-    """Parse a ``project.dependencies`` list, dropping malformed entries."""
+    """Parse a ``project.dependencies`` list, dropping unparseable entries.
+
+    Entries are already validated as strings by :func:`_require_string_list`;
+    a string that is not valid PEP 508 is dropped with a warning.
+    """
     out: list[Requirement] = []
     for dep_str in deps:
-        if not isinstance(dep_str, str):
-            continue
-        try:
-            out.append(Requirement(dep_str))
-        except InvalidRequirement:
-            continue
+        req = _parse_dep(dep_str, None)
+        if req is not None:
+            out.append(req)
     return out
+
+
+def _parse_dep(dep_str: str, extra_name: str | None) -> Requirement | None:
+    """Parse one PEP 508 string, warning and dropping if it is malformed."""
+    # Late import: ``pypi`` imports this module at module load.
+    from ..provider import _add_extra_marker
+
+    try:
+        text = (
+            _add_extra_marker(dep_str, extra_name)
+            if extra_name is not None
+            else dep_str
+        )
+        return Requirement(text)
+    except InvalidRequirement:
+        logger.warning("skipping unparseable requirement: %s", dep_str)
+        return None
 
 
 def find_sdist(

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -52,7 +52,7 @@ def resolve_metadata(
     only sdist values are subject to the :pep:`643` Dynamic
     guarantees and may need a ``pyproject.toml`` fallback.
     """
-    # Late import: ``pypi`` imports this module at module load.
+    # Late import: ``provider`` imports this module at module load.
     from ..provider import MetadataError
 
     _, _, normalized = provider.split_and_normalize(package)

--- a/nab-python/src/nab_python/build_backend.py
+++ b/nab-python/src/nab_python/build_backend.py
@@ -21,6 +21,7 @@ from ._vendor.packaging.specifiers import SpecifierSet
 from ._vendor.packaging.utils import canonicalize_name
 from ._vendor.packaging.version import InvalidVersion, Version
 from .metadata import WheelMetadata, load_static_project
+from .requirements_file import InvalidProjectRequirementError, _require_string_list
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -48,6 +49,11 @@ def extract_static_metadata(source_dir: Path) -> WheelMetadata | None:
     Returns a :class:`WheelMetadata` shape when the static fields are
     authoritative, populating ``name``, ``version``,
     ``requires_python``, ``requires_dist``, and ``provides_extra``.
+
+    Raises :class:`InvalidProjectRequirementError` when ``dependencies``
+    or ``optional-dependencies`` is present but structurally wrong (not
+    an array of strings / not a table), rather than silently dropping the
+    declared dependencies.
 
     The returned ``provides_extra`` includes both the lower-cased
     keys of ``project.optional-dependencies`` and any extras declared
@@ -112,14 +118,27 @@ def _collect_requires_dist(project: dict) -> list[Requirement]:
 
     Optional-dependencies entries get an ``; extra == "name"`` marker
     appended (combined with any existing marker via ``and``).
+
+    A structurally wrong value (``dependencies`` that is not an array of
+    strings, ``optional-dependencies`` that is not a table, or a per-extra
+    value that is not an array of strings) raises
+    :class:`InvalidProjectRequirementError`.  A well-typed entry that is
+    not valid PEP 508 is dropped with a warning.
     """
     out: list[Requirement] = []
-    _extend_with_dep_strings(out, project.get("dependencies"))
-    optional = project.get("optional-dependencies", {})
-    if isinstance(optional, dict):
-        for raw_extra, deps in sorted(optional.items()):
-            extra = canonicalize_name(str(raw_extra))
-            _extend_with_dep_strings(out, deps, extra=extra)
+    _extend_with_dep_strings(
+        out,
+        project.get("dependencies", []),
+        source="[project].dependencies",
+    )
+    for raw_extra, deps in sorted(_require_optional_dependencies(project).items()):
+        extra = canonicalize_name(str(raw_extra))
+        _extend_with_dep_strings(
+            out,
+            deps,
+            source=f"[project].optional-dependencies extra {raw_extra!r}",
+            extra=extra,
+        )
     return out
 
 
@@ -127,28 +146,42 @@ def _extend_with_dep_strings(
     out: list[Requirement],
     raw: object,
     *,
+    source: str,
     extra: str | None = None,
 ) -> None:
-    if not isinstance(raw, list):
-        return
+    for dep in _require_string_list(raw, source):
+        req = _parse_dep(dep, extra)
+        if req is not None:
+            out.append(req)
+
+
+def _parse_dep(dep: str, extra: str | None) -> Requirement | None:
+    """Parse one PEP 508 string, warning and dropping if it is malformed."""
     # Late import: ``pypi`` imports this module at module load.
     from .provider import _add_extra_marker  # noqa: PLC0415
 
-    for dep in raw:
-        if not isinstance(dep, str):
-            continue
-        try:
-            text = _add_extra_marker(dep, extra) if extra is not None else dep
-            out.append(Requirement(text))
-        except (ValueError, TypeError):
-            logger.warning("skipping unparseable requirement: %s", dep)
+    try:
+        text = _add_extra_marker(dep, extra) if extra is not None else dep
+        return Requirement(text)
+    except (ValueError, TypeError):
+        logger.warning("skipping unparseable requirement: %s", dep)
+        return None
+
+
+def _require_optional_dependencies(project: dict) -> dict:
+    """Return ``[project.optional-dependencies]`` as a table, or raise."""
+    optional = project.get("optional-dependencies", {})
+    if not isinstance(optional, dict):
+        msg = "[project].optional-dependencies must be a table"
+        raise InvalidProjectRequirementError(msg)
+    return optional
 
 
 def _collect_provides_extra(project: dict) -> set[str]:
-    optional = project.get("optional-dependencies", {})
-    if not isinstance(optional, dict):
-        return set()
-    return {canonicalize_name(str(extra)) for extra in optional}
+    return {
+        canonicalize_name(str(extra))
+        for extra in _require_optional_dependencies(project)
+    }
 
 
 def extract_metadata(

--- a/nab-python/src/nab_python/build_backend.py
+++ b/nab-python/src/nab_python/build_backend.py
@@ -157,7 +157,7 @@ def _extend_with_dep_strings(
 
 def _parse_dep(dep: str, extra: str | None) -> Requirement | None:
     """Parse one PEP 508 string, warning and dropping if it is malformed."""
-    # Late import: ``pypi`` imports this module at module load.
+    # Late import: avoids a circular import with ``provider``.
     from .provider import _add_extra_marker  # noqa: PLC0415
 
     try:

--- a/nab-python/tests/test_build_backend.py
+++ b/nab-python/tests/test_build_backend.py
@@ -74,7 +74,6 @@ class TestExtractStaticMetadata:
         assert "pytest" in names
         assert "sphinx" in names
         assert sorted(meta.provides_extra) == ["dev", "docs"]
-        # The pytest entry has an extra marker
         pytest_req = next(r for r in meta.requires_dist if r.name == "pytest")
         assert pytest_req.marker is not None
         assert 'extra == "dev"' in str(pytest_req.marker)

--- a/nab-python/tests/test_build_backend.py
+++ b/nab-python/tests/test_build_backend.py
@@ -25,6 +25,7 @@ from nab_python.build_backend import (
     extract_static_metadata,
 )
 from nab_python.metadata import parse_metadata
+from nab_python.requirements_file import InvalidProjectRequirementError
 
 
 def _write_pyproject(tmp: Path, body: str) -> Path:
@@ -203,8 +204,8 @@ class TestExtractStaticMetadata:
         assert "requests" in names
         assert any("unparseable" in rec.message for rec in caplog.records)
 
-    def test_dependencies_with_non_string_entries_skipped(self, tmp_path: Path) -> None:
-        """A TOML array with mixed types skips the non-string entries."""
+    def test_dependencies_with_non_string_entries_raises(self, tmp_path: Path) -> None:
+        """A non-string entry is a structural error that raises."""
         _write_pyproject(
             tmp_path,
             """
@@ -214,21 +215,41 @@ class TestExtractStaticMetadata:
             dependencies = ["valid", 42]
             """,
         )
-        meta = extract_static_metadata(tmp_path)
-        assert meta is not None
-        names = [r.name for r in meta.requires_dist]
-        assert names == ["valid"]
+        with pytest.raises(
+            InvalidProjectRequirementError,
+            match=r"\[project\]\.dependencies must be an array of strings",
+        ):
+            extract_static_metadata(tmp_path)
 
-    def test_dependencies_not_list_ignored(self, tmp_path: Path) -> None:
+    def test_dependencies_not_list_raises(self, tmp_path: Path) -> None:
         _write_pyproject(
             tmp_path,
             '[project]\nname = "foo"\nversion = "1.0"\ndependencies = "not-a-list"\n',
         )
-        meta = extract_static_metadata(tmp_path)
-        assert meta is not None
-        assert meta.requires_dist == []
+        with pytest.raises(
+            InvalidProjectRequirementError,
+            match=r"\[project\]\.dependencies must be an array of strings",
+        ):
+            extract_static_metadata(tmp_path)
 
-    def test_optional_deps_not_dict_ignored(self, tmp_path: Path) -> None:
+    def test_dependencies_table_raises(self, tmp_path: Path) -> None:
+        _write_pyproject(
+            tmp_path,
+            """
+            [project]
+            name = "foo"
+            version = "1.0"
+            [project.dependencies]
+            a = "b"
+            """,
+        )
+        with pytest.raises(
+            InvalidProjectRequirementError,
+            match=r"\[project\]\.dependencies must be an array of strings",
+        ):
+            extract_static_metadata(tmp_path)
+
+    def test_optional_deps_not_dict_raises(self, tmp_path: Path) -> None:
         _write_pyproject(
             tmp_path,
             """
@@ -238,11 +259,13 @@ class TestExtractStaticMetadata:
             optional-dependencies = "not-a-dict"
             """,
         )
-        meta = extract_static_metadata(tmp_path)
-        assert meta is not None
-        assert meta.provides_extra == []
+        with pytest.raises(
+            InvalidProjectRequirementError,
+            match=r"\[project\]\.optional-dependencies must be a table",
+        ):
+            extract_static_metadata(tmp_path)
 
-    def test_optional_deps_value_not_list_ignored(self, tmp_path: Path) -> None:
+    def test_optional_deps_value_not_list_raises(self, tmp_path: Path) -> None:
         _write_pyproject(
             tmp_path,
             """
@@ -254,10 +277,11 @@ class TestExtractStaticMetadata:
             ok = ["pytest"]
             """,
         )
-        meta = extract_static_metadata(tmp_path)
-        assert meta is not None
-        names = [r.name for r in meta.requires_dist]
-        assert "pytest" in names
+        with pytest.raises(
+            InvalidProjectRequirementError,
+            match=r"extra 'dev' must be an array of strings",
+        ):
+            extract_static_metadata(tmp_path)
 
     def test_requires_python_not_str_ignored(self, tmp_path: Path) -> None:
         _write_pyproject(

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -6094,7 +6094,7 @@ class TestStaticSdistMetadata:
         assert "dep-a" in deps
 
     def test_pyproject_dependencies_wrong_type(self) -> None:
-        """``dependencies`` declared as non-list aborts the fallback."""
+        """``dependencies`` declared as non-list rejects the version."""
         pyproject = '[project]\nname = "pkg"\nversion = "1.0"\ndependencies = "dep-a"\n'
         coordinator = make_coordinator(
             [make_sdist("1.0")],
@@ -6106,11 +6106,11 @@ class TestStaticSdistMetadata:
             python_version="3.12.0",
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
-        with pytest.raises(UnsupportedSdistError):
+        with pytest.raises(MetadataError, match="must be an array of strings"):
             provider.get_dependencies("pkg", V("1.0"))
 
     def test_pyproject_optional_dependencies_wrong_type(self) -> None:
-        """``optional-dependencies`` declared as non-table aborts the fallback."""
+        """``optional-dependencies`` declared as non-table rejects the version."""
         pyproject = (
             "[project]\n"
             'name = "pkg"\n'
@@ -6128,7 +6128,7 @@ class TestStaticSdistMetadata:
             python_version="3.12.0",
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
-        with pytest.raises(UnsupportedSdistError):
+        with pytest.raises(MetadataError, match="must be a table"):
             provider.get_dependencies("pkg", V("1.0"))
 
     def test_pyproject_skips_non_string_dynamic_entries(self) -> None:
@@ -6153,8 +6153,8 @@ class TestStaticSdistMetadata:
         deps = provider.get_dependencies("pkg", V("1.0"))
         assert "dep-a" in deps
 
-    def test_pyproject_skips_non_list_extra_value(self) -> None:
-        """An extras value that isn't a list is skipped without aborting."""
+    def test_pyproject_extra_value_not_list_rejects(self) -> None:
+        """An extras value that isn't a list rejects the version."""
         pyproject = (
             "[project]\n"
             'name = "pkg"\n'
@@ -6174,13 +6174,11 @@ class TestStaticSdistMetadata:
             python_version="3.12.0",
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
-        provider.get_dependencies("pkg", V("1.0"))
-        metadata = provider.metadata_cache[("pkg", V("1.0"))]
-        assert "foo" in metadata.provides_extra
-        assert "bad" not in metadata.provides_extra
+        with pytest.raises(MetadataError, match="extra 'bad' must be an array"):
+            provider.get_dependencies("pkg", V("1.0"))
 
-    def test_pyproject_drops_non_string_dep_strings(self) -> None:
-        """Non-string dependency entries are skipped during parsing."""
+    def test_pyproject_non_string_dep_entry_rejects(self) -> None:
+        """A non-string dependency entry rejects the version."""
         pyproject = (
             "[project]\n"
             'name = "pkg"\n'
@@ -6197,9 +6195,8 @@ class TestStaticSdistMetadata:
             python_version="3.12.0",
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
-        deps = provider.get_dependencies("pkg", V("1.0"))
-        assert "dep-a" in deps
-        assert "dep-b" in deps
+        with pytest.raises(MetadataError, match="must be an array of strings"):
+            provider.get_dependencies("pkg", V("1.0"))
 
     def test_pyproject_drops_invalid_requirements(self) -> None:
         """Malformed requirement strings are dropped, not fatal."""
@@ -6246,8 +6243,8 @@ class TestStaticSdistMetadata:
         metadata = provider.metadata_cache[("pkg", V("1.0"))]
         assert "foo" in metadata.provides_extra
 
-    def test_pyproject_skips_non_string_extra_dep(self) -> None:
-        """Non-string entries inside an extras list are skipped."""
+    def test_pyproject_non_string_extra_dep_rejects(self) -> None:
+        """A non-string entry inside an extras list rejects the version."""
         pyproject = (
             "[project]\n"
             'name = "pkg"\n'
@@ -6266,7 +6263,8 @@ class TestStaticSdistMetadata:
             python_version="3.12.0",
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
-        provider.get_dependencies("pkg", V("1.0"))
+        with pytest.raises(MetadataError, match="extra 'foo' must be an array"):
+            provider.get_dependencies("pkg", V("1.0"))
 
     def test_build_remote_invokes_backend(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
A local source, workspace member, or sdist whose pyproject.toml declared `[project].dependencies` with the wrong shape had its dependencies silently dropped. A bare string like `dependencies = "requests"` type-checks as a sequence of strings, so it was iterated character by character into eight one-letter requirements; a table instead of an array, or non-string array entries, were skipped entirely. Either way the package resolved with no error and no warning, missing its real dependencies.

Both static readers (the build-backend `extract_static_metadata` and the dynamic-deps `augment_from_pyproject` fallback) now run `dependencies`, `optional-dependencies`, and each per-extra value through a shared `_require_string_list` check that raises `InvalidProjectRequirementError` when the value is not an array of strings (or a table for `optional-dependencies`). In the resolver that surfaces as a `MetadataError`, so the bad version is rejected rather than presented dependency-free. A well-typed entry that just is not valid PEP 508 is still dropped with a warning, as before.
