### PR TITLE
stop a failed lock write from truncating the existing lockfile

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,6 @@
-"""Top-level conftest: hypothesis profile registration.
+"""Top-level conftest: hypothesis profiles and the ``cap_writes`` fixture.
 
-Three profiles, selectable via the ``HYPOTHESIS_PROFILE`` env var:
+Three hypothesis profiles, selectable via the ``HYPOTHESIS_PROFILE`` env var:
 
 - ``dev`` (default): low ``max_examples`` (20) for fast feedback.
 - ``ci``: more thorough (200 examples) plus ``derandomize=True`` so
@@ -14,13 +14,29 @@ explicitly construct a ``settings(...)`` decorator are unaffected.
 The property suite under ``nab-*/tests/property*/`` uses explicit
 ``PROPERTY_SETTINGS``/``DEEP_SETTINGS``/``BRUTE_FORCE_SETTINGS``
 decorators so its example budget is independent of the profile.
+
+``cap_writes`` lives here because both the ``nab-python`` suite and the
+CLI suite need it to exercise a filesystem that fills up partway through
+a write.
 """
 
 from __future__ import annotations
 
+import errno
+import io
 import os
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
 
+import pytest
 from hypothesis import HealthCheck, settings
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from contextlib import AbstractContextManager
+    from types import TracebackType
+
+    from typing_extensions import Self
 
 settings.register_profile("dev", max_examples=20)
 settings.register_profile(
@@ -37,3 +53,63 @@ settings.register_profile(
     suppress_health_check=[HealthCheck.too_slow],
 )
 settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", "dev"))
+
+
+class _CappedHandle:
+    """A writable file handle that stops accepting content past a budget."""
+
+    def __init__(self, handle: Any, budget: int) -> None:
+        self._handle = handle
+        self._budget = budget
+
+    def write(self, payload: Any) -> int:
+        if len(payload) > self._budget:
+            self._handle.write(payload[: self._budget])
+            self._handle.flush()
+            self._budget = 0
+            msg = os.strerror(errno.ENOSPC)
+            raise OSError(errno.ENOSPC, msg)
+        self._budget -= len(payload)
+        written: int = self._handle.write(payload)
+        return written
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc: BaseException | None,
+        _tb: TracebackType | None,
+    ) -> None:
+        self._handle.close()
+
+
+@contextmanager
+def _cap_writes(budget: int) -> Iterator[None]:
+    real_open = io.open
+
+    def capped_open(file: Any, mode: str = "r", *args: Any, **kwargs: Any) -> Any:
+        handle = real_open(file, mode, *args, **kwargs)
+        if "w" not in mode:
+            return handle
+        return _CappedHandle(handle, budget)
+
+    io.open = capped_open  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        io.open = real_open  # type: ignore[assignment]
+
+
+@pytest.fixture
+def cap_writes() -> Callable[[int], AbstractContextManager[None]]:
+    """Simulate a filesystem that fills up partway through a write.
+
+    Inside ``cap_writes(n)`` every file opened for writing takes the first
+    ``n`` bytes and then raises ``ENOSPC``, leaving those bytes on disk.
+    Patching ``io.open`` rather than a specific writer keeps the fixture
+    honest about how the file is written: both ``Path.write_text`` and a
+    ``tempfile``-staged write route through it.
+    """
+    return _cap_writes

--- a/conftest.py
+++ b/conftest.py
@@ -15,9 +15,8 @@ The property suite under ``nab-*/tests/property*/`` uses explicit
 ``PROPERTY_SETTINGS``/``DEEP_SETTINGS``/``BRUTE_FORCE_SETTINGS``
 decorators so its example budget is independent of the profile.
 
-``cap_writes`` lives here because both the ``nab-python`` suite and the
-CLI suite need it to exercise a filesystem that fills up partway through
-a write.
+``cap_writes`` is here rather than in one suite's conftest because both the
+``nab-python`` suite and the CLI suite use it.
 """
 
 from __future__ import annotations
@@ -69,9 +68,17 @@ class _CappedHandle:
             self._budget = 0
             msg = os.strerror(errno.ENOSPC)
             raise OSError(errno.ENOSPC, msg)
