### PR TITLE
dedupe versions that compare equal but stringify differently in the listing

### DIFF
--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -79,10 +79,19 @@ def versions_only(
     normalized: str,
     version_list: list[tuple[Version, DistFile]],
 ) -> list[Version]:
-    """Return the cached version-only view for ``normalized``."""
+    """Return the cached version-only view for ``normalized``.
+
+    One entry per version, in listing order, so a release with both a
+    wheel and an sdist is not listed twice.
+    """
     cached = provider.versions_only_cache.get(normalized)
     if cached is None:
-        cached = [v for v, _ in version_list]
+        seen: set[Version] = set()
+        cached = []
+        for version, _ in version_list:
+            if version not in seen:
+                seen.add(version)
+                cached.append(version)
         provider.versions_only_cache[normalized] = cached
     return cached
 
@@ -92,12 +101,40 @@ def wheel_by_version(
     normalized: str,
     version_list: list[tuple[Version, DistFile]],
 ) -> dict[Version, DistFile]:
-    """Return the cached ``Version -> DistFile`` mapping for ``normalized``."""
+    """Return the cached ``Version -> DistFile`` mapping for ``normalized``.
+
+    Keeps the cheapest metadata source per version (wheel with PEP 658
+    metadata, then any wheel, then sdist), so a same-version sdist does
+    not displace the wheel.
+    """
     cached = provider.wheel_by_version_cache.get(normalized)
     if cached is None:
-        cached = dict(version_list)
+        cached = {}
+        for version, dist in version_list:
+            cached[version] = _prefer_metadata_source(cached.get(version), dist)
         provider.wheel_by_version_cache[normalized] = cached
     return cached
