### PR TITLE
Re-vendor packaging with set difference operator

### DIFF
--- a/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
+++ b/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
@@ -9,8 +9,8 @@ published to PyPI.
 
 - Upstream repository: https://github.com/pypa/packaging
 - Source branch: `pypa/packaging:main`
-- Pinned commit: `e80f70f8b164ee4b0ef7634aafe8c6cc4ce00ca3`
-- Snapshot date: 2026-06-24
+- Pinned commit: `c7d859d1333887226f521f59b1304257c04eeca2`
+- Snapshot date: 2026-06-30
 
 The snapshot is the full `src/packaging/` tree at that commit, plus
 `LICENSE`, `LICENSE.APACHE`, and `LICENSE.BSD` from the repository
@@ -27,11 +27,14 @@ upstream texts; nothing here is relicensed.
 ## Why vendor instead of depending on it
 
 `packaging` now ships a public `VersionRange` class with set algebra
-(intersection, union, complement), `is_empty`, `filter`, and a
-`SpecifierSet.to_range()` factory that nab's PubGrub solver depends on.
-The class landed in `main` via
-https://github.com/pypa/packaging/pull/1267 but has not yet appeared in
-a PyPI release, so there is no version we can pin in `pyproject.toml`.
+(intersection, union, complement, difference), the `is_subset` /
+`is_superset` / `is_disjoint` relation predicates, `is_empty`, `filter`,
+and a `SpecifierSet.to_range()` factory that nab's PubGrub solver depends
+on. The class landed in `main` via
+https://github.com/pypa/packaging/pull/1267, and the difference operator
+(`-`) plus the relation predicates via
+https://github.com/pypa/packaging/pull/1298. None of this has appeared in
+a PyPI release yet, so there is no version we can pin in `pyproject.toml`.
 Vendoring is a temporary measure.
 
 ## Removal plan

--- a/nab-python/src/nab_python/_vendor/packaging/_elffile.py
+++ b/nab-python/src/nab_python/_vendor/packaging/_elffile.py
@@ -34,7 +34,7 @@ class EMachine(enum.IntEnum):
     S390 = 22
     Arm = 40
     X8664 = 62
-    AArc64 = 183
+    AArch64 = 183
 
 
 class ELFFile:
@@ -57,8 +57,8 @@ class ELFFile:
         self.encoding = ident[5]  # Data structure encoding (endianness).
 
         try:
-            # e_fmt: Format for program header.
-            # p_fmt: Format for section header.
+            # e_fmt: Format for the ELF header.
+            # p_fmt: Format for a program header.
             # p_idx: Indexes to find p_type, p_offset, and p_filesz.
             e_fmt, self._p_fmt, self._p_idx = {
                 (1, 1): ("<HHIIIIIHHH", "<IIIIIIII", (0, 1, 4)),  # 32-bit LSB.
@@ -81,8 +81,8 @@ class ELFFile:
                 _,
                 self.flags,  # Processor-specific flags.
                 _,
-                self._e_phentsize,  # Size of section.
-                self._e_phnum,  # Number of sections.
+                self._e_phentsize,  # Size of a program header entry.
+                self._e_phnum,  # Number of program headers.
             ) = self._read(e_fmt)
         except struct.error as e:
             raise ELFInvalid("unable to parse machine and section information") from e

--- a/nab-python/src/nab_python/_vendor/packaging/_manylinux.py
+++ b/nab-python/src/nab_python/_vendor/packaging/_manylinux.py
@@ -140,11 +140,11 @@ def _glibc_version_string_ctypes() -> str | None:
         # glibc.
         return None
 
-    # Call gnu_get_libc_version, which returns a string like "2.5"
+    # Call gnu_get_libc_version, which returns a string like "2.5".
     gnu_get_libc_version.restype = ctypes.c_char_p
-    version_str: str = gnu_get_libc_version()
-    # py2 / py3 compatibility:
-    if not isinstance(version_str, str):
+    # A c_char_p restype comes back as bytes, so decode to text.
+    version_str: str | bytes = gnu_get_libc_version()
+    if isinstance(version_str, bytes):
         version_str = version_str.decode("ascii")
 
     return version_str

