### PR TITLE
fix flat sdist with one package dir misrouted into that subdir

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -612,9 +612,9 @@ def extract_sdist_archive(data: bytes, target_dir: Path) -> Path:
     any member that would write outside ``target_dir`` (absolute paths, ``..``,
     escaping links) or is a special file (device node, FIFO); a rejected member
     surfaces as a :class:`ValueError`.  A hard link whose target is not present
-    in the archive surfaces the same way.  The single extracted top-level
-    directory is the source root, falling back to ``target_dir`` when the
-    archive has no single top-level directory.
+    in the archive surfaces the same way.  A lone top-level directory that
+    wraps every member is the source root; otherwise (top-level files, as in a
+    flat sdist, or several top-level directories) the root is ``target_dir``.
 
     The data filter is required; a Python that lacks it (before 3.10.12 /
     3.11.4 / 3.12) is unsupported and extraction raises.
@@ -637,14 +637,10 @@ def extract_sdist_archive(data: bytes, target_dir: Path) -> Path:
         msg = f"broken link in sdist member: {exc}"
         raise ValueError(msg) from exc
 
-    # The source root is the single extracted top-level directory, read from
-    # the extracted tree so a sanitised member name cannot mislead it.  A
-    # symlink is not followed here: only a real directory counts as the root.
-    subdirs = [
-        entry
-        for entry in target_dir.iterdir()
-        if entry.is_dir() and not entry.is_symlink()
-    ]
-    if len(subdirs) == 1:
-        return subdirs[0]
+    # A lone wrapping directory is the source root; top-level files (a flat
+    # sdist) leave it at target_dir. Read from disk, not member names, so a
+    # sanitised name cannot mislead the choice.
+    entries = list(target_dir.iterdir())
+    if len(entries) == 1 and entries[0].is_dir() and not entries[0].is_symlink():
+        return entries[0]
     return target_dir

--- a/nab-python/tests/test_archive.py
+++ b/nab-python/tests/test_archive.py
@@ -483,3 +483,55 @@ class TestExtractArchive:
         out.mkdir()
         with pytest.raises(ValueError, match="broken link in sdist member"):
             extract_sdist_archive(buf.getvalue(), out)
+
+    @requires_data_filter
+    def test_flat_archive_with_one_package_dir_keeps_root(self, tmp_path: Path) -> None:
+        # Top-level project files beside a lone package dir: the package dir is
+        # not a wrapping root, so the source root stays the extraction root.
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            for name, text in (
+                ("pyproject.toml", _PYPROJECT),
+                ("setup.py", "from setuptools import setup\n\nsetup()\n"),
+                ("mypkg/__init__.py", ""),
+            ):
+                body = text.encode("utf-8")
+                info = tarfile.TarInfo(name)
+                info.size = len(body)
+                tar.addfile(info, io.BytesIO(body))
+        out = tmp_path / "out"
+        out.mkdir()
+        root = extract_sdist_archive(buf.getvalue(), out)
+        assert root == out.resolve()
+        assert (root / "pyproject.toml").is_file()
+
+    @requires_data_filter
+    def test_wrapping_directory_is_the_source_root(self, tmp_path: Path) -> None:
+        # A conformant sdist holds every member under one name-version directory,
+        # and that directory is the source root the build backend runs in.
+        out = tmp_path / "out"
+        out.mkdir()
+        root = extract_sdist_archive(_make_sdist("foo", "1.0.0", _PYPROJECT), out)
+        assert root == out.resolve() / "foo-1.0.0"
+        assert (root / "pyproject.toml").is_file()
+
+    @requires_data_filter
+    def test_top_level_file_beside_a_directory_keeps_root(self, tmp_path: Path) -> None:
+        # A stray top-level file means no directory wraps every member, so the
+        # root stays at the extraction dir instead of guessing that the lone
+        # directory is the source tree.
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            for name, text in (
+                ("foo-1.0.0/pyproject.toml", _PYPROJECT),
+                ("README", "readme\n"),
+            ):
+                body = text.encode("utf-8")
+                info = tarfile.TarInfo(name)
+                info.size = len(body)
+                tar.addfile(info, io.BytesIO(body))
+        out = tmp_path / "out"
+        out.mkdir()
+        root = extract_sdist_archive(buf.getvalue(), out)
+        assert root == out.resolve()
+        assert (root / "foo-1.0.0" / "pyproject.toml").is_file()


### PR DESCRIPTION
A flat sdist unpacks its build files (pyproject.toml, setup.py) at the top level next to a single package directory. `extract_sdist_archive` picked the source root by looking for a lone top-level directory and returning it whenever exactly one existed, so it returned the package directory and left the top-level build files behind. The source root then had nothing to build from.

Now a subdirectory is only chosen as the source root when the archive has exactly one top-level entry and it is a real directory wrapping every member. When top-level files sit beside a package directory, or there are several top-level directories, the root stays at the extraction directory.
