### PR TITLE
Set-correct extra marker evaluation

### DIFF
--- a/nab-python/src/nab_python/_marker_extras.py
+++ b/nab-python/src/nab_python/_marker_extras.py
@@ -1,0 +1,108 @@
+"""Set-correct evaluation of ``extra`` markers against a full extras set.
+
+The dependency-specifiers spec resolves ``extra`` comparisons against the whole
+set of extras requested for a package: ``==`` is membership, ``!=`` is
+non-membership, and every other operator is undefined (False).  Evaluating one
+extra at a time gets ``extra != "x"`` and the undefined operators wrong -- the
+vendored packaging evaluator even treats ``extra <= "x"`` / ``extra >= "x"`` as
+``==`` (see ``markers._operators``), so ``extra <= "gpu"`` would wrongly gate a
+dependency on the ``gpu`` extra.
+
+packaging's :meth:`Marker.evaluate` only compares ``extra`` against a single
+string, and this module uses **public packaging API only** (nab plans to stop
+vendoring packaging), so it never touches ``Marker._markers`` or the parser.
+Instead it rewrites each ``extra <op> "x"`` comparison in the canonical
+``str(marker)`` into a membership test on the public ``extras`` set variable
+(``"x" in extras`` / ``"x" not in extras``) and evaluates the rewritten marker
+with ``extras`` bound to the requested set.  An empty set is the base (no-extra)
+install.
+
+``str(marker)`` is canonical (validated): values are double-quoted, the operand
+order is preserved, and ``extra`` literals are already :pep:`685` canonicalized.
+
+Reference: https://packaging.python.org/en/latest/specifications/dependency-specifiers/
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from ._vendor.packaging.markers import Marker
+from ._vendor.packaging.utils import canonicalize_name
+
+if TYPE_CHECKING:
+    from collections.abc import Set as AbstractSet
+
+# A bare ``extra <op> "value"`` comparison, in either operand order, plus a
+# passthrough alternative for a whole quoted value.  Ordering matters: the
+# ``extra`` comparisons are tried first, then any remaining ``"..."`` value is
+# consumed atomically so ``extra``/operator text that appears *inside* a value
+# (``os_name == "junk extra =="``) is never mistaken for a comparison.  packaging
+# serializes every value with unescaped double quotes, so a valid ``str(marker)``
+# has all values in the ``"[^"]*"`` shape (a value with an embedded double quote
+# already fails to reparse in packaging itself).  ``\bextra\b`` never matches
+# inside the plural ``extras`` variable, and ``in`` / ``not in`` are excluded on
+# purpose: ``"x" in extras`` is a set-variable test, not an ``extra`` comparison.
+_OPS = r"===|==|!=|<=|>=|~=|<|>"
+_EXTRA_COMPARISON = re.compile(
+    rf'\bextra\b\s*(?P<op1>{_OPS})\s*"(?P<val1>[^"]*)"'
+    rf'|"(?P<val2>[^"]*)"\s*(?P<op2>{_OPS})\s*\bextra\b'
+    r'|"[^"]*"'
+)
+
+# ``extra`` operators other than ``==`` / ``!=`` are undefined by the spec; tools
+# evaluate them False.  A parenthesised self-contradiction is False for every set.
+_ALWAYS_FALSE = '("" in extras and "" not in extras)'
+
+
+def _comparison_op(match: re.Match[str]) -> str | None:
+    """Return the operator when ``match`` is an ``extra`` comparison, else None."""
+    return match.group("op1") or match.group("op2")
+
+
+def _rewrite_leaf(match: re.Match[str]) -> str:
+    op = _comparison_op(match)
+    if op is None:
+        # A bare quoted value: pass it through untouched.
+        return match.group(0)
+    value = match.group("val1")
+    if value is None:
+        value = match.group("val2")
+    name = canonicalize_name(value)
+    if op == "==":
+        return f'"{name}" in extras'
+    if op == "!=":
+        return f'"{name}" not in extras'
+    return _ALWAYS_FALSE
+
+
+def references_extra(marker: Marker) -> bool:
+    """Return whether ``marker`` compares against the ``extra`` variable."""
+    return any(_comparison_op(m) for m in _EXTRA_COMPARISON.finditer(str(marker)))
+
+
+def rewrite_extra_markers(marker: Marker) -> Marker:
+    """Rewrite ``extra`` comparisons into ``extras`` set-membership tests.
+
+    The result evaluates set-correctly when ``extras`` is bound to the full
+    requested set: ``extra == "x"`` becomes ``"x" in extras``, ``extra != "x"``
+    becomes ``"x" not in extras``, and any other operator becomes a
+    constant-False term.  Non-``extra`` leaves are left untouched.
+    """
+    return Marker(_EXTRA_COMPARISON.sub(_rewrite_leaf, str(marker)))
+
+
+def evaluate_marker_with_extras(
+    marker: Marker,
+    extras: AbstractSet[str],
+    environment: dict[str, str | AbstractSet[str]],
+) -> bool:
+    """Evaluate ``marker`` with ``extra`` resolved as membership in ``extras``.
+
+    Convenience wrapper that rewrites on every call; hot paths cache the
+    rewritten marker and reuse a mutated environment instead.  ``environment``
+    supplies the values for the non-``extra`` marker leaves.
+    """
+    env = {**environment, "extras": frozenset(canonicalize_name(e) for e in extras)}
+    return bool(rewrite_extra_markers(marker).evaluate(env))

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 from nab_index.client import SdistFile, WheelFile
 from nab_index.local_index import read_wheel_metadata
 
-from .._conflict_kind import EMPTY_MEMBERSHIP_SETS
+from .._marker_extras import references_extra, rewrite_extra_markers
 from .._vcs_admission import admit_vcs_url
 from .._vendor.packaging.ranges import VersionRange
 from .._vendor.packaging.requirements import InvalidRequirement, Requirement
@@ -323,35 +323,74 @@ def classify_requirement(
     Returns None if the marker doesn't match the environment.
     Returns an empty set if the requirement is a base dep (no extra gating).
     Returns a set of normalized extra names if extra-gated.
+
+    ``extra`` comparisons resolve as set membership per the
+    dependency-specifiers spec (see :mod:`nab_python._marker_extras`):
+    ``extra == "x"`` gates on ``x``, ``extra != "x"`` holds for the base
+    plus every other extra, and any other operator on ``extra`` never
+    matches.  A marker with no ``extra`` comparison is a plain environment
+    marker: it is a base dep when it holds, else dropped.
     """
     marker = req.marker
     if marker is None:
         return set()
     marker_id = id(marker)
