### PR TITLE
Seed solver ranges without arbitrary admission

### DIFF
--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -155,9 +155,14 @@ def parse_requirements(
             )
             raise NotImplementedError(msg)
         name = canonicalize_name(req.name)
-        reqs[name] = reqs.get(name, VersionRange.full()) & req.specifier.to_range()
+        term = (
+            req.specifier.to_range()
+            if req.specifier
+            else VersionRange.full(admit_arbitrary=False)
+        )
+        reqs[name] = reqs.get(name, VersionRange.full()) & term
         for extra in req.extras:
-            reqs[f"{name}[{extra}]"] = VersionRange.full()
+            reqs[f"{name}[{extra}]"] = VersionRange.full(admit_arbitrary=False)
     return reqs
 
 

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -138,9 +138,14 @@ def parse_requirements(
             )
             raise NotImplementedError(msg)
         name = canonicalize_name(req.name)
-        reqs[name] = reqs.get(name, VersionRange.full()) & req.specifier.to_range()
+        term = (
+            req.specifier.to_range()
+            if req.specifier
+            else VersionRange.full(admit_arbitrary=False)
+        )
+        reqs[name] = reqs.get(name, VersionRange.full()) & term
         for extra in req.extras:
-            reqs[f"{name}[{extra}]"] = VersionRange.full()
+            reqs[f"{name}[{extra}]"] = VersionRange.full(admit_arbitrary=False)
     return reqs
 
 

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -558,16 +558,22 @@ def add_classified_dep(
     from ..provider import join_extra
 
     name = canonicalize_name(req.name)
-    vi = req.specifier.to_range()
+    # A bare dependency enters the solver without arbitrary-string admission;
+    # the accumulator identities stay arbitrary-admitting for === literals.
+    vi = (
+        req.specifier.to_range()
+        if req.specifier
+        else VersionRange.full(admit_arbitrary=False)
+    )
     dep_extras: set[str] = req.extras
 
     if not req_extras:
         base_deps[name] = base_deps.get(name, VersionRange.full()) & vi
         for re in dep_extras:
-            base_deps[join_extra(name, re)] = VersionRange.full()
+            base_deps[join_extra(name, re)] = VersionRange.full(admit_arbitrary=False)
     else:
         for extra_name in req_extras:
             edeps = extra_deps_map[extra_name]
             edeps[name] = edeps.get(name, VersionRange.full()) & vi
             for re in dep_extras:
-                edeps[join_extra(name, re)] = VersionRange.full()
+                edeps[join_extra(name, re)] = VersionRange.full(admit_arbitrary=False)

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -342,8 +342,17 @@ def _group_package_ranges(
         if req.url is not None:
             continue
         name = str(canonicalize_name(req.name))
+        # A bare requirement enters the solver without arbitrary-string
+        # admission, keeping subset and equality checks consistent with
+        # algebra-derived full-bounded terms. The accumulator identity stays
+        # arbitrary-admitting so === literals survive their first intersection.
         previous = ranges.get(name, VersionRange.full())
-        ranges[name] = previous & req.specifier.to_range()
+        term = (
+            req.specifier.to_range()
+            if req.specifier
+            else VersionRange.full(admit_arbitrary=False)
+        )
+        ranges[name] = previous & term
         sources[name].append(str(req))
     return ranges, sources
 
@@ -696,11 +705,16 @@ def _build_resolver_inputs(
             raise NotImplementedError(msg)
         name = str(canonicalize_name(req.name))
         previous = resolver_requirements.get(name, VersionRange.full())
-        resolver_requirements[name] = previous & req.specifier.to_range()
+        term = (
+            req.specifier.to_range()
+            if req.specifier
+            else VersionRange.full(admit_arbitrary=False)
+        )
+        resolver_requirements[name] = previous & term
         sources[name].append(str(req))
         for extra in req.extras:
             extra_key = join_extra(name, extra)
-            resolver_requirements[extra_key] = VersionRange.full()
+            resolver_requirements[extra_key] = VersionRange.full(admit_arbitrary=False)
             _, normalized_extra = split_extra(extra_key)
             assert normalized_extra is not None  # join_extra always sets one
             root_extras.add((name, normalized_extra))
@@ -1042,7 +1056,12 @@ def _build_constraints(
             )
             raise NotImplementedError(msg)
         name = str(canonicalize_name(req.name))
-        out[name] = out.get(name, VersionRange.full()) & req.specifier.to_range()
+        term = (
+            req.specifier.to_range()
+            if req.specifier
+            else VersionRange.full(admit_arbitrary=False)
+        )
+        out[name] = out.get(name, VersionRange.full()) & term
         sources[name].append(cstr)
     raise_for_unsatisfiable(out, sources, kind="constraint")
     return out

--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -600,10 +600,15 @@ def _parse_requirements(
             )
             raise NotImplementedError(msg)
         name = canonicalize_name(req.name)
-        out[name] = out.get(name, VersionRange.full()) & req.specifier.to_range()
+        term = (
+            req.specifier.to_range()
+            if req.specifier
+            else VersionRange.full(admit_arbitrary=False)
+        )
+        out[name] = out.get(name, VersionRange.full()) & term
         sources[name].append(req_str)
         for extra in req.extras:
-            out[join_extra(name, extra)] = VersionRange.full()
+            out[join_extra(name, extra)] = VersionRange.full(admit_arbitrary=False)
     raise_for_unsatisfiable(out, sources, kind=kind)
     return out
 

--- a/nab-python/tests/test_benchmark_parse_requirements.py
+++ b/nab-python/tests/test_benchmark_parse_requirements.py
@@ -38,4 +38,6 @@ def test_repeated_name_keeps_pin(harness: str) -> None:
     )
     assert Version("6.0.0") in reqs["inmanta-core"]
     assert Version("4.0.0") not in reqs["inmanta-core"]
-    assert reqs["inmanta-core[pytest-inmanta-extensions]"] == VersionRange.full()
+    assert reqs["inmanta-core[pytest-inmanta-extensions]"] == VersionRange.full(
+        admit_arbitrary=False
+    )

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -822,7 +822,7 @@ class TestPrereleaseAdmission:
         }
         coordinator = make_coordinator(listings=listings, metadata_by_version=metadata)
         root_reqs = {
-            "foo": VersionRange.full(),
+            "foo": VersionRange.full(admit_arbitrary=False),
             "bar": SpecifierSet("==5.0").to_range(),
         }
         provider = Provider(
@@ -1528,8 +1528,8 @@ class TestAddClassifiedDep:
         add_classified_dep(Requirement("bar[a,b]>=1.0"), set(), base, extra_map)
         assert V("2.0") in base["bar"]
         assert V("0.5") not in base["bar"]
-        assert base["bar[a]"] == VersionRange.full()
-        assert base["bar[b]"] == VersionRange.full()
+        assert base["bar[a]"] == VersionRange.full(admit_arbitrary=False)
+        assert base["bar[b]"] == VersionRange.full(admit_arbitrary=False)
 
     def test_extra_gated_multi_extra_splits_into_one_proxy_each(self) -> None:
         """``bar[a,b]`` under extra ``x`` records both proxies in that bucket."""
@@ -1537,8 +1537,8 @@ class TestAddClassifiedDep:
         extra_map: dict[str, dict[str, VersionRange]] = {"x": {}}
         add_classified_dep(Requirement("bar[a,b]>=1.0"), {"x"}, base, extra_map)
         assert V("2.0") in extra_map["x"]["bar"]
-        assert extra_map["x"]["bar[a]"] == VersionRange.full()
-        assert extra_map["x"]["bar[b]"] == VersionRange.full()
+        assert extra_map["x"]["bar[a]"] == VersionRange.full(admit_arbitrary=False)
+        assert extra_map["x"]["bar[b]"] == VersionRange.full(admit_arbitrary=False)
         assert "bar" not in base
 
     def test_multi_extra_proxy_names_normalized(self) -> None:
@@ -4618,7 +4618,7 @@ class TestExtras:
             "Metadata-Version: 2.1\nName: gamma\nVersion: 1.0\n"
             "Requires-Dist: alpha[ext-one]\n",
         )
-        roots = {"gamma": VersionRange.full()}
+        roots = {"gamma": VersionRange.full(admit_arbitrary=False)}
         provider = Provider(
             coordinator, python_version="3.12.0", root_requirements=roots
         )
@@ -4856,8 +4856,8 @@ class TestExtrasPrereleaseAdmission:
         }
         coordinator = make_coordinator(listings=listings, metadata_by_version=metadata)
         root_reqs = {
-            "a": VersionRange.full(),
-            "b": VersionRange.full(),
+            "a": VersionRange.full(admit_arbitrary=False),
+            "b": VersionRange.full(admit_arbitrary=False),
         }
         provider = Provider(
             coordinator, python_version="3.12.0", root_requirements=root_reqs
@@ -4911,7 +4911,7 @@ class TestExtrasPrereleaseBaseRangeBlocks:
     def _resolve_r(
         self, coordinator: MagicMock
     ) -> tuple[dict[str, Version], Resolver[str, Version]]:
-        root_reqs = {"r": VersionRange.full()}
+        root_reqs = {"r": VersionRange.full(admit_arbitrary=False)}
         provider = Provider(
             coordinator,
             python_version="3.12.0",
@@ -7369,8 +7369,8 @@ class TestExtrasInvalidMetadata:
             package="pkg",
         )
         root_reqs = {
-            "pkg": VersionRange.full(),
-            "pkg[feature]": VersionRange.full(),
+            "pkg": VersionRange.full(admit_arbitrary=False),
+            "pkg[feature]": VersionRange.full(admit_arbitrary=False),
         }
         provider = Provider(
             coordinator,

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -690,7 +690,7 @@ class TestParseRequirements:
         """An unconstrained requirement gets the any() range."""
         env = _linux_311().environment
         out = _parse_requirements(["pkg"], env)
-        assert out["pkg"] == VersionRange.full()
+        assert out["pkg"] == VersionRange.full(admit_arbitrary=False)
 
     def test_specifier_yields_intervals(self) -> None:
         """A bounded specifier produces the corresponding interval."""
@@ -855,7 +855,7 @@ class TestResolveOneTuple:
         tr = _resolve_one_tuple(
             coordinator,
             _linux_311(),
-            requirements={"pkg": VersionRange.full()},
+            requirements={"pkg": VersionRange.full(admit_arbitrary=False)},
             constraints=None,
             uploaded_prior_to=None,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
@@ -876,7 +876,7 @@ class TestResolveOneTuple:
         tr = _resolve_one_tuple(
             coordinator,
             _linux_311(),
-            requirements={"pkg": VersionRange.full()},
+            requirements={"pkg": VersionRange.full(admit_arbitrary=False)},
             constraints=None,
             uploaded_prior_to=None,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
@@ -900,7 +900,7 @@ class TestResolveOneTuple:
         tr = _resolve_one_tuple(
             coordinator,
             _linux_311(),
-            requirements={"pkg": VersionRange.full()},
+            requirements={"pkg": VersionRange.full(admit_arbitrary=False)},
             constraints=None,
             uploaded_prior_to=None,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
@@ -922,7 +922,7 @@ class TestResolveOneTuple:
         tr = _resolve_one_tuple(
             coordinator,
             _linux_311(),
-            requirements={"pkg": VersionRange.full()},
+            requirements={"pkg": VersionRange.full(admit_arbitrary=False)},
             constraints=None,
             uploaded_prior_to=None,
             dist_policy=DistPolicy.SDIST_INSTALL,
@@ -954,7 +954,7 @@ class TestVcsConfigPlumbing:
             _resolve_one_tuple(
                 coordinator,
                 _linux_311(),
-                requirements={"pkg": VersionRange.full()},
+                requirements={"pkg": VersionRange.full(admit_arbitrary=False)},
                 constraints=None,
                 uploaded_prior_to=None,
                 dist_policy=DistPolicy.WHEEL_OR_SDIST,
@@ -984,7 +984,7 @@ class TestVcsConfigPlumbing:
         tr = _resolve_one_tuple(
             coordinator,
             _linux_311(),
-            requirements={"other": VersionRange.full()},
+            requirements={"other": VersionRange.full(admit_arbitrary=False)},
             constraints=None,
             uploaded_prior_to=None,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
@@ -1019,7 +1019,7 @@ class TestVcsConfigPlumbing:
             _resolve_one_tuple(
                 coordinator,
                 _linux_311(),
-                requirements={"pkg": VersionRange.full()},
+                requirements={"pkg": VersionRange.full(admit_arbitrary=False)},
                 constraints=None,
                 uploaded_prior_to=None,
                 dist_policy=DistPolicy.WHEEL_OR_SDIST,


### PR DESCRIPTION
Unconstrained requirement, constraint, and dependency terms now enter the solver as full(admit_arbitrary=False); accumulator identities stay full() so === literals survive their first intersection. Under packaging's corrected arbitrary-flag algebra (upstream commit c411a96, unreleased) the old arbitrary-admitting seeds send conflict resolution into an infinite loop; on the current vendored base behavior is unchanged.