### PR TITLE
keep === operand raw in universal validator's requirement key

### DIFF
--- a/nab-python/src/nab_python/universal/validate.py
+++ b/nab-python/src/nab_python/universal/validate.py
@@ -526,6 +526,10 @@ def _requirement_key(req: Requirement) -> str:
     Versions are canonicalized per specifier so equivalent spellings
     (``>=2.0`` vs ``>=2``) compare equal across wheels; the marker is
     omitted because bucketing by extra already accounts for it.
+    Trailing zeros are kept for ``~=`` and ``===`` because both treat
+    them as significant (``~=`` for its implied upper bound, ``===`` as
+    a literal string match), so trimming them would conflate distinct
+    constraints.
     """
     name: str = canonicalize_name(req.name)
     if req.extras:
@@ -536,7 +540,7 @@ def _requirement_key(req: Requirement) -> str:
         sorted(
             spec.operator
             + canonicalize_version(
-                spec.version, strip_trailing_zero=spec.operator != "~="
+                spec.version, strip_trailing_zero=spec.operator not in {"~=", "==="}
             )
             for spec in req.specifier
         )

--- a/nab-python/src/nab_python/universal/validate.py
+++ b/nab-python/src/nab_python/universal/validate.py
@@ -526,10 +526,8 @@ def _requirement_key(req: Requirement) -> str:
     Versions are canonicalized per specifier so equivalent spellings
     (``>=2.0`` vs ``>=2``) compare equal across wheels; the marker is
     omitted because bucketing by extra already accounts for it.
-    Trailing zeros are kept for ``~=`` and ``===`` because both treat
-    them as significant (``~=`` for its implied upper bound, ``===`` as
-    a literal string match), so trimming them would conflate distinct
-    constraints.
+    ``===`` matches the version string literally, so its operand is kept
+    raw, and ``~=`` keeps trailing zeros because they set its upper bound.
     """
     name: str = canonicalize_name(req.name)
     if req.extras:
@@ -539,8 +537,12 @@ def _requirement_key(req: Requirement) -> str:
     return name + ",".join(
         sorted(
             spec.operator
-            + canonicalize_version(
-                spec.version, strip_trailing_zero=spec.operator not in {"~=", "==="}
+            + (
+                spec.version
+                if spec.operator == "==="
+                else canonicalize_version(
+                    spec.version, strip_trailing_zero=spec.operator != "~="
+                )
             )
             for spec in req.specifier
         )

--- a/nab-python/tests/universal/test_validate.py
+++ b/nab-python/tests/universal/test_validate.py
@@ -29,6 +29,7 @@ from nab_python.universal.validate import (
     ValidationReport,
     _dependencies_override_for,
     _evaluate_metadata_deps_by_extra,
+    _requirement_key,
     validate_lock,
 )
 from nab_python.universal.wheel_selection import PlatformSpec
@@ -1225,6 +1226,21 @@ class TestSpecifierDivergence:
         finding = self._validate_single(baseline, chosen)
         assert finding.status == "divergent"
 
+    def test_arbitrary_equality_trailing_zeros_diverge(self) -> None:
+        """``===`` is literal, so ``1.0.0`` and ``1.0`` are different deps."""
+        baseline = (
+            "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n"
+            "Requires-Dist: dep===1.0\n\n"
+        )
+        chosen = (
+            "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n"
+            "Requires-Dist: dep===1.0.0\n\n"
+        )
+        finding = self._validate_single(baseline, chosen)
+        assert finding.status == "divergent"
+        assert finding.extra_deps == ("dep===1.0.0",)
+        assert finding.missing_deps == ("dep===1.0",)
+
 
 def _single_linux_result() -> UniversalResult:
     """A one-tuple result pinning ``pkg==1.0`` on linux/py311."""
@@ -1328,3 +1344,35 @@ class TestDependenciesOverrideValidation:
         overrides = (pkg_override("pkg", requires_python=">=3.11"),)
         report = validate_lock(result, coordinator, overrides)
         assert report.findings[0].status == "divergent"
+
+
+class TestRequirementKey:
+    """``_requirement_key`` normalizes only where PEP 440 allows it."""
+
+    def test_equality_normalizes_trailing_zeros(self) -> None:
+        assert _requirement_key(Requirement("dep==1.0.0")) == _requirement_key(
+            Requirement("dep==1.0")
+        )
+
+    def test_arbitrary_equality_keeps_trailing_zeros_distinct(self) -> None:
+        assert _requirement_key(Requirement("dep===1.0.0")) == "dep===1.0.0"
+        assert _requirement_key(Requirement("dep===1.0")) == "dep===1.0"
+        assert _requirement_key(Requirement("dep===1.0.0")) != _requirement_key(
+            Requirement("dep===1.0")
+        )
+
+    def test_arbitrary_equality_keeps_leading_zeros_distinct(self) -> None:
+        assert _requirement_key(Requirement("dep===01.0")) == "dep===01.0"
+        assert _requirement_key(Requirement("dep===01.0")) != _requirement_key(
+            Requirement("dep===1.0")
+        )
+
+    def test_arbitrary_equality_keeps_prerelease_spelling_distinct(self) -> None:
+        assert _requirement_key(Requirement("dep===1.0.0alpha1")) != _requirement_key(
+            Requirement("dep===1.0.0a1")
+        )
+
+    def test_arbitrary_equality_keeps_local_case_distinct(self) -> None:
+        assert _requirement_key(Requirement("dep===1.0+ABC")) != _requirement_key(
+            Requirement("dep===1.0+abc")
+        )


### PR DESCRIPTION
The universal lock validator builds a per-requirement key to compare a package's dependencies across wheels. For `===` (arbitrary equality) specifiers it ran the operand through `canonicalize_version` with trailing-zero stripping, the same as `==`. But `===` matches the version string literally, so `dep===1.0.0` and `dep===1.0` are different constraints. Canonicalizing the operand gave them the same key, so two wheels carrying those distinct deps looked identical and the validator missed real divergence. Leading zeros, prerelease spelling (`alpha1` vs `a1`), and local-version case were flattened the same way.

The key now keeps the `===` operand raw and only canonicalizes the operators where PEP 440 allows it. `==` still treats `1.0.0` and `1.0` as equal, and `~=` still keeps trailing zeros since they set its upper bound.
