### PR TITLE
abort the resolve on a build-remote sdist hash mismatch

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -14,7 +14,12 @@ from collections import defaultdict, deque
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
-from nab_index.client import SdistFile, WheelFile
+from nab_index.client import (
+    MetadataHashMismatchError,
+    SdistFile,
+    SdistHashMismatchError,
+    WheelFile,
+)
 
 from ._conflict_kind import EMPTY_MEMBERSHIP_SETS
 from ._provider import extras as _extras
@@ -1592,8 +1597,13 @@ class Provider:
         except UnsupportedSdistError:
             self._unsupported_sdists.add(cache_key)
             raise
-        except (UnsupportedVcsError, NotImplementedError):
-            # A refused direct-URL dep is a hard error, not a parse skip.
+        except (
+            SdistHashMismatchError,
+            MetadataHashMismatchError,
+            UnsupportedVcsError,
+            NotImplementedError,
+        ):
+            # A hash mismatch or refused direct-URL dep is a hard error, not a skip.
             raise
         except Exception as exc:
             logger.warning(

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -6457,6 +6457,39 @@ class TestStaticSdistMetadata:
         assert "dep-a" in deps
         assert provider.stats.excluded_by_build_policy == 0
 
+    def test_build_remote_archive_hash_mismatch_aborts_get_dependencies(
+        self,
+    ) -> None:
+        """A tampered build-remote archive aborts get_dependencies."""
+        coordinator = make_coordinator(
+            [make_sdist("1.0")],
+            sdist_pkg_info=PKG_INFO_DYNAMIC_DEPS,
+        )
+
+        def _tampered_archive(
+            pkg: str,
+            ver: str,
+            _url: str,
+            _hashes: tuple[tuple[str, str], ...] = (),
+        ) -> threading.Event:
+            coordinator.index.store_sdist_archive_error(
+                pkg, ver, SdistHashMismatchError("sdist sha256 mismatch")
+            )
+            return _done_event()
+
+        coordinator.request_sdist_archive.side_effect = _tampered_archive
+
+        provider = Provider(
+            coordinator,
+            python_version="3.12.0",
+            dist_policy=DistPolicy.WHEEL_OR_SDIST,
+            build_policy=BuildPolicy.BUILD_REMOTE,
+        )
+        with pytest.raises(SdistHashMismatchError):
+            provider.get_dependencies("pkg", V("1.0"))
+        assert ("pkg", V("1.0")) not in provider.deps_cache
+        assert ("pkg", V("1.0")) not in provider._invalid_metadata
+
     def test_look_ahead_skips_unsupported_sdist(self) -> None:
         """A dynamic sdist is rejected by look-ahead, not raised."""
         # Two versions: 2.0 has a dynamic sdist, 1.0 has a usable wheel.


### PR DESCRIPTION
Under BuildPolicy.BUILD_REMOTE, a downloaded sdist archive is checked against its published hash before it is built. When the hash did not match, the SdistHashMismatchError was caught by the broad except in get_dependencies, logged as unparseable metadata, and downgraded to a version skip. That let a corrupted archive quietly drop the version and continue the resolve on a different one instead of stopping.

Re-raise SdistHashMismatchError and MetadataHashMismatchError alongside the other hard errors so a hash mismatch aborts the resolve.
