### PR TITLE
refuse a source whose tree declares a different project name

### DIFF
--- a/nab-python/src/nab_python/_provider/sources.py
+++ b/nab-python/src/nab_python/_provider/sources.py
@@ -66,14 +66,15 @@ def materialize_local_source(
     path = Path(source.path)
     if source.subdirectory:
         path = path / source.subdirectory
+    descriptor = f"local source {source.name!r}"
     metadata = extract_source_metadata(
         provider,
         path,
-        descriptor=f"local source {source.name!r}",
+        descriptor=descriptor,
         package=canonicalize_name(source.name),
         kind="local",
     )
-    return seed_synthetic_listing(provider, normalized, path, metadata)
+    return seed_synthetic_listing(provider, normalized, path, metadata, descriptor)
 
 
 def extract_source_metadata(
@@ -127,8 +128,24 @@ def seed_synthetic_listing(
     normalized: str,
     path: Path,
     metadata: WheelMetadata,
+    descriptor: str,
 ) -> list[tuple[Version, SdistFile]]:
-    """Produce a one-version listing for a materialised source."""
+    """Produce a one-version listing for a materialised source.
+
+    The source's own ``[project].name`` must canonicalise to ``normalized``,
+    the name the resolver asked for; a mismatch means the tree is a different
+    project and is refused.
+    """
+    actual = canonicalize_name(metadata.name)
+    if actual != normalized:
+        from ..provider import SourceNameMismatchError
+
+        msg = (
+            f"{descriptor} declares package {normalized!r} but its"
+            f" [project].name is {actual!r} (at {path}); a source must not"
+            f" provide a project under a different name"
+        )
+        raise SourceNameMismatchError(msg)
     synthetic_file = SdistFile(
         filename=f"{normalized}-{metadata.version}.tar.gz",
         url=path.as_uri(),
@@ -217,14 +234,15 @@ def materialize_vcs_source(
         raise UnsupportedSdistError(msg) from exc
     provider.vcs_pins[canonicalize_name(source.name)] = clone.commit_sha
     path = clone.path / clone.subdirectory if clone.subdirectory else clone.path
+    descriptor = f"vcs source {source.name!r}"
     metadata = extract_source_metadata(
         provider,
         path,
-        descriptor=f"vcs source {source.name!r}",
+        descriptor=descriptor,
         package=canonicalize_name(source.name),
         kind="vcs",
     )
-    return seed_synthetic_listing(provider, normalized, path, metadata)
+    return seed_synthetic_listing(provider, normalized, path, metadata, descriptor)
 
 
 def index_archive_sources(
@@ -329,14 +347,15 @@ def materialize_archive_source(
 
     # Read the extracted tree's metadata as a local source and seed one candidate.
     path = root / request.subdirectory if request.subdirectory else root
+    descriptor = f"archive source {source.name!r}"
     metadata = extract_source_metadata(
         provider,
         path,
-        descriptor=f"archive source {source.name!r}",
+        descriptor=descriptor,
         package=canonicalize_name(source.name),
         kind="archive",
     )
-    return seed_synthetic_listing(provider, normalized, path, metadata)
+    return seed_synthetic_listing(provider, normalized, path, metadata, descriptor)
 
 
 def _extract_archive(

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -70,6 +70,7 @@ __all__ = [
     "Provider",
     "ProviderStats",
     "ResolutionStrategy",
+    "SourceNameMismatchError",
     "UnsupportedSdistError",
     "UnsupportedVcsError",
     "VcsConfig",
@@ -294,6 +295,19 @@ class UnsupportedSdistError(MetadataError):
 # and would silently reject the version; a naive upload-time is a hard error.
 class InvalidUploadTimeError(Exception):
     """Raised when an index upload-time is not the timezone-aware UTC PEP 700 needs."""
+
+
+# Not a MetadataError, for the reason above: a name mismatch is a
+# misconfiguration that must abort, not a version the look-ahead may skip.
+class SourceNameMismatchError(Exception):
+    """Raised when a source's project name differs from its declaration.
+
+    A local, VCS, or archive source maps a declared ``name`` to a tree that
+    becomes the only candidate for the package.  If the tree's own
+    ``[project].name`` (PEP 503 canonical) does not match the declared name,
+    the source is a different project than requested and would pin the wrong
+    distribution.
+    """
 
 
 @dataclass

--- a/nab-python/tests/test_archive.py
+++ b/nab-python/tests/test_archive.py
@@ -37,7 +37,9 @@ from nab_python.lockfile import ArchivePin, LockInput, TargetLock
 from nab_python.provider import (
     ArchiveSource,
     BuildPolicy,
+    MetadataError,
     Provider,
+    SourceNameMismatchError,
     UnsupportedSdistError,
 )
 from nab_python.target import ResolveTarget
@@ -290,6 +292,29 @@ class TestArchiveMaterialize:
 
         assert len(versions) == 1
         assert str(versions[0][0]) == "1.0.0"
+
+    @requires_data_filter
+    def test_name_mismatch_is_hard_error(self, tmp_path: Path) -> None:
+        # Archive declared for "foo" but its tree is the project "bar".  Hash
+        # and extraction pass, so only the [project].name check catches the swap.
+        pyproject = (
+            '[project]\nname = "bar"\nversion = "2.0.0"'
+            '\ndependencies = ["some-other-dep>=5"]\n'
+        )
+        data = _make_sdist("bar", "2.0.0", pyproject)
+        digest = hashlib.sha256(data).hexdigest()
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/bar-2.0.0.tar.gz#sha256={digest}"
+        )
+        provider = _provider([source], tmp_path / "arch")
+        provider.coordinator.index.store_sdist_archive("foo", digest, data)
+        with pytest.raises(SourceNameMismatchError) as excinfo:
+            provider.fetch_versions("foo")
+        message = str(excinfo.value)
+        assert "foo" in message
+        assert "bar" in message
+        # Must not be a MetadataError, or the look-ahead swallows it as a skip.
+        assert not isinstance(excinfo.value, MetadataError)
 
     def test_missing_cache_dir_raises(self) -> None:
         digest = "a" * 64

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -55,6 +55,7 @@ from nab_python.provider import (
     MissingExtraError,
     Provider,
     ResolutionStrategy,
+    SourceNameMismatchError,
     UnsupportedSdistError,
     UnsupportedVcsError,
     VcsConfig,
@@ -1953,6 +1954,27 @@ class TestLocalSources:
         )
         versions = provider.fetch_versions("Foo.Bar")
         assert len(versions) == 1
+
+    def test_local_source_name_mismatch_raises(self, tmp_path: Path) -> None:
+        """A source whose [project].name differs is refused, not silently pinned."""
+        self._write_local(
+            tmp_path,
+            '[project]\nname = "bar"\nversion = "9.9.9"'
+            '\ndependencies = ["some-other-dep>=5"]\n',
+        )
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(
+            coordinator,
+            local_sources=[LocalSource("foo", str(tmp_path))],
+            build_policy=BuildPolicy.NEVER,
+        )
+        with pytest.raises(SourceNameMismatchError) as excinfo:
+            provider.fetch_versions("foo")
+        message = str(excinfo.value)
+        assert "foo" in message
+        assert "bar" in message
+        # Must not be a MetadataError, or the look-ahead swallows it as a skip.
+        assert not isinstance(excinfo.value, MetadataError)
 
     def test_build_local_source_failure_propagates(
         self,


### PR DESCRIPTION
A local, VCS, or archive source maps a declared name to a source tree, and that tree becomes the only candidate for the package. We never checked that the tree's own [project].name matched the declared name, so pointing a source for "foo" at a tree that is really the project "bar" silently pinned "bar" and pulled in its dependencies under the name "foo". For an archive source the hash and extraction still pass, so nothing else caught the swap.

seed_synthetic_listing now canonicalizes the tree's [project].name and raises SourceNameMismatchError when it differs from the requested name. All three source kinds share that path, so the check covers all of them. The error is not a MetadataError, so the look-ahead treats it as a misconfiguration to abort on rather than a version to skip.
