### PR TITLE
drop empty index hash digests instead of locking an unusable hash

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -422,13 +422,14 @@ def _parse_hashes(value: object) -> tuple[tuple[str, str], ...]:
     # The common case is a single hash; skip the list build.
     if len(value) == 1:
         ((algo, digest),) = value.items()
-        if isinstance(algo, str) and isinstance(digest, str):
+        # An empty digest is not a valid hash; PEP 691 requires a hex string.
+        if isinstance(algo, str) and isinstance(digest, str) and digest:
             return ((sys.intern(algo.lower()), digest.lower()),)
         return ()
 
     out: list[tuple[str, str]] = []
     for algo, digest in value.items():
-        if isinstance(algo, str) and isinstance(digest, str):
+        if isinstance(algo, str) and isinstance(digest, str) and digest:
             out.append((sys.intern(algo.lower()), digest.lower()))
 
     return tuple(out)

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -28,6 +28,7 @@ from nab_index.client import (
     SdistHashMismatchError,
     WheelFile,
     _parse_files,
+    _parse_hashes,
     _parse_sdist_filename,
     _select_artifact_hash,
 )
@@ -538,6 +539,13 @@ class TestParseHashes:
         from nab_index.client import _parse_hashes
 
         result = _parse_hashes({"sha256": "a" * 64, "md5": 123})
+        assert result == (("sha256", "a" * 64),)
+
+    def test_single_entry_empty_digest(self) -> None:
+        assert _parse_hashes({"sha256": ""}) == ()
+
+    def test_multiple_entries_skips_empty_digest(self) -> None:
+        result = _parse_hashes({"sha256": "a" * 64, "sha512": ""})
         assert result == (("sha256", "a" * 64),)
 
     def test_non_dict(self) -> None:


### PR DESCRIPTION
An index that returns an empty string for a hash digest, like `{"sha256": ""}`, had that entry treated as a real hash. The empty digest carried through into the lock as a hash with no value, which can never be verified. With hashes required at install time that left the lock uninstallable, and because the hash field looked present it slipped past the require-hashes check instead of being rejected up front.

`_parse_hashes` now skips any entry whose digest is an empty string, so these malformed entries are dropped when the Simple API response is parsed.
