### PR TITLE
keep required parens when serializing nested double-paren markers

### DIFF
--- a/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
+++ b/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
@@ -30,6 +30,18 @@ model on `pypa/packaging:main` reaches through nab's conflict-resolution
 union path. Refresh both files from that branch until the change lands
 upstream, then snapshot plain `main` again.
 
+## Local divergences
+
+`markers.py` carries one fix on top of the pinned snapshot. When
+`_format_marker` unwraps a redundant `[[...]]` wrapper list it passes
+`first=first` instead of dropping the nesting context, so a nested
+double-parenthesized group keeps the one pair of parentheses its and/or
+precedence needs. The snapshot drops those parentheses unconditionally, so
+`str(Marker(...))` does not round-trip when such a group is nested. Re-apply
+or verify this on any re-vendor that predates the equivalent upstream fix.
+Regression tests: `tests/test_marker_evaluation.py::TestSerializationRoundTrip`,
+`tests/test_requirements_file.py::TestAddExtraMarker`.
+
 ## License
 
 `packaging` is dual-licensed under the Apache License 2.0 and the

--- a/nab-python/src/nab_python/_vendor/packaging/markers.py
+++ b/nab-python/src/nab_python/_vendor/packaging/markers.py
@@ -189,15 +189,15 @@ def _format_marker(
     assert isinstance(marker, (list, tuple, str))
 
     # Sometimes we have a structure like [[...]] which is a single item list
-    # where the single item is itself it's own list. In that case we want skip
-    # the rest of this function so that we don't get extraneous () on the
-    # outside.
+    # where the single item is itself it's own list. In that case we unwrap the
+    # redundant wrapper but keep the current nesting context: a nested group
+    # still needs one pair of parentheses to preserve and/or precedence.
     if (
         isinstance(marker, list)
         and len(marker) == 1
         and isinstance(marker[0], (list, tuple))
     ):
-        return _format_marker(marker[0])
+        return _format_marker(marker[0], first=first)
 
     if isinstance(marker, list):
         inner = (_format_marker(m, first=False) for m in marker)

--- a/nab-python/tests/test_marker_evaluation.py
+++ b/nab-python/tests/test_marker_evaluation.py
@@ -195,6 +195,44 @@ class TestExtraNormalization:
         assert _ev(text, {**LINUX_CP311, "extra": extra_value}) is expected
 
 
+class TestSerializationRoundTrip:
+    """``str(Marker(...))`` must re-parse to a marker that evaluates the same.
+
+    A double-parenthesized group nested inside an and/or expression needs its
+    parentheses for precedence, so serialization has to keep them.
+    """
+
+    @pytest.mark.parametrize(
+        ("text", "env", "expected"),
+        [
+            (
+                'python_version < "3.10" and '
+                '((sys_platform == "linux" or sys_platform == "darwin"))',
+                {"python_version": "3.12", "sys_platform": "darwin"},
+                False,
+            ),
+            (
+                'python_version < "3.10" and '
+                '((sys_platform == "linux" or sys_platform == "darwin"))',
+                {"python_version": "3.9", "sys_platform": "darwin"},
+                True,
+            ),
+            (
+                'extra != "c" or ((python_version > "3.8") and extra != "c") '
+                'and ((python_version != "3.10" or (extra != "a")))',
+                {"python_version": "3.8", "extra": "c"},
+                False,
+            ),
+        ],
+    )
+    def test_nested_double_parens_round_trip(
+        self, text: str, env: dict[str, str], expected: bool
+    ) -> None:
+        marker = Marker(text)
+        assert marker.evaluate(env) is expected
+        assert Marker(str(marker)).evaluate(env) is expected
+
+
 class TestSetMarkers:
     """lock_file-context set membership (extras / dependency_groups)."""
 

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -52,6 +52,22 @@ class TestAddExtraMarker:
         assert req.url == "https://h/a;b/p.tar.gz"
         assert str(req.marker) == 'python_version >= "3.10" and extra == "bar"'
 
+    def test_nested_double_paren_or_group_precedence_kept(self) -> None:
+        """Folding must keep the parens around a nested double-paren or group.
+
+        The dep needs ``python_version < "3.10"``, so on 3.12 it stays inactive
+        only if the or group cannot leak past the and gate.
+        """
+        out = _add_extra_marker(
+            'pkg ; python_version < "3.10" '
+            'and ((sys_platform == "linux" or sys_platform == "darwin"))',
+            "cli",
+        )
+        marker = Requirement(out).marker
+        assert marker is not None
+        env = {"python_version": "3.12", "sys_platform": "darwin", "extra": "cli"}
+        assert marker.evaluate(env) is False
+
 
 class TestReadPyprojectDependencies:
     def test_reads_dependencies(self, tmp_path: object) -> None:


### PR DESCRIPTION
`str(Marker(...))` dropped the parentheses around a double-parenthesized subgroup when that group was nested inside a larger and/or expression. Because nab passes markers around as strings, the re-parsed marker had different and/or precedence and could evaluate to the opposite result. For instance `python_version < "3.10" and ((sys_platform == "linux" or sys_platform == "darwin"))` lost its inner parens and reparsed as `(A and B) or C`, so it wrongly matched on Python 3.12.

Root cause is in the vendored packaging `_format_marker`: when it unwraps a redundant `[[...]]` wrapper it recursed with the default `first=True`, resetting the nesting context to the top level and dropping the parentheses a nested group needs. It now recurses with `first=first` so those parentheses survive.

The change sits on our packaging snapshot; PROVENANCE.md records the divergence so a re-vendor keeps it.
