### PR TITLE
verify remote sdist archive hash before reading metadata or building

### DIFF
--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -22,7 +22,9 @@ from .client import (
     WheelFile,
     _extract_sdist_files,
     _parse_files,
+    _select_artifact_hash,
     _verify_metadata_hash,
+    _verify_sdist_hash,
 )
 
 if TYPE_CHECKING:
@@ -201,7 +203,11 @@ class CachedAsyncSimpleClient:
         return text
 
     async def get_sdist_files(
-        self, package: str, version: str, sdist_url: str
+        self,
+        package: str,
+        version: str,
+        sdist_url: str,
+        sdist_hashes: tuple[tuple[str, str], ...] = (),
     ) -> tuple[str | None, str | None]:
         """Return ``(pkg_info, pyproject_toml)`` for an sdist, caching both.
 
@@ -209,6 +215,12 @@ class CachedAsyncSimpleClient:
         element may be ``None`` if the corresponding file is absent
         from the archive (or the archive cannot be parsed).  Both are
         treated as immutable: cached forever, never revalidated.
+
+        When ``sdist_hashes`` carries an acceptable published digest the
+        downloaded archive is verified against it before extraction; a
+        mismatch raises :class:`SdistHashMismatchError` and nothing is
+        cached.  This is the sdist-archive parallel to the PEP 658
+        metadata-sidecar check in :meth:`get_metadata_text`.
         """
         pkg_info = self._cache.get_sdist_pkginfo(package, version)
         pyproject_toml = self._cache.get_sdist_pyproject(package, version)
@@ -221,6 +233,9 @@ class CachedAsyncSimpleClient:
 
         response = await self._transport.get(sdist_url)
         response.raise_for_status()
+        selected = _select_artifact_hash(sdist_hashes)
+        if selected is not None:
+            _verify_sdist_hash(response.content, selected)
         pkg_info, pyproject_toml = _extract_sdist_files(response.content)
 
         if pkg_info is not None:

--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -216,11 +216,10 @@ class CachedAsyncSimpleClient:
         from the archive (or the archive cannot be parsed).  Both are
         treated as immutable: cached forever, never revalidated.
 
-        When ``sdist_hashes`` carries an acceptable published digest the
-        downloaded archive is verified against it before extraction; a
+        When ``sdist_hashes`` carries an acceptable published digest, the
+        downloaded archive is verified against it before extraction. A
         mismatch raises :class:`SdistHashMismatchError` and nothing is
-        cached.  This is the sdist-archive parallel to the PEP 658
-        metadata-sidecar check in :meth:`get_metadata_text`.
+        cached.
         """
         pkg_info = self._cache.get_sdist_pkginfo(package, version)
         pyproject_toml = self._cache.get_sdist_pyproject(package, version)
@@ -246,7 +245,11 @@ class CachedAsyncSimpleClient:
         return (pkg_info, pyproject_toml)
 
     async def get_sdist_archive(
-        self, package: str, version: str, sdist_url: str
+        self,
+        package: str,
+        version: str,
+        sdist_url: str,
+        sdist_hashes: tuple[tuple[str, str], ...] = (),
     ) -> bytes:
         """Return the raw bytes of an sdist archive.
 
@@ -255,6 +258,10 @@ class CachedAsyncSimpleClient:
         large, builds are rare, and the in-memory index already
         deduplicates within a single resolve.  Offline mode raises
         :class:`OfflineError` because there is no slot to read from.
+
+        When ``sdist_hashes`` carries an acceptable published digest, the
+        downloaded archive is verified before its bytes are returned. A
+        mismatch raises :class:`SdistHashMismatchError`.
         """
         del package, version  # offline check below is the only use
         if self._offline:
@@ -262,4 +269,7 @@ class CachedAsyncSimpleClient:
             raise OfflineError(msg)
         response = await self._transport.get(sdist_url)
         response.raise_for_status()
+        selected = _select_artifact_hash(sdist_hashes)
+        if selected is not None:
+            _verify_sdist_hash(response.content, selected)
         return response.content

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -41,8 +41,7 @@ __all__ = [
     "extract_sdist_archive",
 ]
 
-# Preferred verification order (sha256 is pip's hash-checking baseline). Restated
-# here because nab_index sits below nab_python's ACCEPTED_HASH_ALGORITHMS.
+# Verification order; sha256 is pip's hash-checking baseline.
 _ACCEPTED_HASH_ALGORITHMS = ("sha256", "sha384", "sha512")
 
 
@@ -439,9 +438,9 @@ def _select_artifact_hash(
 ) -> tuple[str, str] | None:
     """Pick the preferred ``(algo, hex)`` to verify, or ``None`` if none qualify.
 
-    Walks :data:`_ACCEPTED_HASH_ALGORITHMS` in order so sha256 is preferred,
-    then sha384, then sha512.  Unacceptable algorithms (e.g. md5) and an
-    empty set yield ``None``, so no check runs.
+    Walks :data:`_ACCEPTED_HASH_ALGORITHMS` in order, so sha256 is preferred,
+    then sha384, then sha512. An empty set or only unaccepted algorithms (md5)
+    yields ``None``.
     """
     by_algo = {algo.lower(): digest.lower() for algo, digest in hashes}
     for algo in _ACCEPTED_HASH_ALGORITHMS:

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -36,13 +36,22 @@ __all__ = [
     "AsyncSimpleClient",
     "MetadataHashMismatchError",
     "SdistFile",
+    "SdistHashMismatchError",
     "WheelFile",
     "extract_sdist_archive",
 ]
 
+# Preferred verification order (sha256 is pip's hash-checking baseline). Restated
+# here because nab_index sits below nab_python's ACCEPTED_HASH_ALGORITHMS.
+_ACCEPTED_HASH_ALGORITHMS = ("sha256", "sha384", "sha512")
+
 
 class MetadataHashMismatchError(Exception):
     """Fetched PEP 658 metadata did not match its published hash."""
+
+
+class SdistHashMismatchError(Exception):
+    """A fetched sdist archive did not match its published hash."""
 
 
 # Mirrors packaging.utils._build_tag_regex: PEP 427 build numbers start with a digit.
@@ -423,6 +432,32 @@ def _verify_metadata_hash(content: bytes, metadata_hash: tuple[str, str]) -> Non
     if actual != expected:
         msg = f"metadata {algo} mismatch: expected {expected}, got {actual}"
         raise MetadataHashMismatchError(msg)
+
+
+def _select_artifact_hash(
+    hashes: tuple[tuple[str, str], ...],
+) -> tuple[str, str] | None:
+    """Pick the preferred ``(algo, hex)`` to verify, or ``None`` if none qualify.
+
+    Walks :data:`_ACCEPTED_HASH_ALGORITHMS` in order so sha256 is preferred,
+    then sha384, then sha512.  Unacceptable algorithms (e.g. md5) and an
+    empty set yield ``None``, so no check runs.
+    """
+    by_algo = {algo.lower(): digest.lower() for algo, digest in hashes}
+    for algo in _ACCEPTED_HASH_ALGORITHMS:
+        digest = by_algo.get(algo)
+        if digest is not None:
+            return (algo, digest)
+    return None
+
+
+def _verify_sdist_hash(content: bytes, sdist_hash: tuple[str, str]) -> None:
+    """Raise :class:`SdistHashMismatchError` if ``content`` fails the hash."""
+    algo, expected = sdist_hash
+    actual = hashlib.new(algo, content).hexdigest()
+    if actual != expected:
+        msg = f"sdist {algo} mismatch: expected {expected}, got {actual}"
+        raise SdistHashMismatchError(msg)
 
 
 def _extract_sdist_files(data: bytes) -> tuple[str | None, str | None]:

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -325,8 +325,8 @@ class LocalIndexClient:
     ) -> tuple[str | None, str | None]:
         """Return ``(pkg_info, pyproject_toml)`` extracted from the sdist.
 