--- a/nab-python/src/nab_python/_vendor/packaging/_parser.py
+++ b/nab-python/src/nab_python/_vendor/packaging/_parser.py
@@ -265,10 +265,19 @@ def _parse_version_many(tokenizer: Tokenizer) -> str:
     parsed_specifiers = ""
     while tokenizer.check("SPECIFIER"):
         span_start = tokenizer.position
-        parsed_specifiers += tokenizer.read().text
+        specifier = tokenizer.read().text
+        parsed_specifiers += specifier
         if tokenizer.check("VERSION_PREFIX_TRAIL", peek=True):
+            message = ".* suffix can only be used with `==` or `!=` operators"
+            if specifier.startswith("!=") or (
+                specifier.startswith("==") and not specifier.startswith("===")
+            ):
+                message = (
+                    ".* suffix cannot be used with pre-release, post-release, "
+                    "dev or local versions"
+                )
             tokenizer.raise_syntax_error(
-                ".* suffix can only be used with `==` or `!=` operators",
+                message,
                 span_start=span_start,
                 span_end=tokenizer.position + 1,
             )

--- a/nab-python/src/nab_python/_vendor/packaging/_tokenizer.py
+++ b/nab-python/src/nab_python/_vendor/packaging/_tokenizer.py
@@ -142,7 +142,7 @@ class Tokenizer:
     def expect(self, name: str, *, expected: str) -> Token:
         """Expect a certain token name next, failing with a syntax error otherwise.
 
-        The token is *not* read.
+        The token is read and returned.
         """
         if not self.check(name):
             raise self.raise_syntax_error(f"Expected {expected}")

--- a/nab-python/src/nab_python/_vendor/packaging/metadata.py
+++ b/nab-python/src/nab_python/_vendor/packaging/metadata.py
@@ -661,7 +661,8 @@ class _Validator(Generic[T]):
         return value
 
     def _process_dynamic(self, value: list[str]) -> list[str]:
