### PR TITLE
trim verbose and stale code comments

### DIFF
--- a/nab-index/src/nab_index/_naming.py
+++ b/nab-index/src/nab_index/_naming.py
@@ -2,8 +2,8 @@
 
 Wraps :func:`packaging.utils.canonicalize_name` so the local- and
 multi-index modules share a single helper.  ``packaging`` is already
-a runtime dependency (see ``pyproject.toml``), so deferring to it
-avoids the divergent regexes the helpers used to carry.
+a runtime dependency (see ``pyproject.toml``), so the helpers defer
+to it.
 """
 
 from __future__ import annotations

--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -5,9 +5,6 @@ before any HTTP transport call. Honors a small subset of RFC 9111:
 fresh entries are served directly, stale entries are revalidated with
 ``If-None-Match``, and PEP 658 metadata + sdist PKG-INFO are treated
 as immutable (cached forever; never revalidated).
-
-Cache hits short-circuit before any HTTP code runs. With a fully
-populated cache the client never opens a socket.
 """
 
 from __future__ import annotations

--- a/nab-python/benchmarks/compare.py
+++ b/nab-python/benchmarks/compare.py
@@ -38,7 +38,6 @@ STAT_LABELS = {
     "look_ahead_rejections": "Look-ahead rejections",
     "packages_resolved": "Packages resolved",
     "wall_time_seconds": "Wall time (s)",
-    # legacy keys (older results before stats rework):
     "listing_requests": "Listing requests (legacy)",
     "metadata_requests": "Metadata requests (legacy)",
 }

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -518,11 +518,7 @@ def process_scenario(
     index_routes = parse_index_routes(scenario_name, scenario)
     build_policy_overrides = parse_build_packages(scenario_name, scenario)
     if marker_environment and build_policy_overrides:
-        # BuildPolicy.BUILD_REMOTE + marker_environment is rejected at
-        # provider construction (host backend cannot reflect the
-        # impersonated target).  Drop the per-package builds so the
-        # scenario still runs; if resolution now fails the override
-        # was load-bearing and the scenario needs an audit.
+        # BUILD_REMOTE + marker_environment is rejected at provider construction.
         print(
             f"\n  [audit] {scenario_name}: dropping {len(build_policy_overrides)}"
             " build_packages override(s) because the scenario uses a"

--- a/nab-python/benchmarks/strategy_sweep.py
+++ b/nab-python/benchmarks/strategy_sweep.py
@@ -216,10 +216,7 @@ def _scenario_inputs(scenario: dict) -> dict | None:
     )
     build_policy_overrides = _scenarios.parse_build_packages("sweep", scenario)
     if marker_env and build_policy_overrides:
-        # See ``scenarios.py``: BUILD_REMOTE + marker_environment is
-        # rejected at provider construction.  Drop the overrides so the
-        # sweep keeps running; a scenario that now fails was relying on
-        # the prior silent passthrough.
+        # BUILD_REMOTE + marker_environment is rejected at provider construction.
         build_policy_overrides = []
     return {
         "requirements": requirements,

--- a/nab-python/src/nab_python/_provider/sources.py
+++ b/nab-python/src/nab_python/_provider/sources.py
@@ -84,8 +84,6 @@ def extract_source_metadata(
     ``"vcs"`` for :class:`VcsSource` clones (admitted only at
     :attr:`BuildPolicy.BUILD_REMOTE`).
     """
-    # Module-level attribute access lets tests patch
-    # ``nab_python.build_backend.extract_metadata`` from the source.
     from .. import build_backend
     from ..build_backend import BuildBackendError, extract_static_metadata
     from ..provider import BuildPolicy, UnsupportedSdistError
@@ -191,8 +189,6 @@ def materialize_vcs_source(
     source: VcsSource,
 ) -> list[tuple[Version, SdistFile]]:
     """Clone ``source`` and materialise it via the same path as a LocalSource."""
-    # Module-level attribute access lets tests patch
-    # ``nab_index.vcs.prepare_clone`` from the source.
     from nab_index import vcs as _vcs
 
     from ..provider import UnsupportedSdistError

--- a/nab-python/src/nab_python/_provider/sources.py
+++ b/nab-python/src/nab_python/_provider/sources.py
@@ -84,6 +84,7 @@ def extract_source_metadata(
     ``"vcs"`` for :class:`VcsSource` clones (admitted only at
     :attr:`BuildPolicy.BUILD_REMOTE`).
     """
+    # Imported in-function so tests can patch the module attribute.
     from .. import build_backend
     from ..build_backend import BuildBackendError, extract_static_metadata
     from ..provider import BuildPolicy, UnsupportedSdistError
@@ -189,6 +190,7 @@ def materialize_vcs_source(
     source: VcsSource,
 ) -> list[tuple[Version, SdistFile]]:
     """Clone ``source`` and materialise it via the same path as a LocalSource."""
+    # Imported in-function so tests can patch the module attribute.
     from nab_index import vcs as _vcs
 
     from ..provider import UnsupportedSdistError

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -410,7 +410,6 @@ class Provider:
     # blockers that are also the right pin.
     _MAX_FORCE_BACKTRACKS_PER_PKG = 3
 
-    # Re-exported from _provider.priority so test references keep resolving.
     TIER_AFFECTED = _priority.TIER_AFFECTED
     TIER_NORMAL = _priority.TIER_NORMAL
     TIER_CULPRIT = _priority.TIER_CULPRIT

--- a/nab-python/src/nab_python/universal/matrix.py
+++ b/nab-python/src/nab_python/universal/matrix.py
@@ -212,8 +212,6 @@ class Matrix:
     tuple.  Users with deployments on later patch releases should
     declare them here so marker evaluation matches reality.  Example:
     ``python_patches={"3.11": "3.11.4", "3.12": "3.12.1"}``.
-    See ``universal_open_questions.md`` section 1.1 for the design
-    discussion.
 
     ``implementations``: the interpreter implementations to model
     (``"cpython"``, ``"pypy"``).  Defaults to ``("cpython",)``.  Each

--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -559,9 +559,7 @@ def _parse_requirements(
     """Convert PEP 508 strings to resolver requirements for ``environment``.
 
     Marker-gated requirements whose marker evaluates to False in
-    ``environment`` are dropped.  This matches what
-    ``Provider._classify_requirement`` does for transitive deps;
-    we just apply the same rule at the root.
+    ``environment`` are dropped, as for transitive deps.
 
     A direct-URL/VCS requirement is refused via :func:`admit_vcs_url`,
     mirroring the single-environment path; universal resolution of such

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -240,7 +240,6 @@ class TestPerTupleMarkerSimplification:
             LockInput(per_tuple_pins=per_tuple, tuple_markers=tuple_markers)
         )
         data = tomllib.loads(text)
-        # Two Package entries, each with a marker
         assert len(data["packages"]) == 2
         markers = [p.get("marker") for p in data["packages"]]
         assert all(m is not None for m in markers)

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -3158,7 +3158,6 @@ class TestExtras:
         provider = Provider(coordinator, python_version="3.12.0")
         provider.get_dependencies("foo[security]", V("1.0"))
         provider.get_dependencies("foo[security]", V("1.0"))
-        # Deps should be cached after first call
         assert ("foo[security]", V("1.0")) in provider.deps_cache
 
     def test_prioritize_extras_before_base(self) -> None:
@@ -3250,10 +3249,8 @@ class TestExtras:
         )
         provider = Provider(coordinator, python_version="3.12.0")
         base_deps = provider.get_dependencies("foo", V("1.0"))
-        # bar is a base dep (env marker, not extra-gated)
         assert "bar" in base_deps
         extra_deps = provider.get_dependencies("foo[dev]", V("1.0"))
-        # baz is from the extra, bar should not be in extra deps
         assert "baz" in extra_deps
         assert "bar" not in extra_deps
 
@@ -3686,7 +3683,6 @@ class TestDistPolicy:
         )
         provider = Provider(coordinator, dist_policy=DistPolicy.WHEEL_ONLY)
         versions = provider.fetch_versions("pkg")
-        # Only the wheel should remain
         assert len(versions) == 1
         assert isinstance(versions[0][1], WheelFile)
 
@@ -4273,7 +4269,6 @@ class TestPickBestCandidateNone:
         coordinator = make_coordinator(wheels, package="foo")
         provider = Provider(coordinator)
         with patch.object(provider, "pick_best_candidate", return_value=None):
-            # Should return without requesting any metadata.
             provider.speculative_prefetch("foo", [(V("1.0"), wheels[0])])
         coordinator.request_metadata.assert_not_called()
 

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -1327,10 +1327,6 @@ class TestResolveUniversalWrapper:
 
     def test_constructs_coordinator_and_delegates(self) -> None:
         """The wrapper constructs a FetchCoordinator and delegates."""
-        # We don't exercise real networking; we verify the wrapper
-        # contract by mocking ``FetchCoordinator`` and
-        # ``HttpxAsyncTransport`` and asserting the inner function
-        # was called with our coordinator.
         sentinel = MagicMock()
         sentinel.success = True
         sentinel.tuple_results = []

--- a/nab-python/tests/universal/test_universal_provider.py
+++ b/nab-python/tests/universal/test_universal_provider.py
@@ -158,7 +158,6 @@ class TestPreferences:
             marker_environment=_LINUX_ENV,
             preferences={"My-Cool_Pkg": Version("1.0")},
         )
-        # canonicalize_name lowercases and replaces underscores with hyphens
         assert "my-cool-pkg" in provider._preferences
 
     def test_preference_used_when_in_range(self) -> None:
@@ -182,10 +181,7 @@ class TestPreferences:
             marker_environment=_LINUX_ENV,
             preferences={"pkg": Version("5.0")},
         )
-        # Range >=2.0 admits 2.0 and 3.0; preference 5.0 isn't in
-        # listing so we fall through to highest.
         result = provider.choose_version("pkg", VersionRange.full())
-        # Highest in the listing is 3.0; preference 5.0 isn't a candidate.
         assert result == Version("3.0")
 
 

--- a/nab-resolver/src/nab_resolver/conflict.py
+++ b/nab-resolver/src/nab_resolver/conflict.py
@@ -68,8 +68,7 @@ def conflict_resolution(
 
     while True:
         if is_terminal_incompatibility(current_incompatibility):
-            # Unreachable in practice: the backjump_target == 0 check below
-            # preempts this path.  Kept as a safety net.
+            # Unreachable: the backjump_target == 0 check below raises first.
             raise ResolutionError(  # pragma: no cover
                 format_error(current_incompatibility),
                 incompatibility=current_incompatibility,

--- a/nab-resolver/tests/test_priority.py
+++ b/nab-resolver/tests/test_priority.py
@@ -133,7 +133,6 @@ class TestConflictCountsReachProvider:
         )
         resolver = Resolver(provider)
         resolver.resolve({"root": Range.singleton(1)})
-        # prioritize was called at least once
         assert len(provider.seen_conflict_counts) > 0
 
     def test_conflict_counts_accumulate(self) -> None:
@@ -152,7 +151,6 @@ class TestConflictCountsReachProvider:
             resolver.resolve({"root": Range.singleton(1)})
         except ResolutionError:
             pass
-        # Later calls to prioritize should see non-empty conflict counts
         non_empty = [c for c in provider.seen_conflict_counts if c]
         assert len(non_empty) > 0
 

--- a/nab-resolver/tests/test_ranges.py
+++ b/nab-resolver/tests/test_ranges.py
@@ -155,7 +155,6 @@ class TestInfinitySentinels:
     def test_infinity_hashing(self) -> None:
         from nab_resolver.ranges import NEGATIVE_INFINITY, POSITIVE_INFINITY
 
-        # Must be hashable for use in sets/dicts
         hashable_set = {NEGATIVE_INFINITY, POSITIVE_INFINITY}
         assert len(hashable_set) == 2
         assert hash(NEGATIVE_INFINITY) == hash(NEGATIVE_INFINITY)
@@ -173,8 +172,8 @@ class TestRangeContainment:
 
     def test_exact_boundary_inclusive(self) -> None:
         r = Range.between(2, 5)
-        assert 2 in r  # inclusive lower
-        assert 5 not in r  # exclusive upper
+        assert 2 in r
+        assert 5 not in r
 
     def test_at_most(self) -> None:
         r = Range.at_most(3)

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -584,7 +584,6 @@ class TestPreference:
 class TestMaxIterations:
     def test_exceeds_max_iterations(self) -> None:
         """Resolver raises when max_iterations is exceeded."""
-        # Create a scenario that needs many rounds
         provider = DictProvider(
             {
                 "root": {1: {"a": Range.full()}},
@@ -1302,7 +1301,6 @@ class TestRestart:
         With restart: after 5 conflicts, a is promoted, decided first,
         and b is only decided once at the end.
         """
-        # Provider that promotes high-conflict packages
         a_versions = {}
         for v in range(10, 0, -1):
             a_versions[v] = {"b": Range.at_least(v)}
@@ -1319,7 +1317,6 @@ class TestRestart:
         assert result["a"] == 1
         assert result["b"] == 1
         assert resolver.stats.restarts >= 1
-        # With restart + promotion, fewer decisions than without
         assert resolver.stats.decisions < 30
 
     def test_restarts_are_bounded(self) -> None:
@@ -1584,7 +1581,6 @@ class TestForceBacktrack:
         )
         resolver = Resolver(provider)
         resolver.resolve({"root": Range.singleton(1)})
-        # Force-backtrack target should have been queued at least once.
         assert provider._fired
 
     def test_resolver_triggers_backtrack_path(self) -> None:
@@ -1715,7 +1711,6 @@ class TestDependencyMerge:
             cause=IncompatibilityCause.DEPENDENCY,
         )
         add_incompatibility(r, second)
-        # One stored clause; package term covers both versions.
         assert len(r.incompatibilities) == 1
         merged = r.incompatibilities[0]
         assert 1 in merged.terms[0].constraint
@@ -1740,7 +1735,6 @@ class TestDependencyMerge:
             cause=IncompatibilityCause.DEPENDENCY,
         )
         add_incompatibility(r, second)
-        # The new clause is fully subsumed by the existing range.
         assert len(r.incompatibilities) == 1
         assert r.incompatibilities[0] is first
 
@@ -1775,7 +1769,6 @@ class TestErrorMessages:
             resolver.resolve({"root": Range.singleton(1)})
         message = str(exc_info.value)
         assert "D" in message or "A" in message or "E" in message
-        # The error should have a derived incompatibility with causes
         root_inc = exc_info.value.incompatibility
         assert root_inc is not None
 


### PR DESCRIPTION
Cuts code comments that were not pulling their weight: ones that narrate what downstream code does with a value, describe how the code used to work, or restate what the next line already says.

No behavior change. The trims span nab-index, nab-python, and nab-resolver, plus the benchmark scripts and tests. Comments that carry a real why (a spec clause, a deliberate tradeoff, why an import is function-local, why a branch is unreachable) stay, shortened to one line where they ran long.