-        The on-disk archive is trusted, so ``sdist_hashes`` is accepted
-        only to match the remote client signature and is not verified.
+        On-disk archives are trusted, so ``sdist_hashes`` matches the remote
+        client signature but is not verified.
         """
         path = _parse_file_url(sdist_url)
         return _extract_sdist_files(path.read_bytes())
@@ -336,7 +336,12 @@ class LocalIndexClient:
         package: str,  # noqa: ARG002 - matches CachedAsyncSimpleClient signature
         version: str,  # noqa: ARG002
         sdist_url: str,
+        sdist_hashes: tuple[tuple[str, str], ...] = (),  # noqa: ARG002
     ) -> bytes:
-        """Return the raw bytes of an sdist archive sitting on disk."""
+        """Return the raw bytes of an sdist archive sitting on disk.
+
+        On-disk archives are trusted, so ``sdist_hashes`` matches the remote
+        client signature but is not verified.
+        """
         path = _parse_file_url(sdist_url)
         return path.read_bytes()

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -321,8 +321,13 @@ class LocalIndexClient:
         package: str,  # noqa: ARG002 - matches CachedAsyncSimpleClient signature
         version: str,  # noqa: ARG002
         sdist_url: str,
+        sdist_hashes: tuple[tuple[str, str], ...] = (),  # noqa: ARG002
     ) -> tuple[str | None, str | None]:
-        """Return ``(pkg_info, pyproject_toml)`` extracted from the sdist."""
+        """Return ``(pkg_info, pyproject_toml)`` extracted from the sdist.
+
+        The on-disk archive is trusted, so ``sdist_hashes`` is accepted
+        only to match the remote client signature and is not verified.
+        """
         path = _parse_file_url(sdist_url)
         return _extract_sdist_files(path.read_bytes())
 

--- a/nab-index/src/nab_index/multi_index.py
+++ b/nab-index/src/nab_index/multi_index.py
@@ -72,7 +72,11 @@ class IndexClient(Protocol):
         ...
 
     async def get_sdist_archive(
-        self, package: str, version: str, sdist_url: str
+        self,
+        package: str,
+        version: str,
+        sdist_url: str,
+        sdist_hashes: tuple[tuple[str, str], ...] = (),
     ) -> bytes:
         """Return the raw sdist archive bytes."""
         ...
@@ -231,10 +235,11 @@ class MultiIndexClient:
         package: str,
         version: str,
         sdist_url: str,
+        sdist_hashes: tuple[tuple[str, str], ...] = (),
     ) -> bytes:
         """Forward to the routed client; presupposes ``get_files`` was called."""
         return await self._client_for(package).get_sdist_archive(
-            package, version, sdist_url
+            package, version, sdist_url, sdist_hashes
         )
 
     def _client_for(self, package: str) -> IndexClient:

--- a/nab-index/src/nab_index/multi_index.py
+++ b/nab-index/src/nab_index/multi_index.py
@@ -62,7 +62,11 @@ class IndexClient(Protocol):
         ...
 
     async def get_sdist_files(
-        self, package: str, version: str, sdist_url: str
+        self,
+        package: str,
+        version: str,
+        sdist_url: str,
+        sdist_hashes: tuple[tuple[str, str], ...] = (),
     ) -> tuple[str | None, str | None]:
         """Return ``(pkg_info_text, pyproject_text)`` for the sdist."""
         ...
@@ -215,10 +219,11 @@ class MultiIndexClient:
         package: str,
         version: str,
         sdist_url: str,
+        sdist_hashes: tuple[tuple[str, str], ...] = (),
     ) -> tuple[str | None, str | None]:
         """Forward to the routed client; presupposes ``get_files`` was called."""
         return await self._client_for(package).get_sdist_files(
-            package, version, sdist_url
+            package, version, sdist_url, sdist_hashes
         )
 
     async def get_sdist_archive(

--- a/nab-python/src/nab_python/_provider/build_remote.py
+++ b/nab-python/src/nab_python/_provider/build_remote.py
@@ -63,8 +63,15 @@ def build_remote_sdist(
         raise UnsupportedSdistError(msg)
 
     ver_str = str(version)
-    event = provider.coordinator.request_sdist_archive(canonical, ver_str, sdist.url)
+    event = provider.coordinator.request_sdist_archive(
+        canonical, ver_str, sdist.url, sdist.hashes
+    )
     event.wait()
+    integrity_error = provider.coordinator.index.get_sdist_archive_error(
+        canonical, ver_str
+    )
+    if integrity_error is not None:
+        raise integrity_error
     data = provider.coordinator.index.get_sdist_archive(canonical, ver_str)
     if data is None:
         msg = (

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -291,10 +291,8 @@ def fetch_sdist_metadata(
 ) -> str | None:
     """Block until the coordinator returns sdist PKG-INFO text.
 
