### PR TITLE
Authorize a pre-release named by a redundant requirement

### DIFF
--- a/nab-python/tests/test_resolver_packaging.py
+++ b/nab-python/tests/test_resolver_packaging.py
@@ -748,13 +748,13 @@ class TestRedundantTransitivePrereleaseOptIn:
     its bound is already implied by another requirement.
 
     ``a`` requires ``c>=0.5a1`` while the root requires ``c>=1.0``. ``>=1.0``
-    already implies ``>=0.5a1``, so unit propagation never folds ``a``'s
-    requirement into ``c`` and the opt-in it carries would be dropped, wrongly
-    leaving the stable ``1.0.0`` to win over the authorized ``2.0.0a1``.
+    implies ``>=0.5a1``, so the requirement is redundant on ``c``'s version
+    set, yet the pre-release opt-in it carries admits ``c`` version
+    ``2.0.0a1`` over stable ``1.0.0``.
     """
 
     def test_redundant_specifier_authorizes_prerelease(self) -> None:
-        """The redundant ``c>=0.5a1`` still opts ``c`` into its pre-release."""
+        """A redundant ``c>=0.5a1`` opts ``c`` into pre-release ``2.0.0a1``."""
         provider = _FilterProvider(
             {
                 "a": {V("1.0.0"): {"c": SpecifierSet(">=0.5a1")}},

--- a/nab-python/tests/test_resolver_packaging.py
+++ b/nab-python/tests/test_resolver_packaging.py
@@ -743,6 +743,73 @@ class TestConflictUnionPrereleaseLeak:
         assert result["c"] == V("3.5")
 
 
+class TestRedundantTransitivePrereleaseOptIn:
+    """A transitive pre-release specifier authorizes its pre-release even when
+    its bound is already implied by another requirement.
+
+    ``a`` requires ``c>=0.5a1`` while the root requires ``c>=1.0``. ``>=1.0``
+    already implies ``>=0.5a1``, so unit propagation never folds ``a``'s
+    requirement into ``c`` and the opt-in it carries would be dropped, wrongly
+    leaving the stable ``1.0.0`` to win over the authorized ``2.0.0a1``.
+    """
+
+    def test_redundant_specifier_authorizes_prerelease(self) -> None:
+        """The redundant ``c>=0.5a1`` still opts ``c`` into its pre-release."""
+        provider = _FilterProvider(
+            {
+                "a": {V("1.0.0"): {"c": SpecifierSet(">=0.5a1")}},
+                "c": {V("1.0.0"): {}, V("2.0.0a1"): {}},
+            }
+        )
+        result = Resolver(provider, range_type=VersionRange, root_version="0").resolve(
+            {
+                "a": SpecifierSet("==1.0.0").to_range(),
+                "c": SpecifierSet(">=1.0").to_range(),
+            }
+        )
+        assert result["c"] == V("2.0.0a1")
+
+    def test_redundant_opt_in_still_prefers_newer_final(self) -> None:
+        """The opt-in admits its pre-release but does not beat a newer final."""
+        provider = _FilterProvider(
+            {
+                "a": {V("1.0.0"): {"c": SpecifierSet(">=0.5a1")}},
+                "c": {V("1.0.0"): {}, V("2.0.0a1"): {}, V("3.0.0"): {}},
+            }
+        )
+        result = Resolver(provider, range_type=VersionRange, root_version="0").resolve(
+            {
+                "a": SpecifierSet("==1.0.0").to_range(),
+                "c": SpecifierSet(">=1.0").to_range(),
+            }
+        )
+        assert result["c"] == V("3.0.0")
+
+    def test_redundant_opt_in_from_rejected_parent_does_not_leak(self) -> None:
+        """A rejected parent's redundant opt-in is undone on backtracking."""
+        provider = _FilterProvider(
+            {
+                "a": {
+                    V("2.0.0"): {
+                        "c": SpecifierSet(">=0.5a1"),
+                        "e": SpecifierSet("==2.0"),
+                    },
+                    V("1.0.0"): {},
+                },
+                "e": {V("1.0"): {}},
+                "c": {V("1.0.0"): {}, V("2.0.0a1"): {}},
+            }
+        )
+        result = Resolver(provider, range_type=VersionRange, root_version="0").resolve(
+            {
+                "a": VersionRange.full(),
+                "c": SpecifierSet(">=1.0").to_range(),
+            }
+        )
+        assert result["a"] == V("1.0.0")
+        assert result["c"] == V("1.0.0")
+
+
 class TestExclusionFallbackPrerelease:
     """A pre-release IS admitted when the only final cannot be used.
 

--- a/nab-resolver/src/nab_resolver/decide.py
+++ b/nab-resolver/src/nab_resolver/decide.py
@@ -12,13 +12,14 @@ from typing import TYPE_CHECKING, Any
 
 from .incompat_index import add_incompatibility
 from .root import ROOT
-from .types import Incompatibility, IncompatibilityCause, Term
+from .types import Incompatibility, IncompatibilityCause, RangeProtocol, Term
 
 if TYPE_CHECKING:
     from .resolver import Resolver
 
 __all__ = [
     "absorb_pending_clauses",
+    "absorb_redundant_requirement",
     "choose_package_to_decide",
     "choose_version",
     "record_no_versions",
@@ -94,6 +95,36 @@ def absorb_pending_clauses(resolver: Resolver[Any, Any]) -> bool:
     for incompatibility in clauses:
         add_incompatibility(resolver, incompatibility)
     return bool(clauses)
+
+
+def absorb_redundant_requirement(
+    resolver: Resolver[Any, Any],
+    package: Any,
+    requirement: RangeProtocol[Any],
+    cause: Incompatibility[Any, Any],
+) -> None:
+    """Re-derive a requirement that refines a package's range without narrowing it.
+
+    Unit propagation fires only when a requirement narrows a package's version
+    set, so a requirement already implied by a tighter bound is skipped. A range
+    can carry a refinement that rides set algebra without changing the version
+    set, and that refinement is dropped along with the skipped requirement. When
+    a version-set-redundant requirement still changes the range, the difference
+    is such a refinement, so derive it onto the package. The derivation rides the
+    parent's decision level and is undone on backtracking. It changes only the
+    range offered for selection, not any term relation, so nothing re-propagates.
+    """
+    positive = resolver.solution.positive_range(package)
+    if positive is None:
+        return
+
+    # Intersect first so an unchanged range (the common case) skips the subset
+    # test; is_subset then tells a refinement (redundant bound) from a narrowing.
+    folded = positive & requirement
+    if folded != positive and positive.is_subset(requirement):
+        resolver.solution.derive(package, requirement, positive=True, cause=cause)
+        resolver.stats.derivations += 1
+        resolver.observer.on_derivation(package, positive=True, cause=cause)
 
 
 def record_no_versions(

--- a/nab-resolver/src/nab_resolver/decide.py
+++ b/nab-resolver/src/nab_resolver/decide.py
@@ -103,23 +103,21 @@ def absorb_redundant_requirement(
     requirement: RangeProtocol[Any],
     cause: Incompatibility[Any, Any],
 ) -> None:
-    """Re-derive a requirement that refines a package's range without narrowing it.
+    """Derive a requirement that refines a package's range without narrowing it.
 
-    Unit propagation fires only when a requirement narrows a package's version
-    set, so a requirement already implied by a tighter bound is skipped. A range
-    can carry a refinement that rides set algebra without changing the version
-    set, and that refinement is dropped along with the skipped requirement. When
-    a version-set-redundant requirement still changes the range, the difference
-    is such a refinement, so derive it onto the package. The derivation rides the
-    parent's decision level and is undone on backtracking. It changes only the
-    range offered for selection, not any term relation, so nothing re-propagates.
+    Unit propagation acts only on requirements that narrow a package's version
+    set. When a version-set-redundant requirement still yields a different
+    range, that difference is a refinement the range type carries (such as a
+    pre-release opt-in), so derive it onto the package. The derivation rides the
+    parent decision level, is undone on backtracking, and leaves every term
+    relation unchanged, so nothing re-propagates.
     """
     positive = resolver.solution.positive_range(package)
     if positive is None:
         return
 
