### PR TITLE
fix unhandled EOFError from a truncated .tar.gz sdist

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -544,8 +544,6 @@ def _extract_sdist_files(data: bytes) -> tuple[str | None, str | None]:
     try:
         return _read_tar_sdist_files(data)
     except (tarfile.TarError, OSError, UnicodeDecodeError, KeyError, EOFError):
-        # gzip raises EOFError on a truncated stream; tarfile maps only zlib
-        # errors to a TarError.
         return (None, None)
 
 
@@ -610,14 +608,14 @@ def _sdist_member_top_level(name: str) -> tuple[int, str, str]:
 def extract_sdist_archive(data: bytes, target_dir: Path) -> Path:
     """Extract a .tar.gz sdist into ``target_dir`` and return the source root.
 
-    Extraction goes through the tar ``data`` filter (:pep:`706`), which refuses
-    any member that would write outside ``target_dir`` (absolute paths, ``..``,
-    escaping links) or is a special file (device node, FIFO); a rejected member
-    surfaces as a :class:`ValueError`.  A hard link whose target is not present
-    in the archive, and an archive whose gzip stream stops early (a partial
-    download), surface the same way.  A lone top-level directory that wraps
-    every member is the source root; otherwise (top-level files, as in a flat
-    sdist, or several top-level directories) the root is ``target_dir``.
+    Anything the extractor cannot read raises :class:`ValueError`: a corrupt or
+    truncated stream, a tar that will not open, and a member the tar ``data``
+    filter (:pep:`706`) refuses.  The filter refuses any member that would write
+    outside ``target_dir`` (absolute paths, ``..``, escaping links), is a special
+    file (device node, FIFO), or is a hard link whose target the archive does not
+    carry.  A lone top-level directory that wraps every member is the source
+    root; otherwise (top-level files, as in a flat sdist, or several top-level
+    directories) the root is ``target_dir``.
 
     The data filter is required; a Python that lacks it (before 3.10.12 /
     3.11.4 / 3.12) is unsupported and extraction raises.
@@ -639,10 +637,10 @@ def extract_sdist_archive(data: bytes, target_dir: Path) -> Path:
     except KeyError as exc:
         msg = f"broken link in sdist member: {exc}"
         raise ValueError(msg) from exc
-    except EOFError as exc:
-        # gzip raises EOFError on a truncated stream; tarfile maps only zlib
-        # errors to a TarError.
-        msg = f"truncated sdist archive: {exc}"
+    except (tarfile.TarError, OSError, EOFError) as exc:
+        # gzip raises BadGzipFile (an OSError) on a bad header, and a bare
+        # EOFError on a truncated stream; neither is a TarError.
+        msg = f"unreadable sdist archive: {exc}"
         raise ValueError(msg) from exc
 
     # A lone wrapping directory is the source root; top-level files (a flat

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -543,7 +543,9 @@ def _extract_sdist_files(data: bytes) -> tuple[str | None, str | None]:
     """
     try:
         return _read_tar_sdist_files(data)
-    except (tarfile.TarError, OSError, UnicodeDecodeError, KeyError):
+    except (tarfile.TarError, OSError, UnicodeDecodeError, KeyError, EOFError):
+        # gzip raises EOFError on a truncated stream; tarfile maps only zlib
+        # errors to a TarError.
         return (None, None)
 
 
@@ -612,9 +614,10 @@ def extract_sdist_archive(data: bytes, target_dir: Path) -> Path:
     any member that would write outside ``target_dir`` (absolute paths, ``..``,
     escaping links) or is a special file (device node, FIFO); a rejected member
     surfaces as a :class:`ValueError`.  A hard link whose target is not present
-    in the archive surfaces the same way.  A lone top-level directory that
-    wraps every member is the source root; otherwise (top-level files, as in a
-    flat sdist, or several top-level directories) the root is ``target_dir``.
+    in the archive, and an archive whose gzip stream stops early (a partial
+    download), surface the same way.  A lone top-level directory that wraps
+    every member is the source root; otherwise (top-level files, as in a flat
+    sdist, or several top-level directories) the root is ``target_dir``.
 
     The data filter is required; a Python that lacks it (before 3.10.12 /
     3.11.4 / 3.12) is unsupported and extraction raises.