-    The archive is verified against ``sdist.hashes`` before its PKG-INFO
-    is read; a hash mismatch is recorded as an integrity error and
-    re-raised here, the sdist parallel to the wheel-sidecar check in
-    :func:`resolve_metadata`.
+    The archive is verified against ``sdist.hashes`` before its PKG-INFO is
+    read. A hash mismatch is recorded as an integrity error and re-raised here.
     """
     event = provider.coordinator.request_sdist(
         package, version, sdist.url, sdist.hashes

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -289,10 +289,21 @@ def find_sdist(
 def fetch_sdist_metadata(
     provider: Provider, package: str, version: str, sdist: SdistFile
 ) -> str | None:
-    """Block until the coordinator returns sdist PKG-INFO text."""
-    event = provider.coordinator.request_sdist(package, version, sdist.url)
+    """Block until the coordinator returns sdist PKG-INFO text.
+
+    The archive is verified against ``sdist.hashes`` before its PKG-INFO
+    is read; a hash mismatch is recorded as an integrity error and
+    re-raised here, the sdist parallel to the wheel-sidecar check in
+    :func:`resolve_metadata`.
+    """
+    event = provider.coordinator.request_sdist(
+        package, version, sdist.url, sdist.hashes
+    )
     event.wait()
     provider.stats.sdist_pkg_info_fetched += 1
+    integrity_error = provider.coordinator.index.get_metadata_error(package, version)
+    if integrity_error is not None:
+        raise integrity_error
     return provider.coordinator.index.get_metadata(package, version)
 
 

--- a/nab-python/src/nab_python/_testing/coordinator_fake.py
+++ b/nab-python/src/nab_python/_testing/coordinator_fake.py
@@ -142,7 +142,12 @@ def _wire_sdist_side_effects(
 ) -> None:
     """Attach ``request_sdist`` and ``request_wheel_metadata`` side effects."""
 
-    def _request_sdist(pkg: str, ver: str, _url: str) -> threading.Event:
+    def _request_sdist(
+        pkg: str,
+        ver: str,
+        _url: str,
+        _hashes: tuple[tuple[str, str], ...] = (),
+    ) -> threading.Event:
         # ``store_sdist_metadata`` is always called; passing ``None``
         # poisons the cache slot, matching the original test_provider
         # helper's contract for sdist-fetch failures.

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -134,6 +134,7 @@ class InMemoryIndex:
         self._metadata_from_sdist: set[tuple[str, str]] = set()
         self._sdist_pyproject: dict[tuple[str, str], str | None] = {}
         self._sdist_archives: dict[tuple[str, str], bytes | None] = {}
+        self._sdist_archive_errors: dict[tuple[str, str], BaseException] = {}
         self._pending: dict[str, _Pending] = {}
 
         # Parsed metadata is a pure function of the underlying text, so we
@@ -270,12 +271,9 @@ class InMemoryIndex:
     ) -> None:
         """Record an sdist integrity failure and unblock the sdist waiter.
 
-        Parallels :meth:`store_metadata_error` for the wheel sidecar:
-        ``store_sdist_metadata(None)`` means the archive yielded no
-        PKG-INFO, while an error means the archive failed its published
-        hash and the resolve must abort rather than fall through.  The
-        error is keyed on ``(package, version)`` so :meth:`get_metadata_error`
-        surfaces it, and the ``sdist:`` pending event is fired.
+        A recorded error is distinct from ``store_sdist_metadata(None)``: None
+        means the archive yielded no PKG-INFO, an error means the archive
+        failed its published hash and the resolve must abort, not fall through.
         """
         key = f"sdist:{package}:{version}"
         with self._lock:
@@ -327,6 +325,29 @@ class InMemoryIndex:
         """Return cached sdist archive bytes, or ``None`` if absent or failed."""
         with self._lock:
             return self._sdist_archives.get((package, version))
+
+    def store_sdist_archive_error(
+        self, package: str, version: str, error: BaseException
+    ) -> None:
+        """Record an sdist-archive integrity failure and unblock the waiter.
+
+        Kept in its own slot rather than ``store_sdist_archive(None)`` so
+        the ``BUILD_REMOTE`` path can tell a failed fetch (skip the
+        version) from a tampered archive (abort the resolve).
+        """
+        key = f"sdist-archive:{package}:{version}"
+        with self._lock:
+            self._sdist_archive_errors[(package, version)] = error
+            pending = self._pending.get(key)
+        if pending is not None:
+            pending.event.set()
+
+    def get_sdist_archive_error(
+        self, package: str, version: str
+    ) -> BaseException | None:
+        """Return a recorded sdist-archive integrity error, or ``None``."""
+        with self._lock:
+            return self._sdist_archive_errors.get((package, version))
 
     def get_or_create_pending(self, key: str) -> tuple[_Pending, bool]:
         """Return (pending, already_existed)."""
@@ -617,9 +638,8 @@ class FetchCoordinator:
 
         Uses a separate ``sdist:`` pending key so it can fire even
         when a prior wheel metadata fetch already cached ``None``
-        for the same ``(package, version)`` slot.  ``sdist_hashes`` is
-        the index-published digest set; the fetcher verifies the
-        downloaded archive against it before extraction.
+        for the same ``(package, version)`` slot. The fetcher verifies the
+        downloaded archive against ``sdist_hashes`` before extraction.
         """
         self._check_alive()
         key = f"sdist:{package}:{version}"
@@ -637,14 +657,20 @@ class FetchCoordinator:
         return pending.event
 
     def request_sdist_archive(
-        self, package: str, version: str, url: str
+        self,
+        package: str,
+        version: str,
+        url: str,
+        sdist_hashes: tuple[tuple[str, str], ...] = (),
     ) -> threading.Event:
         """Request the raw bytes of an sdist archive.
 
         Used by the :class:`~nab_python.provider.BuildPolicy.BUILD_REMOTE`
         path; the bytes are extracted to a temp dir and handed to a
         PEP 517 backend.  Stored under a separate pending key so it can
-        run concurrently with a PKG-INFO fetch for the same version.
+        run concurrently with a PKG-INFO fetch for the same version. The
+        fetcher verifies the downloaded archive against ``sdist_hashes``
+        before storing the bytes.
         """
         self._check_alive()
         key = f"sdist-archive:{package}:{version}"
@@ -656,6 +682,7 @@ class FetchCoordinator:
                     package=package,
                     version=version,
                     url=url,
+                    sdist_hashes=sdist_hashes,
                 )
             )
         return pending.event
@@ -859,6 +886,8 @@ class FetchCoordinator:
                 self.index.store_sdist_metadata_error(req.package, req.version, exc)
             else:
                 self.index.store_sdist_metadata(req.package, req.version, None)
+        elif isinstance(exc, SdistHashMismatchError):
+            self.index.store_sdist_archive_error(req.package, req.version, exc)
         else:
             self.index.store_sdist_archive(req.package, req.version, None)
 
@@ -945,5 +974,7 @@ class FetchCoordinator:
         if req.url is None:
             self.index.store_sdist_archive(req.package, req.version, None)
             return
