### PR TITLE
fix partial sdist cache write that persistently drops pyproject.toml

### DIFF
--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -10,7 +10,7 @@ Layout under ``root``:
     simple-v0/<index>/<package>.json       <- raw PyPI JSON body
     simple-v0/<index>/<package>.policy     <- {fetched_at, max_age, etag}
     metadata-v0/<index>/<package>/<version>.metadata
-    sdist-pkginfo-v0/<index>/<package>/<version>.txt
+    sdist-v1/<index>/<package>/<version>.json  <- {pkg_info, pyproject}
 
 A versioned bucket name (``simple-v0``) gives zero-cost schema
 migration: when the on-disk format changes, bump the suffix and the
@@ -40,7 +40,7 @@ __all__ = [
 
 CACHE_VERSION_SIMPLE = "v0"
 CACHE_VERSION_METADATA = "v0"
-CACHE_VERSION_SDIST = "v0"
+CACHE_VERSION_SDIST = "v1"
 
 DEFAULT_PYPI_URLS = frozenset(
     [
@@ -132,10 +132,7 @@ class OnDiskCache:
         self._index = _index_dirname(index_url)
         self._simple_dir = root / f"simple-{CACHE_VERSION_SIMPLE}" / self._index
         self._metadata_dir = root / f"metadata-{CACHE_VERSION_METADATA}" / self._index
-        self._sdist_dir = root / f"sdist-pkginfo-{CACHE_VERSION_SDIST}" / self._index
-        self._sdist_pyproject_dir = (
-            root / f"sdist-pyproject-{CACHE_VERSION_SDIST}" / self._index
-        )
+        self._sdist_dir = root / f"sdist-{CACHE_VERSION_SDIST}" / self._index
 
     def _simple_paths(self, package: str) -> tuple[Path, Path]:
         segment = _require_single_segment(package)
@@ -195,28 +192,37 @@ class OnDiskCache:
             text.encode("utf-8"),
         )
 
-    def get_sdist_pkginfo(self, package: str, version: str) -> str | None:
-        """Return cached sdist PKG-INFO text, or ``None`` on miss."""
-        return _read_text(self._entry_path(self._sdist_dir, package, version, ".txt"))
+    def get_sdist_files(
+        self, package: str, version: str
+    ) -> tuple[str | None, str | None] | None:
+        """Return the cached ``(pkg_info, pyproject_toml)`` pair, or ``None`` on miss.
 
-    def put_sdist_pkginfo(self, package: str, version: str, text: str) -> None:
-        """Write sdist PKG-INFO text. Treated as immutable."""
+        Written as one record, so a hit is always the complete pair. A hit
+        whose ``pyproject_toml`` is ``None`` means the sdist ships no
+        pyproject.toml, which is not the same as a miss.
+        """
+        text = _read_text(self._entry_path(self._sdist_dir, package, version, ".json"))
+        if text is None:
+            return None
+        try:
+            doc = json.loads(text)
+            return (doc["pkg_info"], doc["pyproject"])
+        except (ValueError, KeyError, TypeError):
+            return None
+
+    def put_sdist_files(
+        self,
+        package: str,
+        version: str,
+        pkg_info: str | None,
+        pyproject_toml: str | None,
+    ) -> None:
+        """Write the ``(pkg_info, pyproject_toml)`` pair as one record."""
         _atomic_write(
-            self._entry_path(self._sdist_dir, package, version, ".txt"),
-            text.encode("utf-8"),
-        )
-
-    def get_sdist_pyproject(self, package: str, version: str) -> str | None:
-        """Return cached sdist pyproject.toml text, or ``None`` on miss."""
-        return _read_text(
-            self._entry_path(self._sdist_pyproject_dir, package, version, ".toml")
-        )
-
-    def put_sdist_pyproject(self, package: str, version: str, text: str) -> None:
-        """Write sdist pyproject.toml text. Treated as immutable."""
-        _atomic_write(
-            self._entry_path(self._sdist_pyproject_dir, package, version, ".toml"),
-            text.encode("utf-8"),
+            self._entry_path(self._sdist_dir, package, version, ".json"),
+            json.dumps({"pkg_info": pkg_info, "pyproject": pyproject_toml}).encode(
+                "utf-8"
+            ),
         )
 
 
@@ -253,20 +259,20 @@ class CacheBackend(Protocol):
         """Store PEP 658 metadata text. Treated as immutable."""
         ...
 
-    def get_sdist_pkginfo(self, package: str, version: str) -> str | None:
-        """Return cached sdist PKG-INFO text, or ``None`` on miss."""
+    def get_sdist_files(
+        self, package: str, version: str
+    ) -> tuple[str | None, str | None] | None:
+        """Return the cached ``(pkg_info, pyproject_toml)`` pair, or ``None``."""
         ...
 
-    def put_sdist_pkginfo(self, package: str, version: str, text: str) -> None:
-        """Store sdist PKG-INFO text. Treated as immutable."""
-        ...
-
-    def get_sdist_pyproject(self, package: str, version: str) -> str | None:
-        """Return cached sdist pyproject.toml text, or ``None`` on miss."""
-        ...
-
-    def put_sdist_pyproject(self, package: str, version: str, text: str) -> None:
-        """Store sdist pyproject.toml text. Treated as immutable."""
+    def put_sdist_files(
+        self,
+        package: str,
+        version: str,
+        pkg_info: str | None,
+        pyproject_toml: str | None,
+    ) -> None:
+        """Store the ``(pkg_info, pyproject_toml)`` pair as one record."""
         ...
 
 
@@ -295,14 +301,16 @@ class NullCache:
     def put_metadata(self, package: str, version: str, text: str) -> None:
         """Discard the entry."""
 
-    def get_sdist_pkginfo(self, package: str, version: str) -> str | None:
+    def get_sdist_files(
+        self, package: str, version: str
+    ) -> tuple[str | None, str | None] | None:
         """Return ``None`` (always a miss)."""
 
-    def put_sdist_pkginfo(self, package: str, version: str, text: str) -> None:
-        """Discard the entry."""
-
-    def get_sdist_pyproject(self, package: str, version: str) -> str | None:
-        """Return ``None`` (always a miss)."""
-
-    def put_sdist_pyproject(self, package: str, version: str, text: str) -> None:
+    def put_sdist_files(
+        self,
+        package: str,
+        version: str,
+        pkg_info: str | None,
+        pyproject_toml: str | None,
+    ) -> None:
         """Discard the entry."""

--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -221,10 +221,9 @@ class CachedAsyncSimpleClient:
         mismatch raises :class:`SdistHashMismatchError` and nothing is
         cached.
         """
-        pkg_info = self._cache.get_sdist_pkginfo(package, version)
-        pyproject_toml = self._cache.get_sdist_pyproject(package, version)
-        if pkg_info is not None or pyproject_toml is not None:
-            return (pkg_info, pyproject_toml)
+        cached = self._cache.get_sdist_files(package, version)
+        if cached is not None:
+            return cached
 
         if self._offline:
             msg = f"No cached sdist PKG-INFO for {package}=={version} (offline mode)"
@@ -237,10 +236,8 @@ class CachedAsyncSimpleClient:
             _verify_sdist_hash(response.content, selected)
         pkg_info, pyproject_toml = _extract_sdist_files(response.content)
 
-        if pkg_info is not None:
-            self._cache.put_sdist_pkginfo(package, version, pkg_info)
-        if pyproject_toml is not None:
-            self._cache.put_sdist_pyproject(package, version, pyproject_toml)
+        if pkg_info is not None or pyproject_toml is not None:
+            self._cache.put_sdist_files(package, version, pkg_info, pyproject_toml)
 
         return (pkg_info, pyproject_toml)
 

--- a/nab-python/tests/property_python/test_cached_client_equiv.py
+++ b/nab-python/tests/property_python/test_cached_client_equiv.py
@@ -91,8 +91,7 @@ class DictCache:
     def __init__(self) -> None:
         self.simple: dict[str, tuple[bytes, CachePolicy]] = {}
         self.metadata: dict[tuple[str, str], str] = {}
-        self.pkginfo: dict[tuple[str, str], str] = {}
-        self.pyproject: dict[tuple[str, str], str] = {}
+        self.sdist: dict[tuple[str, str], tuple[str | None, str | None]] = {}
 
     def get_simple(self, package: str) -> tuple[bytes, CachePolicy] | None:
         return self.simple.get(package)
@@ -110,17 +109,19 @@ class DictCache:
     def put_metadata(self, package: str, version: str, text: str) -> None:
         self.metadata[(package, version)] = text
 
-    def get_sdist_pkginfo(self, package: str, version: str) -> str | None:
-        return self.pkginfo.get((package, version))
+    def get_sdist_files(
+        self, package: str, version: str
+    ) -> tuple[str | None, str | None] | None:
+        return self.sdist.get((package, version))
 
-    def put_sdist_pkginfo(self, package: str, version: str, text: str) -> None:
-        self.pkginfo[(package, version)] = text
-
-    def get_sdist_pyproject(self, package: str, version: str) -> str | None:
-        return self.pyproject.get((package, version))
-
-    def put_sdist_pyproject(self, package: str, version: str, text: str) -> None:
-        self.pyproject[(package, version)] = text
+    def put_sdist_files(
+        self,
+        package: str,
+        version: str,
+        pkg_info: str | None,
+        pyproject_toml: str | None,
+    ) -> None:
+        self.sdist[(package, version)] = (pkg_info, pyproject_toml)
 
 
 def run(coro: Coroutine[Any, Any, _T]) -> _T:

--- a/nab-python/tests/test_cache.py
+++ b/nab-python/tests/test_cache.py
@@ -224,12 +224,24 @@ class TestOnDiskCache:
 
     def test_sdist_round_trip(self, tmp_path: Path) -> None:
         cache = self._make(tmp_path)
-        cache.put_sdist_pkginfo("foo", "1.0", "Name: foo\n")
-        assert cache.get_sdist_pkginfo("foo", "1.0") == "Name: foo\n"
+        cache.put_sdist_files("foo", "1.0", "Name: foo\n", "[project]\n")
+        assert cache.get_sdist_files("foo", "1.0") == ("Name: foo\n", "[project]\n")
 
     def test_sdist_miss(self, tmp_path: Path) -> None:
         cache = self._make(tmp_path)
-        assert cache.get_sdist_pkginfo("foo", "1.0") is None
+        assert cache.get_sdist_files("foo", "1.0") is None
+
+    def test_sdist_no_pyproject_is_a_hit_not_a_miss(self, tmp_path: Path) -> None:
+        cache = self._make(tmp_path)
+        cache.put_sdist_files("foo", "1.0", "Name: foo\n", None)
+        assert cache.get_sdist_files("foo", "1.0") == ("Name: foo\n", None)
+
+    def test_sdist_corrupt_record_is_a_miss(self, tmp_path: Path) -> None:
+        cache = self._make(tmp_path)
+        path = cache._entry_path(cache._sdist_dir, "foo", "1.0", ".json")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not-json", encoding="utf-8")
+        assert cache.get_sdist_files("foo", "1.0") is None
 
     def test_put_metadata_rejects_multi_segment_sentinel(self, tmp_path: Path) -> None:
         cache = self._make(tmp_path)
@@ -250,13 +262,13 @@ class TestNullCache:
         cache = NullCache()
         assert cache.get_simple("foo") is None
         assert cache.get_metadata("foo", "1.0") is None
-        assert cache.get_sdist_pkginfo("foo", "1.0") is None
+        assert cache.get_sdist_files("foo", "1.0") is None
         # Puts must be no-ops with no return value.
         policy = CachePolicy(fetched_at=0, max_age=0, etag=None)
         assert cache.put_simple("foo", b"", policy) is None
         assert cache.refresh_simple_policy("foo", policy) is None
         assert cache.put_metadata("foo", "1.0", "x") is None
-        assert cache.put_sdist_pkginfo("foo", "1.0", "x") is None
+        assert cache.put_sdist_files("foo", "1.0", "x", None) is None
         # And subsequent gets still miss.
         assert cache.get_simple("foo") is None
 

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -14,6 +14,7 @@ from urllib.parse import urljoin
 
 import pytest
 
+import nab_index.cache as cache_mod
 from nab_index.cache import CachePolicy, OfflineError, OnDiskCache
 from nab_index.cached_client import (
     CachedAsyncSimpleClient,
@@ -1015,13 +1016,13 @@ class TestGetSdistFiles:
         assert "Name: pkg" in pkg_info
         assert pyproject is not None
         assert "[project]" in pyproject
-        assert cache.get_sdist_pkginfo("pkg", "1.0") == pkg_info
-        assert cache.get_sdist_pyproject("pkg", "1.0") == pyproject
+        assert cache.get_sdist_files("pkg", "1.0") == (pkg_info, pyproject)
 
     def test_warm_cache_skips_network(self, tmp_path: Path) -> None:
         cache = _make_cache(tmp_path)
-        cache.put_sdist_pkginfo("pkg", "1.0", "Name: cached\n")
-        cache.put_sdist_pyproject("pkg", "1.0", "[project]\nname = 'cached'\n")
+        cache.put_sdist_files(
+            "pkg", "1.0", "Name: cached\n", "[project]\nname = 'cached'\n"
+        )
         transport = _FakeTransport()
 
         async def go() -> tuple[str | None, str | None]:
@@ -1054,8 +1055,7 @@ class TestGetSdistFiles:
                 await client.aclose()
 
         assert asyncio.run(go()) == (None, None)
-        assert cache.get_sdist_pkginfo("pkg", "1.0") is None
-        assert cache.get_sdist_pyproject("pkg", "1.0") is None
+        assert cache.get_sdist_files("pkg", "1.0") is None
 
     def test_offline_miss_raises(self, tmp_path: Path) -> None:
         cache = _make_cache(tmp_path)
@@ -1072,6 +1072,55 @@ class TestGetSdistFiles:
 
         with pytest.raises(OfflineError, match="pkg==1.0"):
             asyncio.run(go())
+
+    def test_partial_write_does_not_poison_cache(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A crash while writing the entry must not leave a partial cache.
+
+        The first fetch fails as the single record is committed; the second
+        must still recover the full PKG-INFO plus pyproject.toml pair.
+        """
+        cache = _make_cache(tmp_path)
+        marker = b"partial-write-marker"
+        pyproject = b"[project]\nname = 'pkg'\n# " + marker + b"\n"
+        body = _build_tarball(
+            [
+                ("pkg-1.0/PKG-INFO", b"Metadata-Version: 2.1\nName: pkg\n"),
+                ("pkg-1.0/pyproject.toml", pyproject),
+            ]
+        )
+        transport = _FakeTransport([_FakeResponse(body), _FakeResponse(body)])
+
+        real_atomic_write = cache_mod._atomic_write
+        fail = {"active": True}
+
+        def flaky_atomic_write(path: Path, data: bytes) -> None:
+            if fail["active"] and marker in data:
+                msg = "simulated crash committing pyproject"
+                raise OSError(msg)
+            real_atomic_write(path, data)
+
+        monkeypatch.setattr(cache_mod, "_atomic_write", flaky_atomic_write)
+
+        async def fetch() -> tuple[str | None, str | None]:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_sdist_files(
+                    "pkg", "1.0", "https://x/pkg.tar.gz"
+                )
+            finally:
+                await client.aclose()
+
+        with pytest.raises(OSError, match="simulated crash"):
+            asyncio.run(fetch())
+
+        fail["active"] = False
+        pkg_info, recovered_pyproject = asyncio.run(fetch())
+        assert pkg_info is not None
+        assert "Name: pkg" in pkg_info
+        assert recovered_pyproject is not None
+        assert "[project]" in recovered_pyproject
 
     def test_matching_hash_returns_and_caches(self, tmp_path: Path) -> None:
         cache = _make_cache(tmp_path)
@@ -1093,7 +1142,7 @@ class TestGetSdistFiles:
         pkg_info, _ = asyncio.run(go())
         assert pkg_info is not None
         assert "Name: pkg" in pkg_info
-        assert cache.get_sdist_pkginfo("pkg", "1.0") == pkg_info
+        assert cache.get_sdist_files("pkg", "1.0") == (pkg_info, None)
 
     def test_mismatching_hash_raises_and_skips_cache(self, tmp_path: Path) -> None:
         cache = _make_cache(tmp_path)
@@ -1117,8 +1166,7 @@ class TestGetSdistFiles:
 
         with pytest.raises(SdistHashMismatchError):
             asyncio.run(go())
-        assert cache.get_sdist_pkginfo("pkg", "1.0") is None
-        assert cache.get_sdist_pyproject("pkg", "1.0") is None
+        assert cache.get_sdist_files("pkg", "1.0") is None
 
     def test_no_published_hash_skips_verification(self, tmp_path: Path) -> None:
         cache = _make_cache(tmp_path)


### PR DESCRIPTION
The sdist metadata cache kept an sdist's PKG-INFO and pyproject.toml in two separate files and wrote them one after the other. If the process crashed or a write failed between the two, the PKG-INFO file was left on disk with no matching pyproject.toml. The next resolve saw the PKG-INFO, counted it as a cache hit, and returned the sdist with no pyproject.toml. From then on every resolve read the wrong dependency data for that sdist, and clearing the cache by hand was the only way out.

This stores the pair as a single JSON record in one file, written atomically, so a hit is always the whole pair and a torn write leaves nothing behind. A record whose pyproject is empty means the sdist ships none, which stays distinct from a miss. The cache bucket moves to v1 so any partial v0 entries left from the old layout fall back to a miss instead of being trusted.
