### PR TITLE
map httpx.InvalidURL and idna errors to HttpError in async transport

### DIFF
--- a/nab-index/src/nab_index/httpx_async_transport.py
+++ b/nab-index/src/nab_index/httpx_async_transport.py
@@ -78,7 +78,9 @@ class HttpxAsyncTransport:
         """Send a GET request."""
         try:
             response = await self._client.get(url, headers=headers)
-        except httpx.HTTPError as exc:
+        except Exception as exc:
+            # httpx raises InvalidURL and lets idna hostname errors escape its
+            # HTTPError hierarchy, so wrap every failure to issue the request.
             msg = f"GET {url} failed: {exc}"
             raise HttpError(msg) from exc
         return _HttpxResponse(response)

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -131,6 +131,35 @@ class TestHttpxAsyncTransport:
         with pytest.raises(HttpError, match="GET https://example.com/ failed"):
             asyncio.run(go())
 
+    @pytest.mark.parametrize(
+        "raised",
+        [
+            httpx.InvalidURL("Invalid IDNA hostname"),
+            UnicodeError("idna codepoint not allowed"),
+        ],
+    )
+    def test_get_wraps_non_httperror_from_request(
+        self, raised: Exception, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-HTTPError raised while issuing the request maps to HttpError."""
+
+        async def go() -> None:
+            transport = HttpxAsyncTransport(http2=False)
+
+            async def boom(*args: object, **kwargs: object) -> object:
+                raise raised
+
+            monkeypatch.setattr(transport._client, "get", boom)
+            try:
+                await transport.get("https://bad.example/simple/pkg/")
+            finally:
+                await transport.aclose()
+
+        with pytest.raises(
+            HttpError, match="GET https://bad.example/simple/pkg/ failed"
+        ):
+            asyncio.run(go())
+
     def test_uses_truststore_ssl_context(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """AsyncClient gets a truststore SSLContext via verify=."""
         cls = MagicMock()


### PR DESCRIPTION
The transports promise to raise HttpError from get so callers can handle index failures without importing a specific HTTP backend. The httpx transport only caught httpx.HTTPError, but httpx.InvalidURL sits outside that hierarchy and idna hostname validation raises a bare UnicodeError, so a malformed index URL leaked the raw backend exception past the transport boundary. The urllib3 transport already routes the same failures through its HTTPError catch, so the two backends behaved differently.

get now wraps any error raised while issuing the request as HttpError, so a bad URL surfaces the same way on both transports.
