### PR TITLE
reject a JSON boolean as a wheel/sdist size in Simple-API parsing

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -423,7 +423,8 @@ def _parse_hashes(value: object) -> tuple[tuple[str, str], ...]:
 
 
 def _parse_size(value: object) -> int | None:
-    if isinstance(value, int) and value >= 0:
+    # bool is an int subclass, so reject it explicitly rather than read True as 1.
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
         return value
     return None
 

--- a/nab-python/tests/test_simple_client_size.py
+++ b/nab-python/tests/test_simple_client_size.py
@@ -1,0 +1,46 @@
+"""Tests for ``size`` parsing in nab_index's Simple API JSON parser.
+
+bool is an int subclass, so a plain ``isinstance(value, int)`` check would
+accept a JSON boolean and read ``True`` as a size of 1; ``_parse_size`` drops it.
+"""
+
+from __future__ import annotations
+
+from nab_index.client import _parse_files, _parse_size
+
+
+def _file(extra: dict[str, object]) -> dict[str, object]:
+    base: dict[str, object] = {
+        "filename": "foo-1.0-py3-none-any.whl",
+        "url": "https://example.com/foo/foo-1.0-py3-none-any.whl",
+        "hashes": {"sha256": "a" * 64},
+    }
+    base.update(extra)
+    return base
+
+
+def test_integer_size_preserved() -> None:
+    assert _parse_size(123) == 123
+
+
+def test_boolean_size_dropped() -> None:
+    for value in (True, False):
+        assert _parse_size(value) is None
+
+
+def test_non_integer_size_dropped() -> None:
+    assert _parse_size(1.5) is None
+    assert _parse_size("9") is None
+    assert _parse_size(-1) is None
+
+
+def test_boolean_size_does_not_reach_wheel_file() -> None:
+    data = {"files": [_file({"size": True})]}
+    files = _parse_files(data, "https://example.com/", "foo")
+    assert files[0].size is None
+
+
+def test_integer_size_reaches_wheel_file() -> None:
+    data = {"files": [_file({"size": 4096})]}
+    files = _parse_files(data, "https://example.com/", "foo")
+    assert files[0].size == 4096


### PR DESCRIPTION
The Simple API JSON `size` field is meant to be an integer, but `_parse_size` only checked `isinstance(value, int)`. Because `bool` is a subclass of `int`, a boolean `size` passed that check and was returned unchanged. A `True` then rode through into the lockfile and serialized as `size = true`, which is not a valid PEP 751 size.

Reject `bool` explicitly so a boolean `size` is dropped to `None` like any other non-integer value, and the field is left out of the entry.