@@ -635,6 +638,11 @@ def extract_sdist_archive(data: bytes, target_dir: Path) -> Path:
         raise ValueError(msg) from exc
     except KeyError as exc:
         msg = f"broken link in sdist member: {exc}"
+        raise ValueError(msg) from exc
+    except EOFError as exc:
+        # gzip raises EOFError on a truncated stream; tarfile maps only zlib
+        # errors to a TarError.
+        msg = f"truncated sdist archive: {exc}"
         raise ValueError(msg) from exc
 
     # A lone wrapping directory is the source root; top-level files (a flat

--- a/nab-python/src/nab_python/_provider/build_remote.py
+++ b/nab-python/src/nab_python/_provider/build_remote.py
@@ -86,7 +86,7 @@ def build_remote_sdist(
     with tempfile.TemporaryDirectory(prefix="nab-build-remote-") as td:
         try:
             source_dir = extract_sdist_archive(data, Path(td))
-        except (OSError, ValueError) as exc:
+        except ValueError as exc:
             msg = f"{package}=={version} sdist archive could not be extracted: {exc}"
             raise UnsupportedSdistError(msg) from exc
         try:

--- a/nab-python/src/nab_python/_provider/sources.py
+++ b/nab-python/src/nab_python/_provider/sources.py
@@ -10,7 +10,6 @@ downloads and hash-verifies a ``.tar.gz`` and extracts it; both reuse the
 from __future__ import annotations
 
 import shutil
-import tarfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -382,7 +381,7 @@ def _extract_archive(
     target.mkdir(parents=True)
     try:
         root = extract_sdist_archive(data, target)
-    except (OSError, ValueError, tarfile.TarError) as exc:
+    except ValueError as exc:
         shutil.rmtree(target, ignore_errors=True)
         msg = f"archive could not be extracted: {exc}"
         raise UnsupportedSdistError(msg) from exc

--- a/nab-python/tests/property_python/test_sdist_archive_safety.py
+++ b/nab-python/tests/property_python/test_sdist_archive_safety.py
@@ -119,6 +119,30 @@ def test_extract_sdist_files_never_raises_on_garbage(blob: bytes) -> None:
     assert _extract_sdist_files(blob) == (None, None)
 
 
+_PKG_INFO = "Metadata-Version: 2.2\nName: pkg\nVersion: 1.0\n"
+
+
+@st.composite
+def truncated_archives(draw: st.DrawFn) -> bytes:
+    """A well-formed sdist cut short, as a half-finished download leaves it.
+
+    Random bytes never form a gzip header, so only a real archive with its
+    tail removed exercises the partly-decodable stream.
+    """
+    archive = make_targz([("pkg-1.0/PKG-INFO", _PKG_INFO.encode())])
+    cut = draw(st.integers(min_value=1, max_value=len(archive) - 1))
+    return archive[:cut]
+
+
+@given(blob=truncated_archives())
+@PROPERTY_SETTINGS
+def test_extract_sdist_files_never_raises_on_truncated_archive(blob: bytes) -> None:
+    """A truncated archive yields whole metadata or none, never an exception."""
+    pkg_info, pyproject = _extract_sdist_files(blob)
+    assert pkg_info in (None, _PKG_INFO)
+    assert pyproject is None
+
+
 hostile_names = st.sampled_from(
     [
         "../evil.txt",

--- a/nab-python/tests/property_python/test_sdist_archive_safety.py
+++ b/nab-python/tests/property_python/test_sdist_archive_safety.py
@@ -124,11 +124,7 @@ _PKG_INFO = "Metadata-Version: 2.2\nName: pkg\nVersion: 1.0\n"
 
 @st.composite
 def truncated_archives(draw: st.DrawFn) -> bytes:
-    """A well-formed sdist cut short, as a half-finished download leaves it.
-
-    Random bytes never form a gzip header, so only a real archive with its
-    tail removed exercises the partly-decodable stream.
-    """
+    """A well-formed sdist cut short at a random byte."""
     archive = make_targz([("pkg-1.0/PKG-INFO", _PKG_INFO.encode())])
     cut = draw(st.integers(min_value=1, max_value=len(archive) - 1))
     return archive[:cut]

--- a/nab-python/tests/test_archive.py
+++ b/nab-python/tests/test_archive.py
@@ -8,6 +8,7 @@ on real ``.tar.gz`` bytes.
 
 from __future__ import annotations
 
+import gzip
 import hashlib
 import io
 import tarfile
@@ -60,6 +61,11 @@ def _make_flat_sdist(pyproject: str) -> bytes:
 
 
 _PYPROJECT = '[project]\nname = "foo"\nversion = "1.0.0"\ndependencies = ["bar>=1"]\n'
+
+
+def _half(data: bytes) -> bytes:
+    """Return the leading half of ``data``, as a cut-short download leaves it."""
+    return data[: len(data) // 2]
 
 
 def _provider(archive_sources: list[ArchiveSource], cache_dir: Path | None) -> Provider:
@@ -293,10 +299,9 @@ class TestArchiveMaterialize:
             provider.fetch_versions("foo")
 
     def test_truncated_archive_raises(self, tmp_path: Path) -> None:
-        # A half-downloaded archive whose hash matches the bytes on hand: the
-        # gzip stream stops early, which is an extraction failure like any other.
-        whole = _make_sdist("foo", "1.0.0", _PYPROJECT)
-        data = whole[: len(whole) // 2]
+        # The hash covers the truncated bytes, so this fails in extraction
+        # rather than in the hash check.
+        data = _half(_make_sdist("foo", "1.0.0", _PYPROJECT))
         digest = hashlib.sha256(data).hexdigest()
         source = ArchiveSource(
             name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
@@ -499,14 +504,23 @@ class TestExtractArchive:
             extract_sdist_archive(buf.getvalue(), out)
 
     @requires_data_filter
-    def test_truncated_archive_raises_value_error(self, tmp_path: Path) -> None:
-        # A half-downloaded archive: gzip stops mid-stream, which reaches the
-        # caller as an EOFError rather than a tarfile error.
-        whole = _make_sdist("foo", "1.0.0", _PYPROJECT)
+    @pytest.mark.parametrize(
+        "data",
+        [
+            b"",
+            b"not a gzip stream",
+            gzip.compress(b"not a tar"),
+            _half(_make_sdist("foo", "1.0.0", _PYPROJECT)),
+        ],
+        ids=["empty", "not-gzip", "gzip-not-tar", "truncated"],
+    )
+    def test_unreadable_archive_raises_value_error(
+        self, data: bytes, tmp_path: Path
+    ) -> None:
         out = tmp_path / "out"
         out.mkdir()
-        with pytest.raises(ValueError, match="truncated sdist archive"):
-            extract_sdist_archive(whole[: len(whole) // 2], out)
+        with pytest.raises(ValueError, match="unreadable sdist archive"):
+            extract_sdist_archive(data, out)
 
     @requires_data_filter
     def test_flat_archive_with_one_package_dir_keeps_root(self, tmp_path: Path) -> None:

--- a/nab-python/tests/test_archive.py
+++ b/nab-python/tests/test_archive.py
@@ -292,6 +292,20 @@ class TestArchiveMaterialize:
         with pytest.raises(UnsupportedSdistError, match="could not be extracted"):
             provider.fetch_versions("foo")
 
+    def test_truncated_archive_raises(self, tmp_path: Path) -> None:
+        # A half-downloaded archive whose hash matches the bytes on hand: the
+        # gzip stream stops early, which is an extraction failure like any other.
+        whole = _make_sdist("foo", "1.0.0", _PYPROJECT)
+        data = whole[: len(whole) // 2]
+        digest = hashlib.sha256(data).hexdigest()
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
+        )
+        provider = _provider([source], tmp_path / "arch")
+        provider.coordinator.index.store_sdist_archive("foo", digest, data)
+        with pytest.raises(UnsupportedSdistError, match="could not be extracted"):
+            provider.fetch_versions("foo")
+
     @requires_data_filter
     def test_reextraction_replaces_stale_partial_tree(self, tmp_path: Path) -> None:
         data = _make_sdist("foo", "1.0.0", _PYPROJECT)
@@ -483,6 +497,16 @@ class TestExtractArchive:
         out.mkdir()
         with pytest.raises(ValueError, match="broken link in sdist member"):
             extract_sdist_archive(buf.getvalue(), out)
+
+    @requires_data_filter
+    def test_truncated_archive_raises_value_error(self, tmp_path: Path) -> None:
+        # A half-downloaded archive: gzip stops mid-stream, which reaches the
+        # caller as an EOFError rather than a tarfile error.
+        whole = _make_sdist("foo", "1.0.0", _PYPROJECT)
+        out = tmp_path / "out"
+        out.mkdir()
+        with pytest.raises(ValueError, match="truncated sdist archive"):
+            extract_sdist_archive(whole[: len(whole) // 2], out)
 
     @requires_data_filter
     def test_flat_archive_with_one_package_dir_keeps_root(self, tmp_path: Path) -> None:

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -234,6 +234,20 @@ class TestFlatWheelhouse:
         assert len(files) == 1
         assert files[0].requires_python is None
 
+    def test_sdist_requires_python_none_for_truncated_archive(
+        self, tmp_path: Path
+    ) -> None:
+        # A half-downloaded sdist: gzip header, deflate stream cut short. It
+        # cannot be read, so the version lists with no Requires-Python bound.
+        path = tmp_path / "foo-1.0.tar.gz"
+        _write_sdist(path, "foo", "1.0", ">=3.12")
+        whole = path.read_bytes()
+        path.write_bytes(whole[: len(whole) // 2])
+        client = LocalIndexClient(tmp_path.as_uri())
+        files = run(client.get_files("foo"))
+        assert len(files) == 1
+        assert files[0].requires_python is None
+
     def test_foreign_sdist_metadata_not_read(self, tmp_path: Path) -> None:
         # A sibling package's sdist Requires-Python must not leak onto foo.
         _write_sdist(tmp_path / "foo-1.0.tar.gz", "foo", "1.0", ">=3.8")

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -237,8 +237,7 @@ class TestFlatWheelhouse:
     def test_sdist_requires_python_none_for_truncated_archive(
         self, tmp_path: Path
     ) -> None:
-        # A half-downloaded sdist: gzip header, deflate stream cut short. It
-        # cannot be read, so the version lists with no Requires-Python bound.
+        # The sdist cannot be read, so the version lists with no Requires-Python.
         path = tmp_path / "foo-1.0.tar.gz"
         _write_sdist(path, "foo", "1.0", ">=3.12")
         whole = path.read_bytes()

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -112,6 +112,20 @@ def _done_event() -> threading.Event:
     return ev
 
 
+def _make_sdist_targz() -> bytes:
+    """Return .tar.gz bytes for a one-file sdist rooted at pkg-1.0."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        body = b"[project]\nname = 'pkg'\n"
+        info = tarfile.TarInfo(name="pkg-1.0/pyproject.toml")
+        info.size = len(body)
+        tar.addfile(info, io.BytesIO(body))
+    return buf.getvalue()
+
+
+_SDIST_TARGZ = _make_sdist_targz()
+
+
 class TestPrefetchListings:
     def test_root_requirements_prefetched(self) -> None:
         """Root requirement listings are fetched in background on init."""
@@ -7071,60 +7085,32 @@ class TestBuildRemoteFailureModes:
         with pytest.raises(SdistHashMismatchError):
             build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
 
-    def test_archive_extract_failure_raises(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    @pytest.mark.parametrize(
+        "data",
+        [
+            b"",
+            b"not a gzip stream",
+            _SDIST_TARGZ[: len(_SDIST_TARGZ) // 2],
+        ],
+        ids=["empty", "not-gzip", "truncated"],
+    )
+    def test_unreadable_archive_raises(self, data: bytes) -> None:
+        """An unreadable archive raises the skippable ``UnsupportedSdistError``."""
         provider = self._provider(with_sdist=True)
         provider.versions_cache["pkg"] = [(V("1.0"), make_sdist("1.0"))]
 
-        def _ok_fetch(
+        def _fetch(
             pkg: str,
             ver: str,
             _url: str,
             _hashes: tuple[tuple[str, str], ...] = (),
         ) -> threading.Event:
-            provider.coordinator.index.store_sdist_archive(pkg, ver, b"corrupt")
+            provider.coordinator.index.store_sdist_archive(pkg, ver, data)
             return _done_event()
 
         cast(
             "MagicMock", provider.coordinator
-        ).request_sdist_archive.side_effect = _ok_fetch
-
-        def _bad_extract(_data: bytes, _target: object) -> object:
-            raise ValueError("malformed archive")
-
-        monkeypatch.setattr(build_remote, "extract_sdist_archive", _bad_extract)
-        with pytest.raises(UnsupportedSdistError, match="could not be extracted"):
-            build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
-
-    def test_truncated_archive_raises(self) -> None:
-        # A half-downloaded archive: the gzip stream stops before the end of
-        # the deflate data, so no build can run against it.
-        provider = self._provider(with_sdist=True)
-        provider.versions_cache["pkg"] = [(V("1.0"), make_sdist("1.0"))]
-
-        buf = io.BytesIO()
-        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-            body = b"[project]\nname = 'pkg'\n"
-            info = tarfile.TarInfo(name="pkg-1.0/pyproject.toml")
-            info.size = len(body)
-            tar.addfile(info, io.BytesIO(body))
-        whole = buf.getvalue()
-
-        def _partial_fetch(
-            pkg: str,
-            ver: str,
-            _url: str,
-            _hashes: tuple[tuple[str, str], ...] = (),
-        ) -> threading.Event:
-            provider.coordinator.index.store_sdist_archive(
-                pkg, ver, whole[: len(whole) // 2]
-            )
-            return _done_event()
-
-        cast(
-            "MagicMock", provider.coordinator
-        ).request_sdist_archive.side_effect = _partial_fetch
+        ).request_sdist_archive.side_effect = _fetch
         with pytest.raises(UnsupportedSdistError, match="could not be extracted"):
             build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
 

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -7097,6 +7097,37 @@ class TestBuildRemoteFailureModes:
         with pytest.raises(UnsupportedSdistError, match="could not be extracted"):
             build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
 
+    def test_truncated_archive_raises(self) -> None:
+        # A half-downloaded archive: the gzip stream stops before the end of
+        # the deflate data, so no build can run against it.
+        provider = self._provider(with_sdist=True)
+        provider.versions_cache["pkg"] = [(V("1.0"), make_sdist("1.0"))]
+
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            body = b"[project]\nname = 'pkg'\n"
+            info = tarfile.TarInfo(name="pkg-1.0/pyproject.toml")
+            info.size = len(body)
+            tar.addfile(info, io.BytesIO(body))
+        whole = buf.getvalue()
+
+        def _partial_fetch(
+            pkg: str,
+            ver: str,
+            _url: str,
+            _hashes: tuple[tuple[str, str], ...] = (),
+        ) -> threading.Event:
+            provider.coordinator.index.store_sdist_archive(
+                pkg, ver, whole[: len(whole) // 2]
+            )
+            return _done_event()
+
+        cast(
+            "MagicMock", provider.coordinator
+        ).request_sdist_archive.side_effect = _partial_fetch
+        with pytest.raises(UnsupportedSdistError, match="could not be extracted"):
+            build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
+
     def test_build_backend_failure_raises(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
A half-downloaded `.tar.gz` in a `file://` find-links index crashes `nab lock` with an unhandled traceback while the index is listed. gzip raises a bare `EOFError` on a truncated stream, and `EOFError` is neither a `TarError` nor an `OSError`, so it slips past every catch tuple in the sdist read and extract path.

Listing now treats a truncated sdist the way it already treats a corrupt one: the version still lists, without `Requires-Python`. `extract_sdist_archive` now raises `ValueError` for any archive it cannot read, so a build turns it into the skippable `UnsupportedSdistError` and both callers can catch `ValueError` alone.
