### PR TITLE
fix shutdown raising "Event loop is closed" after fetcher crash

### DIFF
--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -538,12 +538,41 @@ class FetchCoordinator:
         self._queue_ready.clear()
 
     def _submit(self, item: _QueueItem) -> None:
-        """Schedule ``item`` on the fetcher loop's queue from any thread."""
+        """Schedule ``item`` on the fetcher loop's queue from any thread.
+
+        Requests the loop cannot take are recorded as failures so their
+        waiters unblock instead of hanging.
+        """
         loop = self._loop
         queue = self._async_q
         if loop is None or queue is None:
+            self._refuse(item)
             return
-        loop.call_soon_threadsafe(queue.put_nowait, item)
+        try:
+            loop.call_soon_threadsafe(queue.put_nowait, item)
+        except RuntimeError:
+            # call_soon_threadsafe raises RuntimeError once the loop is closed.
+            self._refuse(item)
+
+    def _refuse(self, item: _QueueItem) -> None:
+        """Record a failure for each request in ``item``, unblocking waiters."""
+        # None is the shutdown sentinel; it has no waiters.
+        if item is None:
+            return
+
+        requests = item if isinstance(item, list) else [item]
+        for req in requests:
+            error = RuntimeError("Fetcher loop is not running, request refused")
+            if req.kind is FetchKind.LISTING:
+                self.index.store_listing_error(req.package, error)
+                continue
+            assert req.version is not None
+            if req.kind is FetchKind.METADATA:
+                self.index.store_metadata_error(req.package, req.version, error)
+            elif req.kind is FetchKind.SDIST:
+                self.index.store_sdist_metadata_error(req.package, req.version, error)
+            else:
+                self.index.store_sdist_archive_error(req.package, req.version, error)
 
     def _check_alive(self) -> None:
         if self._crashed:
@@ -726,8 +755,8 @@ class FetchCoordinator:
         try:
             asyncio.run(self._async_fetcher())
         except Exception:
-            logger.exception("Fetcher thread crashed")
             self._crashed = True
+            logger.exception("Fetcher thread crashed")
 
     def _build_client(
         self,

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -652,6 +652,67 @@ class TestFetchCoordinator:
         coord._run_loop()
         assert coord._crashed is True
 
+    def test_shutdown_completes_after_startup_crash(self) -> None:
+        """shutdown() tears down cleanly when the fetcher crashed at startup."""
+        coord = _coord(index_routes=[IndexRoute(name="foo", index="missing")])
+        coord.start()
+        assert coord._thread is not None
+        coord._thread.join(timeout=5)
+        assert coord._crashed
+
+        coord.shutdown()
+        assert coord._thread is None
+        assert not coord._started
+        assert coord._loop is None
+        assert coord._async_q is None
+
+    def test_startup_crash_surfaces_from_with_block(self) -> None:
+        """The with form raises the crash error, not a teardown error."""
+
+        def request_from_crashed_fetcher() -> None:
+            routes = [IndexRoute(name="foo", index="missing")]
+            with _coord(index_routes=routes) as coord:
+                assert coord._thread is not None
+                coord._thread.join(timeout=5)
+                coord.request_listing("foo")
+
+        with pytest.raises(RuntimeError, match="crashed"):
+            request_from_crashed_fetcher()
+
+    def _crashed_coord_in_race_window(self) -> FetchCoordinator:
+        """Return a crashed coordinator caught before _crashed is visible."""
+        coord = _coord(index_routes=[IndexRoute(name="foo", index="missing")])
+        coord.start()
+        assert coord._thread is not None
+        coord._thread.join(timeout=5)
+        coord._crashed = False
+        return coord
+
+    def test_refused_listing_submit_releases_waiter(self) -> None:
+        """A listing request refused by a closed loop fails instead of hanging."""
+        coord = self._crashed_coord_in_race_window()
+        event = coord.request_listing("foo")
+        assert event.is_set()
+        assert isinstance(coord.index.get_listing_error("foo"), RuntimeError)
+
+    def test_refused_submit_releases_all_request_kinds(self) -> None:
+        """Refused metadata, sdist, archive, and batch requests all fail loudly."""
+        coord = self._crashed_coord_in_race_window()
+        meta = coord.request_metadata("a", "1.0", "https://f.com/a")
+        sdist = coord.request_sdist("b", "1.0", "https://f.com/b.tar.gz")
+        archive = coord.request_sdist_archive("c", "1.0", "https://f.com/c.tar.gz")
+        batch = coord.request_metadata_batch([("d", "1.0", "https://f.com/d", None)])
+
+        assert meta.is_set()
+        assert sdist.is_set()
+        assert archive.is_set()
+        assert batch[0][2].is_set()
+
+        assert isinstance(coord.index.get_metadata_error("a", "1.0"), RuntimeError)
+        assert isinstance(coord.index.get_metadata_error("b", "1.0"), RuntimeError)
+        assert isinstance(coord.index.get_sdist_archive_error("c", "1.0"), RuntimeError)
+        assert isinstance(coord.index.get_metadata_error("d", "1.0"), RuntimeError)
+
     @respx.mock
     def test_drain_queue_empty_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """QueueEmpty during drain loop breaks out of the loop."""


### PR DESCRIPTION
When the fetcher thread crashes at startup, asyncio.run() closes its event loop on the way out. shutdown() then submits the exit sentinel to that closed loop, call_soon_threadsafe raises RuntimeError("Event loop is closed"), and teardown aborts. In the with form the teardown error is what the caller sees, masking the original crash.

_submit now treats a closed loop the same as a missing one: the exit sentinel is dropped, and any real request caught in that window is recorded as a fetch failure so its waiters unblock instead of hanging. _run_loop also sets _crashed before logging the exception, narrowing the window where the thread is dead but the flag is not yet visible.
