### PR TITLE
keep the no-versions cause when a constraint excludes nothing

### DIFF
--- a/nab-python/tests/test_resolver_packaging.py
+++ b/nab-python/tests/test_resolver_packaging.py
@@ -644,3 +644,30 @@ class TestComplementPrereleases:
         versions = [V("2.0b1"), V("1.5"), V("1.0")]
         assert list(r.filter(versions)) == versions
         assert list(r.complement().complement().filter(versions)) == versions
+
+
+class TestNoVersionsConstraintAttribution:
+    """A superset constraint must not steal the NO_VERSIONS cause.
+
+    A constraint naming a prerelease carries a prerelease policy the
+    dependency range lacks. The old structural ``current & constraint ==
+    current`` reported them unequal even though the constraint excluded
+    nothing, so a genuine no-versions failure was labeled CONSTRAINT.
+    """
+
+    def test_superset_prerelease_constraint_keeps_no_versions(self) -> None:
+        """``foo`` has no version in ``>=2.0``; ``>=1.0a1`` excluded nothing."""
+        provider = PackagingProvider(
+            {
+                "root": {V("1.0"): {"foo": SpecifierSet(">=2.0")}},
+                "foo": {V("1.0"): {}},
+            },
+        )
+        with pytest.raises(ResolutionError) as exc_info:
+            Resolver(provider, range_type=VersionRange, root_version="0").resolve(
+                {"root": VersionRange.singleton(V("1.0"))},
+                constraints={"foo": SpecifierSet(">=1.0a1").to_range()},
+            )
+        message = str(exc_info.value)
+        assert "no versions of" in message
+        assert "the user constrained" not in message

--- a/nab-resolver/src/nab_resolver/decide.py
+++ b/nab-resolver/src/nab_resolver/decide.py
@@ -114,9 +114,7 @@ def record_no_versions(
     # When a constraint narrowed the searched range it is the reason no
     # acceptable version was found, so attribute the clause to it.
     constraint = resolver.constraints.get(package)
-    constrained = (
-        constraint is not None and (current_range & constraint) != current_range
-    )
+    constrained = constraint is not None and not (current_range & ~constraint).is_empty
     cause = (
         IncompatibilityCause.CONSTRAINT
         if constrained


### PR DESCRIPTION
`record_no_versions` blamed a no-versions failure on a user constraint whenever `(current_range & constraint) != current_range`. That structural comparison sees the prerelease and arbitrary-version flags a `VersionRange` carries, so a constraint that is a superset of the searched range (it excluded nothing) but differs in those flags was read as narrowing, and a genuine no-versions failure was reported as `because the user constrained ...`.

Decide it with the subset test `(current_range & ~constraint).is_empty` instead, so the clause is labeled CONSTRAINT only when the constraint actually removed something. A constraint naming a prerelease such as `>=1.0a1` over a `>=2.0` dependency is enough to trigger the old misattribution.
