### PR TITLE
Add per-package metadata overrides

### DIFF
--- a/docs/guides/build-policy.md
+++ b/docs/guides/build-policy.md
@@ -89,7 +89,10 @@ build-policy = "build-remote"
 ```
 
 That keeps the rest of the graph in the hermetic default while
-permitting the one package you actually need to build.
+permitting the one package you actually need to build.  When you
+know the package's dependencies, a `dependencies` metadata override
+(see the [configuration guide](configuration.md)) resolves it under
+`never` without building at all.
 
 ## Overrides
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -162,6 +162,12 @@ A body sets any combination of:
   strict pin: only that index is consulted).  Routing requires
   bare-name selectors, because the routing decision happens before any
   version is known; a version specifier alongside `index` is rejected.
+* `dependencies`: a list of PEP 508 requirement strings that replaces
+  the package's declared runtime dependencies (see below).
+* `requires-python`: a PEP 440 specifier that replaces the package's
+  declared Python requirement for the selected versions (see below).
+* `provides-extra`: a list of extra names that replaces the package's
+  declared extras for the selected versions (see below).
 
 A selector is a name plus an optional version specifier, with no extras,
 marker, or URL.  Package names are canonicalised, so `Foo-Bar`,
@@ -185,6 +191,164 @@ By that guarantee, at most one per-package entry governs a given
 (package, version) for a given field.  Two routes for one package always
 overlap (routing needs the full range), so a package may have at most
 one route.
+
+#### Overriding a package's metadata
+
+`dependencies`, `requires-python`, and `provides-extra` substitute for
+what nab would otherwise read from a distribution's metadata, scoped to
+the selected version range.  Together they mirror uv's
+`dependency-metadata`: you state a package's metadata directly instead of
+fetching or building it.  Use them when a package's published metadata is
+wrong, absent, dynamic, or unbuildable on your target.  You take
+responsibility for correctness: nab trusts the values as written and does
+not verify them against the artifact.
+
+Each field replaces its own field independently, so a `dependencies`
+override on one range and a `requires-python` override on another
+(overlapping) range coexist; only two entries setting the **same** field
+over overlapping ranges are an error.
+
+##### `dependencies`
+
+`dependencies` states the runtime dependencies for the selected
+versions, replacing whatever the distribution declares.  Each item
+is a full PEP 508 requirement, so extras, markers, and version
+specifiers are all allowed on a value (unlike the selector key, which
+takes only a name and an optional specifier).
+
+```toml
+# Replace chumpy's declared runtime deps for every version.
+[tool.nab.packages.chumpy]
+dependencies = ["numpy>=1.8.1", "scipy>=0.13.0", "six>=1.11.0"]
+
+# Version-scoped: only versions <= 1.0.
+[tool.nab.packages."broken-pkg <= 1.0"]
+dependencies = ["requests>=2"]
+
+# The many-packages spelling.
+[[tool.nab.package-rules]]
+match = ["some-pkg <= 2.0"]
+dependencies = ["requests>=2"]
+```
+
+The list is the complete replacement, not an addition: the declared
+dependencies for the matched versions are dropped and the override's
+list is used instead.  An empty list removes all runtime dependencies:
+
+```toml
+# Resolve broken-pkg <= 1.0 with no runtime dependencies at all.
+[tool.nab.packages."broken-pkg <= 1.0"]
+dependencies = []
+```
+
+An empty list is distinct from omitting the key: the key absent means
+the declared dependencies stand, while `[]` means "replace with zero
+dependencies."  Both count as setting the field, so both take part in
+the same-field overlap rule above (two entries setting `dependencies`
+over overlapping ranges are a parse-time error).
+
+##### `requires-python`
+
+`requires-python` is a single PEP 440 specifier that replaces the
+package's declared Python requirement for the selected versions.  A bare
+version like `"3.13"` is rejected (it is not a specifier); write
+`">=3.13"` or `"==3.13"`.
+
+```toml
+[tool.nab.packages.flask]
+requires-python = ">=3.6"
+```
+
+The override applies at the point that filters candidates by Python, so
+it both widens and narrows:
+
+* Widen: a package that declares `>=3.10` but actually runs on `3.9` can
+  be admitted for a `3.9` resolve with `requires-python = ">=3.9"`.
+* Narrow: a package that declares `>=3.6` can be held to `>=3.11` so
+  older Pythons reject it.
+
+The override goes through the same comparison a declared
+`Requires-Python` value takes (the full target Python version against
+the specifier), so it admits or rejects a version exactly as a declared
+value would.  An empty string (`requires-python = ""`) removes
+the Python requirement entirely (admits every target).  For an index pin
+the lock records the overridden specifier, so a widened pin stays
+installable by a conforming PEP 751 installer.  A local-path or VCS pin
+has no `requires-python` field, but the override is still what its Python
+check enforces.
+
+##### `provides-extra`
+
+`provides-extra` is the list of extra names the package declares for the
+selected versions, normalised per PEP 685 (so spelling does not matter).
+
+```toml
+[tool.nab.packages.flask]
+dependencies = ["werkzeug>=0.14", "click>=5.1 ; extra == 'dotenv'"]
+provides-extra = ["dotenv"]
+```
+
+When `provides-extra` is set it is authoritative for the whole extra set:
+it is never merged with the package's declared extras.  An extra then
+exists iff `provides-extra` lists it, and its dependencies are exactly
+the dependency lines carrying that extra's `; extra == "name"` marker
+(the override's `dependencies` when set, else the parsed
+`Requires-Dist`).
+
+* When `provides-extra` is absent, the extras fall back to the package's
+  parsed extras, unless `dependencies` is also replaced.  A
+  `requires-python`-only override therefore keeps the package's declared
+  extras and their dependencies.  Replacing `dependencies` without
+  declaring `provides-extra` drops the extras, since the parsed
+  extra-gated dependency lines are gone once the list is replaced.
+* A dropped extra has no effect unless it is requested.  Requesting a
+  dropped extra directly (a root/user `flask[async]`) raises in the
+  error-user and backtrack extras modes; a transitive request (another
+  package depending on `flask[async]`) warns and drops the extra's
+  dependencies, except in the backtrack mode, which skips versions
+  that lack the extra instead.
+* An empty list (`provides-extra = []`) declares no extras and is
+  distinct from omitting the key.
+
+##### Skip-fetch: resolving without the artifact
+
+When an entry sets `dependencies` (an empty list counts), nab resolves
+the matched versions from the declared metadata alone: the resolver
+computes their dependencies without fetching or building the per-version
+metadata.  This is what lets a package that nab cannot fetch or
+build (an sdist-only or dynamic-metadata package under
+`build-policy = "never"`) still resolve:
+
+```toml
+# Resolve a dynamic-metadata, sdist-only package without building it.
+[tool.nab.packages.legacy-pkg]
+dependencies = ["numpy>=1.8.1"]
+```
+
+The package listing is still fetched (the lock needs the files, hashes,
+and upload times, and the Python filter still runs), but the resolver
+does not fetch or build the per-version metadata to compute
+dependencies.  A partial override that sets only `requires-python`
+still needs the artifact for its dependencies and does not skip.  Under
+skip-fetch a co-set `trust-unverified-deps` becomes moot, since no
+sdist is parsed.  A co-set `dist-policy` is not: it still filters the
+candidate listing, so `dist-policy = "wheel-only"` on an sdist-only
+package removes every version before the override can apply.
+
+##### Scope and the per-index rule
+
+These are per-package fields with no per-index form: an index serves many
+packages, so a single dependency list, Python requirement, or extra set
+for all of them is meaningless.  Writing any of them under
+`[tool.nab.index.<name>]` is rejected.
+
+A metadata override annotates versions the resolve already reaches; it
+never introduces a version.  An override scoped to a version no candidate
+has, or a package the resolve never visits, does nothing.  Local-path and
+VCS sources have no listing and their version is not known until the
+source is materialised, so a metadata override governs a source only when
+it uses a bare-name selector (full range); a version-scoped override does
+not match a source.
 
 ### Per-index overrides
 

--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -111,6 +111,12 @@ class LockInputProvider(Protocol):
         """Return the effective :class:`DistPolicy` for ``canonical_name==version``."""
         ...
 
+    def effective_requires_python(
+        self, canonical_name: str, version: Version, /
+    ) -> str | None:
+        """Return the ``requires-python`` override for ``canonical_name==version``."""
+        ...
+
 
 class MissingHashError(ValueError):
     """A distribution chosen by the resolver has no usable hash.
@@ -357,6 +363,12 @@ def _index_pin_from_listing(
     package's wheels stayed in ``versions_cache`` as a possible
     metadata source for the resolver; only the sdist is emitted
     into the lock so installers download and build that archive.
+
+    A ``requires-python`` metadata override takes precedence over the
+    Simple-API value so the pin records the specifier the resolver
+    actually admitted against; a conforming :pep:`751` installer would
+    otherwise reject a widened pin whose lock still carried the narrow
+    artefact value.
     """
     from ..fetch import DEFAULT_INDEX_URL
     from ..lockfile import IndexPin, SdistArtifact, WheelArtifact
@@ -384,7 +396,12 @@ def _index_pin_from_listing(
     sdist = (
         _build_artifact(sdist_file, SdistArtifact) if sdist_file is not None else None
     )
-    requires_python = _common_requires_python(files)
+
+    override_rp = provider.effective_requires_python(canonical, version)
+    requires_python = (
+        override_rp if override_rp is not None else _common_requires_python(files)
+    )
+
     serving_name = provider.coordinator.index.get_listing_index(canonical)
     by_name = {ix.name: ix.url for ix in indexes}
     index_url = by_name.get(serving_name) if serving_name is not None else None

--- a/nab-python/src/nab_python/_provider/build_remote.py
+++ b/nab-python/src/nab_python/_provider/build_remote.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 
 from nab_index.client import SdistFile, WheelFile, extract_sdist_archive
 
+from .._vendor.packaging.specifiers import SpecifierSet
 from .._vendor.packaging.utils import canonicalize_name
 from .._vendor.packaging.version import Version
 
@@ -43,9 +44,11 @@ def build_remote_sdist(
     entry in ``provider.versions_cache``.  A built sdist whose
     ``Requires-Python`` excludes the resolve target is rejected, since the
     Simple-API listing filter only sees the listing's own (possibly absent)
-    Requires-Python, not the value the build produces.  A built sdist whose
-    declared name or version disagrees with the requested candidate is also
-    rejected rather than used for the wrong package.
+    Requires-Python, not the value the build produces.  A per-package
+    ``requires-python`` metadata override substitutes for the built value
+    here, matching the listing gate.  A built sdist whose declared name or
+    version disagrees with the requested candidate is also rejected rather
+    than used for the wrong package.
     """
     # Late imports: ``provider`` imports this module at module load.
     from .. import build_backend
@@ -97,7 +100,10 @@ def build_remote_sdist(
             raise UnsupportedSdistError(msg) from exc
 
     target = provider.python_version
-    spec = built.requires_python
+    override_rp = provider.effective_requires_python(canonical, version)
+    spec = (
+        SpecifierSet(override_rp) if override_rp is not None else built.requires_python
+    )
     if spec is not None and target and Version(target) not in spec:
         msg = (
             f"{package}=={version} built sdist requires Python {spec} but the"

--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -157,6 +157,17 @@ def speculative_prefetch(
         prefetch_transitive_best(provider, normalized, versions)
 
 
+def _has_complete_override(
+    provider: Provider, normalized: str, version: Version
+) -> bool:
+    """Whether a complete ``dependencies`` override replaces this version's metadata.
+
+    Callers skip prefetching such a candidate: ``get_dependencies`` synthesizes
+    its deps without a METADATA fetch, so any prefetch would be wasted.
+    """
+    return provider.effective_dependencies(normalized, version) is not None
+
+
 def prefetch_root_batch(
     provider: Provider,
     normalized: str,
@@ -175,6 +186,8 @@ def prefetch_root_batch(
         if version not in root_range:
             continue
         if (normalized, version) in provider.deps_cache:
+            continue
+        if _has_complete_override(provider, normalized, version):
             continue
         if isinstance(dist, WheelFile) and dist.metadata_url is not None:
             items.append(
@@ -197,6 +210,8 @@ def prefetch_transitive_best(
     if best is None:
         return
     version, dist = best
+    if _has_complete_override(provider, normalized, version):
+        return
     cache_key = (normalized, version)
     if (
         cache_key not in provider.deps_cache
@@ -287,7 +302,7 @@ def filter_distributions(
         if effective_dist_policy in (DistPolicy.PREFER_WHEEL, DistPolicy.SDIST_INSTALL):
             sort_with_wheel_first = True
 
-        if excluded_by_python(provider, dist):
+        if excluded_by_python(provider, normalized, version, dist):
             continue
         if time_filter_active:
             cutoff = provider.effective_uploaded_prior_to(
@@ -349,22 +364,31 @@ def _excluded_by_dist_policy(dist: DistFile, policy: object) -> bool:
     return False
 
 
-def excluded_by_python(provider: Provider, dist: DistFile) -> bool:
-    """Return True when ``dist``'s Requires-Python excludes the target Python."""
-    requires_python = dist.requires_python
-    if not requires_python or not provider.python_version:
+def excluded_by_python(
+    provider: Provider, normalized: str, version: Version, dist: DistFile
+) -> bool:
+    """Return True when the target Python is excluded for this candidate.
+
+    A per-package ``requires-python`` override substitutes for
+    ``dist.requires_python`` and goes through the same cached comparison,
+    keyed by the specifier string; the verdict depends only on that string
+    and the fixed ``provider.python_version``.
+    """
+    override_rp = provider.effective_requires_python(normalized, version)
+    effective = override_rp if override_rp is not None else dist.requires_python
+    if not effective or not provider.python_version:
         return False
-    cached = provider.requires_python_cache.get(requires_python)
+    cached = provider.requires_python_cache.get(effective)
     if cached is None:
         try:
-            spec = SpecifierSet(requires_python)
+            spec = SpecifierSet(effective)
             cached = Version(provider.python_version) not in spec
         except InvalidSpecifier:
             # Malformed Requires-Python on the dist: treat as
             # not-excluded, let downstream logic decide.  Our own
             # python_version is validated at Provider construction.
             cached = False
-        provider.requires_python_cache[requires_python] = cached
+        provider.requires_python_cache[effective] = cached
     if cached:
         provider.stats.excluded_by_python += 1
     return cached
@@ -455,6 +479,8 @@ def prefetch_walk_ahead(
         wheel = wheel_for_v.get(version)
         if wheel is None or (normalized, version) in provider.deps_cache:
             continue
+        if _has_complete_override(provider, normalized, version):
+            continue
         if coordinator_index.has_metadata(normalized, wheel.version):
             continue
         # ``_first_wheel_per_version`` filters out wheels without metadata_url.
@@ -481,6 +507,10 @@ def prefetch_batch(
     version_map: list[tuple[Version, str]] = []
     for v in versions:
         if (package, v) in provider.deps_cache or v not in wheel_by_version_map:
+            continue
+        # On a corrupt-metadata wheel ``await_metadata_batch`` would otherwise
+        # raise on the very metadata this override replaces.
+        if _has_complete_override(provider, package, v):
             continue
         wheel = wheel_by_version_map[v]
         if isinstance(wheel, WheelFile) and wheel.metadata_url is not None:

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -16,15 +16,20 @@ from .._conflict_kind import EMPTY_MEMBERSHIP_SETS
 from .._vcs_admission import admit_vcs_url
 from .._vendor.packaging.ranges import VersionRange
 from .._vendor.packaging.requirements import InvalidRequirement, Requirement
+from .._vendor.packaging.specifiers import SpecifierSet
 from .._vendor.packaging.utils import canonicalize_name
-from ..metadata import DEPENDENCY_FIELDS, metadata_deps_are_static, parse_metadata
+from ..metadata import (
+    DEPENDENCY_FIELDS,
+    WheelMetadata,
+    metadata_deps_are_static,
+    parse_metadata,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from .._vendor.packaging.markers import Marker
     from .._vendor.packaging.version import Version
-    from ..metadata import WheelMetadata
     from ..provider import DistFile, Provider
 
 
@@ -423,15 +428,58 @@ def cache_deps_from_metadata(
     """Populate ``deps_cache`` + ``extra_deps_map`` from a parsed metadata.
 
     Shared by the wheel/sdist path (which calls
-    :func:`parse_and_cache_metadata` after parsing METADATA text)
-    and the local-source path (which already has a
-    :class:`WheelMetadata` from
-    :func:`nab_python.build_backend.extract_static_metadata`).
+    :func:`parse_and_cache_metadata` after parsing METADATA text), the
+    local-source path (which already has a :class:`WheelMetadata` from
+    :func:`nab_python.build_backend.extract_static_metadata`), and the
+    skip-fetch branch of
+    :meth:`nab_python.provider.Provider.get_dependencies` (which hands in a
+    bare :class:`WheelMetadata` for a complete ``dependencies`` override).
     """
     # Late import: ``pypi`` imports this module at module load.
     from ..provider import _normalize_extra
 
-    package, _ = cache_key
+    package, version = cache_key
+    override_deps, override_rp, override_pe = provider.effective_metadata_override(
+        package, version
+    )
+    if override_deps is not None or override_rp is not None or override_pe is not None:
+        # Build a fresh record rather than mutate the input: the raw parse is
+        # shared across tuples via ``store_parsed_metadata``, so mutating it
+        # would leak one tuple's override into another.  Each field falls back
+        # to the parsed value when the override leaves it unset.
+        requires_python = (
+            SpecifierSet(override_rp)
+            if override_rp is not None
+            else metadata.requires_python
+        )
+        requires_dist = (
+            list(override_deps)
+            if override_deps is not None
+            else list(metadata.requires_dist)
+        )
+
+        # An explicit provides-extra wins; else keep the parsed extras, unless
+        # the dep list was replaced, which strips their extra-gated lines and
+        # leaves them incoherent, so declare none.
+        if override_pe is not None:
+            provides_extra = list(override_pe)
+        elif override_deps is not None:
+            provides_extra = []
+        else:
+            provides_extra = list(metadata.provides_extra)
+
+        metadata = WheelMetadata(
+            name=metadata.name,
+            version=metadata.version,
+            requires_python=requires_python,
+            requires_dist=requires_dist,
+            provides_extra=provides_extra,
+            metadata_version=metadata.metadata_version,
+            dynamic=metadata.dynamic,
+        )
+
+    # Split the (possibly overridden) requirements into base deps and
+    # per-extra deps, deferring any direct-URL deps that aren't yet active.
     provider.metadata_cache[cache_key] = metadata
     provided_extras = {_normalize_extra(e) for e in metadata.provides_extra}
     base_deps: dict[str, VersionRange] = {}

--- a/nab-python/src/nab_python/_testing/overrides.py
+++ b/nab-python/src/nab_python/_testing/overrides.py
@@ -1,0 +1,18 @@
+"""Shared :class:`~nab_python.config.PackageOverride` builder for tests."""
+
+from __future__ import annotations
+
+from nab_python._vendor.packaging.requirements import Requirement
+from nab_python._vendor.packaging.utils import canonicalize_name
+from nab_python.config import PackageOverride
+
+
+def pkg_override(req_str: str, **body: object) -> PackageOverride:
+    """Build a :class:`PackageOverride` from a PEP 508 requirement string."""
+    requirement = Requirement(req_str)
+    return PackageOverride(
+        requirement=requirement,
+        name=canonicalize_name(requirement.name),
+        version_range=requirement.specifier.to_range(),
+        **body,  # type: ignore[arg-type]
+    )

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -50,6 +50,7 @@ from .provider import (
     VcsConfig,
     VcsPolicy,
     VcsSource,
+    _normalize_extra,
 )
 from .universal.matrix import Matrix
 from .workspace import (
@@ -245,10 +246,20 @@ class PackageOverride:
     candidate versions inside it.  The *body* sets any combination of
     ``dist_policy`` (with ``dist_trust_unverified_deps`` folding in the
     sdist-trust flag), ``build_policy``, the ``uploaded_prior_to`` cutoff
-    (or ``uploaded_prior_to_disabled`` for the ``false`` form), and the
-    routing ``index``.  An entry that sets ``index`` must use a bare-name
-    requirement (full range), because routing decides where to fetch a
-    listing before any version is known.
+    (or ``uploaded_prior_to_disabled`` for the ``false`` form), the
+    routing ``index``, and the metadata-override fields.  An entry that
+    sets ``index`` must use a bare-name requirement (full range), because
+    routing decides where to fetch a listing before any version is known.
+
+    The metadata-override fields ``dependencies``, ``requires_python``, and
+    ``provides_extra`` substitute for what nab would parse from the
+    distribution, keyed to the matched version range (uv
+    ``dependency-metadata`` parity).  Each replaces its field independently:
+    ``dependencies`` becomes the whole runtime ``Requires-Dist`` list,
+    ``requires_python`` the Python specifier, and ``provides_extra`` the
+    declared extras.  For every one, ``None`` means the entry does not set
+    it; a present-but-empty value (``()`` for the two tuples) is a distinct,
+    first-class value meaning "replace with nothing".
     """
 
     requirement: Requirement
@@ -260,6 +271,9 @@ class PackageOverride:
     uploaded_prior_to: datetime | None = None
     uploaded_prior_to_disabled: bool = False
     index: str | None = None
+    dependencies: tuple[Requirement, ...] | None = None
+    requires_python: str | None = None
+    provides_extra: tuple[str, ...] | None = None
     # The config surface this entry was declared on (e.g. "packages.'numpy'"
     # or "package-rules[0]").  Only used to name the source in an error that
     # is raised after the two project files merge, so it is excluded from
@@ -1110,12 +1124,22 @@ def _check_index_name_uniqueness(indexes: Sequence[IndexConfig]) -> None:
 
 
 _PACKAGE_OVERRIDE_BODY_KEYS = frozenset(
-    {"dist-policy", "build-policy", "uploaded-prior-to", "index", "strict"}
+    {
+        "dist-policy",
+        "build-policy",
+        "uploaded-prior-to",
+        "index",
+        "strict",
+        "dependencies",
+        "requires-python",
+        "provides-extra",
+    }
 )
 # A [[tool.nab.package-rules]] entry carries a ``match`` selector plus body keys.
 _PACKAGE_RULE_KEYS = frozenset({"match"}) | _PACKAGE_OVERRIDE_BODY_KEYS
 _INDEX_OVERRIDE_KEYS = frozenset({"dist-policy", "build-policy", "uploaded-prior-to"})
-# Body keys deferred to later PRs; rejected so nothing inert ships.
+# Override-body keys not supported yet; rejected so nothing inert ships.
+# ``metadata`` is the nested-table form the flat body keys replace.
 _OVERRIDE_DEFERRED_KEYS = frozenset(
     {"resolution", "prereleases", "source", "vcs", "metadata", "marker"}
 )
@@ -1129,6 +1153,9 @@ _PACKAGE_POLICY_FIELDS = (
     ("build-policy", "build_policy"),
     ("uploaded-prior-to", "uploaded_prior_to"),
     ("index", "index"),
+    ("dependencies", "dependencies"),
+    ("requires-python", "requires_python"),
+    ("provides-extra", "provides_extra"),
 )
 
 
@@ -1263,6 +1290,11 @@ def _build_package_overrides(
         present="uploaded-prior-to" in body,
     )
     route = _parse_override_index(body, where)
+    dependencies = _parse_override_dependencies(body.get("dependencies"), where)
+    requires_python = _parse_override_requires_python(
+        body.get("requires-python"), where
+    )
+    provides_extra = _parse_override_provides_extra(body.get("provides-extra"), where)
     has_body = (
         dist_policy is not None
         or dist_trust is not None
@@ -1270,6 +1302,9 @@ def _build_package_overrides(
         or uploaded_prior_to is not None
         or uploaded_disabled
         or route is not None
+        or dependencies is not None
+        or requires_python is not None
+        or provides_extra is not None
     )
     if not has_body:
         msg = (
@@ -1299,6 +1334,9 @@ def _build_package_overrides(
             uploaded_prior_to=uploaded_prior_to,
             uploaded_prior_to_disabled=uploaded_disabled,
             index=route,
+            dependencies=dependencies,
+            requires_python=requires_python,
+            provides_extra=provides_extra,
             source_label=where,
         )
         for requirement in requirements
@@ -1369,15 +1407,23 @@ def _override_sets(override: PackageOverride, attr: str) -> bool:
     return getattr(override, attr) is not None
 
 
-def _reject_deferred(entry: dict[str, Any], where: str) -> None:
-    """Reject override-body keys deferred to a later release."""
+def _reject_deferred(
+    entry: dict[str, Any], where: str, *, flat_metadata_advice: bool = True
+) -> None:
+    """Reject override-body keys that are not supported.
+
+    ``flat_metadata_advice`` gates the package-surface hint to set metadata
+    via the flat body keys; the index surface passes ``False`` since those
+    keys are rejected there too.
+    """
     deferred = sorted(set(entry) & _OVERRIDE_DEFERRED_KEYS)
     if deferred:
-        msg = (
-            f"{where}: key(s) {deferred!r} are not supported in this release;"
-            " marker / resolution / prereleases / source / vcs / metadata"
-            " override bodies are deferred to a later PR"
-        )
+        msg = f"{where}: key(s) {deferred!r} are not supported"
+        if flat_metadata_advice and "metadata" in deferred:
+            msg += (
+                "; set metadata as the flat body keys 'dependencies',"
+                " 'requires-python', and 'provides-extra' instead"
+            )
         raise ConfigError(msg)
 
 
@@ -1415,7 +1461,7 @@ def _parse_index_override_body(
     if not isinstance(body, dict):
         msg = f"{where} must be a table, got {type(body).__name__}"
         raise ConfigError(msg)
-    _reject_deferred(body, where)
+    _reject_deferred(body, where, flat_metadata_advice=False)
     unknown = sorted(set(body) - _INDEX_OVERRIDE_KEYS)
     if unknown:
         msg = (
@@ -1543,6 +1589,95 @@ def _parse_override_uploaded_prior_to(
         msg = f"{where}.uploaded-prior-to: {exc}"
         raise ConfigError(msg) from exc
     return (cutoff, False)
+
+
+def _parse_override_requires_python(value: object, where: str) -> str | None:
+    """Parse a per-package ``requires-python`` override, naming the entry.
+
+    An absent key (``None``) means no override; a present value delegates
+    to :func:`_parse_requires_python` for PEP 440 validation, prefixing the
+    ``where`` selector on failure so the message names the offending entry.
+    """
+    if value is None:
+        return None
+
+    try:
+        return _parse_requires_python(value)
+    except ConfigError as exc:
+        msg = f"{where}.{exc}"
+        raise ConfigError(msg) from exc
+
+
+def _parse_override_dependencies(
+    value: object, where: str
+) -> tuple[Requirement, ...] | None:
+    """Parse the ``dependencies`` body: PEP 508 strings that replace deps.
+
+    The list replaces a package's declared runtime dependencies for the
+    matched version range.  Each item is a full PEP 508 dependency
+    *value*, so extras, markers, and version specifiers are all legal
+    (unlike the override *key*, which :func:`_requirement_from_selector`
+    restricts to a name plus specifier).  A present-but-empty list is
+    stored as ``()`` (replace with zero deps), distinct from the key
+    being absent (``None``).
+    """
+    if value is None:
+        return None
+
+    if not isinstance(value, list):
+        msg = (
+            f"{where}.dependencies must be a list of PEP 508 requirement"
+            f" strings, got {type(value).__name__}"
+        )
+        raise ConfigError(msg)
+
+    out: list[Requirement] = []
+    for i, item in enumerate(value):
+        if not isinstance(item, str):
+            msg = (
+                f"{where}.dependencies[{i}] must be a string, got {type(item).__name__}"
+            )
+            raise ConfigError(msg)
+        try:
+            out.append(Requirement(item))
+        except InvalidRequirement as exc:
+            msg = (
+                f"{where}.dependencies[{i}] is not a valid PEP 508"
+                f" requirement: {item!r}"
+            )
+            raise ConfigError(msg) from exc
+    return tuple(out)
+
+
+def _parse_override_provides_extra(value: object, where: str) -> tuple[str, ...] | None:
+    """Parse the ``provides-extra`` body: the extras the override declares.
+
+    A TOML array of extra names, each normalised per PEP 685 (the same
+    rule :func:`nab_python.provider._normalize_extra` applies to parsed
+    ``Provides-Extra``), so an extra compares equal regardless of spelling.
+    A present-but-empty list is stored as ``()`` (declares no extras),
+    distinct from the key being absent (``None``).
+    """
+    if value is None:
+        return None
+
+    if not isinstance(value, list):
+        msg = (
+            f"{where}.provides-extra must be a list of extra names, got"
+            f" {type(value).__name__}"
+        )
+        raise ConfigError(msg)
+
+    out: list[str] = []
+    for i, item in enumerate(value):
+        if not isinstance(item, str):
+            msg = (
+                f"{where}.provides-extra[{i}] must be a string, got"
+                f" {type(item).__name__}"
+            )
+            raise ConfigError(msg)
+        out.append(_normalize_extra(item))
+    return tuple(out)
 
 
 def _parse_override_index(entry: dict[str, Any], where: str) -> str | None:

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -37,12 +37,12 @@ from ._lockfile.requirements import (
 from ._vendor.packaging.pylock import is_valid_pylock_path
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Sequence
     from datetime import datetime
     from pathlib import Path
 
     from ._vendor.packaging.markers import Marker
-    from .config import ConflictSet
+    from .config import ConflictSet, PackageOverride
 
 
 __all__ = [
@@ -64,6 +64,7 @@ __all__ = [
     "build_lock_input_from_provider",
     "build_pylock",
     "is_valid_pylock_path",
+    "package_metadata_override_records",
     "read_lockfile_anchor",
     "read_lockfile_packages",
     "render_lock",
@@ -245,6 +246,9 @@ class Provenance:
     # ``(flag, rendered value)`` pairs.  Recorded so a reader can see the
     # lock did not derive from the committed files alone.
     cli_project_overrides: tuple[tuple[str, str], ...] = ()
+    # The configured ``[tool.nab]`` per-package metadata overrides as
+    # ``(requirement, (field, ...))`` pairs; input provenance, audit-only.
+    package_metadata_overrides: tuple[tuple[str, tuple[str, ...]], ...] = ()
 
     def to_block(self) -> dict[str, Any]:
         """Render to the dict the TOML writer drops under ``[tool.nab]``."""
@@ -263,7 +267,40 @@ class Provenance:
             block["cli-project-overrides"] = [
                 f"{flag}={value}" for flag, value in self.cli_project_overrides
             ]
+        if self.package_metadata_overrides:
+            block["package-metadata-overrides"] = [
+                f"{requirement}: {', '.join(fields)}"
+                for requirement, fields in self.package_metadata_overrides
+            ]
         return block
+
+
+def package_metadata_override_records(
+    overrides: Sequence[PackageOverride],
+) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    """Summarise the configured per-package metadata overrides for provenance.
+
+    Each returned pair is a requirement string and the metadata fields the
+    entry set (``dependencies``, ``requires-python``, ``provides-extra``).
+    Entries that set no metadata field are skipped.  This records every
+    configured override as input provenance, including any scoped to a
+    version no candidate has (a documented no-op), so an entry here is not a
+    claim that it shaped the lock.  Strictly informational: the reader must
+    not feed it into the install path.
+    """
+    records: list[tuple[str, tuple[str, ...]]] = []
+    for override in overrides:
+        fields: list[str] = []
+        if override.dependencies is not None:
+            fields.append("dependencies")
+        if override.requires_python is not None:
+            fields.append("requires-python")
+        if override.provides_extra is not None:
+            fields.append("provides-extra")
+
+        if fields:
+            records.append((str(override.requirement), tuple(fields)))
+    return tuple(records)
 
 
 @dataclass

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -33,6 +33,7 @@ from ._vendor.packaging.ranges import VersionRange
 from ._vendor.packaging.requirements import Requirement
 from ._vendor.packaging.utils import canonicalize_name
 from ._vendor.packaging.version import InvalidVersion, Version
+from .metadata import WheelMetadata
 
 if TYPE_CHECKING:
     import threading
@@ -44,7 +45,6 @@ if TYPE_CHECKING:
 
     from .config import IndexOverride, NabProjectConfig, PackageOverride
     from .fetch import FetchCoordinator
-    from .metadata import WheelMetadata
 
 __all__ = [
     "BuildPolicy",
@@ -797,6 +797,111 @@ class Provider:
         assert isinstance(result, bool)
         return result
 
+    def effective_dependencies(
+        self, canonical_name: str, version: Version
+    ) -> tuple[Requirement, ...] | None:
+        """Return the ``dependencies`` metadata override for ``name==version``.
+
+        Metadata overrides live only on the per-package surface, so this
+        is a single-surface lookup with no per-index arbitration and no
+        :class:`OverrideConflictError`.  Returns the replacement
+        requirement tuple (possibly empty, meaning "no runtime deps")
+        when a range-matching override sets ``dependencies``, else
+        ``None`` when nothing overrides them.
+        """
+        override = self._matching_package_override(
+            canonical_name,
+            version,
+            lambda o: _unset_if_none(o.dependencies),
+        )
+        if override is None:
+            return None
+        return override.dependencies
+
+    def effective_requires_python(
+        self, canonical_name: str, version: Version
+    ) -> str | None:
+        """Return the ``requires-python`` metadata override for ``name==version``.
+
+        Single-surface (per-package only), like
+        :meth:`effective_dependencies`.  Returns the raw specifier string a
+        range-matching override sets (which may be ``""``, meaning "no Python
+        requirement"), else ``None`` when nothing overrides it.
+        """
+        override = self._matching_package_override(
+            canonical_name,
+            version,
+            lambda o: _unset_if_none(o.requires_python),
+        )
+        if override is None:
+            return None
+        return override.requires_python
+
+    def effective_provides_extra(
+        self, canonical_name: str, version: Version
+    ) -> tuple[str, ...] | None:
+        """Return the ``provides-extra`` metadata override for ``name==version``.
+
+        Single-surface (per-package only).  Returns the declared extras
+        (possibly empty, meaning "no extras") a range-matching override
+        sets, else ``None`` when nothing overrides them.
+        """
+        override = self._matching_package_override(
+            canonical_name,
+            version,
+            lambda o: _unset_if_none(o.provides_extra),
+        )
+        if override is None:
+            return None
+        return override.provides_extra
+
+    def _source_metadata_override(
+        self, canonical_name: str
+    ) -> tuple[tuple[Requirement, ...] | None, str | None, tuple[str, ...] | None]:
+        """Resolve a local/VCS source's metadata override bundle.
+
+        Local/VCS sources have no listing and their version is not known
+        until materialised, so a metadata override governs them only through
+        a bare-name requirement (full range); a version-scoped override does
+        not match a source.  Mirrors
+        :meth:`effective_build_policy_for_source`.  Each field is taken from
+        the first bare-name entry that sets it (a present ``""`` or ``()`` is
+        a set value); the parse-time overlap rules make that entry unique.
+        """
+        deps: tuple[Requirement, ...] | None = None
+        requires_python: str | None = None
+        provides_extra: tuple[str, ...] | None = None
+        for override in self._package_overrides:
+            if override.name != canonical_name:
+                continue
+            if str(override.requirement.specifier):
+                continue
+            if deps is None and override.dependencies is not None:
+                deps = override.dependencies
+            if requires_python is None and override.requires_python is not None:
+                requires_python = override.requires_python
+            if provides_extra is None and override.provides_extra is not None:
+                provides_extra = override.provides_extra
+        return (deps, requires_python, provides_extra)
+
+    def effective_metadata_override(
+        self, canonical_name: str, version: Version
+    ) -> tuple[tuple[Requirement, ...] | None, str | None, tuple[str, ...] | None]:
+        """Resolve the ``(dependencies, requires_python, provides_extra)`` override.
+
+        A local/VCS source selects bare-name-only (its materialised version
+        is not knowable to the user when writing the selector); every other
+        candidate selects version-scoped.  Each field resolves
+        independently, so the three may come from different entries.
+        """
+        if canonical_name in self.local_sources or canonical_name in self.vcs_sources:
+            return self._source_metadata_override(canonical_name)
+        return (
+            self.effective_dependencies(canonical_name, version),
+            self.effective_requires_python(canonical_name, version),
+            self.effective_provides_extra(canonical_name, version),
+        )
+
     @staticmethod
     def _package_uploaded_prior_to(override: PackageOverride) -> object:
         """Per-package upload-time value: a datetime, ``None`` (disabled), or unset."""
@@ -1405,6 +1510,18 @@ class Provider:
             normalized in self.local_sources or normalized in self.vcs_sources
         ):
             self._cache_deps_from_metadata(cache_key, self.metadata_cache[cache_key])
+            return self.deps_cache[cache_key]
+
+        # Skip-fetch: a complete ``dependencies`` override (even an empty
+        # tuple) supplies the deps, so no METADATA fetch or build is needed.
+        # After the local/VCS branch so sources still materialise;
+        # ``_cache_deps_from_metadata`` stamps the remaining override fields
+        # onto the bare record.
+        if self.effective_dependencies(normalized, version) is not None:
+            self._cache_deps_from_metadata(
+                cache_key, WheelMetadata(name=normalized, version=version)
+            )
+            self.prefetch_new_deps(self.deps_cache[cache_key])
             return self.deps_cache[cache_key]
 
         metadata_text, from_sdist = self._resolve_metadata(versions, package, version)

--- a/nab-python/src/nab_python/universal/reresolve.py
+++ b/nab-python/src/nab_python/universal/reresolve.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from .._vendor.packaging.utils import canonicalize_name
+from .._vendor.packaging.version import Version
 from ..provider import (
     BuildPolicy,
     DistPolicy,
@@ -25,6 +26,7 @@ from ..provider import (
 )
 from .matrix import Matrix as _Matrix
 from .resolve import resolve_with_coordinator
+from .validate import _dependencies_override_for
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping, Sequence
@@ -148,7 +150,17 @@ def _reresolve_one_step(  # noqa: PLR0913
         if not tr.success:
             continue
         findings = by_tuple.get(tr.tuple_.label, [])
-        divergent = [f for f in findings if f.status == "divergent"]
+        # A pin whose deps came from a ``dependencies`` override would
+        # re-resolve identically (the override reapplies), so skip it: the
+        # diff would be empty and the fetch wasted.
+        divergent = [
+            f
+            for f in findings
+            if f.status == "divergent"
+            and not _dependencies_override_for(
+                package_overrides, canonicalize_name(f.package), Version(f.version)
+            )
+        ]
         if not divergent:
             continue
         wheel_metadata = _collect_wheel_metadata_overrides(coordinator, divergent)

--- a/nab-python/src/nab_python/universal/validate.py
+++ b/nab-python/src/nab_python/universal/validate.py
@@ -33,6 +33,9 @@ from ..metadata import load_static_project, metadata_deps_are_static, parse_meta
 from .wheel_selection import select_wheel_for_tuple
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from ..config import PackageOverride
     from ..fetch import FetchCoordinator
     from .matrix import MatrixTuple
     from .resolve import UniversalResult
@@ -95,6 +98,10 @@ class PinValidation:
     - ``static_sdist_authoritative``: the sdist's PEP 621 or PEP 643
       metadata guarantees every wheel of this version shares the same
       dep-affecting metadata, so per-wheel fetches were skipped.
+    - ``metadata_overridden``: a ``dependencies`` metadata override
+      replaced this version's deps (skip-fetch), so there is no baseline
+      or wheel metadata to compare; the override reapplies on any
+      resolve, so nothing can diverge.
     """
 
     tuple_label: str
@@ -138,22 +145,29 @@ class ValidationReport:
 def validate_lock(
     result: UniversalResult,
     coordinator: FetchCoordinator,
+    package_overrides: Sequence[PackageOverride] = (),
 ) -> ValidationReport:
     """Validate every pin in ``result`` against its per-tuple wheel metadata.
 
     ``coordinator`` is the same FetchCoordinator the resolver used.
-    Re-using it keeps cached metadata warm.
+    Re-using it keeps cached metadata warm.  ``package_overrides`` are the
+    same metadata overrides the resolver ran with: a ``dependencies``
+    override made the resolver skip-fetch that version, so there is no
+    baseline or wheel metadata to compare against.
     """
     report = ValidationReport()
-    # ``pins_ok`` counts both per-wheel-validated successes and
-    # static-sdist-authoritative pins; both mean "the lock is sound
-    # for this pin", just established via different evidence.
-    ok_statuses = {"ok", "static_sdist_authoritative"}
+    # ``pins_ok`` counts per-wheel-validated successes, static-sdist-
+    # authoritative pins, and dependencies-overridden pins; all mean
+    # "the lock is sound for this pin", just established via different
+    # evidence.
+    ok_statuses = {"ok", "static_sdist_authoritative", "metadata_overridden"}
     for tr in result.tuple_results:
         if not tr.success:
             continue
         for pkg, version in tr.pins.items():
-            finding = _validate_pin(coordinator, tr.tuple_, pkg, version)
+            finding = _validate_pin(
+                coordinator, tr.tuple_, pkg, version, package_overrides
+            )
             report.findings.append(finding)
             report.pins_checked += 1
             if finding.status in ok_statuses:
@@ -161,11 +175,35 @@ def validate_lock(
     return report
 
 
+def _dependencies_override_for(
+    package_overrides: Sequence[PackageOverride],
+    canonical_name: str,
+    version: Version,
+) -> bool:
+    """Whether a ``dependencies`` override covers ``canonical_name==version``.
+
+    Only a ``dependencies`` override drives skip-fetch: it replaces the
+    version's deps and suppresses the metadata fetch, so no listing
+    baseline or wheel metadata exists to compare.  A requires-python-only
+    or provides-extra-only override leaves the baseline in place, so it
+    does not match here.
+    """
+    for override in package_overrides:
+        if override.name != canonical_name:
+            continue
+        if version not in override.version_range:
+            continue
+        if override.dependencies is not None:
+            return True
+    return False
+
+
 def _validate_pin(  # noqa: PLR0911 - one return per outcome reads cleaner here
     coordinator: FetchCoordinator,
     tup: MatrixTuple,
     package: str,
     version: Version,
+    package_overrides: Sequence[PackageOverride] = (),
 ) -> PinValidation:
     """Run the per-pin checks; emit a PinValidation outcome."""
     normalized = canonicalize_name(package)
@@ -213,6 +251,22 @@ def _validate_pin(  # noqa: PLR0911 - one return per outcome reads cleaner here
                 f"{len(wheels_at_version)} wheels at this version but none "
                 f"compatible with {tup.python_version}/{tup.platform_id}"
                 + detail_suffix
+            ),
+        )
+    # A skip-fetch pin has no baseline or wheel metadata, so any comparison
+    # below would spuriously diverge; report the deliberate override instead.
+    # Placed after the artifact-availability checks (an override changes
+    # metadata, not which files exist) and before any fetch.
+    if _dependencies_override_for(package_overrides, normalized, version):
+        return PinValidation(
+            tuple_label=tup.label,
+            package=package,
+            version=str(version),
+            status="metadata_overridden",
+            chosen_wheel=chosen.filename,
+            detail=(
+                "dependencies replaced by a metadata override; "
+                "wheel metadata not compared"
             ),
         )
     # PEP 643 fast path: if the resolver's baseline metadata declares

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -1620,8 +1620,21 @@ class TestPackageSugar:
 
     def test_deferred_key_rejected(self, tmp_path: Path) -> None:
         path = write(tmp_path, '[tool.nab.packages.foo]\nresolution = "lowest"\n')
-        with pytest.raises(ConfigError, match="deferred to a later PR"):
+        with pytest.raises(ConfigError, match="are not supported") as excinfo:
             read_pyproject_config(path, discover_workspace=False)
+        # A non-metadata deferred key carries no flat-body advice.
+        assert "flat body keys" not in str(excinfo.value)
+
+    def test_metadata_key_advises_flat_body(self, tmp_path: Path) -> None:
+        # The nested ``metadata`` table is rejected with a hint pointing at
+        # the flat body keys the package surface accepts.
+        path = write(
+            tmp_path,
+            '[tool.nab.packages.foo]\nmetadata = { requires-python = ">=3.6" }\n',
+        )
+        with pytest.raises(ConfigError, match="flat body keys") as excinfo:
+            read_pyproject_config(path, discover_workspace=False)
+        assert "are not supported" in str(excinfo.value)
 
     def test_marker_in_key_rejected(self, tmp_path: Path) -> None:
         path = write(
@@ -1787,7 +1800,7 @@ class TestPackageRules:
         path = write(
             tmp_path, '[[tool.nab.package-rules]]\nmatch = ["foo"]\nmarker = "x"\n'
         )
-        with pytest.raises(ConfigError, match="deferred to a later PR"):
+        with pytest.raises(ConfigError, match="are not supported"):
             read_pyproject_config(path, discover_workspace=False)
 
     def test_match_with_marker_rejected(self, tmp_path: Path) -> None:
@@ -1990,6 +2003,275 @@ class TestPackageOverrideConflicts:
         assert len(config.package_overrides) == 2
 
 
+class TestPackageOverrideDependencies:
+    """The ``dependencies`` metadata override replaces a package's deps."""
+
+    def test_parses_a_list_of_requirements(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab.packages.chumpy]\n"
+            'dependencies = ["numpy>=1.8.1", "six>=1.11.0 ; python_version < \'3\'"]\n',
+        )
+        (override,) = read_pyproject_config(
+            path, discover_workspace=False
+        ).package_overrides
+        assert override.name == "chumpy"
+        assert override.dependencies is not None
+        rendered = [str(r) for r in override.dependencies]
+        assert rendered == ["numpy>=1.8.1", 'six>=1.11.0; python_version < "3"']
+
+    def test_empty_list_stored_as_empty_tuple(self, tmp_path: Path) -> None:
+        # An empty list is a first-class value (replace with zero deps),
+        # distinct from the key being absent, and lifts the empty-body gate.
+        path = write(tmp_path, "[tool.nab.packages.broken]\ndependencies = []\n")
+        (override,) = read_pyproject_config(
+            path, discover_workspace=False
+        ).package_overrides
+        assert override.dependencies == ()
+        assert override.dist_policy is None
+
+    def test_only_dependencies_is_a_valid_body(self, tmp_path: Path) -> None:
+        # A body carrying only ``dependencies`` is not rejected as empty.
+        path = write(
+            tmp_path,
+            '[tool.nab.packages.foo]\ndependencies = ["bar"]\n',
+        )
+        (override,) = read_pyproject_config(
+            path, discover_workspace=False
+        ).package_overrides
+        assert [str(r) for r in override.dependencies or ()] == ["bar"]
+
+    def test_bad_pep508_string_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab.packages.foo]\ndependencies = ["not a valid == req =="]\n',
+        )
+        with pytest.raises(ConfigError, match="not a valid PEP 508"):
+            read_pyproject_config(path, discover_workspace=False)
+
+    def test_non_list_value_rejected(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab.packages.foo]\ndependencies = "bar"\n')
+        with pytest.raises(ConfigError, match="must be a list of PEP 508"):
+            read_pyproject_config(path, discover_workspace=False)
+
+    def test_non_string_item_rejected(self, tmp_path: Path) -> None:
+        path = write(tmp_path, "[tool.nab.packages.foo]\ndependencies = [1]\n")
+        with pytest.raises(ConfigError, match=r"dependencies\[0\] must be a string"):
+            read_pyproject_config(path, discover_workspace=False)
+
+    def test_via_package_rules(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[[tool.nab.package-rules]]\n"
+            'match = ["some-pkg <= 2.0"]\n'
+            'dependencies = ["requests>=2"]\n',
+        )
+        (override,) = read_pyproject_config(
+            path, discover_workspace=False
+        ).package_overrides
+        assert override.name == "some-pkg"
+        assert [str(r) for r in override.dependencies or ()] == ["requests>=2"]
+
+    def test_overlapping_dependencies_entries_rejected(self, tmp_path: Path) -> None:
+        # Two entries both setting ``dependencies`` over non-disjoint ranges
+        # is a parse error: which list wins for a version in the overlap is
+        # ambiguous.
+        path = write(
+            tmp_path,
+            '[tool.nab.packages."foo <= 2"]\ndependencies = ["a"]\n'
+            '[tool.nab.packages."foo >= 1"]\ndependencies = ["b"]\n',
+        )
+        with pytest.raises(ConfigError, match="overlapping versions"):
+            read_pyproject_config(path, discover_workspace=False)
+
+    def test_disjoint_dependencies_entries_ok(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab.packages."foo <= 2"]\ndependencies = ["a"]\n'
+            '[tool.nab.packages."foo >= 3"]\ndependencies = ["b"]\n',
+        )
+        low, high = read_pyproject_config(
+            path, discover_workspace=False
+        ).package_overrides
+        assert [str(r) for r in low.dependencies or ()] == ["a"]
+        assert [str(r) for r in high.dependencies or ()] == ["b"]
+
+    def test_empty_and_populated_overlap_still_rejected(self, tmp_path: Path) -> None:
+        # An empty list counts as set, so it overlaps a populated entry.
+        path = write(
+            tmp_path,
+            '[tool.nab.packages."foo <= 2"]\ndependencies = []\n'
+            '[tool.nab.packages."foo >= 1"]\ndependencies = ["b"]\n',
+        )
+        with pytest.raises(ConfigError, match="overlapping versions"):
+            read_pyproject_config(path, discover_workspace=False)
+
+    def test_dependencies_and_dist_policy_co_set(self, tmp_path: Path) -> None:
+        # Distinct fields, so both may sit on one entry with no conflict.
+        path = write(
+            tmp_path,
+            "[tool.nab.packages.foo]\n"
+            'dist-policy = "sdist-only"\n'
+            'dependencies = ["bar>=1"]\n',
+        )
+        (override,) = read_pyproject_config(
+            path, discover_workspace=False
+        ).package_overrides
+        assert override.dist_policy is DistPolicy.SDIST_ONLY
+        assert [str(r) for r in override.dependencies or ()] == ["bar>=1"]
+
+    def test_dependencies_key_rejected_on_index_surface(self, tmp_path: Path) -> None:
+        # Metadata fields live only on the per-package surface; the index
+        # body's own unknown-key check rejects ``dependencies``.
+        path = write(
+            tmp_path,
+            "[[tool.nab.indexes]]\n"
+            'name = "internal"\n'
+            'url = "https://pkgs.example.com/simple/"\n'
+            '[tool.nab.index.internal]\ndependencies = ["bar"]\n',
+        )
+        with pytest.raises(ConfigError):
+            read_pyproject_config(path, discover_workspace=False)
+
+
+class TestPackageOverrideRequiresPython:
+    """The ``requires-python`` metadata override replaces the Python spec."""
+
+    def test_parses_a_specifier(self, tmp_path: Path) -> None:
+        # A body carrying only ``requires-python`` is a valid (non-empty)
+        # body, and the specifier stores raw like the top-level field.
+        path = write(
+            tmp_path,
+            '[tool.nab.packages.flask]\nrequires-python = ">=3.6"\n',
+        )
+        (override,) = read_pyproject_config(
+            path, discover_workspace=False
+        ).package_overrides
+        assert override.requires_python == ">=3.6"
+        assert override.dependencies is None
+
+    def test_absent_key_is_none(self, tmp_path: Path) -> None:
+        # An absent requires-python parses to None, like the sibling fields.
+        path = write(
+            tmp_path,
+            '[tool.nab.packages.flask]\ndist-policy = "wheel-only"\n',
+        )
+        (override,) = read_pyproject_config(
+            path, discover_workspace=False
+        ).package_overrides
+        assert override.requires_python is None
+
+    def test_bare_version_rejected_names_the_entry(self, tmp_path: Path) -> None:
+        # A bare "3.13" is not a specifier: the rejection names the entry
+        # selector and reuses the top-level "Did you mean" suggestion.
+        path = write(
+            tmp_path,
+            '[tool.nab.packages.flask]\nrequires-python = "3.13"\n',
+        )
+        with pytest.raises(
+            ConfigError,
+            match=r"packages\.'flask'\.requires-python must be.*Did you mean",
+        ):
+            read_pyproject_config(path, discover_workspace=False)
+
+    def test_non_string_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab.packages.flask]\nrequires-python = 3\n",
+        )
+        with pytest.raises(ConfigError, match="must be a string"):
+            read_pyproject_config(path, discover_workspace=False)
+
+    def test_overlapping_entries_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab.packages."foo <= 2"]\nrequires-python = ">=3.6"\n'
+            '[tool.nab.packages."foo >= 1"]\nrequires-python = ">=3.7"\n',
+        )
+        with pytest.raises(ConfigError, match="overlapping versions"):
+            read_pyproject_config(path, discover_workspace=False)
+
+
+class TestPackageOverrideProvidesExtra:
+    """The ``provides-extra`` metadata override replaces the declared extras."""
+
+    def test_parses_and_normalises(self, tmp_path: Path) -> None:
+        # PEP 685: the names normalise, so spelling does not matter.
+        path = write(
+            tmp_path,
+            '[tool.nab.packages.flask]\nprovides-extra = ["Dot_Env", "async"]\n',
+        )
+        (override,) = read_pyproject_config(
+            path, discover_workspace=False
+        ).package_overrides
+        assert override.provides_extra == ("dot-env", "async")
+
+    def test_empty_list_stored_as_empty_tuple(self, tmp_path: Path) -> None:
+        # A present-but-empty list declares no extras, distinct from absent,
+        # and lifts the empty-body gate.
+        path = write(tmp_path, "[tool.nab.packages.flask]\nprovides-extra = []\n")
+        (override,) = read_pyproject_config(
+            path, discover_workspace=False
+        ).package_overrides
+        assert override.provides_extra == ()
+
+    def test_non_list_rejected(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab.packages.flask]\nprovides-extra = "x"\n')
+        with pytest.raises(ConfigError, match="must be a list of extra names"):
+            read_pyproject_config(path, discover_workspace=False)
+
+    def test_non_string_item_rejected(self, tmp_path: Path) -> None:
+        path = write(tmp_path, "[tool.nab.packages.flask]\nprovides-extra = [1]\n")
+        with pytest.raises(ConfigError, match=r"provides-extra\[0\] must be a string"):
+            read_pyproject_config(path, discover_workspace=False)
+
+    def test_overlapping_entries_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab.packages."foo <= 2"]\nprovides-extra = ["a"]\n'
+            '[tool.nab.packages."foo >= 1"]\nprovides-extra = ["b"]\n',
+        )
+        with pytest.raises(ConfigError, match="overlapping versions"):
+            read_pyproject_config(path, discover_workspace=False)
+
+
+class TestPackageMetadataBundle:
+    """All three metadata fields sit together on one entry (uv parity)."""
+
+    def test_full_bundle_parses(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab.packages.flask]\n"
+            'dependencies = ["werkzeug>=0.14", "click>=5.1 ; extra == \'dotenv\'"]\n'
+            'requires-python = ">=3.6"\n'
+            'provides-extra = ["dotenv"]\n',
+        )
+        (override,) = read_pyproject_config(
+            path, discover_workspace=False
+        ).package_overrides
+        assert [str(r) for r in override.dependencies or ()] == [
+            "werkzeug>=0.14",
+            'click>=5.1; extra == "dotenv"',
+        ]
+        assert override.requires_python == ">=3.6"
+        assert override.provides_extra == ("dotenv",)
+
+    def test_distinct_fields_do_not_overlap(self, tmp_path: Path) -> None:
+        # Different metadata fields over overlapping ranges are legal: the
+        # overlap check is per field, so deps on one range and
+        # requires-python on another (overlapping) range coexist.
+        path = write(
+            tmp_path,
+            '[tool.nab.packages."foo <= 2"]\ndependencies = ["a"]\n'
+            '[tool.nab.packages."foo >= 1"]\nrequires-python = ">=3.7"\n',
+        )
+        low, high = read_pyproject_config(
+            path, discover_workspace=False
+        ).package_overrides
+        assert [str(r) for r in low.dependencies or ()] == ["a"]
+        assert high.requires_python == ">=3.7"
+
+
 class TestIndexOverrides:
     """``[tool.nab.index.<name>]`` parses into a name-keyed policy map."""
 
@@ -2083,8 +2365,20 @@ class TestIndexOverrides:
             tmp_path,
             self._two_indexes() + '[tool.nab.index.internal]\nmarker = "x"\n',
         )
-        with pytest.raises(ConfigError, match="deferred to a later PR"):
+        with pytest.raises(ConfigError, match="are not supported"):
             read_pyproject_config(path, discover_workspace=False)
+
+    def test_metadata_key_rejected_without_flat_advice(self, tmp_path: Path) -> None:
+        # The flat body keys are rejected here too, so the nested ``metadata``
+        # table drops the package surface's flat-body hint.
+        path = write(
+            tmp_path,
+            self._two_indexes()
+            + '[tool.nab.index.internal]\nmetadata = { requires-python = ">=3.6" }\n',
+        )
+        with pytest.raises(ConfigError, match="are not supported") as excinfo:
+            read_pyproject_config(path, discover_workspace=False)
+        assert "flat body keys" not in str(excinfo.value)
 
 
 class TestMatrix:

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -26,8 +26,11 @@ from nab_python._lockfile.pylock import (
     _pin_to_package,
     _relativize_path,
 )
+from nab_python._testing.coordinator_fake import make_coordinator
+from nab_python._testing.overrides import pkg_override
 from nab_python._vendor.packaging.markers import Marker
 from nab_python._vendor.packaging.pylock import Package, PackageWheel, Pylock
+from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python._vendor.packaging.version import Version
 from nab_python.config import (
@@ -54,13 +57,22 @@ from nab_python.lockfile import (
     WheelArtifact,
     build_lock_input_from_provider,
     build_pylock,
+    package_metadata_override_records,
     read_lockfile_anchor,
     read_lockfile_packages,
     write_lock,
     write_requirements_with_hashes,
     write_requirements_without_hashes,
 )
-from nab_python.provider import DistPolicy, LocalSource, VcsConfig, VcsPolicy, VcsSource
+from nab_python.provider import (
+    BuildPolicy,
+    DistPolicy,
+    LocalSource,
+    Provider,
+    VcsConfig,
+    VcsPolicy,
+    VcsSource,
+)
 
 
 def _wheel(name: str = "foo", version: str = "1.0") -> WheelArtifact:
@@ -1187,10 +1199,88 @@ class TestProvenance:
             "macos_arm64",
         ]
 
+    def test_emits_package_metadata_overrides(self) -> None:
+        prov = Provenance(
+            nab_version="9.9.9",
+            created_at=datetime(2026, 5, 7, 12, 0, 0, tzinfo=timezone.utc),
+            command_line=("nab", "lock"),
+            input_path="pyproject.toml",
+            mode="specific",
+            package_metadata_overrides=(
+                ("chumpy", ("dependencies",)),
+                ("broken<=1.0", ("dependencies",)),
+            ),
+        )
+        text = write_lock(LockInput(pins={"foo": _index_pin()}, provenance=prov))
+        data = tomllib.loads(text)
+        assert data["tool"]["nab"]["package-metadata-overrides"] == [
+            "chumpy: dependencies",
+            "broken<=1.0: dependencies",
+        ]
+
+    def test_no_package_metadata_overrides_key_when_empty(self) -> None:
+        prov = Provenance(
+            nab_version="9.9.9",
+            created_at=datetime(2026, 5, 7, 12, 0, 0, tzinfo=timezone.utc),
+            command_line=("nab", "lock"),
+            input_path="pyproject.toml",
+            mode="specific",
+        )
+        text = write_lock(LockInput(pins={"foo": _index_pin()}, provenance=prov))
+        data = tomllib.loads(text)
+        assert "package-metadata-overrides" not in data["tool"]["nab"]
+
     def test_absent_provenance_means_no_tool_block(self) -> None:
         text = write_lock(LockInput(pins={"foo": _index_pin()}))
         data = tomllib.loads(text)
         assert "tool" not in data
+
+
+class TestPackageMetadataOverrideRecords:
+    """``package_metadata_override_records`` summarises metadata overrides."""
+
+    def test_records_dependencies_override(self) -> None:
+        overrides = (pkg_override("foo <= 2", dependencies=(Requirement("bar"),)),)
+        assert package_metadata_override_records(overrides) == (
+            ("foo<=2", ("dependencies",)),
+        )
+
+    def test_empty_dependencies_still_recorded(self) -> None:
+        # An empty tuple is set (not None), so it is recorded.
+        overrides = (pkg_override("foo", dependencies=()),)
+        assert package_metadata_override_records(overrides) == (
+            ("foo", ("dependencies",)),
+        )
+
+    def test_non_metadata_override_skipped(self) -> None:
+        # A policy-only entry sets no metadata field and is not recorded.
+        overrides = (pkg_override("foo", dist_policy=DistPolicy.SDIST_ONLY),)
+        assert package_metadata_override_records(overrides) == ()
+
+    def test_records_requires_python_override(self) -> None:
+        overrides = (pkg_override("foo", requires_python=">=3.6"),)
+        assert package_metadata_override_records(overrides) == (
+            ("foo", ("requires-python",)),
+        )
+
+    def test_records_provides_extra_override(self) -> None:
+        overrides = (pkg_override("foo", provides_extra=("dotenv",)),)
+        assert package_metadata_override_records(overrides) == (
+            ("foo", ("provides-extra",)),
+        )
+
+    def test_records_full_bundle_in_field_order(self) -> None:
+        overrides = (
+            pkg_override(
+                "foo",
+                dependencies=(Requirement("bar"),),
+                requires_python=">=3.6",
+                provides_extra=("dotenv",),
+            ),
+        )
+        assert package_metadata_override_records(overrides) == (
+            ("foo", ("dependencies", "requires-python", "provides-extra")),
+        )
 
 
 class TestReadLockfileAnchor:
@@ -1989,6 +2079,7 @@ class _FakeProvider:
         vcs_pins: dict[str, str] | None = None,
         listing_indexes: dict[str, str] | None = None,
         dist_policy_overrides: dict[str, DistPolicy] | None = None,
+        requires_python_overrides: dict[str, str] | None = None,
         deps_cache: dict[tuple[str, Version], dict[str, object]] | None = None,
         extra_deps_map: (
             dict[tuple[str, Version], dict[str, dict[str, object]]] | None
@@ -1999,6 +2090,7 @@ class _FakeProvider:
         self._vcs = vcs_sources or {}
         self._vcs_pins = vcs_pins or {}
         self._dist_policy_overrides = dist_policy_overrides or {}
+        self._requires_python_overrides = requires_python_overrides or {}
         self.coordinator = _FakeCoordinator(listing_indexes)
         self.deps_cache = deps_cache or {}
         self.extra_deps_map = extra_deps_map or {}
@@ -2021,6 +2113,9 @@ class _FakeProvider:
         self, canonical: str, version: Version, index_name: str | None = None
     ) -> DistPolicy:
         return self._dist_policy_overrides.get(canonical, DistPolicy.WHEEL_OR_SDIST)
+
+    def effective_requires_python(self, canonical: str, version: Version) -> str | None:
+        return self._requires_python_overrides.get(canonical)
 
 
 def _wheel_file(
@@ -2080,6 +2175,77 @@ class TestBuildLockInputFromProvider:
         assert len(pin.wheels) == 1
         assert pin.wheels[0].hashes == (("sha256", "a" * 64),)
         assert lock_input.requires_python == ">=3.10"
+
+    def test_index_pin_prefers_requires_python_override(self) -> None:
+        """A widened requires-python override is what the pin records.
+
+        The Simple-API files say ``>=3.10``; the user widened the package
+        to ``>=3.9``.  The pin must carry the overridden specifier so a
+        conforming PEP 751 installer does not reject a pin the resolver
+        admitted against the wider floor.
+        """
+        provider = _FakeProvider(
+            listings={
+                "foo": [
+                    (Version("1.0"), _wheel_file(requires_python=">=3.10")),
+                    (Version("1.0"), _sdist_file()),
+                ]
+            },
+            requires_python_overrides={"foo": ">=3.9"},
+        )
+        lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0")})
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.requires_python == ">=3.9"
+
+    def test_empty_requires_python_override_omits_lock_key(self) -> None:
+        """An empty-string override records verbatim and drops the lock key.
+
+        The files declare ``>=3.10``; the override clears the specifier to
+        ``""``.  The pin carries the empty string, and the writer's
+        truthiness check leaves ``requires-python`` out of the rendered lock.
+        """
+        provider = _FakeProvider(
+            listings={
+                "foo": [
+                    (Version("1.0"), _wheel_file(requires_python=">=3.10")),
+                    (Version("1.0"), _sdist_file()),
+                ]
+            },
+            requires_python_overrides={"foo": ""},
+        )
+        lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0")})
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.requires_python == ""
+        assert "requires-python" not in write_lock(lock_input)
+
+    def test_skip_fetch_override_pins_sdist_without_metadata(self) -> None:
+        """A skip-fetch package still produces a complete sdist lock pin.
+
+        A complete ``dependencies`` override resolves the version without a
+        METADATA fetch or build; the sdist listing (its hash recorded during
+        ``fetch_versions``) still flows into the pin and the rendered lock.
+        """
+        coordinator = make_coordinator([_sdist_file("pkg", "2.0")], package="pkg")
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            build_policy=BuildPolicy.NEVER,
+            package_overrides=(
+                pkg_override("pkg", dependencies=(Requirement("dep-a>=1"),)),
+            ),
+        )
+        provider.fetch_versions("pkg")
+        deps = provider.get_dependencies("pkg", Version("2.0"))
+        assert "dep-a" in deps
+        coordinator.request_metadata.assert_not_called()
+        coordinator.request_metadata_batch.assert_not_called()
+
+        lock_input = build_lock_input_from_provider(provider, {"pkg": Version("2.0")})
+        text = write_lock(lock_input)
+        assert "pkg-2.0.tar.gz" in text
+        assert "b" * 64 in text
 
     def test_local_path_threads_to_artifact(self, tmp_path: Path) -> None:
         """A WheelFile.local_path reaches the emitted WheelArtifact."""

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -16,20 +16,23 @@ from nab_index.client import (
     SdistHashMismatchError,
     WheelFile,
 )
+from nab_python._provider import build_remote, metadata_resolver
 from nab_python._provider.metadata_resolver import (
     add_classified_dep,
+    cache_deps_from_metadata,
     classify_requirement,
     pick_dist_for_metadata,
 )
 from nab_python._testing.coordinator_fake import make_coordinator
+from nab_python._testing.overrides import pkg_override
 from nab_python._vendor.packaging.markers import Marker
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.specifiers import SpecifierSet
-from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python._vendor.packaging.version import InvalidVersion, Version
 from nab_python.config import IndexOverride, OverrideConflictError, PackageOverride
 from nab_python.fetch import InMemoryIndex
+from nab_python.metadata import WheelMetadata
 from nab_python.provider import (
     BuildPolicy,
     DistPolicy,
@@ -48,21 +51,11 @@ from nab_python.provider import (
     _add_extra_marker,
     python_axis_environment,
 )
-from nab_resolver.resolver import Resolver
+from nab_python.resolve import _raise_for_local_vcs_python
+from nab_resolver.resolver import ResolutionError, Resolver
 from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
 
 V = Version
-
-
-def pkg_override(req_str: str, **body: object) -> PackageOverride:
-    """Build a :class:`PackageOverride` from a PEP 508 requirement string."""
-    requirement = Requirement(req_str)
-    return PackageOverride(
-        requirement=requirement,
-        name=canonicalize_name(requirement.name),
-        version_range=requirement.specifier.to_range(),
-        **body,  # type: ignore[arg-type]
-    )
 
 
 def make_wheel(
@@ -2835,6 +2828,645 @@ class TestEffectiveTrustUnverified:
         assert provider.effective_trust_unverified("foo", V("1.0"), "pypi") is False
 
 
+class TestDependenciesOverride:
+    """A per-package ``dependencies`` override replaces runtime deps."""
+
+    def test_effective_dependencies_version_scoped(self) -> None:
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(
+            coordinator,
+            package_overrides=(
+                pkg_override("foo <= 2", dependencies=(Requirement("bar>=1"),)),
+            ),
+        )
+        in_range = provider.effective_dependencies("foo", V("1.0"))
+        assert in_range is not None
+        assert [str(r) for r in in_range] == ["bar>=1"]
+        # Out of range and unknown package both fall through to None.
+        assert provider.effective_dependencies("foo", V("5.0")) is None
+        assert provider.effective_dependencies("other", V("1.0")) is None
+
+    def test_effective_dependencies_none_without_override(self) -> None:
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(coordinator)
+        assert provider.effective_dependencies("foo", V("1.0")) is None
+
+    def test_substitution_replaces_base_deps(self) -> None:
+        coordinator = make_coordinator(
+            [make_wheel("1.0")],
+            metadata_text=(
+                "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n"
+                "Requires-Dist: original>=1\n"
+            ),
+            package="foo",
+        )
+        provider = Provider(
+            coordinator,
+            package_overrides=(
+                pkg_override("foo", dependencies=(Requirement("replacement>=2"),)),
+            ),
+        )
+        deps = provider.get_dependencies("foo", V("1.0"))
+        assert "replacement" in deps
+        assert "original" not in deps
+
+    def test_empty_list_yields_zero_deps(self) -> None:
+        coordinator = make_coordinator(
+            [make_wheel("1.0")],
+            metadata_text=(
+                "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n"
+                "Requires-Dist: original>=1\n"
+            ),
+            package="foo",
+        )
+        provider = Provider(
+            coordinator,
+            package_overrides=(pkg_override("foo", dependencies=()),),
+        )
+        assert provider.get_dependencies("foo", V("1.0")) == {}
+
+    def test_undeclared_extra_request_raises(self) -> None:
+        # The override declares no ``provides-extra``, so the parsed
+        # ``security`` extra no longer exists; requesting it raises.
+        coordinator = make_coordinator(
+            [make_wheel("1.0")],
+            metadata_text=(
+                "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n"
+                "Provides-Extra: security\n"
+                'Requires-Dist: cryptography>=2.0; extra == "security"\n'
+            ),
+            package="foo",
+        )
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            extras_mode=ExtrasMode.ERROR_USER,
+            root_extras={("foo", "security")},
+            package_overrides=(
+                pkg_override("foo", dependencies=(Requirement("bar>=1"),)),
+            ),
+        )
+        with pytest.raises(MissingExtraError):
+            provider.get_dependencies("foo[security]", V("1.0"))
+
+    def test_funnel_does_not_mutate_shared_metadata(self) -> None:
+        # The raw parse is shared across tuples via ``store_parsed_metadata``,
+        # so the funnel must build a fresh record, never mutate the input.
+        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
+        provider = Provider(
+            coordinator,
+            package_overrides=(
+                pkg_override("foo", dependencies=(Requirement("replacement>=2"),)),
+            ),
+        )
+        shared = WheelMetadata(
+            name="foo",
+            version=V("1.0"),
+            requires_dist=[Requirement("original>=1")],
+            provides_extra=["security"],
+        )
+        cache_key = ("foo", V("1.0"))
+        cache_deps_from_metadata(provider, cache_key, shared)
+        # The shared input object is untouched.
+        assert [str(r) for r in shared.requires_dist] == ["original>=1"]
+        assert shared.provides_extra == ["security"]
+        # The cached record is a fresh, overridden object.
+        cached = provider.metadata_cache[cache_key]
+        assert cached is not shared
+        assert [str(r) for r in cached.requires_dist] == ["replacement>=2"]
+        assert cached.provides_extra == []
+        assert "replacement" in provider.deps_cache[cache_key]
+        assert "original" not in provider.deps_cache[cache_key]
+
+
+class TestEffectiveMetadataOverrideFields:
+    """``effective_requires_python`` / ``effective_provides_extra`` lookups."""
+
+    def test_requires_python_version_scoped(self) -> None:
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(
+            coordinator,
+            package_overrides=(pkg_override("foo <= 2", requires_python=">=3.6"),),
+        )
+        assert provider.effective_requires_python("foo", V("1.0")) == ">=3.6"
+        assert provider.effective_requires_python("foo", V("5.0")) is None
+
+    def test_requires_python_none_without_override(self) -> None:
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(coordinator)
+        assert provider.effective_requires_python("foo", V("1.0")) is None
+
+    def test_provides_extra_version_scoped(self) -> None:
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(
+            coordinator,
+            package_overrides=(pkg_override("foo <= 2", provides_extra=("dotenv",)),),
+        )
+        assert provider.effective_provides_extra("foo", V("1.0")) == ("dotenv",)
+        assert provider.effective_provides_extra("foo", V("5.0")) is None
+
+    def test_provides_extra_none_without_override(self) -> None:
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(coordinator)
+        assert provider.effective_provides_extra("foo", V("1.0")) is None
+
+
+class TestMetadataOverrideForSource:
+    """Local/VCS sources select bare-name-only metadata overrides."""
+
+    def _provider(self, *overrides: PackageOverride) -> Provider:
+        coordinator = make_coordinator([], package="foo")
+        return Provider(
+            coordinator,
+            local_sources=[LocalSource("foo", "/nonexistent")],
+            package_overrides=overrides,
+            build_policy=BuildPolicy.NEVER,
+        )
+
+    def test_bare_name_dependencies_apply(self) -> None:
+        provider = self._provider(
+            pkg_override("foo", dependencies=(Requirement("dep-a>=1"),))
+        )
+        deps, rp, pe = provider.effective_metadata_override("foo", V("1.0"))
+        assert [str(r) for r in deps or ()] == ["dep-a>=1"]
+        assert rp is None
+        assert pe is None
+
+    def test_version_scoped_does_not_apply(self) -> None:
+        # A version-scoped metadata override does not govern a source: the
+        # materialised version is not knowable when writing the selector.
+        provider = self._provider(
+            pkg_override("foo <= 2", dependencies=(Requirement("dep-a>=1"),))
+        )
+        assert provider.effective_metadata_override("foo", V("1.0")) == (
+            None,
+            None,
+            None,
+        )
+
+    def test_other_package_does_not_apply(self) -> None:
+        provider = self._provider(
+            pkg_override("other", dependencies=(Requirement("dep-a>=1"),))
+        )
+        assert provider.effective_metadata_override("foo", V("1.0")) == (
+            None,
+            None,
+            None,
+        )
+
+    def test_bare_name_setting_only_one_field(self) -> None:
+        # A bare-name override that sets only requires-python leaves the other
+        # two fields unset.
+        provider = self._provider(pkg_override("foo", requires_python=">=3.6"))
+        deps, rp, pe = provider.effective_metadata_override("foo", V("1.0"))
+        assert deps is None
+        assert rp == ">=3.6"
+        assert pe is None
+
+    def test_bare_name_setting_no_metadata_field(self) -> None:
+        # A bare-name override that sets only a policy field contributes no
+        # metadata override for the source.
+        provider = self._provider(pkg_override("foo", build_policy=BuildPolicy.NEVER))
+        assert provider.effective_metadata_override("foo", V("1.0")) == (
+            None,
+            None,
+            None,
+        )
+
+    def test_provides_extra_applies(self) -> None:
+        provider = self._provider(pkg_override("foo", provides_extra=("dotenv",)))
+        deps, rp, pe = provider.effective_metadata_override("foo", V("1.0"))
+        assert deps is None
+        assert rp is None
+        assert pe == ("dotenv",)
+
+    def test_fields_from_different_bare_entries(self) -> None:
+        # Two bare-name entries setting different fields: each field is
+        # taken from the entry that sets it.
+        provider = self._provider(
+            pkg_override("foo", dependencies=(Requirement("dep-a>=1"),)),
+            pkg_override("foo", requires_python=">=3.6"),
+        )
+        deps, rp, pe = provider.effective_metadata_override("foo", V("1.0"))
+        assert [str(r) for r in deps or ()] == ["dep-a>=1"]
+        assert rp == ">=3.6"
+        assert pe is None
+
+    def test_metadata_override_source_branch(self) -> None:
+        provider = self._provider(
+            pkg_override(
+                "foo",
+                dependencies=(Requirement("dep-a"),),
+                requires_python=">=3.6",
+                provides_extra=("dotenv",),
+            )
+        )
+        deps, rp, pe = provider.effective_metadata_override("foo", V("1.0"))
+        assert [str(r) for r in deps or ()] == ["dep-a"]
+        assert rp == ">=3.6"
+        assert pe == ("dotenv",)
+
+    def test_metadata_override_index_branch(self) -> None:
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(
+            coordinator,
+            package_overrides=(
+                pkg_override("foo <= 2", dependencies=(Requirement("dep-a"),)),
+            ),
+        )
+        deps, rp, pe = provider.effective_metadata_override("foo", V("1.0"))
+        assert [str(r) for r in deps or ()] == ["dep-a"]
+        assert rp is None
+        assert pe is None
+
+
+class TestMetadataFunnelBundle:
+    """The funnel replaces each of the three metadata fields per-field."""
+
+    @staticmethod
+    def _parsed() -> WheelMetadata:
+        return WheelMetadata(
+            name="foo",
+            version=V("1.0"),
+            requires_python=SpecifierSet(">=3.8"),
+            requires_dist=[
+                Requirement("original>=1"),
+                Requirement('sec-dep; extra == "security"'),
+            ],
+            provides_extra=["security"],
+        )
+
+    def _apply(self, **body: object) -> Provider:
+        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
+        provider = Provider(
+            coordinator,
+            package_overrides=(pkg_override("foo", **body),),
+        )
+        cache_deps_from_metadata(provider, ("foo", V("1.0")), self._parsed())
+        return provider
+
+    def test_dependencies_only(self) -> None:
+        # deps set, rp/pe unset: requires_dist replaced, requires_python
+        # kept from parsed, provides_extra emptied.
+        cached = self._apply(
+            dependencies=(Requirement("replacement>=2"),)
+        ).metadata_cache[("foo", V("1.0"))]
+        assert [str(r) for r in cached.requires_dist] == ["replacement>=2"]
+        assert cached.requires_python == SpecifierSet(">=3.8")
+        assert cached.provides_extra == []
+
+    def test_requires_python_only(self) -> None:
+        # rp set, deps/pe unset: requires_python replaced, requires_dist and
+        # provides_extra kept from parsed.  A non-deps override leaves the dep
+        # list intact, so the parsed extras stay coherent and must survive.
+        provider = self._apply(requires_python=">=3.6")
+        cache_key = ("foo", V("1.0"))
+        cached = provider.metadata_cache[cache_key]
+        assert cached.requires_python == SpecifierSet(">=3.6")
+        assert [str(r) for r in cached.requires_dist] == [
+            "original>=1",
+            'sec-dep; extra == "security"',
+        ]
+        assert cached.provides_extra == ["security"]
+        # The parsed extra's dep is still reachable under that extra.
+        assert "sec-dep" in provider.extra_deps_map[cache_key]["security"]
+
+    def test_provides_extra_only(self) -> None:
+        # pe set, deps/rp unset: provides_extra replaced, requires_dist and
+        # requires_python kept from parsed.
+        provider = self._apply(provides_extra=("security",))
+        cached = provider.metadata_cache[("foo", V("1.0"))]
+        assert cached.provides_extra == ["security"]
+        assert cached.requires_python == SpecifierSet(">=3.8")
+        assert [str(r) for r in cached.requires_dist] == [
+            "original>=1",
+            'sec-dep; extra == "security"',
+        ]
+        # The declared extra keeps its extra-markered dep.
+        assert "sec-dep" in provider.extra_deps_map[("foo", V("1.0"))]["security"]
+
+    def test_full_bundle_extras_coherent(self) -> None:
+        provider = self._apply(
+            dependencies=(
+                Requirement("werkzeug>=0.14"),
+                Requirement('click>=5.1; extra == "dotenv"'),
+            ),
+            requires_python=">=3.6",
+            provides_extra=("dotenv",),
+        )
+        cache_key = ("foo", V("1.0"))
+        cached = provider.metadata_cache[cache_key]
+        assert cached.requires_python == SpecifierSet(">=3.6")
+        assert cached.provides_extra == ["dotenv"]
+        # werkzeug is a base dep; click lives under the declared dotenv extra.
+        assert "werkzeug" in provider.deps_cache[cache_key]
+        assert "click" not in provider.deps_cache[cache_key]
+        assert "click" in provider.extra_deps_map[cache_key]["dotenv"]
+        # The parsed ``security`` extra is gone (override is authoritative).
+        assert "security" not in provider.extra_deps_map[cache_key]
+
+
+class TestRequiresPythonListingGate:
+    """``excluded_by_python`` consults the requires-python override."""
+
+    def test_widen_admits_across_minor_boundary(self) -> None:
+        # Real >=3.10 would exclude a 3.9 target; the override widens to
+        # >=3.9, so the version is admitted.
+        coordinator = make_coordinator(
+            [make_wheel("1.0", requires_python=">=3.10")], package="foo"
+        )
+        provider = Provider(
+            coordinator,
+            python_version="3.9.0",
+            package_overrides=(pkg_override("foo", requires_python=">=3.9"),),
+        )
+        assert [v for v, _ in provider.fetch_versions("foo")] == [V("1.0")]
+
+    def test_narrow_rejects_across_minor_boundary(self) -> None:
+        # Real >=3.6 would admit a 3.10 target; the override narrows to
+        # >=3.11, so the version is rejected.
+        coordinator = make_coordinator(
+            [make_wheel("1.0", requires_python=">=3.6")], package="foo"
+        )
+        provider = Provider(
+            coordinator,
+            python_version="3.10.0",
+            package_overrides=(pkg_override("foo", requires_python=">=3.11"),),
+        )
+        assert provider.fetch_versions("foo") == []
+
+    def test_empty_specifier_admits(self) -> None:
+        # An override of "" (no Python requirement) widens to admit anything.
+        coordinator = make_coordinator(
+            [make_wheel("1.0", requires_python=">=3.99")], package="foo"
+        )
+        provider = Provider(
+            coordinator,
+            python_version="3.9.0",
+            package_overrides=(pkg_override("foo", requires_python=""),),
+        )
+        assert [v for v, _ in provider.fetch_versions("foo")] == [V("1.0")]
+
+    def test_override_does_not_poison_shared_cache(self) -> None:
+        # foo and bar both declare >=3.11 (same raw string). foo widens to
+        # >=3.0; bar has no override. On 3.10, foo is admitted and bar stays
+        # excluded.  The override shares the string-keyed cache under its own
+        # ">=3.0" key, so it never poisons the ">=3.11" entry bar reads.
+        coordinator = make_coordinator(
+            listings={
+                "foo": [make_wheel("1.0", requires_python=">=3.11")],
+                "bar": [make_wheel("1.0", requires_python=">=3.11")],
+            },
+        )
+        provider = Provider(
+            coordinator,
+            python_version="3.10.0",
+            package_overrides=(pkg_override("foo", requires_python=">=3.0"),),
+        )
+        assert [v for v, _ in provider.fetch_versions("foo")] == [V("1.0")]
+        assert provider.fetch_versions("bar") == []
+        assert provider.requires_python_cache == {">=3.0": False, ">=3.11": True}
+
+    def test_override_without_python_version_not_excluded(self) -> None:
+        # With no Python target the override cannot compare, so it does not
+        # exclude the version.
+        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
+        provider = Provider(
+            coordinator,
+            python_version=None,
+            package_overrides=(pkg_override("foo", requires_python=">=3.11"),),
+        )
+        assert len(provider.fetch_versions("foo")) == 1
+
+
+class TestSkipFetch:
+    """A complete ``dependencies`` override skips the metadata fetch/build."""
+
+    def test_fires_when_dependencies_present(self) -> None:
+        # No metadata is available, so a real fetch would raise; the
+        # override resolves the version from declared deps alone.
+        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            package_overrides=(
+                pkg_override("foo", dependencies=(Requirement("dep-a>=1"),)),
+            ),
+        )
+        deps = provider.get_dependencies("foo", V("1.0"))
+        assert "dep-a" in deps
+
+    def test_fires_with_empty_dependencies(self) -> None:
+        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            package_overrides=(pkg_override("foo", dependencies=()),),
+        )
+        assert provider.get_dependencies("foo", V("1.0")) == {}
+
+    def test_prefetches_override_dependencies(self) -> None:
+        # The override introduces dep-a, so its listing is background-fetched
+        # even though foo itself skips the metadata fetch.
+        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            package_overrides=(
+                pkg_override("foo", dependencies=(Requirement("dep-a>=1"),)),
+            ),
+        )
+        provider.get_dependencies("foo", V("1.0"))
+        coordinator.request_listing.assert_any_call("dep-a")
+
+    def test_does_not_fire_for_requires_python_only(self) -> None:
+        # A partial override (only requires-python) still needs the artifact
+        # for deps, so with no metadata available it raises.
+        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            package_overrides=(pkg_override("foo", requires_python=">=3.0"),),
+        )
+        with pytest.raises(MetadataError):
+            provider.get_dependencies("foo", V("1.0"))
+
+    def test_sdist_only_under_never_resolves_via_scan(self) -> None:
+        # Strict PEP 643 x BuildPolicy.NEVER: dynamic-deps sdists are
+        # unresolvable without a build (see the no-override companion in
+        # TestNoVersionsReasons).  A complete override rescues them, reached
+        # through the look-ahead scan in choose_version.
+        coordinator = make_coordinator(
+            [make_sdist("1.0"), make_sdist("2.0")],
+            sdist_pkg_info=PKG_INFO_DYNAMIC_DEPS,
+            package="pkg",
+        )
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            dist_policy=DistPolicy.WHEEL_OR_SDIST,
+            build_policy=BuildPolicy.NEVER,
+            root_requirements={"pkg": VersionRange.full()},
+            package_overrides=(
+                pkg_override("pkg", dependencies=(Requirement("dep-a>=1"),)),
+            ),
+        )
+        assert provider.choose_version("pkg", VersionRange.full()) == V("2.0")
+        assert "dep-a" in provider.deps_cache[("pkg", V("2.0"))]
+
+    def test_corrupt_wheel_resolves_via_scan(self) -> None:
+        # A corrupt-metadata wheel would make await_metadata_batch raise in
+        # the prefetch path.  A complete override short-circuits submission,
+        # so the scan reaches get_dependencies (skip-fetch) and resolves.
+        coordinator = make_coordinator(
+            [make_wheel("3.0"), make_wheel("2.0")],
+            metadata_by_version={
+                "3.0": (
+                    "Metadata-Version: 2.1\nName: pkg\nVersion: 3.0\n"
+                    "Requires-Dist: bar==2.0\n"
+                ),
+            },
+            package="pkg",
+        )
+        coordinator.index.store_metadata_error(
+            "pkg", "2.0", MetadataHashMismatchError("metadata sha256 mismatch")
+        )
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            root_requirements={"pkg": VersionRange.full()},
+            package_overrides=(
+                pkg_override("pkg == 2.0", dependencies=(Requirement("dep-a>=1"),)),
+            ),
+        )
+        # 3.0's real deps conflict with this decision, forcing the scan past
+        # 3.0 into the prefetch batch that would fetch the corrupt 2.0 wheel.
+        provider.solution_decisions["bar"] = V("1.0")
+        assert provider.choose_version("pkg", VersionRange.full()) == V("2.0")
+        assert "dep-a" in provider.deps_cache[("pkg", V("2.0"))]
+
+    def test_prefetch_batch_skips_complete_override(self) -> None:
+        # Direct check: prefetch_batch submits nothing for a version with a
+        # complete override, even though its wheel advertises PEP 658.
+        coordinator = make_coordinator(
+            [make_wheel("1.0"), make_wheel("2.0")], package="pkg"
+        )
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            package_overrides=(
+                pkg_override("pkg", dependencies=(Requirement("dep-a"),)),
+            ),
+        )
+        version_list = provider.fetch_versions("pkg")
+        wheel_by_version = provider._wheel_by_version("pkg", version_list)
+        submitted = provider._prefetch_batch(
+            "pkg", [V("2.0"), V("1.0")], wheel_by_version
+        )
+        assert submitted == []
+
+    def test_prefetch_root_batch_skips_complete_override(self) -> None:
+        # The root-range batch prefetch skips a version whose complete
+        # override replaces its metadata, but still submits the sibling.
+        coordinator = make_coordinator(
+            [make_wheel("2.0"), make_wheel("1.0")], package="pkg"
+        )
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            root_requirements={"pkg": SpecifierSet(">=1.0").to_range()},
+            package_overrides=(
+                pkg_override("pkg == 2.0", dependencies=(Requirement("dep-a"),)),
+            ),
+        )
+        provider.fetch_versions("pkg")
+        items = coordinator.request_metadata_batch.call_args[0][0]
+        versions = [ver for _, ver, _, _ in items]
+        assert "2.0" not in versions
+        assert "1.0" in versions
+
+    def test_prefetch_transitive_best_skips_complete_override(self) -> None:
+        # The single-best transitive prefetch submits nothing when the best
+        # candidate's metadata is replaced by a complete override.
+        coordinator = make_coordinator(
+            [make_wheel("2.0"), make_wheel("1.0")], package="pkg"
+        )
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            package_overrides=(
+                pkg_override("pkg", dependencies=(Requirement("dep-a"),)),
+            ),
+        )
+        provider.fetch_versions("pkg")
+        coordinator.request_metadata.assert_not_called()
+        coordinator.request_metadata_batch.assert_not_called()
+
+    def test_prefetch_walk_ahead_skips_complete_override(self) -> None:
+        # The walk-ahead batch excludes a version whose complete override
+        # replaces its metadata, but keeps the un-overridden sibling.
+        coordinator = make_coordinator(
+            [make_wheel("2.0"), make_wheel("1.0")], package="pkg"
+        )
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            package_overrides=(
+                pkg_override("pkg == 2.0", dependencies=(Requirement("dep-a"),)),
+            ),
+        )
+        provider.fetch_versions("pkg")
+        coordinator.reset_mock()
+        provider.prefetch_walk_ahead("pkg")
+        items = coordinator.request_metadata_batch.call_args[0][0]
+        versions = [ver for _, ver, _, _ in items]
+        assert "2.0" not in versions
+        assert "1.0" in versions
+
+
+class TestLocalVcsPythonGuardOverride:
+    """The local/VCS python guard reads the overridden requires-python."""
+
+    def _local_provider(
+        self, tmp_path: Path, pyproject_rp: str, override_rp: str
+    ) -> Provider:
+        (tmp_path / "pyproject.toml").write_text(
+            "[project]\n"
+            'name = "foo"\n'
+            'version = "1.0"\n'
+            f'requires-python = "{pyproject_rp}"\n'
+            'dependencies = ["dep-a>=1"]\n',
+            encoding="utf-8",
+        )
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(
+            coordinator,
+            python_version="3.9.0",
+            local_sources=[LocalSource("foo", str(tmp_path))],
+            build_policy=BuildPolicy.NEVER,
+            package_overrides=(pkg_override("foo", requires_python=override_rp),),
+        )
+        provider.get_dependencies("foo", V("1.0"))
+        return provider
+
+    def test_widen_admits(self, tmp_path: Path) -> None:
+        # pyproject demands >=3.11 (would reject 3.9); the bare-name override
+        # widens to >=3.0, so the guard admits the 3.9 target.
+        provider = self._local_provider(tmp_path, ">=3.11", ">=3.0")
+        stamped = provider.metadata_cache[("foo", V("1.0"))].requires_python
+        assert stamped == SpecifierSet(">=3.0")
+        _raise_for_local_vcs_python(provider, {"foo": V("1.0")}, V("3.9"))
+
+    def test_narrow_rejects(self, tmp_path: Path) -> None:
+        # pyproject allows >=3.0; the override narrows to >=3.11, so the
+        # guard rejects the 3.9 target.
+        provider = self._local_provider(tmp_path, ">=3.0", ">=3.11")
+        stamped = provider.metadata_cache[("foo", V("1.0"))].requires_python
+        assert stamped == SpecifierSet(">=3.11")
+        with pytest.raises(ResolutionError):
+            _raise_for_local_vcs_python(provider, {"foo": V("1.0")}, V("3.9"))
+
+
 class TestEffectiveFieldResolution:
     """Per-package vs per-index resolution and cross-surface conflicts."""
 
@@ -5165,9 +5797,7 @@ class TestEffectiveBuildPolicy:
         build backend (mocked here).  The previous silent-passthrough
         behaviour (return dynamic metadata as-is) is gone.
         """
-        from nab_python._provider import build_remote, metadata_resolver
         from nab_python._vendor.packaging.version import Version as _Version
-        from nab_python.metadata import WheelMetadata as _WheelMetadata
 
         coordinator = make_coordinator(
             [make_sdist("1.0")],
@@ -5204,7 +5834,7 @@ class TestEffectiveBuildPolicy:
             captured["bytes"] = data
             return target
 
-        built_meta = _WheelMetadata(
+        built_meta = WheelMetadata(
             name="pkg",
             version=_Version("1.0"),
             requires_python=None,
@@ -5214,7 +5844,7 @@ class TestEffectiveBuildPolicy:
 
         def fake_build(
             _path: object, *, config: object, python_version: object
-        ) -> _WheelMetadata:
+        ) -> WheelMetadata:
             captured["config"] = config
             captured["python_version"] = python_version
             return built_meta
@@ -5222,7 +5852,7 @@ class TestEffectiveBuildPolicy:
         monkeypatch.setattr(build_remote, "extract_sdist_archive", fake_extract)
         monkeypatch.setattr("nab_python.build_backend.extract_metadata", fake_build)
 
-        starting = _WheelMetadata(
+        starting = WheelMetadata(
             name="pkg",
             version=_Version("1.0"),
             requires_python=None,
@@ -5245,13 +5875,11 @@ class TestEffectiveBuildPolicy:
         importantly, re-building) the same sdist for every tuple.  The
         cache key is the canonical name + version string.
         """
-        from nab_python._provider import metadata_resolver
         from nab_python._vendor.packaging.version import Version as _Version
-        from nab_python.metadata import WheelMetadata as _WheelMetadata
 
         coordinator = make_coordinator([make_sdist("1.0")], package="pkg")
         provider = Provider(coordinator, python_version="3.12.0")
-        cached_meta = _WheelMetadata(
+        cached_meta = WheelMetadata(
             name="pkg",
             version=_Version("1.0"),
             requires_python=None,
@@ -5260,7 +5888,7 @@ class TestEffectiveBuildPolicy:
         )
         coordinator.index.store_resolved_sdist_metadata("pkg", "1.0", cached_meta)
 
-        starting = _WheelMetadata(
+        starting = WheelMetadata(
             name="pkg",
             version=_Version("1.0"),
             requires_python=None,
@@ -5644,9 +6272,6 @@ class TestStaticSdistMetadata:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """``BUILD_REMOTE`` fetches the sdist, extracts, and builds it."""
-        from nab_python._provider import build_remote
-        from nab_python.metadata import WheelMetadata as _WheelMetadata
-
         coordinator = make_coordinator(
             [make_sdist("1.0")],
             sdist_pkg_info=PKG_INFO_DYNAMIC_DEPS,
@@ -5664,7 +6289,7 @@ class TestStaticSdistMetadata:
 
         coordinator.request_sdist_archive.side_effect = _request_archive
 
-        built = _WheelMetadata(
+        built = WheelMetadata(
             name="pkg",
             version=V("1.0"),
             requires_python=None,
@@ -5734,7 +6359,12 @@ class TestBuildRemoteFailureModes:
     message into the eventual no-versions diagnostic.
     """
 
-    def _provider(self, *, with_sdist: bool) -> Provider:
+    def _provider(
+        self,
+        *,
+        with_sdist: bool,
+        overrides: tuple[PackageOverride, ...] = (),
+    ) -> Provider:
         files = [make_sdist("1.0")] if with_sdist else [make_wheel("1.0")]
         coordinator = make_coordinator(files, package="pkg")
         return Provider(
@@ -5742,11 +6372,10 @@ class TestBuildRemoteFailureModes:
             python_version="3.12.0",
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.BUILD_REMOTE,
+            package_overrides=overrides,
         )
 
     def test_missing_sdist_in_listing_raises(self) -> None:
-        from nab_python._provider import build_remote
-
         provider = self._provider(with_sdist=False)
         # Listing only has a wheel; build_remote_sdist needs an sdist.
         provider.versions_cache["pkg"] = [(V("1.0"), make_wheel("1.0"))]
@@ -5754,8 +6383,6 @@ class TestBuildRemoteFailureModes:
             build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
 
     def test_archive_fetch_failure_raises(self) -> None:
-        from nab_python._provider import build_remote
-
         provider = self._provider(with_sdist=True)
         provider.versions_cache["pkg"] = [(V("1.0"), make_sdist("1.0"))]
 
@@ -5780,8 +6407,6 @@ class TestBuildRemoteFailureModes:
         The error must propagate, not degrade to ``UnsupportedSdistError``,
         which the resolve treats as a skippable version.
         """
-        from nab_python._provider import build_remote
-
         provider = self._provider(with_sdist=True)
         provider.versions_cache["pkg"] = [(V("1.0"), make_sdist("1.0"))]
 
@@ -5805,8 +6430,6 @@ class TestBuildRemoteFailureModes:
     def test_archive_extract_failure_raises(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        from nab_python._provider import build_remote
-
         provider = self._provider(with_sdist=True)
         provider.versions_cache["pkg"] = [(V("1.0"), make_sdist("1.0"))]
 
@@ -5834,7 +6457,6 @@ class TestBuildRemoteFailureModes:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from nab_python import build_backend
-        from nab_python._provider import build_remote
 
         provider = self._provider(with_sdist=True)
         provider.versions_cache["pkg"] = [(V("1.0"), make_sdist("1.0"))]
@@ -5863,8 +6485,6 @@ class TestBuildRemoteFailureModes:
             build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
 
     def test_find_sdist_skips_non_matching_versions(self) -> None:
-        from nab_python._provider import build_remote
-
         provider = self._provider(with_sdist=True)
         # Two versions, only 2.0 has an sdist.
         provider.versions_cache["pkg"] = [
@@ -5888,10 +6508,14 @@ class TestBuildRemoteFailureModes:
         with pytest.raises(UnsupportedSdistError, match="no sdist is available"):
             build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
 
-    def _build_into(self, monkeypatch: pytest.MonkeyPatch, built: object) -> Provider:
-        from nab_python._provider import build_remote
-
-        provider = self._provider(with_sdist=True)
+    def _build_into(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        built: object,
+        *,
+        overrides: tuple[PackageOverride, ...] = (),
+    ) -> Provider:
+        provider = self._provider(with_sdist=True, overrides=overrides)
         provider.versions_cache["pkg"] = [(V("1.0"), make_sdist("1.0"))]
 
         def _ok_fetch(
@@ -5917,10 +6541,7 @@ class TestBuildRemoteFailureModes:
     def test_built_requires_python_excludes_target_raises(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        from nab_python._provider import build_remote
-        from nab_python.metadata import WheelMetadata as _WheelMetadata
-
-        built = _WheelMetadata(
+        built = WheelMetadata(
             name="pkg",
             version=V("1.0"),
             requires_python=SpecifierSet(">=3.13"),
@@ -5934,10 +6555,7 @@ class TestBuildRemoteFailureModes:
     def test_built_requires_python_compatible_accepted(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        from nab_python._provider import build_remote
-        from nab_python.metadata import WheelMetadata as _WheelMetadata
-
-        built = _WheelMetadata(
+        built = WheelMetadata(
             name="pkg",
             version=V("1.0"),
             requires_python=SpecifierSet(">=3.10"),
@@ -5951,10 +6569,7 @@ class TestBuildRemoteFailureModes:
     def test_built_requires_python_no_target_skips_check(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        from nab_python._provider import build_remote
-        from nab_python.metadata import WheelMetadata as _WheelMetadata
-
-        built = _WheelMetadata(
+        built = WheelMetadata(
             name="pkg",
             version=V("1.0"),
             requires_python=SpecifierSet(">=3.13"),
@@ -5966,11 +6581,48 @@ class TestBuildRemoteFailureModes:
         result = build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
         assert result is built
 
-    def test_built_name_mismatch_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        from nab_python._provider import build_remote
-        from nab_python.metadata import WheelMetadata as _WheelMetadata
+    def test_override_widens_requires_python_accepts(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The built value excludes the 3.12 target; a widening override
+        # admits it, matching what the listing gate already accepted.
+        built = WheelMetadata(
+            name="pkg",
+            version=V("1.0"),
+            requires_python=SpecifierSet(">=3.13"),
+            requires_dist=[Requirement("dep-a>=1")],
+            provides_extra=[],
+        )
+        provider = self._build_into(
+            monkeypatch,
+            built,
+            overrides=(pkg_override("pkg", requires_python=">=3.9"),),
+        )
+        result = build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
+        assert result is built
 
-        wrong = _WheelMetadata(
+    def test_override_narrows_requires_python_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The built value admits the 3.12 target; a narrowing override
+        # excludes it, so the build is rejected.
+        built = WheelMetadata(
+            name="pkg",
+            version=V("1.0"),
+            requires_python=SpecifierSet(">=3.10"),
+            requires_dist=[Requirement("dep-a>=1")],
+            provides_extra=[],
+        )
+        provider = self._build_into(
+            monkeypatch,
+            built,
+            overrides=(pkg_override("pkg", requires_python=">=3.13"),),
+        )
+        with pytest.raises(UnsupportedSdistError, match="requires Python"):
+            build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
+
+    def test_built_name_mismatch_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        wrong = WheelMetadata(
             name="other-pkg",
             version=V("1.0"),
             requires_python=None,
@@ -5984,10 +6636,7 @@ class TestBuildRemoteFailureModes:
     def test_built_version_mismatch_raises(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        from nab_python._provider import build_remote
-        from nab_python.metadata import WheelMetadata as _WheelMetadata
-
-        wrong = _WheelMetadata(
+        wrong = WheelMetadata(
             name="pkg",
             version=V("2.0"),
             requires_python=None,

--- a/nab-python/tests/universal/test_reresolve.py
+++ b/nab-python/tests/universal/test_reresolve.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 
 from nab_index.client import WheelFile
 from nab_python._testing.coordinator_fake import make_coordinator
+from nab_python._testing.overrides import pkg_override
 from nab_python._vendor.packaging.version import Version
 from nab_python.provider import BuildPolicy, DistPolicy
 from nab_python.universal import reresolve as reresolve_module
@@ -255,6 +256,54 @@ class TestReresolveDivergentTuples:
             diffs = reresolve_divergent_tuples(coordinator, ["pkg"], original, report)
         diff = diffs["py311-linux_x86_64"]
         assert diff.removed == {"pkg": "1.0"}
+
+    def test_dependencies_override_skips_reresolve(self) -> None:
+        """A divergent pin under a dependencies override is not re-resolved.
+
+        The metadata is cached (so without the override the pin would
+        re-resolve), but the override would reapply on any re-resolve, so
+        the pass skips it and does no work.
+        """
+        wheel = _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl")
+        coordinator = _make_coordinator(
+            {"pkg": [wheel]},
+            per_wheel_metadata={
+                wheel.filename: "Name: pkg\nVersion: 1.0\nRequires-Dist: foo\n\n"
+            },
+        )
+        original = UniversalResult(
+            matrix=MagicMock(),
+            tuple_results=[
+                TupleResult(
+                    tuple_=_linux_311(),
+                    success=True,
+                    pins={"pkg": Version("1.0")},
+                ),
+            ],
+        )
+        report = ValidationReport(
+            findings=[
+                PinValidation(
+                    tuple_label="py311-linux_x86_64",
+                    package="pkg",
+                    version="1.0",
+                    status="divergent",
+                    chosen_wheel=wheel.filename,
+                ),
+            ],
+        )
+        with patch.object(
+            reresolve_module, "_resolve_one_tuple_with_overrides"
+        ) as inner:
+            diffs = reresolve_divergent_tuples(
+                coordinator,
+                ["pkg"],
+                original,
+                report,
+                package_overrides=(pkg_override("pkg", dependencies=()),),
+            )
+        assert diffs == {}
+        inner.assert_not_called()
 
 
 class TestCollectWheelMetadataOverrides:

--- a/nab-python/tests/universal/test_universal_provider.py
+++ b/nab-python/tests/universal/test_universal_provider.py
@@ -16,7 +16,9 @@ import pytest
 
 from nab_index.client import SdistFile, WheelFile
 from nab_python._testing.coordinator_fake import make_coordinator
+from nab_python._testing.overrides import pkg_override
 from nab_python._vendor.packaging.ranges import VersionRange
+from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.version import Version
 from nab_python.config import NabProjectConfig
 from nab_python.fetch import InMemoryIndex
@@ -79,6 +81,73 @@ _LINUX_ENV: dict[str, str] = {
     "platform_version": "",
     "sys_platform": "linux",
 }
+
+
+class TestPerTupleRequiresPythonOverride:
+    """A requires-python override participates in per-tuple python filtering."""
+
+    @staticmethod
+    def _env(py: str) -> dict[str, str]:
+        env = dict(_LINUX_ENV)
+        env["python_version"] = py
+        env["python_full_version"] = f"{py}.0"
+        return env
+
+    def _provider(self, py: str) -> UniversalProvider:
+        coordinator = make_coordinator(
+            [_make_wheel("1.0", requires_python=">=3.6")],
+            package="pkg",
+            auto_metadata=True,
+        )
+        return UniversalProvider(
+            coordinator,
+            marker_environment=self._env(py),
+            package_overrides=(pkg_override("pkg", requires_python=">=3.11"),),
+        )
+
+    def test_tuple_below_override_rejects(self) -> None:
+        # Real >=3.6 admits 3.10, but the override narrows to >=3.11.
+        provider = self._provider("3.10")
+        assert provider.fetch_versions("pkg") == []
+
+    def test_tuple_meeting_override_admits(self) -> None:
+        provider = self._provider("3.11")
+        assert [v for v, _ in provider.fetch_versions("pkg")] == [Version("1.0")]
+
+
+class TestProvidesExtraDependenciesOverride:
+    """A dependencies + provides-extra override gates deps behind the extra."""
+
+    def _provider(self) -> UniversalProvider:
+        coordinator = make_coordinator(
+            [_make_wheel("1.0")],
+            package="pkg",
+            auto_metadata=True,
+        )
+        return UniversalProvider(
+            coordinator,
+            marker_environment=_LINUX_ENV,
+            package_overrides=(
+                pkg_override(
+                    "pkg",
+                    dependencies=(Requirement('dep ; extra == "cli"'),),
+                    provides_extra=("cli",),
+                ),
+            ),
+        )
+
+    def test_base_pkg_does_not_carry_extra_dep(self) -> None:
+        """The extra-gated dep is absent from the base package's deps."""
+        provider = self._provider()
+        base_deps = provider.get_dependencies("pkg", Version("1.0"))
+        assert "dep" not in base_deps
+
+    def test_extra_proxy_carries_gated_dep(self) -> None:
+        """Requesting ``pkg[cli]`` yields the extra-gated dep plus the base pin."""
+        provider = self._provider()
+        extra_deps = provider.get_dependencies("pkg[cli]", Version("1.0"))
+        assert "dep" in extra_deps
+        assert "pkg" in extra_deps
 
 
 class TestEnvironmentOverlay:

--- a/nab-python/tests/universal/test_validate.py
+++ b/nab-python/tests/universal/test_validate.py
@@ -19,12 +19,15 @@ import pytest
 
 from nab_index.client import MetadataHashMismatchError, SdistFile, WheelFile
 from nab_python._testing.coordinator_fake import make_coordinator
+from nab_python._testing.overrides import pkg_override
+from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.version import Version
 from nab_python.universal.matrix import MatrixTuple
 from nab_python.universal.resolve import TupleResult, UniversalResult
 from nab_python.universal.validate import (
     PinValidation,
     ValidationReport,
+    _dependencies_override_for,
     _evaluate_metadata_deps_by_extra,
     validate_lock,
 )
@@ -1221,3 +1224,107 @@ class TestSpecifierDivergence:
         )
         finding = self._validate_single(baseline, chosen)
         assert finding.status == "divergent"
+
+
+def _single_linux_result() -> UniversalResult:
+    """A one-tuple result pinning ``pkg==1.0`` on linux/py311."""
+    return UniversalResult(
+        matrix=MagicMock(),
+        tuple_results=[
+            TupleResult(
+                tuple_=_linux_311(),
+                success=True,
+                pins={"pkg": Version("1.0")},
+            ),
+        ],
+    )
+
+
+class TestDependenciesOverrideFor:
+    """Branch coverage for the ``dependencies`` override predicate."""
+
+    def test_matches_when_dependencies_set(self) -> None:
+        """A dependencies override covering the version matches."""
+        overrides = (pkg_override("pkg", dependencies=()),)
+        assert _dependencies_override_for(overrides, "pkg", Version("1.0")) is True
+
+    def test_name_mismatch_does_not_match(self) -> None:
+        """An override for a different package does not match."""
+        overrides = (pkg_override("other", dependencies=()),)
+        assert _dependencies_override_for(overrides, "pkg", Version("1.0")) is False
+
+    def test_version_outside_range_does_not_match(self) -> None:
+        """An override scoped to another version does not match."""
+        overrides = (pkg_override("pkg==2.0", dependencies=()),)
+        assert _dependencies_override_for(overrides, "pkg", Version("1.0")) is False
+
+    def test_requires_python_only_does_not_match(self) -> None:
+        """A requires-python-only override leaves the baseline in place."""
+        overrides = (pkg_override("pkg", requires_python=">=3.11"),)
+        assert _dependencies_override_for(overrides, "pkg", Version("1.0")) is False
+
+
+class TestDependenciesOverrideValidation:
+    """A ``dependencies`` override makes the pin metadata-override-aware."""
+
+    def test_overridden_pin_reports_metadata_overridden(self) -> None:
+        """A would-be divergent pin becomes ``metadata_overridden`` and is sound."""
+        wheel = _wheel("pkg-1.0-cp311-cp311-linux_x86_64.whl")
+        coordinator = _make_coordinator(
+            {"pkg": [wheel]},
+            baseline_metadata={"pkg": _BASE_METADATA},
+            per_wheel_metadata={wheel.filename: _DIVERGENT_METADATA},
+        )
+        result = _single_linux_result()
+        # Without the override the chosen wheel diverges from the baseline.
+        assert validate_lock(result, coordinator).findings[0].status == "divergent"
+        overrides = (pkg_override("pkg", dependencies=(Requirement("newdep"),)),)
+        report = validate_lock(result, coordinator, overrides)
+        finding = report.findings[0]
+        assert finding.status == "metadata_overridden"
+        assert finding.chosen_wheel == wheel.filename
+        assert report.pins_ok == 1
+        assert report.fatal_findings(build_allowed=False) == []
+
+    def test_corrupt_wheel_metadata_under_override_does_not_raise(self) -> None:
+        """A metadata integrity error is bypassed by the skip-fetch override."""
+        wheel = _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl")
+        coordinator = _make_coordinator(
+            {"pkg": [wheel]},
+            baseline_metadata={"pkg": _BASE_METADATA},
+        )
+        coordinator.index.store_metadata_error(
+            "pkg",
+            f"1.0#{wheel.filename}",
+            MetadataHashMismatchError("metadata sha256 mismatch"),
+        )
+        result = _single_linux_result()
+        overrides = (pkg_override("pkg", dependencies=()),)
+        report = validate_lock(result, coordinator, overrides)
+        assert report.findings[0].status == "metadata_overridden"
+
+    def test_override_on_different_version_falls_through(self) -> None:
+        """An override scoped to another version runs normal validation."""
+        wheel = _wheel("pkg-1.0-cp311-cp311-linux_x86_64.whl")
+        coordinator = _make_coordinator(
+            {"pkg": [wheel]},
+            baseline_metadata={"pkg": _BASE_METADATA},
+            per_wheel_metadata={wheel.filename: _BASE_METADATA},
+        )
+        result = _single_linux_result()
+        overrides = (pkg_override("pkg==2.0", dependencies=()),)
+        report = validate_lock(result, coordinator, overrides)
+        assert report.findings[0].status == "ok"
+
+    def test_requires_python_only_override_falls_through(self) -> None:
+        """A requires-python-only override does not skip metadata comparison."""
+        wheel = _wheel("pkg-1.0-cp311-cp311-linux_x86_64.whl")
+        coordinator = _make_coordinator(
+            {"pkg": [wheel]},
+            baseline_metadata={"pkg": _BASE_METADATA},
+            per_wheel_metadata={wheel.filename: _DIVERGENT_METADATA},
+        )
+        result = _single_linux_result()
+        overrides = (pkg_override("pkg", requires_python=">=3.11"),)
+        report = validate_lock(result, coordinator, overrides)
+        assert report.findings[0].status == "divergent"

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -35,6 +35,7 @@ from nab_python.lockfile import (
     LockInput,
     Provenance,
     is_valid_pylock_path,
+    package_metadata_override_records,
     read_lockfile_anchor,
     read_lockfile_packages,
 )
@@ -774,6 +775,9 @@ def _build_provenance(
         python_specifier=python_specifier,
         platforms=platforms,
         cli_project_overrides=cli_project_overrides,
+        package_metadata_overrides=package_metadata_override_records(
+            config.package_overrides
+        ),
     )
 
 


### PR DESCRIPTION
Adds per-package metadata overrides on the existing `[tool.nab.packages]` and `[[tool.nab.package-rules]]` surface, keyed by a PEP 508 requirement so an override scopes to a version range (or all versions):

- `dependencies` replaces a package's runtime dependencies (an empty list means none)
- `requires-python` replaces its Python requirement
- `provides-extra` declares its extras

Two entries setting the same field over overlapping ranges are a parse-time error. A complete `dependencies` override lets a package resolve without fetching or building its metadata, so an sdist-only or dynamic-metadata package under `build-policy = "never"` can still resolve. The overridden `requires-python` is enforced at admission and recorded in the lockfile pin.

See the configuration guide for the surface and semantics.

Closes #211
