### PR TITLE
Widen decided versions in dependency clauses

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,9 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
+        # Vendoring patches carry unified-diff context lines whose
+        # leading space must survive verbatim for git apply.
+        exclude: ^tasks/vendoring/
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: 745be0411e3c150e246d527e531e5a221b8c3462  # frozen: v0.15.19

--- a/nab-python/src/nab_python/_packaging_provider.py
+++ b/nab-python/src/nab_python/_packaging_provider.py
@@ -106,3 +106,15 @@ class PackagingProvider:
     def consume_force_backtrack_targets(self) -> list[str]:
         """No force-backtrack signal from this in-memory provider."""
         return []
+
+    def widen_decision(self, package: str, version: Version) -> VersionRange | None:
+        """No widening: dependency clauses keep the exact decided version."""
+        del package, version
+        return None
+
+    def narrow_for_display(
+        self, package: str, constraint: RangeProtocol[Version]
+    ) -> RangeProtocol[Version]:
+        """Identity: constraints render as stored."""
+        del package
+        return constraint

--- a/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
+++ b/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
@@ -11,7 +11,12 @@ plus at most one checked-in patch, and nothing else.
   to.
 - `tasks/vendoring/packaging.patch`, when present, is the only divergence from
   pristine; the rebuild reapplies it after refreshing. With no patch file the
-  tree is byte-identical to upstream at the pin.
+  tree is byte-identical to upstream at the pin. The current patch adds
+  `VersionRange.from_bounds` and `VersionRange.snap_bounds` to `ranges.py`,
+  generated from the `range-from-bounds` branch of the packaging fork
+  (`git diff upstream/main..range-from-bounds -- src/packaging/ranges.py`,
+  paths rewritten to this directory). An upstream PR is planned; until it
+  lands the patch carries the two methods.
 - `tasks/vendor-packaging.sh` fetches `pypa/packaging` at the pin, replaces this
   package with the pristine `src/packaging/` tree plus the repo-root license
   texts, and reapplies the patch. `--check` rebuilds into a temp location and

