### PR TITLE
reject local wheels whose .dist-info contradicts the filename

### DIFF
--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -43,8 +43,18 @@ if TYPE_CHECKING:
 
 __all__ = [
     "LocalIndexClient",
+    "UnsupportedWheelError",
     "read_wheel_metadata",
 ]
+
+
+class UnsupportedWheelError(Exception):
+    """A local wheel's ``.dist-info`` contradicts its own filename.
+
+    Raised when a wheel carries more than one top-level ``.dist-info``
+    directory, or a single one whose name does not canonicalise to the
+    distribution named by the wheel's filename.
+    """
 
 
 def _parse_file_url(url: str) -> Path:
@@ -232,7 +242,9 @@ def _flat_requires_python(entry: Path, canonical: str) -> str | None:
     """Read a flat-wheelhouse dist's ``Requires-Python``; not in the filename."""
     wheel = _parse_wheel_filename(entry.name)
     if wheel is not None:
-        return _read_wheel_requires_python(entry) if wheel[0] == canonical else None
+        if wheel[0] != canonical:
+            return None
+        return _read_wheel_requires_python(entry, canonical)
     sdist = _parse_sdist_filename(entry.name)
     if sdist is not None and sdist[0] == canonical:
         return _read_sdist_requires_python(entry)
@@ -254,33 +266,19 @@ def _read_sdist_requires_python(sdist_path: Path) -> str | None:
     return value if isinstance(value, str) else None
 
 
-def _read_wheel_requires_python(wheel_path: Path) -> str | None:
+def _read_wheel_requires_python(wheel_path: Path, expected: str) -> str | None:
     """Return ``Requires-Python`` from a wheel's METADATA, or ``None``."""
     try:
         with zipfile.ZipFile(wheel_path) as archive:
-            member = _metadata_member(archive.namelist())
+            member = _wheel_metadata_member(archive.namelist(), expected)
             if member is None:
                 return None
             raw = archive.read(member)
-    except (zipfile.BadZipFile, OSError):
+    except (zipfile.BadZipFile, OSError, UnsupportedWheelError):
         return None
 
     value = BytesParser().parsebytes(raw, headersonly=True).get("Requires-Python")
     return value if isinstance(value, str) else None