-        for dynamic_field in map(str.lower, value):
+        dynamic_fields = list(map(str.lower, value))
+        for dynamic_field in dynamic_fields:
             if dynamic_field in {"name", "version", "metadata-version"}:
                 raise self._invalid_metadata(
                     f"{dynamic_field!r} is not allowed as a dynamic field"
@@ -670,7 +671,7 @@ class _Validator(Generic[T]):
                 raise self._invalid_metadata(
                     f"{dynamic_field!r} is not a valid dynamic field"
                 )
-        return list(map(str.lower, value))
+        return dynamic_fields
 
     def _process_provides_extra(
         self,

--- a/nab-python/src/nab_python/_vendor/packaging/ranges.py
+++ b/nab-python/src/nab_python/_vendor/packaging/ranges.py
@@ -5,8 +5,8 @@
 
 A set-algebra view of the versions accepted by a
 :class:`~packaging.specifiers.SpecifierSet`. Ranges support intersection,
-union, and complement; membership and filtering match the originating
-specifier set.
+union, complement, and difference; membership and filtering match the
+originating specifier set.
 
 .. testsetup::
 
@@ -17,6 +17,7 @@ specifier set.
 
 from __future__ import annotations
 
+import enum
 import typing
 from typing import (
     TYPE_CHECKING,
@@ -58,6 +59,14 @@ __all__ = ["VersionRange"]
 T = TypeVar("T")
 UnparsedVersion = Union[Version, str]
 UnparsedVersionVar = TypeVar("UnparsedVersionVar", bound=UnparsedVersion)
+
+
+class _SetOp(enum.Enum):
+    """The binary set operation ``_combine_literals`` resolves over ``===`` literals."""
+
+    INTERSECTION = enum.auto()
+    UNION = enum.auto()
+    DIFFERENCE = enum.auto()
 
 
 def __dir__() -> list[str]:
@@ -303,14 +312,17 @@ class VersionRange:
 
     Construct via :meth:`~packaging.specifiers.SpecifierSet.to_range`, or with
     the :meth:`full`, :meth:`empty`, and :meth:`singleton` class methods.
-    Compose with :meth:`intersection`, :meth:`union`, and :meth:`complement`
-    (or the ``&`` / ``|`` / ``~`` operators). Test membership with ``in`` or
-    :meth:`contains`, filter an iterable with :meth:`filter`.
+    Compose with :meth:`intersection`, :meth:`union`, :meth:`complement`, and
+    :meth:`difference` (or the ``&`` / ``|`` / ``~`` / ``-`` operators). Test
+    membership with ``in`` or :meth:`contains`, filter an iterable with
+    :meth:`filter`.
 
     The configured pre-release policy of the originating specifier set carries
     onto the range and controls whether pre-releases are admitted under ``in``,
-    :meth:`contains`, and :meth:`filter`. :meth:`intersection` and
-    :meth:`union` require both operands to share the same policy.
+    :meth:`contains`, and :meth:`filter`. :meth:`intersection`,
+    :meth:`union`, and the :meth:`is_subset` / :meth:`is_superset` /
+    :meth:`is_disjoint` predicates require both operands to share the same
+    policy; set difference (``-``) does not.
 
     >>> r = SpecifierSet(">=1.0,<2.0").to_range()
     >>> "1.5" in r
@@ -324,6 +336,8 @@ class VersionRange:
     (case-insensitive) rather than a set of versions. Ranges built from
     ``===`` specifiers still support membership and set operations; matching
     follows the literal-equality rule.
+
+    .. versionadded:: 26.3
     """
 
     __slots__ = (
@@ -424,6 +438,16 @@ class VersionRange:
         bounds; on narrower bounds it is metadata awaiting a later widening.
         """
         return self._admit_arbitrary and self._bounds == FULL_RANGE
+
+    def _is_plain(self) -> bool:
+        """True when membership is decided by ``_bounds`` alone, enabling the
+        bounds-only fast paths in :meth:`is_subset` and :meth:`is_disjoint`.
+        """
+        return (
+            not self._has_literals()
+            and not self._admit_arbitrary
+            and self._prereleases is not False
+        )
 
     def _check_policy_compat(self, other: VersionRange) -> None:
         """Refuse combining ranges with different pre-release policies."""
@@ -552,6 +576,7 @@ class VersionRange:
         resolved, configured = self._combined_policy(other)
         new_bounds = tuple(intersect_ranges(self._bounds, other._bounds))
         combined_arb = self._admit_arbitrary and other._admit_arbitrary
+
         if not self._has_literals() and not other._has_literals():
             return self._build(
                 new_bounds,
@@ -563,7 +588,7 @@ class VersionRange:
         return self._combine_literals(
             other,
             new_bounds,
-            intersect=True,
+            op=_SetOp.INTERSECTION,
             admit_arbitrary=combined_arb,
             prereleases=resolved,
             prereleases_configured=configured,
@@ -584,37 +609,27 @@ class VersionRange:
         """
         self._check_policy_compat(other)
 
+        # The merged pre-release policy rides along in (resolved, configured).
         resolved, configured = self._combined_policy(other)
         new_bounds = tuple(_union_ranges(self._bounds, other._bounds))
         combined_arb = self._admit_arbitrary or other._admit_arbitrary
+
         if not self._has_literals() and not other._has_literals():
-            result = self._build(
+            return self._build(
                 new_bounds,
                 admit_arbitrary=combined_arb,
                 prereleases=resolved,
                 prereleases_configured=configured,
             )
-        else:
-            result = self._combine_literals(
-                other,
-                new_bounds,
-                intersect=False,
-                admit_arbitrary=combined_arb,
-                prereleases=resolved,
-                prereleases_configured=configured,
-            )
 
-        # ``r | full()`` collapses to the canonical universal range only when
-        # both sides carry the autodetect default; an explicit policy survives.
-        if (
-            result._bounds == FULL_RANGE
-            and result._admit_arbitrary
-            and not result._has_literals()
-            and self._prereleases_configured is None
-        ):
-            return self.full()
-
-        return result
+        return self._combine_literals(
+            other,
+            new_bounds,
+            op=_SetOp.UNION,
+            admit_arbitrary=combined_arb,
+            prereleases=resolved,
+            prereleases_configured=configured,
+        )
 
     def complement(self) -> VersionRange:
         """Range containing every version not in self.
@@ -642,23 +657,84 @@ class VersionRange:
             prereleases_configured=self._prereleases_configured,
         )
 
+    def difference(self, other: VersionRange) -> VersionRange:
+        """Range containing the versions in self but not in other.
+
+        On the version set this matches ``self & ~other``, but the result keeps
+        only ``self``'s admissions and pre-release policy: a non-version string
+        or ``===`` literal is a member exactly when ``self`` admits it and
+        ``other`` does not. ``other`` is treated purely as an exclusion, so the
+        operands need not share a configured pre-release policy (unlike
+        :meth:`intersection` and :meth:`union`), and ``a - empty()`` returns a
+        range equal to ``a``.
+
+        >>> a = SpecifierSet(">=1.0").to_range()
+        >>> b = SpecifierSet(">=2.0").to_range()
+        >>> "1.5" in a.difference(b)
+        True
+        >>> "2.0" in a.difference(b)
+        False
+        >>> a.difference(VersionRange.empty()) == a
+        True
+        """
+        if not isinstance(other, VersionRange):
+            raise TypeError(f"expected VersionRange, got {type(other).__name__}")
+
+        # Bound complement is two-way, so subtracting other's versions is an
+        # intersection with its gaps.
+        new_bounds = tuple(
+            intersect_ranges(self._bounds, _complement_ranges(other._bounds))
+        )
+
+        # Complement is one-way for arbitrary strings and ``===`` literals, so
+        # read admission off other directly: a string survives when self admits
+        # it and other does not.
+        combined_arb = self._admit_arbitrary and not other._admit_arbitrary
+
+        if not self._has_literals() and not other._has_literals():
+            return self._build(
+                new_bounds,
+                admit_arbitrary=combined_arb,
+                prereleases=self._prereleases,
+                prereleases_configured=self._prereleases_configured,
+            )
+
+        return self._combine_literals(
+            other,
+            new_bounds,
+            op=_SetOp.DIFFERENCE,
+            admit_arbitrary=combined_arb,
+            prereleases=self._prereleases,
+            prereleases_configured=self._prereleases_configured,
+        )
+
     def _combine_literals(
         self,
         other: VersionRange,
         new_bounds: tuple[_Interval, ...],
         *,
-        intersect: bool,
+        op: _SetOp,
         admit_arbitrary: bool,
         prereleases: bool | None,
         prereleases_configured: bool | None,
     ) -> VersionRange:
-        """Resolve admit/reject for ``self & other`` or ``self | other``."""
+        """Resolve admit/reject for ``self`` ``op`` ``other`` over their literals."""
         admits: set[str] = set()
         rejects: set[str] = set()
+
+        # Each literal is decided on its own: test it against both operands,
+        # then admit or reject it by the set operation.
         for literal in self._admit | self._reject | other._admit | other._reject:
             self_in = self._matches_literal(literal)
             other_in = other._matches_literal(literal)
-            want = (self_in and other_in) if intersect else (self_in or other_in)
+
+            if op is _SetOp.INTERSECTION:
+                want = self_in and other_in
+            elif op is _SetOp.UNION:
+                want = self_in or other_in
+            else:
+                want = self_in and not other_in
+
             if want:
                 admits.add(literal)
             else:
@@ -700,6 +776,77 @@ class VersionRange:
     def __invert__(self) -> VersionRange:
         """Operator alias for :meth:`complement`."""
         return self.complement()
+
+    def __sub__(self, other: object) -> VersionRange:
+        """Operator alias for :meth:`difference`."""
+        if not isinstance(other, VersionRange):
+            return NotImplemented
+        return self.difference(other)
+
+    def is_subset(self, other: VersionRange) -> bool:
+        """Return whether every member of self is also a member of other.
+
+        Equivalent to ``(self & ~other).is_empty``. For ``===`` ranges and the
+        arbitrary-admitting full range, complement is one-way, so the result
+        matches :meth:`contains` for versions but not for the non-version
+        strings those ranges admit.
+
+        Both operands must share the same configured pre-release policy;
+        otherwise :exc:`ValueError` is raised.
+
+        >>> inner = SpecifierSet(">=1.5,<1.8").to_range()
+        >>> outer = SpecifierSet(">=1.0,<2.0").to_range()
+        >>> inner.is_subset(outer)
+        True
+        >>> outer.is_subset(inner)
+        False
+        >>> VersionRange.empty().is_subset(outer)
+        True
+        """
+        self._check_policy_compat(other)
+
+        # Plain ranges: subset reduces to bounds containment, no algebra needed.
+        if self._is_plain() and other._is_plain():
+            return not intersect_ranges(self._bounds, _complement_ranges(other._bounds))
+        return self.intersection(other.complement()).is_empty
+
+    def is_superset(self, other: VersionRange) -> bool:
+        """Return whether every member of other is also a member of self.
+
+        The mirror of :meth:`is_subset`: ``a.is_superset(b)`` is
+        ``b.is_subset(a)``.
+
+        Both operands must share the same configured pre-release policy;
+        otherwise :exc:`ValueError` is raised.
+
+        >>> outer = SpecifierSet(">=1.0,<2.0").to_range()
+        >>> outer.is_superset(SpecifierSet(">=1.5,<1.8").to_range())
+        True
+        """
+        # Type-guards a non-VersionRange other before delegating to is_subset.
+        self._check_policy_compat(other)
+        return other.is_subset(self)
+
+    def is_disjoint(self, other: VersionRange) -> bool:
+        """Return whether self and other share no member.
+
+        Equivalent to ``(self & other).is_empty``.
+
+        Both operands must share the same configured pre-release policy;
+        otherwise :exc:`ValueError` is raised.
+
+        >>> a = SpecifierSet(">=1.0,<2.0").to_range()
+        >>> a.is_disjoint(SpecifierSet(">=2.0,<3.0").to_range())
+        True
+        >>> a.is_disjoint(SpecifierSet(">=1.5,<2.5").to_range())
+        False
+        """
+        self._check_policy_compat(other)
+
+        # Plain ranges: disjointness is an empty bounds intersection.
+        if self._is_plain() and other._is_plain():
+            return not intersect_ranges(self._bounds, other._bounds)
+        return self.intersection(other).is_empty
 
     @typing.overload
     def filter(

--- a/nab-python/src/nab_python/_vendor/packaging/requirements.py
+++ b/nab-python/src/nab_python/_vendor/packaging/requirements.py
@@ -52,6 +52,10 @@ class Requirement:
         The dedicated pickle support introduced in 26.2 did not preserve the
         specifier's explicit :attr:`~packaging.specifiers.SpecifierSet.prereleases`
         override; it is now included again.
+
+        Equality and hashing normalize requirement names, extras, and
+        equivalent specifiers. The string representation still preserves the
+        parsed name and extras spelling.
     """
 
     # TODO: Can we test whether something is contained within a requirement?
@@ -67,7 +71,7 @@ class Requirement:
 
         self.name: str = parsed.name
         self.url: str | None = parsed.url or None
-        self.extras: set[str] = set(parsed.extras or [])
+        self.extras: set[str] = set(parsed.extras)
         self.specifier: SpecifierSet = SpecifierSet(parsed.specifier)
         self.marker: Marker | None = None
         if parsed.marker is not None:
@@ -145,7 +149,7 @@ class Requirement:
         return hash(
             (
                 canonicalize_name(self.name),
-                frozenset(self.extras),
+                frozenset(canonicalize_name(e) for e in self.extras),
                 self.specifier,
                 self.url,
                 self.marker,
@@ -156,9 +160,12 @@ class Requirement:
         if not isinstance(other, Requirement):
             return NotImplemented
 
+        # Extras must be normalized before comparison as per PEP 685.
+        self_extras = frozenset(canonicalize_name(e) for e in self.extras)
+        other_extras = frozenset(canonicalize_name(e) for e in other.extras)
         return (
             canonicalize_name(self.name) == canonicalize_name(other.name)
-            and self.extras == other.extras
+            and self_extras == other_extras
             and self.specifier == other.specifier
             and self.url == other.url
             and self.marker == other.marker

--- a/nab-python/src/nab_python/_vendor/packaging/tags.py
+++ b/nab-python/src/nab_python/_vendor/packaging/tags.py
@@ -33,6 +33,7 @@ __all__ = [
     "InvalidTag",
     "PythonVersion",
     "Tag",
+    "TooManyTagsError",
     "UnsortedTagsError",
     "android_platforms",
     "compatible_tags",
@@ -95,6 +96,14 @@ class UnsortedTagsError(ValueError):
 class InvalidTag(ValueError):
     """
     Raised when a tag has an empty interpreter, ABI, or platform component.
+
+    .. versionadded:: 26.3
+    """
+
+
+class TooManyTagsError(ValueError):
+    """
+    Raised when a compressed tag set exceeds the configured limit.
 
     .. versionadded:: 26.3
     """
@@ -215,7 +224,9 @@ class Tag:
         raise TypeError(f"Cannot restore Tag from {state!r}")
 
 
-def parse_tag(tag: str, *, validate_order: bool = False) -> frozenset[Tag]:
+def parse_tag(
+    tag: str, *, validate_order: bool = False, limit: int | None = None
+) -> frozenset[Tag]:
     """
     Parses the provided tag (e.g. `py3-none-any`) into a frozenset of
     :class:`Tag` instances.
@@ -227,20 +238,33 @@ def parse_tag(tag: str, *, validate_order: bool = False) -> frozenset[Tag]:
     If **validate_order** is true, compressed tag set components are checked
     to be in sorted order as required by PEP 425.
 
+    If **limit** is not ``None``, the compressed tag set can generate at most
+    that many tags.
+
     :param str tag: The tag to parse, e.g. ``"py3-none-any"``.
     :param bool validate_order: Check whether compressed tag set components
         are in sorted order.
+    :param int | None limit: The maximum number of tags to parse.
     :raises UnsortedTagsError: If **validate_order** is true and any compressed tag
         set component is not in sorted order.
     :raises InvalidTag: If the interpreter, ABI, or platform field (or any member
         of a compressed tag set) is empty.
+    :raises TooManyTagsError: If **limit** is not ``None`` and the compressed tag
+        set would generate more than **limit** tags.
+    :raises ValueError: If **limit** is negative.
 
     .. versionadded:: 26.1
        The *validate_order* parameter.
 
     .. versionadded:: 26.3
        Raises :class:`InvalidTag` on empty tag components.
+       Added the *limit* parameter. Raises :class:`TooManyTagsError` if the compressed
+       tag set would generate more than *limit* tags.
     """
+
+    if limit is not None and limit < 0:
+        raise ValueError("limit must be non-negative")
+
     component_parts = [component.split(".") for component in tag.split("-")]
     for parts in component_parts:
         if "" in parts:
@@ -251,6 +275,16 @@ def parse_tag(tag: str, *, validate_order: bool = False) -> frozenset[Tag]:
             raise UnsortedTagsError(
                 f"Tag component {component!r} is not in sorted order per PEP 425"
             )
+
+    tag_count = 1
+    for parts in component_parts:
+        tag_count *= len(parts)
+
+    if limit is not None and tag_count > limit:
+        raise TooManyTagsError(
+            f"Compressed tag set would generate {tag_count} tags, exceeding "
+            f"limit {limit}"
+        )
 
     interpreters, abis, platforms = component_parts
     return frozenset(
@@ -668,7 +702,6 @@ def mac_platforms(
             for binary_format in binary_formats:
                 yield f"macosx_{major_version}_{minor_version}_{binary_format}"
 
-    if version >= (11, 0):
         # Mac OS 11 on x86_64 is compatible with binaries from previous releases.
         # Arm64 support was introduced in 11.0, so no Arm binaries from previous
         # releases exist.

--- a/nab-python/src/nab_python/_vendor/packaging/utils.py
+++ b/nab-python/src/nab_python/_vendor/packaging/utils.py
@@ -65,7 +65,8 @@ _normalized_regex = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*", re.ASCII)
 # PEP 427: The build number must start with a digit.
 _build_tag_regex = re.compile(r"(\d+)(.*)", re.ASCII)
 # PEP 427: Valid characters for an escaped project name in a wheel filename.
-_wheel_name_regex = re.compile(r"^[\w._]*$", re.UNICODE)
+# Requires at least one character so an empty project name is rejected.
+_wheel_name_regex = re.compile(r"^[\w._]+$", re.UNICODE)
 
 
 def canonicalize_name(name: str, *, validate: bool = False) -> NormalizedName:
@@ -210,7 +211,8 @@ def parse_wheel_filename(
        The *validate_order* parameter.
 
     .. versionchanged:: 26.3
-       Raises :class:`InvalidWheelFilename` on empty tag set components.
+       Raises :class:`InvalidWheelFilename` on empty tag set components or an
+       empty project name.
     """
     if not filename.endswith(".whl"):
         raise InvalidWheelFilename(
@@ -274,7 +276,8 @@ def parse_sdist_filename(filename: str) -> tuple[NormalizedName, Version]:
     :raises InvalidSdistFilename: If the filename does not end
         with an sdist extension (``.zip`` or ``.tar.gz``), if it does not
         contain a dash separating the name and the version of the distribution,
-        or if the version portion is not a valid version.
+        if the project name is empty, or if the version portion is not a valid
+        version.
 
     >>> from packaging.utils import parse_sdist_filename
     >>> from packaging.version import Version
@@ -283,6 +286,9 @@ def parse_sdist_filename(filename: str) -> tuple[NormalizedName, Version]:
     'foo'
     >>> ver == Version('1.0')
     True
+
+    .. versionchanged:: 26.3
+       Raises :class:`InvalidSdistFilename` on an empty project name.
 
     .. _Source distribution format: https://packaging.python.org/specifications/source-distribution-format/#source-distribution-file-name
     """
@@ -301,6 +307,10 @@ def parse_sdist_filename(filename: str) -> tuple[NormalizedName, Version]:
     name_part, sep, version_part = file_stem.rpartition("-")
     if not sep:
         raise InvalidSdistFilename(f"Invalid sdist filename: {filename!r}")
+    if not name_part:
+        raise InvalidSdistFilename(
+            f"Invalid sdist filename (empty project name): {filename!r}"
+        )
 
     name = canonicalize_name(name_part)
 


### PR DESCRIPTION
Bumps the vendored `packaging` snapshot from `e80f70f` to `c7d859d` (`pypa/packaging:main`).

The reason for the bump is `VersionRange.__sub__` / `difference` and the `is_subset` / `is_superset` / `is_disjoint` relation predicates landing upstream in pypa/packaging#1298, so the resolver can use a real vendored set difference instead of a hand-added one. The snapshot also picks up the union-collapse pre-release policy fix (pypa/packaging#1295), extra-name normalization (pypa/packaging#1278), empty project-name rejection in the wheel/sdist filename parsers (pypa/packaging#1305), and assorted small cleanups.

The tree is byte-identical to upstream `src/packaging` at that commit; the only hand edit is PROVENANCE.md, recording the new pin and snapshot date.

Sequencing note: #282 hand-added `VersionRange.__sub__` to the vendored copy before this snapshot existed. Once this lands, #282 should rebase on top and drop that vendored addition, keeping only its `nab_resolver` changes.