+    if not marker_refs_extra(provider, marker, marker_id):
+        return set() if env_marker_holds(provider, marker, marker_id) else None
     if marker_matches_base(provider, marker, marker_id):
         return set()
-    if "extra" not in marker_text(provider, marker, marker_id):
-        return None
     matched_extras = marker_matched_extras(provider, marker, marker_id, provided_extras)
     return matched_extras or None
 
 
-def marker_matches_base(provider: Provider, marker: Marker, marker_id: int) -> bool:
-    """Evaluate ``marker`` against the env without ``extra`` set, cached."""
+def marker_refs_extra(provider: Provider, marker: Marker, marker_id: int) -> bool:
+    """Whether ``marker`` compares against ``extra`` at all, cached."""
+    result = provider.marker_refs_extra_cache.get(marker_id)
+    if result is None:
+        result = references_extra(marker)
+        provider.marker_refs_extra_cache[marker_id] = result
+    return result
+
+
+def env_marker_holds(provider: Provider, marker: Marker, marker_id: int) -> bool:
+    """Evaluate a non-``extra`` marker against the environment, cached.
+
+    The plural lockfile-only set variables (``extras``,
+    ``dependency_groups``) are empty at resolve time, so a marker testing
+    one drops its dep.
+    """
     result = provider.marker_base_cache.get(marker_id)
     if result is None:
-        result = marker.evaluate({**provider.environment, **EMPTY_MEMBERSHIP_SETS})
+        env = provider.env_with_extra
+        env["extras"] = frozenset()
+        result = bool(marker.evaluate(env))
         provider.marker_base_cache[marker_id] = result
     return result
 
 
