### PR TITLE
fix crash when a self-referential extra is gated by "x" in extras

### DIFF
--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
@@ -319,6 +320,20 @@ def _and_markers(marker: Marker | None, gates: frozenset[str]) -> Marker:
     return Marker(" and ".join(f"({p})" for p in parts))
 
 
+_QUOTED_LITERAL = re.compile(r"'[^']*'|\"[^\"]*\"")
+_EXTRA_VARIABLE = re.compile(r"\bextra\b")
+
+
+def _references_extra(text: str) -> bool:
+    """Whether ``text`` references the singular ``extra`` marker variable.
+
+    Quoted literals are stripped first so ``"extras"`` or a PEP 685 membership
+    such as ``"widget" in extras`` is not misread as ``extra``: both contain the
+    substring ``extra`` that a plain containment test would match.
+    """
+    return bool(_EXTRA_VARIABLE.search(_QUOTED_LITERAL.sub("", text)))
+
+
 def _decide_extra_conjunct(conjunct: str, extra: str) -> bool:
     """Evaluate a single ``extra`` comparison under the bound value.
 
@@ -401,12 +416,12 @@ def _reduce_conjunct(conjunct: str, extra: str) -> str | bool:
     """
     inner = _strip_wrapping_parens(conjunct)
     is_group = len(_split_top_level(inner, "or")) > 1 or (
-        "extra" in inner and len(_split_top_level(inner, "and")) > 1
+        _references_extra(inner) and len(_split_top_level(inner, "and")) > 1
     )
     if is_group:
         reduced = _reduce_marker_string(inner, extra)
         return reduced if isinstance(reduced, bool) else _wrap_for_and(reduced)
-    if "extra" not in inner:
+    if not _references_extra(inner):
         return inner
     return _decide_extra_conjunct(inner, extra)
 

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -795,6 +795,41 @@ class TestExpandExtraRequirements:
         names = {r.name for r in expand_extra_requirements(opt, "mypkg", ["all"])}
         assert "some-dep" not in names
 
+    def test_self_ref_extras_membership_gate_survives_as_residual(self) -> None:
+        """A PEP 685 ``"x" in extras`` gate is set membership over an
+        environment variable, not an ``extra ==`` comparison. The substring
+        ``extra`` inside ``extras`` must not route it to the extra decider; it
+        survives as a residual marker."""
+        opt = {
+            "all": ['mypkg[fast]; "widget" in extras'],
+            "fast": ["cowsay>=5"],
+        }
+        dep = next(
+            r
+            for r in expand_extra_requirements(opt, "mypkg", ["all"])
+            if r.name == "cowsay"
+        )
+        assert dep.marker is not None
+        assert dep.marker.evaluate({"extras": frozenset({"widget"})})
+        assert not dep.marker.evaluate({"extras": frozenset()})
+
+    def test_self_ref_extras_membership_combined_with_extra_gate(self) -> None:
+        """When an ``extra ==`` clause and an ``"x" in extras`` clause are
+        joined by ``and``, the extra clause is decided at expansion and the
+        membership survives as the residual."""
+        opt = {
+            "all": ['mypkg[fast]; extra == "all" and "widget" in extras'],
+            "fast": ["cowsay>=5"],
+        }
+        dep = next(
+            r
+            for r in expand_extra_requirements(opt, "mypkg", ["all"])
+            if r.name == "cowsay"
+        )
+        assert dep.marker is not None
+        assert dep.marker.evaluate({"extras": frozenset({"widget"})})
+        assert not dep.marker.evaluate({"extras": frozenset()})
+
     def test_unknown_extra_raises(self) -> None:
         with pytest.raises(LookupError, match="not declared"):
             expand_extra_requirements({"a": ["depA"]}, "mypkg", ["missing"])


### PR DESCRIPTION
`nab lock` crashed with an uncaught `UndefinedEnvironmentName` when a package declared a self-referential extra gated by a PEP 685 membership marker, e.g. `mypkg[fast]; "widget" in extras`.

While reducing `extra ==` markers at expansion time, the code used a plain `"extra" in inner` substring check to decide whether a conjunct references the singular `extra` variable. `"widget" in extras` contains that substring in the plural `extras` environment variable, so it was routed to the extra decider, which evaluates the marker with only `extra` bound and leaves `extras` undefined.

The check now strips quoted literals and matches `extra` on a word boundary, so a plural `extras` or a quoted string value is no longer mistaken for the singular variable. The membership clause survives as a residual environment marker.
