### PR TITLE
defer the lockfile hash check to the emitting format

### DIFF
--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -47,6 +47,7 @@ __all__ = [
     "build_lock_input_from_provider",
     "read_lockfile_anchor",
     "read_lockfile_packages",
+    "require_artifact_hashes",
 ]
 
 
@@ -377,15 +378,11 @@ def _index_pin_from_listing(
             raise MissingSdistError(msg)
 
     wheels = tuple(
-        _build_artifact(canonical, f, WheelArtifact)
-        for f in files
-        if isinstance(f, WheelFile)
+        _build_artifact(f, WheelArtifact) for f in files if isinstance(f, WheelFile)
     )
     sdist_file = next((f for f in files if isinstance(f, SdistFile)), None)
     sdist = (
-        _build_artifact(canonical, sdist_file, SdistArtifact)
-        if sdist_file is not None
-        else None
+        _build_artifact(sdist_file, SdistArtifact) if sdist_file is not None else None
     )
     requires_python = _common_requires_python(files)
     serving_name = provider.coordinator.index.get_listing_index(canonical)
@@ -414,22 +411,19 @@ def _index_pin_from_listing(
 
 @overload
 def _build_artifact(
-    canonical: str,
     source: WheelFile | SdistFile,
     cls: type[WheelArtifact],
 ) -> WheelArtifact: ...
 @overload
 def _build_artifact(
-    canonical: str,
     source: WheelFile | SdistFile,
     cls: type[SdistArtifact],
 ) -> SdistArtifact: ...
 def _build_artifact(
-    canonical: str,
     source: WheelFile | SdistFile,
     cls: type[WheelArtifact | SdistArtifact],
 ) -> WheelArtifact | SdistArtifact:
-    hashes = _filter_acceptable_hashes(canonical, source.filename, source.hashes)
+    hashes = _filter_acceptable_hashes(source.hashes)
     return cls(
         filename=source.filename,
         url=_strip_userinfo(source.url),
@@ -461,30 +455,50 @@ def _parse_upload_time(raw: str | None) -> datetime | None:
 
 
 def _filter_acceptable_hashes(
-    canonical: str, filename: str, hashes: tuple[tuple[str, str], ...]
+    hashes: tuple[tuple[str, str], ...],
 ) -> tuple[tuple[str, str], ...]:
     """Return the subset of ``hashes`` whose algorithm is consumable.
 
     Pip's hash-checking mode and PEP 751 both accept any of sha256,
     sha384, or sha512; nab forwards every recorded entry so consumers
-    can pick.  Raise :class:`MissingHashError` when none of the
-    acceptable algorithms are present.
+    can pick.  Unacceptable algorithms (e.g. md5) are dropped, so the
+    result may be empty.
     """
     from ..lockfile import ACCEPTED_HASH_ALGORITHMS
 
-    accepted = tuple(
+    return tuple(
         (algo, digest)
         for algo, digest in sorted(hashes)
         if algo in ACCEPTED_HASH_ALGORITHMS
     )
-    if not accepted:
-        algos = sorted({algo for algo, _ in hashes})
-        msg = (
-            f"{canonical}: artefact {filename!r} has no acceptable hash"
-            f" (need one of {list(ACCEPTED_HASH_ALGORITHMS)!r}, got {algos!r})"
-        )
-        raise MissingHashError(msg)
-    return accepted
+
+
+def require_artifact_hashes(lock_input: LockInput) -> None:
+    """Raise :class:`MissingHashError` if a pinned artefact has no hash.
+
+    PEP 751 and pip's hash-checking mode each need at least one of
+    sha256/sha384/sha512 per artefact.  The plain ``name==version``
+    writer records no hash and does not call this.
+    """
+    from ..lockfile import ACCEPTED_HASH_ALGORITHMS, IndexPin
+
+    pin_groups: Iterable[Mapping[str, PinShape]] = (
+        lock_input.pins,
+        *lock_input.per_tuple_pins.values(),
+    )
+    for pins in pin_groups:
+        for pin in pins.values():
+            if not isinstance(pin, IndexPin):
+                continue
+            artefacts = (*pin.wheels, *((pin.sdist,) if pin.sdist is not None else ()))
+            for artefact in artefacts:
+                if not artefact.hashes:
+                    msg = (
+                        f"{pin.name}: artefact {artefact.filename!r} has no "
+                        f"acceptable hash (need one of "
+                        f"{list(ACCEPTED_HASH_ALGORITHMS)!r})"
+                    )
+                    raise MissingHashError(msg)
 
 
 def _common_requires_python(files: Iterable[WheelFile | SdistFile]) -> str | None:

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -31,6 +31,7 @@ from .._vendor.packaging.specifiers import SpecifierSet
 from .._vendor.packaging.utils import canonicalize_name
 from .._vendor.packaging.version import Version
 from ..config import conflict_exclusion_groups, conflict_member_groups
+from .builder import require_artifact_hashes
 from .disjointness import validate_marker_disjointness
 
 if TYPE_CHECKING:
@@ -81,6 +82,7 @@ def write_lock(
     machines (PEP 751 records those paths relative to the lock file).
     With no ``output_path`` the current directory is the base.
     """
+    require_artifact_hashes(lock_input)
     lock_dir = Path(output_path).parent if output_path is not None else None
     pylock = build_pylock(lock_input, lock_dir=lock_dir)
     pylock.validate()

--- a/nab-python/src/nab_python/_lockfile/requirements.py
+++ b/nab-python/src/nab_python/_lockfile/requirements.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import quote
 
+from .builder import require_artifact_hashes
+
 if TYPE_CHECKING:
     import os
     from collections.abc import Mapping
@@ -39,6 +41,7 @@ def write_requirements_with_hashes(
     ``#subdirectory=`` fragment.  Returns the text and, when
     ``output_path`` is provided, atomically writes it.
     """
+    require_artifact_hashes(lock_input)
     return _render_requirements(lock_input, with_hashes=True, output_path=output_path)
 
 

--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -35,7 +35,6 @@ from ..fetch import (
 )
 from ..lockfile import (
     LockInput,
-    MissingHashError,
     MissingSdistError,
     PinShape,
     build_lock_input_from_provider,
@@ -742,7 +741,7 @@ def _resolve_one_tuple(  # noqa: PLR0913
         lock_input = build_lock_input_from_provider(
             provider, pins, indexes=coordinator.indexes
         )
-    except (MissingHashError, MissingSdistError) as exc:
+    except MissingSdistError as exc:
         return TupleResult(
             tuple_=t,
             success=False,

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -2704,8 +2704,9 @@ class TestBuildLockInputFromProvider:
     def test_missing_acceptable_hash_raises(self) -> None:
         wheel = _wheel_file(sha256=None)
         provider = _FakeProvider(listings={"foo": [(Version("1.0"), wheel)]})
+        lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0")})
         with pytest.raises(MissingHashError, match="no acceptable hash"):
-            build_lock_input_from_provider(provider, {"foo": Version("1.0")})
+            write_lock(lock_input)
 
     def test_unsupported_algorithm_raises(self) -> None:
         wheel_md5_only = WheelFile(
@@ -2719,8 +2720,9 @@ class TestBuildLockInputFromProvider:
             size=1234,
         )
         provider = _FakeProvider(listings={"foo": [(Version("1.0"), wheel_md5_only)]})
+        lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0")})
         with pytest.raises(MissingHashError, match="no acceptable hash"):
-            build_lock_input_from_provider(provider, {"foo": Version("1.0")})
+            write_lock(lock_input)
 
     def test_sha384_and_sha512_emit(self) -> None:
         wheel = WheelFile(
@@ -2795,8 +2797,9 @@ class TestBuildLockInputFromProvider:
             size=None,
         )
         provider = _FakeProvider(listings={"foo": [(Version("1.0"), wheel)]})
+        lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0")})
         with pytest.raises(MissingHashError, match="sha256"):
-            build_lock_input_from_provider(provider, {"foo": Version("1.0")})
+            write_requirements_with_hashes(lock_input)
 
     def test_files_without_requires_python_drop_field(self) -> None:
         wheel = _wheel_file(requires_python=None)
@@ -2805,6 +2808,60 @@ class TestBuildLockInputFromProvider:
         pin = lock_input.pins["foo"]
         assert isinstance(pin, IndexPin)
         assert pin.requires_python is None
+
+
+class TestMissingHashFormatAware:
+    """The hash requirement is enforced per output format, not at build."""
+
+    def test_build_tolerates_hashless_artifact(self) -> None:
+        provider = _FakeProvider(
+            listings={"foo": [(Version("1.0"), _wheel_file(sha256=None))]}
+        )
+        lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0")})
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.wheels[0].hashes == ()
+
+    def test_build_drops_unacceptable_algorithm(self) -> None:
+        wheel = WheelFile(
+            filename="foo-1.0-py3-none-any.whl",
+            url="https://example.com/foo-1.0.whl",
+            version="1.0",
+            requires_python=None,
+            has_metadata=False,
+            upload_time=None,
+            hashes=(("md5", "x" * 32),),
+            size=None,
+        )
+        provider = _FakeProvider(listings={"foo": [(Version("1.0"), wheel)]})
+        lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0")})
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.wheels[0].hashes == ()
+
+    def test_without_hashes_emits_hashless_pin(self) -> None:
+        provider = _FakeProvider(
+            listings={"foo": [(Version("1.0"), _wheel_file(sha256=None))]}
+        )
+        lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0")})
+        text = write_requirements_without_hashes(lock_input)
+        assert text.strip() == "foo==1.0"
+
+    def test_with_hashes_raises_on_hashless_pin(self) -> None:
+        provider = _FakeProvider(
+            listings={"foo": [(Version("1.0"), _wheel_file(sha256=None))]}
+        )
+        lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0")})
+        with pytest.raises(MissingHashError, match="no acceptable hash"):
+            write_requirements_with_hashes(lock_input)
+
+    def test_pylock_raises_on_hashless_pin(self) -> None:
+        provider = _FakeProvider(
+            listings={"foo": [(Version("1.0"), _wheel_file(sha256=None))]}
+        )
+        lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0")})
+        with pytest.raises(MissingHashError, match="no acceptable hash"):
+            write_lock(lock_input)
 
 
 class TestDirectoryFields:

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -26,7 +26,15 @@ from nab_python.config import (
     ConflictSet,
     conflict_forks,
 )
-from nab_python.lockfile import DisjointnessError, IndexPin, LockInput, build_pylock
+from nab_python.lockfile import (
+    DisjointnessError,
+    IndexPin,
+    LockInput,
+    MissingHashError,
+    build_pylock,
+    write_requirements_with_hashes,
+    write_requirements_without_hashes,
+)
 from nab_python.provider import (
     BuildPolicy,
     DistPolicy,
@@ -874,8 +882,8 @@ class TestResolveOneTuple:
         assert tr.error is not None
         assert "ResolutionError" in tr.error
 
-    def test_missing_hash_reports_failed_tuple(self) -> None:
-        """An unhashed wheel resolves but the tuple fails with MissingHashError."""
+    def test_unhashed_tuple_defers_hash_check_to_emit(self) -> None:
+        """An unhashed wheel resolves; the hash check is per output format."""
         unhashed = WheelFile(
             filename="pkg-1.0-py3-none-any.whl",
             url="https://example.com/pkg-1.0.whl",
@@ -894,10 +902,15 @@ class TestResolveOneTuple:
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.NEVER,
         )
-        assert not tr.success
-        assert tr.error is not None
-        assert "MissingHashError" in tr.error
+        assert tr.success
         assert tr.pins == {"pkg": Version("1.0")}
+        assert tr.lock_input is not None
+        pin = tr.lock_input.pins["pkg"]
+        assert isinstance(pin, IndexPin)
+        assert pin.wheels[0].hashes == ()
+        assert write_requirements_without_hashes(tr.lock_input).strip() == "pkg==1.0"
+        with pytest.raises(MissingHashError, match="no acceptable hash"):
+            write_requirements_with_hashes(tr.lock_input)
 
     def test_sdist_install_without_sdist_reports_failed_tuple(self) -> None:
         """A wheel-only version under sdist-install fails the tuple."""

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -228,6 +228,21 @@ def _emit_specific(
     if provenance is not None:
         lock_input.provenance = provenance
 
+    try:
+        _write_specific(result, lock_input, format=format, output=output)
+    except _cli.MissingHashError as e:
+        sys.stderr.write(f"Cannot lock: {e}\n")
+        sys.exit(1)
+
+
+def _write_specific(
+    result: ResolutionResult,
+    lock_input: LockInput,
+    *,
+    format: str,  # noqa: A002 - shadows builtin by convention
+    output: Path | None,
+) -> None:
+    """Render ``lock_input`` in ``format``."""
     if _cli.is_stdout(output):
         if format == "pylock":
             sys.stdout.write(_cli.write_lock(lock_input))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -255,6 +255,65 @@ class TestLockCommandSpecific:
         text = out.read_text()
         assert text.strip() == "foo==1.0"
 
+    def test_hashless_pin_locks_without_hashes(self, tmp_path: Path) -> None:
+        """A pin whose artefact lacks a usable hash still locks plain pins."""
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "requirements.txt"
+        result = ResolutionResult(
+            pins={"foo": V("1.0")},
+            lock_input=LockInput(
+                pins={
+                    "foo": IndexPin(
+                        name="foo",
+                        version="1.0",
+                        index="pypi",
+                        wheels=(
+                            WheelArtifact(
+                                filename="foo-1.0-py3-none-any.whl",
+                                url="https://example.com/foo-1.0-py3-none-any.whl",
+                                hashes=(),
+                            ),
+                        ),
+                    )
+                }
+            ),
+        )
+        with patch("nab.cli.resolve_pyproject", return_value=result):
+            lock(pyproject, output=out, format="requirements-without-hashes")
+        assert out.read_text().strip() == "foo==1.0"
+
+    def test_hashless_pin_fails_pylock(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The same hashless pin is fatal for the hash-bearing pylock format."""
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        result = ResolutionResult(
+            pins={"foo": V("1.0")},
+            lock_input=LockInput(
+                pins={
+                    "foo": IndexPin(
+                        name="foo",
+                        version="1.0",
+                        index="pypi",
+                        wheels=(
+                            WheelArtifact(
+                                filename="foo-1.0-py3-none-any.whl",
+                                url="https://example.com/foo-1.0-py3-none-any.whl",
+                                hashes=(),
+                            ),
+                        ),
+                    )
+                }
+            ),
+        )
+        with (
+            patch("nab.cli.resolve_pyproject", return_value=result),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, output=out, format="pylock")
+        assert "no acceptable hash" in capsys.readouterr().err
+
     def test_pylock_to_stdout(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
Locking with requirements-without-hashes aborted with MissingHashError when any index artifact only carried an unusable hash (or none of sha256/sha384/sha512), even though that format writes plain name==version lines and never emits a hash. So a lockable resolution failed on a hash the output does not use.

The check was raised while building the lock input, before the output format was known. This moves it to the point of emit: the build now keeps a pin with no acceptable hash (dropping md5 and other unusable algorithms to an empty hash list), and only the formats that need hashes (pylock and requirements) require them. requirements-without-hashes locks the hashless pin as name==version.

In the universal resolver an unhashed wheel no longer fails the tuple at build time; the tuple resolves and the hash requirement is applied per output format instead. The CLI turns a MissingHashError from a hash-bearing format into a "Cannot lock" message and a non-zero exit rather than a traceback.