-def marker_text(provider: Provider, marker: Marker, marker_id: int) -> str:
-    """Return ``str(marker)``, cached. Walks the AST on big graphs."""
-    text = provider.marker_text_cache.get(marker_id)
-    if text is None:
-        text = str(marker)
-        provider.marker_text_cache[marker_id] = text
-    return text
+def rewritten_marker(provider: Provider, marker: Marker, marker_id: int) -> Marker:
+    """Return the ``extras``-membership rewrite of ``marker``, cached.
+
+    The rewrite is independent of which extras are requested, so it is built
+    once per marker and evaluated against different ``extras`` bindings.
+    """
+    cached = provider.rewritten_marker_cache.get(marker_id)
+    if cached is None:
+        cached = provider.rewritten_marker_cache[marker_id] = rewrite_extra_markers(
+            marker
+        )
+    return cached
+
+
+def marker_matches_base(provider: Provider, marker: Marker, marker_id: int) -> bool:
+    """Whether an ``extra`` marker holds for the base (empty) extras set, cached."""
+    result = provider.marker_base_cache.get(marker_id)
+    if result is None:
+        env = provider.env_with_extra
+        env["extras"] = frozenset()
+        result = bool(rewritten_marker(provider, marker, marker_id).evaluate(env))
+        provider.marker_base_cache[marker_id] = result
+    return result
 
 
 def marker_matched_extras(
@@ -360,17 +399,23 @@ def marker_matched_extras(
     marker_id: int,
     provided_extras: set[str],
 ) -> set[str]:
-    """Return the extras for which the marker evaluates to True."""
+    """Return the provided extras whose singleton set satisfies the marker.
+
+    Each extra ``x`` is evaluated as the full requested set ``{x}``, so a
+    ``extra == "x"`` line lands on ``x``; a line that also holds for the
+    empty set is already classified base and never reaches here.
+    """
     per_marker = provider.marker_extra_cache.get(marker_id)
     if per_marker is None:
         per_marker = provider.marker_extra_cache[marker_id] = {}
+    rewritten = rewritten_marker(provider, marker, marker_id)
     env = provider.env_with_extra
     matched: set[str] = set()
     for extra_name in provided_extras:
         result = per_marker.get(extra_name)
         if result is None:
-            env["extra"] = extra_name
-            result = marker.evaluate(env)
+            env["extras"] = frozenset((canonicalize_name(extra_name),))
+            result = bool(rewritten.evaluate(env))
             per_marker[extra_name] = result
         if result:
             matched.add(extra_name)

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
 
     from nab_resolver.types import Incompatibility, RangeProtocol
 
+    from ._vendor.packaging.markers import Marker
     from .config import IndexOverride, NabProjectConfig, PackageOverride
     from .fetch import FetchCoordinator
 
@@ -556,11 +557,17 @@ class Provider:
         # alive (see its note above).
         self.marker_base_cache: dict[int, bool] = {}
         self.marker_extra_cache: dict[int, dict[str, bool]] = {}
-        # Memoised str(marker) for the cheap "extra" in marker_text gate.
-        self.marker_text_cache: dict[int, str] = {}
-        # Reused per-evaluation environment dict (avoids a copy per requirement),
-        # seeded with the empty lockfile-only set variables (see
-        # EMPTY_MEMBERSHIP_SETS) so a marker testing one evaluates False.
+        # Whether a marker references ``extra`` at all; gates the per-extra
+        # membership pass in ``classify_requirement``.
+        self.marker_refs_extra_cache: dict[int, bool] = {}
+        # ``extra`` markers rewritten to ``extras`` set-membership tests, cached
+        # per marker so the rewrite/reparse happens once and is evaluated against
+        # different ``extras`` bindings.
+        self.rewritten_marker_cache: dict[int, Marker] = {}
+        # Environment for marker evaluation, seeded with the empty lockfile-only
+        # set variables (see EMPTY_MEMBERSHIP_SETS).  ``classify_requirement``
+        # rebinds the ``extras`` key per evaluation to answer ``extra``
+        # comparisons as set membership (see ``_marker_extras``).
         self.env_with_extra: dict[str, str | frozenset[str]] = {
             **self.environment,
             **EMPTY_MEMBERSHIP_SETS,

--- a/nab-python/tests/test_marker_extras.py
+++ b/nab-python/tests/test_marker_extras.py
@@ -1,0 +1,208 @@
+"""Set-correct ``extra`` marker evaluation (:mod:`nab_python._marker_extras`).
+
+The dependency-specifiers spec resolves ``extra`` comparisons against the
+whole set of extras requested for a package: ``==`` is membership, ``!=``
+is non-membership, and every other operator is undefined (False).  These
+tests pin that matrix, the delegation of non-``extra`` leaves to
+packaging, and PEP 685 name normalization.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nab_python._conflict_kind import EMPTY_MEMBERSHIP_SETS
+from nab_python._marker_extras import (
+    evaluate_marker_with_extras,
+    references_extra,
+)
+from nab_python._vendor.packaging.markers import Marker, default_environment
+
+# A concrete linux / CPython 3.12 environment, seeded with the empty
+# lockfile-only set variables exactly as the provider seeds it.
+ENV: dict[str, str | frozenset[str]] = {
+    **{k: v for k, v in default_environment().items() if isinstance(v, str)},
+    "python_version": "3.12",
+    "python_full_version": "3.12.0",
+    "sys_platform": "linux",
+    "platform_machine": "x86_64",
+    **EMPTY_MEMBERSHIP_SETS,
+}
+
+
+def _eval(marker_text: str, extras: set[str]) -> bool:
+    return evaluate_marker_with_extras(Marker(marker_text), frozenset(extras), ENV)
+
+
+class TestPositiveOperator:
+    """``extra == "x"`` is membership in the requested set."""
+
+    @pytest.mark.parametrize(
+        ("extras", "expected"),
+        [
+            (set(), False),
+            ({"gpu"}, True),
+            ({"cpu"}, False),
+            ({"cpu", "gpu"}, True),
+        ],
+    )
+    def test_eq(self, extras: set[str], expected: bool) -> None:
+        assert _eval('extra == "gpu"', extras) is expected
+
+    def test_operand_order_is_symmetric(self) -> None:
+        """The extra literal may sit on either side of the operator."""
+        assert _eval('"gpu" == extra', {"gpu"}) is True
+        assert _eval('"gpu" == extra', {"cpu"}) is False
+
+
+class TestNegativeOperator:
+    """``extra != "x"`` is non-membership; True for the base install."""
+
+    @pytest.mark.parametrize(
+        ("extras", "expected"),
+        [
+            (set(), True),
+            ({"gpu"}, False),
+            ({"cpu"}, True),
+            ({"cpu", "gpu"}, False),
+        ],
+    )
+    def test_ne(self, extras: set[str], expected: bool) -> None:
+        assert _eval('extra != "gpu"', extras) is expected
+
+
+class TestUndefinedOperators:
+    """Every operator on ``extra`` other than ``==``/``!=`` evaluates False.
+
+    The vendored packaging evaluator treats ``<=``/``>=`` on a string key
+    as ``==``, so without this rule ``extra <= "gpu"`` would wrongly gate
+    on the ``gpu`` extra.
+    """
+
+    @pytest.mark.parametrize("op", ["<=", ">=", "<", ">", "==="])
+    @pytest.mark.parametrize("extras", [set(), {"gpu"}, {"cpu"}])
+    def test_undefined_operator_never_matches(
+        self, op: str, extras: set[str]
+    ) -> None:
+        assert _eval(f'extra {op} "gpu"', extras) is False
+
+
+class TestBooleanCombinations:
+    """``and``/``or`` combine leaf results as packaging groups them."""
+
+    @pytest.mark.parametrize(
+        ("marker", "extras", "expected"),
+        [
+            ('extra == "a" and extra == "b"', {"a"}, False),
+            ('extra == "a" and extra == "b"', {"a", "b"}, True),
+            ('extra == "a" or extra == "b"', set(), False),
+            ('extra == "a" or extra == "b"', {"b"}, True),
+            ('extra != "a" and extra != "b"', set(), True),
+            ('extra != "a" and extra != "b"', {"a"}, False),
+            ('extra != "a" and extra != "b"', {"c"}, True),
+            ('extra != "a" and extra != "b"', {"a", "b"}, False),
+            ('extra == "a" and extra != "b"', {"a"}, True),
+            ('extra == "a" and extra != "b"', {"a", "b"}, False),
+        ],
+    )
+    def test_combination(
+        self, marker: str, extras: set[str], expected: bool
+    ) -> None:
+        assert _eval(marker, extras) is expected
+
+    def test_nested_parentheses(self) -> None:
+        marker = '(extra == "a" or extra == "b") and sys_platform == "linux"'
+        assert _eval(marker, {"a"}) is True
+        assert _eval(marker, set()) is False
+
+
+class TestNonExtraLeavesDelegate:
+    """Leaves that do not reference ``extra`` use the resolve environment."""
+
+    def test_pure_environment_marker(self) -> None:
+        assert _eval('sys_platform == "linux"', set()) is True
+        assert _eval('sys_platform == "win32"', {"gpu"}) is False
+
+    def test_extra_gated_by_environment(self) -> None:
+        marker = 'python_version >= "3.10" and extra == "a"'
+        assert _eval(marker, {"a"}) is True
+        assert _eval(marker, set()) is False
+
+    def test_env_marker_gate_can_veto_extra(self) -> None:
+        marker = 'extra == "a" and sys_platform == "win32"'
+        assert _eval(marker, {"a"}) is False
+
+    def test_plural_extras_variable_binds_to_the_set(self) -> None:
+        """A literal ``"x" in extras`` leaf tests the bound ``extras`` set.
+
+        The provider never routes such a marker through this primitive (see
+        ``references_extra``): a plural-set marker in metadata is a base-path
+        environment marker evaluated against the empty set and dropped.
+        """
+        assert _eval('"x" in extras', {"x"}) is True
+        assert _eval('"x" in extras', set()) is False
+
+
+class TestNameNormalization:
+    """Extra names compare under PEP 685 canonicalization."""
+
+    def test_literal_and_requested_name_normalize(self) -> None:
+        assert _eval('extra == "Foo.Bar"', {"foo-bar"}) is True
+        assert evaluate_marker_with_extras(
+            Marker('extra == "foo-bar"'), frozenset({"Foo_Bar"}), ENV
+        ) is True
+
+
+class TestQuoteAwareRewrite:
+    """A value that merely contains ``extra``/operator text is never a comparison.
+
+    packaging can serialize a value like ``"junk extra =="``; a rewrite that is
+    not quote-aware would match the ``extra ==`` inside it and corrupt the
+    marker across the value boundary.
+    """
+
+    def test_extra_text_inside_a_value_is_not_a_comparison(self) -> None:
+        marker = Marker('os_name == "junk extra ==" and sys_platform == "linux"')
+        assert references_extra(marker) is False
+
+    def test_value_with_extra_text_is_preserved_alongside_a_real_comparison(
+        self,
+    ) -> None:
+        from nab_python._marker_extras import rewrite_extra_markers
+
+        marker = Marker('os_name == "junk extra ==" and extra == "gpu"')
+        assert references_extra(marker) is True
+        rewritten = str(rewrite_extra_markers(marker))
+        assert rewritten == 'os_name == "junk extra ==" and "gpu" in extras'
+
+    def test_value_containing_extra_text_evaluates_as_environment(self) -> None:
+        # os_name is "posix" here, so the value comparison is simply False; the
+        # point is that it is not corrupted into an extras membership test.
+        assert _eval('os_name == "an extra == thing"', {"gpu"}) is False
+
+    def test_reversed_operand_canonicalizes(self) -> None:
+        assert _eval('"GPU_Foo" == extra', {"gpu-foo"}) is True
+        assert _eval('"GPU_Foo" != extra', {"gpu-foo"}) is False
+
+
+class TestReferencesExtra:
+    """``marker_references_extra`` detects an ``extra`` comparison anywhere."""
+
+    @pytest.mark.parametrize(
+        ("marker", "expected"),
+        [
+            ('extra == "a"', True),
+            ('extra != "a"', True),
+            ('"a" == extra', True),
+            ('(extra == "a") or sys_platform == "linux"', True),
+            ('python_version >= "3.10" and extra == "a"', True),
+            ('python_version >= "3.10"', False),
+            ('sys_platform == "linux" and os_name == "posix"', False),
+            # A parenthesised group that does not reference extra still has
+            # to be walked past to reach the rest of the marker.
+            ('(sys_platform == "linux") and os_name == "posix"', False),
+            ('"x" in extras', False),
+        ],
+    )
+    def test_references_extra(self, marker: str, expected: bool) -> None:
+        assert references_extra(Marker(marker)) is expected

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -4116,6 +4116,43 @@ class TestExtras:
         assert "cryptography" not in base_deps
         assert "cryptography" not in sec_deps
 
+    def test_undefined_extra_operator_never_matches(self) -> None:
+        """An ``extra`` operator other than ==/!= gates nothing (spec: False).
+
+        The vendored packaging evaluator treats ``extra <= "gpu"`` like
+        ``extra == "gpu"``; the set-correct classifier drops it from the
+        base deps and from every extra.
+        """
+        metadata = (
+            "Metadata-Version: 2.1\n"
+            "Name: foo\n"
+            "Version: 1.0\n"
+            "Provides-Extra: gpu\n"
+            'Requires-Dist: weirddep; extra <= "gpu"\n'
+        )
+        coordinator = make_coordinator(
+            [make_wheel("1.0")], metadata_text=metadata, package="foo"
+        )
+        provider = Provider(coordinator, python_version="3.12.0")
+        assert "weirddep" not in provider.get_dependencies("foo", V("1.0"))
+        assert "weirddep" not in provider.get_dependencies("foo[gpu]", V("1.0"))
+
+    def test_negative_extra_marker_is_a_base_dep(self) -> None:
+        """``extra != "gpu"`` holds for the base install, so it is a base dep."""
+        metadata = (
+            "Metadata-Version: 2.1\n"
+            "Name: foo\n"
+            "Version: 1.0\n"
+            "Provides-Extra: gpu\n"
+            'Requires-Dist: defaultdep; extra != "gpu"\n'
+        )
+        coordinator = make_coordinator(
+            [make_wheel("1.0")], metadata_text=metadata, package="foo"
+        )
+        provider = Provider(coordinator, python_version="3.12.0")
+        req = Requirement('defaultdep; extra != "gpu"')
+        assert classify_requirement(provider, req, {"gpu"}) == set()
+
     def test_multiple_extras_same_package(self) -> None:
         """Different extras on the same package get separate deps."""
         metadata = (


### PR DESCRIPTION
Evaluate `extra` markers against the whole requested-extras set, per the [dependency-specifiers spec](https://packaging.python.org/en/latest/specifications/dependency-specifiers/): `extra == "x"` is membership, `extra != "x"` is non-membership, and any other operator on `extra` is undefined and evaluates False.

The previous per-extra evaluation relied on packaging's single-value `extra` comparison, which treats `extra <= "x"` and `extra >= "x"` as `==` (see `markers._operators`). So `foo; extra <= "gpu"` wrongly gated `foo` on the `gpu` extra: resolving `pkg[gpu]` where `pkg` declares `dep; extra <= "gpu"` pulled in `dep`. It no longer does.

The implementation uses public packaging API only (no `Marker._markers`): it rewrites each `extra <op> "x"` comparison in the canonical `str(marker)` into a membership test on the public `extras` set variable, then evaluates with `extras` bound to the requested set. The rewrite is quote-aware, so operator text inside a value (`os_name == "junk extra =="`) is never mistaken for a comparison.

This is the shared primitive for correct extra handling. It does not by itself change how a negative-extra dependency flows through the proxy model (a `dep; extra != "gpu"` line is still a base dependency of a plain install); that is the additive-model question tracked separately.
