### PR TITLE
keep sdist PKG-INFO when a late sidecar metadata fetch fails

### DIFF
--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -215,14 +215,28 @@ class InMemoryIndex:
             return (package, version) in self._metadata
 
     def store_metadata(self, package: str, version: str, data: str | None) -> None:
-        """Cache metadata text (or ``None`` for a failed fetch)."""
+        """Cache metadata text (or ``None`` for a failed fetch).
+
+        ``None`` means no PEP 658 sidecar arrived and readers fall back to
+        the sdist, so it never overwrites sdist PKG-INFO already in the slot.
+        """
         key = f"metadata:{package}:{version}"
+        slot = (package, version)
         with self._lock:
-            self._metadata[(package, version)] = data
-            self._metadata_from_sdist.discard((package, version))
+            keep_sdist_text = (
+                data is None
+                and slot in self._metadata_from_sdist
+                and self._metadata[slot] is not None
+            )
+            if not keep_sdist_text:
+                self._metadata[slot] = data
+                self._metadata_from_sdist.discard(slot)
+
+            # the waiter gets whatever the slot holds, which may be kept text
+            result = self._metadata[slot]
             pending = self._pending.get(key)
         if pending is not None:
-            pending.result = data
+            pending.result = result
             pending.event.set()
 
     def store_metadata_error(

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -160,6 +160,23 @@ class TestInMemoryIndex:
         idx.store_metadata("foo", "1.0", "METADATA\n")
         assert not idx.metadata_from_sdist("foo", "1.0")
 
+    def test_metadata_none_keeps_stored_sdist_pkg_info(self) -> None:
+        """A failed sidecar fetch must not erase stored sdist PKG-INFO."""
+        idx = InMemoryIndex()
+        pending, _ = idx.get_or_create_pending("metadata:foo:1.0")
+        idx.store_sdist_metadata("foo", "1.0", "PKG-INFO\n")
+        idx.store_metadata("foo", "1.0", None)
+        assert pending.event.is_set()
+        assert idx.get_metadata("foo", "1.0") == "PKG-INFO\n"
+        assert idx.metadata_from_sdist("foo", "1.0")
+
+    def test_metadata_none_after_sdist_none_stays_none(self) -> None:
+        idx = InMemoryIndex()
+        idx.store_sdist_metadata("foo", "1.0", None)
+        idx.store_metadata("foo", "1.0", None)
+        assert idx.get_metadata("foo", "1.0") is None
+        assert not idx.metadata_from_sdist("foo", "1.0")
+
     def test_sdist_archive_pending_event_fires(self) -> None:
         idx = InMemoryIndex()
         pending, _ = idx.get_or_create_pending("sdist-archive:foo:1.0")
@@ -562,6 +579,46 @@ class TestFetchCoordinator:
             event.wait(timeout=5)
             assert not coord._crashed
             assert coord.index.get_metadata("broken", "1.0") is None
+
+    @respx.mock
+    def test_late_sidecar_failure_keeps_stored_sdist_pkg_info(self) -> None:
+        """A sidecar fetch failing after the sdist stored PKG-INFO keeps it."""
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            info = tarfile.TarInfo(name="pkg-1.0/PKG-INFO")
+            data = b"Metadata-Version: 2.2\nName: pkg\nVersion: 1.0\n"
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+
+        respx.get("https://files.example.com/pkg-1.0.tar.gz").mock(
+            return_value=httpx.Response(200, content=buf.getvalue())
+        )
+        respx.get("https://files.example.com/pkg-1.0.whl.metadata").mock(
+            return_value=httpx.Response(404)
+        )
+
+        with _coord() as coord:
+            sdist_event = coord.request_sdist(
+                "pkg", "1.0", "https://files.example.com/pkg-1.0.tar.gz"
+            )
+            assert sdist_event.wait(timeout=5)
+
+            # queue the request directly: request_metadata would short-circuit
+            # on has_metadata, but a prefetch already in flight still lands
+            pending, _ = coord.index.get_or_create_pending("metadata:pkg:1.0")
+            coord._submit(
+                FetchRequest(
+                    kind=FetchKind.METADATA,
+                    package="pkg",
+                    version="1.0",
+                    url="https://files.example.com/pkg-1.0.whl.metadata",
+                )
+            )
+
+            assert pending.event.wait(timeout=5)
+            assert not coord._crashed
+            assert "Name: pkg" in (coord.index.get_metadata("pkg", "1.0") or "")
+            assert coord.index.metadata_from_sdist("pkg", "1.0")
 
     @respx.mock
     def test_metadata_hash_mismatch_records_integrity_error(self) -> None:


### PR DESCRIPTION
A failed PEP 658 sidecar fetch stores metadata as None. If an sdist build had already stored PKG-INFO for the same package and version, that None clobbered the stored text and cleared the from-sdist flag, so later readers saw no metadata for a version they had in hand and the resolve outcome depended on which fetch finished last.

store_metadata now leaves the slot alone when the incoming value is None and it already holds sdist text: a missing sidecar only means readers fall back to the sdist, which is exactly what the slot contains. Waiters on the pending metadata event receive whatever the slot holds after the store.
