### PR TITLE
drop wheel-only versions under sdist-install instead of a lock failure

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -472,7 +472,10 @@ PEP 658 when one is published, falling back to the sdist's
 PKG-INFO (with the usual PEP 643 and `pyproject.toml` fallbacks)
 when no wheel exists.  Equivalent in spirit to pip's
 `--no-binary <pkg>` for the install side, without paying the
-build cost on the resolve side.
+build cost on the resolve side.  A version that publishes no sdist
+has no source to install, so it is skipped the way `sdist-only`
+skips a wheel-only release and the resolver settles on the newest
+version that ships one.
 
 Scope the policy to a subset of packages with a per-package override:
 

--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from nab_resolver.types import RangeProtocol
 
     from .._vendor.packaging.ranges import VersionRange
-    from ..provider import DistFile, Provider
+    from ..provider import DistFile, DistPolicy, Provider
     from ..tags import TagSet
 
 
@@ -294,11 +294,12 @@ def filter_distributions(
     requirement's range, so each version's policy is evaluated against
     its own :class:`Version`.
 
-    :attr:`~nab_python.provider.DistPolicy.SDIST_INSTALL` is *not*
-    filtered here: both wheels and sdists stay in ``versions_cache``
-    so the resolver can read whichever source is cheapest at the
-    chosen version.  The wheels are dropped later, at lock
-    construction time, so only the sdist ends up pinned.
+    Under :attr:`~nab_python.provider.DistPolicy.SDIST_INSTALL` a
+    version keeps its wheels in ``versions_cache`` as a cheap metadata
+    source only when it also publishes an sdist; a version whose only
+    surviving artifact is a wheel has no source to install, so it is
+    dropped and never becomes a candidate.  The kept wheels are dropped
+    later, at lock construction time, so only the sdist is pinned.
 
     The filter runs in two passes.  :func:`base_distributions` applies
     everything that has no platform axis (dist policy, Requires-Python,
@@ -349,6 +350,13 @@ def _filter_base(
     same list back.  Canonicalized here, ahead of the tag pass, so the
     representative version of an equal group is picked from the whole
     listing and does not vary with what a target's tags keep.
+
+    The :attr:`~nab_python.provider.DistPolicy.SDIST_INSTALL` drop of a
+    wheel-only version belongs here rather than in the tag pass: it asks
+    whether the version publishes an installable source, and an sdist
+    carries no tags, so no target can lose the sdist that keeps the
+    version alive.  The answer is the same for every target that shares
+    the listing and the policy config, which is what the memo assumes.
     """
     # Late import: ``provider`` imports this module at module load.
     from ..provider import DistPolicy
@@ -362,6 +370,7 @@ def _filter_base(
 
     result: list[tuple[Version, DistFile]] = []
     sort_with_wheel_first = False
+    policy_by_version: dict[Version, DistPolicy] = {}
     for dist in files:
         provider.stats.distributions_seen += 1
         if isinstance(dist, WheelFile):
@@ -383,6 +392,7 @@ def _filter_base(
         if _excluded_by_dist_policy(dist, effective_dist_policy):
             provider.stats.excluded_by_dist_policy += 1
             continue
+        policy_by_version[version] = effective_dist_policy
         if effective_dist_policy in (DistPolicy.PREFER_WHEEL, DistPolicy.SDIST_INSTALL):
             sort_with_wheel_first = True
 
@@ -397,6 +407,8 @@ def _filter_base(
             continue
 
         result.append((version, dist))
+
+    result = _drop_sdist_install_wheel_only(result, policy_by_version)
 
     if sort_with_wheel_first:
         result.sort(
@@ -489,6 +501,30 @@ def excluded_by_wheel_tags(
         provider.tag_excluded_wheels.get(normalized, 0) + 1
     )
     return True
+
+
+def _drop_sdist_install_wheel_only(
+    result: list[tuple[Version, DistFile]],
+    policy_by_version: Mapping[Version, DistPolicy],
+) -> list[tuple[Version, DistFile]]:
+    """Drop SDIST_INSTALL versions whose surviving artifacts are all wheels.
+
+    Such a version has no source to install, so it must not reach the
+    resolver even though its wheels stay as a cheap metadata source.
+    """
+    # Late import: ``provider`` imports this module at module load.
+    from ..provider import DistPolicy
+
+    versions_with_sdist = {v for v, d in result if isinstance(d, SdistFile)}
+    drop = {
+        v
+        for v in policy_by_version
+        if policy_by_version[v] is DistPolicy.SDIST_INSTALL
+        and v not in versions_with_sdist
+    }
+    if not drop:
+        return result
+    return [pair for pair in result if pair[0] not in drop]
 
 
 def _canonicalize_equal_versions(

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -5223,6 +5223,24 @@ class TestDistPolicy:
         assert isinstance(versions[0][1], WheelFile)
         assert isinstance(versions[1][1], SdistFile)
 
+    def test_sdist_install_drops_wheel_only_version(self) -> None:
+        """A wheel-only version is not a candidate under SDIST_INSTALL.
+
+        The newest release (2.0) publishes only a wheel, so it has no
+        source to install and is dropped before the resolver sees it.
+        The older 1.0 ships a wheel and an sdist, so it stays: the
+        wheel as the cheap metadata source, sorted before the sdist.
+        """
+        coordinator = make_coordinator(
+            [make_wheel("2.0"), make_wheel("1.0"), make_sdist("1.0")],
+            metadata_text="Metadata-Version: 2.1\nName: pkg\nVersion: 2.0\n",
+        )
+        provider = Provider(coordinator, dist_policy=DistPolicy.SDIST_INSTALL)
+        versions = provider.fetch_versions("pkg")
+        assert [str(v) for v, _ in versions] == ["1.0", "1.0"]
+        assert isinstance(versions[0][1], WheelFile)
+        assert isinstance(versions[1][1], SdistFile)
+
     def test_sdist_install_resolves_from_wheel_metadata(self) -> None:
         """A dynamic-deps sdist is not built when a wheel publishes the deps.
 

--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from nab_index.client import WheelFile
+from nab_index.client import SdistFile, WheelFile
 from nab_python import resolve as resolve_mod
 from nab_python._provider import listing as listing_mod
 from nab_python._testing.coordinator_fake import make_coordinator
@@ -38,7 +38,6 @@ from nab_python.lockfile import (
     IndexPin,
     LockInput,
     MissingHashError,
-    MissingSdistError,
     TargetLock,
     build_pylock,
     write_requirements_with_hashes,
@@ -94,6 +93,17 @@ def _make_wheel(version: str, *, package: str) -> WheelFile:
         has_metadata=True,
         upload_time=None,
         hashes=(("sha256", "a" * 64),),
+    )
+
+
+def _make_sdist(version: str, *, package: str) -> SdistFile:
+    return SdistFile(
+        filename=f"{package}-{version}.tar.gz",
+        url=f"https://example.com/{package}-{version}.tar.gz",
+        version=version,
+        requires_python=None,
+        upload_time=None,
+        hashes=(("sha256", "b" * 64),),
     )
 
 
@@ -1105,19 +1115,52 @@ class TestResolveOneTarget:
         with pytest.raises(MissingHashError, match="no acceptable hash"):
             write_requirements_with_hashes(lock_input)
 
-    def test_sdist_install_without_sdist_raises(self) -> None:
-        """A wheel-only version under sdist-install fails the resolve.
+    def test_sdist_install_wheel_only_version_not_a_candidate(self) -> None:
+        """A wheel-only version under sdist-install is never a candidate.
 
-        The pin is the one the lock cannot record, so the refusal comes
-        from the lock builder and propagates out rather than landing on
-        the target as a resolution failure.
+        pkg 1.0 publishes only a wheel, so under sdist-install it has no
+        installable source and drops out of the listing.  With nothing
+        left to try the target fails with a no-versions ResolutionError,
+        not a post-resolution MissingSdistError.
         """
         coordinator = _make_coordinator({"pkg": [_make_wheel("1.0", package="pkg")]})
         settings = _settings(
             coordinator, _no_build(dist_policy=DistPolicy.SDIST_INSTALL)
         )
-        with pytest.raises(MissingSdistError, match="pkg==1.0 has no sdist"):
-            _resolve_one_target(_linux_311(), _reqs("pkg"), (), settings, {})
+        tr = _resolve_one_target(_linux_311(), _reqs("pkg"), (), settings, {})
+        assert not tr.success
+        assert isinstance(tr.error, ResolutionError)
+        assert tr.pins == {}
+
+    def test_sdist_install_yields_to_older_sdist_version(self) -> None:
+        """A wheel-only newest version yields to an older sdist release.
+
+        foo 2.0 publishes only a wheel, so under sdist-install it has no
+        source to install; foo 1.0 ships a wheel and an sdist.  The
+        resolve pins 1.0 and locks its sdist rather than failing on the
+        wheel-only 2.0.
+        """
+        coordinator = make_coordinator(
+            listings={
+                "foo": [
+                    _make_wheel("2.0", package="foo"),
+                    _make_wheel("1.0", package="foo"),
+                    _make_sdist("1.0", package="foo"),
+                ]
+            },
+            auto_metadata=True,
+        )
+        settings = _settings(
+            coordinator, _no_build(dist_policy=DistPolicy.SDIST_INSTALL)
+        )
+        tr = _resolve_one_target(_linux_311(), _reqs("foo"), (), settings, {})
+        assert tr.success
+        assert tr.pins == {"foo": Version("1.0")}
+        assert tr.lock is not None
+        pin = tr.lock.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.wheels == ()
+        assert pin.sdist is not None
 
 
 class TestVcsConfigPlumbing:


### PR DESCRIPTION
With dist-policy sdist-install, a version that publishes only a wheel was still admitted as a candidate. When the resolver picked one, the run went all the way to lock construction and then hard-failed with MissingSdistError, because there was no source to pin, rather than settling on an older version that ships an sdist.

Now a wheel-only version is dropped in filter_distributions under sdist-install, so it never becomes a candidate. A version that also publishes an sdist still keeps its wheel as the cheap metadata source; only the source-less versions go. The resolver then lands on the newest version that ships an sdist, the same way sdist-only skips a wheel-only release.

Since the wheel-only case can no longer reach lock construction, the universal resolve path no longer needs to catch MissingSdistError there.