+
         self._budget -= len(payload)
         written: int = self._handle.write(payload)
         return written
+
+    def flush(self) -> None:
+        self._handle.flush()
+
+    def fileno(self) -> int:
+        fd: int = self._handle.fileno()
+        return fd
 
     def __enter__(self) -> Self:
         return self
@@ -106,10 +113,9 @@ def _cap_writes(budget: int) -> Iterator[None]:
 def cap_writes() -> Callable[[int], AbstractContextManager[None]]:
     """Simulate a filesystem that fills up partway through a write.
 
-    Inside ``cap_writes(n)`` every file opened for writing takes the first
-    ``n`` bytes and then raises ``ENOSPC``, leaving those bytes on disk.
-    Patching ``io.open`` rather than a specific writer keeps the fixture
-    honest about how the file is written: both ``Path.write_text`` and a
-    ``tempfile``-staged write route through it.
+    Inside ``cap_writes(n)`` every file opened for writing takes the first ``n``
+    bytes and then raises ``ENOSPC``, leaving those bytes on disk. Patching
+    ``io.open`` rather than a writer keeps the fixture agnostic about how the
+    file gets written.
     """
     return _cap_writes

--- a/nab-index/src/nab_index/atomic.py
+++ b/nab-index/src/nab_index/atomic.py
@@ -1,0 +1,61 @@
+"""Write a file by staging it beside the destination and renaming over it.
+
+Shared by the on-disk cache and the lockfile emitters. A plain
+``write_text`` truncates the destination before the first byte of the new
+content lands, so a write that runs out of space, hits an I/O error, or is
+interrupted destroys the old file and leaves a prefix of the new one in its
+place. Staging the content in a temp file and renaming means the
+destination only ever holds a complete version.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+__all__ = [
+    "atomic_write",
+    "atomic_write_text",
+]
+
+
+@contextmanager
+def _staged(path: Path) -> Iterator[int]:
+    """Yield a file descriptor for a temp file beside ``path``.
+
+    On a clean exit the temp file is renamed over ``path``; on any
+    exception it is removed and ``path`` is left as it was. The temp file
+    sits in the destination directory so the rename is a same-filesystem
+    operation.
+    """
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
+    tmp_path = Path(tmp)
+    try:
+        yield fd
+        # Path.replace would route around os.replace on Python 3.10
+        # (pathlib captures it at import time), defeating monkeypatches.
+        os.replace(tmp_path, path)  # noqa: PTH105
+    except BaseException:
+        with contextlib.suppress(OSError):
+            tmp_path.unlink()
+        raise
+
+
+def atomic_write(path: Path, data: bytes) -> None:
+    """Replace ``path`` with ``data``."""
+    with _staged(path) as fd, os.fdopen(fd, "wb") as f:
+        f.write(data)
+
+
+def atomic_write_text(path: Path, text: str) -> None:
+    """Replace ``path`` with ``text``, encoded as UTF-8."""
+    with _staged(path) as fd, os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(text)

--- a/nab-index/src/nab_index/atomic.py
+++ b/nab-index/src/nab_index/atomic.py
@@ -1,18 +1,16 @@
 """Write a file by staging it beside the destination and renaming over it.
 
-Shared by the on-disk cache and the lockfile emitters. A plain
-``write_text`` truncates the destination before the first byte of the new
-content lands, so a write that runs out of space, hits an I/O error, or is
-interrupted destroys the old file and leaves a prefix of the new one in its
-place. Staging the content in a temp file and renaming means the
-destination only ever holds a complete version.
+Shared by the on-disk cache and the lockfile emitters. A write that fails
+partway leaves any existing file untouched.
 """
 
 from __future__ import annotations
 
 import contextlib
 import os
+import shutil
 import tempfile
+import threading
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -26,20 +24,42 @@ __all__ = [
     "atomic_write_text",
 ]
 
+_umask_lock = threading.Lock()
+
+
+def _default_mode() -> int:
+    """Return the mode ``open`` would have given a new file.
+
+    The umask can only be read by setting it, so set a restrictive one and
+    put it straight back, under a lock because the cache writes from the
+    fetch threads.
+    """
+    with _umask_lock:
+        umask = os.umask(0o077)
+        os.umask(umask)
+    return 0o666 & ~umask
+
 
 @contextmanager
 def _staged(path: Path) -> Iterator[int]:
     """Yield a file descriptor for a temp file beside ``path``.
 
