### PR TITLE
enforce universal require-one conflicts per matrix tuple

### DIFF
--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -28,6 +28,7 @@ from .config import (
     ConfigError,
     ConflictFork,
     ConflictKind,
+    ConflictSelectionError,
     ConflictSet,
     NabProjectConfig,
     ResolveMode,
@@ -750,6 +751,32 @@ def _raise_for_local_vcs_python(
             raise ResolutionError(msg)
 
 
+def _validate_universal_conflict_minimums(
+    conflicts: Sequence[ConflictSet],
+    tables: _ForkTables,
+    selected_extras: Sequence[str],
+    active_groups: Sequence[str],
+    tuples: Sequence[MatrixTuple],
+) -> None:
+    """Run the require-one minimums check per tuple, marker-aware.
+
+    A member reached only through a marker-gated self reference is active
+    only on the tuples whose environment satisfies that marker, so the
+    check expands the self-extra closure against each tuple's environment.
+    A tuple on which no member is active fails the policy even when another
+    tuple satisfies it.
+    """
+    for t in tuples:
+        active_extras = expand_self_extras(
+            tables.optional, tables.project_name, selected_extras, t.environment
+        )
+        try:
+            validate_conflict_minimums(conflicts, active_extras, active_groups)
+        except ConflictSelectionError as exc:
+            msg = f"{exc} (tuple {t.label})"
+            raise ConflictSelectionError(msg) from exc
+
+
 def resolve_universal_pyproject(
     path: Path,
     *,
@@ -818,10 +845,12 @@ def resolve_universal_pyproject(
         _validate_conflict_members_exist(
             config.conflicts, tables.optional, tables.groups
         )
-        validate_conflict_minimums(
+        _validate_universal_conflict_minimums(
             config.conflicts,
-            expand_self_extras(tables.optional, tables.project_name, extras),
+            tables,
+            extras,
             expand_group_includes(tables.groups, effective_groups),
+            expanded_tuples,
         )
 
     conflict_fork_list = conflict_forks(extras, effective_groups, config.conflicts)

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -1305,6 +1305,57 @@ class TestResolveUniversalPyproject:
         forks = mock_resolve_universal.call_args.kwargs["forks"]
         assert len(forks) == 2
 
+    def test_marker_gated_member_unreachable_on_a_tuple_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """A require-one member reachable only on a win32-gated tuple
+        leaves the non-win32 tuple with no member, so the resolve raises."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "myproj"\ndependencies = ["base"]\n'
+            "[project.optional-dependencies]\n"
+            "all = ['myproj[gpu]; sys_platform == \"win32\"']\n"
+            'gpu = ["cupy"]\n'
+            'cpu = ["numpy"]\n'
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'conflicts = [{ members = [{ extra = "cpu" },'
+            ' { extra = "gpu" }], policy = "exactly-one" }]\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.11"\n'
+            'platforms = ["linux_x86_64", "windows_amd64"]\n'
+        )
+        with (
+            patch("nab_python.resolve.resolve_universal") as mock_universal,
+            pytest.raises(ConflictSelectionError, match="exactly one"),
+        ):
+            resolve_universal_pyproject(pyproject, extras=["all"])
+        mock_universal.assert_not_called()
+
+    @patch("nab_python.resolve.resolve_universal")
+    def test_marker_gated_member_reachable_on_every_tuple_passes(
+        self, mock_resolve_universal: MagicMock, tmp_path: Path
+    ) -> None:
+        """A self reference whose marker holds on every tuple keeps the
+        require-one set satisfied, so the resolve proceeds."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "myproj"\ndependencies = ["base"]\n'
+            "[project.optional-dependencies]\n"
+            "all = [\"myproj[gpu]; python_version >= '3.0'\"]\n"
+            'gpu = ["cupy"]\n'
+            'cpu = ["numpy"]\n'
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'conflicts = [{ members = [{ extra = "cpu" },'
+            ' { extra = "gpu" }], policy = "exactly-one" }]\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.11"\n'
+            'platforms = ["linux_x86_64", "windows_amd64"]\n'
+        )
+        resolve_universal_pyproject(pyproject, extras=["all"])
+        mock_resolve_universal.assert_called_once()
+
     @patch("nab_python.resolve.resolve_universal")
     @patch("nab_python.resolve._check_group_disjointness_across_tuples")
     def test_repeated_active_groups_check_once(


### PR DESCRIPTION
In universal mode the require-one conflict check (exactly-one and at-least-one) ran once with the self-extra closure expanded marker-blind. A member reached only through a marker-gated self reference, like `myproj[gpu]; sys_platform == "win32"`, was treated as always reachable, so it silently satisfied the set even on tuples whose environment makes that marker false. Those tuples were left with no active member but the resolve still went ahead.

The check now runs per tuple. For each tuple the self-extra closure is expanded against that tuple's own environment, so a member is only counted on tuples where its marker holds. A tuple where no member is active now fails the policy, and the error names the tuple. A self reference whose marker holds on every tuple still satisfies the set everywhere, so those resolves proceed unchanged.
