### PR TITLE
keep local file:// index artifacts when uploaded-prior-to is set

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -26,7 +26,8 @@ requires-python = "3.12.0"
 
 # Reproducibility cutoff.  Distributions uploaded after this timestamp
 # are ignored.  Accepts ISO 8601 strings, native TOML datetimes, or a
-# "P<n>D" duration relative to the resolve anchor.
+# "P<n>D" duration relative to the resolve anchor.  Artifacts from a
+# local file:// index carry no upload time and are always kept.
 uploaded-prior-to = "2026-05-01T00:00:00Z"
 
 # Version selection within an allowed range.  Mirrors uv's --resolution.

--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -381,6 +381,9 @@ def excluded_by_time(
     """
     if cutoff is None:
         return False
+    if dist.local_path is not None:
+        # A local file:// artifact has no upload time, so the cutoff cannot apply.
+        return False
     if dist.upload_time is None:
         provider.stats.excluded_by_time += 1
         return True

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -65,6 +65,7 @@ def make_wheel(
     requires_python: str | None = None,
     has_metadata: bool = True,
     upload_time: str | None = None,
+    local_path: Path | None = None,
 ) -> WheelFile:
     """Build a WheelFile for testing."""
     return WheelFile(
@@ -74,6 +75,7 @@ def make_wheel(
         requires_python=requires_python,
         has_metadata=has_metadata,
         upload_time=upload_time,
+        local_path=local_path,
     )
 
 
@@ -81,6 +83,7 @@ def make_sdist(
     version: str = "1.0",
     requires_python: str | None = None,
     upload_time: str | None = None,
+    local_path: Path | None = None,
 ) -> SdistFile:
     """Build a SdistFile for testing."""
     return SdistFile(
@@ -89,6 +92,7 @@ def make_sdist(
         version=version,
         requires_python=requires_python,
         upload_time=upload_time,
+        local_path=local_path,
     )
 
 
@@ -2536,6 +2540,37 @@ class TestUploadedPriorTo:
         wheels = [
             make_wheel("2.0", upload_time=None),
             make_wheel("1.0", upload_time="2024-01-01T00:00:00Z"),
+        ]
+        coordinator = make_coordinator(wheels, package="foo")
+        cutoff = datetime(2024, 3, 1, tzinfo=timezone.utc)
+        provider = Provider(coordinator, uploaded_prior_to=cutoff)
+        versions = [v for v, _ in provider.fetch_versions("foo")]
+        assert versions == [V("1.0")]
+
+    def test_keeps_local_artifact_without_upload_time(self) -> None:
+        """A local file:// artifact carries no upload time and is kept."""
+        wheels = [
+            make_wheel(
+                "1.0",
+                upload_time=None,
+                local_path=Path("/wheelhouse/pkg-1.0-py3-none-any.whl"),
+            ),
+        ]
+        coordinator = make_coordinator(wheels, package="foo")
+        cutoff = datetime(2024, 3, 1, tzinfo=timezone.utc)
+        provider = Provider(coordinator, uploaded_prior_to=cutoff)
+        versions = [v for v, _ in provider.fetch_versions("foo")]
+        assert versions == [V("1.0")]
+
+    def test_excludes_remote_but_keeps_local_without_upload_time(self) -> None:
+        """The cutoff drops a remote no-upload-time wheel but keeps a local one."""
+        wheels = [
+            make_wheel("2.0", upload_time=None),
+            make_wheel(
+                "1.0",
+                upload_time=None,
+                local_path=Path("/wheelhouse/pkg-1.0-py3-none-any.whl"),
+            ),
         ]
         coordinator = make_coordinator(wheels, package="foo")
         cutoff = datetime(2024, 3, 1, tzinfo=timezone.utc)


### PR DESCRIPTION
An active `uploaded-prior-to` cutoff dropped every artifact from a local `file://` index. Local files carry no upload time, and `excluded_by_time` treated a missing upload time as "uploaded after the cutoff", so it excluded them all. With nothing left to resolve from, an offline resolve against a local wheelhouse or find-links directory failed.

`excluded_by_time` now returns early for any distribution with a `local_path`: a local artifact has no upload time for the cutoff to apply to, so it is always kept. Remote distributions with a missing upload time are still excluded as before.
