### PR TITLE
reject --output template with a format spec or conversion

### DIFF
--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -528,7 +528,13 @@ def _emit_universal_pylock(
 
 
 def _check_output_template(output: Path, template: str) -> None:
-    """Reject unknown placeholders in --output before str.format is called."""
+    """Reject an --output template that ``str.format`` cannot render.
+
+    Only bare ``{python_version}`` and ``{platform_id}`` fields are
+    accepted. An unbalanced brace, an unknown field name, or a field
+    carrying a format spec (``{platform_id:d}``) or conversion
+    (``{python_version!r}``) is rejected here.
+    """
     allowed_vars = _cli.TUPLE_TEMPLATE_VARS
     allowed = {
         name
@@ -537,18 +543,30 @@ def _check_output_template(output: Path, template: str) -> None:
         if name is not None
     }
     try:
-        fields = {
-            name for _, name, _, _ in Formatter().parse(template) if name is not None
-        }
+        fields = [
+            (name, spec, conversion)
+            for _, name, spec, conversion in Formatter().parse(template)
+            if name is not None
+        ]
     except ValueError as e:
         sys.stderr.write(f"Error: --output {output} is not a valid template: {e}\n")
         sys.exit(1)
-    unknown = sorted(f"{{{name}}}" for name in fields if name not in allowed)
+    supported = " and ".join(allowed_vars)
+    unknown = sorted(f"{{{name}}}" for name, _, _ in fields if name not in allowed)
     if unknown:
-        supported = " and ".join(allowed_vars)
         sys.stderr.write(
             f"Error: --output {output} has unknown template placeholder(s)"
             f" {', '.join(unknown)}; only {supported} are supported.\n"
+        )
+        sys.exit(1)
+    decorated = sorted(
+        {f"{{{name}}}" for name, spec, conversion in fields if spec or conversion}
+    )
+    if decorated:
+        sys.stderr.write(
+            f"Error: --output {output} is not a valid template:"
+            f" {', '.join(decorated)} may not carry a format spec or conversion;"
+            f" only bare {supported} are supported.\n"
         )
         sys.exit(1)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1427,6 +1427,40 @@ class TestLockCommandUniversal:
             lock(pyproject, format="requirements-without-hashes", output=out)
         assert "not a valid template" in capsys.readouterr().err
 
+    def test_template_invalid_format_spec_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A bad format spec on a tuple var exits 1 instead of a raw ValueError."""
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "req-{python_version}-{platform_id:d}.txt"
+        with (
+            patch(
+                "nab.cli.resolve_universal_pyproject",
+                return_value=_universal_result(success=True),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, format="requirements-without-hashes", output=out)
+        assert "not a valid template" in capsys.readouterr().err
+        assert not (tmp_path / "req-3.11-linux_x86_64.txt").exists()
+
+    def test_template_conversion_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A ``!r`` conversion exits 1 instead of writing a quoted filename."""
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "req-{platform_id}-{python_version!r}.txt"
+        with (
+            patch(
+                "nab.cli.resolve_universal_pyproject",
+                return_value=_universal_result(success=True),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, format="requirements-without-hashes", output=out)
+        assert "not a valid template" in capsys.readouterr().err
+        assert list(tmp_path.glob("req-*.txt")) == []
+
     def test_template_with_one_tuple_writes_one_file(self, tmp_path: Path) -> None:
         """A template with a single-tuple matrix still works."""
         pyproject = _universal_pyproject(tmp_path)


### PR DESCRIPTION
`nab lock --output` accepts `{python_version}` and `{platform_id}` in the filename template. The up-front check only looked at the field names, so a known name carrying a format spec like `{platform_id:d}` slipped through and then crashed with an uncaught `ValueError` when the template was rendered. A conversion like `{python_version!r}` was also accepted and wrote a filename with the quotes baked in.

Both now fail the same way as any other bad template: a placeholder that carries a format spec or conversion is rejected before anything is written, with an "invalid template" error, since only bare `{python_version}` and `{platform_id}` are supported.
