### PR TITLE
exit cleanly on a malformed Simple-API listing, not a raw TypeError

### DIFF
--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -18,6 +18,7 @@ from .cache import CacheBackend, CachePolicy, OfflineError
 from .client import (
     _HTTP_NOT_FOUND,
     DEFAULT_INDEX,
+    MalformedSimpleResponseError,
     SdistFile,
     WheelFile,
     _extract_sdist_files,
@@ -127,10 +128,11 @@ class CachedAsyncSimpleClient:
         return await self._fetch_simple(package)
 
     def _parse_listing(self, body: bytes, package: str) -> list[WheelFile | SdistFile]:
-        """Parse a Simple-API listing body, raising :class:`TypeError` on non-JSON.
+        """Parse a Simple-API listing body.
 
-        A non-JSON body raises the same :class:`TypeError` as a valid-JSON body
-        of the wrong shape, not a raw :class:`json.JSONDecodeError`.
+        A non-JSON body raises the same
+        :class:`MalformedSimpleResponseError` as a valid-JSON body of the
+        wrong shape, not a raw :class:`json.JSONDecodeError`.
         """
         try:
             data = json.loads(body)
@@ -139,7 +141,7 @@ class CachedAsyncSimpleClient:
                 f"{self._index_url} served a malformed Simple-API response for "
                 f"{package!r}: body is not valid JSON"
             )
-            raise TypeError(msg) from exc
+            raise MalformedSimpleResponseError(msg) from exc
         return _parse_files(data, self._index_url, package)
 
     async def _revalidate_simple(

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -24,6 +24,8 @@ from packaging.utils import (
 )
 from packaging.version import InvalidVersion, Version
 
+from .transport import HttpError
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -35,6 +37,7 @@ if TYPE_CHECKING:
 __all__ = [
     "DEFAULT_INDEX",
     "AsyncSimpleClient",
+    "MalformedSimpleResponseError",
     "MetadataHashMismatchError",
     "SdistFile",
     "SdistHashMismatchError",
@@ -49,6 +52,14 @@ _ACCEPTED_HASH_ALGORITHMS = ("sha256", "sha384", "sha512")
 # 3.10.12 / 3.11.4; sdist extraction requires it (see extract_sdist_archive).
 # data_filter appears with the same change, so its presence detects support.
 _SUPPORTS_DATA_FILTER = hasattr(tarfile, "data_filter")
+
+
+class MalformedSimpleResponseError(HttpError):
+    """The index served a 200 response that is not a usable Simple-API listing.
+
+    Subclasses :class:`HttpError` so a broken listing is caught alongside
+    transport and 4xx/5xx failures.
+    """
 
 
 class MetadataHashMismatchError(Exception):
@@ -284,10 +295,10 @@ def _parse_files(
     / ``url``) is skipped so the usable entries in the same listing are
     kept.  A malformed *body* (not a JSON object, or a ``files`` value
     that is not a list) is a broken response, not an empty one, so it
-    raises :class:`TypeError` rather than returning no files: an empty
-    result means "package absent" to the multi-index router, which would
-    otherwise fall through to a lower-priority index and risk pinning a
-    different version.
+    raises :class:`MalformedSimpleResponseError` rather than returning no
+    files: an empty result means "package absent" to the multi-index router,
+    which would otherwise fall through to a lower-priority index and risk
+    pinning a different version.
     """
     expected = canonicalize_name(package)
     # PEP 691: relative URLs resolve against the package page, not the index root.
@@ -298,14 +309,14 @@ def _parse_files(
             f"{index_url} served a malformed Simple-API response for "
             f"{package!r}: body is {type(data).__name__}, expected a JSON object"
         )
-        raise TypeError(msg)
+        raise MalformedSimpleResponseError(msg)
     raw_files = data.get("files")
     if not isinstance(raw_files, list):
         msg = (
             f"{index_url} served a malformed Simple-API response for "
             f"{package!r}: 'files' is {type(raw_files).__name__}, expected a list"
         )
-        raise TypeError(msg)
+        raise MalformedSimpleResponseError(msg)
     for file_info in raw_files:
         if not isinstance(file_info, dict):
             continue

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -22,6 +22,7 @@ from nab_index.cached_client import (
     _parse_max_age,
 )
 from nab_index.client import (
+    MalformedSimpleResponseError,
     MetadataHashMismatchError,
     SdistFile,
     SdistHashMismatchError,
@@ -973,7 +974,7 @@ class TestNonJsonListingBody:
             finally:
                 await client.aclose()
 
-        with pytest.raises(TypeError, match="malformed Simple-API"):
+        with pytest.raises(MalformedSimpleResponseError, match="malformed Simple-API"):
             asyncio.run(go())
         assert cache.get_simple("foo") is None
 
@@ -988,7 +989,7 @@ class TestNonJsonListingBody:
             finally:
                 await client.aclose()
 
-        with pytest.raises(TypeError, match="malformed Simple-API"):
+        with pytest.raises(MalformedSimpleResponseError, match="malformed Simple-API"):
             asyncio.run(cold())
         assert len(online.calls) == 1
 
@@ -1023,7 +1024,7 @@ class TestNonJsonListingBody:
             finally:
                 await client.aclose()
 
-        with pytest.raises(TypeError, match="malformed Simple-API"):
+        with pytest.raises(MalformedSimpleResponseError, match="malformed Simple-API"):
             asyncio.run(go())
         cached = cache.get_simple("pkg")
         assert cached is not None

--- a/nab-python/tests/test_simple_client_malformed.py
+++ b/nab-python/tests/test_simple_client_malformed.py
@@ -10,7 +10,12 @@ from __future__ import annotations
 
 import pytest
 
-from nab_index.client import WheelFile, _parse_files
+from nab_index.client import (
+    MalformedSimpleResponseError,
+    WheelFile,
+    _parse_files,
+)
+from nab_index.transport import HttpError
 
 _INDEX = "https://example.com/"
 
@@ -30,25 +35,31 @@ def test_valid_body_parses() -> None:
     assert files[0].filename == "foo-1.0-py3-none-any.whl"
 
 
+def test_malformed_body_is_index_error() -> None:
+    """A malformed body raises ``HttpError``, not just the subclass."""
+    with pytest.raises(HttpError, match="malformed Simple-API"):
+        _parse_files("oops", _INDEX, "foo")
+
+
 def test_non_dict_body_raises() -> None:
-    with pytest.raises(TypeError, match="malformed Simple-API"):
+    with pytest.raises(MalformedSimpleResponseError, match="malformed Simple-API"):
         _parse_files(["foo"], _INDEX, "foo")
 
 
 def test_non_string_body_raises() -> None:
-    with pytest.raises(TypeError, match="malformed Simple-API"):
+    with pytest.raises(MalformedSimpleResponseError, match="malformed Simple-API"):
         _parse_files("oops", _INDEX, "foo")
 
 
 def test_non_list_files_value_raises() -> None:
-    with pytest.raises(TypeError, match="malformed Simple-API"):
+    with pytest.raises(MalformedSimpleResponseError, match="malformed Simple-API"):
         _parse_files({"files": "oops"}, _INDEX, "foo")
-    with pytest.raises(TypeError, match="malformed Simple-API"):
+    with pytest.raises(MalformedSimpleResponseError, match="malformed Simple-API"):
         _parse_files({"files": {"a": 1}}, _INDEX, "foo")
 
 
 def test_missing_files_key_raises() -> None:
-    with pytest.raises(TypeError, match="malformed Simple-API"):
+    with pytest.raises(MalformedSimpleResponseError, match="malformed Simple-API"):
         _parse_files({}, _INDEX, "foo")
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -508,6 +508,29 @@ class TestLockCommandSpecific:
         assert "Cannot lock" in err
         assert "503" in err
 
+    def test_malformed_simple_response_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A malformed Simple-API listing exits 1 cleanly, not a raw traceback.
+
+        Raises the parser's real error so the test tracks whatever type a
+        broken 200 body produces.
+        """
+        from nab_index.client import _parse_files
+
+        with pytest.raises(HttpError, match="malformed Simple-API") as caught:
+            _parse_files(b"<!doctype html>", "https://pypi.org/simple/", "foo")
+
+        pyproject = _make_pyproject(tmp_path)
+        with (
+            patch("nab.cli.resolve_pyproject", side_effect=caught.value),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject)
+        err = capsys.readouterr().err
+        assert "malformed Simple-API" in err
+        assert "Traceback" not in err
+
     def test_missing_sdist_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -1204,6 +1227,25 @@ class TestLockCommandUniversal:
         err = capsys.readouterr().err
         assert "Cannot lock" in err
         assert "503" in err
+
+    def test_malformed_simple_response_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A malformed Simple-API listing exits 1 cleanly, not a raw traceback."""
+        from nab_index.client import _parse_files
+
+        with pytest.raises(HttpError, match="malformed Simple-API") as caught:
+            _parse_files(b"<!doctype html>", "https://pypi.org/simple/", "foo")
+
+        pyproject = _universal_pyproject(tmp_path)
+        with (
+            patch("nab.cli.resolve_universal_pyproject", side_effect=caught.value),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, format="requirements-without-hashes")
+        err = capsys.readouterr().err
+        assert "Cannot lock" in err
+        assert "malformed Simple-API" in err
 
     def test_requirements_missing_hash_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
When an index returns a 200 whose body is not a usable Simple-API listing (an HTML error page, or JSON of the wrong shape), the listing parser raised a plain TypeError. The CLI maps HttpError and a handful of other errors to a clean exit but not TypeError, so a broken listing escaped as a raw Python traceback.

This adds MalformedSimpleResponseError as a subclass of HttpError and raises it in that case, so a broken listing exits 1 with the same readable message the transport and 4xx/5xx failures already produce.
