### PR TITLE
Fix pre-release leak across resolver backtracking

### DIFF
--- a/nab-python/tests/property_python/test_prerelease_admission.py
+++ b/nab-python/tests/property_python/test_prerelease_admission.py
@@ -1,0 +1,163 @@
+"""Property tests guarding the pre-release admission bug class.
+
+The resolver must not admit a pre-release that no active requirement asked
+for when a final release would have served. The leak that motivated these
+tests was an exclusion (negative) range leaking its pre-release policy into
+selection; the fix uses set difference (``positive - negative``) so an
+exclusion grants no admission.
+
+The drop-in-final invariant below catches that whole class while allowing
+the intended "only a pre-release can satisfy the surviving constraints"
+case: a pre-release is a leak only when a *valid final substitute* exists
+(one that satisfies the active requirements and whose own dependencies the
+rest of the solution already meets). When the only spec-compatible final is
+unusable downstream, no such substitute exists and the pre-release stands.
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_python._packaging_provider import PackagingProvider
+from nab_python._vendor.packaging.ranges import VersionRange
+from nab_python._vendor.packaging.specifiers import SpecifierSet
+from nab_python._vendor.packaging.version import Version
+from nab_resolver.resolver import ResolutionError, Resolver
+
+from .strategies import PROPERTY_SETTINGS
+
+pytestmark = pytest.mark.property
+
+_PKGS = ["a", "b", "c", "d"]
+_VERSIONS = ["0.9", "1.0", "1.5a1", "1.5", "2.0b1", "2.0", "3.0a1", "3.0"]
+_SPECS = ["", ">=1.0", ">=2.0", "==1.0", "==2.0", ">=2.0b1", "<2.0", "!=1.5", "~=1.0"]
+_RANGE_SPECS = ["", ">=1.0", "<2.0", ">=1.0,<2.0", "==1.5", "!=1.5", ">=2.0b1"]
+
+
+class _FilterProvider(PackagingProvider):
+    """Selects via ``version_range.filter`` like the real PyPI provider."""
+
+    def choose_version(
+        self, package: str, version_range: VersionRange
+    ) -> Version | None:
+        return next(iter(version_range.filter(self._get_versions(package))), None)
+
+
+@st.composite
+def _prerelease_graphs(
+    draw: st.DrawFn,
+) -> tuple[dict[str, dict[Version, dict[str, SpecifierSet]]], dict[str, SpecifierSet]]:
+    """Small graphs over a/b/c/d whose version pool mixes finals and pre-releases."""
+    graph: dict[str, dict[Version, dict[str, SpecifierSet]]] = {}
+    for pkg in _PKGS:
+        versions = draw(
+            st.lists(st.sampled_from(_VERSIONS), min_size=1, max_size=3, unique=True)
+        )
+        graph[pkg] = {}
+        for raw in versions:
+            deps: dict[str, SpecifierSet] = {}
+            for dep in _PKGS:
+                if dep != pkg and draw(st.booleans()):
+                    deps[dep] = SpecifierSet(draw(st.sampled_from(_SPECS)))
+            graph[pkg][Version(raw)] = deps
+    root_deps = {
+        dep: SpecifierSet(draw(st.sampled_from(_SPECS)))
+        for dep in draw(st.lists(st.sampled_from(_PKGS), min_size=1, unique=True))
+    }
+    graph["root"] = {Version("1.0"): root_deps}
+    return graph, root_deps
+
+
+def _active_specs(
+    package: str,
+    solution: dict[str, Version],
+    graph: dict[str, dict[Version, dict[str, SpecifierSet]]],
+) -> list[SpecifierSet]:
+    specs: list[SpecifierSet] = []
+    for parent, version in solution.items():
+        spec = graph.get(parent, {}).get(version, {}).get(package)
+        if spec is not None:
+            specs.append(spec)
+    return specs
+
+
+def _has_valid_final_dropin(
+    package: str,
+    solution: dict[str, Version],
+    graph: dict[str, dict[Version, dict[str, SpecifierSet]]],
+    specs: list[SpecifierSet],
+) -> bool:
+    """A final of ``package`` that satisfies the active specs and whose own
+    dependencies the rest of the solution already meets."""
+    for candidate in graph.get(package, {}):
+        if candidate.is_prerelease or candidate == solution[package]:
+            continue
+        if not all(spec.contains(candidate, prereleases=True) for spec in specs):
+            continue
+        deps = graph[package][candidate]
+        if all(
+            dep in solution and spec.contains(solution[dep], prereleases=True)
+            for dep, spec in deps.items()
+        ):
+            return True
+    return False
+
+
+class TestNoUnauthorizedPrereleaseDropIn:
+    """No package resolves to a pre-release when an unrequested final fits."""
+
+    @given(graph_and_roots=_prerelease_graphs())
+    @PROPERTY_SETTINGS
+    def test_no_unauthorized_prerelease_dropin(
+        self,
+        graph_and_roots: tuple[
+            dict[str, dict[Version, dict[str, SpecifierSet]]], dict[str, SpecifierSet]
+        ],
+    ) -> None:
+        graph, _root_deps = graph_and_roots
+        resolver = Resolver(
+            _FilterProvider(graph),
+            range_type=VersionRange,
+            root_version="0",
+            max_iterations=2000,
+        )
+        try:
+            solution = resolver.resolve(
+                {"root": VersionRange.singleton(Version("1.0"))}
+            )
+        except ResolutionError:
+            return
+
+        for package, version in solution.items():
+            if package == "root" or not version.is_prerelease:
+                continue
+            specs = _active_specs(package, solution, graph)
+            if any(spec.prereleases is True for spec in specs):
+                continue  # a requirement legitimately admits the pre-release
+            assert not _has_valid_final_dropin(package, solution, graph, specs), (
+                f"{package}=={version} is a pre-release no requirement asked for, "
+                f"yet a final release would satisfy the same solution"
+            )
+
+
+class TestIsEmptyPolicyIndependent:
+    """``(a - b).is_empty == (a & ~b).is_empty`` for nab-built ranges.
+
+    Justifies expressing the resolver's subset tests as set difference: the
+    two agree on emptiness because nab never sets an explicit pre-release
+    policy, so ``is_empty`` does not depend on the carried policy.
+    """
+
+    @given(
+        left=st.sampled_from(_RANGE_SPECS),
+        right=st.sampled_from(_RANGE_SPECS),
+    )
+    @PROPERTY_SETTINGS
+    def test_difference_emptiness_matches_complement(
+        self, left: str, right: str
+    ) -> None:
+        a = SpecifierSet(left).to_range()
+        b = SpecifierSet(right).to_range()
+        assert (a - b).is_empty == (a & ~b).is_empty

--- a/nab-python/tests/test_resolver_packaging.py
+++ b/nab-python/tests/test_resolver_packaging.py
@@ -13,6 +13,7 @@ from nab_python._packaging_provider import PackagingProvider
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.version import Version
+from nab_resolver.report import union_terms
 from nab_resolver.resolver import ResolutionError, Resolver
 from nab_resolver.types import Term
 
@@ -606,6 +607,107 @@ class _FilterProvider(PackagingProvider):
         return next(iter(version_range.filter(self._get_versions(package))), None)
 
 
+class TestPrereleaseAuthorizationBacktracking:
+    """Pre-release admission follows the dependency edge that introduced it."""
+
+    def test_rejected_parent_does_not_leak_prerelease_admission(self) -> None:
+        """A rejected parent must not make an unrelated pre-release beat a final."""
+        provider = _FilterProvider(
+            {
+                "a": {
+                    V("1.0"): {"c": SpecifierSet(">=1.0")},
+                    V("2.0"): {"c": SpecifierSet(">=2.0b1")},
+                },
+                "c": {
+                    V("1.0"): {},
+                    V("1.5a1"): {},
+                    V("2.0b1"): {"d": SpecifierSet("==2.0")},
+                },
+                "d": {
+                    V("1.0"): {},
+                    V("2.0"): {},
+                },
+            }
+        )
+
+        result = Resolver(provider, range_type=VersionRange, root_version="0").resolve(
+            {
+                "a": VersionRange.full(),
+                "d": SpecifierSet("==1.0").to_range(),
+            }
+        )
+
+        assert result["a"] == V("1.0")
+        assert result["d"] == V("1.0")
+        assert result["c"] == V("1.0")
+
+
+class TestConflictPathPrereleaseAdmission:
+    """Conflict-resolution term algebra must not leak pre-release admission.
+
+    ``Term.intersect`` and ``union_terms`` subtract a negative (exclusion)
+    term from a positive one. The result must keep only the positive (or
+    negative-minuend) side's pre-release policy, so a learned exclusion
+    grants no pre-release admission when its negation is propagated back
+    into a positive range.
+    """
+
+    def test_intersect_positive_minus_negative_drops_prerelease(self) -> None:
+        """``c>=1.0`` AND not ``c>=2.0b1`` admits no pre-release."""
+        positive = Term("c", SpecifierSet(">=1.0").to_range(), positive=True)
+        negative = Term("c", SpecifierSet(">=2.0b1").to_range(), positive=False)
+        result = positive.intersect(negative)
+        assert result is not None
+        assert result.is_positive()
+        picked = list(result.constraint.filter([V("2.0b1"), V("1.5a1"), V("1.0")]))
+        assert picked == [V("1.0")]
+
+    def test_union_terms_negative_minus_positive_drops_prerelease(self) -> None:
+        """The mixed-term remainder keeps the negative term's policy only."""
+        negative = Term("c", SpecifierSet(">=1.0").to_range(), positive=False)
+        positive = Term("c", SpecifierSet(">=2.0b1").to_range(), positive=True)
+        result = union_terms(negative, positive)
+        assert result is not None
+        assert not result.is_positive()
+        picked = list(result.constraint.filter([V("1.5a1"), V("1.0")]))
+        assert picked == [V("1.0")]
+
+
+class TestExclusionFallbackPrerelease:
+    """A pre-release IS admitted when the only final cannot be used.
+
+    When backtracking excludes the only final that satisfies a requirement,
+    every surviving candidate is a pre-release, and nab admits one rather
+    than failing. This is the PEP 440 default (pre-releases are eligible
+    when no final satisfies) applied to the surviving range; pip and uv
+    reject the case instead. It is not the leaked-admission bug: the
+    effective range's policy stays neutral and no usable final drop-in
+    exists.
+    """
+
+    def test_admits_prerelease_when_only_final_is_unusable(self) -> None:
+        """``c``'s only final (1.0) forces ``a>=2.0b1`` against ``a==1.0``."""
+        provider = _FilterProvider(
+            {
+                "a": {V("1.0"): {}, V("2.0"): {}},
+                "c": {
+                    V("1.0"): {"d": SpecifierSet("==2.0")},
+                    V("1.5a1"): {},
+                    V("2.0b1"): {"a": SpecifierSet(">=2.0")},
+                },
+                "d": {V("1.0"): {}, V("2.0"): {"a": SpecifierSet(">=2.0b1")}},
+            }
+        )
+        result = Resolver(provider, range_type=VersionRange, root_version="0").resolve(
+            {
+                "a": SpecifierSet("==1.0").to_range(),
+                "c": SpecifierSet(">=1.0").to_range(),
+            }
+        )
+        assert result["a"] == V("1.0")
+        assert result["c"] == V("1.5a1")
+
+
 class TestConstraintPrereleases:
     """A constraint that names a prerelease must enable that prerelease."""
 
