### PR TITLE
validate extra names before interpolating them into a marker

### DIFF
--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -15,7 +15,7 @@ from ._vendor.packaging.dependency_groups import resolve_dependency_groups
 from ._vendor.packaging.errors import ExceptionGroup
 from ._vendor.packaging.markers import Marker
 from ._vendor.packaging.requirements import InvalidRequirement, Requirement
-from ._vendor.packaging.utils import canonicalize_name
+from ._vendor.packaging.utils import InvalidName, canonicalize_name
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -68,9 +68,16 @@ def _add_extra_marker(dep_str: str, extra_name: str) -> str:
     Parses with :class:`Requirement` rather than splitting on the first
     ``;`` so a semicolon inside a direct-reference URL is not mistaken
     for the marker separator; an existing marker is combined with ``and``.
+
+    ``extra_name`` is a table key interpolated into the quoted marker, so
+    it is canonicalised with ``validate=True`` (PEP 685). A key that is
+    not a valid name (say one containing a quote) then raises
+    :class:`InvalidName` instead of producing a marker that gates the dep
+    wrongly.
     """
     req = Requirement(dep_str)
-    extra_marker = f'extra == "{extra_name}"'
+    canonical_extra = canonicalize_name(extra_name, validate=True)
+    extra_marker = f'extra == "{canonical_extra}"'
     if req.marker is not None:
         marker = f"({req.marker}) and {extra_marker}"
     else:
@@ -92,7 +99,7 @@ def _parse_project_requirement(
     try:
         text = _add_extra_marker(dep_str, extra) if extra is not None else dep_str
         return Requirement(text)
-    except InvalidRequirement as exc:
+    except (InvalidRequirement, InvalidName) as exc:
         msg = f"invalid requirement in {source}: {exc}"
         raise InvalidProjectRequirementError(msg) from exc
 

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -8,9 +8,11 @@ import pytest
 
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.specifiers import SpecifierSet
+from nab_python._vendor.packaging.utils import InvalidName
 from nab_python.requirements_file import (
     InvalidProjectRequirementError,
     _add_extra_marker,
+    _parse_project_requirement,
     expand_extra_requirements,
     expand_group_includes,
     expand_self_extras,
@@ -51,6 +53,31 @@ class TestAddExtraMarker:
         req = Requirement(out)
         assert req.url == "https://h/a;b/p.tar.gz"
         assert str(req.marker) == 'python_version >= "3.10" and extra == "bar"'
+
+    def test_non_canonical_extra_name_normalized(self) -> None:
+        """A non-canonical extra name is normalised (PEP 685) in the gate."""
+        out = _add_extra_marker("numpy", "My.Extra")
+        assert out == 'numpy ; extra == "my-extra"'
+
+    def test_extra_name_with_marker_syntax_rejected(self) -> None:
+        """A name that is not a valid PEP 685 name is rejected.
+
+        A ``[project.optional-dependencies]`` key like
+        ``a" or os_name != "x`` would otherwise close the quote and leave
+        the dep gated on a marker that is always true.
+        """
+        with pytest.raises(InvalidName):
+            _add_extra_marker("pkg", 'a" or os_name != "x')
+
+    def test_invalid_extra_name_rejected_as_project_requirement(self) -> None:
+        """An invalid extra name is rejected by the synthesis path, not
+        folded into a dependency with a marker that is always true."""
+        with pytest.raises(InvalidProjectRequirementError):
+            _parse_project_requirement(
+                "pkg",
+                "[project.optional-dependencies] extra 'x'",
+                extra='a" or os_name != "x',
+            )
 
 
 class TestReadPyprojectDependencies:


### PR DESCRIPTION
When expanding a distribution's optional-dependencies, the extra name was interpolated straight into `extra == "<name>"`. That name is a `[project.optional-dependencies]` table key taken from the distribution's own metadata, so a key containing a double quote closes the quoted string and appends its own clause. A key of `a" or os_name != "x` produces the marker `extra == "a" or os_name != "x"`, which is always true, so a dependency that should only install for that extra installs unconditionally.

Canonicalize the extra name with `validate=True` (PEP 685) before building the marker. Valid names are normalized (`My.Extra` becomes `my-extra`), and a name that is not a valid PEP 685 name raises `InvalidName`, which the synthesis path reports as an invalid requirement instead of emitting a bad marker.