-    # Intersect first so an unchanged range (the common case) skips the subset
-    # test; is_subset then tells a refinement (redundant bound) from a narrowing.
+    # Intersect first: an unchanged range short-circuits before the costlier
+    # subset test, which then separates a refinement from a narrowing.
     folded = positive & requirement
     if folded != positive and positive.is_subset(requirement):
         resolver.solution.derive(package, requirement, positive=True, cause=cause)

--- a/nab-resolver/src/nab_resolver/partial_solution.py
+++ b/nab-resolver/src/nab_resolver/partial_solution.py
@@ -320,6 +320,10 @@ class PartialSolution(Generic[PackageType, VersionType]):
         """Return a copy of the positive-range map for each package."""
         return dict(self._positive_ranges)
 
+    def positive_range(self, package: PackageType) -> RangeProtocol[VersionType] | None:
+        """Return the package's accumulated positive range, or None if unset."""
+        return self._positive_ranges.get(package)
+
     def _satisfied_at(
         self,
         assignment: Assignment[PackageType, VersionType],

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -397,7 +397,8 @@ class Resolver(Generic[PackageType, VersionType]):
                 self.range_type.singleton(chosen_version),
                 positive=True,
             )
-            if dependency_package == next_package:
+            cross_package = dependency_package != next_package
+            if not cross_package:
                 # An incompatibility holds at most one term per package,
                 # so self-dependency terms merge to {v} & ~range: empty
                 # (a vacuous clause) when the range contains the chosen