@@ -671,3 +773,72 @@ class TestNoVersionsConstraintAttribution:
         message = str(exc_info.value)
         assert "no versions of" in message
         assert "the user constrained" not in message
+
+
+class TestVersionRangeDifference:
+    """``A - B`` keeps only the minuend's pre-release policy."""
+
+    def test_difference_selects_versions_in_self_not_other(self) -> None:
+        """``a - b`` selects the same versions as ``a & ~b``."""
+        a = SpecifierSet(">=1.0").to_range()
+        b = SpecifierSet(">=2.0").to_range()
+        diff = a - b
+        assert V("1.5") in diff
+        assert V("1.0") in diff
+        assert V("2.0") not in diff
+        assert V("2.5") not in diff
+        assert diff == a & ~b
+
+    def test_difference_with_empty_is_self(self) -> None:
+        a = SpecifierSet(">=1.0,<2.0").to_range()
+        assert (a - VersionRange.empty()) == a
+
+    def test_difference_with_full_is_empty(self) -> None:
+        assert (SpecifierSet(">=1.0").to_range() - VersionRange.full()).is_empty
+
+    def test_difference_drops_subtrahend_prerelease_policy(self) -> None:
+        """A final-only requirement minus a prerelease exclusion admits no pre.
+
+        ``>=1.0`` admits no prereleases; subtracting ``>=2.0b1`` (which on its
+        own admits 2.0b1) must NOT grant prerelease admission to the result.
+        This is the resolver leak in miniature.
+        """
+        result = SpecifierSet(">=1.0").to_range() - SpecifierSet(">=2.0b1").to_range()
+        assert list(result.filter([V("2.0b1"), V("1.5a1"), V("1.0")])) == [V("1.0")]
+
+    def test_difference_keeps_minuend_prerelease_policy(self) -> None:
+        """A prerelease-naming requirement keeps admitting its prerelease."""
+        result = SpecifierSet(">=2.0b1").to_range() - SpecifierSet(">=3.0").to_range()
+        assert list(result.filter([V("2.5"), V("2.0b1")])) == [V("2.5"), V("2.0b1")]
+
+    def test_difference_keeps_explicit_minuend_policy(self) -> None:
+        """An explicit ``prereleases`` policy on the minuend survives."""
+        allow = SpecifierSet(">=1.0", prereleases=True).to_range()
+        deny = SpecifierSet(">=1.0", prereleases=False).to_range()
+        sub = SpecifierSet(">=2.0").to_range()
+        assert list((allow - sub).filter([V("1.5a1"), V("1.0")])) == [
+            V("1.5a1"),
+            V("1.0"),
+        ]
+        assert list((deny - sub).filter([V("1.5a1"), V("1.0")])) == [V("1.0")]
+
+    def test_difference_over_arbitrary_literals(self) -> None:
+        """Difference handles ``===`` literal ranges on both sides."""
+        a = SpecifierSet("===1.0").to_range()
+        assert V("1.0") in (a - SpecifierSet("===2.0").to_range())
+        assert V("2.0") not in (a - SpecifierSet("===2.0").to_range())
+        assert V("1.0") in (a - SpecifierSet(">=2.0").to_range())
+
+    def test_difference_allows_mismatched_configured_policy(self) -> None:
+        """Unlike intersection, difference drops the subtrahend's policy, so
+        operands need not share a configured policy."""
+        a = SpecifierSet(">=1.0").to_range()
+        explicit_true = SpecifierSet(">=2.0", prereleases=True).to_range()
+        explicit_false = SpecifierSet(">=2.0", prereleases=False).to_range()
+        assert list((a - explicit_true).filter([V("2.0b1"), V("1.5a1"), V("1.0")])) == [
+            V("1.0")
+        ]
+        assert list((a - explicit_false).filter([V("1.5a1"), V("1.0")])) == [V("1.0")]
+
+    def test_sub_not_implemented_for_non_range(self) -> None:
+        assert VersionRange.full().__sub__(object()) is NotImplemented  # type: ignore[arg-type]

