### PR TITLE
Formalize the universal resolution axes

### DIFF
--- a/docs/explanation/universal.md
+++ b/docs/explanation/universal.md
@@ -247,12 +247,86 @@ resolve. The lockfile does not carry that synthetic value: a non-CPython
 `environments` entry leaves `implementation_version` open, so a real PyPy
 still accepts the lock (a dep gated on the axis may be missed at install).
 
-## Trade-offs versus marker-fork PubGrub
+## Resolution axes
 
-| Property | Matrix (nab) | Marker-fork (uv) |
+The `[tool.nab.matrix]` keys above drive two decisions per tuple: how
+each PEP 508 marker evaluates, and which wheels the tuple can install.
+
+### Marker variables
+
+Every PEP 508 environment variable gets a value in every tuple, so no
+marker ever evaluates against a missing key. Each takes its value from
+the axis or fixed default shown:
+
+| Marker variable | Set by | Default |
 | --- | --- | --- |
-| Resolver core | Untouched. A matrix is a longer target list, not extra solver state. | Forks pervade the resolver state. |
-| Universe | Exactly what the user declared. | All of PEP 508, narrowed by `tool.uv.environments`. |
-| Errors | "no wheel for python 3.11 on macos arm64" - actionable. | "no wheel for some marker environment the resolver cared about" - less actionable. |
-| Wasted work | High: solver state is rebuilt per target. Only the fetcher and its metadata cache are shared. | Low: shared whenever markers don't fork. |
-| Implementation cost | Small. One engine over a target list. | Large. Conflict explanations and lockfile shape are research-grade work. |
+| `python_version` | `python` | one value per minor in range |
+| `python_full_version` | `python`, `python-patches` | `<minor>.0` |
+| `implementation_version` | `python`, `python-patches` | same as `python_full_version` |
+| `implementation_name` | `implementations` | `cpython` |
+| `platform_python_implementation` | `implementations` | `CPython` |
+| `sys_platform` | `platforms` | per id (`linux`, `darwin`, `win32`) |
+| `platform_system` | `platforms` | per id (`Linux`, `Darwin`, `Windows`) |
+| `platform_machine` | `platforms` | per id (`x86_64`, `aarch64`, `i686`, `armv7l`, `arm64`, `AMD64`, `ARM64`) |
+| `os_name` | `platforms` | per id (`posix`, `nt`) |
+| `platform_release` | `platforms` (`platform-release`) | `""` |
+| `platform_version` | `platforms` (`platform-version`) | `""` |
+
+`extra`, `extras` and `dependency_groups` are not axes. `extra` is bound
+one name at a time as a version's dependencies are sorted into the base
+package and its extras, so `extra == "cpu"` names the dependencies of
+`pkg[cpu]` and a requirement read with no extra active sees none. The
+other two are empty during resolution, so a dependency gated on
+`'x' in extras` is always dropped; nab emits that clause only onto a
+package's lockfile marker, where it fires for the installer consuming
+the lock.
+
+### How the axes couple
+
+One axis usually sets several variables at once, so an impossible
+combination cannot be declared:
+
+* `platforms` sets `sys_platform`, `platform_system`,
+  `platform_machine`, and `os_name` together per id. You pick
+  `linux_x86_64`, not the four separately, so a Linux `sys_platform`
+  can never pair with a macOS `platform_machine`.
+* `implementations` sets `implementation_name` and
+  `platform_python_implementation` together.
+* `python` sets `python_version`, `python_full_version`, and
+  `implementation_version` together.
+
+### Wheel selection
+
+The matrix also decides which wheels a tuple can install, computed from
+the python version, platform, and implementation without a live
+interpreter. A version whose only wheels are tag-incompatible with a
+tuple is dropped for that tuple; a version that also ships an sdist
+stays, subject to the build policy. Each tuple accepts three wheel-tag
+dimensions:
+
+* interpreter: `cpXY` for CPython, `ppXY` for PyPy, plus the
+  interpreter-agnostic `py3` tags.
+* abi: `cpXY` and `abi3` for CPython, `cpXYt` and `abi3t` on a
+  free-threaded target, `pypyXY_pp73` for PyPy, and `none`.
+* platform: manylinux or musllinux for the declared libc family, macosx,
+  and win.
+
+The tag knobs live on the platform, written as a table in `platforms`
+rather than a bare id. The "Platform tag knobs" table in
+[Configuration](../reference/configuration.md) lists each with its
+default and the rules it carries.
+
+### What the axes do not cover
+
+The `[tool.nab.matrix]` keys and the platform tag knobs are the whole of
+it. The platform ids and the implementations are fixed enumerations, and
+an unknown name is a config error rather than a silently skipped tuple.
+The Python minors are an enumeration too, but `python` is a specifier
+intersected with it: a range reaching past the newest minor nab knows
+expands to the ones it knows, and only a range matching none of them is
+an error.
+
+`platform_release` and `platform_version` name one machine's kernel
+build. Both default to the empty string, so a marker gated on the kernel
+(`platform_release >= "5.10"`) evaluates False and its dependency is
+dropped: a target that does run that kernel has to declare it.

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -17,6 +17,7 @@ from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.version import Version
 from nab_python.config import (
     _MATRIX_KEYS,
+    _PEP508_MARKER_VARIABLES,
     ConfigError,
     ConflictKind,
     ConflictMember,
@@ -2016,6 +2017,14 @@ class TestMarkerEnvironmentDeprecation:
         )
         with pytest.raises(ConfigError, match="unknown marker-environment variable"):
             read_pyproject_config(path)
