### PR TITLE
fix resolver error printing a forbidden version as a dependency

### DIFF
--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -2414,6 +2414,64 @@ class TestDecisionLookAhead:
         terms = clauses[0].terms
         assert {t.package for t in terms} == {"foo", "bar"}
 
+    def test_full_resolve_reports_lookahead_clause_as_incompatible(self) -> None:
+        """The look-ahead grouped clause renders as an incompatibility.
+
+        Root needs foo and app; foo 1.0 requires lib==9.0 while app 3.0
+        requires lib==5.0.  The resolve fails, and the grouped clause that
+        rejects app against the decided lib==9.0 carries the blocker term
+        positive.  It must render as app being incompatible with lib 9.0, not
+        as app depending on it; app's real dependency is lib 5.0.
+        """
+
+        def named_wheel(pkg: str, version: str) -> WheelFile:
+            return WheelFile(
+                filename=f"{pkg}-{version}-py3-none-any.whl",
+                url=f"https://example.com/{pkg}-{version}.whl",
+                version=version,
+                requires_python=None,
+                has_metadata=True,
+                upload_time=None,
+                local_path=None,
+            )
+
+        def meta(name: str, version: str, *reqs: str) -> str:
+            lines = ["Metadata-Version: 2.1", f"Name: {name}", f"Version: {version}"]
+            lines += [f"Requires-Dist: {r}" for r in reqs]
+            return "\n".join(lines) + "\n"
+
+        coordinator = make_coordinator(
+            listings={
+                "foo": [named_wheel("foo", "1.0")],
+                "app": [named_wheel("app", "3.0")],
+                "lib": [named_wheel("lib", "5.0"), named_wheel("lib", "9.0")],
+            },
+            metadata_by_version={
+                "1.0": meta("foo", "1.0", "lib==9.0"),
+                "3.0": meta("app", "3.0", "lib==5.0"),
+                "5.0": meta("lib", "5.0"),
+                "9.0": meta("lib", "9.0"),
+            },
+        )
+        root_reqs = {
+            "foo": VersionRange.full(admit_arbitrary=False),
+            "app": VersionRange.full(admit_arbitrary=False),
+        }
+        provider = Provider(
+            coordinator, python_version="3.12.0", root_requirements=root_reqs
+        )
+        resolver = Resolver(provider, range_type=VersionRange, root_version="0")
+        with pytest.raises(ResolutionError) as exc_info:
+            resolver.resolve(dict(root_reqs))
+
+        lines = str(exc_info.value).splitlines()
+        assert not [
+            ln for ln in lines if "app" in ln and "lib" in ln and "depends on" in ln
+        ]
+        assert any(
+            "app" in ln and "lib" in ln and "incompatible with" in ln for ln in lines
+        )
+
 
 class TestLookAheadAbort:
     """Look-ahead abort path: when the scan rejects ``_LOOKAHEAD_ABORT_THRESHOLD``

--- a/nab-resolver/src/nab_resolver/report.py
+++ b/nab-resolver/src/nab_resolver/report.py
@@ -97,8 +97,13 @@ def _render_line(
         and len(terms) == _ATTRIBUTION_CLAUSE_TERMS
     ):
         parent, dep = terms
-        positive_dep = dep if dep.is_positive() else dep.negate()
-        return f"because {format_term(parent)} depends on {format_term(positive_dep)}"
+        # A negative dep term holds the parent's required range (negate to
+        # show it); a positive dep term holds a version the parent forbids.
+        if dep.is_positive():
+            return (
+                f"because {format_term(parent)} is incompatible with {format_term(dep)}"
+            )
+        return f"because {format_term(parent)} depends on {format_term(dep.negate())}"
 
     if cause is IncompatibilityCause.ROOT and len(terms) == _ATTRIBUTION_CLAUSE_TERMS:
         _, dep = terms

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -1797,6 +1797,23 @@ class TestErrorMessages:
         message = format_error(clause)
         assert message == "because foo 2 depends on bar [3, +inf)"
 
+    def test_positive_dependency_term_reads_as_incompatible(self) -> None:
+        """A both-positive DEPENDENCY clause reads as an incompatibility.
+
+        The look-ahead flush groups rejected candidates into
+        ``{candidate in {v}, blocker == w}`` with the blocker term positive,
+        so it holds the version the candidate forbids, not a required range.
+        It must not claim the candidate depends on that version.
+        """
+        candidate = Term("app", Range.singleton(3), positive=True)
+        blocker = Term("lib", Range.singleton(9), positive=True)
+        clause = Incompatibility(
+            [candidate, blocker], cause=IncompatibilityCause.DEPENDENCY
+        )
+        message = format_error(clause)
+        assert message == "because app 3 is incompatible with lib 9"
+        assert "depends on" not in message
+
     def test_root_clause_attributes_to_the_project(self) -> None:
         """A ROOT clause reads as a project dependency and ignores the root term."""
         root = Term("root", Range.singleton(0), positive=True)


### PR DESCRIPTION
A failed resolve could print an error like `app 3 depends on lib 9` when app actually requires lib 5. The line named the exact version the resolver had ruled out for app and stated it as if app had asked for it.

Real dependency clauses store the requirement as a negative term, and the renderer negates it to show the required range. A look-ahead exclusion instead groups the rejected candidate with the blocking version as a positive term, so the two cannot hold together. The renderer treated both the same and printed the positive term as a dependency. It now reads such a clause as `app 3 is incompatible with lib 9`.
