### PR TITLE
fix prepare_clone treating a mid-fetch VCS clone as complete

### DIFF
--- a/nab-index/src/nab_index/vcs.py
+++ b/nab-index/src/nab_index/vcs.py
@@ -11,7 +11,9 @@ Cache layout under ``cache_root / "vcs"``:
 ``repo-key`` is the 16-char prefix of a SHA-256 over the canonicalised
 repo URL (``vcs+`` prefix stripped).  ``commit-sha`` is always a
 concrete 40-char hash; floating refs are resolved via
-``git ls-remote`` before the clone runs.
+``git ls-remote`` before the clone runs.  A finished clone carries a
+``.git/nab-complete`` marker file; a tree without it is discarded and
+recloned.
 """
 
 from __future__ import annotations
@@ -22,13 +24,11 @@ import os
 import re
 import shutil
 import subprocess
+import tempfile
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 from ._subdir import subdirectory_escapes
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 __all__ = [
     "FULL_GIT_SHA_RE",
@@ -47,6 +47,10 @@ logger = logging.getLogger(__name__)
 # the clone-time validation in this module.
 FULL_GIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
 _VCS_PREFIX_RE = re.compile(r"^git\+")
+
+# Written inside ``.git`` after checkout.  ``git init`` creates ``.git``
+# before the fetch, so the directory alone cannot prove a finished clone.
+_COMPLETE_MARKER = "nab-complete"
 
 
 class VcsCloneError(Exception):
@@ -153,12 +157,15 @@ def prepare_clone(
     the named ref to a SHA, then performs a shallow clone of that
     commit.
 
-    Idempotent: if the destination already exists with a populated
-    ``.git`` folder, no fetch happens.
+    Idempotent: a destination carrying the completion marker is reused
+    without a fetch.  A fresh clone lands in a temporary sibling
+    directory and is renamed into place only once fully checked out, so
+    a concurrent or interrupted run never leaves a partial tree at the
+    cache path.
     """
     sha = _resolve_sha(request, require_pin=require_pin)
     dest = cache_root / "vcs" / _repo_key(request.repo_url) / sha
