### PR TITLE
fix over-constrained requires-python when some artifacts of a pin declare none

### DIFF
--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -519,11 +519,17 @@ def require_artifact_hashes(lock_input: LockInput) -> None:
 
 
 def _common_requires_python(files: Iterable[WheelFile | SdistFile]) -> str | None:
-    """Return a single Requires-Python value if all files agree, else ``None``."""
+    """Return the package-level Requires-Python value, or ``None``.
+
+    An artefact with no Requires-Python imposes no Python floor, so a
+    single unconstrained artefact leaves the package unconstrained.
+    Otherwise the value is returned only when every artefact agrees.
+    """
     seen: set[str] = set()
     for f in files:
-        if f.requires_python is not None:
-            seen.add(f.requires_python)
+        if f.requires_python is None:
+            return None
+        seen.add(f.requires_python)
     if len(seen) == 1:
         return next(iter(seen))
     return None

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -456,8 +456,9 @@ def _merge_pins_in_group(pins: list[PinShape]) -> PinShape:
 
     For :class:`IndexPin`, accumulates every distinct wheel filename
     across the contributing tuples and keeps the first non-``None``
-    sdist.  ``requires_python`` survives only when every tuple agreed,
-    matching :func:`_common_requires_python`'s rule.
+    sdist.  ``requires_python`` survives only when every tuple carried
+    the same value and none was unconstrained, matching
+    :func:`_common_requires_python`'s rule.
     Non-IndexPin shapes are already fully discriminated, so the first
     pin is returned unchanged.
     """
@@ -469,16 +470,21 @@ def _merge_pins_in_group(pins: list[PinShape]) -> PinShape:
     seen_wheels: dict[str, WheelArtifact] = {}
     sdist = head.sdist
     requires_python_set: set[str] = set()
+    any_unconstrained = False
     for pin in pins:
         assert isinstance(pin, IndexPin)
         for wheel in pin.wheels:
             seen_wheels.setdefault(wheel.filename, wheel)
         if sdist is None and pin.sdist is not None:
             sdist = pin.sdist
-        if pin.requires_python is not None:
+        if pin.requires_python is None:
+            any_unconstrained = True
+        else:
             requires_python_set.add(pin.requires_python)
     requires_python = (
-        next(iter(requires_python_set)) if len(requires_python_set) == 1 else None
+        next(iter(requires_python_set))
+        if not any_unconstrained and len(requires_python_set) == 1
+        else None
     )
     return IndexPin(
         name=head.name,

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -1004,6 +1004,11 @@ class TestConflictForkRequiresPythonMerge:
         assert foo.requires_python is not None
         assert str(foo.requires_python) == ">=3.10"
 
+    def test_unconstrained_fork_drops_requires_python(self) -> None:
+        pylock = build_pylock(self._build(">=3.10", None))
+        foo = next(p for p in pylock.packages if str(p.name) == "foo")
+        assert foo.requires_python is None
+
 
 class TestConflictForkByteStability:
     """``write_lock`` is deterministic across multiple conflict forks.
@@ -2945,6 +2950,31 @@ class TestBuildLockInputFromProvider:
         )
         provider = _FakeProvider(
             listings={"foo": [(Version("1.0"), wheel_a), (Version("1.0"), wheel_b)]}
+        )
+        lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0")})
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.requires_python is None
+
+    def test_unconstrained_artifact_drops_requires_python(self) -> None:
+        constrained = _wheel_file(requires_python=">=3.10")
+        unconstrained = WheelFile(
+            filename="foo-1.0-cp312-cp312-linux_x86_64.whl",
+            url="https://example.com/foo-1.0-cp312-cp312-linux_x86_64.whl",
+            version="1.0",
+            requires_python=None,
+            has_metadata=False,
+            upload_time=None,
+            hashes=(("sha256", "c" * 64),),
+            size=1024,
+        )
+        provider = _FakeProvider(
+            listings={
+                "foo": [
+                    (Version("1.0"), constrained),
+                    (Version("1.0"), unconstrained),
+                ]
+            }
         )
         lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0")})
         pin = lock_input.pins["foo"]


### PR DESCRIPTION
When a pinned version's artifacts disagree on Requires-Python, with some wheels declaring a value and others declaring none, the lock recorded the declared value as the package-level requires-python. That excludes the Python versions the unconstrained artifacts support, so a lock could refuse to install on an interpreter the package runs on.

An artifact with no Requires-Python imposes no Python floor, so `_common_requires_python` now treats a single unconstrained artifact as leaving the whole pin unconstrained instead of ignoring it. The conflict-fork merge path in `pylock.py` follows the same rule when combining pins across forks.
