### PR TITLE
refuse vcs repo whose ../ path segments escape the allowed prefix

### DIFF
--- a/nab-python/src/nab_python/_vcs_admission.py
+++ b/nab-python/src/nab_python/_vcs_admission.py
@@ -15,6 +15,7 @@ after admission lets the URL through.
 from __future__ import annotations
 
 import enum
+import posixpath
 from dataclasses import dataclass
 from urllib.parse import urlsplit, urlunsplit
 
@@ -142,7 +143,15 @@ def _repo_prefix_matches(inner_url: str, prefix: str) -> bool:
     prefix and skipped once on the candidate before the boundary check.
     Both URLs have their authority ``user[:pass]@`` / ``git@`` stripped
     by the caller.
+
+    A path git would rewrite is refused first: git applies RFC 3986
+    dot-segment removal at fetch time, so a raw ``..`` path could pass the
+    string match while git fetches a repo outside the prefix.
     """
+    path = urlsplit(inner_url).path
+    if path and posixpath.normpath(path) != path:
+        return False
+
     prefix = prefix.removesuffix(".git")
     if not inner_url.startswith(prefix):
         return False

--- a/nab-python/tests/property_python/test_vcs_admission.py
+++ b/nab-python/tests/property_python/test_vcs_admission.py
@@ -21,6 +21,7 @@ Invariants:
 
 from __future__ import annotations
 
+import posixpath
 from urllib.parse import urlsplit, urlunsplit
 
 import pytest
@@ -141,8 +142,13 @@ def _prefix_under_repo(inner: str, prefix: str) -> bool:
     the prefix (``.../airflow.git`` vs ``.../airflow.git.other``) is refused.
     Git's optional ``.git`` suffix is stripped from the prefix and skipped
     once on the candidate so an exact-repo prefix and the ``.git`` clone URL
-    match either way round.
+    match either way round.  A candidate whose path git would rewrite (its
+    dot-segment-normalised form differs from the raw path) is refused first.
     """
+    path = urlsplit(inner).path
+    if path and posixpath.normpath(path) != path:
+        return False
+
     prefix = prefix.removesuffix(".git")
     if not inner.startswith(prefix):
         return False

--- a/nab-python/tests/test_vcs_admission.py
+++ b/nab-python/tests/test_vcs_admission.py
@@ -383,6 +383,32 @@ class TestAdmitVcsUrlRepo:
                 config,
             )
 
+    def test_dot_segment_escape_above_prefix_refused(self) -> None:
+        """A ``../`` path git resolves outside the prefix is refused."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com/trusted/repo",),
+        )
+        with pytest.raises(UnsupportedVcsError, match="not in vcs.allowed-repos"):
+            admit_vcs_url(
+                f"git+https://github.com/trusted/repo/../../other/repo@{_FORTY}",
+                config,
+            )
+
+    def test_plain_repo_under_same_prefix_still_admits(self) -> None:
+        """A plain in-repo URL under that prefix still admits."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com/trusted/repo",),
+        )
+        scheme = admit_vcs_url(
+            f"git+https://github.com/trusted/repo@{_FORTY}",
+            config,
+        )
+        assert scheme == "git+https"
+
     def test_full_repo_prefix_with_fragment_passes(self) -> None:
         """A fragment directly after an allowed full-repo URL stays in-repo."""
         config = VcsConfig(


### PR DESCRIPTION
The vcs.allowed-repos matcher compared each candidate URL against the allowed prefixes with a plain startswith on the raw string. A URL like `git+https://github.com/trusted/repo/../../other/repo@<sha>` passed because it begins with the trusted prefix, but git applies RFC 3986 dot-segment removal before it fetches, so the clone would actually target `github.com/other/repo`, outside the allowlist.

The matcher now normalizes the URL path and refuses any candidate whose normalized path differs from what was written, so a `..` segment git would rewrite is rejected before the prefix comparison runs. Plain URLs under the same prefix still pass.
