### PR TITLE
treat the .git suffix as optional when matching vcs.allowed-repos

### DIFF
--- a/nab-python/src/nab_python/_vcs_admission.py
+++ b/nab-python/src/nab_python/_vcs_admission.py
@@ -138,12 +138,15 @@ def _repo_prefix_matches(inner_url: str, prefix: str) -> bool:
     at a path-segment boundary: the candidate must equal the prefix, the
     prefix must already end in a separator, or the next candidate
     character must be ``/`` (path), ``@`` (ref) or ``#`` (fragment).
+    Git treats the ``.git`` suffix as optional, so it is stripped from the
+    prefix and skipped once on the candidate before the boundary check.
     Both URLs have their authority ``user[:pass]@`` / ``git@`` stripped
     by the caller.
     """
+    prefix = prefix.removesuffix(".git")
     if not inner_url.startswith(prefix):
         return False
-    rest = inner_url[len(prefix) :]
+    rest = inner_url[len(prefix) :].removeprefix(".git")
     if not rest or not prefix or prefix[-1] in _REPO_BOUNDARY_CHARS:
         return True
     return rest[0] in _REPO_BOUNDARY_CHARS

--- a/nab-python/tests/property_python/test_vcs_admission.py
+++ b/nab-python/tests/property_python/test_vcs_admission.py
@@ -139,10 +139,14 @@ def _prefix_under_repo(inner: str, prefix: str) -> bool:
     A candidate is under an allowed prefix only when the prefix ends at a
     path-segment boundary, so a sibling repo whose URL merely begins with
     the prefix (``.../airflow.git`` vs ``.../airflow.git.other``) is refused.
+    Git's optional ``.git`` suffix is stripped from the prefix and skipped
+    once on the candidate so an exact-repo prefix and the ``.git`` clone URL
+    match either way round.
     """
+    prefix = prefix.removesuffix(".git")
     if not inner.startswith(prefix):
         return False
-    rest = inner[len(prefix) :]
+    rest = inner[len(prefix) :].removeprefix(".git")
     if not rest or not prefix or prefix[-1] in "/@#":
         return True
     return rest[0] in "/@#"

--- a/nab-python/tests/test_vcs_admission.py
+++ b/nab-python/tests/test_vcs_admission.py
@@ -344,6 +344,45 @@ class TestAdmitVcsUrlRepo:
         )
         assert scheme == "git+https"
 
+    def test_exact_repo_prefix_matches_dot_git_clone_url(self) -> None:
+        """An exact-repo prefix admits git's canonical ``.git`` clone URL."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com/myorg/myrepo",),
+        )
+        scheme = admit_vcs_url(
+            f"git+https://github.com/myorg/myrepo.git@{_FORTY}",
+            config,
+        )
+        assert scheme == "git+https"
+
+    def test_dot_git_prefix_matches_url_without_git_suffix(self) -> None:
+        """A ``.git`` prefix admits the same repo written without ``.git``."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com/myorg/myrepo.git",),
+        )
+        scheme = admit_vcs_url(
+            f"git+https://github.com/myorg/myrepo@{_FORTY}",
+            config,
+        )
+        assert scheme == "git+https"
+
+    def test_dot_git_strip_does_not_admit_sibling_repo(self) -> None:
+        """Treating ``.git`` as optional must not admit a distinct sibling."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com/myorg/myrepo",),
+        )
+        with pytest.raises(UnsupportedVcsError, match="not in vcs.allowed-repos"):
+            admit_vcs_url(
+                f"git+https://github.com/myorg/myrepo.gitother@{_FORTY}",
+                config,
+            )
+
     def test_full_repo_prefix_with_fragment_passes(self) -> None:
         """A fragment directly after an allowed full-repo URL stays in-repo."""
         config = VcsConfig(


### PR DESCRIPTION
A `vcs.allowed-repos` entry written without the `.git` suffix, like `https://github.com/myorg/myrepo`, refused the canonical clone URL for the same repo, `https://github.com/myorg/myrepo.git@<sha>`. The boundary check saw the `.` right after the prefix, which is not a path separator, so it read `myrepo.git...` as a different sibling repo and rejected it.

Git treats the `.git` suffix as optional, so this strips it from the prefix and skips one `.git` on the candidate before the boundary check. An entry and its clone URL now match whichever side carries the suffix, and a genuine sibling like `myrepo.gitother` is still refused.
