### PR TITLE
Document the --locked CI drift check

### DIFF
--- a/docs/guides/lockfile.md
+++ b/docs/guides/lockfile.md
@@ -146,6 +146,24 @@ identical inputs are byte-for-byte identical. A relative `P<n>D`
 cutoff is anchored to the wall clock, so `created-at` stays the
 run time; `--upgrade` always re-anchors to now.
 
+## Checking the lock in CI
+
+`nab lock --locked` re-resolves from your project inputs,
+checks that the committed `pylock.toml` already matches, and
+writes nothing. It exits non-zero if the lock would change or
+is missing, so a CI step can assert the lock is current:
+
+```bash
+nab lock --locked
+```
+
+The committed pins are never seeded into the resolve, so the
+check confirms the lock still reflects those inputs rather than
+that it round-trips through itself. Only a real change to the
+locked packages fails it; volatile provenance metadata is
+ignored. `--locked` applies to a `pylock.toml` file in
+single-environment mode.
+
 ## `nab download`
 
 `nab download` walks the same pin set, fetches every wheel and


### PR DESCRIPTION
Adds a "Checking the lock in CI" section to the lockfile guide for the existing `nab lock --locked`: a read-only re-resolve that writes nothing and exits non-zero when the committed `pylock.toml` would change or is missing. cli.md documents the flag already; the lockfile reference did not mention it.

The core drift check ships as `--locked`, so this documents it rather than adding a flag; a rich per-package diff and a `--check` spelling are out of scope.

Closes #18
