### PR TITLE
keep never build-policy for a marker-environment workspace member

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -749,10 +749,13 @@ def _apply_workspace_discovery(
         return config
     merged = merge_workspace_local_sources(config.local_sources, discovered)
     explicit_names = {canonicalize_name(src.name) for src in config.local_sources}
-    # Universal mode forbids host builds (see _enforce_universal_build_policy),
-    # so the workspace BUILD_LOCAL floor does not apply: keep its never.
+    # A universal matrix or a marker-environment overlay both forbid host
+    # builds, so the workspace BUILD_LOCAL floor does not apply: keep never.
+    forbids_host_builds = config.mode is ResolveMode.UNIVERSAL or bool(
+        config.marker_environment
+    )
     promoted_policy = config.build_policy
-    if config.mode is not ResolveMode.UNIVERSAL:
+    if not forbids_host_builds:
         promoted_policy = auto_promote_build_policy_for_workspace(config.build_policy)
     if promoted_policy is not config.build_policy:
         _logger.info(

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -2967,6 +2967,23 @@ class TestWorkspaceDiscoveryIntegration:
         config = read_pyproject_config(member)
         assert config.build_policy is BuildPolicy.NEVER
 
+    def test_marker_environment_member_not_promoted(self, tmp_path: Path) -> None:
+        """A marker overlay keeps never; discovery does not promote it.
+
+        A host build cannot reflect the impersonated marker target, so the
+        BUILD_LOCAL floor applied to workspace members is skipped.
+        """
+        member = self._ws(tmp_path)
+        member.write_text(
+            '[project]\nname = "alpha"\nversion = "0"\n'
+            "[tool.nab]\n"
+            'build-policy = "never"\n'
+            "[tool.nab.marker-environment]\n"
+            'python_version = "3.9"\n',
+        )
+        config = read_pyproject_config(member)
+        assert config.build_policy is BuildPolicy.NEVER
+
     def test_no_discovery_skips_walk(self, tmp_path: Path) -> None:
         member = self._ws(tmp_path)
         config = read_pyproject_config(member, discover_workspace=False)


### PR DESCRIPTION
Locking a workspace member that impersonates one environment through `[tool.nab.marker-environment]` crashed with a raw ValueError instead of resolving.

Workspace discovery floors each member's build-policy at `build-local`, and that floor overrode the member's explicit `never`. The marker-environment guard rejects anything but `never`, since a host build cannot reflect the impersonated target, so the resolve raised as soon as it started.

Skip the floor when a marker-environment overlay is set, the same as we already do under universal mode, so the member keeps `never`.
