### PR TITLE
stop universal manylinux floor descending below an arch's oldest glibc

### DIFF
--- a/nab-python/src/nab_python/universal/wheel_selection.py
+++ b/nab-python/src/nab_python/universal/wheel_selection.py
@@ -71,6 +71,15 @@ _LEGACY_MANYLINUX: dict[tuple[int, int], str] = {
     (2, 5): "manylinux1",
 }
 
+# Lowest glibc 2.x minor a manylinux wheel may target, by arch.  manylinux1
+# (PEP 513) and manylinux2010 (PEP 571) cover only x86_64/i686; manylinux2014
+# (PEP 599, glibc 2.17) was the first to add other arches, so every other arch
+# stops at glibc 2.17.
+_LEGACY_GLIBC_MAJOR = 2
+_X86_MANYLINUX_ARCHS = frozenset({"x86_64", "i686"})
+_X86_MIN_GLIBC2_MINOR = 5
+_OTHER_MIN_GLIBC2_MINOR = 17
+
 
 @dataclass(frozen=True)
 class PlatformSpec:
@@ -178,23 +187,31 @@ def _linux_platform_tags(
 
     Returns the tag list in install-preference order: most-specific
     (highest glibc/musl version) first.  Accepts every minor version
-    at or below the declared floor; this is the spec-compliant
-    interpretation of "manylinux_X_Y means glibc X.Y or older".
+    at or below the declared floor, down to the arch's oldest
+    supported glibc; this is the spec-compliant interpretation of
+    "manylinux_X_Y means glibc X.Y or older".
 
     Note: PEP 600 says installers prefer wheels with the *highest*
     glibc among compatible ones.  Our use case is "decide which
     wheel a tuple would install"; the tag list ordering matches
     that preference.
     """
-    # manylinux_X_Y: PEP 600 form.  We accept any minor at or below
-    # the floor (a wheel built for glibc 2.5 runs on a system with
-    # glibc 2.17; a wheel built for glibc 2.34 does not).  Iterate
-    # high-to-low for preference order, emitting each legacy alias
-    # right after its equivalent PEP 600 tag so a legacy-named wheel
-    # ranks at its own glibc, matching packaging.tags.
+    # manylinux_X_Y: PEP 600 form.  Iterate high-to-low for preference
+    # order, emitting each legacy alias right after its equivalent
+    # PEP 600 tag so a legacy-named wheel ranks at its own glibc, matching
+    # packaging.tags.  A glibc 2.x floor stops at the arch's oldest tag
+    # (2.5 for x86, 2.17 otherwise); any other major stops at minor 0.
     major, minor = manylinux_floor
+    if major == _LEGACY_GLIBC_MAJOR:
+        min_minor = (
+            _X86_MIN_GLIBC2_MINOR
+            if arch in _X86_MANYLINUX_ARCHS
+            else _OTHER_MIN_GLIBC2_MINOR
+        )
+    else:
+        min_minor = 0
     out: list[str] = []
-    for m in range(minor, -1, -1):
+    for m in range(minor, min_minor - 1, -1):
         out.append(f"manylinux_{major}_{m}_{arch}")
         legacy = _LEGACY_MANYLINUX.get((major, m))
         if legacy is not None:

--- a/nab-python/tests/universal/test_wheel_selection.py
+++ b/nab-python/tests/universal/test_wheel_selection.py
@@ -118,6 +118,46 @@ class TestCompatibleTagsForTuple:
         assert "cp311-cp311-manylinux2014_x86_64" not in tag_strs
         assert "cp311-cp311-manylinux2010_x86_64" in tag_strs
 
+    def test_aarch64_manylinux_floor_stops_at_2_17(self) -> None:
+        """aarch64 does not descend below glibc 2.17 (PEP 599)."""
+        spec = PlatformSpec("linux_aarch64", manylinux_floor=(2, 17))
+        tag_strs = {
+            str(t) for t in compatible_tags_for_tuple(python_version="3.11", spec=spec)
+        }
+        assert "cp311-cp311-manylinux_2_17_aarch64" in tag_strs
+        assert "cp311-cp311-manylinux2014_aarch64" in tag_strs
+        assert "cp311-cp311-manylinux_2_16_aarch64" not in tag_strs
+        assert "cp311-cp311-manylinux_2_5_aarch64" not in tag_strs
+        assert "cp311-cp311-manylinux2010_aarch64" not in tag_strs
+        assert "cp311-cp311-manylinux1_aarch64" not in tag_strs
+
+    def test_aarch64_rejects_legacy_alias_wheels(self) -> None:
+        """A manylinux1/manylinux2010 aarch64 wheel is not installable."""
+        spec = PlatformSpec("linux_aarch64")
+        for alias in ("manylinux1", "manylinux2010"):
+            wheel = _wheel(f"foo-1.0-cp311-cp311-{alias}_aarch64.whl")
+            assert not wheel_compatible_with_tuple(
+                wheel, python_version="3.11", spec=spec
+            )
+
+    def test_x86_64_keeps_legacy_alias_floor(self) -> None:
+        """x86_64 still descends to manylinux1 (glibc 2.5)."""
+        spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
+        tag_strs = {
+            str(t) for t in compatible_tags_for_tuple(python_version="3.11", spec=spec)
+        }
+        assert "cp311-cp311-manylinux1_x86_64" in tag_strs
+        assert "cp311-cp311-manylinux_2_5_x86_64" in tag_strs
+
+    def test_non_glibc2_floor_descends_to_x_0(self) -> None:
+        """A glibc 3.x floor descends to 3.0 on any arch (the 2.17 cap is glibc 2.x only)."""
+        spec = PlatformSpec("linux_aarch64", manylinux_floor=(3, 1))
+        tag_strs = {
+            str(t) for t in compatible_tags_for_tuple(python_version="3.11", spec=spec)
+        }
+        assert "cp311-cp311-manylinux_3_1_aarch64" in tag_strs
+        assert "cp311-cp311-manylinux_3_0_aarch64" in tag_strs
+
     def test_linux_includes_musllinux_at_floor(self) -> None:
         """Musllinux at-or-below the floor is admitted."""
         spec = PlatformSpec("linux_x86_64", musllinux_floor=(1, 2))


### PR DESCRIPTION
Universal wheel selection generated the full manylinux tag ladder down to glibc 2.0 for every architecture, including the manylinux1 and manylinux2010 legacy aliases. Those aliases only ever covered x86_64 and i686 (PEPs 513 and 571); manylinux2014 (PEP 599, glibc 2.17) was the first to add other arches. So for aarch64 (and any non-x86 arch) nab emitted tags like manylinux1_aarch64 and manylinux_2_5_aarch64 that no real wheel uses, and would have judged such wheels installable even though packaging.tags and pip reject them.

The fix floors the glibc 2.x ladder at the arch's oldest real tag: minor 2.5 for x86_64/i686, minor 2.17 otherwise. A non-glibc-2 floor (a hypothetical glibc 3.x) is unaffected and still descends to minor 0.
