### PR TITLE
resolve file:// index URLs with a localhost or host authority

### DIFF
--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -21,6 +21,7 @@ multi-index router can treat local and remote indexes uniformly.
 from __future__ import annotations
 
 import re
+import sys
 import zipfile
 import zlib
 from email.parser import BytesParser, Parser
@@ -77,16 +78,25 @@ def parse_file_url(url: str) -> Path:
 
     Uses :func:`urllib.request.url2pathname` so Windows-style drive
     paths (``file:///C:/...``) and percent-encoded characters round-trip
-    cleanly across platforms.
+    cleanly across platforms. An empty or ``localhost`` authority (RFC
+    8089) means the local machine; any other host becomes a UNC share on
+    Windows and is rejected elsewhere.
     """
     parsed = urlparse(url)
     if parsed.scheme != "file":
         msg = f"expected file:// URL, got {url!r}"
         raise ValueError(msg)
-    raw = parsed.path
-    if parsed.netloc:
-        raw = f"//{parsed.netloc}{raw}"
-    return Path(url2pathname(raw))
+
+    netloc = parsed.netloc
+    if not netloc or netloc == "localhost":
+        netloc = ""
+    elif sys.platform == "win32":
+        netloc = "\\\\" + netloc
+    else:
+        msg = f"non-local file:// URL is not supported on this platform: {url!r}"
+        raise ValueError(msg)
+
+    return Path(url2pathname(netloc + parsed.path))
 
 
 _REQUIRES_PYTHON_ATTR = "data-requires-python"

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import io
 import struct
+import sys
 import tarfile
 import zipfile
 import zlib
@@ -149,6 +150,27 @@ class TestParseFileUrl:
     def test_rejects_non_file_scheme(self) -> None:
         with pytest.raises(ValueError, match="expected file:// URL"):
             parse_file_url("https://example.com/")
+
+    def test_localhost_authority_is_local(self, tmp_path: Path) -> None:
+        # RFC 8089: a "localhost" authority resolves like an empty one.
+        with_host = tmp_path.as_uri().replace("file://", "file://localhost", 1)
+        assert parse_file_url(with_host) == tmp_path
+
+    def test_remote_authority_rejected_off_windows(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sys, "platform", "linux")
+        with pytest.raises(ValueError, match="non-local file://"):
+            parse_file_url("file://otherhost/srv/wheels")
+
+    def test_remote_authority_is_unc_on_windows(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sys, "platform", "win32")
+        with_host = str(parse_file_url("file://server/srv/wheels"))
+        without_host = str(parse_file_url("file:///srv/wheels"))
+        assert "server" in with_host
+        assert "server" not in without_host
 
 
 class TestFlatWheelhouse:


### PR DESCRIPTION
A file:// index URL that carried an authority, like file://localhost/srv/wheels or file://host/share, was passed straight to url2pathname. The localhost form resolved to a bogus //localhost/... path, so a valid local index was silently ignored; on Python 3.14 url2pathname rejects the non-local authority and the resolve crashes instead.

_parse_file_url now normalizes the authority before building the path. An empty or localhost authority (RFC 8089) means the local machine and is dropped. On Windows a real host becomes a UNC path. On any other platform a real remote host is rejected with an error rather than a silent miss.
