### PR TITLE
Add set-relation predicates to Range

### DIFF
--- a/nab-resolver/src/nab_resolver/decide.py
+++ b/nab-resolver/src/nab_resolver/decide.py
@@ -114,7 +114,7 @@ def record_no_versions(
     # When a constraint narrowed the searched range it is the reason no
     # acceptable version was found, so attribute the clause to it.
     constraint = resolver.constraints.get(package)
-    constrained = constraint is not None and not (current_range & ~constraint).is_empty
+    constrained = constraint is not None and not current_range.is_subset(constraint)
     cause = (
         IncompatibilityCause.CONSTRAINT
         if constrained

--- a/nab-resolver/src/nab_resolver/propagate.py
+++ b/nab-resolver/src/nab_resolver/propagate.py
@@ -153,20 +153,16 @@ def classify_intersection(
     constraint; contradicted when the intersection is empty.
     Negative term: satisfied when the intersection is empty; contradicted
     when the assignment falls entirely inside the forbidden range.
-
-    The subset test is emptiness of ``assignment - constraint``, not a
-    range equality, so it agrees with :meth:`Term.satisfies` on flagged
-    range types (see that docstring).
     """
     if term.is_positive():
-        covers = (assignment - term.constraint).is_empty
-        empty = intersection.is_empty
+        satisfied = assignment.is_subset(term.constraint)
+        contradicted = intersection.is_empty
     else:
-        covers = intersection.is_empty
-        empty = (assignment - term.constraint).is_empty
+        satisfied = intersection.is_empty
+        contradicted = assignment.is_subset(term.constraint)
 
-    if covers:
+    if satisfied:
         return SetRelation.SATISFIED
-    if empty:
+    if contradicted:
         return SetRelation.CONTRADICTED
     return SetRelation.UNDETERMINED

--- a/nab-resolver/src/nab_resolver/ranges.py
+++ b/nab-resolver/src/nab_resolver/ranges.py
@@ -335,6 +335,18 @@ class Range(Generic[VersionType]):
             return NotImplemented
         return self & ~other
 
+    def is_subset(self, other: Range[VersionType]) -> bool:
+        """Return whether every version in self is also in other."""
+        return (self - other).is_empty
+
+    def is_superset(self, other: Range[VersionType]) -> bool:
+        """Return whether every version in other is also in self."""
+        return other.is_subset(self)
+
+    def is_disjoint(self, other: Range[VersionType]) -> bool:
+        """Return whether self and other share no version."""
+        return (self & other).is_empty
+
     @override
     def __eq__(self, other: object) -> bool:
         """Test equality by comparing interval tuples."""

--- a/nab-resolver/src/nab_resolver/types.py
+++ b/nab-resolver/src/nab_resolver/types.py
@@ -84,6 +84,18 @@ class RangeProtocol(Protocol[VersionType_contra]):
         """Set difference: versions in self but not in other."""
         ...
 
+    def is_subset(self, other: Self) -> bool:
+        """Return whether every version in self is also in other."""
+        ...
+
+    def is_superset(self, other: Self) -> bool:
+        """Return whether every version in other is also in self."""
+        ...
+
+    def is_disjoint(self, other: Self) -> bool:
+        """Return whether self and other share no version."""
+        ...
+
     # __eq__ and __hash__ come from object; redeclaring them in the
     # Protocol adds no constraint and mypy and zuban disagree on @override.
 
@@ -129,20 +141,12 @@ class Term(Generic[PackageType, VersionType]):
         Positive: satisfied when assignment is a subset of constraint
         (every version in the assignment is also in the constraint).
 
-        Negative: satisfied when assignment doesn't intersect constraint
+        Negative: satisfied when assignment is disjoint from constraint
         (no version in the assignment is in the constraint).
-
-        The subset test is ``(assignment - constraint).is_empty`` rather
-        than ``(assignment & constraint) == assignment``: range types may
-        carry flags (the vendored packaging ranges mark specifier-built
-        ranges as also admitting arbitrary ``===`` versions) under which
-        extensionally equal ranges compare unequal.  Emptiness of the set
-        difference sidesteps that, which is what PubGrub's
-        conflict-resolution progress argument relies on.
         """
         if self._positive:
-            return (assignment - self.constraint).is_empty
-        return (assignment & self.constraint).is_empty
+            return assignment.is_subset(self.constraint)
+        return assignment.is_disjoint(self.constraint)
 
     def intersect(
         self, other: Term[PackageType, VersionType]

--- a/nab-resolver/tests/test_ranges.py
+++ b/nab-resolver/tests/test_ranges.py
@@ -364,6 +364,29 @@ class TestRangeDifference:
         assert Range.full().__sub__(object()) is NotImplemented  # type: ignore[arg-type]
 
 
+class TestRangeSetRelations:
+    def test_is_subset_true(self) -> None:
+        assert Range.between(2, 4).is_subset(Range.between(1, 5))
+
+    def test_is_subset_false(self) -> None:
+        assert not Range.between(1, 5).is_subset(Range.between(2, 4))
+
+    def test_empty_is_subset_of_any(self) -> None:
+        assert Range.empty().is_subset(Range.between(2, 4))
+
+    def test_is_superset_true(self) -> None:
+        assert Range.between(1, 5).is_superset(Range.between(2, 4))
+
+    def test_is_superset_false(self) -> None:
+        assert not Range.between(2, 4).is_superset(Range.between(1, 5))
+
+    def test_is_disjoint_true(self) -> None:
+        assert Range.between(1, 3).is_disjoint(Range.between(3, 5))
+
+    def test_is_disjoint_false(self) -> None:
+        assert not Range.between(1, 4).is_disjoint(Range.between(2, 5))
+
+
 class TestRangeStr:
     def test_any_str(self) -> None:
         assert str(Range.full()) == "*"


### PR DESCRIPTION
Adds `is_subset`, `is_superset`, and `is_disjoint` to `RangeProtocol` and the generic `Range`, and uses them in the resolver where a manual set-relation check appeared.

- `Term.satisfies`, `classify_intersection`, and the constraint-narrowing check in `decide.py` now read as set relations instead of `(a - b).is_empty` / `(a & b).is_empty` forms.
- This also lets the generic solver drop a packaging-specific aside (the `===` arbitrary-version flag) from its docstrings; that detail belongs to the range type, not the resolver.
- Behavior is unchanged: for both `Range` and packaging's `VersionRange`, `is_subset` is difference-emptiness and `is_disjoint` is intersection-emptiness, matching the code they replace.

Left `incompat_index` and the backjump emptiness check alone: the former's `==` is intentionally flag-sensitive, the latter needs the computed term, not a relation.

Stacked on #298.
