### PR TITLE
fix no-versions diagnostic printing solution range as the requirement

### DIFF
--- a/nab-python/src/nab_python/_provider/lookahead.py
+++ b/nab-python/src/nab_python/_provider/lookahead.py
@@ -90,9 +90,9 @@ def look_ahead_ok(
                 and decided_version is None
                 and (dep_range & pos_range).is_empty
             ):
-                provider.pending_range_blocks[
-                    (package, dep_normalized, pos_range)
-                ].append(version)
+                range_key = (package, dep_normalized, pos_range)
+                provider.pending_range_blocks[range_key].append(version)
+                provider.pending_range_dep_ranges[range_key] |= dep_range
                 return False
 
     return True
@@ -149,6 +149,7 @@ def flush_pending_blocks(provider: Provider) -> None:
             )
         )
     provider.pending_range_blocks = defaultdict(list)
+    provider.pending_range_dep_ranges = defaultdict(VersionRange.empty)
 
     # Root- and metadata-blocks are diagnostic-only; drop them without
     # emitting clauses.

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -636,6 +636,13 @@ class Provider:
             tuple[str, str, RangeProtocol[Version]], list[Version]
         ] = defaultdict(list)
 
+        # Diagnostic-only: the dep range each rejected candidate declared for the
+        # blocker, unioned per group, read only by the no-versions message. The
+        # flushed clause uses the blocker's positive range, not this.
+        self.pending_range_dep_ranges: defaultdict[
+            tuple[str, str, RangeProtocol[Version]], RangeProtocol[Version]
+        ] = defaultdict(VersionRange.empty)
+
         # Diagnostic-only: root_requirements feed PubGrub directly, so these
         # blockers never need flushing as incompatibilities; they exist purely
         # so the failure message can name the excluding root requirement.
@@ -1462,12 +1469,13 @@ class Provider:
                 continue
             out.append(f"requires {blocker_pkg} != {blocker_version}")
 
-        for cand, blocker_pkg, blocker_range in self.pending_range_blocks:
+        for cand, blocker_pkg, pos_range in self.pending_range_blocks:
             if cand != normalized:
                 continue
+            dep_range = self.pending_range_dep_ranges[(cand, blocker_pkg, pos_range)]
             out.append(
-                f"requires {blocker_pkg} in {blocker_range}"
-                " (disjoint with current solution range)"
+                f"requires {blocker_pkg} in {dep_range}"
+                f" but solution has it in {pos_range}"
             )
 
         for (

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -1008,12 +1008,18 @@ class TestNoVersionsReasons:
             python_version="3.12.0",
             root_requirements={"foo": VersionRange.full(admit_arbitrary=False)},
         )
-        provider.solution_ranges["bar"] = SpecifierSet("<2.0").to_range()
+        pos_range = SpecifierSet("<2.0").to_range()
+        dep_range = SpecifierSet("==2.0").to_range()
+        provider.solution_ranges["bar"] = pos_range
         result = provider.choose_version("foo", VersionRange.full())
         assert result is None
         reason = provider.get_no_versions_reason("foo")
         assert reason is not None
-        assert "bar" in reason
+        # foo requires bar==2.0; the message must name that, not the solution range.
+        assert (
+            f"requires bar in {dep_range} but solution has it in {pos_range}" in reason
+        )
+        assert "disjoint with current solution range" not in reason
 
 
 class TestGetDependencies:


### PR DESCRIPTION
When a package failed to resolve because look-ahead rejected every candidate over a positive-range disagreement, the no-versions message named the current solution range as the candidate's own requirement. For a candidate that required `bar==2.0` while the solution had bar pinned to `<2.0`, it read `requires bar in <2.0 (disjoint with current solution range)`, so it reported the solution's constraint as the thing the candidate asked for.

The range-block now records the dependency range each rejected candidate declared, unioned per blocker, and the message reports both sides: `requires bar in ==2.0 but solution has it in <2.0`.
