### PR TITLE
fix KeyError: 'headers' when a build requirement ships wheel headers

### DIFF
--- a/nab-python/src/nab_python/_build/env.py
+++ b/nab-python/src/nab_python/_build/env.py
@@ -12,7 +12,7 @@
   resolved wheels into a temp directory.
 * :func:`installer.install` writes each wheel into the venv via
   ``installer.SchemeDictionaryDestination``, configured from the
-  venv's own ``sysconfig.get_paths()``.
+  venv's own scheme paths.
 
 The env is a context manager.  Entering it builds the venv and
 installs the requirements; exiting removes the temp tree.  The
@@ -80,6 +80,15 @@ _LAUNCHER_KIND = (
     else "win-ia32"
     if sys.platform == "win32"
     else "posix"
+)
+
+_SCHEME_PROBE = (
+    "import json, sys, sysconfig;"
+    "print(json.dumps({"
+    "'paths': sysconfig.get_paths(),"
+    "'prefix': sys.prefix,"
+    "'py_version': '%d.%d' % sys.version_info[:2],"
+    "}))"
 )
 
 
@@ -151,21 +160,27 @@ class NabBuildEnv:
         self._python_executable = _venv_python(self._venv_path)
         self._scripts_dir = self._python_executable.parent
 
-        scheme_dict = _venv_scheme_paths(self._python_executable)
+        scheme_paths = _venv_scheme_paths(self._python_executable)
 
         if not self._requires:
             return
-        wheel_paths = self._resolve_and_download(wheel_dir)
-        destination = _FastSchemeDictionaryDestination(
-            scheme_dict=scheme_dict,
-            interpreter=str(self._python_executable),
-            script_kind=_LAUNCHER_KIND,
-            bytecode_optimization_levels=(),
-            overwrite_existing=True,
-        )
+
+        self._install_wheels(self._resolve_and_download(wheel_dir), scheme_paths)
+
+    def _install_wheels(
+        self, wheel_paths: list[Path], scheme_paths: dict[str, str]
+    ) -> None:
+        """Write each wheel into the venv with ``installer``."""
         for wheel_path in wheel_paths:
             logger.debug("installing %s", wheel_path.name)
             with WheelFile.open(wheel_path) as source:
+                destination = _FastSchemeDictionaryDestination(
+                    scheme_dict=_dist_scheme_paths(scheme_paths, source.distribution),
+                    interpreter=str(self._python_executable),
+                    script_kind=_LAUNCHER_KIND,
+                    bytecode_optimization_levels=(),
+                    overwrite_existing=True,
+                )
                 installer_install(
                     source=source,
                     destination=destination,
@@ -224,21 +239,7 @@ class NabBuildEnv:
         sub = wheel_dir / f"_extra_{len(list(wheel_dir.iterdir()))}"
         sub.mkdir(parents=True, exist_ok=True)
         wheel_paths = self._resolve_and_download(sub, extra=requirements)
-        scheme_dict = _venv_scheme_paths(self._python_executable)
-        destination = SchemeDictionaryDestination(
-            scheme_dict=scheme_dict,
-            interpreter=str(self._python_executable),
-            script_kind=_LAUNCHER_KIND,
-            bytecode_optimization_levels=(),
-            overwrite_existing=True,
-        )
-        for wheel_path in wheel_paths:
-            with WheelFile.open(wheel_path) as source:
-                installer_install(
-                    source=source,
-                    destination=destination,
-                    additional_metadata={"INSTALLER": b"nab\n"},
-                )
+        self._install_wheels(wheel_paths, _venv_scheme_paths(self._python_executable))
 
     def _resolve_and_download(
         self,
@@ -326,24 +327,39 @@ def _venv_python(venv_path: Path) -> Path:
 
 
 def _venv_scheme_paths(python_executable: Path) -> dict[str, str]:
-    """Ask the venv's interpreter for its own ``sysconfig.get_paths()``.
+    """Ask the venv's interpreter for the scheme paths ``installer`` writes to.
 
     Subprocessing the venv guarantees the returned paths reflect the
     venv's layout (``site-packages`` under the venv root, scripts in
     its ``bin``/``Scripts`` dir, etc.) regardless of how nab itself
     was installed.  One subprocess per env construction; negligible.
+
+    ``sysconfig`` has no ``headers`` scheme, and its ``include`` names
+    the base interpreter rather than the venv, so the header root comes
+    from the venv's own prefix instead.
     """
     result = subprocess.run(  # noqa: S603 - controlled command, no shell
-        [
-            str(python_executable),
-            "-c",
-            "import json, sysconfig; print(json.dumps(sysconfig.get_paths()))",
-        ],
+        [str(python_executable), "-c", _SCHEME_PROBE],
         capture_output=True,
         text=True,
         check=True,
     )
-    return dict(json.loads(result.stdout))
+    probe = json.loads(result.stdout)
+
+    paths: dict[str, str] = dict(probe["paths"])
+    paths["headers"] = str(
+        Path(probe["prefix"], "include", "site", f"python{probe['py_version']}")
+    )
+    return paths
+
+
+def _dist_scheme_paths(
+    scheme_paths: dict[str, str], distribution: str
+) -> dict[str, str]:
+    """Scheme paths for one wheel; its headers go in a directory of its own."""
+    paths = dict(scheme_paths)
+    paths["headers"] = str(Path(paths["headers"], distribution))
+    return paths
 
 
 def _supports_symlinks() -> bool:

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import base64
 import hashlib
 import io
+import json
+import subprocess
 import sys
 import tarfile
 import zipfile
@@ -23,13 +25,14 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from installer.utils import Scheme
+from installer.utils import SCHEME_NAMES, Scheme
 
 from nab_index.multi_index import IndexConfig
 from nab_python._build.env import (
     BuildEnvError,
     NabBuildEnv,
     _FastSchemeDictionaryDestination,
+    _venv_scheme_paths,
 )
 from nab_python._build.runner import BuildBackendError, run_build_backend
 from nab_python.config import NabProjectConfig
@@ -116,8 +119,17 @@ def _wheel_record_hash(data: bytes) -> str:
     return "sha256=" + digest.decode()
 
 
-def _make_installable_wheel(path: Path, name: str, version: str) -> None:
-    """Write a minimal but installer-valid pure-Python wheel."""
+def _make_installable_wheel(
+    path: Path,
+    name: str,
+    version: str,
+    data_files: dict[str, bytes] | None = None,
+) -> None:
+    """Write a minimal but installer-valid pure-Python wheel.
+
+    ``data_files`` are placed under the PEP 427 ``<dist>.data``
+    directory, keyed by their path within it (``headers/foo.h``).
+    """
     dist = f"{name}-{version}"
     files = {
         f"{name}/__init__.py": b"",
@@ -129,6 +141,8 @@ def _make_installable_wheel(path: Path, name: str, version: str) -> None:
             b"Root-Is-Purelib: true\nTag: py3-none-any\n"
         ),
     }
+    for data_path, data in (data_files or {}).items():
+        files[f"{dist}.data/{data_path}"] = data
     record = "".join(
         f"{p},{_wheel_record_hash(d)},{len(d)}\n" for p, d in files.items()
     )
@@ -738,10 +752,13 @@ class TestNabBuildEnvInstall:
         )
         monkeypatch.setattr(
             "nab_python._build.env._venv_scheme_paths",
-            lambda _python: {"purelib": str(tmp_path / "site")},
+            lambda _python: {
+                "purelib": str(tmp_path / "site"),
+                "headers": str(tmp_path / "include"),
+            },
         )
         opened = MagicMock()
-        opened.__enter__.return_value = MagicMock()
+        opened.__enter__.return_value = MagicMock(distribution="fake")
         opened.__exit__.return_value = False
         monkeypatch.setattr(WheelFile, "open", lambda _path: opened)
         installer_calls: list[object] = []
@@ -861,7 +878,12 @@ class TestNabBuildEnvEnterInstall:
 
         monkeypatch.setattr(venv_mod, "EnvBuilder", _Builder)
         monkeypatch.setattr(
-            env_mod, "_venv_scheme_paths", lambda _python: {"purelib": str(tmp_path)}
+            env_mod,
+            "_venv_scheme_paths",
+            lambda _python: {
+                "purelib": str(tmp_path),
+                "headers": str(tmp_path / "include"),
+            },
         )
         fake_wheel = tmp_path / "fake-1.0-py3-none-any.whl"
         fake_wheel.touch()
@@ -871,7 +893,7 @@ class TestNabBuildEnvEnterInstall:
             lambda self, _wd: [fake_wheel],
         )
         opened = MagicMock()
-        opened.__enter__.return_value = MagicMock()
+        opened.__enter__.return_value = MagicMock(distribution="fake")
         opened.__exit__.return_value = False
         monkeypatch.setattr(WheelFile, "open", lambda _path: opened)
         installer_calls: list[object] = []
@@ -920,6 +942,87 @@ class TestNabBuildEnvEnterInstall:
         with pytest.raises(RuntimeError, match="resolve failed"):
             env.__enter__()
         assert env._tmpdir is None  # type: ignore[attr-defined]
+
+
+class TestBuildEnvHeaderScheme:
+    """A build requirement whose wheel ships a ``.data/headers/`` payload.
+
+    greenlet, a build requirement of gevent, ships ``greenlet.h`` that way.
+    """
+
+    def _py_version(self) -> str:
+        return f"{sys.version_info.major}.{sys.version_info.minor}"
+
+    def _patch_probe(self, monkeypatch: pytest.MonkeyPatch, venv_path: Path) -> None:
+        """Answer the scheme probe with what a venv interpreter prints."""
+        py_version = self._py_version()
+        site = venv_path / "lib" / f"python{py_version}" / "site-packages"
+        payload = json.dumps(
+            {
+                "paths": {
+                    "purelib": str(site),
+                    "platlib": str(site),
+                    "scripts": str(venv_path / "bin"),
+                    "data": str(venv_path),
+                    "include": f"/usr/include/python{py_version}",
+                },
+                "prefix": str(venv_path),
+                "py_version": py_version,
+            }
+        )
+
+        def _run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(cmd, 0, stdout=payload, stderr="")
+
+        monkeypatch.setattr(subprocess, "run", _run)
+
+    def test_scheme_paths_cover_every_installer_scheme(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        venv_path = tmp_path / "venv"
+        self._patch_probe(monkeypatch, venv_path)
+
+        paths = _venv_scheme_paths(venv_path / "bin" / "python")
+
+        assert set(SCHEME_NAMES) <= set(paths)
+        expected = venv_path / "include" / "site" / f"python{self._py_version()}"
+        assert paths["headers"] == str(expected)
+
+    def test_header_payload_lands_under_the_dist_include_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        env = NabBuildEnv(requires=[], config=NabProjectConfig())
+        venv_path = tmp_path / "venv"
+        venv_path.mkdir()
+        (tmp_path / "wheels").mkdir()
+        env._venv_path = venv_path  # type: ignore[attr-defined]
+        env._python_executable = venv_path / "bin" / "python"  # type: ignore[attr-defined]
+
+        wheel = tmp_path / "greenlet-3.2.4-py3-none-any.whl"
+        _make_installable_wheel(
+            wheel,
+            "greenlet",
+            "3.2.4",
+            data_files={"headers/greenlet.h": b"#define GREENLET_H\n"},
+        )
+
+        monkeypatch.setattr(env, "_resolve_and_download", lambda *_a, **_k: [wheel])
+        self._patch_probe(monkeypatch, venv_path)
+
+        env.install(["greenlet==3.2.4"])
+
+        py_version = self._py_version()
+        header = (
+            venv_path
+            / "include"
+            / "site"
+            / f"python{py_version}"
+            / "greenlet"
+            / "greenlet.h"
+        )
+        assert header.read_bytes() == b"#define GREENLET_H\n"
+        site = venv_path / "lib" / f"python{py_version}" / "site-packages"
+        assert (site / "greenlet" / "__init__.py").is_file()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Installing a build requirement whose wheel ships a `<dist>.data/headers/` payload fails with a raw `KeyError: 'headers'` from installer. greenlet hits this, and greenlet is the documented build requirement of gevent, so building gevent from source never reaches the backend.

The build env configures installer's destination from the venv's `sysconfig.get_paths()`, which has no `headers` key, and whose `include` points at the base interpreter rather than the venv. The scheme probe now derives the header root from the venv's own prefix and gives each wheel its own directory under it, which is the layout pip installs headers into.
