### PR TITLE
normalize a 3-component python_version from marker_environment

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -130,15 +130,21 @@ def apply_python_axis_overlay(
     yields ``python_full_version`` ``3.8.0`` like the universal matrix. On
     CPython ``implementation_version`` equals ``python_full_version``, so move
     it with the axis; other implementations version separately and keep their
-    host value unless the overlay sets it. Keys the overlay sets explicitly are
-    kept verbatim.
+    host value unless the overlay sets it. Non-axis keys the overlay sets are
+    kept verbatim; the ``python_version``/``python_full_version`` pair is always
+    the derived one, so a patch-precision ``python_version`` (e.g. ``3.10.5``)
+    normalizes to major.minor.
     """
     source = overlay.get("python_full_version") or overlay.get("python_version")
-    if source is not None:
-        environment.update(python_axis_environment(source))
-        if environment.get("implementation_name") == "cpython":
-            environment["implementation_version"] = environment["python_full_version"]
+    if source is None:
+        environment.update(overlay)
+        return
+
+    axis = python_axis_environment(source)
+    if environment.get("implementation_name") == "cpython":
+        environment["implementation_version"] = axis["python_full_version"]
     environment.update(overlay)
+    environment.update(axis)
 
 
 def _normalize_extra(extra: str) -> str:

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -2070,6 +2070,30 @@ class TestApplyPythonAxisOverlay:
             == provider.environment["python_full_version"]
         )
 
+    def test_patch_precision_python_version_normalizes_to_minor(self) -> None:
+        """A patch-precision python_version overlay normalizes to major.minor."""
+        env = {
+            "implementation_name": "cpython",
+            "python_version": "3.11",
+            "python_full_version": "3.11.5",
+            "implementation_version": "3.11.5",
+        }
+        apply_python_axis_overlay(env, {"python_version": "3.10.5"})
+        assert env["python_version"] == "3.10"
+        assert env["python_full_version"] == "3.10.5"
+        assert Marker('python_version == "3.10"').evaluate(env) is True
+
+    def test_provider_marker_env_patch_python_version_normalizes(self) -> None:
+        """A marker-env python_version like 3.10.5 normalizes to major.minor."""
+        provider = Provider(
+            make_coordinator(),
+            python_version="3.12.3",
+            build_policy=BuildPolicy.NEVER,
+            marker_environment={"python_version": "3.10.5"},
+        )
+        assert provider.environment["python_version"] == "3.10"
+        assert provider.environment["python_full_version"] == "3.10.5"
+
 
 class TestLookAhead:
     def test_skips_version_conflicting_with_root(self) -> None:


### PR DESCRIPTION
A `marker_environment` override that set `python_version` to a value carrying a patch component, such as `3.10.5`, left it in the environment unchanged. PEP 508 defines `python_version` as major.minor only, so a `python_version == "3.10"` marker then evaluated to false and any dependency gated on it resolved incorrectly.

The cause was ordering: the override was merged after the derived Python axis, so a raw `python_version` overwrote the normalized value. Now the `python_version` and `python_full_version` pair is always derived from whichever axis key the override supplies and applied last, so `3.10.5` yields `python_version` `3.10` with `python_full_version` `3.10.5`. Other override keys are still kept as given.