-    if (dest / ".git").is_dir():
+    if _clone_complete(dest):
         return VcsClone(
             path=dest,
             commit_sha=sha,
@@ -167,14 +174,33 @@ def prepare_clone(
 
     dest.parent.mkdir(parents=True, exist_ok=True)
     if dest.exists():
-        # Partial clone from a prior failure: wipe and retry.
+        # Unmarked tree from an interrupted run: wipe and retry.
         shutil.rmtree(dest)
-    _shallow_clone(request.repo_url, sha, dest)
+
+    tmp = Path(tempfile.mkdtemp(dir=dest.parent, prefix=f"{sha}.", suffix=".tmp"))
+    _shallow_clone(request.repo_url, sha, tmp)
+    try:
+        tmp.rename(dest)
+    except OSError as exc:
+        # A concurrent run renamed its own finished clone first: use it.
+        shutil.rmtree(tmp, ignore_errors=True)
+        if not _clone_complete(dest):
+            msg = (
+                f"clone of {request.repo_url} @ {sha} could not be"
+                f" moved into place: {exc}"
+            )
+            raise VcsCloneError(msg) from exc
+
     return VcsClone(
         path=dest,
         commit_sha=sha,
         subdirectory=request.subdirectory,
     )
+
+
+def _clone_complete(dest: Path) -> bool:
+    """Return True when ``dest`` holds a fully fetched and checked-out clone."""
+    return (dest / ".git" / _COMPLETE_MARKER).is_file()
 
 
 def _resolve_sha(request: VcsRequest, *, require_pin: bool) -> str:
@@ -236,9 +262,13 @@ def _shallow_clone(repo_url: str, sha: str, dest: Path) -> None:
     Uses ``git init`` + ``git fetch --depth 1`` to land precisely the
     chosen commit without pulling history.  Hosts that disallow
     direct sha fetch surface as a :class:`VcsCloneError` from the
-    fetch step.
+    fetch step.  The completion marker is written last, so its
+    presence proves the checkout finished.
+
+    ``dest`` is the temporary directory ``prepare_clone`` created with
+    :func:`tempfile.mkdtemp`, so it already exists.
     """
-    dest.mkdir(parents=True)
+    dest.mkdir(parents=True, exist_ok=True)
     init_args = ["git", "init", "--quiet"]
     fetch_args = ["git", "fetch", "--quiet", "--depth", "1", repo_url, sha]
     checkout_args = ["git", "checkout", "--quiet", "FETCH_HEAD"]
@@ -261,6 +291,7 @@ def _shallow_clone(repo_url: str, sha: str, dest: Path) -> None:
             cwd=dest,
             env=_git_env(),
         )
+        (dest / ".git" / _COMPLETE_MARKER).touch()
     except (FileNotFoundError, subprocess.CalledProcessError) as exc:
         # Roll back the partial clone so the cache stays clean.
         shutil.rmtree(dest, ignore_errors=True)

--- a/nab-python/tests/test_vcs.py
+++ b/nab-python/tests/test_vcs.py
@@ -14,6 +14,7 @@ import pytest
 
 from nab_index.client import SdistFile, WheelFile  # noqa: F401 - re-exported by helpers
 from nab_index.vcs import (
+    _COMPLETE_MARKER,
     VcsCloneError,
     VcsRequest,
     _resolve_sha,
@@ -32,6 +33,12 @@ from nab_python.provider import (
     VcsPolicy,
     VcsSource,
 )
+
+
+def _mark_complete(clone_dir: Path) -> None:
+    """Fabricate a finished cached clone the way ``prepare_clone`` leaves one."""
+    (clone_dir / ".git").mkdir(parents=True, exist_ok=True)
+    (clone_dir / ".git" / _COMPLETE_MARKER).touch()
 
 
 class TestVcsRequestParse:
@@ -263,14 +270,14 @@ class TestResolveShaAnnotatedTag:
 
 
 class TestPrepareClone:
-    def test_idempotent_when_dest_exists(
+    def test_idempotent_when_marked_complete(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         sha = "c" * 40
         dest = tmp_path / "vcs" / "1234567890abcdef" / sha
-        (dest / ".git").mkdir(parents=True)
+        _mark_complete(dest)
 
         monkeypatch.setattr("nab_index.vcs._repo_key", lambda _url: "1234567890abcdef")
 
@@ -352,11 +359,124 @@ class TestPrepareClone:
     ) -> None:
         sha = "f" * 40
         dest = tmp_path / "vcs" / "k" / sha
-        (dest / ".git").mkdir(parents=True)
+        _mark_complete(dest)
         monkeypatch.setattr("nab_index.vcs._repo_key", lambda _url: "k")
         req = VcsRequest("git", "https://example/r.git", sha, "subpkg")
         clone = prepare_clone(tmp_path, req, require_pin=True)
         assert clone.subdirectory == "subpkg"
+
+    def test_init_only_tree_from_interrupted_fetch_is_recloned(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A tree whose fetch never finished is discarded and recloned.
+
+        ``git init`` creates ``.git`` before the network fetch runs, so a
+        run killed mid-fetch leaves a tree containing only ``.git``.
+        """
+        sha = "d" * 40
+        repo_key = "aaaa0000bbbb1111"
+        dest = tmp_path / "vcs" / repo_key / sha
+        (dest / ".git").mkdir(parents=True)
+        monkeypatch.setattr("nab_index.vcs._repo_key", lambda _url: repo_key)
+
+        def fake_run(cmd: list[str], **kwargs: object) -> object:
+            cwd = Path(str(kwargs["cwd"]))
+            if cmd[:2] == ["git", "init"]:
+                (cwd / ".git").mkdir(exist_ok=True)
+            if cmd[:2] == ["git", "checkout"]:
+                (cwd / "pyproject.toml").write_text("[project]\n")
+            return type("P", (), {"returncode": 0})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        req = VcsRequest("git", "https://example/repo.git", sha, "")
+        clone = prepare_clone(tmp_path, req, require_pin=True)
+        assert clone.path == dest
+        assert (dest / "pyproject.toml").is_file()
+
+    def test_incomplete_clone_never_visible_at_cache_path(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Mid-fetch state must not appear at the shared cache path."""
+        sha = "e" * 40
+        repo_key = "cccc2222dddd3333"
+        dest = tmp_path / "vcs" / repo_key / sha
+        monkeypatch.setattr("nab_index.vcs._repo_key", lambda _url: repo_key)
+        dest_seen_during_fetch: list[bool] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> object:
+            cwd = Path(str(kwargs["cwd"]))
+            if cmd[:2] == ["git", "init"]:
+                (cwd / ".git").mkdir(exist_ok=True)
+            if cmd[:2] == ["git", "fetch"]:
+                dest_seen_during_fetch.append(dest.exists())
+            if cmd[:2] == ["git", "checkout"]:
+                (cwd / "pyproject.toml").write_text("[project]\n")
+            return type("P", (), {"returncode": 0})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        req = VcsRequest("git", "https://example/repo.git", sha, "")
+        clone = prepare_clone(tmp_path, req, require_pin=True)
+        assert dest_seen_during_fetch == [False]
+        assert clone.path == dest
+        assert (dest / "pyproject.toml").is_file()
+
+    def test_lost_publish_race_returns_winner_clone(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When a concurrent run finishes first, its clone is used as-is."""
+        sha = "f" * 40
+        repo_key = "eeee4444ffff5555"
+        dest = tmp_path / "vcs" / repo_key / sha
+        monkeypatch.setattr("nab_index.vcs._repo_key", lambda _url: repo_key)
+
+        def fake_run(cmd: list[str], **kwargs: object) -> object:
+            cwd = Path(str(kwargs["cwd"]))
+            if cmd[:2] == ["git", "init"]:
+                (cwd / ".git").mkdir(exist_ok=True)
+            if cmd[:2] == ["git", "fetch"]:
+                _mark_complete(dest)
+                (dest / "pyproject.toml").write_text("winner")
+            if cmd[:2] == ["git", "checkout"]:
+                (cwd / "pyproject.toml").write_text("loser")
+            return type("P", (), {"returncode": 0})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        req = VcsRequest("git", "https://example/repo.git", sha, "")
+        clone = prepare_clone(tmp_path, req, require_pin=True)
+        assert clone.path == dest
+        assert (dest / "pyproject.toml").read_text() == "winner"
+        assert [p for p in dest.parent.iterdir() if p != dest] == []
+
+    def test_unmarked_tree_appearing_during_clone_raises(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A foreign unmarked tree blocking the cache path fails loudly."""
+        sha = "a" * 40
+        repo_key = "9999888877776666"
+        dest = tmp_path / "vcs" / repo_key / sha
+        monkeypatch.setattr("nab_index.vcs._repo_key", lambda _url: repo_key)
+
+        def fake_run(cmd: list[str], **kwargs: object) -> object:
+            cwd = Path(str(kwargs["cwd"]))
+            if cmd[:2] == ["git", "init"]:
+                (cwd / ".git").mkdir(exist_ok=True)
+            if cmd[:2] == ["git", "fetch"]:
+                (dest / ".git").mkdir(parents=True)
+            return type("P", (), {"returncode": 0})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        req = VcsRequest("git", "https://example/repo.git", sha, "")
+        with pytest.raises(VcsCloneError, match="could not be moved into place"):
+            prepare_clone(tmp_path, req, require_pin=True)
+        assert [p for p in dest.parent.iterdir() if p != dest] == []
 
 
 class TestProviderVcsIntegration:
@@ -373,7 +493,7 @@ class TestProviderVcsIntegration:
         """End-to-end: provider materialises a VCS source via the cache."""
         sha = "a" * 40
         clone_dir = tmp_path / "cache" / "vcs" / "k" / sha
-        (clone_dir / ".git").mkdir(parents=True)
+        _mark_complete(clone_dir)
         (clone_dir / "pyproject.toml").write_text(
             '[project]\nname = "foo"\nversion = "1.0.0"\n',
             encoding="utf-8",
@@ -418,7 +538,7 @@ class TestProviderVcsIntegration:
         """
         sha = "b" * 40
         clone_dir = tmp_path / "cache" / "vcs" / "k" / sha
-        (clone_dir / ".git").mkdir(parents=True)
+        _mark_complete(clone_dir)
         (clone_dir / "pyproject.toml").write_text(
             '[project]\nname = "foo"\nversion = "1.0.0"\n',
             encoding="utf-8",
@@ -526,7 +646,7 @@ class TestProviderVcsIntegration:
         """
         sha = "a" * 40
         clone_dir = tmp_path / "cache" / "vcs" / "k" / sha
-        (clone_dir / ".git").mkdir(parents=True)
+        _mark_complete(clone_dir)
         (clone_dir / "pyproject.toml").write_text(
             '[project]\nname = "foo"\nversion = "1.0"\ndynamic = ["dependencies"]\n',
             encoding="utf-8",


### PR DESCRIPTION
prepare_clone took any existing .git directory as proof of a finished clone, but git init creates .git before the fetch runs. A second process resolving the same VCS requirement, or a rerun after a fetch was killed, could pick up the tree mid-fetch and build from an empty source tree in the shared cache.

Clones now land in a temporary sibling directory and are renamed into the cache path only after checkout, with a .git/nab-complete marker written last. Only marked trees are reused; an unmarked tree is wiped and recloned. If a concurrent run renames its finished clone into place first, that clone is used as-is.