-
-
-def _metadata_member(names: list[str]) -> str | None:
-    """Return the top-level ``*.dist-info/METADATA`` member name, or ``None``."""
-    for name in names:
-        head, sep, tail = name.rpartition("/")
-        if (
-            sep
-            and tail == "METADATA"
-            and head.endswith(".dist-info")
-            and "/" not in head
-        ):
-            return name
-    return None
 
 
 def _make_record(
@@ -334,11 +332,19 @@ def _make_record(
 def read_wheel_metadata(wheel_path: Path) -> str | None:
     """Return a wheel's ``<name>-<version>.dist-info/METADATA`` text.
 
-    Returns ``None`` if the file is not a readable zip or has no METADATA member.
+    The ``.dist-info`` directory must name the wheel's own distribution
+    (taken from its filename); a wheel with several top-level ``.dist-info``
+    directories, or one naming a different distribution, raises
+    :class:`UnsupportedWheelError` rather than reading another package's
+    metadata.  Returns ``None`` when the file is not a readable zip, its name
+    is not a wheel filename, or it carries no METADATA member.
     """
+    parsed = _parse_wheel_filename(wheel_path.name)
+    if parsed is None:
+        return None
     try:
         with zipfile.ZipFile(wheel_path) as zf:
-            member = _wheel_metadata_member(zf.namelist())
+            member = _wheel_metadata_member(zf.namelist(), parsed[0])
             if member is None:
                 return None
             return zf.read(member).decode("utf-8")
@@ -346,13 +352,46 @@ def read_wheel_metadata(wheel_path: Path) -> str | None:
         return None
 
 
-def _wheel_metadata_member(names: list[str]) -> str | None:
-    """Return the top-level ``*.dist-info/METADATA`` member name, or ``None``."""
-    for name in names:
-        head, sep, tail = name.partition("/")
-        if sep and tail == "METADATA" and head.endswith(".dist-info"):
-            return name
-    return None
+def _wheel_metadata_member(names: list[str], expected: str) -> str | None:
+    """Return ``expected``'s own top-level ``*.dist-info/METADATA`` member.
+
+    ``expected`` is the wheel's canonical name from its filename.  Returns
+    ``None`` when no top-level ``.dist-info`` holds a METADATA file.  Raises
+    :class:`UnsupportedWheelError` when the wheel carries several top-level
+    ``.dist-info`` directories, or a single one whose name does not
+    canonicalise to ``expected``.
+    """
+    info_dirs = sorted(
+        {
+            head
+            for head, sep, _ in (name.partition("/") for name in names)
+            if sep and head.endswith(".dist-info")
+        }
+    )
+    if not info_dirs:
+        return None
+
+    if len(info_dirs) > 1:
+        joined = ", ".join(info_dirs)
+        msg = f"wheel for {expected!r} has multiple .dist-info directories: {joined}"
+        raise UnsupportedWheelError(msg)
+
+    info_dir = info_dirs[0]
+    if _dist_info_name(info_dir) != expected:
+        msg = (
+            f"wheel for {expected!r} carries .dist-info directory {info_dir!r} "
+            f"for a different distribution"
+        )
+        raise UnsupportedWheelError(msg)
+
+    member = f"{info_dir}/METADATA"
+    return member if member in names else None
+
+
+def _dist_info_name(info_dir: str) -> str:
+    """Return the canonical distribution name from a ``.dist-info`` dir name."""
+    stem = info_dir.removesuffix(".dist-info")
+    return _canonical(stem.rsplit("-", 1)[0])
 
 
 class LocalIndexClient:

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from nab_index.client import SdistFile, WheelFile
-from nab_index.local_index import read_wheel_metadata
+from nab_index.local_index import UnsupportedWheelError, read_wheel_metadata
 
 from .._conflict_kind import EMPTY_MEMBERSHIP_SETS
 from .._vcs_admission import admit_vcs_url
@@ -86,7 +86,11 @@ def resolve_metadata(
             raise integrity_error
         metadata_text = provider.coordinator.index.get_metadata(normalized, ver_str)
     elif isinstance(dist, WheelFile) and dist.local_path is not None:
-        metadata_text = read_wheel_metadata(dist.local_path)
+        try:
+            metadata_text = read_wheel_metadata(dist.local_path)
+        except UnsupportedWheelError:
+            # A contradictory .dist-info is unusable, like an unreadable wheel.
+            metadata_text = None
     else:
         metadata_text = None
 

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -14,6 +14,7 @@ import pytest
 from nab_index.client import SdistFile, WheelFile
 from nab_index.local_index import (
     LocalIndexClient,
+    UnsupportedWheelError,
     _make_record,
     _parse_file_url,
     _read_sdist_requires_python,
@@ -189,6 +190,23 @@ class TestFlatWheelhouse:
         client = LocalIndexClient(tmp_path.as_uri())
         files = run(client.get_files("foo"))
         assert [f.requires_python for f in files] == [">=3.8"]
+
+    def test_flat_wheelhouse_skips_mismatched_dist_info(self, tmp_path: Path) -> None:
+        # A foo wheel carrying a bar .dist-info has no readable Requires-Python;
+        # the good sibling still lists.
+        mismatched = tmp_path / "foo-1.0-py3-none-any.whl"
+        with zipfile.ZipFile(mismatched, "w") as zf:
+            zf.writestr(
+                "bar-2.0.dist-info/METADATA",
+                "Metadata-Version: 2.1\nName: bar\nRequires-Python: >=3.12\n",
+            )
+        _write_wheel(tmp_path / "foo-2.0-py3-none-any.whl", "foo", "2.0", ">=3.8")
+        client = LocalIndexClient(tmp_path.as_uri())
+        files = run(client.get_files("foo"))
+        assert {f.version: f.requires_python for f in files} == {
+            "1.0": None,
+            "2.0": ">=3.8",
+        }
 
     def test_sdist_requires_python_read_from_pkg_info(self, tmp_path: Path) -> None:
         # Requires-Python is absent from the filename; it comes from PKG-INFO.
@@ -563,6 +581,45 @@ class TestReadWheelMetadata:
         not_a_wheel = tmp_path / "foo-1.0-py3-none-any.whl"
         not_a_wheel.write_bytes(b"not a zip archive")
         assert read_wheel_metadata(not_a_wheel) is None
+
+    def test_returns_none_for_non_wheel_filename(self, tmp_path: Path) -> None:
+        assert read_wheel_metadata(tmp_path / "notes.txt") is None
+
+    def test_rejects_multiple_dist_info_dirs(self, tmp_path: Path) -> None:
+        wheel = tmp_path / "foo-1.0-py3-none-any.whl"
+        with zipfile.ZipFile(wheel, "w") as zf:
+            zf.writestr(
+                "bar-2.0.dist-info/METADATA",
+                "Metadata-Version: 2.1\nName: bar\nRequires-Dist: wrong-dep\n",
+            )
+            zf.writestr(
+                "foo-1.0.dist-info/METADATA",
+                "Metadata-Version: 2.1\nName: foo\nRequires-Dist: real-dep\n",
+            )
+            zf.writestr("foo/__init__.py", b"")
+        with pytest.raises(UnsupportedWheelError):
+            read_wheel_metadata(wheel)
+
+    def test_rejects_mismatched_dist_info_name(self, tmp_path: Path) -> None:
+        wheel = tmp_path / "foo-1.0-py3-none-any.whl"
+        with zipfile.ZipFile(wheel, "w") as zf:
+            zf.writestr(
+                "bar-2.0.dist-info/METADATA",
+                "Metadata-Version: 2.1\nName: bar\nRequires-Dist: wrong-dep\n",
+            )
+        with pytest.raises(UnsupportedWheelError):
+            read_wheel_metadata(wheel)
+
+    def test_reads_matching_dist_info_with_dashed_name(self, tmp_path: Path) -> None:
+        wheel = tmp_path / "zope.interface-5.0-py3-none-any.whl"
+        with zipfile.ZipFile(wheel, "w") as zf:
+            zf.writestr(
+                "zope_interface-5.0.dist-info/METADATA",
+                "Metadata-Version: 2.1\nName: zope.interface\nVersion: 5.0\n",
+            )
+        text = read_wheel_metadata(wheel)
+        assert text is not None
+        assert "Name: zope.interface" in text
 
 
 class TestContextManager:

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -1205,6 +1205,24 @@ class TestGetDependencies:
         assert V("2.0") in deps["bar"]
         assert V("1.0") not in deps["bar"]
 
+    def test_local_wheel_with_mismatched_dist_info_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        """A local wheel whose .dist-info names another distribution is rejected."""
+        wheel_path = tmp_path / "foo-1.0-py3-none-any.whl"
+        with zipfile.ZipFile(wheel_path, "w") as zf:
+            zf.writestr(
+                "bar-2.0.dist-info/METADATA",
+                "Metadata-Version: 2.1\nName: bar\nVersion: 2.0\nRequires-Dist: baz\n",
+            )
+        coordinator = make_coordinator(
+            [make_wheel("1.0", has_metadata=False, local_path=wheel_path)],
+            package="foo",
+        )
+        provider = Provider(coordinator, python_version="3.12.0")
+        with pytest.raises(MetadataError):
+            provider.get_dependencies("foo", V("1.0"))
+
     def test_filters_deps_by_marker(self) -> None:
         """Dependencies with non-matching markers are excluded."""
         coordinator = make_coordinator(


### PR DESCRIPTION
Reading a local wheel's METADATA picked the first `.dist-info/METADATA` in zip order rather than the one matching the wheel's own name. A wheel carrying a stray or mismatched top-level `.dist-info` (for example a `foo` wheel that also contains `bar-2.0.dist-info`) would drive the resolve with another package's metadata.

`read_wheel_metadata` now takes the distribution name from the wheel filename and only reads a `.dist-info` that canonicalises to it. A wheel with more than one top-level `.dist-info`, or a single one naming a different distribution, is treated as unusable instead of silently using the wrong metadata, so the candidate is rejected the same way an unreadable wheel is. The flat-wheelhouse `Requires-Python` read applies the same name match.
