### PR TITLE
fix config and cli guide intros that miss nab.toml and --project flags

### DIFF
--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -2,8 +2,9 @@
 
 `nab` exposes three subcommands: `lock`, `download`, and `config`. The
 first two read project shape from `[tool.nab]` in the project's
-`pyproject.toml`; the CLI itself carries only runtime knobs. `config`
-inspects the layered configuration.
+`pyproject.toml` or a project-directory `nab.toml`; the CLI carries
+runtime knobs and can override a project key for one run with a
+`--project-<key>` flag. `config` inspects the layered configuration.
 
 ## Synopsis
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1,8 +1,10 @@
 # Configuration
 
-All project shape lives in `[tool.nab]` inside the project's
-`pyproject.toml`.  The CLI is intentionally narrow: it carries only
-runtime knobs (cache directory, offline mode, HTTP backend).
+The keys that decide what nab resolves live in `[tool.nab]` inside the
+project's `pyproject.toml`, or in a project-directory `nab.toml` that
+sets the same keys.  The CLI carries runtime knobs (cache directory,
+offline mode, HTTP backend), and can also override a project key for a
+single run with a `--project-<key>` flag.
 
 ## Top-level keys
 
@@ -539,7 +541,7 @@ If both are present, the matrix `python` wins under universal mode
 and `requires-python` wins under specific mode.  Pick one shape
 based on whether you want one lock or many.
 
-## CLI flags (runtime only)
+## CLI flags
 
 ```
 nab lock [PATH]
@@ -563,8 +565,9 @@ the resolved set, so it prints a notice and is recorded in the lockfile.
 `dist-policy` value and resets `trust-unverified-deps`; set the table form
 in a file to keep that flag.
 
-Anything that defines *what* gets resolved goes in `[tool.nab]`; the
-CLI only carries knobs about *how this run executes*.
+The CLI carries knobs about *how this run executes*; the one exception
+is a `--project-*` flag, which overrides a *what-gets-resolved* key for
+the single run.
 
 ## Layered configuration sources
 


### PR DESCRIPTION
The opening paragraphs of `configuration.md` and `cli.md` still said all project shape lives in `[tool.nab]` and the CLI carries only runtime knobs. That stopped being true when the layered config registry landed: project-scope keys can also come from a project-directory `nab.toml`, and a `--project-*` flag can override a project key for one run.

The "Layered configuration sources" section already spells both out, so this only brings the two intros, the "CLI flags (runtime only)" heading, and the closing summary in line with it.
