### PR TITLE
fix NO_VERSIONS reason mislabeling a filtered package as absent

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -1441,9 +1441,23 @@ class Provider:
         missing from the index when in fact it is the resolver's
         transitive constraints (or a too-strict build policy) that
         excluded every candidate.
+
+        ``all_versions`` is post-filter, so an empty one means either the
+        index served no files or every file it served was dropped by
+        requires-python, dist-policy, or the upload-time cutoff.  The raw
+        listing tells the two apart: a non-empty one is present but
+        incompatible, not absent.
         """
         if not all_versions:
-            reason = "package not found on any configured index"
+            _, _, normalized = self.split_and_normalize(package)
+            raw_listing = self.coordinator.index.get_listing(normalized)
+            if raw_listing:
+                reason = (
+                    "found on index but no distribution is compatible "
+                    "(all filtered by requires-python, dist-policy, or upload-time)"
+                )
+            else:
+                reason = "package not found on any configured index"
         elif blockers:
             # Look-ahead rejection: candidates DID match the range but
             # were rejected.  Naming the blocker is more useful than

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -854,6 +854,35 @@ class TestNoVersionsReasons:
             == "no version matches the requirement"
         )
 
+    def test_present_but_requires_python_filtered_reports_incompatible(self) -> None:
+        """A requires-python-filtered package reports incompatible, not absent."""
+        coordinator = make_coordinator(
+            [
+                make_wheel("1.0", requires_python=">=3.13"),
+                make_wheel("2.0", requires_python=">=3.13"),
+                make_wheel("3.0", requires_python=">=3.13"),
+            ],
+            package="foo",
+        )
+        provider = Provider(coordinator, python_version="3.9.0")
+        provider.choose_version("foo", SpecifierSet("").to_range())
+        assert (
+            provider.get_no_versions_reason("foo")
+            == "found on index but no distribution is compatible "
+            "(all filtered by requires-python, dist-policy, or upload-time)"
+        )
+
+    def test_present_but_dist_policy_filtered_reports_incompatible(self) -> None:
+        """A dist-policy-filtered package reports incompatible, not absent."""
+        coordinator = make_coordinator([make_sdist("1.0")], package="foo")
+        provider = Provider(coordinator, dist_policy=DistPolicy.WHEEL_ONLY)
+        provider.choose_version("foo", SpecifierSet("").to_range())
+        assert (
+            provider.get_no_versions_reason("foo")
+            == "found on index but no distribution is compatible "
+            "(all filtered by requires-python, dist-policy, or upload-time)"
+        )
+
     def test_get_reason_returns_none_for_unknown_package(self) -> None:
         """Packages without a recorded reason return ``None``."""
         coordinator = make_coordinator([], package="foo")


### PR DESCRIPTION
When a package is present on a configured index but every distribution gets filtered out (by requires-python, dist-policy, or the upload-time cutoff), the NO_VERSIONS reason read "package not found on any configured index". That points people at the wrong thing: they go check the package name or their index config when the real problem is that nothing served is compatible.

The version list is post-filter, so on its own it can't tell "absent" from "all filtered". The reason now consults the raw index listing. If that listing is non-empty the message says the package was found but no distribution is compatible, and it keeps "not found on any configured index" only when the index truly served nothing.
