### PR TITLE
Re-vendor packaging to fix the prerelease backtrack leak

### DIFF
--- a/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
+++ b/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
@@ -1,16 +1,22 @@
 # Vendored `packaging` snapshot
 
-This directory holds an unmodified copy of the `packaging` library taken
-from `pypa/packaging:main`, vendored so nab can use the public
-`VersionRange` API before a `packaging` release containing it is
-published to PyPI.
+This directory holds an unmodified copy of the `packaging` library,
+vendored so nab can use the public `VersionRange` API before a
+`packaging` release containing it is published to PyPI.
 
 ## Source
 
-- Upstream repository: https://github.com/pypa/packaging
-- Source branch: `pypa/packaging:main`
-- Pinned commit: `e80f70f8b164ee4b0ef7634aafe8c6cc4ce00ca3`
-- Snapshot date: 2026-06-24
+- Repository: https://github.com/notatallshaw/packaging
+- Source branch: `experiment-prerelease-range`
+- Pinned commit: `a6a6d038d55b3a265670efb84dc06e428fd302c9`
+- Snapshot date: 2026-06-29
+
+This branch is the head of `pypa/packaging` PR
+https://github.com/pypa/packaging/pull/1304. It descends directly from
+`pypa/packaging:main` (the previous snapshot commit
+`e80f70f8b164ee4b0ef7634aafe8c6cc4ce00ca3` is its merge base) and adds
+the pre-release-region model described below, plus other commits already
+merged to `main`.
 
 The snapshot is the full `src/packaging/` tree at that commit, plus
 `LICENSE`, `LICENSE.APACHE`, and `LICENSE.BSD` from the repository
@@ -26,19 +32,40 @@ upstream texts; nothing here is relicensed.
 
 ## Why vendor instead of depending on it
 
-`packaging` now ships a public `VersionRange` class with set algebra
-(intersection, union, complement), `is_empty`, `filter`, and a
-`SpecifierSet.to_range()` factory that nab's PubGrub solver depends on.
+`packaging` ships a public `VersionRange` class with set algebra
+(intersection, union, complement, difference), `is_empty`, `filter`, and
+a `SpecifierSet.to_range()` factory that nab's PubGrub solver depends on.
 The class landed in `main` via
 https://github.com/pypa/packaging/pull/1267 but has not yet appeared in
 a PyPI release, so there is no version we can pin in `pyproject.toml`.
 Vendoring is a temporary measure.
 
+## Why this branch and not `pypa/packaging:main`
+
+The solver derives a package's effective range as `positive & ~negative`,
+where `negative` is an exclusion (an excluded version range, e.g. left
+behind by a backtracked branch). On `main`, a `VersionRange` modeled its
+pre-release opt-in as a single policy flag, so the complement of an
+exclusion that named a pre-release carried that opt-in onto the result.
+The intersection then admitted pre-releases no active requirement asked
+for, and an unrelated pre-release could beat a final.
+
+PR #1304 scopes the pre-release opt-in to a region of versions rather
+than a whole-range flag, and tracks that region through set algebra. A
+complement (an exclusion) carries no opt-in, so `a & ~b` sheds `b`'s
+opt-in and admits no pre-release `b` named. This makes
+`positive & ~negative` correct for the pre-release policy without any
+change to the solver. The pinned commit includes the follow-up fix that
+drops the opt-in on complement (`fix(ranges): drop pre-release opt-in on
+complement`); the published region model alone left a residual leak when
+an excluded pre-release specifier also carried an upper bound.
+
 ## Removal plan
 
 Delete this entire directory and reinstate `packaging` as a normal
 dependency once a `packaging` release containing the merged
