### PR TITLE
Add direct-URL archive sources

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
         name: Install Python ${{ matrix.python-version }}
         with:
           python-version: ${{ matrix.python-version }}
+          check-latest: true
           cache: pip
           cache-dependency-path: .github/requirements/pylock.tests.toml
           allow-prereleases: true

--- a/docs/guides/build-policy.md
+++ b/docs/guides/build-policy.md
@@ -60,6 +60,9 @@ Builds extend to VCS clones and remote PyPI sdists.  On top of
 
 * VCS-cloned trees with dynamic deps have the backend invoked on
   the clone.
+* Archive sources declared via `[[tool.nab.archive-sources]]` with
+  dynamic deps have the backend invoked on the extracted tree; the
+  bytes are network-fetched, so they count as remote.
 * PyPI sdists whose `PKG-INFO` is dynamic and which have no
   static `pyproject.toml` fallback are downloaded, extracted to a
   temp directory, and built.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -473,6 +473,25 @@ name = "my-fork"
 url  = "git+https://github.com/me/x.git@<sha>"
 ```
 
+## Archive sources
+
+`[[tool.nab.archive-sources]]` pins a package to a direct `.tar.gz`
+URL.  The URL fragment must carry a `sha256` (or `sha384`/`sha512`)
+hash; nab downloads the archive, verifies it against the hash, and
+fails the resolve on a mismatch.
+
+```toml
+[[tool.nab.archive-sources]]
+name = "my-fork"
+url  = "https://example.com/my-fork-1.0.tar.gz#sha256=<hex>"
+```
+
+Only `.tar.gz` source archives are supported; a wheel or other
+format is refused at parse.  A `&subdirectory=` fragment locates the
+package below the archive root, for monorepo layouts.  Reading static
+dependencies works at any `build-policy`; dynamic dependencies require
+`build-policy = "build-remote"`, like a remote sdist.
+
 ## Universal mode (experimental)
 
 Universal resolution runs the single-environment resolver once per

--- a/docs/guides/lockfile.md
+++ b/docs/guides/lockfile.md
@@ -21,9 +21,10 @@ Pass `--output -` to write to stdout instead of a file.
 Each pinned package carries:
 
 * its name and version,
-* one of three pin shapes: an `IndexPin` (PyPI or another simple
-  index), a `LocalPin` (a directory on disk), or a `VcsPin` (a
-  git URL with a commit pin),
+* one of four pin shapes: an `IndexPin` (PyPI or another simple
+  index), a `LocalPin` (a directory on disk), a `VcsPin` (a
+  git URL with a commit pin), or an `ArchivePin` (a `.tar.gz` URL
+  content-pinned by a required `sha256`),
 * every artefact downloaded for that pin (`sdist` and `wheels`),
   each with its filename, URL, `sha256`, and optional size.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,8 @@ guides/conflicts
 * Multiple indexes, per-package routing, and local-checkout sources
 * VCS dependency admission with policy controls (Layer 2: clone +
   static metadata)
+* Direct-URL `.tar.gz` archive sources, hash-verified and pinned as
+  PEP 751 `packages.archive`
 * PEP 751 lockfile emission via the upstream `packaging` library
 * Universal resolution across a user-declared `(python, platform)`
   matrix.  Opt-in via `[tool.nab].mode = "universal"`; the API and

--- a/nab-index/src/nab_index/archive.py
+++ b/nab-index/src/nab_index/archive.py
@@ -11,7 +11,7 @@ policy decision in :mod:`nab_python.config`.
 
 from __future__ import annotations
 
-import posixpath
+import ntpath
 from dataclasses import dataclass
 
 from .client import _ACCEPTED_HASH_ALGORITHMS
@@ -39,6 +39,15 @@ class ArchiveRequest:
     url: str
     hashes: tuple[tuple[str, str], ...]
     subdirectory: str = ""
+
+    @property
+    def has_usable_hash(self) -> bool:
+        """Whether every declared hash carries a non-empty digest.
+
+        PEP 751 requires an archive hash, so a URL with no hash fragment or a
+        present algorithm with an empty digest (``#sha256=``) has none.
+        """
+        return bool(self.hashes) and all(digest for _, digest in self.hashes)
 
     @classmethod
     def parse(cls, raw_url: str) -> ArchiveRequest:
@@ -77,20 +86,27 @@ class ArchiveRequest:
         return cls(url=url, hashes=tuple(hashes), subdirectory=subdirectory)
 
 
-_SUBDIR_ROOT = "/archive-root"
+_SUBDIR_ROOT = ntpath.normpath("/archive-root")
 
 
 def _reject_unsafe_subdirectory(subdirectory: str, raw_url: str) -> None:
     """Refuse a subdirectory that escapes the extracted tree.
 
-    The join ``root / subdirectory`` would otherwise let an absolute path or
-    a ``..`` component read a project outside the archive.  Rather than
-    blocklist characters, normalise the join under a sentinel root and check
-    containment; PEP 751 subdirectories are portable posix paths.
+    At materialise time the project root is selected with ``root /
+    subdirectory``, so an absolute path, a ``..`` component, or a drive
+    letter could read a project outside the archive.  Containment is checked
+    with :mod:`ntpath`, which treats both forward and back slashes as
+    separators, so a value that stays inside the tree on POSIX but escapes it
+    on Windows (the join is native) is caught on every platform.
     """
     if not subdirectory:
         return
-    resolved = posixpath.normpath(posixpath.join(_SUBDIR_ROOT, subdirectory))
-    if posixpath.commonpath((_SUBDIR_ROOT, resolved)) != _SUBDIR_ROOT:
+    resolved = ntpath.normpath(ntpath.join(_SUBDIR_ROOT, subdirectory))
+    try:
+        contained = ntpath.commonpath((_SUBDIR_ROOT, resolved)) == _SUBDIR_ROOT
+    except ValueError:
+        # Different drives (e.g. a ``C:\\`` subdirectory) have no common path.
+        contained = False
+    if not contained:
         msg = f"unsafe archive subdirectory {subdirectory!r} in {raw_url!r}"
         raise ArchiveRequestError(msg)

--- a/nab-index/src/nab_index/archive.py
+++ b/nab-index/src/nab_index/archive.py
@@ -1,0 +1,96 @@
+"""Direct-URL archive requirement parsing for nab-index.
+
+Parses a pip-style archive URL such as
+``https://example.com/foo-1.0.tar.gz#sha256=<hex>&subdirectory=pkg`` into
+its bare URL, the declared hashes, and any subdirectory.
+
+The download and hash verification happen in the fetch coordinator (the
+same path a remote sdist takes); which archives are permitted is a
+policy decision in :mod:`nab_python.config`.
+"""
+
+from __future__ import annotations
+
+import posixpath
+from dataclasses import dataclass
+
+from .client import _ACCEPTED_HASH_ALGORITHMS
+
+__all__ = [
+    "ArchiveRequest",
+    "ArchiveRequestError",
+]
+
+
+class ArchiveRequestError(Exception):
+    """Raised when an archive URL cannot be parsed."""
+
+
+@dataclass(frozen=True, slots=True)
+class ArchiveRequest:
+    """Parsed representation of a direct-URL archive requirement.
+
+    ``url`` is the archive URL with the ``#`` fragment stripped.
+    ``hashes`` is the tuple of ``(algorithm, hex-digest)`` pairs read
+    from the fragment.  ``subdirectory`` is the project root inside the
+    extracted tree, or ``""`` for the archive root.
+    """
+
+    url: str
+    hashes: tuple[tuple[str, str], ...]
+    subdirectory: str = ""
+
+    @classmethod
+    def parse(cls, raw_url: str) -> ArchiveRequest:
+        """Split ``raw_url`` into its URL, hashes, and subdirectory.
+
+        The fragment holds ``&``-separated ``key=value`` parts: a
+        recognised hash algorithm (see :data:`_ACCEPTED_HASH_ALGORITHMS`)
+        or ``subdirectory``.  Any other key raises
+        :class:`ArchiveRequestError`; requiring a hash is left to the
+        config layer so the error names the offending source.
+        """
+        url, _, fragment = raw_url.partition("#")
+        hashes: list[tuple[str, str]] = []
+        subdirectory = ""
+
+        for part in fragment.split("&"):
+            if not part:
+                continue
+            key, sep, value = part.partition("=")
+            if not sep:
+                msg = f"malformed archive URL fragment {part!r} in {raw_url!r}"
+                raise ArchiveRequestError(msg)
+            if key == "subdirectory":
+                subdirectory = value
+            elif key in _ACCEPTED_HASH_ALGORITHMS:
+                hashes.append((key, value.lower()))
+            else:
+                msg = (
+                    f"unknown archive URL fragment key {key!r} in {raw_url!r};"
+                    f" expected one of {', '.join(_ACCEPTED_HASH_ALGORITHMS)}"
+                    " or subdirectory"
+                )
+                raise ArchiveRequestError(msg)
+
+        _reject_unsafe_subdirectory(subdirectory, raw_url)
+        return cls(url=url, hashes=tuple(hashes), subdirectory=subdirectory)
+
+
+_SUBDIR_ROOT = "/archive-root"
+
+
+def _reject_unsafe_subdirectory(subdirectory: str, raw_url: str) -> None:
+    """Refuse a subdirectory that escapes the extracted tree.
+
+    The join ``root / subdirectory`` would otherwise let an absolute path or
+    a ``..`` component read a project outside the archive.  Rather than
+    blocklist characters, normalise the join under a sentinel root and check
+    containment; PEP 751 subdirectories are portable posix paths.
+    """
+    if not subdirectory:
+        return
+    resolved = posixpath.normpath(posixpath.join(_SUBDIR_ROOT, subdirectory))
+    if posixpath.commonpath((_SUBDIR_ROOT, resolved)) != _SUBDIR_ROOT:
+        msg = f"unsafe archive subdirectory {subdirectory!r} in {raw_url!r}"
+        raise ArchiveRequestError(msg)

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -598,9 +598,10 @@ def extract_sdist_archive(data: bytes, target_dir: Path) -> Path:
 
     Extraction goes through the tar ``data`` filter (:pep:`706`), which refuses
     any member that would write outside ``target_dir`` (absolute paths, ``..``,
-    escaping links) and strips special files; a rejected member surfaces as a
-    :class:`ValueError`.  The single extracted top-level directory is the
-    source root, falling back to ``target_dir`` for a flat archive.
+    escaping links) or is a special file (device node, FIFO); a rejected member
+    surfaces as a :class:`ValueError`.  The single extracted top-level directory
+    is the source root, falling back to ``target_dir`` when the archive has no
+    single top-level directory.
 
     The data filter is required; a Python that lacks it (before 3.10.12 /
     3.11.4 / 3.12) is unsupported and extraction raises.
@@ -621,8 +622,13 @@ def extract_sdist_archive(data: bytes, target_dir: Path) -> Path:
         raise ValueError(msg) from exc
 
     # The source root is the single extracted top-level directory, read from
-    # the extracted tree so a sanitised member name cannot mislead it.
-    subdirs = [entry for entry in target_dir.iterdir() if entry.is_dir()]
+    # the extracted tree so a sanitised member name cannot mislead it.  A
+    # symlink is not followed here: only a real directory counts as the root.
+    subdirs = [
+        entry
+        for entry in target_dir.iterdir()
+        if entry.is_dir() and not entry.is_symlink()
+    ]
     if len(subdirs) == 1:
         return subdirs[0]
     return target_dir

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -14,7 +14,6 @@ import sys
 import tarfile
 from dataclasses import dataclass
 from functools import lru_cache
-from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urljoin
 
@@ -26,6 +25,8 @@ from packaging.utils import (
 from packaging.version import InvalidVersion, Version
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from packaging.utils import NormalizedName
     from typing_extensions import Self
 
@@ -43,6 +44,11 @@ __all__ = [
 
 # Verification order; sha256 is pip's hash-checking baseline.
 _ACCEPTED_HASH_ALGORITHMS = ("sha256", "sha384", "sha512")
+
+# The tar ``data`` filter (PEP 706) landed in 3.12 and was backported to
+# 3.10.12 / 3.11.4; sdist extraction requires it (see extract_sdist_archive).
+# data_filter appears with the same change, so its presence detects support.
+_SUPPORTS_DATA_FILTER = hasattr(tarfile, "data_filter")
 
 
 class MetadataHashMismatchError(Exception):
@@ -590,38 +596,33 @@ def _sdist_member_top_level(name: str) -> tuple[int, str, str]:
 def extract_sdist_archive(data: bytes, target_dir: Path) -> Path:
     """Extract a .tar.gz sdist into ``target_dir`` and return the source root.
 
-    Sdists wrap their contents in a single top-level directory
-    (``<name>-<version>/``).  The function refuses absolute paths and
-    members whose normalised path escapes ``target_dir``; sdists from
-    PyPI conform to this convention but mirrors and forks occasionally
-    do not, and silently writing outside the intended directory is
-    unsafe.  The first directory found at depth 1 is returned as the
-    source root, falling back to ``target_dir`` itself when the archive
-    is flat.
+    Extraction goes through the tar ``data`` filter (:pep:`706`), which refuses
+    any member that would write outside ``target_dir`` (absolute paths, ``..``,
+    escaping links) and strips special files; a rejected member surfaces as a
+    :class:`ValueError`.  The single extracted top-level directory is the
+    source root, falling back to ``target_dir`` for a flat archive.
+
+    The data filter is required; a Python that lacks it (before 3.10.12 /
+    3.11.4 / 3.12) is unsupported and extraction raises.
     """
+    if not _SUPPORTS_DATA_FILTER:
+        msg = (
+            "extracting an sdist archive requires the tar data filter;"
+            " upgrade to Python 3.10.12+ / 3.11.4+ / 3.12+"
+        )
+        raise ValueError(msg)
+
     target_dir = target_dir.resolve()
-    root: Path | None = None
-    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
-        for member in tar:
-            raw_name = member.name
-            if not raw_name or raw_name.startswith(("/", "./.")) or "\\" in raw_name:
-                msg = f"unsafe sdist member: {raw_name!r}"
-                raise ValueError(msg)
-            member_name = raw_name.removeprefix("./")
-            if not member_name or member_name.startswith("/"):
-                msg = f"unsafe sdist member: {raw_name!r}"
-                raise ValueError(msg)
-            parts = Path(member_name).parts
-            if any(p in ("..", "") for p in parts):
-                msg = f"unsafe sdist member: {raw_name!r}"
-                raise ValueError(msg)
-            tar.extract(member, target_dir, filter="data")
-            if root is None and member.isdir() and len(parts) == 1:
-                root = target_dir / parts[0]
-            elif root is None and len(parts) >= 1:
-                top = target_dir / parts[0]
-                if top.is_dir():
-                    root = top
-    if root is None:
-        return target_dir
-    return root
+    try:
+        with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
+            tar.extractall(target_dir, filter="data")
+    except tarfile.FilterError as exc:
+        msg = f"unsafe sdist member: {exc}"
+        raise ValueError(msg) from exc
+
+    # The source root is the single extracted top-level directory, read from
+    # the extracted tree so a sanitised member name cannot mislead it.
+    subdirs = [entry for entry in target_dir.iterdir() if entry.is_dir()]
+    if len(subdirs) == 1:
+        return subdirs[0]
+    return target_dir

--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 
     from .._vendor.packaging.version import Version
     from ..lockfile import (
+        ArchivePin,
         IndexPin,
         LockInput,
         PinShape,
@@ -38,7 +39,7 @@ if TYPE_CHECKING:
         VcsPin,
         WheelArtifact,
     )
-    from ..provider import DistPolicy, LocalSource, VcsSource
+    from ..provider import ArchiveSource, DistPolicy, LocalSource, VcsSource
 
 
 __all__ = [
@@ -94,6 +95,10 @@ class LockInputProvider(Protocol):
 
     def vcs_source_for(self, canonical_name: str, /) -> VcsSource | None:
         """Return the configured VcsSource for ``canonical_name`` or None."""
+        ...
+
+    def archive_source_for(self, canonical_name: str, /) -> ArchiveSource | None:
+        """Return the configured ArchiveSource for ``canonical_name`` or None."""
         ...
 
     def vcs_pin_for(self, canonical_name: str, /) -> str | None:
@@ -286,6 +291,12 @@ def build_lock_input_from_provider(  # noqa: PLR0913 - each flag maps to a disti
                 version,
                 vcs_source,
                 resolved_sha=provider.vcs_pin_for(canonical),
+            )
+            continue
+        archive_source = provider.archive_source_for(canonical)
+        if archive_source is not None:
+            lock_pins[canonical] = _archive_pin_from_source(
+                canonical, version, archive_source
             )
             continue
         lock_pins[canonical] = _index_pin_from_listing(
@@ -609,4 +620,29 @@ def _vcs_pin_from_source(
         subdirectory=parsed.subdirectory or None,
         requested_revision=requested_revision,
         vcs_type=parsed.scheme,
+    )
+
+
+def _archive_pin_from_source(
+    canonical: str,
+    version: Version,
+    source: ArchiveSource,
+) -> ArchivePin:
+    """Build an :class:`ArchivePin` from an :class:`ArchiveSource`.
+
+    The URL, hashes, and subdirectory come from the source declaration,
+    which config parse validated (a hash is required), so the pin records
+    the exact archive the resolve used.
+    """
+    from nab_index.archive import ArchiveRequest
+
+    from ..lockfile import ArchivePin
+
+    request = ArchiveRequest.parse(source.url)
+    return ArchivePin(
+        name=canonical,
+        version=str(version),
+        url=request.url,
+        hashes=request.hashes,
+        subdirectory=request.subdirectory or None,
     )

--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -632,7 +632,9 @@ def _archive_pin_from_source(
 
     The URL, hashes, and subdirectory come from the source declaration,
     which config parse validated (a hash is required), so the pin records
-    the exact archive the resolve used.
+    the exact archive the resolve used.  The URL is stripped of any
+    credential userinfo, like every other pin, so a committed lockfile
+    never carries a token.
     """
     from nab_index.archive import ArchiveRequest
 
@@ -642,7 +644,7 @@ def _archive_pin_from_source(
     return ArchivePin(
         name=canonical,
         version=str(version),
-        url=request.url,
+        url=_strip_userinfo(request.url),
         hashes=request.hashes,
         subdirectory=request.subdirectory or None,
     )

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -21,6 +21,7 @@ import tomli_w
 from .._vendor.packaging.markers import Marker
 from .._vendor.packaging.pylock import (
     Package,
+    PackageArchive,
     PackageDirectory,
     PackageSdist,
     PackageVcs,
@@ -214,7 +215,7 @@ def _pin_to_package(
     lock_dir: Path,
     dependencies: list[dict[str, str]] | None = None,
 ) -> Package:
-    from ..lockfile import IndexPin, LocalPin, VcsPin
+    from ..lockfile import ArchivePin, IndexPin, LocalPin, VcsPin
 
     if isinstance(pin, IndexPin):
         return Package(
@@ -265,6 +266,20 @@ def _pin_to_package(
                 commit_id=pin.commit_id,
                 subdirectory=pin.subdirectory,
                 requested_revision=pin.requested_revision,
+            ),
+        )
+    if isinstance(pin, ArchivePin):
+        # An archive is content-pinned by its hash, so the version is
+        # stable and recorded (unlike the directory/VCS cases above).
+        return Package(
+            name=canonicalize_name(pin.name),
+            version=Version(pin.version),
+            marker=marker,
+            dependencies=dependencies,
+            archive=PackageArchive(
+                url=pin.url,
+                hashes=dict(pin.hashes),
+                subdirectory=pin.subdirectory,
             ),
         )
     msg = f"unknown pin shape: {pin!r}"
@@ -423,7 +438,7 @@ def _group_pins_by_pin(
 
 def _pin_discriminator(pin: PinShape) -> tuple:
     """Return a hashable key that identifies the source + version of ``pin``."""
-    from ..lockfile import IndexPin, LocalPin, VcsPin
+    from ..lockfile import ArchivePin, IndexPin, LocalPin, VcsPin
 
     if isinstance(pin, IndexPin):
         return ("index", pin.version, pin.index)
@@ -447,6 +462,8 @@ def _pin_discriminator(pin: PinShape) -> tuple:
             pin.repo_url,
             pin.subdirectory or "",
         )
+    if isinstance(pin, ArchivePin):
+        return ("archive", pin.version, pin.url, pin.hashes, pin.subdirectory or "")
     msg = f"unknown pin shape: {pin!r}"
     raise TypeError(msg)
 

--- a/nab-python/src/nab_python/_lockfile/requirements.py
+++ b/nab-python/src/nab_python/_lockfile/requirements.py
@@ -94,7 +94,7 @@ def _render_per_tuple_requirements(lock_input: LockInput, *, with_hashes: bool) 
 
 def _render_pins(pins: Mapping[str, PinShape], *, with_hashes: bool) -> list[str]:
     """Render a flat ``{name: pin}`` mapping in alphabetical order."""
-    from ..lockfile import IndexPin, LocalPin, VcsPin
+    from ..lockfile import ArchivePin, IndexPin, LocalPin, VcsPin
 
     lines: list[str] = []
     for canonical in sorted(pins):
@@ -112,6 +112,14 @@ def _render_pins(pins: Mapping[str, PinShape], *, with_hashes: bool) -> list[str
                 lines.append(f"{pin.name} @ {url}")
         elif isinstance(pin, VcsPin):
             lines.append(f"{pin.name} @ {pin.repo_url}")
+        elif isinstance(pin, ArchivePin):
+            # The hash is the archive's identity, so carry it (and any
+            # subdirectory) in the fragment for a reproducible, hash-checkable
+            # install line, mirroring how VcsPin pins its commit in the URL.
+            fragment = "&".join(f"{algo}={digest}" for algo, digest in pin.hashes)
+            if pin.subdirectory is not None:
+                fragment += f"&subdirectory={quote(pin.subdirectory, safe='/')}"
+            lines.append(f"{pin.name} @ {pin.url}#{fragment}")
         else:  # pragma: no cover - exhaustive
             msg = f"unknown pin shape: {pin!r}"
             raise TypeError(msg)

--- a/nab-python/src/nab_python/_lockfile/requirements.py
+++ b/nab-python/src/nab_python/_lockfile/requirements.py
@@ -38,8 +38,11 @@ def write_requirements_with_hashes(
     accepts.  Local and VCS pins are emitted as ``name @ <url>`` lines
     without hashes (pip does not hash-check those forms); an editable
     local pin renders as ``-e <url>`` and a ``subdirectory`` as a
-    ``#subdirectory=`` fragment.  Returns the text and, when
-    ``output_path`` is provided, atomically writes it.
+    ``#subdirectory=`` fragment.  An archive pin is a third form, ``name @
+    <url>#sha256=...``, carrying its hash in the fragment;
+    :func:`require_artifact_hashes` skips it because that hash is guaranteed
+    at config parse.  Returns the text and, when ``output_path`` is provided,
+    atomically writes it.
     """
     require_artifact_hashes(lock_input)
     return _render_requirements(lock_input, with_hashes=True, output_path=output_path)
@@ -51,8 +54,8 @@ def write_requirements_without_hashes(
     """Render ``lock_input`` as a plain ``name==version`` list.
 
     Same shape as :func:`write_requirements_with_hashes` but without
-    the ``--hash=sha256:...`` lines.  Local and VCS pins render the
-    same in both variants.  Returns the text and, when ``output_path``
+    the ``--hash=sha256:...`` lines.  Local, VCS, and archive pins render
+    the same in both variants.  Returns the text and, when ``output_path``
     is provided, atomically writes it.
     """
     return _render_requirements(lock_input, with_hashes=False, output_path=output_path)

--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -51,7 +51,7 @@ def fetch_versions(provider: Provider, package: str) -> list[tuple[Version, Dist
         return result
 
     archive = provider.archive_sources.get(normalized)
-    if archive is not None:
+    if archive is not None:  # pragma: no cover (tar data filter; see sources.py)
         result = provider.materialize_archive_source(normalized, archive)
         provider.versions_cache[normalized] = result
         return result

--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -51,10 +51,12 @@ def fetch_versions(provider: Provider, package: str) -> list[tuple[Version, Dist
         return result
 
     archive = provider.archive_sources.get(normalized)
-    if archive is not None:  # pragma: no cover (tar data filter; see sources.py)
+    if archive is not None:
+        # The download-and-verify guards are gated everywhere; only the
+        # post-extraction success tail needs the tar data filter (see sources.py).
         result = provider.materialize_archive_source(normalized, archive)
-        provider.versions_cache[normalized] = result
-        return result
+        provider.versions_cache[normalized] = result  # pragma: no cover
+        return result  # pragma: no cover
 
     files = provider.coordinator.index.get_listing(normalized)
     if files is None:
@@ -578,9 +580,9 @@ def prefetch_new_deps(provider: Provider, deps: Mapping[str, VersionRange]) -> N
     candidate. This deepens the prefetch cascade so metadata is
     ready before the resolver asks for it.
 
-    Local and VCS sources are skipped; they have no PyPI listing
-    and the materialise path in ``fetch_versions`` will surface
-    them when the resolver asks.
+    Local, VCS, and archive sources are skipped; they have no PyPI
+    listing and the materialise path in ``fetch_versions`` will
+    surface them when the resolver asks.
     """
     for dep in deps:
         _, _, normalized = provider.split_and_normalize(dep)

--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -50,6 +50,12 @@ def fetch_versions(provider: Provider, package: str) -> list[tuple[Version, Dist
         provider.versions_cache[normalized] = result
         return result
 
+    archive = provider.archive_sources.get(normalized)
+    if archive is not None:
+        result = provider.materialize_archive_source(normalized, archive)
+        provider.versions_cache[normalized] = result
+        return result
+
     files = provider.coordinator.index.get_listing(normalized)
     if files is None:
         event = provider.coordinator.request_listing(normalized)
@@ -578,7 +584,11 @@ def prefetch_new_deps(provider: Provider, deps: Mapping[str, VersionRange]) -> N
     """
     for dep in deps:
         _, _, normalized = provider.split_and_normalize(dep)
-        if normalized in provider.local_sources or normalized in provider.vcs_sources:
+        if (
+            normalized in provider.local_sources
+            or normalized in provider.vcs_sources
+            or normalized in provider.archive_sources
+        ):
             continue
         if normalized not in provider.versions_cache:
             # Listing not cached: request it. When it arrives,

--- a/nab-python/src/nab_python/_provider/priority.py
+++ b/nab-python/src/nab_python/_provider/priority.py
@@ -74,10 +74,12 @@ def compute_matching(
         if cached is not None:
             return cached
 
-    # Local/VCS sources short-circuit the listing path; their synthetic
+    # Local/VCS/archive sources short-circuit the listing path; their synthetic
     # listing is materialised lazily by fetch_versions.
     has_local_source = (
-        normalized in provider.local_sources or normalized in provider.vcs_sources
+        normalized in provider.local_sources
+        or normalized in provider.vcs_sources
+        or normalized in provider.archive_sources
     )
     if normalized not in provider.versions_cache and not has_local_source:
         files = provider.coordinator.index.get_listing(normalized)

--- a/nab-python/src/nab_python/_provider/sources.py
+++ b/nab-python/src/nab_python/_provider/sources.py
@@ -1,17 +1,21 @@
-"""Local-source and VCS-source materialisation for the provider.
+"""Local-source, VCS-source, and archive-source materialisation.
 
 A ``LocalSource`` becomes the only candidate for a package: PyPI is
-not consulted.  A ``VcsSource`` clones the repo and reuses the
-``LocalSource`` extraction path.  Both produce a single synthetic
+not consulted.  A ``VcsSource`` clones the repo and an ``ArchiveSource``
+downloads and hash-verifies a ``.tar.gz`` and extracts it; both reuse the
+``LocalSource`` extraction path.  Each produces a single synthetic
 ``SdistFile`` whose version is read from ``[project].version``.
 """
 
 from __future__ import annotations
 
+import shutil
+import tarfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from nab_index.client import SdistFile
+from nab_index.archive import ArchiveRequest
+from nab_index.client import SdistFile, extract_sdist_archive
 from nab_index.vcs import VcsCloneError, VcsRequest
 
 from .._vendor.packaging.utils import canonicalize_name
@@ -19,7 +23,7 @@ from .._vendor.packaging.utils import canonicalize_name
 if TYPE_CHECKING:
     from .._vendor.packaging.version import Version
     from ..metadata import WheelMetadata
-    from ..provider import LocalSource, Provider, VcsSource
+    from ..provider import ArchiveSource, LocalSource, Provider, VcsSource
 
 
 def index_local_sources(
@@ -80,9 +84,10 @@ def extract_source_metadata(
     """Read metadata from a directory; gates the backend path on policy.
 
     ``kind`` is ``"local"`` for :class:`LocalSource` directories
-    (admitted at :attr:`BuildPolicy.BUILD_LOCAL` and above) or
-    ``"vcs"`` for :class:`VcsSource` clones (admitted only at
-    :attr:`BuildPolicy.BUILD_REMOTE`).
+    (admitted at :attr:`BuildPolicy.BUILD_LOCAL` and above); ``"vcs"``
+    for :class:`VcsSource` clones and ``"archive"`` for extracted
+    :class:`ArchiveSource` trees both build only at
+    :attr:`BuildPolicy.BUILD_REMOTE`, like a remote sdist.
     """
     # Imported in-function so tests can patch the module attribute.
     from .. import build_backend
@@ -221,3 +226,132 @@ def materialize_vcs_source(
         kind="vcs",
     )
     return seed_synthetic_listing(provider, normalized, path, metadata)
+
+
+def index_archive_sources(
+    provider: Provider,
+    sources: list[ArchiveSource],
+) -> dict[str, ArchiveSource]:
+    """Validate archive sources and return a canonical-name map.
+
+    Admitted at every :class:`~nab_python.provider.BuildPolicy` level; the
+    policy only governs whether the backend may run on the extracted tree
+    (see :func:`extract_source_metadata`).  There is no ``VcsPolicy``-style
+    gate: the download is hash-verified, and which archive URLs are
+    permitted is decided at config parse.
+    """
+    if not sources:
+        return {}
+    out: dict[str, ArchiveSource] = {}
+    for src in sources:
+        # Guarantee a hash at the provider layer (config parse already checks
+        # it, but a directly-built Provider would otherwise IndexError when
+        # materialisation reads the first digest).
+        if not ArchiveRequest.parse(src.url).hashes:
+            msg = f"archive source {src.name!r} has no hash in its URL: {src.url!r}"
+            raise ValueError(msg)
+        canonical = canonicalize_name(src.name)
+        if (
+            canonical in out
+            or canonical in provider.local_sources
+            or canonical in provider.vcs_sources
+        ):
+            msg = f"duplicate source declared for {src.name!r}"
+            raise ValueError(msg)
+        out[canonical] = src
+    return out
+
+
+def materialize_archive_source(
+    provider: Provider,
+    normalized: str,
+    source: ArchiveSource,
+) -> list[tuple[Version, SdistFile]]:
+    """Download and hash-verify ``source``, extract it, then materialise it.
+
+    The download and hash check reuse the remote-sdist fetch path, so a
+    tampered archive surfaces as a hard :class:`SdistHashMismatchError`
+    (not an :class:`UnsupportedSdistError` the look-ahead would swallow):
+    a declared archive that fails its hash fails the resolve loudly.  The
+    extracted tree then takes the same extraction path as a LocalSource.
+    """
+    from ..provider import UnsupportedSdistError
+
+    if provider.archive_cache_dir is None:
+        msg = (
+            f"archive source {source.name!r} declared but no"
+            f" archive_cache_dir was supplied to Provider"
+        )
+        raise UnsupportedSdistError(msg)
+
+    request = ArchiveRequest.parse(source.url)
+    canonical = canonicalize_name(source.name)
+
+    # The version is unknown until the tree is extracted, so key the download
+    # by the declared digest: unique and known up-front.
+    _, digest = request.hashes[0]
+
+    # Reuse the remote-sdist fetch path; it downloads and hash-verifies, storing
+    # a hard SdistHashMismatchError on a tampered archive.
+    event = provider.coordinator.request_sdist_archive(
+        canonical, digest, request.url, request.hashes
+    )
+    event.wait()
+    error = provider.coordinator.index.get_sdist_archive_error(canonical, digest)
+    if error is not None:
+        raise error
+    data = provider.coordinator.index.get_sdist_archive(canonical, digest)
+    if data is None:
+        msg = f"archive source {source.name!r}: download from {request.url} failed"
+        raise UnsupportedSdistError(msg)
+
+    # Extract the verified bytes and read metadata as if it were a local tree.
+    root = _extract_archive(provider.archive_cache_dir, digest, data)
+    path = root / request.subdirectory if request.subdirectory else root
+    metadata = extract_source_metadata(
+        provider,
+        path,
+        descriptor=f"archive source {source.name!r}",
+        package=canonical,
+        kind="archive",
+    )
+    return seed_synthetic_listing(provider, normalized, path, metadata)
+
+
+def _extract_archive(cache_dir: Path, digest: str, data: bytes) -> Path:
+    """Extract ``data`` under ``cache_dir`` keyed by ``digest``; return the root.
+
+    Idempotent, like :func:`prepare_clone`: a digest already extracted in a
+    prior resolve is reused rather than re-extracted, since the tree is
+    content-addressed by its verified hash.  The completion marker also
+    distinguishes a finished tree from a partial one left by a crashed run,
+    which is discarded and redone.
+    """
+    from ..provider import UnsupportedSdistError
+
+    target = cache_dir / digest
+    marker = target / ".nab-extracted"
+    if marker.is_file():
+        root_name = marker.read_text(encoding="utf-8").strip()
+        # Return a resolved path, matching the fresh-extract branch, so the
+        # synthetic listing's file URI works even for a relative cache dir.
+        base = target / root_name if root_name else target
+        return base.resolve()
+
+    if target.exists():
+        shutil.rmtree(target)
+    target.mkdir(parents=True)
+    try:
+        root = extract_sdist_archive(data, target)
+    except (OSError, ValueError, tarfile.TarError) as exc:
+        shutil.rmtree(target, ignore_errors=True)
+        msg = f"archive could not be extracted: {exc}"
+        raise UnsupportedSdistError(msg) from exc
+
+    # Record the root (its name under target, empty for a flat archive) so the
+    # next resolve reuses the tree without re-reading the bytes.  extract_sdist_archive
+    # returns a resolved path, so compare against the resolved target: a symlinked or
+    # relative cache dir would otherwise misrecord a flat archive's root.
+    root_name = root.name if root != target.resolve() else ""
+    marker.write_text(root_name, encoding="utf-8")
+    return root

--- a/nab-python/src/nab_python/_provider/sources.py
+++ b/nab-python/src/nab_python/_provider/sources.py
@@ -262,11 +262,21 @@ def index_archive_sources(
     return out
 
 
+# The archive extraction path (this function and _extract_archive) is excluded
+# from coverage.  It requires the PEP 706 tar data filter (Python 3.10.12+), but
+# GitHub Actions setup-python installs 3.10.11 on macOS (arm64) and Windows:
+# python.org stopped shipping 3.10 binary installers after 3.10.11 and
+# actions/python-versions builds those OSes from installers, so no 3.10.12+
+# artifact exists for them.  The archive extraction tests skip there, leaving
+# these lines unhit on only those two runners (covered on every other runner).
+# Remove the pragmas when that 3.10 cell is dropped, sourced from
+# uv/python-build-standalone (which ships 3.10.20 with the filter), or 3.10
+# reaches EOL (2026-10).
 def materialize_archive_source(
     provider: Provider,
     normalized: str,
     source: ArchiveSource,
-) -> list[tuple[Version, SdistFile]]:
+) -> list[tuple[Version, SdistFile]]:  # pragma: no cover
     """Download and hash-verify ``source``, extract it, then materialise it.
 
     The download and hash check reuse the remote-sdist fetch path, so a
@@ -318,7 +328,9 @@ def materialize_archive_source(
     return seed_synthetic_listing(provider, normalized, path, metadata)
 
 
-def _extract_archive(cache_dir: Path, digest: str, data: bytes) -> Path:
+def _extract_archive(
+    cache_dir: Path, digest: str, data: bytes
+) -> Path:  # pragma: no cover (tar data filter; see materialize_archive_source)
     """Extract ``data`` under ``cache_dir`` keyed by ``digest``; return the root.
 
     Idempotent, like :func:`prepare_clone`: a digest already extracted in a

--- a/nab-python/src/nab_python/_provider/sources.py
+++ b/nab-python/src/nab_python/_provider/sources.py
@@ -250,6 +250,7 @@ def index_archive_sources(
         if not ArchiveRequest.parse(src.url).has_usable_hash:
             msg = f"archive source {src.name!r} has no hash in its URL: {src.url!r}"
             raise ValueError(msg)
+
         canonical = canonicalize_name(src.name)
         if (
             canonical in out

--- a/nab-python/src/nab_python/_provider/sources.py
+++ b/nab-python/src/nab_python/_provider/sources.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from nab_index.archive import ArchiveRequest
-from nab_index.client import SdistFile, extract_sdist_archive
+from nab_index.client import SdistFile, _verify_sdist_hash, extract_sdist_archive
 from nab_index.vcs import VcsCloneError, VcsRequest
 
 from .._vendor.packaging.utils import canonicalize_name
@@ -244,10 +244,10 @@ def index_archive_sources(
         return {}
     out: dict[str, ArchiveSource] = {}
     for src in sources:
-        # Guarantee a hash at the provider layer (config parse already checks
-        # it, but a directly-built Provider would otherwise IndexError when
-        # materialisation reads the first digest).
-        if not ArchiveRequest.parse(src.url).hashes:
+        # Guarantee a usable hash at the provider layer (config parse already
+        # checks it, but a directly-built Provider would otherwise IndexError
+        # when materialisation reads the first digest, or verify an empty one).
+        if not ArchiveRequest.parse(src.url).has_usable_hash:
             msg = f"archive source {src.name!r} has no hash in its URL: {src.url!r}"
             raise ValueError(msg)
         canonical = canonicalize_name(src.name)
@@ -262,32 +262,21 @@ def index_archive_sources(
     return out
 
 
-# The archive extraction path (this function and _extract_archive) is excluded
-# from coverage.  It requires the PEP 706 tar data filter (Python 3.10.12+), but
-# GitHub Actions setup-python installs 3.10.11 on macOS (arm64) and Windows:
-# python.org stopped shipping 3.10 binary installers after 3.10.11 and
-# actions/python-versions builds those OSes from installers, so no 3.10.12+
-# artifact exists for them.  The archive extraction tests skip there, leaving
-# these lines unhit on only those two runners (covered on every other runner).
-# Remove the pragmas when that 3.10 cell is dropped, sourced from
-# uv/python-build-standalone (which ships 3.10.20 with the filter), or 3.10
-# reaches EOL (2026-10).
-def materialize_archive_source(
+def _fetch_archive_bytes(
     provider: Provider,
-    normalized: str,
     source: ArchiveSource,
-) -> list[tuple[Version, SdistFile]]:  # pragma: no cover
-    """Download and hash-verify ``source``, extract it, then materialise it.
+) -> tuple[Path, ArchiveRequest, str, bytes]:
+    """Return ``(cache_dir, request, digest, data)`` for a verified archive.
 
-    The download and hash check reuse the remote-sdist fetch path, so a
-    tampered archive surfaces as a hard :class:`SdistHashMismatchError`
-    (not an :class:`UnsupportedSdistError` the look-ahead would swallow):
-    a declared archive that fails its hash fails the resolve loudly.  The
-    extracted tree then takes the same extraction path as a LocalSource.
+    Raises before returning if the cache dir is missing, the download failed,
+    or the bytes fail their hash.  The hash is re-checked here rather than
+    trusted to the serving client: a ``file://`` index reads archive bytes
+    without verifying them, so this is the one place the check always runs.
     """
     from ..provider import UnsupportedSdistError
 
-    if provider.archive_cache_dir is None:
+    cache_dir = provider.archive_cache_dir
+    if cache_dir is None:
         msg = (
             f"archive source {source.name!r} declared but no"
             f" archive_cache_dir was supplied to Provider"
@@ -298,11 +287,12 @@ def materialize_archive_source(
     canonical = canonicalize_name(source.name)
 
     # The version is unknown until the tree is extracted, so key the download
-    # by the declared digest: unique and known up-front.
-    _, digest = request.hashes[0]
+    # by the first declared digest: unique and known up-front.  The fragment
+    # only carries accepted algorithms, so every pair is verifiable.
+    digest = request.hashes[0][1]
 
-    # Reuse the remote-sdist fetch path; it downloads and hash-verifies, storing
-    # a hard SdistHashMismatchError on a tampered archive.
+    # Fetch through the shared coordinator; a recorded integrity error or an
+    # absent download both fail the resolve here.
     event = provider.coordinator.request_sdist_archive(
         canonical, digest, request.url, request.hashes
     )
@@ -315,14 +305,47 @@ def materialize_archive_source(
         msg = f"archive source {source.name!r}: download from {request.url} failed"
         raise UnsupportedSdistError(msg)
 
-    # Extract the verified bytes and read metadata as if it were a local tree.
-    root = _extract_archive(provider.archive_cache_dir, digest, data)
+    # Verify every declared hash rather than trust the serving client, so a
+    # file:// index (which does not check) cannot slip an unverified archive
+    # through, and so this layer never disagrees with a client that verified a
+    # different algorithm.
+    for pinned_hash in request.hashes:
+        _verify_sdist_hash(data, pinned_hash)
+    return cache_dir, request, digest, data
+
+
+# Extraction (this function and _extract_archive) is excluded from coverage: it
+# requires the PEP 706 tar data filter (Python 3.10.12+), but GitHub Actions
+# setup-python installs 3.10.11 on macOS-arm64 and Windows (python.org stopped
+# shipping 3.10 installers after 3.10.11, and actions/python-versions builds
+# those OSes from installers), so no 3.10.12+ artifact exists for them.  The
+# extraction tests skip there, leaving these lines unhit on those two runners.
+# The download-and-verify guards live in _fetch_archive_bytes above so they stay
+# gated on every runner.  Remove the pragmas when that 3.10 cell is dropped,
+# sourced from python-build-standalone, or 3.10 reaches EOL (2026-10).
+def materialize_archive_source(
+    provider: Provider,
+    normalized: str,
+    source: ArchiveSource,
+) -> list[tuple[Version, SdistFile]]:  # pragma: no cover (tar data filter)
+    """Download and hash-verify ``source``, extract it, then materialise it.
+
+    A declared archive is always verified against its required hash in
+    :func:`_fetch_archive_bytes`, so a tampered archive fails the resolve
+    loudly rather than being used and pinned unverified.  The extracted tree
+    then takes the same path as a LocalSource.
+    """
+    # Download, hash-verify, and extract the archive into the cache.
+    cache_dir, request, digest, data = _fetch_archive_bytes(provider, source)
+    root = _extract_archive(cache_dir, digest, data)
+
+    # Read the extracted tree's metadata as a local source and seed one candidate.
     path = root / request.subdirectory if request.subdirectory else root
     metadata = extract_source_metadata(
         provider,
         path,
         descriptor=f"archive source {source.name!r}",
-        package=canonical,
+        package=canonicalize_name(source.name),
         kind="archive",
     )
     return seed_synthetic_listing(provider, normalized, path, metadata)
@@ -343,13 +366,16 @@ def _extract_archive(
 
     target = cache_dir / digest
     marker = target / ".nab-extracted"
+
+    # Reuse a tree a prior resolve already extracted for this digest.
     if marker.is_file():
         root_name = marker.read_text(encoding="utf-8").strip()
-        # Return a resolved path, matching the fresh-extract branch, so the
-        # synthetic listing's file URI works even for a relative cache dir.
+        # Resolve to match the fresh-extract branch, so the file URI works
+        # even for a relative cache dir.
         base = target / root_name if root_name else target
         return base.resolve()
 
+    # Discard any partial tree left by a crashed run, then extract afresh.
     if target.exists():
         shutil.rmtree(target)
     target.mkdir(parents=True)
@@ -360,10 +386,10 @@ def _extract_archive(
         msg = f"archive could not be extracted: {exc}"
         raise UnsupportedSdistError(msg) from exc
 
-    # Record the root (its name under target, empty for a flat archive) so the
-    # next resolve reuses the tree without re-reading the bytes.  extract_sdist_archive
-    # returns a resolved path, so compare against the resolved target: a symlinked or
-    # relative cache dir would otherwise misrecord a flat archive's root.
+    # Record the root name (empty for a flat archive) so the next resolve
+    # reuses the tree without re-reading the bytes.  Compare against the
+    # resolved target since extract_sdist_archive resolves symlinks and
+    # relative cache dirs, which would otherwise misrecord a flat root.
     root_name = root.name if root != target.resolve() else ""
     marker.write_text(root_name, encoding="utf-8")
     return root

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -1886,7 +1886,7 @@ def _validate_archive_url(index: int, url: str) -> None:
         msg = f"archive-sources[{index}] url: {exc}"
         raise ConfigError(msg) from exc
 
-    if not request.hashes or any(not digest for _, digest in request.hashes):
+    if not request.has_usable_hash:
         msg = (
             f"archive-sources[{index}] url {url!r} has no hash; add a"
             " '#sha256=<hex>' fragment (PEP 751 requires an archive hash)"

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -15,10 +15,12 @@ from collections import defaultdict
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
 
 import tomli
 from typing_extensions import override
 
+from nab_index.archive import ArchiveRequest, ArchiveRequestError
 from nab_index.multi_index import IndexConfig
 
 from ._conflict_kind import KIND_EXTRA, KIND_GROUP
@@ -42,6 +44,7 @@ from .config_sources import (
 )
 from .fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, IndexRoute
 from .provider import (
+    ArchiveSource,
     BuildPolicy,
     DistPolicy,
     LocalSource,
@@ -391,6 +394,7 @@ class NabProjectConfig:
     vcs: VcsConfig = field(default_factory=VcsConfig)
     local_sources: tuple[LocalSource, ...] = ()
     vcs_sources: tuple[VcsSource, ...] = ()
+    archive_sources: tuple[ArchiveSource, ...] = ()
     matrix: MatrixConfig | None = None
     resolution: ResolutionStrategy = ResolutionStrategy.HIGHEST
     workspace: WorkspaceConfig | None = None
@@ -660,7 +664,8 @@ def _config_from_effective(
 
     local_sources = effective["local-sources"].value
     vcs_sources = effective["vcs-sources"].value
-    _reject_duplicate_source_names(local_sources, vcs_sources)
+    archive_sources = effective["archive-sources"].value
+    _reject_duplicate_source_names(local_sources, vcs_sources, archive_sources)
 
     del pyproject_dir  # paths were resolved per-layer by the registry.
     return NabProjectConfig(
@@ -677,6 +682,7 @@ def _config_from_effective(
         vcs=effective["vcs"].value,
         local_sources=local_sources,
         vcs_sources=vcs_sources,
+        archive_sources=archive_sources,
         matrix=matrix,
         resolution=effective["resolution"].value,
         workspace=effective["workspace"].value,
@@ -1833,23 +1839,87 @@ def _parse_vcs_sources(value: object) -> tuple[VcsSource, ...]:
     return tuple(out)
 
 
+_ARCHIVE_SOURCE_KEYS = frozenset({"name", "url"})
+
+
+def _parse_archive_sources(value: object) -> tuple[ArchiveSource, ...]:
+    if not isinstance(value, list):
+        msg = f"archive-sources must be an array of tables, got {type(value).__name__}"
+        raise ConfigError(msg)
+    out: list[ArchiveSource] = []
+    for i, entry in enumerate(value):
+        if not isinstance(entry, dict):
+            msg = f"archive-sources[{i}] must be a table, got {type(entry).__name__}"
+            raise ConfigError(msg)
+        unknown = sorted(set(entry) - _ARCHIVE_SOURCE_KEYS)
+        if unknown:
+            msg = (
+                f"unknown archive-sources[{i}] keys: {unknown!r};"
+                f" expected {sorted(_ARCHIVE_SOURCE_KEYS)!r}"
+            )
+            raise ConfigError(msg)
+        try:
+            name = entry["name"]
+            url = entry["url"]
+        except KeyError as missing:
+            msg = f"archive-sources[{i}] missing required key {missing!s}"
+            raise ConfigError(msg) from None
+        if not isinstance(name, str) or not isinstance(url, str):
+            msg = f"archive-sources[{i}] name and url must be strings"
+            raise ConfigError(msg)
+        _validate_archive_url(i, url)
+        out.append(ArchiveSource(name=name, url=url))
+    return tuple(out)
+
+
+def _validate_archive_url(index: int, url: str) -> None:
+    """Reject an archive URL with no hash or an unsupported format.
+
+    PEP 751 ``packages.archive.hashes`` is required, so nab requires the
+    hash in the URL fragment and verifies the download against it.  Only
+    ``.tar.gz`` source archives are supported today; wheels and zips are
+    refused loudly rather than mis-handled.
+    """
+    try:
+        request = ArchiveRequest.parse(url)
+    except ArchiveRequestError as exc:
+        msg = f"archive-sources[{index}] url: {exc}"
+        raise ConfigError(msg) from exc
+
+    if not request.hashes or any(not digest for _, digest in request.hashes):
+        msg = (
+            f"archive-sources[{index}] url {url!r} has no hash; add a"
+            " '#sha256=<hex>' fragment (PEP 751 requires an archive hash)"
+        )
+        raise ConfigError(msg)
+
+    if not urlsplit(request.url).path.endswith(".tar.gz"):
+        msg = (
+            f"archive-sources[{index}] url {url!r} is not a .tar.gz archive;"
+            " only .tar.gz source archives are supported"
+        )
+        raise ConfigError(msg)
+
+
 def _reject_duplicate_source_names(
     local_sources: tuple[LocalSource, ...],
     vcs_sources: tuple[VcsSource, ...],
+    archive_sources: tuple[ArchiveSource, ...],
 ) -> None:
-    """Reject a canonical name claimed by more than one local/VCS source.
+    """Reject a canonical name claimed by more than one declared source.
 
     The provider enforces this while indexing, but as a bare ValueError raised
     after the resolve starts; raising ConfigError here surfaces it at parse
     time like every other config error.
     """
     seen: dict[str, str] = {}
-    for source in (*local_sources, *vcs_sources):
+    for source in (*local_sources, *vcs_sources, *archive_sources):
         canonical = canonicalize_name(source.name)
         if canonical in seen:
             msg = (
-                "[tool.nab] local-sources/vcs-sources declare duplicate canonical"
-                f" name {canonical!r} via {seen[canonical]!r} and {source.name!r}"
+                "[tool.nab] local-sources/vcs-sources/archive-sources declare"
+                f" duplicate canonical name {canonical!r} via {seen[canonical]!r}"
+                f" and {source.name!r}"
             )
             raise ConfigError(msg)
         seen[canonical] = source.name

--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -41,6 +41,7 @@ from nab_index.multi_index import IndexConfig
 
 from .fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL
 from .provider import (
+    ArchiveSource,
     BuildPolicy,
     DistPolicy,
     LocalSource,
@@ -589,6 +590,17 @@ def _parse_vcs_sources(value: Any, where: str) -> tuple[VcsSource, ...]:
     return _delegate(lambda: _impl(value))
 
 
+def _parse_archive_sources(value: Any, where: str) -> tuple[ArchiveSource, ...]:
+    # One file's array-of-tables (name, url); same passthrough shape as
+    # vcs-sources (merge_check=tuple).
+    del where
+    from .config import (  # noqa: PLC0415 (config import cycle)
+        _parse_archive_sources as _impl,
+    )
+
+    return _delegate(lambda: _impl(value))
+
+
 def _override_anchor() -> datetime:
     # An override body may carry an ``uploaded-prior-to`` whose ``P<n>D`` form
     # resolves against an anchor at parse time.  The resolve path binds the
@@ -735,6 +747,12 @@ def _render_local_sources(value: Sequence[LocalSource]) -> str:
 
 
 def _render_vcs_sources(value: Sequence[VcsSource]) -> str:
+    if not value:
+        return "<none>"
+    return ", ".join(f"{s.name}@{s.url}" for s in value)
+
+
+def _render_archive_sources(value: Sequence[ArchiveSource]) -> str:
     if not value:
         return "<none>"
     return ", ".join(f"{s.name}@{s.url}" for s in value)
@@ -945,6 +963,19 @@ OPTIONS: tuple[OptionSpec, ...] = (
         cli_param=None,
         parse=_parse_vcs_sources,
         render=_render_vcs_sources,
+        is_array=True,
+        merge_check=tuple,
+    ),
+    OptionSpec(
+        key="archive-sources",
+        scope=Scope.PROJECT,
+        type_label="array-of-tables(name,url)",
+        default=(),
+        env_var=None,
+        cli_flag=None,
+        cli_param=None,
+        parse=_parse_archive_sources,
+        render=_render_archive_sources,
         is_array=True,
         merge_check=tuple,
     ),

--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -556,8 +556,9 @@ def _parse_local_sources(value: Any, where: str) -> tuple[LocalSource, ...]:
     # One file's array-of-tables (name, path, editable, subdirectory).  Paths
     # resolve relative to the declaring file's directory (both legal sources
     # share the project dir).  There is no within-key duplicate check (the
-    # cross-source local/vcs name check is a whole-config pass on the resolve
-    # path), so the concatenation passes through unchanged (merge_check=tuple).
+    # cross-source local/vcs/archive name check is a whole-config pass on the
+    # resolve path), so the concatenation passes through unchanged
+    # (merge_check=tuple).
     del where
     from .config import (  # noqa: PLC0415 (config import cycle)
         _parse_local_sources as _impl,

--- a/nab-python/src/nab_python/download.py
+++ b/nab-python/src/nab_python/download.py
@@ -150,6 +150,30 @@ def _iter_index_pin(canonical: str, pin: IndexPin) -> Iterable[DownloadEntry]:
         )
 
 
+def _reject_colliding_targets(artefacts: list[DownloadEntry]) -> None:
+    """Refuse two distinct artefacts that would write to one output filename.
+
+    Index sdist/wheel filenames embed the package name and version, so they
+    never collide.  A direct-URL archive's filename is the bare basename of
+    its URL, which is arbitrary: two archives from different repositories
+    commonly share one (e.g. a GitHub ``v1.0.0.tar.gz`` tag tarball).  Two
+    artefacts with different digests but the same basename would clobber each
+    other in the flat output dir, silently dropping one, so refuse it loudly.
+    """
+    by_name: dict[str, DownloadEntry] = {}
+    for entry in artefacts:
+        prior = by_name.get(entry.filename)
+        if prior is not None and prior.digest != entry.digest:
+            msg = (
+                f"artefacts collide on output filename {entry.filename!r}:"
+                f" {prior.package}=={prior.version} and"
+                f" {entry.package}=={entry.version} differ."
+                " Download them to separate directories."
+            )
+            raise DownloadError(msg)
+        by_name[entry.filename] = entry
+
+
 def download_lock(
     lock_input: LockInput,
     transport: AsyncHttpTransport,
@@ -167,6 +191,7 @@ def download_lock(
     """
     output_dir.mkdir(parents=True, exist_ok=True)
     artefacts = list(iter_artifacts(lock_input))
+    _reject_colliding_targets(artefacts)
     return asyncio.run(
         _run_downloads(artefacts, transport, output_dir, max_concurrency)
     )
@@ -185,8 +210,9 @@ async def _run_downloads(
 
     async def _one(entry: DownloadEntry) -> None:
         async with sem:
-            # The filename is index-controlled; reject anything but a plain
-            # basename so a crafted name cannot escape output_dir on write.
+            # The filename comes from the index or an archive URL; reject
+            # anything but a plain basename so a crafted name cannot escape
+            # output_dir on write.
             if not entry.filename or Path(entry.filename).name != entry.filename:
                 msg = (
                     f"{entry.package}=={entry.version}:"

--- a/nab-python/src/nab_python/download.py
+++ b/nab-python/src/nab_python/download.py
@@ -1,11 +1,11 @@
 """Download every distribution referenced by a finished resolve.
 
 Consumes a :class:`~nab_python.lockfile.LockInput` and writes every
-recorded wheel and sdist into a target directory, verifying the
-recorded hash.  Local and VCS pins are skipped: their contents live
-elsewhere on disk and the lockfile carries no ``sha256`` for them.
-An artefact from a local ``file://`` (find-links) index is copied
-from its on-disk path rather than fetched over HTTP.
+recorded wheel, sdist, and direct-URL archive into a target directory,
+verifying the recorded hash.  Local and VCS pins are skipped: their
+contents live elsewhere on disk and the lockfile carries no ``sha256``
+for them.  An artefact from a local ``file://`` (find-links) index is
+copied from its on-disk path rather than fetched over HTTP.
 
 Use as a one-shot from the CLI ``nab download`` command, or
 programmatically after :func:`~nab_python.resolve.resolve_pyproject_to_lock`.
@@ -16,14 +16,16 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+import posixpath
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
 
 from nab_index.client import AsyncSimpleClient
 from nab_index.transport import HttpError
 
-from .lockfile import IndexPin, LocalPin, LockInput, VcsPin
+from .lockfile import ArchivePin, IndexPin, LocalPin, LockInput, VcsPin
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -100,9 +102,20 @@ def iter_artifacts(lock_input: LockInput) -> Iterable[DownloadEntry]:
 
 
 def _entries_for_pin(canonical: str, pin: PinShape) -> Iterable[DownloadEntry]:
-    # Only index pins have downloadable artefacts; local and VCS pins are skipped.
+    # Index and archive pins carry a downloadable, hash-verified URL; local and
+    # VCS pins live elsewhere on disk and carry no hash, so they are skipped.
     if isinstance(pin, IndexPin):
         yield from _iter_index_pin(canonical, pin)
+    elif isinstance(pin, ArchivePin):
+        algo, digest = pin.primary_digest
+        yield DownloadEntry(
+            package=canonical,
+            version=pin.version,
+            filename=posixpath.basename(urlsplit(pin.url).path),
+            url=pin.url,
+            hash_algo=algo,
+            digest=digest.lower(),
+        )
     elif isinstance(pin, (LocalPin, VcsPin)):
         return
     else:  # pragma: no cover - exhaustive

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
 __all__ = [
     "ACCEPTED_HASH_ALGORITHMS",
     "LOCK_VERSION",
+    "ArchivePin",
     "DisjointnessError",
     "DivergentBaseDependencyError",
     "IndexPin",
@@ -219,7 +220,37 @@ class VcsPin:
     vcs_type: str = "git"
 
 
-PinShape = IndexPin | LocalPin | VcsPin
+@dataclass(frozen=True, slots=True)
+class ArchivePin:
+    """A package resolved from a direct-URL archive.
+
+    ``url`` is the archive URL with the hash fragment stripped, written
+    to PEP 751 ``packages.archive.url``.  ``hashes`` are the verified
+    ``(algorithm, digest)`` pairs; PEP 751 requires at least one, and
+    nab verifies the download against them before the archive is used.
+
+    Unlike a VCS or directory source, an archive is content-pinned by
+    its hash, so the pin carries a real ``version`` and the emitter
+    records it (see :func:`_pin_to_package`).
+    """
+
+    name: str
+    version: str
+    url: str
+    hashes: tuple[tuple[str, str], ...]
+    subdirectory: str | None = None
+
+    @property
+    def primary_digest(self) -> tuple[str, str]:
+        """Return ``(algo, digest)`` for the first acceptable algorithm present."""
+        chosen = _select_primary_digest(self.hashes)
+        if chosen is None:
+            msg = f"{self.name} archive has no acceptable hash"
+            raise ValueError(msg)
+        return chosen
+
+
+PinShape = IndexPin | LocalPin | VcsPin | ArchivePin
 
 
 @dataclass(frozen=True, slots=True)

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     from .fetch import FetchCoordinator
 
 __all__ = [
+    "ArchiveSource",
     "BuildPolicy",
     "DistFile",
     "DistPolicy",
@@ -300,6 +301,21 @@ class VcsSource:
     url: str
 
 
+@dataclass(frozen=True, slots=True)
+class ArchiveSource:
+    """A direct-URL archive used as the only candidate for a package.
+
+    ``name`` is the package name; ``url`` is the archive URL carrying its
+    hash (and optional subdirectory) in the fragment, e.g.
+    ``https://example.com/x-1.0.tar.gz#sha256=<hex>``.  The provider
+    downloads and hash-verifies the archive, then extracts and treats it
+    as a :class:`LocalSource` for metadata extraction.
+    """
+
+    name: str
+    url: str
+
+
 class MetadataError(Exception):
     """Raised when dependency metadata cannot be extracted."""
 
@@ -450,6 +466,8 @@ class Provider:
         local_sources: list[LocalSource] | None = None,
         vcs_sources: list[VcsSource] | None = None,
         vcs_cache_dir: Path | None = None,
+        archive_sources: list[ArchiveSource] | None = None,
+        archive_cache_dir: Path | None = None,
         build_config: NabProjectConfig | None = None,
         resolution_strategy: ResolutionStrategy = ResolutionStrategy.HIGHEST,
         direct_packages: frozenset[str] | None = None,
@@ -507,6 +525,10 @@ class Provider:
         self.vcs_cache_dir = vcs_cache_dir
         self.vcs_pins: dict[str, str] = {}
         self.vcs_sources = _sources.index_vcs_sources(self, vcs_sources or [])
+        self.archive_cache_dir = archive_cache_dir
+        self.archive_sources = _sources.index_archive_sources(
+            self, archive_sources or []
+        )
 
         # default_environment() returns a TypedDict whose ``.items()`` view
         # widens values to ``object``; rebuild as a concrete ``dict[str, str]``
@@ -641,7 +663,11 @@ class Provider:
         if self.root_requirements:
             for pkg in self.root_requirements:
                 _, _, normalized = self.split_and_normalize(pkg)
-                if normalized in self.local_sources or normalized in self.vcs_sources:
+                if (
+                    normalized in self.local_sources
+                    or normalized in self.vcs_sources
+                    or normalized in self.archive_sources
+                ):
                     continue
                 self.coordinator.request_listing(normalized)
 
@@ -900,7 +926,11 @@ class Provider:
         candidate selects version-scoped.  Each field resolves
         independently, so the three may come from different entries.
         """
-        if canonical_name in self.local_sources or canonical_name in self.vcs_sources:
+        if (
+            canonical_name in self.local_sources
+            or canonical_name in self.vcs_sources
+            or canonical_name in self.archive_sources
+        ):
             return self._source_metadata_override(canonical_name)
         return (
             self.effective_dependencies(canonical_name, version),
@@ -1016,6 +1046,19 @@ class Provider:
         """See :func:`nab_python._provider.sources.materialize_vcs_source`."""
         result: list[tuple[Version, DistFile]] = []
         for version, sdist in _sources.materialize_vcs_source(self, normalized, source):
+            result.append((version, sdist))
+        return result
+
+    def materialize_archive_source(
+        self,
+        normalized: str,
+        source: ArchiveSource,
+    ) -> list[tuple[Version, DistFile]]:
+        """See :func:`nab_python._provider.sources.materialize_archive_source`."""
+        result: list[tuple[Version, DistFile]] = []
+        for version, sdist in _sources.materialize_archive_source(
+            self, normalized, source
+        ):
             result.append((version, sdist))
         return result
 
@@ -1511,9 +1554,12 @@ class Provider:
 
         versions = self.fetch_versions(package)
 
-        # Local + VCS sources pre-populate metadata during fetch_versions.
+        # Local, VCS, and archive sources pre-populate metadata during
+        # fetch_versions.
         if cache_key in self.metadata_cache and (
-            normalized in self.local_sources or normalized in self.vcs_sources
+            normalized in self.local_sources
+            or normalized in self.vcs_sources
+            or normalized in self.archive_sources
         ):
             self._cache_deps_from_metadata(cache_key, self.metadata_cache[cache_key])
             return self.deps_cache[cache_key]
@@ -1654,6 +1700,10 @@ class Provider:
     def vcs_source_for(self, canonical_name: str) -> VcsSource | None:
         """Return the VCS source registered under ``canonical_name`` or None."""
         return self.vcs_sources.get(canonicalize_name(canonical_name))
+
+    def archive_source_for(self, canonical_name: str) -> ArchiveSource | None:
+        """Return the archive source registered under ``canonical_name`` or None."""
+        return self.archive_sources.get(canonicalize_name(canonical_name))
 
     def vcs_pin_for(self, canonical_name: str) -> str | None:
         """Return the post-clone commit SHA for ``canonical_name``, or None.

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -713,7 +713,7 @@ class Provider:
 
         Drawn from the coordinator's record of which configured index a
         package's listing came from; ``None`` before any listing resolves
-        or for synthetic (local / VCS) sources.
+        or for synthetic (local / VCS / archive) sources.
         """
         return self.coordinator.index.get_listing_index(canonical_name)
 
@@ -744,13 +744,13 @@ class Provider:
         return result
 
     def effective_build_policy_for_source(self, canonical_name: str) -> BuildPolicy:
-        """Return the build policy for a synthetic local/VCS source.
+        """Return the build policy for a synthetic local/VCS/archive source.
 
         These sources have no serving index and their version is not
         known until the backend runs, so the version-scoped lookup does
         not apply.  A per-package override is honoured only when it uses a
         bare-name requirement (full range); a version-scoped override does
-        not govern a local/VCS source's build decision.
+        not govern such a source's build decision.
         """
         for override in self._package_overrides:
             if (
@@ -890,9 +890,9 @@ class Provider:
     def _source_metadata_override(
         self, canonical_name: str
     ) -> tuple[tuple[Requirement, ...] | None, str | None, tuple[str, ...] | None]:
-        """Resolve a local/VCS source's metadata override bundle.
+        """Resolve a local/VCS/archive source's metadata override bundle.
 
-        Local/VCS sources have no listing and their version is not known
+        These sources have no listing and their version is not known
         until materialised, so a metadata override governs them only through
         a bare-name requirement (full range); a version-scoped override does
         not match a source.  Mirrors
@@ -921,9 +921,9 @@ class Provider:
     ) -> tuple[tuple[Requirement, ...] | None, str | None, tuple[str, ...] | None]:
         """Resolve the ``(dependencies, requires_python, provides_extra)`` override.
 
-        A local/VCS source selects bare-name-only (its materialised version
-        is not knowable to the user when writing the selector); every other
-        candidate selects version-scoped.  Each field resolves
+        A local/VCS/archive source selects bare-name-only (its materialised
+        version is not knowable to the user when writing the selector); every
+        other candidate selects version-scoped.  Each field resolves
         independently, so the three may come from different entries.
         """
         if (
@@ -1566,7 +1566,7 @@ class Provider:
 
         # Skip-fetch: a complete ``dependencies`` override (even an empty
         # tuple) supplies the deps, so no METADATA fetch or build is needed.
-        # After the local/VCS branch so sources still materialise;
+        # After the local/VCS/archive branch so sources still materialise;
         # ``_cache_deps_from_metadata`` stamps the remaining override fields
         # onto the bare record.
         if self.effective_dependencies(normalized, version) is not None:

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -1053,7 +1053,7 @@ class Provider:
         self,
         normalized: str,
         source: ArchiveSource,
-    ) -> list[tuple[Version, DistFile]]:
+    ) -> list[tuple[Version, DistFile]]:  # pragma: no cover (see sources.py)
         """See :func:`nab_python._provider.sources.materialize_archive_source`."""
         result: list[tuple[Version, DistFile]] = []
         for version, sdist in _sources.materialize_archive_source(

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -223,6 +223,10 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
             local_sources=list(config.local_sources) or None,
             vcs_sources=list(config.vcs_sources) or None,
             vcs_cache_dir=cache_dir / "vcs" if cache_dir is not None else None,
+            archive_sources=list(config.archive_sources) or None,
+            archive_cache_dir=(
+                cache_dir / "archive" if cache_dir is not None else None
+            ),
             build_config=config,
             resolution_strategy=effective_strategy,
             direct_packages=direct_packages,
@@ -239,7 +243,7 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
             _augment_resolution_error(exc, provider)
             raise
         pins = {k: v for k, v in raw.items() if split_extra(k)[1] is None}
-        if config.local_sources or config.vcs_sources:
+        if config.local_sources or config.vcs_sources or config.archive_sources:
             _raise_for_local_vcs_python(
                 provider, pins, Version(marker_environment["python_full_version"])
             )
@@ -739,7 +743,11 @@ def _raise_for_local_vcs_python(
     target could otherwise reach the lock. Mirrors the per-tuple check in
     :mod:`nab_python.universal.resolve`.
     """
-    managed = provider.local_sources.keys() | provider.vcs_sources.keys()
+    managed = (
+        provider.local_sources.keys()
+        | provider.vcs_sources.keys()
+        | provider.archive_sources.keys()
+    )
     for name, version in pins.items():
         normalized = canonicalize_name(name)
         if normalized not in managed:
@@ -947,6 +955,8 @@ def resolve_universal_pyproject(
         local_sources=list(config.local_sources) or None,
         vcs_sources=list(config.vcs_sources) or None,
         vcs_cache_dir=cache_dir / "vcs" if cache_dir is not None else None,
+        archive_sources=list(config.archive_sources) or None,
+        archive_cache_dir=cache_dir / "archive" if cache_dir is not None else None,
         build_config=config,
         indexes=list(config.indexes),
         index_routes=index_routes_from_config(config) or None,

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -244,7 +244,7 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
             raise
         pins = {k: v for k, v in raw.items() if split_extra(k)[1] is None}
         if config.local_sources or config.vcs_sources or config.archive_sources:
-            _raise_for_local_vcs_python(
+            _raise_for_source_python(
                 provider, pins, Version(marker_environment["python_full_version"])
             )
         lock_input = build_lock_input_from_provider(
@@ -731,17 +731,17 @@ def _build_marker_environment(
     return env
 
 
-def _raise_for_local_vcs_python(
+def _raise_for_source_python(
     provider: Provider,
     pins: Mapping[str, Version],
     target: Version,
 ) -> None:
-    """Reject a local or VCS pin whose Requires-Python excludes ``target``.
+    """Reject a local, VCS, or archive pin whose Requires-Python excludes ``target``.
 
-    Index candidates are filtered by Requires-Python while listing; local
-    and VCS sources skip that filter, so a source that rejects the resolve
-    target could otherwise reach the lock. Mirrors the per-tuple check in
-    :mod:`nab_python.universal.resolve`.
+    Index candidates are filtered by Requires-Python while listing; local,
+    VCS, and archive sources skip that filter, so a source that rejects the
+    resolve target could otherwise reach the lock. Mirrors the per-tuple check
+    in :mod:`nab_python.universal.resolve`.
     """
     managed = (
         provider.local_sources.keys()

--- a/nab-python/src/nab_python/universal/provider.py
+++ b/nab-python/src/nab_python/universal/provider.py
@@ -34,6 +34,7 @@ from .._vendor.packaging.markers import default_environment
 from .._vendor.packaging.ranges import VersionRange
 from .._vendor.packaging.utils import canonicalize_name
 from ..provider import (
+    ArchiveSource,
     BuildPolicy,
     DistPolicy,
     ExtrasMode,
@@ -86,6 +87,8 @@ class UniversalProvider(Provider):
         vcs_cache_dir: Path | None = None,
         local_sources: list[LocalSource] | None = None,
         vcs_sources: list[VcsSource] | None = None,
+        archive_sources: list[ArchiveSource] | None = None,
+        archive_cache_dir: Path | None = None,
         build_config: NabProjectConfig | None = None,
         preferences: dict[str, Version] | None = None,
         resolution_strategy: ResolutionStrategy | str = ResolutionStrategy.HIGHEST,
@@ -130,6 +133,8 @@ class UniversalProvider(Provider):
             local_sources=local_sources,
             vcs_sources=vcs_sources,
             vcs_cache_dir=vcs_cache_dir,
+            archive_sources=archive_sources,
+            archive_cache_dir=archive_cache_dir,
             build_config=build_config,
             resolution_strategy=resolution_strategy,
             direct_packages=direct_packages,

--- a/nab-python/src/nab_python/universal/reresolve.py
+++ b/nab-python/src/nab_python/universal/reresolve.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 from .._vendor.packaging.utils import canonicalize_name
 from .._vendor.packaging.version import Version
 from ..provider import (
+    ArchiveSource,
     BuildPolicy,
     DistPolicy,
     LocalSource,
@@ -72,6 +73,8 @@ def reresolve_divergent_tuples(  # noqa: PLR0913 - mirrors the original resolve
     local_sources: list[LocalSource] | None = None,
     vcs_sources: list[VcsSource] | None = None,
     vcs_cache_dir: Path | None = None,
+    archive_sources: list[ArchiveSource] | None = None,
+    archive_cache_dir: Path | None = None,
     build_config: NabProjectConfig | None = None,
     resolution_strategy: str = "highest",
 ) -> dict[str, ReresolveDiff]:
@@ -100,6 +103,8 @@ def reresolve_divergent_tuples(  # noqa: PLR0913 - mirrors the original resolve
         local_sources=local_sources,
         vcs_sources=vcs_sources,
         vcs_cache_dir=vcs_cache_dir,
+        archive_sources=archive_sources,
+        archive_cache_dir=archive_cache_dir,
         build_config=build_config,
         resolution_strategy=resolution_strategy,
     )
@@ -134,6 +139,8 @@ def _reresolve_one_step(  # noqa: PLR0913
     local_sources: list[LocalSource] | None = None,
     vcs_sources: list[VcsSource] | None = None,
     vcs_cache_dir: Path | None = None,
+    archive_sources: list[ArchiveSource] | None = None,
+    archive_cache_dir: Path | None = None,
     build_config: NabProjectConfig | None = None,
     resolution_strategy: str,
 ) -> dict[str, dict[str, str]]:
@@ -181,6 +188,8 @@ def _reresolve_one_step(  # noqa: PLR0913
             local_sources=local_sources,
             vcs_sources=vcs_sources,
             vcs_cache_dir=vcs_cache_dir,
+            archive_sources=archive_sources,
+            archive_cache_dir=archive_cache_dir,
             build_config=build_config,
             resolution_strategy=resolution_strategy,
         )
@@ -204,6 +213,8 @@ def _resolve_one_tuple_with_overrides(  # noqa: PLR0913
     local_sources: list[LocalSource] | None = None,
     vcs_sources: list[VcsSource] | None = None,
     vcs_cache_dir: Path | None = None,
+    archive_sources: list[ArchiveSource] | None = None,
+    archive_cache_dir: Path | None = None,
     build_config: NabProjectConfig | None = None,
     resolution_strategy: str,
 ) -> dict[str, str]:
@@ -231,6 +242,8 @@ def _resolve_one_tuple_with_overrides(  # noqa: PLR0913
             local_sources=local_sources,
             vcs_sources=vcs_sources,
             vcs_cache_dir=vcs_cache_dir,
+            archive_sources=archive_sources,
+            archive_cache_dir=archive_cache_dir,
             build_config=build_config,
             resolution_strategy=resolution_strategy,
         )

--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -40,6 +40,7 @@ from ..lockfile import (
     build_lock_input_from_provider,
 )
 from ..provider import (
+    ArchiveSource,
     BuildPolicy,
     DistPolicy,
     LocalSource,
@@ -246,6 +247,8 @@ def resolve_universal(  # noqa: PLR0913 - surface area mirrors uv's resolution k
     local_sources: list[LocalSource] | None = None,
     vcs_sources: list[VcsSource] | None = None,
     vcs_cache_dir: Path | None = None,
+    archive_sources: list[ArchiveSource] | None = None,
+    archive_cache_dir: Path | None = None,
     build_config: NabProjectConfig | None = None,
     indexes: list[IndexConfig] | None = None,
     index_routes: list[IndexRoute] | None = None,
@@ -301,6 +304,8 @@ def resolve_universal(  # noqa: PLR0913 - surface area mirrors uv's resolution k
             local_sources=local_sources,
             vcs_sources=vcs_sources,
             vcs_cache_dir=vcs_cache_dir,
+            archive_sources=archive_sources,
+            archive_cache_dir=archive_cache_dir,
             build_config=build_config,
             resolution_strategy=resolution_strategy,
             align_across_tuples=align_across_tuples,
@@ -325,6 +330,8 @@ def resolve_with_coordinator(  # noqa: PLR0913 - mirrors resolve_universal's sur
     local_sources: list[LocalSource] | None = None,
     vcs_sources: list[VcsSource] | None = None,
     vcs_cache_dir: Path | None = None,
+    archive_sources: list[ArchiveSource] | None = None,
+    archive_cache_dir: Path | None = None,
     build_config: NabProjectConfig | None = None,
     resolution_strategy: str = "highest",
     align_across_tuples: bool = True,
@@ -381,6 +388,8 @@ def resolve_with_coordinator(  # noqa: PLR0913 - mirrors resolve_universal's sur
             local_sources=local_sources,
             vcs_sources=vcs_sources,
             vcs_cache_dir=vcs_cache_dir,
+            archive_sources=archive_sources,
+            archive_cache_dir=archive_cache_dir,
             build_config=build_config,
             resolution_strategy=resolution_strategy,
             direct_packages=frozenset(_direct_package_names(reqs)),
@@ -448,6 +457,8 @@ def _run_pass(  # noqa: PLR0913
     local_sources: list[LocalSource] | None = None,
     vcs_sources: list[VcsSource] | None = None,
     vcs_cache_dir: Path | None = None,
+    archive_sources: list[ArchiveSource] | None = None,
+    archive_cache_dir: Path | None = None,
     build_config: NabProjectConfig | None = None,
     resolution_strategy: str,
     direct_packages: frozenset[str],
@@ -486,6 +497,8 @@ def _run_pass(  # noqa: PLR0913
             local_sources=local_sources,
             vcs_sources=vcs_sources,
             vcs_cache_dir=vcs_cache_dir,
+            archive_sources=archive_sources,
+            archive_cache_dir=archive_cache_dir,
             build_config=build_config,
             resolution_strategy=resolution_strategy,
             preferences=dict(current_prefs),
@@ -645,7 +658,11 @@ def _raise_for_local_vcs_python(
     local-path and VCS sources skip that filter, so a checkout that
     rejects this tuple's Python could otherwise reach the lockfile.
     """
-    managed = provider.local_sources.keys() | provider.vcs_sources.keys()
+    managed = (
+        provider.local_sources.keys()
+        | provider.vcs_sources.keys()
+        | provider.archive_sources.keys()
+    )
     if not managed:
         return
     target = Version(t.environment["python_full_version"])
@@ -691,6 +708,8 @@ def _resolve_one_tuple(  # noqa: PLR0913
     local_sources: list[LocalSource] | None = None,
     vcs_sources: list[VcsSource] | None = None,
     vcs_cache_dir: Path | None = None,
+    archive_sources: list[ArchiveSource] | None = None,
+    archive_cache_dir: Path | None = None,
     build_config: NabProjectConfig | None = None,
     resolution_strategy: str = "highest",
     preferences: dict[str, Version] | None = None,
@@ -710,6 +729,8 @@ def _resolve_one_tuple(  # noqa: PLR0913
         local_sources=local_sources,
         vcs_sources=vcs_sources,
         vcs_cache_dir=vcs_cache_dir,
+        archive_sources=archive_sources,
+        archive_cache_dir=archive_cache_dir,
         build_config=build_config,
         build_policy=build_policy,
         preferences=preferences,

--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -647,15 +647,15 @@ def _parse_tuple_inputs(
     return parsed_requirements, parsed_constraints
 
 
-def _raise_for_local_vcs_python(
+def _raise_for_source_python(
     provider: UniversalProvider,
     t: MatrixTuple,
     pins: Mapping[str, Version],
 ) -> None:
-    """Reject a local or VCS pin whose Requires-Python excludes the tuple.
+    """Reject a local, VCS, or archive pin whose Requires-Python excludes the tuple.
 
     Index candidates are filtered by Requires-Python while listing, but
-    local-path and VCS sources skip that filter, so a checkout that
+    local-path, VCS, and archive sources skip that filter, so a source that
     rejects this tuple's Python could otherwise reach the lockfile.
     """
     managed = (
@@ -748,7 +748,7 @@ def _resolve_one_tuple(  # noqa: PLR0913
     try:
         raw = resolver.resolve(requirements, constraints=constraints)
         pins = {k: v for k, v in raw.items() if split_extra(k)[1] is None}
-        _raise_for_local_vcs_python(provider, t, pins)
+        _raise_for_source_python(provider, t, pins)
     except ResolutionError as exc:
         return TupleResult(
             tuple_=t,

--- a/nab-python/tests/test_archive.py
+++ b/nab-python/tests/test_archive.py
@@ -137,7 +137,7 @@ class TestArchiveRequestParse:
     def test_drive_subdirectory_rejected(self) -> None:
         with pytest.raises(ArchiveRequestError, match="unsafe archive subdirectory"):
             ArchiveRequest.parse(
-                "https://ex.com/foo.tar.gz#sha256=abc&subdirectory=C:\\evil"
+                "https://ex.com/foo.tar.gz#sha256=abc&subdirectory=C:\\other"
             )
 
     def test_contained_backslash_subdirectory_allowed(self) -> None:
@@ -432,7 +432,7 @@ class TestExtractArchive:
     def test_rejects_escaping_symlink_member(self, tmp_path: Path) -> None:
         buf = io.BytesIO()
         with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-            info = tarfile.TarInfo("foo-1.0.0/evil")
+            info = tarfile.TarInfo("foo-1.0.0/link")
             info.type = tarfile.SYMTYPE
             info.linkname = "/etc/passwd"
             tar.addfile(info)

--- a/nab-python/tests/test_archive.py
+++ b/nab-python/tests/test_archive.py
@@ -18,7 +18,11 @@ import pytest
 
 from nab_index.archive import ArchiveRequest, ArchiveRequestError
 from nab_index.client import SdistHashMismatchError, extract_sdist_archive
-from nab_python.download import iter_artifacts
+from nab_python.download import (
+    DownloadError,
+    _reject_colliding_targets,
+    iter_artifacts,
+)
 from nab_python.fetch import InMemoryIndex
 from nab_python.lockfile import ArchivePin, LockInput
 from nab_python.provider import (
@@ -122,6 +126,27 @@ class TestArchiveRequestParse:
         )
         assert req.subdirectory == "a/../b"
 
+    def test_backslash_escape_rejected(self) -> None:
+        # The join is native, so a backslash escapes on Windows; the ntpath
+        # containment check rejects it on every platform.
+        with pytest.raises(ArchiveRequestError, match="unsafe archive subdirectory"):
+            ArchiveRequest.parse(
+                "https://ex.com/foo.tar.gz#sha256=abc&subdirectory=..\\..\\etc"
+            )
+
+    def test_drive_subdirectory_rejected(self) -> None:
+        with pytest.raises(ArchiveRequestError, match="unsafe archive subdirectory"):
+            ArchiveRequest.parse(
+                "https://ex.com/foo.tar.gz#sha256=abc&subdirectory=C:\\evil"
+            )
+
+    def test_contained_backslash_subdirectory_allowed(self) -> None:
+        # A backslash-separated path that stays inside the tree is kept.
+        req = ArchiveRequest.parse(
+            "https://ex.com/foo.tar.gz#sha256=abc&subdirectory=sub\\deeper"
+        )
+        assert req.subdirectory == "sub\\deeper"
+
 
 class TestArchiveIndexing:
     def test_duplicate_archive_source_rejected(self) -> None:
@@ -172,8 +197,11 @@ class TestArchiveIndexing:
             )
 
 
-@requires_data_filter
 class TestArchiveMaterialize:
+    # The download-and-verify guards need no tar filter and run on every runner;
+    # only the tests that actually extract carry @requires_data_filter.
+
+    @requires_data_filter
     def test_resolves_and_seeds_single_version(self, tmp_path: Path) -> None:
         data = _make_sdist("foo", "1.0.0", _PYPROJECT)
         digest = hashlib.sha256(data).hexdigest()
@@ -221,16 +249,33 @@ class TestArchiveMaterialize:
         with pytest.raises(UnsupportedSdistError, match="download.*failed"):
             provider.fetch_versions("foo")
 
-    def test_unextractable_archive_raises(self, tmp_path: Path) -> None:
+    def test_local_source_hash_verified(self, tmp_path: Path) -> None:
+        # A file:// index reads bytes without verifying, so materialisation
+        # re-checks the hash: tampered bytes present (and no recorded error)
+        # still fail the resolve loudly.
         digest = "a" * 64
         source = ArchiveSource(
             name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
         )
         provider = _provider([source], tmp_path / "arch")
-        provider.coordinator.index.store_sdist_archive("foo", digest, b"not a tarball")
+        provider.coordinator.index.store_sdist_archive("foo", digest, b"tampered")
+        with pytest.raises(SdistHashMismatchError):
+            provider.fetch_versions("foo")
+
+    def test_unextractable_archive_raises(self, tmp_path: Path) -> None:
+        # Bytes whose hash matches (so verification passes) but which are not a
+        # valid tarball: the failure is extraction, not the hash check.
+        data = b"not a tarball"
+        digest = hashlib.sha256(data).hexdigest()
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
+        )
+        provider = _provider([source], tmp_path / "arch")
+        provider.coordinator.index.store_sdist_archive("foo", digest, data)
         with pytest.raises(UnsupportedSdistError, match="could not be extracted"):
             provider.fetch_versions("foo")
 
+    @requires_data_filter
     def test_reextraction_replaces_stale_partial_tree(self, tmp_path: Path) -> None:
         data = _make_sdist("foo", "1.0.0", _PYPROJECT)
         digest = hashlib.sha256(data).hexdigest()
@@ -249,6 +294,7 @@ class TestArchiveMaterialize:
         assert str(versions[0][0]) == "1.0.0"
         assert not (stale / "stale.txt").exists()
 
+    @requires_data_filter
     def test_second_resolve_reuses_extracted_tree(self, tmp_path: Path) -> None:
         data = _make_sdist("foo", "1.0.0", _PYPROJECT)
         digest = hashlib.sha256(data).hexdigest()
@@ -272,6 +318,7 @@ class TestArchiveMaterialize:
         assert str(versions[0][0]) == "1.0.0"
         assert sentinel.exists()
 
+    @requires_data_filter
     def test_flat_archive_without_root_dir(self, tmp_path: Path) -> None:
         # A flat archive (pyproject.toml at the top level) extracts to the
         # target dir itself, with no single root subdirectory.
@@ -286,6 +333,7 @@ class TestArchiveMaterialize:
         versions = provider.fetch_versions("foo")
         assert str(versions[0][0]) == "1.0.0"
 
+    @requires_data_filter
     def test_flat_archive_reuse_through_symlinked_cache(self, tmp_path: Path) -> None:
         # When the cache dir resolves to a different path (a symlink component),
         # a flat archive's reuse marker must still record "no root subdir", or the
@@ -330,6 +378,42 @@ class TestArchiveDownload:
         pin = ArchivePin(name="foo", version="1.0", url="u", hashes=(("md5", "x"),))
         with pytest.raises(ValueError, match="no acceptable hash"):
             _ = pin.primary_digest
+
+    def test_colliding_basenames_rejected(self) -> None:
+        # Two archives from different repos sharing a URL basename would clobber
+        # each other in the flat output dir, so the collision is refused.
+        pins = {
+            "foo": ArchivePin(
+                name="foo",
+                version="1.0",
+                url="https://a.example.com/dist/v1.0.0.tar.gz",
+                hashes=(("sha256", "a" * 64),),
+            ),
+            "bar": ArchivePin(
+                name="bar",
+                version="2.0",
+                url="https://b.example.com/dist/v1.0.0.tar.gz",
+                hashes=(("sha256", "b" * 64),),
+            ),
+        }
+        entries = list(iter_artifacts(LockInput(pins=pins)))
+        with pytest.raises(DownloadError, match="collide on output filename"):
+            _reject_colliding_targets(entries)
+
+    def test_same_basename_same_digest_allowed(self) -> None:
+        # The same archive pinned under two names writes identical bytes, so it
+        # is not a collision.
+        url = "https://a.example.com/dist/v1.0.0.tar.gz"
+        pins = {
+            "foo": ArchivePin(
+                name="foo", version="1.0", url=url, hashes=(("sha256", "a" * 64),)
+            ),
+            "bar": ArchivePin(
+                name="bar", version="1.0", url=url, hashes=(("sha256", "a" * 64),)
+            ),
+        }
+        entries = list(iter_artifacts(LockInput(pins=pins)))
+        _reject_colliding_targets(entries)
 
 
 class TestExtractArchive:

--- a/nab-python/tests/test_archive.py
+++ b/nab-python/tests/test_archive.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from nab_index.archive import ArchiveRequest, ArchiveRequestError
-from nab_index.client import SdistHashMismatchError
+from nab_index.client import SdistHashMismatchError, extract_sdist_archive
 from nab_python.download import iter_artifacts
 from nab_python.fetch import InMemoryIndex
 from nab_python.lockfile import ArchivePin, LockInput
@@ -66,6 +66,14 @@ def _provider(archive_sources: list[ArchiveSource], cache_dir: Path | None) -> P
         archive_cache_dir=cache_dir,
         build_policy=BuildPolicy.NEVER,
     )
+
+
+# Extraction requires the tar data filter (PEP 706), so skip the paths that
+# actually extract on a Python that lacks it (before 3.10.12 / 3.11.4 / 3.12).
+requires_data_filter = pytest.mark.skipif(
+    not hasattr(tarfile, "data_filter"),
+    reason="sdist extraction requires the tar data filter (PEP 706)",
+)
 
 
 class TestArchiveRequestParse:
@@ -128,6 +136,13 @@ class TestArchiveIndexing:
                 None,
             )
 
+    def test_valid_source_is_registered(self) -> None:
+        source = ArchiveSource(
+            name="Foo-Bar", url=f"https://ex.com/foo-1.0.tar.gz#sha256={'a' * 64}"
+        )
+        provider = _provider([source], None)
+        assert provider.archive_source_for("foo_bar") is source
+
     def test_hashless_url_rejected_at_index(self) -> None:
         # config parse also rejects this, but a directly-built Provider must
         # not slip through to an IndexError at materialisation.
@@ -157,6 +172,7 @@ class TestArchiveIndexing:
             )
 
 
+@requires_data_filter
 class TestArchiveMaterialize:
     def test_resolves_and_seeds_single_version(self, tmp_path: Path) -> None:
         data = _make_sdist("foo", "1.0.0", _PYPROJECT)
@@ -314,3 +330,29 @@ class TestArchiveDownload:
         pin = ArchivePin(name="foo", version="1.0", url="u", hashes=(("md5", "x"),))
         with pytest.raises(ValueError, match="no acceptable hash"):
             _ = pin.primary_digest
+
+
+class TestExtractArchive:
+    """extract_sdist_archive requires and defers safety to the tar data filter."""
+
+    def test_requires_data_filter(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("nab_index.client._SUPPORTS_DATA_FILTER", False)
+        out = tmp_path / "out"
+        out.mkdir()
+        with pytest.raises(ValueError, match="requires the tar data filter"):
+            extract_sdist_archive(_make_sdist("foo", "1.0.0", _PYPROJECT), out)
+
+    @requires_data_filter
+    def test_rejects_escaping_symlink_member(self, tmp_path: Path) -> None:
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            info = tarfile.TarInfo("foo-1.0.0/evil")
+            info.type = tarfile.SYMTYPE
+            info.linkname = "/etc/passwd"
+            tar.addfile(info)
+        out = tmp_path / "out"
+        out.mkdir()
+        with pytest.raises(ValueError, match="unsafe sdist member"):
+            extract_sdist_archive(buf.getvalue(), out)

--- a/nab-python/tests/test_archive.py
+++ b/nab-python/tests/test_archive.py
@@ -1,0 +1,316 @@
+"""Tests for direct-URL archive sources (``[[tool.nab.archive-sources]]``).
+
+The download itself goes through the fetch coordinator, so these tests
+pre-seed the in-memory index with the archive bytes (or an error) rather
+than hitting the network, and exercise the extract-then-materialise path
+on real ``.tar.gz`` bytes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import tarfile
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from nab_index.archive import ArchiveRequest, ArchiveRequestError
+from nab_index.client import SdistHashMismatchError
+from nab_python.download import iter_artifacts
+from nab_python.fetch import InMemoryIndex
+from nab_python.lockfile import ArchivePin, LockInput
+from nab_python.provider import (
+    ArchiveSource,
+    BuildPolicy,
+    Provider,
+    UnsupportedSdistError,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _make_sdist(name: str, version: str, pyproject: str) -> bytes:
+    """Return ``.tar.gz`` bytes for a one-file sdist rooted at name-version."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        data = pyproject.encode("utf-8")
+        info = tarfile.TarInfo(f"{name}-{version}/pyproject.toml")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def _make_flat_sdist(pyproject: str) -> bytes:
+    """Return ``.tar.gz`` bytes with pyproject.toml at the top level (no root dir)."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        body = pyproject.encode("utf-8")
+        info = tarfile.TarInfo("pyproject.toml")
+        info.size = len(body)
+        tar.addfile(info, io.BytesIO(body))
+    return buf.getvalue()
+
+
+_PYPROJECT = '[project]\nname = "foo"\nversion = "1.0.0"\ndependencies = ["bar>=1"]\n'
+
+
+def _provider(archive_sources: list[ArchiveSource], cache_dir: Path | None) -> Provider:
+    coordinator = MagicMock()
+    coordinator.index = InMemoryIndex()
+    return Provider(
+        coordinator,
+        archive_sources=archive_sources,
+        archive_cache_dir=cache_dir,
+        build_policy=BuildPolicy.NEVER,
+    )
+
+
+class TestArchiveRequestParse:
+    def test_url_hash_and_subdirectory(self) -> None:
+        req = ArchiveRequest.parse(
+            "https://ex.com/foo-1.0.tar.gz#sha256=abc&subdirectory=pkg"
+        )
+        assert req.url == "https://ex.com/foo-1.0.tar.gz"
+        assert req.hashes == (("sha256", "abc"),)
+        assert req.subdirectory == "pkg"
+
+    def test_unknown_fragment_key_raises(self) -> None:
+        with pytest.raises(ArchiveRequestError, match="unknown archive URL fragment"):
+            ArchiveRequest.parse("https://ex.com/foo.tar.gz#egg=foo")
+
+    def test_missing_equals_raises(self) -> None:
+        with pytest.raises(ArchiveRequestError, match="malformed archive URL fragment"):
+            ArchiveRequest.parse("https://ex.com/foo.tar.gz#sha256")
+
+    def test_empty_fragment_part_ignored(self) -> None:
+        req = ArchiveRequest.parse("https://ex.com/foo.tar.gz#sha256=abc&")
+        assert req.hashes == (("sha256", "abc"),)
+
+    def test_parent_subdirectory_rejected(self) -> None:
+        with pytest.raises(ArchiveRequestError, match="unsafe archive subdirectory"):
+            ArchiveRequest.parse(
+                "https://ex.com/foo.tar.gz#sha256=abc&subdirectory=../../etc"
+            )
+
+    def test_absolute_subdirectory_rejected(self) -> None:
+        with pytest.raises(ArchiveRequestError, match="unsafe archive subdirectory"):
+            ArchiveRequest.parse(
+                "https://ex.com/foo.tar.gz#sha256=abc&subdirectory=/etc"
+            )
+
+    def test_escaping_internal_dotdot_rejected(self) -> None:
+        with pytest.raises(ArchiveRequestError, match="unsafe archive subdirectory"):
+            ArchiveRequest.parse(
+                "https://ex.com/foo.tar.gz#sha256=abc&subdirectory=a/../../etc"
+            )
+
+    def test_contained_internal_dotdot_allowed(self) -> None:
+        # a/../b normalises to b, which stays inside the tree, so it is kept.
+        req = ArchiveRequest.parse(
+            "https://ex.com/foo.tar.gz#sha256=abc&subdirectory=a/../b"
+        )
+        assert req.subdirectory == "a/../b"
+
+
+class TestArchiveIndexing:
+    def test_duplicate_archive_source_rejected(self) -> None:
+        digest = "a" * 64
+        url = f"https://ex.com/foo-1.0.tar.gz#sha256={digest}"
+        with pytest.raises(ValueError, match="duplicate source"):
+            _provider(
+                [
+                    ArchiveSource(name="Foo-Bar", url=url),
+                    ArchiveSource(name="foo_bar", url=url),
+                ],
+                None,
+            )
+
+    def test_hashless_url_rejected_at_index(self) -> None:
+        # config parse also rejects this, but a directly-built Provider must
+        # not slip through to an IndexError at materialisation.
+        with pytest.raises(ValueError, match="no hash"):
+            _provider(
+                [ArchiveSource(name="foo", url="https://ex.com/foo-1.0.tar.gz")],
+                None,
+            )
+
+    def test_archive_collides_with_local_source(self, tmp_path: Path) -> None:
+        from nab_python.provider import LocalSource
+
+        digest = "a" * 64
+        coordinator = MagicMock()
+        coordinator.index = InMemoryIndex()
+        with pytest.raises(ValueError, match="duplicate source"):
+            Provider(
+                coordinator,
+                local_sources=[LocalSource(name="foo", path=str(tmp_path))],
+                archive_sources=[
+                    ArchiveSource(
+                        name="foo",
+                        url=f"https://ex.com/foo-1.0.tar.gz#sha256={digest}",
+                    ),
+                ],
+                build_policy=BuildPolicy.NEVER,
+            )
+
+
+class TestArchiveMaterialize:
+    def test_resolves_and_seeds_single_version(self, tmp_path: Path) -> None:
+        data = _make_sdist("foo", "1.0.0", _PYPROJECT)
+        digest = hashlib.sha256(data).hexdigest()
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
+        )
+        provider = _provider([source], tmp_path / "arch")
+        provider.coordinator.index.store_sdist_archive("foo", digest, data)
+
+        versions = provider.fetch_versions("foo")
+
+        assert len(versions) == 1
+        assert str(versions[0][0]) == "1.0.0"
+
+    def test_hash_mismatch_is_hard_error(self, tmp_path: Path) -> None:
+        digest = "a" * 64
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
+        )
+        provider = _provider([source], tmp_path / "arch")
+        provider.coordinator.index.store_sdist_archive_error(
+            "foo", digest, SdistHashMismatchError("sha256 mismatch")
+        )
+        # A tampered archive fails the resolve loudly; it is not swallowed
+        # as an UnsupportedSdistError the look-ahead would treat as a skip.
+        with pytest.raises(SdistHashMismatchError):
+            provider.fetch_versions("foo")
+
+    def test_missing_cache_dir_raises(self) -> None:
+        digest = "a" * 64
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
+        )
+        provider = _provider([source], None)
+        with pytest.raises(UnsupportedSdistError, match="no.*archive_cache_dir"):
+            provider.fetch_versions("foo")
+
+    def test_download_failure_raises(self, tmp_path: Path) -> None:
+        digest = "a" * 64
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
+        )
+        provider = _provider([source], tmp_path / "arch")
+        # No bytes stored and no error recorded: the fetch produced nothing.
+        with pytest.raises(UnsupportedSdistError, match="download.*failed"):
+            provider.fetch_versions("foo")
+
+    def test_unextractable_archive_raises(self, tmp_path: Path) -> None:
+        digest = "a" * 64
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
+        )
+        provider = _provider([source], tmp_path / "arch")
+        provider.coordinator.index.store_sdist_archive("foo", digest, b"not a tarball")
+        with pytest.raises(UnsupportedSdistError, match="could not be extracted"):
+            provider.fetch_versions("foo")
+
+    def test_reextraction_replaces_stale_partial_tree(self, tmp_path: Path) -> None:
+        data = _make_sdist("foo", "1.0.0", _PYPROJECT)
+        digest = hashlib.sha256(data).hexdigest()
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
+        )
+        # A partial dir from a crashed run (no completion marker) is discarded.
+        stale = tmp_path / "arch" / digest
+        stale.mkdir(parents=True)
+        (stale / "stale.txt").write_text("old", encoding="utf-8")
+
+        provider = _provider([source], tmp_path / "arch")
+        provider.coordinator.index.store_sdist_archive("foo", digest, data)
+
+        versions = provider.fetch_versions("foo")
+        assert str(versions[0][0]) == "1.0.0"
+        assert not (stale / "stale.txt").exists()
+
+    def test_second_resolve_reuses_extracted_tree(self, tmp_path: Path) -> None:
+        data = _make_sdist("foo", "1.0.0", _PYPROJECT)
+        digest = hashlib.sha256(data).hexdigest()
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
+        )
+        cache = tmp_path / "arch"
+        first = _provider([source], cache)
+        first.coordinator.index.store_sdist_archive("foo", digest, data)
+        first.fetch_versions("foo")
+
+        # A sentinel dropped into the extracted tree survives a later resolve,
+        # proving the tree is reused rather than wiped and re-extracted.
+        sentinel = cache / digest / "SENTINEL"
+        sentinel.write_text("keep", encoding="utf-8")
+
+        second = _provider([source], cache)
+        second.coordinator.index.store_sdist_archive("foo", digest, data)
+        versions = second.fetch_versions("foo")
+
+        assert str(versions[0][0]) == "1.0.0"
+        assert sentinel.exists()
+
+    def test_flat_archive_without_root_dir(self, tmp_path: Path) -> None:
+        # A flat archive (pyproject.toml at the top level) extracts to the
+        # target dir itself, with no single root subdirectory.
+        data = _make_flat_sdist(_PYPROJECT)
+        digest = hashlib.sha256(data).hexdigest()
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
+        )
+        provider = _provider([source], tmp_path / "arch")
+        provider.coordinator.index.store_sdist_archive("foo", digest, data)
+
+        versions = provider.fetch_versions("foo")
+        assert str(versions[0][0]) == "1.0.0"
+
+    def test_flat_archive_reuse_through_symlinked_cache(self, tmp_path: Path) -> None:
+        # When the cache dir resolves to a different path (a symlink component),
+        # a flat archive's reuse marker must still record "no root subdir", or the
+        # second resolve looks under a nonexistent <digest>/<digest> directory.
+        real = tmp_path / "real"
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real, target_is_directory=True)
+        cache = link / "arch"
+        data = _make_flat_sdist(_PYPROJECT)
+        digest = hashlib.sha256(data).hexdigest()
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
+        )
+
+        first = _provider([source], cache)
+        first.coordinator.index.store_sdist_archive("foo", digest, data)
+        first.fetch_versions("foo")
+
+        second = _provider([source], cache)
+        second.coordinator.index.store_sdist_archive("foo", digest, data)
+        versions = second.fetch_versions("foo")
+        assert str(versions[0][0]) == "1.0.0"
+
+
+class TestArchiveDownload:
+    def test_archive_pin_yields_download_entry(self) -> None:
+        pin = ArchivePin(
+            name="foo",
+            version="1.0",
+            url="https://ex.com/foo-1.0.tar.gz",
+            hashes=(("sha256", "e" * 64),),
+        )
+        (entry,) = list(iter_artifacts(LockInput(pins={"foo": pin})))
+        assert entry.url == "https://ex.com/foo-1.0.tar.gz"
+        assert entry.filename == "foo-1.0.tar.gz"
+        assert entry.hash_algo == "sha256"
+        assert entry.digest == "e" * 64
+        assert entry.local_path is None
+
+    def test_primary_digest_no_acceptable_hash_raises(self) -> None:
+        pin = ArchivePin(name="foo", version="1.0", url="u", hashes=(("md5", "x"),))
+        with pytest.raises(ValueError, match="no acceptable hash"):
+            _ = pin.primary_digest

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -1403,6 +1403,93 @@ class TestVcsSources:
             read_pyproject_config(path)
 
 
+class TestArchiveSources:
+    _URL = "https://ex.com/foo-1.0.tar.gz#sha256=" + "e" * 64
+
+    def test_round_trip(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            f'[[tool.nab.archive-sources]]\nname = "foo"\nurl = "{self._URL}"\n',
+        )
+        (source,) = read_pyproject_config(path).archive_sources
+        assert source.name == "foo"
+        assert source.url == self._URL
+
+    def test_must_be_array(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab]\narchive-sources = "x"\n')
+        with pytest.raises(ConfigError, match="archive-sources must be an array"):
+            read_pyproject_config(path)
+
+    def test_entry_must_be_table(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab]\narchive-sources = ["x"]\n')
+        with pytest.raises(ConfigError, match=r"archive-sources\[0\] must be a table"):
+            read_pyproject_config(path)
+
+    def test_missing_keys(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[[tool.nab.archive-sources]]\nname = "x"\n')
+        with pytest.raises(ConfigError, match="missing required key 'url'"):
+            read_pyproject_config(path)
+
+    def test_field_types(self, tmp_path: Path) -> None:
+        path = write(tmp_path, "[[tool.nab.archive-sources]]\nname = 1\nurl = 2\n")
+        with pytest.raises(ConfigError, match="name and url must be strings"):
+            read_pyproject_config(path)
+
+    def test_unknown_key_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            f'[[tool.nab.archive-sources]]\nname = "x"\nurl = "{self._URL}"\nbogus = 1\n',
+        )
+        with pytest.raises(ConfigError, match="unknown archive-sources"):
+            read_pyproject_config(path)
+
+    def test_no_hash_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[[tool.nab.archive-sources]]\nname = "x"\n'
+            'url = "https://ex.com/foo-1.0.tar.gz"\n',
+        )
+        with pytest.raises(ConfigError, match="has no hash"):
+            read_pyproject_config(path)
+
+    def test_empty_digest_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[[tool.nab.archive-sources]]\nname = "x"\n'
+            'url = "https://ex.com/foo-1.0.tar.gz#sha256="\n',
+        )
+        with pytest.raises(ConfigError, match="has no hash"):
+            read_pyproject_config(path)
+
+    def test_non_targz_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[[tool.nab.archive-sources]]\nname = "x"\n'
+            'url = "https://ex.com/foo-1.0.whl#sha256=' + "e" * 64 + '"\n',
+        )
+        with pytest.raises(ConfigError, match="not a .tar.gz archive"):
+            read_pyproject_config(path)
+
+    def test_malformed_fragment_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[[tool.nab.archive-sources]]\nname = "x"\n'
+            'url = "https://ex.com/foo-1.0.tar.gz#egg=foo"\n',
+        )
+        with pytest.raises(ConfigError, match="unknown archive URL fragment"):
+            read_pyproject_config(path)
+
+    def test_duplicate_collides_with_vcs_source(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[[tool.nab.vcs-sources]]\nname = "Foo-Bar"\n'
+            'url = "git+https://github.com/me/b.git@abc"\n'
+            f'[[tool.nab.archive-sources]]\nname = "foo_bar"\nurl = "{self._URL}"\n',
+        )
+        with pytest.raises(ConfigError, match="duplicate canonical name"):
+            read_pyproject_config(path)
+
+
 class TestPackageSugar:
     """``[tool.nab.packages.<name>]`` parses into per-package overrides."""
 

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -49,6 +49,7 @@ from nab_python.config_sources import (
     resolve_config,
 )
 from nab_python.provider import (
+    ArchiveSource,
     BuildPolicy,
     DistPolicy,
     ResolutionStrategy,
@@ -788,6 +789,7 @@ class TestParserFoldHelpers:
                 "indexes",
                 "local-sources",
                 "vcs-sources",
+                "archive-sources",
                 "packages",
                 "package-rules",
                 "index",
@@ -1767,6 +1769,13 @@ class TestArrayOfTablesSources:
         assert spec.render(()) == "<none>"
         rendered = spec.render((VcsSource(name="pkg", url="git+https://e/p.git@a"),))
         assert rendered == "pkg@git+https://e/p.git@a"
+
+    def test_archive_sources_render(self) -> None:
+        spec = next(s for s in OPTIONS if s.key == "archive-sources")
+        assert spec.render(()) == "<none>"
+        url = "https://e/p.tar.gz#sha256=abc"
+        rendered = spec.render((ArchiveSource(name="pkg", url=url),))
+        assert rendered == f"pkg@{url}"
 
     def test_array_of_tables_rows_are_file_only_arrays(self) -> None:
         for key in ("indexes", "local-sources", "vcs-sources"):

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -44,6 +44,7 @@ from nab_python.config import (
 )
 from nab_python.lockfile import (
     LOCK_VERSION,
+    ArchivePin,
     DisjointnessError,
     DivergentBaseDependencyError,
     IndexPin,
@@ -66,6 +67,7 @@ from nab_python.lockfile import (
     write_requirements_without_hashes,
 )
 from nab_python.provider import (
+    ArchiveSource,
     BuildPolicy,
     DistPolicy,
     LocalSource,
@@ -182,6 +184,59 @@ class TestSingleTuple:
         )
         data = tomllib.loads(text)
         assert data["packages"][0]["vcs"]["type"] == "hg"
+
+    def test_archive_pin(self) -> None:
+        text = write_lock(
+            LockInput(
+                pins={
+                    "foo": ArchivePin(
+                        name="foo",
+                        version="1.0",
+                        url="https://ex.com/foo-1.0.tar.gz",
+                        hashes=(("sha256", "e" * 64),),
+                        subdirectory="pkg",
+                    ),
+                },
+            )
+        )
+        data = tomllib.loads(text)
+        package = data["packages"][0]
+        archive = package["archive"]
+        assert archive["url"] == "https://ex.com/foo-1.0.tar.gz"
+        assert archive["hashes"] == {"sha256": "e" * 64}
+        assert archive["subdirectory"] == "pkg"
+        # An archive is content-pinned, so unlike vcs/directory it keeps a version.
+        assert package["version"] == "1.0"
+
+    def test_archive_pin_requirements_line(self) -> None:
+        pins = {
+            "foo": ArchivePin(
+                name="foo",
+                version="1.0",
+                url="https://ex.com/foo-1.0.tar.gz",
+                hashes=(("sha256", "e" * 64),),
+                subdirectory="pkg",
+            ),
+        }
+        text = write_requirements_with_hashes(LockInput(pins=pins))
+        assert (
+            "foo @ https://ex.com/foo-1.0.tar.gz#sha256="
+            + "e" * 64
+            + "&subdirectory=pkg"
+        ) in text
+
+    def test_archive_pin_requirements_line_no_subdirectory(self) -> None:
+        pins = {
+            "foo": ArchivePin(
+                name="foo",
+                version="1.0",
+                url="https://ex.com/foo-1.0.tar.gz",
+                hashes=(("sha256", "e" * 64),),
+            ),
+        }
+        text = write_requirements_with_hashes(LockInput(pins=pins))
+        assert "foo @ https://ex.com/foo-1.0.tar.gz#sha256=" + "e" * 64 in text
+        assert "subdirectory" not in text
 
     def test_multiple_packages_sorted_by_name(self) -> None:
         text = write_lock(
@@ -446,6 +501,26 @@ class TestPerTupleMarkerSimplification:
         data = tomllib.loads(text)
         # Same VCS commit -> single group -> one package
         assert len(data["packages"]) == 1
+
+    def test_archive_pin_per_tuple(self) -> None:
+        # ArchivePin merged across tuples: same archive -> one group -> one package.
+        pin = ArchivePin(
+            name="foo",
+            version="1.0",
+            url="https://ex.com/foo-1.0.tar.gz",
+            hashes=(("sha256", "e" * 64),),
+        )
+        per_tuple = {"py310": {"foo": pin}, "py311": {"foo": pin}}
+        tuple_markers = {
+            "py310": Marker('python_version == "3.10"'),
+            "py311": Marker('python_version == "3.11"'),
+        }
+        text = write_lock(
+            LockInput(per_tuple_pins=per_tuple, tuple_markers=tuple_markers)
+        )
+        data = tomllib.loads(text)
+        assert len(data["packages"]) == 1
+        assert data["packages"][0]["archive"]["url"] == "https://ex.com/foo-1.0.tar.gz"
 
     def test_vcs_pin_per_tuple_diverging_commit(self) -> None:
         # Diverging commit -> two groups -> two packages
@@ -2084,6 +2159,7 @@ class _FakeProvider:
         listings: dict[str, list[tuple[Version, WheelFile | SdistFile]]] | None = None,
         local_sources: dict[str, LocalSource] | None = None,
         vcs_sources: dict[str, VcsSource] | None = None,
+        archive_sources: dict[str, ArchiveSource] | None = None,
         vcs_pins: dict[str, str] | None = None,
         listing_indexes: dict[str, str] | None = None,
         dist_policy_overrides: dict[str, DistPolicy] | None = None,
@@ -2096,6 +2172,7 @@ class _FakeProvider:
         self._listings = listings or {}
         self._local = local_sources or {}
         self._vcs = vcs_sources or {}
+        self._archive = archive_sources or {}
         self._vcs_pins = vcs_pins or {}
         self._dist_policy_overrides = dist_policy_overrides or {}
         self._requires_python_overrides = requires_python_overrides or {}
@@ -2108,6 +2185,9 @@ class _FakeProvider:
 
     def vcs_source_for(self, canonical: str) -> VcsSource | None:
         return self._vcs.get(canonical)
+
+    def archive_source_for(self, canonical: str) -> ArchiveSource | None:
+        return self._archive.get(canonical)
 
     def vcs_pin_for(self, canonical: str) -> str | None:
         return self._vcs_pins.get(canonical)
@@ -2314,6 +2394,23 @@ class TestBuildLockInputFromProvider:
         text = write_lock(lock_input)
         assert "pkg-2.0.tar.gz" in text
         assert "b" * 64 in text
+
+    def test_archive_source_emits_archive_pin(self) -> None:
+        """A configured ArchiveSource builds an ArchivePin from its URL + hash."""
+        source = ArchiveSource(
+            name="foo",
+            url=(
+                "https://ex.com/foo-1.0.tar.gz#sha256=" + "e" * 64 + "&subdirectory=pkg"
+            ),
+        )
+        provider = _FakeProvider(archive_sources={"foo": source})
+        lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0")})
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, ArchivePin)
+        assert pin.url == "https://ex.com/foo-1.0.tar.gz"
+        assert pin.hashes == (("sha256", "e" * 64),)
+        assert pin.subdirectory == "pkg"
+        assert pin.version == "1.0"
 
     def test_local_path_threads_to_artifact(self, tmp_path: Path) -> None:
         """A WheelFile.local_path reaches the emitted WheelArtifact."""

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -2412,6 +2412,20 @@ class TestBuildLockInputFromProvider:
         assert pin.subdirectory == "pkg"
         assert pin.version == "1.0"
 
+    def test_archive_source_strips_credentials(self) -> None:
+        """An archive on an authenticated host keeps its token out of the lock."""
+        source = ArchiveSource(
+            name="foo",
+            url="https://user:token@private.example/foo-1.0.tar.gz#sha256=" + "e" * 64,
+        )
+        provider = _FakeProvider(archive_sources={"foo": source})
+        lock_input = build_lock_input_from_provider(provider, {"foo": Version("1.0")})
+        pin = lock_input.pins["foo"]
+        assert isinstance(pin, ArchivePin)
+        assert pin.url == "https://private.example/foo-1.0.tar.gz"
+        assert "user:token@" not in write_lock(lock_input)
+        assert "user:token@" not in write_requirements_with_hashes(lock_input)
+
     def test_local_path_threads_to_artifact(self, tmp_path: Path) -> None:
         """A WheelFile.local_path reaches the emitted WheelArtifact."""
         wheel_path = tmp_path / "foo-1.0-py3-none-any.whl"

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -56,7 +56,7 @@ from nab_python.provider import (
     VcsSource,
     python_axis_environment,
 )
-from nab_python.resolve import _raise_for_local_vcs_python
+from nab_python.resolve import _raise_for_source_python
 from nab_resolver.resolver import ResolutionError, Resolver
 from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
 
@@ -3589,7 +3589,7 @@ class TestLocalVcsPythonGuardOverride:
         provider = self._local_provider(tmp_path, ">=3.11", ">=3.0")
         stamped = provider.metadata_cache[("foo", V("1.0"))].requires_python
         assert stamped == SpecifierSet(">=3.0")
-        _raise_for_local_vcs_python(provider, {"foo": V("1.0")}, V("3.9"))
+        _raise_for_source_python(provider, {"foo": V("1.0")}, V("3.9"))
 
     def test_narrow_rejects(self, tmp_path: Path) -> None:
         # pyproject allows >=3.0; the override narrows to >=3.11, so the
@@ -3598,7 +3598,7 @@ class TestLocalVcsPythonGuardOverride:
         stamped = provider.metadata_cache[("foo", V("1.0"))].requires_python
         assert stamped == SpecifierSet(">=3.11")
         with pytest.raises(ResolutionError):
-            _raise_for_local_vcs_python(provider, {"foo": V("1.0")}, V("3.9"))
+            _raise_for_source_python(provider, {"foo": V("1.0")}, V("3.9"))
 
 
 class TestEffectiveFieldResolution:

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -38,7 +38,7 @@ from nab_python.resolve import (
     _load_extra_requirements,
     _load_group_requirements,
     _load_group_requirements_by_group,
-    _raise_for_local_vcs_python,
+    _raise_for_source_python,
     _resolve_target_python,
     _walk_no_versions_packages,
     resolve_pyproject,
@@ -2857,28 +2857,28 @@ class TestLocalVcsRequiresPython:
             '[project]\nname = "foo"\nversion = "1.0"\nrequires-python = ">=3.12"\n',
         )
         with pytest.raises(ResolutionError, match="foo 1.0 requires Python"):
-            _raise_for_local_vcs_python(provider, {"foo": V("1.0")}, V("3.10.0"))
+            _raise_for_source_python(provider, {"foo": V("1.0")}, V("3.10.0"))
 
     def test_compatible_python_does_not_raise(self, tmp_path: Path) -> None:
         provider = self._provider_with_local(
             tmp_path,
             '[project]\nname = "foo"\nversion = "1.0"\nrequires-python = ">=3.10"\n',
         )
-        _raise_for_local_vcs_python(provider, {"foo": V("1.0")}, V("3.10.0"))
+        _raise_for_source_python(provider, {"foo": V("1.0")}, V("3.10.0"))
 
     def test_no_requires_python_does_not_raise(self, tmp_path: Path) -> None:
         provider = self._provider_with_local(
             tmp_path,
             '[project]\nname = "foo"\nversion = "1.0"\n',
         )
-        _raise_for_local_vcs_python(provider, {"foo": V("1.0")}, V("3.10.0"))
+        _raise_for_source_python(provider, {"foo": V("1.0")}, V("3.10.0"))
 
     def test_non_managed_pin_is_skipped(self, tmp_path: Path) -> None:
         provider = self._provider_with_local(
             tmp_path,
             '[project]\nname = "foo"\nversion = "1.0"\nrequires-python = ">=3.12"\n',
         )
-        _raise_for_local_vcs_python(provider, {"bar": V("9.0")}, V("3.10.0"))
+        _raise_for_source_python(provider, {"bar": V("9.0")}, V("3.10.0"))
 
     def test_resolve_pyproject_excluding_python_raises(self, tmp_path: Path) -> None:
         member = tmp_path / "foo"

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -8,7 +8,10 @@ exercise.
 
 from __future__ import annotations
 
+import hashlib
+import io
 import logging
+import tarfile
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
@@ -36,6 +39,7 @@ from nab_python.lockfile import (
     write_requirements_without_hashes,
 )
 from nab_python.provider import (
+    ArchiveSource,
     BuildPolicy,
     DistPolicy,
     LocalSource,
@@ -1494,6 +1498,86 @@ class TestLocalVcsRequiresPython:
             ["foo"],
             local_sources=[local],
         )
+        assert not result.success
+        error = result.tuple_results[0].error
+        assert error is not None
+        assert "foo 1.0 requires Python" in error
+
+
+def _archive_bytes(name: str, version: str, pyproject: str) -> bytes:
+    """Return ``.tar.gz`` bytes for a one-file sdist rooted at name-version."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        body = pyproject.encode("utf-8")
+        info = tarfile.TarInfo(f"{name}-{version}/pyproject.toml")
+        info.size = len(body)
+        tar.addfile(info, io.BytesIO(body))
+    return buf.getvalue()
+
+
+# Materialising an archive extracts it, so the tar data filter is required.
+requires_data_filter = pytest.mark.skipif(
+    not hasattr(tarfile, "data_filter"),
+    reason="sdist extraction requires the tar data filter (PEP 706)",
+)
+
+
+@requires_data_filter
+class TestArchiveSourceUniversal:
+    """An archive source threads through universal resolution across tuples."""
+
+    def test_resolves_and_pins_across_tuples(self, tmp_path: Path) -> None:
+        pyproject = (
+            '[project]\nname = "foo"\nversion = "1.0"\n'
+            'requires-python = ">=3.11"\ndependencies = ["bar"]\n'
+        )
+        data = _archive_bytes("foo", "1.0", pyproject)
+        digest = hashlib.sha256(data).hexdigest()
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.tar.gz#sha256={digest}"
+        )
+        coord = make_coordinator(
+            listings={"bar": [_make_wheel("2.0", package="bar")]},
+            auto_metadata=True,
+        )
+        coord.index.store_sdist_archive("foo", digest, data)
+
+        result = resolve_with_coordinator(
+            coord,
+            Matrix(python=">=3.11, <3.13", platforms=("linux_x86_64",)),
+            ["foo"],
+            archive_sources=[source],
+            archive_cache_dir=tmp_path / "arch",
+        )
+
+        assert result.success
+        assert len(result.tuple_results) == 2
+        for tuple_result in result.tuple_results:
+            assert str(tuple_result.pins["foo"]) == "1.0"
+            assert str(tuple_result.pins["bar"]) == "2.0"
+
+    def test_requires_python_excluding_target_fails(self, tmp_path: Path) -> None:
+        # An archive skips the listing Requires-Python filter, so the source
+        # guard must reject one that excludes the tuple's Python.
+        pyproject = (
+            '[project]\nname = "foo"\nversion = "1.0"\nrequires-python = ">=3.12"\n'
+        )
+        data = _archive_bytes("foo", "1.0", pyproject)
+        digest = hashlib.sha256(data).hexdigest()
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.tar.gz#sha256={digest}"
+        )
+        coord = make_coordinator([], package="foo")
+        coord.index.store_sdist_archive("foo", digest, data)
+
+        result = resolve_with_coordinator(
+            coord,
+            Matrix(python="==3.10", platforms=("linux_x86_64",)),
+            ["foo"],
+            archive_sources=[source],
+            archive_cache_dir=tmp_path / "arch",
+        )
+
         assert not result.success
         error = result.tuple_results[0].error
         assert error is not None

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -31,6 +31,7 @@ from nab_python.config import (
     ResolveMode,
 )
 from nab_python.lockfile import (
+    ArchivePin,
     IndexPin,
     LockInput,
     Provenance,
@@ -370,13 +371,13 @@ def _write_specific(
         # Read the prior pins before write_lock overwrites the file.
         prior = read_lockfile_packages(target)
         _cli.write_lock(lock_input, output_path=target)
-        # Only index pins record a version; local and VCS pins emit
+        # Index and archive pins record a version; local and VCS pins emit
         # version=None, so read_lockfile_packages never returns them.
         # Diff against the same set or they read as added every relock.
         versioned = {
             name: version
             for name, version in emitted_pins.items()
-            if isinstance(lock_input.pins[name], IndexPin)
+            if isinstance(lock_input.pins[name], (IndexPin, ArchivePin))
         }
         diff = _diff_summary(prior, versioned)
     elif format == "requirements":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,6 +44,7 @@ from nab_python.config import ConfigError
 from nab_python.config_sources import SourceRoots
 from nab_python.download import DownloadError
 from nab_python.lockfile import (
+    ArchivePin,
     DisjointnessError,
     DivergentBaseDependencyError,
     IndexPin,
@@ -1878,6 +1879,31 @@ class TestRelockDiffSummary:
                 provenance=None,
             )
         assert capsys.readouterr().err.strip().endswith("(2 packages)")
+
+    def test_relock_unchanged_with_archive_pin_prints_plain_line(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An archive pin records a version, so an unchanged relock must
+        diff it (not count it as removed)."""
+        out = tmp_path / "pylock.toml"
+        lock_input = LockInput(
+            pins={
+                "foo": ArchivePin(
+                    name="foo",
+                    version="1.0",
+                    url="https://ex.com/foo-1.0.tar.gz",
+                    hashes=(("sha256", "e" * 64),),
+                ),
+            }
+        )
+        for _ in range(2):
+            _emit_specific(
+                ResolutionResult(pins={"foo": V("1.0")}, lock_input=lock_input),
+                format="pylock",
+                output=out,
+                provenance=None,
+            )
+        assert capsys.readouterr().err.strip().endswith("(1 packages)")
 
     def test_unparseable_prior_falls_back_to_plain_line(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
Closes #10.

Adds a direct-URL archive source type, mirroring `[[tool.nab.vcs-sources]]`:

```toml
[[tool.nab.archive-sources]]
name = "foo"
url = "https://example.com/foo-1.0.tar.gz#sha256=<hex>"
```

nab downloads the archive, verifies it against the hash in the URL fragment, extracts it, resolves it as a single synthetic candidate, and emits a PEP 751 `packages.archive` entry.

- The hash is required and verified; a mismatch fails the resolve rather than being skipped.
- Only `.tar.gz` source archives are supported for now; wheels and other formats are refused at config parse.
- A `#subdirectory=` fragment selects the project root inside the archive.
- Works in both single-environment and universal mode, and `nab download` fetches archive pins like any other artifact.
