### PR TITLE
skip user-extra versions with unextractable base metadata

### DIFF
--- a/nab-python/src/nab_python/_provider/extras.py
+++ b/nab-python/src/nab_python/_provider/extras.py
@@ -77,23 +77,15 @@ def _pick_in_mode(
 ) -> Version | None:
     """Pick a candidate honoring ``ExtrasMode``.
 
-    Fetches base metadata so an extraction failure (unparseable
-    PKG-INFO, or an sdist build the policy disallows) becomes a
-    candidate skip instead of a fatal error during the later
-    dependency fetch.  BACKTRACK mode additionally checks
-    ``Provides-Extra`` for transitive extras.
-
-    Missing-metadata cases (no PEP 658, no sdist) skip transitive
-    extras but fall through for user-requested ones; mock test
-    coordinators rely on this.
+    Fetches base metadata so an extraction failure (unparseable PKG-INFO,
+    a disallowed sdist build, or no metadata source at all) skips the
+    candidate rather than raising later, when the proxy refetches the base
+    to expand the extra. This applies to user-requested extras too, since
+    the proxy always needs the base metadata. BACKTRACK mode additionally
+    checks ``Provides-Extra`` for transitive extras.
     """
     # Late import: ``pypi`` imports this module at module load.
-    from ..provider import (
-        ExtrasMode,
-        MetadataError,
-        UnsupportedSdistError,
-        _normalize_extra,
-    )
+    from ..provider import ExtrasMode, MetadataError, _normalize_extra
 
     _, _, normalized = provider.split_and_normalize(base)
     is_user = (normalized, extra) in provider.root_extras
@@ -103,12 +95,8 @@ def _pick_in_mode(
             continue
         try:
             provider.get_dependencies(base, version)
-        except UnsupportedSdistError:
-            continue
         except MetadataError:
-            if not is_user or provider.has_invalid_metadata(normalized, version):
-                continue
-            return version
+            continue
         if is_user or not backtrack:
             return version
         metadata = provider.metadata_cache.get((normalized, version))

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -4495,9 +4495,14 @@ class TestExtras:
         assert provider.choose_version("foo[security]", spec.to_range()) is None
 
     def test_backtrack_mode_user_extra_returns_first(self) -> None:
-        """BACKTRACK mode returns first candidate for user-provided extras."""
+        """BACKTRACK mode returns first candidate for user-provided extras.
+
+        A user extra skips the ``Provides-Extra`` gating that transitive
+        extras get in BACKTRACK mode, so 2.0 is returned even though its
+        minimal metadata declares no extras.
+        """
         wheels = [make_wheel("2.0"), make_wheel("1.0")]
-        coordinator = make_coordinator(wheels, package="foo")
+        coordinator = make_coordinator(wheels, package="foo", auto_metadata=True)
         provider = Provider(
             coordinator,
             extras_mode=ExtrasMode.BACKTRACK,
@@ -6869,6 +6874,55 @@ class TestExtrasInvalidMetadata:
         )
         version = provider.choose_version("foo[security]", VersionRange.full())
         assert version == V("1.0")
+
+    def test_user_extra_skips_version_with_no_metadata_source(self) -> None:
+        """A user extra skips a version with no PEP 658 metadata and no sdist.
+
+        resolve_metadata raises a generic MetadataError before
+        get_dependencies records the version, so has_invalid_metadata stays
+        False. The pick must still skip 2.0 and choose 1.0.
+        """
+        wheels = [make_wheel("2.0"), make_wheel("1.0")]
+        coordinator = make_coordinator(
+            wheels,
+            metadata_by_version={"1.0": EXTRA_METADATA},
+            package="foo",
+        )
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            root_extras={("foo", "security")},
+        )
+        version = provider.choose_version("foo[security]", VersionRange.full())
+        assert version == V("1.0")
+
+    def test_user_extra_no_metadata_resolves_end_to_end(self) -> None:
+        """A user extra whose top version lacks metadata still resolves.
+
+        The extras proxy sorts before its base, so pkg[feature] is decided
+        first. With 2.0 unreadable, the proxy must fall to 1.0.
+        """
+        metadata = (
+            "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\nProvides-Extra: feature\n"
+        )
+        coordinator = make_coordinator(
+            [make_wheel("2.0"), make_wheel("1.0")],
+            metadata_by_version={"1.0": metadata},
+            package="pkg",
+        )
+        root_reqs = {
+            "pkg": VersionRange.full(),
+            "pkg[feature]": VersionRange.full(),
+        }
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            root_requirements=root_reqs,
+            root_extras={("pkg", "feature")},
+        )
+        resolver = Resolver(provider, range_type=VersionRange, root_version="0")
+        pins = resolver.resolve(root_reqs)
+        assert pins["pkg"] == V("1.0")
 
 
 class TestScanBatchNoFirstCandidate:


### PR DESCRIPTION
A user-requested extra like `pkg[feature]` whose top matching version has metadata that can't be read (no PEP 658 metadata and no buildable sdist, or an unparseable PKG-INFO) crashed the whole resolve with an uncaught MetadataError. The plain `pkg` requirement in the same situation just skips that version and picks the next one, so the two paths disagreed.

The cause is in `_pick_in_mode`: for a user extra it only skipped a MetadataError when `has_invalid_metadata` was already set, but a generic MetadataError raised before `get_dependencies` records the version leaves that flag False, so the unreadable version was returned as usable. Later the extras proxy refetches the base to expand the extra, hits the same error, and this time nothing catches it.

Now any MetadataError skips the candidate for user extras too, matching the base requirement, so the resolver falls to the next version instead of crashing.
