### PR TITLE
keep an extra-only prerelease eligible in the extras proxy chooser

### DIFF
--- a/nab-python/src/nab_python/_provider/extras.py
+++ b/nab-python/src/nab_python/_provider/extras.py
@@ -43,7 +43,10 @@ def choose_extra_version(
     _, _, normalized = provider.split_and_normalize(base)
     version_list = provider.fetch_versions(base)
     all_versions = provider.versions_only(normalized, version_list)
-    candidates = list(version_range.filter(all_versions))
+    # The proxy's satisfying set is the versions that declare the extra, not
+    # the version bounds, so a prerelease that uniquely provides it must
+    # survive the range filter.
+    candidates = list(version_range.filter(all_versions, prereleases=True))
 
     # Filter by base's positive range so we don't pick a proxy version
     # that would force base==V into a known-conflicting state.
@@ -98,26 +101,32 @@ def _pick_in_mode(
     _, _, normalized = provider.split_and_normalize(base)
     is_user = (normalized, extra) in provider.root_extras
     backtrack = provider.extras_mode == ExtrasMode.BACKTRACK
-    for version in candidates:
+
+    def qualifies(version: Version) -> bool:
         if provider.has_invalid_metadata(normalized, version):
-            continue
+            return False
         try:
             provider.get_dependencies(base, version)
         except UnsupportedSdistError:
-            continue
+            return False
         except MetadataError:
-            if not is_user or provider.has_invalid_metadata(normalized, version):
-                continue
-            return version
+            return is_user and not provider.has_invalid_metadata(normalized, version)
         if is_user or not backtrack:
-            return version
+            return True
         metadata = provider.metadata_cache.get((normalized, version))
         provided = (
             {_normalize_extra(e) for e in metadata.provides_extra}
             if metadata
             else set()
         )
-        if metadata is None or extra in provided:
+        return metadata is None or extra in provided
+
+    # Prefer a final over a prerelease only when both qualify, so a
+    # prerelease that uniquely provides the extra is still eligible.
+    finals = [v for v in candidates if not v.is_prerelease]
+    prereleases = [v for v in candidates if v.is_prerelease]
+    for version in (*finals, *prereleases):
+        if qualifies(version):
             return version
     return None
 

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -4429,6 +4429,71 @@ class TestExtras:
         version = provider.choose_version("foo[security]", spec.to_range())
         assert version == V("1.0")
 
+    def test_backtrack_mode_keeps_prerelease_that_provides_extra(self) -> None:
+        """A prerelease uniquely providing the extra stays a candidate.
+
+        ``foo`` ships a final 2.0 without the extra and a prerelease
+        2.0rc1 that declares it. The range filter would drop 2.0rc1, but
+        the proxy must still be able to choose it.
+        """
+        meta_final = "Metadata-Version: 2.1\nName: foo\nVersion: 2.0\n"
+        meta_pre = (
+            "Metadata-Version: 2.1\nName: foo\nVersion: 2.0rc1\n"
+            "Provides-Extra: security\n"
+            'Requires-Dist: cryptography; extra == "security"\n'
+        )
+        coordinator = make_coordinator(
+            [make_wheel("2.0"), make_wheel("2.0rc1")],
+            metadata_by_version={"2.0": meta_final, "2.0rc1": meta_pre},
+            package="foo",
+        )
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            extras_mode=ExtrasMode.BACKTRACK,
+        )
+        version = provider.choose_version("foo[security]", VersionRange.full())
+        assert version == V("2.0rc1")
+
+    def test_full_resolve_prerelease_uniquely_provides_extra(self) -> None:
+        """End to end: a coexisting non-extra final must not hard-fail.
+
+        ``app`` requires ``foo[security]``. Only the prerelease
+        ``foo==2.0rc1`` declares the extra; the final ``foo==2.0`` does
+        not. The resolve must pin the prerelease and pull in its extra
+        dependency.
+        """
+        listings = {
+            "app": [make_wheel("1.0")],
+            "foo": [make_wheel("2.0"), make_wheel("2.0rc1")],
+            "cryptography": [make_wheel("9.0")],
+        }
+        metadata = {
+            "1.0": (
+                "Metadata-Version: 2.1\nName: app\nVersion: 1.0\n"
+                "Requires-Dist: foo[security]\n"
+            ),
+            "2.0": "Metadata-Version: 2.1\nName: foo\nVersion: 2.0\n",
+            "2.0rc1": (
+                "Metadata-Version: 2.1\nName: foo\nVersion: 2.0rc1\n"
+                "Provides-Extra: security\n"
+                'Requires-Dist: cryptography; extra == "security"\n'
+            ),
+            "9.0": "Metadata-Version: 2.1\nName: cryptography\nVersion: 9.0\n",
+        }
+        coordinator = make_coordinator(listings=listings, metadata_by_version=metadata)
+        root_reqs = {"app": SpecifierSet("==1.0").to_range()}
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            extras_mode=ExtrasMode.BACKTRACK,
+            root_requirements=root_reqs,
+        )
+        resolver = Resolver(provider, range_type=VersionRange, root_version="0")
+        pins = resolver.resolve(root_reqs)
+        assert pins["foo"] == V("2.0rc1")
+        assert pins["cryptography"] == V("9.0")
+
     def test_no_metadata_raises(self) -> None:
         """Extras on a package with no metadata raises MetadataError."""
         coordinator = make_coordinator(


### PR DESCRIPTION
When a requested extra is declared only on a prerelease and a coexisting final release lacks it, the extras proxy chooser dropped that prerelease and the resolve failed with no candidate for the extra.

The proxy package for `foo[bar]` is satisfied by whichever versions of `foo` declare `bar`, not by version bounds, so the prerelease has to survive the range filter and stay reachable even when a final exists. Two things were dropping it: the range filter excluded prereleases, and the chooser preferred the final so strongly that a non-providing final short-circuited the scan before reaching the providing prerelease.

The fix keeps prereleases in the candidate set and prefers a final over a prerelease only when both qualify, so a prerelease that uniquely provides the extra can still be picked.
