### PR TITLE
don't steer an extras proxy to a version that lacks the extra

### DIFF
--- a/nab-python/src/nab_python/_provider/extras.py
+++ b/nab-python/src/nab_python/_provider/extras.py
@@ -122,6 +122,32 @@ def _pick_in_mode(
     return None
 
 
+def version_provides_extra(
+    provider: Provider,
+    base: str,
+    extra: str,
+    version: Version,
+) -> bool:
+    """Whether ``version`` of ``base`` declares ``extra`` and yields metadata here.
+
+    Honoring a cross-tuple preference for a ``base[extra]`` proxy is only
+    safe when the preferred version both provides the extra and has
+    extractable metadata in this tuple.
+    """
+    # Late import: provider imports this module at module load.
+    from ..provider import MetadataError, _normalize_extra
+
+    _, _, normalized = provider.split_and_normalize(base)
+    try:
+        provider.get_dependencies(base, version)
+    except MetadataError:
+        return False
+
+    metadata = provider.metadata_cache[(normalized, version)]
+    provided = {_normalize_extra(e) for e in metadata.provides_extra}
+    return extra in provided
+
+
 def _record_base_range_blocks(
     provider: Provider,
     proxy_pkg: str,

--- a/nab-python/src/nab_python/universal/provider.py
+++ b/nab-python/src/nab_python/universal/provider.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING
 from nab_index.client import SdistFile, WheelFile
 
 from .._conflict_kind import EMPTY_MEMBERSHIP_SETS
+from .._provider.extras import version_provides_extra
 from .._vendor.packaging.markers import default_environment
 from .._vendor.packaging.ranges import VersionRange
 from .._vendor.packaging.utils import canonicalize_name
@@ -157,18 +158,18 @@ class UniversalProvider(Provider):
     ) -> Version | None:
         """Pick a version under the configured strategy, honoring preferences."""
         assert isinstance(version_range, VersionRange)
-        _, _, normalized = self.split_and_normalize(package)
+        base, extra, normalized = self.split_and_normalize(package)
 
-        # Preferences win when the version is still in range AND its metadata
-        # is extractable in this tuple; the look-ahead gate matters for
-        # cross-tuple alignment (a candidate that worked elsewhere may be
-        # tag-incompatible or unbuildable here).
+        # Honor a preference only when the version is in range and usable
+        # here: a base version needs extractable metadata, an extras proxy
+        # additionally needs to declare the extra.
         preferred = self._preferences.get(normalized)
         if preferred is not None:
             all_versions = self.versions_only(normalized, self.fetch_versions(package))
             if preferred in set(version_range.filter(all_versions)) and (
-                self.split_and_normalize(package)[1] is not None
-                or self._look_ahead_ok(normalized, preferred, check_decisions=True)
+                version_provides_extra(self, base, extra, preferred)
+                if extra is not None
+                else self._look_ahead_ok(normalized, preferred, check_decisions=True)
             ):
                 self._flush_pending_blocks()
                 return preferred

--- a/nab-python/tests/universal/test_universal_provider.py
+++ b/nab-python/tests/universal/test_universal_provider.py
@@ -254,6 +254,77 @@ class TestPreferences:
         assert result == Version("3.0")
 
 
+class TestExtrasProxyPreference:
+    """A cross-tuple preference for an extras proxy respects Provides-Extra."""
+
+    _NO_EXTRA = "Metadata-Version: 2.1\nName: foo\nVersion: {ver}\n\n"
+    _WITH_EXTRA = (
+        "Metadata-Version: 2.1\nName: foo\nVersion: {ver}\n"
+        'Provides-Extra: bar\nRequires-Dist: cryptography; extra == "bar"\n\n'
+    )
+
+    def _provider(
+        self,
+        *,
+        versions: Sequence[str],
+        metadata_by_version: dict[str, str | None],
+        preferred: str,
+    ) -> UniversalProvider:
+        wheels = [_make_wheel(v, package="foo") for v in versions]
+        coordinator = make_coordinator(
+            wheels,
+            package="foo",
+            metadata_by_version=metadata_by_version,
+        )
+        return UniversalProvider(
+            coordinator,
+            marker_environment=_LINUX_ENV,
+            root_extras={("foo", "bar")},
+            preferences={"foo": Version(preferred)},
+        )
+
+    def test_non_providing_preference_falls_through(self) -> None:
+        """A preferred base version lacking the extra yields the providing one."""
+        provider = self._provider(
+            versions=("1.5", "2.0"),
+            metadata_by_version={
+                "1.5": self._NO_EXTRA.format(ver="1.5"),
+                "2.0": self._WITH_EXTRA.format(ver="2.0"),
+            },
+            preferred="1.5",
+        )
+        chosen = provider.choose_version("foo[bar]", VersionRange.full())
+        assert chosen == Version("2.0")
+        deps = provider.get_dependencies("foo[bar]", Version("2.0"))
+        assert "cryptography" in deps
+
+    def test_unreadable_preference_falls_through(self) -> None:
+        """A preferred version whose metadata cannot be read is not honored."""
+        provider = self._provider(
+            versions=("1.5", "2.0"),
+            metadata_by_version={
+                "1.5": None,
+                "2.0": self._WITH_EXTRA.format(ver="2.0"),
+            },
+            preferred="1.5",
+        )
+        chosen = provider.choose_version("foo[bar]", VersionRange.full())
+        assert chosen == Version("2.0")
+
+    def test_providing_preference_wins_over_highest(self) -> None:
+        """A preferred version that declares the extra beats the highest one."""
+        provider = self._provider(
+            versions=("2.0", "3.0"),
+            metadata_by_version={
+                "2.0": self._WITH_EXTRA.format(ver="2.0"),
+                "3.0": self._WITH_EXTRA.format(ver="3.0"),
+            },
+            preferred="2.0",
+        )
+        chosen = provider.choose_version("foo[bar]", VersionRange.full())
+        assert chosen == Version("2.0")
+
+
 class TestStrategyChoiceVersion:
     """``choose_version`` honors the resolution_strategy flag."""
 


### PR DESCRIPTION
A universal `nab lock` could crash with an uncaught `MissingExtraError`. When picking a version for a `foo[bar]` proxy, the provider honored a cross-tuple preference as soon as the preferred version was in range, without checking that the version actually declares `bar`. If it didn't, the later `get_dependencies` call for the user's extra raised and aborted the resolve.

Now an extras proxy honors a preference only when the preferred version declares the extra and has readable metadata in this tuple. Otherwise it falls through to the normal pick, which lands on a version that provides the extra.
