### PR TITLE
Reject a candidate with an invalid dependency

### DIFF
--- a/nab-python/src/nab_python/_build/runner.py
+++ b/nab-python/src/nab_python/_build/runner.py
@@ -33,12 +33,12 @@ import build
 import pyproject_hooks
 import tomli
 
-from .._vendor.packaging.requirements import Requirement
+from nab_resolver.resolver import ResolutionError
+
+from .._vendor.packaging.requirements import InvalidRequirement, Requirement
 from .._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from .._vendor.packaging.utils import canonicalize_name
 from .._vendor.packaging.version import InvalidVersion, Version
-from nab_resolver.resolver import ResolutionError
-
 from ..metadata import WheelMetadata
 from .env import BuildEnvError, NabBuildEnv
 from .errors import BuildBackendError
@@ -238,15 +238,19 @@ def _parse_metadata(metadata_path: Path) -> WheelMetadata:
             SpecifierSet(requires_python_raw) if requires_python_raw else None
         )
     except InvalidSpecifier as exc:
-        msg = f"backend METADATA has invalid Requires-Python {requires_python_raw!r}: {exc}"
+        msg = (
+            f"backend METADATA has invalid Requires-Python "
+            f"{requires_python_raw!r}: {exc}"
+        )
         raise BuildBackendError(msg) from exc
 
