### PR TITLE
wrap malformed build-system table errors as BuildBackendError

### DIFF
--- a/nab-python/src/nab_python/_build/runner.py
+++ b/nab-python/src/nab_python/_build/runner.py
@@ -120,7 +120,11 @@ def run_build_backend(
                 else:
                     metadata_dir = Path(project.metadata_path(output_dir))
                 return _parse_metadata(metadata_dir / "METADATA")
-    except build.BuildBackendException as exc:
+    except (
+        build.BuildException,
+        build.BuildBackendException,
+        build.FailedProcessError,
+    ) as exc:
         msg = f"build backend {backend!r} failed: {exc}"
         raise BuildBackendError(msg) from exc
     except (BuildEnvError, ResolutionError) as exc:

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -360,6 +360,23 @@ class TestRunBuildBackend:
         ):
             run_build_backend(tmp_path, config=config)
 
+    def test_build_system_table_rejected_wrapped(
+        self, tmp_path: Path, config: NabProjectConfig
+    ) -> None:
+        """build.BuildSystemTableValidationError from an invalid build-system table is wrapped as BuildBackendError."""
+        (tmp_path / "pyproject.toml").write_text(
+            '[build-system]\nbuild-backend = "setuptools.build_meta"\n',
+            encoding="utf-8",
+        )
+        env = MagicMock()
+        env.__enter__ = MagicMock(return_value=env)
+        env.__exit__ = MagicMock(return_value=None)
+        with (
+            patch("nab_python._build.runner.NabBuildEnv", return_value=env),
+            pytest.raises(BuildBackendError, match="setuptools.build_meta"),
+        ):
+            run_build_backend(tmp_path, config=config)
+
 
 class TestShouldSkipPrepare:
     """Unit tests for the hatchling+dynamic-deps detection predicate."""


### PR DESCRIPTION
run_build_backend promises to raise BuildBackendError on any failure, but a source whose [build-system] table our reader tolerates while the build library rejects it (for example, a table with no requires) leaked a raw build.BuildSystemTableValidationError. On the local, VCS, and archive source paths that error slipped past extract_source_metadata's BuildBackendError catch and the CLI's except list, so the resolve crashed with an unhandled traceback instead of reporting the build failure.

The except clause only caught build.BuildBackendException. BuildSystemTableValidationError derives from build.BuildException, and FailedProcessError is a separate sibling, so neither was covered. Widen the catch to build.BuildException and build.FailedProcessError, so anything raised by the build call comes back as a BuildBackendError.
