### PR TITLE
use pp3-none-any for pure-Python PyPy wheel compatibility

### DIFF
--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -691,13 +691,19 @@ def _tags_in_order(
             yield ptags.Tag(interpreter, abi, platform_)
         for platform_ in platforms:
             yield ptags.Tag(interpreter, "none", platform_)
+        # ``sys_tags`` hands ``compatible_tags`` the major-only ``pp3``, so a
+        # real PyPy advertises ``pp3-none-any`` and never ``ppXY-none-any``.
+        compat_interpreter = f"pp{major}"
     else:
         interpreter = f"cp{major}{minor}"
         abi = _cpython_abi(py_version, free_threaded=free_threaded)
         yield from ptags.cpython_tags(
             python_version=py_version, abis=[abi], platforms=platforms
         )
+        compat_interpreter = interpreter
 
     yield from ptags.compatible_tags(
-        python_version=py_version, interpreter=interpreter, platforms=platforms
+        python_version=py_version,
+        interpreter=compat_interpreter,
+        platforms=platforms,
     )

--- a/nab-python/tests/property_python/test_tags_differential.py
+++ b/nab-python/tests/property_python/test_tags_differential.py
@@ -114,6 +114,10 @@ def _oracle_tags_in_order(
         abi = f"pypy{major}{minor}_pp73"
         out += [(interpreter, abi, p) for p in platforms]
         out += [(interpreter, "none", p) for p in platforms]
+        # Upstream ``sys_tags`` hands ``compatible_tags`` the major-only
+        # ``pp3`` on PyPy, so the interpreter-specific "any" tag a real
+        # PyPy advertises is ``pp3-none-any``.
+        compat_interpreter = f"pp{major}"
     else:
         interpreter = f"cp{major}{minor}"
         cp_abi = interpreter + ("t" if free_threaded else "")
@@ -122,9 +126,10 @@ def _oracle_tags_in_order(
                 python_version=py, abis=[cp_abi], platforms=platforms
             )
         )
+        compat_interpreter = interpreter
     out += _triples(
         upstream_tags.compatible_tags(
-            python_version=py, interpreter=interpreter, platforms=platforms
+            python_version=py, interpreter=compat_interpreter, platforms=platforms
         )
     )
     return out

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -893,6 +893,28 @@ class TestPyPyTags:
         ).pick([pure, native])
         assert chosen is native
 
+    def test_pypy_pure_python_pp3_wheel_matches(self) -> None:
+        """A ``pp3-none-any`` PyPy pure-Python wheel matches its target."""
+        wheel = _wheel("foo-1.0-pp3-none-any.whl")
+        assert _compatible(
+            wheel, python_version="3.10", spec=self.SPEC, implementation="pypy"
+        )
+
+    def test_pypy_ppxy_none_any_wheel_rejected(self) -> None:
+        """``ppXY-none-any`` is not a tag any PyPy install advertises."""
+        wheel = _wheel("bar-2.0-pp310-none-any.whl")
+        assert not _compatible(
+            wheel, python_version="3.10", spec=self.SPEC, implementation="pypy"
+        )
+
+    def test_pypy_compat_set_interpreter_any_tag_is_major_only(self) -> None:
+        """The interpreter-specific ``any`` tag is ``pp3-none-any``, not ``ppXY``."""
+        compat = TagSet.for_spec(
+            python_version="3.10", spec=self.SPEC, implementation="pypy"
+        ).members
+        assert Tag("pp3", "none", "any") in compat
+        assert Tag("pp310", "none", "any") not in compat
+
     def test_compat_tag_sets_differ_by_implementation(self) -> None:
         """The CPython and PyPy tuples accept disjoint native-tag sets."""
         cp = TagSet.for_spec(python_version="3.11", spec=self.SPEC).members


### PR DESCRIPTION
When nab builds the accepted-tag set for a PyPy tuple it passes the full `pp310` interpreter to packaging's `compatible_tags`, so the interpreter-specific "any" tag comes out as `pp310-none-any`. No real PyPy install advertises that tag. packaging's `sys_tags` feeds `compatible_tags` the major-only `pp3`, so an actual PyPy reports `pp3-none-any`.

That gets pure-Python PyPy wheels backwards: nab accepts a `pp310-none-any` wheel that nothing produces and rejects the `pp3-none-any` wheel a PyPy build actually publishes.

This passes `pp3` to `compatible_tags` on the PyPy branch so the "any" tag matches what a real installer sees.
