### PR TITLE
verify sidecar metadata hashes published under an uppercase algorithm name

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -400,14 +400,19 @@ def _metadata_hash(file_info: dict) -> tuple[str, str] | None:
     """Return the sidecar's published ``(algo, hex)`` to verify, or None.
 
     Only sha256 is checked: it is what PyPI publishes for core metadata
-    and what pip verifies.  A bare ``true`` (sidecar exists, no hash)
-    or a table without sha256 yields None, so no check runs.
+    and what pip verifies.  The algorithm name is matched case-insensitively.
+    A bare ``true`` (sidecar exists, no hash) or a table without sha256
+    yields None, so no check runs.
     """
     value = _metadata_value(file_info)
     if isinstance(value, dict):
-        digest = value.get("sha256")
-        if isinstance(digest, str):
-            return ("sha256", digest.lower())
+        for algo, digest in value.items():
+            if (
+                isinstance(algo, str)
+                and algo.lower() == "sha256"
+                and isinstance(digest, str)
+            ):
+                return ("sha256", digest.lower())
     return None
 
 

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -150,6 +150,14 @@ class TestMetadataHashParsing:
             "abcd",
         )
 
+    def test_uppercase_algo_name(self) -> None:
+        from nab_index.client import _metadata_hash
+
+        assert _metadata_hash({"core-metadata": {"SHA256": "ABCD"}}) == (
+            "sha256",
+            "abcd",
+        )
+
     def test_legacy_key_used(self) -> None:
         from nab_index.client import _metadata_hash
 


### PR DESCRIPTION
A PEP 658/714 sidecar can publish its core-metadata digest under an uppercase algorithm key such as `SHA256`, which is valid since algorithm names are case-insensitive. `_metadata_hash` only looked up the lowercase `sha256` key, so for those entries it returned None and the fetched metadata was used with no hash check.

Now the digest table is matched case-insensitively, so an uppercase `SHA256` (or mixed case) is recognized and the metadata is verified rather than trusted unchecked.
