### PR TITLE
read file:// archive pins from disk on download

### DIFF
--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
 __all__ = [
     "LocalIndexClient",
     "UnsupportedWheelError",
+    "parse_file_url",
     "read_wheel_metadata",
 ]
 
@@ -57,7 +58,7 @@ class UnsupportedWheelError(Exception):
     """
 
 
-def _parse_file_url(url: str) -> Path:
+def parse_file_url(url: str) -> Path:
     """Resolve a ``file://`` URL to an absolute filesystem path.
 
     Uses :func:`urllib.request.url2pathname` so Windows-style drive
@@ -191,7 +192,7 @@ def _resolve_local_link(
         filename = unquote(parsed.path.rsplit("/", 1)[-1]) or None
         return (filename, href_no_frag, None, hashes)
     if parsed.scheme == "file":
-        path = _parse_file_url(href_no_frag)
+        path = parse_file_url(href_no_frag)
         return (path.name, href_no_frag, path, hashes)
 
     # A relative href resolves against the package page wherever it points;
@@ -406,7 +407,7 @@ class LocalIndexClient:
 
     def __init__(self, index_url: str) -> None:
         """Hold the resolved root path for ``index_url``."""
-        self._root = _parse_file_url(index_url)
+        self._root = parse_file_url(index_url)
 
     async def aclose(self) -> None:
         """No-op; nothing to release."""
@@ -441,7 +442,7 @@ class LocalIndexClient:
         The on-disk sidecar is trusted, so ``metadata_hash`` is accepted
         only to match the remote client signature and is not verified.
         """
-        path = _parse_file_url(metadata_url)
+        path = parse_file_url(metadata_url)
         return path.read_text(encoding="utf-8")
 
     async def get_sdist_files(
@@ -456,7 +457,7 @@ class LocalIndexClient:
         On-disk archives are trusted, so ``sdist_hashes`` matches the remote
         client signature but is not verified.
         """
-        path = _parse_file_url(sdist_url)
+        path = parse_file_url(sdist_url)
         return _extract_sdist_files(path.read_bytes())
 
     async def get_sdist_archive(
@@ -471,5 +472,5 @@ class LocalIndexClient:
         On-disk archives are trusted, so ``sdist_hashes`` matches the remote
         client signature but is not verified.
         """
-        path = _parse_file_url(sdist_url)
+        path = parse_file_url(sdist_url)
         return path.read_bytes()

--- a/nab-python/src/nab_python/download.py
+++ b/nab-python/src/nab_python/download.py
@@ -4,8 +4,9 @@ Consumes a :class:`~nab_python.lockfile.LockInput` and writes every
 recorded wheel, sdist, and direct-URL archive into a target directory,
 verifying the recorded hash.  Local and VCS pins are skipped: their
 contents live elsewhere on disk and the lockfile carries no ``sha256``
-for them.  An artefact from a local ``file://`` (find-links) index is
-copied from its on-disk path rather than fetched over HTTP.
+for them.  An artefact with a local ``file://`` URL (a find-links
+index entry or a direct-URL archive) is copied from its on-disk path
+rather than fetched over HTTP.
 
 Use as a one-shot from the CLI ``nab download`` command, or
 programmatically after :func:`~nab_python.resolve.resolve_pyproject_to_lock`.
@@ -23,6 +24,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
 from nab_index.client import AsyncSimpleClient
+from nab_index.local_index import parse_file_url
 from nab_index.transport import HttpError
 
 from .lockfile import ArchivePin, IndexPin, LocalPin, LockInput, VcsPin
@@ -59,9 +61,10 @@ class DownloadEntry:
     The downloader verifies against the first acceptable algorithm the
     index published, preferring sha256 over sha384 over sha512.
 
-    ``local_path`` is set for an artefact from a local ``file://``
-    (find-links) index; its bytes are read from disk instead of fetched
-    over ``url``.
+    ``local_path`` is set for an artefact read from disk instead of
+    fetched over ``url``: a wheel or sdist from a local ``file://``
+    (find-links) index, or a direct-URL archive whose ``url`` is
+    ``file://``.
     """
 
     package: str
@@ -108,13 +111,16 @@ def _entries_for_pin(canonical: str, pin: PinShape) -> Iterable[DownloadEntry]:
         yield from _iter_index_pin(canonical, pin)
     elif isinstance(pin, ArchivePin):
         algo, digest = pin.primary_digest
+        parts = urlsplit(pin.url)
+        local_path = parse_file_url(pin.url) if parts.scheme == "file" else None
         yield DownloadEntry(
             package=canonical,
             version=pin.version,
-            filename=posixpath.basename(urlsplit(pin.url).path),
+            filename=posixpath.basename(parts.path),
             url=pin.url,
             hash_algo=algo,
             digest=digest.lower(),
+            local_path=local_path,
         )
     elif isinstance(pin, (LocalPin, VcsPin)):
         return

--- a/nab-python/tests/property_python/test_sdist_archive_safety.py
+++ b/nab-python/tests/property_python/test_sdist_archive_safety.py
@@ -6,7 +6,7 @@ directory that carries a PKG-INFO, and only for files one level below it.
 ``extract_sdist_archive`` must never write outside the
 target directory, whatever the member names are (``..``, absolute,
 backslash, ``./.`` prefixes, symlink members); it either raises or
-extracts safely.  ``_parse_file_url`` round-trips ``Path.as_uri()`` for
+extracts safely.  ``parse_file_url`` round-trips ``Path.as_uri()`` for
 spacey and unicode paths.
 """
 
@@ -23,7 +23,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from nab_index.client import _extract_sdist_files, extract_sdist_archive
-from nab_index.local_index import _parse_file_url
+from nab_index.local_index import parse_file_url
 
 from .strategies import PROPERTY_SETTINGS
 
@@ -205,6 +205,6 @@ path_segments = st.from_regex(r"[A-Za-z0-9 _.é京-]{1,12}", fullmatch=True).fil
 @given(segments=st.lists(path_segments, min_size=1, max_size=4))
 @PROPERTY_SETTINGS
 def test_parse_file_url_roundtrips_as_uri(segments: list[str]) -> None:
-    """``_parse_file_url`` inverts ``Path.as_uri`` for odd but legal paths."""
+    """``parse_file_url`` inverts ``Path.as_uri`` for odd but legal paths."""
     path = Path("/", *segments)
-    assert _parse_file_url(path.as_uri()) == path
+    assert parse_file_url(path.as_uri()) == path

--- a/nab-python/tests/test_archive.py
+++ b/nab-python/tests/test_archive.py
@@ -391,6 +391,19 @@ class TestArchiveDownload:
         assert entry.digest == "e" * 64
         assert entry.local_path is None
 
+    def test_file_url_archive_pin_carries_local_path(self, tmp_path: Path) -> None:
+        archive = tmp_path / "foo-1.0.0.tar.gz"
+        archive.write_bytes(b"ARCHIVE")
+        pin = ArchivePin(
+            name="foo",
+            version="1.0.0",
+            url=archive.as_uri(),
+            hashes=(("sha256", hashlib.sha256(b"ARCHIVE").hexdigest()),),
+        )
+        (entry,) = list(iter_artifacts(LockInput(pins={"foo": pin})))
+        assert entry.filename == "foo-1.0.0.tar.gz"
+        assert entry.local_path == archive
+
     def test_primary_digest_no_acceptable_hash_raises(self) -> None:
         pin = ArchivePin(name="foo", version="1.0", url="u", hashes=(("md5", "x"),))
         with pytest.raises(ValueError, match="no acceptable hash"):

--- a/nab-python/tests/test_download.py
+++ b/nab-python/tests/test_download.py
@@ -19,6 +19,7 @@ from nab_python.download import (
     iter_artifacts,
 )
 from nab_python.lockfile import (
+    ArchivePin,
     IndexPin,
     LocalPin,
     LockInput,
@@ -471,6 +472,29 @@ class TestLocalIndexArtefacts:
         assert (out / "foo-1.0-py3-none-any.whl").read_bytes() == wheel_bytes
         assert (out / "foo-1.0.tar.gz").read_bytes() == sdist_bytes
         assert len(result.written) == 2
+        assert transport.requested == []
+
+    def test_file_url_archive_copied_from_disk(self, tmp_path: Path) -> None:
+        src = tmp_path / "wheelhouse"
+        src.mkdir()
+        out = tmp_path / "out"
+        archive_bytes = b"ARCHIVEDATA"
+        archive_file = src / "foo-1.0.0.tar.gz"
+        archive_file.write_bytes(archive_bytes)
+        pin = ArchivePin(
+            name="foo",
+            version="1.0.0",
+            url=archive_file.as_uri(),
+            hashes=(("sha256", hashlib.sha256(archive_bytes).hexdigest()),),
+        )
+        transport = _FakeTransport({archive_file.as_uri(): b"WRONG"})
+        result = download_lock(
+            LockInput(pins={"foo": pin}),
+            transport,  # type: ignore[arg-type]
+            out,
+        )
+        assert (out / "foo-1.0.0.tar.gz").read_bytes() == archive_bytes
+        assert len(result.written) == 1
         assert transport.requested == []
 
     def test_missing_local_file_raises_download_error(self, tmp_path: Path) -> None:

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -16,8 +16,8 @@ from nab_index.local_index import (
     LocalIndexClient,
     UnsupportedWheelError,
     _make_record,
-    _parse_file_url,
     _read_sdist_requires_python,
+    parse_file_url,
     read_wheel_metadata,
 )
 
@@ -78,7 +78,7 @@ def _write_sdist(
 class TestParseFileUrl:
     def test_absolute_path(self, tmp_path: Path) -> None:
         url = tmp_path.as_uri()
-        assert _parse_file_url(url) == tmp_path
+        assert parse_file_url(url) == tmp_path
 
     def test_url_encoding_round_trip(self, tmp_path: Path) -> None:
         # Spaces and unicode in the path must round-trip cleanly.
@@ -87,11 +87,11 @@ class TestParseFileUrl:
         path.parent.mkdir(parents=True)
         path.touch()
         url = path.as_uri()
-        assert _parse_file_url(url) == path
+        assert parse_file_url(url) == path
 
     def test_rejects_non_file_scheme(self) -> None:
         with pytest.raises(ValueError, match="expected file:// URL"):
-            _parse_file_url("https://example.com/")
+            parse_file_url("https://example.com/")
 
 
 class TestFlatWheelhouse:


### PR DESCRIPTION
`nab download` failed on a direct-URL archive pin whose URL is a `file://` path. `ArchivePin` never set `local_path`, so the downloader treated it like a remote artifact and tried to fetch the `file://` URL over HTTP, which errors out.

Now when an archive pin's URL scheme is `file://`, its URL is resolved to an on-disk path and the bytes are read from disk. This matches how wheels and sdists from a local find-links index are already materialized.

The `file://` path conversion reuses `parse_file_url` from `nab_index.local_index`, promoted from a private helper to public API so `download` uses the public interface rather than importing another module's private name. It already backed the local find-links index, and its callers and tests move to the public name.
