### PR TITLE
Vendor upstream marker serialization fix

### DIFF
--- a/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
+++ b/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
@@ -8,8 +8,8 @@ API before a `packaging` release containing it is published to PyPI.
 
 - Upstream repository: https://github.com/pypa/packaging
 - Source branch: `pypa/packaging:main`
-- Pinned commit: `c7d859d1333887226f521f59b1304257c04eeca2`
-- Snapshot date: 2026-06-30
+- Pinned commit: `0a85b41e24c9b55b83f05ae696d73e8294a5b094`
+- Snapshot date: 2026-07-06
 
 The snapshot is the full `src/packaging/` tree at that commit, plus
 `LICENSE`, `LICENSE.APACHE`, and `LICENSE.BSD` from the repository

--- a/nab-python/src/nab_python/_vendor/packaging/markers.py
+++ b/nab-python/src/nab_python/_vendor/packaging/markers.py
@@ -188,16 +188,14 @@ def _format_marker(
 ) -> str:
     assert isinstance(marker, (list, tuple, str))
 
-    # Sometimes we have a structure like [[...]] which is a single item list
-    # where the single item is itself it's own list. In that case we want skip
-    # the rest of this function so that we don't get extraneous () on the
-    # outside.
+    # Unwrap a redundant [[...]] wrapper, but keep the nesting context so a
+    # nested group keeps the parentheses its and/or precedence needs.
     if (
         isinstance(marker, list)
         and len(marker) == 1
         and isinstance(marker[0], (list, tuple))
     ):
-        return _format_marker(marker[0])
+        return _format_marker(marker[0], first=first)
 
     if isinstance(marker, list):
         inner = (_format_marker(m, first=False) for m in marker)

--- a/nab-python/tests/test_marker_evaluation.py
+++ b/nab-python/tests/test_marker_evaluation.py
@@ -195,6 +195,44 @@ class TestExtraNormalization:
         assert _ev(text, {**LINUX_CP311, "extra": extra_value}) is expected
 
 
+class TestSerializationRoundTrip:
+    """``str(Marker(...))`` must re-parse to a marker that evaluates the same.
+
+    A double-parenthesized group nested inside an and/or expression needs its
+    parentheses for precedence, so serialization has to keep them.
+    """
+
+    @pytest.mark.parametrize(
+        ("text", "env", "expected"),
+        [
+            (
+                'python_version < "3.10" and '
+                '((sys_platform == "linux" or sys_platform == "darwin"))',
+                {"python_version": "3.12", "sys_platform": "darwin"},
+                False,
+            ),
+            (
+                'python_version < "3.10" and '
+                '((sys_platform == "linux" or sys_platform == "darwin"))',
+                {"python_version": "3.9", "sys_platform": "darwin"},
+                True,
+            ),
+            (
+                'extra != "c" or ((python_version > "3.8") and extra != "c") '
+                'and ((python_version != "3.10" or (extra != "a")))',
+                {"python_version": "3.8", "extra": "c"},
+                False,
+            ),
+        ],
+    )
+    def test_nested_double_parens_round_trip(
+        self, text: str, env: dict[str, str], expected: bool
+    ) -> None:
+        marker = Marker(text)
+        assert marker.evaluate(env) is expected
+        assert Marker(str(marker)).evaluate(env) is expected
+
+
 class TestSetMarkers:
     """lock_file-context set membership (extras / dependency_groups)."""
 

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -54,6 +54,22 @@ class TestAddExtraMarker:
         assert req.url == "https://h/a;b/p.tar.gz"
         assert str(req.marker) == 'python_version >= "3.10" and extra == "bar"'
 
+    def test_nested_double_paren_or_group_precedence_kept(self) -> None:
+        """Folding must keep the parens around a nested double-paren or group.
+
+        The dep needs ``python_version < "3.10"``, so on 3.12 it stays inactive
+        only if the or group cannot leak past the and gate.
+        """
+        out = _add_extra_marker(
+            'pkg ; python_version < "3.10" '
+            'and ((sys_platform == "linux" or sys_platform == "darwin"))',
+            "cli",
+        )
+        marker = Requirement(out).marker
+        assert marker is not None
+        env = {"python_version": "3.12", "sys_platform": "darwin", "extra": "cli"}
+        assert marker.evaluate(env) is False
+
     def test_non_canonical_extra_name_normalized(self) -> None:
         """A non-canonical extra name is normalised (PEP 685) in the gate."""
         out = _add_extra_marker("numpy", "My.Extra")


### PR DESCRIPTION
Re-vendors the packaging snapshot to pin the current `pypa/packaging:main`, which includes the marker serialization fix pypa/packaging#1316.

`str(Marker(...))` dropped the parentheses around a double-parenthesized subgroup nested inside a larger and/or expression. nab passes markers around as strings, so the reparsed marker had different and/or precedence and could evaluate to the opposite result. For instance `python_version < "3.10" and ((sys_platform == "linux" or sys_platform == "darwin"))` lost its inner parens and reparsed as `(A and B) or C`, so it wrongly matched on Python 3.12.

Only `markers.py` changes in the snapshot; `ranges.py`/`_ranges.py` still track the pre-release clip branch (pypa/packaging#1311). Adds regression tests for the round trip through `str(Marker(...))` and `_add_extra_marker`.

Supersedes #317, which patched the vendored file directly; this takes the fix from upstream instead.
