### PR TITLE
fix implementation_version stuck at host value in single-env resolve

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -120,12 +120,17 @@ def apply_python_axis_overlay(
     level and the two would describe different interpreters. Re-derive both
     from whichever axis key the overlay supplies (``python_full_version``
     wins when both are present), so an overlay of ``python_version`` ``3.8``
-    yields ``python_full_version`` ``3.8.0`` like the universal matrix. Keys
-    the overlay sets explicitly are kept verbatim.
+    yields ``python_full_version`` ``3.8.0`` like the universal matrix. On
+    CPython ``implementation_version`` equals ``python_full_version``, so move
+    it with the axis; other implementations version separately and keep their
+    host value unless the overlay sets it. Keys the overlay sets explicitly are
+    kept verbatim.
     """
     source = overlay.get("python_full_version") or overlay.get("python_version")
     if source is not None:
         environment.update(python_axis_environment(source))
+        if environment.get("implementation_name") == "cpython":
+            environment["implementation_version"] = environment["python_full_version"]
     environment.update(overlay)
 
 
@@ -518,7 +523,9 @@ class Provider:
         }
         self.environment: dict[str, str] = env_init
         if python_version is not None:
-            self.environment.update(python_axis_environment(python_version))
+            apply_python_axis_overlay(
+                self.environment, python_axis_environment(python_version)
+            )
         if marker_environment:
             apply_python_axis_overlay(self.environment, marker_environment)
 

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -722,7 +722,7 @@ def _build_marker_environment(
         for key, value in default_environment().items()
         if isinstance(value, str)
     }
-    env.update(python_axis_environment(python_version))
+    apply_python_axis_overlay(env, python_axis_environment(python_version))
     apply_python_axis_overlay(env, overrides)
     return env
 

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -54,6 +54,7 @@ from nab_python.provider import (
     VcsConfig,
     VcsPolicy,
     VcsSource,
+    apply_python_axis_overlay,
     python_axis_environment,
 )
 from nab_python.resolve import _raise_for_local_vcs_python
@@ -1930,6 +1931,41 @@ class TestPythonAxisEnvironment:
         env = python_axis_environment("3.14rc1")
         assert Marker('python_full_version >= "3.14.0"').evaluate(env) is False
         assert Marker('python_full_version == "3.14.0"').evaluate(env) is False
+
+
+class TestApplyPythonAxisOverlay:
+    def test_cpython_moves_implementation_version_with_axis(self) -> None:
+        """On CPython the axis move drags implementation_version along."""
+        env = {
+            "implementation_name": "cpython",
+            "python_version": "3.11",
+            "python_full_version": "3.11.5",
+            "implementation_version": "3.11.5",
+        }
+        apply_python_axis_overlay(env, {"python_version": "3.8"})
+        assert env["python_full_version"] == "3.8.0"
+        assert env["implementation_version"] == "3.8.0"
+
+    def test_non_cpython_keeps_its_implementation_version(self) -> None:
+        """A PyPy axis move keeps the interpreter's own release version."""
+        env = {
+            "implementation_name": "pypy",
+            "python_version": "3.9",
+            "python_full_version": "3.9.18",
+            "implementation_version": "7.3.13",
+        }
+        apply_python_axis_overlay(env, {"python_version": "3.10"})
+        assert env["python_full_version"] == "3.10.0"
+        assert env["implementation_version"] == "7.3.13"
+
+    def test_provider_target_python_moves_implementation_version(self) -> None:
+        """A Provider target Python moves implementation_version too."""
+        provider = Provider(make_coordinator(), python_version="3.9.0")
+        assert provider.environment["implementation_version"] == "3.9.0"
+        assert (
+            provider.environment["implementation_version"]
+            == provider.environment["python_full_version"]
+        )
 
 
 class TestLookAhead:

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -2601,6 +2601,27 @@ class TestBuildMarkerEnvironment:
         assert env["python_full_version"] == "3.12.3"
         assert env["sys_platform"] == "win32"
 
+    def test_target_python_moves_implementation_version(self) -> None:
+        """implementation_version follows a non-host target on CPython."""
+        env = _build_marker_environment(python_version="3.9.0", overrides={})
+        assert env["implementation_version"] == "3.9.0"
+        assert env["implementation_version"] == env["python_full_version"]
+
+    def test_overlay_python_moves_implementation_version(self) -> None:
+        """An overlay python-axis move drags implementation_version along."""
+        env = _build_marker_environment(
+            python_version="3.12.3", overrides={"python_version": "3.8"}
+        )
+        assert env["implementation_version"] == "3.8.0"
+
+    def test_explicit_implementation_version_override_wins(self) -> None:
+        """An explicit implementation_version override is kept verbatim."""
+        env = _build_marker_environment(
+            python_version="3.9.0",
+            overrides={"implementation_version": "3.9.7"},
+        )
+        assert env["implementation_version"] == "3.9.7"
+
 
 class TestCheckGroupDisjointnessAcrossTuples:
     """``_check_group_disjointness_across_tuples`` runs the per-group


### PR DESCRIPTION
Resolving for a non-host target Python left `implementation_version` at the host interpreter's value. Targeting, say, Python 3.9 from a 3.12 host moved `python_version` and `python_full_version` to the target but not `implementation_version`, so any marker testing `implementation_version` was evaluated against the host and could pick or reject the wrong candidates.

On CPython `implementation_version` is the same as `python_full_version`, so it now moves with the python axis. Other implementations version separately (PyPy ships its own 7.x line for a 3.9 runtime, for example), so they keep their host value unless an overlay sets `implementation_version` explicitly. The `Provider` constructor and `_build_marker_environment` now route the target Python through `apply_python_axis_overlay`, so the move happens for the resolve target and not just for universal overlays.
