### PR TITLE
defer direct-URL refusal for deps gated on an unrequested extra

### DIFF
--- a/nab-python/src/nab_python/_provider/extras.py
+++ b/nab-python/src/nab_python/_provider/extras.py
@@ -13,6 +13,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from .._vendor.packaging.ranges import VersionRange
+from .metadata_resolver import refuse_url_dep
 
 if TYPE_CHECKING:
     from nab_resolver.types import RangeProtocol
@@ -186,6 +187,11 @@ def get_extra_dependencies(
         # metadata_cache on success or raises; this is defensive.
         msg = f"No metadata cached for {base}=={version}"
         raise MetadataError(msg)
+
+    deferred = provider.deferred_url_extras.get(base_cache_key, {}).get(extra)
+    if deferred:
+        req, url = deferred[0]
+        refuse_url_dep(provider, req, url)
 
     extra_map = provider.extra_deps_map.get(base_cache_key, {})
     if extra not in extra_map:

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -417,26 +417,53 @@ def cache_deps_from_metadata(
     # Late import: ``pypi`` imports this module at module load.
     from ..provider import _normalize_extra
 
+    package, _ = cache_key
     provider.metadata_cache[cache_key] = metadata
     provided_extras = {_normalize_extra(e) for e in metadata.provides_extra}
     base_deps: dict[str, VersionRange] = {}
     extra_deps_map: dict[str, dict[str, VersionRange]] = {
         e: {} for e in provided_extras
     }
+    deferred_url_extras: dict[str, list[tuple[Requirement, str]]] = {}
     for req in metadata.requires_dist:
         req_extras = classify_requirement(provider, req, provided_extras)
         if req_extras is None:
             continue
         if req.url is not None:
-            admit_vcs_url(req.url, provider.vcs_config)
-            msg = (
-                f"VCS dependency admitted by policy but resolver path is not"
-                f" implemented: {req.name} @ {req.url}"
-            )
-            raise NotImplementedError(msg)
+            if _url_dep_is_active(provider, package, req_extras):
+                refuse_url_dep(provider, req, req.url)
+            else:
+                for extra_name in req_extras:
+                    deferred_url_extras.setdefault(extra_name, []).append(
+                        (req, req.url)
+                    )
+            continue
         add_classified_dep(req, req_extras, base_deps, extra_deps_map)
     provider.deps_cache[cache_key] = base_deps
     provider.extra_deps_map[cache_key] = extra_deps_map
+    provider.deferred_url_extras[cache_key] = deferred_url_extras
+
+
+def _url_dep_is_active(provider: Provider, package: str, req_extras: set[str]) -> bool:
+    """Whether a direct-URL dep must be refused at base-metadata time.
+
+    A base dep (no extra gating) is always active. An extra-gated dep is active
+    only when the user requested one of its extras at the root; otherwise its
+    refusal defers to the per-extra path.
+    """
+    if not req_extras:
+        return True
+    return any((package, extra) in provider.root_extras for extra in req_extras)
+
+
+def refuse_url_dep(provider: Provider, req: Requirement, url: str) -> None:
+    """Refuse a direct-URL requirement, or raise ``NotImplementedError``."""
+    admit_vcs_url(url, provider.vcs_config)
+    msg = (
+        f"VCS dependency admitted by policy but resolver path is not"
+        f" implemented: {req.name} @ {url}"
+    )
+    raise NotImplementedError(msg)
 
 
 def add_classified_dep(

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -513,6 +513,12 @@ class Provider:
         self.extra_deps_map: dict[
             tuple[str, Version], dict[str, dict[str, VersionRange]]
         ] = {}
+        # Direct-URL deps gated behind a provided-but-unrequested extra. The
+        # refusal is deferred until the extra is selected, so a plain resolve of
+        # a package that merely offers such an extra is not aborted.
+        self.deferred_url_extras: dict[
+            tuple[str, Version], dict[str, list[tuple[Requirement, str]]]
+        ] = {}
 
         # Memoised sdist-rejections so re-tries do not re-parse PKG-INFO.
         self._unsupported_sdists: set[tuple[str, Version]] = set()

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -1095,6 +1095,87 @@ class TestTransitiveDirectUrlDep:
         assert "bar" not in deps
         assert "baz" in deps
 
+    @staticmethod
+    def _provider_with_extra_url(
+        url: str,
+        *,
+        root_extras: set[tuple[str, str]] | None = None,
+        vcs_config: VcsConfig | None = None,
+    ) -> Provider:
+        coordinator = make_coordinator(
+            [make_wheel("1.0")],
+            metadata_text=(
+                "Metadata-Version: 2.1\n"
+                "Name: foo\n"
+                "Version: 1.0\n"
+                "Provides-Extra: uvloop\n"
+                f'Requires-Dist: bar @ {url} ; extra == "uvloop"\n'
+                "Requires-Dist: baz>=1.0\n"
+            ),
+            package="foo",
+        )
+        return Provider(
+            coordinator,
+            python_version="3.12.0",
+            root_extras=root_extras,
+            vcs_config=vcs_config,
+        )
+
+    def test_unrequested_extra_url_dep_does_not_abort_base(self) -> None:
+        """A url dep gated on a provided-but-unrequested extra is skipped at base."""
+        provider = self._provider_with_extra_url("https://example.com/bar.whl")
+        deps = provider.get_dependencies("foo", V("1.0"))
+        assert "bar" not in deps
+        assert "baz" in deps
+
+    def test_unrequested_extra_vcs_url_dep_does_not_abort_base(self) -> None:
+        """A VCS url under an unrequested extra is also skipped at base."""
+        provider = self._provider_with_extra_url(
+            "git+https://example.com/bar.git@" + "a" * 40
+        )
+        deps = provider.get_dependencies("foo", V("1.0"))
+        assert "bar" not in deps
+        assert "baz" in deps
+
+    def test_selected_extra_url_dep_is_refused(self) -> None:
+        """Selecting the extra fires the deferred direct-URL refusal."""
+        provider = self._provider_with_extra_url("https://example.com/bar.whl")
+        provider.get_dependencies("foo", V("1.0"))
+        with pytest.raises(UnsupportedVcsError, match="not a recognized VCS scheme"):
+            provider.get_dependencies("foo[uvloop]", V("1.0"))
+
+    def test_selected_extra_vcs_url_dep_is_refused(self) -> None:
+        """Selecting the extra fires the deferred VCS refusal under BLOCK."""
+        provider = self._provider_with_extra_url(
+            "git+https://example.com/bar.git@" + "a" * 40
+        )
+        provider.get_dependencies("foo", V("1.0"))
+        with pytest.raises(UnsupportedVcsError, match='vcs.policy is "block"'):
+            provider.get_dependencies("foo[uvloop]", V("1.0"))
+
+    def test_selected_extra_admitted_vcs_url_raises_not_implemented(self) -> None:
+        """An admitted VCS url under a selected extra raises NotImplementedError."""
+        provider = self._provider_with_extra_url(
+            "git+https://example.com/bar.git@" + "a" * 40,
+            vcs_config=VcsConfig(
+                policy=VcsPolicy.ALLOW,
+                allowed_schemes=frozenset({"git+https"}),
+                allowed_repos=("https://example.com/",),
+            ),
+        )
+        provider.get_dependencies("foo", V("1.0"))
+        with pytest.raises(NotImplementedError, match="not implemented"):
+            provider.get_dependencies("foo[uvloop]", V("1.0"))
+
+    def test_root_requested_extra_url_dep_refused_eagerly(self) -> None:
+        """When the extra is a root extra, the url dep is refused at base parse."""
+        provider = self._provider_with_extra_url(
+            "https://example.com/bar.whl",
+            root_extras={("foo", "uvloop")},
+        )
+        with pytest.raises(UnsupportedVcsError, match="not a recognized VCS scheme"):
+            provider.get_dependencies("foo", V("1.0"))
+
 
 class TestAddClassifiedDep:
     """``add_classified_dep`` intersects duplicate dependency names."""


### PR DESCRIPTION
Resolving a package that offers an extra whose dependency is a direct URL (or VCS) link failed even when that extra was never requested. Parsing the base metadata refused the URL dep right away, so a plain resolve of, say, a package that merely advertises a `foo[uvloop]` extra would abort the whole resolution instead of just leaving the extra alone.

Now an extra-gated direct-URL dep is stashed when the base metadata is parsed and only refused if that extra is actually selected. The base dependencies and any other extras resolve normally. A URL dep that is not gated on an extra, or one gated on an extra requested at the root, is still refused eagerly as before.