-        data = await client.get_sdist_archive(req.package, req.version, req.url)
+        data = await client.get_sdist_archive(
+            req.package, req.version, req.url, req.sdist_hashes
+        )
         self.index.store_sdist_archive(req.package, req.version, data)

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -20,7 +20,12 @@ from typing import TYPE_CHECKING, Any
 
 from nab_index.cache import CacheBackend, NullCache, OfflineError, OnDiskCache
 from nab_index.cached_client import CachedAsyncSimpleClient
-from nab_index.client import MetadataHashMismatchError, SdistFile, WheelFile
+from nab_index.client import (
+    MetadataHashMismatchError,
+    SdistFile,
+    SdistHashMismatchError,
+    WheelFile,
+)
 from nab_index.local_index import LocalIndexClient
 from nab_index.multi_index import IndexConfig, MultiIndexClient
 
@@ -100,6 +105,7 @@ class FetchRequest:
     version: str | None = None
     url: str | None = None
     metadata_hash: tuple[str, str] | None = None
+    sdist_hashes: tuple[tuple[str, str], ...] = ()
 
 
 @dataclass
@@ -257,6 +263,25 @@ class InMemoryIndex:
             pending = self._pending.get(key)
         if pending is not None:
             pending.result = data
+            pending.event.set()
+
+    def store_sdist_metadata_error(
+        self, package: str, version: str, error: BaseException
+    ) -> None:
+        """Record an sdist integrity failure and unblock the sdist waiter.
+
+        Parallels :meth:`store_metadata_error` for the wheel sidecar:
+        ``store_sdist_metadata(None)`` means the archive yielded no
+        PKG-INFO, while an error means the archive failed its published
+        hash and the resolve must abort rather than fall through.  The
+        error is keyed on ``(package, version)`` so :meth:`get_metadata_error`
+        surfaces it, and the ``sdist:`` pending event is fired.
+        """
+        key = f"sdist:{package}:{version}"
+        with self._lock:
+            self._metadata_errors[(package, version)] = error
+            pending = self._pending.get(key)
+        if pending is not None:
             pending.event.set()
 
     def metadata_from_sdist(self, package: str, version: str) -> bool:
@@ -581,12 +606,20 @@ class FetchCoordinator:
             )
         return pending.event
 
-    def request_sdist(self, package: str, version: str, url: str) -> threading.Event:
+    def request_sdist(
+        self,
+        package: str,
+        version: str,
+        url: str,
+        sdist_hashes: tuple[tuple[str, str], ...] = (),
+    ) -> threading.Event:
         """Request sdist PKG-INFO extraction.
 
         Uses a separate ``sdist:`` pending key so it can fire even
         when a prior wheel metadata fetch already cached ``None``
-        for the same ``(package, version)`` slot.
+        for the same ``(package, version)`` slot.  ``sdist_hashes`` is
+        the index-published digest set; the fetcher verifies the
+        downloaded archive against it before extraction.
         """
         self._check_alive()
         key = f"sdist:{package}:{version}"
@@ -598,6 +631,7 @@ class FetchCoordinator:
                     package=package,
                     version=version,
                     url=url,
+                    sdist_hashes=sdist_hashes,
                 )
             )
         return pending.event
@@ -821,7 +855,10 @@ class FetchCoordinator:
             else:
                 self.index.store_metadata(req.package, req.version, None)
         elif req.kind is FetchKind.SDIST:
-            self.index.store_sdist_metadata(req.package, req.version, None)
+            if isinstance(exc, SdistHashMismatchError):
+                self.index.store_sdist_metadata_error(req.package, req.version, exc)
+            else:
+                self.index.store_sdist_metadata(req.package, req.version, None)
         else:
             self.index.store_sdist_archive(req.package, req.version, None)
 
@@ -890,7 +927,7 @@ class FetchCoordinator:
         assert req.version is not None
         assert req.url is not None
         pkg_info, pyproject = await client.get_sdist_files(
-            req.package, req.version, req.url
+            req.package, req.version, req.url, req.sdist_hashes
         )
         # Store pyproject.toml first: store_sdist_metadata fires the
         # pending event, and a released waiter reads the pyproject slot

--- a/nab-python/tests/property_python/test_fetch_coordinator.py
+++ b/nab-python/tests/property_python/test_fetch_coordinator.py
@@ -110,7 +110,11 @@ class FakeClient:
         return f"META:{package}:{version}"
 
     async def get_sdist_files(
-        self, package: str, version: str, url: str
+        self,
+        package: str,
+        version: str,
+        url: str,
+        sdist_hashes: tuple[tuple[str, str], ...] = (),
     ) -> tuple[str, str | None]:
         await self._common(("sdist", package, version))
         return (f"PKGINFO:{package}:{version}", f"PYPROJECT:{package}:{version}")

--- a/nab-python/tests/property_python/test_fetch_coordinator.py
+++ b/nab-python/tests/property_python/test_fetch_coordinator.py
@@ -119,7 +119,13 @@ class FakeClient:
         await self._common(("sdist", package, version))
         return (f"PKGINFO:{package}:{version}", f"PYPROJECT:{package}:{version}")
 
-    async def get_sdist_archive(self, package: str, version: str, url: str) -> bytes:
+    async def get_sdist_archive(
+        self,
+        package: str,
+        version: str,
+        url: str,
+        sdist_hashes: tuple[tuple[str, str], ...] = (),
+    ) -> bytes:
         await self._common(("sdist-archive", package, version))
         return f"BYTES:{package}:{version}".encode()
 

--- a/nab-python/tests/property_python/test_multi_index_pep503.py
+++ b/nab-python/tests/property_python/test_multi_index_pep503.py
@@ -83,9 +83,13 @@ class _Stub:
         return ""
 
     async def get_sdist_files(
-        self, package: str, version: str, sdist_url: str
+        self,
+        package: str,
+        version: str,
+        sdist_url: str,
+        sdist_hashes: tuple[tuple[str, str], ...] = (),
     ) -> tuple[str | None, str | None]:
