### PR TITLE
abort the resolve when PEP 658 metadata fails its published hash

### DIFF
--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -446,6 +446,11 @@ def await_metadata_batch(
         if cache_key in provider.deps_cache:
             continue
         event.wait()
+        integrity_error = provider.coordinator.index.get_metadata_error(
+            package, ver_str
+        )
+        if integrity_error is not None:
+            raise integrity_error
         text = provider.coordinator.index.get_metadata(package, ver_str)
         if text is None:
             # No PEP 658 text arrived: leave the version un-cached so

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -67,6 +67,11 @@ def resolve_metadata(
             normalized, ver_str, dist.metadata_url, dist.metadata_hash
         )
         event.wait()
+        integrity_error = provider.coordinator.index.get_metadata_error(
+            normalized, ver_str
+        )
+        if integrity_error is not None:
+            raise integrity_error
         metadata_text = provider.coordinator.index.get_metadata(normalized, ver_str)
     else:
         metadata_text = None

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any
 
 from nab_index.cache import CacheBackend, NullCache, OfflineError, OnDiskCache
 from nab_index.cached_client import CachedAsyncSimpleClient
-from nab_index.client import SdistFile, WheelFile
+from nab_index.client import MetadataHashMismatchError, SdistFile, WheelFile
 from nab_index.local_index import LocalIndexClient
 from nab_index.multi_index import IndexConfig, MultiIndexClient
 
@@ -121,6 +121,7 @@ class InMemoryIndex:
         self._listing_errors: dict[str, BaseException] = {}
         self._listing_indexes: dict[str, str] = {}
         self._metadata: dict[tuple[str, str], str | None] = {}
+        self._metadata_errors: dict[tuple[str, str], BaseException] = {}
         # Keys whose ``_metadata`` slot was last written from an sdist
         # PKG-INFO rather than a wheel METADATA; readers need the
         # origin because only sdist deps go through the PEP 643 gate.
@@ -216,6 +217,27 @@ class InMemoryIndex:
         if pending is not None:
             pending.result = data
             pending.event.set()
+
+    def store_metadata_error(
+        self, package: str, version: str, error: BaseException
+    ) -> None:
+        """Record an integrity failure for a metadata fetch and unblock waiters.
+
+        Distinct from ``store_metadata(None)``: ``None`` means no PEP 658
+        sidecar arrived and the resolver may fall back to the sdist, while an
+        error means the sidecar was served but failed its published hash.
+        """
+        key = f"metadata:{package}:{version}"
+        with self._lock:
+            self._metadata_errors[(package, version)] = error
+            pending = self._pending.get(key)
+        if pending is not None:
+            pending.event.set()
+
+    def get_metadata_error(self, package: str, version: str) -> BaseException | None:
+        """Return a recorded metadata integrity error, or ``None``."""
+        with self._lock:
+            return self._metadata_errors.get((package, version))
 
     def store_sdist_metadata(
         self, package: str, version: str, data: str | None
@@ -770,28 +792,38 @@ class FetchCoordinator:
                     await self._fetch_sdist_archive(client, req)
             except Exception as exc:
                 logger.exception("Fetch failed: %s %s", req.kind.value, req.package)
-                # Record a result so any waiter unblocks; without it the
-                # resolver deadlocks on event.wait().
-                if req.kind is FetchKind.LISTING:
-                    # Offline + cold cache is a deliberate empty listing
-                    # (the resolver proceeds with no candidates); any other
-                    # failure is stored as an error so fetch_versions can
-                    # surface it instead of reporting no candidates.
-                    if isinstance(exc, OfflineError):
-                        # Record the serving index before the empty listing
-                        # fires the pending event (see _fetch_listing).
-                        self._record_serving_index(client, req.package)
-                        self.index.store_listing(req.package, [])
-                    else:
-                        self.index.store_listing_error(req.package, exc)
-                else:
-                    assert req.version is not None
-                    if req.kind is FetchKind.METADATA:
-                        self.index.store_metadata(req.package, req.version, None)
-                    elif req.kind is FetchKind.SDIST:
-                        self.index.store_sdist_metadata(req.package, req.version, None)
-                    else:
-                        self.index.store_sdist_archive(req.package, req.version, None)
+                self._record_fetch_failure(client, req, exc)
+
+    def _record_fetch_failure(
+        self,
+        client: CachedAsyncSimpleClient | LocalIndexClient | MultiIndexClient,
+        req: FetchRequest,
+        exc: Exception,
+    ) -> None:
+        """Record a failed fetch so any waiter unblocks (else a deadlock)."""
+        if req.kind is FetchKind.LISTING:
+            # Offline + cold cache is a deliberate empty listing (the
+            # resolver proceeds with no candidates); any other failure is
+            # stored as an error so fetch_versions can surface it instead of
+            # reporting no candidates.
+            if isinstance(exc, OfflineError):
+                # Record the serving index before the empty listing fires the
+                # pending event (see _fetch_listing).
+                self._record_serving_index(client, req.package)
+                self.index.store_listing(req.package, [])
+            else:
+                self.index.store_listing_error(req.package, exc)
+            return
+        assert req.version is not None
+        if req.kind is FetchKind.METADATA:
+            if isinstance(exc, MetadataHashMismatchError):
+                self.index.store_metadata_error(req.package, req.version, exc)
+            else:
+                self.index.store_metadata(req.package, req.version, None)
+        elif req.kind is FetchKind.SDIST:
+            self.index.store_sdist_metadata(req.package, req.version, None)
+        else:
+            self.index.store_sdist_archive(req.package, req.version, None)
 
     async def _fetch_listing(
         self,

--- a/nab-python/src/nab_python/universal/validate.py
+++ b/nab-python/src/nab_python/universal/validate.py
@@ -422,7 +422,11 @@ def _fetch_wheel_metadata(
         wheel.metadata_hash,
     )
     event.wait()
-    return coordinator.index.get_metadata(normalized, f"{version}#{wheel.filename}")
+    sentinel = f"{version}#{wheel.filename}"
+    integrity_error = coordinator.index.get_metadata_error(normalized, sentinel)
+    if integrity_error is not None:
+        raise integrity_error
+    return coordinator.index.get_metadata(normalized, sentinel)
 
 
 def _evaluate_metadata_deps_by_extra(

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import io
 import json
 import tarfile
@@ -18,7 +19,7 @@ import respx
 
 from nab_index.cache import NullCache
 from nab_index.cached_client import CachedAsyncSimpleClient
-from nab_index.client import SdistFile, WheelFile
+from nab_index.client import MetadataHashMismatchError, SdistFile, WheelFile
 from nab_index.httpx_async_transport import HttpxAsyncTransport
 from nab_index.local_index import LocalIndexClient
 from nab_index.multi_index import IndexConfig, MultiIndexClient
@@ -69,6 +70,25 @@ class TestInMemoryIndex:
         idx = InMemoryIndex()
         idx.store_metadata("foo", "1.0", None)
         assert idx.has_metadata("foo", "1.0")
+
+    def test_metadata_error_roundtrip(self) -> None:
+        idx = InMemoryIndex()
+        assert idx.get_metadata_error("foo", "1.0") is None
+        error = MetadataHashMismatchError("metadata sha256 mismatch")
+        idx.store_metadata_error("foo", "1.0", error)
+        assert idx.get_metadata_error("foo", "1.0") is error
+        assert idx.get_metadata("foo", "1.0") is None
+
+    def test_store_metadata_error_fires_metadata_pending(self) -> None:
+        idx = InMemoryIndex()
+        pending, _ = idx.get_or_create_pending("metadata:foo:1.0")
+        idx.store_metadata_error("foo", "1.0", MetadataHashMismatchError("bad"))
+        assert pending.event.is_set()
+
+    def test_store_metadata_error_without_pending(self) -> None:
+        idx = InMemoryIndex()
+        idx.store_metadata_error("foo", "1.0", MetadataHashMismatchError("bad"))
+        assert idx.get_metadata_error("foo", "1.0") is not None
         assert idx.get_metadata("foo", "1.0") is None
 
     def test_pending_event_set_on_listing(self) -> None:
@@ -409,6 +429,8 @@ class TestFetchCoordinator:
 
     @respx.mock
     def test_listing_triggers_metadata_prefetch(self) -> None:
+        metadata_body = "Metadata-Version: 2.1\n"
+        digest = hashlib.sha256(metadata_body.encode()).hexdigest()
         listing = {
             "meta": {"api-version": "1.0"},
             "name": "pkg",
@@ -416,17 +438,17 @@ class TestFetchCoordinator:
                 {
                     "filename": "pkg-3.0-py3-none-any.whl",
                     "url": "https://f.com/pkg-3.0-py3-none-any.whl",
-                    "dist-info-metadata": {"sha256": "x"},
+                    "dist-info-metadata": {"sha256": digest},
                 },
                 {
                     "filename": "pkg-2.0-py3-none-any.whl",
                     "url": "https://f.com/pkg-2.0-py3-none-any.whl",
-                    "dist-info-metadata": {"sha256": "y"},
+                    "dist-info-metadata": {"sha256": digest},
                 },
                 {
                     "filename": "pkg-1.0-py3-none-any.whl",
                     "url": "https://f.com/pkg-1.0-py3-none-any.whl",
-                    "dist-info-metadata": {"sha256": "z"},
+                    "dist-info-metadata": {"sha256": digest},
                 },
             ],
         }
@@ -434,7 +456,7 @@ class TestFetchCoordinator:
             return_value=httpx.Response(200, json=listing)
         )
         respx.get(url__regex=r".*\.whl\.metadata$").mock(
-            return_value=httpx.Response(200, text="Metadata-Version: 2.1\n")
+            return_value=httpx.Response(200, text=metadata_body)
         )
         with _coord() as coord:
             event = coord.request_listing("pkg")
@@ -503,6 +525,29 @@ class TestFetchCoordinator:
             event.wait(timeout=5)
             assert not coord._crashed
             assert coord.index.get_metadata("broken", "1.0") is None
+
+    @respx.mock
+    def test_metadata_hash_mismatch_records_integrity_error(self) -> None:
+        """A PEP 658 sidecar that fails its published hash is recorded as an
+        integrity error, not stored as a None (no-metadata) result."""
+        good = b"Metadata-Version: 2.1\nName: tampered\n"
+        good_digest = hashlib.sha256(good).hexdigest()
+        tampered = b"Metadata-Version: 2.1\nName: evil\n"
+        respx.get("https://files.example.com/tampered-1.0.whl.metadata").mock(
+            return_value=httpx.Response(200, content=tampered)
+        )
+        with _coord() as coord:
+            event = coord.request_metadata(
+                "tampered",
+                "1.0",
+                "https://files.example.com/tampered-1.0.whl.metadata",
+                ("sha256", good_digest),
+            )
+            event.wait(timeout=5)
+            assert not coord._crashed
+            assert coord.index.get_metadata("tampered", "1.0") is None
+            error = coord.index.get_metadata_error("tampered", "1.0")
+            assert isinstance(error, MetadataHashMismatchError)
 
     def test_crashed_raises(self) -> None:
         coord = _coord()

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from nab_index.client import SdistFile, WheelFile
+from nab_index.client import MetadataHashMismatchError, SdistFile, WheelFile
 from nab_python._provider.metadata_resolver import (
     add_classified_dep,
     classify_requirement,
@@ -856,6 +856,27 @@ class TestGetDependencies:
         # Metadata should only be requested once (via speculative prefetch
         # or direct request), second call uses the deps cache
         assert ("foo", V("1.0")) in provider.deps_cache
+
+    def test_metadata_hash_mismatch_aborts_no_sdist_fallback(self) -> None:
+        """A recorded PEP 658 integrity failure aborts get_dependencies rather
+        than degrading to the sdist's PKG-INFO deps."""
+        coordinator = make_coordinator(
+            [make_wheel("1.0"), make_sdist("1.0")],
+            sdist_pkg_info=(
+                "Metadata-Version: 2.2\n"
+                "Name: foo\n"
+                "Version: 1.0\n"
+                "Requires-Dist: from-sdist\n"
+            ),
+            package="foo",
+        )
+        coordinator.index.store_metadata_error(
+            "foo", "1.0", MetadataHashMismatchError("metadata sha256 mismatch")
+        )
+        provider = Provider(coordinator, python_version="3.12.0")
+        with pytest.raises(MetadataHashMismatchError):
+            provider.get_dependencies("foo", V("1.0"))
+        assert ("foo", V("1.0")) not in provider.deps_cache
 
     def test_unknown_version_raises(self) -> None:
         """Raise MetadataError when version doesn't exist."""
@@ -4351,6 +4372,22 @@ class TestAwaitMetadataBatchEdgeCases:
         result = provider.choose_version("foo", spec.to_range())
         assert result == V("1.0")
         assert ("foo", V("2.0")) not in provider.deps_cache
+
+    def test_batch_metadata_hash_mismatch_aborts(self) -> None:
+        """A recorded integrity failure in the batch path aborts the wait
+        rather than leaving the version un-cached for an sdist fallback."""
+        wheels = [make_wheel("1.0")]
+        coordinator = make_coordinator(wheels, package="foo")
+        coordinator.index.store_metadata_error(
+            "foo", "1.0", MetadataHashMismatchError("metadata sha256 mismatch")
+        )
+        provider = Provider(coordinator, python_version="3.12.0")
+        with pytest.raises(MetadataHashMismatchError):
+            provider._await_metadata_batch(
+                "foo",
+                [(V("1.0"), "1.0", _done_event())],
+            )
+        assert ("foo", V("1.0")) not in provider.deps_cache
 
     def test_batch_does_not_parse_sdist_pkg_info_as_wheel_metadata(self) -> None:
         """Sdist PKG-INFO in the shared slot is not cached by the batch path.

--- a/nab-python/tests/universal/test_validate.py
+++ b/nab-python/tests/universal/test_validate.py
@@ -15,7 +15,9 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from unittest.mock import MagicMock
 
-from nab_index.client import SdistFile, WheelFile
+import pytest
+
+from nab_index.client import MetadataHashMismatchError, SdistFile, WheelFile
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.version import Version
 from nab_python.universal.matrix import MatrixTuple
@@ -371,6 +373,32 @@ class TestFetchWheelMetadata:
         )
         report = validate_lock(result, coordinator)
         assert report.findings[0].status == "no_metadata"
+
+    def test_metadata_hash_mismatch_aborts_validation(self) -> None:
+        """An integrity failure recorded for the chosen wheel aborts the
+        validation pass rather than degrading to a no-metadata finding."""
+        wheel = _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl")
+        coordinator = _make_coordinator(
+            {"pkg": [wheel]},
+            baseline_metadata={"pkg": _BASE_METADATA},
+        )
+        coordinator.index.store_metadata_error(
+            "pkg",
+            f"1.0#{wheel.filename}",
+            MetadataHashMismatchError("metadata sha256 mismatch"),
+        )
+        result = UniversalResult(
+            matrix=MagicMock(),
+            tuple_results=[
+                TupleResult(
+                    tuple_=_linux_311(),
+                    success=True,
+                    pins={"pkg": Version("1.0")},
+                ),
+            ],
+        )
+        with pytest.raises(MetadataHashMismatchError):
+            validate_lock(result, coordinator)
 
     def test_fetch_via_coordinator_populates_cache(self) -> None:
         """A successful coordinator fetch lands metadata at the sentinel key."""


### PR DESCRIPTION
When a PEP 658 metadata sidecar was served but did not match the hash declared in the index, the resolve kept going and quietly fell back to building the sdist instead of failing. The integrity error was being raised inside the fetch worker, where the coordinator's broad `except Exception` caught it and stored it the same way it stores "no sidecar arrived" (`store_metadata(None)`). Those two cases are not the same: a missing sidecar is a legitimate reason to fall back to the sdist, but a hash mismatch means the served metadata is untrustworthy and the resolve should stop.

This gives metadata integrity failures their own slot on `InMemoryIndex` (`store_metadata_error` / `get_metadata_error`), keeps the missing-sidecar path on `store_metadata(None)`, and re-raises the recorded `MetadataHashMismatchError` at each point that waits on a metadata fetch: the provider's listing prefetch, the metadata resolver, and the universal wheel-metadata path.
