### PR TITLE
abort on config override conflict instead of dropping a version

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -1720,6 +1720,8 @@ class Provider:
 
         metadata_text, from_sdist = self._resolve_metadata(versions, package, version)
 
+        from .config import OverrideConflictError  # noqa: PLC0415 (config import cycle)
+
         try:
             self.parse_and_cache_metadata(
                 cache_key, metadata_text, from_sdist=from_sdist
@@ -1733,9 +1735,11 @@ class Provider:
             UnsupportedVcsError,
             NotImplementedError,
             InvalidUploadTimeError,
+            OverrideConflictError,
         ):
-            # A hash mismatch, refused direct-URL dep, or naive upload-time hit
-            # while building an sdist is a hard error, not a skip.
+            # A hash mismatch, refused direct-URL dep, naive upload-time hit, or
+            # a contradictory config override while building an sdist is a hard
+            # error, not a skip.
             raise
         except Exception as exc:
             logger.warning(

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -5260,6 +5260,29 @@ class TestDistPolicy:
         with pytest.raises(UnsupportedSdistError):
             provider.get_dependencies("pkg", V("1.0"))
 
+    def test_cross_surface_trust_conflict_aborts_get_dependencies(self) -> None:
+        """Matching per-package and per-index trust overrides raise
+        OverrideConflictError instead of being swallowed as invalid metadata.
+        """
+        coordinator = make_coordinator(
+            [make_sdist("1.0")],
+            sdist_pkg_info=PRE_22_SDIST_PKG_INFO,
+        )
+        coordinator.index.store_listing_index("pkg", "internal")
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            dist_policy=DistPolicy.WHEEL_OR_SDIST,
+            build_policy=BuildPolicy.NEVER,
+            package_overrides=(pkg_override("pkg", dist_trust_unverified_deps=True),),
+            index_overrides={
+                "internal": IndexOverride(dist_trust_unverified_deps=True)
+            },
+        )
+        with pytest.raises(OverrideConflictError, match="override conflict for pkg"):
+            provider.get_dependencies("pkg", V("1.0"))
+        assert not provider.has_invalid_metadata("pkg", V("1.0"))
+
     def test_sdist_no_pkg_info_raises(self) -> None:
         """Raise MetadataError when PKG-INFO cannot be extracted."""
         coordinator = make_coordinator(


### PR DESCRIPTION
A config override conflict was being hidden instead of aborting the resolve.

When a candidate is covered by both a per-package override and the serving index's override, and both set the same policy field, `get_dependencies` raises `OverrideConflictError` while parsing metadata. That exception landed in the broad `except Exception` block, which treats any parse failure as invalid metadata: it warns, caches the failure, and raises `MetadataError`. The resolver reads that as an unusable version and quietly drops it, so a contradictory config produced a wrong resolve rather than an error.

`OverrideConflictError` now sits alongside `UnsupportedVcsError` and `NotImplementedError` in the re-raise branch, so it propagates as a hard error and stops the resolve.
