### PR TITLE
Set up Read the Docs publishing

### DIFF
--- a/.github/requirements/pylock.docs.toml
+++ b/.github/requirements/pylock.docs.toml
@@ -1,0 +1,2335 @@
+lock-version = "1.0"
+environments = [
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
+    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
+    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
+    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
+    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
+    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
+    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
+    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
+    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
+    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
+    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
+    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
+    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
+    "python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
+]
+dependency-groups = [
+    "docs",
+]
+created-by = "nab"
+
+[[packages]]
+name = "accessible-pygments"
+version = "0.0.5"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "accessible_pygments-0.0.5.tar.gz"
+upload-time = 2024-05-10 11:23:10.216775+00:00
+url = "https://files.pythonhosted.org/packages/bc/c1/bbac6a50d02774f91572938964c582fff4270eee73ab822a4aeea4d8b11b/accessible_pygments-0.0.5.tar.gz"
+size = 1377899
+
+[packages.sdist.hashes]
+sha256 = "40918d3e6a2b619ad424cb91e556bd3bd8865443d9f22f1dcdf79e33c8046872"
+
+[[packages.wheels]]
+name = "accessible_pygments-0.0.5-py3-none-any.whl"
+upload-time = 2024-05-10 11:23:08.421378+00:00
+url = "https://files.pythonhosted.org/packages/8d/3f/95338030883d8c8b91223b4e21744b04d11b161a3ef117295d8241f50ab4/accessible_pygments-0.0.5-py3-none-any.whl"
+size = 1395903
+
+[packages.wheels.hashes]
+sha256 = "88ae3211e68a1d0b011504b2ffc1691feafce124b845bd072ab6f9f66f34d4b7"
+
+[[packages]]
+name = "alabaster"
+version = "1.0.0"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "alabaster-1.0.0.tar.gz"
+upload-time = 2024-07-26 18:15:03.762569+00:00
+url = "https://files.pythonhosted.org/packages/a6/f8/d9c74d0daf3f742840fd818d69cfae176fa332022fd44e3469487d5a9420/alabaster-1.0.0.tar.gz"
+size = 24210
+
+[packages.sdist.hashes]
+sha256 = "c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e"
+
+[[packages.wheels]]
+name = "alabaster-1.0.0-py3-none-any.whl"
+upload-time = 2024-07-26 18:15:02.050654+00:00
+url = "https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl"
+size = 13929
+
+[packages.wheels.hashes]
+sha256 = "fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b"
+
+[[packages]]
+name = "babel"
+version = "2.18.0"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "babel-2.18.0.tar.gz"
+upload-time = 2026-02-01 12:30:56.078194+00:00
+url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz"
+size = 9959554
+
+[packages.sdist.hashes]
+sha256 = "b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d"
+
+[[packages.wheels]]
+name = "babel-2.18.0-py3-none-any.whl"
+upload-time = 2026-02-01 12:30:53.445172+00:00
+url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl"
+size = 10196845
+
+[packages.wheels.hashes]
+sha256 = "e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35"
+
+[[packages]]
+name = "beautifulsoup4"
+version = "4.15.0"
+requires-python = ">=3.7.0"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "beautifulsoup4-4.15.0.tar.gz"
+upload-time = 2026-06-07 16:44:20.453113+00:00
+url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz"
+size = 632571
+
+[packages.sdist.hashes]
+sha256 = "288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7"
+
+[[packages.wheels]]
+name = "beautifulsoup4-4.15.0-py3-none-any.whl"
+upload-time = 2026-06-07 16:44:21.566528+00:00
+url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl"
+size = 109924
+
+[packages.wheels.hashes]
+sha256 = "d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9"
+
+[[packages]]
+name = "build"
+version = "1.5.0"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "build-1.5.0.tar.gz"
+upload-time = 2026-04-30 03:18:25.170465+00:00
+url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz"
+size = 89796
+
+[packages.sdist.hashes]
+sha256 = "302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647"
+
+[[packages.wheels]]
+name = "build-1.5.0-py3-none-any.whl"
+upload-time = 2026-04-30 03:18:23.644906+00:00
+url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl"
+size = 26018
+
+[packages.wheels.hashes]
+sha256 = "13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f"
+
+[[packages]]
+name = "certifi"
+version = "2026.6.17"
+requires-python = ">=3.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "certifi-2026.6.17.tar.gz"
+upload-time = 2026-06-17 10:31:07.894439+00:00
+url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz"
+size = 134594
+
+[packages.sdist.hashes]
+sha256 = "024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432"
+
+[[packages.wheels]]
+name = "certifi-2026.6.17-py3-none-any.whl"
+upload-time = 2026-06-17 10:31:06.348672+00:00
+url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl"
+size = 133289
+
+[packages.wheels.hashes]
+sha256 = "2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"
+
+[[packages]]
+name = "charset-normalizer"
+version = "3.4.7"
+requires-python = ">=3.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "charset_normalizer-3.4.7.tar.gz"
+upload-time = 2026-04-02 09:28:39.342869+00:00
+url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz"
+size = 144271
+
+[packages.sdist.hashes]
+sha256 = "ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl"
+upload-time = 2026-04-02 09:25:40.673194+00:00
+url = "https://files.pythonhosted.org/packages/26/08/0f303cb0b529e456bb116f2d50565a482694fbb94340bf56d44677e7ed03/charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl"
+size = 315182
+
+[packages.wheels.hashes]
+sha256 = "cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-04-02 09:25:42.354016+00:00
+url = "https://files.pythonhosted.org/packages/24/47/b192933e94b546f1b1fe4df9cc1f84fcdbf2359f8d1081d46dd029b50207/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 209329
+
+[packages.wheels.hashes]
+sha256 = "e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-04-02 09:25:46.580440+00:00
+url = "https://files.pythonhosted.org/packages/20/e7/bed0024a0f4ab0c8a9c64d4445f39b30c99bd1acd228291959e3de664247/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 216930
+
+[packages.wheels.hashes]
+sha256 = "cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl"
+upload-time = 2026-04-02 09:25:50.671425+00:00
+url = "https://files.pythonhosted.org/packages/71/94/8c61d8da9f062fdf457c80acfa25060ec22bf1d34bbeaca4350f13bcfd07/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl"
+size = 212785
+
+[packages.wheels.hashes]
+sha256 = "b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl"
+upload-time = 2026-04-02 09:25:57.074827+00:00
+url = "https://files.pythonhosted.org/packages/1d/98/3a45bf8247889cf28262ebd3d0872edff11565b2a1e3064ccb132db3fbb0/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl"
+size = 218884
+
+[packages.wheels.hashes]
+sha256 = "94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl"
+upload-time = 2026-04-02 09:25:59.322069+00:00
+url = "https://files.pythonhosted.org/packages/35/1b/3b8c8c77184af465ee9ad88b5aea46ea6b2e1f7b9dc9502891e37af21e30/charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl"
+size = 159174
+
+[packages.wheels.hashes]
+sha256 = "6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl"
+upload-time = 2026-04-02 09:26:02.191455+00:00
+url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl"
+size = 309705
+
+[packages.wheels.hashes]
+sha256 = "7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-04-02 09:26:03.583935+00:00
+url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 206419
+
+[packages.wheels.hashes]
+sha256 = "202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-04-02 09:26:08.347975+00:00
+url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 214061
+
+[packages.wheels.hashes]
+sha256 = "2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl"
+upload-time = 2026-04-02 09:26:12.142221+00:00
+url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl"
+size = 209841
+
+[packages.wheels.hashes]
+sha256 = "e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl"
+upload-time = 2026-04-02 09:26:18.981084+00:00
+url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl"
+size = 216277
+
+[packages.wheels.hashes]
+sha256 = "ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl"
+upload-time = 2026-04-02 09:26:21.740282+00:00
+url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl"
+size = 159281
+
+[packages.wheels.hashes]
+sha256 = "8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl"
+upload-time = 2026-04-02 09:26:24.331339+00:00
+url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl"
+size = 311328
+
+[packages.wheels.hashes]
+sha256 = "eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-04-02 09:26:25.568153+00:00
+url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 208061
+
+[packages.wheels.hashes]
+sha256 = "6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-04-02 09:26:29.239485+00:00
+url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 216589
+
+[packages.wheels.hashes]
+sha256 = "5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl"
+upload-time = 2026-04-02 09:26:33.282753+00:00
+url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl"
+size = 211229
+
+[packages.wheels.hashes]
+sha256 = "708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl"
+upload-time = 2026-04-02 09:26:40.170193+00:00
+url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl"
+size = 218468
+
+[packages.wheels.hashes]
+sha256 = "bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl"
+upload-time = 2026-04-02 09:26:42.554156+00:00
+url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl"
+size = 159330
+
+[packages.wheels.hashes]
+sha256 = "5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl"
+upload-time = 2026-04-02 09:26:45.198440+00:00
+url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl"
+size = 309627
+
+[packages.wheels.hashes]
+sha256 = "f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-04-02 09:26:46.824388+00:00
+url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 207008
+
+[packages.wheels.hashes]
+sha256 = "0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-04-02 09:26:50.915844+00:00
+url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 215595
+
+[packages.wheels.hashes]
+sha256 = "e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl"
+upload-time = 2026-04-02 09:26:54.975572+00:00
+url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl"
+size = 210036
+
+[packages.wheels.hashes]
+sha256 = "7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl"
+upload-time = 2026-04-02 09:27:02.021863+00:00
+url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl"
+size = 217723
+
+[packages.wheels.hashes]
+sha256 = "64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl"
+upload-time = 2026-04-02 09:27:04.454986+00:00
+url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl"
+size = 158819
+
+[packages.wheels.hashes]
+sha256 = "3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl"
+upload-time = 2026-04-02 09:27:07.194784+00:00
+url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl"
+size = 309234
+
+[packages.wheels.hashes]
+sha256 = "c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-04-02 09:27:08.749412+00:00
+url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 208042
+
+[packages.wheels.hashes]
+sha256 = "1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-04-02 09:27:12.446519+00:00
+url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 215882
+
+[packages.wheels.hashes]
+sha256 = "bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl"
+upload-time = 2026-04-02 09:27:16.834768+00:00
+url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl"
+size = 211276
+
+[packages.wheels.hashes]
+sha256 = "e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl"
+upload-time = 2026-04-02 09:27:23.486452+00:00
+url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl"
+size = 217869
+
+[packages.wheels.hashes]
+sha256 = "7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl"
+upload-time = 2026-04-02 09:27:26.642081+00:00
+url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl"
+size = 159634
+
+[packages.wheels.hashes]
+sha256 = "92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f"
+
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-py3-none-any.whl"
+upload-time = 2026-04-02 09:28:37.794693+00:00
+url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl"
+size = 61958
+
+[packages.wheels.hashes]
+sha256 = "3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d"
+
+[[packages]]
+name = "colorama"
+version = "0.4.6"
+marker = "(python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+requires-python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "colorama-0.4.6.tar.gz"
+upload-time = 2022-10-25 02:36:22.414799+00:00
+url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz"
+size = 27697
+
+[packages.sdist.hashes]
+sha256 = "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+
+[[packages.wheels]]
+name = "colorama-0.4.6-py2.py3-none-any.whl"
+upload-time = 2022-10-25 02:36:20.889702+00:00
+url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl"
+size = 25335
+
+[packages.wheels.hashes]
+sha256 = "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+
+[[packages]]
+name = "docstring-parser"
+version = "0.18.0"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "docstring_parser-0.18.0.tar.gz"
+upload-time = 2026-04-14 04:09:19.867229+00:00
+url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz"
+size = 29341
+
+[packages.sdist.hashes]
+sha256 = "292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015"
+
+[[packages.wheels]]
+name = "docstring_parser-0.18.0-py3-none-any.whl"
+upload-time = 2026-04-14 04:09:18.638975+00:00
+url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl"
+size = 22484
+
+[packages.wheels.hashes]
+sha256 = "b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b"
+
+[[packages]]
+name = "docutils"
+version = "0.21.2"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "docutils-0.21.2.tar.gz"
+upload-time = 2024-04-23 18:57:18.240686+00:00
+url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz"
+size = 2204444
+
+[packages.sdist.hashes]
+sha256 = "3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f"
+
+[[packages.wheels]]
+name = "docutils-0.21.2-py3-none-any.whl"
+upload-time = 2024-04-23 18:57:14.835505+00:00
+url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl"
+size = 587408
+
+[packages.wheels.hashes]
+sha256 = "dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2"
+
+[[packages]]
+name = "furo"
+version = "2025.12.19"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "furo-2025.12.19.tar.gz"
+upload-time = 2025-12-19 17:34:40.889109+00:00
+url = "https://files.pythonhosted.org/packages/ec/20/5f5ad4da6a5a27c80f2ed2ee9aee3f9e36c66e56e21c00fde467b2f8f88f/furo-2025.12.19.tar.gz"
+size = 1661473
+
+[packages.sdist.hashes]
+sha256 = "188d1f942037d8b37cd3985b955839fea62baa1730087dc29d157677c857e2a7"
+
+[[packages.wheels]]
+name = "furo-2025.12.19-py3-none-any.whl"
+upload-time = 2025-12-19 17:34:38.905692+00:00
+url = "https://files.pythonhosted.org/packages/f4/b2/50e9b292b5cac13e9e81272c7171301abc753a60460d21505b606e15cf21/furo-2025.12.19-py3-none-any.whl"
+size = 339262
+
+[packages.wheels.hashes]
+sha256 = "bb0ead5309f9500130665a26bee87693c41ce4dbdff864dbfb6b0dae4673d24f"
+
+[[packages]]
+name = "idna"
+version = "3.18"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "idna-3.18.tar.gz"
+upload-time = 2026-06-02 14:34:07.794523+00:00
+url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz"
+size = 196711
+
+[packages.sdist.hashes]
+sha256 = "ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"
+
+[[packages.wheels]]
+name = "idna-3.18-py3-none-any.whl"
+upload-time = 2026-06-02 14:34:06.319954+00:00
+url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl"
+size = 65455
+
+[packages.wheels.hashes]
+sha256 = "7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"
+
+[[packages]]
+name = "imagesize"
+version = "2.0.0"
+requires-python = "<3.15,>=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "imagesize-2.0.0.tar.gz"
+upload-time = 2026-03-03 14:18:29.941652+00:00
+url = "https://files.pythonhosted.org/packages/6c/e6/7bf14eeb8f8b7251141944835abd42eb20a658d89084b7e1f3e5fe394090/imagesize-2.0.0.tar.gz"
+size = 1773045
+
+[packages.sdist.hashes]
+sha256 = "8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3"
+
+[[packages.wheels]]
+name = "imagesize-2.0.0-py2.py3-none-any.whl"
+upload-time = 2026-03-03 14:18:27.892459+00:00
+url = "https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl"
+size = 9441
+
+[packages.wheels.hashes]
+sha256 = "5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96"
+
+[[packages]]
+name = "importlib-metadata"
+version = "9.0.0"
+marker = "(python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "importlib_metadata-9.0.0.tar.gz"
+upload-time = 2026-03-20 06:42:56.999805+00:00
+url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz"
+size = 56405
+
+[packages.sdist.hashes]
+sha256 = "a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc"
+
+[[packages.wheels]]
+name = "importlib_metadata-9.0.0-py3-none-any.whl"
+upload-time = 2026-03-20 06:42:55.665400+00:00
+url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl"
+size = 27789
+
+[packages.wheels.hashes]
+sha256 = "2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7"
+
+[[packages]]
+name = "installer"
+version = "1.0.1"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "installer-1.0.1.tar.gz"
+upload-time = 2026-05-11 18:13:28.158660+00:00
+url = "https://files.pythonhosted.org/packages/06/fe/b9f481cf0cc867958a21338baa900357b7b7d86cac9b025948049d77923c/installer-1.0.1.tar.gz"
+size = 481132
+
+[packages.sdist.hashes]
+sha256 = "052c7fc3721d54c696e2dea019be67539d7b144e924f559f54beb3121831c364"
+
+[[packages.wheels]]
+name = "installer-1.0.1-py3-none-any.whl"
+upload-time = 2026-05-11 18:13:26.252723+00:00
+url = "https://files.pythonhosted.org/packages/26/48/bedf3ba4163e7db392c9d4cbdfc8217423196c8fccbe5a404a0f094fde63/installer-1.0.1-py3-none-any.whl"
+size = 464455
+
+[packages.wheels.hashes]
+sha256 = "011d045df8b954ced7dde3a7e42ae4418da40ecda7990f2d11d5ed7c146fd98b"
+
+[[packages]]
+name = "jinja2"
+version = "3.1.6"
+requires-python = ">=3.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "jinja2-3.1.6.tar.gz"
+upload-time = 2025-03-05 20:05:02.478302+00:00
+url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz"
+size = 245115
+
+[packages.sdist.hashes]
+sha256 = "0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"
+
+[[packages.wheels]]
+name = "jinja2-3.1.6-py3-none-any.whl"
+upload-time = 2025-03-05 20:05:00.369721+00:00
+url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl"
+size = 134899
+
+[packages.wheels.hashes]
+sha256 = "85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"
+
+[[packages]]
+name = "linkify-it-py"
+version = "2.1.0"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "linkify_it_py-2.1.0.tar.gz"
+upload-time = 2026-03-01 07:48:47.683141+00:00
+url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz"
+size = 29158
+
+[packages.sdist.hashes]
+sha256 = "43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b"
+
+[[packages.wheels]]
+name = "linkify_it_py-2.1.0-py3-none-any.whl"
+upload-time = 2026-03-01 07:48:46.098014+00:00
+url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl"
+size = 19878
+
+[packages.wheels.hashes]
+sha256 = "0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e"
+
+[[packages]]
+name = "markdown-it-py"
+version = "3.0.0"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "markdown-it-py-3.0.0.tar.gz"
+upload-time = 2023-06-03 06:41:14.443886+00:00
+url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz"
+size = 74596
+
+[packages.sdist.hashes]
+sha256 = "e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"
+
+[[packages.wheels]]
+name = "markdown_it_py-3.0.0-py3-none-any.whl"
+upload-time = 2023-06-03 06:41:11.019475+00:00
+url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl"
+size = 87528
+
+[packages.wheels.hashes]
+sha256 = "355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1"
+
+[[packages]]
+name = "markupsafe"
+version = "3.0.3"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "markupsafe-3.0.3.tar.gz"
+upload-time = 2025-09-27 18:37:40.426446+00:00
+url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz"
+size = 80313
+
+[packages.sdist.hashes]
+sha256 = "722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl"
+upload-time = 2025-09-27 18:36:05.558229+00:00
+url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl"
+size = 11631
+
+[packages.wheels.hashes]
+sha256 = "2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl"
+upload-time = 2025-09-27 18:36:07.165203+00:00
+url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl"
+size = 12057
+
+[packages.wheels.hashes]
+sha256 = "e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2025-09-27 18:36:08.005391+00:00
+url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 22050
+
+[packages.wheels.hashes]
+sha256 = "1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2025-09-27 18:36:08.881294+00:00
+url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 20681
+
+[packages.wheels.hashes]
+sha256 = "f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl"
+upload-time = 2025-09-27 18:36:11.324694+00:00
+url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl"
+size = 21524
+
+[packages.wheels.hashes]
+sha256 = "0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl"
+upload-time = 2025-09-27 18:36:13.504651+00:00
+url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl"
+size = 20745
+
+[packages.wheels.hashes]
+sha256 = "177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp310-cp310-win_amd64.whl"
+upload-time = 2025-09-27 18:36:16.125184+00:00
+url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl"
+size = 15056
+
+[packages.wheels.hashes]
+sha256 = "c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl"
+upload-time = 2025-09-27 18:36:18.185318+00:00
+url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl"
+size = 11631
+
+[packages.wheels.hashes]
+sha256 = "1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl"
+upload-time = 2025-09-27 18:36:19.444952+00:00
+url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl"
+size = 12058
+
+[packages.wheels.hashes]
+sha256 = "4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2025-09-27 18:36:20.768877+00:00
+url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 24287
+
+[packages.wheels.hashes]
+sha256 = "6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2025-09-27 18:36:22.249510+00:00
+url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 22940
+
+[packages.wheels.hashes]
+sha256 = "0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl"
+upload-time = 2025-09-27 18:36:24.823399+00:00
+url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl"
+size = 23692
+
+[packages.wheels.hashes]
+sha256 = "068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl"
+upload-time = 2025-09-27 18:36:27.109615+00:00
+url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl"
+size = 22923
+
+[packages.wheels.hashes]
+sha256 = "f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp311-cp311-win_amd64.whl"
+upload-time = 2025-09-27 18:36:29.025751+00:00
+url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl"
+size = 15077
+
+[packages.wheels.hashes]
+sha256 = "de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2025-09-27 18:36:30.854850+00:00
+url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 11615
+
+[packages.wheels.hashes]
+sha256 = "d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl"
+upload-time = 2025-09-27 18:36:31.971542+00:00
+url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl"
+size = 12020
+
+[packages.wheels.hashes]
+sha256 = "1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2025-09-27 18:36:32.813259+00:00
+url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 24332
+
+[packages.wheels.hashes]
+sha256 = "3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2025-09-27 18:36:33.860371+00:00
+url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 22947
+
+[packages.wheels.hashes]
+sha256 = "d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl"
+upload-time = 2025-09-27 18:36:36.001009+00:00
+url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl"
+size = 23760
+
+[packages.wheels.hashes]
+sha256 = "be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl"
+upload-time = 2025-09-27 18:36:37.868766+00:00
+url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl"
+size = 23015
+
+[packages.wheels.hashes]
+sha256 = "77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp312-cp312-win_amd64.whl"
+upload-time = 2025-09-27 18:36:39.701297+00:00
+url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl"
+size = 15105
+
+[packages.wheels.hashes]
+sha256 = "26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2025-09-27 18:36:41.777722+00:00
+url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 11622
+
+[packages.wheels.hashes]
+sha256 = "e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl"
+upload-time = 2025-09-27 18:36:43.257546+00:00
+url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl"
+size = 12029
+
+[packages.wheels.hashes]
+sha256 = "116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2025-09-27 18:36:44.508151+00:00
+url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 24374
+
+[packages.wheels.hashes]
+sha256 = "133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2025-09-27 18:36:45.385915+00:00
+url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 22980
+
+[packages.wheels.hashes]
+sha256 = "ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl"
+upload-time = 2025-09-27 18:36:47.884331+00:00
+url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl"
+size = 23784
+
+[packages.wheels.hashes]
+sha256 = "a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl"
+upload-time = 2025-09-27 18:36:49.797317+00:00
+url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl"
+size = 23041
+
+[packages.wheels.hashes]
+sha256 = "8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp313-cp313-win_amd64.whl"
+upload-time = 2025-09-27 18:36:52.537899+00:00
+url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl"
+size = 15113
+
+[packages.wheels.hashes]
+sha256 = "9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl"
+upload-time = 2025-09-27 18:37:06.342766+00:00
+url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl"
+size = 11619
+
+[packages.wheels.hashes]
+sha256 = "eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl"
+upload-time = 2025-09-27 18:37:07.213735+00:00
+url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl"
+size = 12029
+
+[packages.wheels.hashes]
+sha256 = "c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2025-09-27 18:37:09.572958+00:00
+url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 24408
+
+[packages.wheels.hashes]
+sha256 = "f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2025-09-27 18:37:10.580716+00:00
+url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 23005
+
+[packages.wheels.hashes]
+sha256 = "457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl"
+upload-time = 2025-09-27 18:37:12.480067+00:00
+url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl"
+size = 23821
+
+[packages.wheels.hashes]
+sha256 = "ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl"
+upload-time = 2025-09-27 18:37:14.408734+00:00
+url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl"
+size = 23043
+
+[packages.wheels.hashes]
+sha256 = "2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe"
+
+[[packages.wheels]]
+name = "markupsafe-3.0.3-cp314-cp314-win_amd64.whl"
+upload-time = 2025-09-27 18:37:16.496852+00:00
+url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl"
+size = 15341
+
+[packages.wheels.hashes]
+sha256 = "bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581"
+
+[[packages]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "mdit_py_plugins-0.6.1.tar.gz"
+upload-time = 2026-05-13 09:03:38.910230+00:00
+url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz"
+size = 56114
+
+[packages.sdist.hashes]
+sha256 = "a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0"
+
+[[packages.wheels]]
+name = "mdit_py_plugins-0.6.1-py3-none-any.whl"
+upload-time = 2026-05-13 09:03:37.760000+00:00
+url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl"
+size = 66663
+
+[packages.wheels.hashes]
+sha256 = "214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d"
+
+[[packages]]
+name = "mdurl"
+version = "0.1.2"
+requires-python = ">=3.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "mdurl-0.1.2.tar.gz"
+upload-time = 2022-08-14 12:40:10.846281+00:00
+url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz"
+size = 8729
+
+[packages.sdist.hashes]
+sha256 = "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"
+
+[[packages.wheels]]
+name = "mdurl-0.1.2-py3-none-any.whl"
+upload-time = 2022-08-14 12:40:09.779676+00:00
+url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl"
+size = 9979
+
+[packages.wheels.hashes]
+sha256 = "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"
+
+[[packages]]
+name = "myst-parser"
+version = "4.0.1"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "myst_parser-4.0.1.tar.gz"
+upload-time = 2025-02-12 10:53:03.833302+00:00
+url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz"
+size = 93985
+
+[packages.sdist.hashes]
+sha256 = "5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4"
+
+[[packages.wheels]]
+name = "myst_parser-4.0.1-py3-none-any.whl"
+upload-time = 2025-02-12 10:53:02.078771+00:00
+url = "https://files.pythonhosted.org/packages/5f/df/76d0321c3797b54b60fef9ec3bd6f4cfd124b9e422182156a1dd418722cf/myst_parser-4.0.1-py3-none-any.whl"
+size = 84579
+
+[packages.wheels.hashes]
+sha256 = "9134e88959ec3b5780aedf8a99680ea242869d012e8821db3126d427edc9c95d"
+
+[[packages]]
+name = "packaging"
+version = "26.2"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "packaging-26.2.tar.gz"
+upload-time = 2026-04-24 20:15:23.917886+00:00
+url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz"
+size = 228134
+
+[packages.sdist.hashes]
+sha256 = "ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"
+
+[[packages.wheels]]
+name = "packaging-26.2-py3-none-any.whl"
+upload-time = 2026-04-24 20:15:22.081511+00:00
+url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl"
+size = 100195
+
+[packages.wheels.hashes]
+sha256 = "5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"
+
+[[packages]]
+name = "pygments"
+version = "2.20.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pygments-2.20.0.tar.gz"
+upload-time = 2026-03-29 13:29:33.898791+00:00
+url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz"
+size = 4955991
+
+[packages.sdist.hashes]
+sha256 = "6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"
+
+[[packages.wheels]]
+name = "pygments-2.20.0-py3-none-any.whl"
+upload-time = 2026-03-29 13:29:30.038266+00:00
+url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl"
+size = 1231151
+
+[packages.wheels.hashes]
+sha256 = "81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"
+
+[[packages]]
+name = "pyproject-hooks"
+version = "1.2.0"
+requires-python = ">=3.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pyproject_hooks-1.2.0.tar.gz"
+upload-time = 2024-09-29 09:24:13.293934+00:00
+url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz"
+size = 19228
+
+[packages.sdist.hashes]
+sha256 = "1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8"
+
+[[packages.wheels]]
+name = "pyproject_hooks-1.2.0-py3-none-any.whl"
+upload-time = 2024-09-29 09:24:11.978642+00:00
+url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl"
+size = 10216
+
+[packages.wheels.hashes]
+sha256 = "9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913"
+
+[[packages]]
+name = "pyyaml"
+version = "6.0.3"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pyyaml-6.0.3.tar.gz"
+upload-time = 2025-09-25 21:33:16.546886+00:00
+url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz"
+size = 130960
+
+[packages.sdist.hashes]
+sha256 = "d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl"
+upload-time = 2025-09-25 21:31:46.040932+00:00
+url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl"
+size = 184227
+
+[packages.wheels.hashes]
+sha256 = "214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl"
+upload-time = 2025-09-25 21:31:47.706282+00:00
+url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl"
+size = 174019
+
+[packages.wheels.hashes]
+sha256 = "02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2025-09-25 21:31:49.210067+00:00
+url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 740646
+
+[packages.wheels.hashes]
+sha256 = "b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2025-09-25 21:31:51.828716+00:00
+url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 770293
+
+[packages.wheels.hashes]
+sha256 = "9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl"
+upload-time = 2025-09-25 21:31:53.282215+00:00
+url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl"
+size = 732872
+
+[packages.wheels.hashes]
+sha256 = "418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl"
+upload-time = 2025-09-25 21:31:54.807344+00:00
+url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl"
+size = 758828
+
+[packages.wheels.hashes]
+sha256 = "5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp310-cp310-win_amd64.whl"
+upload-time = 2025-09-25 21:31:57.406115+00:00
+url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl"
+size = 158561
+
+[packages.wheels.hashes]
+sha256 = "bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl"
+upload-time = 2025-09-25 21:31:58.655967+00:00
+url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl"
+size = 185826
+
+[packages.wheels.hashes]
+sha256 = "44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl"
+upload-time = 2025-09-25 21:32:00.088486+00:00
+url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl"
+size = 175577
+
+[packages.wheels.hashes]
+sha256 = "652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2025-09-25 21:32:01.310546+00:00
+url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 775556
+
+[packages.wheels.hashes]
+sha256 = "10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2025-09-25 21:32:04.553491+00:00
+url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 806638
+
+[packages.wheels.hashes]
+sha256 = "b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl"
+upload-time = 2025-09-25 21:32:06.152188+00:00
+url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl"
+size = 767463
+
+[packages.wheels.hashes]
+sha256 = "1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl"
+upload-time = 2025-09-25 21:32:07.367150+00:00
+url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl"
+size = 794986
+
+[packages.wheels.hashes]
+sha256 = "37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp311-cp311-win_amd64.whl"
+upload-time = 2025-09-25 21:32:09.960416+00:00
+url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl"
+size = 158763
+
+[packages.wheels.hashes]
+sha256 = "9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2025-09-25 21:32:11.445337+00:00
+url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 182063
+
+[packages.wheels.hashes]
+sha256 = "7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl"
+upload-time = 2025-09-25 21:32:12.492377+00:00
+url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl"
+size = 173973
+
+[packages.wheels.hashes]
+sha256 = "fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2025-09-25 21:32:13.652062+00:00
+url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 775116
+
+[packages.wheels.hashes]
+sha256 = "9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2025-09-25 21:32:16.431392+00:00
+url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 807870
+
+[packages.wheels.hashes]
+sha256 = "ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl"
+upload-time = 2025-09-25 21:32:17.560500+00:00
+url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl"
+size = 761089
+
+[packages.wheels.hashes]
+sha256 = "8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl"
+upload-time = 2025-09-25 21:32:18.834540+00:00
+url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl"
+size = 790181
+
+[packages.wheels.hashes]
+sha256 = "41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp312-cp312-win_amd64.whl"
+upload-time = 2025-09-25 21:32:21.167929+00:00
+url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl"
+size = 154003
+
+[packages.wheels.hashes]
+sha256 = "5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2025-09-25 21:32:23.673728+00:00
+url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 181669
+
+[packages.wheels.hashes]
+sha256 = "8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl"
+upload-time = 2025-09-25 21:32:25.149340+00:00
+url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl"
+size = 173252
+
+[packages.wheels.hashes]
+sha256 = "2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2025-09-25 21:32:26.575286+00:00
+url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 767081
+
+[packages.wheels.hashes]
+sha256 = "ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2025-09-25 21:32:28.878522+00:00
+url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 801626
+
+[packages.wheels.hashes]
+sha256 = "0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl"
+upload-time = 2025-09-25 21:32:30.178904+00:00
+url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl"
+size = 753613
+
+[packages.wheels.hashes]
+sha256 = "f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl"
+upload-time = 2025-09-25 21:32:31.353769+00:00
+url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl"
+size = 794115
+
+[packages.wheels.hashes]
+sha256 = "eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp313-cp313-win_amd64.whl"
+upload-time = 2025-09-25 21:32:33.659120+00:00
+url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl"
+size = 154090
+
+[packages.wheels.hashes]
+sha256 = "79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl"
+upload-time = 2025-09-25 21:32:35.712547+00:00
+url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl"
+size = 181814
+
+[packages.wheels.hashes]
+sha256 = "8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl"
+upload-time = 2025-09-25 21:32:36.789261+00:00
+url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl"
+size = 173809
+
+[packages.wheels.hashes]
+sha256 = "34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2025-09-25 21:32:37.966620+00:00
+url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 766454
+
+[packages.wheels.hashes]
+sha256 = "501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2025-09-25 21:32:40.865549+00:00
+url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 794175
+
+[packages.wheels.hashes]
+sha256 = "c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl"
+upload-time = 2025-09-25 21:32:42.084806+00:00
+url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl"
+size = 755228
+
+[packages.wheels.hashes]
+sha256 = "7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl"
+upload-time = 2025-09-25 21:32:43.362137+00:00
+url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl"
+size = 789194
+
+[packages.wheels.hashes]
+sha256 = "5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp314-cp314-win_amd64.whl"
+upload-time = 2025-09-25 21:32:57.844103+00:00
+url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl"
+size = 156429
+
+[packages.wheels.hashes]
+sha256 = "4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac"
+
+[[packages]]
+name = "requests"
+version = "2.34.2"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "requests-2.34.2.tar.gz"
+upload-time = 2026-05-14 19:25:27.735762+00:00
+url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz"
+size = 142856
+
+[packages.sdist.hashes]
+sha256 = "f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed"
+
+[[packages.wheels]]
+name = "requests-2.34.2-py3-none-any.whl"
+upload-time = 2026-05-14 19:25:26.443000+00:00
+url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl"
+size = 73075
+
+[packages.wheels.hashes]
+sha256 = "2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"
+
+[[packages]]
+name = "snowballstemmer"
+version = "3.1.1"
+requires-python = ">=3.3"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "snowballstemmer-3.1.1.tar.gz"
+upload-time = 2026-06-03 00:56:40.194915+00:00
+url = "https://files.pythonhosted.org/packages/43/f8/0a71edf031f03c40db17503cb8ca78a69a171254e568e7db241b0ab57ea1/snowballstemmer-3.1.1.tar.gz"
+size = 123314
+
+[packages.sdist.hashes]
+sha256 = "e07bbc54a0d798fe6010a12398422e62a8bfbba95c394fd0956ef58cb4d3e260"
+
+[[packages.wheels]]
+name = "snowballstemmer-3.1.1-py3-none-any.whl"
+upload-time = 2026-06-03 00:56:38.614300+00:00
+url = "https://files.pythonhosted.org/packages/4c/07/2ebca9b11fb9be7340a818d8d6f63feaebb146be2c4afbd6061701d6df6e/snowballstemmer-3.1.1-py3-none-any.whl"
+size = 104164
+
+[packages.wheels.hashes]
+sha256 = "7e207fa178741da09cdee59d3ecec3827ad5f92b1fc5c9ff3755b639f71f5752"
+
+[[packages]]
+name = "soupsieve"
+version = "2.8.4"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "soupsieve-2.8.4.tar.gz"
+upload-time = 2026-05-24 13:55:57.154773+00:00
+url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz"
+size = 121110
+
+[packages.sdist.hashes]
+sha256 = "e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e"
+
+[[packages.wheels]]
+name = "soupsieve-2.8.4-py3-none-any.whl"
+upload-time = 2026-05-24 13:55:55.406808+00:00
+url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl"
+size = 37304
+
+[packages.wheels.hashes]
+sha256 = "e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65"
+
+[[packages]]
+name = "sphinx"
+version = "8.1.3"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "sphinx-8.1.3.tar.gz"
+upload-time = 2024-10-13 20:27:13.930361+00:00
+url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz"
+size = 8184611
+
+[packages.sdist.hashes]
+sha256 = "43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927"
+
+[[packages.wheels]]
+name = "sphinx-8.1.3-py3-none-any.whl"
+upload-time = 2024-10-13 20:27:10.448453+00:00
+url = "https://files.pythonhosted.org/packages/26/60/1ddff83a56d33aaf6f10ec8ce84b4c007d9368b21008876fceda7e7381ef/sphinx-8.1.3-py3-none-any.whl"
+size = 3487125
+
+[packages.wheels.hashes]
+sha256 = "09719015511837b76bf6e03e42eb7595ac8c2e41eeb9c29c5b755c6b677992a2"
+
+[[packages]]
+name = "sphinx-basic-ng"
+version = "1.0.0b2"
+requires-python = ">=3.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "sphinx_basic_ng-1.0.0b2.tar.gz"
+upload-time = 2023-07-08 18:40:54.166146+00:00
+url = "https://files.pythonhosted.org/packages/98/0b/a866924ded68efec7a1759587a4e478aec7559d8165fac8b2ad1c0e774d6/sphinx_basic_ng-1.0.0b2.tar.gz"
+size = 20736
+
+[packages.sdist.hashes]
+sha256 = "9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9"
+
+[[packages.wheels]]
+name = "sphinx_basic_ng-1.0.0b2-py3-none-any.whl"
+upload-time = 2023-07-08 18:40:52.659879+00:00
+url = "https://files.pythonhosted.org/packages/3c/dd/018ce05c532a22007ac58d4f45232514cd9d6dd0ee1dc374e309db830983/sphinx_basic_ng-1.0.0b2-py3-none-any.whl"
+size = 22496
+
+[packages.wheels.hashes]
+sha256 = "eb09aedbabfb650607e9b4b68c9d240b90b1e1be221d6ad71d61c52e29f7932b"
+
+[[packages]]
+name = "sphinx-copybutton"
+version = "0.5.2"
+requires-python = ">=3.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "sphinx-copybutton-0.5.2.tar.gz"
+upload-time = 2023-04-14 08:10:22.998763+00:00
+url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz"
+size = 23039
+
+[packages.sdist.hashes]
+sha256 = "4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd"
+
+[[packages.wheels]]
+name = "sphinx_copybutton-0.5.2-py3-none-any.whl"
+upload-time = 2023-04-14 08:10:20.844249+00:00
+url = "https://files.pythonhosted.org/packages/9e/48/1ea60e74949eecb12cdd6ac43987f9fd331156388dcc2319b45e2ebb81bf/sphinx_copybutton-0.5.2-py3-none-any.whl"
+size = 13343
+
+[packages.wheels.hashes]
+sha256 = "fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e"
+
+[[packages]]
+name = "sphinx-design"
+version = "0.6.1"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "sphinx_design-0.6.1.tar.gz"
+upload-time = 2024-08-02 13:48:44.277940+00:00
+url = "https://files.pythonhosted.org/packages/2b/69/b34e0cb5336f09c6866d53b4a19d76c227cdec1bbc7ac4de63ca7d58c9c7/sphinx_design-0.6.1.tar.gz"
+size = 2193689
+
+[packages.sdist.hashes]
+sha256 = "b44eea3719386d04d765c1a8257caca2b3e6f8421d7b3a5e742c0fd45f84e632"
+
+[[packages.wheels]]
+name = "sphinx_design-0.6.1-py3-none-any.whl"
+upload-time = 2024-08-02 13:48:42.106155+00:00
+url = "https://files.pythonhosted.org/packages/c6/43/65c0acbd8cc6f50195a3a1fc195c404988b15c67090e73c7a41a9f57d6bd/sphinx_design-0.6.1-py3-none-any.whl"
+size = 2215338
+
+[packages.wheels.hashes]
+sha256 = "b11f37db1a802a183d61b159d9a202314d4d2fe29c163437001324fe2f19549c"
+
+[[packages]]
+name = "sphinxcontrib-applehelp"
+version = "2.0.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "sphinxcontrib_applehelp-2.0.0.tar.gz"
+upload-time = 2024-07-29 01:09:00.465812+00:00
+url = "https://files.pythonhosted.org/packages/ba/6e/b837e84a1a704953c62ef8776d45c3e8d759876b4a84fe14eba2859106fe/sphinxcontrib_applehelp-2.0.0.tar.gz"
+size = 20053
+
+[packages.sdist.hashes]
+sha256 = "2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1"
+
+[[packages.wheels]]
+name = "sphinxcontrib_applehelp-2.0.0-py3-none-any.whl"
+upload-time = 2024-07-29 01:08:58.990722+00:00
+url = "https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl"
+size = 119300
+
+[packages.wheels.hashes]
+sha256 = "4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5"
+
+[[packages]]
+name = "sphinxcontrib-devhelp"
+version = "2.0.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "sphinxcontrib_devhelp-2.0.0.tar.gz"
+upload-time = 2024-07-29 01:09:23.417467+00:00
+url = "https://files.pythonhosted.org/packages/f6/d2/5beee64d3e4e747f316bae86b55943f51e82bb86ecd325883ef65741e7da/sphinxcontrib_devhelp-2.0.0.tar.gz"
+size = 12967
+
+[packages.sdist.hashes]
+sha256 = "411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad"
+
+[[packages.wheels]]
+name = "sphinxcontrib_devhelp-2.0.0-py3-none-any.whl"
+upload-time = 2024-07-29 01:09:21.945229+00:00
+url = "https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl"
+size = 82530
+
+[packages.wheels.hashes]
+sha256 = "aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2"
+
+[[packages]]
+name = "sphinxcontrib-htmlhelp"
+version = "2.1.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "sphinxcontrib_htmlhelp-2.1.0.tar.gz"
+upload-time = 2024-07-29 01:09:37.889318+00:00
+url = "https://files.pythonhosted.org/packages/43/93/983afd9aa001e5201eab16b5a444ed5b9b0a7a010541e0ddfbbfd0b2470c/sphinxcontrib_htmlhelp-2.1.0.tar.gz"
+size = 22617
+
+[packages.sdist.hashes]
+sha256 = "c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9"
+
+[[packages.wheels]]
+name = "sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl"
+upload-time = 2024-07-29 01:09:36.407072+00:00
+url = "https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl"
+size = 98705
+
+[packages.wheels.hashes]
+sha256 = "166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8"
+
+[[packages]]
+name = "sphinxcontrib-jsmath"
+version = "1.0.1"
+requires-python = ">=3.5"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "sphinxcontrib-jsmath-1.0.1.tar.gz"
+upload-time = 2019-01-21 16:10:16.347697+00:00
+url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz"
+size = 5787
+
+[packages.sdist.hashes]
+sha256 = "a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"
+
+[[packages.wheels]]
+name = "sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl"
+upload-time = 2019-01-21 16:10:14.333769+00:00
+url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl"
+size = 5071
+
+[packages.wheels.hashes]
+sha256 = "2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178"
+
+[[packages]]
+name = "sphinxcontrib-qthelp"
+version = "2.0.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "sphinxcontrib_qthelp-2.0.0.tar.gz"
+upload-time = 2024-07-29 01:09:56.435212+00:00
+url = "https://files.pythonhosted.org/packages/68/bc/9104308fc285eb3e0b31b67688235db556cd5b0ef31d96f30e45f2e51cae/sphinxcontrib_qthelp-2.0.0.tar.gz"
+size = 17165
+
+[packages.sdist.hashes]
+sha256 = "4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab"
+
+[[packages.wheels]]
+name = "sphinxcontrib_qthelp-2.0.0-py3-none-any.whl"
+upload-time = 2024-07-29 01:09:54.885300+00:00
+url = "https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl"
+size = 88743
+
+[packages.wheels.hashes]
+sha256 = "b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb"
+
+[[packages]]
+name = "sphinxcontrib-serializinghtml"
+version = "2.0.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "sphinxcontrib_serializinghtml-2.0.0.tar.gz"
+upload-time = 2024-07-29 01:10:09.332393+00:00
+url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz"
+size = 16080
+
+[packages.sdist.hashes]
+sha256 = "e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d"
+
+[[packages.wheels]]
+name = "sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl"
+upload-time = 2024-07-29 01:10:08.203690+00:00
+url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl"
+size = 92072
+
+[packages.wheels.hashes]
+sha256 = "6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331"
+
+[[packages]]
+name = "tomli"
+version = "2.4.1"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "tomli-2.4.1.tar.gz"
+upload-time = 2026-03-25 20:22:03.828102+00:00
+url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz"
+size = 17543
+
+[packages.sdist.hashes]
+sha256 = "7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
+upload-time = 2026-03-25 20:21:10.473841+00:00
+url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
+size = 154704
+
+[packages.wheels.hashes]
+sha256 = "f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl"
+upload-time = 2026-03-25 20:21:12.036923+00:00
+url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl"
+size = 149454
+
+[packages.wheels.hashes]
+sha256 = "4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:13.098441+00:00
+url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 237561
+
+[packages.wheels.hashes]
+sha256 = "96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:14.569419+00:00
+url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 243824
+
+[packages.wheels.hashes]
+sha256 = "5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl"
+upload-time = 2026-03-25 20:21:15.712337+00:00
+url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl"
+size = 242227
+
+[packages.wheels.hashes]
+sha256 = "47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl"
+upload-time = 2026-03-25 20:21:17.001171+00:00
+url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl"
+size = 247859
+
+[packages.wheels.hashes]
+sha256 = "ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-win_amd64.whl"
+upload-time = 2026-03-25 20:21:18.978514+00:00
+url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl"
+size = 108084
+
+[packages.wheels.hashes]
+sha256 = "5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2026-03-25 20:21:21.626567+00:00
+url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 155924
+
+[packages.wheels.hashes]
+sha256 = "c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl"
+upload-time = 2026-03-25 20:21:23.002533+00:00
+url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl"
+size = 150018
+
+[packages.wheels.hashes]
+sha256 = "7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:24.040813+00:00
+url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 244948
+
+[packages.wheels.hashes]
+sha256 = "ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:25.177901+00:00
+url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 253341
+
+[packages.wheels.hashes]
+sha256 = "136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl"
+upload-time = 2026-03-25 20:21:26.364996+00:00
+url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl"
+size = 248159
+
+[packages.wheels.hashes]
+sha256 = "5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl"
+upload-time = 2026-03-25 20:21:27.460413+00:00
+url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl"
+size = 253290
+
+[packages.wheels.hashes]
+sha256 = "5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-win_amd64.whl"
+upload-time = 2026-03-25 20:21:29.386807+00:00
+url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl"
+size = 108847
+
+[packages.wheels.hashes]
+sha256 = "52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2026-03-25 20:21:31.650748+00:00
+url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 155866
+
+[packages.wheels.hashes]
+sha256 = "36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl"
+upload-time = 2026-03-25 20:21:33.028949+00:00
+url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl"
+size = 149887
+
+[packages.wheels.hashes]
+sha256 = "eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:34.510750+00:00
+url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 243704
+
+[packages.wheels.hashes]
+sha256 = "c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:36.012836+00:00
+url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 251628
+
+[packages.wheels.hashes]
+sha256 = "f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl"
+upload-time = 2026-03-25 20:21:37.136802+00:00
+url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl"
+size = 247180
+
+[packages.wheels.hashes]
+sha256 = "d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl"
+upload-time = 2026-03-25 20:21:38.298846+00:00
+url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl"
+size = 251674
+
+[packages.wheels.hashes]
+sha256 = "51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-win_amd64.whl"
+upload-time = 2026-03-25 20:21:40.248121+00:00
+url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl"
+size = 108755
+
+[packages.wheels.hashes]
+sha256 = "8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl"
+upload-time = 2026-03-25 20:21:43.386384+00:00
+url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl"
+size = 149859
+
+[packages.wheels.hashes]
+sha256 = "a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:44.474645+00:00
+url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 244713
+
+[packages.wheels.hashes]
+sha256 = "559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:45.620261+00:00
+url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 252084
+
+[packages.wheels.hashes]
+sha256 = "01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl"
+upload-time = 2026-03-25 20:21:46.937942+00:00
+url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl"
+size = 247973
+
+[packages.wheels.hashes]
+sha256 = "7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl"
+upload-time = 2026-03-25 20:21:48.467732+00:00
+url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl"
+size = 256223
+
+[packages.wheels.hashes]
+sha256 = "ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-win_amd64.whl"
+upload-time = 2026-03-25 20:21:50.506850+00:00
+url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl"
+size = 109082
+
+[packages.wheels.hashes]
+sha256 = "88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-py3-none-any.whl"
+upload-time = 2026-03-25 20:22:03.012768+00:00
+url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl"
+size = 14583
+
+[packages.wheels.hashes]
+sha256 = "0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe"
+
+[[packages]]
+name = "tomli-w"
+version = "1.2.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "tomli_w-1.2.0.tar.gz"
+upload-time = 2025-01-15 12:07:24.262974+00:00
+url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz"
+size = 7184
+
+[packages.sdist.hashes]
+sha256 = "2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021"
+
+[[packages.wheels]]
+name = "tomli_w-1.2.0-py3-none-any.whl"
+upload-time = 2025-01-15 12:07:22.074224+00:00
+url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl"
+size = 6675
+
+[packages.wheels.hashes]
+sha256 = "188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90"
+
+[[packages]]
+name = "truststore"
+version = "0.10.4"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "truststore-0.10.4.tar.gz"
+upload-time = 2025-08-12 18:49:02.730234+00:00
+url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz"
+size = 26169
+
+[packages.sdist.hashes]
+sha256 = "9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301"
+
+[[packages.wheels]]
+name = "truststore-0.10.4-py3-none-any.whl"
+upload-time = 2025-08-12 18:49:01.460601+00:00
+url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl"
+size = 18660
+
+[packages.wheels.hashes]
+sha256 = "adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"
+
+[[packages]]
+name = "typeguard"
+version = "4.5.2"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "typeguard-4.5.2.tar.gz"
+upload-time = 2026-05-14 12:59:40.857502+00:00
+url = "https://files.pythonhosted.org/packages/67/1c/dfba5c4633cafc4c701f237d2ba63b416805047fd6d96aab4cfc40969f98/typeguard-4.5.2.tar.gz"
+size = 80240
+
+[packages.sdist.hashes]
+sha256 = "5a16dcac23502039299c97c8941651bc33d7ea8cc4b2f7d6bbb1b528f6eea423"
+
+[[packages.wheels]]
+name = "typeguard-4.5.2-py3-none-any.whl"
+upload-time = 2026-05-14 12:59:39.473017+00:00
+url = "https://files.pythonhosted.org/packages/5b/29/74eeb4d3f3ae61ca096b018ad486b3b3c74b17bec09ab4edab721cbefec3/typeguard-4.5.2-py3-none-any.whl"
+size = 36748
+
+[packages.wheels.hashes]
+sha256 = "fcf9de18bd945cdb4c7b996e12b4c51ce83f92f191314a6d7cf1739586ec98cf"
+
+[[packages]]
+name = "typing-extensions"
+version = "4.16.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "typing_extensions-4.16.0.tar.gz"
+upload-time = 2026-07-02 08:40:05.920538+00:00
+url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz"
+size = 113555
+
+[packages.sdist.hashes]
+sha256 = "dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5"
+
+[[packages.wheels]]
+name = "typing_extensions-4.16.0-py3-none-any.whl"
+upload-time = 2026-07-02 08:40:04.659120+00:00
+url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl"
+size = 45571
+
+[packages.wheels.hashes]
+sha256 = "481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8"
+
+[[packages]]
+name = "tyro"
+version = "1.0.15"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "tyro-1.0.15.tar.gz"
+upload-time = 2026-06-20 08:48:28.364151+00:00
+url = "https://files.pythonhosted.org/packages/12/78/a5749a6c1ee9abc2999e294f339f8f72476d1a60bb95fc0e86156aafed3b/tyro-1.0.15.tar.gz"
+size = 593822
+
+[packages.sdist.hashes]
+sha256 = "3f1d60887723eecb9c489f195d11f079c4a1f33df74b723552ad31ec57c667bb"
+
+[[packages.wheels]]
+name = "tyro-1.0.15-py3-none-any.whl"
+upload-time = 2026-06-20 08:48:27.104712+00:00
+url = "https://files.pythonhosted.org/packages/5d/28/d607636187cf6c18eb72efb5d65c1d1b9e451db03d84676f835dd488fdbd/tyro-1.0.15-py3-none-any.whl"
+size = 215045
+
+[packages.wheels.hashes]
+sha256 = "982da1d566005f1b2a6b56f6be6c6929c96f0e5fab9d61bc6097573ddfaf8d13"
+
+[[packages]]
+name = "uc-micro-py"
+version = "2.0.0"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "uc_micro_py-2.0.0.tar.gz"
+upload-time = 2026-03-01 06:31:27.526616+00:00
+url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz"
+size = 6611
+
+[packages.sdist.hashes]
+sha256 = "c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811"
+
+[[packages.wheels]]
+name = "uc_micro_py-2.0.0-py3-none-any.whl"
+upload-time = 2026-03-01 06:31:26.257412+00:00
+url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl"
+size = 6383
+
+[packages.wheels.hashes]
+sha256 = "3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c"
+
+[[packages]]
+name = "urllib3"
+version = "2.7.0"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "urllib3-2.7.0.tar.gz"
+upload-time = 2026-05-07 16:13:18.596909+00:00
+url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz"
+size = 433602
+
+[packages.sdist.hashes]
+sha256 = "231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"
+
+[[packages.wheels]]
+name = "urllib3-2.7.0-py3-none-any.whl"
+upload-time = 2026-05-07 16:13:17.151740+00:00
+url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl"
+size = 131087
+
+[packages.wheels.hashes]
+sha256 = "9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
+
+[[packages]]
+name = "zipp"
+version = "4.1.0"
+marker = "(python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "zipp-4.1.0.tar.gz"
+upload-time = 2026-05-18 20:08:57.967214+00:00
+url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz"
+size = 26214
+
+[packages.sdist.hashes]
+sha256 = "4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602"
+
+[[packages.wheels]]
+name = "zipp-4.1.0-py3-none-any.whl"
+upload-time = 2026-05-18 20:08:57.045692+00:00
+url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl"
+size = 10238
+
+[packages.wheels.hashes]
+sha256 = "25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f"
+
+[tool.nab]
+nab-version = "0.0.9.dev0"
+created-at = 2026-07-12 21:09:20.266433+00:00
+command-line = [
+    "/home/damian/opensource/remote/projects/resolver/worktrees/docs-diataxis/src/nab/__main__.py",
+    "lock",
+    "--groups",
+    "docs",
+    "--no-emit-workspace",
+    "--output",
+    ".github/requirements/pylock.docs.toml",
+]
+input-path = "pyproject.toml"
+mode = "universal"
+python-specifier = ">=3.10,<3.15"
+platforms = [
+    "linux_x86_64",
+    "linux_aarch64",
+    "macos_arm64",
+    "macos_x86_64",
+    "windows_amd64",
+]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -71,21 +71,20 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.13"
+          cache: pip
+          cache-dependency-path: .github/requirements/pylock.docs.toml
 
-      - name: Upgrade pip to dependency-cooldown support
+      - name: Upgrade pip to PEP 751 install support
         run: python -m pip install --upgrade "pip>=26.1"
 
-      # Same commands Read the Docs runs (.readthedocs.yaml), so a dead
-      # cross-reference fails the PR instead of the publish.  The docs env is
-      # unpinned, so both pip runs take the cooldown: the env var carries it
-      # into the pip that hatch drives to build the env.
-      - name: Install hatch
-        run: python -m pip install --uploaded-prior-to P3D hatch
+      - name: Install docs deps
+        run: pip install -r .github/requirements/pylock.docs.toml
 
+      # Same lock and same sphinx invocation Read the Docs runs
+      # (.readthedocs.yaml), so a dead cross-reference fails the PR rather
+      # than the publish.  -W turns warnings into errors.
       - name: Build the docs
-        run: hatch run docs:build
-        env:
-          PIP_UPLOADED_PRIOR_TO: P3D
+        run: python -m sphinx -W -b html docs docs/_build/html
 
   types:
     name: ${{ matrix.checker }}

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,8 +4,13 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.13"
-  commands:
-    - pip install hatch
-    - hatch run docs:build
-    - mkdir -p $READTHEDOCS_OUTPUT/html
-    - cp -r docs/_build/html/. $READTHEDOCS_OUTPUT/html
+  jobs:
+    install:
+      # pylock.docs.toml is a PEP 751 lock nab writes for its own docs group
+      # (tasks/refresh-locks.sh), so the published build resolves nothing.
+      # Installing a pylock needs pip 26.1.
+      - python -m pip install --upgrade "pip>=26.1"
+      - python -m pip install -r .github/requirements/pylock.docs.toml
+    build:
+      html:
+        - python -m sphinx -W -b html docs $READTHEDOCS_OUTPUT/html

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ nab reads a `pyproject.toml`, resolves the dependency tree, and
 writes a pinned set of versions or a PEP 751 lockfile. It does not
 install. Hand the lockfile to whatever installer you trust.
 
+## Documentation
+
+<https://nab.readthedocs.io/>
+
 ## Install
 
 For package hygiene, and security reasons, the preference is to install nab itself

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 project = "nab"
 author = "Damian Shaw"
 copyright = "2026, Damian Shaw"  # noqa: A001 - Sphinx convention
@@ -30,6 +32,10 @@ intersphinx_mapping = {
 html_theme = "furo"
 html_title = "nab"
 html_static_path: list[str] = []
+
+# Read the Docs serves several versions from one domain.  Without a canonical
+# URL, search engines and link previews pick an arbitrary one.
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
 
 source_suffix = {
     ".md": "markdown",

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -52,6 +52,13 @@ hatch run docs:build     # sphinx-build -W, warnings are errors
 hatch run docs:serve     # live-reloading preview
 ```
 
+The `docs` dependency-group in `pyproject.toml` is the one place the doc
+tooling is declared. nab locks it into
+`.github/requirements/pylock.docs.toml` (`tasks/refresh-locks.sh`), and both
+CI and Read the Docs install from that lock, so a published build resolves
+nothing. After changing the group, re-run the refresh script and commit the
+lock.
+
 ## Coverage policy
 
 The `pyproject.toml` `[tool.coverage.report] fail_under = 100`

--- a/hatch.toml
+++ b/hatch.toml
@@ -54,15 +54,13 @@ fix = "ruff check --fix ."
 fmt = "ruff format ."
 fmt-check = "ruff format --check ."
 
+# The docs dependency-group in pyproject.toml is the single source of truth: it
+# is what nab locks into .github/requirements/pylock.docs.toml, which is what CI
+# and Read the Docs install.  Only the live-reload server is local-only.
 [envs.docs]
-detached = true
+skip-install = true
+dependency-groups = ["docs"]
 dependencies = [
-    "sphinx>=8",
-    "furo>=2024.8",
-    "myst-parser>=4",
-    "linkify-it-py>=2",
-    "sphinx-design>=0.6",
-    "sphinx-copybutton>=0.5",
     "sphinx-autobuild>=2024.10",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,14 @@ types = [
 pre-commit = [
     "pre-commit>=4",
 ]
+docs = [
+    "sphinx>=8",
+    "furo>=2024.8",
+    "myst-parser>=4",
+    "linkify-it-py>=2",
+    "sphinx-design>=0.6",
+    "sphinx-copybutton>=0.5",
+]
 release = [
     "packaging>=24.0",
     "tomlkit>=0.13",

--- a/tasks/refresh-locks.sh
+++ b/tasks/refresh-locks.sh
@@ -18,7 +18,7 @@ fi
 
 EXTRA_ARGS=("$@")
 
-for group in tests types pre-commit crosshair release; do
+for group in tests types pre-commit crosshair release docs; do
     echo "==> Locking group: ${group}"
     "${NAB[@]}" lock \
         --groups "${group}" \


### PR DESCRIPTION
Prepares the repo side of publishing to Read the Docs. The RTD project itself still has to be imported in their UI; the slug `nab` is free.

The docs tooling was the last set of dependencies not under a lock. It lived in `hatch.toml` with loose bounds, so the published build would have resolved live on every commit, and RTD's first reproducibility recommendation is to pin. The `docs` dependency-group in `pyproject.toml` is now the single declaration, `tasks/refresh-locks.sh` locks it with nab into `.github/requirements/pylock.docs.toml` like the other five groups, and CI, Read the Docs, and the hatch env all read that one group. The published build now resolves nothing.

`.readthedocs.yaml` moves from `build.commands` to `build.jobs`, which is the structure RTD recommends, and installs the lock rather than `pip install hatch`. The CI `docs` job runs the same lock and the same `sphinx -W` invocation, so a green PR means a green publish.

`conf.py` sets `html_baseurl` from `READTHEDOCS_CANONICAL_URL`. RTD serves several versions from one domain, and without it search engines and link previews pick one at random.

The lock resolves sphinx 8.1.3 rather than 9.x because the group is locked universally across the project's full python range and sphinx 9 has dropped 3.10. That matches how the other CI locks behave. Narrowing the docs lock to the 3.13 that actually builds it would take a separate matrix, so it is left alone.