### PR TITLE
Reduce an extra-gated self-ref marker so universal keeps the dep

### DIFF
--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -319,6 +319,148 @@ def _and_markers(marker: Marker | None, gates: frozenset[str]) -> Marker:
     return Marker(" and ".join(f"({p})" for p in parts))
 
 
+def _decide_extra_conjunct(conjunct: str, extra: str) -> bool:
+    """Evaluate a single ``extra`` comparison under the bound value.
+
+    The caller only passes a lone comparison that references ``extra`` (and so
+    no environment variable), so packaging's public ``Marker.evaluate`` decides
+    it outright.
+    """
+    return Marker(conjunct).evaluate({"extra": extra})
+
+
+def _split_top_level(text: str, op: str) -> list[str]:
+    """Split ``text`` on its top-level `` op `` (quote- and paren-aware).
+
+    The scan skips the operator inside quoted operands (e.g. ``"android"``
+    contains ``and``) and inside parenthesised groups, so only the outermost
+    ``and`` / ``or`` operands split.
+    """
+    sep = f" {op} "
+    parts: list[str] = []
+    depth = 0
+    quote = ""
+    start = 0
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if quote:
+            if ch == quote:
+                quote = ""
+        elif ch in "'\"":
+            quote = ch
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif depth == 0 and text.startswith(sep, i):
+            parts.append(text[start:i].strip())
+            i += len(sep)
+            start = i
+            continue
+        i += 1
+    parts.append(text[start:].strip())
+    return parts
+
+
+def _strip_wrapping_parens(text: str) -> str:
+    """Remove parentheses that wrap the whole expression, repeatedly."""
+    while text.startswith("(") and text.endswith(")"):
+        depth = 0
+        quote = ""
+        wraps = True
+        for i, ch in enumerate(text):
+            if quote:
+                if ch == quote:
+                    quote = ""
+            elif ch in "'\"":
+                quote = ch
+            elif ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth == 0 and i != len(text) - 1:
+                    wraps = False
+                    break
+        if not wraps:
+            break
+        text = text[1:-1].strip()
+    return text
+
+
+def _wrap_for_and(text: str) -> str:
+    """Parenthesise ``text`` when it is a top-level ``or`` (precedence)."""
+    return f"({text})" if len(_split_top_level(text, "or")) > 1 else text
+
+
+def _reduce_conjunct(conjunct: str, extra: str) -> str | bool:
+    """Reduce one ``and`` conjunct under a bound ``extra``.
+
+    Returns ``True`` when the conjunct is satisfied (and drops out), ``False``
+    for a contradiction, or a residual string of environment conditions.
+    """
+    inner = _strip_wrapping_parens(conjunct)
+    is_group = len(_split_top_level(inner, "or")) > 1 or (
+        "extra" in inner and len(_split_top_level(inner, "and")) > 1
+    )
+    if is_group:
+        reduced = _reduce_marker_string(inner, extra)
+        return reduced if isinstance(reduced, bool) else _wrap_for_and(reduced)
+    if "extra" not in inner:
+        return inner
+    return _decide_extra_conjunct(inner, extra)
+
+
+def _reduce_marker_string(text: str, extra: str) -> str | bool:
+    """Reduce a marker string under a bound ``extra`` (interim, string-based).
+
+    Returns ``True`` (tautology), ``False`` (contradiction), or a residual
+    marker string of the surviving environment conditions.  Handles a
+    top-level ``or`` of ``and`` groups and recurses into parenthesised
+    subgroups; each conjunct that references only ``extra`` is decided
+    through packaging's public ``Marker.evaluate``.
+
+    This should move to a public packaging marker-reduction API once one
+    exists; nab deliberately does not reach into ``Marker._markers`` (see the
+    rejected-precedent note in :mod:`nab_python._lockfile.disjointness`).
+    """
+    text = _strip_wrapping_parens(text)
+    disjuncts = _split_top_level(text, "or")
+    if len(disjuncts) > 1:
+        surviving: list[str] = []
+        for disjunct in disjuncts:
+            reduced = _reduce_marker_string(disjunct, extra)
+            if reduced is True:
+                return True
+            if isinstance(reduced, str):
+                surviving.append(reduced)
+        if not surviving:
+            return False
+        return " or ".join(surviving)
+    residual: list[str] = []
+    for conjunct in _split_top_level(text, "and"):
+        reduced = _reduce_conjunct(conjunct, extra)
+        if reduced is False:
+            return False
+        if isinstance(reduced, str):
+            residual.append(reduced)
+    if not residual:
+        return True
+    return " and ".join(residual)
+
+
+def _environment_residual(marker: Marker, extra: str) -> str | bool:
+    """Reduce a self-ref activation marker against a bound ``extra``.
+
+    A self-reference is reached only because its extra is selected, so its
+    ``extra == "<extra>"`` clause is already decided at expansion.  Delegates
+    to :func:`_reduce_marker_string` over ``str(marker)``: returns ``True``
+    (tautology, a bare dep), ``False`` (contradiction, does not activate), or
+    a residual string of the surviving environment conditions.
+    """
+    return _reduce_marker_string(str(marker), extra)
+
+
 def expand_extra_requirements(
     optional_deps: Mapping[str, Sequence[str]],
     project_name: str | None,
@@ -367,13 +509,32 @@ def expand_extra_requirements(
             if canonical_project is not None and (
                 canonicalize_name(req.name) == canonical_project
             ):
-                edge = gates if req.marker is None else gates | {str(req.marker)}
-                worklist.extend((canonicalize_name(sub), edge) for sub in req.extras)
+                worklist.extend(_self_ref_edges(req, extra, gates))
                 continue
             if gates:
                 req.marker = _and_markers(req.marker, gates)
             out.append(req)
     return out
+
+
+def _self_ref_edges(
+    req: Requirement, extra: str, gates: frozenset[str]
+) -> list[tuple[str, frozenset[str]]]:
+    """Worklist entries for the extras a self-reference activates.
+
+    The self-ref's own marker is reduced against the walked ``extra``: a
+    contradiction means it does not activate (no entries), a tautology
+    propagates the inherited ``gates`` unchanged, and an environment
+    residual is added to the gate carried onto the reached extras.
+    """
+    edge = gates
+    if req.marker is not None:
+        residual = _environment_residual(req.marker, extra)
+        if residual is False:
+            return []
+        if isinstance(residual, str):
+            edge = gates | {residual}
+    return [(canonicalize_name(sub), edge) for sub in req.extras]
 
 
 def expand_group_includes(

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -580,6 +580,221 @@ class TestExpandExtraRequirements:
         assert any(d.marker.evaluate(win_only) for d in deps)
         assert not any(d.marker.evaluate(neither) for d in deps)
 
+    def test_self_ref_extra_gate_does_not_survive_as_marker(self) -> None:
+        """An ``extra ==`` self-ref gate is satisfied at expansion, so the
+        flattened dep is bare; carrying ``extra == "all"`` forward would
+        drop it on every universal tuple, where ``extra`` is unbound."""
+        opt = {
+            "all": ['mypkg[fast]; extra == "all"'],
+            "fast": ["some-dep"],
+        }
+        dep = next(
+            r
+            for r in expand_extra_requirements(opt, "mypkg", ["all"])
+            if r.name == "some-dep"
+        )
+        assert dep.marker is None
+
+    def test_self_ref_combined_gate_keeps_only_env_residual(self) -> None:
+        """A gate of ``extra == "all" and python_version < "3.10"`` drops the
+        tautological extra clause and keeps the environment condition, so the
+        dep survives on 3.9 and not on 3.11."""
+        opt = {
+            "all": ['mypkg[fast]; extra == "all" and python_version < "3.10"'],
+            "fast": ["some-dep"],
+        }
+        dep = next(
+            r
+            for r in expand_extra_requirements(opt, "mypkg", ["all"])
+            if r.name == "some-dep"
+        )
+        assert dep.marker is not None
+        assert dep.marker.evaluate({"python_version": "3.9"})
+        assert not dep.marker.evaluate({"python_version": "3.11"})
+
+    def test_self_ref_combined_gate_keeps_two_anded_env_residuals(self) -> None:
+        """Two environment conditions joined by ``and`` alongside the extra
+        clause both survive: the residual must keep the ``and`` between them so
+        it stays parseable, not collapse to two adjacent comparisons."""
+        opt = {
+            "all": [
+                'mypkg[fast]; extra == "all" and python_version < "3.10"'
+                ' and sys_platform == "linux"'
+            ],
+            "fast": ["some-dep"],
+        }
+        dep = next(
+            r
+            for r in expand_extra_requirements(opt, "mypkg", ["all"])
+            if r.name == "some-dep"
+        )
+        assert dep.marker is not None
+        assert dep.marker.evaluate({"python_version": "3.9", "sys_platform": "linux"})
+        assert not dep.marker.evaluate(
+            {"python_version": "3.9", "sys_platform": "win32"}
+        )
+        assert not dep.marker.evaluate(
+            {"python_version": "3.11", "sys_platform": "linux"}
+        )
+
+    def test_self_ref_combined_gate_keeps_or_of_two_anded_env_groups(self) -> None:
+        """An OR of two multi-conjunct AND-groups keeps each group's inner
+        ``and`` and wraps the groups so ``and``/``or`` precedence holds across
+        both surviving OR branches."""
+        opt = {
+            "all": [
+                'mypkg[fast]; (extra == "all" and python_version < "3.10"'
+                ' and sys_platform == "linux") or (extra == "all"'
+                ' and python_version >= "3.12" and sys_platform == "win32")'
+            ],
+            "fast": ["some-dep"],
+        }
+        dep = next(
+            r
+            for r in expand_extra_requirements(opt, "mypkg", ["all"])
+            if r.name == "some-dep"
+        )
+        assert dep.marker is not None
+        assert dep.marker.evaluate({"python_version": "3.9", "sys_platform": "linux"})
+        assert dep.marker.evaluate({"python_version": "3.12", "sys_platform": "win32"})
+        assert not dep.marker.evaluate(
+            {"python_version": "3.9", "sys_platform": "win32"}
+        )
+        assert not dep.marker.evaluate(
+            {"python_version": "3.12", "sys_platform": "linux"}
+        )
+
+    def test_self_ref_combined_gate_keeps_env_then_nested_disjunction(self) -> None:
+        """A plain env conjunct followed by a surviving nested disjunction keeps
+        the ``and`` between them, so the residual is ``env and (a or b)``."""
+        opt = {
+            "all": [
+                'mypkg[fast]; extra == "all" and python_version < "3.10"'
+                ' and (sys_platform == "linux" or sys_platform == "darwin")'
+            ],
+            "fast": ["some-dep"],
+        }
+        dep = next(
+            r
+            for r in expand_extra_requirements(opt, "mypkg", ["all"])
+            if r.name == "some-dep"
+        )
+        assert dep.marker is not None
+        assert dep.marker.evaluate({"python_version": "3.9", "sys_platform": "linux"})
+        assert dep.marker.evaluate({"python_version": "3.9", "sys_platform": "darwin"})
+        assert not dep.marker.evaluate(
+            {"python_version": "3.9", "sys_platform": "win32"}
+        )
+        assert not dep.marker.evaluate(
+            {"python_version": "3.11", "sys_platform": "linux"}
+        )
+
+    def test_self_ref_extra_gate_combined_with_dep_marker(self) -> None:
+        """The dep's own marker survives when the self-ref gate is a pure
+        ``extra ==``: the gate drops out and only the dep marker remains."""
+        opt = {
+            "all": ['mypkg[fast]; extra == "all"'],
+            "fast": ["some-dep; sys_platform == 'linux'"],
+        }
+        dep = next(
+            r
+            for r in expand_extra_requirements(opt, "mypkg", ["all"])
+            if r.name == "some-dep"
+        )
+        assert dep.marker is not None
+        assert dep.marker.evaluate({"sys_platform": "linux"})
+        assert not dep.marker.evaluate({"sys_platform": "win32"})
+
+    def test_self_ref_extra_gate_for_other_extra_does_not_activate(self) -> None:
+        """A self-ref gated by ``extra == "<other>"`` than the one being walked
+        never activates, so its extras are not flattened in."""
+        opt = {
+            "all": ['mypkg[fast]; extra == "other"'],
+            "fast": ["some-dep"],
+        }
+        names = {r.name for r in expand_extra_requirements(opt, "mypkg", ["all"])}
+        assert "some-dep" not in names
+
+    def test_self_ref_extra_gate_or_env_is_unconditional(self) -> None:
+        """``extra == "all" or python_version`` is a tautology when ``all`` is
+        the walked extra, so the dep is required on every environment."""
+        opt = {
+            "all": ['mypkg[fast]; extra == "all" or python_version < "3.10"'],
+            "fast": ["some-dep"],
+        }
+        dep = next(
+            r
+            for r in expand_extra_requirements(opt, "mypkg", ["all"])
+            if r.name == "some-dep"
+        )
+        assert dep.marker is None
+
+    def test_self_ref_extra_gate_nested_keeps_env_disjunction(self) -> None:
+        """A nested ``extra == "all" and (env_a or env_b)`` keeps the env
+        disjunction after the satisfied extra clause drops."""
+        opt = {
+            "all": [
+                'mypkg[fast]; extra == "all" and '
+                '(python_version < "3.10" or sys_platform == "win32")'
+            ],
+            "fast": ["some-dep"],
+        }
+        dep = next(
+            r
+            for r in expand_extra_requirements(opt, "mypkg", ["all"])
+            if r.name == "some-dep"
+        )
+        assert dep.marker is not None
+        assert dep.marker.evaluate({"python_version": "3.9", "sys_platform": "linux"})
+        assert dep.marker.evaluate({"python_version": "3.11", "sys_platform": "win32"})
+        assert not dep.marker.evaluate(
+            {"python_version": "3.11", "sys_platform": "linux"}
+        )
+
+    def test_self_ref_extra_gate_chain_drops_each_link(self) -> None:
+        """A chain of ``extra ==`` self-refs flattens to a bare dep: every
+        link's gate is satisfied at expansion."""
+        opt = {
+            "all": ['mypkg[mid]; extra == "all"'],
+            "mid": ['mypkg[leaf]; extra == "mid"'],
+            "leaf": ["dep"],
+        }
+        dep = next(
+            r
+            for r in expand_extra_requirements(opt, "mypkg", ["all"])
+            if r.name == "dep"
+        )
+        assert dep.marker is None
+
+    def test_self_ref_parenthesised_extra_clause_drops(self) -> None:
+        """A bracketed ``(extra == "all")`` conjunct is a satisfied nested
+        group, so only the environment condition survives."""
+        opt = {
+            "all": ['mypkg[fast]; (extra == "all") and python_version < "3.10"'],
+            "fast": ["some-dep"],
+        }
+        dep = next(
+            r
+            for r in expand_extra_requirements(opt, "mypkg", ["all"])
+            if r.name == "some-dep"
+        )
+        assert dep.marker is not None
+        assert dep.marker.evaluate({"python_version": "3.9"})
+        assert not dep.marker.evaluate({"python_version": "3.11"})
+
+    def test_self_ref_parenthesised_other_extras_do_not_activate(self) -> None:
+        """A bracketed disjunction of non-matching ``extra`` clauses is a
+        contradiction, so the self-reference does not activate."""
+        opt = {
+            "all": [
+                'mypkg[fast]; (extra == "other" or extra == "x") '
+                'and python_version < "3.10"'
+            ],
+            "fast": ["some-dep"],
+        }
+        names = {r.name for r in expand_extra_requirements(opt, "mypkg", ["all"])}
+        assert "some-dep" not in names
+
     def test_unknown_extra_raises(self) -> None:
         with pytest.raises(LookupError, match="not declared"):
             expand_extra_requirements({"a": ["depA"]}, "mypkg", ["missing"])


### PR DESCRIPTION
In universal mode a self-referencing extra dep was silently dropped whenever its self-reference carried an `extra ==` gate. With `all = ["mypkg[fast]; extra == \"all\""]` and `fast = ["some-dep"]`, selecting `all` should pull in `some-dep` on every tuple, but it never appeared: `expand_extra_requirements` folded the whole self-ref marker, including the `extra == "all"` clause, into the gate carried onto the reached extras, and the per-tuple universal parser evaluates markers with `extra` unbound, so `extra == "all"` was always false.

The self-reference is only reached because its extra is selected, so that clause is already decided at expansion. The self-ref marker is now reduced against the walked extra before it becomes a gate: a pure `extra ==` clause is a tautology and drops out (a bare dep), a clause gated by a different extra is a contradiction so the self-reference does not activate, and any surviving environment conditions (`python_version`, `sys_platform`, and nested `and`/`or` groups) are kept and carried forward.

The reduction works on the marker's string form: it splits the top-level `and`/`or`, recurses into parenthesised groups, and decides each `extra` comparison through packaging's public `Marker.evaluate`. This mirrors the string-based approach in `_lockfile/disjointness.py` and avoids reaching into packaging's private marker internals. It should eventually move to a public packaging marker-reduction API.