-    On a clean exit the temp file is renamed over ``path``; on any
-    exception it is removed and ``path`` is left as it was. The temp file
-    sits in the destination directory so the rename is a same-filesystem
-    operation.
+    On a clean exit the temp file is renamed over ``path``; on any exception it
+    is removed and ``path`` is left as it was. Staging in the destination
+    directory keeps the rename on one filesystem.
     """
     fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
     tmp_path = Path(tmp)
     try:
         yield fd
+
+        # The rename carries the temp file's own mode across, and mkstemp
+        # creates at 0600.
+        if path.exists():
+            shutil.copymode(path, tmp_path)
+        else:
+            tmp_path.chmod(_default_mode())
+
         # Path.replace would route around os.replace on Python 3.10
         # (pathlib captures it at import time), defeating monkeypatches.
         os.replace(tmp_path, path)  # noqa: PTH105
@@ -54,8 +74,16 @@ def atomic_write(path: Path, data: bytes) -> None:
     with _staged(path) as fd, os.fdopen(fd, "wb") as f:
         f.write(data)
 
+        # close() only reaches the page cache, where a full disk can still
+        # surface at writeback, after the rename has replaced the file.
+        f.flush()
+        os.fsync(f.fileno())
+
 
 def atomic_write_text(path: Path, text: str) -> None:
     """Replace ``path`` with ``text``, encoded as UTF-8."""
     with _staged(path) as fd, os.fdopen(fd, "w", encoding="utf-8") as f:
         f.write(text)
+
+        f.flush()
+        os.fsync(f.fileno())

--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -19,15 +19,14 @@ old directory is harmless.
 
 from __future__ import annotations
 
-import contextlib
 import hashlib
 import json
-import os
-import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
+
+from .atomic import atomic_write
 
 __all__ = [
     "CacheBackend",
@@ -76,25 +75,9 @@ def _index_dirname(index_url: str) -> str:
 
 
 def _atomic_write(path: Path, data: bytes) -> None:
-    """Write ``data`` to ``path`` atomically via tempfile + replace.
-
-    The temp file is created in the destination directory so the rename
-    is a same-filesystem operation. A partial write or a crash leaves
-    the target file untouched.
-    """
+    """Create the cache bucket for ``path``, then write ``data`` into it."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
-    tmp_path = Path(tmp)
-    try:
-        with os.fdopen(fd, "wb") as f:
-            f.write(data)
-        # Path.replace would route around os.replace on Python 3.10
-        # (pathlib captures it at import time), defeating monkeypatches.
-        os.replace(tmp_path, path)  # noqa: PTH105
-    except BaseException:
-        with contextlib.suppress(OSError):
-            tmp_path.unlink()
-        raise
+    atomic_write(path, data)
 
 
 def _read_text(path: Path) -> str | None:

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -79,9 +79,8 @@ def write_lock(
 
     Returns the TOML text.  When ``output_path`` is provided, also
     writes it there; the caller chooses the path (PEP 751 does not
-    mandate one).  The write goes through a temp file and a rename, so a
-    failed write leaves any previously committed lockfile intact rather
-    than replacing it with a valid-looking prefix of the new one.
+    mandate one).  The write is staged and renamed into place, so a
+    failed write leaves any existing file intact.
 
     Directory, wheel and sdist paths are written relative to
     ``output_path``'s parent so the lockfile stays portable between

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING, Any
 
 import tomli_w
 