-        del package, version, sdist_url
+        del package, version, sdist_url, sdist_hashes
         return (None, None)
 
     async def get_sdist_archive(

--- a/nab-python/tests/property_python/test_multi_index_pep503.py
+++ b/nab-python/tests/property_python/test_multi_index_pep503.py
@@ -93,9 +93,13 @@ class _Stub:
         return (None, None)
 
     async def get_sdist_archive(
-        self, package: str, version: str, sdist_url: str
+        self,
+        package: str,
+        version: str,
+        sdist_url: str,
+        sdist_hashes: tuple[tuple[str, str], ...] = (),
     ) -> bytes:
-        del package, version, sdist_url
+        del package, version, sdist_url, sdist_hashes
         return b""
 
     async def aclose(self) -> None:

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -27,6 +27,7 @@ from nab_index.client import (
     WheelFile,
     _parse_files,
     _parse_sdist_filename,
+    _select_artifact_hash,
 )
 
 LISTING = {
@@ -469,33 +470,23 @@ class TestParseHashes:
 
 class TestSelectArtifactHash:
     def test_prefers_sha256(self) -> None:
-        from nab_index.client import _select_artifact_hash
-
         hashes = (("sha512", "f" * 128), ("sha256", "a" * 64))
         assert _select_artifact_hash(hashes) == ("sha256", "a" * 64)
 
     def test_falls_through_to_sha384(self) -> None:
-        from nab_index.client import _select_artifact_hash
-
         hashes = (("sha512", "f" * 128), ("sha384", "b" * 96))
         assert _select_artifact_hash(hashes) == ("sha384", "b" * 96)
 
     def test_falls_through_to_sha512(self) -> None:
-        from nab_index.client import _select_artifact_hash
-
         assert _select_artifact_hash((("sha512", "f" * 128),)) == (
             "sha512",
             "f" * 128,
         )
 
     def test_empty_returns_none(self) -> None:
-        from nab_index.client import _select_artifact_hash
-
         assert _select_artifact_hash(()) is None
 
     def test_only_unacceptable_returns_none(self) -> None:
-        from nab_index.client import _select_artifact_hash
-
         assert _select_artifact_hash((("md5", "d" * 32),)) is None
 
 
@@ -1131,6 +1122,76 @@ class TestGetSdistFiles:
         pkg_info, _ = asyncio.run(go())
         assert pkg_info is not None
         assert "Name: pkg" in pkg_info
+
+
+class TestGetSdistArchive:
+    def test_matching_hash_returns_bytes(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        body = _build_tarball([("pkg-1.0/PKG-INFO", b"Name: pkg\n")])
+        digest = hashlib.sha256(body).hexdigest()
+        transport = _FakeTransport([_FakeResponse(body)])
+
+        async def go() -> bytes:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_sdist_archive(
+                    "pkg", "1.0", "https://x/pkg.tar.gz", (("sha256", digest),)
+                )
+            finally:
+                await client.aclose()
+
+        assert asyncio.run(go()) == body
+
+    def test_mismatching_hash_raises(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        published = _build_tarball([("pkg-1.0/PKG-INFO", b"Name: pkg\n")])
+        digest = hashlib.sha256(published).hexdigest()
+        tampered = _build_tarball([("pkg-1.0/PKG-INFO", b"Name: evil\n")])
+        transport = _FakeTransport([_FakeResponse(tampered)])
+
+        async def go() -> bytes:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_sdist_archive(
+                    "pkg", "1.0", "https://x/pkg.tar.gz", (("sha256", digest),)
+                )
+            finally:
+                await client.aclose()
+
+        with pytest.raises(SdistHashMismatchError):
+            asyncio.run(go())
+
+    def test_no_published_hash_returns_bytes(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        body = _build_tarball([("pkg-1.0/PKG-INFO", b"Name: pkg\n")])
+        transport = _FakeTransport([_FakeResponse(body)])
+
+        async def go() -> bytes:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_sdist_archive(
+                    "pkg", "1.0", "https://x/pkg.tar.gz", ()
+                )
+            finally:
+                await client.aclose()
+
+        assert asyncio.run(go()) == body
+
+    def test_offline_raises(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport([])
+
+        async def go() -> bytes:
+            client = CachedAsyncSimpleClient(transport, cache, offline=True)
+            try:
+                return await client.get_sdist_archive(
+                    "pkg", "1.0", "https://x/pkg.tar.gz", ()
+                )
+            finally:
+                await client.aclose()
+
+        with pytest.raises(OfflineError):
+            asyncio.run(go())
 
 
 class TestContextManager:

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -23,6 +23,7 @@ from nab_index.cached_client import (
 from nab_index.client import (
     MetadataHashMismatchError,
     SdistFile,
+    SdistHashMismatchError,
     WheelFile,
     _parse_files,
     _parse_sdist_filename,
@@ -464,6 +465,38 @@ class TestParseHashes:
         from nab_index.client import _parse_hashes
 
         assert _parse_hashes({}) == ()
+
+
+class TestSelectArtifactHash:
+    def test_prefers_sha256(self) -> None:
+        from nab_index.client import _select_artifact_hash
+
+        hashes = (("sha512", "f" * 128), ("sha256", "a" * 64))
+        assert _select_artifact_hash(hashes) == ("sha256", "a" * 64)
+
+    def test_falls_through_to_sha384(self) -> None:
+        from nab_index.client import _select_artifact_hash
+
+        hashes = (("sha512", "f" * 128), ("sha384", "b" * 96))
+        assert _select_artifact_hash(hashes) == ("sha384", "b" * 96)
+
+    def test_falls_through_to_sha512(self) -> None:
+        from nab_index.client import _select_artifact_hash
+
+        assert _select_artifact_hash((("sha512", "f" * 128),)) == (
+            "sha512",
+            "f" * 128,
+        )
+
+    def test_empty_returns_none(self) -> None:
+        from nab_index.client import _select_artifact_hash
+
+        assert _select_artifact_hash(()) is None
+
+    def test_only_unacceptable_returns_none(self) -> None:
+        from nab_index.client import _select_artifact_hash
+
+        assert _select_artifact_hash((("md5", "d" * 32),)) is None
 
 
 class TestParseMaxAge:
@@ -1011,6 +1044,93 @@ class TestGetSdistFiles:
 
         with pytest.raises(OfflineError, match="pkg==1.0"):
             asyncio.run(go())
+
+    def test_matching_hash_returns_and_caches(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        body = _build_tarball(
+            [("pkg-1.0/PKG-INFO", b"Metadata-Version: 2.1\nName: pkg\n")]
+        )
+        digest = hashlib.sha256(body).hexdigest()
+        transport = _FakeTransport([_FakeResponse(body)])
+
+        async def go() -> tuple[str | None, str | None]:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_sdist_files(
+                    "pkg", "1.0", "https://x/pkg.tar.gz", (("sha256", digest),)
+                )
+            finally:
+                await client.aclose()
+
+        pkg_info, _ = asyncio.run(go())
+        assert pkg_info is not None
+        assert "Name: pkg" in pkg_info
+        assert cache.get_sdist_pkginfo("pkg", "1.0") == pkg_info
+
+    def test_mismatching_hash_raises_and_skips_cache(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        published = _build_tarball(
+            [("pkg-1.0/PKG-INFO", b"Metadata-Version: 2.1\nName: pkg\n")]
+        )
+        digest = hashlib.sha256(published).hexdigest()
+        tampered = _build_tarball(
+            [("pkg-1.0/PKG-INFO", b"Metadata-Version: 2.1\nName: evil\n")]
+        )
+        transport = _FakeTransport([_FakeResponse(tampered)])
+
+        async def go() -> tuple[str | None, str | None]:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_sdist_files(
+                    "pkg", "1.0", "https://x/pkg.tar.gz", (("sha256", digest),)
+                )
+            finally:
+                await client.aclose()
+
+        with pytest.raises(SdistHashMismatchError):
+            asyncio.run(go())
+        assert cache.get_sdist_pkginfo("pkg", "1.0") is None
+        assert cache.get_sdist_pyproject("pkg", "1.0") is None
+
+    def test_no_published_hash_skips_verification(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        body = _build_tarball(
+            [("pkg-1.0/PKG-INFO", b"Metadata-Version: 2.1\nName: pkg\n")]
+        )
+        transport = _FakeTransport([_FakeResponse(body)])
+
+        async def go() -> tuple[str | None, str | None]:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_sdist_files(
+                    "pkg", "1.0", "https://x/pkg.tar.gz", ()
+                )
+            finally:
+                await client.aclose()
+
+        pkg_info, _ = asyncio.run(go())
+        assert pkg_info is not None
+        assert "Name: pkg" in pkg_info
+
+    def test_only_unacceptable_hash_skips_verification(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        body = _build_tarball(
+            [("pkg-1.0/PKG-INFO", b"Metadata-Version: 2.1\nName: pkg\n")]
+        )
+        transport = _FakeTransport([_FakeResponse(body)])
+
+        async def go() -> tuple[str | None, str | None]:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_sdist_files(
+                    "pkg", "1.0", "https://x/pkg.tar.gz", (("md5", "deadbeef"),)
+                )
+            finally:
+                await client.aclose()
+
+        pkg_info, _ = asyncio.run(go())
+        assert pkg_info is not None
+        assert "Name: pkg" in pkg_info
 
 
 class TestContextManager:

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -174,6 +174,22 @@ class TestInMemoryIndex:
         idx.store_sdist_archive("foo", "1.0", None)
         assert idx.get_sdist_archive("foo", "1.0") is None
 
+    def test_store_sdist_archive_error_fires_pending(self) -> None:
+        idx = InMemoryIndex()
+        pending, _ = idx.get_or_create_pending("sdist-archive:foo:1.0")
+        assert not pending.event.is_set()
+        err = SdistHashMismatchError("boom")
+        idx.store_sdist_archive_error("foo", "1.0", err)
+        assert pending.event.is_set()
+        assert idx.get_sdist_archive_error("foo", "1.0") is err
+        assert idx.get_sdist_archive("foo", "1.0") is None
+
+    def test_store_sdist_archive_error_without_pending(self) -> None:
+        idx = InMemoryIndex()
+        err = SdistHashMismatchError("boom")
+        idx.store_sdist_archive_error("foo", "1.0", err)
+        assert idx.get_sdist_archive_error("foo", "1.0") is err
+
     def test_parsed_metadata_roundtrip(self) -> None:
         """``store_parsed_metadata`` and ``get_parsed_metadata`` round-trip."""
         idx = InMemoryIndex()
@@ -1012,6 +1028,46 @@ class TestFetchCoordinator:
             )
             event.wait(timeout=5)
             assert coord.index.get_sdist_archive("pkg", "1.0") == b"archive-bytes"
+
+    @respx.mock
+    def test_request_sdist_archive_verifies_published_hash(self) -> None:
+        """A matching published hash lets the archive bytes through."""
+        body = b"archive-bytes"
+        digest = hashlib.sha256(body).hexdigest()
+        respx.get("https://files.example.com/pkg-1.0.tar.gz").mock(
+            return_value=httpx.Response(200, content=body),
+        )
+        with _coord() as coord:
+            event = coord.request_sdist_archive(
+                "pkg",
+                "1.0",
+                "https://files.example.com/pkg-1.0.tar.gz",
+                (("sha256", digest),),
+            )
+            event.wait(timeout=5)
+            assert coord.index.get_sdist_archive("pkg", "1.0") == body
+            assert coord.index.get_sdist_archive_error("pkg", "1.0") is None
+
+    @respx.mock
+    def test_request_sdist_archive_hash_mismatch_records_error(self) -> None:
+        """A tampered archive records an integrity error and stores no bytes."""
+        respx.get("https://files.example.com/pkg-1.0.tar.gz").mock(
+            return_value=httpx.Response(200, content=b"tampered"),
+        )
+        with _coord() as coord:
+            event = coord.request_sdist_archive(
+                "pkg",
+                "1.0",
+                "https://files.example.com/pkg-1.0.tar.gz",
+                (("sha256", "0" * 64),),
+            )
+            event.wait(timeout=5)
+            assert not coord._crashed
+            assert coord.index.get_sdist_archive("pkg", "1.0") is None
+            assert isinstance(
+                coord.index.get_sdist_archive_error("pkg", "1.0"),
+                SdistHashMismatchError,
+            )
 
     @respx.mock
     def test_request_sdist_archive_deduplicates(self) -> None:

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -19,7 +19,12 @@ import respx
 
 from nab_index.cache import NullCache
 from nab_index.cached_client import CachedAsyncSimpleClient
-from nab_index.client import MetadataHashMismatchError, SdistFile, WheelFile
+from nab_index.client import (
+    MetadataHashMismatchError,
+    SdistFile,
+    SdistHashMismatchError,
+    WheelFile,
+)
 from nab_index.httpx_async_transport import HttpxAsyncTransport
 from nab_index.local_index import LocalIndexClient
 from nab_index.multi_index import IndexConfig, MultiIndexClient
@@ -130,6 +135,22 @@ class TestInMemoryIndex:
         idx.store_sdist_metadata("foo", "1.0", None)
         assert idx.has_metadata("foo", "1.0")
         assert idx.get_metadata("foo", "1.0") is None
+
+    def test_store_sdist_metadata_error_fires_sdist_pending(self) -> None:
+        idx = InMemoryIndex()
+        pending, _ = idx.get_or_create_pending("sdist:foo:1.0")
+        assert not pending.event.is_set()
+        err = SdistHashMismatchError("boom")
+        idx.store_sdist_metadata_error("foo", "1.0", err)
+        assert pending.event.is_set()
+        assert idx.get_metadata_error("foo", "1.0") is err
+        assert idx.get_metadata("foo", "1.0") is None
+
+    def test_store_sdist_metadata_error_without_pending(self) -> None:
+        idx = InMemoryIndex()
+        err = SdistHashMismatchError("boom")
+        idx.store_sdist_metadata_error("foo", "1.0", err)
+        assert idx.get_metadata_error("foo", "1.0") is err
 
     def test_metadata_from_sdist_tracks_last_write(self) -> None:
         idx = InMemoryIndex()
@@ -808,6 +829,58 @@ class TestFetchCoordinator:
             )
             event.wait(timeout=5)
             assert "Name: pkg" in (coord.index.get_metadata("pkg", "1.0") or "")
+
+    @respx.mock
+    def test_request_sdist_verifies_published_hash(self) -> None:
+        """A matching published hash lets extraction proceed."""
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            info = tarfile.TarInfo(name="pkg-1.0/PKG-INFO")
+            data = b"Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n"
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+        body = buf.getvalue()
+        digest = hashlib.sha256(body).hexdigest()
+        respx.get("https://files.example.com/pkg-1.0.tar.gz").mock(
+            return_value=httpx.Response(200, content=body)
+        )
+        with _coord() as coord:
+            event = coord.request_sdist(
+                "pkg",
+                "1.0",
+                "https://files.example.com/pkg-1.0.tar.gz",
+                (("sha256", digest),),
+            )
+            event.wait(timeout=5)
+            assert "Name: pkg" in (coord.index.get_metadata("pkg", "1.0") or "")
+            assert coord.index.get_metadata_error("pkg", "1.0") is None
+
+    @respx.mock
+    def test_request_sdist_hash_mismatch_records_error(self) -> None:
+        """Tampered sdist bytes record an integrity error, not the PKG-INFO."""
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            info = tarfile.TarInfo(name="pkg-1.0/PKG-INFO")
+            data = b"Metadata-Version: 2.1\nName: evil\nVersion: 1.0\n"
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+        respx.get("https://files.example.com/pkg-1.0.tar.gz").mock(
+            return_value=httpx.Response(200, content=buf.getvalue())
+        )
+        with _coord() as coord:
+            event = coord.request_sdist(
+                "pkg",
+                "1.0",
+                "https://files.example.com/pkg-1.0.tar.gz",
+                (("sha256", "0" * 64),),
+            )
+            event.wait(timeout=5)
+            assert not coord._crashed
+            assert coord.index.get_metadata("pkg", "1.0") is None
+            assert isinstance(
+                coord.index.get_metadata_error("pkg", "1.0"),
+                SdistHashMismatchError,
+            )
 
     @respx.mock
     def test_request_sdist_stores_pyproject(self) -> None:

--- a/nab-python/tests/test_multi_index.py
+++ b/nab-python/tests/test_multi_index.py
@@ -58,7 +58,11 @@ class FakeClient:
         return f"meta:{package}:{version}"
 
     async def get_sdist_files(
-        self, package: str, version: str, sdist_url: str
+        self,
+        package: str,
+        version: str,
+        sdist_url: str,
+        sdist_hashes: tuple[tuple[str, str], ...] = (),
     ) -> tuple[str | None, str | None]:
         self.sdist_calls.append((package, version, sdist_url))
         return (None, None)

--- a/nab-python/tests/test_multi_index.py
+++ b/nab-python/tests/test_multi_index.py
@@ -68,7 +68,11 @@ class FakeClient:
         return (None, None)
 
     async def get_sdist_archive(
-        self, package: str, version: str, sdist_url: str
+        self,
+        package: str,
+        version: str,
+        sdist_url: str,
+        sdist_hashes: tuple[tuple[str, str], ...] = (),
     ) -> bytes:
         return b""
 

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -10,7 +10,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from nab_index.client import MetadataHashMismatchError, SdistFile, WheelFile
+from nab_index.client import (
+    MetadataHashMismatchError,
+    SdistFile,
+    SdistHashMismatchError,
+    WheelFile,
+)
 from nab_python._provider.metadata_resolver import (
     add_classified_dep,
     classify_requirement,
@@ -938,6 +943,37 @@ class TestGetDependencies:
         )
         provider = Provider(coordinator, python_version="3.12.0")
         with pytest.raises(MetadataHashMismatchError):
+            provider.get_dependencies("foo", V("1.0"))
+        assert ("foo", V("1.0")) not in provider.deps_cache
+
+    def test_sdist_hash_mismatch_aborts(self) -> None:
+        """A recorded sdist integrity failure aborts get_dependencies rather
+        than degrading to a generic no-metadata error."""
+        coordinator = make_coordinator(
+            [make_sdist("1.0")],
+            sdist_pkg_info=(
+                "Metadata-Version: 2.2\n"
+                "Name: foo\n"
+                "Version: 1.0\n"
+                "Requires-Dist: from-sdist\n"
+            ),
+            package="foo",
+        )
+
+        def _poisoned_request_sdist(
+            pkg: str,
+            ver: str,
+            _url: str,
+            _hashes: tuple[tuple[str, str], ...] = (),
+        ) -> threading.Event:
+            coordinator.index.store_sdist_metadata_error(
+                pkg, ver, SdistHashMismatchError("sdist sha256 mismatch")
+            )
+            return _done_event()
+
+        coordinator.request_sdist.side_effect = _poisoned_request_sdist
+        provider = Provider(coordinator, python_version="3.12.0")
+        with pytest.raises(SdistHashMismatchError):
             provider.get_dependencies("foo", V("1.0"))
         assert ("foo", V("1.0")) not in provider.deps_cache
 
@@ -5623,7 +5659,12 @@ class TestStaticSdistMetadata:
             metadata_by_version={"1.0": meta_v1, "2.0": None},
         )
 
-        def _request_sdist(pkg: str, ver: str, url: str) -> threading.Event:
+        def _request_sdist(
+            pkg: str,
+            ver: str,
+            url: str,
+            hashes: tuple[tuple[str, str], ...] = (),
+        ) -> threading.Event:
             coordinator.index.store_sdist_metadata(pkg, ver, PKG_INFO_DYNAMIC_DEPS)
             coordinator.index.store_sdist_pyproject(pkg, ver, None)
             return _done_event()

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -947,8 +947,7 @@ class TestGetDependencies:
         assert ("foo", V("1.0")) not in provider.deps_cache
 
     def test_sdist_hash_mismatch_aborts(self) -> None:
-        """A recorded sdist integrity failure aborts get_dependencies rather
-        than degrading to a generic no-metadata error."""
+        """A recorded sdist integrity failure raises from get_dependencies."""
         coordinator = make_coordinator(
             [make_sdist("1.0")],
             sdist_pkg_info=(
@@ -5153,7 +5152,12 @@ class TestEffectiveBuildPolicy:
         provider.versions_cache["pkg"] = [(_Version("1.0"), make_sdist("1.0"))]
         archive_bytes = b"sdist-archive-bytes"
 
-        def _request_archive(pkg: str, ver: str, _url: str) -> threading.Event:
+        def _request_archive(
+            pkg: str,
+            ver: str,
+            _url: str,
+            _hashes: tuple[tuple[str, str], ...] = (),
+        ) -> threading.Event:
             coordinator.index.store_sdist_archive(pkg, ver, archive_bytes)
             return _done_event()
 
@@ -5614,7 +5618,12 @@ class TestStaticSdistMetadata:
         )
         archive_bytes = b"sdist-archive"
 
-        def _request_archive(pkg: str, ver: str, _url: str) -> threading.Event:
+        def _request_archive(
+            pkg: str,
+            ver: str,
+            _url: str,
+            _hashes: tuple[tuple[str, str], ...] = (),
+        ) -> threading.Event:
             coordinator.index.store_sdist_archive(pkg, ver, archive_bytes)
             return _done_event()
 
@@ -5715,7 +5724,12 @@ class TestBuildRemoteFailureModes:
         provider = self._provider(with_sdist=True)
         provider.versions_cache["pkg"] = [(V("1.0"), make_sdist("1.0"))]
 
-        def _failed_fetch(pkg: str, ver: str, _url: str) -> threading.Event:
+        def _failed_fetch(
+            pkg: str,
+            ver: str,
+            _url: str,
+            _hashes: tuple[tuple[str, str], ...] = (),
+        ) -> threading.Event:
             provider.coordinator.index.store_sdist_archive(pkg, ver, None)
             return _done_event()
 
@@ -5723,6 +5737,34 @@ class TestBuildRemoteFailureModes:
             "MagicMock", provider.coordinator
         ).request_sdist_archive.side_effect = _failed_fetch
         with pytest.raises(UnsupportedSdistError, match="archive.*fetch.*failed"):
+            build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
+
+    def test_archive_hash_mismatch_aborts(self) -> None:
+        """A tampered archive raises the integrity error from the build.
+
+        The error must propagate, not degrade to ``UnsupportedSdistError``,
+        which the resolve treats as a skippable version.
+        """
+        from nab_python._provider import build_remote
+
+        provider = self._provider(with_sdist=True)
+        provider.versions_cache["pkg"] = [(V("1.0"), make_sdist("1.0"))]
+
+        def _tampered_fetch(
+            pkg: str,
+            ver: str,
+            _url: str,
+            _hashes: tuple[tuple[str, str], ...] = (),
+        ) -> threading.Event:
+            provider.coordinator.index.store_sdist_archive_error(
+                pkg, ver, SdistHashMismatchError("sdist sha256 mismatch")
+            )
+            return _done_event()
+
+        cast(
+            "MagicMock", provider.coordinator
+        ).request_sdist_archive.side_effect = _tampered_fetch
+        with pytest.raises(SdistHashMismatchError):
             build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
 
     def test_archive_extract_failure_raises(
@@ -5733,7 +5775,12 @@ class TestBuildRemoteFailureModes:
         provider = self._provider(with_sdist=True)
         provider.versions_cache["pkg"] = [(V("1.0"), make_sdist("1.0"))]
 
-        def _ok_fetch(pkg: str, ver: str, _url: str) -> threading.Event:
+        def _ok_fetch(
+            pkg: str,
+            ver: str,
+            _url: str,
+            _hashes: tuple[tuple[str, str], ...] = (),
+        ) -> threading.Event:
             provider.coordinator.index.store_sdist_archive(pkg, ver, b"corrupt")
             return _done_event()
 
@@ -5757,7 +5804,12 @@ class TestBuildRemoteFailureModes:
         provider = self._provider(with_sdist=True)
         provider.versions_cache["pkg"] = [(V("1.0"), make_sdist("1.0"))]
 
-        def _ok_fetch(pkg: str, ver: str, _url: str) -> threading.Event:
+        def _ok_fetch(
+            pkg: str,
+            ver: str,
+            _url: str,
+            _hashes: tuple[tuple[str, str], ...] = (),
+        ) -> threading.Event:
             provider.coordinator.index.store_sdist_archive(pkg, ver, b"data")
             return _done_event()
 
@@ -5785,7 +5837,12 @@ class TestBuildRemoteFailureModes:
             (V("2.0"), make_sdist("2.0")),
         ]
 
-        def _ok_fetch(pkg: str, ver: str, _url: str) -> threading.Event:
+        def _ok_fetch(
+            pkg: str,
+            ver: str,
+            _url: str,
+            _hashes: tuple[tuple[str, str], ...] = (),
+        ) -> threading.Event:
             provider.coordinator.index.store_sdist_archive(pkg, ver, b"data")
             return _done_event()
 
@@ -5802,7 +5859,12 @@ class TestBuildRemoteFailureModes:
         provider = self._provider(with_sdist=True)
         provider.versions_cache["pkg"] = [(V("1.0"), make_sdist("1.0"))]
 
-        def _ok_fetch(pkg: str, ver: str, _url: str) -> threading.Event:
+        def _ok_fetch(
+            pkg: str,
+            ver: str,
+            _url: str,
+            _hashes: tuple[tuple[str, str], ...] = (),
+        ) -> threading.Event:
             provider.coordinator.index.store_sdist_archive(pkg, ver, b"data")
             return _done_event()
 


### PR DESCRIPTION
Remote sdists were downloaded and parsed for PKG-INFO and pyproject.toml, and downloaded again for the BUILD_REMOTE path, without ever checking the bytes against the hash the index published for them. That means the dependency graph and the eventual build could be driven by an archive that does not match what the index claims to serve.

This threads the published hashes from the sdist file record through the fetch coordinator and index clients. Before an archive is extracted or its bytes are returned, it is verified against the published digest, preferring sha256, then sha384, then sha512. A mismatch raises a hash error that is recorded as an integrity failure and re-raised on the resolve, so a tampered archive aborts the resolve instead of being treated as a version with no metadata or being silently built.

Archives loaded from a local file URL are trusted and not verified. When the index publishes no acceptable digest (empty, or only md5), nothing is checked and behavior is unchanged.
