### PR TITLE
don't blame an unrelated constraint for a no-versions failure

### DIFF
--- a/nab-python/src/nab_python/_packaging_provider.py
+++ b/nab-python/src/nab_python/_packaging_provider.py
@@ -47,6 +47,12 @@ class PackagingProvider:
                 return version
         return None
 
+    def has_satisfying_version(
+        self, package: str, version_range: RangeProtocol[Version]
+    ) -> bool:
+        """Report whether any available version falls in the range."""
+        return any(v in version_range for v in self._get_versions(package))
+
     def get_dependencies(
         self, package: str, version: Version
     ) -> dict[str, VersionRange]:

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -1151,6 +1151,32 @@ class Provider:
             normalized, candidates, wheel_by_version, package, all_versions
         )
 
+    def has_satisfying_version(
+        self, package: str, version_range: RangeProtocol[Version]
+    ) -> bool:
+        """Report whether ``choose_version`` would pick a version, side-effect-free.
+
+        Runs the real ``choose_version`` over ``version_range`` so look-ahead
+        rejections are honored, then rolls back the state it records: the queued
+        clauses and force-backtrack signal are drained, and the per-package abort
+        markers, force-backtrack budget, and no-versions reasons are restored to
+        their pre-probe values.  A failed-resolve attribution probe therefore
+        cannot alter a later decision.
+        """
+        saved_aborted = dict(self._lookahead_aborted)
+        saved_counts = dict(self._force_backtrack_counts)
+        saved_reasons = dict(self._no_versions_reasons)
+
+        found = self.choose_version(package, version_range) is not None
+
+        self.consume_pending_clauses()
+        self.consume_force_backtrack_targets()
+        self._lookahead_aborted = saved_aborted
+        self._force_backtrack_counts = saved_counts
+        self._no_versions_reasons = saved_reasons
+
+        return found
+
     def _try_abort_skip(self, normalized: str, first: Version) -> Version | None:
         """Return the first candidate when a prior abort is still valid.
 

--- a/nab-python/tests/property_python/test_prerelease_admission.py
+++ b/nab-python/tests/property_python/test_prerelease_admission.py
@@ -44,6 +44,9 @@ class _FilterProvider(PackagingProvider):
     ) -> Version | None:
         return next(iter(version_range.filter(self._get_versions(package))), None)
 
+    def has_satisfying_version(self, package: str, version_range: VersionRange) -> bool:
+        return self.choose_version(package, version_range) is not None
+
 
 @st.composite
 def _prerelease_graphs(

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -508,6 +508,53 @@ class TestChooseVersion:
         assert provider.choose_version("foo", spec.to_range()) is None
 
 
+class TestHasSatisfyingVersion:
+    def test_true_when_a_version_is_in_range(self) -> None:
+        """A candidate inside the range reports True."""
+        wheels = [make_wheel(v) for v in ("1.0", "2.0")]
+        coordinator = make_coordinator(wheels, package="foo")
+        provider = Provider(coordinator)
+        assert provider.has_satisfying_version("foo", SpecifierSet(">=1.0").to_range())
+
+    def test_false_when_no_version_in_range(self) -> None:
+        """No candidate inside the range reports False."""
+        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
+        provider = Provider(coordinator)
+        assert not provider.has_satisfying_version(
+            "foo", SpecifierSet(">=5.0").to_range()
+        )
+
+    def test_false_for_empty_index(self) -> None:
+        """A package with no versions reports False."""
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(coordinator)
+        assert not provider.has_satisfying_version("foo", VersionRange.full())
+
+    def test_restores_recorded_no_versions_reason(self) -> None:
+        """The probe reverts the no-versions reason its own scan records.
+
+        A miss over ``>=5.0`` would otherwise overwrite the stored reason for
+        ``foo``; the restore keeps the pre-probe value.
+        """
+        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
+        provider = Provider(coordinator)
+        provider._no_versions_reasons["foo"] = "sentinel"
+        assert not provider.has_satisfying_version(
+            "foo", SpecifierSet(">=5.0").to_range()
+        )
+        assert provider.get_no_versions_reason("foo") == "sentinel"
+
+    def test_preserves_prior_abort_state(self) -> None:
+        """Abort markers and force-backtrack counts survive the probe."""
+        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
+        provider = Provider(coordinator)
+        provider._lookahead_aborted["bar"] = ("baz", V("1.0"))
+        provider._force_backtrack_counts["baz"] = 2
+        provider.has_satisfying_version("foo", VersionRange.full())
+        assert provider._lookahead_aborted == {"bar": ("baz", V("1.0"))}
+        assert provider._force_backtrack_counts == {"baz": 2}
+
+
 class TestResolutionStrategy:
     """``choose_version`` honours ``ResolutionStrategy``."""
 

--- a/nab-python/tests/test_resolver_packaging.py
+++ b/nab-python/tests/test_resolver_packaging.py
@@ -607,6 +607,9 @@ class _FilterProvider(PackagingProvider):
     ) -> Version | None:
         return next(iter(version_range.filter(self._get_versions(package))), None)
 
+    def has_satisfying_version(self, package: str, version_range: VersionRange) -> bool:
+        return self.choose_version(package, version_range) is not None
+
 
 class TestPrereleaseAuthorizationBacktracking:
     """Pre-release admission follows the dependency edge that introduced it."""

--- a/nab-resolver/src/nab_resolver/decide.py
+++ b/nab-resolver/src/nab_resolver/decide.py
@@ -125,6 +125,25 @@ def absorb_redundant_requirement(
         resolver.observer.on_derivation(package, positive=True, cause=cause)
 
 
+def _constraint_hid_a_version(
+    resolver: Resolver[Any, Any], package: Any, current_range: RangeProtocol[Any]
+) -> bool:
+    """Return whether a user constraint is why ``choose_version`` found nothing.
+
+    ``choose_version`` already returned None over the constraint-narrowed range.
+    Re-probe the un-narrowed ``current_range``: a hit means the constraint
+    clipped away the version that would otherwise have been chosen, so the
+    constraint is the cause; a miss means the package fails on its own (no
+    versions, or none satisfy the requirement) and the constraint is irrelevant.
+    The probe's queued clauses and force-backtrack targets are drained so the
+    diagnostic look-ahead never leaks into the next decision.
+    """
+    found = resolver.provider.choose_version(package, current_range) is not None
+    resolver.provider.consume_pending_clauses()
+    resolver.provider.consume_force_backtrack_targets()
+    return found
+
+
 def record_no_versions(
     resolver: Resolver[Any, Any], package: Any, *, had_pending: bool
 ) -> None:
@@ -140,10 +159,10 @@ def record_no_versions(
     current_range = resolver.solution.get(package) or resolver.range_type.full()
     resolver.observer.on_no_versions(package, current_range)
 
-    # When a constraint narrowed the searched range it is the reason no
-    # acceptable version was found, so attribute the clause to it.
     constraint = resolver.constraints.get(package)
-    constrained = constraint is not None and not current_range.is_subset(constraint)
+    constrained = constraint is not None and _constraint_hid_a_version(
+        resolver, package, current_range
+    )
     cause = (
         IncompatibilityCause.CONSTRAINT
         if constrained

--- a/nab-resolver/src/nab_resolver/decide.py
+++ b/nab-resolver/src/nab_resolver/decide.py
@@ -131,17 +131,12 @@ def _constraint_hid_a_version(
     """Return whether a user constraint is why ``choose_version`` found nothing.
 
     ``choose_version`` already returned None over the constraint-narrowed range.
