### PR TITLE
apply subdirectory containment to VCS and local sources

### DIFF
--- a/nab-index/src/nab_index/_subdir.py
+++ b/nab-index/src/nab_index/_subdir.py
@@ -1,0 +1,31 @@
+"""Containment check for a source-tree subdirectory.
+
+The project root inside a materialised source (an extracted archive, a
+VCS clone, or a local directory) is selected with ``root / subdirectory``.
+An absolute path, a ``..`` component, or a Windows drive letter would make
+that join land outside the tree.
+"""
+
+from __future__ import annotations
+
+import ntpath
+
+__all__ = ["subdirectory_escapes"]
+
+# ntpath treats both slash kinds as separators, so a value that stays
+# inside on POSIX but escapes on Windows (the real join is native) is
+# caught on every platform.
+_SUBDIR_ROOT = ntpath.normpath("/source-root")
+
+
+def subdirectory_escapes(subdirectory: str) -> bool:
+    """Return True if ``subdirectory`` would resolve outside the source tree."""
+    if not subdirectory:
+        return False
+
+    resolved = ntpath.normpath(ntpath.join(_SUBDIR_ROOT, subdirectory))
+    try:
+        return ntpath.commonpath((_SUBDIR_ROOT, resolved)) != _SUBDIR_ROOT
+    except ValueError:
+        # Different drives (e.g. a ``C:\\`` subdirectory) have no common path.
+        return True

--- a/nab-index/src/nab_index/archive.py
+++ b/nab-index/src/nab_index/archive.py
@@ -11,9 +11,9 @@ policy decision in :mod:`nab_python.config`.
 
 from __future__ import annotations
 
-import ntpath
 from dataclasses import dataclass
 
+from ._subdir import subdirectory_escapes
 from .client import _ACCEPTED_HASH_ALGORITHMS
 
 __all__ = [
@@ -86,27 +86,8 @@ class ArchiveRequest:
         return cls(url=url, hashes=tuple(hashes), subdirectory=subdirectory)
 
 
-_SUBDIR_ROOT = ntpath.normpath("/archive-root")
-
-
 def _reject_unsafe_subdirectory(subdirectory: str, raw_url: str) -> None:
-    """Refuse a subdirectory that escapes the extracted tree.
-
-    At materialise time the project root is selected with ``root /
-    subdirectory``, so an absolute path, a ``..`` component, or a drive
-    letter could read a project outside the archive.  Containment is checked
-    with :mod:`ntpath`, which treats both forward and back slashes as
-    separators, so a value that stays inside the tree on POSIX but escapes it
-    on Windows (the join is native) is caught on every platform.
-    """
-    if not subdirectory:
-        return
-    resolved = ntpath.normpath(ntpath.join(_SUBDIR_ROOT, subdirectory))
-    try:
-        contained = ntpath.commonpath((_SUBDIR_ROOT, resolved)) == _SUBDIR_ROOT
-    except ValueError:
-        # Different drives (e.g. a ``C:\\`` subdirectory) have no common path.
-        contained = False
-    if not contained:
+    """Refuse a subdirectory that escapes the extracted tree."""
+    if subdirectory_escapes(subdirectory):
         msg = f"unsafe archive subdirectory {subdirectory!r} in {raw_url!r}"
         raise ArchiveRequestError(msg)

--- a/nab-index/src/nab_index/vcs.py
+++ b/nab-index/src/nab_index/vcs.py
@@ -25,6 +25,8 @@ import subprocess
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from ._subdir import subdirectory_escapes
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -98,6 +100,9 @@ class VcsRequest:
             key, _, value = fragment_part.partition("=")
             if key == "subdirectory":
                 subdirectory = value
+        if subdirectory_escapes(subdirectory):
+            msg = f"unsafe VCS subdirectory {subdirectory!r} in {url!r}"
+            raise VcsCloneError(msg)
         return cls(scheme="git", repo_url=repo, ref=ref, subdirectory=subdirectory)
 
 

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -20,6 +20,7 @@ from urllib.parse import urlsplit
 import tomli
 from typing_extensions import override
 
+from nab_index._subdir import subdirectory_escapes
 from nab_index.archive import ArchiveRequest, ArchiveRequestError
 from nab_index.multi_index import IndexConfig
 
@@ -1802,6 +1803,12 @@ def _parse_local_sources(
         subdirectory = entry.get("subdirectory")
         if subdirectory is not None and not isinstance(subdirectory, str):
             msg = f"local-sources[{i}] subdirectory must be a string"
+            raise ConfigError(msg)
+        if subdirectory is not None and subdirectory_escapes(subdirectory):
+            msg = (
+                f"local-sources[{i}] subdirectory {subdirectory!r}"
+                " escapes the source tree"
+            )
             raise ConfigError(msg)
         resolved = str((pyproject_dir / path_value).resolve())
         out.append(

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -1333,6 +1333,24 @@ class TestLocalSources:
         with pytest.raises(ConfigError, match="subdirectory must be a string"):
             read_pyproject_config(path)
 
+    def test_subdirectory_parent_escape_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[[tool.nab.local-sources]]\n"
+            'name = "x"\npath = "../x"\nsubdirectory = "../../../../etc"\n',
+        )
+        with pytest.raises(ConfigError, match="escapes the source tree"):
+            read_pyproject_config(path)
+
+    def test_subdirectory_absolute_escape_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[[tool.nab.local-sources]]\n"
+            'name = "x"\npath = "../x"\nsubdirectory = "/etc/secrets"\n',
+        )
+        with pytest.raises(ConfigError, match="escapes the source tree"):
+            read_pyproject_config(path)
+
     def test_unknown_key_rejected(self, tmp_path: Path) -> None:
         path = write(
             tmp_path,

--- a/nab-python/tests/test_vcs.py
+++ b/nab-python/tests/test_vcs.py
@@ -92,6 +92,24 @@ class TestVcsRequestParse:
         assert req.repo_url == "git@github.com:x/y.git"
         assert req.ref == "c" * 40
 
+    def test_parent_subdirectory_rejected(self) -> None:
+        with pytest.raises(VcsCloneError, match="unsafe VCS subdirectory"):
+            VcsRequest.parse(
+                "git+https://ex.com/r.git@" + "a" * 40 + "#subdirectory=../../../../etc"
+            )
+
+    def test_absolute_subdirectory_rejected(self) -> None:
+        with pytest.raises(VcsCloneError, match="unsafe VCS subdirectory"):
+            VcsRequest.parse(
+                "git+https://ex.com/r.git@" + "a" * 40 + "#subdirectory=/etc/secrets"
+            )
+
+    def test_contained_internal_dotdot_allowed(self) -> None:
+        req = VcsRequest.parse(
+            "git+https://ex.com/r.git@" + "a" * 40 + "#subdirectory=a/../b"
+        )
+        assert req.subdirectory == "a/../b"
+
 
 class TestSplitRepoRef:
     def test_url_with_ref(self) -> None:


### PR DESCRIPTION
Only archive sources checked their `#subdirectory=` value for containment. A git URL fragment and a `subdirectory` key on a `[[tool.nab.local-sources]]` entry went unchecked, so a value with a `..` component, an absolute path, or a Windows drive letter would join outside the checkout and select a project directory somewhere else on disk.

This moves the archive containment check into a shared `_subdir` helper and runs the VCS parser and the local-source config reader through it, so all three reject a subdirectory that resolves outside the source tree. A `..` that stays inside the tree (`a/../b`) is still allowed.
