### PR TITLE
read Requires-Python from flat find-links sdist metadata

### DIFF
--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import re
 import zipfile
-from email.parser import BytesParser
+from email.parser import BytesParser, Parser
 from html.parser import HTMLParser
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -213,7 +213,7 @@ def _scan_flat_wheelhouse(
             continue
         if _FLAT_EXTS.search(entry.name) is None:
             continue
-        requires_python = _flat_wheel_requires_python(entry, canonical)
+        requires_python = _flat_requires_python(entry, canonical)
         record = _make_record(
             entry.name,
             entry.as_uri(),
@@ -228,12 +228,30 @@ def _scan_flat_wheelhouse(
     return files
 
 
-def _flat_wheel_requires_python(entry: Path, canonical: str) -> str | None:
-    """Read a matching wheel's ``Requires-Python``; the filename cannot encode it."""
-    parsed = _parse_wheel_filename(entry.name)
-    if parsed is None or parsed[0] != canonical:
+def _flat_requires_python(entry: Path, canonical: str) -> str | None:
+    """Read a flat-wheelhouse dist's ``Requires-Python``; not in the filename."""
+    wheel = _parse_wheel_filename(entry.name)
+    if wheel is not None:
+        return _read_wheel_requires_python(entry) if wheel[0] == canonical else None
+    sdist = _parse_sdist_filename(entry.name)
+    if sdist is not None and sdist[0] == canonical:
+        return _read_sdist_requires_python(entry)
+    return None
+
+
+def _read_sdist_requires_python(sdist_path: Path) -> str | None:
+    """Return ``Requires-Python`` from an sdist's PKG-INFO, or ``None``."""
+    try:
+        data = sdist_path.read_bytes()
+    except OSError:
         return None
-    return _read_wheel_requires_python(entry)
+
+    pkg_info, _ = _extract_sdist_files(data)
+    if pkg_info is None:
+        return None
+
+    value = Parser().parsestr(pkg_info, headersonly=True).get("Requires-Python")
+    return value if isinstance(value, str) else None
 
 
 def _read_wheel_requires_python(wheel_path: Path) -> str | None:

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -16,6 +16,7 @@ from nab_index.local_index import (
     LocalIndexClient,
     _make_record,
     _parse_file_url,
+    _read_sdist_requires_python,
     read_wheel_metadata,
 )
 
@@ -48,6 +49,29 @@ def _write_wheel(
                 f"{dist}.dist-info/METADATA",
                 f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n{rp}",
             )
+
+
+def _write_sdist(
+    path: Path,
+    name: str,
+    version: str,
+    requires_python: str | None = None,
+    *,
+    with_pkg_info: bool = True,
+) -> None:
+    """Write a real (tar.gz) sdist whose PKG-INFO carries ``requires_python``."""
+    dist = f"{name}-{version}"
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        if with_pkg_info:
+            rp = f"Requires-Python: {requires_python}\n" if requires_python else ""
+            body = (
+                f"Metadata-Version: 2.2\nName: {name}\nVersion: {version}\n{rp}"
+            ).encode()
+            info = tarfile.TarInfo(name=f"{dist}/PKG-INFO")
+            info.size = len(body)
+            tar.addfile(info, io.BytesIO(body))
+    path.write_bytes(buf.getvalue())
 
 
 class TestParseFileUrl:
@@ -165,6 +189,43 @@ class TestFlatWheelhouse:
         client = LocalIndexClient(tmp_path.as_uri())
         files = run(client.get_files("foo"))
         assert [f.requires_python for f in files] == [">=3.8"]
+
+    def test_sdist_requires_python_read_from_pkg_info(self, tmp_path: Path) -> None:
+        # Requires-Python is absent from the filename; it comes from PKG-INFO.
+        _write_sdist(tmp_path / "foo-1.0.tar.gz", "foo", "1.0", ">=3.12")
+        client = LocalIndexClient(tmp_path.as_uri())
+        files = run(client.get_files("foo"))
+        assert len(files) == 1
+        assert isinstance(files[0], SdistFile)
+        assert files[0].requires_python == ">=3.12"
+
+    def test_sdist_requires_python_none_when_pkg_info_omits_it(
+        self, tmp_path: Path
+    ) -> None:
+        _write_sdist(tmp_path / "foo-1.0.tar.gz", "foo", "1.0")
+        client = LocalIndexClient(tmp_path.as_uri())
+        files = run(client.get_files("foo"))
+        assert files[0].requires_python is None
+
+    def test_sdist_requires_python_none_for_unreadable_archive(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "foo-1.0.tar.gz").write_bytes(b"not a gzip")
+        client = LocalIndexClient(tmp_path.as_uri())
+        files = run(client.get_files("foo"))
+        assert len(files) == 1
+        assert files[0].requires_python is None
+
+    def test_foreign_sdist_metadata_not_read(self, tmp_path: Path) -> None:
+        # A sibling package's sdist Requires-Python must not leak onto foo.
+        _write_sdist(tmp_path / "foo-1.0.tar.gz", "foo", "1.0", ">=3.8")
+        _write_sdist(tmp_path / "bar-1.0.tar.gz", "bar", "1.0", ">=3.12")
+        client = LocalIndexClient(tmp_path.as_uri())
+        files = run(client.get_files("foo"))
+        assert [f.requires_python for f in files] == [">=3.8"]
+
+    def test_read_sdist_requires_python_missing_file(self, tmp_path: Path) -> None:
+        assert _read_sdist_requires_python(tmp_path / "absent.tar.gz") is None
 
 
 class TestPep503Directory:

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import io
+import tarfile
 import threading
 import zipfile
 from datetime import datetime, timezone
@@ -383,6 +385,27 @@ class TestFetchVersions:
                     f"Metadata-Version: 2.1\nName: foo\nVersion: {version}\n"
                     f"Requires-Python: {requires_python}\n",
                 )
+        records = asyncio.run(LocalIndexClient(tmp_path.as_uri()).get_files("foo"))
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(coordinator, python_version="3.8.0")
+        versions = [v for v, _ in provider.filter_distributions("foo", records)]
+        assert versions == [V("1.0")]
+
+    def test_flat_wheelhouse_sdist_requires_python_excludes_candidate(
+        self, tmp_path: Path
+    ) -> None:
+        """A flat find-links sdist's PKG-INFO Requires-Python filters candidates."""
+        for version, requires_python in (("2.0", ">=3.12"), ("1.0", ">=3.8")):
+            buf = io.BytesIO()
+            with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+                body = (
+                    f"Metadata-Version: 2.2\nName: foo\nVersion: {version}\n"
+                    f"Requires-Python: {requires_python}\n"
+                ).encode()
+                info = tarfile.TarInfo(name=f"foo-{version}/PKG-INFO")
+                info.size = len(body)
+                tar.addfile(info, io.BytesIO(body))
+            (tmp_path / f"foo-{version}.tar.gz").write_bytes(buf.getvalue())
         records = asyncio.run(LocalIndexClient(tmp_path.as_uri()).get_files("foo"))
         coordinator = make_coordinator([], package="foo")
         provider = Provider(coordinator, python_version="3.8.0")


### PR DESCRIPTION
Resolving against a flat find-links directory could pin an sdist that doesn't support the running Python. Sdist filenames don't encode Requires-Python, and the flat-wheelhouse scan left it unset on every sdist record, so the compatibility filter had nothing to check and never dropped incompatible versions.

Now the scan opens each matching sdist and reads Requires-Python from its PKG-INFO, so a version that excludes the running Python is filtered out instead of being selected. This is the sdist counterpart to #304, which did the same for wheels.