-`VersionRange` class has been published to PyPI.
+`VersionRange` class (including the PR #1304 pre-release-region model)
+has been published to PyPI.
 
 Once that holds:
 
@@ -51,21 +78,23 @@ Once that holds:
 
 ## Updating the snapshot
 
-To refresh against a newer `pypa/packaging:main`:
+While PR #1304 is unmerged, refresh against its branch:
 
 ```
-cd packaging  # the upstream fork checkout
-git fetch upstream main
-NEW_SHA=$(git rev-parse upstream/main)
+cd packaging  # the notatallshaw/packaging fork checkout
+git fetch origin experiment-prerelease-range
+REF=origin/experiment-prerelease-range
+NEW_SHA=$(git rev-parse $REF)
 DEST=/path/to/nab/nab-python/src/nab_python/_vendor/packaging
-for f in $(git ls-tree -r --name-only upstream/main -- src/packaging); do
+for f in $(git ls-tree -r --name-only $REF -- src/packaging); do
     rel=${f#src/packaging/}
     mkdir -p "$(dirname "$DEST/$rel")"
-    git show "upstream/main:$f" > "$DEST/$rel"
+    git show "$REF:$f" > "$DEST/$rel"
 done
 for f in LICENSE LICENSE.APACHE LICENSE.BSD; do
-    git show "upstream/main:$f" > "$DEST/$f"
+    git show "$REF:$f" > "$DEST/$f"
 done
 ```
 
-Then update the **Pinned commit** and **Snapshot date** lines above.
+Once PR #1304 merges, switch `REF` back to `upstream/main`. Then update
+the **Source**, **Pinned commit**, and **Snapshot date** lines above.

--- a/nab-python/src/nab_python/_vendor/packaging/_elffile.py
+++ b/nab-python/src/nab_python/_vendor/packaging/_elffile.py
@@ -34,7 +34,7 @@ class EMachine(enum.IntEnum):
     S390 = 22
     Arm = 40
     X8664 = 62
-    AArc64 = 183
+    AArch64 = 183
 
 
 class ELFFile:
@@ -57,8 +57,8 @@ class ELFFile:
         self.encoding = ident[5]  # Data structure encoding (endianness).
 
         try:
-            # e_fmt: Format for program header.
-            # p_fmt: Format for section header.
+            # e_fmt: Format for the ELF header.
+            # p_fmt: Format for a program header.
             # p_idx: Indexes to find p_type, p_offset, and p_filesz.
             e_fmt, self._p_fmt, self._p_idx = {
                 (1, 1): ("<HHIIIIIHHH", "<IIIIIIII", (0, 1, 4)),  # 32-bit LSB.
@@ -81,8 +81,8 @@ class ELFFile:
                 _,
                 self.flags,  # Processor-specific flags.
                 _,
-                self._e_phentsize,  # Size of section.
-                self._e_phnum,  # Number of sections.
+                self._e_phentsize,  # Size of a program header entry.
+                self._e_phnum,  # Number of program headers.
             ) = self._read(e_fmt)
         except struct.error as e:
             raise ELFInvalid("unable to parse machine and section information") from e

--- a/nab-python/src/nab_python/_vendor/packaging/_manylinux.py
+++ b/nab-python/src/nab_python/_vendor/packaging/_manylinux.py
@@ -140,11 +140,11 @@ def _glibc_version_string_ctypes() -> str | None:
         # glibc.
         return None
 
-    # Call gnu_get_libc_version, which returns a string like "2.5"
+    # Call gnu_get_libc_version, which returns a string like "2.5".
     gnu_get_libc_version.restype = ctypes.c_char_p
-    version_str: str = gnu_get_libc_version()
-    # py2 / py3 compatibility:
-    if not isinstance(version_str, str):
+    # A c_char_p restype comes back as bytes, so decode to text.
+    version_str: str | bytes = gnu_get_libc_version()
+    if isinstance(version_str, bytes):
         version_str = version_str.decode("ascii")
 
     return version_str

--- a/nab-python/src/nab_python/_vendor/packaging/_parser.py
+++ b/nab-python/src/nab_python/_vendor/packaging/_parser.py
@@ -265,10 +265,19 @@ def _parse_version_many(tokenizer: Tokenizer) -> str:
     parsed_specifiers = ""
     while tokenizer.check("SPECIFIER"):
         span_start = tokenizer.position
-        parsed_specifiers += tokenizer.read().text
+        specifier = tokenizer.read().text
+        parsed_specifiers += specifier
         if tokenizer.check("VERSION_PREFIX_TRAIL", peek=True):
+            message = ".* suffix can only be used with `==` or `!=` operators"
+            if specifier.startswith("!=") or (
+                specifier.startswith("==") and not specifier.startswith("===")
+            ):
+                message = (
+                    ".* suffix cannot be used with pre-release, post-release, "
+                    "dev or local versions"
+                )
             tokenizer.raise_syntax_error(
-                ".* suffix can only be used with `==` or `!=` operators",
+                message,
                 span_start=span_start,
                 span_end=tokenizer.position + 1,
             )

--- a/nab-python/src/nab_python/_vendor/packaging/_ranges.py
+++ b/nab-python/src/nab_python/_vendor/packaging/_ranges.py
@@ -531,20 +531,23 @@ def filter_by_ranges(
     iterable: Iterable[Any],
     key: Callable[[Any], Version | str] | None,
     prereleases: bool | None,
+    region: Sequence[VersionRange] = (),
 ) -> Iterator[Any]:
     """Filter *iterable* against precomputed version *ranges*.
 
-    With ``prereleases=None``, the PEP 440 default applies: pre-releases
-    are excluded unless no final matches, in which case buffered
-    pre-releases come out at the end.
+    With ``prereleases=None``, the PEP 440 default applies: pre-releases are
+    excluded unless no final matches, in which case buffered pre-releases come
+    out at the end. A pre-release inside the opt-in ``region`` is the exception:
+    it is force-admitted in place, as ``prereleases=True`` would yield it. A
+    force-admitted pre-release is not a final, so it never suppresses the buffer.
     """
     if prereleases is None:
-        # PEP 440 default: yield finals immediately; buffer
-        # pre-releases until at least one final has been emitted.
         prerelease_buffer: list[Any] = []
         found_final = False
 
         if len(ranges) == 1:
+            # Hot path: most specifiers and small SpecifierSets reduce to
+            # a single contiguous range.
             lower, upper = ranges[0]
             above = lower._above
             below = upper._below
@@ -556,12 +559,13 @@ def filter_by_ranges(
                     continue
                 if below is not None and not below(parsed):
                     continue
-                if parsed.is_prerelease:
-                    if not found_final:
-                        prerelease_buffer.append(item)
-                else:
+                if not parsed.is_prerelease:
                     found_final = True
                     yield item
+                elif region and matches_bounds_only(region, parsed):
+                    yield item
+                elif not found_final:
+                    prerelease_buffer.append(item)
             if not found_final:
                 yield from prerelease_buffer
             return
@@ -576,12 +580,13 @@ def filter_by_ranges(
                     break
                 below = upper._below
                 if below is None or below(parsed):
-                    if parsed.is_prerelease:
-                        if not found_final:
-                            prerelease_buffer.append(item)
-                    else:
+                    if not parsed.is_prerelease:
                         found_final = True
                         yield item
+                    elif region and matches_bounds_only(region, parsed):
+                        yield item
+                    elif not found_final:
+                        prerelease_buffer.append(item)
                     break
         if not found_final:
             yield from prerelease_buffer

--- a/nab-python/src/nab_python/_vendor/packaging/_tokenizer.py
+++ b/nab-python/src/nab_python/_vendor/packaging/_tokenizer.py
@@ -142,7 +142,7 @@ class Tokenizer:
     def expect(self, name: str, *, expected: str) -> Token:
         """Expect a certain token name next, failing with a syntax error otherwise.
 
-        The token is *not* read.
+        The token is read and returned.
         """
         if not self.check(name):
             raise self.raise_syntax_error(f"Expected {expected}")

--- a/nab-python/src/nab_python/_vendor/packaging/metadata.py
+++ b/nab-python/src/nab_python/_vendor/packaging/metadata.py
@@ -661,7 +661,8 @@ class _Validator(Generic[T]):
         return value
 
     def _process_dynamic(self, value: list[str]) -> list[str]:
-        for dynamic_field in map(str.lower, value):
+        dynamic_fields = list(map(str.lower, value))
+        for dynamic_field in dynamic_fields:
             if dynamic_field in {"name", "version", "metadata-version"}:
                 raise self._invalid_metadata(
                     f"{dynamic_field!r} is not allowed as a dynamic field"
@@ -670,7 +671,7 @@ class _Validator(Generic[T]):
                 raise self._invalid_metadata(
                     f"{dynamic_field!r} is not a valid dynamic field"
                 )
-        return list(map(str.lower, value))
+        return dynamic_fields
 
     def _process_provides_extra(
         self,

--- a/nab-python/src/nab_python/_vendor/packaging/ranges.py
+++ b/nab-python/src/nab_python/_vendor/packaging/ranges.py
@@ -5,8 +5,8 @@
 
 A set-algebra view of the versions accepted by a
 :class:`~packaging.specifiers.SpecifierSet`. Ranges support intersection,
-union, and complement; membership and filtering match the originating
-specifier set.
+union, complement, and difference; membership and filtering match the
+originating specifier set.
 
 .. testsetup::
 
@@ -17,6 +17,7 @@ specifier set.
 
 from __future__ import annotations
 
+import enum
 import typing
 from typing import (
     TYPE_CHECKING,
@@ -58,6 +59,14 @@ __all__ = ["VersionRange"]
 T = TypeVar("T")
 UnparsedVersion = Union[Version, str]
 UnparsedVersionVar = TypeVar("UnparsedVersionVar", bound=UnparsedVersion)
+
+
+class _SetOp(enum.Enum):
+    """The binary set operation ``_combine_literals`` resolves over ``===`` literals."""
+
+    INTERSECTION = enum.auto()
+    UNION = enum.auto()
+    DIFFERENCE = enum.auto()
 
 
 def __dir__() -> list[str]:
@@ -297,20 +306,35 @@ def _format_upper(bound: UpperBound) -> str:
     return f"{_bound_version_str(bound.version)}{bracket}"
 
 
+def _format_intervals(intervals: Sequence[_Interval]) -> str:
+    """Render a sorted interval list as ``lower, upper | lower, upper``."""
+    return " | ".join(
+        f"{_format_lower(lower)}, {_format_upper(upper)}" for lower, upper in intervals
+    )
+
+
 class VersionRange:
     """A set of :class:`~packaging.version.Version` values accepted by a
     :class:`~packaging.specifiers.SpecifierSet`.
 
     Construct via :meth:`~packaging.specifiers.SpecifierSet.to_range`, or with
     the :meth:`full`, :meth:`empty`, and :meth:`singleton` class methods.
-    Compose with :meth:`intersection`, :meth:`union`, and :meth:`complement`
-    (or the ``&`` / ``|`` / ``~`` operators). Test membership with ``in`` or
-    :meth:`contains`, filter an iterable with :meth:`filter`.
+    Compose with :meth:`intersection`, :meth:`union`, :meth:`complement`, and
+    :meth:`difference` (or the ``&`` / ``|`` / ``~`` / ``-`` operators). Test
+    membership with ``in`` or :meth:`contains`, filter an iterable with
+    :meth:`filter`.
 
     The configured pre-release policy of the originating specifier set carries
     onto the range and controls whether pre-releases are admitted under ``in``,
-    :meth:`contains`, and :meth:`filter`. :meth:`intersection` and
-    :meth:`union` require both operands to share the same policy.
+    :meth:`contains`, and :meth:`filter`. With no configured policy,
+    :meth:`filter` also admits pre-releases in the autodetected opt-in region
+    (the versions a pre-release-naming specifier asked for). Set algebra keeps
+    that opt-in scoped to those versions, so unrelated pre-releases are not
+    admitted wholesale.
+
+    :meth:`intersection`, :meth:`union`, and the :meth:`is_subset` /
+    :meth:`is_superset` / :meth:`is_disjoint` predicates require both operands
+    to share the same configured policy.
 
     >>> r = SpecifierSet(">=1.0,<2.0").to_range()
     >>> "1.5" in r
@@ -323,14 +347,18 @@ class VersionRange:
     PEP 440's ``===`` operator matches a candidate string verbatim
     (case-insensitive) rather than a set of versions. Ranges built from
     ``===`` specifiers still support membership and set operations; matching
-    follows the literal-equality rule.
+    follows the literal-equality rule. A ``===`` literal that names a
+    pre-release is admitted under the default policy by both :meth:`contains`
+    and :meth:`filter`, since it was named outright.
+
+    .. versionadded:: 26.3
     """
 
     __slots__ = (
         "_admit",
         "_admit_arbitrary",
         "_bounds",
-        "_prereleases",
+        "_pre_region",
         "_prereleases_configured",
         "_reject",
     )
@@ -339,9 +367,11 @@ class VersionRange:
     _bounds: tuple[_Interval, ...]
 
     #: Whether this range matches non-version strings as well as versions.
-    #: True only by construction on ``SpecifierSet("")`` / :meth:`full`. Set
-    #: algebra ANDs on intersection, ORs on union, and preserves on complement.
-    #: Part of equality, since membership reads it.
+    #: True only by construction on ``SpecifierSet("")`` / :meth:`full`. The flag
+    #: rides set algebra but is inert except at full bounds (see
+    #: :meth:`_arbitrary_active`). A binary op that empties out drops it
+    #: (``full() & ~full()`` is plain empty); :meth:`complement` keeps it, so
+    #: ``~~full() == full()``. Part of equality, since membership reads it.
     _admit_arbitrary: bool
 
     #: Case-folded strings the range admits in addition to its bounds.
@@ -349,17 +379,28 @@ class VersionRange:
     _admit: frozenset[str]
 
     #: Case-folded strings the range rejects (overrides ``_admit`` and the
-    #: bounds). Populated only by :meth:`complement` of an admit-bearing range.
+    #: bounds). Populated by :meth:`complement` of an admit-bearing range and by
+    #: literal resolution in :meth:`_combine_literals`.
     _reject: frozenset[str]
 
-    #: Resolved pre-release policy used by :meth:`filter` and :meth:`contains`
-    #: when their ``prereleases`` argument is ``None``. Part of equality, so
-    #: two ranges that compare equal always filter the same versions.
-    _prereleases: bool | None
+    #: Sorted, disjoint intervals where pre-releases are force-admitted under
+    #: the PEP 440 default policy (a ``None`` ``prereleases`` argument and no
+    #: configured override). The opt-in flows only from the pre-release-naming
+    #: specifiers that built the range. :meth:`union` and :meth:`intersection`
+    #: accumulate it raw (not clipped to the result bounds), which keeps it
+    #: distributive; :meth:`difference` keeps only the minuend's; and
+    #: :meth:`complement` drops it, since an exclusion grants no opt-in. The raw
+    #: union may reach past the bounds, but :meth:`filter` only force-admits a
+    #: pre-release that already passed the bounds check, so the out-of-bounds
+    #: part never fires. Equality keys on the raw region, so it stays a
+    #: congruence.
+    _pre_region: tuple[_Interval, ...]
 
-    #: Raw configured pre-release override of the originating specifier set.
-    #: Distinguishes autodetect-True from explicit-True. :meth:`intersection`
-    #: and :meth:`union` require it to match on both operands. Part of equality.
+    #: Raw configured pre-release override of the originating specifier set
+    #: (an explicit ``True`` / ``False``, else ``None``). When set, :meth:`_build`
+    #: forces ``_pre_region`` empty since the policy governs globally.
+    #: :meth:`intersection` and :meth:`union` require it to match on both
+    #: operands. Part of equality.
     _prereleases_configured: bool | None
 
     def __new__(cls, *args: object, **kwargs: object) -> VersionRange:  # noqa: PYI034
@@ -377,7 +418,7 @@ class VersionRange:
         reject: frozenset[str] = frozenset(),
         admit_arbitrary: bool = False,
         *,
-        prereleases: bool | None = None,
+        pre_region: tuple[_Interval, ...] = (),
         prereleases_configured: bool | None = None,
     ) -> VersionRange:
         """Internal factory; bypasses :meth:`__new__`.
@@ -385,10 +426,12 @@ class VersionRange:
         Canonicalizes the bounds so equal version sets share one representation,
         then drops admit literals the bounds already admit and reject literals
         the bounds do not match anyway. Reject wins over admit on overlap. The
-        pre-release policy is set here, so a built range never has its policy
-        reassigned afterwards.
+        pre-release policy is set here and never reassigned afterwards;
+        ``pre_region`` is canonicalized like the bounds (never clipped to them),
+        or dropped when a configured policy makes it inert.
         """
         bounds = _canonicalize(bounds)
+
         if admit and reject:
             admit = admit - reject
         if admit:
@@ -409,8 +452,15 @@ class VersionRange:
         instance._admit = admit
         instance._reject = reject
         instance._admit_arbitrary = admit_arbitrary
-        instance._prereleases = prereleases
         instance._prereleases_configured = prereleases_configured
+
+        # A configured policy makes the region inert, so drop it. Otherwise fold
+        # least-successor bounds (_from_specifier_set passes the region unfolded),
+        # so ``>1.0a1`` and ``>=1.0a2.dev0`` carry the same region.
+        if prereleases_configured is not None or not pre_region:
+            instance._pre_region = ()
+        else:
+            instance._pre_region = _canonicalize(pre_region)
 
         return instance
 
@@ -425,6 +475,16 @@ class VersionRange:
         """
         return self._admit_arbitrary and self._bounds == FULL_RANGE
 
+    def _is_plain(self) -> bool:
+        """True when membership is decided by ``_bounds`` alone, enabling the
+        bounds-only fast paths in :meth:`is_subset` and :meth:`is_disjoint`.
+        """
+        return (
+            not self._has_literals()
+            and not self._admit_arbitrary
+            and self._prereleases_configured is not False
+        )
+
     def _check_policy_compat(self, other: VersionRange) -> None:
         """Refuse combining ranges with different pre-release policies."""
         if not isinstance(other, VersionRange):
@@ -436,24 +496,26 @@ class VersionRange:
                 f"and {other._prereleases_configured!r}"
             )
 
-    def _combined_policy(self, other: VersionRange) -> tuple[bool | None, bool | None]:
-        """The ``(resolved, configured)`` pre-release policy for ``self`` combined
-        with ``other``, ready to feed into :meth:`_build`.
+    def _merged_region(self, other: VersionRange) -> tuple[_Interval, ...]:
+        """Union of ``self`` and ``other``'s opt-in regions, kept raw.
 
-        Both operands share a configured policy by the time this is called (see
-        :meth:`_check_policy_compat`).
+        Used by :meth:`union` and :meth:`intersection`; see the ``_pre_region``
+        slot for why the union stays unclipped. A configured operand carries an
+        empty region, so it contributes nothing to the merge.
         """
-        configured = self._prereleases_configured
-        if configured is not None:
-            resolved: bool | None = configured
-        elif self._prereleases is True or other._prereleases is True:
-            resolved = True
-        else:
-            resolved = None
-        return resolved, configured
+        # Reuse an operand's canonical tuple when only one side has a region;
+        # an empty side contributes nothing to the union.
+        if not other._pre_region:
+            return self._pre_region
+        if not self._pre_region:
+            return other._pre_region
+
+        # Both sides carry a region; merge them. _build re-canonicalizes, so the
+        # raw union is fine here.
+        return tuple(_union_ranges(self._pre_region, other._pre_region))
 
     def _with_policy(
-        self, *, resolved: bool | None, configured: bool | None
+        self, *, pre_region: tuple[_Interval, ...], configured: bool | None
     ) -> VersionRange:
         """A structural copy of this range carrying the given pre-release policy."""
         return self._build(
@@ -461,7 +523,7 @@ class VersionRange:
             admit=self._admit,
             reject=self._reject,
             admit_arbitrary=self._admit_arbitrary,
-            prereleases=resolved,
+            pre_region=pre_region,
             prereleases_configured=configured,
         )
 
@@ -474,9 +536,7 @@ class VersionRange:
         >>> "1.0" in VersionRange.empty()
         False
         """
-        return cls._build(
-            (), prereleases=prereleases, prereleases_configured=prereleases
-        )
+        return cls._build((), prereleases_configured=prereleases)
 
     @classmethod
     def full(
@@ -500,7 +560,6 @@ class VersionRange:
         return cls._build(
             FULL_RANGE,
             admit_arbitrary=admit_arbitrary,
-            prereleases=prereleases,
             prereleases_configured=prereleases,
         )
 
@@ -532,7 +591,6 @@ class VersionRange:
         # ``0.dev0`` singleton is ``(-inf, 0.dev0]`` in canonical form.
         return cls._build(
             _canonical_floor(((lower, upper),)),
-            prereleases=prereleases,
             prereleases_configured=prereleases,
         )
 
@@ -549,23 +607,31 @@ class VersionRange:
         """
         self._check_policy_compat(other)
 
-        resolved, configured = self._combined_policy(other)
+        configured = self._prereleases_configured
         new_bounds = tuple(intersect_ranges(self._bounds, other._bounds))
-        combined_arb = self._admit_arbitrary and other._admit_arbitrary
+        new_region = self._merged_region(other)
+
+        # An empty intersection (e.g. ``full() & ~full()``) is the empty range,
+        # so it drops the arbitrary flag rather than keeping an inert one that a
+        # later union could revive.
+        combined_arb = (
+            self._admit_arbitrary and other._admit_arbitrary and bool(new_bounds)
+        )
+
         if not self._has_literals() and not other._has_literals():
             return self._build(
                 new_bounds,
                 admit_arbitrary=combined_arb,
-                prereleases=resolved,
+                pre_region=new_region,
                 prereleases_configured=configured,
             )
 
         return self._combine_literals(
             other,
             new_bounds,
-            intersect=True,
+            op=_SetOp.INTERSECTION,
             admit_arbitrary=combined_arb,
-            prereleases=resolved,
+            pre_region=new_region,
             prereleases_configured=configured,
         )
 
@@ -584,44 +650,47 @@ class VersionRange:
         """
         self._check_policy_compat(other)
 
-        resolved, configured = self._combined_policy(other)
+        configured = self._prereleases_configured
         new_bounds = tuple(_union_ranges(self._bounds, other._bounds))
-        combined_arb = self._admit_arbitrary or other._admit_arbitrary
+        new_region = self._merged_region(other)
+
+        # An empty-bounds operand (e.g. ``~full()``) carries an inert arbitrary
+        # flag only to keep complement an involution; it admits nothing, so it
+        # must not revive arbitrary admission as the union re-widens the bounds.
+        combined_arb = (self._admit_arbitrary and bool(self._bounds)) or (
+            other._admit_arbitrary and bool(other._bounds)
+        )
+
         if not self._has_literals() and not other._has_literals():
-            result = self._build(
+            return self._build(
                 new_bounds,
                 admit_arbitrary=combined_arb,
-                prereleases=resolved,
-                prereleases_configured=configured,
-            )
-        else:
-            result = self._combine_literals(
-                other,
-                new_bounds,
-                intersect=False,
-                admit_arbitrary=combined_arb,
-                prereleases=resolved,
+                pre_region=new_region,
                 prereleases_configured=configured,
             )
 
-        # ``r | full()`` collapses to the canonical universal range only when
-        # both sides carry the autodetect default; an explicit policy survives.
-        if (
-            result._bounds == FULL_RANGE
-            and result._admit_arbitrary
-            and not result._has_literals()
-            and self._prereleases_configured is None
-        ):
-            return self.full()
-
-        return result
+        return self._combine_literals(
+            other,
+            new_bounds,
+            op=_SetOp.UNION,
+            admit_arbitrary=combined_arb,
+            pre_region=new_region,
+            prereleases_configured=configured,
+        )
 
     def complement(self) -> VersionRange:
         """Range containing every version not in self.
 
-        Preserves the configured pre-release policy. Within the PEP 440
-        universe (no ``===`` literals and no arbitrary admission) double
-        negation holds; for ``===`` ranges complement is one-way.
+        Preserves the configured pre-release policy. Double negation holds for a
+        range with no ``===`` literals (the arbitrary-string flag round-trips, so
+        ``~~full() == full()``); for ``===`` ranges complement is one-way.
+
+        The opt-in region is dropped: a complement is an exclusion, and an
+        exclusion expresses no pre-release preference. This is what lets
+        ``a & ~b`` shed ``b``'s opt-in, so an excluded ``b`` never force-admits a
+        pre-release into the result. Complement stays involutive on the version
+        set, but not on the opt-in region: ``~~r`` covers the same versions as
+        ``r`` yet force-admits none of its pre-releases.
 
         >>> r = SpecifierSet(">=1.0").to_range()
         >>> "0.5" in r.complement()
@@ -632,13 +701,75 @@ class VersionRange:
         True
         """
         # Complement swaps literal admission: what the range rejects, its
-        # complement admits, and vice versa.
+        # complement admits.
         return self._build(
             tuple(_complement_ranges(self._bounds)),
             admit=self._reject,
             reject=self._admit,
             admit_arbitrary=self._admit_arbitrary,
-            prereleases=self._prereleases,
+            pre_region=(),
+            prereleases_configured=self._prereleases_configured,
+        )
+
+    def difference(self, other: VersionRange) -> VersionRange:
+        """Range containing the versions in self but not in other.
+
+        Matches ``self & ~other`` on the version set and opt-in region. They part
+        only on non-version-string admission, whose complement is one-way: a
+        ``===`` literal stays when ``self`` admits it and ``other`` does not, and
+        the arbitrary-string flag is kept from ``self``. ``other`` acts as a
+        bounds-only exclusion.
+
+        >>> a = SpecifierSet(">=1.0").to_range()
+        >>> b = SpecifierSet(">=2.0").to_range()
+        >>> "1.5" in a.difference(b)
+        True
+        >>> "2.0" in a.difference(b)
+        False
+        >>> a.difference(VersionRange.empty()) == a
+        True
+        """
+        if not isinstance(other, VersionRange):
+            raise TypeError(f"expected VersionRange, got {type(other).__name__}")
+
+        # Subtracting a nothing-admitting set is a no-op. Short-circuit so an
+        # empty-bounds self (e.g. ``~full()``) keeps its arbitrary-string flag,
+        # which the general path would drop.
+        if not other._bounds and not other._admit:
+            return self
+
+        # Bound complement is two-way, so subtracting other's versions is an
+        # intersection with its gaps.
+        new_bounds = tuple(
+            intersect_ranges(self._bounds, _complement_ranges(other._bounds))
+        )
+
+        # Match ``self & ~other`` on the opt-in region: a complement carries no
+        # opt-in, so only ``self``'s region survives. ``other`` acts as a
+        # bounds-only exclusion. A configured ``self`` keeps no region.
+        new_region: tuple[_Interval, ...] = ()
+        if self._prereleases_configured is None:
+            new_region = self._pre_region
+
+        # Keep self's arbitrary admission. Other only removes it at full bounds,
+        # where nothing survives, so the empty result drops it (as in
+        # :meth:`intersection`) with no separate other-side test.
+        combined_arb = self._admit_arbitrary and bool(new_bounds)
+
+        if not self._has_literals() and not other._has_literals():
+            return self._build(
+                new_bounds,
+                admit_arbitrary=combined_arb,
+                pre_region=new_region,
+                prereleases_configured=self._prereleases_configured,
+            )
+
+        return self._combine_literals(
+            other,
+            new_bounds,
+            op=_SetOp.DIFFERENCE,
+            admit_arbitrary=combined_arb,
+            pre_region=new_region,
             prereleases_configured=self._prereleases_configured,
         )
 
@@ -647,18 +778,27 @@ class VersionRange:
         other: VersionRange,
         new_bounds: tuple[_Interval, ...],
         *,
-        intersect: bool,
+        op: _SetOp,
         admit_arbitrary: bool,
-        prereleases: bool | None,
+        pre_region: tuple[_Interval, ...],
         prereleases_configured: bool | None,
     ) -> VersionRange:
-        """Resolve admit/reject for ``self & other`` or ``self | other``."""
+        """Resolve admit/reject for ``self`` ``op`` ``other`` over their literals."""
         admits: set[str] = set()
         rejects: set[str] = set()
+
+        # Each literal is decided independently of the others.
         for literal in self._admit | self._reject | other._admit | other._reject:
             self_in = self._matches_literal(literal)
             other_in = other._matches_literal(literal)
-            want = (self_in and other_in) if intersect else (self_in or other_in)
+
+            if op is _SetOp.INTERSECTION:
+                want = self_in and other_in
+            elif op is _SetOp.UNION:
+                want = self_in or other_in
+            else:
+                want = self_in and not other_in
+
             if want:
                 admits.add(literal)
             else:
@@ -669,7 +809,7 @@ class VersionRange:
             admit=frozenset(admits),
             reject=frozenset(rejects),
             admit_arbitrary=admit_arbitrary,
-            prereleases=prereleases,
+            pre_region=pre_region,
             prereleases_configured=prereleases_configured,
         )
 
@@ -701,6 +841,77 @@ class VersionRange:
         """Operator alias for :meth:`complement`."""
         return self.complement()
 
+    def __sub__(self, other: object) -> VersionRange:
+        """Operator alias for :meth:`difference`."""
+        if not isinstance(other, VersionRange):
+            return NotImplemented
+        return self.difference(other)
+
+    def is_subset(self, other: VersionRange) -> bool:
+        """Return whether every member of self is also a member of other.
+
+        Equivalent to ``(self & ~other).is_empty``. Complement is one-way for
+        ``===`` ranges and the arbitrary-admitting full range, so the result
+        tracks :meth:`contains` on versions but not on the non-version strings
+        those ranges admit.
+
+        Both operands must share the same configured pre-release policy;
+        otherwise :exc:`ValueError` is raised.
+
+        >>> inner = SpecifierSet(">=1.5,<1.8").to_range()
+        >>> outer = SpecifierSet(">=1.0,<2.0").to_range()
+        >>> inner.is_subset(outer)
+        True
+        >>> outer.is_subset(inner)
+        False
+        >>> VersionRange.empty().is_subset(outer)
+        True
+        """
+        self._check_policy_compat(other)
+
+        # Plain ranges: subset reduces to bounds containment, no algebra needed.
+        if self._is_plain() and other._is_plain():
+            return not intersect_ranges(self._bounds, _complement_ranges(other._bounds))
+        return self.intersection(other.complement()).is_empty
+
+    def is_superset(self, other: VersionRange) -> bool:
+        """Return whether every member of other is also a member of self.
+
+        The mirror of :meth:`is_subset`: ``a.is_superset(b)`` is
+        ``b.is_subset(a)``.
+
+        Both operands must share the same configured pre-release policy;
+        otherwise :exc:`ValueError` is raised.
+
+        >>> outer = SpecifierSet(">=1.0,<2.0").to_range()
+        >>> outer.is_superset(SpecifierSet(">=1.5,<1.8").to_range())
+        True
+        """
+        # Type-guards a non-VersionRange other before delegating to is_subset.
+        self._check_policy_compat(other)
+        return other.is_subset(self)
+
+    def is_disjoint(self, other: VersionRange) -> bool:
+        """Return whether self and other share no member.
+
+        Equivalent to ``(self & other).is_empty``.
+
+        Both operands must share the same configured pre-release policy;
+        otherwise :exc:`ValueError` is raised.
+
+        >>> a = SpecifierSet(">=1.0,<2.0").to_range()
+        >>> a.is_disjoint(SpecifierSet(">=2.0,<3.0").to_range())
+        True
+        >>> a.is_disjoint(SpecifierSet(">=1.5,<2.5").to_range())
+        False
+        """
+        self._check_policy_compat(other)
+
+        # Plain ranges: disjointness is an empty bounds intersection.
+        if self._is_plain() and other._is_plain():
+            return not intersect_ranges(self._bounds, other._bounds)
+        return self.intersection(other).is_empty
+
     @typing.overload
     def filter(
         self,
@@ -726,7 +937,10 @@ class VersionRange:
         """Yield items from iterable whose version falls inside the range.
 
         With prereleases ``None`` the PEP 440 default applies: pre-releases are
-        buffered and only emitted if no final release in iterable is in range.
+        buffered and only emitted if no final release in iterable is in range,
+        except that a pre-release inside the autodetected opt-in region, or named
+        outright by a ``===`` literal, is force-admitted in place (as
+        ``prereleases=True`` would yield it).
 
         The signature mirrors
         :meth:`~packaging.specifiers.SpecifierSet.filter`.
@@ -735,13 +949,25 @@ class VersionRange:
         >>> list(r.filter(["0.9", "1.5", "2.0"]))
         ['1.5']
         """
+        region: tuple[_Interval, ...] = ()
         if prereleases is None:
-            prereleases = self._prereleases
+            # The region applies only under the autodetect default; a configured
+            # policy governs instead (and then ``_pre_region`` is already empty).
+            prereleases = self._prereleases_configured
+            region = self._pre_region
 
         arbitrary_active = self._arbitrary_active()
         if not self._admit and not self._reject and not arbitrary_active:
-            return filter_by_ranges(self._bounds, iterable, key, prereleases)
-        return self._filter_with_admission(iterable, key, prereleases, arbitrary_active)
+            # A region spanning the whole bounds force-admits every in-bounds
+            # pre-release, i.e. ``prereleases=True``; take the cheaper no-buffer
+            # path. (Confined to this branch: the admission path orders arbitrary
+            # strings differently under True than under the region.)
+            if region and region == self._bounds:
+                return filter_by_ranges(self._bounds, iterable, key, True)
+            return filter_by_ranges(self._bounds, iterable, key, prereleases, region)
+        return self._filter_with_admission(
+            iterable, key, prereleases, arbitrary_active, region
+        )
 
     def _filter_with_admission(
         self,
@@ -749,38 +975,40 @@ class VersionRange:
         key: Callable[[Any], Version | str] | None,
         prereleases: bool | None,
         arbitrary_active: bool,
+        region: tuple[_Interval, ...],
     ) -> Iterator[Any]:
         """Filter for ranges with admit/reject literals or live arbitrary
         admission (including the universal ``SpecifierSet("")`` range)."""
         admit_set = self._admit
         reject_set = self._reject
 
-        def admit(item: Any) -> tuple[bool, Version | None]:  # noqa: ANN401
+        def admit(item: Any) -> tuple[bool, Version | None, bool]:  # noqa: ANN401
             raw: Version | str = item if key is None else key(item)
             raw_lower = str(raw).lower()
 
             if reject_set and raw_lower in reject_set:
-                return False, None
+                return False, None, False
             if admit_set and raw_lower in admit_set:
-                return True, coerce_version(raw)
+                # An explicit ``===`` literal names this version outright.
+                return True, coerce_version(raw), True
 
             parsed = coerce_version(raw)
             if parsed is None:
-                return arbitrary_active, None
+                return arbitrary_active, None, False
             if not matches_bounds_only(self._bounds, parsed):
-                return False, None
-            return True, parsed
+                return False, None, False
+            return True, parsed, False
 
         if prereleases is True:
             for item in iterable:
-                ok, _ = admit(item)
+                ok, _, _ = admit(item)
                 if ok:
                     yield item
             return
 
         if prereleases is False:
             for item in iterable:
-                ok, parsed = admit(item)
+                ok, parsed, _ = admit(item)
                 if not ok:
                     continue
                 if parsed is not None and parsed.is_prerelease:
@@ -788,11 +1016,14 @@ class VersionRange:
                 yield item
             return
 
+        # PEP 440 default: emit finals eagerly and buffer the other pre-releases,
+        # releasing the buffer only if no final ever matches.
         all_nonfinal: list[Any] = []
         arbitrary_strings: list[Any] = []
         found_final = False
+
         for item in iterable:
-            ok, parsed = admit(item)
+            ok, parsed, by_literal = admit(item)
             if not ok:
                 continue
 
@@ -809,6 +1040,13 @@ class VersionRange:
                     yield from arbitrary_strings
                     arbitrary_strings.clear()
                     found_final = True
+                yield item
+                continue
+
+            # A pre-release is force-admitted when it is named outright by a
+            # ``===`` literal or falls in the opt-in region, as ``prereleases=True``
+            # would yield it; otherwise the PEP 440 default buffers it.
+            if by_literal or (region and matches_bounds_only(region, parsed)):
                 yield item
                 continue
 
@@ -846,8 +1084,19 @@ class VersionRange:
                     )
                 result = result.intersection(operand)
 
+        # Each pre-release-naming specifier opts its own versions in; their raw
+        # union is the region, the same value _merged_region accumulates (so a set
+        # built directly equals one built from its specifiers).
+        region: list[_Interval] = []
+        if specifier_set._prereleases is None:  # a configured policy has no region
+            for spec in specifier_set:
+                # ``===`` literals are not a range; filter force-admits them.
+                if spec.operator != "===" and spec.prereleases:
+                    spec_bounds = _canonical_floor(tuple(spec._to_ranges()))
+                    region = _union_ranges(region, spec_bounds)
+
         return result._with_policy(
-            resolved=specifier_set.prereleases,
+            pre_region=tuple(region),
             configured=specifier_set._prereleases,
         )
 
@@ -871,8 +1120,9 @@ class VersionRange:
         if self._arbitrary_active():
             return False
 
+        excludes_prereleases = self._prereleases_configured is False
         for literal in self._admit:
-            if self._prereleases is False:
+            if excludes_prereleases:
                 parsed = coerce_version(literal)
                 if parsed is not None and parsed.is_prerelease:
                     continue
@@ -881,7 +1131,7 @@ class VersionRange:
         if not self._bounds:
             return True
 
-        return self._prereleases is False and ranges_are_prerelease_only(self._bounds)
+        return excludes_prereleases and ranges_are_prerelease_only(self._bounds)
 
     def contains(
         self,
@@ -896,6 +1146,11 @@ class VersionRange:
             uses the range's own policy.
         :param installed: when ``True``, accept a pre-release item even if the
             range would not otherwise allow it.
+
+        Unlike :meth:`filter`, this does not consult the autodetected pre-release
+        opt-in region; it reads only the configured policy. This mirrors
+        :meth:`~packaging.specifiers.SpecifierSet.contains` versus
+        :meth:`~packaging.specifiers.SpecifierSet.filter`.
 
         Unparsable strings do not match, except where the full
         ``SpecifierSet`` would also match: the full range admits any string,
@@ -961,20 +1216,22 @@ class VersionRange:
     def __eq__(self, other: object) -> bool:
         """Structural equality.
 
-        Two ranges compare equal when every input to :meth:`contains` and
-        :meth:`filter` agrees: the bounds, the ``===`` admit/reject literals,
-        the arbitrary-string flag, and both the configured and resolved
-        pre-release policies. Equal ranges therefore filter identically.
+        Compares the bounds, the ``===`` admit/reject literals, the
+        arbitrary-string flag, the configured pre-release policy, and the raw
+        opt-in region, not just the version set. Keying on the raw region makes
+        equality a congruence (equal ranges stay equal under further operations),
+        so equal implies same :meth:`contains` and :meth:`filter`, but not the
+        converse: an empty range keeps the inert region and flag it was built
+        with, so two empty ranges need not be equal.
 
-        Different specifiers for the same set fold to one canonical bound form,
-        so they compare equal. ``>1.0a1`` excludes ``1.0a1``'s post-releases, so
-        its smallest member is ``1.0a2.dev0``, the same set as ``>=1.0a2.dev0``:
+        Different specifiers for the same range fold to one canonical form:
 
         >>> SpecifierSet(">1.0a1").to_range() == SpecifierSet(">=1.0a2.dev0").to_range()
         True
 
-        The pre-release policy is still part of equality, so two ranges with the
-        same versions but different policies stay unequal:
+        The opt-in region is part of equality, so ``<=1.0`` (no pre-releases) and
+        ``<1.0.post0.dev0`` (autodetects a ``.dev`` opt-in) cover the same
+        versions yet compare unequal:
 
         >>> le, lt = SpecifierSet("<=1.0"), SpecifierSet("<1.0.post0.dev0")
         >>> le.to_range() == lt.to_range()
@@ -992,7 +1249,7 @@ class VersionRange:
             and self._reject == other._reject
             and self._admit_arbitrary == other._admit_arbitrary
             and self._prereleases_configured == other._prereleases_configured
-            and self._prereleases == other._prereleases
+            and self._pre_region == other._pre_region
         )
 
     def __hash__(self) -> int:
@@ -1003,7 +1260,7 @@ class VersionRange:
                 self._reject,
                 self._admit_arbitrary,
                 self._prereleases_configured,
-                self._prereleases,
+                self._pre_region,
             )
         )
 
@@ -1017,24 +1274,25 @@ class VersionRange:
         >>> SpecifierSet(">=2.0,<1.0").to_range()
         <VersionRange '(empty)'>
         """
+        # Body: the bounds and any ``===``-admitted literals.
         parts: list[str] = []
         if self._bounds:
-            parts.append(
-                " | ".join(
-                    f"{_format_lower(lower)}, {_format_upper(upper)}"
-                    for lower, upper in self._bounds
-                )
-            )
+            parts.append(_format_intervals(self._bounds))
         if self._admit:
             parts.append("{" + ", ".join(sorted(self._admit)) + "}")
-
         body = " | ".join(parts) if parts else "(empty)"
+
+        # Rejected literals subtract from the body.
         if self._reject:
             body = f"{body} \\ {{{', '.join(sorted(self._reject))}}}"
 
+        # Tail: the policy flags carried alongside the version set.
         tail = ""
         if self._admit_arbitrary:
             tail += " arbitrary"
         if self._prereleases_configured is not None:
             tail += f" pre={self._prereleases_configured}"
+        if self._pre_region:
+            tail += f" pre-region={_format_intervals(self._pre_region)!r}"
+
         return f"<{self.__class__.__name__} {body!r}{tail}>"

--- a/nab-python/src/nab_python/_vendor/packaging/requirements.py
+++ b/nab-python/src/nab_python/_vendor/packaging/requirements.py
@@ -67,7 +67,7 @@ class Requirement:
 
         self.name: str = parsed.name
         self.url: str | None = parsed.url or None
-        self.extras: set[str] = set(parsed.extras or [])
+        self.extras: set[str] = set(parsed.extras)
         self.specifier: SpecifierSet = SpecifierSet(parsed.specifier)
         self.marker: Marker | None = None
         if parsed.marker is not None:
@@ -145,7 +145,7 @@ class Requirement:
         return hash(
             (
                 canonicalize_name(self.name),
-                frozenset(self.extras),
+                frozenset(canonicalize_name(e) for e in self.extras),
                 self.specifier,
                 self.url,
                 self.marker,
@@ -156,9 +156,12 @@ class Requirement:
         if not isinstance(other, Requirement):
             return NotImplemented
 
+        # Extras must be normalized before comparison as per PEP 685.
+        self_extras = frozenset(canonicalize_name(e) for e in self.extras)
+        other_extras = frozenset(canonicalize_name(e) for e in other.extras)
         return (
             canonicalize_name(self.name) == canonicalize_name(other.name)
-            and self.extras == other.extras
+            and self_extras == other_extras
             and self.specifier == other.specifier
             and self.url == other.url
             and self.marker == other.marker

--- a/nab-python/src/nab_python/_vendor/packaging/tags.py
+++ b/nab-python/src/nab_python/_vendor/packaging/tags.py
@@ -668,7 +668,6 @@ def mac_platforms(
             for binary_format in binary_formats:
                 yield f"macosx_{major_version}_{minor_version}_{binary_format}"
 
-    if version >= (11, 0):
         # Mac OS 11 on x86_64 is compatible with binaries from previous releases.
         # Arm64 support was introduced in 11.0, so no Arm binaries from previous
         # releases exist.

--- a/nab-python/tests/property_python/test_prerelease_admission.py
+++ b/nab-python/tests/property_python/test_prerelease_admission.py
@@ -1,0 +1,157 @@
+"""Property tests guarding the pre-release admission bug class.
+
+The resolver must not admit a pre-release that no active requirement asked
+for when a final release would have served. The leak that motivated these
+tests was an exclusion (negative) range leaking its pre-release policy into
+selection: the solver derives an effective range as ``positive & ~negative``,
+and on the old vendored ``packaging`` the complement of a pre-release-naming
+exclusion carried that opt-in onto the result. The vendored ``packaging`` now
+scopes a pre-release opt-in to a region of versions and keeps it there under
+set algebra, so ``positive & ~negative`` admits no pre-release of its own.
+
+The drop-in-final invariant below catches that whole class while allowing
+the intended "only a pre-release can satisfy the surviving constraints"
+case: a pre-release is a leak only when a *valid final substitute* exists
+(one that satisfies the active requirements and whose own dependencies the
+rest of the solution already meets). When the only spec-compatible final is
+unusable downstream, no such substitute exists and the pre-release stands.
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_python._packaging_provider import PackagingProvider
+from nab_python._vendor.packaging.ranges import VersionRange
+from nab_python._vendor.packaging.specifiers import SpecifierSet
+from nab_python._vendor.packaging.version import Version
+from nab_resolver.resolver import ResolutionError, Resolver
+
+from .strategies import PROPERTY_SETTINGS
+
+pytestmark = pytest.mark.property
+
+_PKGS = ["a", "b", "c", "d"]
+_VERSIONS = ["0.9", "1.0", "1.5a1", "1.5", "2.0b1", "2.0", "3.0a1", "3.0"]
+_SPECS = [
+    "",
+    ">=1.0",
+    ">=2.0",
+    "==1.0",
+    "==2.0",
+    ">=2.0b1",
+    "<2.0",
+    "!=1.5",
+    "~=1.0",
+    ">=2.0b1,<3",
+    ">=1.0a1,<2.0",
+    "~=2.0b1",
+]
+
+
+class _FilterProvider(PackagingProvider):
+    """Selects via ``version_range.filter`` like the real PyPI provider."""
+
+    def choose_version(
+        self, package: str, version_range: VersionRange
+    ) -> Version | None:
+        return next(iter(version_range.filter(self._get_versions(package))), None)
+
+
+@st.composite
+def _prerelease_graphs(
+    draw: st.DrawFn,
+) -> tuple[dict[str, dict[Version, dict[str, SpecifierSet]]], dict[str, SpecifierSet]]:
+    """Small graphs over a/b/c/d whose version pool mixes finals and pre-releases."""
+    graph: dict[str, dict[Version, dict[str, SpecifierSet]]] = {}
+    for pkg in _PKGS:
+        versions = draw(
+            st.lists(st.sampled_from(_VERSIONS), min_size=1, max_size=3, unique=True)
+        )
+        graph[pkg] = {}
+        for raw in versions:
+            deps: dict[str, SpecifierSet] = {}
+            for dep in _PKGS:
+                if dep != pkg and draw(st.booleans()):
+                    deps[dep] = SpecifierSet(draw(st.sampled_from(_SPECS)))
+            graph[pkg][Version(raw)] = deps
+    root_deps = {
+        dep: SpecifierSet(draw(st.sampled_from(_SPECS)))
+        for dep in draw(st.lists(st.sampled_from(_PKGS), min_size=1, unique=True))
+    }
+    graph["root"] = {Version("1.0"): root_deps}
+    return graph, root_deps
+
+
+def _active_specs(
+    package: str,
+    solution: dict[str, Version],
+    graph: dict[str, dict[Version, dict[str, SpecifierSet]]],
+) -> list[SpecifierSet]:
+    specs: list[SpecifierSet] = []
+    for parent, version in solution.items():
+        spec = graph.get(parent, {}).get(version, {}).get(package)
+        if spec is not None:
+            specs.append(spec)
+    return specs
+
+
+def _has_valid_final_dropin(
+    package: str,
+    solution: dict[str, Version],
+    graph: dict[str, dict[Version, dict[str, SpecifierSet]]],
+    specs: list[SpecifierSet],
+) -> bool:
+    """A final of ``package`` that satisfies the active specs and whose own
+    dependencies the rest of the solution already meets."""
+    for candidate in graph.get(package, {}):
+        if candidate.is_prerelease or candidate == solution[package]:
+            continue
+        if not all(spec.contains(candidate, prereleases=True) for spec in specs):
+            continue
+        deps = graph[package][candidate]
+        if all(
+            dep in solution and spec.contains(solution[dep], prereleases=True)
+            for dep, spec in deps.items()
+        ):
+            return True
+    return False
+
+
+class TestNoUnauthorizedPrereleaseDropIn:
+    """No package resolves to a pre-release when an unrequested final fits."""
+
+    @given(graph_and_roots=_prerelease_graphs())
+    @PROPERTY_SETTINGS
+    def test_no_unauthorized_prerelease_dropin(
+        self,
+        graph_and_roots: tuple[
+            dict[str, dict[Version, dict[str, SpecifierSet]]], dict[str, SpecifierSet]
+        ],
+    ) -> None:
+        graph, _root_deps = graph_and_roots
+        resolver = Resolver(
+            _FilterProvider(graph),
+            range_type=VersionRange,
+            root_version="0",
+            max_iterations=2000,
+        )
+        try:
+            solution = resolver.resolve(
+                {"root": VersionRange.singleton(Version("1.0"))}
+            )
+        except ResolutionError:
+            return
+
+        for package, version in solution.items():
+            if package == "root" or not version.is_prerelease:
+                continue
+            specs = _active_specs(package, solution, graph)
+            if any(spec.prereleases is True for spec in specs):
+                continue  # a requirement legitimately admits the pre-release
+            assert not _has_valid_final_dropin(package, solution, graph, specs), (
+                f"{package}=={version} is a pre-release no requirement asked for, "
+                f"yet a final release would satisfy the same solution"
+            )

--- a/nab-python/tests/test_resolver_packaging.py
+++ b/nab-python/tests/test_resolver_packaging.py
@@ -13,8 +13,10 @@ from nab_python._packaging_provider import PackagingProvider
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.version import Version
+from nab_resolver.partial_solution import PartialSolution
+from nab_resolver.report import union_terms
 from nab_resolver.resolver import ResolutionError, Resolver
-from nab_resolver.types import Term
+from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
 
 V = Version
 
@@ -606,6 +608,181 @@ class _FilterProvider(PackagingProvider):
         return next(iter(version_range.filter(self._get_versions(package))), None)
 
 
+class TestExclusionComplementPrerelease:
+    """The vendored range algebra scopes a pre-release opt-in to its region.
+
+    The solver derives an effective range as ``positive & ~negative``. An
+    exclusion ``negative`` that names a pre-release must not carry that
+    pre-release admission onto the intersection: ``~negative`` keeps the
+    opt-in attached to ``negative``'s own versions, which the intersection
+    has already removed, so the result admits no pre-release of its own.
+    This is the leak the resolver hit, reproduced at the API it relies on.
+    """
+
+    def test_intersection_with_complement_drops_exclusion_prerelease(self) -> None:
+        """``>=1.0 & ~(>=2.0b1)`` admits no pre-release."""
+        positive = SpecifierSet(">=1.0").to_range()
+        negative = SpecifierSet(">=2.0b1").to_range()
+        effective = positive & ~negative
+        picked = list(effective.filter([V("2.0b1"), V("1.5a1"), V("1.0")]))
+        assert picked == [V("1.0")]
+
+    def test_intersection_with_complement_keeps_own_prerelease(self) -> None:
+        """A positive that names its own pre-release still admits it."""
+        positive = SpecifierSet(">=2.0b1").to_range()
+        negative = SpecifierSet(">=3.0").to_range()
+        effective = positive & ~negative
+        assert list(effective.filter([V("2.5"), V("2.0b1")])) == [V("2.5"), V("2.0b1")]
+
+
+class TestPrereleaseAuthorizationBacktracking:
+    """Pre-release admission follows the dependency edge that introduced it."""
+
+    def test_rejected_parent_does_not_leak_prerelease_admission(self) -> None:
+        """A rejected parent must not make an unrelated pre-release beat a final."""
+        provider = _FilterProvider(
+            {
+                "a": {
+                    V("1.0"): {"c": SpecifierSet(">=1.0")},
+                    V("2.0"): {"c": SpecifierSet(">=2.0b1")},
+                },
+                "c": {
+                    V("1.0"): {},
+                    V("1.5a1"): {},
+                    V("2.0b1"): {"d": SpecifierSet("==2.0")},
+                },
+                "d": {
+                    V("1.0"): {},
+                    V("2.0"): {},
+                },
+            }
+        )
+
+        result = Resolver(provider, range_type=VersionRange, root_version="0").resolve(
+            {
+                "a": VersionRange.full(),
+                "d": SpecifierSet("==1.0").to_range(),
+            }
+        )
+
+        assert result["a"] == V("1.0")
+        assert result["d"] == V("1.0")
+        assert result["c"] == V("1.0")
+
+    def test_capped_prerelease_exclusion_does_not_leak_above_cap(self) -> None:
+        """A backtracked ``>=2.0b1,<3`` edge must not admit a pre-release at 3.5.
+
+        The pre-release-naming edge caps ``c`` below 3, so once ``a 2.0`` is
+        backtracked away no requirement opts ``c`` into a pre-release. The final
+        ``c 1.0`` must win over ``c 3.5a1``.
+        """
+        provider = _FilterProvider(
+            {
+                "a": {
+                    V("2.0"): {"c": SpecifierSet(">=2.0b1,<3")},
+                    V("1.0"): {},
+                },
+                "c": {
+                    V("3.5a1"): {},
+                    V("2.0b1"): {"d": SpecifierSet("==2.0")},
+                    V("1.0"): {},
+                },
+                "d": {V("1.0"): {}, V("2.0"): {}},
+            }
+        )
+        result = Resolver(provider, range_type=VersionRange, root_version="0").resolve(
+            {
+                "a": VersionRange.full(),
+                "c": SpecifierSet(">=1.0").to_range(),
+                "d": SpecifierSet("==1.0").to_range(),
+            }
+        )
+        assert result["a"] == V("1.0")
+        assert result["c"] == V("1.0")
+
+
+class TestConflictPathPrereleaseAdmission:
+    """Conflict-resolution term algebra must not leak pre-release admission.
+
+    ``Term.intersect`` and ``union_terms`` subtract a negative (exclusion)
+    term from a positive one. The result must keep only the positive (or
+    negative-minuend) side's pre-release policy, so a learned exclusion
+    grants no pre-release admission when its negation is propagated back
+    into a positive range.
+    """
+
+    def test_intersect_positive_minus_negative_drops_prerelease(self) -> None:
+        """``c>=1.0`` AND not ``c>=2.0b1`` admits no pre-release."""
+        positive = Term("c", SpecifierSet(">=1.0").to_range(), positive=True)
+        negative = Term("c", SpecifierSet(">=2.0b1").to_range(), positive=False)
+        result = positive.intersect(negative)
+        assert result is not None
+        assert result.is_positive()
+        picked = list(result.constraint.filter([V("2.0b1"), V("1.5a1"), V("1.0")]))
+        assert picked == [V("1.0")]
+
+    def test_union_terms_negative_minus_positive_drops_prerelease(self) -> None:
+        """The mixed-term remainder keeps the negative term's policy only."""
+        negative = Term("c", SpecifierSet(">=1.0").to_range(), positive=False)
+        positive = Term("c", SpecifierSet(">=2.0b1").to_range(), positive=True)
+        result = union_terms(negative, positive)
+        assert result is not None
+        assert not result.is_positive()
+        picked = list(result.constraint.filter([V("1.5a1"), V("1.0")]))
+        assert picked == [V("1.0")]
+
+
+class TestNegativeOnlyEffectiveRange:
+    """A package holding only an exclusion grants no pre-release admission."""
+
+    def test_negative_only_get_drops_prerelease(self) -> None:
+        """``~negative`` keeps the neutral policy, not the exclusion's."""
+        solution = PartialSolution(range_type=VersionRange)
+        root = Incompatibility([], cause=IncompatibilityCause.ROOT)
+        solution.derive(
+            "foo", SpecifierSet(">=2.0b1").to_range(), positive=False, cause=root
+        )
+        effective = solution.get("foo")
+        assert effective is not None
+        picked = list(effective.filter([V("2.0b1"), V("1.5a1"), V("1.0")]))
+        assert picked == [V("1.0")]
+
+
+class TestExclusionFallbackPrerelease:
+    """A pre-release IS admitted when the only final cannot be used.
+
+    Intended behaviour: when backtracking excludes the only final that
+    satisfies a requirement, the surviving candidates are all pre-releases,
+    and nab admits one rather than failing. This is the PEP 440 default
+    (pre-releases are eligible when no final satisfies) applied to the
+    surviving range, and is deliberate; nab finds a solution here where pip
+    and uv give up. It is not the leaked-admission bug: the effective range's
+    policy stays neutral, and no usable final drop-in exists.
+    """
+
+    def test_admits_prerelease_when_only_final_is_unusable(self) -> None:
+        """``c``'s only final (1.0) forces ``a==2.0b1`` against ``a==1.0``."""
+        provider = _FilterProvider(
+            {
+                "a": {V("1.0"): {}, V("2.0"): {}},
+                "c": {
+                    V("1.0"): {"d": SpecifierSet("==2.0")},
+                    V("1.5a1"): {},
+                    V("2.0b1"): {"a": SpecifierSet(">=2.0")},
+                },
+                "d": {V("1.0"): {}, V("2.0"): {"a": SpecifierSet(">=2.0b1")}},
+            }
+        )
+        result = Resolver(provider, range_type=VersionRange, root_version="0").resolve(
+            {
+                "a": SpecifierSet("==1.0").to_range(),
+                "c": SpecifierSet(">=1.0").to_range(),
+            }
+        )
+        assert result["a"] == V("1.0")
+        assert result["c"] == V("1.5a1")
+
+
 class TestConstraintPrereleases:
     """A constraint that names a prerelease must enable that prerelease."""
 
@@ -631,19 +808,24 @@ class TestConstraintPrereleases:
 
 
 class TestComplementPrereleases:
-    """``VersionRange.complement`` preserves the prerelease policy."""
+    """``VersionRange.complement`` drops the autodetected opt-in region."""
 
-    def test_double_complement_keeps_prerelease_filtering(self) -> None:
-        """``~~r`` filters a named prerelease in, just as ``r`` does.
+    def test_double_complement_drops_prerelease_admission(self) -> None:
+        """``~~r`` keeps the versions but force-admits none of its prereleases.
 
-        Resetting the policy on complement made the double complement
-        that constraint injection performs buffer 2.0b1 out under the
-        PEP 440 default.
+        A complement is an exclusion and carries no opt-in, so the double
+        complement covers the same versions as ``r`` yet buffers ``2.0b1`` away
+        under the PEP 440 default. The resolver applies a user constraint by
+        intersection (``current_range & constraint``), which keeps the opt-in,
+        so a prerelease-naming constraint still resolves to its prerelease.
         """
         r = SpecifierSet("<=2.0b1").to_range()
         versions = [V("2.0b1"), V("1.5"), V("1.0")]
         assert list(r.filter(versions)) == versions
-        assert list(r.complement().complement().filter(versions)) == versions
+        assert list(r.complement().complement().filter(versions)) == [
+            V("1.5"),
+            V("1.0"),
+        ]
 
 
 class TestNoVersionsConstraintAttribution:


### PR DESCRIPTION
The solver derives a package's effective range as `positive & ~negative`, where `negative` is an exclusion left behind by a backtracked branch. The complement of a pre-release-naming exclusion carried that opt-in onto the result, so the intersection admitted a pre-release no active requirement asked for and an unrelated pre-release could beat a final (e.g. `c` resolved to `1.5a1`, or to `3.5a1` past an upper cap, over `1.0`).

This re-vendors `packaging` from https://github.com/pypa/packaging/pull/1304, whose region-scoped pre-release model, plus a follow-up commit that drops the opt-in on complement, makes an exclusion carry no opt-in. `positive & ~negative` is now correct for the pre-release policy with no change to the solver.

Tests cover the leak regression, the capped-prerelease variant, the intended exclusion fallback (a pre-release is still admitted when the only final is unusable), the conflict-path term algebra, and a leak-invariant property fuzzer.

`PROVENANCE.md` records the source branch and pinned commit.
