### PR TITLE
reject posix subdirectory escapes hidden by a literal backslash

### DIFF
--- a/nab-index/src/nab_index/_subdir.py
+++ b/nab-index/src/nab_index/_subdir.py
@@ -9,23 +9,34 @@ that join land outside the tree.
 from __future__ import annotations
 
 import ntpath
+import posixpath
 
 __all__ = ["subdirectory_escapes"]
 
-# ntpath treats both slash kinds as separators, so a value that stays
-# inside on POSIX but escapes on Windows (the real join is native) is
-# caught on every platform.
-_SUBDIR_ROOT = ntpath.normpath("/source-root")
-
 
 def subdirectory_escapes(subdirectory: str) -> bool:
-    """Return True if ``subdirectory`` would resolve outside the source tree."""
+    r"""Return True if ``subdirectory`` would resolve outside the source tree.
+
+    The materialisation join is native, so the value must stay contained
+    under both separator conventions. ntpath catches Windows escapes such
+    as drive letters and backslash separators. posixpath catches an escape
+    a literal backslash hides from ntpath: ``c\d`` is one segment on POSIX
+    but two under ntpath, which would then absorb a trailing ``..``.
+    """
     if not subdirectory:
         return False
 
-    resolved = ntpath.normpath(ntpath.join(_SUBDIR_ROOT, subdirectory))
-    try:
-        return ntpath.commonpath((_SUBDIR_ROOT, resolved)) != _SUBDIR_ROOT
-    except ValueError:
-        # Different drives (e.g. a ``C:\\`` subdirectory) have no common path.
-        return True
+    for normpath, join, commonpath in (
+        (ntpath.normpath, ntpath.join, ntpath.commonpath),
+        (posixpath.normpath, posixpath.join, posixpath.commonpath),
+    ):
+        root = normpath("/source-root")
+        resolved = normpath(join(root, subdirectory))
+        try:
+            escapes = commonpath((root, resolved)) != root
+        except ValueError:
+            # Different drives (e.g. a ``C:\\`` subdirectory) have no common path.
+            return True
+        if escapes:
+            return True
+    return False

--- a/nab-python/tests/test_archive.py
+++ b/nab-python/tests/test_archive.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from nab_index._subdir import subdirectory_escapes
 from nab_index.archive import ArchiveRequest, ArchiveRequestError
 from nab_index.client import SdistHashMismatchError, extract_sdist_archive
 from nab_python.download import (
@@ -146,6 +147,22 @@ class TestArchiveRequestParse:
             "https://ex.com/foo.tar.gz#sha256=abc&subdirectory=sub\\deeper"
         )
         assert req.subdirectory == "sub\\deeper"
+
+    def test_posix_backslash_parent_escape_rejected(self) -> None:
+        # On POSIX ``c\d`` is a single segment, so ``c\d/../..`` climbs above
+        # the source root even though ntpath alone reports it contained.
+        with pytest.raises(ArchiveRequestError, match="unsafe archive subdirectory"):
+            ArchiveRequest.parse(
+                "https://ex.com/foo.tar.gz#sha256=abc&subdirectory=c\\d/../.."
+            )
+
+
+class TestSubdirectoryEscapes:
+    def test_posix_backslash_parent_escapes(self) -> None:
+        assert subdirectory_escapes("c\\d/../..") is True
+
+    def test_backslash_segment_stays_contained(self) -> None:
+        assert subdirectory_escapes("sub\\deeper") is False
 
 
 class TestArchiveIndexing:

--- a/nab-python/tests/test_vcs.py
+++ b/nab-python/tests/test_vcs.py
@@ -104,6 +104,12 @@ class TestVcsRequestParse:
                 "git+https://ex.com/r.git@" + "a" * 40 + "#subdirectory=/etc/secrets"
             )
 
+    def test_posix_backslash_parent_escape_rejected(self) -> None:
+        with pytest.raises(VcsCloneError, match="unsafe VCS subdirectory"):
+            VcsRequest.parse(
+                "git+https://ex.com/r.git@" + "a" * 40 + "#subdirectory=c\\d/../.."
+            )
+
     def test_contained_internal_dotdot_allowed(self) -> None:
         req = VcsRequest.parse(
             "git+https://ex.com/r.git@" + "a" * 40 + "#subdirectory=a/../b"


### PR DESCRIPTION
`subdirectory_escapes` normalised the subdirectory value with ntpath only. On POSIX a backslash is an ordinary filename character, so `c\d/../..` is one segment followed by two `..` components and lands above the source root. ntpath instead reads the backslash as a separator, splits `c\d` into two segments, and the `..` pair cancels them out, so the guard reported the value as contained and let the escape through. A URL fragment like `subdirectory=c\d/../..` would then create a source tree outside the source root on Linux and macOS.

The check now runs the value under both posixpath and ntpath and rejects it if either convention resolves outside the root, so an escape is caught on whichever platform does the real join.
