### PR TITLE
print the user's constraint value in CONSTRAINT failure messages

### DIFF
--- a/nab-resolver/src/nab_resolver/decide.py
+++ b/nab-resolver/src/nab_resolver/decide.py
@@ -158,16 +158,18 @@ def record_no_versions(
     constrained = constraint is not None and _constraint_hid_a_version(
         resolver, package, current_range
     )
-    cause = (
-        IncompatibilityCause.CONSTRAINT
-        if constrained
-        else IncompatibilityCause.NO_VERSIONS
-    )
+    if constrained:
+        cause = IncompatibilityCause.CONSTRAINT
+        constraint_range = constraint
+    else:
+        cause = IncompatibilityCause.NO_VERSIONS
+        constraint_range = None
 
     add_incompatibility(
         resolver,
         Incompatibility(
             [Term(package, current_range, positive=True)],
             cause=cause,
+            constraint_range=constraint_range,
         ),
     )

--- a/nab-resolver/src/nab_resolver/report.py
+++ b/nab-resolver/src/nab_resolver/report.py
@@ -75,9 +75,15 @@ def _render_line(incompatibility: Incompatibility[Any, Any]) -> str:
         positive_dep = dep if dep.is_positive() else dep.negate()
         return f"because your project depends on {format_term(positive_dep)}"
 
+    if cause is IncompatibilityCause.CONSTRAINT:
+        (term,) = terms
+        return (
+            f"because the user constrained "
+            f"{term.package} {incompatibility.constraint_range}"
+        )
+
     prefix = {
         IncompatibilityCause.ROOT: "because root requires",
-        IncompatibilityCause.CONSTRAINT: "because the user constrained",
         IncompatibilityCause.DEPENDENCY: "because",
         IncompatibilityCause.NO_VERSIONS: "because no versions of",
         IncompatibilityCause.DERIVED: "so",

--- a/nab-resolver/src/nab_resolver/types.py
+++ b/nab-resolver/src/nab_resolver/types.py
@@ -240,10 +240,14 @@ class Incompatibility(Generic[PackageType, VersionType]):
     The ``cause_left`` and ``cause_right`` fields form a derivation tree
     (a DAG) that can be walked to produce human-readable error messages.
 
+    ``constraint_range`` holds the user's constraint for a ``CONSTRAINT``
+    clause. The clause's term carries the requirement range that backtracking
+    needs, so the user's constraint is kept here for the message.
+
     Reference: https://github.com/dart-lang/pub/blob/master/doc/solver.md#incompatibility
     """
 
-    __slots__ = ("cause", "cause_left", "cause_right", "terms")
+    __slots__ = ("cause", "cause_left", "cause_right", "constraint_range", "terms")
 
     def __init__(
         self,
@@ -251,12 +255,14 @@ class Incompatibility(Generic[PackageType, VersionType]):
         cause: IncompatibilityCause,
         cause_left: Incompatibility[PackageType, VersionType] | None = None,
         cause_right: Incompatibility[PackageType, VersionType] | None = None,
+        constraint_range: RangeProtocol[VersionType] | None = None,
     ) -> None:
         """Create an incompatibility with terms and a cause."""
         self.terms = terms
         self.cause = cause
         self.cause_left = cause_left
         self.cause_right = cause_right
+        self.constraint_range = constraint_range
 
     @override
     def __repr__(self) -> str:

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -1877,6 +1877,32 @@ class TestConstraints:
         message = str(exc_info.value)
         assert "the user constrained" in message
 
+    def test_constraint_conflict_message_shows_user_constraint(self) -> None:
+        """The CONSTRAINT line names the user's constraint, not the requirement.
+
+        The user constrains bar<2 while foo depends on bar>=3. The line that
+        attributes a range to the user must show bar<2, never foo's bar>=3.
+        """
+        provider = DictProvider(
+            {
+                "root": {1: {"foo": Range.at_least(1)}},
+                "foo": {1: {"bar": Range.at_least(3)}},
+                "bar": {3: {}, 2: {}, 1: {}},
+            }
+        )
+        resolver = Resolver(provider)
+        with pytest.raises(ResolutionError) as exc_info:
+            resolver.resolve(
+                {"root": Range.singleton(1)},
+                constraints={"bar": Range.less_than(2)},
+            )
+        message = str(exc_info.value)
+        constraint_line = next(
+            line for line in message.splitlines() if "the user constrained" in line
+        )
+        assert str(Range.less_than(2)) in constraint_line
+        assert str(Range.at_least(3)) not in constraint_line
+
     def test_constraint_with_matching_requirement(self) -> None:
         """A constraint on a root requirement narrows the range."""
         provider = DictProvider(


### PR DESCRIPTION
When a resolve fails because a user constraint hides the version a dependency needs, the "the user constrained ..." line showed the dependency's required range instead of the constraint the user actually set. If the user constrains bar<2 while foo depends on bar>=3, the message claimed the user constrained bar>=3, which points at the wrong value and hides the real constraint.

The CONSTRAINT incompatibility's term carries the requirement range (backtracking needs it), and the renderer read the range straight off that term. This keeps the user's constraint on the incompatibility as a separate field and renders that value on the CONSTRAINT line, so the message names the constraint the user set.
