### PR TITLE
fix top-level requires-python example the config parser rejects

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -20,9 +20,9 @@ constraints = ["urllib3<2"]
 default-groups = ["dev"]
 
 # Override the host's Python for a single-environment resolve.
-# Single value, not a range; for multi-Python locking use the
-# [tool.nab.matrix] table below.
-requires-python = "3.12.0"
+# A PEP 440 specifier, not a bare version; for multi-Python
+# locking use the [tool.nab.matrix] table below.
+requires-python = "==3.12.0"
 
 # Reproducibility cutoff.  Distributions uploaded after this timestamp
 # are ignored.  Accepts ISO 8601 strings, native TOML datetimes, or a
@@ -524,8 +524,8 @@ error.  See [Build policy](build-policy.md).
 
 The two `python` knobs cover different shapes of resolve:
 
-* `[tool.nab].requires-python`: a single Python version (or a bare
-  specifier like `>=3.12.0`).  Treated as a host-environment
+* `[tool.nab].requires-python`: a PEP 440 specifier like `==3.12.0`
+  or `>=3.12`.  Treated as a host-environment
   override for a single-environment resolve.  Mostly useful when
   you need to lock against a different Python than the one running
   nab and you only need one lock.

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -51,6 +52,20 @@ def write(tmp_path: Path, body: str) -> Path:
     p = tmp_path / "pyproject.toml"
     p.write_text(body)
     return p
+
+
+DOCS_CONFIGURATION = (
+    Path(__file__).resolve().parents[2] / "docs" / "guides" / "configuration.md"
+)
+
+
+def first_tool_nab_example() -> str:
+    """Return the first ``[tool.nab]`` fenced TOML block in the config guide."""
+    text = DOCS_CONFIGURATION.read_text()
+    for block in re.findall(r"```toml\n(.*?)```", text, re.DOTALL):
+        if block.lstrip().startswith("[tool.nab]"):
+            return block
+    raise AssertionError("no [tool.nab] example block in configuration.md")
 
 
 class TestCliOverridesFold:
@@ -702,6 +717,16 @@ class TestRequiresPython:
         path = write(tmp_path, "[tool.nab]\nrequires-python = 3\n")
         with pytest.raises(ConfigError, match="requires-python must be a string"):
             read_pyproject_config(path)
+
+    def test_top_level_doc_example_is_a_valid_specifier(self, tmp_path: Path) -> None:
+        """The config guide's top-level example must parse as a valid specifier."""
+        block = first_tool_nab_example()
+        match = re.search(r'^requires-python = "([^"]*)"', block, re.MULTILINE)
+        assert match is not None, "top-level example dropped requires-python"
+        value = match.group(1)
+
+        path = write(tmp_path, f'[tool.nab]\nrequires-python = "{value}"\n')
+        assert read_pyproject_config(path).requires_python == value
 
 
 class TestUploadedPriorTo:


### PR DESCRIPTION
The `[tool.nab]` example in the configuration guide set `requires-python = "3.12.0"`, a bare version. The parser runs that value through `SpecifierSet`, which rejects bare versions, so anyone copying the example straight into their pyproject.toml hits a ConfigError. It also contradicted the per-package override section, which already documents `requires-python` as a PEP 440 specifier.

Change the example to `==3.12.0` and reword the surrounding prose to say a PEP 440 specifier. Also add a test that reads the example out of the guide and checks it parses, so the doc and the parser can't drift apart again.
