### PR TITLE
drop empty index hash digests instead of failing verification

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -416,19 +416,21 @@ def _parse_hashes(value: object) -> tuple[tuple[str, str], ...]:
     # Both halves are lowercased: PEP 503/691 don't mandate a case, pip
     # treats them case-insensitively, and the acceptable-algorithm filter
     # and hashlib.hexdigest() both expect the lowercase form.
+    # An empty digest carries no integrity claim and can never match a real
+    # file, so it is dropped rather than recorded and later failed against.
     if not isinstance(value, dict):
         return ()
 
     # The common case is a single hash; skip the list build.
     if len(value) == 1:
         ((algo, digest),) = value.items()
-        if isinstance(algo, str) and isinstance(digest, str):
+        if isinstance(algo, str) and isinstance(digest, str) and digest:
             return ((sys.intern(algo.lower()), digest.lower()),)
         return ()
 
     out: list[tuple[str, str]] = []
     for algo, digest in value.items():
-        if isinstance(algo, str) and isinstance(digest, str):
+        if isinstance(algo, str) and isinstance(digest, str) and digest:
             out.append((sys.intern(algo.lower()), digest.lower()))
 
     return tuple(out)

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -550,6 +550,23 @@ class TestParseHashes:
 
         assert _parse_hashes({}) == ()
 
+    def test_single_empty_digest_dropped(self) -> None:
+        from nab_index.client import _parse_hashes
+
+        assert _parse_hashes({"sha256": ""}) == ()
+
+    def test_empty_digest_falls_through_to_valid(self) -> None:
+        from nab_index.client import _parse_hashes
+
+        assert _parse_hashes({"sha256": "", "sha512": "f" * 128}) == (
+            ("sha512", "f" * 128),
+        )
+
+    def test_empty_digest_yields_no_sdist_check(self) -> None:
+        from nab_index.client import _parse_hashes, _select_artifact_hash
+
+        assert _select_artifact_hash(_parse_hashes({"sha256": ""})) is None
+
 
 class TestSelectArtifactHash:
     def test_prefers_sha256(self) -> None:


### PR DESCRIPTION
When an index publishes a hash with an empty digest string, like `{"sha256": ""}` on an artifact or a PEP 658/714 metadata sidecar, nab kept it as an `("sha256", "")` pair. That value can never match a real file, so verification against it always failed and the resolve aborted, even though an empty digest carries no integrity claim.

`_parse_hashes` and `_metadata_hash` now skip entries whose digest string is empty. If a stronger digest is also published it is used instead; if none is, the file is consumed unverified, the same as when the index publishes no hash at all.
