### PR TITLE
Fix stale pypi refs in late-import comments

### DIFF
--- a/nab-python/src/nab_python/_provider/extras.py
+++ b/nab-python/src/nab_python/_provider/extras.py
@@ -101,7 +101,7 @@ def _pick_in_mode(
     the proxy always needs the base metadata. BACKTRACK mode additionally
     checks ``Provides-Extra`` for transitive extras.
     """
-    # Late import: ``pypi`` imports this module at module load.
+    # Late import: ``provider`` imports this module at module load.
     from ..provider import ExtrasMode, MetadataError, _normalize_extra
 
     _, _, normalized = provider.split_and_normalize(base)
@@ -176,7 +176,7 @@ def _record_base_range_blocks(
     tighter (a singleton blocker) than recording against the range.
     """
     # Late import: ``lookahead`` shares state with this module
-    # through ``pypi`` and importing it at module load creates a cycle.
+    # through ``provider`` and importing it at module load creates a cycle.
     from .lookahead import flush_pending_blocks
 
     base_decision = provider.solution_decisions.get(base_normalized)
@@ -200,7 +200,7 @@ def get_extra_dependencies(
     version: Version,
 ) -> dict[str, VersionRange]:
     """Get dependencies for an extras proxy package."""
-    # Late import: ``pypi`` imports this module at module load.
+    # Late import: ``provider`` imports this module at module load.
     from ..provider import MetadataError, join_extra
 
     _, _, normalized = provider.split_and_normalize(base)
@@ -254,7 +254,7 @@ def handle_missing_extra(
     only the base dep (BACKTRACK skips these versions in
     choose_version before we get here).
     """
-    # Late import: ``pypi`` imports this module at module load.
+    # Late import: ``provider`` imports this module at module load.
     from ..provider import ExtrasMode, MissingExtraError
 
     is_user = (normalized, extra) in provider.root_extras

--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -274,7 +274,7 @@ def filter_distributions(
     chosen version.  The wheels are dropped later, at lock
     construction time, so only the sdist ends up pinned.
     """
-    # Late import: ``pypi`` imports this module at module load.
+    # Late import: ``provider`` imports this module at module load.
     from ..provider import DistPolicy
 
     index_name = provider.serving_index(normalized)
@@ -362,7 +362,7 @@ def _excluded_by_dist_policy(dist: DistFile, policy: object) -> bool:
     other policies admit both kinds here (``SDIST_INSTALL`` keeps wheels
     as a metadata source and prunes them at lock-construction time).
     """
-    # Late import: ``pypi`` imports this module at module load.
+    # Late import: ``provider`` imports this module at module load.
     from ..provider import DistPolicy
 
     if policy == DistPolicy.WHEEL_ONLY:

--- a/nab-python/src/nab_python/_provider/lookahead.py
+++ b/nab-python/src/nab_python/_provider/lookahead.py
@@ -40,7 +40,7 @@ def look_ahead_ok(
     rejection so the resolver moves on; the message is recorded for the
     eventual no-versions diagnostic.
     """
-    # Late import: pypi imports this module at module load.
+    # Late import: provider imports this module at module load.
     from ..provider import MetadataError
 
     if provider.split_and_normalize(package)[1] is not None:

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -181,7 +181,7 @@ def resolve_dynamic_sdist(
     :func:`nab_python._provider.lookahead.look_ahead_ok` and surfaces the
     accumulated reasons if no candidate ultimately works.
     """
-    # Late import: ``pypi`` imports this module at module load.
+    # Late import: ``provider`` imports this module at module load.
     from ..provider import BuildPolicy, UnsupportedSdistError
     from .build_remote import build_remote_sdist
 
@@ -450,7 +450,7 @@ def cache_deps_from_metadata(
     :meth:`nab_python.provider.Provider.get_dependencies` (which hands in a
     bare :class:`WheelMetadata` for a complete ``dependencies`` override).
     """
-    # Late import: ``pypi`` imports this module at module load.
+    # Late import: ``provider`` imports this module at module load.
     from ..provider import _normalize_extra
 
     package, version = cache_key
@@ -554,7 +554,7 @@ def add_classified_dep(
     A name appearing on several ``Requires-Dist`` lines is intersected
     into one range.
     """
-    # Late import: ``pypi`` imports this module at module load.
+    # Late import: ``provider`` imports this module at module load.
     from ..provider import join_extra
 
     name = canonicalize_name(req.name)

--- a/nab-python/src/nab_python/_provider/sources.py
+++ b/nab-python/src/nab_python/_provider/sources.py
@@ -163,7 +163,7 @@ def index_vcs_sources(
     repo, and pin allowlists apply to ``[[tool.nab.vcs-sources]]``
     just like project-root direct-URL requirements.
     """
-    # Late import: ``pypi`` imports this module at module load.
+    # Late import: ``provider`` imports this module at module load.
     from .._vcs_admission import admit_vcs_url
     from ..provider import VcsPolicy
 


### PR DESCRIPTION
The late-import comments in `_provider/` said `pypi` imports the module, but `pypi.py` was renamed to `provider.py`. Point the comments at the module that actually does the import.

Comment-only, no behavior change.