### PR TITLE
bind extra when walking extra-gated self-references

### DIFF
--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -198,9 +198,11 @@ def expand_self_extras(
 
     A self-reference carrying a PEP 508 marker (``{name}[fast];
     python_version < "3.10"``) activates its extra only when the marker
-    evaluates true under ``environment``.  ``environment`` ``None`` skips
-    that check and walks every self-reference, which is what the
-    universal path wants (it defers marker evaluation to each tuple).
+    evaluates true under ``environment``.  ``extra`` is bound to the
+    extra being walked so a marker like ``extra == "all"`` resolves
+    against it.  ``environment`` ``None`` skips that check and walks
+    every self-reference, which is what the universal path wants (it
+    defers marker evaluation to each tuple).
 
     The original ``selected`` order is preserved at the front of the
     result; reachable extras are appended in BFS order without
@@ -233,7 +235,9 @@ def expand_self_extras(
             if (
                 environment is not None
                 and req.marker is not None
-                and not dependency_marker_holds(req.marker, environment)
+                and not dependency_marker_holds(
+                    req.marker, {**environment, "extra": extra}
+                )
             ):
                 continue
             worklist.extend(

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -399,6 +399,24 @@ class TestExpandSelfExtras:
         env = {"python_version": "3.12", "python_full_version": "3.12.0"}
         assert expand_self_extras(opt, "mypkg", ["all"], env) == ["all"]
 
+    def test_self_reference_extra_equals_own_extra_walked(self) -> None:
+        """A self-ref gated by ``extra == "<own-extra>"`` activates its extra."""
+        opt = {
+            "all": ['mypkg[fast]; extra == "all"'],
+            "fast": ["some-dep"],
+        }
+        env = {"python_version": "3.11", "python_full_version": "3.11.0"}
+        assert expand_self_extras(opt, "mypkg", ["all"], env) == ["all", "fast"]
+
+    def test_self_reference_extra_equals_other_extra_skipped(self) -> None:
+        """A self-ref gated by ``extra == "<other-extra>"`` does not activate."""
+        opt = {
+            "all": ['mypkg[fast]; extra == "other"'],
+            "fast": ["some-dep"],
+        }
+        env = {"python_version": "3.11", "python_full_version": "3.11.0"}
+        assert expand_self_extras(opt, "mypkg", ["all"], env) == ["all"]
+
 
 class TestExpandExtraRequirements:
     def test_empty_selection_returns_empty(self) -> None:


### PR DESCRIPTION
When a package's extra contains a self-reference gated on its own extra, like `all = ['mypkg[fast]; extra == "all"']`, single-environment expansion dropped the referenced extra. So selecting `[all]` never pulled in `fast` and its deps were left out of the resolver's root requirements.

The self-reference walk evaluated the PEP 508 marker against the environment without binding `extra`, so `extra == "all"` always came out false. Bind `extra` to the extra being walked before evaluating the marker.

Markers that name a different extra still skip, and the universal path (no environment) is unchanged.
