### PR TITLE
pick sdist PKG-INFO and pyproject.toml from one top-level root

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -482,42 +482,61 @@ def _extract_sdist_files(data: bytes) -> tuple[str | None, str | None]:
 
 
 def _read_tar_sdist_files(data: bytes) -> tuple[str | None, str | None]:
-    pkg_info: str | None = None
-    pyproject_toml: str | None = None
+    pkg_infos: dict[str, str] = {}
+    pyprojects: dict[str, str] = {}
 
     with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
         for member in tar:
-            depth, basename = _sdist_member_top_level(member.name)
-            if depth > 1:
+            depth, top_dir, basename = _sdist_member_top_level(member.name)
+            if depth != 1:
                 continue
-            if pkg_info is None and basename == "PKG-INFO":
-                extracted = tar.extractfile(member)
-                if extracted is not None:
-                    pkg_info = extracted.read().decode("utf-8")
-            elif pyproject_toml is None and basename == "pyproject.toml":
-                extracted = tar.extractfile(member)
-                if extracted is not None:
-                    pyproject_toml = extracted.read().decode("utf-8")
+            target = (
+                pkg_infos
+                if basename == "PKG-INFO"
+                else pyprojects
+                if basename == "pyproject.toml"
+                else None
+            )
+            if target is None or top_dir in target:
+                continue
+            extracted = tar.extractfile(member)
+            if extracted is not None:
+                target[top_dir] = extracted.read().decode("utf-8")
 
-            if pkg_info is not None and pyproject_toml is not None:
-                break
-
-    return (pkg_info, pyproject_toml)
+    return _select_sdist_root(pkg_infos, pyprojects)
 
 
-def _sdist_member_top_level(name: str) -> tuple[int, str]:
-    """Return ``(depth, basename)`` for a tar member relative to the sdist root.
+def _select_sdist_root(
+    pkg_infos: dict[str, str], pyprojects: dict[str, str]
+) -> tuple[str | None, str | None]:
+    """Pick PKG-INFO and pyproject.toml from one ``<name>-<version>/`` root.
+
+    A conformant sdist has a single top-level directory holding both
+    files.  PKG-INFO is the defining file, so its directory is the root;
+    pyproject.toml counts only when it shares that directory.  If several
+    top-level directories carry a PKG-INFO the root is ambiguous, so both
+    return ``None`` rather than risk pairing files from different roots.
+    """
+    if len(pkg_infos) != 1:
+        return (None, None)
+    root, pkg_info = next(iter(pkg_infos.items()))
+    return (pkg_info, pyprojects.get(root))
+
+
+def _sdist_member_top_level(name: str) -> tuple[int, str, str]:
+    """Return ``(depth, top_dir, basename)`` for a tar member.
 
     Strips a single leading ``./``.  Depth 0 means the file sits at the
-    archive root (rare); depth 1 means it sits directly under the
-    conventional ``<name>-<version>/`` top-level directory.  Anything
+    archive root; depth 1 means it sits directly under a top-level
+    directory, whose name is ``top_dir`` (empty at depth 0).  Anything
     deeper is reported as-is so callers can ignore it.
     """
     stripped = name.removeprefix("./")
     if not stripped or stripped.startswith("/"):
-        return (-1, "")
+        return (-1, "", "")
     parts = stripped.split("/")
-    return (len(parts) - 1, parts[-1])
+    top_dir = parts[0] if len(parts) > 1 else ""
+    return (len(parts) - 1, top_dir, parts[-1])
 
 
 def extract_sdist_archive(data: bytes, target_dir: Path) -> Path:

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -475,6 +475,69 @@ class TestExtractSdistFiles:
         _, pyproject = _extract_sdist_files(body)
         assert pyproject is None
 
+    def test_ignores_pkg_info_at_archive_root(self) -> None:
+        """A PKG-INFO at archive root never shadows the real one under the root dir."""
+        body = _build_tarball(
+            [
+                ("PKG-INFO", b"Metadata-Version: 2.1\nName: stray\n"),
+                ("realpkg-1.0/PKG-INFO", b"Metadata-Version: 2.1\nName: realpkg\n"),
+            ]
+        )
+        pkg_info, _ = _extract_sdist_files(body)
+        assert pkg_info is not None
+        assert "Name: realpkg" in pkg_info
+
+    def test_drops_metadata_when_top_level_dir_is_ambiguous(self) -> None:
+        """Two sibling top-level dirs each with a PKG-INFO has no canonical root."""
+        body = _build_tarball(
+            [
+                ("zzz/PKG-INFO", b"Metadata-Version: 2.1\nName: wrong\n"),
+                ("realpkg-1.0/PKG-INFO", b"Metadata-Version: 2.1\nName: realpkg\n"),
+                ("realpkg-1.0/pyproject.toml", b"[project]\nname = 'realpkg'\n"),
+            ]
+        )
+        pkg_info, pyproject = _extract_sdist_files(body)
+        assert pkg_info is None
+        assert pyproject is None
+
+    def test_pyproject_must_share_pkg_info_top_level_dir(self) -> None:
+        """A pyproject.toml from a sibling dir does not pair with the real PKG-INFO."""
+        body = _build_tarball(
+            [
+                ("realpkg-1.0/PKG-INFO", b"Metadata-Version: 2.1\nName: realpkg\n"),
+                ("other-2.0/pyproject.toml", b"[project]\nname = 'other'\n"),
+            ]
+        )
+        pkg_info, pyproject = _extract_sdist_files(body)
+        assert pkg_info is not None
+        assert "Name: realpkg" in pkg_info
+        assert pyproject is None
+
+    def test_first_member_wins_within_one_root(self) -> None:
+        """A duplicate basename in the same root keeps the first occurrence."""
+        body = _build_tarball(
+            [
+                ("realpkg-1.0/PKG-INFO", b"Metadata-Version: 2.1\nName: first\n"),
+                ("realpkg-1.0/PKG-INFO", b"Metadata-Version: 2.1\nName: second\n"),
+            ]
+        )
+        pkg_info, _ = _extract_sdist_files(body)
+        assert pkg_info is not None
+        assert "Name: first" in pkg_info
+
+    def test_pairs_pkg_info_and_pyproject_from_same_root(self) -> None:
+        """PKG-INFO and pyproject.toml under one root pair normally."""
+        body = _build_tarball(
+            [
+                ("realpkg-1.0/PKG-INFO", b"Metadata-Version: 2.1\nName: realpkg\n"),
+                ("realpkg-1.0/pyproject.toml", b"[project]\nname = 'realpkg'\n"),
+            ]
+        )
+        pkg_info, pyproject = _extract_sdist_files(body)
+        assert pkg_info is not None
+        assert "Name: realpkg" in pkg_info
+        assert pyproject == "[project]\nname = 'realpkg'\n"
+
     def test_returns_none_on_tar_error(self) -> None:
         assert _extract_sdist_files(b"not-a-tarball") == (None, None)
 


### PR DESCRIPTION
When reading metadata out of a .tar.gz sdist, we matched PKG-INFO and pyproject.toml by basename anywhere at the top of the archive and kept whichever the tar happened to list first. A stray PKG-INFO at the archive root, or one sitting in a sibling top-level directory, could shadow the real package's metadata, and a pyproject.toml from a different directory could get paired with it. That drives the resolve with the wrong metadata.

Now we group the top-level PKG-INFO and pyproject.toml files by their directory and treat the directory that holds PKG-INFO as the package root. The pyproject.toml is only used when it sits in that same root. If more than one top-level directory carries a PKG-INFO the root is ambiguous, so we return no metadata instead of guessing.