-    Re-probe the un-narrowed ``current_range``: a hit means the constraint
-    clipped away the version that would otherwise have been chosen, so the
-    constraint is the cause; a miss means the package fails on its own (no
+    Ask whether the un-narrowed ``current_range`` would still yield a version: a
+    hit means the constraint clipped away what would otherwise have been chosen,
+    so the constraint is the cause; a miss means the package fails on its own (no
     versions, or none satisfy the requirement) and the constraint is irrelevant.
-    The probe's queued clauses and force-backtrack targets are drained so the
-    diagnostic look-ahead never leaks into the next decision.
     """
-    found = resolver.provider.choose_version(package, current_range) is not None
-    resolver.provider.consume_pending_clauses()
-    resolver.provider.consume_force_backtrack_targets()
-    return found
+    return resolver.provider.has_satisfying_version(package, current_range)
 
 
 def record_no_versions(

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -72,6 +72,19 @@ class ResolverProvider(Protocol[PackageType, VersionType]):
         """Pick a version for package within version_range, or None."""
         ...
 
+    def has_satisfying_version(
+        self, package: PackageType, version_range: RangeProtocol[VersionType]
+    ) -> bool:
+        """Return whether ``choose_version`` would pick a version in ``version_range``.
+
+        A diagnostic query with no lasting side effect: it is used to attribute a
+        ``NO_VERSIONS`` failure to a user constraint only when the un-narrowed
+        range still offers a version the constraint clipped away.  Providers that
+        queue clauses or record state during ``choose_version`` must not let any
+        of that escape here.
+        """
+        ...
+
     def get_dependencies(
         self, package: PackageType, version: VersionType
     ) -> Mapping[PackageType, RangeProtocol[VersionType]]:

--- a/nab-resolver/tests/property/providers.py
+++ b/nab-resolver/tests/property/providers.py
@@ -41,6 +41,12 @@ class FuzzProvider:
                 return version
         return None
 
+    def has_satisfying_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> bool:
+        """Report whether any available version falls in the range."""
+        return any(v in version_range for v in self._get_versions(package))
+
     def get_dependencies(self, package: str, version: int) -> dict[str, Range[int]]:
         """Return dependencies for a specific version."""
         return self._graph.get(package, {}).get(version, {})
@@ -111,6 +117,12 @@ class PromotingFuzzProvider:
                 return version
         return None
 
+    def has_satisfying_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> bool:
+        """Report whether any available version falls in the range."""
+        return any(v in version_range for v in self._get_versions(package))
+
     def get_dependencies(self, package: str, version: int) -> dict[str, Range[int]]:
         """Return dependencies for a specific version."""
         return self._graph.get(package, {}).get(version, {})
@@ -179,6 +191,12 @@ class OldestFirstProvider:
             if version in version_range:
                 return version
         return None
+
+    def has_satisfying_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> bool:
+        """Report whether any available version falls in the range."""
+        return any(v in version_range for v in self._get_versions(package))
 
     def get_dependencies(self, package: str, version: int) -> dict[str, Range[int]]:
         """Return dependencies for a specific version."""

--- a/nab-resolver/tests/property/test_resolver_oracle.py
+++ b/nab-resolver/tests/property/test_resolver_oracle.py
@@ -106,6 +106,12 @@ class ConstantPriorityProvider:
                 best = version
         return best
 
+    def has_satisfying_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> bool:
+        """Report whether any available version falls in the range."""
+        return any(v in version_range for v in self._versions.get(package, []))
+
     def get_dependencies(self, package: str, version: int) -> dict[str, Range[int]]:
         """Return dependencies for a specific version."""
         return self._deps.get((package, version), {})
@@ -193,6 +199,12 @@ class LookaheadProvider:
                 if self._blockers_seen % self._force_every == 0:
                     self._force_targets.append(dep)
         return None
+
+    def has_satisfying_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> bool:
+        """Report whether any available version falls in the range."""
+        return any(v in version_range for v in self._versions.get(package, []))
 
     def get_dependencies(self, package: str, version: int) -> dict[str, Range[int]]:
         """Return dependencies for a specific version."""

--- a/nab-resolver/tests/test_decide.py
+++ b/nab-resolver/tests/test_decide.py
@@ -95,6 +95,11 @@ class _InertProvider:
     ) -> int | None:
         return None
 
+    def has_satisfying_version(
+        self, package: Any, version_range: RangeProtocol[int]
+    ) -> bool:
+        return False
+
     def get_dependencies(
         self, package: Any, version: int
     ) -> Mapping[Any, RangeProtocol[int]]:

--- a/nab-resolver/tests/test_priority.py
+++ b/nab-resolver/tests/test_priority.py
@@ -47,6 +47,11 @@ class _TrackingProvider:
         versions = list(self._packages.get(package, {}).keys())
         return sum(1 for v in versions if v in version_range)
 
+    def has_satisfying_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> bool:
+        return any(v in version_range for v in self._packages.get(package, {}))
+
     def is_ready(self, package: str) -> bool:
         """All packages are immediately decidable in tests."""
         return True
@@ -100,6 +105,11 @@ class _PromotingProvider:
         versions = list(self._packages.get(package, {}).keys())
         count = sum(1 for v in versions if v in version_range)
         return (promoted, count)
+
+    def has_satisfying_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> bool:
+        return any(v in version_range for v in self._packages.get(package, {}))
 
     def is_ready(self, package: str) -> bool:
         """All packages are immediately decidable in tests."""

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -67,6 +67,11 @@ class DictProvider:
                 return version
         return None
 
+    def has_satisfying_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> bool:
+        return any(v in version_range for v in self._get_versions(package))
+
     def get_dependencies(self, package: str, version: int) -> dict[str, Range]:
         return self._packages.get(package, {}).get(version, {})
 

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -2013,6 +2013,61 @@ class TestConstraints:
             )
         assert "the user constrained" not in str(exc_info.value)
 
+    def test_missing_package_not_blamed_on_clipping_constraint(self) -> None:
+        """A package with zero versions fails as NO_VERSIONS even when a
+        benign constraint clips the searched range.
+
+        The constraint narrows ``*`` to ``< 100`` but is not why no version
+        was found, so it must not take the blame nor have its range printed.
+        """
+        provider = DictProvider({"root": {1: {"foo": Range.full()}}})
+        resolver = Resolver(provider)
+        with pytest.raises(ResolutionError) as exc_info:
+            resolver.resolve(
+                {"root": Range.singleton(1)},
+                constraints={"foo": Range.less_than(100)},
+            )
+        message = str(exc_info.value)
+        assert "the user constrained" not in message
+        assert "no versions of foo * are available" in message
+
+    def test_out_of_range_version_not_blamed_on_constraint(self) -> None:
+        """foo publishes only v5 but is required ``>= 10``. A ``!= 50``
+        constraint cannot exclude a candidate that never fell in range, so
+        the failure stays NO_VERSIONS over the requirement range."""
+        provider = DictProvider(
+            {
+                "root": {1: {"foo": Range.at_least(10)}},
+                "foo": {5: {}},
+            }
+        )
+        resolver = Resolver(provider)
+        with pytest.raises(ResolutionError) as exc_info:
+            resolver.resolve(
+                {"root": Range.singleton(1)},
+                constraints={"foo": ~Range.singleton(50)},
+            )
+        message = str(exc_info.value)
+        assert "the user constrained" not in message
+        assert "no versions of foo [10, +inf) are available" in message
+
+    def test_constraint_that_excludes_only_candidate_is_blamed(self) -> None:
+        """When the sole in-range version is the one the constraint excludes,
+        the constraint is the genuine cause and keeps the blame."""
+        provider = DictProvider(
+            {
+                "root": {1: {"foo": Range.at_least(10)}},
+                "foo": {50: {}},
+            }
+        )
+        resolver = Resolver(provider)
+        with pytest.raises(ResolutionError) as exc_info:
+            resolver.resolve(
+                {"root": Range.singleton(1)},
+                constraints={"foo": ~Range.singleton(50)},
+            )
+        assert "the user constrained" in str(exc_info.value)
+
 
 class TestForceResolutionStep:
     """Direct unit tests for ``try_force_resolution_step``.


### PR DESCRIPTION
A package that fails for its own reasons, no versions published or none in the required range, was still blamed on any user constraint that happened to narrow the searched range. The error read `because the user constrained foo <range>` and printed the searched range instead of the constraint's, pointing the user at something irrelevant to the failure.

The attribution only asked whether the constraint narrowed the range, not whether that narrowing is what hid a usable version. It now probes the un-narrowed range first and keeps the plain no-versions reason unless dropping the constraint would have produced a candidate. Only when the sole in-range version is the one the constraint excludes does the constraint keep the blame.

The probe needs a new `has_satisfying_version` query on the provider. The PyPI provider runs the real version pick so look-ahead rejections still count, then rolls back the clauses, backtrack signal, and per-package markers it records, so a failed-resolve probe cannot sway a later decision.
