### PR TITLE
Validate vcs.allowed-schemes at config parse

### DIFF
--- a/nab-python/src/nab_python/_vcs_admission.py
+++ b/nab-python/src/nab_python/_vcs_admission.py
@@ -81,6 +81,17 @@ _VCS_SCHEMES: frozenset[str] = frozenset(
     }
 )
 
+
+def known_vcs_schemes() -> frozenset[str]:
+    """Return the VCS URL schemes nab recognises (e.g. ``git+https``).
+
+    nab is git-only, so every entry is a ``git+`` scheme.  Exposed so
+    config parsing can reject an unknown ``vcs.allowed-schemes`` entry
+    without importing the private scheme set.
+    """
+    return _VCS_SCHEMES
+
+
 _VCS_INSECURE_SCHEMES: frozenset[str] = frozenset({"git+git", "git+http"})
 
 

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -23,6 +23,7 @@ from nab_index.multi_index import IndexConfig
 
 from ._conflict_kind import KIND_EXTRA, KIND_GROUP
 from ._toml import tool_nab_section
+from ._vcs_admission import known_vcs_schemes
 from ._vendor.packaging.requirements import InvalidRequirement, Requirement
 from ._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from ._vendor.packaging.utils import InvalidName, canonicalize_name
@@ -1736,6 +1737,13 @@ def _parse_vcs(value: object) -> VcsConfig:
     allowed_schemes = _parse_string_list(
         "vcs.allowed-schemes", value.get("allowed-schemes", [])
     )
+    unknown_schemes = sorted(set(allowed_schemes) - known_vcs_schemes())
+    if unknown_schemes:
+        msg = (
+            f"unknown vcs.allowed-schemes: {unknown_schemes!r}; nab recognises"
+            f" {sorted(known_vcs_schemes())!r}"
+        )
+        raise ConfigError(msg)
     allowed_repos = _parse_string_list(
         "vcs.allowed-repos", value.get("allowed-repos", [])
     )

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -1210,6 +1210,17 @@ class TestVcs:
         with pytest.raises(ConfigError, match="vcs.require-pin must be a boolean"):
             read_pyproject_config(path)
 
+    def test_unknown_scheme_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab.vcs]\npolicy = "allow"\nallowed-schemes = ["git+htps"]\n',
+        )
+        with pytest.raises(
+            ConfigError,
+            match=r"unknown vcs.allowed-schemes: \['git\+htps'\]; nab recognises",
+        ):
+            read_pyproject_config(path)
+
 
 class TestLocalSources:
     def test_relative_path_resolved_against_pyproject(self, tmp_path: Path) -> None:
@@ -2944,11 +2955,11 @@ class TestProjectNabTomlConfiguresResolve:
         path = self._write(
             tmp_path,
             '[project]\nname = "x"\nversion = "0"\n',
-            '[vcs]\npolicy = "allow"\nallowed-schemes = ["https"]\n',
+            '[vcs]\npolicy = "allow"\nallowed-schemes = ["git+https"]\n',
         )
         config = read_pyproject_config(path, discover_workspace=False)
         assert config.vcs.policy is VcsPolicy.ALLOW
-        assert config.vcs.allowed_schemes == frozenset({"https"})
+        assert config.vcs.allowed_schemes == frozenset({"git+https"})
         assert "policy=allow" in _inspect(path, "vcs")
 
     def test_table_marker_environment(self, tmp_path: Path) -> None:


### PR DESCRIPTION
`[tool.nab.vcs]` validated its keys but not the values of `allowed-schemes`, so a typo like `git+htps` or an unsupported entry like `hg+https` parsed cleanly and then silently refused the URL it was meant to allow.

Each entry is now checked against the recognised scheme set at parse time, and an unknown entry raises `ConfigError` naming the bad entries and the recognised schemes.