--- a/nab-resolver/src/nab_resolver/partial_solution.py
+++ b/nab-resolver/src/nab_resolver/partial_solution.py
@@ -94,7 +94,7 @@ class PartialSolution(Generic[PackageType, VersionType]):
         # Incrementally maintained as set(positive) - set(decided).
         self._undecided: set[PackageType] = set()
 
-        # Memoises positive & ~negative per package.
+        # Memoises positive - negative per package.
         self._effective_range_cache: dict[
             PackageType, RangeProtocol[VersionType] | None
         ] = {}
@@ -124,7 +124,10 @@ class PartialSolution(Generic[PackageType, VersionType]):
     def get(self, package: PackageType) -> RangeProtocol[VersionType] | None:
         """Get the combined allowed range for a package, or None if unassigned.
 
-        Computes ``positive & ~negative``, cached per package.
+        Computes ``positive - negative``, cached per package. Difference
+        (not ``positive & ~negative``) keeps the requirement's pre-release
+        policy and drops the exclusion's, which ``& ~`` would leak into the
+        range offered for selection.
         """
         cached = self._effective_range_cache.get(package, _UNSET)
         if cached is not _UNSET:
@@ -136,12 +139,14 @@ class PartialSolution(Generic[PackageType, VersionType]):
         if positive is None and negative is None:
             result: RangeProtocol[VersionType] | None = None
         elif positive is None:
