### PR TITLE
exit cleanly on non-UTF-8 local index listing

### DIFF
--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -37,12 +37,14 @@ from .client import (
     _parse_sdist_filename,
     _parse_wheel_filename,
 )
+from .transport import HttpError
 
 if TYPE_CHECKING:
     from typing_extensions import Self
 
 __all__ = [
     "LocalIndexClient",
+    "MalformedLocalListingError",
     "UnsupportedWheelError",
     "parse_file_url",
     "read_wheel_metadata",
@@ -55,6 +57,17 @@ class UnsupportedWheelError(Exception):
     Raised when a wheel carries more than one top-level ``.dist-info``
     directory, or a single one whose name does not canonicalise to the
     distribution named by the wheel's filename.
+    """
+
+
+class MalformedLocalListingError(HttpError):
+    """A local ``file://`` index's ``index.html`` is not a usable listing.
+
+    Subclasses :class:`~nab_index.transport.HttpError` so a broken local
+    listing fails through the same path as a remote index error rather
+    than surfacing a raw decode error.  Raising, rather than returning an
+    empty listing, keeps a malformed index from reading as an absent
+    package.
     """
 
 
@@ -147,8 +160,15 @@ def _scan_pep503_directory(
     index_html = package_dir / "index.html"
     if not index_html.exists():
         return []
+
+    try:
+        text = index_html.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        msg = f"{index_html} is not valid UTF-8: {exc}"
+        raise MalformedLocalListingError(msg) from exc
+
     parser = _Pep503Parser()
-    parser.feed(index_html.read_text(encoding="utf-8"))
+    parser.feed(text)
     files: list[WheelFile | SdistFile] = []
     for href, requires_python, has_metadata in parser.links:
         filename, file_url, local_path, hashes = _resolve_local_link(href, package_dir)

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -14,12 +14,14 @@ import pytest
 from nab_index.client import SdistFile, WheelFile
 from nab_index.local_index import (
     LocalIndexClient,
+    MalformedLocalListingError,
     UnsupportedWheelError,
     _make_record,
     _read_sdist_requires_python,
     parse_file_url,
     read_wheel_metadata,
 )
+from nab_index.transport import HttpError
 
 if TYPE_CHECKING:
     from collections.abc import Coroutine, Iterator
@@ -363,6 +365,20 @@ class TestPep503Directory:
         client = LocalIndexClient(tmp_path.as_uri())
         result = run(client.get_files("foo"))
         assert result == []
+
+    def test_non_utf8_index_html_raises_http_error(self, tmp_path: Path) -> None:
+        # A non-UTF-8 listing must raise, not return an empty list: an empty
+        # result would read as "package absent".
+        package_dir = tmp_path / "foo"
+        package_dir.mkdir()
+        (package_dir / "index.html").write_bytes(
+            b'<a href="foo-1.0-py3-none-any.whl">foo-1.0</a>\xff\xfe'
+        )
+        client = LocalIndexClient(tmp_path.as_uri())
+        with pytest.raises(MalformedLocalListingError) as caught:
+            run(client.get_files("foo"))
+        assert isinstance(caught.value, HttpError)
+        assert "not valid UTF-8" in str(caught.value)
 
     def test_file_scheme_href(self, tmp_path: Path) -> None:
         # Uncommon but legal: a file:// scheme on the anchor


### PR DESCRIPTION
Pointing nab at a `file://` index whose `index.html` isn't valid UTF-8 crashed `nab lock` with a raw `UnicodeDecodeError` traceback instead of a readable error.

`_scan_pep503_directory` read the listing with `read_text(encoding="utf-8")` and let the decode error propagate. Now a decode failure raises `MalformedLocalListingError`, which subclasses `HttpError`, so the CLI's existing handler catches it and exits with a message and status 1, the same as any other bad index. It raises rather than returning an empty listing, so a malformed index doesn't read as an absent package.
