### PR TITLE
Don't list a package as its own dependency in the PEP 751 lock

### DIFF
--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -340,6 +340,9 @@ def _forward_dependency_graph(
                 for dep in extra_map.get(extra, {})
             )
         dep_names &= pinned
+        # An umbrella extra (pkg[all] pulling pkg[graphviz]) can name its own
+        # package; drop it so pkg is never an edge to itself.
+        dep_names.discard(canonical)
         if dep_names:
             graph[canonical] = tuple(sorted(dep_names))
     return graph

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -3632,6 +3632,41 @@ class TestDependencyGraph:
         )
         assert lock_input.dependencies == {"foo": ("plugin",)}
 
+    def test_umbrella_extra_drops_self_edge(self) -> None:
+        # ``all`` pulls ``mypkg[graphviz]`` and ``mypkg[otel]``, so its recorded
+        # deps name ``mypkg`` itself; the graph keeps only the transitive deps.
+        provider = _FakeProvider(
+            listings={
+                name: [(Version("1.0"), _wheel_file(name))]
+                for name in ("mypkg", "graphviz-lib", "otel-lib")
+            },
+            deps_cache={("mypkg", Version("1.0")): {}},
+            extra_deps_map={
+                ("mypkg", Version("1.0")): {
+                    "all": dict.fromkeys(["mypkg[graphviz]", "mypkg[otel]"]),
+                    "graphviz": dict.fromkeys(["graphviz-lib"]),
+                    "otel": dict.fromkeys(["otel-lib"]),
+                }
+            },
+        )
+        lock_input = build_lock_input_from_provider(
+            provider,
+            {
+                "mypkg": Version("1.0"),
+                "graphviz-lib": Version("1.0"),
+                "otel-lib": Version("1.0"),
+            },
+            resolved_keys=(
+                "mypkg",
+                "mypkg[all]",
+                "mypkg[graphviz]",
+                "mypkg[otel]",
+                "graphviz-lib",
+                "otel-lib",
+            ),
+        )
+        assert lock_input.dependencies == {"mypkg": ("graphviz-lib", "otel-lib")}
+
     def test_emitted_as_pep751_dependencies(self) -> None:
         text = write_lock(
             LockInput(


### PR DESCRIPTION
A single-env PEP 751 lock could list a package as one of its own dependencies. It showed up for umbrella extras, where one extra activates other extras of the same package, like `pkg[all]` pulling in `pkg[graphviz]` and `pkg[otel]`.

When the lock builder folds an activated extra's requirements into the forward dependency graph, those `pkg[graphviz]` style requirements canonicalize back to `pkg` itself, so the package landed in its own dependency set and got emitted as a self-edge. Dropping the package's own name from that set keeps every edge pointing at another package.
