### PR TITLE
treat dynamic requires-python as non-static in the pyproject reader

### DIFF
--- a/nab-python/src/nab_python/build_backend.py
+++ b/nab-python/src/nab_python/build_backend.py
@@ -42,8 +42,9 @@ def extract_static_metadata(source_dir: Path) -> WheelMetadata | None:
     """Build :class:`WheelMetadata` from a directory's static pyproject.toml.
 
     Returns ``None`` when ``[project]`` is missing, malformed, or
-    ``project.dynamic`` includes ``dependencies`` /
-    ``optional-dependencies`` (the field cannot be trusted as static).
+    ``project.dynamic`` includes ``dependencies``,
+    ``optional-dependencies``, ``version``, or ``requires-python`` (the
+    field cannot be trusted as static).
     Returns a :class:`WheelMetadata` shape when the static fields are
     authoritative, populating ``name``, ``version``,
     ``requires_python``, ``requires_dist``, and ``provides_extra``.
@@ -81,8 +82,10 @@ def _project_to_metadata(project: dict) -> WheelMetadata | None:
     if not isinstance(name, str) or not isinstance(version_raw, str):
         return None
     dynamic = project.get("dynamic")
-    if isinstance(dynamic, list) and "version" in dynamic:
-        # A dynamic version is computed by the build backend; a static
+    if isinstance(dynamic, list) and (
+        "version" in dynamic or "requires-python" in dynamic
+    ):
+        # A dynamic field is computed by the build backend; a static
         # value alongside it is a stale placeholder, not authoritative.
         return None
     try:

--- a/nab-python/tests/test_build_backend.py
+++ b/nab-python/tests/test_build_backend.py
@@ -125,6 +125,18 @@ class TestExtractStaticMetadata:
         )
         assert extract_static_metadata(tmp_path) is None
 
+    def test_dynamic_requires_python_returns_none(self, tmp_path: Path) -> None:
+        _write_pyproject(
+            tmp_path,
+            """
+            [project]
+            name = "foo"
+            version = "1.0"
+            dynamic = ["requires-python"]
+            """,
+        )
+        assert extract_static_metadata(tmp_path) is None
+
     def test_dynamic_non_version_keeps_static_version(self, tmp_path: Path) -> None:
         _write_pyproject(
             tmp_path,


### PR DESCRIPTION
The static pyproject.toml reader only bailed out when `project.dynamic` listed `version`. If a project declared `requires-python` as dynamic, the reader still took whatever static `requires-python` happened to be in the table, or treated it as unconstrained (`None`) when it was absent. That let a local or VCS source resolve and install on a Python it doesn't actually support, since the real constraint is only known after the build backend runs.

The reader now returns `None` whenever `dynamic` includes `requires-python`, so the source falls through to a PEP 517 backend invocation that produces the authoritative metadata, the same as we already do for a dynamic `version`.
