### PR TITLE
handle a linked PKG-INFO in an sdist without crashing the resolve

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -532,7 +532,7 @@ def _extract_sdist_files(data: bytes) -> tuple[str | None, str | None]:
     """
     try:
         return _read_tar_sdist_files(data)
-    except (tarfile.TarError, OSError, UnicodeDecodeError):
+    except (tarfile.TarError, OSError, UnicodeDecodeError, KeyError):
         return (None, None)
 
 

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -600,9 +600,10 @@ def extract_sdist_archive(data: bytes, target_dir: Path) -> Path:
     Extraction goes through the tar ``data`` filter (:pep:`706`), which refuses
     any member that would write outside ``target_dir`` (absolute paths, ``..``,
     escaping links) or is a special file (device node, FIFO); a rejected member
-    surfaces as a :class:`ValueError`.  The single extracted top-level directory
-    is the source root, falling back to ``target_dir`` when the archive has no
-    single top-level directory.
+    surfaces as a :class:`ValueError`.  A hard link whose target is not present
+    in the archive surfaces the same way.  The single extracted top-level
+    directory is the source root, falling back to ``target_dir`` when the
+    archive has no single top-level directory.
 
     The data filter is required; a Python that lacks it (before 3.10.12 /
     3.11.4 / 3.12) is unsupported and extraction raises.
@@ -620,6 +621,9 @@ def extract_sdist_archive(data: bytes, target_dir: Path) -> Path:
             tar.extractall(target_dir, filter="data")
     except tarfile.FilterError as exc:
         msg = f"unsafe sdist member: {exc}"
+        raise ValueError(msg) from exc
+    except KeyError as exc:
+        msg = f"broken link in sdist member: {exc}"
         raise ValueError(msg) from exc
 
     # The source root is the single extracted top-level directory, read from

--- a/nab-python/tests/test_archive.py
+++ b/nab-python/tests/test_archive.py
@@ -440,3 +440,16 @@ class TestExtractArchive:
         out.mkdir()
         with pytest.raises(ValueError, match="unsafe sdist member"):
             extract_sdist_archive(buf.getvalue(), out)
+
+    @requires_data_filter
+    def test_broken_hard_link_member_raises_value_error(self, tmp_path: Path) -> None:
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            info = tarfile.TarInfo("foo-1.0.0/PKG-INFO")
+            info.type = tarfile.LNKTYPE
+            info.linkname = "foo-1.0.0/absent"
+            tar.addfile(info)
+        out = tmp_path / "out"
+        out.mkdir()
+        with pytest.raises(ValueError, match="broken link in sdist member"):
+            extract_sdist_archive(buf.getvalue(), out)

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -546,3 +546,19 @@ class TestExtractSdistFiles:
         pkg_info, pyproject = _extract_sdist_files(body)
         assert pkg_info is None
         assert pyproject is None
+
+    @pytest.mark.parametrize("link_type", [tarfile.SYMTYPE, tarfile.LNKTYPE])
+    def test_returns_none_when_pkg_info_is_a_broken_link(
+        self, link_type: bytes
+    ) -> None:
+        """A PKG-INFO that is a link to an absent member is treated as absent."""
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            directory = tarfile.TarInfo("pkg-1.0")
+            directory.type = tarfile.DIRTYPE
+            tar.addfile(directory)
+            link = tarfile.TarInfo("pkg-1.0/PKG-INFO")
+            link.type = link_type
+            link.linkname = "pkg-1.0/absent"
+            tar.addfile(link)
+        assert _extract_sdist_files(buf.getvalue()) == (None, None)


### PR DESCRIPTION
An sdist whose PKG-INFO is a symlink or hard link pointing at a member that is not present in the archive crashed the resolve with an uncaught KeyError out of `_extract_sdist_files`, so a single such file in find-links (or any sdist source) took down the whole run.

tarfile raises KeyError when it cannot find a link's target, both when reading a member with `extractfile` and when writing one with `extractall`, and neither the metadata read nor the archive extract caught it.

Now a broken link during metadata extraction is treated as an absent file, so the sdist has no static PKG-INFO. A broken link during full extraction is reported as a ValueError, which the sdist source already turns into UnsupportedSdistError, so the candidate is skipped instead of aborting the resolve.