+            # No requirement to subtract from. An exclusion-only package is
+            # never offered for selection, so the plain complement is enough.
             assert negative is not None
             result = ~negative
         elif negative is None:
             result = positive
         else:
-            result = positive & ~negative
+            result = positive - negative
 
         self._effective_range_cache[package] = result
         return result
@@ -340,7 +345,7 @@ class PartialSolution(Generic[PackageType, VersionType]):
         elif assignment.cum_negative is None:
             effective = cum_positive
         else:
-            effective = cum_positive & ~assignment.cum_negative
+            effective = cum_positive - assignment.cum_negative
 
         return term.satisfies(effective)
 

--- a/nab-resolver/src/nab_resolver/propagate.py
+++ b/nab-resolver/src/nab_resolver/propagate.py
@@ -154,16 +154,16 @@ def classify_intersection(
     Negative term: satisfied when the intersection is empty; contradicted
     when the assignment falls entirely inside the forbidden range.
 
-    The subset test is emptiness of ``assignment & ~constraint``, not a
+    The subset test is emptiness of ``assignment - constraint``, not a
     range equality, so it agrees with :meth:`Term.satisfies` on flagged
     range types (see that docstring).
     """
     if term.is_positive():
-        covers = (assignment & ~term.constraint).is_empty
+        covers = (assignment - term.constraint).is_empty
         empty = intersection.is_empty
     else:
         covers = intersection.is_empty
-        empty = (assignment & ~term.constraint).is_empty
+        empty = (assignment - term.constraint).is_empty
 
     if covers:
         return SetRelation.SATISFIED

--- a/nab-resolver/src/nab_resolver/ranges.py
+++ b/nab-resolver/src/nab_resolver/ranges.py
@@ -329,6 +329,12 @@ class Range(Generic[VersionType]):
 
         return Range(tuple(result))
 
+    def __sub__(self, other: object) -> Range[VersionType]:
+        """Set difference: versions in self but not in other."""
+        if not isinstance(other, Range):
+            return NotImplemented
+        return self & ~other
+
     @override
     def __eq__(self, other: object) -> bool:
         """Test equality by comparing interval tuples."""

--- a/nab-resolver/src/nab_resolver/report.py
+++ b/nab-resolver/src/nab_resolver/report.py
@@ -172,10 +172,11 @@ def union_terms(
             return None
         return Term(first.package, merged, positive=False)
 
-    # Mixed: keep the negative's range minus the positive's.
+    # Mixed: the negative's range minus the positive's (set difference, so
+    # the subtracted positive's pre-release policy does not leak).
     positive_term = first if first.is_positive() else second
     negative_term = second if first.is_positive() else first
-    remainder = negative_term.constraint & ~positive_term.constraint
+    remainder = negative_term.constraint - positive_term.constraint
     if remainder.is_empty:
         return None
     return Term(first.package, remainder, positive=False)

--- a/nab-resolver/src/nab_resolver/types.py
+++ b/nab-resolver/src/nab_resolver/types.py
@@ -80,6 +80,10 @@ class RangeProtocol(Protocol[VersionType_contra]):
         """Complement the range."""
         ...
 
+    def __sub__(self, other: object) -> Self:
+        """Set difference: versions in self but not in other."""
+        ...
+
     # __eq__ and __hash__ come from object; redeclaring them in the
     # Protocol adds no constraint and mypy and zuban disagree on @override.
 
@@ -128,16 +132,16 @@ class Term(Generic[PackageType, VersionType]):
         Negative: satisfied when assignment doesn't intersect constraint
         (no version in the assignment is in the constraint).
 
-        The subset test is ``(assignment & ~constraint).is_empty`` rather
+        The subset test is ``(assignment - constraint).is_empty`` rather
         than ``(assignment & constraint) == assignment``: range types may
         carry flags (the vendored packaging ranges mark specifier-built
         ranges as also admitting arbitrary ``===`` versions) under which
-        extensionally equal ranges compare unequal.  Emptiness of the
-        difference agrees with the algebra's own complement, which is what
-        PubGrub's conflict-resolution progress argument relies on.
+        extensionally equal ranges compare unequal.  Emptiness of the set
+        difference sidesteps that, which is what PubGrub's
+        conflict-resolution progress argument relies on.
         """
         if self._positive:
-            return (assignment & ~self.constraint).is_empty
+            return (assignment - self.constraint).is_empty
         return (assignment & self.constraint).is_empty
 
     def intersect(
@@ -165,10 +169,11 @@ class Term(Generic[PackageType, VersionType]):
                 positive=False,
             )
 
-        # positive AND not(negative) = positive minus negative
+        # positive AND not(negative) = positive minus negative (set
+        # difference, so the exclusion's pre-release policy does not leak).
         positive_term = self if self._positive else other
         negative_term = other if self._positive else self
-        difference = positive_term.constraint & ~negative_term.constraint
+        difference = positive_term.constraint - negative_term.constraint
         return Term(self.package, difference, positive=True)
 
     @override

--- a/nab-resolver/tests/property/test_ranges_set_algebra.py
+++ b/nab-resolver/tests/property/test_ranges_set_algebra.py
@@ -425,3 +425,58 @@ class TestNAryChain:
                 if version in range_:
                     assert version in union
                     break
+
+
+class TestDifference:
+    """Set difference ``A - B`` contains exactly the versions in ``A`` but
+    not in ``B``.
+
+    The solver computes a package's effective range as ``positive -
+    negative`` instead of ``positive & ~negative`` so an exclusion can
+    never grant pre-release admission.  On the policy-free ``Range[int]``
+    the two are identical sets, which these laws pin down.
+    """
+
+    @given(left=version_ranges(), right=version_ranges())
+    @DEEP_SETTINGS
+    def test_difference_is_intersection_with_complement(
+        self, left: Range[int], right: Range[int]
+    ) -> None:
+        """``v in (A - B)`` iff ``v in A and v not in B``."""
+        difference = left - right
+        for version in VERSION_RANGE:
+            assert (version in difference) == (version in left and version not in right)
+
+    @given(left=version_ranges(), right=version_ranges())
+    @DEEP_SETTINGS
+    def test_difference_equals_and_complement(
+        self, left: Range[int], right: Range[int]
+    ) -> None:
+        """``A - B == A & ~B`` (no pre-release policy on ``Range[int]``)."""
+        assert (left - right) == (left & ~right)
+
+    @given(left=version_ranges(), right=version_ranges())
+    @DEEP_SETTINGS
+    def test_difference_disjoint_from_subtrahend(
+        self, left: Range[int], right: Range[int]
+    ) -> None:
+        """``(A - B) ∩ B == ∅``."""
+        assert ((left - right) & right).is_empty
+
+    @given(range_=version_ranges())
+    @DEEP_SETTINGS
+    def test_self_difference_is_empty(self, range_: Range[int]) -> None:
+        """``A - A == ∅``."""
+        assert (range_ - range_).is_empty
+
+    @given(range_=version_ranges())
+    @DEEP_SETTINGS
+    def test_difference_identity_with_empty(self, range_: Range[int]) -> None:
+        """``A - ∅ == A`` (Empty is the right identity)."""
+        assert (range_ - Range.empty()) == range_
+
+    @given(range_=version_ranges())
+    @DEEP_SETTINGS
+    def test_difference_full_is_empty(self, range_: Range[int]) -> None:
+        """``A - Universe == ∅`` (Universe is the absorbing subtrahend)."""
+        assert (range_ - Range.full()).is_empty

--- a/nab-resolver/tests/test_ranges.py
+++ b/nab-resolver/tests/test_ranges.py
@@ -342,6 +342,28 @@ class TestRangeIntersectionEdgeCases:
         assert Range.full().__or__(object()) is NotImplemented  # type: ignore[arg-type]
 
 
+class TestRangeDifference:
+    def test_difference_removes_subtrahend(self) -> None:
+        a = Range.at_least(1)
+        b = Range.at_least(5)
+        c = a - b
+        assert 1 in c
+        assert 4 in c
+        assert 5 not in c
+        assert c == a & ~b
+
+    def test_difference_with_empty_is_self(self) -> None:
+        a = Range.between(2, 5)
+        assert (a - Range.empty()) == a
+
+    def test_difference_with_full_is_empty(self) -> None:
+        a = Range.between(2, 5)
+        assert (a - Range.full()).is_empty
+
+    def test_sub_not_implemented(self) -> None:
+        assert Range.full().__sub__(object()) is NotImplemented  # type: ignore[arg-type]
+
+
 class TestRangeStr:
     def test_any_str(self) -> None:
         assert str(Range.full()) == "*"


### PR DESCRIPTION
A package whose higher version named a pre-release dependency could leak pre-release admission to an unrelated package after that higher version was backtracked away. With requirements `a` (any) and `d==1.0`, where `a 2.0` needs `c>=2.0b1` (rejected because `c 2.0b1` needs `d==2.0`), the resolver fell back to `a 1.0` (needs `c>=1.0`) yet still admitted the pre-release `c 1.5a1` over the final `c 1.0`.

The solver derived a package's effective range as `positive & ~negative`. An exclusion (a negative range, here left behind by the backtracked branch) carried a pre-release policy through the range algebra, and intersection OR-combined it onto the result, so the range admitted pre-releases no active requirement asked for.

The solver now uses set difference, `positive - negative`, wherever it subtracts an exclusion from a requirement (effective-range selection and the conflict-resolution term algebra). Difference keeps only the requirement's pre-release policy; an exclusion grants no pre-release admission. It uses the `VersionRange.__sub__`/`difference` operator re-vendored from packaging main in #290, plus a matching `Range.__sub__` on the generic solver range.

A package that holds only an exclusion (no positive requirement) is never offered for candidate selection, so that case keeps the plain complement `~negative`.