### PR TITLE
fix extra marker reducer misclassifying the extras set variable

### DIFF
--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
@@ -393,6 +394,20 @@ def _wrap_for_and(text: str) -> str:
     return f"({text})" if len(_split_top_level(text, "or")) > 1 else text
 
 
+_QUOTED_LITERAL = re.compile(r"'[^']*'|\"[^\"]*\"")
+_EXTRA_VARIABLE = re.compile(r"\bextra\b")
+
+
+def _references_extra_variable(text: str) -> bool:
+    """Whether ``text`` uses the ``extra`` marker variable.
+
+    Quoted values are dropped and a word boundary applied so neither a value
+    that contains ``extra`` (``sys_platform == "extraos"``) nor the distinct
+    ``extras`` set variable is mistaken for it.
+    """
+    return bool(_EXTRA_VARIABLE.search(_QUOTED_LITERAL.sub("", text)))
+
+
 def _reduce_conjunct(conjunct: str, extra: str) -> str | bool:
     """Reduce one ``and`` conjunct under a bound ``extra``.
 
@@ -400,13 +415,14 @@ def _reduce_conjunct(conjunct: str, extra: str) -> str | bool:
     for a contradiction, or a residual string of environment conditions.
     """
     inner = _strip_wrapping_parens(conjunct)
+    references_extra = _references_extra_variable(inner)
     is_group = len(_split_top_level(inner, "or")) > 1 or (
-        "extra" in inner and len(_split_top_level(inner, "and")) > 1
+        references_extra and len(_split_top_level(inner, "and")) > 1
     )
     if is_group:
         reduced = _reduce_marker_string(inner, extra)
         return reduced if isinstance(reduced, bool) else _wrap_for_and(reduced)
-    if "extra" not in inner:
+    if not references_extra:
         return inner
     return _decide_extra_conjunct(inner, extra)
 

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -795,6 +795,67 @@ class TestExpandExtraRequirements:
         names = {r.name for r in expand_extra_requirements(opt, "mypkg", ["all"])}
         assert "some-dep" not in names
 
+    def test_self_ref_extras_set_marker_carried_as_residual(self) -> None:
+        """A self-ref gated on the ``extras`` set variable (distinct from the
+        ``extra`` scalar) is carried onto the reached dep as a residual gate,
+        not routed through ``extra`` evaluation, which raises on ``extras``."""
+        opt = {
+            "all": ['mypkg[fast]; "docs" in extras'],
+            "fast": ["some-dep"],
+        }
+        dep = next(
+            r
+            for r in expand_extra_requirements(opt, "mypkg", ["all"])
+            if r.name == "some-dep"
+        )
+        assert dep.marker is not None
+        assert dep.marker.evaluate({"extras": frozenset({"docs"})}, context="lock_file")
+        assert not dep.marker.evaluate({"extras": frozenset()}, context="lock_file")
+
+    def test_self_ref_env_value_containing_extra_substring_kept(self) -> None:
+        """A self-ref env gate whose value contains the substring ``extra``
+        (``sys_platform == "extraos"``) is kept as a residual, not decided
+        against the walked extra and dropped."""
+        opt = {
+            "all": ['mypkg[fast]; sys_platform == "extraos"'],
+            "fast": ["some-dep"],
+        }
+        dep = next(
+            r
+            for r in expand_extra_requirements(opt, "mypkg", ["all"])
+            if r.name == "some-dep"
+        )
+        assert dep.marker is not None
+        assert dep.marker.evaluate({"sys_platform": "extraos"})
+        assert not dep.marker.evaluate({"sys_platform": "linux"})
+
+    def test_self_ref_extras_set_marker_group_gate_kept(self) -> None:
+        """A grouped gate mixing the ``extras`` set variable with an environment
+        condition is kept whole; the ``extras`` clause is not decided as an
+        ``extra`` comparison."""
+        opt = {
+            "all": ['mypkg[fast]; ("docs" in extras and python_version < "3.10")'],
+            "fast": ["some-dep"],
+        }
+        dep = next(
+            r
+            for r in expand_extra_requirements(opt, "mypkg", ["all"])
+            if r.name == "some-dep"
+        )
+        assert dep.marker is not None
+        assert dep.marker.evaluate(
+            {"extras": frozenset({"docs"}), "python_version": "3.9"},
+            context="lock_file",
+        )
+        assert not dep.marker.evaluate(
+            {"extras": frozenset(), "python_version": "3.9"},
+            context="lock_file",
+        )
+        assert not dep.marker.evaluate(
+            {"extras": frozenset({"docs"}), "python_version": "3.11"},
+            context="lock_file",
+        )
+
     def test_unknown_extra_raises(self) -> None:
         with pytest.raises(LookupError, match="not declared"):
             expand_extra_requirements({"a": ["depA"]}, "mypkg", ["missing"])


### PR DESCRIPTION
The self-ref extra marker reducer decided whether a conjunct references the `extra` variable with a plain `"extra" in inner` substring test. That also matched the distinct `extras` set variable and any quoted value that happened to contain the substring, like `sys_platform == "extraos"`.

The effect was a self-referencing dependency gated on the `extras` set (`'"docs" in extras'`) getting routed through `extra` evaluation, which raises `UndefinedEnvironmentName` on the set variable and crashes the resolve. An environment gate whose value merely contained `extra` was decided against the walked extra and silently dropped instead of kept.

The check now strips quoted literals and matches `extra` on a word boundary, so only a real `extra` reference is decided against the bound extra. The `extras` set gate and unrelated environment conditions are carried onto the reached dependency as a residual marker.