--- a/nab-python/src/nab_python/_vendor/packaging/ranges.py
+++ b/nab-python/src/nab_python/_vendor/packaging/ranges.py
@@ -280,6 +280,47 @@ def _struct_admits(
     return matches_bounds_only(bounds, parsed)
 
 
+def _bisect_predicate(
+    versions: Sequence[Version], predicate: Callable[[Version], bool]
+) -> int:
+    """First index whose ``predicate`` is true over an ascending list.
+
+    The predicate must be monotonic (false runs then true runs). Equivalent to
+    ``bisect.bisect_left`` on the mapped booleans, done by hand because the
+    ``key`` parameter for :mod:`bisect` only exists on Python 3.10 and later.
+    """
+    low, high = 0, len(versions)
+    while low < high:
+        mid = (low + high) // 2
+        if predicate(versions[mid]):
+            high = mid
+        else:
+            low = mid + 1
+    return low
+
+
+def _partition_indexes(
+    versions: Sequence[Version], lower: LowerBound, upper: UpperBound
+) -> tuple[int, int]:
+    """Locate one interval's bounds in an ascending version list.
+
+    Returns ``(first_inside, first_above)``: the index of the first version at
+    or above ``lower`` and of the first version strictly above ``upper``, so
+    ``versions[first_inside:first_above]`` are the versions the interval
+    contains. The bound predicates are monotonic over an ascending list, so
+    both cuts bisect on the predicate value.
+    """
+    above = lower._above
+    below = upper._below
+
+    first_inside = 0 if above is None else _bisect_predicate(versions, above)
+    if below is None:
+        first_above = len(versions)
+    else:
+        first_above = _bisect_predicate(versions, lambda v: not below(v))
+    return first_inside, first_above
+
+
 # Repr helpers:
 
 
@@ -316,7 +357,8 @@ class VersionRange:
     :class:`~packaging.specifiers.SpecifierSet`.
 
     Construct via :meth:`~packaging.specifiers.SpecifierSet.to_range`, or with
-    the :meth:`full`, :meth:`empty`, and :meth:`singleton` class methods.
+    the :meth:`full`, :meth:`empty`, :meth:`singleton`, and :meth:`from_bounds`
+    class methods.
     Compose with :meth:`intersection`, :meth:`union`, :meth:`complement`, and
     :meth:`difference` (or the ``&`` / ``|`` / ``~`` / ``-`` operators). Test
     membership with ``in`` or :meth:`contains`, filter an iterable with
@@ -407,7 +449,8 @@ class VersionRange:
         raise TypeError(
             "cannot create 'VersionRange' instances directly; use "
             "SpecifierSet.to_range(), VersionRange.full(), "
-            "VersionRange.empty(), or VersionRange.singleton() instead"
+            "VersionRange.empty(), VersionRange.singleton(), or "
+            "VersionRange.from_bounds() instead"
         )
 
     @classmethod
@@ -596,6 +639,73 @@ class VersionRange:
         # ``0.dev0`` singleton is ``(-inf, 0.dev0]`` in canonical form.
         return cls._build(
             _canonical_floor(((lower, upper),)),
+            prereleases_configured=prereleases,
+        )
+
+    @classmethod
+    def from_bounds(
+        cls,
+        lower: Version | str | None = None,
+        upper: Version | str | None = None,
+        *,
+        include_lower: bool = True,
+        include_upper: bool = True,
+        prereleases: bool | None = None,
+    ) -> VersionRange:
+        """Return the raw version-order interval from ``lower`` to ``upper``.
+
+        A single interval in the PEP 440 total order. The bounds are pure order
+        cuts, not specifier semantics: ``None`` on a side is unbounded there.
+        Both ends are inclusive by default, so ``from_bounds(v, v)`` is
+        :meth:`singleton`; pass ``include_lower=False`` or ``include_upper=False``
+        for a half-open interval.
+
+        >>> "2.0" in VersionRange.from_bounds("1.0", "2.0")
+        True
+        >>> "2.0" in VersionRange.from_bounds("1.0", "2.0", include_upper=False)
+        False
+        >>> VersionRange.from_bounds("1.5", "1.5") == VersionRange.singleton("1.5")
+        True
+
+        Membership is decided by the bounds alone, so pre-releases, post-releases,
+        and locals inside them are members even where the matching specifier
+        would exclude them:
+
+        >>> "1.0.post1" in VersionRange.from_bounds("1.0", "2.0", include_lower=False)
+        True
+        >>> "1.0.post1" in SpecifierSet(">1.0,<2.0").to_range()
+        False
+        >>> "2.0rc1" in VersionRange.from_bounds("1.0", "2.0")
+        True
+        >>> "2.0rc1" in SpecifierSet(">=1.0,<2.0").to_range()
+        False
+
+        An inverted pair, or an equal pair with either end exclusive, is the
+        empty range; an unbounded pair is the versions-only full range.
+
+        >>> VersionRange.from_bounds("2.0", "1.0").is_empty
+        True
+        >>> VersionRange.from_bounds() == VersionRange.full(admit_arbitrary=False)
+        True
+
+        :raises packaging.version.InvalidVersion: if ``lower`` or ``upper`` is a
+            string that does not parse as a PEP 440 version.
+        """
+        if lower is not None and not isinstance(lower, Version):
+            lower = Version(lower)
+        if upper is not None and not isinstance(upper, Version):
+            upper = Version(upper)
+
+        if lower is not None and upper is not None:
+            closed = include_lower and include_upper
+            if lower > upper or (lower == upper and not closed):
+                return cls.empty(prereleases=prereleases)
+
+        lower_bound = NEG_INF if lower is None else LowerBound(lower, include_lower)
+        upper_bound = POS_INF if upper is None else UpperBound(upper, include_upper)
+
+        return cls._build(
+            _canonical_floor(((lower_bound, upper_bound),)),
             prereleases_configured=prereleases,
         )
 
@@ -1077,6 +1187,75 @@ class VersionRange:
 
         if not found_final:
             yield from all_nonfinal
+
+    def snap_bounds(self, versions: Iterable[Version | str]) -> VersionRange:
+        """Snap each finite bound inward onto the given versions.
+
+        Returns a subset of self that agrees with self on membership of every
+        given version: each finite segment end moves inward onto the outermost
+        given version its segment contains, and a bound with no given version
+        to land on is unchanged, as are unbounded ends.
+
+        Solver arithmetic and set algebra leave bounds at versions nobody
+        released; snapping them onto real versions yields the range a human
+        would write, and the subset guarantee means the snapped range never
+        admits a version the original excluded, even if the given list was
+        stale.
+
+        ``versions`` may be any iterable of versions or version strings, in any
+        order; it is sorted internally. ``snap_bounds([])`` returns an equal
+        range.
+
+        >>> r = SpecifierSet(">=1.0,<2.0").to_range()
+        >>> r.snap_bounds(["1.2", "1.5", "1.8"])
+        <VersionRange '[1.2, 1.8]'>
+        >>> SpecifierSet(">=1.0").to_range().snap_bounds(["1.2", "1.5"])
+        <VersionRange '[1.2, +inf)'>
+        >>> r.snap_bounds([]) == r
+        True
+
+        A version-order gap round-trips to the singleton it surrounds:
+
+        >>> versions = [Version("1.0"), Version("2.0"), Version("3.0")]
+        >>> gap = VersionRange.from_bounds(
+        ...     "1.0", "3.0", include_lower=False, include_upper=False
+        ... )
+        >>> gap.snap_bounds(versions) == VersionRange.singleton("2.0")
+        True
+
+        :raises packaging.version.InvalidVersion: if a string does not parse as a
+            PEP 440 version.
+        """
+        anchors = sorted(v if isinstance(v, Version) else Version(v) for v in versions)
+        if not self._bounds:
+            return self
+
+        simplified: list[Interval] = []
+        for lower, upper in self._bounds:
+            first_inside, first_above = _partition_indexes(anchors, lower, upper)
+            if first_inside >= first_above:
+                simplified.append((lower, upper))
+                continue
+            new_lower = (
+                lower
+                if lower.version is None
+                else LowerBound(anchors[first_inside], True)
+            )
+            new_upper = (
+                upper
+                if upper.version is None
+                else UpperBound(anchors[first_above - 1], True)
+            )
+            simplified.append((new_lower, new_upper))
+
+        return self._build(
+            _canonical_floor(tuple(simplified)),
+            admit=self._admit,
+            reject=self._reject,
+            admit_arbitrary=self._admit_arbitrary,
+            pre_region=self._pre_region,
+            prereleases_configured=self._prereleases_configured,
+        )
 
     @classmethod
     def _from_specifier_set(cls, specifier_set: SpecifierSet) -> VersionRange:

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -7,6 +7,7 @@ types.  Uses a thread pool with a shared HTTP session to overlap I/O.
 
 from __future__ import annotations
 
+import bisect
 import enum
 import logging
 import re
@@ -620,8 +621,13 @@ class Provider:
         self.versions_only_cache: dict[str, list[Version]] = {}
         self.wheel_by_version_cache: dict[str, dict[Version, DistFile]] = {}
 
-        self.solution_ranges: dict[str, RangeProtocol[Version]] = {}
-        self.solution_decisions: dict[str, Version] = {}
+        # Widening state: the ascending versions_only view per normalized
+        # name, and the widened parent range per decided (name, version).
+        self._ascending_versions_cache: dict[str, list[Version]] = {}
+        self._widened_ranges: dict[tuple[str, Version], VersionRange] = {}
+
+        self.solution_ranges: Mapping[str, RangeProtocol[Version]] = {}
+        self.solution_decisions: Mapping[str, Version] = {}
         self.pending_clauses: list[Incompatibility[str, Version]] = []
         self.pending_blocks: defaultdict[tuple[str, str, Version], list[Version]] = (
             defaultdict(list)
@@ -1519,8 +1525,8 @@ class Provider:
 
     def receive_partial_solution_hint(
         self,
-        positive_ranges: dict[str, RangeProtocol[Version]],
-        decisions: dict[str, Version],
+        positive_ranges: Mapping[str, RangeProtocol[Version]],
+        decisions: Mapping[str, Version],
     ) -> None:
         """Accept a snapshot of the resolver's positive-range assignments.
 
@@ -1563,6 +1569,82 @@ class Provider:
         targets = self._force_backtrack_targets
         self._force_backtrack_targets = []
         return targets
+
+    def _ascending_versions(
+        self,
+        normalized: str,
+        version_list: list[tuple[Version, DistFile]],
+    ) -> list[Version]:
+        """Return the widening universe for ``normalized``: ascending, cached.
+
+        The reversed ``versions_only`` view of the post-filter listing, so
+        pre-release, dev, post, and local versions all fence widening.
+        Yanked files are dropped at nab-index parse time and can never be
+        selected; if that ever moves into a provider-level filter, this
+        universe must be sourced below it, or widened ranges would span
+        selectable yanked versions.
+        """
+        cached = self._ascending_versions_cache.get(normalized)
+        if cached is None:
+            cached = list(reversed(self.versions_only(normalized, version_list)))
+            self._ascending_versions_cache[normalized] = cached
+        return cached
+
+    def widen_decision(self, package: str, version: Version) -> VersionRange | None:
+        """Return the widened parent range for a decided ``version``, or None.
+
+        The widened range spans the open gap between ``version``'s listed
+        neighbors, so it contains no other selectable version (see
+        ``ResolverProvider.widen_decision`` for the contract).  Extras
+        proxies share the base package's universe.  Local, VCS, and archive
+        sources (synthesized single-version listings) and packages whose
+        listing is not cached are not widened.
+        """
+        _, _, normalized = self.split_and_normalize(package)
+        if (
+            normalized in self.local_sources
+            or normalized in self.vcs_sources
+            or normalized in self.archive_sources
+        ):
+            return None
+        version_list = self.versions_cache.get(normalized)
+        if version_list is None:
+            return None
+
+        key = (normalized, version)
+        widened = self._widened_ranges.get(key)
+        if widened is None:
+            universe = self._ascending_versions(normalized, version_list)
+            below = bisect.bisect_left(universe, version)
+            above = bisect.bisect_right(universe, version)
+            prev = universe[below - 1] if below else None
+            nxt = universe[above] if above < len(universe) else None
+
+            widened = VersionRange.from_bounds(
+                prev, nxt, include_lower=False, include_upper=False
+            )
+            self._widened_ranges[key] = widened
+        return widened
+
+    def narrow_for_display(
+        self, package: object, constraint: RangeProtocol[Version]
+    ) -> RangeProtocol[Version]:
+        """Map a possibly-widened ``constraint`` back onto listed versions.
+
+        Render-time only and cache-only: the ROOT sentinel (a non-str
+        package) and packages whose listing is not cached return
+        ``constraint`` unchanged, and nothing is ever fetched.
+        """
+        if not isinstance(package, str):
+            return constraint
+        _, _, normalized = self.split_and_normalize(package)
+        version_list = self.versions_cache.get(normalized)
+        if version_list is None:
+            return constraint
+        assert isinstance(constraint, VersionRange)
+        return constraint.snap_bounds(
+            self._ascending_versions(normalized, version_list)
+        )
 
     def get_dependencies(
         self, package: str, version: Version

--- a/nab-python/tests/property_python/test_from_bounds_snap_bounds.py
+++ b/nab-python/tests/property_python/test_from_bounds_snap_bounds.py
@@ -1,0 +1,119 @@
+"""Property tests for ``VersionRange.from_bounds`` and ``VersionRange.snap_bounds``.
+
+Over random ascending universes mixing final, pre-release, post, dev,
+local, and epoch versions: a ``from_bounds``-built open gap around a listed
+version contains that version and no other listed version, and unions of
+adjacent gaps coalesce into one interval per maximal run of consecutive
+universe indexes. ``snap_bounds`` over a random subset of a universe returns
+a subset of the original that agrees with it on every given version.
+"""
+
+from __future__ import annotations
+
+import bisect
+from functools import reduce
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_python._vendor.packaging.ranges import VersionRange
+from nab_python._vendor.packaging.version import Version
+
+from .strategies import PROPERTY_SETTINGS
+
+pytestmark = pytest.mark.property
+
+_POOL = sorted(
+    Version(text)
+    for text in (
+        "0.1",
+        "1.0.dev1",
+        "1.0.dev2",
+        "1.0a1",
+        "1.0a2",
+        "1.0b1",
+        "1.0rc1",
+        "1.0",
+        "1.0+cu118",
+        "1.0.post1",
+        "1.1",
+        "2.0b1",
+        "2.0",
+        "2.0+local",
+        "2.0.post1",
+        "3.0",
+        "1!0.5",
+        "1!1.0.dev3",
+        "1!1.0",
+        "2!0.1",
+    )
+)
+
+
+def _gap(universe: list[Version], version: Version) -> VersionRange:
+    """The open gap around ``version`` between its listed neighbors."""
+    below = bisect.bisect_left(universe, version)
+    above = bisect.bisect_right(universe, version)
+    prev = universe[below - 1] if below else None
+    nxt = universe[above] if above < len(universe) else None
+    return VersionRange.from_bounds(prev, nxt, include_lower=False, include_upper=False)
+
+
+@st.composite
+def _universes(draw: st.DrawFn) -> list[Version]:
+    return sorted(
+        draw(st.lists(st.sampled_from(_POOL), min_size=1, max_size=8, unique=True))
+    )
+
+
+@st.composite
+def _universes_with_subset(draw: st.DrawFn) -> tuple[list[Version], list[int]]:
+    universe = draw(_universes())
+    indexes = sorted(
+        draw(st.sets(st.integers(min_value=0, max_value=len(universe) - 1), min_size=1))
+    )
+    return universe, indexes
+
+
+@PROPERTY_SETTINGS
+@given(universe=_universes())
+def test_gap_contains_self_and_no_other_listed(universe: list[Version]) -> None:
+    for position, version in enumerate(universe):
+        gap = _gap(universe, version)
+        assert version in gap
+        for other_position, other in enumerate(universe):
+            if other_position != position:
+                assert gap.is_disjoint(VersionRange.singleton(other))
+
+
+@PROPERTY_SETTINGS
+@given(pair=_universes_with_subset())
+def test_union_of_adjacent_gaps_coalesces(
+    pair: tuple[list[Version], list[int]],
+) -> None:
+    universe, indexes = pair
+    gaps = [_gap(universe, universe[index]) for index in indexes]
+    union = reduce(lambda left, right: left | right, gaps)
+    runs = sum(
+        1
+        for position, index in enumerate(indexes)
+        if position == 0 or index != indexes[position - 1] + 1
+    )
+    assert len(union._bounds) == runs
+
+
+@PROPERTY_SETTINGS
+@given(pair=_universes_with_subset())
+def test_snap_bounds_is_subset_and_agrees_on_universe(
+    pair: tuple[list[Version], list[int]],
+) -> None:
+    universe, indexes = pair
+    original = reduce(
+        lambda left, right: left | right,
+        (_gap(universe, universe[index]) for index in indexes),
+    )
+    simplified = original.snap_bounds(universe)
+    assert simplified.is_subset(original)
+    for version in universe:
+        assert (version in simplified) == (version in original)

--- a/nab-python/tests/test_vendor_from_bounds_snap_bounds.py
+++ b/nab-python/tests/test_vendor_from_bounds_snap_bounds.py
@@ -1,0 +1,214 @@
+"""Tests for ``VersionRange.from_bounds`` and ``VersionRange.snap_bounds``.
+
+``from_bounds`` builds a raw version-order interval, so a decided pre-release,
+post, or local version stays inside its own open gap even where the
+matching specifier would exclude it. ``snap_bounds`` re-anchors a range's
+finite bounds onto known versions for display, returning a subset of self
+that agrees with self on every given version.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nab_python._vendor.packaging.ranges import VersionRange
+from nab_python._vendor.packaging.specifiers import SpecifierSet
+from nab_python._vendor.packaging.version import InvalidVersion, Version
+
+V = Version
+
+
+def _range(spec: str) -> VersionRange:
+    return SpecifierSet(spec).to_range()
+
+
+class TestFromBounds:
+    def test_closed_default(self) -> None:
+        r = VersionRange.from_bounds("1.0", "2.0")
+        assert V("1.0") in r
+        assert V("2.0") in r
+        assert V("0.9") not in r
+        assert V("2.1") not in r
+
+    def test_half_open_upper(self) -> None:
+        r = VersionRange.from_bounds("1.0", "2.0", include_upper=False)
+        assert V("1.0") in r
+        assert V("2.0") not in r
+
+    def test_half_open_lower(self) -> None:
+        r = VersionRange.from_bounds("1.0", "2.0", include_lower=False)
+        assert V("1.0") not in r
+        assert V("2.0") in r
+
+    def test_open_both(self) -> None:
+        r = VersionRange.from_bounds(
+            "1.0", "2.0", include_lower=False, include_upper=False
+        )
+        assert V("1.0") not in r
+        assert V("1.5") in r
+        assert V("2.0") not in r
+
+    def test_unbounded_lower(self) -> None:
+        r = VersionRange.from_bounds(upper="2.0")
+        assert V("0.1") in r
+        assert V("2.0") in r
+        assert V("2.1") not in r
+
+    def test_unbounded_upper(self) -> None:
+        r = VersionRange.from_bounds("1.0")
+        assert V("1.0") in r
+        assert V("99") in r
+        assert V("0.9") not in r
+
+    def test_unbounded_both_equals_full_no_arbitrary(self) -> None:
+        assert VersionRange.from_bounds() == VersionRange.full(admit_arbitrary=False)
+        assert "garbage" not in VersionRange.from_bounds()
+
+    def test_inverted_is_empty(self) -> None:
+        assert VersionRange.from_bounds("2.0", "1.0").is_empty
+
+    def test_equal_bounds_closed_is_singleton(self) -> None:
+        assert VersionRange.from_bounds("1.5", "1.5") == VersionRange.singleton("1.5")
+
+    def test_equal_bounds_exclusive_upper_is_empty(self) -> None:
+        assert VersionRange.from_bounds("1.5", "1.5", include_upper=False).is_empty
+
+    def test_equal_bounds_exclusive_lower_is_empty(self) -> None:
+        assert VersionRange.from_bounds("1.5", "1.5", include_lower=False).is_empty
+
+    def test_accepts_version_objects(self) -> None:
+        r = VersionRange.from_bounds(V("1.0"), V("2.0"))
+        assert V("1.5") in r
+
+    def test_invalid_lower(self) -> None:
+        with pytest.raises(InvalidVersion):
+            VersionRange.from_bounds("not a version")
+
+    def test_invalid_upper(self) -> None:
+        with pytest.raises(InvalidVersion):
+            VersionRange.from_bounds(upper="not a version")
+
+    def test_prereleases_false_excludes(self) -> None:
+        r = VersionRange.from_bounds("1.0", "2.0", prereleases=False)
+        assert r._prereleases_configured is False
+        assert not r.contains("1.5a1")
+
+    def test_prereleases_true_admits(self) -> None:
+        r = VersionRange.from_bounds("1.0", "2.0", prereleases=True)
+        assert r._prereleases_configured is True
+        assert r.contains("1.5a1")
+
+    def test_bounds_only_admits_post_of_lower(self) -> None:
+        r = VersionRange.from_bounds("1.0", "2.0", include_lower=False)
+        assert V("1.0.post1") in r
+        assert V("1.0.post1") not in _range(">1.0,<2.0")
+
+    def test_bounds_only_admits_local(self) -> None:
+        r = VersionRange.from_bounds("1.0", "2.0", include_lower=False)
+        assert V("1.0+local") in r
+
+    def test_bounds_only_admits_rc_below_upper(self) -> None:
+        r = VersionRange.from_bounds("1.0", "2.0")
+        assert V("2.0rc1") in r
+        assert V("2.0rc1") not in _range(">=1.0,<2.0")
+
+    def test_floor_empty_canonical(self) -> None:
+        """(-inf, 0.dev0) holds no version; ``_canonical_floor`` drops the
+        interval, which plain bound comparison cannot see with an unbounded
+        lower."""
+        assert VersionRange.from_bounds(None, "0.dev0", include_upper=False).is_empty
+
+    def test_floor_empty_epoch_variant(self) -> None:
+        """0!0.dev0 is the same version as 0.dev0, so it is floor-empty too."""
+        assert VersionRange.from_bounds(None, "0!0.dev0", include_upper=False).is_empty
+
+    def test_higher_epoch_floor_not_collapsed(self) -> None:
+        r = VersionRange.from_bounds(None, "1!0.dev0", include_upper=False)
+        assert not r.is_empty
+        assert V("5.0") in r
+
+    def test_inclusive_lower_at_floor_folds_to_full(self) -> None:
+        assert VersionRange.from_bounds("0.dev0") == VersionRange.full(
+            admit_arbitrary=False
+        )
+
+
+class TestSnapBounds:
+    def test_anchors_finite_bounds_inward(self) -> None:
+        r = _range(">=1.0,<2.0")
+        assert r.snap_bounds(["1.2", "1.5", "1.8"]) == VersionRange.from_bounds(
+            "1.2", "1.8"
+        )
+
+    def test_keeps_unbounded_end(self) -> None:
+        r = _range(">=1.0")
+        assert r.snap_bounds(["1.2", "1.5"]) == VersionRange.from_bounds("1.2")
+
+    def test_witnessless_segment_kept(self) -> None:
+        r = _range(">=1.0,<2.0")
+        assert r.snap_bounds(["5.0", "6.0"]) == r
+
+    def test_empty_anchors_identity(self) -> None:
+        r = _range(">=1.0,<2.0")
+        assert r.snap_bounds([]) == r
+
+    def test_empty_range_returns_self(self) -> None:
+        r = VersionRange.empty()
+        assert r.snap_bounds(["1.0"]) is r
+
+    def test_unsorted_and_duplicate_anchors(self) -> None:
+        r = _range(">=1.0,<2.0")
+        result = r.snap_bounds(["1.8", "1.2", "1.5", "1.2"])
+        assert result == VersionRange.from_bounds("1.2", "1.8")
+
+    def test_mixed_string_and_version_anchors(self) -> None:
+        r = _range(">=1.0,<2.0")
+        result = r.snap_bounds(["1.2", V("1.8")])
+        assert result == VersionRange.from_bounds("1.2", "1.8")
+
+    def test_invalid_anchor_raises(self) -> None:
+        with pytest.raises(InvalidVersion):
+            _range(">=1.0").snap_bounds(["not a version"])
+
+    def test_multi_segment_independent(self) -> None:
+        r = _range(">=1.0,<2.0") | _range(">=3.0,<4.0")
+        result = r.snap_bounds(["1.5", "3.5"])
+        expected = VersionRange.singleton("1.5") | VersionRange.singleton("3.5")
+        assert result == expected
+
+    def test_literal_carriage(self) -> None:
+        r = _range(">=1.0,<2.0") | SpecifierSet("===wat").to_range()
+        result = r.snap_bounds(["1.2", "1.8"])
+        assert result._admit == frozenset({"wat"})
+        assert result.contains("wat")
+
+    def test_pre_region_carriage(self) -> None:
+        r = _range(">=1.0a1,<2.0")
+        assert r._pre_region
+        result = r.snap_bounds(["1.0a1", "1.5"])
+        assert result._pre_region
+        assert list(result.filter([V("1.0a1")])) == [V("1.0a1")]
+
+    def test_configured_policy_carriage(self) -> None:
+        r = SpecifierSet(">=1.0,<2.0", prereleases=False).to_range()
+        result = r.snap_bounds(["1.2", "1.8"])
+        assert result._prereleases_configured is False
+
+    def test_result_is_subset(self) -> None:
+        r = _range(">=1.0,<2.0")
+        result = r.snap_bounds(["1.2", "1.5", "1.8"])
+        assert result.is_subset(r)
+
+    def test_agrees_on_given_versions(self) -> None:
+        r = _range(">=1.0,<2.0")
+        versions = ["0.5", "1.0", "1.5", "1.9", "2.0", "3.0"]
+        result = r.snap_bounds(versions)
+        for text in versions:
+            assert result.contains(text) == r.contains(text)
+
+    def test_gap_round_trips_to_singleton(self) -> None:
+        versions = [V("1.0"), V("2.0"), V("3.0")]
+        gap = VersionRange.from_bounds(
+            "1.0", "3.0", include_lower=False, include_upper=False
+        )
+        assert gap.snap_bounds(versions) == VersionRange.singleton("2.0")

--- a/nab-python/tests/test_widen_decision.py
+++ b/nab-python/tests/test_widen_decision.py
@@ -1,0 +1,269 @@
+"""Tests for ``Provider.widen_decision`` and ``Provider.narrow_for_display``.
+
+The widening universe is the post-filter listing for the normalized base
+package: ascending, including pre-release, dev, post, and local versions.
+Local, VCS, and archive sources (synthesized single-version listings) and
+packages with no cached listing are never widened, and display narrowing
+reads caches only.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from nab_index.client import WheelFile
+from nab_python._packaging_provider import PackagingProvider
+from nab_python._testing.coordinator_fake import make_coordinator
+from nab_python._vendor.packaging.ranges import VersionRange
+from nab_python._vendor.packaging.specifiers import SpecifierSet
+from nab_python._vendor.packaging.version import Version
+from nab_python.provider import (
+    ArchiveSource,
+    BuildPolicy,
+    LocalSource,
+    Provider,
+    VcsSource,
+)
+from nab_resolver.resolver import Resolver
+from nab_resolver.root import ROOT
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+V = Version
+
+_METADATA = "Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n"
+
+
+def _wheel(package: str, version: str) -> WheelFile:
+    """Build a WheelFile for ``package`` at ``version``."""
+    return WheelFile(
+        filename=f"{package}-{version}-py3-none-any.whl",
+        url=f"https://example.com/{package}-{version}-py3-none-any.whl",
+        version=version,
+        requires_python=None,
+        has_metadata=True,
+        upload_time=None,
+    )
+
+
+def _graph_coordinator(graph: dict[str, dict[str, list[str]]]) -> MagicMock:
+    """Coordinator for ``{package: {version: [Requires-Dist lines]}}``.
+
+    Metadata is pre-stored per ``(package, version)`` so packages may
+    share version strings.
+    """
+    listings = {
+        package: [_wheel(package, version) for version in versions]
+        for package, versions in graph.items()
+    }
+    coordinator = make_coordinator(listings=listings)
+    for package, versions in graph.items():
+        for version, requires in versions.items():
+            text = _METADATA.format(name=package, version=version)
+            for requirement in requires:
+                text += f"Requires-Dist: {requirement}\n"
+            coordinator.index.store_metadata(package, version, text + "\n")
+    return coordinator
+
+
+def _listing_provider(package: str, versions: list[str]) -> Provider:
+    """Provider with ``package``'s listing already fetched into the cache."""
+    coordinator = _graph_coordinator({package: {v: [] for v in versions}})
+    provider = Provider(coordinator, python_version="3.12.0")
+    provider.fetch_versions(package)
+    return provider
+
+
+class TestWidenDecision:
+    def test_none_before_listing_is_cached(self) -> None:
+        coordinator = _graph_coordinator({"p": {"1.0": []}})
+        provider = Provider(coordinator, python_version="3.12.0")
+        assert provider.widen_decision("p", V("1.0")) is None
+
+    def test_universe_includes_prereleases(self) -> None:
+        """The listed pre-release fences the widened interval; it must not
+        be spanned even though the default filter buffers it."""
+        provider = _listing_provider("p", ["2.0", "2.0b1", "1.0"])
+        widened = provider.widen_decision("p", V("2.0"))
+        assert widened is not None
+        assert V("2.0") in widened
+        assert V("2.0b1") not in widened
+        assert V("1.0") not in widened
+        assert V("3.0") in widened
+
+    def test_universe_includes_locals(self) -> None:
+        provider = _listing_provider("p", ["2.1", "2.0+cu118", "2.0"])
+        widened = provider.widen_decision("p", V("2.0+cu118"))
+        assert widened is not None
+        assert V("2.0+cu118") in widened
+        assert V("2.0") not in widened
+        assert V("2.1") not in widened
+
+    def test_extras_proxy_uses_base_universe(self) -> None:
+        provider = _listing_provider("foo", ["3.0", "2.0", "1.0"])
+        base = provider.widen_decision("foo", V("2.0"))
+        proxy = provider.widen_decision("foo[bar]", V("2.0"))
+        assert base is not None
+        assert proxy is base
+
+    def test_memoized_per_package_version(self) -> None:
+        provider = _listing_provider("p", ["3.0", "2.0", "1.0"])
+        first = provider.widen_decision("p", V("2.0"))
+        second = provider.widen_decision("p", V("2.0"))
+        assert first is not None
+        assert second is first
+
+    def test_single_listed_version_widens_to_full_bounds(self) -> None:
+        provider = _listing_provider("p", ["1.5"])
+        widened = provider.widen_decision("p", V("1.5"))
+        assert widened is not None
+        assert V("0.1") in widened
+        assert V("99") in widened
+        assert V("1.5rc1") in widened
+        assert "garbage" not in widened
+
+    def test_none_for_local_source(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "foo"\nversion = "1.2.3"\n', encoding="utf-8"
+        )
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(
+            coordinator,
+            local_sources=[LocalSource("foo", str(tmp_path))],
+            build_policy=BuildPolicy.NEVER,
+        )
+        version = provider.fetch_versions("foo")[0][0]
+        assert provider.widen_decision("foo", version) is None
+
+    def test_none_for_vcs_source(self) -> None:
+        coordinator = make_coordinator([], package="bar")
+        provider = Provider(coordinator, python_version="3.12.0")
+        provider.vcs_sources["bar"] = VcsSource(
+            "bar", "git+https://example.com/bar.git@abc123"
+        )
+        provider.versions_cache["bar"] = [(V("1.0"), _wheel("bar", "1.0"))]
+        assert provider.widen_decision("bar", V("1.0")) is None
+
+    def test_none_for_archive_source(self) -> None:
+        coordinator = make_coordinator([], package="baz")
+        provider = Provider(coordinator, python_version="3.12.0")
+        provider.archive_sources["baz"] = ArchiveSource(
+            "baz", "https://example.com/baz-1.0.tar.gz#sha256=00"
+        )
+        provider.versions_cache["baz"] = [(V("1.0"), _wheel("baz", "1.0"))]
+        assert provider.widen_decision("baz", V("1.0")) is None
+
+
+class TestNarrowForDisplay:
+    def test_root_sentinel_returns_constraint_unchanged(self) -> None:
+        provider = _listing_provider("p", ["1.0"])
+        constraint = SpecifierSet(">=1").to_range()
+        assert provider.narrow_for_display(ROOT, constraint) is constraint
+
+    def test_narrows_widened_range_onto_listed_versions(self) -> None:
+        provider = _listing_provider("p", ["3.0", "2.0", "1.0"])
+        widened = provider.widen_decision("p", V("2.0"))
+        assert widened is not None
+        narrowed = provider.narrow_for_display("p", widened)
+        assert V("2.0") in narrowed
+        assert V("2.0.post1") not in narrowed
+        assert V("2.5") not in narrowed
+
+    def test_unfetched_package_returns_constraint_unchanged(self) -> None:
+        provider = _listing_provider("p", ["1.0"])
+        constraint = SpecifierSet(">=1,<2").to_range()
+        assert provider.narrow_for_display("ghost", constraint) is constraint
+
+    def test_never_triggers_a_fetch(self) -> None:
+        coordinator = _graph_coordinator({"p": {"3.0": [], "2.0": [], "1.0": []}})
+        provider = Provider(coordinator, python_version="3.12.0")
+        provider.fetch_versions("p")
+        coordinator.request_listing.side_effect = AssertionError(
+            "narrow_for_display fetched a listing"
+        )
+        coordinator.request_listing.reset_mock()
+        constraint = SpecifierSet(">=1,<2").to_range()
+        assert provider.narrow_for_display("ghost", constraint) is constraint
+        provider.narrow_for_display("p", VersionRange.full(admit_arbitrary=False))
+        coordinator.request_listing.assert_not_called()
+
+
+class TestPackagingProviderHooks:
+    def test_widen_decision_returns_none(self) -> None:
+        provider = PackagingProvider({"a": {V("1.0"): {}}})
+        assert provider.widen_decision("a", V("1.0")) is None
+
+    def test_narrow_for_display_is_identity(self) -> None:
+        provider = PackagingProvider({"a": {V("1.0"): {}}})
+        constraint = SpecifierSet(">=1").to_range()
+        assert provider.narrow_for_display("a", constraint) is constraint
+
+
+class TestWideningRegressionGraphs:
+    """The prerelease-admission regression graphs stay green through the
+    production Provider, which is where widening is active."""
+
+    @staticmethod
+    def _resolve(
+        graph: dict[str, dict[str, list[str]]],
+        root_reqs: dict[str, VersionRange],
+    ) -> dict[str, Version]:
+        coordinator = _graph_coordinator(graph)
+        provider = Provider(
+            coordinator, python_version="3.12.0", root_requirements=root_reqs
+        )
+        resolver = Resolver(provider, range_type=VersionRange, root_version="0")
+        return resolver.resolve(root_reqs)
+
+    def test_rejected_parent_does_not_leak_prerelease_admission(self) -> None:
+        """The prerelease-backtrack-leak graph: a rejected parent must not
+        make an unrelated pre-release beat a final."""
+        pins = self._resolve(
+            {
+                "a": {"1.0": ["c>=1.0"], "2.0": ["c>=2.0b1"]},
+                "c": {"1.0": [], "1.5a1": [], "2.0b1": ["d==2.0"]},
+                "d": {"1.0": [], "2.0": []},
+            },
+            {
+                "a": VersionRange.full(),
+                "d": SpecifierSet("==1.0").to_range(),
+            },
+        )
+        assert pins["a"] == V("1.0")
+        assert pins["d"] == V("1.0")
+        assert pins["c"] == V("1.0")
+
+    def test_exclusion_fallback_still_admits_prerelease(self) -> None:
+        """The intended exclusion-fallback graph: when the only final is
+        unusable, the surviving pre-release is admitted."""
+        pins = self._resolve(
+            {
+                "a": {"1.0": [], "2.0": []},
+                "c": {"1.0": ["d==2.0"], "1.5a1": [], "2.0b1": ["a>=2.0"]},
+                "d": {"1.0": [], "2.0": ["a>=2.0b1"]},
+            },
+            {
+                "a": SpecifierSet("==1.0").to_range(),
+                "c": SpecifierSet(">=1.0").to_range(),
+            },
+        )
+        assert pins["a"] == V("1.0")
+        assert pins["c"] == V("1.5a1")
+
+    def test_capped_prerelease_clip_does_not_leak(self) -> None:
+        """The capped-prerelease clip graph: a failed parent's capped opt-in
+        must not survive into c's range and beat the final 3.5."""
+        pins = self._resolve(
+            {
+                "c": {"2.5": [], "3.5": [], "3.6b1": []},
+                "a": {"2.5": ["c==2.5"], "3.6b1": []},
+                "e": {"1.0": ["c!=2.5"], "4.0": ["c==2.0b1"]},
+            },
+            {
+                "e": SpecifierSet("!=2.5").to_range(),
+                "a": SpecifierSet(">=2.5").to_range(),
+            },
+        )
+        assert pins["c"] == V("3.5")

--- a/nab-resolver/src/nab_resolver/conflict.py
+++ b/nab-resolver/src/nab_resolver/conflict.py
@@ -70,7 +70,10 @@ def conflict_resolution(
         if is_terminal_incompatibility(current_incompatibility):
             # Unreachable: the backjump_target == 0 check below raises first.
             raise ResolutionError(  # pragma: no cover
-                format_error(current_incompatibility),
+                format_error(
+                    current_incompatibility,
+                    narrow=resolver.provider.narrow_for_display,
+                ),
                 incompatibility=current_incompatibility,
             )
 
@@ -128,7 +131,10 @@ def conflict_resolution(
 
             if backjump_target == 0:
                 raise ResolutionError(
-                    format_error(current_incompatibility),
+                    format_error(
+                        current_incompatibility,
+                        narrow=resolver.provider.narrow_for_display,
+                    ),
                     incompatibility=current_incompatibility,
                 )
 

--- a/nab-resolver/src/nab_resolver/conflict.py
+++ b/nab-resolver/src/nab_resolver/conflict.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "apply_targeted_backtrack",
+    "conflict_credit_target",
     "conflict_resolution",
     "find_most_recent_satisfier",
     "force_targeted_backtrack",
@@ -143,10 +144,12 @@ def conflict_resolution(
             resolver.stats.backjumps += 1
             resolver.observer.on_backjump(from_level, backjump_target)
 
-            # Count only the "affected" package so it gets decided first
+            # Count only one package per conflict so it gets decided first
             # after restart and its dependencies constrain the culprit.
             affected_package = most_recent_satisfier.package
-            resolver.stats.package_conflict_counts[affected_package] += 1
+            resolver.stats.package_conflict_counts[
+                conflict_credit_target(most_recent_satisfier)
+            ] += 1
 
             update_culprit_counts(
                 resolver,
@@ -217,6 +220,28 @@ def update_culprit_counts(
             and package not in resolver.pending_targeted_backtrack
         ):
             resolver.pending_targeted_backtrack.append(package)
+
+
+def conflict_credit_target(satisfier: Assignment[Any, Any]) -> Any:
+    """Return the package whose decision receives the conflict credit.
+
+    A positive term over a decided package used to be satisfied only by the
+    decision itself, so the credit landed on the package whose decision
+    triggered the conflict.  A widened parent term is often already
+    satisfied by the earlier derivation propagated from its dependency
+    clause; crediting the derivation's own package then starves the
+    promotion heuristics, while crediting both packages over-promotes the
+    whole cluster past the backjump horizon.  The clause's depending parent
+    receives the one credit instead.
+    """
+    if satisfier.is_decision or satisfier.cause is None:
+        return satisfier.package
+    if satisfier.cause.cause is not IncompatibilityCause.DEPENDENCY:
+        return satisfier.package
+    parent = satisfier.cause.terms[0].package
+    if parent == satisfier.package:
+        return satisfier.package
+    return parent
 
 
 def iterate_force_resolution(

--- a/nab-resolver/src/nab_resolver/report.py
+++ b/nab-resolver/src/nab_resolver/report.py
@@ -9,12 +9,16 @@ Reference: https://github.com/dart-lang/pub/blob/master/doc/solver.md#error-repo
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 from .types import IncompatibilityCause, PackageType, Term, VersionType
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from .types import Incompatibility
+
+    _NarrowFn: TypeAlias = Callable[[Any, Any], Any]  # (package, constraint) -> shown
 
 __all__ = [
     "explain_incompatibility",
@@ -25,10 +29,19 @@ __all__ = [
 ]
 
 
-def format_error(root_incompatibility: Incompatibility[Any, Any]) -> str:
-    """Format a human-readable error from an incompatibility derivation tree."""
+def format_error(
+    root_incompatibility: Incompatibility[Any, Any],
+    narrow: _NarrowFn | None = None,
+) -> str:
+    """Format a human-readable error from an incompatibility derivation tree.
+
+    ``narrow`` maps ``(package, constraint)`` to a display constraint and is
+    applied to originally-positive terms only; a negative dependency-side
+    term renders as requested even when displayed negated.  Narrowing
+    happens at render time only, never mutating the derivation tree.
+    """
     lines: list[str] = []
-    explain_incompatibility(root_incompatibility, lines, set())
+    explain_incompatibility(root_incompatibility, lines, set(), narrow)
     return "\n".join(lines) if lines else "Resolution impossible"
 
 
@@ -41,6 +54,7 @@ def explain_incompatibility(
     incompatibility: Incompatibility[Any, Any],
     lines: list[str],
     visited_ids: set[int],
+    narrow: _NarrowFn | None = None,
 ) -> None:
     """Walk the cause tree appending one explanatory line per node."""
     if id(incompatibility) in visited_ids:
@@ -49,17 +63,33 @@ def explain_incompatibility(
 
     if incompatibility.cause == IncompatibilityCause.DERIVED:
         if incompatibility.cause_left:
-            explain_incompatibility(incompatibility.cause_left, lines, visited_ids)
+            explain_incompatibility(
+                incompatibility.cause_left, lines, visited_ids, narrow
+            )
         if incompatibility.cause_right:
-            explain_incompatibility(incompatibility.cause_right, lines, visited_ids)
+            explain_incompatibility(
+                incompatibility.cause_right, lines, visited_ids, narrow
+            )
 
-    lines.append(_render_line(incompatibility))
+    lines.append(_render_line(incompatibility, narrow))
 
 
-def _render_line(incompatibility: Incompatibility[Any, Any]) -> str:
+def _narrow_positive(term: Term[Any, Any], narrow: _NarrowFn) -> Term[Any, Any]:
+    """Return ``term`` with a narrowed constraint when originally positive."""
+    if not term.is_positive():
+        return term
+    return Term(term.package, narrow(term.package, term.constraint), positive=True)
+
+
+def _render_line(
+    incompatibility: Incompatibility[Any, Any],
+    narrow: _NarrowFn | None,
+) -> str:
     """Render a single incompatibility as one explanation line."""
     cause = incompatibility.cause
     terms = incompatibility.terms
+    if narrow is not None:
+        terms = [_narrow_positive(term, narrow) for term in terms]
 
     # Attribution form for the two standard two-term clauses.
     if (

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -155,6 +155,33 @@ class ResolverProvider(Protocol[PackageType, VersionType]):
         """
         ...
 
+    def widen_decision(
+        self, package: PackageType, version: VersionType
+    ) -> RangeProtocol[VersionType] | None:
+        """Return a widened stand-in for ``version`` in dependency clauses, or None.
+
+        Soundness contract: the returned range must contain ``version`` and
+        no other version that could ever be chosen for ``package`` in this
+        resolution; versions inside it that can never be selected are
+        harmless.  ``None`` keeps the exact singleton.  Widening lets
+        dependency clauses for adjacent rejected versions merge into
+        contiguous ranges instead of accumulating one hole per version.
+        """
+        ...
+
+    def narrow_for_display(
+        self, package: PackageType, constraint: RangeProtocol[VersionType]
+    ) -> RangeProtocol[VersionType]:
+        """Map a possibly-widened ``constraint`` back onto known versions.
+
+        Applied at error-render time only; the derivation state is never
+        mutated.  The renderer narrows every originally-positive term, so
+        ``package`` may be the virtual root sentinel or another package
+        outside the provider's namespace; return such constraints
+        unchanged, as providers that do not widen do for all input.
+        """
+        ...
+
 
 @dataclass
 class ResolverStats(Generic[PackageType]):
@@ -404,24 +431,25 @@ class Resolver(Generic[PackageType, VersionType]):
         )
 
         dependencies = self.provider.get_dependencies(next_package, chosen_version)
+        if not dependencies:
+            return next_package
+        exact_range = self.range_type.singleton(chosen_version)
+        widened = self.provider.widen_decision(next_package, chosen_version)
+        parent_range = exact_range if widened is None else widened
         for dependency_package, dependency_range in dependencies.items():
-            package_term = Term(
-                next_package,
-                self.range_type.singleton(chosen_version),
-                positive=True,
-            )
             cross_package = dependency_package != next_package
             if not cross_package:
                 # An incompatibility holds at most one term per package,
                 # so self-dependency terms merge to {v} & ~range: empty
                 # (a vacuous clause) when the range contains the chosen
-                # version, else exactly {v}.
+                # version, else exactly {v}.  The exact singleton is kept:
+                # widening a single-term clause only degrades error text.
                 if chosen_version in dependency_range:
                     continue
-                terms = [package_term]
+                terms = [Term(next_package, exact_range, positive=True)]
             else:
                 terms = [
-                    package_term,
+                    Term(next_package, parent_range, positive=True),
                     Term(dependency_package, dependency_range, positive=False),
                 ]
             incompatibility = Incompatibility(

--- a/nab-resolver/tests/property/providers.py
+++ b/nab-resolver/tests/property/providers.py
@@ -84,6 +84,18 @@ class FuzzProvider:
         """No force-backtrack signal from this test provider."""
         return []
 
+    def widen_decision(self, package: str, version: int) -> RangeProtocol[int] | None:
+        """No widening: dependency clauses keep the exact decided version."""
+        del package, version
+        return None
+
+    def narrow_for_display(
+        self, package: str, constraint: RangeProtocol[int]
+    ) -> RangeProtocol[int]:
+        """Identity: constraints render as stored."""
+        del package
+        return constraint
+
 
 class PromotingFuzzProvider:
     """Provider that promotes packages above a conflict threshold.
@@ -164,6 +176,18 @@ class PromotingFuzzProvider:
         """No force-backtrack signal from this test provider."""
         return []
 
+    def widen_decision(self, package: str, version: int) -> RangeProtocol[int] | None:
+        """No widening: dependency clauses keep the exact decided version."""
+        del package, version
+        return None
+
+    def narrow_for_display(
+        self, package: str, constraint: RangeProtocol[int]
+    ) -> RangeProtocol[int]:
+        """Identity: constraints render as stored."""
+        del package
+        return constraint
+
 
 class OldestFirstProvider:
     """Provider that picks the oldest version instead of newest.
@@ -234,6 +258,18 @@ class OldestFirstProvider:
     def consume_force_backtrack_targets(self) -> list[str]:
         """No force-backtrack signal from this test provider."""
         return []
+
+    def widen_decision(self, package: str, version: int) -> RangeProtocol[int] | None:
+        """No widening: dependency clauses keep the exact decided version."""
+        del package, version
+        return None
+
+    def narrow_for_display(
+        self, package: str, constraint: RangeProtocol[int]
+    ) -> RangeProtocol[int]:
+        """Identity: constraints render as stored."""
+        del package
+        return constraint
 
 
 def verify_solution(

--- a/nab-resolver/tests/property/test_resolver_oracle.py
+++ b/nab-resolver/tests/property/test_resolver_oracle.py
@@ -148,6 +148,18 @@ class ConstantPriorityProvider:
         """No force-backtrack signal from this provider."""
         return []
 
+    def widen_decision(self, package: str, version: int) -> RangeProtocol[int] | None:
+        """No widening: dependency clauses keep the exact decided version."""
+        del package, version
+        return None
+
+    def narrow_for_display(
+        self, package: str, constraint: RangeProtocol[int]
+    ) -> RangeProtocol[int]:
+        """Identity: constraints render as stored."""
+        del package
+        return constraint
+
 
 class LookaheadProvider:
     """Provider exercising the pending-clauses and force-backtrack contract.
@@ -246,6 +258,18 @@ class LookaheadProvider:
         targets = self._force_targets
         self._force_targets = []
         return targets
+
+    def widen_decision(self, package: str, version: int) -> RangeProtocol[int] | None:
+        """No widening: dependency clauses keep the exact decided version."""
+        del package, version
+        return None
+
+    def narrow_for_display(
+        self, package: str, constraint: RangeProtocol[int]
+    ) -> RangeProtocol[int]:
+        """Identity: constraints render as stored."""
+        del package
+        return constraint
 
 
 def _assert_closure(result: dict[str, int], deps: Deps, roots: Roots) -> None:

--- a/nab-resolver/tests/test_decide.py
+++ b/nab-resolver/tests/test_decide.py
@@ -130,6 +130,14 @@ class _InertProvider:
     def consume_force_backtrack_targets(self) -> list[Any]:
         return []
 
+    def widen_decision(self, package: Any, version: int) -> RangeProtocol[int] | None:
+        return None
+
+    def narrow_for_display(
+        self, package: Any, constraint: RangeProtocol[int]
+    ) -> RangeProtocol[int]:
+        return constraint
+
 
 def _resolver() -> tuple[Resolver[Any, int], _RecordingObserver]:
     observer = _RecordingObserver()

--- a/nab-resolver/tests/test_priority.py
+++ b/nab-resolver/tests/test_priority.py
@@ -71,6 +71,16 @@ class _TrackingProvider:
         """No force-backtrack signal from this test provider."""
         return []
 
+    def widen_decision(self, package: str, version: int) -> RangeProtocol[int] | None:
+        """No widening: dependency clauses keep the exact decided version."""
+        return None
+
+    def narrow_for_display(
+        self, package: str, constraint: RangeProtocol[int]
+    ) -> RangeProtocol[int]:
+        """Identity: constraints render as stored."""
+        return constraint
+
 
 class _PromotingProvider:
     """Provider that promotes packages with 3+ conflicts."""
@@ -129,6 +139,16 @@ class _PromotingProvider:
     def consume_force_backtrack_targets(self) -> list[str]:
         """No force-backtrack signal from this test provider."""
         return []
+
+    def widen_decision(self, package: str, version: int) -> RangeProtocol[int] | None:
+        """No widening: dependency clauses keep the exact decided version."""
+        return None
+
+    def narrow_for_display(
+        self, package: str, constraint: RangeProtocol[int]
+    ) -> RangeProtocol[int]:
+        """Identity: constraints render as stored."""
+        return constraint
 
 
 class TestConflictCountsReachProvider:

--- a/nab-resolver/tests/test_priority.py
+++ b/nab-resolver/tests/test_priority.py
@@ -203,4 +203,6 @@ class TestPromotingProvider:
         except ResolutionError:
             pass
         assert resolver.stats.conflicts > 0
-        assert resolver.stats.package_conflict_counts.get("D", 0) > 0
+        # The credit lands on the depending package whose clause pinned D
+        # (conflict_credit_target), not on D itself.
+        assert resolver.stats.package_conflict_counts.get("E", 0) > 0

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -104,6 +104,16 @@ class DictProvider:
         """No force-backtrack signal from this provider."""
         return []
 
+    def widen_decision(self, package: str, version: int) -> RangeProtocol[int] | None:
+        """No widening: dependency clauses keep the exact decided version."""
+        return None
+
+    def narrow_for_display(
+        self, package: str, constraint: RangeProtocol[int]
+    ) -> RangeProtocol[int]:
+        """Identity: constraints render as stored."""
+        return constraint
+
 
 class PromotingProvider(DictProvider):
     """DictProvider that promotes packages with 5+ conflicts."""

--- a/nab-resolver/tests/test_widen_hook.py
+++ b/nab-resolver/tests/test_widen_hook.py
@@ -1,0 +1,335 @@
+"""Tests for the decision-widening provider hooks.
+
+``widen_decision`` lets a provider replace the exact singleton parent term
+of a cross-package dependency clause with a wider range containing no other
+selectable version, so adjacent clauses merge contiguously instead of
+accumulating one hole per rejected version. ``narrow_for_display`` maps
+possibly-widened constraints back onto known versions at error-render time.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pytest
+
+from nab_resolver.ranges import Range
+from nab_resolver.report import format_error
+from nab_resolver.resolver import ResolutionError, Resolver
+from nab_resolver.root import ROOT
+from nab_resolver.types import (
+    Incompatibility,
+    IncompatibilityCause,
+    RangeProtocol,
+    Term,
+)
+
+
+class _BaseProvider:
+    """In-memory provider mirroring test_resolver's DictProvider."""
+
+    def __init__(self, packages: dict[str, dict[int, dict[str, Range]]]) -> None:
+        self._packages = packages
+
+    def _get_versions(self, package: str) -> list[int]:
+        if package not in self._packages:
+            return []
+        return sorted(self._packages[package].keys(), reverse=True)
+
+    def choose_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> int | None:
+        for version in self._get_versions(package):
+            if version in version_range:
+                return version
+        return None
+
+    def has_satisfying_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> bool:
+        return any(v in version_range for v in self._get_versions(package))
+
+    def get_dependencies(self, package: str, version: int) -> dict[str, Range]:
+        return self._packages.get(package, {}).get(version, {})
+
+    def prioritize(
+        self,
+        package: str,
+        version_range: RangeProtocol[int],
+        conflict_counts: Mapping[str, int],
+        culprit_counts: Mapping[str, int] | None = None,
+    ) -> object:
+        versions = self._get_versions(package)
+        return sum(1 for v in versions if v in version_range)
+
+    def is_ready(self, package: str) -> bool:
+        """All packages decidable immediately in tests."""
+        return True
+
+    def receive_partial_solution_hint(
+        self,
+        positive_ranges: Mapping[str, RangeProtocol[int]],
+        decisions: Mapping[str, int],
+    ) -> None:
+        """No-op: test provider does not use partial solution state."""
+
+    def consume_pending_clauses(self) -> list[Incompatibility[str, int]]:
+        """No queued clauses for this in-memory provider."""
+        return []
+
+    def consume_force_backtrack_targets(self) -> list[str]:
+        """No force-backtrack signal from this provider."""
+        return []
+
+    def widen_decision(self, package: str, version: int) -> RangeProtocol[int] | None:
+        """No widening: dependency clauses keep the exact decided version."""
+        return None
+
+    def narrow_for_display(
+        self, package: str, constraint: RangeProtocol[int]
+    ) -> RangeProtocol[int]:
+        """Identity: constraints render as stored."""
+        return constraint
+
+
+class _RecordingWidenProvider(_BaseProvider):
+    """Records every ``widen_decision`` call and declines to widen."""
+
+    def __init__(self, packages: dict[str, dict[int, dict[str, Range]]]) -> None:
+        super().__init__(packages)
+        self.widen_calls: list[tuple[object, int]] = []
+
+    def widen_decision(self, package: str, version: int) -> RangeProtocol[int] | None:
+        self.widen_calls.append((package, version))
+        return None
+
+
+class _WideningProvider(_BaseProvider):
+    """Widens a decided version to the open gap between its listed neighbors."""
+
+    def widen_decision(self, package: str, version: int) -> RangeProtocol[int] | None:
+        universe = sorted(self._packages.get(package, {}).keys())
+        if version not in universe:
+            return None
+        index = universe.index(version)
+        widened: Range[int] = Range.full()
+        if index > 0:
+            widened = widened & Range.greater_than(universe[index - 1])
+        if index < len(universe) - 1:
+            widened = widened & Range.less_than(universe[index + 1])
+        return widened
+
+
+class _NarrowingProvider(_BaseProvider):
+    """Narrows displayed constraints for one package to a fixed range."""
+
+    def __init__(
+        self,
+        packages: dict[str, dict[int, dict[str, Range]]],
+        target: str,
+        narrowed: Range[int],
+    ) -> None:
+        super().__init__(packages)
+        self._target = target
+        self._narrowed = narrowed
+        self.narrow_calls: list[object] = []
+
+    def narrow_for_display(
+        self, package: str, constraint: RangeProtocol[int]
+    ) -> RangeProtocol[int]:
+        self.narrow_calls.append(package)
+        if package == self._target:
+            return self._narrowed
+        return constraint
+
+
+class TestWidenDecisionNoneIsToday:
+    """The default hook (returning None) must not change behavior."""
+
+    def test_multi_package_backtracking_scenario_unchanged(self) -> None:
+        """Deep-backtracking graph: same result and same decision count as
+        the exact-singleton resolver produces (captured before the hook
+        existed: result {root: 1, a: 1, c: 2}, 9 decisions)."""
+        provider = _BaseProvider(
+            {
+                "root": {1: {"a": Range.full(), "c": Range.full()}},
+                "a": {2: {"b": Range.at_least(2)}, 1: {}},
+                "b": {2: {"c": Range.at_least(3)}, 1: {}},
+                "c": {2: {}, 1: {}},
+            }
+        )
+        resolver = Resolver(provider)
+        result = resolver.resolve({"root": Range.singleton(1)})
+        assert result == {"root": 1, "a": 1, "c": 2}
+        assert resolver.stats.decisions == 9
+
+
+class TestWideningMergesDependencyClauses:
+    def test_widened_clauses_merge_into_single_interval(self) -> None:
+        """Three rejected versions of ``a`` sharing one dep constraint must
+        leave a single-interval merged DEPENDENCY clause, not a 3-hole union.
+        """
+        provider = _WideningProvider(
+            {
+                "root": {1: {"a": Range.full()}},
+                "a": {
+                    3: {"b": Range.singleton(5)},
+                    2: {"b": Range.singleton(5)},
+                    1: {"b": Range.singleton(5)},
+                },
+                "b": {1: {}},
+            }
+        )
+        resolver = Resolver(provider)
+        with pytest.raises(ResolutionError):
+            resolver.resolve({"root": Range.singleton(1)})
+
+        merged = [
+            inc
+            for inc in resolver.incompatibilities
+            if inc.cause is IncompatibilityCause.DEPENDENCY
+            and len(inc.terms) == 2
+            and inc.terms[0].package == "a"
+            and inc.terms[1].package == "b"
+        ]
+        assert len(merged) == 1
+        constraint = merged[0].terms[0].constraint
+        assert isinstance(constraint, Range)
+        assert len(constraint._intervals) == 1
+        assert 1 in constraint
+        assert 2 in constraint
+        assert 3 in constraint
+
+    def test_widening_does_not_change_unsat_outcome(self) -> None:
+        """The same impossible graph fails with and without widening."""
+        packages = {
+            "root": {1: {"a": Range.full()}},
+            "a": {
+                3: {"b": Range.singleton(5)},
+                2: {"b": Range.singleton(5)},
+                1: {"b": Range.singleton(5)},
+            },
+            "b": {1: {}},
+        }
+        with pytest.raises(ResolutionError):
+            Resolver(_BaseProvider(packages)).resolve({"root": Range.singleton(1)})
+        with pytest.raises(ResolutionError):
+            Resolver(_WideningProvider(packages)).resolve({"root": Range.singleton(1)})
+
+
+class TestSelfDependencyStaysExact:
+    def test_self_dep_clause_keeps_singleton_term(self) -> None:
+        """foo@2 depends on foo=={1}: the single-term clause asserts exactly
+        "foo is never 2", even when the provider widens decisions."""
+        provider = _WideningProvider({"foo": {2: {"foo": Range.singleton(1)}, 1: {}}})
+        resolver = Resolver(provider, max_iterations=100)
+        result = resolver.resolve({"foo": Range.full()})
+        assert result == {"foo": 1}
+
+        self_clauses = [
+            inc
+            for inc in resolver.incompatibilities
+            if inc.cause is IncompatibilityCause.DEPENDENCY
+            and len(inc.terms) == 1
+            and inc.terms[0].package == "foo"
+        ]
+        assert len(self_clauses) == 1
+        assert self_clauses[0].terms[0].constraint == Range.singleton(2)
+        assert self_clauses[0].terms[0].is_positive()
+
+
+class TestRootIsNeverWidened:
+    def test_widen_decision_never_called_with_root_sentinel(self) -> None:
+        provider = _RecordingWidenProvider(
+            {
+                "root": {1: {"foo": Range.full(), "bar": Range.full()}},
+                "foo": {1: {"baz": Range.at_least(2)}},
+                "bar": {1: {}},
+                "baz": {2: {}, 1: {}},
+            }
+        )
+        resolver = Resolver(provider)
+        resolver.resolve({"root": Range.singleton(1)})
+        assert provider.widen_calls
+        assert all(package is not ROOT for package, _ in provider.widen_calls)
+
+
+class TestFormatErrorNarrow:
+    def test_narrow_applies_to_parent_side_not_dependency_side(self) -> None:
+        """The positive parent term is narrowed; the originally-negative dep
+        term renders as requested even though it is displayed positively."""
+        clause = Incompatibility(
+            [
+                Term("foo", Range.between(1, 4), positive=True),
+                Term("bar", Range.at_least(3), positive=False),
+            ],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+        narrowed_packages: list[object] = []
+
+        def narrow(package: object, constraint: Range[int]) -> Range[int]:
+            narrowed_packages.append(package)
+            if package == "foo":
+                return Range.singleton(2)
+            return Range.singleton(9)
+
+        message = format_error(clause, narrow=narrow)
+        assert message == "because foo 2 depends on bar [3, +inf)"
+        assert narrowed_packages == ["foo"]
+
+    def test_narrow_applies_to_no_versions_term(self) -> None:
+        clause = Incompatibility(
+            [Term("qux", Range.at_least(5), positive=True)],
+            cause=IncompatibilityCause.NO_VERSIONS,
+        )
+        message = format_error(
+            clause, narrow=lambda package, constraint: Range.singleton(7)
+        )
+        assert message == "because no versions of qux 7 are available"
+
+    def test_narrow_applies_to_derived_positive_terms(self) -> None:
+        clause = Incompatibility(
+            [
+                Term("a", Range.between(1, 9), positive=True),
+                Term("b", Range.between(1, 9), positive=False),
+            ],
+            cause=IncompatibilityCause.DERIVED,
+        )
+
+        def narrow(package: object, constraint: Range[int]) -> Range[int]:
+            return Range.singleton(3)
+
+        message = format_error(clause, narrow=narrow)
+        assert message == "so a 3 and not b [1, 9)"
+
+    def test_raise_site_narrows_through_provider(self) -> None:
+        """The resolver passes ``narrow_for_display`` to ``format_error``:
+        the positive NO_VERSIONS term is narrowed, the negative dep side of
+        the DEPENDENCY clause still renders the requested range."""
+        provider = _NarrowingProvider(
+            {"root": {1: {"foo": Range.full()}}},
+            target="foo",
+            narrowed=Range.between(5, 7),
+        )
+        resolver = Resolver(provider)
+        with pytest.raises(ResolutionError) as exc_info:
+            resolver.resolve({"root": Range.singleton(1)})
+        message = str(exc_info.value)
+        assert "because no versions of foo [5, 7) are available" in message
+        assert "depends on foo *" in message
+        assert provider.narrow_calls
+
+    def test_identity_narrow_keeps_message_byte_identical(self) -> None:
+        """A provider with the identity ``narrow_for_display`` renders the
+        exact message the resolver produced before the hook existed."""
+        provider = _BaseProvider({"root": {1: {"foo": Range.full()}}})
+        resolver = Resolver(provider)
+        with pytest.raises(ResolutionError) as exc_info:
+            resolver.resolve({"root": Range.singleton(1)})
+        assert str(exc_info.value) == (
+            "because no versions of foo * are available\n"
+            "because root 1 depends on foo *\n"
+            "so root 1\n"
+            "because your project depends on root 1\n"
+            "so <root> 1"
+        )

--- a/nab-resolver/tests/test_widen_hook.py
+++ b/nab-resolver/tests/test_widen_hook.py
@@ -13,6 +13,8 @@ from collections.abc import Mapping
 
 import pytest
 
+from nab_resolver.conflict import conflict_credit_target
+from nab_resolver.partial_solution import Assignment
 from nab_resolver.ranges import Range
 from nab_resolver.report import format_error
 from nab_resolver.resolver import ResolutionError, Resolver
@@ -333,3 +335,56 @@ class TestFormatErrorNarrow:
             "because your project depends on root 1\n"
             "so <root> 1"
         )
+
+
+class TestConflictCreditTarget:
+    """The one conflict credit moves to the depending package when the
+    satisfier is a derivation propagated from its dependency clause (the
+    situation widened parent terms make common)."""
+
+    def _dependency_clause(self) -> Incompatibility[str, int]:
+        return Incompatibility(
+            [
+                Term("parent", Range.between(1, 3), positive=True),
+                Term("child", Range.at_least(2), positive=False),
+            ],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+
+    def _derivation(
+        self, package: str, cause: Incompatibility[str, int]
+    ) -> Assignment[str, int]:
+        return Assignment(
+            package=package,
+            accumulated_range=Range.at_least(2),
+            decision_level=3,
+            is_decision=False,
+            cause=cause,
+        )
+
+    def test_derivation_from_dependency_clause_targets_parent(self) -> None:
+        satisfier = self._derivation("child", self._dependency_clause())
+        assert conflict_credit_target(satisfier) == "parent"
+
+    def test_decision_satisfier_targets_itself(self) -> None:
+        decision = Assignment(
+            package="child",
+            accumulated_range=Range.singleton(2),
+            decision_level=3,
+            is_decision=True,
+        )
+        assert conflict_credit_target(decision) == "child"
+
+    def test_non_dependency_cause_targets_itself(self) -> None:
+        derived: Incompatibility[str, int] = Incompatibility(
+            [Term("child", Range.at_least(2), positive=False)],
+            cause=IncompatibilityCause.DERIVED,
+        )
+        assert conflict_credit_target(self._derivation("child", derived)) == "child"
+
+    def test_self_dependency_clause_targets_itself(self) -> None:
+        self_dep: Incompatibility[str, int] = Incompatibility(
+            [Term("child", Range.singleton(2), positive=True)],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+        assert conflict_credit_target(self._derivation("child", self_dep)) == "child"

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -1,0 +1,222 @@
+diff --git a/nab-python/src/nab_python/_vendor/packaging/ranges.py b/nab-python/src/nab_python/_vendor/packaging/ranges.py
+index 8dd5e66..0d33d1c 100644
+--- a/nab-python/src/nab_python/_vendor/packaging/ranges.py
++++ b/nab-python/src/nab_python/_vendor/packaging/ranges.py
+@@ -280,6 +280,47 @@ def _struct_admits(
+     return matches_bounds_only(bounds, parsed)
+ 
+ 
++def _bisect_predicate(
++    versions: Sequence[Version], predicate: Callable[[Version], bool]
++) -> int:
++    """First index whose ``predicate`` is true over an ascending list.
++
++    The predicate must be monotonic (false runs then true runs). Equivalent to
++    ``bisect.bisect_left`` on the mapped booleans, done by hand because the
++    ``key`` parameter for :mod:`bisect` only exists on Python 3.10 and later.
++    """
++    low, high = 0, len(versions)
++    while low < high:
++        mid = (low + high) // 2
++        if predicate(versions[mid]):
++            high = mid
++        else:
++            low = mid + 1
++    return low
++
++
++def _partition_indexes(
++    versions: Sequence[Version], lower: LowerBound, upper: UpperBound
++) -> tuple[int, int]:
++    """Locate one interval's bounds in an ascending version list.
++
++    Returns ``(first_inside, first_above)``: the index of the first version at
++    or above ``lower`` and of the first version strictly above ``upper``, so
++    ``versions[first_inside:first_above]`` are the versions the interval
++    contains. The bound predicates are monotonic over an ascending list, so
++    both cuts bisect on the predicate value.
++    """
++    above = lower._above
++    below = upper._below
++
++    first_inside = 0 if above is None else _bisect_predicate(versions, above)
++    if below is None:
++        first_above = len(versions)
++    else:
++        first_above = _bisect_predicate(versions, lambda v: not below(v))
++    return first_inside, first_above
++
++
+ # Repr helpers:
+ 
+ 
+@@ -316,7 +357,8 @@ class VersionRange:
+     :class:`~packaging.specifiers.SpecifierSet`.
+ 
+     Construct via :meth:`~packaging.specifiers.SpecifierSet.to_range`, or with
+-    the :meth:`full`, :meth:`empty`, and :meth:`singleton` class methods.
++    the :meth:`full`, :meth:`empty`, :meth:`singleton`, and :meth:`from_bounds`
++    class methods.
+     Compose with :meth:`intersection`, :meth:`union`, :meth:`complement`, and
+     :meth:`difference` (or the ``&`` / ``|`` / ``~`` / ``-`` operators). Test
+     membership with ``in`` or :meth:`contains`, filter an iterable with
+@@ -407,7 +449,8 @@ class VersionRange:
+         raise TypeError(
+             "cannot create 'VersionRange' instances directly; use "
+             "SpecifierSet.to_range(), VersionRange.full(), "
+-            "VersionRange.empty(), or VersionRange.singleton() instead"
++            "VersionRange.empty(), VersionRange.singleton(), or "
++            "VersionRange.from_bounds() instead"
+         )
+ 
+     @classmethod
+@@ -599,6 +642,73 @@ class VersionRange:
+             prereleases_configured=prereleases,
+         )
+ 
++    @classmethod
++    def from_bounds(
++        cls,
++        lower: Version | str | None = None,
++        upper: Version | str | None = None,
++        *,
++        include_lower: bool = True,
++        include_upper: bool = True,
++        prereleases: bool | None = None,
++    ) -> VersionRange:
++        """Return the raw version-order interval from ``lower`` to ``upper``.
++
++        A single interval in the PEP 440 total order. The bounds are pure order
++        cuts, not specifier semantics: ``None`` on a side is unbounded there.
++        Both ends are inclusive by default, so ``from_bounds(v, v)`` is
++        :meth:`singleton`; pass ``include_lower=False`` or ``include_upper=False``
++        for a half-open interval.
++
++        >>> "2.0" in VersionRange.from_bounds("1.0", "2.0")
++        True
++        >>> "2.0" in VersionRange.from_bounds("1.0", "2.0", include_upper=False)
++        False
++        >>> VersionRange.from_bounds("1.5", "1.5") == VersionRange.singleton("1.5")
++        True
++
++        Membership is decided by the bounds alone, so pre-releases, post-releases,
++        and locals inside them are members even where the matching specifier
++        would exclude them:
++
++        >>> "1.0.post1" in VersionRange.from_bounds("1.0", "2.0", include_lower=False)
++        True
++        >>> "1.0.post1" in SpecifierSet(">1.0,<2.0").to_range()
++        False
++        >>> "2.0rc1" in VersionRange.from_bounds("1.0", "2.0")
++        True
++        >>> "2.0rc1" in SpecifierSet(">=1.0,<2.0").to_range()
++        False
++
++        An inverted pair, or an equal pair with either end exclusive, is the
++        empty range; an unbounded pair is the versions-only full range.
++
++        >>> VersionRange.from_bounds("2.0", "1.0").is_empty
++        True
++        >>> VersionRange.from_bounds() == VersionRange.full(admit_arbitrary=False)
++        True
++
++        :raises packaging.version.InvalidVersion: if ``lower`` or ``upper`` is a
++            string that does not parse as a PEP 440 version.
++        """
++        if lower is not None and not isinstance(lower, Version):
++            lower = Version(lower)
++        if upper is not None and not isinstance(upper, Version):
++            upper = Version(upper)
++
++        if lower is not None and upper is not None:
++            closed = include_lower and include_upper
++            if lower > upper or (lower == upper and not closed):
++                return cls.empty(prereleases=prereleases)
++
++        lower_bound = NEG_INF if lower is None else LowerBound(lower, include_lower)
++        upper_bound = POS_INF if upper is None else UpperBound(upper, include_upper)
++
++        return cls._build(
++            _canonical_floor(((lower_bound, upper_bound),)),
++            prereleases_configured=prereleases,
++        )
++
+     def intersection(self, other: VersionRange) -> VersionRange:
+         """Range containing exactly the versions in both self and other.
+ 
+@@ -1078,6 +1188,75 @@ class VersionRange:
+         if not found_final:
+             yield from all_nonfinal
+ 
++    def snap_bounds(self, versions: Iterable[Version | str]) -> VersionRange:
++        """Snap each finite bound inward onto the given versions.
++
++        Returns a subset of self that agrees with self on membership of every
++        given version: each finite segment end moves inward onto the outermost
++        given version its segment contains, and a bound with no given version
++        to land on is unchanged, as are unbounded ends.
++
++        Solver arithmetic and set algebra leave bounds at versions nobody
++        released; snapping them onto real versions yields the range a human
++        would write, and the subset guarantee means the snapped range never
++        admits a version the original excluded, even if the given list was
++        stale.
++
++        ``versions`` may be any iterable of versions or version strings, in any
++        order; it is sorted internally. ``snap_bounds([])`` returns an equal
++        range.
++
++        >>> r = SpecifierSet(">=1.0,<2.0").to_range()
++        >>> r.snap_bounds(["1.2", "1.5", "1.8"])
++        <VersionRange '[1.2, 1.8]'>
++        >>> SpecifierSet(">=1.0").to_range().snap_bounds(["1.2", "1.5"])
++        <VersionRange '[1.2, +inf)'>
++        >>> r.snap_bounds([]) == r
++        True
++
++        A version-order gap round-trips to the singleton it surrounds:
++
++        >>> versions = [Version("1.0"), Version("2.0"), Version("3.0")]
++        >>> gap = VersionRange.from_bounds(
++        ...     "1.0", "3.0", include_lower=False, include_upper=False
++        ... )
++        >>> gap.snap_bounds(versions) == VersionRange.singleton("2.0")
++        True
++
++        :raises packaging.version.InvalidVersion: if a string does not parse as a
++            PEP 440 version.
++        """
++        anchors = sorted(v if isinstance(v, Version) else Version(v) for v in versions)
++        if not self._bounds:
++            return self
++
++        simplified: list[Interval] = []
++        for lower, upper in self._bounds:
++            first_inside, first_above = _partition_indexes(anchors, lower, upper)
++            if first_inside >= first_above:
++                simplified.append((lower, upper))
++                continue
++            new_lower = (
++                lower
++                if lower.version is None
++                else LowerBound(anchors[first_inside], True)
++            )
++            new_upper = (
++                upper
++                if upper.version is None
++                else UpperBound(anchors[first_above - 1], True)
++            )
++            simplified.append((new_lower, new_upper))
++
++        return self._build(
++            _canonical_floor(tuple(simplified)),
++            admit=self._admit,
++            reject=self._reject,
++            admit_arbitrary=self._admit_arbitrary,
++            pre_region=self._pre_region,
++            prereleases_configured=self._prereleases_configured,
++        )
++
+     @classmethod
+     def _from_specifier_set(cls, specifier_set: SpecifierSet) -> VersionRange:
+         """Build the range accepted by ``specifier_set``.


### PR DESCRIPTION
Ports uv's decided-version widening (astral-sh/pubgrub PR 75) to nab. A positive term over an already-decided package is widened to the open gap between its listed neighbours, cutting intersection and range work in conflict-heavy backtracking.

Wall time across scenarios that pass on both sides: about -23% (kedro 21s to 4s, langchain 15s to 4s). Net +4 successes (six FAIL to OK, including pandas-with-aws-s3 and apache-airflow-311-full).

Widening changes which derivation satisfies a decided term, which starved nab's conflict crediting, so the credit moves to the dependency parent (second commit). Open item: pdm-skypilot-dvc regresses under the current crediting shape, which is why this is a draft.
