### PR TITLE
lock --locked: clean error on a malformed committed pylock

### DIFF
--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -178,7 +178,7 @@ def read_lockfile_anchor(path: Path) -> datetime | None:
     try:
         with path.open("rb") as f:
             data = tomli.load(f)
-    except (OSError, tomli.TOMLDecodeError):
+    except (OSError, UnicodeDecodeError, tomli.TOMLDecodeError):
         return None
     nab = tool_nab_section(data)
     raw = nab.get("created-at") if isinstance(nab, dict) else None
@@ -212,7 +212,7 @@ def read_lockfile_packages(path: Path) -> dict[str, Version] | None:
         with path.open("rb") as f:
             data = tomli.load(f)
         pylock = Pylock.from_dict(data)
-    except (OSError, tomli.TOMLDecodeError, PylockValidationError):
+    except (OSError, UnicodeDecodeError, tomli.TOMLDecodeError, PylockValidationError):
         return None
     return {
         str(pkg.name): pkg.version for pkg in pylock.packages if pkg.version is not None

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -1381,6 +1381,11 @@ class TestReadLockfileAnchor:
         path.write_text("this is not [[[ valid TOML")
         assert read_lockfile_anchor(path) is None
 
+    def test_returns_none_when_not_utf8(self, tmp_path: Path) -> None:
+        path = tmp_path / "pylock.toml"
+        path.write_bytes(b"\xff\xfe not utf-8")
+        assert read_lockfile_anchor(path) is None
+
     def test_returns_none_when_no_tool_nab(self, tmp_path: Path) -> None:
         path = tmp_path / "pylock.toml"
         path.write_text('lock-version = "1.0"\n')
@@ -1451,6 +1456,11 @@ class TestReadLockfilePackages:
     def test_returns_none_when_toml_invalid(self, tmp_path: Path) -> None:
         path = tmp_path / "pylock.toml"
         path.write_text("this is not [[[ valid TOML")
+        assert read_lockfile_packages(path) is None
+
+    def test_returns_none_when_not_utf8(self, tmp_path: Path) -> None:
+        path = tmp_path / "pylock.toml"
+        path.write_bytes(b"\xff\xfe not utf-8")
         assert read_lockfile_packages(path) is None
 
     def test_returns_none_when_not_a_pylock(self, tmp_path: Path) -> None:

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -335,7 +335,14 @@ def _check_locked(
     except _cli.MissingHashError as e:
         sys.stderr.write(f"Cannot lock: {e}\n")
         sys.exit(1)
-    committed = _packages_only(target.read_text(encoding="utf-8"))
+    try:
+        committed = _packages_only(target.read_text(encoding="utf-8"))
+    except (UnicodeDecodeError, tomli.TOMLDecodeError) as e:
+        sys.stderr.write(
+            f"Error: --locked: lockfile {target} is not valid TOML: {e};"
+            " re-run `nab lock` to regenerate it.\n"
+        )
+        sys.exit(1)
     if _packages_only(new_text) == committed:
         sys.stderr.write(f"Lockfile {target} is up to date.\n")
         return

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2423,6 +2423,44 @@ class TestLockedFlag:
         assert "Cannot lock" in capsys.readouterr().err
         assert out.read_bytes() == before
 
+    def test_malformed_committed_lock_exits_one(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # A committed pylock that is not valid TOML exits with a message,
+        # not a raw TOMLDecodeError.
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        self._write_lock(
+            pyproject, out, _stub_resolution_result(pins={"foo": V("1.0")})
+        )
+        capsys.readouterr()
+        out.write_text('lock-version = "1.0"\n<<<<<<< HEAD\n', encoding="utf-8")
+        with pytest.raises(SystemExit) as exc:
+            self._run_locked(
+                pyproject, out, _stub_resolution_result(pins={"foo": V("1.0")})
+            )
+        assert exc.value.code == 1
+        assert "is not valid TOML" in capsys.readouterr().err
+
+    def test_non_utf8_committed_lock_exits_one(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # A committed pylock that is not valid UTF-8 exits the same way,
+        # not a raw UnicodeDecodeError.
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        self._write_lock(
+            pyproject, out, _stub_resolution_result(pins={"foo": V("1.0")})
+        )
+        capsys.readouterr()
+        out.write_bytes(b"\xff\xfe not utf-8")
+        with pytest.raises(SystemExit) as exc:
+            self._run_locked(
+                pyproject, out, _stub_resolution_result(pins={"foo": V("1.0")})
+            )
+        assert exc.value.code == 1
+        assert "is not valid TOML" in capsys.readouterr().err
+
     def test_requirements_format_unsupported(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
`nab lock --locked` reads the committed `pylock.toml` back and compares it to a fresh resolve, but nothing caught a parse failure on that read. If the committed file was corrupt (an unresolved merge conflict left in it, a truncated write) or not valid UTF-8, the command crashed with a raw `TOMLDecodeError` or `UnicodeDecodeError` traceback instead of saying what was wrong.

It now catches both and exits 1 with a message naming the file and pointing at `nab lock` to regenerate it.

While here, the two read helpers in the lockfile builder that already ignored TOML and OS errors now also ignore `UnicodeDecodeError`, so a non-UTF-8 committed lock returns `None` rather than raising.
