### PR TITLE
set a default request timeout on the urllib3 transport

### DIFF
--- a/nab-index/src/nab_index/urllib3_async_transport.py
+++ b/nab-index/src/nab_index/urllib3_async_transport.py
@@ -29,6 +29,9 @@ __all__ = [
 
 _HTTP_BAD_REQUEST = 400
 
+# urllib3's default read timeout is None, so bound it against a stalled index.
+_DEFAULT_TIMEOUT_SECONDS = 5.0
+
 
 class _SSLContext(truststore.SSLContext):
     """truststore SSLContext that answers urllib3-future's cert probe.
@@ -97,10 +100,17 @@ class Urllib3AsyncTransport:
     within each thread.
     """
 
-    def __init__(self, *, num_pools: int = 10, maxsize: int = 50) -> None:
+    def __init__(
+        self,
+        *,
+        num_pools: int = 10,
+        maxsize: int = 50,
+        timeout: float = _DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
         """Create a transport."""
         self._num_pools = num_pools
         self._maxsize = maxsize
+        self._timeout = timeout
         self._local = threading.local()
         self._pools: list[urllib3.PoolManager] = []
         self._pools_lock = threading.Lock()
@@ -120,7 +130,7 @@ class Urllib3AsyncTransport:
         return pool
 
     def _request(self, url: str, headers: dict[str, str]) -> urllib3.BaseHTTPResponse:
-        return self._pool().request("GET", url, headers=headers)
+        return self._pool().request("GET", url, headers=headers, timeout=self._timeout)
 
     async def get(
         self, url: str, *, headers: dict[str, str] | None = None

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -172,7 +172,10 @@ class TestUrllib3AsyncTransport:
         assert content == b"world"
         assert text == "world"
         pool.request.assert_called_once_with(
-            "GET", "https://example.com/", headers={"Accept-Encoding": "gzip", "k": "v"}
+            "GET",
+            "https://example.com/",
+            headers={"Accept-Encoding": "gzip", "k": "v"},
+            timeout=5.0,
         )
         pool.clear.assert_called_once()
 
@@ -219,7 +222,10 @@ class TestUrllib3AsyncTransport:
 
         asyncio.run(go())
         pool.request.assert_called_once_with(
-            "GET", "https://example.com/", headers={"Accept-Encoding": "gzip"}
+            "GET",
+            "https://example.com/",
+            headers={"Accept-Encoding": "gzip"},
+            timeout=5.0,
         )
 
     def test_get_lets_caller_override_accept_encoding(
@@ -243,8 +249,49 @@ class TestUrllib3AsyncTransport:
 
         asyncio.run(go())
         pool.request.assert_called_once_with(
-            "GET", "https://example.com/", headers={"Accept-Encoding": "identity"}
+            "GET",
+            "https://example.com/",
+            headers={"Accept-Encoding": "identity"},
+            timeout=5.0,
         )
+
+    def test_get_applies_bounded_default_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The default request carries a finite timeout."""
+        pool = self._fake_pool(b"{}")
+        monkeypatch.setattr(
+            "nab_index.urllib3_async_transport.urllib3.PoolManager",
+            lambda **kw: pool,
+        )
+
+        async def go() -> None:
+            transport = Urllib3AsyncTransport()
+            try:
+                await transport.get("https://example.com/")
+            finally:
+                await transport.aclose()
+
+        asyncio.run(go())
+        assert pool.request.call_args.kwargs["timeout"] == 5.0
+
+    def test_get_forwards_custom_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A caller-chosen timeout reaches the underlying request."""
+        pool = self._fake_pool(b"{}")
+        monkeypatch.setattr(
+            "nab_index.urllib3_async_transport.urllib3.PoolManager",
+            lambda **kw: pool,
+        )
+
+        async def go() -> None:
+            transport = Urllib3AsyncTransport(timeout=1.5)
+            try:
+                await transport.get("https://example.com/")
+            finally:
+                await transport.aclose()
+
+        asyncio.run(go())
+        assert pool.request.call_args.kwargs["timeout"] == 1.5
 
     def test_response_json(self) -> None:
         fake = MagicMock(spec=urllib3.BaseHTTPResponse)


### PR DESCRIPTION
The urllib3 HTTP transport passed no timeout to `pool.request()`, so urllib3's default read timeout of None applied and a stalled index could hang a resolve indefinitely. The httpx transport already inherits httpx's 5 second default, so the two backends behaved differently.

This gives the urllib3 transport a 5 second default request timeout to match, and adds a `timeout` constructor argument so a caller can raise or lower it.