-    requires_dist: list[Requirement] = []
-    for raw in msg_obj.get_all("Requires-Dist") or ():
-        try:
-            requires_dist.append(Requirement(raw))
-        except (ValueError, TypeError):  # noqa: PERF203
-            logger.warning("skipping unparseable Requires-Dist: %s", raw)
+    try:
+        requires_dist: list[Requirement] = [
+            Requirement(raw) for raw in msg_obj.get_all("Requires-Dist") or ()
+        ]
+    except InvalidRequirement as exc:
+        msg = f"backend METADATA has an invalid Requires-Dist: {exc}"
+        raise BuildBackendError(msg) from exc
 
     provides_extra: list[str] = sorted(
         {

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -8,7 +8,6 @@ each ``Requires-Dist`` entry into base deps vs per-extra deps.
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
 
 from nab_index.client import SdistFile, WheelFile
@@ -17,7 +16,6 @@ from nab_index.local_index import read_wheel_metadata
 from .._conflict_kind import EMPTY_MEMBERSHIP_SETS
 from .._vcs_admission import admit_vcs_url
 from .._vendor.packaging.ranges import VersionRange
-from .._vendor.packaging.requirements import InvalidRequirement, Requirement
 from .._vendor.packaging.specifiers import SpecifierSet
 from .._vendor.packaging.utils import canonicalize_name
 from ..metadata import (
@@ -26,17 +24,20 @@ from ..metadata import (
     metadata_deps_are_static,
     parse_metadata,
 )
-from ..requirements_file import InvalidProjectRequirementError, _require_string_list
+from ..requirements_file import (
+    InvalidProjectRequirementError,
+    _parse_project_requirement,
+    _parse_requirements,
+    _require_string_list,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from .._vendor.packaging.markers import Marker
+    from .._vendor.packaging.requirements import Requirement
     from .._vendor.packaging.version import Version
     from ..provider import DistFile, Provider
-
-
-logger = logging.getLogger(__name__)
 
 
 def resolve_metadata(
@@ -264,50 +265,30 @@ def augment_from_pyproject(
 def extend_with_extras(requires_dist: list[Requirement], optional: dict) -> list[str]:
     """Append extras-gated requirements and return Provides-Extra names.
 
-    A per-extra value that is not an array of strings raises
-    :class:`InvalidProjectRequirementError`; a well-typed entry that is
-    not valid PEP 508 is dropped with a warning.
+    A per-extra value that is not an array of strings, or a per-extra entry
+    that is not valid PEP 508, raises :class:`InvalidProjectRequirementError`,
+    so the version is rejected rather than resolved with the entry dropped.
     """
     provides_extra: list[str] = []
     for extra_name, extra_deps in optional.items():
         source = f"[project].optional-dependencies extra {extra_name!r}"
         provides_extra.append(extra_name)
-        for dep_str in _require_string_list(extra_deps, source):
-            req = _parse_dep(dep_str, extra_name)
-            if req is not None:
-                requires_dist.append(req)
+        requires_dist.extend(
+            _parse_project_requirement(dep_str, source, extra=extra_name)
+            for dep_str in _require_string_list(extra_deps, source)
+        )
     return provides_extra
 
 
 def parse_pyproject_deps(deps: list) -> list[Requirement]:
-    """Parse a ``project.dependencies`` list, dropping unparseable entries.
+    """Parse a ``project.dependencies`` list, raising on a malformed entry.
 
     Entries are already validated as strings by :func:`_require_string_list`;
-    a string that is not valid PEP 508 is dropped with a warning.
+    a string that is not valid PEP 508 raises
+    :class:`InvalidProjectRequirementError`, so the whole version is rejected
+    rather than resolved with the dependency dropped.
     """
-    out: list[Requirement] = []
-    for dep_str in deps:
-        req = _parse_dep(dep_str, None)
-        if req is not None:
-            out.append(req)
-    return out
-
-
-def _parse_dep(dep_str: str, extra_name: str | None) -> Requirement | None:
-    """Parse one PEP 508 string, warning and dropping if it is malformed."""
-    # Late import: ``pypi`` imports this module at module load.
-    from ..provider import _add_extra_marker
-
-    try:
-        text = (
-            _add_extra_marker(dep_str, extra_name)
-            if extra_name is not None
-            else dep_str
-        )
-        return Requirement(text)
-    except InvalidRequirement:
-        logger.warning("skipping unparseable requirement: %s", dep_str)
-        return None
+    return _parse_requirements(deps, "[project].dependencies")
 
 
 def find_sdist(

--- a/nab-python/src/nab_python/build_backend.py
+++ b/nab-python/src/nab_python/build_backend.py
@@ -9,23 +9,26 @@ dynamic path needs a :class:`NabProjectConfig`.
 
 from __future__ import annotations
 
-import logging
 from functools import lru_cache
 from typing import TYPE_CHECKING
 
 from ._build.errors import (
     BuildBackendError as BuildBackendError,  # noqa: PLC0414  (public re-export)
 )
-from ._vendor.packaging.requirements import Requirement
 from ._vendor.packaging.specifiers import SpecifierSet
 from ._vendor.packaging.utils import canonicalize_name
 from ._vendor.packaging.version import InvalidVersion, Version
 from .metadata import WheelMetadata, load_static_project
-from .requirements_file import InvalidProjectRequirementError, _require_string_list
+from .requirements_file import (
+    InvalidProjectRequirementError,
+    _parse_project_requirement,
+    _require_string_list,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from ._vendor.packaging.requirements import Requirement
     from .config import NabProjectConfig
 
 __all__ = [
@@ -33,9 +36,6 @@ __all__ = [
     "extract_metadata",
     "extract_static_metadata",
 ]
-
-
-logger = logging.getLogger(__name__)
 
 
 @lru_cache(maxsize=4096)
@@ -149,23 +149,10 @@ def _extend_with_dep_strings(
     source: str,
     extra: str | None = None,
 ) -> None:
-    for dep in _require_string_list(raw, source):
-        req = _parse_dep(dep, extra)
-        if req is not None:
-            out.append(req)
-
-
-def _parse_dep(dep: str, extra: str | None) -> Requirement | None:
-    """Parse one PEP 508 string, warning and dropping if it is malformed."""
-    # Late import: avoids a circular import with ``provider``.
-    from .provider import _add_extra_marker  # noqa: PLC0415
-
-    try:
-        text = _add_extra_marker(dep, extra) if extra is not None else dep
-        return Requirement(text)
-    except (ValueError, TypeError):
-        logger.warning("skipping unparseable requirement: %s", dep)
-        return None
+    out.extend(
+        _parse_project_requirement(dep, source, extra=extra)
+        for dep in _require_string_list(raw, source)
+    )
 
 
 def _require_optional_dependencies(project: dict) -> dict:

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -30,7 +30,6 @@ from ._vcs_admission import (
 )
 from ._vendor.packaging.markers import default_environment
 from ._vendor.packaging.ranges import VersionRange
-from ._vendor.packaging.requirements import Requirement
 from ._vendor.packaging.utils import canonicalize_name
 from ._vendor.packaging.version import InvalidVersion, Version
 from .metadata import WheelMetadata
@@ -43,6 +42,7 @@ if TYPE_CHECKING:
 
     from nab_resolver.types import Incompatibility, RangeProtocol
 
+    from ._vendor.packaging.requirements import Requirement
     from .config import IndexOverride, NabProjectConfig, PackageOverride
     from .fetch import FetchCoordinator
 
@@ -301,23 +301,6 @@ class UnsupportedSdistError(MetadataError):
 # and would silently reject the version; a naive upload-time is a hard error.
 class InvalidUploadTimeError(Exception):
     """Raised when an index upload-time is not the timezone-aware UTC PEP 700 needs."""
-
-
-def _add_extra_marker(dep_str: str, extra_name: str) -> str:
-    """Append ``extra == "name"`` to a :pep:`508` dep string.
-
-    Parses with :class:`Requirement` rather than splitting on the first
-    ``;`` so a semicolon inside a direct-reference URL is not mistaken
-    for the marker separator; an existing marker is combined with ``and``.
-    """
-    req = Requirement(dep_str)
-    extra_marker = f'extra == "{extra_name}"'
-    if req.marker is not None:
-        marker = f"({req.marker}) and {extra_marker}"
-    else:
-        marker = extra_marker
-    req.marker = None
-    return f"{req} ; {marker}"
 
 
 @dataclass

--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -50,6 +50,41 @@ def _parse_requirements(strings: Sequence[str], source: str) -> list[Requirement
         raise InvalidProjectRequirementError(msg) from exc
 
 
+def _add_extra_marker(dep_str: str, extra_name: str) -> str:
+    """Append ``extra == "name"`` to a :pep:`508` dep string.
+
+    Parses with :class:`Requirement` rather than splitting on the first
+    ``;`` so a semicolon inside a direct-reference URL is not mistaken
+    for the marker separator; an existing marker is combined with ``and``.
+    """
+    req = Requirement(dep_str)
+    extra_marker = f'extra == "{extra_name}"'
+    if req.marker is not None:
+        marker = f"({req.marker}) and {extra_marker}"
+    else:
+        marker = extra_marker
+    req.marker = None
+    return f"{req} ; {marker}"
+
+
+def _parse_project_requirement(
+    dep_str: str, source: str, *, extra: str | None = None
+) -> Requirement:
+    """Parse one PEP 508 dependency string, raising if it is malformed.
+
+    An ``extra`` name is folded in as an ``extra == "name"`` marker. A string
+    that is not valid PEP 508 raises :class:`InvalidProjectRequirementError`,
+    so a candidate declaring one malformed dependency is rejected whole rather
+    than resolved with the dependency silently dropped.
+    """
+    try:
+        text = _add_extra_marker(dep_str, extra) if extra is not None else dep_str
+        return Requirement(text)
+    except InvalidRequirement as exc:
+        msg = f"invalid requirement in {source}: {exc}"
+        raise InvalidProjectRequirementError(msg) from exc
+
+
 def _require_string_list(value: object, source: str) -> list[str]:
     """Validate that a PEP 621 dependency value is an array of strings.
 

--- a/nab-python/tests/test_build_backend.py
+++ b/nab-python/tests/test_build_backend.py
@@ -165,9 +165,8 @@ class TestExtractStaticMetadata:
         )
         assert extract_static_metadata(tmp_path) is None
 
-    def test_unparseable_dep_skipped_with_warning(
-        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_unparseable_dep_raises(self, tmp_path: Path) -> None:
+        """A dep string that is not valid PEP 508 is invalid metadata; raise."""
         _write_pyproject(
             tmp_path,
             """
@@ -177,15 +176,11 @@ class TestExtractStaticMetadata:
             dependencies = ["requests>=2.0", "this is not a valid req"]
             """,
         )
-        meta = extract_static_metadata(tmp_path)
-        assert meta is not None
-        names = [r.name for r in meta.requires_dist]
-        assert "requests" in names
-        assert any("unparseable" in rec.message for rec in caplog.records)
+        with pytest.raises(InvalidProjectRequirementError, match="invalid requirement"):
+            extract_static_metadata(tmp_path)
 
-    def test_unparseable_optional_dep_skipped(
-        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_unparseable_optional_dep_raises(self, tmp_path: Path) -> None:
+        """An optional dep that is not valid PEP 508 is invalid metadata; raise."""
         _write_pyproject(
             tmp_path,
             """
@@ -197,11 +192,8 @@ class TestExtractStaticMetadata:
             ok = ["requests"]
             """,
         )
-        meta = extract_static_metadata(tmp_path)
-        assert meta is not None
-        names = [r.name for r in meta.requires_dist]
-        assert "requests" in names
-        assert any("unparseable" in rec.message for rec in caplog.records)
+        with pytest.raises(InvalidProjectRequirementError, match="invalid requirement"):
+            extract_static_metadata(tmp_path)
 
     def test_dependencies_with_non_string_entries_raises(self, tmp_path: Path) -> None:
         """A non-string entry is a structural error that raises."""
@@ -488,9 +480,13 @@ class TestStaticExtractAugmentParity:
         assert bar.url == "https://h/a;b/p.tar.gz"
         assert str(bar.marker) == 'extra == "net"'
 
-    def test_malformed_static_dep_dropped_like_augment_index_refuses(
-        self, tmp_path: Path
-    ) -> None:
+    def test_malformed_static_dep_raises_like_metadata(self, tmp_path: Path) -> None:
+        """Every dep reader rejects a malformed dependency, not drops it.
+
+        The static build-backend reader, the pyproject augment path, and the
+        METADATA parser each raise on an invalid PEP 508 string, so the version
+        is rejected rather than resolved with the dependency dropped.
+        """
         deps = ["requests>=2", "this is not a valid !! req"]
         _write_pyproject(
             tmp_path,
@@ -504,11 +500,10 @@ class TestStaticExtractAugmentParity:
             ]
             """,
         )
-        meta = extract_static_metadata(tmp_path)
-        assert meta is not None
-        bb_names = [r.name for r in meta.requires_dist]
-        aug_names = [r.name for r in parse_pyproject_deps(deps)]
-        assert bb_names == aug_names == ["requests"]
+        with pytest.raises(InvalidProjectRequirementError, match="invalid requirement"):
+            extract_static_metadata(tmp_path)
+        with pytest.raises(InvalidProjectRequirementError, match="invalid requirement"):
+            parse_pyproject_deps(deps)
 
         md = (
             "Metadata-Version: 2.3\nName: foo\nVersion: 1.0\n"

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -494,9 +494,8 @@ class TestParseMetadata:
         with pytest.raises(BuildBackendError, match="invalid Requires-Python"):
             _parse_metadata(path)
 
-    def test_unparseable_requires_dist_is_skipped(self, tmp_path: Path) -> None:
-        """A malformed Requires-Dist line logs and is dropped; well-formed
-        siblings still come through."""
+    def test_unparseable_requires_dist_raises(self, tmp_path: Path) -> None:
+        """A malformed Requires-Dist line is invalid metadata, so parsing raises."""
         from nab_python._build.runner import _parse_metadata
 
         path = tmp_path / "METADATA"
@@ -506,9 +505,8 @@ class TestParseMetadata:
             "Requires-Dist: click>=8\n",
             encoding="utf-8",
         )
-        meta = _parse_metadata(path)
-        names = sorted(r.name for r in meta.requires_dist)
-        assert names == ["click"]
+        with pytest.raises(BuildBackendError, match="invalid Requires-Dist"):
+            _parse_metadata(path)
 
     def test_provides_extra_whitespace_stripped(self, tmp_path: Path) -> None:
         """Surrounding whitespace on a Provides-Extra value is insignificant

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -54,7 +54,6 @@ from nab_python.provider import (
     VcsConfig,
     VcsPolicy,
     VcsSource,
-    _add_extra_marker,
     python_axis_environment,
 )
 from nab_python.resolve import _raise_for_local_vcs_python
@@ -5625,34 +5624,6 @@ PKG_INFO_DYNAMIC_PROVIDES_EXTRA = (
 )
 
 
-class TestAddExtraMarker:
-    def test_no_existing_marker(self) -> None:
-        """A bare requirement gets a fresh ``extra ==`` marker."""
-        out = _add_extra_marker("numpy>=1.0", "foo")
-        assert out == 'numpy>=1.0 ; extra == "foo"'
-
-    def test_with_existing_marker(self) -> None:
-        """An existing marker is wrapped and combined with ``and``."""
-        out = _add_extra_marker("numpy>=1.0 ; python_version >= '3.10'", "foo")
-        assert out == 'numpy>=1.0 ; (python_version >= "3.10") and extra == "foo"'
-
-    def test_semicolon_in_direct_url_kept(self) -> None:
-        """A ``;`` in a direct-URL is part of the URL, not the marker."""
-        out = _add_extra_marker("foo @ https://h/a;b/p.tar.gz", "bar")
-        req = Requirement(out)
-        assert req.url == "https://h/a;b/p.tar.gz"
-        assert str(req.marker) == 'extra == "bar"'
-
-    def test_semicolon_in_direct_url_with_marker_kept(self) -> None:
-        """The URL ``;`` survives and the existing marker is kept with extra."""
-        out = _add_extra_marker(
-            "foo @ https://h/a;b/p.tar.gz ; python_version >= '3.10'", "bar"
-        )
-        req = Requirement(out)
-        assert req.url == "https://h/a;b/p.tar.gz"
-        assert str(req.marker) == 'python_version >= "3.10" and extra == "bar"'
-
-
 class TestSharedSlotProvenance:
     def test_pkg_info_stays_gated_for_provider_with_wheel_in_view(self) -> None:
         """PKG-INFO stored by one provider stays sdist-gated for another.
@@ -6307,8 +6278,8 @@ class TestStaticSdistMetadata:
         with pytest.raises(MetadataError, match="must be an array of strings"):
             provider.get_dependencies("pkg", V("1.0"))
 
-    def test_pyproject_drops_invalid_requirements(self) -> None:
-        """Malformed requirement strings are dropped, not fatal."""
+    def test_pyproject_invalid_requirement_rejects(self) -> None:
+        """A malformed requirement string rejects the version."""
         pyproject = (
             "[project]\n"
             'name = "pkg"\n'
@@ -6325,11 +6296,11 @@ class TestStaticSdistMetadata:
             python_version="3.12.0",
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
-        deps = provider.get_dependencies("pkg", V("1.0"))
-        assert "dep-a" in deps
+        with pytest.raises(MetadataError, match="invalid requirement"):
+            provider.get_dependencies("pkg", V("1.0"))
 
-    def test_pyproject_drops_invalid_extra_dep_string(self) -> None:
-        """Malformed extras entries fall through the inner try."""
+    def test_pyproject_invalid_extra_dep_rejects(self) -> None:
+        """A malformed extras entry rejects the version."""
         pyproject = (
             "[project]\n"
             'name = "pkg"\n'
@@ -6348,9 +6319,8 @@ class TestStaticSdistMetadata:
             python_version="3.12.0",
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
-        provider.get_dependencies("pkg", V("1.0"))
-        metadata = provider.metadata_cache[("pkg", V("1.0"))]
-        assert "foo" in metadata.provides_extra
+        with pytest.raises(MetadataError, match="invalid requirement"):
+            provider.get_dependencies("pkg", V("1.0"))
 
     def test_pyproject_non_string_extra_dep_rejects(self) -> None:
         """A non-string entry inside an extras list rejects the version."""

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -6,9 +6,11 @@ from pathlib import Path
 
 import pytest
 
+from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python.requirements_file import (
     InvalidProjectRequirementError,
+    _add_extra_marker,
     expand_extra_requirements,
     expand_group_includes,
     expand_self_extras,
@@ -21,6 +23,34 @@ from nab_python.requirements_file import (
     select_optional_dependencies,
 )
 from nab_resolver.errors import ResolutionError
+
+
+class TestAddExtraMarker:
+    def test_no_existing_marker(self) -> None:
+        """A bare requirement gets a fresh ``extra ==`` marker."""
+        out = _add_extra_marker("numpy>=1.0", "foo")
+        assert out == 'numpy>=1.0 ; extra == "foo"'
+
+    def test_with_existing_marker(self) -> None:
+        """An existing marker is wrapped and combined with ``and``."""
+        out = _add_extra_marker("numpy>=1.0 ; python_version >= '3.10'", "foo")
+        assert out == 'numpy>=1.0 ; (python_version >= "3.10") and extra == "foo"'
+
+    def test_semicolon_in_direct_url_kept(self) -> None:
+        """A ``;`` in a direct-URL is part of the URL, not the marker."""
+        out = _add_extra_marker("foo @ https://h/a;b/p.tar.gz", "bar")
+        req = Requirement(out)
+        assert req.url == "https://h/a;b/p.tar.gz"
+        assert str(req.marker) == 'extra == "bar"'
+
+    def test_semicolon_in_direct_url_with_marker_kept(self) -> None:
+        """The URL ``;`` survives and the existing marker is kept with extra."""
+        out = _add_extra_marker(
+            "foo @ https://h/a;b/p.tar.gz ; python_version >= '3.10'", "bar"
+        )
+        req = Requirement(out)
+        assert req.url == "https://h/a;b/p.tar.gz"
+        assert str(req.marker) == 'python_version >= "3.10" and extra == "bar"'
 
 
 class TestReadPyprojectDependencies:


### PR DESCRIPTION
An invalid PEP 508 dependency string in a candidate's metadata was dropped with a warning, leaving the candidate to resolve with a dependency missing. #264 already made a structurally-malformed `[project].dependencies` (not an array of strings) raise; this extends the same rule to an entry that is a valid string but not valid PEP 508, across every reader that builds a candidate's dependencies: the static build-backend reader, the sdist `pyproject.toml` augment path, and a built wheel's METADATA `Requires-Dist` (`_build/runner.py`, which already raised on an invalid `Requires-Python`).

An invalid dependency now raises, so `get_dependencies` rejects the version (a `MetadataError`) and the resolver moves on to another; for a local source it is fatal. A candidate whose dependency metadata nab cannot fully read is not pinned with a dependency silently missing.

The two copies of the drop-and-warn parse helper collapse into one `_parse_project_requirement` in `requirements_file.py`, next to the existing `_require_string_list` structural check. `_add_extra_marker` moves there as well, so the readers no longer need a late import of `provider`.
