### PR TITLE
read Requires-Python from flat find-links wheel metadata

### DIFF
--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -21,6 +21,8 @@ multi-index router can treat local and remote indexes uniformly.
 from __future__ import annotations
 
 import re
+import zipfile
+from email.parser import BytesParser
 from html.parser import HTMLParser
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -210,12 +212,56 @@ def _scan_flat_wheelhouse(
             continue
         if _FLAT_EXTS.search(entry.name) is None:
             continue
+        requires_python = _flat_wheel_requires_python(entry, canonical)
         record = _make_record(
-            entry.name, entry.as_uri(), entry, None, (), canonical, has_metadata=False
+            entry.name,
+            entry.as_uri(),
+            entry,
+            requires_python,
+            (),
+            canonical,
+            has_metadata=False,
         )
         if record is not None:
             files.append(record)
     return files
+
+
+def _flat_wheel_requires_python(entry: Path, canonical: str) -> str | None:
+    """Read a matching wheel's ``Requires-Python``; the filename cannot encode it."""
+    parsed = _parse_wheel_filename(entry.name)
+    if parsed is None or parsed[0] != canonical:
+        return None
+    return _read_wheel_requires_python(entry)
+
+
+def _read_wheel_requires_python(wheel_path: Path) -> str | None:
+    """Return ``Requires-Python`` from a wheel's METADATA, or ``None``."""
+    try:
+        with zipfile.ZipFile(wheel_path) as archive:
+            member = _metadata_member(archive.namelist())
+            if member is None:
+                return None
+            raw = archive.read(member)
+    except (zipfile.BadZipFile, OSError):
+        return None
+
+    value = BytesParser().parsebytes(raw, headersonly=True).get("Requires-Python")
+    return value if isinstance(value, str) else None
+
+
+def _metadata_member(names: list[str]) -> str | None:
+    """Return the top-level ``*.dist-info/METADATA`` member name, or ``None``."""
+    for name in names:
+        head, sep, tail = name.rpartition("/")
+        if (
+            sep
+            and tail == "METADATA"
+            and head.endswith(".dist-info")
+            and "/" not in head
+        ):
+            return name
+    return None
 
 
 def _make_record(

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import io
 import tarfile
+import zipfile
 from pathlib import Path
 from typing import TYPE_CHECKING, TypeVar
 
@@ -26,6 +27,26 @@ _T = TypeVar("_T")
 
 def run(coro: Coroutine[Any, Any, _T]) -> _T:
     return asyncio.run(coro)
+
+
+def _write_wheel(
+    path: Path,
+    name: str,
+    version: str,
+    requires_python: str | None = None,
+    *,
+    with_metadata: bool = True,
+) -> None:
+    """Write a real (zip) wheel whose METADATA carries ``requires_python``."""
+    dist = f"{name}-{version}"
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr(f"{name}/__init__.py", b"")
+        if with_metadata:
+            rp = f"Requires-Python: {requires_python}\n" if requires_python else ""
+            zf.writestr(
+                f"{dist}.dist-info/METADATA",
+                f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n{rp}",
+            )
 
 
 class TestParseFileUrl:
@@ -106,6 +127,43 @@ class TestFlatWheelhouse:
         missing = tmp_path / "does-not-exist"
         client = LocalIndexClient(missing.as_uri())
         assert run(client.get_files("foo")) == []
+
+    def test_requires_python_read_from_wheel_metadata(self, tmp_path: Path) -> None:
+        # Requires-Python is absent from the filename; it comes from METADATA.
+        _write_wheel(tmp_path / "foo-2.0-py3-none-any.whl", "foo", "2.0", ">=3.12")
+        client = LocalIndexClient(tmp_path.as_uri())
+        files = run(client.get_files("foo"))
+        assert len(files) == 1
+        assert files[0].requires_python == ">=3.12"
+
+    def test_requires_python_none_when_metadata_omits_it(self, tmp_path: Path) -> None:
+        _write_wheel(tmp_path / "foo-1.0-py3-none-any.whl", "foo", "1.0")
+        client = LocalIndexClient(tmp_path.as_uri())
+        files = run(client.get_files("foo"))
+        assert files[0].requires_python is None
+
+    def test_requires_python_none_without_metadata_member(self, tmp_path: Path) -> None:
+        _write_wheel(
+            tmp_path / "foo-1.0-py3-none-any.whl", "foo", "1.0", with_metadata=False
+        )
+        client = LocalIndexClient(tmp_path.as_uri())
+        files = run(client.get_files("foo"))
+        assert files[0].requires_python is None
+
+    def test_requires_python_none_for_unreadable_zip(self, tmp_path: Path) -> None:
+        (tmp_path / "foo-1.0-py3-none-any.whl").write_bytes(b"not a zip")
+        client = LocalIndexClient(tmp_path.as_uri())
+        files = run(client.get_files("foo"))
+        assert len(files) == 1
+        assert files[0].requires_python is None
+
+    def test_foreign_wheel_metadata_not_read(self, tmp_path: Path) -> None:
+        # A sibling package's Requires-Python must not leak onto foo.
+        _write_wheel(tmp_path / "foo-1.0-py3-none-any.whl", "foo", "1.0", ">=3.8")
+        _write_wheel(tmp_path / "bar-1.0-py3-none-any.whl", "bar", "1.0", ">=3.12")
+        client = LocalIndexClient(tmp_path.as_uri())
+        files = run(client.get_files("foo"))
+        assert [f.requires_python for f in files] == [">=3.8"]
 
 
 class TestPep503Directory:

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import threading
+import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import cast
@@ -16,6 +18,7 @@ from nab_index.client import (
     SdistHashMismatchError,
     WheelFile,
 )
+from nab_index.local_index import LocalIndexClient
 from nab_python._provider import build_remote, metadata_resolver
 from nab_python._provider.metadata_resolver import (
     add_classified_dep,
@@ -365,6 +368,25 @@ class TestFetchVersions:
             },
         )
         versions = [v for v, _ in provider.fetch_versions("foo")]
+        assert versions == [V("1.0")]
+
+    def test_flat_wheelhouse_requires_python_excludes_candidate(
+        self, tmp_path: Path
+    ) -> None:
+        """A flat find-links wheel's METADATA Requires-Python filters candidates."""
+        for version, requires_python in (("2.0", ">=3.12"), ("1.0", ">=3.8")):
+            wheel = tmp_path / f"foo-{version}-py3-none-any.whl"
+            with zipfile.ZipFile(wheel, "w") as zf:
+                zf.writestr("foo/__init__.py", b"")
+                zf.writestr(
+                    f"foo-{version}.dist-info/METADATA",
+                    f"Metadata-Version: 2.1\nName: foo\nVersion: {version}\n"
+                    f"Requires-Python: {requires_python}\n",
+                )
+        records = asyncio.run(LocalIndexClient(tmp_path.as_uri()).get_files("foo"))
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(coordinator, python_version="3.8.0")
+        versions = [v for v, _ in provider.filter_distributions("foo", records)]
         assert versions == [V("1.0")]
 
     def test_sorted_descending(self) -> None:


### PR DESCRIPTION
Resolving against a flat find-links directory could pin a wheel that doesn't support the running Python. Wheel filenames don't encode Requires-Python, and the flat-wheelhouse scan left it unset on every record, so the compatibility filter had nothing to check and never dropped incompatible versions.

Now the scan opens each matching wheel and reads Requires-Python from its METADATA, so a version that excludes the running Python is filtered out instead of being selected.
