### PR TITLE
offline: don't let a cold remote index mask a local index

### DIFF
--- a/nab-index/src/nab_index/multi_index.py
+++ b/nab-index/src/nab_index/multi_index.py
@@ -4,7 +4,9 @@ Each index in the list is named and addressable; the order alone is
 semantically significant (no "primary vs extras" split).  Per package,
 the router walks the list left-to-right and stops at the first index
 whose listing for the package is non-empty (presence-based first-index,
-matching uv's ``--index-strategy first-index``).
+matching uv's ``--index-strategy first-index``).  An index that raises
+:class:`~nab_index.cache.OfflineError` (offline mode, cold cache) is
+treated as having no listing, so later indexes are still consulted.
 
 Per-package overrides route a package to a *named* index regardless
 of order; when an override matches, *only* that index is consulted
@@ -23,6 +25,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol
 
 from ._naming import canonical as _normalise_name
+from .cache import OfflineError
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -195,7 +198,11 @@ class MultiIndexClient:
 
         for index_name in self._order:
             client = self._clients[index_name]
-            files = await client.get_files(package)
+            try:
+                files = await client.get_files(package)
+            except OfflineError:
+                # Offline with a cold cache: treat as no listing.
+                continue
             if files:
                 self._record_route(package, index_name)
                 return files

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -1474,6 +1474,28 @@ class TestMultiIndexCoordinator:
         with pytest.raises(ValueError, match="at least one"):
             FetchCoordinator(transport=HttpxAsyncTransport(), indexes=[])
 
+    @respx.mock
+    def test_offline_cold_remote_falls_through_to_local(self, tmp_path: Path) -> None:
+        """Offline + cold cache on the remote index still serves local files."""
+        wheelhouse = tmp_path / "wheelhouse"
+        wheelhouse.mkdir()
+        (wheelhouse / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+
+        with _coord(
+            cache_dir=tmp_path / "cache",
+            offline=True,
+            indexes=[
+                IndexConfig("pypi", "https://pypi.org/simple/"),
+                IndexConfig("local", wheelhouse.as_uri()),
+            ],
+        ) as coord:
+            coord.request_listing("foo").wait(timeout=5)
+            listing = coord.index.get_listing("foo")
+            assert listing is not None
+            assert [f.filename for f in listing] == ["foo-1.0-py3-none-any.whl"]
+            assert coord.index.get_listing_error("foo") is None
+            assert coord.index.get_listing_index("foo") == "local"
+
     def test_local_index(self, tmp_path: Path) -> None:
         """A file:// index uses LocalIndexClient."""
         wheelhouse = tmp_path / "wheelhouse"

--- a/nab-python/tests/test_multi_index.py
+++ b/nab-python/tests/test_multi_index.py
@@ -8,12 +8,16 @@ from typing import TYPE_CHECKING, TypeVar
 import pytest
 
 from nab_index._naming import canonical as _normalise_name
+from nab_index.cache import OfflineError, OnDiskCache
+from nab_index.cached_client import CachedAsyncSimpleClient
 from nab_index.client import SdistFile, WheelFile
+from nab_index.local_index import LocalIndexClient
 from nab_index.multi_index import IndexConfig, MultiIndexClient
 
 if TYPE_CHECKING:
     from collections.abc import Coroutine
-    from typing import Any
+    from pathlib import Path
+    from typing import Any, NoReturn
 
 _T = TypeVar("_T")
 
@@ -78,6 +82,24 @@ class FakeClient:
 
     async def aclose(self) -> None:
         self.closed = True
+
+
+class _NoNetworkTransport:
+    """Transport that fails the test on any request."""
+
+    async def get(self, url: str, *, headers: dict[str, str] | None = None) -> NoReturn:
+        msg = f"unexpected network call: {url}"
+        raise AssertionError(msg)
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _offline_client(tmp_path: Path, name: str) -> CachedAsyncSimpleClient:
+    """Real cached client in offline mode with a cold on-disk cache."""
+    url = f"https://{name}.example/simple/"
+    cache = OnDiskCache(tmp_path / name, url)
+    return CachedAsyncSimpleClient(_NoNetworkTransport(), cache, url, offline=True)
 
 
 class TestIndexConfig:
@@ -146,6 +168,58 @@ class TestPresenceBased:
         run(client.get_files("foo"))
         assert first.get_files_calls == ["foo"]
         assert second.get_files_calls == ["foo", "foo"]
+
+
+class TestOfflinePresenceWalk:
+    """A cold offline index must not mask later indexes in the walk."""
+
+    def test_cold_offline_index_falls_through_to_local(self, tmp_path: Path) -> None:
+        wheelhouse = tmp_path / "wheelhouse"
+        wheelhouse.mkdir()
+        (wheelhouse / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+
+        client = MultiIndexClient(
+            {
+                "pypi": _offline_client(tmp_path, "pypi"),
+                "local": LocalIndexClient(wheelhouse.as_uri()),
+            },
+            ["pypi", "local"],
+            {},
+        )
+
+        files = run(client.get_files("foo"))
+        assert [f.filename for f in files] == ["foo-1.0-py3-none-any.whl"]
+        assert client.route_for("foo") == "local"
+
+    def test_cold_offline_all_indexes_returns_empty(self, tmp_path: Path) -> None:
+        client = MultiIndexClient(
+            {
+                "a": _offline_client(tmp_path, "a"),
+                "b": _offline_client(tmp_path, "b"),
+            },
+            ["a", "b"],
+            {},
+        )
+
+        assert run(client.get_files("foo")) == []
+        assert client.route_for("foo") == "a"
+
+    def test_override_pin_to_cold_offline_index_raises(self, tmp_path: Path) -> None:
+        wheelhouse = tmp_path / "wheelhouse"
+        wheelhouse.mkdir()
+        (wheelhouse / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+
+        client = MultiIndexClient(
+            {
+                "pypi": _offline_client(tmp_path, "pypi"),
+                "local": LocalIndexClient(wheelhouse.as_uri()),
+            },
+            ["pypi", "local"],
+            {"foo": "pypi"},
+        )
+
+        with pytest.raises(OfflineError):
+            run(client.get_files("foo"))
 
 
 class TestOverrides:


### PR DESCRIPTION
In offline mode with a remote index ordered before a local one, a cold cache on the remote index raised OfflineError and aborted the per-package index walk, so packages sitting in the local index were reported as unavailable. The walk now treats an OfflineError as an empty listing and moves on to the next index.

If every index is cold the result is an empty listing, and a per-package override pinned to a cold index still raises, since an override consults only that index.
