### PR TITLE
Crash on corrupt static version/requires-python

### DIFF
--- a/nab-python/src/nab_python/build_backend.py
+++ b/nab-python/src/nab_python/build_backend.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 from ._build.errors import (
     BuildBackendError as BuildBackendError,  # noqa: PLC0414  (public re-export)
 )
-from ._vendor.packaging.specifiers import SpecifierSet
+from ._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from ._vendor.packaging.utils import canonicalize_name
 from ._vendor.packaging.version import InvalidVersion, Version
 from .metadata import WheelMetadata, load_static_project
@@ -99,11 +99,13 @@ def _project_to_metadata(project: dict) -> WheelMetadata | None:
     except InvalidVersion:
         return None
     requires_python_raw = project.get("requires-python")
-    requires_python = (
-        SpecifierSet(requires_python_raw)
-        if isinstance(requires_python_raw, str)
-        else None
-    )
+    if isinstance(requires_python_raw, str):
+        try:
+            requires_python = SpecifierSet(requires_python_raw)
+        except InvalidSpecifier:
+            return None
+    else:
+        requires_python = None
     return WheelMetadata(
         name=canonicalize_name(name),
         version=version,

--- a/nab-python/src/nab_python/build_backend.py
+++ b/nab-python/src/nab_python/build_backend.py
@@ -50,10 +50,13 @@ def extract_static_metadata(source_dir: Path) -> WheelMetadata | None:
     authoritative, populating ``name``, ``version``,
     ``requires_python``, ``requires_dist``, and ``provides_extra``.
 
-    Raises :class:`InvalidProjectRequirementError` when ``dependencies``
-    or ``optional-dependencies`` is present but structurally wrong (not
-    an array of strings / not a table), rather than silently dropping the
-    declared dependencies.
+    Raises :class:`InvalidProjectRequirementError` when a static field is
+    present but corrupt: ``dependencies`` or ``optional-dependencies`` that
+    is structurally wrong (not an array of strings / not a table), a
+    ``version`` that is not a valid :pep:`440` version, or a
+    ``requires-python`` that is not a valid specifier.  A corrupt static
+    value is not something the build backend can compute, so it raises
+    rather than falling through to a build that reads the same broken file.
 
     The returned ``provides_extra`` includes both the lower-cased
     keys of ``project.optional-dependencies`` and any extras declared
@@ -94,16 +97,23 @@ def _project_to_metadata(project: dict) -> WheelMetadata | None:
         # A dynamic field is computed by the build backend; a static
         # value alongside it is a stale placeholder, not authoritative.
         return None
+    # ``version`` and ``requires-python`` are present as static strings here
+    # (the dynamic case returned above), so an unparseable value is corrupt
+    # metadata, not a field the build backend can compute. Raise rather than
+    # fall through to a build that reads the same broken file, matching
+    # ``metadata.parse_metadata`` and ``_build.runner._parse_metadata``.
     try:
         version = Version(version_raw)
-    except InvalidVersion:
-        return None
+    except InvalidVersion as exc:
+        msg = f"invalid [project].version {version_raw!r}: {exc}"
+        raise InvalidProjectRequirementError(msg) from exc
     requires_python_raw = project.get("requires-python")
     if isinstance(requires_python_raw, str):
         try:
             requires_python = SpecifierSet(requires_python_raw)
-        except InvalidSpecifier:
-            return None
+        except InvalidSpecifier as exc:
+            msg = f"invalid [project].requires-python {requires_python_raw!r}: {exc}"
+            raise InvalidProjectRequirementError(msg) from exc
     else:
         requires_python = None
     return WheelMetadata(

--- a/nab-python/src/nab_python/build_backend.py
+++ b/nab-python/src/nab_python/build_backend.py
@@ -50,13 +50,13 @@ def extract_static_metadata(source_dir: Path) -> WheelMetadata | None:
     authoritative, populating ``name``, ``version``,
     ``requires_python``, ``requires_dist``, and ``provides_extra``.
 
-    Raises :class:`InvalidProjectRequirementError` when a static field is
-    present but corrupt: ``dependencies`` or ``optional-dependencies`` that
-    is structurally wrong (not an array of strings / not a table), a
-    ``version`` that is not a valid :pep:`440` version, or a
-    ``requires-python`` that is not a valid specifier.  A corrupt static
-    value is not something the build backend can compute, so it raises
-    rather than falling through to a build that reads the same broken file.
+    Raises :class:`InvalidProjectRequirementError` when a present,
+    non-dynamic field is corrupt: a structurally wrong ``dependencies`` /
+    ``optional-dependencies`` (not an array of strings / not a table), a
+    ``version`` string that is not valid :pep:`440`, or a
+    ``requires-python`` that is not a string or not a valid specifier.  A
+    corrupt static value is not something the build backend can compute,
+    so it raises rather than deferring to a build of the same broken file.
 
     The returned ``provides_extra`` includes both the lower-cased
     keys of ``project.optional-dependencies`` and any extras declared
@@ -90,32 +90,25 @@ def _project_to_metadata(project: dict) -> WheelMetadata | None:
     version_raw = project.get("version")
     if not isinstance(name, str) or not isinstance(version_raw, str):
         return None
+
+    # A dynamic field is computed by the build backend; a static value
+    # alongside it is a stale placeholder, not authoritative.
     dynamic = project.get("dynamic")
     if isinstance(dynamic, list) and (
         "version" in dynamic or "requires-python" in dynamic
     ):
-        # A dynamic field is computed by the build backend; a static
-        # value alongside it is a stale placeholder, not authoritative.
         return None
-    # ``version`` and ``requires-python`` are present as static strings here
-    # (the dynamic case returned above), so an unparseable value is corrupt
-    # metadata, not a field the build backend can compute. Raise rather than
-    # fall through to a build that reads the same broken file, matching
-    # ``metadata.parse_metadata`` and ``_build.runner._parse_metadata``.
+
+    # Past the dynamic guard, version is authoritative, so a corrupt value
+    # raises instead of returning None.
     try:
         version = Version(version_raw)
     except InvalidVersion as exc:
         msg = f"invalid [project].version {version_raw!r}: {exc}"
         raise InvalidProjectRequirementError(msg) from exc
-    requires_python_raw = project.get("requires-python")
-    if isinstance(requires_python_raw, str):
-        try:
-            requires_python = SpecifierSet(requires_python_raw)
-        except InvalidSpecifier as exc:
-            msg = f"invalid [project].requires-python {requires_python_raw!r}: {exc}"
-            raise InvalidProjectRequirementError(msg) from exc
-    else:
-        requires_python = None
+
+    requires_python = _static_requires_python(project.get("requires-python"))
+
     return WheelMetadata(
         name=canonicalize_name(name),
         version=version,
@@ -123,6 +116,25 @@ def _project_to_metadata(project: dict) -> WheelMetadata | None:
         requires_dist=_collect_requires_dist(project),
         provides_extra=sorted(_collect_provides_extra(project)),
     )
+
+
+def _static_requires_python(raw: object) -> SpecifierSet | None:
+    """Parse a static ``requires-python``, raising when it is corrupt.
+
+    Absent is a valid "no constraint". A non-string or an unparseable
+    specifier is corrupt: it raises rather than silently dropping the
+    Python bound, which would admit candidates the bound excludes.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        msg = f"[project].requires-python must be a string, got {type(raw).__name__}"
+        raise InvalidProjectRequirementError(msg)
+    try:
+        return SpecifierSet(raw)
+    except InvalidSpecifier as exc:
+        msg = f"invalid [project].requires-python {raw!r}: {exc}"
+        raise InvalidProjectRequirementError(msg) from exc
 
 
 def _collect_requires_dist(project: dict) -> list[Requirement]:

--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -40,7 +40,7 @@ __all__ = [
 
 
 class InvalidProjectRequirementError(ValueError):
-    """A requirement string in pyproject.toml is not valid PEP 508."""
+    """A pyproject.toml dependency or metadata value is invalid or unresolvable."""
 
 
 class InvalidProjectTableError(TypeError):

--- a/nab-python/tests/test_build_backend.py
+++ b/nab-python/tests/test_build_backend.py
@@ -291,7 +291,8 @@ class TestExtractStaticMetadata:
         ):
             extract_static_metadata(tmp_path)
 
-    def test_requires_python_not_str_ignored(self, tmp_path: Path) -> None:
+    def test_requires_python_not_str_raises(self, tmp_path: Path) -> None:
+        """A non-string requires-python is corrupt, not "no constraint"; raise."""
         _write_pyproject(
             tmp_path,
             """
@@ -301,9 +302,11 @@ class TestExtractStaticMetadata:
             requires-python = 42
             """,
         )
-        meta = extract_static_metadata(tmp_path)
-        assert meta is not None
-        assert meta.requires_python is None
+        with pytest.raises(
+            InvalidProjectRequirementError,
+            match=r"\[project\]\.requires-python must be a string, got int",
+        ):
+            extract_static_metadata(tmp_path)
 
     def test_pyproject_unreadable_returns_none(self, tmp_path: Path) -> None:
         # A directory in place of pyproject.toml: ``is_file`` is False so

--- a/nab-python/tests/test_build_backend.py
+++ b/nab-python/tests/test_build_backend.py
@@ -159,19 +159,28 @@ class TestExtractStaticMetadata:
         _write_pyproject(tmp_path, '[project]\nname = "foo"\n')
         assert extract_static_metadata(tmp_path) is None
 
-    def test_invalid_version_returns_none(self, tmp_path: Path) -> None:
+    def test_invalid_version_raises(self, tmp_path: Path) -> None:
+        """A static version that is not valid PEP 440 is corrupt; raise."""
         _write_pyproject(
             tmp_path, '[project]\nname = "foo"\nversion = "not.a.version!"\n'
         )
-        assert extract_static_metadata(tmp_path) is None
+        with pytest.raises(
+            InvalidProjectRequirementError,
+            match=r"invalid \[project\]\.version 'not.a.version!'",
+        ):
+            extract_static_metadata(tmp_path)
 
-    def test_invalid_requires_python_returns_none(self, tmp_path: Path) -> None:
-        # A bare "3.11" has no operator, so it is not a valid PEP 440 specifier.
+    def test_invalid_requires_python_raises(self, tmp_path: Path) -> None:
+        """A bare "3.11" has no operator, so it is not a valid specifier; raise."""
         _write_pyproject(
             tmp_path,
             '[project]\nname = "foo"\nversion = "1.0"\nrequires-python = "3.11"\n',
         )
-        assert extract_static_metadata(tmp_path) is None
+        with pytest.raises(
+            InvalidProjectRequirementError,
+            match=r"invalid \[project\]\.requires-python '3.11'",
+        ):
+            extract_static_metadata(tmp_path)
 
     def test_unparseable_dep_raises(self, tmp_path: Path) -> None:
         """A dep string that is not valid PEP 508 is invalid metadata; raise."""

--- a/nab-python/tests/test_build_backend.py
+++ b/nab-python/tests/test_build_backend.py
@@ -165,6 +165,14 @@ class TestExtractStaticMetadata:
         )
         assert extract_static_metadata(tmp_path) is None
 
+    def test_invalid_requires_python_returns_none(self, tmp_path: Path) -> None:
+        # A bare "3.11" has no operator, so it is not a valid PEP 440 specifier.
+        _write_pyproject(
+            tmp_path,
+            '[project]\nname = "foo"\nversion = "1.0"\nrequires-python = "3.11"\n',
+        )
+        assert extract_static_metadata(tmp_path) is None
+
     def test_unparseable_dep_raises(self, tmp_path: Path) -> None:
         """A dep string that is not valid PEP 508 is invalid metadata; raise."""
         _write_pyproject(


### PR DESCRIPTION
A local or workspace source with a malformed `requires-python` (a bare `3.11`, no operator) made `nab lock` fall over with a raw `InvalidSpecifier`.

A present-but-corrupt static `version` or `requires-python` (an unparseable string, or the wrong TOML type) is not something the build backend can compute, so the static reader now raises `InvalidProjectRequirementError` naming the field and value instead of returning `None` and deferring to a build of the same broken file. A non-string `requires-python` (e.g. an unquoted `3.11`, parsed as a float) previously dropped the Python bound silently; it now raises too.

`nab lock` exits 1 with a clear message, e.g. `Error: invalid [project].requires-python '3.11': Invalid specifier: '3.11'`.