### PR TITLE
fix fetch_versions cache tests that never checked caching

### DIFF
--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -290,8 +290,7 @@ class TestFetchVersions:
         provider = Provider(coordinator)
         provider.fetch_versions("foo")
         provider.fetch_versions("foo")
-        # request_listing called at most once (from init or first fetch)
-        assert coordinator.request_listing.call_count <= 1
+        assert provider.stats.listings_fetched == 1
 
     def test_skips_unparseable_version(self) -> None:
         """Wheels with invalid version strings are skipped."""
@@ -480,8 +479,7 @@ class TestFetchVersions:
         provider = Provider(coordinator)
         provider.fetch_versions("Foo-Bar")
         provider.fetch_versions("foo_bar")
-        # Both resolve to the same normalized name, only one lookup needed
-        assert coordinator.request_listing.call_count <= 1
+        assert provider.stats.listings_fetched == 1
 
 
 class TestChooseVersion:


### PR DESCRIPTION
Both caching tests in TestFetchVersions asserted on coordinator.request_listing.call_count. The shared coordinator fake pre-populates the in-memory index, so the provider reads the listing directly and never calls request_listing. The counter is stuck at 0, the assertion held no matter what, and neither test could catch a regression that broke the versions cache.

Switch them to assert provider.stats.listings_fetched == 1. The provider bumps that counter once per real listing fetch and skips it on a cache hit, so a second fetch_versions call has to come from the cache for the count to stay at 1.