+from nab_index.atomic import atomic_write_text
+
 from .._conflict_kind import MARKER_VARIABLE_FOR_KIND
 from .._vendor.packaging.markers import Marker
 from .._vendor.packaging.pylock import (
@@ -77,7 +79,9 @@ def write_lock(
 
     Returns the TOML text.  When ``output_path`` is provided, also
     writes it there; the caller chooses the path (PEP 751 does not
-    mandate one).
+    mandate one).  The write goes through a temp file and a rename, so a
+    failed write leaves any previously committed lockfile intact rather
+    than replacing it with a valid-looking prefix of the new one.
 
     Directory, wheel and sdist paths are written relative to
     ``output_path``'s parent so the lockfile stays portable between
@@ -87,7 +91,7 @@ def write_lock(
     lock_dir = Path(output_path).parent if output_path is not None else None
     text = render_lock(lock_input, lock_dir=lock_dir)
     if output_path is not None:
-        Path(output_path).write_text(text, encoding="utf-8")
+        atomic_write_text(Path(output_path), text)
     return text
 
 

--- a/nab-python/src/nab_python/_lockfile/requirements.py
+++ b/nab-python/src/nab_python/_lockfile/requirements.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import quote
 
+from nab_index.atomic import atomic_write_text
+
 from .builder import require_artifact_hashes
 
 if TYPE_CHECKING:
@@ -93,7 +95,7 @@ def _render_requirements(
         }
         text = "\n".join(_render_pins(pins, with_hashes=with_hashes)) + "\n"
     if output_path is not None:
-        Path(output_path).write_text(text, encoding="utf-8")
+        atomic_write_text(Path(output_path), text)
     return text
 
 

--- a/nab-python/tests/test_cache.py
+++ b/nab-python/tests/test_cache.py
@@ -96,7 +96,7 @@ class TestAtomicWrite:
             msg = "boom"
             raise OSError(msg)
 
-        monkeypatch.setattr("nab_index.cache.os.replace", fail_replace)
+        monkeypatch.setattr("nab_index.atomic.os.replace", fail_replace)
         with pytest.raises(OSError, match="boom"):
             _atomic_write(target, b"data")
         assert not target.exists()
@@ -107,7 +107,7 @@ class TestAtomicWrite:
     ) -> None:
         target = tmp_path / "x.txt"
         monkeypatch.setattr(
-            "nab_index.cache.os.replace",
+            "nab_index.atomic.os.replace",
             lambda _s, _d: (_ for _ in ()).throw(RuntimeError("rep")),
         )
 
@@ -115,7 +115,7 @@ class TestAtomicWrite:
             msg = "unlink-fail"
             raise OSError(msg)
 
-        monkeypatch.setattr("nab_index.cache.os.unlink", fail_unlink)
+        monkeypatch.setattr("nab_index.atomic.os.unlink", fail_unlink)
         with pytest.raises(RuntimeError, match="rep"):
             _atomic_write(target, b"data")
 

--- a/nab-python/tests/test_cache.py
+++ b/nab-python/tests/test_cache.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
+from nab_index.atomic import atomic_write_text
 from nab_index.cache import (
     CachePolicy,
     NullCache,
@@ -118,6 +120,43 @@ class TestAtomicWrite:
         monkeypatch.setattr("nab_index.atomic.os.unlink", fail_unlink)
         with pytest.raises(RuntimeError, match="rep"):
             _atomic_write(target, b"data")
+
+    def test_new_file_gets_the_mode_open_would_have_given_it(
+        self, tmp_path: Path
+    ) -> None:
+        reference = tmp_path / "reference.txt"
+        reference.write_bytes(b"x")
+        target = tmp_path / "x.txt"
+        _atomic_write(target, b"data")
+        assert target.stat().st_mode == reference.stat().st_mode
+
+    def test_mode_of_the_replaced_file_is_kept(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.txt"
+        target.write_bytes(b"old")
+        target.chmod(0o640)
+        mode = target.stat().st_mode
+        _atomic_write(target, b"new")
+        assert target.stat().st_mode == mode
+
+    def test_content_is_synced_before_the_rename(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[str] = []
+        real_fsync = os.fsync
+        real_replace = os.replace
+
+        def spy_fsync(fd: int) -> None:
+            calls.append("fsync")
+            real_fsync(fd)
+
+        def spy_replace(src: Path, dst: Path) -> None:
+            calls.append("replace")
+            real_replace(src, dst)
+
+        monkeypatch.setattr("nab_index.atomic.os.fsync", spy_fsync)
+        monkeypatch.setattr("nab_index.atomic.os.replace", spy_replace)
+        atomic_write_text(tmp_path / "x.txt", "data")
+        assert calls == ["fsync", "replace"]
 
 
 class TestOnDiskCache:

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
+from contextlib import AbstractContextManager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import ClassVar, cast
@@ -1315,6 +1316,68 @@ class TestErrorPaths:
         )
         with pytest.raises(ValueError, match="acceptable hash"):
             _ = artifact.primary_digest
+
+
+class TestFailedWriteKeepsCommittedFile:
+    """A write that dies partway must not leave a shortened lockfile behind.
+
+    The emitters replace an existing file, and both formats are
+    newline-delimited records, so a prefix of the new text parses as a
+    complete lock holding a subset of the pins.  A consumer would install
+    that subset without complaint, so the previously committed file has to
+    survive a failed write untouched.
+    """
+
+    def _committed(self) -> LockInput:
+        return LockInput(targets=_one({"foo": _index_pin()}))
+
+    def _bigger(self) -> LockInput:
+        return LockInput(
+            targets=_one(
+                {
+                    name: _index_pin(name=name, version="2.0")
+                    for name in ("aaa", "bbb", "ccc", "ddd", "eee", "fff")
+                }
+            )
+        )
+
+    def test_pylock(
+        self,
+        tmp_path: Path,
+        cap_writes: Callable[[int], AbstractContextManager[None]],
+    ) -> None:
+        target = tmp_path / "pylock.toml"
+        write_lock(self._committed(), output_path=target)
+        committed = target.read_bytes()
+        half = len(write_lock(self._bigger())) // 2
+
+        with cap_writes(half), pytest.raises(OSError, match="No space left"):
+            write_lock(self._bigger(), output_path=target)
+
+        assert target.read_bytes() == committed
+        assert [p.name for p in tmp_path.iterdir()] == ["pylock.toml"]
+
+    @pytest.mark.parametrize(
+        "write",
+        [write_requirements_with_hashes, write_requirements_without_hashes],
+        ids=["with_hashes", "without_hashes"],
+    )
+    def test_requirements(
+        self,
+        write: Callable[..., str],
+        tmp_path: Path,
+        cap_writes: Callable[[int], AbstractContextManager[None]],
+    ) -> None:
+        target = tmp_path / "requirements.txt"
+        write(self._committed(), output_path=target)
+        committed = target.read_bytes()
+        half = len(write(self._bigger())) // 2
+
+        with cap_writes(half), pytest.raises(OSError, match="No space left"):
+            write(self._bigger(), output_path=target)
+
+        assert target.read_bytes() == committed
+        assert [p.name for p in tmp_path.iterdir()] == ["requirements.txt"]
 
 
 class TestRoundTrip:

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -1321,11 +1321,8 @@ class TestErrorPaths:
 class TestFailedWriteKeepsCommittedFile:
     """A write that dies partway must not leave a shortened lockfile behind.
 
-    The emitters replace an existing file, and both formats are
-    newline-delimited records, so a prefix of the new text parses as a
-    complete lock holding a subset of the pins.  A consumer would install
-    that subset without complaint, so the previously committed file has to
-    survive a failed write untouched.
+    Both formats are newline-delimited records, so a prefix of the new text
+    parses as a complete lock holding a subset of the pins.
     """
 
     def _committed(self) -> LockInput:

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -551,8 +551,9 @@ def _emit_requirements(
     if not any(var in template for var in _cli.TUPLE_TEMPLATE_VARS):
         if multi_target:
             _refuse_untemplated(lock_input, target)
-        text, count = _render_requirements_or_exit(lock_input, with_hashes)
-        target.write_text(text, encoding="utf-8")
+        _, count = _render_requirements_or_exit(
+            lock_input, with_hashes, output_path=target
+        )
         sys.stderr.write(f"Wrote {target} ({count} packages)\n")
         return
 
@@ -726,13 +727,24 @@ def _discard(staged: Path) -> None:
 def _render_requirements_or_exit(
     lock_input: LockInput,
     with_hashes: bool,  # noqa: FBT001 - internal, one call shape
+    *,
+    output_path: Path | None = None,
 ) -> tuple[str, int]:
-    """Render the requirements text and pin count, exiting on a missing hash."""
+    """Render the requirements text and pin count, exiting on a missing hash.
+
+    The emitter does the writing when ``output_path`` is given, so the
+    text lands through a temp file and a rename rather than truncating
+    the destination first.
+    """
     try:
         if with_hashes:
-            text = _cli.write_requirements_with_hashes(lock_input)
+            text = _cli.write_requirements_with_hashes(
+                lock_input, output_path=output_path
+            )
         else:
-            text = _cli.write_requirements_without_hashes(lock_input)
+            text = _cli.write_requirements_without_hashes(
+                lock_input, output_path=output_path
+            )
     except _cli.MissingHashError as e:
         sys.stderr.write(f"Cannot lock: {e}\n")
         sys.exit(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,8 @@ import io
 import runpy
 import stat
 import sys
+from collections.abc import Callable
+from contextlib import AbstractContextManager
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
@@ -783,6 +785,26 @@ class TestLockCommandSpecific:
             lock(pyproject, output=out)
         assert "cannot write output" in capsys.readouterr().err
 
+    def test_full_disk_keeps_committed_lock(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        cap_writes: Callable[[int], AbstractContextManager[None]],
+    ) -> None:
+        """A write that runs out of space leaves the committed lock in place."""
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        committed = b'lock-version = "1.0"\n'
+        out.write_bytes(committed)
+        with (
+            patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
+            cap_writes(64),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, output=out)
+        assert "cannot write output" in capsys.readouterr().err
+        assert out.read_bytes() == committed
+
     def test_resolution_flag_threads_to_resolver(self, tmp_path: Path) -> None:
         """``--project-resolution lowest`` reaches resolve_for_targets as the enum."""
         pyproject = _make_pyproject(tmp_path)
@@ -1104,6 +1126,29 @@ class TestLockCommandUniversal:
         text = out.read_text()
         assert 'lock-version = "1.0"' in text
         assert 'name = "foo"' in text
+
+    def test_full_disk_keeps_committed_requirements(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        cap_writes: Callable[[int], AbstractContextManager[None]],
+    ) -> None:
+        """A requirements write that runs out of space keeps the committed file."""
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "requirements.txt"
+        committed = b"foo==0.9\n"
+        out.write_bytes(committed)
+        with (
+            patch(
+                "nab.cli.resolve_for_targets",
+                return_value=_universal_result(success=True),
+            ),
+            cap_writes(4),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, output=out, format="requirements")
+        assert "cannot write output" in capsys.readouterr().err
+        assert out.read_bytes() == committed
 
     def test_default_groups_from_config_not_cli_groups(self, tmp_path: Path) -> None:
         """Universal pylock records ``default-groups`` from config, not ``--groups``."""


### PR DESCRIPTION
`nab lock` wrote the lockfile with `Path.write_text`, which truncates the destination before it writes anything. If the write then failed partway, on a full disk for instance, the committed lockfile was already gone and what remained was a prefix of the new text. Both formats are record-oriented, so that prefix parses as a valid lock holding a subset of the pins, and an install from it succeeds with packages quietly missing.

The emitters now stage the text in a temp file beside the destination, fsync it, and rename it over the target, so a failed write leaves the existing file as it was. The on-disk cache already worked this way, so its atomic write moves to `nab_index.atomic` and the lockfile writers share it. The staged file takes the mode of the file it replaces, or the mode `open` would have given a new one, since the rename otherwise carries mkstemp's 0600 across.

The per-tuple requirements path already stages its files all-or-nothing and keeps doing that; this covers the two writes that still truncated, the pylock write and the single-file requirements write, by passing the output path down to the emitter rather than writing the returned text at the call site. The requirements emitter docstrings already promised an atomic write; it now happens.
