### PR TITLE
reject workspace member colliding with a vcs or archive source name

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -748,6 +748,7 @@ def _apply_workspace_discovery(
     if not discovered:
         return config
     merged = merge_workspace_local_sources(config.local_sources, discovered)
+    _reject_duplicate_source_names(merged, config.vcs_sources, config.archive_sources)
     explicit_names = {canonicalize_name(src.name) for src in config.local_sources}
     # Universal mode forbids host builds (see _enforce_universal_build_policy),
     # so the workspace BUILD_LOCAL floor does not apply: keep its never.

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -2922,6 +2922,45 @@ class TestWorkspaceDiscoveryIntegration:
         config = read_pyproject_config(member)
         assert config.workspace_member_names == frozenset()
 
+    def test_member_colliding_with_vcs_source_rejected(self, tmp_path: Path) -> None:
+        """A discovered member sharing a vcs-source name is rejected at parse."""
+        root = tmp_path / "pyproject.toml"
+        root.write_text(
+            '[project]\nname = "ws"\nversion = "0"\n'
+            "[tool.nab.workspace]\n"
+            'members = ["pkg"]\n'
+            "[[tool.nab.vcs-sources]]\n"
+            'name = "Alpha"\n'
+            'url = "git+https://github.com/me/alpha.git@abc"\n',
+        )
+        member_dir = tmp_path / "pkg"
+        member_dir.mkdir()
+        (member_dir / "pyproject.toml").write_text(
+            '[project]\nname = "alpha"\nversion = "0"\n',
+        )
+        with pytest.raises(ConfigError, match="duplicate canonical name"):
+            read_pyproject_config(root)
+
+    def test_member_colliding_with_archive_source_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "pyproject.toml"
+        root.write_text(
+            '[project]\nname = "ws"\nversion = "0"\n'
+            "[tool.nab.workspace]\n"
+            'members = ["pkg"]\n'
+            "[[tool.nab.archive-sources]]\n"
+            'name = "alpha"\n'
+            'url = "https://ex.com/alpha-1.0.tar.gz#sha256=' + "e" * 64 + '"\n',
+        )
+        member_dir = tmp_path / "pkg"
+        member_dir.mkdir()
+        (member_dir / "pyproject.toml").write_text(
+            '[project]\nname = "alpha"\nversion = "0"\n',
+        )
+        with pytest.raises(ConfigError, match="duplicate canonical name"):
+            read_pyproject_config(root)
+
     def test_workspace_promotes_never_to_build_local_and_logs(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:


### PR DESCRIPTION
Source-name uniqueness was only checked against the sources declared directly in pyproject.toml. Workspace discovery merges member packages into local-sources afterward, so a discovered member whose canonical name matched a vcs-source or archive-source slipped past that check and later crashed mid-resolve with a raw ValueError from the provider.

Rerun the uniqueness check on the merged sources right after workspace discovery, so the collision is reported as a config error at parse time like every other duplicate source name.
