### PR TITLE
Compare pin versions as parsed Version, not raw string

### DIFF
--- a/nab-python/src/nab_python/universal/validate.py
+++ b/nab-python/src/nab_python/universal/validate.py
@@ -28,11 +28,11 @@ from .._vendor.packaging.requirements import (
     Requirement,
 )
 from .._vendor.packaging.utils import canonicalize_name, canonicalize_version
+from .._vendor.packaging.version import Version
 from ..metadata import load_static_project, metadata_deps_are_static, parse_metadata
 from .wheel_selection import select_wheel_for_tuple
 
 if TYPE_CHECKING:
-    from .._vendor.packaging.version import Version
     from ..fetch import FetchCoordinator
     from .matrix import MatrixTuple
     from .resolve import UniversalResult
@@ -170,7 +170,7 @@ def _validate_pin(  # noqa: PLR0911 - one return per outcome reads cleaner here
     """Run the per-pin checks; emit a PinValidation outcome."""
     normalized = canonicalize_name(package)
     listing = coordinator.index.get_listing(normalized) or []
-    files_at_version = [f for f in listing if f.version == str(version)]
+    files_at_version = [f for f in listing if Version(f.version) == version]
     wheels_at_version = [f for f in files_at_version if isinstance(f, WheelFile)]
     has_sdist = any(not isinstance(f, WheelFile) for f in files_at_version)
     if not files_at_version:

--- a/nab-python/tests/universal/test_validate.py
+++ b/nab-python/tests/universal/test_validate.py
@@ -722,6 +722,57 @@ class TestPyprojectStaticDepsFastPath:
         assert _pyproject_is_pep621_static(coordinator, "pkg", Version("1.0")) is True
 
 
+class TestEqualVersionsDifferentStrings:
+    """One release whose wheel and sdist filenames stringify to equal but
+    different versions (``pkg-1.0-...`` vs ``pkg-1.0.0.tar.gz``).  The
+    validator matches listing files by Version, not by raw string.
+    """
+
+    def test_wheel_matched_when_pin_string_differs(self) -> None:
+        """Pin ``1.0.0`` finds the wheel filed as ``1.0`` rather than reporting sdist_only."""
+        wheel = _wheel("pkg-1.0-cp311-cp311-linux_x86_64.whl")
+        sdist = _sdist("pkg-1.0.0.tar.gz")
+        assert wheel.version == "1.0"
+        assert sdist.version == "1.0.0"
+        coordinator = _make_coordinator({"pkg": [wheel, sdist]})
+        coordinator.index.store_metadata("pkg", "1.0.0", _BASE_METADATA)
+        coordinator.index.store_metadata(
+            "pkg", f"1.0.0#{wheel.filename}", _BASE_METADATA
+        )
+        result = UniversalResult(
+            matrix=MagicMock(),
+            tuple_results=[
+                TupleResult(
+                    tuple_=_linux_311(),
+                    success=True,
+                    pins={"pkg": Version("1.0.0")},
+                ),
+            ],
+        )
+        report = validate_lock(result, coordinator)
+        assert report.findings[0].status == "ok"
+
+    def test_sdist_matched_when_pin_string_differs(self) -> None:
+        """Pin ``1.0`` sees the sdist filed as ``1.0.0`` (buildable, not a hard error)."""
+        only_win = _wheel("pkg-1.0.0-cp311-cp311-win_amd64.whl")
+        sdist = _sdist("pkg-1.0.tar.gz")
+        assert only_win.version == "1.0.0"
+        assert sdist.version == "1.0"
+        coordinator = _make_coordinator({"pkg": [only_win, sdist]})
+        result = UniversalResult(
+            matrix=MagicMock(),
+            tuple_results=[
+                TupleResult(
+                    tuple_=_linux_311(),
+                    success=True,
+                    pins={"pkg": Version("1.0")},
+                ),
+            ],
+        )
+        report = validate_lock(result, coordinator)
+        assert report.findings[0].status == "no_compatible_wheel_with_sdist"
+
+
 class TestNoCompatibleWheelWithSdist:
     """When wheels exist but none compatible, sdist availability matters."""
 


### PR DESCRIPTION
The universal lock validator picked the index files for a pinned release by comparing raw version strings (`f.version == str(version)`). When a release's wheel and sdist filenames stringify to equal but differently spelled PEP 440 versions (say a `pkg-1.0-...whl` wheel next to a `pkg-1.0.0.tar.gz` sdist), those files do not string-match the pin, so they were dropped from the candidate set.

The validator then reported the wrong outcome for that pin: a release with a usable wheel could come back as `sdist_only` or `version_not_found`.

`_validate_pin` now parses both sides to `Version` and compares for equality, so every file at the release is matched no matter how its version is spelled in the filename.
