### PR TITLE
read METADATA from a local wheel without a PEP 658 sidecar

### DIFF
--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "LocalIndexClient",
+    "read_wheel_metadata",
 ]
 
 
@@ -309,6 +310,30 @@ def _make_record(
             hashes=hashes,
             local_path=local_path,
         )
+    return None
+
+
+def read_wheel_metadata(wheel_path: Path) -> str | None:
+    """Return a wheel's ``<name>-<version>.dist-info/METADATA`` text.
+
+    Returns ``None`` if the file is not a readable zip or has no METADATA member.
+    """
+    try:
+        with zipfile.ZipFile(wheel_path) as zf:
+            member = _wheel_metadata_member(zf.namelist())
+            if member is None:
+                return None
+            return zf.read(member).decode("utf-8")
+    except (zipfile.BadZipFile, OSError, UnicodeDecodeError):
+        return None
+
+
+def _wheel_metadata_member(names: list[str]) -> str | None:
+    """Return the top-level ``*.dist-info/METADATA`` member name, or ``None``."""
+    for name in names:
+        head, sep, tail = name.partition("/")
+        if sep and tail == "METADATA" and head.endswith(".dist-info"):
+            return name
     return None
 
 

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from nab_index.client import SdistFile, WheelFile
+from nab_index.local_index import read_wheel_metadata
 
 from .._conflict_kind import EMPTY_MEMBERSHIP_SETS
 from .._vcs_admission import admit_vcs_url
@@ -78,6 +79,8 @@ def resolve_metadata(
         if integrity_error is not None:
             raise integrity_error
         metadata_text = provider.coordinator.index.get_metadata(normalized, ver_str)
+    elif isinstance(dist, WheelFile) and dist.local_path is not None:
+        metadata_text = read_wheel_metadata(dist.local_path)
     else:
         metadata_text = None
 

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -16,6 +16,7 @@ from nab_index.local_index import (
     LocalIndexClient,
     _make_record,
     _parse_file_url,
+    read_wheel_metadata,
 )
 
 if TYPE_CHECKING:
@@ -476,6 +477,31 @@ class TestMakeRecord:
             )
             is None
         )
+
+
+class TestReadWheelMetadata:
+    def test_reads_metadata_from_wheel_zip(self, tmp_path: Path) -> None:
+        wheel = tmp_path / "foo-1.0-py3-none-any.whl"
+        with zipfile.ZipFile(wheel, "w") as zf:
+            zf.writestr(
+                "foo-1.0.dist-info/METADATA",
+                "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n",
+            )
+        text = read_wheel_metadata(wheel)
+        assert text is not None
+        assert text.startswith("Metadata-Version: 2.1")
+
+    def test_returns_none_when_no_metadata_member(self, tmp_path: Path) -> None:
+        wheel = tmp_path / "foo-1.0-py3-none-any.whl"
+        with zipfile.ZipFile(wheel, "w") as zf:
+            zf.writestr("foo/__init__.py", "")
+            zf.writestr("foo-1.0.dist-info/WHEEL", "Wheel-Version: 1.0\n")
+        assert read_wheel_metadata(wheel) is None
+
+    def test_returns_none_for_non_zip(self, tmp_path: Path) -> None:
+        not_a_wheel = tmp_path / "foo-1.0-py3-none-any.whl"
+        not_a_wheel.write_bytes(b"not a zip archive")
+        assert read_wheel_metadata(not_a_wheel) is None
 
 
 class TestContextManager:

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -1092,6 +1092,27 @@ class TestGetDependencies:
         with pytest.raises(MetadataError):
             provider.get_dependencies("foo", V("1.0"))
 
+    def test_local_wheel_without_sidecar_reads_metadata_from_zip(
+        self, tmp_path: Path
+    ) -> None:
+        """A local wheel with no sidecar resolves by reading METADATA from the .whl."""
+        wheel_path = tmp_path / "foo-1.0-py3-none-any.whl"
+        with zipfile.ZipFile(wheel_path, "w") as zf:
+            zf.writestr(
+                "foo-1.0.dist-info/METADATA",
+                "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n"
+                "Requires-Dist: bar>=2\n",
+            )
+        coordinator = make_coordinator(
+            [make_wheel("1.0", has_metadata=False, local_path=wheel_path)],
+            package="foo",
+        )
+        provider = Provider(coordinator, python_version="3.12.0")
+        deps = provider.get_dependencies("foo", V("1.0"))
+        assert "bar" in deps
+        assert V("2.0") in deps["bar"]
+        assert V("1.0") not in deps["bar"]
+
     def test_filters_deps_by_marker(self) -> None:
         """Dependencies with non-matching markers are excluded."""
         coordinator = make_coordinator(


### PR DESCRIPTION
A wheel served from a local find-links directory failed to resolve when it had no PEP 658 `.metadata` sidecar, even though the wheel is installable and carries its own METADATA inside the archive.

`resolve_metadata` only had a path for a remote wheel with a sidecar URL, so a local wheel with no sidecar and no accompanying sdist fell through to a `MetadataError` about missing PEP 658 metadata.

Now when the chosen dist is a local wheel, read its `*.dist-info/METADATA` member straight out of the `.whl` zip and use that text.