+
+
+def _prefer_metadata_source(current: DistFile | None, candidate: DistFile) -> DistFile:
+    """Return the cheaper metadata source of ``current`` and ``candidate``.
+
+    Same ranking as
+    :func:`nab_python._provider.metadata_resolver.pick_dist_for_metadata`:
+    a wheel with a PEP 658 ``metadata_url``, then any wheel, then an sdist.
+    """
+    if current is None:
+        return candidate
+    return (
+        current if _metadata_rank(current) <= _metadata_rank(candidate) else candidate
+    )
+
+
+def _metadata_rank(dist: DistFile) -> int:
+    """Rank a dist by metadata-fetch cost (lower is cheaper)."""
+    if isinstance(dist, WheelFile):
+        return 0 if dist.metadata_url is not None else 1
+    return 2
 
 
 def speculative_prefetch(
@@ -268,7 +305,31 @@ def filter_distributions(
         )
     else:
         result.sort(key=lambda pair: pair[0], reverse=True)
-    return result
+    return _canonicalize_equal_versions(result)
+
+
+def _canonicalize_equal_versions(
+    result: list[tuple[Version, DistFile]],
+) -> list[tuple[Version, DistFile]]:
+    """Share one ``Version`` object across artifacts of one logical release.
+
+    ``Version("1.0") == Version("1.0.0")`` yet their ``str()`` differ, so a
+    release shipping a wheel filename ``1.0`` and an sdist filename ``1.0.0``
+    would carry two equal but differently stringed versions, and the pin
+    string (``str`` of the decided version) would then vary with resolution
+    strategy and listing order.  Collapse each equal group to one
+    representative, chosen by fewest release segments then string, so the
+    pin is deterministic.
+    """
+    representative: dict[Version, Version] = {}
+    for version, _ in result:
+        chosen = representative.get(version)
+        if chosen is None or (len(version.release), str(version)) < (
+            len(chosen.release),
+            str(chosen),
+        ):
+            representative[version] = version
+    return [(representative[version], dist) for version, dist in result]
 
 
 def _excluded_by_dist_policy(dist: DistFile, policy: object) -> bool:

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -513,6 +513,69 @@ class TestResolutionStrategy:
         assert provider.choose_version("foo", VersionRange.full()) == V("2.0")
 
 
+class TestEqualVersionDifferentStrings:
+    """One logical release published with mismatched filename version strings.
+
+    A wheel filename reading ``1.0`` and an sdist filename reading ``1.0.0``
+    are the same version (``Version("1.0") == Version("1.0.0")``) with
+    distinct ``str()`` forms.  The listing collapses them to one version,
+    keeps the wheel as the metadata source, and pins the same string under
+    every resolution strategy.
+    """
+
+    @staticmethod
+    def _files() -> list[WheelFile | SdistFile]:
+        return [make_wheel("1.0"), make_sdist("1.0.0")]
+
+    def test_listing_collapses_to_one_logical_version(self) -> None:
+        coordinator = make_coordinator(self._files(), package="pkg")
+        provider = Provider(coordinator, python_version="3.12.0")
+        version_list = provider.fetch_versions("pkg")
+        versions = provider.versions_only("pkg", version_list)
+        assert versions == [V("1.0")]
+        assert {str(v) for v in versions} == {"1.0"}
+
+    def test_wheel_not_evicted_by_same_version_sdist(self) -> None:
+        coordinator = make_coordinator(self._files(), package="pkg")
+        provider = Provider(coordinator, python_version="3.12.0")
+        version_list = provider.fetch_versions("pkg")
+        mapping = provider._wheel_by_version("pkg", version_list)
+        assert len(mapping) == 1
+        dist = mapping[V("1.0")]
+        assert isinstance(dist, WheelFile)
+        assert dist.metadata_url is not None
+
+    def test_pin_string_is_strategy_independent(self) -> None:
+        chosen: dict[ResolutionStrategy, Version | None] = {}
+        for strategy in (ResolutionStrategy.HIGHEST, ResolutionStrategy.LOWEST):
+            coordinator = make_coordinator(self._files(), package="pkg")
+            provider = Provider(
+                coordinator,
+                python_version="3.12.0",
+                resolution_strategy=strategy,
+            )
+            chosen[strategy] = provider.choose_version(
+                "pkg", SpecifierSet(">=1.0").to_range()
+            )
+        highest = chosen[ResolutionStrategy.HIGHEST]
+        lowest = chosen[ResolutionStrategy.LOWEST]
+        assert highest is not None
+        assert lowest is not None
+        assert str(highest) == str(lowest)
+
+    def test_pin_string_independent_of_file_order(self) -> None:
+        forward = make_coordinator(self._files(), package="pkg")
+        reverse_files = list(reversed(self._files()))
+        backward = make_coordinator(reverse_files, package="pkg")
+        p_forward = Provider(forward, python_version="3.12.0")
+        p_backward = Provider(backward, python_version="3.12.0")
+        v_forward = p_forward.choose_version("pkg", SpecifierSet(">=1.0").to_range())
+        v_backward = p_backward.choose_version("pkg", SpecifierSet(">=1.0").to_range())
+        assert v_forward is not None
+        assert v_backward is not None
+        assert str(v_forward) == str(v_backward)
+
+
 class TestPrereleaseAdmission:
     """The real Provider applies PEP 440 pre-release admission end to end.
 


### PR DESCRIPTION
When a release ships a wheel with filename version `1.0` and an sdist with filename version `1.0.0`, those two filenames parse to versions that compare equal (`Version("1.0") == Version("1.0.0")`) but stringify differently. That broke the listing in three ways:

- `wheel_by_version` built the mapping with `dict(version_list)`, so the second equal entry overwrote the first and the sdist could displace the wheel as the metadata source.
- `versions_only` listed the same release twice.
- The locked pin (the `str()` of the decided version) flipped between `1.0` and `1.0.0` depending on resolution strategy and the order the files were listed.

This shares one `Version` object across all artifacts of a logical release, picking the representative deterministically (fewest release segments, then string), so the pin no longer depends on strategy or order. `wheel_by_version` now keeps the cheapest metadata source per version (a wheel with PEP 658 metadata, then any wheel, then an sdist) instead of letting the last entry win, and the version-only view is deduped to one entry per release.
