### PR TITLE
evaluate self-ref markers in the universal conflict-exclusion check

### DIFF
--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -777,6 +777,32 @@ def _validate_universal_conflict_minimums(
             raise ConflictSelectionError(msg) from exc
 
 
+def _validate_universal_conflict_exclusions(
+    conflicts: Sequence[ConflictSet],
+    tables: _ForkTables,
+    active_extras: Sequence[str],
+    active_groups: Sequence[str],
+    tuples: Sequence[MatrixTuple],
+) -> None:
+    """Run the at-most-one exclusion check per tuple, marker-aware.
+
+    A self reference reaches its target only on tuples whose environment
+    satisfies its marker, so the self-extra closure is expanded against each
+    tuple's environment. Members reached under disjoint markers never share a
+    tuple and pass; two that co-activate on one tuple fail.
+    """
+    expanded_groups = expand_group_includes(tables.groups, active_groups)
+    for t in tuples:
+        expanded_extras = expand_self_extras(
+            tables.optional, tables.project_name, active_extras, t.environment
+        )
+        try:
+            validate_conflict_exclusions(conflicts, expanded_extras, expanded_groups)
+        except ConflictSelectionError as exc:
+            msg = f"{exc} (tuple {t.label})"
+            raise ConflictSelectionError(msg) from exc
+
+
 def resolve_universal_pyproject(
     path: Path,
     *,
@@ -861,15 +887,14 @@ def resolve_universal_pyproject(
     seen_group_selections: set[tuple[str, ...]] = set()
     for fork in conflict_fork_list:
         if config.conflicts:
-            # A fork that still reaches two members of one exclusive set
-            # (for example through an umbrella extra) has no disjoint
-            # resolution, so refuse rather than silently merge them.
-            validate_conflict_exclusions(
+            # Refuse a fork that reaches two members of one exclusive set on a
+            # single tuple (for example through an umbrella extra).
+            _validate_universal_conflict_exclusions(
                 config.conflicts,
-                expand_self_extras(
-                    tables.optional, tables.project_name, fork.active_extras
-                ),
-                expand_group_includes(tables.groups, fork.active_groups),
+                tables,
+                fork.active_extras,
+                fork.active_groups,
+                expanded_tuples,
             )
         if (
             len(fork.active_groups) > 1

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -1463,6 +1463,69 @@ class TestResolveUniversalPyproject:
         mock_universal.assert_not_called()
 
     @patch("nab_python.resolve.resolve_universal")
+    def test_umbrella_extra_disjoint_markers_resolve(
+        self, mock_resolve_universal: MagicMock, tmp_path: Path
+    ) -> None:
+        """Self-refs to both members under disjoint markers do not co-select.
+
+        ``all`` reaches cpu only below 3.10 and gpu only at 3.10+, so no
+        single tuple activates both. The exclusion check runs per tuple
+        against each tuple's environment, so the resolve proceeds.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = ["base"]\n'
+            "[project.optional-dependencies]\n"
+            'cpu = ["foo==1.0"]\n'
+            'gpu = ["foo==2.0"]\n'
+            "all = [\n"
+            "    \"x[cpu]; python_version < '3.10'\",\n"
+            "    \"x[gpu]; python_version >= '3.10'\",\n"
+            "]\n"
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+            "[tool.nab.matrix]\n"
+            'python = ">=3.9,<3.13"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+        resolve_universal_pyproject(pyproject, extras=["all"])
+        mock_resolve_universal.assert_called_once()
+
+    def test_umbrella_extra_co_selecting_on_one_tuple_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """Overlapping self-ref markers co-activate both members on a tuple.
+
+        ``all`` reaches cpu at 3.10+ and gpu at every version, so the 3.11
+        tuple activates both. The per-tuple exclusion check must refuse the
+        resolve even though the 3.9 tuple reaches only gpu.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = ["base"]\n'
+            "[project.optional-dependencies]\n"
+            'cpu = ["foo==1.0"]\n'
+            'gpu = ["foo==2.0"]\n'
+            "all = [\n"
+            "    \"x[cpu]; python_version >= '3.10'\",\n"
+            '    "x[gpu]",\n'
+            "]\n"
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+            "[tool.nab.matrix]\n"
+            'python = ">=3.9,<3.13"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+        with (
+            patch("nab_python.resolve.resolve_universal") as mock_universal,
+            pytest.raises(ConflictSelectionError, match="cannot be selected together"),
+        ):
+            resolve_universal_pyproject(pyproject, extras=["all"])
+        mock_universal.assert_not_called()
+
+    @patch("nab_python.resolve.resolve_universal")
     def test_umbrella_extra_reaching_one_member_single_fork(
         self, mock_resolve_universal: MagicMock, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
In universal mode, an umbrella extra whose self-references carry disjoint markers wrongly failed with ConflictSelectionError and refused a valid lock. For example, `all = ["x[cpu]; python_version < '3.10'", "x[gpu]; python_version >= '3.10'"]` with cpu and gpu declared mutually exclusive: no single environment activates both, but the resolve still raised.

The at-most-one exclusion check expanded the umbrella's self-references with markers stripped, so it saw both cpu and gpu active at once and refused to merge them.

The check now runs once per matrix tuple, expanding self-extras against that tuple's environment so the markers are evaluated. Members reached only under disjoint markers never share a tuple and pass; two that co-activate on a single tuple still fail.
