### PR TITLE
Let --project-mode override a declared matrix

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -537,9 +537,20 @@ The two `python` knobs cover different shapes of resolve:
   `[tool.nab.matrix].python-patches` to control the resolve and
   marker shape across all tuples.
 
-If both are present, the matrix `python` wins under universal mode
-and `requires-python` wins under specific mode.  Pick one shape
-based on whether you want one lock or many.
+Declaring a `[tool.nab.matrix]` table while `mode` is `specific` is an
+error: the matrix is the universal resolver's input, so leaving mode
+behind is almost always an oversight rather than an intent.
+
+The one exception is an explicit `--project-mode specific` on the
+command line.  A CLI override outranks the `[tool.nab]` table, so it
+selects a single-environment resolve for that run and the declared
+matrix does not apply; `requires-python` then chooses the Python to
+resolve against.  This is how a universal project takes one
+single-environment lock without editing its `pyproject.toml`:
+
+```bash
+nab lock --project-mode specific --project-requires-python "==3.13.*"
+```
 
 ## CLI flags
 

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -611,8 +611,10 @@ def _config_from_effective(
     caller afterwards.
     """
     del anchor  # P<n>D durations are already anchored in the effective map.
-    mode: ResolveMode = effective["mode"].value
-    matrix: MatrixConfig | None = effective["matrix"].value
+    mode_value = effective["mode"]
+    matrix_value = effective["matrix"]
+    mode: ResolveMode = mode_value.value
+    matrix: MatrixConfig | None = matrix_value.value
     if mode is ResolveMode.UNIVERSAL and matrix is None:
         msg = (
             "mode = 'universal' requires a [tool.nab.matrix] table"
@@ -620,12 +622,16 @@ def _config_from_effective(
         )
         raise ConfigError(msg)
     if mode is ResolveMode.SPECIFIC and matrix is not None:
-        msg = (
-            "[tool.nab.matrix] is set but mode is 'specific'; set"
-            " mode = 'universal' to opt in to the experimental"
-            " matrix-based resolver"
-        )
-        raise ConfigError(msg)
+        if not mode_value.origin.outranks(matrix_value.origin):
+            msg = (
+                "[tool.nab.matrix] is set but mode is 'specific'; set"
+                " mode = 'universal' to opt in to the experimental"
+                " matrix-based resolver"
+            )
+            raise ConfigError(msg)
+        # A higher-precedence source (--project-mode) selected a
+        # single-environment resolve, so the matrix it shadows does not apply.
+        matrix = None
 
     dist_policy, trust_unverified = effective["dist-policy"].value
     indexes: tuple[IndexConfig, ...] = effective["indexes"].value

--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -1145,6 +1145,14 @@ class Origin:
         """
         return _scope_label(self.kind)
 
+    def outranks(self, other: Origin) -> bool:
+        """Whether this origin sits at a strictly higher precedence level.
+
+        A tie is not an outranking: ``PYPROJECT`` and ``PROJECT_TOML``
+        share a rank, so neither overrides the other here.
+        """
+        return _PRECEDENCE[self.kind] > _PRECEDENCE[other.kind]
+
 
 def _scope_label(kind: SourceKind) -> str:
     """Return the scope name ``nab config`` reports for a source kind.

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -100,6 +100,19 @@ class TestCliOverridesFold:
                 path, discover_workspace=False, cli_overrides={"mode": "universal"}
             )
 
+    def test_cli_mode_specific_shadows_declared_matrix(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab]\nmode = "universal"\n'
+            '[tool.nab.matrix]\npython = ">=3.11,<3.13"\n'
+            'platforms = ["linux_x86_64"]\n',
+        )
+        config = read_pyproject_config(
+            path, discover_workspace=False, cli_overrides={"mode": "specific"}
+        )
+        assert config.mode is ResolveMode.SPECIFIC
+        assert config.matrix is None
+
 
 class TestDefaults:
     def test_no_tool_nab_table_returns_defaults(self, tmp_path: Path) -> None:
@@ -138,6 +151,17 @@ class TestMode:
     def test_matrix_without_universal_mode_rejected(self, tmp_path: Path) -> None:
         path = write(
             tmp_path,
+            '[tool.nab.matrix]\npython = ">=3.11"\nplatforms = ["linux_x86_64"]\n',
+        )
+        with pytest.raises(ConfigError, match="set mode = 'universal'"):
+            read_pyproject_config(path)
+
+    def test_matrix_with_specific_mode_in_same_file_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab]\nmode = "specific"\n'
             '[tool.nab.matrix]\npython = ">=3.11"\nplatforms = ["linux_x86_64"]\n',
         )
         with pytest.raises(ConfigError, match="set mode = 'universal'"):


### PR DESCRIPTION
The configuration reference promises that `requires-python` wins under specific mode when both it and a matrix are present. The code never allowed it: `_from_effective` raised whenever the merged config had `mode = specific` and a matrix table, whatever the origin of `mode`. So a project that declares `[tool.nab.matrix]` could not take a single-environment lock at all, and `nab lock --project-mode specific` was dead on arrival.

The guard exists to catch a real mistake, declaring a matrix and leaving `mode` at its default, so it stays. What it should not do is override an explicit instruction. The config ladder already records where each value came from, and the same function reads `.origin.kind` a few lines below to decide whether build-policy was set, so the fix is to raise only when `mode` does not outrank the matrix.

`Origin.outranks` is the new public predicate. A tie is not an outranking, so `mode = "specific"` sitting in the same pyproject as the matrix still errors, as does the default-mode case. Only a strictly higher-precedence source, which for `mode` means the CLI, wins. When it does, the shadowed matrix is dropped rather than carried into the resolve.

Found by dogfooding: nab locks its own docs dependency-group, and that group is the one thing in the repo that should be a single resolution for the one interpreter that builds the docs, rather than the project's universal matrix.