### PR TITLE
verify metadata sidecar with sha384/sha512 when sha256 is absent

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -408,23 +408,29 @@ def _has_metadata(file_info: dict) -> bool:
     return value is True or isinstance(value, dict)
 
 
+_ACCEPTED_METADATA_HASHES: tuple[str, ...] = ("sha256", "sha384", "sha512")
+
+
 def _metadata_hash(file_info: dict) -> tuple[str, str] | None:
     """Return the sidecar's published ``(algo, hex)`` to verify, or None.
 
-    Only sha256 is checked: it is what PyPI publishes for core metadata
-    and what pip verifies.  The algorithm name is matched case-insensitively.
-    A bare ``true`` (sidecar exists, no hash) or a table without sha256
-    yields None, so no check runs.
+    Prefers sha256, then sha384, then sha512, so a sidecar published with
+    only a stronger digest is still verified. Algorithm names match
+    case-insensitively. A bare ``true`` (sidecar exists, no hash) or a table
+    with no accepted algorithm yields None, so no check runs.
     """
     value = _metadata_value(file_info)
-    if isinstance(value, dict):
-        for algo, digest in value.items():
-            if (
-                isinstance(algo, str)
-                and algo.lower() == "sha256"
-                and isinstance(digest, str)
-            ):
-                return ("sha256", digest.lower())
+    if not isinstance(value, dict):
+        return None
+    published = {
+        algo.lower(): digest
+        for algo, digest in value.items()
+        if isinstance(algo, str) and isinstance(digest, str)
+    }
+    for algo in _ACCEPTED_METADATA_HASHES:
+        digest = published.get(algo)
+        if digest is not None:
+            return (algo, digest.lower())
     return None
 
 

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -142,7 +142,7 @@ class TestHasMetadataFlag:
 
 
 class TestMetadataHashParsing:
-    """``_metadata_hash`` carries the published sha256 to verify, or None."""
+    """``_metadata_hash`` carries the published hash to verify, or None."""
 
     def test_sha256_lowercased(self) -> None:
         from nab_index.client import _metadata_hash
@@ -177,6 +177,43 @@ class TestMetadataHashParsing:
         from nab_index.client import _metadata_hash
 
         assert _metadata_hash({"core-metadata": {"blake2b": "ab"}}) is None
+
+    def test_sha512_only_verified(self) -> None:
+        from nab_index.client import _metadata_hash
+
+        assert _metadata_hash({"core-metadata": {"sha512": "ABCD"}}) == (
+            "sha512",
+            "abcd",
+        )
+
+    def test_sha384_only_verified(self) -> None:
+        from nab_index.client import _metadata_hash
+
+        assert _metadata_hash({"core-metadata": {"sha384": "ABCD"}}) == (
+            "sha384",
+            "abcd",
+        )
+
+    def test_sha256_preferred_over_sha512(self) -> None:
+        from nab_index.client import _metadata_hash
+
+        assert _metadata_hash(
+            {"core-metadata": {"sha512": "aaaa", "sha256": "bbbb"}}
+        ) == ("sha256", "bbbb")
+
+    def test_sha384_preferred_over_sha512(self) -> None:
+        from nab_index.client import _metadata_hash
+
+        assert _metadata_hash(
+            {"core-metadata": {"sha512": "aaaa", "sha384": "bbbb"}}
+        ) == ("sha384", "bbbb")
+
+    def test_unsupported_with_supported_skips_unsupported(self) -> None:
+        from nab_index.client import _metadata_hash
+
+        assert _metadata_hash(
+            {"core-metadata": {"blake2b": "aaaa", "sha512": "bbbb"}}
+        ) == ("sha512", "bbbb")
 
     def test_missing_field_yields_none(self) -> None:
         from nab_index.client import _metadata_hash


### PR DESCRIPTION
A PEP 658/714 metadata sidecar that publishes only a stronger digest (sha384 or sha512, no sha256) was fetched and consumed without any hash check. `_metadata_hash` only returned a value for `sha256`, so for those entries it returned `None` and `_verify_metadata_hash` never ran, leaving the metadata unverified.

`_metadata_hash` now accepts sha256, sha384, and sha512, preferring them in that order, so a sidecar with only a stronger digest is still verified. sha256 stays the first choice when present, and entries with no accepted algorithm still return `None` as before.
