### PR TITLE
treat an empty index hash digest as no hash, not a failed check

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -498,13 +498,13 @@ def _select_artifact_hash(
     """Pick the preferred ``(algo, hex)`` to verify, or ``None`` if none qualify.
 
     Walks :data:`_ACCEPTED_HASH_ALGORITHMS` in order, so sha256 is preferred,
-    then sha384, then sha512. An empty set or only unaccepted algorithms (md5)
-    yields ``None``.
+    then sha384, then sha512. An empty set, an empty digest, or only unaccepted
+    algorithms (md5) yields ``None``.
     """
     by_algo = {algo.lower(): digest.lower() for algo, digest in hashes}
     for algo in _ACCEPTED_HASH_ALGORITHMS:
         digest = by_algo.get(algo)
-        if digest is not None:
+        if digest:
             return (algo, digest)
     return None
 

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -465,8 +465,8 @@ def _metadata_hash(file_info: dict) -> tuple[str, str] | None:
 
     Prefers sha256, then sha384, then sha512, so a sidecar published with
     only a stronger digest is still verified. Algorithm names match
-    case-insensitively. A bare ``true`` (sidecar exists, no hash) or a table
-    with no accepted algorithm yields None, so no check runs.
+    case-insensitively. A bare ``true`` (sidecar exists, no hash), an empty
+    digest, or a table with no accepted algorithm yields None, so no check runs.
     """
     value = _metadata_value(file_info)
     if not isinstance(value, dict):
@@ -478,7 +478,7 @@ def _metadata_hash(file_info: dict) -> tuple[str, str] | None:
     }
     for algo in _ACCEPTED_METADATA_HASHES:
         digest = published.get(algo)
-        if digest is not None:
+        if digest:
             return (algo, digest.lower())
     return None
 

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -267,6 +267,35 @@ class TestMetadataHashParsing:
         assert isinstance(wheel, WheelFile)
         assert wheel.metadata_hash == ("sha256", "dead")
 
+    def test_empty_digest_yields_none(self) -> None:
+        from nab_index.client import _metadata_hash
+
+        assert _metadata_hash({"core-metadata": {"sha256": ""}}) is None
+
+    def test_empty_digest_falls_through_to_valid_algo(self) -> None:
+        from nab_index.client import _metadata_hash
+
+        assert _metadata_hash(
+            {"core-metadata": {"sha256": "", "sha512": "a" * 128}}
+        ) == ("sha512", "a" * 128)
+
+    def test_parse_files_empty_digest_leaves_metadata_unverified(self) -> None:
+        from nab_index.client import WheelFile, _parse_files
+
+        data = {
+            "files": [
+                {
+                    "filename": "foo-1.0-py3-none-any.whl",
+                    "url": "https://example.com/foo-1.0-py3-none-any.whl",
+                    "core-metadata": {"sha256": ""},
+                },
+            ],
+        }
+        (wheel,) = _parse_files(data, "https://example.com/", "foo")
+        assert isinstance(wheel, WheelFile)
+        assert wheel.has_metadata
+        assert wheel.metadata_hash is None
+
 
 class TestYankedFiltering:
     """PEP 592 ``yanked`` files are dropped from the listing."""

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -556,6 +556,13 @@ class TestSelectArtifactHash:
     def test_only_unacceptable_returns_none(self) -> None:
         assert _select_artifact_hash((("md5", "d" * 32),)) is None
 
+    def test_empty_digest_returns_none(self) -> None:
+        assert _select_artifact_hash((("sha256", ""),)) is None
+
+    def test_empty_digest_falls_through_to_valid_algo(self) -> None:
+        hashes = (("sha256", ""), ("sha512", "f" * 128))
+        assert _select_artifact_hash(hashes) == ("sha512", "f" * 128)
+
 
 class TestParseMaxAge:
     def test_default_when_none(self) -> None:


### PR DESCRIPTION
An index that publishes a hash entry with an empty digest string, like `{"sha256": ""}`, made nab treat the empty value as a real hash to verify. The computed digest never equals an empty string, so the metadata sidecar check raised a mismatch and aborted the whole resolve. When a valid stronger digest sat next to the empty one, such as `{"sha256": "", "sha512": "..."}`, the empty sha256 was selected first and shadowed the good sha512.

`_metadata_hash` and `_select_artifact_hash` were gating on `digest is not None`, which lets an empty string through. They now require a truthy digest, so an empty one falls through to the next accepted algorithm and, if none is present, no check runs.