@@ -410,10 +411,15 @@ class Resolver(Generic[PackageType, VersionType]):
                     package_term,
                     Term(dependency_package, dependency_range, positive=False),
                 ]
-            incompat_index.add_incompatibility(
-                self,
-                Incompatibility(terms, cause=IncompatibilityCause.DEPENDENCY),
+            incompatibility = Incompatibility(
+                terms, cause=IncompatibilityCause.DEPENDENCY
             )
+            incompat_index.add_incompatibility(self, incompatibility)
+
+            if cross_package:
+                decide.absorb_redundant_requirement(
+                    self, dependency_package, dependency_range, incompatibility
+                )
         return next_package
 
     def _build_result(self) -> dict[PackageType, VersionType]:

--- a/nab-resolver/tests/test_decide.py
+++ b/nab-resolver/tests/test_decide.py
@@ -1,0 +1,233 @@
+"""Unit tests for :func:`nab_resolver.decide.absorb_redundant_requirement`.
+
+The generic solver re-derives a requirement that is redundant on a package's
+version set yet still changes its range. Packaging's pre-release opt-in is one
+such refinement. Here a range double carries a plain passenger flag that rides
+set algebra, so the contract can be exercised without any PEP 440 semantics.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, cast
+
+from nab_resolver import decide
+from nab_resolver.ranges import Range
+from nab_resolver.resolver import Resolver, ResolverObserver
+from nab_resolver.types import (
+    Incompatibility,
+    IncompatibilityCause,
+    RangeProtocol,
+    Term,
+)
+
+
+class RefiningRange(Range[int]):
+    """A Range with a passenger flag that rides intersection and union.
+
+    The flag is invisible to the version-set predicates (membership,
+    ``is_subset``) but counts toward equality, so two ranges over the same
+    versions can compare unequal. Intersecting or uniting keeps the flag when
+    either side carries it.
+    """
+
+    __slots__ = ("_flag",)
+
+    def __init__(self, intervals: tuple[Any, ...] = (), *, flag: bool = False) -> None:
+        super().__init__(intervals)
+        self._flag = flag
+
+    @property
+    def flag(self) -> bool:
+        return self._flag
+
+    def __and__(self, other: object) -> RefiningRange:
+        """Intersect, keeping the flag if either side carries it."""
+        base = super().__and__(other)
+        if base is NotImplemented:
+            return NotImplemented
+        return RefiningRange(base._intervals, flag=self._flag or _flag_of(other))
+
+    def __or__(self, other: object) -> RefiningRange:
+        """Unite, keeping the flag if either side carries it."""
+        base = super().__or__(other)
+        if base is NotImplemented:
+            return NotImplemented
+        return RefiningRange(base._intervals, flag=self._flag or _flag_of(other))
+
+    def __eq__(self, other: object) -> bool:
+        """Equal when the version sets match and the flags agree."""
+        if not isinstance(other, Range):
+            return NotImplemented
+        return self._intervals == other._intervals and self._flag == _flag_of(other)
+
+    def __hash__(self) -> int:
+        """Hash the version set together with the flag."""
+        return hash((self._intervals, self._flag))
+
+
+def _flag_of(range_: object) -> bool:
+    return isinstance(range_, RefiningRange) and range_.flag
+
+
+def _flagged(base: Range[int]) -> Range[int]:
+    """Return a copy of ``base`` carrying the passenger flag."""
+    return RefiningRange(base._intervals, flag=True)
+
+
+class _RecordingObserver(ResolverObserver[Any, int]):
+    """Records the packages that receive a derivation."""
+
+    def __init__(self) -> None:
+        self.derived: list[Any] = []
+
+    def on_derivation(
+        self, package: Any, *, positive: bool, cause: Incompatibility[Any, int]
+    ) -> None:
+        self.derived.append(package)
+
+
+class _InertProvider:
+    """Provider stub; these tests drive ``decide`` directly, never ``resolve``."""
+
+    def choose_version(
+        self, package: Any, version_range: RangeProtocol[int]
+    ) -> int | None:
+        return None
+
+    def get_dependencies(
+        self, package: Any, version: int
+    ) -> Mapping[Any, RangeProtocol[int]]:
+        return {}
+
+    def prioritize(
+        self,
+        package: Any,
+        version_range: RangeProtocol[int],
+        conflict_counts: Mapping[Any, int],
+        culprit_counts: Mapping[Any, int] | None = None,
+    ) -> Any:
+        return 0
+
+    def is_ready(self, package: Any) -> bool:
+        return True
+
+    def receive_partial_solution_hint(
+        self,
+        positive_ranges: Mapping[Any, RangeProtocol[int]],
+        decisions: Mapping[Any, int],
+    ) -> None:
+        pass
+
+    def consume_pending_clauses(self) -> list[Incompatibility[Any, int]]:
+        return []
+
+    def consume_force_backtrack_targets(self) -> list[Any]:
+        return []
+
+
+def _resolver() -> tuple[Resolver[Any, int], _RecordingObserver]:
+    observer = _RecordingObserver()
+    # RefiningRange is a valid range at runtime; the cast satisfies the
+    # Self-typed RangeProtocol that a plain subclass cannot express.
+    resolver = Resolver(
+        _InertProvider(),
+        observer=observer,
+        range_type=cast("type[RangeProtocol[int]]", RefiningRange),
+    )
+    return resolver, observer
+
+
+def _dependency_cause() -> Incompatibility[Any, int]:
+    return Incompatibility(
+        [Term("a", RefiningRange.singleton(1), positive=True)],
+        cause=IncompatibilityCause.DEPENDENCY,
+    )
+
+
+class TestAbsorbRedundantRequirement:
+    """A version-set-redundant requirement is re-derived onto a package only
+    when it still refines the range, and the refinement rides the parent
+    decision level.
+    """
+
+    def test_first_seen_dependency_is_left_to_propagation(self) -> None:
+        """A dependency with no accumulated range yet gains no derivation."""
+        resolver, observer = _resolver()
+
+        decide.absorb_redundant_requirement(
+            resolver, "c", RefiningRange.at_least(1), _dependency_cause()
+        )
+
+        assert resolver.solution.positive_range("c") is None
+        assert resolver.stats.derivations == 0
+        assert observer.derived == []
+
+    def test_unchanged_range_gains_no_derivation(self) -> None:
+        """A requirement that leaves the range identical adds no derivation."""
+        resolver, observer = _resolver()
+        resolver.solution.derive(
+            "c", RefiningRange.between(1, 3), positive=True, cause=_dependency_cause()
+        )
+
+        decide.absorb_redundant_requirement(
+            resolver, "c", RefiningRange.at_least(1), _dependency_cause()
+        )
+
+        assert resolver.stats.derivations == 0
+        assert observer.derived == []
+
+    def test_narrowing_requirement_is_left_to_propagation(self) -> None:
+        """A requirement that narrows the version set adds no derivation."""
+        resolver, observer = _resolver()
+        resolver.solution.derive(
+            "c", RefiningRange.at_least(1), positive=True, cause=_dependency_cause()
+        )
+
+        decide.absorb_redundant_requirement(
+            resolver, "c", RefiningRange.between(1, 3), _dependency_cause()
+        )
+
+        assert resolver.stats.derivations == 0
+        assert observer.derived == []
+
+    def test_redundant_refinement_reaches_the_package(self) -> None:
+        """A refinement redundant on the version set is derived onto the range."""
+        resolver, observer = _resolver()
+        resolver.solution.derive(
+            "c", RefiningRange.singleton(1), positive=True, cause=_dependency_cause()
+        )
+
+        requirement = _flagged(RefiningRange.at_least(1))
+        decide.absorb_redundant_requirement(
+            resolver, "c", requirement, _dependency_cause()
+        )
+
+        refined = resolver.solution.positive_range("c")
+        assert isinstance(refined, RefiningRange)
+        assert refined.flag is True
+        assert 1 in refined
+        assert resolver.stats.derivations == 1
+        assert observer.derived == ["c"]
+
+    def test_refinement_is_undone_on_backtracking(self) -> None:
+        """The refinement rides the parent decision level, so backtracking lifts it."""
+        resolver, _ = _resolver()
+        resolver.solution.decide("root", 1)
+        resolver.solution.derive(
+            "c", RefiningRange.singleton(1), positive=True, cause=_dependency_cause()
+        )
+        resolver.solution.decide("a", 1)
+
+        requirement = _flagged(RefiningRange.at_least(1))
+        decide.absorb_redundant_requirement(
+            resolver, "c", requirement, _dependency_cause()
+        )
+        refined = resolver.solution.positive_range("c")
+        assert isinstance(refined, RefiningRange)
+        assert refined.flag is True
+
+        resolver.solution.backtrack(1)
+        reverted = resolver.solution.positive_range("c")
+        assert isinstance(reverted, RefiningRange)
+        assert reverted.flag is False


### PR DESCRIPTION
A transitive requirement that names a pre-release was dropped when its bound was already implied by a tighter requirement. With roots `a==1.0.0` and `c>=1.0` where `a` requires `c>=0.5a1`, `c>=1.0` already implies `c>=0.5a1`, so `c` resolved to the stable `1.0.0` instead of the authorized `2.0.0a1`.

Unit propagation acts on a requirement only when it narrows a package's version set, so one redundant on the bounds is skipped, and any refinement its range carries beyond that set is dropped with it. The resolver now re-derives a redundant requirement that still changes the range, restoring the refinement (here the pre-release opt-in region held by the packaging range). It never inspects what the refinement is, so a plain range is unaffected. The re-derivation rides the parent's decision level, so a rejected parent grants nothing.
