### PR TITLE
sort requirement extras so resolve order is deterministic

### DIFF
--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -314,7 +314,7 @@ def expand_self_extras(
                 continue
             worklist.extend(
                 canonicalize_name(sub)
-                for sub in req.extras
+                for sub in sorted(req.extras)
                 if canonicalize_name(sub) not in seen
             )
     return out
@@ -557,7 +557,7 @@ def _self_ref_edges(
             return []
         if isinstance(residual, str):
             edge = gates | {residual}
-    return [(canonicalize_name(sub), edge) for sub in req.extras]
+    return [(canonicalize_name(sub), edge) for sub in sorted(req.extras)]
 
 
 def expand_group_includes(

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -712,7 +712,7 @@ def _build_resolver_inputs(
         )
         resolver_requirements[name] = previous & term
         sources[name].append(str(req))
-        for extra in req.extras:
+        for extra in sorted(req.extras):
             extra_key = join_extra(name, extra)
             resolver_requirements[extra_key] = VersionRange.full(admit_arbitrary=False)
             _, normalized_extra = split_extra(extra_key)

--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -607,7 +607,7 @@ def _parse_requirements(
         )
         out[name] = out.get(name, VersionRange.full()) & term
         sources[name].append(req_str)
-        for extra in req.extras:
+        for extra in sorted(req.extras):
             out[join_extra(name, extra)] = VersionRange.full(admit_arbitrary=False)
     raise_for_unsatisfiable(out, sources, kind=kind)
     return out

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -405,12 +405,33 @@ class TestExpandSelfExtras:
             "a": ["depA"],
             "b": ["depB"],
         }
-        # ``Requirement.extras`` is a set: order between siblings is
-        # not guaranteed.  Originally-selected extras appear before
-        # transitively-discovered ones.
-        result = expand_self_extras(opt, "mypkg", ["all"])
-        assert result[0] == "all"
-        assert sorted(result[1:]) == ["a", "b"]
+        # Selected extras stay in front; self-ref siblings follow in sorted order.
+        assert expand_self_extras(opt, "mypkg", ["all"]) == ["all", "a", "b"]
+
+    def test_self_reference_siblings_walked_in_sorted_order(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Sibling extras enter the worklist in sorted order.
+
+        ``Requirement.extras`` is a set with PYTHONHASHSEED-dependent order, and
+        the order siblings enter the worklist decides their
+        ``root_package_order`` tiebreak. A reversed extras order must still give
+        the sorted result.
+        """
+        opt = {
+            "all": ["mypkg[a, b, c]"],
+            "a": ["depA"],
+            "b": ["depB"],
+            "c": ["depC"],
+        }
+
+        def reversed_extras(req_str: str) -> Requirement:
+            req = Requirement(req_str)
+            monkeypatch.setattr(req, "extras", sorted(req.extras, reverse=True))
+            return req
+
+        monkeypatch.setattr("nab_python.requirements_file.Requirement", reversed_extras)
+        assert expand_self_extras(opt, "mypkg", ["all"]) == ["all", "a", "b", "c"]
 
     def test_canonical_match_collapses_underscore_dot_hyphen(self) -> None:
         """PEP 503 canonicalisation makes ``my_pkg``/``My.Pkg``/``mypkg`` all match."""
@@ -554,6 +575,32 @@ class TestExpandExtraRequirements:
         out = expand_extra_requirements(opt, "mypkg", ["all"])
         dep = next(r for r in out if r.name == "some-dep")
         assert dep.marker is None
+
+    def test_self_ref_siblings_flattened_in_sorted_order(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Self-ref siblings feed the flattened requirements in sorted order.
+
+        ``Requirement.extras`` is a set with PYTHONHASHSEED-dependent order, and
+        on the universal path the order ``_self_ref_edges`` walks siblings
+        becomes the resolver's root package order. A reversed extras order must
+        still give the sorted result.
+        """
+        opt = {
+            "all": ["mypkg[a, b, c]"],
+            "a": ["depA"],
+            "b": ["depB"],
+            "c": ["depC"],
+        }
+
+        def reversed_extras(req_str: str) -> Requirement:
+            req = Requirement(req_str)
+            monkeypatch.setattr(req, "extras", sorted(req.extras, reverse=True))
+            return req
+
+        monkeypatch.setattr("nab_python.requirements_file.Requirement", reversed_extras)
+        out = expand_extra_requirements(opt, "mypkg", ["all"])
+        assert [r.name for r in out] == ["depA", "depB", "depC"]
 
     def test_self_reference_not_emitted_as_requirement(self) -> None:
         """The self-reference activates its extra but never lands as a

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -2003,6 +2003,24 @@ class TestBuildResolverInputs:
         assert "foo" not in resolver_requirements
         assert not caplog.records
 
+    def test_multi_extra_proxy_keys_sorted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Extra proxy keys are inserted in sorted order.
+
+        ``Requirement.extras`` is a set with PYTHONHASHSEED-dependent order, and
+        the insertion order of the proxy keys becomes the resolver's
+        ``root_package_order`` tiebreak. A reversed extras order must still give
+        the sorted keys.
+        """
+        req = Requirement("demo[x,y,z]")
+        monkeypatch.setattr(req, "extras", ["z", "y", "x"])
+        resolver_requirements, _ = _build_resolver_inputs(
+            [req], NabProjectConfig(), environment={}
+        )
+        proxy_keys = [k for k in resolver_requirements if k.startswith("demo[")]
+        assert proxy_keys == ["demo[x]", "demo[y]", "demo[z]"]
+
 
 class TestBuildConstraints:
     """``_build_constraints`` folds duplicate constraint lines."""

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -686,6 +686,28 @@ class TestParseRequirements:
         assert "pkg[foo]" in out
         assert "pkg[bar]" in out
 
+    def test_multi_extra_proxy_keys_sorted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Extra proxy keys are inserted in sorted order.
+
+        ``Requirement.extras`` is a set with PYTHONHASHSEED-dependent order, and
+        the insertion order of the proxy keys becomes the resolver's root
+        package order. A reversed extras order must still give the sorted keys.
+        """
+        env = _linux_311().environment
+        real_requirement = resolve_mod.Requirement
+
+        def reversed_extras(req_str: str) -> object:
+            req = real_requirement(req_str)
+            monkeypatch.setattr(req, "extras", sorted(req.extras, reverse=True))
+            return req
+
+        monkeypatch.setattr(resolve_mod, "Requirement", reversed_extras)
+        out = _parse_requirements(["pkg[a,b,c]"], env)
+        proxy_keys = [k for k in out if k.startswith("pkg[")]
+        assert proxy_keys == ["pkg[a]", "pkg[b]", "pkg[c]"]
+
     def test_no_specifier_yields_any(self) -> None:
         """An unconstrained requirement gets the any() range."""
         env = _linux_311().environment


### PR DESCRIPTION
When a requirement lists more than one extra (`foo[b,a,c]`), we expanded its extras by iterating `Requirement.extras`. That is a set, so the iteration order depends on PYTHONHASHSEED. The expansion order sets the insertion order of the extra proxy keys, and that insertion order becomes the resolver's `root_package_order` tiebreak for choosing the next package to decide.

So the same requirements could take a different decision order from one run to the next, and when the input does not resolve, the ResolutionError text pointed at different packages each time. Sort the extras everywhere they feed insertion order (self-extras expansion, self-ref edges, and both the standard and universal resolver-input builders) so identical inputs always give the same result.
