### PR TITLE
reject empty-tag-component wheel filenames in nab-index

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -84,10 +84,9 @@ def _parse_wheel_filename(filename: str) -> tuple[NormalizedName, str] | None:
     not ``"2"``.
 
     This reproduces :func:`packaging.utils.parse_wheel_filename`'s
-    name/version validation but skips its ``parse_tag`` call, whose
-    ``frozenset[Tag]`` result nab discards. With ``validate_order=False``
-    (nab's default) ``parse_tag`` never raises, so the accepted filename
-    set is unchanged. A differential test guards against drift.
+    name/version validation and its rejection of empty tag components,
+    but discards the ``frozenset[Tag]`` that the tag parser builds and
+    nab does not use.
     """
     if not filename.endswith(".whl"):
         return None
@@ -107,7 +106,12 @@ def _parse_wheel_filename(filename: str) -> tuple[NormalizedName, str] | None:
     except InvalidVersion:
         return None
 
-    if dashes == _WHEEL_DASHES_WITH_BUILD and _BUILD_TAG_RE.match(parts[2]) is None:
+    bad_build = (
+        dashes == _WHEEL_DASHES_WITH_BUILD and _BUILD_TAG_RE.match(parts[2]) is None
+    )
+    # No tag component may be empty (the tag triple is parts[-1]).
+    empty_tag = any("" in component.split(".") for component in parts[-1].split("-"))
+    if bad_build or empty_tag:
         return None
 
     return (_intern_name(name_part), version)

--- a/nab-python/tests/test_simple_client_filenames.py
+++ b/nab-python/tests/test_simple_client_filenames.py
@@ -65,6 +65,22 @@ def test_matches_packaging(filename: str) -> None:
     assert _parse_wheel_filename(filename) == _packaging_result(filename)
 
 
+EMPTY_TAG_COMPONENT = [
+    "foo-1.0-py3--any.whl",
+    "foo-1.0--none-any.whl",
+    "foo-1.0-py3-none-.whl",
+    "foo-1.0-py2.-none-any.whl",
+    "foo-1.0-py3-none-.x86.whl",
+    "foo-1.0-1-py3--any.whl",
+    "foo-1.0-2-cp39-cp39-.whl",
+]
+
+
+@pytest.mark.parametrize("filename", EMPTY_TAG_COMPONENT)
+def test_rejects_empty_tag_component(filename: str) -> None:
+    assert _parse_wheel_filename(filename) is None
+
+
 def test_canonical_form_and_trailing_zeros() -> None:
     assert _parse_wheel_filename("Foo.Bar-2.0.0-py3-none-any.whl") == (
         canonicalize_name("Foo.Bar"),


### PR DESCRIPTION
nab-index's fast wheel-filename parser skips packaging's parse_tag call to avoid building a frozenset of tags it never uses. That parser also rejects wheels whose tag triple has an empty component (for example foo-1.0-py3--any.whl), and we did not reproduce that check, so nab-index admitted filenames the re-vendored packaging rejects. The resolve succeeded and then nab lock crashed at pylock validation when packaging re-parsed the filename.

This adds an explicit empty-tag-component check to _parse_wheel_filename: any empty tag field in the python-tag, abi-tag, or platform-tag is rejected up front, matching parse_wheel_filename. A parametrized test covers the empty-component cases across all three tag positions, with and without a build tag.