+
+    def test_accepted_variables_are_the_ones_packaging_defines(self) -> None:
+        """Every variable packaging defines is accepted, and nothing else is.
+
+        A variable packaging adds fails here rather than reading as a
+        misspelling in a user's config.
+        """
+        assert set(default_environment()) == _PEP508_MARKER_VARIABLES
 
     def test_python_version_must_be_pep440(self, tmp_path: Path) -> None:
         path = write(

--- a/nab-python/tests/test_conflict_kind.py
+++ b/nab-python/tests/test_conflict_kind.py
@@ -12,10 +12,11 @@ from collections.abc import Set as AbstractSet
 import pytest
 
 from nab_python._conflict_kind import (
+    EMPTY_MEMBERSHIP_SETS,
     UnevaluableMarkerError,
     dependency_marker_holds,
 )
-from nab_python._vendor.packaging.markers import Marker
+from nab_python._vendor.packaging.markers import MARKERS_ALLOWING_SET, Marker
 
 _ENV: dict[str, str] = {
     "python_version": "3.11",
@@ -76,6 +77,15 @@ class TestDependencyMarkerHoldsSetExtra:
         tests ``extras`` evaluates False rather than raising."""
         assert _holds('"docs" not in extras', frozenset({"cpu"})) is True
         assert _holds('"docs" in extras', frozenset({"cpu"})) is False
+
+    def test_seeding_covers_every_packaging_set_variable(self) -> None:
+        """Every variable packaging allows as a set is one of the seeded names.
+
+        The seeded names come from the conflict kinds, so a variable packaging
+        newly allows as a set would arrive unseeded and raise instead of
+        testing False against no members.
+        """
+        assert set(EMPTY_MEMBERSHIP_SETS) == set(MARKERS_ALLOWING_SET)
 
 
 class TestDependencyMarkerHoldsScalarExtra:

--- a/nab-python/tests/test_matrix.py
+++ b/nab-python/tests/test_matrix.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from nab_python._vendor.packaging.markers import Marker
+from nab_python._vendor.packaging.markers import Marker, default_environment
 from nab_python.tags import PlatformSpec
 from nab_python.target import (
     KNOWN_PYTHON_MINORS,
@@ -78,29 +78,32 @@ class TestMatrixExpand:
             ("3.11", "windows_amd64"),
         }
 
-    def test_environment_has_all_required_pep508_keys(self) -> None:
-        """Every PEP 508 marker variable must be set per tuple."""
+    def test_environment_models_every_scalar_marker_variable(self) -> None:
+        """Every scalar packaging marker variable is set per target.
+
+        A variable the matrix leaves out does not read as missing. The
+        provider evaluates through ``Marker.evaluate``, which seeds the host
+        ``default_environment()`` beneath the environment it is handed, so the
+        host's value answers the marker on every target; the root-requirement
+        path evaluates through ``MarkerSet``, which raises instead. Deriving
+        the required set from packaging rather than a hardcoded list makes a
+        newly added variable fail here.
+        """
         matrix = Matrix(python="==3.12", platforms=(PlatformSpec("macos_arm64"),))
-        tuples = matrix.expand()
-        assert len(tuples) == 1
-        env = tuples[0].marker_env
-        required_keys = {
-            "python_version",
-            "python_full_version",
-            "implementation_name",
-            "implementation_version",
-            "os_name",
-            "platform_machine",
-            "platform_python_implementation",
-            "platform_release",
-            "platform_system",
-            "platform_version",
-            "sys_platform",
-        }
-        assert required_keys.issubset(env)
-        assert env["python_version"] == "3.12"
-        assert env["sys_platform"] == "darwin"
-        assert env["platform_machine"] == "arm64"
+        (only,) = matrix.expand()
+        missing = set(default_environment()) - set(only.marker_env)
+        assert not missing, (
+            f"matrix target does not model {sorted(missing)!r}; add each to "
+            "declared_environment or the resolve answers it from the host"
+        )
+
+    def test_environment_has_expected_axis_values(self) -> None:
+        """The python and platform axes drive their marker values."""
+        matrix = Matrix(python="==3.12", platforms=(PlatformSpec("macos_arm64"),))
+        (only,) = matrix.expand()
+        assert only.marker_env["python_version"] == "3.12"
+        assert only.marker_env["sys_platform"] == "darwin"
+        assert only.marker_env["platform_machine"] == "arm64"
 
     def test_unknown_platform_id_raises(self) -> None:
         """An unknown platform id is a user error, raised eagerly."""

--- a/nab-python/tests/test_target.py
+++ b/nab-python/tests/test_target.py
@@ -12,7 +12,11 @@ from pathlib import Path
 
 import pytest
 
-from nab_python._vendor.packaging.markers import InvalidMarker, Marker
+from nab_python._vendor.packaging.markers import (
+    InvalidMarker,
+    Marker,
+    default_environment,
+)
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.tags import Tag
@@ -758,6 +762,15 @@ class TestMarkerVariables:
     def test_every_declared_variable_is_a_marker_environment_key(self) -> None:
         target = ResolveTarget.for_host(env_source=_host_env, tags_source=_host_tags)
         assert target.marker_env.keys() >= PEP508_MARKER_VARIABLES
+
+    def test_variables_are_exactly_the_ones_packaging_defines(self) -> None:
+        """The filter set is packaging's environment, not a subset of it.
+
+        ``marker_variables`` intersects with it, so a variable missing here
+        drops out of the lock's ``environments`` declaration and the lock
+        claims to cover an installer that answers the marker the other way.
+        """
+        assert set(default_environment()) == PEP508_MARKER_VARIABLES
 
 
 class TestEnvironmentDeclaration:


### PR DESCRIPTION
Adds a "Resolution axes" section to the universal-resolution guide: which axis sets each PEP 508 marker variable, the wheel-tag dimensions a tuple accepts, and what `[tool.nab.matrix]` gives you no way to set.

The tests stop pinning the matrix environment to a hardcoded list of marker variables and derive it from `default_environment()`, so a variable packaging adds fails the suite instead of being answered from the host. Same for `PEP508_MARKER_VARIABLES` and the `[tool.nab.marker-environment]` accept list.

Closes #209
