### PR TITLE
reject a non-JSON Simple-API listing before it is cached

### DIFF
--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -118,13 +118,29 @@ class CachedAsyncSimpleClient:
         if cached is not None:
             body, policy = cached
             if policy.is_fresh() or self._offline:
-                return _parse_files(json.loads(body), self._index_url, package)
+                return self._parse_listing(body, package)
             return await self._revalidate_simple(package, body, policy)
 
         if self._offline:
             msg = f"No cached listing for {package} (offline mode)"
             raise OfflineError(msg)
         return await self._fetch_simple(package)
+
+    def _parse_listing(self, body: bytes, package: str) -> list[WheelFile | SdistFile]:
+        """Parse a Simple-API listing body, raising :class:`TypeError` on non-JSON.
+
+        A non-JSON body raises the same :class:`TypeError` as a valid-JSON body
+        of the wrong shape, not a raw :class:`json.JSONDecodeError`.
+        """
+        try:
+            data = json.loads(body)
+        except json.JSONDecodeError as exc:
+            msg = (
+                f"{self._index_url} served a malformed Simple-API response for "
+                f"{package!r}: body is not valid JSON"
+            )
+            raise TypeError(msg) from exc
+        return _parse_files(data, self._index_url, package)
 
     async def _revalidate_simple(
         self, package: str, body: bytes, policy: CachePolicy
@@ -141,19 +157,23 @@ class CachedAsyncSimpleClient:
                 etag=_header(response, "etag") or policy.etag,
             )
             self._cache.refresh_simple_policy(package, new_policy)
-            return _parse_files(json.loads(body), self._index_url, package)
+            return self._parse_listing(body, package)
 
         if response.status_code == _HTTP_NOT_FOUND:
             return []
         response.raise_for_status()
         new_body = response.content
+
+        # Parse before caching so a bad body never poisons the cache.
+        files = self._parse_listing(new_body, package)
+
         new_policy = CachePolicy(
             fetched_at=int(time.time()),
             max_age=_parse_max_age(_header(response, "cache-control")),
             etag=_header(response, "etag"),
         )
         self._cache.put_simple(package, new_body, new_policy)
-        return _parse_files(json.loads(new_body), self._index_url, package)
+        return files
 
     async def _fetch_simple(self, package: str) -> list[WheelFile | SdistFile]:
         url = f"{self._index_url}{package}/"
@@ -162,13 +182,17 @@ class CachedAsyncSimpleClient:
             return []
         response.raise_for_status()
         body = response.content
+
+        # Parse before caching so a bad body never poisons the cache.
+        files = self._parse_listing(body, package)
+
         policy = CachePolicy(
             fetched_at=int(time.time()),
             max_age=_parse_max_age(_header(response, "cache-control")),
             etag=_header(response, "etag"),
         )
         self._cache.put_simple(package, body, policy)
-        return _parse_files(json.loads(body), self._index_url, package)
+        return files
 
     async def get_metadata_text(
         self,

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -951,6 +951,86 @@ class TestGetFiles:
         assert len(files) == 1
 
 
+class TestNonJsonListingBody:
+    """A 200 response whose body is not JSON must not poison the cache.
+
+    An index that ignores the JSON Accept header can serve PEP 503 HTML
+    (or a proxy/captive-portal page) with status 200.
+    """
+
+    _HTML_BODY = b"<!DOCTYPE html><html><body>links</body></html>"
+
+    def test_cold_non_json_body_raises_clean_and_skips_cache(
+        self, tmp_path: Path
+    ) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport([_FakeResponse(self._HTML_BODY, status=200)])
+
+        async def go() -> list:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_files("foo")
+            finally:
+                await client.aclose()
+
+        with pytest.raises(TypeError, match="malformed Simple-API"):
+            asyncio.run(go())
+        assert cache.get_simple("foo") is None
+
+    def test_poisoned_cache_not_reproduced_offline(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        online = _FakeTransport([_FakeResponse(self._HTML_BODY, status=200)])
+
+        async def cold() -> list:
+            client = CachedAsyncSimpleClient(online, cache)
+            try:
+                return await client.get_files("foo")
+            finally:
+                await client.aclose()
+
+        with pytest.raises(TypeError, match="malformed Simple-API"):
+            asyncio.run(cold())
+        assert len(online.calls) == 1
+
+        offline = _FakeTransport()
+
+        async def later() -> list:
+            client = CachedAsyncSimpleClient(offline, cache, offline=True)
+            try:
+                return await client.get_files("foo")
+            finally:
+                await client.aclose()
+
+        with pytest.raises(OfflineError, match="foo"):
+            asyncio.run(later())
+        assert offline.calls == []
+
+    def test_revalidate_non_json_body_preserves_good_cache(
+        self, tmp_path: Path
+    ) -> None:
+        cache = _make_cache(tmp_path)
+        cache.put_simple(
+            "pkg",
+            LISTING_BYTES,
+            CachePolicy(fetched_at=0, max_age=1, etag="old"),
+        )
+        transport = _FakeTransport([_FakeResponse(self._HTML_BODY, status=200)])
+
+        async def go() -> list:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_files("pkg")
+            finally:
+                await client.aclose()
+
+        with pytest.raises(TypeError, match="malformed Simple-API"):
+            asyncio.run(go())
+        cached = cache.get_simple("pkg")
+        assert cached is not None
+        body, _ = cached
+        assert body == LISTING_BYTES
+
+
 class TestGetMetadataText:
     def test_cold_cache_fetches_and_stores(self, tmp_path: Path) -> None:
         cache = _make_cache(tmp_path)


### PR DESCRIPTION
A 200 Simple-API response with a non-JSON body crashed with a raw json.JSONDecodeError, and because the body was cached before it was parsed, every later resolve read that cached entry and aborted the same way, including --offline where there is no way to refetch.

This shows up when an index ignores the JSON Accept header and returns PEP 503 HTML, or when a proxy or captive portal answers 200 with its own page.

Parse each listing before caching it so a bad body never reaches disk. A non-JSON body now raises a TypeError naming the index and package, the same error type a valid-JSON body of the wrong shape already raised.
