### PR TITLE
reject a source whose project name differs from its declaration

### DIFF
--- a/nab-python/src/nab_python/_provider/sources.py
+++ b/nab-python/src/nab_python/_provider/sources.py
@@ -66,14 +66,15 @@ def materialize_local_source(
     path = Path(source.path)
     if source.subdirectory:
         path = path / source.subdirectory
+    descriptor = f"local source {source.name!r}"
     metadata = extract_source_metadata(
         provider,
         path,
-        descriptor=f"local source {source.name!r}",
+        descriptor=descriptor,
         package=canonicalize_name(source.name),
         kind="local",
     )
-    return seed_synthetic_listing(provider, normalized, path, metadata)
+    return seed_synthetic_listing(provider, normalized, path, metadata, descriptor)
 
 
 def extract_source_metadata(
@@ -127,8 +128,23 @@ def seed_synthetic_listing(
     normalized: str,
     path: Path,
     metadata: WheelMetadata,
+    descriptor: str,
 ) -> list[tuple[Version, SdistFile]]:
     """Produce a one-version listing for a materialised source."""
+    # The source's own [project].name must canonicalise to the requested name;
+    # otherwise it declares a different project, and pinning it here would carry
+    # the wrong version and dependencies.
+    actual = canonicalize_name(metadata.name)
+    if actual != normalized:
+        from ..provider import SourceNameMismatchError
+
+        msg = (
+            f"{descriptor} declares package {normalized!r} but its"
+            f" [project].name is {actual!r} (at {path}); a source declared for"
+            f" one name must not provide a different project"
+        )
+        raise SourceNameMismatchError(msg)
+
     synthetic_file = SdistFile(
         filename=f"{normalized}-{metadata.version}.tar.gz",
         url=path.as_uri(),
@@ -217,14 +233,15 @@ def materialize_vcs_source(
         raise UnsupportedSdistError(msg) from exc
     provider.vcs_pins[canonicalize_name(source.name)] = clone.commit_sha
     path = clone.path / clone.subdirectory if clone.subdirectory else clone.path
+    descriptor = f"vcs source {source.name!r}"
     metadata = extract_source_metadata(
         provider,
         path,
-        descriptor=f"vcs source {source.name!r}",
+        descriptor=descriptor,
         package=canonicalize_name(source.name),
         kind="vcs",
     )
-    return seed_synthetic_listing(provider, normalized, path, metadata)
+    return seed_synthetic_listing(provider, normalized, path, metadata, descriptor)
 
 
 def index_archive_sources(
@@ -329,14 +346,15 @@ def materialize_archive_source(
 
     # Read the extracted tree's metadata as a local source and seed one candidate.
     path = root / request.subdirectory if request.subdirectory else root
+    descriptor = f"archive source {source.name!r}"
     metadata = extract_source_metadata(
         provider,
         path,
-        descriptor=f"archive source {source.name!r}",
+        descriptor=descriptor,
         package=canonicalize_name(source.name),
         kind="archive",
     )
-    return seed_synthetic_listing(provider, normalized, path, metadata)
+    return seed_synthetic_listing(provider, normalized, path, metadata, descriptor)
 
 
 def _extract_archive(

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -70,6 +70,7 @@ __all__ = [
     "Provider",
     "ProviderStats",
     "ResolutionStrategy",
+    "SourceNameMismatchError",
     "UnsupportedSdistError",
     "UnsupportedVcsError",
     "VcsConfig",
@@ -294,6 +295,19 @@ class UnsupportedSdistError(MetadataError):
 # and would silently reject the version; a naive upload-time is a hard error.
 class InvalidUploadTimeError(Exception):
     """Raised when an index upload-time is not the timezone-aware UTC PEP 700 needs."""
+
+
+# Deliberately not a MetadataError: _look_ahead_ok catches those and skips the
+# version, but a name mismatch is a misconfiguration that must abort.
+class SourceNameMismatchError(Exception):
+    """Raised when a materialised source's project name differs from its declaration.
+
+    A local, VCS, or archive source maps a declared ``name`` to a directory,
+    repo, or archive and becomes the only candidate for that package.  When the
+    source's own ``[project].name`` does not canonicalise to the declared name,
+    it provides a different distribution, so pinning it would carry the wrong
+    version and dependencies.
+    """
 
 
 @dataclass

--- a/nab-python/tests/test_archive.py
+++ b/nab-python/tests/test_archive.py
@@ -38,6 +38,7 @@ from nab_python.provider import (
     ArchiveSource,
     BuildPolicy,
     Provider,
+    SourceNameMismatchError,
     UnsupportedSdistError,
 )
 from nab_python.target import ResolveTarget
@@ -290,6 +291,26 @@ class TestArchiveMaterialize:
 
         assert len(versions) == 1
         assert str(versions[0][0]) == "1.0.0"
+
+    @requires_data_filter
+    def test_project_name_mismatch_is_hard_error(self, tmp_path: Path) -> None:
+        # The archive unpacks to a project whose [project].name (bar) is not the
+        # declared source name (foo), so pinning it would carry a different
+        # distribution's version and dependencies under the requested name.
+        pyproject = (
+            '[project]\nname = "bar"\nversion = "9.9.9"\n'
+            'dependencies = ["unrelated-dep==6.6.6"]\n'
+        )
+        data = _make_sdist("bar", "9.9.9", pyproject)
+        digest = hashlib.sha256(data).hexdigest()
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/bar-9.9.9.tar.gz#sha256={digest}"
+        )
+        provider = _provider([source], tmp_path / "arch")
+        provider.coordinator.index.store_sdist_archive("foo", digest, data)
+        with pytest.raises(SourceNameMismatchError, match="bar") as excinfo:
+            provider.fetch_versions("foo")
+        assert "foo" in str(excinfo.value)
 
     def test_missing_cache_dir_raises(self) -> None:
         digest = "a" * 64

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -55,6 +55,7 @@ from nab_python.provider import (
     MissingExtraError,
     Provider,
     ResolutionStrategy,
+    SourceNameMismatchError,
     UnsupportedSdistError,
     UnsupportedVcsError,
     VcsConfig,
@@ -1953,6 +1954,28 @@ class TestLocalSources:
         )
         versions = provider.fetch_versions("Foo.Bar")
         assert len(versions) == 1
+
+    def test_local_source_name_mismatch_refused(self, tmp_path: Path) -> None:
+        """A source declared for one name backed by a different project is refused.
+
+        The directory's ``[project].name`` (``bar``) does not canonicalise to the
+        declared source name (``foo``), so materialising it would pin ``foo`` with
+        ``bar``'s version and dependencies.
+        """
+        self._write_local(
+            tmp_path,
+            '[project]\nname = "bar"\nversion = "9.9.9"\n'
+            'dependencies = ["unrelated-dep==6.6.6"]\n',
+        )
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(
+            coordinator,
+            local_sources=[LocalSource("foo", str(tmp_path))],
+            build_policy=BuildPolicy.NEVER,
+        )
+        with pytest.raises(SourceNameMismatchError, match="bar") as excinfo:
+            provider.fetch_versions("foo")
+        assert "foo" in str(excinfo.value)
 
     def test_build_local_source_failure_propagates(
         self,

--- a/nab-python/tests/test_vcs.py
+++ b/nab-python/tests/test_vcs.py
@@ -28,6 +28,7 @@ from nab_python.provider import (
     BuildPolicy,
     LocalSource,
     Provider,
+    SourceNameMismatchError,
     UnsupportedSdistError,
     VcsConfig,
     VcsPolicy,
@@ -649,6 +650,40 @@ class TestProviderVcsIntegration:
         assert isinstance(pin, VcsPin)
         assert pin.commit_id == sha
         assert pin.requested_revision == "main"
+
+    def test_name_mismatch_refused(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A cloned repo whose [project].name differs from the source name aborts."""
+        sha = "a" * 40
+        clone_dir = tmp_path / "cache" / "vcs" / "k" / sha
+        _mark_complete(clone_dir)
+        (clone_dir / "pyproject.toml").write_text(
+            '[project]\nname = "bar"\nversion = "9.9.9"\n'
+            'dependencies = ["unrelated-dep==6.6.6"]\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("nab_index.vcs._repo_key", lambda _url: "k")
+
+        provider = Provider(
+            self.coordinator(),
+            vcs_config=VcsConfig(
+                policy=VcsPolicy.ALLOW,
+                allowed_schemes=frozenset({"git+https"}),
+                allowed_repos=("https://example.com/",),
+                require_pin=True,
+            ),
+            vcs_sources=[
+                VcsSource(name="foo", url=f"git+https://example.com/foo.git@{sha}"),
+            ],
+            vcs_cache_dir=tmp_path / "cache",
+            build_policy=BuildPolicy.NEVER,
+        )
+        with pytest.raises(SourceNameMismatchError, match="bar") as excinfo:
+            provider.fetch_versions("foo")
+        assert "foo" in str(excinfo.value)
 
     def test_vcs_under_block_policy_raises(self, tmp_path: Path) -> None:
         with pytest.raises(ValueError, match="VcsPolicy.ALLOW"):


### PR DESCRIPTION
A local, VCS, or archive source maps a declared `name` to a directory, repo, or archive and becomes the only candidate for that package. If the extracted tree's own `[project].name` was actually a different project, nab seeded that candidate anyway and pinned it under the declared name, carrying the wrong project's version and dependencies. Nothing checked that the two names agreed.

`seed_synthetic_listing` now canonicalizes the extracted `[project].name` and compares it to the declared name before seeding. On a mismatch it raises `SourceNameMismatchError` naming both the declared and actual name and the source path, instead of producing a candidate.

The new exception is deliberately not a `MetadataError`, since `_look_ahead_ok` catches those and just skips the version. A source pointed at the wrong project is a misconfiguration that should abort the resolve, not be silently dropped.
