### PR TITLE
drop lock requires-python when a package has an unconstrained artifact

### DIFF
--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -519,11 +519,17 @@ def require_artifact_hashes(lock_input: LockInput) -> None:
 
 
 def _common_requires_python(files: Iterable[WheelFile | SdistFile]) -> str | None:
-    """Return a single Requires-Python value if all files agree, else ``None``."""
+    """Return the package-level Requires-Python value, or ``None``.
+
+    An artefact with no Requires-Python is unconstrained, so a single
+    such artefact leaves the whole package unconstrained. Otherwise the
+    value survives only when every artefact agrees.
+    """
     seen: set[str] = set()
     for f in files:
-        if f.requires_python is not None:
-            seen.add(f.requires_python)
+        if f.requires_python is None:
+            return None
+        seen.add(f.requires_python)
     if len(seen) == 1:
         return next(iter(seen))
     return None

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -456,8 +456,9 @@ def _merge_pins_in_group(pins: list[PinShape]) -> PinShape:
 
     For :class:`IndexPin`, accumulates every distinct wheel filename
     across the contributing tuples and keeps the first non-``None``
-    sdist.  ``requires_python`` survives only when every tuple agreed,
-    matching :func:`_common_requires_python`'s rule.
+    sdist.  ``requires_python`` survives only when every tuple carried
+    the same value and none was unconstrained, matching
+    :func:`_common_requires_python`'s rule.
     Non-IndexPin shapes are already fully discriminated, so the first
     pin is returned unchanged.
     """
@@ -469,16 +470,21 @@ def _merge_pins_in_group(pins: list[PinShape]) -> PinShape:
     seen_wheels: dict[str, WheelArtifact] = {}
     sdist = head.sdist
     requires_python_set: set[str] = set()
+    any_unconstrained = False
     for pin in pins:
         assert isinstance(pin, IndexPin)
         for wheel in pin.wheels:
             seen_wheels.setdefault(wheel.filename, wheel)
         if sdist is None and pin.sdist is not None:
             sdist = pin.sdist
-        if pin.requires_python is not None:
+        if pin.requires_python is None:
+            any_unconstrained = True
+        else:
             requires_python_set.add(pin.requires_python)
     requires_python = (
-        next(iter(requires_python_set)) if len(requires_python_set) == 1 else None
+        next(iter(requires_python_set))
+        if not any_unconstrained and len(requires_python_set) == 1
+        else None
     )
     return IndexPin(
         name=head.name,

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -1004,6 +1004,13 @@ class TestConflictForkRequiresPythonMerge:
         assert foo.requires_python is not None
         assert str(foo.requires_python) == ">=3.10"
 
+    def test_unconstrained_fork_drops_requires_python(self) -> None:
+        """A fork with no Requires-Python imposes no Python floor, so a
+        merge that mixes it with a constrained fork records ``None``."""
+        pylock = build_pylock(self._build(">=3.10", None))
+        foo = next(p for p in pylock.packages if str(p.name) == "foo")
+        assert foo.requires_python is None
+
 
 class TestConflictForkByteStability:
     """``write_lock`` is deterministic across multiple conflict forks.
@@ -2197,6 +2204,35 @@ class TestBuildLockInputFromProvider:
         pin = lock_input.pins["foo"]
         assert isinstance(pin, IndexPin)
         assert pin.requires_python == ">=3.9"
+
+    def test_unconstrained_wheel_drops_requires_python(self) -> None:
+        """A version that mixes a Requires-Python wheel with an
+        unconstrained ``py3-none-any`` wheel records ``None``: the
+        unconstrained wheel installs everywhere, so there is no floor.
+        """
+        constrained = WheelFile(
+            filename="foo-1.0-cp312-cp312-linux_x86_64.whl",
+            url="https://pypi.org/simple/foo/foo-1.0-cp312-cp312-linux_x86_64.whl",
+            version="1.0",
+            requires_python=">=3.10",
+            has_metadata=False,
+            upload_time=None,
+            hashes=(("sha256", "a" * 64),),
+            size=1234,
+            local_path=None,
+        )
+        provider = _FakeProvider(
+            listings={
+                "foo": [
+                    (Version("1.0"), constrained),
+                    (Version("1.0"), _wheel_file(requires_python=None)),
+                ]
+            },
+        )
+        lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0")})
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.requires_python is None
 
     def test_empty_requires_python_override_omits_lock_key(self) -> None:
         """An empty-string override records verbatim and drops the lock key.


### PR DESCRIPTION
When building a lockfile's per-package `requires-python`, artifacts with no Requires-Python were skipped instead of counted. A package that ships a constrained artifact (say a platform wheel with `Requires-Python >=3.10`) alongside an unconstrained one (a `py3-none-any` wheel with no Requires-Python) was recorded with `requires-python >=3.10`, even though the unconstrained wheel installs on any Python. The lockfile then carried a Python floor that is too high and could reject an interpreter the package actually supports.

An unconstrained artifact means the package as a whole has no floor, so `_common_requires_python` and the pin merge in `_merge_pins_in_group` now return `None` as soon as any artifact has no Requires-Python, and keep a value only when every artifact agrees on the same one.
