### PR TITLE
Move wheel tags to nab_python.tags and fix the libc model

### DIFF
--- a/docs/explanation/universal.md
+++ b/docs/explanation/universal.md
@@ -47,8 +47,9 @@ python-order = "asc"
 minor version. `platforms` is a list of platform ids
 (`linux_x86_64`, `linux_aarch64`, `macos_x86_64`, `macos_arm64`,
 `windows_amd64`), each optionally written as a table to declare its
-wheel-tag knobs (libc family and version, macOS deployment target).
-See [Configuration](../reference/configuration.md).
+wheel-tag knobs (libc family and version, macOS deployment target,
+free-threaded build).  See
+[Configuration](../reference/configuration.md).
 
 `python-order` selects the resolution direction:
 

--- a/docs/explanation/universal.md
+++ b/docs/explanation/universal.md
@@ -46,7 +46,9 @@ python-order = "asc"
 `python` is a PEP 440 specifier expanded into one tuple per
 minor version. `platforms` is a list of platform ids
 (`linux_x86_64`, `linux_aarch64`, `macos_x86_64`, `macos_arm64`,
-`windows_amd64`).
+`windows_amd64`), each optionally written as a table to declare its
+wheel-tag knobs (libc family and version, macOS deployment target).
+See [Configuration](../reference/configuration.md).
 
 `python-order` selects the resolution direction:
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -564,9 +564,15 @@ on Apple Silicon) there is no machine to model and no tag to name, so
 that is a config error.
 
 A knob belongs to its platform.  `libc` and `libc-version` are Linux
-knobs and `macos-min` is a macOS one; declaring one on a platform that
-cannot read it is a config error, not a target carrying a setting that
-selects no wheel and still names the machine in the lock.
+knobs and `macos-min` is a macOS one, so declaring one on a platform
+that cannot read it is a config error.  It would select no wheel, and it
+would still name the machine the lock was resolved for.
+
+`platform-release` and `platform-version` are the exception: they set
+PEP 508 marker values and never enter wheel-tag selection.  Left empty,
+every comparison against them evaluates False, so a dependency gated on
+`platform_release >= "5.10"` (or on any other comparison) is dropped.  A
+target that does run that kernel has to say so.
 
 `free-threaded` picks the `cp3XXt` ABI, so the target takes the
 free-threaded wheels and neither the ordinary `cp3XX` ones nor `abi3`

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -521,6 +521,45 @@ uv's `fork-strategy=fewest`; `desc` mirrors `fork-strategy=
 requires-python`).  `python-patches` overrides the per-minor
 `python_full_version` marker value for marker evaluation.
 
+### Platform tag knobs
+
+A `platforms` entry is either a bare platform id, which takes that
+platform's defaults, or a table declaring the wheel-tag knobs:
+
+```toml
+[tool.nab.matrix]
+python = ">=3.11,<3.14"
+platforms = [
+    "linux_x86_64",
+    { id = "linux_x86_64", libc = "musl", libc-version = "1.2" },
+    { id = "macos_arm64", macos-min = "14.0" },
+    { id = "linux_aarch64", platform-release = "5.15.0" },
+]
+```
+
+| Key | Default | Meaning |
+| --- | --- | --- |
+| `id` | required | One of the five platform ids |
+| `libc` | `"glibc"` | The Linux C library: `"glibc"` or `"musl"` |
+| `libc-version` | glibc `2.28`, musl `1.2` | The libc version the target runs |
+| `macos-min` | arm64 `12.0`, x86_64 `10.13` | The macOS deployment target |
+| `platform-release` | `""` | The `platform_release` marker value |
+| `platform-version` | `""` | The `platform_version` marker value |
+
+A machine links one C library, so a target accepts one family's wheels:
+a `glibc` target takes manylinux wheels and never musllinux ones, and a
+`musl` target the reverse.  `libc-version` is the version the target
+guarantees, and a wheel built against an older libc runs on a newer one,
+so the target accepts every version at or below it.  The glibc default
+is 2.28 because numpy, pandas and scipy publish nothing older.
+`macos-min` works the same way in the other direction: `mac_platforms`
+treats it as the newest macOS a wheel may target.
+
+The same id may appear more than once with different knobs; each becomes
+its own tuple, labelled with a discriminator suffix
+(`py312-linux_x86_64-musl`).  Two entries that render the same label are
+a duplicate and an error.
+
 Each tuple impersonates a platform, so universal mode cannot build on
 the host: `build-policy` defaults to `never` and cannot be raised.  An
 explicit non-`never` value (global or in any override) is a config

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -551,11 +551,20 @@ A machine links one C library, so a target accepts one family's wheels:
 a `glibc` target takes manylinux wheels and never musllinux ones, and a
 `musl` target the reverse.  `libc-version` is the version the target
 guarantees, and a wheel built against an older libc runs on a newer one,
-so the target accepts every version at or below it.  The glibc default
-is 2.28 because numpy, pandas and scipy publish nothing older.  Its
-major has to match the family (glibc `2.x`, musl `1.x`): those are the
-only majors either has shipped, so no wheel targets another.
-`macos-min` reads the same way, as the newest macOS a wheel may target.
+so the target accepts every version at or below it.  A higher value
+therefore accepts more wheels, not fewer.  The glibc default is 2.28,
+which is the `manylinux_2_28` build image and the oldest glibc a
+supported distribution still ships: it accepts every manylinux wheel
+published today without naming a machine nobody runs.  Its major has to
+match the family (glibc `2.x`, musl `1.x`): those are the only majors
+either has shipped, so no wheel targets another.  `macos-min` reads the
+same way, as the newest macOS a wheel may target; below 10.0 no wheel
+tag exists to name, so that is a config error.
+
+A knob belongs to its platform.  `libc` and `libc-version` are Linux
+knobs and `macos-min` is a macOS one; declaring one on a platform that
+cannot read it is a config error, not a target carrying a setting that
+selects no wheel and still names the machine in the lock.
 
 `free-threaded` picks the `cp3XXt` ABI, so the target takes the
 free-threaded wheels and neither the ordinary `cp3XX` ones nor `abi3`

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -539,7 +539,7 @@ platforms = [
 
 | Key | Default | Meaning |
 | --- | --- | --- |
-| `id` | required | One of the five platform ids |
+| `id` | required | `linux_x86_64`, `linux_aarch64`, `macos_arm64`, `macos_x86_64`, or `windows_amd64` |
 | `libc` | `"glibc"` | The Linux C library: `"glibc"` or `"musl"` |
 | `libc-version` | glibc `2.28`, musl `1.2` | The libc version the target runs |
 | `macos-min` | arm64 `12.0`, x86_64 `10.13` | The macOS deployment target |
@@ -556,11 +556,12 @@ therefore accepts more wheels, not fewer.  The glibc default is 2.28,
 the `manylinux_2_28` build image; a target that runs a newer glibc
 should say so, because a wheel built above 2.28 is otherwise rejected.
 Its major has to match the family (glibc `2.x`, musl `1.x`): those are
-the only majors either has shipped, so no wheel targets another.  `macos-min` reads the
-same way, as the newest macOS a wheel may target.  Below the oldest
-macOS the architecture ever ran (10.4 on x86_64, 11.0 on Apple Silicon)
-there is no machine to model and no tag to name, so that is a config
-error.
+the only majors either has shipped, so no wheel targets another.
+
+`macos-min` reads the same way, as the newest macOS a wheel may target.
+Below the oldest macOS the architecture ever ran (10.4 on x86_64, 11.0
+on Apple Silicon) there is no machine to model and no tag to name, so
+that is a config error.
 
 A knob belongs to its platform.  `libc` and `libc-version` are Linux
 knobs and `macos-min` is a macOS one; declaring one on a platform that

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -558,8 +558,10 @@ supported distribution still ships: it accepts every manylinux wheel
 published today without naming a machine nobody runs.  Its major has to
 match the family (glibc `2.x`, musl `1.x`): those are the only majors
 either has shipped, so no wheel targets another.  `macos-min` reads the
-same way, as the newest macOS a wheel may target; below 10.0 no wheel
-tag exists to name, so that is a config error.
+same way, as the newest macOS a wheel may target.  Below the oldest
+macOS the architecture ever ran (10.4 on x86_64, 11.0 on Apple Silicon)
+there is no machine to model and no tag to name, so that is a config
+error.
 
 A knob belongs to its platform.  `libc` and `libc-version` are Linux
 knobs and `macos-min` is a macOS one; declaring one on a platform that

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -552,9 +552,10 @@ a `glibc` target takes manylinux wheels and never musllinux ones, and a
 `musl` target the reverse.  `libc-version` is the version the target
 guarantees, and a wheel built against an older libc runs on a newer one,
 so the target accepts every version at or below it.  The glibc default
-is 2.28 because numpy, pandas and scipy publish nothing older.
-`macos-min` works the same way in the other direction: `mac_platforms`
-treats it as the newest macOS a wheel may target.
+is 2.28 because numpy, pandas and scipy publish nothing older.  Its
+major has to match the family (glibc `2.x`, musl `1.x`): those are the
+only majors either has shipped, so no wheel targets another.
+`macos-min` reads the same way, as the newest macOS a wheel may target.
 
 `free-threaded` picks the `cp3XXt` ABI, so the target takes the
 free-threaded wheels and neither the ordinary `cp3XX` ones nor `abi3`

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -530,7 +530,7 @@ platform's defaults, or a table declaring the wheel-tag knobs:
 [tool.nab.matrix]
 python = ">=3.11,<3.14"
 platforms = [
-    "linux_x86_64",
+    "windows_amd64",
     { id = "linux_x86_64", libc = "musl", libc-version = "1.2" },
     { id = "macos_arm64", macos-min = "14.0" },
     { id = "linux_aarch64", platform-release = "5.15.0" },
@@ -545,6 +545,7 @@ platforms = [
 | `macos-min` | arm64 `12.0`, x86_64 `10.13` | The macOS deployment target |
 | `platform-release` | `""` | The `platform_release` marker value |
 | `platform-version` | `""` | The `platform_version` marker value |
+| `free-threaded` | `false` | Target the free-threaded (`cp3XXt`) CPython build |
 
 A machine links one C library, so a target accepts one family's wheels:
 a `glibc` target takes manylinux wheels and never musllinux ones, and a
@@ -555,10 +556,19 @@ is 2.28 because numpy, pandas and scipy publish nothing older.
 `macos-min` works the same way in the other direction: `mac_platforms`
 treats it as the newest macOS a wheel may target.
 
-The same id may appear more than once with different knobs; each becomes
-its own tuple, labelled with a discriminator suffix
-(`py312-linux_x86_64-musl`).  Two entries that render the same label are
-a duplicate and an error.
+`free-threaded` picks the `cp3XXt` ABI, so the target takes the
+free-threaded wheels and neither the ordinary `cp3XX` ones nor `abi3`
+(a free-threaded interpreter cannot load either).  It needs CPython
+3.13 or newer, the first release with a free-threaded build; a matrix
+that admits an older minor, or a non-CPython implementation, is a
+config error.
+
+An id may appear once.  A lockfile entry is selected by a PEP 508
+marker, and PEP 508 has no variable for the libc family or the
+free-threaded build, so two targets sharing an id would render the same
+marker and the lock could not tell their pins apart.  Locking a second
+libc family, or a free-threaded build alongside the GIL one, is a
+second lock run with its own config and output file.
 
 Each tuple impersonates a platform, so universal mode cannot build on
 the host: `build-policy` defaults to `never` and cannot be raised.  An

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -553,11 +553,10 @@ a `glibc` target takes manylinux wheels and never musllinux ones, and a
 guarantees, and a wheel built against an older libc runs on a newer one,
 so the target accepts every version at or below it.  A higher value
 therefore accepts more wheels, not fewer.  The glibc default is 2.28,
-which is the `manylinux_2_28` build image and the oldest glibc a
-supported distribution still ships: it accepts every manylinux wheel
-published today without naming a machine nobody runs.  Its major has to
-match the family (glibc `2.x`, musl `1.x`): those are the only majors
-either has shipped, so no wheel targets another.  `macos-min` reads the
+the `manylinux_2_28` build image; a target that runs a newer glibc
+should say so, because a wheel built above 2.28 is otherwise rejected.
+Its major has to match the family (glibc `2.x`, musl `1.x`): those are
+the only majors either has shipped, so no wheel targets another.  `macos-min` reads the
 same way, as the newest macOS a wheel may target.  Below the oldest
 macOS the architecture ever ran (10.4 on x86_64, 11.0 on Apple Silicon)
 there is no machine to model and no tag to name, so that is a config

--- a/nab-python/benchmarks/universal_scenarios.py
+++ b/nab-python/benchmarks/universal_scenarios.py
@@ -33,6 +33,7 @@ else:
 
 from nab_python._lockfile.pylock import build_pylock
 from nab_python._vendor.packaging.utils import canonicalize_name
+from nab_python.tags import PlatformSpec
 from nab_python.universal.matrix import Matrix
 from nab_python.universal.resolve import (
     UniversalResult,
@@ -177,7 +178,11 @@ def process_scenario(
             return
 
     print(f"  {scenario_name} ", end="", flush=True)
-    matrix = Matrix(python=python_spec, platforms=platforms, python_order=python_order)
+    matrix = Matrix(
+        python=python_spec,
+        platforms=tuple(PlatformSpec(p) for p in platforms),
+        python_order=python_order,
+    )
 
     previous_handler = signal.signal(signal.SIGALRM, _alarm_handler)
     signal.alarm(SCENARIO_WALL_TIMEOUT_SECONDS)

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -2229,7 +2229,7 @@ _PLATFORM_TABLE_KEYS = frozenset(
         "free-threaded",
     }
 )
-# The platform kind each knob key belongs to.  Every other kind ignores it.
+# The platform kind that reads each knob key; any other kind rejects it.
 _PLATFORM_KNOB_OWNER: Mapping[str, frozenset[str]] = MappingProxyType(
     {
         "linux": frozenset({"libc", "libc-version"}),

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -69,12 +69,11 @@ from .workspace import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping, Sequence
+    from collections.abc import Mapping, Sequence
     from collections.abc import Set as AbstractSet
     from pathlib import Path
 
     from ._vendor.packaging.ranges import VersionRange
-    from .universal.matrix import MatrixTuple
 
 __all__ = [
     "ConfigError",
@@ -2238,9 +2237,6 @@ _PLATFORM_KNOB_OWNER: Mapping[str, frozenset[str]] = MappingProxyType(
     }
 )
 
-# The free-threaded build ships from CPython 3.13 (PEP 703).
-_FREE_THREADED_MIN_PYTHON = (3, 13)
-
 
 def _parse_matrix_platforms(value: object) -> tuple[PlatformSpec, ...]:
     """Parse ``matrix.platforms``: bare ids, tables, or a mix of both.
@@ -2430,37 +2426,10 @@ def _validate_matrix_axes(config: MatrixConfig) -> None:
         implementations=config.implementations,
     )
     try:
-        tuples = matrix.expand()
+        matrix.expand()
     except ValueError as exc:
         msg = f"invalid [tool.nab.matrix]: {exc}"
         raise ConfigError(msg) from exc
-    _validate_free_threaded(tuples)
-
-
-def _validate_free_threaded(tuples: Iterable[MatrixTuple]) -> None:
-    """Reject free-threaded targets no interpreter build can satisfy.
-
-    A ``cpXYt`` ABI exists only for CPython 3.13 and up.
-    """
-    for tup in tuples:
-        if not tup.platform_spec.free_threaded:
-            continue
-        if tup.implementation != "cpython":
-            msg = (
-                f"matrix.platforms target {tup.label!r} is free-threaded:"
-                f" only CPython has a free-threaded build, not"
-                f" {tup.implementation!r}"
-            )
-            raise ConfigError(msg)
-        version = tuple(int(p) for p in tup.python_version.split("."))
-        if version < _FREE_THREADED_MIN_PYTHON:
-            floor = ".".join(str(p) for p in _FREE_THREADED_MIN_PYTHON)
-            msg = (
-                f"matrix.platforms target {tup.label!r} is free-threaded:"
-                f" the free-threaded build starts at CPython {floor},"
-                f" but matrix.python admits {tup.python_version}"
-            )
-            raise ConfigError(msg)
 
 
 _KNOWN_IMPLEMENTATIONS = ("cpython", "pypy")

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -57,7 +57,7 @@ from .provider import (
     VcsSource,
     _normalize_extra,
 )
-from .tags import Libc, PlatformSpec, platform_label
+from .tags import Libc, PlatformSpec
 from .universal.matrix import Matrix
 from .workspace import (
     WorkspaceConfig,
@@ -68,11 +68,12 @@ from .workspace import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Iterable, Mapping, Sequence
     from collections.abc import Set as AbstractSet
     from pathlib import Path
 
     from ._vendor.packaging.ranges import VersionRange
+    from .universal.matrix import MatrixTuple
 
 __all__ = [
     "ConfigError",
@@ -2230,9 +2231,13 @@ _PLATFORM_TABLE_KEYS = frozenset(
         "macos-min",
         "platform-release",
         "platform-version",
+        "free-threaded",
     }
 )
 _KNOWN_LIBC: tuple[Libc, ...] = ("glibc", "musl")
+
+# The free-threaded build ships from CPython 3.13 (PEP 703).
+_FREE_THREADED_MIN_PYTHON = (3, 13)
 
 
 def _parse_matrix_platforms(value: object) -> tuple[str | PlatformSpec, ...]:
@@ -2240,7 +2245,8 @@ def _parse_matrix_platforms(value: object) -> tuple[str | PlatformSpec, ...]:
 
     A bare id takes the platform's default tag knobs.  The table form
     declares the knobs a bare id cannot reach: the libc family and
-    version, the macOS deployment target, and the kernel marker values.
+    version, the macOS deployment target, the kernel marker values, and
+    the free-threaded build.
     """
     if not isinstance(value, list):
         msg = f"matrix.platforms must be a list, got {type(value).__name__}"
@@ -2288,6 +2294,9 @@ def _parse_platform_table(where: str, value: dict[str, Any]) -> PlatformSpec:
         ),
         platform_version=_parse_string_value(
             f"{where}.platform-version", value.get("platform-version", "")
+        ),
+        free_threaded=_parse_bool(
+            f"{where}.free-threaded", value.get("free-threaded"), default=False
         ),
     )
 
@@ -2343,7 +2352,14 @@ def _parse_matrix(value: object) -> MatrixConfig | None:
     if not platforms:
         msg = "matrix.platforms must list at least one platform id"
         raise ConfigError(msg)
-    _reject_duplicates("matrix.platforms", tuple(platform_label(p) for p in platforms))
+    # One target per platform id: a lockfile entry is selected by a PEP 508
+    # marker, which has no libc or free-threading variable, so two targets
+    # sharing an id would render the same marker and the lock could not tell
+    # their pins apart.  The other libc family needs its own lock run.
+    _reject_duplicates(
+        "matrix.platforms",
+        tuple(p if isinstance(p, str) else p.platform_id for p in platforms),
+    )
     python_order = value.get("python-order", "asc")
     if python_order not in {"asc", "desc"}:
         msg = f"matrix.python-order must be 'asc' or 'desc', got {python_order!r}"
@@ -2373,10 +2389,39 @@ def _validate_matrix_axes(config: MatrixConfig) -> None:
         implementations=config.implementations,
     )
     try:
-        matrix.expand()
+        tuples = matrix.expand()
     except ValueError as exc:
         msg = f"invalid [tool.nab.matrix]: {exc}"
         raise ConfigError(msg) from exc
+    _validate_free_threaded(tuples)
+
+
+def _validate_free_threaded(tuples: Iterable[MatrixTuple]) -> None:
+    """Reject free-threaded targets no interpreter build can satisfy.
+
+    A ``cpXYt`` ABI exists only for CPython 3.13 and up, so any other
+    tuple would advertise an ABI no wheel carries and silently lose
+    every binary wheel.
+    """
+    for tup in tuples:
+        if not tup.platform_spec.free_threaded:
+            continue
+        if tup.implementation != "cpython":
+            msg = (
+                f"matrix.platforms target {tup.label!r} is free-threaded:"
+                f" only CPython has a free-threaded build, not"
+                f" {tup.implementation!r}"
+            )
+            raise ConfigError(msg)
+        version = tuple(int(p) for p in tup.python_version.split("."))
+        if version < _FREE_THREADED_MIN_PYTHON:
+            floor = ".".join(str(p) for p in _FREE_THREADED_MIN_PYTHON)
+            msg = (
+                f"matrix.platforms target {tup.label!r} is free-threaded:"
+                f" the free-threaded build starts at CPython {floor},"
+                f" but matrix.python admits {tup.python_version}"
+            )
+            raise ConfigError(msg)
 
 
 _KNOWN_IMPLEMENTATIONS = ("cpython", "pypy")

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -14,7 +14,7 @@ import re
 from collections import defaultdict
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlsplit
 
 import tomli
@@ -125,15 +125,10 @@ _VERSION_MARKER_VARIABLES = frozenset({"python_version", "python_full_version"})
 
 @dataclass(frozen=True, slots=True)
 class MatrixConfig:
-    """User-declared matrix axes for universal resolution.
-
-    A ``platforms`` entry is either a bare platform id, which takes the
-    platform's default tag knobs, or a :class:`PlatformSpec` parsed from
-    the table form.
-    """
+    """User-declared matrix axes for universal resolution."""
 
     python: str
-    platforms: tuple[str | PlatformSpec, ...]
+    platforms: tuple[PlatformSpec, ...]
     python_order: str = "asc"
     python_patches: Mapping[str, str] | None = None
     implementations: tuple[str, ...] = ("cpython",)
@@ -2234,35 +2229,42 @@ _PLATFORM_TABLE_KEYS = frozenset(
         "free-threaded",
     }
 )
-_KNOWN_LIBC: tuple[Libc, ...] = ("glibc", "musl")
 
 # The free-threaded build ships from CPython 3.13 (PEP 703).
 _FREE_THREADED_MIN_PYTHON = (3, 13)
 
 
-def _parse_matrix_platforms(value: object) -> tuple[str | PlatformSpec, ...]:
+def _parse_matrix_platforms(value: object) -> tuple[PlatformSpec, ...]:
     """Parse ``matrix.platforms``: bare ids, tables, or a mix of both.
 
     A bare id takes the platform's default tag knobs; the table form declares
     them (libc family and version, macOS deployment target, kernel marker
-    values, free-threaded build).
+    values, free-threaded build).  Both become a :class:`PlatformSpec`, so
+    everything downstream reads one shape.
     """
     if not isinstance(value, list):
         msg = f"matrix.platforms must be a list, got {type(value).__name__}"
         raise ConfigError(msg)
-    platforms: list[str | PlatformSpec] = []
+    platforms: list[PlatformSpec] = []
     for i, item in enumerate(value):
+        where = f"matrix.platforms[{i}]"
         if isinstance(item, str):
-            platforms.append(item)
+            platforms.append(_platform_spec(where, platform_id=item))
         elif isinstance(item, dict):
-            platforms.append(_parse_platform_table(f"matrix.platforms[{i}]", item))
+            platforms.append(_parse_platform_table(where, item))
         else:
-            msg = (
-                f"matrix.platforms[{i}] must be a platform id or a table,"
-                f" got {type(item).__name__}"
-            )
+            msg = f"{where} must be a platform id or a table, got {type(item).__name__}"
             raise ConfigError(msg)
     return tuple(platforms)
+
+
+def _platform_spec(where: str, **knobs: Any) -> PlatformSpec:
+    """Build a :class:`PlatformSpec`, reporting its knob check as a config error."""
+    try:
+        return PlatformSpec(**knobs)
+    except ValueError as exc:
+        msg = f"invalid {where}: {exc}"
+        raise ConfigError(msg) from exc
 
 
 def _parse_platform_table(where: str, value: dict[str, Any]) -> PlatformSpec:
@@ -2278,27 +2280,13 @@ def _parse_platform_table(where: str, value: dict[str, Any]) -> PlatformSpec:
         msg = f"{where} missing required key 'id'"
         raise ConfigError(msg)
 
-    libc = value.get("libc", "glibc")
-    if libc not in _KNOWN_LIBC:
-        msg = f"{where}.libc must be one of {list(_KNOWN_LIBC)!r}, got {libc!r}"
-        raise ConfigError(msg)
-
-    libc_version = _parse_major_minor(
-        f"{where}.libc-version", value.get("libc-version")
-    )
-    # A foreign major (glibc 3.0, musl 2.0) names tags no wheel carries.
-    expected_major = LIBC_MAJOR[libc]
-    if libc_version is not None and libc_version[0] != expected_major:
-        msg = (
-            f"{where}.libc-version must be a {expected_major}.x version"
-            f" for {libc}, got {libc_version[0]}.{libc_version[1]}"
-        )
-        raise ConfigError(msg)
-
-    return PlatformSpec(
+    return _platform_spec(
+        where,
         platform_id=_parse_string_value(f"{where}.id", value["id"]),
-        libc=libc,
-        libc_version=libc_version,
+        libc=_parse_libc(f"{where}.libc", value.get("libc")),
+        libc_version=_parse_major_minor(
+            f"{where}.libc-version", value.get("libc-version")
+        ),
         macos_min=_parse_major_minor(f"{where}.macos-min", value.get("macos-min")),
         platform_release=_parse_string_value(
             f"{where}.platform-release", value.get("platform-release", "")
@@ -2310,6 +2298,17 @@ def _parse_platform_table(where: str, value: dict[str, Any]) -> PlatformSpec:
             f"{where}.free-threaded", value.get("free-threaded"), default=False
         ),
     )
+
+
+def _parse_libc(key: str, value: object) -> Libc | None:
+    """Parse a libc family name; an absent key leaves the family undeclared."""
+    if value is None:
+        return None
+    text = _parse_string_value(key, value)
+    if text not in LIBC_MAJOR:
+        msg = f"{key} must be one of {sorted(LIBC_MAJOR)!r}, got {text!r}"
+        raise ConfigError(msg)
+    return cast("Libc", text)
 
 
 def _parse_major_minor(key: str, value: object) -> tuple[int, int] | None:
@@ -2366,10 +2365,7 @@ def _parse_matrix(value: object) -> MatrixConfig | None:
     # One target per platform id.  A lockfile entry is selected by a PEP 508
     # marker, which has no libc or free-threading variable, so two targets
     # sharing an id would render the same marker.
-    _reject_duplicates(
-        "matrix.platforms",
-        tuple(p if isinstance(p, str) else p.platform_id for p in platforms),
-    )
+    _reject_duplicates("matrix.platforms", tuple(p.platform_id for p in platforms))
     python_order = value.get("python-order", "asc")
     if python_order not in {"asc", "desc"}:
         msg = f"matrix.python-order must be 'asc' or 'desc', got {python_order!r}"

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -14,6 +14,7 @@ import re
 from collections import defaultdict
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta, timezone
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlsplit
 
@@ -57,7 +58,7 @@ from .provider import (
     VcsSource,
     _normalize_extra,
 )
-from .tags import LIBC_MAJOR, Libc, PlatformSpec
+from .tags import DEFAULT_LIBC, LIBC_MAJOR, Libc, PlatformSpec, platform_kind
 from .universal.matrix import Matrix
 from .workspace import (
     WorkspaceConfig,
@@ -2229,6 +2230,13 @@ _PLATFORM_TABLE_KEYS = frozenset(
         "free-threaded",
     }
 )
+# The platform kind each knob key belongs to.  Every other kind ignores it.
+_PLATFORM_KNOB_OWNER: Mapping[str, frozenset[str]] = MappingProxyType(
+    {
+        "linux": frozenset({"libc", "libc-version"}),
+        "macos": frozenset({"macos-min"}),
+    }
+)
 
 # The free-threaded build ships from CPython 3.13 (PEP 703).
 _FREE_THREADED_MIN_PYTHON = (3, 13)
@@ -2280,9 +2288,12 @@ def _parse_platform_table(where: str, value: dict[str, Any]) -> PlatformSpec:
         msg = f"{where} missing required key 'id'"
         raise ConfigError(msg)
 
+    platform_id = _parse_string_value(f"{where}.id", value["id"])
+    _reject_foreign_knobs(where, value, platform_id)
+
     return _platform_spec(
         where,
-        platform_id=_parse_string_value(f"{where}.id", value["id"]),
+        platform_id=platform_id,
         libc=_parse_libc(f"{where}.libc", value.get("libc")),
         libc_version=_parse_major_minor(
             f"{where}.libc-version", value.get("libc-version")
@@ -2300,10 +2311,34 @@ def _parse_platform_table(where: str, value: dict[str, Any]) -> PlatformSpec:
     )
 
 
-def _parse_libc(key: str, value: object) -> Libc | None:
-    """Parse a libc family name; an absent key leaves the family undeclared."""
+def _reject_foreign_knobs(where: str, value: dict[str, Any], platform_id: str) -> None:
+    """Reject a knob key the declared platform's kind cannot read.
+
+    :class:`PlatformSpec` refuses a knob whose *value* moves a platform that
+    ignores it, but it cannot see a key written at its own default.  The
+    table can, and a key that selects no wheel is a mistake either way.  An
+    unknown ``platform_id`` is left to the matrix, which names the whole
+    unknown set at once.
+    """
+    kind = platform_kind(platform_id)
+    if kind is None:
+        return
+    for owner, keys in _PLATFORM_KNOB_OWNER.items():
+        if kind == owner:
+            continue
+        foreign = sorted(keys & set(value))
+        if foreign:
+            msg = (
+                f"{where} declares {foreign!r}, which only a {owner} platform"
+                f" reads, but its id is {platform_id!r}"
+            )
+            raise ConfigError(msg)
+
+
+def _parse_libc(key: str, value: object) -> Libc:
+    """Parse a libc family name; an absent key takes the default family."""
     if value is None:
-        return None
+        return DEFAULT_LIBC
     text = _parse_string_value(key, value)
     if text not in LIBC_MAJOR:
         msg = f"{key} must be one of {sorted(LIBC_MAJOR)!r}, got {text!r}"

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -57,6 +57,7 @@ from .provider import (
     VcsSource,
     _normalize_extra,
 )
+from .tags import Libc, PlatformSpec, platform_label
 from .universal.matrix import Matrix
 from .workspace import (
     WorkspaceConfig,
@@ -123,10 +124,15 @@ _VERSION_MARKER_VARIABLES = frozenset({"python_version", "python_full_version"})
 
 @dataclass(frozen=True, slots=True)
 class MatrixConfig:
-    """User-declared matrix axes for universal resolution."""
+    """User-declared matrix axes for universal resolution.
+
+    A ``platforms`` entry is either a bare platform id, which takes the
+    platform's default tag knobs, or a :class:`PlatformSpec` parsed from
+    the table form.
+    """
 
     python: str
-    platforms: tuple[str, ...]
+    platforms: tuple[str | PlatformSpec, ...]
     python_order: str = "asc"
     python_patches: Mapping[str, str] | None = None
     implementations: tuple[str, ...] = ("cpython",)
@@ -2216,6 +2222,96 @@ def _validate_matrix_python(spec: str) -> None:
             raise ConfigError(msg)
 
 
+_PLATFORM_TABLE_KEYS = frozenset(
+    {
+        "id",
+        "libc",
+        "libc-version",
+        "macos-min",
+        "platform-release",
+        "platform-version",
+    }
+)
+_KNOWN_LIBC: tuple[Libc, ...] = ("glibc", "musl")
+
+
+def _parse_matrix_platforms(value: object) -> tuple[str | PlatformSpec, ...]:
+    """Parse ``matrix.platforms``: bare ids, tables, or a mix of both.
+
+    A bare id takes the platform's default tag knobs.  The table form
+    declares the knobs a bare id cannot reach: the libc family and
+    version, the macOS deployment target, and the kernel marker values.
+    """
+    if not isinstance(value, list):
+        msg = f"matrix.platforms must be a list, got {type(value).__name__}"
+        raise ConfigError(msg)
+    platforms: list[str | PlatformSpec] = []
+    for i, item in enumerate(value):
+        if isinstance(item, str):
+            platforms.append(item)
+        elif isinstance(item, dict):
+            platforms.append(_parse_platform_table(f"matrix.platforms[{i}]", item))
+        else:
+            msg = (
+                f"matrix.platforms[{i}] must be a platform id or a table,"
+                f" got {type(item).__name__}"
+            )
+            raise ConfigError(msg)
+    return tuple(platforms)
+
+
+def _parse_platform_table(where: str, value: dict[str, Any]) -> PlatformSpec:
+    """Parse one ``matrix.platforms`` table entry into a :class:`PlatformSpec`."""
+    unknown = sorted(set(value) - _PLATFORM_TABLE_KEYS)
+    if unknown:
+        msg = (
+            f"unknown {where} keys: {unknown!r};"
+            f" expected {sorted(_PLATFORM_TABLE_KEYS)!r}"
+        )
+        raise ConfigError(msg)
+    if "id" not in value:
+        msg = f"{where} missing required key 'id'"
+        raise ConfigError(msg)
+    libc = value.get("libc", "glibc")
+    if libc not in _KNOWN_LIBC:
+        msg = f"{where}.libc must be one of {list(_KNOWN_LIBC)!r}, got {libc!r}"
+        raise ConfigError(msg)
+    return PlatformSpec(
+        platform_id=_parse_string_value(f"{where}.id", value["id"]),
+        libc=libc,
+        libc_version=_parse_major_minor(
+            f"{where}.libc-version", value.get("libc-version")
+        ),
+        macos_min=_parse_major_minor(f"{where}.macos-min", value.get("macos-min")),
+        platform_release=_parse_string_value(
+            f"{where}.platform-release", value.get("platform-release", "")
+        ),
+        platform_version=_parse_string_value(
+            f"{where}.platform-version", value.get("platform-version", "")
+        ),
+    )
+
+
+def _parse_major_minor(key: str, value: object) -> tuple[int, int] | None:
+    """Parse a ``major.minor`` string into a pair; ``None`` passes through."""
+    if value is None:
+        return None
+    text = _parse_string_value(key, value)
+    try:
+        version = Version(text)
+    except InvalidVersion as exc:
+        msg = f"{key} must be a 'major.minor' version, got {text!r}"
+        raise ConfigError(msg) from exc
+    release = version.release
+    two_part = len(release) == _MINOR_RELEASE_PARTS
+    # str() round-trips the normalized version, so an epoch or a
+    # pre/post/dev/local qualifier shows up as a mismatch here.
+    if not two_part or str(version) != f"{release[0]}.{release[1]}":
+        msg = f"{key} must be exactly 'major.minor', got {text!r}"
+        raise ConfigError(msg)
+    return (release[0], release[1])
+
+
 def _parse_matrix(value: object) -> MatrixConfig | None:
     if not isinstance(value, dict):
         msg = f"[tool.nab.matrix] must be a table, got {type(value).__name__}"
@@ -2243,11 +2339,11 @@ def _parse_matrix(value: object) -> MatrixConfig | None:
         msg = "matrix.python must be a string PEP 440 specifier"
         raise ConfigError(msg)
     _validate_matrix_python(python)
-    platforms = _parse_string_list("matrix.platforms", platforms_raw)
+    platforms = _parse_matrix_platforms(platforms_raw)
     if not platforms:
         msg = "matrix.platforms must list at least one platform id"
         raise ConfigError(msg)
-    _reject_duplicates("matrix.platforms", platforms)
+    _reject_duplicates("matrix.platforms", tuple(platform_label(p) for p in platforms))
     python_order = value.get("python-order", "asc")
     if python_order not in {"asc", "desc"}:
         msg = f"matrix.python-order must be 'asc' or 'desc', got {python_order!r}"

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -57,7 +57,7 @@ from .provider import (
     VcsSource,
     _normalize_extra,
 )
-from .tags import Libc, PlatformSpec
+from .tags import LIBC_MAJOR, Libc, PlatformSpec
 from .universal.matrix import Matrix
 from .workspace import (
     WorkspaceConfig,
@@ -2243,10 +2243,9 @@ _FREE_THREADED_MIN_PYTHON = (3, 13)
 def _parse_matrix_platforms(value: object) -> tuple[str | PlatformSpec, ...]:
     """Parse ``matrix.platforms``: bare ids, tables, or a mix of both.
 
-    A bare id takes the platform's default tag knobs.  The table form
-    declares the knobs a bare id cannot reach: the libc family and
-    version, the macOS deployment target, the kernel marker values, and
-    the free-threaded build.
+    A bare id takes the platform's default tag knobs; the table form declares
+    them (libc family and version, macOS deployment target, kernel marker
+    values, free-threaded build).
     """
     if not isinstance(value, list):
         msg = f"matrix.platforms must be a list, got {type(value).__name__}"
@@ -2278,16 +2277,28 @@ def _parse_platform_table(where: str, value: dict[str, Any]) -> PlatformSpec:
     if "id" not in value:
         msg = f"{where} missing required key 'id'"
         raise ConfigError(msg)
+
     libc = value.get("libc", "glibc")
     if libc not in _KNOWN_LIBC:
         msg = f"{where}.libc must be one of {list(_KNOWN_LIBC)!r}, got {libc!r}"
         raise ConfigError(msg)
+
+    libc_version = _parse_major_minor(
+        f"{where}.libc-version", value.get("libc-version")
+    )
+    # A foreign major (glibc 3.0, musl 2.0) names tags no wheel carries.
+    expected_major = LIBC_MAJOR[libc]
+    if libc_version is not None and libc_version[0] != expected_major:
+        msg = (
+            f"{where}.libc-version must be a {expected_major}.x version"
+            f" for {libc}, got {libc_version[0]}.{libc_version[1]}"
+        )
+        raise ConfigError(msg)
+
     return PlatformSpec(
         platform_id=_parse_string_value(f"{where}.id", value["id"]),
         libc=libc,
-        libc_version=_parse_major_minor(
-            f"{where}.libc-version", value.get("libc-version")
-        ),
+        libc_version=libc_version,
         macos_min=_parse_major_minor(f"{where}.macos-min", value.get("macos-min")),
         platform_release=_parse_string_value(
             f"{where}.platform-release", value.get("platform-release", "")
@@ -2313,8 +2324,8 @@ def _parse_major_minor(key: str, value: object) -> tuple[int, int] | None:
         raise ConfigError(msg) from exc
     release = version.release
     two_part = len(release) == _MINOR_RELEASE_PARTS
-    # str() round-trips the normalized version, so an epoch or a
-    # pre/post/dev/local qualifier shows up as a mismatch here.
+    # str() renders the normalized version, so an epoch or a pre/post/dev/local
+    # qualifier shows up as a mismatch here.
     if not two_part or str(version) != f"{release[0]}.{release[1]}":
         msg = f"{key} must be exactly 'major.minor', got {text!r}"
         raise ConfigError(msg)
@@ -2352,10 +2363,9 @@ def _parse_matrix(value: object) -> MatrixConfig | None:
     if not platforms:
         msg = "matrix.platforms must list at least one platform id"
         raise ConfigError(msg)
-    # One target per platform id: a lockfile entry is selected by a PEP 508
+    # One target per platform id.  A lockfile entry is selected by a PEP 508
     # marker, which has no libc or free-threading variable, so two targets
-    # sharing an id would render the same marker and the lock could not tell
-    # their pins apart.  The other libc family needs its own lock run.
+    # sharing an id would render the same marker.
     _reject_duplicates(
         "matrix.platforms",
         tuple(p if isinstance(p, str) else p.platform_id for p in platforms),
@@ -2399,9 +2409,7 @@ def _validate_matrix_axes(config: MatrixConfig) -> None:
 def _validate_free_threaded(tuples: Iterable[MatrixTuple]) -> None:
     """Reject free-threaded targets no interpreter build can satisfy.
 
-    A ``cpXYt`` ABI exists only for CPython 3.13 and up, so any other
-    tuple would advertise an ABI no wheel carries and silently lose
-    every binary wheel.
+    A ``cpXYt`` ABI exists only for CPython 3.13 and up.
     """
     for tup in tuples:
         if not tup.platform_spec.free_threaded:

--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -50,7 +50,6 @@ from .provider import (
     VcsConfig,
     VcsSource,
 )
-from .tags import platform_label
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
@@ -721,7 +720,7 @@ def _render_conflicts(value: Sequence[Any]) -> str:
 def _render_matrix(value: Any) -> str:
     if value is None:
         return "<none>"
-    platforms = [platform_label(p) for p in value.platforms]
+    platforms = [p.label for p in value.platforms]
     return f"python={value.python}, platforms={platforms}"
 
 

--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -50,6 +50,7 @@ from .provider import (
     VcsConfig,
     VcsSource,
 )
+from .tags import platform_label
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
@@ -720,7 +721,8 @@ def _render_conflicts(value: Sequence[Any]) -> str:
 def _render_matrix(value: Any) -> str:
     if value is None:
         return "<none>"
-    return f"python={value.python}, platforms={list(value.platforms)}"
+    platforms = [platform_label(p) for p in value.platforms]
+    return f"python={value.python}, platforms={platforms}"
 
 
 def _render_package_overrides(value: Sequence[Any]) -> str:

--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -33,7 +33,6 @@ if TYPE_CHECKING:
 __all__ = [
     "DEFAULT_LIBC",
     "LIBC_MAJOR",
-    "MACOS_TAG_FLOOR",
     "Libc",
     "PlatformSpec",
     "platform_kind",
@@ -55,12 +54,11 @@ _WHEEL_PARTS_WITH_BUILD = 6
 _BUILD_TAG_RE = re.compile(r"(\d+)(.*)", re.ASCII)
 
 # A libc version is a floor on the machine and a ceiling on the tag: the
-# target accepts every manylinux/musllinux tag at or below it.  glibc 2.28
-# is the manylinux_2_28 build image, and the oldest glibc the distros still
-# under support ship, so it accepts every manylinux wheel published today
-# without claiming a machine nobody runs.
+# target accepts every manylinux/musllinux tag at or below it, so a target
+# that runs a newer libc has to say so to reach the wheels built above the
+# default.  glibc 2.28 is the manylinux_2_28 build image; musl 1.2 is the
+# Alpine 3.13 baseline musllinux wheels target.
 _DEFAULT_GLIBC_VERSION = (2, 28)
-# The Alpine 3.13+ baseline that musllinux wheels target.
 _DEFAULT_MUSL_VERSION = (1, 2)
 DEFAULT_LIBC: Libc = "glibc"
 _DEFAULT_LIBC_VERSION: dict[Libc, tuple[int, int]] = {
@@ -86,7 +84,7 @@ _DEFAULT_MACOS_X86_64_MIN = (10, 13)
 # 11.0, so below these there is no machine to model.  An empty platform list
 # also reads to packaging as "unset", which would silently hand the target
 # the tags of whatever host nab is running on.
-MACOS_TAG_FLOOR: Mapping[str, tuple[int, int]] = MappingProxyType(
+_MACOS_TAG_FLOOR: Mapping[str, tuple[int, int]] = MappingProxyType(
     {"x86_64": (10, 4), "arm64": (11, 0)}
 )
 
@@ -96,6 +94,11 @@ _LEGACY_MANYLINUX: dict[tuple[int, int], str] = {
     (2, 12): "manylinux2010",
     (2, 5): "manylinux1",
 }
+
+# A tag list runs one entry per version below the declared one, so a typo
+# like "2.99999999" would build tags until it ran out of memory.  No libc or
+# macOS release is anywhere near this cap.
+_MAX_VERSION_PART = 99
 
 # Lowest glibc 2.x minor a manylinux wheel may target, by arch.  manylinux1
 # (PEP 513) and manylinux2010 (PEP 571) cover only x86_64/i686; manylinux2014
@@ -161,24 +164,30 @@ class PlatformSpec:
 
     def _check_libc_version(self) -> None:
         """Reject a libc version outside its family's only major."""
+        if self.libc_version is None:
+            return
         major = LIBC_MAJOR[self.libc]
-        if self.libc_version is not None and self.libc_version[0] != major:
+        if self.libc_version[0] != major:
             msg = (
                 f"{self.libc} has only a {major}.x series, so libc-version"
                 f" {_version_tag(self.libc_version)} names platform tags"
                 f" nothing is built for"
             )
             raise ValueError(msg)
+        _check_version_cap("libc-version", self.libc_version)
 
     def _check_macos_min(self) -> None:
         """Reject a macOS version below the oldest this arch can name a tag for."""
-        floor = MACOS_TAG_FLOOR[self.arch]
-        if self.macos_min is not None and self.macos_min < floor:
+        if self.macos_min is None:
+            return
+        floor = _MACOS_TAG_FLOOR[self.arch]
+        if self.macos_min < floor:
             msg = (
                 f"macos-min {_version_tag(self.macos_min)} is below"
                 f" {_version_tag(floor)}, the oldest macOS {self.arch} runs"
             )
             raise ValueError(msg)
+        _check_version_cap("macos-min", self.macos_min)
 
     @property
     def arch(self) -> str:
@@ -235,6 +244,16 @@ _PLATFORM_KIND: dict[str, str] = {
     "macos_x86_64": "macos",
     "windows_amd64": "windows",
 }
+
+
+def _check_version_cap(key: str, version: tuple[int, int]) -> None:
+    """Reject a version so high the tag list it names would exhaust memory."""
+    if max(version) > _MAX_VERSION_PART:
+        msg = (
+            f"{key} {_version_tag(version)} is higher than any release,"
+            f" and one tag is named per version below it"
+        )
+        raise ValueError(msg)
 
 
 def platform_kind(platform_id: str) -> str | None:
@@ -305,8 +324,7 @@ def _linux_platform_tags(
     else:
         # manylinux_X_Y: PEP 600.
         out = _manylinux_platform_tags(arch, libc_version)
-    # Plain linux_<arch>: the most generic Linux tag.  Most installers
-    # accept this only when no manylinux/musllinux wheel is present.
+    # The most generic Linux tag, so it ranks below every libc-specific one.
     out.append(f"linux_{arch}")
     return out
 
@@ -333,9 +351,10 @@ def _platform_tags_for_spec(spec: PlatformSpec) -> list[str]:
     if kind == "windows":
         return [f"win_{arch}"]
 
-    # Unreachable; PlatformSpec construction validates.
-    msg = f"Unknown platform kind: {kind}"  # pragma: no cover
-    raise ValueError(msg)  # pragma: no cover
+    # No id maps to a fourth kind today, so this fires only for one added
+    # without a tag rule, where a silent fallthrough would tag it as Windows.
+    msg = f"Unknown platform kind: {kind}"
+    raise ValueError(msg)
 
 
 # PyPy 7.3.x soabi, stable across every Python minor PyPy 3 ships

--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "DEFAULT_LIBC",
+    "FREE_THREADED_MIN_PYTHON",
     "LIBC_MAJOR",
     "Libc",
     "PlatformSpec",
@@ -43,10 +44,18 @@ __all__ = [
 
 Libc = Literal["glibc", "musl"]
 
+# The free-threaded build ships from CPython 3.13 (PEP 703).
+FREE_THREADED_MIN_PYTHON = (3, 13)
+
 
 # PEP 427: a wheel filename has at least 5 dash-separated segments
 # (name-version-pythontag-abitag-platformtag.whl), or 6 with a build tag.
 _MIN_WHEEL_FILENAME_PARTS = 5
+
+# A PEP 425 compressed tag set is a cross product, so an index-supplied
+# filename naming 40 interpreters, 40 abis and 40 platforms would parse into
+# 64000 tags.  No real wheel comes close to this bound.
+_MAX_WHEEL_TAGS = 4096
 
 # PEP 427: a build tag adds a sixth dash-separated segment at index 2,
 # and build tags start with a digit (captured here for ordering).
@@ -76,8 +85,9 @@ LIBC_MAJOR: Mapping[Libc, int] = MappingProxyType({"glibc": 2, "musl": 1})
 # only misses the newest wheels and falls back to an older version or an
 # sdist, while too high writes a wheel into the lock that an older machine
 # cannot install.
-_DEFAULT_MACOS_MIN = (12, 0)
-_DEFAULT_MACOS_X86_64_MIN = (10, 13)
+_DEFAULT_MACOS_MIN: Mapping[str, tuple[int, int]] = MappingProxyType(
+    {"arm64": (12, 0), "x86_64": (10, 13)}
+)
 
 # The oldest macOS each arch can name a wheel tag for.  ``mac_platforms``
 # yields no x86_64 binary format below 10.4, and Apple Silicon shipped at
@@ -340,19 +350,15 @@ def _platform_tags_for_spec(spec: PlatformSpec) -> list[str]:
         )
 
     if kind == "macos":
-        macos_min = spec.macos_min
-        if macos_min is None:
-            macos_min = (
-                _DEFAULT_MACOS_MIN if arch == "arm64" else _DEFAULT_MACOS_X86_64_MIN
-            )
+        macos_min = spec.macos_min or _DEFAULT_MACOS_MIN[arch]
         # mac_platforms treats the declared OS as a max and yields older too.
         return list(ptags.mac_platforms(version=macos_min, arch=arch))
 
     if kind == "windows":
         return [f"win_{arch}"]
 
-    # No id maps to a fourth kind today, so this fires only for one added
-    # without a tag rule, where a silent fallthrough would tag it as Windows.
+    # The id-to-kind table holds three kinds; a fourth added without a tag
+    # rule of its own is a programming error.
     msg = f"Unknown platform kind: {kind}"
     raise ValueError(msg)
 
@@ -403,7 +409,7 @@ def _parse_tag_str(tag_str: str) -> frozenset[Tag] | None:
     Returns ``None`` for unparseable input.
     """
     try:
-        raw = ptags.parse_tag(tag_str)
+        raw = ptags.parse_tag(tag_str, limit=_MAX_WHEEL_TAGS)
     except Exception:  # noqa: BLE001 - never trust upstream parser
         return None
     return frozenset(_intern_tag(t) for t in raw)

--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -1,14 +1,15 @@
-"""Predict which wheel a tuple would install.
+"""Predict which wheel a target environment would install.
 
-Universal resolution needs the install-time wheel selection answer
-without a live interpreter, so the tag set is computed from
-:class:`PlatformSpec` and the implementation name directly. CPython
-tags come from ``packaging.tags.cpython_tags``; PyPy tags are emitted
-directly (interpreter ``ppXY``, abi ``pypyXY_pp73``). Both add
-interpreter-agnostic tags from ``compatible_tags``. Platform tags use
-``mac_platforms`` for macOS and expand manylinux / musllinux from the
-declared glibc / musl floor. A wheel matches the tuple iff its parsed
-tags share a member with the tuple's compatible-tag set.
+Resolution needs the install-time wheel selection answer without a
+live interpreter, so the tag set is computed from :class:`PlatformSpec`
+and the implementation name directly. CPython tags come from
+``packaging.tags.cpython_tags``; PyPy tags are emitted directly
+(interpreter ``ppXY``, abi ``pypyXY_pp73``). Both add
+interpreter-agnostic tags from ``packaging.tags.compatible_tags``.
+Platform tags use ``mac_platforms`` for macOS and expand manylinux /
+musllinux from the declared glibc / musl floor. A wheel matches the
+target iff its parsed tags share a member with the target's accepted
+tag set.
 """
 
 from __future__ import annotations
@@ -18,26 +19,26 @@ from dataclasses import dataclass
 from functools import cache, lru_cache
 from typing import TYPE_CHECKING
 
-from .._vendor.packaging import tags as ptags
+from ._vendor.packaging import tags as ptags
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from nab_index.client import WheelFile
 
-    from .._vendor.packaging.tags import Tag
+    from ._vendor.packaging.tags import Tag
+
+
+__all__ = [
+    "PlatformSpec",
+    "select_wheel",
+    "tags_for_target",
+    "wheel_tag_set",
+]
 
 
 # PEP 427: a wheel filename has at least 5 dash-separated segments
 # (name-version-pythontag-abitag-platformtag.whl), or 6 with a build tag.
-__all__ = [
-    "PlatformSpec",
-    "compatible_tags_for_tuple",
-    "select_wheel_for_tuple",
-    "wheel_compatible_with_tuple",
-]
-
-
 _MIN_WHEEL_FILENAME_PARTS = 5
 
 # PEP 427: a build tag adds a sixth dash-separated segment at index 2,
@@ -260,7 +261,7 @@ _PYPY_SOABI = "73"
 
 
 @cache
-def compatible_tags_for_tuple(
+def tags_for_target(
     *,
     python_version: str,
     spec: PlatformSpec,
@@ -271,7 +272,7 @@ def compatible_tags_for_tuple(
     Builds the same ordered tags as :func:`_tags_in_order` and returns
     them as a frozenset.  Cached on the three immutable inputs (str,
     frozen dataclass, str): the resulting set is identical across every
-    wheel-compatibility check for the same tuple, so the cache skips
+    wheel-compatibility check for the same target, so the cache skips
     rebuilding the same :class:`Tag` set per call.
     """
     return frozenset(_tags_in_order(python_version, spec, implementation))
@@ -328,40 +329,20 @@ def wheel_tag_set(filename: str) -> frozenset[Tag] | None:
     return _parse_tag_str("-".join(parts[-3:]))
 
 
-def wheel_compatible_with_tuple(
-    wheel: WheelFile,
-    *,
-    python_version: str,
-    spec: PlatformSpec,
-    implementation: str = "cpython",
-) -> bool:
-    """Return True iff ``wheel`` is a candidate for the given tuple."""
-    wheel_tags = wheel_tag_set(wheel.filename)
-    if wheel_tags is None:
-        return False
-    compat = compatible_tags_for_tuple(
-        python_version=python_version, spec=spec, implementation=implementation
-    )
-    # ``frozenset.isdisjoint`` is a C-level builtin that beats the
-    # Python ``any(t in compat for t in wheel_tags)`` generator on
-    # the per-wheel hot loop.
-    return not wheel_tags.isdisjoint(compat)
-
-
-def select_wheel_for_tuple(
+def select_wheel(
     wheels: Iterable[WheelFile],
     *,
     python_version: str,
     spec: PlatformSpec,
     implementation: str = "cpython",
 ) -> WheelFile | None:
-    """Pick the most-specific compatible wheel for the tuple, or None.
+    """Pick the most-specific compatible wheel for the target, or None.
 
     Implements PEP 425 preference: wheels matching earlier
-    (more-specific) tags in ``compatible_tags_for_tuple`` win over
-    those matching later (more-generic) tags.  Within the same tag
-    rank, the wheel with the highest PEP 427 build tag wins (an absent
-    tag sorts lowest); exact ties keep input order.
+    (more-specific) tags in :func:`tags_for_target` win over those
+    matching later (more-generic) tags.  Within the same tag rank, the
+    wheel with the highest PEP 427 build tag wins (an absent tag sorts
+    lowest); exact ties keep input order.
     """
     compat_list = list(_tags_in_order(python_version, spec, implementation))
     rank: dict[Tag, int] = {tag: i for i, tag in enumerate(compat_list)}
@@ -403,13 +384,13 @@ def _build_tag_sort_key(filename: str) -> tuple[int, str]:
 def _tags_in_order(
     python_version: str, spec: PlatformSpec, implementation: str = "cpython"
 ) -> Iterable[Tag]:
-    """Yield the tags a tuple accepts in install preference order.
+    """Yield the tags a target accepts in install preference order.
 
-    CPython tuples use ``packaging.tags.cpython_tags`` (cpXY-cpXY,
-    cpXY-abi3 forward-compat, cpXY-none).  PyPy tuples cannot reuse that
-    (it forces the ``cp`` interpreter and abi3, which PyPy lacks), so
-    their interpreter/abi/none tags are emitted directly.  Both then add
-    the interpreter-agnostic tags (pyXY-none-any, py3-none-any, ...).
+    CPython targets use ``packaging.tags.cpython_tags`` (cpXY-cpXY,
+    cpXY-abi3 forward-compat, cpXY-none).  PyPy targets cannot reuse
+    that (it forces the ``cp`` interpreter and abi3, which PyPy lacks),
+    so their interpreter/abi/none tags are emitted directly.  Both then
+    add the interpreter-agnostic tags (pyXY-none-any, py3-none-any, ...).
     """
     major, minor = (int(p) for p in python_version.split("."))
     py_version = (major, minor)

--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -6,10 +6,9 @@ and the implementation name directly. CPython tags come from
 ``packaging.tags.cpython_tags``; PyPy tags are emitted directly
 (interpreter ``ppXY``, abi ``pypyXY_pp73``). Both add
 interpreter-agnostic tags from ``packaging.tags.compatible_tags``.
-Platform tags use ``mac_platforms`` for macOS and expand manylinux /
-musllinux from the declared glibc / musl floor. A wheel matches the
-target iff its parsed tags share a member with the target's accepted
-tag set.
+Platform tags use ``mac_platforms`` for macOS and expand the declared
+libc family's tags on Linux. A wheel matches the target iff its parsed
+tags share a member with the target's accepted tag set.
 """
 
 from __future__ import annotations
@@ -17,7 +16,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from functools import cache, lru_cache
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from ._vendor.packaging import tags as ptags
 
@@ -30,11 +29,15 @@ if TYPE_CHECKING:
 
 
 __all__ = [
+    "Libc",
     "PlatformSpec",
+    "platform_label",
     "select_wheel",
     "tags_for_target",
     "wheel_tag_set",
 ]
+
+Libc = Literal["glibc", "musl"]
 
 
 # PEP 427: a wheel filename has at least 5 dash-separated segments
@@ -46,13 +49,16 @@ _MIN_WHEEL_FILENAME_PARTS = 5
 _WHEEL_PARTS_WITH_BUILD = 6
 _BUILD_TAG_RE = re.compile(r"(\d+)(.*)", re.ASCII)
 
-# Default manylinux floor: glibc 2.17 (the manylinux2014 generation,
-# adopted by every mainstream distro since CentOS 7 / Ubuntu 14.04).
-# A tighter floor reduces accepted wheels; a looser floor accepts
-# wheels that may not run on older glibc.
-_DEFAULT_MANYLINUX_FLOOR = (2, 17)
-# Default musllinux floor: musl 1.2 (adopted by Alpine 3.13+, 2021+).
-_DEFAULT_MUSLLINUX_FLOOR = (1, 2)
+# manylinux_2_28 is the modern baseline: numpy, pandas and scipy ship
+# nothing older, so a lower default rejects their only Linux wheels.
+_DEFAULT_GLIBC_VERSION = (2, 28)
+# musl 1.2 is the Alpine 3.13+ (2021) baseline that musllinux wheels target.
+_DEFAULT_MUSL_VERSION = (1, 2)
+_DEFAULT_LIBC: Libc = "glibc"
+_DEFAULT_LIBC_VERSION: dict[Libc, tuple[int, int]] = {
+    "glibc": _DEFAULT_GLIBC_VERSION,
+    "musl": _DEFAULT_MUSL_VERSION,
+}
 # The macOS defaults model the deployment-target (system) macOS version.
 # ``mac_platforms`` treats this as a ceiling: a system at macOS V installs
 # wheels built for V and older, never newer, so a higher value accepts more
@@ -65,7 +71,7 @@ _DEFAULT_MACOS_MIN = (12, 0)
 # below 10.13.
 _DEFAULT_MACOS_X86_64_MIN = (10, 13)
 
-# Legacy manylinux aliases (PEPs 513/571/599) keyed by their glibc floor.
+# Legacy manylinux aliases (PEPs 513/571/599) keyed by the glibc they mean.
 _LEGACY_MANYLINUX: dict[tuple[int, int], str] = {
     (2, 17): "manylinux2014",
     (2, 12): "manylinux2010",
@@ -84,26 +90,28 @@ _OTHER_MIN_GLIBC2_MINOR = 17
 
 @dataclass(frozen=True)
 class PlatformSpec:
-    """Concrete tag floors for one matrix platform_id.
+    """Concrete tag knobs for one matrix platform_id.
 
-    Users can override the per-platform floors when their
-    deployment target requires it.  The defaults are deliberately
-    permissive (manylinux 2.17, musl 1.2, macOS 12 arm64 / 10.13
-    x86_64) so most real deployments work out of the box.
+    ``libc`` names the C library the Linux target runs.  A machine
+    has one, so a target emits that family's wheel tags and never the
+    other's.  ``libc_version`` is the version the target guarantees:
+    a wheel built against an older libc runs on a newer one, so every
+    version at or below it is accepted.  Unset, it takes the family
+    default (glibc 2.28, musl 1.2).
 
     ``platform_release`` and ``platform_version`` set the
-    corresponding PEP 508 marker values on this platform's tuples
-    (hole 1.3 plug).  When unset, both default to the empty string,
-    which makes any kernel-version-conditioned marker
-    (``platform_release >= "5.10"``) evaluate False (the safe
-    direction: drop the gated dep) but a silent failure if the
-    target machine actually has that kernel.  Users who declare a
-    minimum target kernel get the gated deps included.
+    corresponding PEP 508 marker values on this platform's tuples.
+    When unset, both default to the empty string, which makes any
+    kernel-version-conditioned marker (``platform_release >= "5.10"``)
+    evaluate False (the safe direction: drop the gated dep) but a
+    silent failure if the target machine actually has that kernel.
+    Users who declare a minimum target kernel get the gated deps
+    included.
     """
 
     platform_id: str
-    manylinux_floor: tuple[int, int] = _DEFAULT_MANYLINUX_FLOOR
-    musllinux_floor: tuple[int, int] = _DEFAULT_MUSLLINUX_FLOOR
+    libc: Libc = _DEFAULT_LIBC
+    libc_version: tuple[int, int] | None = None  # family-dependent default
     macos_min: tuple[int, int] | None = None  # arch-dependent default
     platform_release: str = ""
     platform_version: str = ""
@@ -113,25 +121,43 @@ class PlatformSpec:
         """The architecture suffix used in platform tags."""
         return _PLATFORM_ARCH[self.platform_id]
 
+    @property
+    def effective_libc_version(self) -> tuple[int, int]:
+        """The declared libc version, or this family's default."""
+        if self.libc_version is None:
+            return _DEFAULT_LIBC_VERSION[self.libc]
+        return self.libc_version
+
     def label_suffix(self) -> str:
         """Return a label discriminator, empty for the platform default.
 
         Two specs sharing a ``platform_id`` collapse to one matrix-tuple
-        label unless their floors set them apart, which silently merges
-        their per-tuple pins.  The suffix encodes the floors so distinct
+        label unless their knobs set them apart, which silently merges
+        their per-tuple pins.  The suffix encodes the knobs so distinct
         specs stay distinct; a spec left at the platform default emits no
         suffix and keeps the plain ``pyXY-platform`` label.
         """
         if self == PlatformSpec(self.platform_id):
             return ""
+        parts: list[str] = []
+        # A non-default libc always shows, with or without a version, so a
+        # musl target can never render the suffix of a glibc one.
+        if self.libc != _DEFAULT_LIBC or self.libc_version is not None:
+            parts.append(f"-{self.libc}{_version_tag(self.libc_version)}")
         fields = (
-            ("glibc", _floor_tag(self.manylinux_floor)),
-            ("musl", _floor_tag(self.musllinux_floor)),
-            ("macos", _floor_tag(self.macos_min)),
+            ("macos", _version_tag(self.macos_min)),
             ("rel", _escape_label_value(self.platform_release)),
             ("ver", _escape_label_value(self.platform_version)),
         )
-        return "".join(f"-{tag}{value}" for tag, value in fields if value)
+        parts += [f"-{tag}{value}" for tag, value in fields if value]
+        return "".join(parts)
+
+
+def platform_label(platform: str | PlatformSpec) -> str:
+    """Render a declared matrix platform as its label."""
+    if isinstance(platform, str):
+        return platform
+    return platform.platform_id + platform.label_suffix()
 
 
 # Map our matrix platform_ids to (kind, arch).  Kind is one of
@@ -153,9 +179,9 @@ _PLATFORM_KIND: dict[str, str] = {
 }
 
 
-def _floor_tag(floor: tuple[int, int] | None) -> str:
-    """Render a ``(major, minor)`` floor as ``major.minor``, or ``""`` if unset."""
-    return f"{floor[0]}.{floor[1]}" if floor is not None else ""
+def _version_tag(version: tuple[int, int] | None) -> str:
+    """Render a ``(major, minor)`` pair as ``major.minor``, or ``""`` if unset."""
+    return f"{version[0]}.{version[1]}" if version is not None else ""
 
 
 def _escape_label_value(value: str) -> str:
@@ -178,31 +204,15 @@ def _escape_label_value(value: str) -> str:
     return "".join(out)
 
 
-def _linux_platform_tags(
-    arch: str,
-    *,
-    manylinux_floor: tuple[int, int],
-    musllinux_floor: tuple[int, int],
-) -> list[str]:
-    """Generate manylinux + musllinux + plain linux tags for an arch.
+def _manylinux_platform_tags(arch: str, glibc_version: tuple[int, int]) -> list[str]:
+    """Generate the manylinux tags a glibc target accepts, newest first.
 
-    Returns the tag list in install-preference order: most-specific
-    (highest glibc/musl version) first.  Accepts every minor version
-    at or below the declared floor, down to the arch's oldest
-    supported glibc; this is the spec-compliant interpretation of
-    "manylinux_X_Y means glibc X.Y or older".
-
-    Note: PEP 600 says installers prefer wheels with the *highest*
-    glibc among compatible ones.  Our use case is "decide which
-    wheel a tuple would install"; the tag list ordering matches
-    that preference.
+    Emits each legacy alias right after its equivalent PEP 600 tag so a
+    legacy-named wheel ranks at its own glibc, matching packaging.tags.
+    A glibc 2.x target stops at the arch's oldest tag (2.5 for x86,
+    2.17 otherwise); any other major stops at minor 0.
     """
-    # manylinux_X_Y: PEP 600 form.  Iterate high-to-low for preference
-    # order, emitting each legacy alias right after its equivalent
-    # PEP 600 tag so a legacy-named wheel ranks at its own glibc, matching
-    # packaging.tags.  A glibc 2.x floor stops at the arch's oldest tag
-    # (2.5 for x86, 2.17 otherwise); any other major stops at minor 0.
-    major, minor = manylinux_floor
+    major, minor = glibc_version
     if major == _LEGACY_GLIBC_MAJOR:
         min_minor = (
             _X86_MIN_GLIBC2_MINOR
@@ -217,9 +227,27 @@ def _linux_platform_tags(
         legacy = _LEGACY_MANYLINUX.get((major, m))
         if legacy is not None:
             out.append(f"{legacy}_{arch}")
-    # musllinux_X_Y: PEP 656 form.  Same accept-at-or-below rule.
-    mu_major, mu_minor = musllinux_floor
-    out.extend(f"musllinux_{mu_major}_{m}_{arch}" for m in range(mu_minor, -1, -1))
+    return out
+
+
+def _linux_platform_tags(
+    arch: str, *, libc: Libc, libc_version: tuple[int, int]
+) -> list[str]:
+    """Generate the declared libc family's tags plus plain linux, for an arch.
+
+    Returns the tag list in install-preference order: most-specific
+    (highest libc version) first, down to the oldest the family and arch
+    allow.  A target links one C library, so a glibc target emits no
+    musllinux tags and a musl target emits no manylinux tags; the other
+    family's wheels do not run there.
+    """
+    major, minor = libc_version
+    if libc == "musl":
+        # musllinux_X_Y: PEP 656.
+        out = [f"musllinux_{major}_{m}_{arch}" for m in range(minor, -1, -1)]
+    else:
+        # manylinux_X_Y: PEP 600.
+        out = _manylinux_platform_tags(arch, libc_version)
     # Plain linux_<arch>: the most generic Linux tag.  Most installers
     # accept this only when no manylinux/musllinux wheel is present.
     out.append(f"linux_{arch}")
@@ -233,9 +261,7 @@ def _platform_tags_for_spec(spec: PlatformSpec) -> list[str]:
 
     if kind == "linux":
         return _linux_platform_tags(
-            arch,
-            manylinux_floor=spec.manylinux_floor,
-            musllinux_floor=spec.musllinux_floor,
+            arch, libc=spec.libc, libc_version=spec.effective_libc_version
         )
 
     if kind == "macos":
@@ -387,10 +413,13 @@ def _tags_in_order(
     """Yield the tags a target accepts in install preference order.
 
     CPython targets use ``packaging.tags.cpython_tags`` (cpXY-cpXY,
-    cpXY-abi3 forward-compat, cpXY-none).  PyPy targets cannot reuse
-    that (it forces the ``cp`` interpreter and abi3, which PyPy lacks),
-    so their interpreter/abi/none tags are emitted directly.  Both then
-    add the interpreter-agnostic tags (pyXY-none-any, py3-none-any, ...).
+    cpXY-abi3 forward-compat, cpXY-none) with the abi list left to
+    packaging, which derives the interpreter's real ABIs the same way
+    it does for the host; naming them here hides the free-threaded
+    ``cpXYt`` ABI.  PyPy targets cannot reuse that (it forces the ``cp``
+    interpreter and abi3, which PyPy lacks), so their interpreter/abi/none
+    tags are emitted directly.  Both then add the interpreter-agnostic
+    tags (pyXY-none-any, py3-none-any, ...).
     """
     major, minor = (int(p) for p in python_version.split("."))
     py_version = (major, minor)
@@ -404,9 +433,7 @@ def _tags_in_order(
             yield ptags.Tag(interpreter, "none", platform_)
     else:
         interpreter = f"cp{major}{minor}"
-        yield from ptags.cpython_tags(
-            python_version=py_version, abis=[interpreter], platforms=platforms
-        )
+        yield from ptags.cpython_tags(python_version=py_version, platforms=platforms)
     yield from ptags.compatible_tags(
         python_version=py_version, interpreter=interpreter, platforms=platforms
     )

--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -17,12 +17,13 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from functools import cache, lru_cache
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Literal
 
 from ._vendor.packaging import tags as ptags
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Mapping
 
     from nab_index.client import WheelFile
 
@@ -30,6 +31,7 @@ if TYPE_CHECKING:
 
 
 __all__ = [
+    "LIBC_MAJOR",
     "Libc",
     "PlatformSpec",
     "platform_label",
@@ -50,16 +52,19 @@ _MIN_WHEEL_FILENAME_PARTS = 5
 _WHEEL_PARTS_WITH_BUILD = 6
 _BUILD_TAG_RE = re.compile(r"(\d+)(.*)", re.ASCII)
 
-# manylinux_2_28 is the modern baseline: numpy, pandas and scipy ship
-# nothing older, so a lower default rejects their only Linux wheels.
+# numpy, pandas and scipy ship no manylinux wheel below 2_28, and a target
+# under 2.28 would not accept one.
 _DEFAULT_GLIBC_VERSION = (2, 28)
-# musl 1.2 is the Alpine 3.13+ (2021) baseline that musllinux wheels target.
+# The Alpine 3.13+ baseline that musllinux wheels target.
 _DEFAULT_MUSL_VERSION = (1, 2)
 _DEFAULT_LIBC: Libc = "glibc"
 _DEFAULT_LIBC_VERSION: dict[Libc, tuple[int, int]] = {
     "glibc": _DEFAULT_GLIBC_VERSION,
     "musl": _DEFAULT_MUSL_VERSION,
 }
+# The only major each family has shipped.  Tags expand within the declared
+# major, so a foreign major names platform tags no wheel is built for.
+LIBC_MAJOR: Mapping[Libc, int] = MappingProxyType({"glibc": 2, "musl": 1})
 # The macOS defaults model the deployment-target (system) macOS version.
 # ``mac_platforms`` treats this as a ceiling: a system at macOS V installs
 # wheels built for V and older, never newer, so a higher value accepts more
@@ -83,7 +88,6 @@ _LEGACY_MANYLINUX: dict[tuple[int, int], str] = {
 # (PEP 513) and manylinux2010 (PEP 571) cover only x86_64/i686; manylinux2014
 # (PEP 599, glibc 2.17) was the first to add other arches, so every other arch
 # stops at glibc 2.17.
-_LEGACY_GLIBC_MAJOR = 2
 _X86_MANYLINUX_ARCHS = frozenset({"x86_64", "i686"})
 _X86_MIN_GLIBC2_MINOR = 5
 _OTHER_MIN_GLIBC2_MINOR = 17
@@ -93,25 +97,19 @@ _OTHER_MIN_GLIBC2_MINOR = 17
 class PlatformSpec:
     """Concrete tag knobs for one matrix platform_id.
 
-    ``libc`` names the C library the Linux target runs.  A machine
-    has one, so a target emits that family's wheel tags and never the
-    other's.  ``libc_version`` is the version the target guarantees:
-    a wheel built against an older libc runs on a newer one, so every
-    version at or below it is accepted.  Unset, it takes the family
-    default (glibc 2.28, musl 1.2).
+    ``libc`` names the C library the Linux target runs; a machine links one,
+    so the target emits that family's wheel tags and never the other's.
+    ``libc_version`` is the version the target guarantees, and a wheel built
+    against an older libc runs on a newer one, so every version at or below
+    it is accepted.  Unset, it takes the family default.
 
-    ``platform_release`` and ``platform_version`` set the
-    corresponding PEP 508 marker values on this platform's tuples.
-    When unset, both default to the empty string, which makes any
-    kernel-version-conditioned marker (``platform_release >= "5.10"``)
-    evaluate False (the safe direction: drop the gated dep) but a
-    silent failure if the target machine actually has that kernel.
-    Users who declare a minimum target kernel get the gated deps
-    included.
+    ``platform_release`` and ``platform_version`` set the corresponding PEP 508
+    marker values.  Left empty, a kernel-conditioned marker
+    (``platform_release >= "5.10"``) evaluates False and its dependency is
+    dropped, so a target that does have that kernel has to declare it.
 
-    ``free_threaded`` declares a CPython 3.13+ free-threaded target.
-    It picks the ``cpXYt`` ABI (and with it ``abi3t`` in place of
-    ``abi3``), which is what such an interpreter installs.
+    ``free_threaded`` picks the ``cpXYt`` ABI (and ``abi3t`` in place of
+    ``abi3``) of a CPython 3.13+ free-threaded build.
     """
 
     platform_id: str
@@ -137,21 +135,23 @@ class PlatformSpec:
     def label_suffix(self) -> str:
         """Return a label discriminator, empty for the platform default.
 
-        A tuple's label names its target, so the suffix encodes the
-        knobs that set this spec apart from the platform's defaults and
-        two distinct specs never render the same suffix.  A spec left at
-        the platform default emits no suffix and keeps the plain
-        ``pyXY-platform`` label.
+        The suffix encodes the knobs that set this spec apart from the
+        platform defaults, so two distinct specs never render the same
+        label.  A spec left at the defaults emits no suffix and keeps the
+        plain ``pyXY-platform`` label.
         """
         if self == PlatformSpec(self.platform_id):
             return ""
+
         parts: list[str] = []
         if self.free_threaded:
             parts.append("-ft")
-        # A non-default libc always shows, with or without a version, so a
-        # musl target can never render the suffix of a glibc one.
+
+        # The family shows even without a version, so a musl target never
+        # renders the suffix of a glibc one.
         if self.libc != _DEFAULT_LIBC or self.libc_version is not None:
             parts.append(f"-{self.libc}{_version_tag(self.libc_version)}")
+
         fields = (
             ("macos", _version_tag(self.macos_min)),
             ("rel", _escape_label_value(self.platform_release)),
@@ -221,7 +221,7 @@ def _manylinux_platform_tags(arch: str, glibc_version: tuple[int, int]) -> list[
     2.17 otherwise); any other major stops at minor 0.
     """
     major, minor = glibc_version
-    if major == _LEGACY_GLIBC_MAJOR:
+    if major == LIBC_MAJOR["glibc"]:
         min_minor = (
             _X86_MIN_GLIBC2_MINOR
             if arch in _X86_MANYLINUX_ARCHS
@@ -243,11 +243,9 @@ def _linux_platform_tags(
 ) -> list[str]:
     """Generate the declared libc family's tags plus plain linux, for an arch.
 
-    Returns the tag list in install-preference order: most-specific
-    (highest libc version) first, down to the oldest the family and arch
-    allow.  A target links one C library, so a glibc target emits no
-    musllinux tags and a musl target emits no manylinux tags; the other
-    family's wheels do not run there.
+    Ordered by install preference: most-specific (highest libc version)
+    first, down to the oldest the family and arch allow.  A target links one
+    C library, so only that family's tags are emitted.
     """
     major, minor = libc_version
     if libc == "musl":
@@ -421,14 +419,13 @@ def _tags_in_order(
     """Yield the tags a target accepts in install preference order.
 
     CPython targets use ``packaging.tags.cpython_tags`` (cpXY-cpXY,
-    cpXY-abi3 forward-compat, cpXY-none).  The abi is named from the
-    declared target (``cpXYt`` for a free-threaded one, ``cpXY``
-    otherwise): left to packaging it would come from the config vars of
-    the interpreter running nab, which would make a target's wheels a
-    function of the host.  PyPy targets cannot reuse ``cpython_tags``
-    (it forces the ``cp`` interpreter and abi3, which PyPy lacks), so
-    their interpreter/abi/none tags are emitted directly.  Both then add
-    the interpreter-agnostic tags (pyXY-none-any, py3-none-any, ...).
+    cpXY-abi3 forward-compat, cpXY-none), with the abi named from the
+    declared target (``cpXYt`` when free-threaded); left to packaging it
+    would come from the config vars of the host interpreter.  PyPy targets
+    cannot reuse ``cpython_tags`` (it forces the ``cp`` interpreter and abi3,
+    which PyPy lacks), so their interpreter/abi/none tags are emitted
+    directly.  Both then add the interpreter-agnostic tags (pyXY-none-any,
+    py3-none-any, ...).
     """
     major, minor = (int(p) for p in python_version.split("."))
     py_version = (major, minor)

--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -367,6 +367,13 @@ def _platform_tags_for_spec(spec: PlatformSpec) -> list[str]:
 # (pp36..pp311 all use ``_pp73``); the abi tag is ``pypyXY_pp73``.
 _PYPY_SOABI = "73"
 
+# CPython carried the pymalloc flag in its ABI tag through 3.7, so its wheels
+# are tagged cp37m, not cp37.  3.8 dropped the flag.  Left to packaging the
+# flag would come from the config vars of the host interpreter, which says
+# nothing about a declared target.
+_PYMALLOC_ABI_SUFFIX = "m"
+_PYMALLOC_LAST_VERSION = (3, 7)
+
 
 @cache
 def tags_for_target(
@@ -489,6 +496,16 @@ def _build_tag_sort_key(filename: str) -> tuple[int, str]:
     return (int(match.group(1)), match.group(2) or "")
 
 
+def _cpython_abi(py_version: tuple[int, int], *, free_threaded: bool) -> str:
+    """Name the ABI a CPython target loads."""
+    abi = f"cp{py_version[0]}{py_version[1]}"
+    if free_threaded:
+        return abi + "t"
+    if py_version <= _PYMALLOC_LAST_VERSION:
+        return abi + _PYMALLOC_ABI_SUFFIX
+    return abi
+
+
 def _tags_in_order(
     python_version: str, spec: PlatformSpec, implementation: str = "cpython"
 ) -> Iterable[Tag]:
@@ -515,7 +532,7 @@ def _tags_in_order(
             yield ptags.Tag(interpreter, "none", platform_)
     else:
         interpreter = f"cp{major}{minor}"
-        abi = interpreter + ("t" if spec.free_threaded else "")
+        abi = _cpython_abi(py_version, free_threaded=spec.free_threaded)
         yield from ptags.cpython_tags(
             python_version=py_version, abis=[abi], platforms=platforms
         )

--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -57,23 +57,22 @@ _MIN_WHEEL_FILENAME_PARTS = 5
 # 64000 tags.  No real wheel comes close to this bound.
 _MAX_WHEEL_TAGS = 4096
 
-# PEP 427: a build tag adds a sixth dash-separated segment at index 2,
-# and build tags start with a digit (captured here for ordering).
+# PEP 427: a build tag adds a sixth dash-separated segment at index 2, and
+# starts with a digit (captured here for ordering).  The digit run is bounded
+# because the index names it and int() raises above 4300 digits, so an absurd
+# one is malformed and sorts lowest, like any other unreadable build tag.
 _WHEEL_PARTS_WITH_BUILD = 6
-_BUILD_TAG_RE = re.compile(r"(\d+)(.*)", re.ASCII)
+_BUILD_TAG_RE = re.compile(r"(\d{1,9})(\D.*)?$", re.ASCII)
 
 # A libc version is a floor on the machine and a ceiling on the tag: the
 # target accepts every manylinux/musllinux tag at or below it, so a target
 # that runs a newer libc has to say so to reach the wheels built above the
 # default.  glibc 2.28 is the manylinux_2_28 build image; musl 1.2 is the
 # Alpine 3.13 baseline musllinux wheels target.
-_DEFAULT_GLIBC_VERSION = (2, 28)
-_DEFAULT_MUSL_VERSION = (1, 2)
 DEFAULT_LIBC: Libc = "glibc"
-_DEFAULT_LIBC_VERSION: dict[Libc, tuple[int, int]] = {
-    "glibc": _DEFAULT_GLIBC_VERSION,
-    "musl": _DEFAULT_MUSL_VERSION,
-}
+_DEFAULT_LIBC_VERSION: Mapping[Libc, tuple[int, int]] = MappingProxyType(
+    {"glibc": (2, 28), "musl": (1, 2)}
+)
 # The only major each family has shipped.  Tags expand within the declared
 # major, so a foreign major names platform tags no wheel is built for.
 LIBC_MAJOR: Mapping[Libc, int] = MappingProxyType({"glibc": 2, "musl": 1})
@@ -237,8 +236,7 @@ class PlatformSpec:
         return "".join(parts)
 
 
-# Map our matrix platform_ids to (kind, arch).  Kind is one of
-# "linux", "macos", "windows".  Used for tag generation.
+# The arch suffix each platform id names in its wheel tags.
 _PLATFORM_ARCH: dict[str, str] = {
     "linux_x86_64": "x86_64",
     "linux_aarch64": "aarch64",
@@ -247,6 +245,8 @@ _PLATFORM_ARCH: dict[str, str] = {
     "windows_amd64": "amd64",
 }
 
+# The kind behind :func:`platform_kind`, which both tag generation and the
+# knob checks read.
 _PLATFORM_KIND: dict[str, str] = {
     "linux_x86_64": "linux",
     "linux_aarch64": "linux",
@@ -486,7 +486,7 @@ def _build_tag_sort_key(filename: str) -> tuple[int, str]:
     match = _BUILD_TAG_RE.match(parts[2])
     if match is None:
         return (-1, "")
-    return (int(match.group(1)), match.group(2))
+    return (int(match.group(1)), match.group(2) or "")
 
 
 def _tags_in_order(

--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -36,6 +36,7 @@ __all__ = [
     "MACOS_TAG_FLOOR",
     "Libc",
     "PlatformSpec",
+    "platform_kind",
     "select_wheel",
     "tags_for_target",
     "wheel_tag_set",
@@ -70,16 +71,24 @@ _DEFAULT_LIBC_VERSION: dict[Libc, tuple[int, int]] = {
 # major, so a foreign major names platform tags no wheel is built for.
 LIBC_MAJOR: Mapping[Libc, int] = MappingProxyType({"glibc": 2, "musl": 1})
 
-# ``mac_platforms`` reads the macOS version as a ceiling: a system at macOS V
-# installs wheels built for V and older, never newer, so a higher value
-# accepts more wheels.  Apple Silicon arrived at 11.0, but most arm64 wheels
-# published since 2023 target macosx_12_0 or newer, so a lower default would
-# reject them; 10.13 was the last x86_64 version with wide wheel coverage.
+# The macOS version is the deployment target of the machine, which
+# ``mac_platforms`` reads as a ceiling: the target accepts a wheel built for
+# its own version and older, never newer.  The defaults are deliberately
+# conservative, because the two ways to be wrong are not symmetric: too low
+# only misses the newest wheels and falls back to an older version or an
+# sdist, while too high writes a wheel into the lock that an older machine
+# cannot install.
 _DEFAULT_MACOS_MIN = (12, 0)
 _DEFAULT_MACOS_X86_64_MIN = (10, 13)
-# ``mac_platforms`` names no tag below 10.0, and an empty platform list reads
-# to packaging as "unset", which falls back to the tags of the running host.
-MACOS_TAG_FLOOR = (10, 0)
+
+# The oldest macOS each arch can name a wheel tag for.  ``mac_platforms``
+# yields no x86_64 binary format below 10.4, and Apple Silicon shipped at
+# 11.0, so below these there is no machine to model.  An empty platform list
+# also reads to packaging as "unset", which would silently hand the target
+# the tags of whatever host nab is running on.
+MACOS_TAG_FLOOR: Mapping[str, tuple[int, int]] = MappingProxyType(
+    {"x86_64": (10, 4), "arm64": (11, 0)}
+)
 
 # Legacy manylinux aliases (PEPs 513/571/599) keyed by the glibc they mean.
 _LEGACY_MANYLINUX: dict[tuple[int, int], str] = {
@@ -117,7 +126,7 @@ class PlatformSpec:
     """
 
     platform_id: str
-    libc: Libc | None = None  # unset: the platform default
+    libc: Libc = DEFAULT_LIBC
     libc_version: tuple[int, int] | None = None  # unset: the family default
     macos_min: tuple[int, int] | None = None  # unset: the arch default
     platform_release: str = ""
@@ -136,12 +145,12 @@ class PlatformSpec:
         whole unknown set at once, and that says more than a complaint
         about a knob on a platform that does not exist.
         """
-        kind = _PLATFORM_KIND.get(self.platform_id)
+        kind = platform_kind(self.platform_id)
         if kind is None:
             return
         if kind == "linux":
             self._check_libc_version()
-        elif self.libc is not None or self.libc_version is not None:
+        elif self.libc != DEFAULT_LIBC or self.libc_version is not None:
             msg = f"libc is a Linux knob, and {self.platform_id} is not Linux"
             raise ValueError(msg)
         if kind == "macos":
@@ -152,22 +161,22 @@ class PlatformSpec:
 
     def _check_libc_version(self) -> None:
         """Reject a libc version outside its family's only major."""
-        major = LIBC_MAJOR[self.effective_libc]
+        major = LIBC_MAJOR[self.libc]
         if self.libc_version is not None and self.libc_version[0] != major:
             msg = (
-                f"{self.effective_libc} has only a {major}.x series, so"
-                f" libc-version {_version_tag(self.libc_version)} names"
-                f" platform tags nothing is built for"
+                f"{self.libc} has only a {major}.x series, so libc-version"
+                f" {_version_tag(self.libc_version)} names platform tags"
+                f" nothing is built for"
             )
             raise ValueError(msg)
 
     def _check_macos_min(self) -> None:
-        """Reject a macOS version below the oldest that names a platform tag."""
-        if self.macos_min is not None and self.macos_min < MACOS_TAG_FLOOR:
+        """Reject a macOS version below the oldest this arch can name a tag for."""
+        floor = MACOS_TAG_FLOOR[self.arch]
+        if self.macos_min is not None and self.macos_min < floor:
             msg = (
                 f"macos-min {_version_tag(self.macos_min)} is below"
-                f" {_version_tag(MACOS_TAG_FLOOR)}, the oldest macOS a wheel"
-                f" tag can name"
+                f" {_version_tag(floor)}, the oldest macOS {self.arch} runs"
             )
             raise ValueError(msg)
 
@@ -177,17 +186,10 @@ class PlatformSpec:
         return _PLATFORM_ARCH[self.platform_id]
 
     @property
-    def effective_libc(self) -> Libc:
-        """The declared C library, or the default family."""
-        if self.libc is None:
-            return DEFAULT_LIBC
-        return self.libc
-
-    @property
     def effective_libc_version(self) -> tuple[int, int]:
         """The declared libc version, or this family's default."""
         if self.libc_version is None:
-            return _DEFAULT_LIBC_VERSION[self.effective_libc]
+            return _DEFAULT_LIBC_VERSION[self.libc]
         return self.libc_version
 
     @property
@@ -204,8 +206,8 @@ class PlatformSpec:
 
         # The family shows even without a version, so a musl target never
         # renders the label of a glibc one.
-        if self.libc is not None or self.libc_version is not None:
-            parts.append(f"-{self.effective_libc}{_version_tag(self.libc_version)}")
+        if self.libc != DEFAULT_LIBC or self.libc_version is not None:
+            parts.append(f"-{self.libc}{_version_tag(self.libc_version)}")
 
         fields = (
             ("macos", _version_tag(self.macos_min)),
@@ -233,6 +235,11 @@ _PLATFORM_KIND: dict[str, str] = {
     "macos_x86_64": "macos",
     "windows_amd64": "windows",
 }
+
+
+def platform_kind(platform_id: str) -> str | None:
+    """Return a platform id's kind, or ``None`` if nab does not know the id."""
+    return _PLATFORM_KIND.get(platform_id)
 
 
 def _version_tag(version: tuple[int, int] | None) -> str:
@@ -311,9 +318,7 @@ def _platform_tags_for_spec(spec: PlatformSpec) -> list[str]:
 
     if kind == "linux":
         return _linux_platform_tags(
-            arch,
-            libc=spec.effective_libc,
-            libc_version=spec.effective_libc_version,
+            arch, libc=spec.libc, libc_version=spec.effective_libc_version
         )
 
     if kind == "macos":

--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -2,13 +2,14 @@
 
 Resolution needs the install-time wheel selection answer without a
 live interpreter, so the tag set is computed from :class:`PlatformSpec`
-and the implementation name directly. CPython tags come from
-``packaging.tags.cpython_tags``; PyPy tags are emitted directly
-(interpreter ``ppXY``, abi ``pypyXY_pp73``). Both add
-interpreter-agnostic tags from ``packaging.tags.compatible_tags``.
-Platform tags use ``mac_platforms`` for macOS and expand the declared
-libc family's tags on Linux. A wheel matches the target iff its parsed
-tags share a member with the target's accepted tag set.
+and the implementation name directly, never from the interpreter
+running nab. CPython tags come from ``packaging.tags.cpython_tags``;
+PyPy tags are emitted directly (interpreter ``ppXY``, abi
+``pypyXY_pp73``). Both add interpreter-agnostic tags from
+``packaging.tags.compatible_tags``. Platform tags use ``mac_platforms``
+for macOS and expand the declared libc family's tags on Linux. A wheel
+matches the target iff its parsed tags share a member with the target's
+accepted tag set.
 """
 
 from __future__ import annotations
@@ -107,6 +108,10 @@ class PlatformSpec:
     silent failure if the target machine actually has that kernel.
     Users who declare a minimum target kernel get the gated deps
     included.
+
+    ``free_threaded`` declares a CPython 3.13+ free-threaded target.
+    It picks the ``cpXYt`` ABI (and with it ``abi3t`` in place of
+    ``abi3``), which is what such an interpreter installs.
     """
 
     platform_id: str
@@ -115,6 +120,7 @@ class PlatformSpec:
     macos_min: tuple[int, int] | None = None  # arch-dependent default
     platform_release: str = ""
     platform_version: str = ""
+    free_threaded: bool = False
 
     @property
     def arch(self) -> str:
@@ -131,15 +137,17 @@ class PlatformSpec:
     def label_suffix(self) -> str:
         """Return a label discriminator, empty for the platform default.
 
-        Two specs sharing a ``platform_id`` collapse to one matrix-tuple
-        label unless their knobs set them apart, which silently merges
-        their per-tuple pins.  The suffix encodes the knobs so distinct
-        specs stay distinct; a spec left at the platform default emits no
-        suffix and keeps the plain ``pyXY-platform`` label.
+        A tuple's label names its target, so the suffix encodes the
+        knobs that set this spec apart from the platform's defaults and
+        two distinct specs never render the same suffix.  A spec left at
+        the platform default emits no suffix and keeps the plain
+        ``pyXY-platform`` label.
         """
         if self == PlatformSpec(self.platform_id):
             return ""
         parts: list[str] = []
+        if self.free_threaded:
+            parts.append("-ft")
         # A non-default libc always shows, with or without a version, so a
         # musl target can never render the suffix of a glibc one.
         if self.libc != _DEFAULT_LIBC or self.libc_version is not None:
@@ -413,13 +421,14 @@ def _tags_in_order(
     """Yield the tags a target accepts in install preference order.
 
     CPython targets use ``packaging.tags.cpython_tags`` (cpXY-cpXY,
-    cpXY-abi3 forward-compat, cpXY-none) with the abi list left to
-    packaging, which derives the interpreter's real ABIs the same way
-    it does for the host; naming them here hides the free-threaded
-    ``cpXYt`` ABI.  PyPy targets cannot reuse that (it forces the ``cp``
-    interpreter and abi3, which PyPy lacks), so their interpreter/abi/none
-    tags are emitted directly.  Both then add the interpreter-agnostic
-    tags (pyXY-none-any, py3-none-any, ...).
+    cpXY-abi3 forward-compat, cpXY-none).  The abi is named from the
+    declared target (``cpXYt`` for a free-threaded one, ``cpXY``
+    otherwise): left to packaging it would come from the config vars of
+    the interpreter running nab, which would make a target's wheels a
+    function of the host.  PyPy targets cannot reuse ``cpython_tags``
+    (it forces the ``cp`` interpreter and abi3, which PyPy lacks), so
+    their interpreter/abi/none tags are emitted directly.  Both then add
+    the interpreter-agnostic tags (pyXY-none-any, py3-none-any, ...).
     """
     major, minor = (int(p) for p in python_version.split("."))
     py_version = (major, minor)
@@ -433,7 +442,10 @@ def _tags_in_order(
             yield ptags.Tag(interpreter, "none", platform_)
     else:
         interpreter = f"cp{major}{minor}"
-        yield from ptags.cpython_tags(python_version=py_version, platforms=platforms)
+        abi = interpreter + ("t" if spec.free_threaded else "")
+        yield from ptags.cpython_tags(
+            python_version=py_version, abis=[abi], platforms=platforms
+        )
     yield from ptags.compatible_tags(
         python_version=py_version, interpreter=interpreter, platforms=platforms
     )

--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -31,10 +31,11 @@ if TYPE_CHECKING:
 
 
 __all__ = [
+    "DEFAULT_LIBC",
     "LIBC_MAJOR",
+    "MACOS_TAG_FLOOR",
     "Libc",
     "PlatformSpec",
-    "platform_label",
     "select_wheel",
     "tags_for_target",
     "wheel_tag_set",
@@ -52,12 +53,15 @@ _MIN_WHEEL_FILENAME_PARTS = 5
 _WHEEL_PARTS_WITH_BUILD = 6
 _BUILD_TAG_RE = re.compile(r"(\d+)(.*)", re.ASCII)
 
-# numpy, pandas and scipy ship no manylinux wheel below 2_28, and a target
-# under 2.28 would not accept one.
+# A libc version is a floor on the machine and a ceiling on the tag: the
+# target accepts every manylinux/musllinux tag at or below it.  glibc 2.28
+# is the manylinux_2_28 build image, and the oldest glibc the distros still
+# under support ship, so it accepts every manylinux wheel published today
+# without claiming a machine nobody runs.
 _DEFAULT_GLIBC_VERSION = (2, 28)
 # The Alpine 3.13+ baseline that musllinux wheels target.
 _DEFAULT_MUSL_VERSION = (1, 2)
-_DEFAULT_LIBC: Libc = "glibc"
+DEFAULT_LIBC: Libc = "glibc"
 _DEFAULT_LIBC_VERSION: dict[Libc, tuple[int, int]] = {
     "glibc": _DEFAULT_GLIBC_VERSION,
     "musl": _DEFAULT_MUSL_VERSION,
@@ -65,17 +69,17 @@ _DEFAULT_LIBC_VERSION: dict[Libc, tuple[int, int]] = {
 # The only major each family has shipped.  Tags expand within the declared
 # major, so a foreign major names platform tags no wheel is built for.
 LIBC_MAJOR: Mapping[Libc, int] = MappingProxyType({"glibc": 2, "musl": 1})
-# The macOS defaults model the deployment-target (system) macOS version.
-# ``mac_platforms`` treats this as a ceiling: a system at macOS V installs
-# wheels built for V and older, never newer, so a higher value accepts more
-# (newer) wheels. Default arm64 target: 12.0 (Monterey). Apple Silicon was
-# introduced at 11.0, but most arm64 wheels published since 2023 target
-# macosx_12_0 or newer, so a value below 12.0 would reject them.
+
+# ``mac_platforms`` reads the macOS version as a ceiling: a system at macOS V
+# installs wheels built for V and older, never newer, so a higher value
+# accepts more wheels.  Apple Silicon arrived at 11.0, but most arm64 wheels
+# published since 2023 target macosx_12_0 or newer, so a lower default would
+# reject them; 10.13 was the last x86_64 version with wide wheel coverage.
 _DEFAULT_MACOS_MIN = (12, 0)
-# Default macOS minimum for x86_64 builds.  10.13 was the last with
-# wide wheel coverage; newer macOS x86_64 builds rarely declare
-# below 10.13.
 _DEFAULT_MACOS_X86_64_MIN = (10, 13)
+# ``mac_platforms`` names no tag below 10.0, and an empty platform list reads
+# to packaging as "unset", which falls back to the tags of the running host.
+MACOS_TAG_FLOOR = (10, 0)
 
 # Legacy manylinux aliases (PEPs 513/571/599) keyed by the glibc they mean.
 _LEGACY_MANYLINUX: dict[tuple[int, int], str] = {
@@ -113,12 +117,59 @@ class PlatformSpec:
     """
 
     platform_id: str
-    libc: Libc = _DEFAULT_LIBC
-    libc_version: tuple[int, int] | None = None  # family-dependent default
-    macos_min: tuple[int, int] | None = None  # arch-dependent default
+    libc: Libc | None = None  # unset: the platform default
+    libc_version: tuple[int, int] | None = None  # unset: the family default
+    macos_min: tuple[int, int] | None = None  # unset: the arch default
     platform_release: str = ""
     platform_version: str = ""
     free_threaded: bool = False
+
+    def __post_init__(self) -> None:
+        """Reject a knob the declared platform cannot carry.
+
+        The tag generator reads a libc only on Linux and a macOS version
+        only on macOS, so a knob on the wrong platform changes no wheel it
+        selects.  It does reach the target's label and the lock's
+        provenance, which would then name a machine nothing modelled.
+
+        An unrecognised ``platform_id`` passes: the matrix reports the
+        whole unknown set at once, and that says more than a complaint
+        about a knob on a platform that does not exist.
+        """
+        kind = _PLATFORM_KIND.get(self.platform_id)
+        if kind is None:
+            return
+        if kind == "linux":
+            self._check_libc_version()
+        elif self.libc is not None or self.libc_version is not None:
+            msg = f"libc is a Linux knob, and {self.platform_id} is not Linux"
+            raise ValueError(msg)
+        if kind == "macos":
+            self._check_macos_min()
+        elif self.macos_min is not None:
+            msg = f"macos-min is a macOS knob, and {self.platform_id} is not macOS"
+            raise ValueError(msg)
+
+    def _check_libc_version(self) -> None:
+        """Reject a libc version outside its family's only major."""
+        major = LIBC_MAJOR[self.effective_libc]
+        if self.libc_version is not None and self.libc_version[0] != major:
+            msg = (
+                f"{self.effective_libc} has only a {major}.x series, so"
+                f" libc-version {_version_tag(self.libc_version)} names"
+                f" platform tags nothing is built for"
+            )
+            raise ValueError(msg)
+
+    def _check_macos_min(self) -> None:
+        """Reject a macOS version below the oldest that names a platform tag."""
+        if self.macos_min is not None and self.macos_min < MACOS_TAG_FLOOR:
+            msg = (
+                f"macos-min {_version_tag(self.macos_min)} is below"
+                f" {_version_tag(MACOS_TAG_FLOOR)}, the oldest macOS a wheel"
+                f" tag can name"
+            )
+            raise ValueError(msg)
 
     @property
     def arch(self) -> str:
@@ -126,31 +177,35 @@ class PlatformSpec:
         return _PLATFORM_ARCH[self.platform_id]
 
     @property
+    def effective_libc(self) -> Libc:
+        """The declared C library, or the default family."""
+        if self.libc is None:
+            return DEFAULT_LIBC
+        return self.libc
+
+    @property
     def effective_libc_version(self) -> tuple[int, int]:
         """The declared libc version, or this family's default."""
         if self.libc_version is None:
-            return _DEFAULT_LIBC_VERSION[self.libc]
+            return _DEFAULT_LIBC_VERSION[self.effective_libc]
         return self.libc_version
 
-    def label_suffix(self) -> str:
-        """Return a label discriminator, empty for the platform default.
+    @property
+    def label(self) -> str:
+        """Render the spec as its label: the id, plus what sets it apart.
 
-        The suffix encodes the knobs that set this spec apart from the
-        platform defaults, so two distinct specs never render the same
-        label.  A spec left at the defaults emits no suffix and keeps the
-        plain ``pyXY-platform`` label.
+        The suffix encodes every knob the spec declares, so two distinct
+        specs never render one label.  A spec that declares none is just
+        its id.
         """
-        if self == PlatformSpec(self.platform_id):
-            return ""
-
-        parts: list[str] = []
+        parts: list[str] = [self.platform_id]
         if self.free_threaded:
             parts.append("-ft")
 
         # The family shows even without a version, so a musl target never
-        # renders the suffix of a glibc one.
-        if self.libc != _DEFAULT_LIBC or self.libc_version is not None:
-            parts.append(f"-{self.libc}{_version_tag(self.libc_version)}")
+        # renders the label of a glibc one.
+        if self.libc is not None or self.libc_version is not None:
+            parts.append(f"-{self.effective_libc}{_version_tag(self.libc_version)}")
 
         fields = (
             ("macos", _version_tag(self.macos_min)),
@@ -159,13 +214,6 @@ class PlatformSpec:
         )
         parts += [f"-{tag}{value}" for tag, value in fields if value]
         return "".join(parts)
-
-
-def platform_label(platform: str | PlatformSpec) -> str:
-    """Render a declared matrix platform as its label."""
-    if isinstance(platform, str):
-        return platform
-    return platform.platform_id + platform.label_suffix()
 
 
 # Map our matrix platform_ids to (kind, arch).  Kind is one of
@@ -217,18 +265,14 @@ def _manylinux_platform_tags(arch: str, glibc_version: tuple[int, int]) -> list[
 
     Emits each legacy alias right after its equivalent PEP 600 tag so a
     legacy-named wheel ranks at its own glibc, matching packaging.tags.
-    A glibc 2.x target stops at the arch's oldest tag (2.5 for x86,
-    2.17 otherwise); any other major stops at minor 0.
+    The target stops at the arch's oldest tag: 2.5 for x86, 2.17 otherwise.
     """
     major, minor = glibc_version
-    if major == LIBC_MAJOR["glibc"]:
-        min_minor = (
-            _X86_MIN_GLIBC2_MINOR
-            if arch in _X86_MANYLINUX_ARCHS
-            else _OTHER_MIN_GLIBC2_MINOR
-        )
-    else:
-        min_minor = 0
+    min_minor = (
+        _X86_MIN_GLIBC2_MINOR
+        if arch in _X86_MANYLINUX_ARCHS
+        else _OTHER_MIN_GLIBC2_MINOR
+    )
     out: list[str] = []
     for m in range(minor, min_minor - 1, -1):
         out.append(f"manylinux_{major}_{m}_{arch}")
@@ -267,7 +311,9 @@ def _platform_tags_for_spec(spec: PlatformSpec) -> list[str]:
 
     if kind == "linux":
         return _linux_platform_tags(
-            arch, libc=spec.libc, libc_version=spec.effective_libc_version
+            arch,
+            libc=spec.effective_libc,
+            libc_version=spec.effective_libc_version,
         )
 
     if kind == "macos":

--- a/nab-python/src/nab_python/universal/matrix.py
+++ b/nab-python/src/nab_python/universal/matrix.py
@@ -127,7 +127,7 @@ class MatrixTuple:
 
         Uses the interpreter prefix (``py`` for CPython, ``pp`` for
         PyPy) so tuples that differ only by implementation get distinct
-        labels, and appends the platform spec's floor discriminator so
+        labels, and appends the platform spec's knob discriminator so
         two specs sharing a ``platform_id`` do not collapse.  A
         conflict-fork ``selection`` then appends each active member as
         ``kind-name``, joined by ``.``, in sorted order so the forks of
@@ -233,9 +233,9 @@ class Matrix:
         minors, an empty python range, or an invalid ``python_order``
         each raise a ``ValueError`` before any work happens.
 
-        ``platforms`` accepts either bare platform-id strings (use
-        default tag floors) or :class:`PlatformSpec` instances for
-        per-platform glibc/musl/macOS overrides.
+        ``platforms`` accepts either bare platform-id strings (use the
+        default tag knobs) or :class:`PlatformSpec` instances for
+        per-platform libc/macOS overrides.
         """
         if self.python_order not in {"asc", "desc"}:
             msg = f"python_order must be 'asc' or 'desc'; got {self.python_order!r}"

--- a/nab-python/src/nab_python/universal/matrix.py
+++ b/nab-python/src/nab_python/universal/matrix.py
@@ -143,8 +143,7 @@ class MatrixTuple:
         """
         prefix = _IMPLEMENTATION_PREFIX[self.implementation]
         base = (
-            f"{prefix}{self.python_version.replace('.', '')}-{self.platform_id}"
-            + self.platform_spec.label_suffix()
+            f"{prefix}{self.python_version.replace('.', '')}-{self.platform_spec.label}"
         )
         if not self.selection:
             return base
@@ -220,7 +219,7 @@ class Matrix:
     """
 
     python: str
-    platforms: tuple[str | PlatformSpec, ...]
+    platforms: tuple[PlatformSpec, ...]
     python_order: str = "asc"
     python_patches: dict[str, str] | None = None
     implementations: tuple[str, ...] = ("cpython",)
@@ -232,20 +231,14 @@ class Matrix:
         implementations, ``python_patches`` keys that are not known
         minors, an empty python range, or an invalid ``python_order``
         each raise a ``ValueError`` before any work happens.
-
-        ``platforms`` accepts either bare platform-id strings (use the
-        default tag knobs) or :class:`PlatformSpec` instances for
-        per-platform libc/macOS overrides.
         """
         if self.python_order not in {"asc", "desc"}:
             msg = f"python_order must be 'asc' or 'desc'; got {self.python_order!r}"
             raise ValueError(msg)
-        specs = [
-            p if isinstance(p, PlatformSpec) else PlatformSpec(p)
-            for p in self.platforms
-        ]
         unknown = [
-            s.platform_id for s in specs if s.platform_id not in _PLATFORM_DEFAULTS
+            s.platform_id
+            for s in self.platforms
+            if s.platform_id not in _PLATFORM_DEFAULTS
         ]
         if unknown:
             msg = f"Unknown platform ids: {unknown!r}"
@@ -281,7 +274,7 @@ class Matrix:
                 multi_implementation=multi_impl,
             )
             for py in py_versions
-            for spec in specs
+            for spec in self.platforms
             for impl in self.implementations
         ]
 

--- a/nab-python/src/nab_python/universal/matrix.py
+++ b/nab-python/src/nab_python/universal/matrix.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 from .._conflict_kind import MARKER_VARIABLE_FOR_KIND
 from .._vendor.packaging.specifiers import SpecifierSet
 from .._vendor.packaging.version import Version
-from .wheel_selection import PlatformSpec
+from ..tags import PlatformSpec
 
 if TYPE_CHECKING:
     from collections.abc import Iterable

--- a/nab-python/src/nab_python/universal/matrix.py
+++ b/nab-python/src/nab_python/universal/matrix.py
@@ -127,8 +127,8 @@ class MatrixTuple:
 
         Uses the interpreter prefix (``py`` for CPython, ``pp`` for
         PyPy) so tuples that differ only by implementation get distinct
-        labels, and appends the platform spec's knob discriminator so
-        the label names the target the spec declares.  A
+        labels, and appends the platform spec's knob discriminator so a
+        spec off the platform defaults keeps its own label.  A
         conflict-fork ``selection`` then appends each active member as
         ``kind-name``, joined by ``.``, in sorted order so the forks of
         one python/platform stay distinct, e.g.

--- a/nab-python/src/nab_python/universal/matrix.py
+++ b/nab-python/src/nab_python/universal/matrix.py
@@ -16,10 +16,11 @@ from typing import TYPE_CHECKING
 from .._conflict_kind import MARKER_VARIABLE_FOR_KIND
 from .._vendor.packaging.specifiers import SpecifierSet
 from .._vendor.packaging.version import Version
-from ..tags import PlatformSpec
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+
+    from ..tags import PlatformSpec
 
 # Common Python minor releases. An unrecognized minor declared in the
 # user range raises.
@@ -110,16 +111,16 @@ class MatrixTuple:
     """
 
     python_version: str
-    platform_id: str
+    platform_spec: PlatformSpec
     environment: dict[str, str] = field(hash=False, compare=False)
-    platform_spec: PlatformSpec = field(
-        hash=False,
-        compare=False,
-        default_factory=lambda: PlatformSpec("linux_x86_64"),
-    )
     implementation: str = "cpython"
     multi_implementation: bool = field(default=False, hash=False, compare=False)
     selection: tuple[tuple[str, str], ...] = ()
+
+    @property
+    def platform_id(self) -> str:
+        """The platform this tuple models, as the spec declares it."""
+        return self.platform_spec.platform_id
 
     @property
     def label(self) -> str:
@@ -267,9 +268,8 @@ class Matrix:
         return [
             MatrixTuple(
                 python_version=py,
-                platform_id=spec.platform_id,
-                environment=_build_environment(py, spec, impl, patches.get(py)),
                 platform_spec=spec,
+                environment=_build_environment(py, spec, impl, patches.get(py)),
                 implementation=impl,
                 multi_implementation=multi_impl,
             )

--- a/nab-python/src/nab_python/universal/matrix.py
+++ b/nab-python/src/nab_python/universal/matrix.py
@@ -238,7 +238,6 @@ class Matrix:
         if self.python_order not in {"asc", "desc"}:
             msg = f"python_order must be 'asc' or 'desc'; got {self.python_order!r}"
             raise ValueError(msg)
-        self._check_free_threaded()
         unknown = [
             s.platform_id
             for s in self.platforms
@@ -261,6 +260,7 @@ class Matrix:
                 " keys must be major.minor like '3.11'"
             )
             raise ValueError(msg)
+        self._check_free_threaded()
         py_versions = list(_pythons_in_range(self.python))
         if not py_versions:
             msg = f"No known Python versions match {self.python!r}"

--- a/nab-python/src/nab_python/universal/matrix.py
+++ b/nab-python/src/nab_python/universal/matrix.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 from .._conflict_kind import MARKER_VARIABLE_FOR_KIND
 from .._vendor.packaging.specifiers import SpecifierSet
 from .._vendor.packaging.version import Version
+from ..tags import FREE_THREADED_MIN_PYTHON
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -230,12 +231,14 @@ class Matrix:
 
         Validates inputs eagerly: unknown platform ids, unknown
         implementations, ``python_patches`` keys that are not known
-        minors, an empty python range, or an invalid ``python_order``
-        each raise a ``ValueError`` before any work happens.
+        minors, an empty python range, an invalid ``python_order``, or a
+        free-threaded platform no interpreter build can satisfy each raise a
+        ``ValueError`` before any work happens.
         """
         if self.python_order not in {"asc", "desc"}:
             msg = f"python_order must be 'asc' or 'desc'; got {self.python_order!r}"
             raise ValueError(msg)
+        self._check_free_threaded()
         unknown = [
             s.platform_id
             for s in self.platforms
@@ -277,6 +280,35 @@ class Matrix:
             for spec in self.platforms
             for impl in self.implementations
         ]
+
+    def _check_free_threaded(self) -> None:
+        """Reject a free-threaded platform no interpreter build can satisfy.
+
+        The ``cpXYt`` ABI ships only from CPython 3.13, and only the matrix
+        sees both axes the rule needs: the platform carries the flag, and the
+        implementation and the python range live here.
+        """
+        if not any(spec.free_threaded for spec in self.platforms):
+            return
+        foreign = [i for i in self.implementations if i != "cpython"]
+        if foreign:
+            msg = (
+                f"a free-threaded platform needs CPython, not {foreign!r};"
+                f" only CPython has a free-threaded build"
+            )
+            raise ValueError(msg)
+        floor = ".".join(str(p) for p in FREE_THREADED_MIN_PYTHON)
+        too_old = [
+            py
+            for py in _pythons_in_range(self.python)
+            if tuple(int(p) for p in py.split(".")) < FREE_THREADED_MIN_PYTHON
+        ]
+        if too_old:
+            msg = (
+                f"a free-threaded platform needs CPython {floor} or newer,"
+                f" but matrix.python admits {too_old!r}"
+            )
+            raise ValueError(msg)
 
 
 def _build_environment(

--- a/nab-python/src/nab_python/universal/matrix.py
+++ b/nab-python/src/nab_python/universal/matrix.py
@@ -128,7 +128,7 @@ class MatrixTuple:
         Uses the interpreter prefix (``py`` for CPython, ``pp`` for
         PyPy) so tuples that differ only by implementation get distinct
         labels, and appends the platform spec's knob discriminator so
-        two specs sharing a ``platform_id`` do not collapse.  A
+        the label names the target the spec declares.  A
         conflict-fork ``selection`` then appends each active member as
         ``kind-name``, joined by ``.``, in sorted order so the forks of
         one python/platform stay distinct, e.g.

--- a/nab-python/src/nab_python/universal/provider.py
+++ b/nab-python/src/nab_python/universal/provider.py
@@ -15,8 +15,8 @@ inherited from :class:`Provider` and threaded through via the
 parent's ``resolution_strategy`` and ``direct_packages`` kwargs.
 
 When ``platform_spec`` is supplied, the provider also filters wheel
-candidates by tag compatibility at resolve time (hole 2 in
-``universal_open_questions.md``).  Versions whose only wheels are for
+candidates by tag compatibility at resolve time.  Versions whose only wheels
+are for
 another libc family, or above the spec's libc/macOS version, become
 unavailable unless an sdist is present, which keeps the version alive
 at every ``build_policy`` level (look-ahead rejects an unreadable
@@ -198,7 +198,7 @@ class UniversalProvider(Provider):
     ) -> list[tuple[Version, DistFile]]:
         """Filter parent's result by wheel-tag compatibility.
 
-        Hole 2 plug: a version is unavailable to the resolver if its
+        A version is unavailable to the resolver if its
         only wheels are tag-incompatible with this tuple's
         ``platform_spec``.  Sdists keep the version alive at every
         :class:`BuildPolicy` level because static PKG-INFO and the

--- a/nab-python/src/nab_python/universal/provider.py
+++ b/nab-python/src/nab_python/universal/provider.py
@@ -16,9 +16,9 @@ parent's ``resolution_strategy`` and ``direct_packages`` kwargs.
 
 When ``platform_spec`` is supplied, the provider also filters wheel
 candidates by tag compatibility at resolve time (hole 2 in
-``universal_open_questions.md``).  Versions whose only wheels are
-above the spec's manylinux/musllinux/macOS floor become unavailable
-unless an sdist is present, which keeps the version alive at every
+``universal_open_questions.md``).  Versions whose only wheels are for
+another libc family, or above the spec's libc/macOS version, become
+unavailable unless an sdist is present, which keeps the version alive at every
 ``build_policy`` level (look-ahead rejects an unreadable sdist).
 """
 

--- a/nab-python/src/nab_python/universal/provider.py
+++ b/nab-python/src/nab_python/universal/provider.py
@@ -44,7 +44,7 @@ from ..provider import (
     VcsConfig,
     VcsSource,
 )
-from .wheel_selection import compatible_tags_for_tuple, wheel_tag_set
+from ..tags import tags_for_target, wheel_tag_set
 
 __all__ = [
     "DistFile",
@@ -64,7 +64,7 @@ if TYPE_CHECKING:
     from .._vendor.packaging.version import Version
     from ..config import IndexOverride, NabProjectConfig, PackageOverride
     from ..fetch import FetchCoordinator
-    from .wheel_selection import PlatformSpec
+    from ..tags import PlatformSpec
 
 
 class UniversalProvider(Provider):
@@ -217,11 +217,11 @@ class UniversalProvider(Provider):
 
         spec = self._platform_spec
         py_minor = self._py_minor
-        # Look up the per-tuple compat tag set once outside the per-wheel
+        # Look up the per-tuple accepted tag set once outside the per-wheel
         # loop and inline the membership check; this loop runs for every
         # wheel of every package on every tuple, so the hoist matters on
         # large workloads.
-        compat = compatible_tags_for_tuple(
+        accepted = tags_for_target(
             python_version=py_minor, spec=spec, implementation=self._implementation
         )
         kept: list[tuple[Version, DistFile]] = []
@@ -230,7 +230,7 @@ class UniversalProvider(Provider):
         for version, dist in base:
             if isinstance(dist, WheelFile):
                 wheel_tags = wheel_tag_set(dist.filename)
-                if wheel_tags is not None and not wheel_tags.isdisjoint(compat):
+                if wheel_tags is not None and not wheel_tags.isdisjoint(accepted):
                     kept.append((version, dist))
                     versions_with_wheel.add(version)
                 else:

--- a/nab-python/src/nab_python/universal/provider.py
+++ b/nab-python/src/nab_python/universal/provider.py
@@ -15,12 +15,11 @@ inherited from :class:`Provider` and threaded through via the
 parent's ``resolution_strategy`` and ``direct_packages`` kwargs.
 
 When ``platform_spec`` is supplied, the provider also filters wheel
-candidates by tag compatibility at resolve time.  Versions whose only wheels
-are for
-another libc family, or above the spec's libc/macOS version, become
-unavailable unless an sdist is present, which keeps the version alive
-at every ``build_policy`` level (look-ahead rejects an unreadable
-sdist).
+candidates by tag compatibility at resolve time.  Versions whose only
+wheels are for another libc family, or above the spec's libc/macOS
+version, become unavailable unless an sdist is present, which keeps the
+version alive at every ``build_policy`` level (look-ahead rejects an
+unreadable sdist).
 """
 
 from __future__ import annotations
@@ -198,9 +197,9 @@ class UniversalProvider(Provider):
     ) -> list[tuple[Version, DistFile]]:
         """Filter parent's result by wheel-tag compatibility.
 
-        A version is unavailable to the resolver if its
-        only wheels are tag-incompatible with this tuple's
-        ``platform_spec``.  Sdists keep the version alive at every
+        A version is unavailable to the resolver if its only wheels are
+        tag-incompatible with this tuple's ``platform_spec``.  Sdists
+        keep the version alive at every
         :class:`BuildPolicy` level because static PKG-INFO and the
         bundled ``pyproject.toml`` fallback are read unconditionally;
         ``BUILD_LOCAL`` adds backend invocation on local checkouts and

--- a/nab-python/src/nab_python/universal/provider.py
+++ b/nab-python/src/nab_python/universal/provider.py
@@ -18,8 +18,9 @@ When ``platform_spec`` is supplied, the provider also filters wheel
 candidates by tag compatibility at resolve time (hole 2 in
 ``universal_open_questions.md``).  Versions whose only wheels are for
 another libc family, or above the spec's libc/macOS version, become
-unavailable unless an sdist is present, which keeps the version alive at every
-``build_policy`` level (look-ahead rejects an unreadable sdist).
+unavailable unless an sdist is present, which keeps the version alive
+at every ``build_policy`` level (look-ahead rejects an unreadable
+sdist).
 """
 
 from __future__ import annotations

--- a/nab-python/src/nab_python/universal/validate.py
+++ b/nab-python/src/nab_python/universal/validate.py
@@ -30,7 +30,7 @@ from .._vendor.packaging.requirements import (
 from .._vendor.packaging.utils import canonicalize_name, canonicalize_version
 from .._vendor.packaging.version import Version
 from ..metadata import load_static_project, metadata_deps_are_static, parse_metadata
-from .wheel_selection import select_wheel_for_tuple
+from ..tags import select_wheel
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -227,7 +227,7 @@ def _validate_pin(  # noqa: PLR0911 - one return per outcome reads cleaner here
             status="sdist_only",
             detail="no wheels at this version; install requires building from sdist",
         )
-    chosen = select_wheel_for_tuple(
+    chosen = select_wheel(
         wheels_at_version,
         python_version=tup.python_version,
         spec=tup.platform_spec,

--- a/nab-python/tests/property_python/test_tags_differential.py
+++ b/nab-python/tests/property_python/test_tags_differential.py
@@ -31,6 +31,8 @@ from packaging.version import InvalidVersion
 from nab_index.client import WheelFile
 from nab_python._vendor.packaging import tags as vendored_tags
 from nab_python.tags import (
+    _PLATFORM_ARCH,
+    MACOS_TAG_FLOOR,
     PlatformSpec,
     _platform_tags_for_spec,
     _tags_in_order,
@@ -51,24 +53,44 @@ PLATFORM_IDS = (
     "windows_amd64",
 )
 
-specs = st.one_of(
+LINUX_IDS = tuple(p for p in PLATFORM_IDS if p.startswith("linux_"))
+MACOS_IDS = tuple(p for p in PLATFORM_IDS if p.startswith("macos_"))
+
+# A knob only its own platform reads is a construction error, so each
+# platform draws its own.
+linux_specs = st.one_of(
     st.builds(
         PlatformSpec,
-        platform_id=st.sampled_from(PLATFORM_IDS),
+        platform_id=st.sampled_from(LINUX_IDS),
         libc=st.just("glibc"),
         libc_version=st.tuples(st.just(2), st.integers(0, 35)),
-        macos_min=st.none() | st.tuples(st.integers(10, 14), st.integers(0, 15)),
         free_threaded=st.booleans(),
     ),
     st.builds(
         PlatformSpec,
-        platform_id=st.sampled_from(PLATFORM_IDS),
+        platform_id=st.sampled_from(LINUX_IDS),
         libc=st.just("musl"),
         libc_version=st.tuples(st.just(1), st.integers(0, 4)),
-        macos_min=st.none() | st.tuples(st.integers(10, 14), st.integers(0, 15)),
         free_threaded=st.booleans(),
     ),
 )
+macos_specs = st.sampled_from(MACOS_IDS).flatmap(
+    lambda platform_id: st.builds(
+        PlatformSpec,
+        platform_id=st.just(platform_id),
+        macos_min=st.none()
+        | st.tuples(st.integers(10, 15), st.integers(0, 15)).filter(
+            lambda v: v >= MACOS_TAG_FLOOR[_PLATFORM_ARCH[platform_id]]
+        ),
+        free_threaded=st.booleans(),
+    )
+)
+windows_specs = st.builds(
+    PlatformSpec,
+    platform_id=st.just("windows_amd64"),
+    free_threaded=st.booleans(),
+)
+specs = st.one_of(linux_specs, macos_specs, windows_specs)
 
 
 def _triples(tag_iter: object) -> list[tuple[str, str, str]]:
@@ -340,3 +362,20 @@ class TestSelectWheelMinimizesUpstreamRank:
             f"chose {chosen.filename} rank {best_rank(chosen)}; "
             f"best available {min(oracle_ranks)}"
         )
+
+
+class TestAcceptedSpecNamesAPlatform:
+    """Every spec :class:`PlatformSpec` accepts names at least one platform tag.
+
+    ``packaging.tags`` reads an empty ``platforms`` argument as "unset" and
+    falls back to the tags of the running host, so a spec that named no
+    platform tag would not resolve for the machine it declares: it would
+    resolve for nab's own.  The knob checks exist to make that unreachable,
+    and this is the invariant they buy.
+    """
+
+    @given(spec=specs)
+    @PROPERTY_SETTINGS
+    def test_platform_tags_are_never_empty(self, spec: PlatformSpec) -> None:
+        """An accepted spec always names a platform tag of its own."""
+        assert _platform_tags_for_spec(spec)

--- a/nab-python/tests/property_python/test_tags_differential.py
+++ b/nab-python/tests/property_python/test_tags_differential.py
@@ -58,6 +58,7 @@ specs = st.one_of(
         libc=st.just("glibc"),
         libc_version=st.tuples(st.just(2), st.integers(0, 35)),
         macos_min=st.none() | st.tuples(st.integers(10, 14), st.integers(0, 15)),
+        free_threaded=st.booleans(),
     ),
     st.builds(
         PlatformSpec,
@@ -65,6 +66,7 @@ specs = st.one_of(
         libc=st.just("musl"),
         libc_version=st.tuples(st.just(1), st.integers(0, 4)),
         macos_min=st.none() | st.tuples(st.integers(10, 14), st.integers(0, 15)),
+        free_threaded=st.booleans(),
     ),
 )
 
@@ -75,7 +77,11 @@ def _triples(tag_iter: object) -> list[tuple[str, str, str]]:
 
 
 def _oracle_tags_in_order(
-    python_version: str, platforms: list[str], implementation: str
+    python_version: str,
+    platforms: list[str],
+    implementation: str,
+    *,
+    free_threaded: bool,
 ) -> list[tuple[str, str, str]]:
     """Rebuild ``tags._tags_in_order`` with upstream ``packaging.tags``."""
     major, minor = (int(p) for p in python_version.split("."))
@@ -88,8 +94,11 @@ def _oracle_tags_in_order(
         out += [(interpreter, "none", p) for p in platforms]
     else:
         interpreter = f"cp{major}{minor}"
+        cp_abi = interpreter + ("t" if free_threaded else "")
         out += _triples(
-            upstream_tags.cpython_tags(python_version=py, platforms=platforms)
+            upstream_tags.cpython_tags(
+                python_version=py, abis=[cp_abi], platforms=platforms
+            )
         )
     out += _triples(
         upstream_tags.compatible_tags(
@@ -120,7 +129,12 @@ class TestTagOrderMatchesUpstream:
         # An empty platform list falls back to host tags, which drifted upstream after 26.2.
         assume(platforms)
         got = _triples(_tags_in_order(python_version, spec, implementation))
-        expected = _oracle_tags_in_order(python_version, platforms, implementation)
+        expected = _oracle_tags_in_order(
+            python_version,
+            platforms,
+            implementation,
+            free_threaded=spec.free_threaded,
+        )
         assert got == expected
 
 
@@ -293,7 +307,12 @@ class TestSelectWheelMinimizesUpstreamRank:
         platforms = _platform_tags_for_spec(spec)
         # An empty platform list falls back to host tags, which drifted upstream after 26.2.
         assume(platforms)
-        order = _oracle_tags_in_order(python_version, platforms, implementation)
+        order = _oracle_tags_in_order(
+            python_version,
+            platforms,
+            implementation,
+            free_threaded=spec.free_threaded,
+        )
         rank = {t: i for i, t in enumerate(order)}
 
         def best_rank(w: WheelFile) -> int | None:

--- a/nab-python/tests/property_python/test_tags_differential.py
+++ b/nab-python/tests/property_python/test_tags_differential.py
@@ -1,7 +1,7 @@
 """Differential property tests: nab wheel selection vs upstream ``packaging.tags``.
 
-:mod:`nab_python.universal.wheel_selection` implements `PEP 425`_
-wheel-tag preference on top of the vendored ``packaging.tags``.
+:mod:`nab_python.tags` implements `PEP 425`_ wheel-tag preference on
+top of the vendored ``packaging.tags``.
 Each test here re-derives one layer with the upstream ``packaging``
 distribution as the oracle and requires agreement:
 
@@ -12,8 +12,8 @@ distribution as the oracle and requires agreement:
 3. ``parse_tag`` must expand compressed tag sets identically.
 4. ``wheel_tag_set`` must agree with upstream
    ``parse_wheel_filename`` on every spec-valid filename.
-5. ``select_wheel_for_tuple`` must pick a wheel whose best upstream
-   rank is the minimum over all candidate wheels.
+5. ``select_wheel`` must pick a wheel whose best upstream rank is
+   the minimum over all candidate wheels.
 
 .. _PEP 425: https://peps.python.org/pep-0425/
 """
@@ -30,11 +30,11 @@ from packaging.version import InvalidVersion
 
 from nab_index.client import WheelFile
 from nab_python._vendor.packaging import tags as vendored_tags
-from nab_python.universal.wheel_selection import (
+from nab_python.tags import (
     PlatformSpec,
     _platform_tags_for_spec,
     _tags_in_order,
-    select_wheel_for_tuple,
+    select_wheel,
     wheel_tag_set,
 )
 
@@ -68,7 +68,7 @@ def _triples(tag_iter: object) -> list[tuple[str, str, str]]:
 def _oracle_tags_in_order(
     python_version: str, platforms: list[str], implementation: str
 ) -> list[tuple[str, str, str]]:
-    """Rebuild ``wheel_selection._tags_in_order`` with upstream ``packaging.tags``."""
+    """Rebuild ``tags._tags_in_order`` with upstream ``packaging.tags``."""
     major, minor = (int(p) for p in python_version.split("."))
     py = (major, minor)
     out: list[tuple[str, str, str]] = []
@@ -300,7 +300,7 @@ class TestSelectWheelMinimizesUpstreamRank:
             return min(ranks) if ranks else None
 
         oracle_ranks = [r for w in wheels if (r := best_rank(w)) is not None]
-        chosen = select_wheel_for_tuple(
+        chosen = select_wheel(
             wheels,
             python_version=python_version,
             spec=spec,

--- a/nab-python/tests/property_python/test_tags_differential.py
+++ b/nab-python/tests/property_python/test_tags_differential.py
@@ -21,7 +21,7 @@ distribution as the oracle and requires agreement:
 from __future__ import annotations
 
 import pytest
-from hypothesis import assume, given
+from hypothesis import given
 from hypothesis import strategies as st
 from packaging import tags as upstream_tags
 from packaging import utils as upstream_utils
@@ -148,8 +148,6 @@ class TestTagOrderMatchesUpstream:
     ) -> None:
         """Vendored tag order equals the upstream-rebuilt order."""
         platforms = _platform_tags_for_spec(spec)
-        # An empty platform list falls back to host tags, which drifted upstream after 26.2.
-        assume(platforms)
         got = _triples(_tags_in_order(python_version, spec, implementation))
         expected = _oracle_tags_in_order(
             python_version,
@@ -327,8 +325,6 @@ class TestSelectWheelMinimizesUpstreamRank:
     ) -> None:
         """The selected wheel's best upstream rank is the minimum over all wheels."""
         platforms = _platform_tags_for_spec(spec)
-        # An empty platform list falls back to host tags, which drifted upstream after 26.2.
-        assume(platforms)
         order = _oracle_tags_in_order(
             python_version,
             platforms,

--- a/nab-python/tests/property_python/test_tags_differential.py
+++ b/nab-python/tests/property_python/test_tags_differential.py
@@ -51,12 +51,21 @@ PLATFORM_IDS = (
     "windows_amd64",
 )
 
-specs = st.builds(
-    PlatformSpec,
-    platform_id=st.sampled_from(PLATFORM_IDS),
-    manylinux_floor=st.tuples(st.just(2), st.integers(0, 35)),
-    musllinux_floor=st.tuples(st.just(1), st.integers(0, 4)),
-    macos_min=st.none() | st.tuples(st.integers(10, 14), st.integers(0, 15)),
+specs = st.one_of(
+    st.builds(
+        PlatformSpec,
+        platform_id=st.sampled_from(PLATFORM_IDS),
+        libc=st.just("glibc"),
+        libc_version=st.tuples(st.just(2), st.integers(0, 35)),
+        macos_min=st.none() | st.tuples(st.integers(10, 14), st.integers(0, 15)),
+    ),
+    st.builds(
+        PlatformSpec,
+        platform_id=st.sampled_from(PLATFORM_IDS),
+        libc=st.just("musl"),
+        libc_version=st.tuples(st.just(1), st.integers(0, 4)),
+        macos_min=st.none() | st.tuples(st.integers(10, 14), st.integers(0, 15)),
+    ),
 )
 
 
@@ -80,9 +89,7 @@ def _oracle_tags_in_order(
     else:
         interpreter = f"cp{major}{minor}"
         out += _triples(
-            upstream_tags.cpython_tags(
-                python_version=py, abis=[interpreter], platforms=platforms
-            )
+            upstream_tags.cpython_tags(python_version=py, platforms=platforms)
         )
     out += _triples(
         upstream_tags.compatible_tags(

--- a/nab-python/tests/property_python/test_tags_differential.py
+++ b/nab-python/tests/property_python/test_tags_differential.py
@@ -31,8 +31,8 @@ from packaging.version import InvalidVersion
 from nab_index.client import WheelFile
 from nab_python._vendor.packaging import tags as vendored_tags
 from nab_python.tags import (
+    _MACOS_TAG_FLOOR,
     _PLATFORM_ARCH,
-    MACOS_TAG_FLOOR,
     PlatformSpec,
     _platform_tags_for_spec,
     _tags_in_order,
@@ -80,7 +80,7 @@ macos_specs = st.sampled_from(MACOS_IDS).flatmap(
         platform_id=st.just(platform_id),
         macos_min=st.none()
         | st.tuples(st.integers(10, 15), st.integers(0, 15)).filter(
-            lambda v: v >= MACOS_TAG_FLOOR[_PLATFORM_ARCH[platform_id]]
+            lambda v: v >= _MACOS_TAG_FLOOR[_PLATFORM_ARCH[platform_id]]
         ),
         free_threaded=st.booleans(),
     )

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -2764,13 +2764,12 @@ class TestMatrix:
     @pytest.mark.parametrize(
         ("entry", "message"),
         [
-            ('{ id = "windows_amd64", libc = "musl" }', "libc is a Linux knob"),
-            ('{ id = "macos_arm64", libc-version = "2.28" }', "libc is a Linux knob"),
-            (
-                '{ id = "linux_x86_64", macos-min = "14.0" }',
-                "macos-min is a macOS knob",
-            ),
-            ('{ id = "macos_arm64", macos-min = "9.0" }', "below 10.0"),
+            ('{ id = "windows_amd64", libc = "musl" }', "only a linux platform"),
+            ('{ id = "windows_amd64", libc = "glibc" }', "only a linux platform"),
+            ('{ id = "macos_arm64", libc-version = "2.28" }', "only a linux platform"),
+            ('{ id = "linux_x86_64", macos-min = "14.0" }', "only a macos platform"),
+            ('{ id = "macos_arm64", macos-min = "10.15" }', "below 11.0"),
+            ('{ id = "macos_x86_64", macos-min = "10.3" }', "below 10.4"),
         ],
     )
     def test_platform_table_rejects_a_knob_the_platform_cannot_use(

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -2857,6 +2857,30 @@ class TestMatrix:
         with pytest.raises(ConfigError, match="libc-version must be a string"):
             read_pyproject_config(path)
 
+    def test_platform_table_glibc_version_major_must_be_2(self, tmp_path: Path) -> None:
+        """A glibc major other than 2 tags a platform no wheel is built for."""
+        path = write(
+            tmp_path,
+            self._platforms_body('[{ id = "linux_x86_64", libc-version = "3.0" }]'),
+        )
+        with pytest.raises(
+            ConfigError, match=r"libc-version must be a 2.x version for glibc, got 3.0"
+        ):
+            read_pyproject_config(path)
+
+    def test_platform_table_musl_version_major_must_be_1(self, tmp_path: Path) -> None:
+        """musl has only ever shipped 1.x, so a 2.x target is a typo."""
+        path = write(
+            tmp_path,
+            self._platforms_body(
+                '[{ id = "linux_x86_64", libc = "musl", libc-version = "2.0" }]'
+            ),
+        )
+        with pytest.raises(
+            ConfigError, match=r"libc-version must be a 1.x version for musl, got 2.0"
+        ):
+            read_pyproject_config(path)
+
     def test_same_id_under_two_libc_families_is_a_duplicate(
         self, tmp_path: Path
     ) -> None:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -2750,14 +2750,14 @@ class TestMatrix:
         path = write(
             tmp_path,
             self._platforms_body(
-                '["linux_x86_64", { id = "linux_x86_64", libc = "musl",'
+                '["macos_arm64", { id = "linux_x86_64", libc = "musl",'
                 ' libc-version = "1.2" }]'
             ),
         )
         matrix = read_pyproject_config(path).matrix
         assert matrix is not None
         assert matrix.platforms == (
-            "linux_x86_64",
+            "macos_arm64",
             PlatformSpec("linux_x86_64", libc="musl", libc_version=(1, 2)),
         )
 
@@ -2857,25 +2857,94 @@ class TestMatrix:
         with pytest.raises(ConfigError, match="libc-version must be a string"):
             read_pyproject_config(path)
 
-    def test_same_id_different_libc_is_not_a_duplicate(self, tmp_path: Path) -> None:
-        """One id under two libc families is two distinct targets."""
+    def test_same_id_under_two_libc_families_is_a_duplicate(
+        self, tmp_path: Path
+    ) -> None:
+        """Both libc families of one id cannot share a lock.
+
+        The two targets render the same PEP 508 marker (there is no libc
+        marker variable), so the lockfile could not tell their pins apart.
+        """
         path = write(
             tmp_path,
             self._platforms_body(
                 '["linux_x86_64", { id = "linux_x86_64", libc = "musl" }]'
             ),
         )
-        matrix = read_pyproject_config(path).matrix
-        assert matrix is not None
-        assert len(matrix.platforms) == 2
+        with pytest.raises(ConfigError, match="matrix.platforms has duplicate entry"):
+            read_pyproject_config(path)
+
+    def test_same_id_free_threaded_and_gil_is_a_duplicate(self, tmp_path: Path) -> None:
+        """A free-threaded and a GIL target of one id cannot share a lock."""
+        path = write(
+            tmp_path,
+            self._platforms_body(
+                '["linux_x86_64", { id = "linux_x86_64", free-threaded = true }]'
+            ),
+        )
+        with pytest.raises(ConfigError, match="matrix.platforms has duplicate entry"):
+            read_pyproject_config(path)
 
     def test_table_repeating_a_bare_id_is_a_duplicate(self, tmp_path: Path) -> None:
-        """A defaults-only table collapses onto the bare id's label."""
+        """A defaults-only table repeats the bare id."""
         path = write(
             tmp_path,
             self._platforms_body('["linux_x86_64", { id = "linux_x86_64" }]'),
         )
         with pytest.raises(ConfigError, match="matrix.platforms has duplicate entry"):
+            read_pyproject_config(path)
+
+    def test_free_threaded_platform(self, tmp_path: Path) -> None:
+        """``free-threaded`` lands on the spec."""
+        path = write(
+            tmp_path,
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.13"\n'
+            'platforms = [{ id = "linux_x86_64", free-threaded = true }]\n',
+        )
+        matrix = read_pyproject_config(path).matrix
+        assert matrix is not None
+        assert matrix.platforms == (PlatformSpec("linux_x86_64", free_threaded=True),)
+
+    def test_free_threaded_must_be_a_boolean(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            self._platforms_body(
+                '[{ id = "linux_x86_64", free-threaded = "yes" }]',
+            ),
+        )
+        with pytest.raises(ConfigError, match="free-threaded must be a boolean"):
+            read_pyproject_config(path)
+
+    def test_free_threaded_rejects_python_below_3_13(self, tmp_path: Path) -> None:
+        """3.12 has no free-threaded build, so its cp312t ABI matches nothing."""
+        path = write(
+            tmp_path,
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            "[tool.nab.matrix]\n"
+            'python = ">=3.12,<3.14"\n'
+            'platforms = [{ id = "linux_x86_64", free-threaded = true }]\n',
+        )
+        with pytest.raises(
+            ConfigError, match="the free-threaded build starts at CPython 3.13"
+        ):
+            read_pyproject_config(path)
+
+    def test_free_threaded_rejects_pypy(self, tmp_path: Path) -> None:
+        """PyPy has no free-threaded build."""
+        path = write(
+            tmp_path,
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.13"\n'
+            'platforms = [{ id = "linux_x86_64", free-threaded = true }]\n'
+            'implementations = ["cpython", "pypy"]\n',
+        )
+        with pytest.raises(ConfigError, match="only CPython has a free-threaded build"):
             read_pyproject_config(path)
 
     def test_invalid_python_order(self, tmp_path: Path) -> None:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -2599,7 +2599,7 @@ class TestMatrix:
         assert config.mode is ResolveMode.UNIVERSAL
         assert config.matrix == MatrixConfig(
             python=">=3.11,<3.14",
-            platforms=("linux_x86_64", "macos_arm64"),
+            platforms=(PlatformSpec("linux_x86_64"), PlatformSpec("macos_arm64")),
         )
 
     def test_python_order_and_patches(self, tmp_path: Path) -> None:
@@ -2757,9 +2757,29 @@ class TestMatrix:
         matrix = read_pyproject_config(path).matrix
         assert matrix is not None
         assert matrix.platforms == (
-            "macos_arm64",
+            PlatformSpec("macos_arm64"),
             PlatformSpec("linux_x86_64", libc="musl", libc_version=(1, 2)),
         )
+
+    @pytest.mark.parametrize(
+        ("entry", "message"),
+        [
+            ('{ id = "windows_amd64", libc = "musl" }', "libc is a Linux knob"),
+            ('{ id = "macos_arm64", libc-version = "2.28" }', "libc is a Linux knob"),
+            (
+                '{ id = "linux_x86_64", macos-min = "14.0" }',
+                "macos-min is a macOS knob",
+            ),
+            ('{ id = "macos_arm64", macos-min = "9.0" }', "below 10.0"),
+        ],
+    )
+    def test_platform_table_rejects_a_knob_the_platform_cannot_use(
+        self, tmp_path: Path, entry: str, message: str
+    ) -> None:
+        """A knob the platform never reads still names the target, so it raises."""
+        path = write(tmp_path, self._platforms_body(f"[{entry}]"))
+        with pytest.raises(ConfigError, match=message):
+            read_pyproject_config(path)
 
     def test_platform_table_all_knobs(self, tmp_path: Path) -> None:
         """Every table key lands on the spec."""
@@ -2863,9 +2883,7 @@ class TestMatrix:
             tmp_path,
             self._platforms_body('[{ id = "linux_x86_64", libc-version = "3.0" }]'),
         )
-        with pytest.raises(
-            ConfigError, match=r"libc-version must be a 2.x version for glibc, got 3.0"
-        ):
+        with pytest.raises(ConfigError, match=r"glibc has only a 2.x series"):
             read_pyproject_config(path)
 
     def test_platform_table_musl_version_major_must_be_1(self, tmp_path: Path) -> None:
@@ -2876,9 +2894,7 @@ class TestMatrix:
                 '[{ id = "linux_x86_64", libc = "musl", libc-version = "2.0" }]'
             ),
         )
-        with pytest.raises(
-            ConfigError, match=r"libc-version must be a 1.x version for musl, got 2.0"
-        ):
+        with pytest.raises(ConfigError, match=r"musl has only a 1.x series"):
             read_pyproject_config(path)
 
     def test_same_id_under_two_libc_families_is_a_duplicate(
@@ -3491,7 +3507,7 @@ class TestProjectNabTomlConfiguresResolve:
         config = read_pyproject_config(path, discover_workspace=False)
         assert config.mode is ResolveMode.UNIVERSAL
         assert config.matrix is not None
-        assert config.matrix.platforms == ("linux_x86_64",)
+        assert config.matrix.platforms == (PlatformSpec("linux_x86_64"),)
         # Universal mode forces the build-policy floor to never even though
         # the project-nab.toml set no build-policy.
         assert config.build_policy is BuildPolicy.NEVER

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -2967,9 +2967,7 @@ class TestMatrix:
             'python = ">=3.12,<3.14"\n'
             'platforms = [{ id = "linux_x86_64", free-threaded = true }]\n',
         )
-        with pytest.raises(
-            ConfigError, match="the free-threaded build starts at CPython 3.13"
-        ):
+        with pytest.raises(ConfigError, match="needs CPython 3.13 or newer"):
             read_pyproject_config(path)
 
     def test_free_threaded_rejects_pypy(self, tmp_path: Path) -> None:
@@ -2983,7 +2981,7 @@ class TestMatrix:
             'platforms = [{ id = "linux_x86_64", free-threaded = true }]\n'
             'implementations = ["cpython", "pypy"]\n',
         )
-        with pytest.raises(ConfigError, match="only CPython has a free-threaded build"):
+        with pytest.raises(ConfigError, match="needs CPython, not"):
             read_pyproject_config(path)
 
     def test_invalid_python_order(self, tmp_path: Path) -> None:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -45,6 +45,7 @@ from nab_python.provider import (
     VcsPolicy,
     VcsSource,
 )
+from nab_python.tags import PlatformSpec
 from nab_python.workspace import WorkspaceConfig
 
 
@@ -2733,6 +2734,148 @@ class TestMatrix:
         with pytest.raises(
             ConfigError, match="matrix.platforms must list at least one"
         ):
+            read_pyproject_config(path)
+
+    def _platforms_body(self, platforms: str) -> str:
+        return (
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.12"\n'
+            f"platforms = {platforms}\n"
+        )
+
+    def test_platform_table_form(self, tmp_path: Path) -> None:
+        """A table entry reaches the tag knobs a bare id cannot."""
+        path = write(
+            tmp_path,
+            self._platforms_body(
+                '["linux_x86_64", { id = "linux_x86_64", libc = "musl",'
+                ' libc-version = "1.2" }]'
+            ),
+        )
+        matrix = read_pyproject_config(path).matrix
+        assert matrix is not None
+        assert matrix.platforms == (
+            "linux_x86_64",
+            PlatformSpec("linux_x86_64", libc="musl", libc_version=(1, 2)),
+        )
+
+    def test_platform_table_all_knobs(self, tmp_path: Path) -> None:
+        """Every table key lands on the spec."""
+        path = write(
+            tmp_path,
+            self._platforms_body(
+                '[{ id = "macos_arm64", macos-min = "14.0",'
+                ' platform-release = "23.1.0", platform-version = "Darwin 23" }]'
+            ),
+        )
+        matrix = read_pyproject_config(path).matrix
+        assert matrix is not None
+        assert matrix.platforms == (
+            PlatformSpec(
+                "macos_arm64",
+                macos_min=(14, 0),
+                platform_release="23.1.0",
+                platform_version="Darwin 23",
+            ),
+        )
+
+    def test_platform_table_defaults_match_bare_id(self, tmp_path: Path) -> None:
+        """A table with only ``id`` is the bare-string form."""
+        path = write(tmp_path, self._platforms_body('[{ id = "linux_x86_64" }]'))
+        matrix = read_pyproject_config(path).matrix
+        assert matrix is not None
+        assert matrix.platforms == (PlatformSpec("linux_x86_64"),)
+
+    def test_platform_table_unknown_key(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            self._platforms_body('[{ id = "linux_x86_64", glibc = "2.28" }]'),
+        )
+        with pytest.raises(
+            ConfigError, match=r"unknown matrix.platforms\[0\] keys: \['glibc'\]"
+        ):
+            read_pyproject_config(path)
+
+    def test_platform_table_missing_id(self, tmp_path: Path) -> None:
+        path = write(tmp_path, self._platforms_body('[{ libc = "musl" }]'))
+        with pytest.raises(
+            ConfigError, match=r"matrix.platforms\[0\] missing required key 'id'"
+        ):
+            read_pyproject_config(path)
+
+    def test_platform_table_bad_libc(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            self._platforms_body('[{ id = "linux_x86_64", libc = "uclibc" }]'),
+        )
+        with pytest.raises(ConfigError, match="libc must be one of"):
+            read_pyproject_config(path)
+
+    def test_platform_table_id_must_be_a_string(self, tmp_path: Path) -> None:
+        path = write(tmp_path, self._platforms_body("[{ id = 3 }]"))
+        with pytest.raises(
+            ConfigError, match=r"matrix.platforms\[0\].id must be a string"
+        ):
+            read_pyproject_config(path)
+
+    def test_platform_entry_must_be_string_or_table(self, tmp_path: Path) -> None:
+        path = write(tmp_path, self._platforms_body("[3]"))
+        with pytest.raises(
+            ConfigError, match=r"matrix.platforms\[0\] must be a platform id or a table"
+        ):
+            read_pyproject_config(path)
+
+    def test_platforms_must_be_a_list(self, tmp_path: Path) -> None:
+        path = write(tmp_path, self._platforms_body('"linux_x86_64"'))
+        with pytest.raises(ConfigError, match="matrix.platforms must be a list"):
+            read_pyproject_config(path)
+
+    def test_platform_table_unknown_id_still_rejected(self, tmp_path: Path) -> None:
+        """The table form does not bypass the known-platform-id check."""
+        path = write(tmp_path, self._platforms_body('[{ id = "linux_riscv64" }]'))
+        with pytest.raises(ConfigError, match="Unknown platform ids"):
+            read_pyproject_config(path)
+
+    @pytest.mark.parametrize("value", ["2", "2.28.1", "1!2.28", "2.28rc1", "garbage"])
+    def test_platform_table_bad_libc_version(self, tmp_path: Path, value: str) -> None:
+        path = write(
+            tmp_path,
+            self._platforms_body(
+                f'[{{ id = "linux_x86_64", libc-version = "{value}" }}]'
+            ),
+        )
+        with pytest.raises(ConfigError, match="libc-version must be"):
+            read_pyproject_config(path)
+
+    def test_platform_table_libc_version_must_be_a_string(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            self._platforms_body('[{ id = "linux_x86_64", libc-version = 2.28 }]'),
+        )
+        with pytest.raises(ConfigError, match="libc-version must be a string"):
+            read_pyproject_config(path)
+
+    def test_same_id_different_libc_is_not_a_duplicate(self, tmp_path: Path) -> None:
+        """One id under two libc families is two distinct targets."""
+        path = write(
+            tmp_path,
+            self._platforms_body(
+                '["linux_x86_64", { id = "linux_x86_64", libc = "musl" }]'
+            ),
+        )
+        matrix = read_pyproject_config(path).matrix
+        assert matrix is not None
+        assert len(matrix.platforms) == 2
+
+    def test_table_repeating_a_bare_id_is_a_duplicate(self, tmp_path: Path) -> None:
+        """A defaults-only table collapses onto the bare id's label."""
+        path = write(
+            tmp_path,
+            self._platforms_body('["linux_x86_64", { id = "linux_x86_64" }]'),
+        )
+        with pytest.raises(ConfigError, match="matrix.platforms has duplicate entry"):
             read_pyproject_config(path)
 
     def test_invalid_python_order(self, tmp_path: Path) -> None:

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -58,6 +58,7 @@ from nab_python.provider import (
     VcsPolicy,
     VcsSource,
 )
+from nab_python.tags import PlatformSpec
 from nab_python.workspace import WorkspaceConfig
 
 
@@ -2250,7 +2251,9 @@ class TestCrossFieldProjectOptions:
         _project(tmp_path, _MATRIX_PYPROJECT)
         eff = _resolve(SourceRoots(project_dir=tmp_path))
         value = eff["matrix"].value
-        assert value == MatrixConfig(python=">=3.11,<3.12", platforms=("linux_x86_64",))
+        assert value == MatrixConfig(
+            python=">=3.11,<3.12", platforms=(PlatformSpec("linux_x86_64"),)
+        )
         assert eff["matrix"].origin.kind is SourceKind.PYPROJECT
 
     def test_matrix_from_project_nab_toml(self, tmp_path: Path) -> None:
@@ -2258,7 +2261,7 @@ class TestCrossFieldProjectOptions:
         _write(tmp_path / "nab.toml", _MATRIX_PROJECT_TOML)
         eff = _resolve(SourceRoots(project_dir=tmp_path))
         assert eff["matrix"].value == MatrixConfig(
-            python=">=3.11,<3.12", platforms=("linux_x86_64",)
+            python=">=3.11,<3.12", platforms=(PlatformSpec("linux_x86_64"),)
         )
         assert eff["matrix"].origin.kind is SourceKind.PROJECT_TOML
 
@@ -2302,7 +2305,7 @@ class TestCrossFieldProjectOptions:
         _write(tmp_path / "nab.toml", _MATRIX_PROJECT_TOML)
         eff = _resolve(SourceRoots(project_dir=tmp_path))
         assert eff["matrix"].value == MatrixConfig(
-            python=">=3.11,<3.12", platforms=("linux_x86_64",)
+            python=">=3.11,<3.12", platforms=(PlatformSpec("linux_x86_64"),)
         )
         assert eff["matrix"].origin.kind is SourceKind.PROJECT_TOML
 
@@ -2315,7 +2318,10 @@ class TestCrossFieldProjectOptions:
     def test_matrix_render_axes(self) -> None:
         spec = next(s for s in OPTIONS if s.key == "matrix")
         rendered = spec.render(
-            MatrixConfig(python=">=3.11", platforms=("linux_x86_64", "macos_arm64"))
+            MatrixConfig(
+                python=">=3.11",
+                platforms=(PlatformSpec("linux_x86_64"), PlatformSpec("macos_arm64")),
+            )
         )
         assert rendered == "python=>=3.11, platforms=['linux_x86_64', 'macos_arm64']"
 

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -44,6 +44,7 @@ from nab_python.resolve import (
     resolve_pyproject,
     resolve_universal_pyproject,
 )
+from nab_python.tags import PlatformSpec
 from nab_python.universal.matrix import MatrixTuple
 from nab_resolver.ranges import Range
 from nab_resolver.resolver import (
@@ -1176,7 +1177,10 @@ class TestResolveUniversalPyproject:
         assert result is sentinel
         kwargs = mock_resolve_universal.call_args.kwargs
         assert kwargs["matrix"].python == ">=3.11,<3.13"
-        assert kwargs["matrix"].platforms == ("linux_x86_64", "macos_arm64")
+        assert kwargs["matrix"].platforms == (
+            PlatformSpec("linux_x86_64"),
+            PlatformSpec("macos_arm64"),
+        )
         # No conflicts: a single unforked fork carrying the base deps.
         (fork,) = kwargs["forks"]
         assert fork.selection == ()
@@ -1214,7 +1218,9 @@ class TestResolveUniversalPyproject:
         pyproject.write_text('[project]\ndependencies = ["foo"]\n')
         config = NabProjectConfig(
             mode=ResolveMode.UNIVERSAL,
-            matrix=MatrixConfig(python=">=3.12,<3.14", platforms=("linux_x86_64",)),
+            matrix=MatrixConfig(
+                python=">=3.12,<3.14", platforms=(PlatformSpec("linux_x86_64"),)
+            ),
         )
         resolve_universal_pyproject(pyproject, config=config)
         kwargs = mock_resolve_universal.call_args.kwargs

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -2557,7 +2557,7 @@ def _tuple_for_python(python_version: str) -> MatrixTuple:
     """
     return MatrixTuple(
         python_version=python_version,
-        platform_id="linux_x86_64",
+        platform_spec=PlatformSpec("linux_x86_64"),
         environment={
             "python_version": python_version,
             "python_full_version": f"{python_version}.0",

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -17,15 +17,31 @@ from unittest.mock import patch
 import pytest
 
 from nab_index.client import WheelFile
-from nab_python.universal.wheel_selection import (
+from nab_python.tags import (
     _PLATFORM_ARCH,
     _PLATFORM_KIND,
     PlatformSpec,
     _platform_tags_for_spec,
-    compatible_tags_for_tuple,
-    select_wheel_for_tuple,
-    wheel_compatible_with_tuple,
+    select_wheel,
+    tags_for_target,
 )
+
+
+def _compatible(
+    wheel: WheelFile,
+    *,
+    python_version: str,
+    spec: PlatformSpec,
+    implementation: str = "cpython",
+) -> bool:
+    """True iff the target would install ``wheel``, given only that wheel."""
+    chosen = select_wheel(
+        [wheel],
+        python_version=python_version,
+        spec=spec,
+        implementation=implementation,
+    )
+    return chosen is not None
 
 
 def _wheel(filename: str) -> WheelFile:
@@ -79,32 +95,26 @@ class TestPlatformSpec:
         assert spec.label_suffix() == "-glibc2.17-musl1.2-rel5.15.0_2d_generic"
 
 
-class TestCompatibleTagsForTuple:
-    """``compatible_tags_for_tuple`` produces the full PEP 425 tag set."""
+class TestTagsForTarget:
+    """``tags_for_target`` produces the full PEP 425 tag set."""
 
     def test_linux_includes_manylinux_at_or_below_floor(self) -> None:
         """A linux_x86_64 spec with floor 2.17 admits manylinux_2_17 and below."""
         spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
-        tag_strs = {
-            str(t) for t in compatible_tags_for_tuple(python_version="3.11", spec=spec)
-        }
+        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
         assert "cp311-cp311-manylinux_2_17_x86_64" in tag_strs
         assert "cp311-cp311-manylinux_2_5_x86_64" in tag_strs
 
     def test_linux_excludes_manylinux_above_floor(self) -> None:
         """manylinux_2_28 is NOT in the set when floor is 2.17."""
         spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
-        tag_strs = {
-            str(t) for t in compatible_tags_for_tuple(python_version="3.11", spec=spec)
-        }
+        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
         assert "cp311-cp311-manylinux_2_28_x86_64" not in tag_strs
 
     def test_linux_includes_legacy_aliases(self) -> None:
         """manylinux1, manylinux2010, manylinux2014 aliases are included."""
         spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
-        tag_strs = {
-            str(t) for t in compatible_tags_for_tuple(python_version="3.11", spec=spec)
-        }
+        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
         assert "cp311-cp311-manylinux1_x86_64" in tag_strs
         assert "cp311-cp311-manylinux2010_x86_64" in tag_strs
         assert "cp311-cp311-manylinux2014_x86_64" in tag_strs
@@ -112,18 +122,14 @@ class TestCompatibleTagsForTuple:
     def test_linux_excludes_aliases_above_floor(self) -> None:
         """manylinux2014 is excluded when floor is below 2.17."""
         spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 12))
-        tag_strs = {
-            str(t) for t in compatible_tags_for_tuple(python_version="3.11", spec=spec)
-        }
+        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
         assert "cp311-cp311-manylinux2014_x86_64" not in tag_strs
         assert "cp311-cp311-manylinux2010_x86_64" in tag_strs
 
     def test_aarch64_manylinux_floor_stops_at_2_17(self) -> None:
         """aarch64 does not descend below glibc 2.17 (PEP 599)."""
         spec = PlatformSpec("linux_aarch64", manylinux_floor=(2, 17))
-        tag_strs = {
-            str(t) for t in compatible_tags_for_tuple(python_version="3.11", spec=spec)
-        }
+        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
         assert "cp311-cp311-manylinux_2_17_aarch64" in tag_strs
         assert "cp311-cp311-manylinux2014_aarch64" in tag_strs
         assert "cp311-cp311-manylinux_2_16_aarch64" not in tag_strs
@@ -136,43 +142,33 @@ class TestCompatibleTagsForTuple:
         spec = PlatformSpec("linux_aarch64")
         for alias in ("manylinux1", "manylinux2010"):
             wheel = _wheel(f"foo-1.0-cp311-cp311-{alias}_aarch64.whl")
-            assert not wheel_compatible_with_tuple(
-                wheel, python_version="3.11", spec=spec
-            )
+            assert not _compatible(wheel, python_version="3.11", spec=spec)
 
     def test_x86_64_keeps_legacy_alias_floor(self) -> None:
         """x86_64 still descends to manylinux1 (glibc 2.5)."""
         spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
-        tag_strs = {
-            str(t) for t in compatible_tags_for_tuple(python_version="3.11", spec=spec)
-        }
+        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
         assert "cp311-cp311-manylinux1_x86_64" in tag_strs
         assert "cp311-cp311-manylinux_2_5_x86_64" in tag_strs
 
     def test_non_glibc2_floor_descends_to_x_0(self) -> None:
         """A glibc 3.x floor descends to 3.0 on any arch (the 2.17 cap is glibc 2.x only)."""
         spec = PlatformSpec("linux_aarch64", manylinux_floor=(3, 1))
-        tag_strs = {
-            str(t) for t in compatible_tags_for_tuple(python_version="3.11", spec=spec)
-        }
+        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
         assert "cp311-cp311-manylinux_3_1_aarch64" in tag_strs
         assert "cp311-cp311-manylinux_3_0_aarch64" in tag_strs
 
     def test_linux_includes_musllinux_at_floor(self) -> None:
         """Musllinux at-or-below the floor is admitted."""
         spec = PlatformSpec("linux_x86_64", musllinux_floor=(1, 2))
-        tag_strs = {
-            str(t) for t in compatible_tags_for_tuple(python_version="3.11", spec=spec)
-        }
+        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
         assert "cp311-cp311-musllinux_1_2_x86_64" in tag_strs
         assert "cp311-cp311-musllinux_1_0_x86_64" in tag_strs
 
     def test_macos_arm64_default_accepts_modern_wheels(self) -> None:
         """The default ``macos_arm64`` admits ``macosx_11_0`` and ``macosx_12_0``."""
         spec = PlatformSpec("macos_arm64")
-        tag_strs = {
-            str(t) for t in compatible_tags_for_tuple(python_version="3.11", spec=spec)
-        }
+        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
         # mac_platforms yields versions <= the declared one
         assert "cp311-cp311-macosx_11_0_arm64" in tag_strs
         assert "cp311-cp311-macosx_12_0_arm64" in tag_strs
@@ -182,52 +178,43 @@ class TestCompatibleTagsForTuple:
     def test_macos_x86_64_uses_default_floor(self) -> None:
         """``macos_x86_64`` defaults to macOS 10.13 (x86_64-era)."""
         spec = PlatformSpec("macos_x86_64")
-        tag_strs = {
-            str(t) for t in compatible_tags_for_tuple(python_version="3.11", spec=spec)
-        }
+        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
         assert "cp311-cp311-macosx_10_13_x86_64" in tag_strs
 
     def test_macos_explicit_min(self) -> None:
         """An explicit ``macos_min`` overrides the default."""
         spec = PlatformSpec("macos_arm64", macos_min=(14, 0))
-        tag_strs = {
-            str(t) for t in compatible_tags_for_tuple(python_version="3.11", spec=spec)
-        }
+        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
         assert "cp311-cp311-macosx_14_0_arm64" in tag_strs
 
     def test_windows_amd64(self) -> None:
         """Windows amd64 generates ``win_amd64`` tags."""
         spec = PlatformSpec("windows_amd64")
-        tag_strs = {
-            str(t) for t in compatible_tags_for_tuple(python_version="3.11", spec=spec)
-        }
+        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
         assert "cp311-cp311-win_amd64" in tag_strs
 
     def test_includes_universal_tags(self) -> None:
         """``py3-none-any`` and ``cp311-none-any`` are always in the set."""
         spec = PlatformSpec("linux_x86_64")
-        tag_strs = {
-            str(t) for t in compatible_tags_for_tuple(python_version="3.11", spec=spec)
-        }
-        # cp311-none-any only appears for windows in compatible_tags;
-        # py3-none-any is the universal pure-Python tag.
-        assert any(t == "py3-none-any" for t in tag_strs)
+        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
+        assert "py3-none-any" in tag_strs
+        assert "cp311-none-any" in tag_strs
 
 
 class TestWheelCompatibility:
-    """``wheel_compatible_with_tuple`` accepts/rejects per the tag rules."""
+    """A wheel is a candidate iff its tags meet the target's tag set."""
 
     def test_accepts_at_floor_manylinux(self) -> None:
         """A manylinux_2_17 wheel matches a 2.17-floor linux spec."""
         spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
         wheel = _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl")
-        assert wheel_compatible_with_tuple(wheel, python_version="3.11", spec=spec)
+        assert _compatible(wheel, python_version="3.11", spec=spec)
 
     def test_rejects_above_floor_manylinux(self) -> None:
         """A manylinux_2_28 wheel does not match a 2.17-floor linux spec."""
         spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
         wheel = _wheel("pkg-1.0-cp311-cp311-manylinux_2_28_x86_64.whl")
-        assert not wheel_compatible_with_tuple(wheel, python_version="3.11", spec=spec)
+        assert not _compatible(wheel, python_version="3.11", spec=spec)
 
     def test_accepts_universal_wheel(self) -> None:
         """``py3-none-any`` is accepted by every platform."""
@@ -238,40 +225,40 @@ class TestWheelCompatibility:
             "windows_amd64",
         ):
             spec = PlatformSpec(platform_id)
-            assert wheel_compatible_with_tuple(wheel, python_version="3.11", spec=spec)
+            assert _compatible(wheel, python_version="3.11", spec=spec)
 
     def test_rejects_wrong_arch(self) -> None:
         """An aarch64 wheel does not match a x86_64 spec."""
         spec = PlatformSpec("linux_x86_64")
         wheel = _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_aarch64.whl")
-        assert not wheel_compatible_with_tuple(wheel, python_version="3.11", spec=spec)
+        assert not _compatible(wheel, python_version="3.11", spec=spec)
 
     def test_rejects_wrong_python_minor(self) -> None:
         """A cp311 wheel does not match a 3.12 tuple."""
         spec = PlatformSpec("linux_x86_64")
         wheel = _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl")
-        assert not wheel_compatible_with_tuple(wheel, python_version="3.12", spec=spec)
+        assert not _compatible(wheel, python_version="3.12", spec=spec)
 
     def test_compressed_tag_set(self) -> None:
         """A wheel with cp310.cp311 matches both 3.10 and 3.11."""
         spec = PlatformSpec("linux_x86_64")
         wheel = _wheel("pkg-1.0-cp310.cp311-cp310.cp311-manylinux_2_17_x86_64.whl")
-        assert wheel_compatible_with_tuple(wheel, python_version="3.10", spec=spec)
-        assert wheel_compatible_with_tuple(wheel, python_version="3.11", spec=spec)
+        assert _compatible(wheel, python_version="3.10", spec=spec)
+        assert _compatible(wheel, python_version="3.11", spec=spec)
 
     def test_abi3_forward_compat(self) -> None:
         """A cp310-abi3 wheel works on 3.10, 3.11, etc."""
         spec = PlatformSpec("linux_x86_64")
         wheel = _wheel("pkg-1.0-cp310-abi3-manylinux_2_17_x86_64.whl")
-        assert wheel_compatible_with_tuple(wheel, python_version="3.10", spec=spec)
-        assert wheel_compatible_with_tuple(wheel, python_version="3.13", spec=spec)
+        assert _compatible(wheel, python_version="3.10", spec=spec)
+        assert _compatible(wheel, python_version="3.13", spec=spec)
 
     def test_default_macos_arm64_accepts_modern_arm64_wheel(self) -> None:
         """``macosx_11_0`` and ``macosx_12_0`` wheels match the default spec."""
         spec = PlatformSpec("macos_arm64")
         for tag in ("macosx_11_0_arm64", "macosx_12_0_arm64"):
             wheel = _wheel(f"pkg-1.0-cp311-cp311-{tag}.whl")
-            assert wheel_compatible_with_tuple(wheel, python_version="3.11", spec=spec)
+            assert _compatible(wheel, python_version="3.11", spec=spec)
 
     def test_garbage_filename(self) -> None:
         """A non-wheel filename is rejected."""
@@ -284,7 +271,7 @@ class TestWheelCompatibility:
             has_metadata=False,
             upload_time=None,
         )
-        assert not wheel_compatible_with_tuple(wheel, python_version="3.11", spec=spec)
+        assert not _compatible(wheel, python_version="3.11", spec=spec)
 
     def test_too_few_dashes(self) -> None:
         """A wheel filename with too few dashes is rejected."""
@@ -297,7 +284,7 @@ class TestWheelCompatibility:
             has_metadata=False,
             upload_time=None,
         )
-        assert not wheel_compatible_with_tuple(wheel, python_version="3.11", spec=spec)
+        assert not _compatible(wheel, python_version="3.11", spec=spec)
 
     def test_non_whl_extension_rejected(self) -> None:
         """A filename without ``.whl`` extension is rejected."""
@@ -310,9 +297,7 @@ class TestWheelCompatibility:
             has_metadata=False,
             upload_time=None,
         )
-        assert not wheel_compatible_with_tuple(
-            sdist_like, python_version="3.11", spec=spec
-        )
+        assert not _compatible(sdist_like, python_version="3.11", spec=spec)
 
     def test_unparseable_tag_string(self) -> None:
         """A wheel whose tag segment trips ``parse_tag`` is rejected.
@@ -321,7 +306,7 @@ class TestWheelCompatibility:
         few error paths (e.g. an empty tag).  We patch it to raise
         and verify our ``except Exception`` handler returns None.
         """
-        from nab_python.universal.wheel_selection import _parse_tag_str
+        from nab_python.tags import _parse_tag_str
 
         spec = PlatformSpec("linux_x86_64")
         wheel = WheelFile(
@@ -332,32 +317,34 @@ class TestWheelCompatibility:
             has_metadata=False,
             upload_time=None,
         )
-        # Clear any prior cached result on this tag suffix so the
-        # patched ``parse_tag`` is exercised regardless of test ordering.
+        # Clear any prior cached result on this tag suffix so the patched
+        # ``parse_tag`` is exercised, and clear the None it caches so no
+        # later test sees this common suffix as unparseable.
         _parse_tag_str.cache_clear()
-        with patch(
-            "nab_python.universal.wheel_selection.ptags.parse_tag",
-            side_effect=ValueError("forced"),
-        ):
-            assert not wheel_compatible_with_tuple(
-                wheel, python_version="3.11", spec=spec
-            )
+        try:
+            with patch(
+                "nab_python.tags.ptags.parse_tag",
+                side_effect=ValueError("forced"),
+            ):
+                assert not _compatible(wheel, python_version="3.11", spec=spec)
+        finally:
+            _parse_tag_str.cache_clear()
 
 
-class TestSelectWheelForTuple:
+class TestSelectWheel:
     """Selection prefers more-specific tags."""
 
     def test_no_compatible_returns_none(self) -> None:
         """No compatible wheel -> None."""
         spec = PlatformSpec("linux_x86_64")
         wheels = [_wheel("pkg-1.0-cp311-cp311-win_amd64.whl")]
-        assert select_wheel_for_tuple(wheels, python_version="3.11", spec=spec) is None
+        assert select_wheel(wheels, python_version="3.11", spec=spec) is None
 
     def test_default_macos_arm64_selects_modern_only_wheel(self) -> None:
         """A version shipping only a ``macosx_12_0`` arm64 wheel is selectable."""
         spec = PlatformSpec("macos_arm64")
         wheels = [_wheel("pkg-2.2.0-cp312-cp312-macosx_12_0_arm64.whl")]
-        chosen = select_wheel_for_tuple(wheels, python_version="3.12", spec=spec)
+        chosen = select_wheel(wheels, python_version="3.12", spec=spec)
         assert chosen is not None
         assert chosen.filename == "pkg-2.2.0-cp312-cp312-macosx_12_0_arm64.whl"
 
@@ -368,7 +355,7 @@ class TestSelectWheelForTuple:
             _wheel("pkg-2.2.0-py3-none-any.whl"),
             _wheel("pkg-2.2.0-cp312-cp312-macosx_12_0_arm64.whl"),
         ]
-        chosen = select_wheel_for_tuple(wheels, python_version="3.12", spec=spec)
+        chosen = select_wheel(wheels, python_version="3.12", spec=spec)
         assert chosen is not None
         assert chosen.filename == "pkg-2.2.0-cp312-cp312-macosx_12_0_arm64.whl"
 
@@ -379,7 +366,7 @@ class TestSelectWheelForTuple:
             _wheel("pkg-1.0-py3-none-any.whl"),
             _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl"),
         ]
-        chosen = select_wheel_for_tuple(wheels, python_version="3.11", spec=spec)
+        chosen = select_wheel(wheels, python_version="3.11", spec=spec)
         assert chosen is not None
         assert "manylinux" in chosen.filename
 
@@ -387,7 +374,7 @@ class TestSelectWheelForTuple:
         """When only py3-none-any is compatible, it wins."""
         spec = PlatformSpec("linux_x86_64")
         wheels = [_wheel("pkg-1.0-py3-none-any.whl")]
-        chosen = select_wheel_for_tuple(wheels, python_version="3.11", spec=spec)
+        chosen = select_wheel(wheels, python_version="3.11", spec=spec)
         assert chosen is not None
         assert chosen.filename == "pkg-1.0-py3-none-any.whl"
 
@@ -406,7 +393,7 @@ class TestSelectWheelForTuple:
             ),
             good,
         ]
-        chosen = select_wheel_for_tuple(wheels, python_version="3.11", spec=spec)
+        chosen = select_wheel(wheels, python_version="3.11", spec=spec)
         assert chosen is good
 
     def test_higher_glibc_wheel_wins_over_lower(self) -> None:
@@ -421,7 +408,7 @@ class TestSelectWheelForTuple:
             _wheel("pkg-1.0-cp311-cp311-manylinux_2_5_x86_64.whl"),
             _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl"),
         ]
-        chosen = select_wheel_for_tuple(wheels, python_version="3.11", spec=spec)
+        chosen = select_wheel(wheels, python_version="3.11", spec=spec)
         assert chosen is not None
         assert "manylinux_2_17" in chosen.filename
 
@@ -438,7 +425,7 @@ class TestSelectWheelForTuple:
             _wheel("pkg-1.0-cp311-cp311-manylinux_2_5_x86_64.whl"),
             _wheel("pkg-1.0-cp311-cp311-manylinux2014_x86_64.whl"),
         ]
-        chosen = select_wheel_for_tuple(wheels, python_version="3.11", spec=spec)
+        chosen = select_wheel(wheels, python_version="3.11", spec=spec)
         assert chosen is not None
         assert "manylinux2014" in chosen.filename
 
@@ -454,7 +441,7 @@ class TestSelectWheelForTuple:
             _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl"),
             _wheel("pkg-1.0-cp311-cp311-manylinux_2_5_x86_64.whl"),
         ]
-        chosen = select_wheel_for_tuple(wheels, python_version="3.11", spec=spec)
+        chosen = select_wheel(wheels, python_version="3.11", spec=spec)
         assert chosen is not None
         assert "manylinux_2_17" in chosen.filename
 
@@ -463,9 +450,7 @@ class TestSelectWheelForTuple:
         spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
         build1 = _wheel("pkg-1.0-1-cp311-cp311-manylinux_2_17_x86_64.whl")
         build5 = _wheel("pkg-1.0-5-cp311-cp311-manylinux_2_17_x86_64.whl")
-        chosen = select_wheel_for_tuple(
-            [build1, build5], python_version="3.11", spec=spec
-        )
+        chosen = select_wheel([build1, build5], python_version="3.11", spec=spec)
         assert chosen is build5
 
     def test_build_tag_selection_is_order_independent(self) -> None:
@@ -473,12 +458,8 @@ class TestSelectWheelForTuple:
         spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
         build1 = _wheel("pkg-1.0-1-cp311-cp311-manylinux_2_17_x86_64.whl")
         build5 = _wheel("pkg-1.0-5-cp311-cp311-manylinux_2_17_x86_64.whl")
-        forward = select_wheel_for_tuple(
-            [build1, build5], python_version="3.11", spec=spec
-        )
-        reverse = select_wheel_for_tuple(
-            [build5, build1], python_version="3.11", spec=spec
-        )
+        forward = select_wheel([build1, build5], python_version="3.11", spec=spec)
+        reverse = select_wheel([build5, build1], python_version="3.11", spec=spec)
         assert forward is build5
         assert reverse is build5
 
@@ -487,9 +468,7 @@ class TestSelectWheelForTuple:
         spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
         untagged = _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl")
         build3 = _wheel("pkg-1.0-3-cp311-cp311-manylinux_2_17_x86_64.whl")
-        chosen = select_wheel_for_tuple(
-            [untagged, build3], python_version="3.11", spec=spec
-        )
+        chosen = select_wheel([untagged, build3], python_version="3.11", spec=spec)
         assert chosen is build3
 
     def test_malformed_build_tag_treated_as_absent(self) -> None:
@@ -497,9 +476,7 @@ class TestSelectWheelForTuple:
         spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
         malformed = _wheel("pkg-1.0-x-cp311-cp311-manylinux_2_17_x86_64.whl")
         build5 = _wheel("pkg-1.0-5-cp311-cp311-manylinux_2_17_x86_64.whl")
-        chosen = select_wheel_for_tuple(
-            [malformed, build5], python_version="3.11", spec=spec
-        )
+        chosen = select_wheel([malformed, build5], python_version="3.11", spec=spec)
         assert chosen is build5
 
 
@@ -533,42 +510,42 @@ class TestPyPyTags:
     def test_pypy_wheel_matches_pypy_tuple(self) -> None:
         """A real ``ppXY-pypyXY_pp73`` wheel matches its PyPy tuple."""
         wheel = _wheel("numpy-1.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.whl")
-        assert wheel_compatible_with_tuple(
+        assert _compatible(
             wheel, python_version="3.11", spec=self.SPEC, implementation="pypy"
         )
 
     def test_pypy_none_wheel_matches_pypy_tuple(self) -> None:
         """A ``ppXY-none`` interpreter-specific wheel matches too."""
         wheel = _wheel("foo-1.0-pp311-none-manylinux_2_17_x86_64.whl")
-        assert wheel_compatible_with_tuple(
+        assert _compatible(
             wheel, python_version="3.11", spec=self.SPEC, implementation="pypy"
         )
 
     def test_cpython_wheel_rejected_on_pypy_tuple(self) -> None:
         """A CPython wheel is not a candidate for a PyPy tuple."""
         wheel = _wheel("numpy-1.0-cp311-cp311-manylinux_2_17_x86_64.whl")
-        assert not wheel_compatible_with_tuple(
+        assert not _compatible(
             wheel, python_version="3.11", spec=self.SPEC, implementation="pypy"
         )
 
     def test_pypy_wheel_rejected_on_cpython_tuple(self) -> None:
         """A PyPy wheel is not a candidate for the default CPython tuple."""
         wheel = _wheel("numpy-1.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.whl")
-        assert not wheel_compatible_with_tuple(
+        assert not _compatible(
             wheel, python_version="3.11", spec=self.SPEC, implementation="cpython"
         )
 
     def test_pypy_minor_must_match(self) -> None:
         """A PyPy 3.10 wheel does not match a PyPy 3.11 tuple."""
         wheel = _wheel("numpy-1.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.whl")
-        assert not wheel_compatible_with_tuple(
+        assert not _compatible(
             wheel, python_version="3.11", spec=self.SPEC, implementation="pypy"
         )
 
     def test_pure_python_wheel_matches_either(self) -> None:
         """A ``py3-none-any`` wheel matches both implementations."""
         wheel = _wheel("foo-1.0-py3-none-any.whl")
-        assert wheel_compatible_with_tuple(
+        assert _compatible(
             wheel, python_version="3.11", spec=self.SPEC, implementation="pypy"
         )
 
@@ -576,7 +553,7 @@ class TestPyPyTags:
         """The PyPy-specific wheel outranks the pure-Python fallback."""
         pure = _wheel("numpy-1.0-py3-none-any.whl")
         native = _wheel("numpy-1.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.whl")
-        chosen = select_wheel_for_tuple(
+        chosen = select_wheel(
             [pure, native],
             python_version="3.11",
             spec=self.SPEC,
@@ -586,8 +563,8 @@ class TestPyPyTags:
 
     def test_compat_tag_sets_differ_by_implementation(self) -> None:
         """The CPython and PyPy tuples accept disjoint native-tag sets."""
-        cp = compatible_tags_for_tuple(python_version="3.11", spec=self.SPEC)
-        pp = compatible_tags_for_tuple(
+        cp = tags_for_target(python_version="3.11", spec=self.SPEC)
+        pp = tags_for_target(
             python_version="3.11", spec=self.SPEC, implementation="pypy"
         )
         cp_native = {t for t in cp if t.abi.startswith("cp")}

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -105,15 +105,25 @@ class TestPlatformSpecKnobsBelongToTheirPlatform:
         with pytest.raises(ValueError, match="macos-min is a macOS knob"):
             PlatformSpec(platform_id, macos_min=(14, 0))
 
-    def test_macos_min_below_the_tag_floor_raises(self) -> None:
-        """No wheel tag names a macOS older than 10.0.
+    @pytest.mark.parametrize(
+        ("platform_id", "macos_min", "floor"),
+        [
+            ("macos_x86_64", (10, 3), "10.4"),
+            ("macos_arm64", (10, 15), "11.0"),
+        ],
+    )
+    def test_macos_min_below_the_arch_floor_raises(
+        self, platform_id: str, macos_min: tuple[int, int], floor: str
+    ) -> None:
+        """No wheel tag names a macOS older than the arch itself.
 
-        ``mac_platforms`` yields nothing below it, and packaging reads an
-        empty platform list as "unset", which would silently hand the
-        target the tags of the host nab happens to be running on.
+        ``mac_platforms`` yields no x86_64 binary format below 10.4, and
+        Apple Silicon shipped at 11.0.  An empty platform list also reads to
+        packaging as "unset", which would hand the target the tags of the
+        host nab happens to be running on.
         """
-        with pytest.raises(ValueError, match="below 10.0"):
-            PlatformSpec("macos_arm64", macos_min=(9, 0))
+        with pytest.raises(ValueError, match=f"below {floor}"):
+            PlatformSpec(platform_id, macos_min=macos_min)
 
     def test_unknown_platform_id_defers_to_the_matrix(self) -> None:
         """An unknown id is the matrix's error to report, not the spec's."""
@@ -126,8 +136,7 @@ class TestPlatformSpec:
     def test_default_libc_is_glibc_2_28(self) -> None:
         """An undeclared Linux target is glibc 2.28."""
         spec = PlatformSpec("linux_x86_64")
-        assert spec.libc is None
-        assert spec.effective_libc == "glibc"
+        assert spec.libc == "glibc"
         assert spec.effective_libc_version == (2, 28)
 
     def test_musl_libc_version_defaults_per_family(self) -> None:

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -3,8 +3,8 @@
 These tests pin the spec-compliant tag selector's behavior on the
 common cases that real resolvers encounter:
 
-- manylinux / musllinux floor enforcement (PEP 600 / PEP 656)
-- macOS arch + version-floor compatibility
+- one libc family per target, at or below its version (PEP 600 / PEP 656)
+- macOS arch + version compatibility
 - Windows arch matching
 - ``py3-none-any`` fallback ordering
 - Compressed-tag-set wheels (``cp310.cp311``)
@@ -22,8 +22,19 @@ from nab_python.tags import (
     _PLATFORM_KIND,
     PlatformSpec,
     _platform_tags_for_spec,
+    platform_label,
     select_wheel,
     tags_for_target,
+)
+
+# numpy 2.5.1 ships one manylinux wheel (tagged 2.27 and 2.28, no older),
+# one musllinux wheel, and one free-threaded wheel per platform.
+NUMPY_MANYLINUX = (
+    "numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+)
+NUMPY_MUSLLINUX = "numpy-2.5.1-cp313-cp313-musllinux_1_2_x86_64.whl"
+NUMPY_FREETHREADED = (
+    "numpy-2.5.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
 )
 
 
@@ -58,7 +69,44 @@ def _wheel(filename: str) -> WheelFile:
 
 
 class TestPlatformSpec:
-    """``PlatformSpec`` exposes per-platform tag floors."""
+    """``PlatformSpec`` exposes per-platform tag knobs."""
+
+    def test_default_libc_is_glibc_2_28(self) -> None:
+        """An undeclared Linux target is glibc, at the modern baseline."""
+        spec = PlatformSpec("linux_x86_64")
+        assert spec.libc == "glibc"
+        assert spec.effective_libc_version == (2, 28)
+
+    def test_musl_libc_version_defaults_per_family(self) -> None:
+        """A musl target with no version takes musl's default, not glibc's."""
+        spec = PlatformSpec("linux_x86_64", libc="musl")
+        assert spec.effective_libc_version == (1, 2)
+
+    def test_declared_libc_version_wins(self) -> None:
+        """An explicit ``libc_version`` overrides the family default."""
+        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
+        assert spec.effective_libc_version == (2, 17)
+
+    def test_label_of_bare_id_is_the_id(self) -> None:
+        """A bare platform id renders as itself."""
+        assert platform_label("linux_x86_64") == "linux_x86_64"
+
+    def test_label_of_spec_carries_the_suffix(self) -> None:
+        """A spec renders as its id plus the knob discriminator."""
+        spec = PlatformSpec("linux_x86_64", libc="musl")
+        assert platform_label(spec) == "linux_x86_64-musl"
+
+    def test_label_suffix_separates_libc_families(self) -> None:
+        """A musl spec never renders the suffix of an otherwise-equal glibc one.
+
+        Both are the same ``platform_id`` with the same version pair, so a
+        suffix that dropped the family would collapse two targets with
+        disjoint wheel sets onto one label.
+        """
+        glibc = PlatformSpec("linux_x86_64", libc_version=(1, 2))
+        musl = PlatformSpec("linux_x86_64", libc="musl", libc_version=(1, 2))
+        assert glibc.label_suffix() == "-glibc1.2"
+        assert musl.label_suffix() == "-musl1.2"
 
     def test_default_linux_arch(self) -> None:
         """``linux_x86_64`` carries the right architecture name."""
@@ -92,43 +140,129 @@ class TestPlatformSpec:
     def test_label_suffix_escapes_kernel_release(self) -> None:
         """Pins the escaped suffix shape for a realistic kernel release."""
         spec = PlatformSpec("linux_x86_64", platform_release="5.15.0-generic")
-        assert spec.label_suffix() == "-glibc2.17-musl1.2-rel5.15.0_2d_generic"
+        assert spec.label_suffix() == "-rel5.15.0_2d_generic"
+
+
+class TestLibcFamilyExclusivity:
+    """A target links one C library, so it accepts one family's wheels.
+
+    Emitting both families let a declared glibc target install a
+    musllinux wheel, which cannot run there.
+    """
+
+    def test_glibc_target_emits_no_musllinux(self) -> None:
+        """The default (glibc) linux target has no musllinux platform tag."""
+        platforms = _platform_tags_for_spec(PlatformSpec("linux_x86_64"))
+        assert any(p.startswith("manylinux") for p in platforms)
+        assert not any(p.startswith("musllinux") for p in platforms)
+
+    def test_musl_target_emits_no_manylinux(self) -> None:
+        """A musl target has no manylinux platform tag."""
+        spec = PlatformSpec("linux_x86_64", libc="musl")
+        platforms = _platform_tags_for_spec(spec)
+        assert any(p.startswith("musllinux") for p in platforms)
+        assert not any(p.startswith("manylinux") for p in platforms)
+
+    def test_glibc_target_takes_numpy_manylinux_wheel(self) -> None:
+        """numpy ships manylinux_2_28 only; the default glibc target installs it."""
+        spec = PlatformSpec("linux_x86_64")
+        assert _compatible(_wheel(NUMPY_MANYLINUX), python_version="3.13", spec=spec)
+
+    def test_glibc_target_rejects_numpy_musllinux_wheel(self) -> None:
+        """The same glibc target must not pick numpy's musl wheel."""
+        spec = PlatformSpec("linux_x86_64")
+        assert not _compatible(
+            _wheel(NUMPY_MUSLLINUX), python_version="3.13", spec=spec
+        )
+
+    def test_musl_target_takes_numpy_musllinux_wheel(self) -> None:
+        """A musl target installs numpy's musllinux wheel."""
+        spec = PlatformSpec("linux_x86_64", libc="musl")
+        assert _compatible(_wheel(NUMPY_MUSLLINUX), python_version="3.13", spec=spec)
+
+    def test_musl_target_rejects_numpy_manylinux_wheel(self) -> None:
+        """A musl target must not pick numpy's glibc wheel."""
+        spec = PlatformSpec("linux_x86_64", libc="musl")
+        assert not _compatible(
+            _wheel(NUMPY_MANYLINUX), python_version="3.13", spec=spec
+        )
+
+    def test_glibc_target_selects_manylinux_over_musllinux(self) -> None:
+        """Given numpy's full wheel list, the glibc target picks the glibc wheel."""
+        spec = PlatformSpec("linux_x86_64")
+        wheels = [_wheel(NUMPY_MUSLLINUX), _wheel(NUMPY_MANYLINUX)]
+        chosen = select_wheel(wheels, python_version="3.13", spec=spec)
+        assert chosen is not None
+        assert chosen.filename == NUMPY_MANYLINUX
+
+
+class TestFreeThreadedAbi:
+    """``cpython_tags`` owns the abi list, so free-threaded ABIs are visible."""
+
+    def test_free_threaded_wheel_visible_on_free_threaded_build(self) -> None:
+        """A cp313t wheel is a candidate when packaging derives a ``t`` abi.
+
+        The abi list is no longer forced to ``cpXY``, so the target picks
+        up whatever ABIs ``packaging.tags`` derives.  Simulate a
+        free-threaded build by flipping the config var packaging reads.
+        """
+        spec = PlatformSpec("linux_x86_64")
+        wheel = _wheel(NUMPY_FREETHREADED)
+        assert not _compatible(wheel, python_version="3.13", spec=spec)
+
+        tags_for_target.cache_clear()
+        try:
+            with patch(
+                "nab_python.tags.ptags._get_config_var",
+                side_effect=lambda name, warn=False: (
+                    1 if name == "Py_GIL_DISABLED" else None
+                ),
+            ):
+                assert _compatible(wheel, python_version="3.13", spec=spec)
+        finally:
+            tags_for_target.cache_clear()
 
 
 class TestTagsForTarget:
     """``tags_for_target`` produces the full PEP 425 tag set."""
 
-    def test_linux_includes_manylinux_at_or_below_floor(self) -> None:
-        """A linux_x86_64 spec with floor 2.17 admits manylinux_2_17 and below."""
-        spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
+    def test_linux_includes_manylinux_at_or_below_libc_version(self) -> None:
+        """A glibc 2.17 target admits manylinux_2_17 and below."""
+        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
         tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
         assert "cp311-cp311-manylinux_2_17_x86_64" in tag_strs
         assert "cp311-cp311-manylinux_2_5_x86_64" in tag_strs
 
-    def test_linux_excludes_manylinux_above_floor(self) -> None:
-        """manylinux_2_28 is NOT in the set when floor is 2.17."""
-        spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
+    def test_linux_excludes_manylinux_above_libc_version(self) -> None:
+        """manylinux_2_28 needs glibc 2.28; a 2.17 target cannot run it."""
+        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
         tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
         assert "cp311-cp311-manylinux_2_28_x86_64" not in tag_strs
 
+    def test_default_linux_admits_manylinux_2_28(self) -> None:
+        """The default glibc version admits the modern manylinux baseline."""
+        spec = PlatformSpec("linux_x86_64")
+        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
+        assert "cp311-cp311-manylinux_2_28_x86_64" in tag_strs
+
     def test_linux_includes_legacy_aliases(self) -> None:
         """manylinux1, manylinux2010, manylinux2014 aliases are included."""
-        spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
+        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
         tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
         assert "cp311-cp311-manylinux1_x86_64" in tag_strs
         assert "cp311-cp311-manylinux2010_x86_64" in tag_strs
         assert "cp311-cp311-manylinux2014_x86_64" in tag_strs
 
-    def test_linux_excludes_aliases_above_floor(self) -> None:
-        """manylinux2014 is excluded when floor is below 2.17."""
-        spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 12))
+    def test_linux_excludes_aliases_above_libc_version(self) -> None:
+        """manylinux2014 means glibc 2.17; a 2.12 target excludes it."""
+        spec = PlatformSpec("linux_x86_64", libc_version=(2, 12))
         tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
         assert "cp311-cp311-manylinux2014_x86_64" not in tag_strs
         assert "cp311-cp311-manylinux2010_x86_64" in tag_strs
 
-    def test_aarch64_manylinux_floor_stops_at_2_17(self) -> None:
+    def test_aarch64_manylinux_stops_at_2_17(self) -> None:
         """aarch64 does not descend below glibc 2.17 (PEP 599)."""
-        spec = PlatformSpec("linux_aarch64", manylinux_floor=(2, 17))
+        spec = PlatformSpec("linux_aarch64", libc_version=(2, 17))
         tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
         assert "cp311-cp311-manylinux_2_17_aarch64" in tag_strs
         assert "cp311-cp311-manylinux2014_aarch64" in tag_strs
@@ -144,23 +278,23 @@ class TestTagsForTarget:
             wheel = _wheel(f"foo-1.0-cp311-cp311-{alias}_aarch64.whl")
             assert not _compatible(wheel, python_version="3.11", spec=spec)
 
-    def test_x86_64_keeps_legacy_alias_floor(self) -> None:
+    def test_x86_64_keeps_legacy_alias_range(self) -> None:
         """x86_64 still descends to manylinux1 (glibc 2.5)."""
-        spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
+        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
         tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
         assert "cp311-cp311-manylinux1_x86_64" in tag_strs
         assert "cp311-cp311-manylinux_2_5_x86_64" in tag_strs
 
-    def test_non_glibc2_floor_descends_to_x_0(self) -> None:
-        """A glibc 3.x floor descends to 3.0 on any arch (the 2.17 cap is glibc 2.x only)."""
-        spec = PlatformSpec("linux_aarch64", manylinux_floor=(3, 1))
+    def test_non_glibc2_major_descends_to_x_0(self) -> None:
+        """A glibc 3.x target descends to 3.0 on any arch (the 2.17 cap is glibc 2.x only)."""
+        spec = PlatformSpec("linux_aarch64", libc_version=(3, 1))
         tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
         assert "cp311-cp311-manylinux_3_1_aarch64" in tag_strs
         assert "cp311-cp311-manylinux_3_0_aarch64" in tag_strs
 
-    def test_linux_includes_musllinux_at_floor(self) -> None:
-        """Musllinux at-or-below the floor is admitted."""
-        spec = PlatformSpec("linux_x86_64", musllinux_floor=(1, 2))
+    def test_musl_includes_musllinux_at_or_below_version(self) -> None:
+        """A musl 1.2 target admits musllinux_1_2 and below."""
+        spec = PlatformSpec("linux_x86_64", libc="musl", libc_version=(1, 2))
         tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
         assert "cp311-cp311-musllinux_1_2_x86_64" in tag_strs
         assert "cp311-cp311-musllinux_1_0_x86_64" in tag_strs
@@ -175,7 +309,7 @@ class TestTagsForTarget:
         # Still a ceiling: a newer-than-default macOS wheel is excluded.
         assert "cp311-cp311-macosx_13_0_arm64" not in tag_strs
 
-    def test_macos_x86_64_uses_default_floor(self) -> None:
+    def test_macos_x86_64_uses_default_min(self) -> None:
         """``macos_x86_64`` defaults to macOS 10.13 (x86_64-era)."""
         spec = PlatformSpec("macos_x86_64")
         tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
@@ -204,15 +338,15 @@ class TestTagsForTarget:
 class TestWheelCompatibility:
     """A wheel is a candidate iff its tags meet the target's tag set."""
 
-    def test_accepts_at_floor_manylinux(self) -> None:
-        """A manylinux_2_17 wheel matches a 2.17-floor linux spec."""
-        spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
+    def test_accepts_manylinux_at_libc_version(self) -> None:
+        """A manylinux_2_17 wheel matches a glibc 2.17 target."""
+        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
         wheel = _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl")
         assert _compatible(wheel, python_version="3.11", spec=spec)
 
-    def test_rejects_above_floor_manylinux(self) -> None:
-        """A manylinux_2_28 wheel does not match a 2.17-floor linux spec."""
-        spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
+    def test_rejects_manylinux_above_libc_version(self) -> None:
+        """A manylinux_2_28 wheel does not match a glibc 2.17 target."""
+        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
         wheel = _wheel("pkg-1.0-cp311-cp311-manylinux_2_28_x86_64.whl")
         assert not _compatible(wheel, python_version="3.11", spec=spec)
 
@@ -397,13 +531,13 @@ class TestSelectWheel:
         assert chosen is good
 
     def test_higher_glibc_wheel_wins_over_lower(self) -> None:
-        """Among manylinux candidates, higher glibc (closer to floor) wins.
+        """Among manylinux candidates, the highest runnable glibc wins.
 
-        With floor 2.17, both manylinux_2_5 and manylinux_2_17 are
+        On a glibc 2.17 target both manylinux_2_5 and manylinux_2_17 are
         compatible.  manylinux_2_17 is the more-specific tag (PEP 600
         recommends preferring it) and should be selected.
         """
-        spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
+        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
         wheels = [
             _wheel("pkg-1.0-cp311-cp311-manylinux_2_5_x86_64.whl"),
             _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl"),
@@ -420,7 +554,7 @@ class TestSelectWheel:
         its equivalent manylinux_X_Y tag, so manylinux2014 outranks
         manylinux_2_5.
         """
-        spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
+        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
         wheels = [
             _wheel("pkg-1.0-cp311-cp311-manylinux_2_5_x86_64.whl"),
             _wheel("pkg-1.0-cp311-cp311-manylinux2014_x86_64.whl"),
@@ -436,7 +570,7 @@ class TestSelectWheel:
         and manylinux_2_5 second, the loop must keep the first as
         best and not replace it.
         """
-        spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
+        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
         wheels = [
             _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl"),
             _wheel("pkg-1.0-cp311-cp311-manylinux_2_5_x86_64.whl"),
@@ -447,7 +581,7 @@ class TestSelectWheel:
 
     def test_higher_build_tag_wins_at_same_rank(self) -> None:
         """Among same-tag wheels, the higher PEP 427 build tag wins."""
-        spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
+        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
         build1 = _wheel("pkg-1.0-1-cp311-cp311-manylinux_2_17_x86_64.whl")
         build5 = _wheel("pkg-1.0-5-cp311-cp311-manylinux_2_17_x86_64.whl")
         chosen = select_wheel([build1, build5], python_version="3.11", spec=spec)
@@ -455,7 +589,7 @@ class TestSelectWheel:
 
     def test_build_tag_selection_is_order_independent(self) -> None:
         """The same wheel is chosen regardless of index file order."""
-        spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
+        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
         build1 = _wheel("pkg-1.0-1-cp311-cp311-manylinux_2_17_x86_64.whl")
         build5 = _wheel("pkg-1.0-5-cp311-cp311-manylinux_2_17_x86_64.whl")
         forward = select_wheel([build1, build5], python_version="3.11", spec=spec)
@@ -465,7 +599,7 @@ class TestSelectWheel:
 
     def test_build_tagged_wheel_beats_untagged_at_same_rank(self) -> None:
         """An absent build tag sorts lowest, so a tagged wheel wins."""
-        spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
+        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
         untagged = _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl")
         build3 = _wheel("pkg-1.0-3-cp311-cp311-manylinux_2_17_x86_64.whl")
         chosen = select_wheel([untagged, build3], python_version="3.11", spec=spec)
@@ -473,7 +607,7 @@ class TestSelectWheel:
 
     def test_malformed_build_tag_treated_as_absent(self) -> None:
         """A build segment without a leading digit sorts lowest."""
-        spec = PlatformSpec("linux_x86_64", manylinux_floor=(2, 17))
+        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
         malformed = _wheel("pkg-1.0-x-cp311-cp311-manylinux_2_17_x86_64.whl")
         build5 = _wheel("pkg-1.0-5-cp311-cp311-manylinux_2_17_x86_64.whl")
         chosen = select_wheel([malformed, build5], python_version="3.11", spec=spec)

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -23,7 +23,6 @@ from nab_python.tags import (
     PlatformSpec,
     _platform_tags_for_spec,
     _tags_in_order,
-    platform_label,
     select_wheel,
     tags_for_target,
 )
@@ -79,13 +78,56 @@ def _wheel(filename: str) -> WheelFile:
     )
 
 
+class TestPlatformSpecKnobsBelongToTheirPlatform:
+    """A knob the platform cannot read is a construction error.
+
+    The tag generator consults a libc only on Linux and a macOS version
+    only on macOS, so a knob on any other platform selects no different
+    wheel.  It does reach the target's label, so accepting one would name
+    a machine that was never modelled.
+    """
+
+    @pytest.mark.parametrize("platform_id", ["macos_arm64", "windows_amd64"])
+    def test_libc_outside_linux_raises(self, platform_id: str) -> None:
+        """Only a Linux target links a C library."""
+        with pytest.raises(ValueError, match="libc is a Linux knob"):
+            PlatformSpec(platform_id, libc="musl")
+
+    @pytest.mark.parametrize("platform_id", ["macos_arm64", "windows_amd64"])
+    def test_libc_version_outside_linux_raises(self, platform_id: str) -> None:
+        """A libc version is as Linux-only as the family it versions."""
+        with pytest.raises(ValueError, match="libc is a Linux knob"):
+            PlatformSpec(platform_id, libc_version=(2, 28))
+
+    @pytest.mark.parametrize("platform_id", ["linux_x86_64", "windows_amd64"])
+    def test_macos_min_outside_macos_raises(self, platform_id: str) -> None:
+        """A deployment target means nothing off macOS."""
+        with pytest.raises(ValueError, match="macos-min is a macOS knob"):
+            PlatformSpec(platform_id, macos_min=(14, 0))
+
+    def test_macos_min_below_the_tag_floor_raises(self) -> None:
+        """No wheel tag names a macOS older than 10.0.
+
+        ``mac_platforms`` yields nothing below it, and packaging reads an
+        empty platform list as "unset", which would silently hand the
+        target the tags of the host nab happens to be running on.
+        """
+        with pytest.raises(ValueError, match="below 10.0"):
+            PlatformSpec("macos_arm64", macos_min=(9, 0))
+
+    def test_unknown_platform_id_defers_to_the_matrix(self) -> None:
+        """An unknown id is the matrix's error to report, not the spec's."""
+        assert PlatformSpec("freebsd_amd64", libc="musl").libc == "musl"
+
+
 class TestPlatformSpec:
     """``PlatformSpec`` exposes per-platform tag knobs."""
 
     def test_default_libc_is_glibc_2_28(self) -> None:
         """An undeclared Linux target is glibc 2.28."""
         spec = PlatformSpec("linux_x86_64")
-        assert spec.libc == "glibc"
+        assert spec.libc is None
+        assert spec.effective_libc == "glibc"
         assert spec.effective_libc_version == (2, 28)
 
     def test_musl_libc_version_defaults_per_family(self) -> None:
@@ -98,26 +140,26 @@ class TestPlatformSpec:
         spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
         assert spec.effective_libc_version == (2, 17)
 
-    def test_label_of_bare_id_is_the_id(self) -> None:
-        """A bare platform id renders as itself."""
-        assert platform_label("linux_x86_64") == "linux_x86_64"
+    def test_label_of_default_spec_is_the_id(self) -> None:
+        """A spec left at the platform defaults renders as its id."""
+        assert PlatformSpec("linux_x86_64").label == "linux_x86_64"
 
-    def test_label_of_spec_carries_the_suffix(self) -> None:
-        """A spec renders as its id plus the knob discriminator."""
+    def test_label_carries_the_knobs(self) -> None:
+        """A spec off the defaults renders its id plus what sets it apart."""
         spec = PlatformSpec("linux_x86_64", libc="musl")
-        assert platform_label(spec) == "linux_x86_64-musl"
+        assert spec.label == "linux_x86_64-musl"
 
-    def test_label_suffix_separates_libc_families(self) -> None:
-        """A musl spec never renders the suffix of an otherwise-equal glibc one.
+    def test_label_names_the_libc_family(self) -> None:
+        """A musl target never renders the label of a glibc one.
 
-        Both are the same ``platform_id`` with the same version pair, so a
-        suffix that dropped the family would collapse two targets with
-        disjoint wheel sets onto one label.
+        The two families' version numbers are not comparable, so a label
+        that dropped the family could collapse two targets with disjoint
+        wheel sets onto one key.
         """
-        glibc = PlatformSpec("linux_x86_64", libc_version=(1, 2))
-        musl = PlatformSpec("linux_x86_64", libc="musl", libc_version=(1, 2))
-        assert glibc.label_suffix() == "-glibc1.2"
-        assert musl.label_suffix() == "-musl1.2"
+        glibc = PlatformSpec("linux_x86_64", libc_version=(2, 17))
+        musl = PlatformSpec("linux_x86_64", libc="musl", libc_version=(1, 1))
+        assert glibc.label == "linux_x86_64-glibc2.17"
+        assert musl.label == "linux_x86_64-musl1.1"
 
     def test_default_linux_arch(self) -> None:
         """``linux_x86_64`` carries the right architecture name."""
@@ -129,29 +171,28 @@ class TestPlatformSpec:
         spec = PlatformSpec("macos_arm64")
         assert spec.arch == "arm64"
 
-    def test_label_suffix_distinguishes_space_from_underscore(self) -> None:
+    def test_label_distinguishes_space_from_underscore(self) -> None:
         """Whitespace and ``_`` in ``platform_release`` encode differently.
 
-        Both are legal release characters; if they folded to the same
-        suffix the two specs' matrix tuples would share a label and
-        their per-tuple pins would silently merge.
+        Both are legal release characters; if they folded together the two
+        specs' targets would share a label and their pins would merge.
         """
         with_space = PlatformSpec("linux_x86_64", platform_release="a a")
         with_underscore = PlatformSpec("linux_x86_64", platform_release="a_a")
-        assert with_space.label_suffix() != with_underscore.label_suffix()
+        assert with_space.label != with_underscore.label
 
-    def test_label_suffix_release_cannot_forge_version_field(self) -> None:
+    def test_label_release_cannot_forge_a_version_field(self) -> None:
         """A ``-`` in ``platform_release`` cannot fake a ``ver`` field."""
         release_only = PlatformSpec("linux_x86_64", platform_release="r-ver1")
         release_and_version = PlatformSpec(
             "linux_x86_64", platform_release="r", platform_version="1"
         )
-        assert release_only.label_suffix() != release_and_version.label_suffix()
+        assert release_only.label != release_and_version.label
 
-    def test_label_suffix_escapes_kernel_release(self) -> None:
-        """Pins the escaped suffix shape for a realistic kernel release."""
+    def test_label_escapes_a_kernel_release(self) -> None:
+        """Pins the escaped label shape for a realistic kernel release."""
         spec = PlatformSpec("linux_x86_64", platform_release="5.15.0-generic")
-        assert spec.label_suffix() == "-rel5.15.0_2d_generic"
+        assert spec.label == "linux_x86_64-rel5.15.0_2d_generic"
 
 
 class TestLibcFamilyExclusivity:
@@ -247,7 +288,7 @@ class TestFreeThreadedTarget:
     def test_label_carries_the_free_threaded_discriminator(self) -> None:
         """A free-threaded target renders its own label."""
         spec = PlatformSpec("linux_x86_64", free_threaded=True)
-        assert platform_label(spec) == "linux_x86_64-ft"
+        assert spec.label == "linux_x86_64-ft"
 
 
 class TestAbiIsHostIndependent:
@@ -347,16 +388,6 @@ class TestTagsForTarget:
         tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
         assert "cp311-cp311-manylinux1_x86_64" in tag_strs
         assert "cp311-cp311-manylinux_2_5_x86_64" in tag_strs
-
-    def test_non_glibc2_major_descends_to_x_0(self) -> None:
-        """A glibc 3.x target descends to 3.0 on any arch.
-
-        The 2.17 floor is a glibc 2.x rule only.
-        """
-        spec = PlatformSpec("linux_aarch64", libc_version=(3, 1))
-        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
-        assert "cp311-cp311-manylinux_3_1_aarch64" in tag_strs
-        assert "cp311-cp311-manylinux_3_0_aarch64" in tag_strs
 
     def test_musl_includes_musllinux_at_or_below_version(self) -> None:
         """A musl 1.2 target admits musllinux_1_2 and below."""

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -125,6 +125,24 @@ class TestPlatformSpecKnobsBelongToTheirPlatform:
         with pytest.raises(ValueError, match=f"below {floor}"):
             PlatformSpec(platform_id, macos_min=macos_min)
 
+    @pytest.mark.parametrize(
+        ("kwargs", "message"),
+        [
+            ({"platform_id": "linux_x86_64", "libc_version": (2, 500)}, "libc-version"),
+            ({"platform_id": "macos_arm64", "macos_min": (500, 0)}, "macos-min"),
+        ],
+    )
+    def test_a_version_above_every_release_raises(
+        self, kwargs: dict[str, object], message: str
+    ) -> None:
+        """One tag is named per version below the declared one.
+
+        A typo of a few extra digits would otherwise build platform tags
+        until the process ran out of memory.
+        """
+        with pytest.raises(ValueError, match=f"{message}.*higher than any release"):
+            PlatformSpec(**kwargs)  # type: ignore[arg-type]
+
     def test_unknown_platform_id_defers_to_the_matrix(self) -> None:
         """An unknown id is the matrix's error to report, not the spec's."""
         assert PlatformSpec("freebsd_amd64", libc="musl").libc == "musl"
@@ -720,16 +738,14 @@ class TestSelectWheel:
 
 
 class TestUnknownPlatformKindGuard:
-    """Explicit guard for the unreachable platform-kind branch."""
+    """A platform kind with no tag rule raises rather than tagging as Windows."""
 
-    def test_unknown_kind_raises_via_indirection(self) -> None:
-        """Constructing a PlatformSpec with an unmapped id has no kind.
+    def test_unknown_kind_raises(self) -> None:
+        """A kind the tag generator does not handle is a loud error.
 
-        We don't expose a way to construct one in normal use; the
-        Matrix.expand validator catches unknown ids.  This test pokes
-        the helper directly to cover the unreachable branch.
+        No id maps to a fourth kind today, so the branch is reachable only
+        by adding one, which is what this test stands in for.
         """
-        # Add a fake entry to test the unknown-kind branch.
         _PLATFORM_ARCH["fake_x"] = "x"
         _PLATFORM_KIND["fake_x"] = "exotic"
         try:

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -22,6 +22,7 @@ from nab_python.tags import (
     _PLATFORM_KIND,
     PlatformSpec,
     _platform_tags_for_spec,
+    _tags_in_order,
     platform_label,
     select_wheel,
     tags_for_target,
@@ -36,6 +37,16 @@ NUMPY_MUSLLINUX = "numpy-2.5.1-cp313-cp313-musllinux_1_2_x86_64.whl"
 NUMPY_FREETHREADED = (
     "numpy-2.5.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
 )
+# cryptography ships one abi3 wheel per platform, usable from cp37 up.
+CRYPTOGRAPHY_ABI3 = "cryptography-44.0.0-cp37-abi3-manylinux_2_28_x86_64.whl"
+
+
+def _free_threaded_host() -> object:
+    """Patch the config vars packaging reads to fake a free-threaded host."""
+    return patch(
+        "nab_python.tags.ptags._get_config_var",
+        side_effect=lambda name, warn=False: 1 if name == "Py_GIL_DISABLED" else None,
+    )
 
 
 def _compatible(
@@ -196,31 +207,87 @@ class TestLibcFamilyExclusivity:
         assert chosen.filename == NUMPY_MANYLINUX
 
 
-class TestFreeThreadedAbi:
-    """``cpython_tags`` owns the abi list, so free-threaded ABIs are visible."""
+class TestFreeThreadedTarget:
+    """``free_threaded`` declares the ``cpXYt`` ABI, which is exclusive.
 
-    def test_free_threaded_wheel_visible_on_free_threaded_build(self) -> None:
-        """A cp313t wheel is a candidate when packaging derives a ``t`` abi.
+    A free-threaded interpreter loads neither an ordinary ``cpXY``
+    extension nor an ``abi3`` one, and a GIL interpreter cannot load a
+    ``cpXYt`` one, so the two targets take disjoint binary wheels.
+    """
 
-        The abi list is no longer forced to ``cpXY``, so the target picks
-        up whatever ABIs ``packaging.tags`` derives.  Simulate a
-        free-threaded build by flipping the config var packaging reads.
-        """
+    def test_free_threaded_target_takes_the_cp313t_wheel(self) -> None:
+        """numpy's cp313t wheel is a candidate for a free-threaded target."""
+        spec = PlatformSpec("linux_x86_64", free_threaded=True)
+        assert _compatible(_wheel(NUMPY_FREETHREADED), python_version="3.13", spec=spec)
+
+    def test_free_threaded_target_rejects_the_gil_wheel(self) -> None:
+        """The same target must not pick numpy's ordinary cp313 wheel."""
+        spec = PlatformSpec("linux_x86_64", free_threaded=True)
+        assert not _compatible(
+            _wheel(NUMPY_MANYLINUX), python_version="3.13", spec=spec
+        )
+
+    def test_free_threaded_target_rejects_abi3(self) -> None:
+        """abi3 wheels do not load on a free-threaded build (PEP 703)."""
+        spec = PlatformSpec("linux_x86_64", free_threaded=True)
+        assert not _compatible(
+            _wheel(CRYPTOGRAPHY_ABI3), python_version="3.13", spec=spec
+        )
+
+    def test_free_threaded_target_keeps_abi3t_and_pure_python(self) -> None:
+        """The stable free-threaded ABI and the pure-Python fallback remain."""
+        spec = PlatformSpec("linux_x86_64", free_threaded=True)
+        tag_strs = {str(t) for t in tags_for_target(python_version="3.13", spec=spec)}
+        assert "cp313-abi3t-manylinux_2_28_x86_64" in tag_strs
+        assert "py3-none-any" in tag_strs
+
+    def test_gil_target_rejects_the_free_threaded_wheel(self) -> None:
+        """The default (GIL) target must not pick numpy's cp313t wheel."""
         spec = PlatformSpec("linux_x86_64")
-        wheel = _wheel(NUMPY_FREETHREADED)
-        assert not _compatible(wheel, python_version="3.13", spec=spec)
+        assert not _compatible(
+            _wheel(NUMPY_FREETHREADED), python_version="3.13", spec=spec
+        )
 
-        tags_for_target.cache_clear()
-        try:
-            with patch(
-                "nab_python.tags.ptags._get_config_var",
-                side_effect=lambda name, warn=False: (
-                    1 if name == "Py_GIL_DISABLED" else None
-                ),
-            ):
+    def test_label_carries_the_free_threaded_discriminator(self) -> None:
+        """A free-threaded target renders its own label."""
+        spec = PlatformSpec("linux_x86_64", free_threaded=True)
+        assert platform_label(spec) == "linux_x86_64-ft"
+
+
+class TestAbiIsHostIndependent:
+    """The ABI comes from the declared target, not from the running host.
+
+    packaging derives ABIs from the host's ``Py_GIL_DISABLED`` /
+    ``Py_DEBUG`` config vars when it is not told which ABI to use.  nab
+    runs on any interpreter, so a host-derived ABI would make the same
+    matrix lock differently under a free-threaded or debug build.
+    """
+
+    def test_gil_target_unchanged_on_a_free_threaded_host(self) -> None:
+        """A declared GIL target keeps its cp313 and abi3 tags on such a host."""
+        spec = PlatformSpec("linux_x86_64")
+        with _free_threaded_host():
+            tag_strs = {str(t) for t in _tags_in_order("3.13", spec)}
+        assert "cp313-cp313-manylinux_2_28_x86_64" in tag_strs
+        assert "cp313-abi3-manylinux_2_28_x86_64" in tag_strs
+        assert not any("cp313t" in t for t in tag_strs)
+
+    def test_ordinary_wheels_stay_candidates_on_a_free_threaded_host(self) -> None:
+        """The cp313 and abi3 wheels a GIL target installs stay selectable."""
+        spec = PlatformSpec("linux_x86_64")
+        wheels = [_wheel(NUMPY_MANYLINUX), _wheel(CRYPTOGRAPHY_ABI3)]
+        with _free_threaded_host():
+            for wheel in wheels:
                 assert _compatible(wheel, python_version="3.13", spec=spec)
-        finally:
-            tags_for_target.cache_clear()
+            assert not _compatible(
+                _wheel(NUMPY_FREETHREADED), python_version="3.13", spec=spec
+            )
+
+    def test_free_threaded_target_reachable_from_any_host(self) -> None:
+        """A declared free-threaded target gets its cp313t tag with no host help."""
+        spec = PlatformSpec("linux_x86_64", free_threaded=True)
+        tag_strs = {str(t) for t in _tags_in_order("3.13", spec)}
+        assert "cp313-cp313t-manylinux_2_28_x86_64" in tag_strs
 
 
 class TestTagsForTarget:

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -320,6 +320,29 @@ class TestFreeThreadedTarget:
         assert spec.label == "linux_x86_64-ft"
 
 
+class TestPymallocAbi:
+    """CPython carried the pymalloc flag in its ABI tag through 3.7."""
+
+    def test_a_37_target_names_the_m_abi(self) -> None:
+        """Every 3.7 wheel is tagged cp37m, so a cp37 target matches none."""
+        spec = PlatformSpec("linux_x86_64")
+        tags = tags_for_target(python_version="3.7", spec=spec)
+        assert "cp37m" in {t.abi for t in tags}
+        wheel = wheel_tag_set(
+            "numpy-1.21.6-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
+        )
+        assert wheel is not None
+        assert wheel & tags
+
+    def test_38_dropped_the_flag(self) -> None:
+        spec = PlatformSpec("linux_x86_64")
+        tags = tags_for_target(python_version="3.8", spec=spec)
+        assert "cp38m" not in {t.abi for t in tags}
+        wheel = wheel_tag_set("numpy-1.24.4-cp38-cp38-manylinux_2_17_x86_64.whl")
+        assert wheel is not None
+        assert wheel & tags
+
+
 class TestAbiIsHostIndependent:
     """The ABI comes from the declared target, not from the running host.
 

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -21,10 +21,12 @@ from nab_python.tags import (
     _PLATFORM_ARCH,
     _PLATFORM_KIND,
     PlatformSpec,
+    _parse_tag_str,
     _platform_tags_for_spec,
     _tags_in_order,
     select_wheel,
     tags_for_target,
+    wheel_tag_set,
 )
 
 # numpy 2.5.1 ships one manylinux wheel (tagged 2.27 and 2.28, no older),
@@ -462,6 +464,22 @@ class TestTagsForTarget:
 class TestWheelCompatibility:
     """A wheel is a candidate iff its tags meet the target's tag set."""
 
+    def test_an_oversized_compressed_tag_set_drops_the_wheel(self) -> None:
+        """A PEP 425 compressed tag set is a cross product, and the index names it.
+
+        A filename listing 40 interpreters, 40 abis and 40 platforms parses
+        into 64000 tags.  The parser is bounded, and a filename over the bound
+        is unreadable, which drops the whole candidate.
+        """
+        _parse_tag_str.cache_clear()
+        try:
+            big = ".".join(f"cp3{i}" for i in range(40))
+            abis = ".".join(f"abi{i}" for i in range(40))
+            plats = ".".join(f"plat{i}" for i in range(40))
+            assert wheel_tag_set(f"pkg-1.0-{big}-{abis}-{plats}.whl") is None
+        finally:
+            _parse_tag_str.cache_clear()
+
     def test_accepts_manylinux_at_libc_version(self) -> None:
         """A manylinux_2_17 wheel matches a glibc 2.17 target."""
         spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
@@ -564,8 +582,6 @@ class TestWheelCompatibility:
         few error paths (e.g. an empty tag).  We patch it to raise
         and verify our ``except Exception`` handler returns None.
         """
-        from nab_python.tags import _parse_tag_str
-
         spec = PlatformSpec("linux_x86_64")
         wheel = WheelFile(
             filename="forced-1.0-cp311-cp311-linux_x86_64.whl",

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -1,13 +1,13 @@
-"""Tests for the wheel-selection logic backed by ``packaging.tags``.
+"""Tests for ``nab_python.tags``: the tags a target accepts, and the wheel it picks.
 
-These tests pin the spec-compliant tag selector's behavior on the
-common cases that real resolvers encounter:
+Pins:
 
+- the knobs a platform can carry, and the ones it refuses
 - one libc family per target, at or below its version (PEP 600 / PEP 656)
-- macOS arch + version compatibility
-- Windows arch matching
+- the macOS deployment target as a ceiling, and its floor per arch
+- the free-threaded ``cpXYt`` ABI, and ``abi3t`` in place of ``abi3``
 - ``py3-none-any`` fallback ordering
-- Compressed-tag-set wheels (``cp310.cp311``)
+- compressed-tag-set wheels (``cp310.cp311``)
 """
 
 from __future__ import annotations
@@ -743,6 +743,14 @@ class TestSelectWheel:
         build3 = _wheel("pkg-1.0-3-cp311-cp311-manylinux_2_17_x86_64.whl")
         chosen = select_wheel([untagged, build3], python_version="3.11", spec=spec)
         assert chosen is build3
+
+    def test_an_absurd_build_number_is_malformed(self) -> None:
+        """The index names the build tag, and int() raises above 4300 digits."""
+        spec = PlatformSpec("linux_x86_64")
+        build5 = _wheel("pkg-1.0-5-cp311-cp311-manylinux_2_17_x86_64.whl")
+        absurd = _wheel(f"pkg-1.0-{'9' * 5000}-cp311-cp311-manylinux_2_17_x86_64.whl")
+        chosen = select_wheel([absurd, build5], python_version="3.11", spec=spec)
+        assert chosen is build5
 
     def test_malformed_build_tag_treated_as_absent(self) -> None:
         """A build segment without a leading digit sorts lowest."""

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -83,7 +83,7 @@ class TestPlatformSpec:
     """``PlatformSpec`` exposes per-platform tag knobs."""
 
     def test_default_libc_is_glibc_2_28(self) -> None:
-        """An undeclared Linux target is glibc, at the modern baseline."""
+        """An undeclared Linux target is glibc 2.28."""
         spec = PlatformSpec("linux_x86_64")
         assert spec.libc == "glibc"
         assert spec.effective_libc_version == (2, 28)
@@ -155,11 +155,7 @@ class TestPlatformSpec:
 
 
 class TestLibcFamilyExclusivity:
-    """A target links one C library, so it accepts one family's wheels.
-
-    Emitting both families let a declared glibc target install a
-    musllinux wheel, which cannot run there.
-    """
+    """A target links one C library, so it accepts one family's wheels."""
 
     def test_glibc_target_emits_no_musllinux(self) -> None:
         """The default (glibc) linux target has no musllinux platform tag."""
@@ -307,7 +303,7 @@ class TestTagsForTarget:
         assert "cp311-cp311-manylinux_2_28_x86_64" not in tag_strs
 
     def test_default_linux_admits_manylinux_2_28(self) -> None:
-        """The default glibc version admits the modern manylinux baseline."""
+        """The default glibc version admits manylinux_2_28."""
         spec = PlatformSpec("linux_x86_64")
         tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
         assert "cp311-cp311-manylinux_2_28_x86_64" in tag_strs
@@ -353,7 +349,10 @@ class TestTagsForTarget:
         assert "cp311-cp311-manylinux_2_5_x86_64" in tag_strs
 
     def test_non_glibc2_major_descends_to_x_0(self) -> None:
-        """A glibc 3.x target descends to 3.0 on any arch (the 2.17 cap is glibc 2.x only)."""
+        """A glibc 3.x target descends to 3.0 on any arch.
+
+        The 2.17 floor is a glibc 2.x rule only.
+        """
         spec = PlatformSpec("linux_aarch64", libc_version=(3, 1))
         tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
         assert "cp311-cp311-manylinux_3_1_aarch64" in tag_strs
@@ -518,9 +517,8 @@ class TestWheelCompatibility:
             has_metadata=False,
             upload_time=None,
         )
-        # Clear any prior cached result on this tag suffix so the patched
-        # ``parse_tag`` is exercised, and clear the None it caches so no
-        # later test sees this common suffix as unparseable.
+        # Clear before, so the patched ``parse_tag`` runs, and after, so no
+        # later test sees this suffix cached as unparseable.
         _parse_tag_str.cache_clear()
         try:
             with patch(

--- a/nab-python/tests/universal/property_universal/test_alignment.py
+++ b/nab-python/tests/universal/property_universal/test_alignment.py
@@ -22,6 +22,7 @@ from hypothesis import strategies as st
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.version import Version
 from nab_python.lockfile import IndexPin, LockInput
+from nab_python.tags import PlatformSpec
 from nab_python.universal.matrix import Matrix, MatrixTuple
 from nab_python.universal.resolve import (
     TupleResult,
@@ -41,7 +42,7 @@ def _fake_tuple() -> MatrixTuple:
     """Build a minimal linux/3.11 ``MatrixTuple`` for property fixtures."""
     return MatrixTuple(
         python_version="3.11",
-        platform_id="linux_x86_64",
+        platform_spec=PlatformSpec("linux_x86_64"),
         environment=LINUX_ENV,
     )
 
@@ -179,7 +180,7 @@ def tuple_lock_inputs(
     for platform in chosen_platforms:
         tup = MatrixTuple(
             python_version="3.11",
-            platform_id=platform,
+            platform_spec=PlatformSpec(platform),
             environment={**LINUX_ENV, "sys_platform": platform.split("_", 1)[0]},
         )
         pairs.append((tup, draw(pin_maps())))

--- a/nab-python/tests/universal/property_universal/test_matrix.py
+++ b/nab-python/tests/universal/property_universal/test_matrix.py
@@ -23,6 +23,7 @@ from hypothesis import strategies as st
 from nab_python._vendor.packaging.markers import Marker
 from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.version import Version
+from nab_python.tags import PlatformSpec
 from nab_python.universal.matrix import (
     _KNOWN_PYTHON_MINORS,
     _PLATFORM_DEFAULTS,
@@ -173,7 +174,7 @@ class TestPythonOrderingFlip:
         with pytest.raises(ValueError, match="python_order"):
             Matrix(
                 python=">=3.10",
-                platforms=("linux_x86_64",),
+                platforms=(PlatformSpec("linux_x86_64"),),
                 python_order=bad_order,
             ).expand()
 

--- a/nab-python/tests/universal/property_universal/test_matrix.py
+++ b/nab-python/tests/universal/property_universal/test_matrix.py
@@ -60,8 +60,8 @@ def python_specs_admitting_some_minor(draw: st.DrawFn) -> str:
 
 
 @st.composite
-def platform_subsets(draw: st.DrawFn) -> tuple[str, ...]:
-    """Sample a non-empty subset of known platform ids."""
+def platform_subsets(draw: st.DrawFn) -> tuple[PlatformSpec, ...]:
+    """Sample a non-empty subset of the known platforms, at their defaults."""
     chosen = draw(
         st.lists(
             st.sampled_from(PLATFORM_IDS),
@@ -70,7 +70,7 @@ def platform_subsets(draw: st.DrawFn) -> tuple[str, ...]:
             unique=True,
         )
     )
-    return tuple(chosen)
+    return tuple(PlatformSpec(platform_id) for platform_id in chosen)
 
 
 class TestCartesianCardinality:
@@ -88,7 +88,7 @@ class TestCartesianCardinality:
     @given(spec=python_specs_admitting_some_minor(), platforms=platform_subsets())
     @PROPERTY_SETTINGS
     def test_cardinality_equals_pythons_times_platforms(
-        self, spec: str, platforms: tuple[str, ...]
+        self, spec: str, platforms: tuple[PlatformSpec, ...]
     ) -> None:
         """``|tuples|`` is the cross-product of admitted Pythons and platforms."""
         matrix = Matrix(python=spec, platforms=platforms)
@@ -109,7 +109,9 @@ class TestExpansionDeterminism:
 
     @given(spec=python_specs_admitting_some_minor(), platforms=platform_subsets())
     @PROPERTY_SETTINGS
-    def test_expand_is_idempotent(self, spec: str, platforms: tuple[str, ...]) -> None:
+    def test_expand_is_idempotent(
+        self, spec: str, platforms: tuple[PlatformSpec, ...]
+    ) -> None:
         """Two ``expand()`` calls on the same Matrix produce equal sequences."""
         matrix = Matrix(python=spec, platforms=platforms)
         first = matrix.expand()
@@ -121,7 +123,7 @@ class TestExpansionDeterminism:
     @given(spec=python_specs_admitting_some_minor(), platforms=platform_subsets())
     @PROPERTY_SETTINGS
     def test_expand_environment_dict_stable(
-        self, spec: str, platforms: tuple[str, ...]
+        self, spec: str, platforms: tuple[PlatformSpec, ...]
     ) -> None:
         """The per-tuple ``environment`` dict is identical across calls.
 
@@ -154,7 +156,7 @@ class TestPythonOrderingFlip:
     @given(spec=python_specs_admitting_some_minor(), platforms=platform_subsets())
     @PROPERTY_SETTINGS
     def test_desc_is_reverse_of_asc(
-        self, spec: str, platforms: tuple[str, ...]
+        self, spec: str, platforms: tuple[PlatformSpec, ...]
     ) -> None:
         """``desc`` reverses the Python axis but keeps platform order."""
         asc = Matrix(python=spec, platforms=platforms).expand()
@@ -236,7 +238,7 @@ class TestQuotePEP508MarkerKeys:
     @given(spec=python_specs_admitting_some_minor(), platforms=platform_subsets())
     @PROPERTY_SETTINGS
     def test_every_tuple_has_required_marker_keys(
-        self, spec: str, platforms: tuple[str, ...]
+        self, spec: str, platforms: tuple[PlatformSpec, ...]
     ) -> None:
         """Every per-tuple environment has the full PEP 508 key set."""
         required = {
@@ -276,7 +278,7 @@ class TestQuoteSysPlatformConsistency:
     @given(platforms=platform_subsets())
     @PROPERTY_SETTINGS
     def test_sys_platform_marker_consistent_with_platform_id(
-        self, platforms: tuple[str, ...]
+        self, platforms: tuple[PlatformSpec, ...]
     ) -> None:
         """``sys_platform == 'X'`` evaluates True iff ``platform_id`` matches."""
         matrix = Matrix(python="==3.11", platforms=platforms)
@@ -294,7 +296,7 @@ class TestQuoteSysPlatformConsistency:
     @given(spec=python_specs_admitting_some_minor(), platforms=platform_subsets())
     @PROPERTY_SETTINGS
     def test_python_version_marker_matches_axis(
-        self, spec: str, platforms: tuple[str, ...]
+        self, spec: str, platforms: tuple[PlatformSpec, ...]
     ) -> None:
         """``python_version == X`` evaluates True iff ``X`` is the tuple's value."""
         matrix = Matrix(python=spec, platforms=platforms)

--- a/nab-python/tests/universal/property_universal/test_matrix_labels.py
+++ b/nab-python/tests/universal/property_universal/test_matrix_labels.py
@@ -16,10 +16,10 @@ from hypothesis import assume, given
 from hypothesis import strategies as st
 
 from nab_python.tags import (
+    _MACOS_TAG_FLOOR,
     _PLATFORM_ARCH,
     _PLATFORM_KIND,
     LIBC_MAJOR,
-    MACOS_TAG_FLOOR,
     PlatformSpec,
 )
 from nab_python.universal.matrix import (
@@ -46,8 +46,8 @@ python_specs = st.one_of(
     st.sampled_from(_KNOWN_PYTHON_MINORS).map(lambda v: f"!={v}"),
 )
 
-# No whitespace: the label collapses runs of it into "_", which collides
-# with a literal underscore.
+# The alphabet a real platform_release or platform_version draws from, which
+# also keeps a shrunk counterexample readable.
 rel_strings = st.text(alphabet="_-abc0123456789.", min_size=0, max_size=8)
 
 
@@ -70,7 +70,7 @@ def _macos_knobs(platform_id: str) -> st.SearchStrategy[dict[str, object]]:
     """Draw the macOS knob the platform admits: none unless it is macOS."""
     if _PLATFORM_KIND[platform_id] != "macos":
         return st.just({})
-    floor = MACOS_TAG_FLOOR[_PLATFORM_ARCH[platform_id]]
+    floor = _MACOS_TAG_FLOOR[_PLATFORM_ARCH[platform_id]]
     return st.fixed_dictionaries(
         {
             "macos_min": st.none()

--- a/nab-python/tests/universal/property_universal/test_matrix_labels.py
+++ b/nab-python/tests/universal/property_universal/test_matrix_labels.py
@@ -44,7 +44,7 @@ python_specs = st.one_of(
 # with a literal underscore.
 rel_strings = st.text(alphabet="_-abc0123456789.", min_size=0, max_size=8)
 
-floors = st.tuples(st.integers(0, 3), st.integers(0, 20))
+libc_versions = st.none() | st.tuples(st.integers(0, 3), st.integers(0, 20))
 
 
 def _specs_for(platform_id: str) -> st.SearchStrategy[PlatformSpec]:
@@ -52,8 +52,8 @@ def _specs_for(platform_id: str) -> st.SearchStrategy[PlatformSpec]:
     return st.builds(
         PlatformSpec,
         platform_id=st.just(platform_id),
-        manylinux_floor=floors,
-        musllinux_floor=floors,
+        libc=st.sampled_from(["glibc", "musl"]),
+        libc_version=libc_versions,
         macos_min=st.none() | st.tuples(st.integers(10, 15), st.integers(0, 3)),
         platform_release=rel_strings,
         platform_version=rel_strings,

--- a/nab-python/tests/universal/property_universal/test_matrix_labels.py
+++ b/nab-python/tests/universal/property_universal/test_matrix_labels.py
@@ -15,7 +15,13 @@ import pytest
 from hypothesis import assume, given
 from hypothesis import strategies as st
 
-from nab_python.tags import _PLATFORM_KIND, LIBC_MAJOR, PlatformSpec
+from nab_python.tags import (
+    _PLATFORM_ARCH,
+    _PLATFORM_KIND,
+    LIBC_MAJOR,
+    MACOS_TAG_FLOOR,
+    PlatformSpec,
+)
 from nab_python.universal.matrix import (
     _IMPLEMENTATION_DEFAULTS,
     _KNOWN_PYTHON_MINORS,
@@ -64,8 +70,14 @@ def _macos_knobs(platform_id: str) -> st.SearchStrategy[dict[str, object]]:
     """Draw the macOS knob the platform admits: none unless it is macOS."""
     if _PLATFORM_KIND[platform_id] != "macos":
         return st.just({})
+    floor = MACOS_TAG_FLOOR[_PLATFORM_ARCH[platform_id]]
     return st.fixed_dictionaries(
-        {"macos_min": st.none() | st.tuples(st.integers(10, 15), st.integers(0, 3))}
+        {
+            "macos_min": st.none()
+            | st.tuples(st.integers(10, 15), st.integers(0, 3)).filter(
+                lambda version: version >= floor
+            )
+        }
     )
 
 

--- a/nab-python/tests/universal/property_universal/test_matrix_labels.py
+++ b/nab-python/tests/universal/property_universal/test_matrix_labels.py
@@ -57,6 +57,7 @@ def _specs_for(platform_id: str) -> st.SearchStrategy[PlatformSpec]:
         macos_min=st.none() | st.tuples(st.integers(10, 15), st.integers(0, 3)),
         platform_release=rel_strings,
         platform_version=rel_strings,
+        free_threaded=st.booleans(),
     )
 
 

--- a/nab-python/tests/universal/property_universal/test_matrix_labels.py
+++ b/nab-python/tests/universal/property_universal/test_matrix_labels.py
@@ -15,7 +15,7 @@ import pytest
 from hypothesis import assume, given
 from hypothesis import strategies as st
 
-from nab_python.tags import PlatformSpec
+from nab_python.tags import _PLATFORM_KIND, LIBC_MAJOR, PlatformSpec
 from nab_python.universal.matrix import (
     _IMPLEMENTATION_DEFAULTS,
     _KNOWN_PYTHON_MINORS,
@@ -40,24 +40,55 @@ python_specs = st.one_of(
     st.sampled_from(_KNOWN_PYTHON_MINORS).map(lambda v: f"!={v}"),
 )
 
-# No whitespace: label_suffix collapses runs of it into "_", which collides
+# No whitespace: the label collapses runs of it into "_", which collides
 # with a literal underscore.
 rel_strings = st.text(alphabet="_-abc0123456789.", min_size=0, max_size=8)
 
-libc_versions = st.none() | st.tuples(st.integers(0, 3), st.integers(0, 20))
+
+def _libc_knobs(platform_id: str) -> st.SearchStrategy[dict[str, object]]:
+    """Draw the libc knobs the platform admits: none unless it is Linux."""
+    if _PLATFORM_KIND[platform_id] != "linux":
+        return st.just({})
+    return st.sampled_from(sorted(LIBC_MAJOR)).flatmap(
+        lambda libc: st.fixed_dictionaries(
+            {
+                "libc": st.just(libc),
+                "libc_version": st.none()
+                | st.tuples(st.just(LIBC_MAJOR[libc]), st.integers(0, 20)),
+            }
+        )
+    )
+
+
+def _macos_knobs(platform_id: str) -> st.SearchStrategy[dict[str, object]]:
+    """Draw the macOS knob the platform admits: none unless it is macOS."""
+    if _PLATFORM_KIND[platform_id] != "macos":
+        return st.just({})
+    return st.fixed_dictionaries(
+        {"macos_min": st.none() | st.tuples(st.integers(10, 15), st.integers(0, 3))}
+    )
 
 
 def _specs_for(platform_id: str) -> st.SearchStrategy[PlatformSpec]:
-    """Build a ``PlatformSpec`` strategy fixed to one platform id."""
+    """Build a ``PlatformSpec`` strategy fixed to one platform id.
+
+    Only the knobs that platform admits are drawn, since the others are a
+    construction error rather than a spec whose label needs to stay apart.
+    """
     return st.builds(
-        PlatformSpec,
-        platform_id=st.just(platform_id),
-        libc=st.sampled_from(["glibc", "musl"]),
-        libc_version=libc_versions,
-        macos_min=st.none() | st.tuples(st.integers(10, 15), st.integers(0, 3)),
-        platform_release=rel_strings,
-        platform_version=rel_strings,
-        free_threaded=st.booleans(),
+        lambda libc, macos, release, version, ft: PlatformSpec(
+            platform_id=platform_id,
+            platform_release=release,
+            platform_version=version,
+            free_threaded=ft,
+            **libc,
+            **macos,
+        ),
+        libc=_libc_knobs(platform_id),
+        macos=_macos_knobs(platform_id),
+        release=rel_strings,
+        version=rel_strings,
+        ft=st.booleans(),
     )
 
 
@@ -90,7 +121,7 @@ class TestExpansionExactCoverage:
         """Expansion covers the exact cross product, repeatably, with unique labels."""
         matrix = Matrix(
             python=python,
-            platforms=tuple(platforms),
+            platforms=tuple(PlatformSpec(p) for p in platforms),
             python_order=order,
             implementations=tuple(impls),
         )
@@ -111,23 +142,23 @@ class TestExpansionExactCoverage:
         assert len(set(labels)) == len(labels), labels
 
 
-class TestLabelSuffixInjective:
-    """``PlatformSpec.label_suffix`` is the documented disambiguator
-    for specs sharing a ``platform_id``: distinct specs must render
-    distinct suffixes, otherwise their per-tuple pins silently merge
-    under one dict key.
+class TestLabelInjective:
+    """``PlatformSpec.label`` is the documented disambiguator for specs
+    sharing a ``platform_id``: distinct specs must render distinct
+    labels, otherwise their per-tuple pins silently merge under one
+    dict key.
     """
 
     @given(pair=spec_pairs())
     @PROPERTY_SETTINGS
-    def test_label_suffix_injective_for_distinct_specs(
+    def test_label_injective_for_distinct_specs(
         self, pair: tuple[PlatformSpec, PlatformSpec]
     ) -> None:
-        """Two distinct same-platform specs never share a label suffix."""
+        """Two distinct same-platform specs never share a label."""
         spec_a, spec_b = pair
         assume(spec_a != spec_b)
-        assert spec_a.label_suffix() != spec_b.label_suffix(), (
-            f"{spec_a!r} and {spec_b!r} collide on suffix {spec_a.label_suffix()!r}"
+        assert spec_a.label != spec_b.label, (
+            f"{spec_a!r} and {spec_b!r} collide on label {spec_a.label!r}"
         )
 
 
@@ -149,7 +180,7 @@ class TestPythonPatchesEnvironment:
         full = f"{minor}.{patch}"
         matrix = Matrix(
             python=f"=={minor}",
-            platforms=("linux_x86_64",),
+            platforms=(PlatformSpec("linux_x86_64"),),
             python_patches={minor: full},
         )
         (tup,) = matrix.expand()

--- a/nab-python/tests/universal/property_universal/test_matrix_labels.py
+++ b/nab-python/tests/universal/property_universal/test_matrix_labels.py
@@ -15,13 +15,13 @@ import pytest
 from hypothesis import assume, given
 from hypothesis import strategies as st
 
+from nab_python.tags import PlatformSpec
 from nab_python.universal.matrix import (
     _IMPLEMENTATION_DEFAULTS,
     _KNOWN_PYTHON_MINORS,
     _PLATFORM_DEFAULTS,
     Matrix,
 )
-from nab_python.universal.wheel_selection import PlatformSpec
 
 from .strategies import PROPERTY_SETTINGS
 

--- a/nab-python/tests/universal/property_universal/test_provider_pep425.py
+++ b/nab-python/tests/universal/property_universal/test_provider_pep425.py
@@ -20,15 +20,17 @@ from hypothesis import strategies as st
 from nab_index.client import SdistFile, WheelFile
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python.provider import BuildPolicy, DistPolicy
+from nab_python.tags import PlatformSpec, select_wheel
 from nab_python.universal.provider import UniversalProvider
-from nab_python.universal.wheel_selection import (
-    PlatformSpec,
-    wheel_compatible_with_tuple,
-)
 
 from .strategies import LINUX_ENV, PROPERTY_SETTINGS
 
 pytestmark = pytest.mark.property
+
+
+def compatible(wheel: WheelFile, spec: PlatformSpec) -> bool:
+    """True iff a CPython 3.11 target on ``spec`` would install ``wheel``."""
+    return select_wheel([wheel], python_version="3.11", spec=spec) is not None
 
 
 _PLATFORM_TAGS = (
@@ -174,9 +176,9 @@ class TestOnlyCompatibleWheelsKept:
         out = provider.filter_distributions("pkg", files)
         for _v, dist in out:
             if isinstance(dist, WheelFile):
-                assert wheel_compatible_with_tuple(
-                    dist, python_version="3.11", spec=spec
-                ), f"Incompatible wheel survived: {dist.filename}"
+                assert compatible(dist, spec), (
+                    f"Incompatible wheel survived: {dist.filename}"
+                )
 
 
 class TestVersionAdmissionPolicy:
@@ -211,7 +213,7 @@ class TestVersionAdmissionPolicy:
         versions_with_sdist: set = set()
         for v, d in super_out:
             if isinstance(d, WheelFile):
-                if wheel_compatible_with_tuple(d, python_version="3.11", spec=spec):
+                if compatible(d, spec):
                     versions_with_compat_wheel.add(v)
             else:
                 versions_with_sdist.add(v)
@@ -240,9 +242,6 @@ class TestVersionAdmissionPolicy:
         out = provider.filter_distributions("pkg", files)
         out_versions = {v for v, _ in out}
         expected = {
-            v
-            for v, d in super_out
-            if isinstance(d, WheelFile)
-            and wheel_compatible_with_tuple(d, python_version="3.11", spec=spec)
+            v for v, d in super_out if isinstance(d, WheelFile) and compatible(d, spec)
         } | {v for v, d in super_out if isinstance(d, SdistFile)}
         assert out_versions == expected

--- a/nab-python/tests/universal/property_universal/test_reresolve_fixed_point.py
+++ b/nab-python/tests/universal/property_universal/test_reresolve_fixed_point.py
@@ -20,6 +20,7 @@ from hypothesis import strategies as st
 from nab_index.client import WheelFile
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python.provider import BuildPolicy
+from nab_python.tags import PlatformSpec
 from nab_python.universal.matrix import Matrix
 from nab_python.universal.reresolve import (
     _collect_wheel_metadata_overrides,
@@ -75,7 +76,7 @@ def _build_universe(baseline_deps: list[str], wheel_deps: list[str]) -> MagicMoc
 
 def _matrix() -> Matrix:
     """Build the single-tuple linux/3.11 matrix used by every test."""
-    return Matrix(python="==3.11", platforms=("linux_x86_64",))
+    return Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),))
 
 
 deps_sets = st.lists(st.sampled_from(DEP_POOL), unique=True, max_size=3).map(sorted)

--- a/nab-python/tests/universal/property_universal/test_validate_mutations.py
+++ b/nab-python/tests/universal/property_universal/test_validate_mutations.py
@@ -18,6 +18,7 @@ from hypothesis import strategies as st
 from nab_index.client import WheelFile
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.version import Version
+from nab_python.tags import PlatformSpec
 from nab_python.universal.matrix import Matrix
 from nab_python.universal.resolve import TupleResult, UniversalResult
 from nab_python.universal.validate import validate_lock
@@ -44,7 +45,7 @@ def _wheel(filename: str) -> WheelFile:
 
 def _matrix() -> Matrix:
     """Build the single-tuple linux/3.11 matrix used by every test."""
-    return Matrix(python=">=3.11,<3.12", platforms=("linux_x86_64",))
+    return Matrix(python=">=3.11,<3.12", platforms=(PlatformSpec("linux_x86_64"),))
 
 
 def _metadata(deps: list[str], version: str = "1.0") -> str:

--- a/nab-python/tests/universal/test_matrix.py
+++ b/nab-python/tests/universal/test_matrix.py
@@ -441,21 +441,25 @@ class TestMatrixTuple:
         assert "in dependency_groups" not in t.marker_string
 
     def test_duplicate_platform_id_specs_get_distinct_labels(self) -> None:
-        """Two specs sharing a platform_id but differing in a floor stay distinct.
+        """Two specs sharing a platform_id but differing in a knob stay distinct.
 
-        The default-floor spec keeps the bare label; a non-default floor
-        gets a discriminator suffix so the tuples do not collapse.
+        The default spec keeps the bare label; a declared libc family or
+        version gets a discriminator suffix so the tuples do not collapse.
         """
         matrix = Matrix(
             python="==3.11",
             platforms=(
-                PlatformSpec("linux_x86_64", manylinux_floor=(2, 17)),
-                PlatformSpec("linux_x86_64", manylinux_floor=(2, 34)),
+                PlatformSpec("linux_x86_64"),
+                PlatformSpec("linux_x86_64", libc_version=(2, 34)),
+                PlatformSpec("linux_x86_64", libc="musl"),
             ),
         )
         labels = [t.label for t in matrix.expand()]
-        assert len(set(labels)) == 2
-        assert "py311-linux_x86_64" in labels
+        assert labels == [
+            "py311-linux_x86_64",
+            "py311-linux_x86_64-glibc2.34",
+            "py311-linux_x86_64-musl",
+        ]
 
     def test_cpython_marker_omits_implementation(self) -> None:
         """The default CPython marker keeps its three-clause form."""

--- a/nab-python/tests/universal/test_matrix.py
+++ b/nab-python/tests/universal/test_matrix.py
@@ -291,7 +291,7 @@ class TestMatrixTuple:
         """``label`` is a short id suitable for filenames and logs."""
         t = MatrixTuple(
             python_version="3.11",
-            platform_id="linux_x86_64",
+            platform_spec=PlatformSpec("linux_x86_64"),
             environment={},
         )
         assert t.label == "py311-linux_x86_64"
@@ -300,7 +300,7 @@ class TestMatrixTuple:
         """A PyPy tuple's label uses the ``pp`` interpreter prefix."""
         t = MatrixTuple(
             python_version="3.11",
-            platform_id="linux_x86_64",
+            platform_spec=PlatformSpec("linux_x86_64"),
             environment={},
             implementation="pypy",
         )
@@ -310,7 +310,7 @@ class TestMatrixTuple:
         """A conflict-fork selection appends sorted ``kind-name`` members."""
         t = MatrixTuple(
             python_version="3.11",
-            platform_id="linux_x86_64",
+            platform_spec=PlatformSpec("linux_x86_64"),
             environment={},
             selection=(("group", "isort5"), ("group", "black22")),
         )
@@ -325,7 +325,7 @@ class TestMatrixTuple:
         """
         t = MatrixTuple(
             python_version="3.11",
-            platform_id="linux_x86_64",
+            platform_spec=PlatformSpec("linux_x86_64"),
             environment={},
             selection=(("group", "isort5"), ("extra", "cpu")),
         )
@@ -341,13 +341,13 @@ class TestMatrixTuple:
         """
         first = MatrixTuple(
             python_version="3.11",
-            platform_id="linux_x86_64",
+            platform_spec=PlatformSpec("linux_x86_64"),
             environment={},
             selection=(("extra", "a-b"), ("extra", "c")),
         )
         second = MatrixTuple(
             python_version="3.11",
-            platform_id="linux_x86_64",
+            platform_spec=PlatformSpec("linux_x86_64"),
             environment={},
             selection=(("extra", "a"), ("extra", "b-c")),
         )
@@ -357,13 +357,13 @@ class TestMatrixTuple:
         """An extra and a group of the same name get distinct labels."""
         as_extra = MatrixTuple(
             python_version="3.11",
-            platform_id="linux_x86_64",
+            platform_spec=PlatformSpec("linux_x86_64"),
             environment={},
             selection=(("extra", "cpu"),),
         )
         as_group = MatrixTuple(
             python_version="3.11",
-            platform_id="linux_x86_64",
+            platform_spec=PlatformSpec("linux_x86_64"),
             environment={},
             selection=(("group", "cpu"),),
         )
@@ -373,7 +373,7 @@ class TestMatrixTuple:
         """An extra member adds a bare ``in extras`` clause to the marker."""
         t = MatrixTuple(
             python_version="3.11",
-            platform_id="linux_x86_64",
+            platform_spec=PlatformSpec("linux_x86_64"),
             environment={
                 "sys_platform": "linux",
                 "platform_machine": "x86_64",
@@ -387,7 +387,7 @@ class TestMatrixTuple:
         """A group member adds a bare ``in dependency_groups`` clause."""
         t = MatrixTuple(
             python_version="3.11",
-            platform_id="linux_x86_64",
+            platform_spec=PlatformSpec("linux_x86_64"),
             environment={
                 "sys_platform": "linux",
                 "platform_machine": "x86_64",
@@ -401,7 +401,7 @@ class TestMatrixTuple:
         """Selection clauses emit in sorted order for byte-stable output."""
         t = MatrixTuple(
             python_version="3.11",
-            platform_id="linux_x86_64",
+            platform_spec=PlatformSpec("linux_x86_64"),
             environment={
                 "sys_platform": "linux",
                 "platform_machine": "x86_64",
@@ -418,7 +418,7 @@ class TestMatrixTuple:
         """The env-only marker drops the conflict membership clause."""
         t = MatrixTuple(
             python_version="3.11",
-            platform_id="linux_x86_64",
+            platform_spec=PlatformSpec("linux_x86_64"),
             environment={
                 "sys_platform": "linux",
                 "platform_machine": "x86_64",
@@ -435,7 +435,7 @@ class TestMatrixTuple:
         """The default empty selection is a no-op (back-compat)."""
         t = MatrixTuple(
             python_version="3.11",
-            platform_id="linux_x86_64",
+            platform_spec=PlatformSpec("linux_x86_64"),
             environment={
                 "sys_platform": "linux",
                 "platform_machine": "x86_64",
@@ -471,7 +471,7 @@ class TestMatrixTuple:
         """The default CPython marker keeps its three-clause form."""
         t = MatrixTuple(
             python_version="3.11",
-            platform_id="linux_x86_64",
+            platform_spec=PlatformSpec("linux_x86_64"),
             environment={
                 "sys_platform": "linux",
                 "platform_machine": "x86_64",
@@ -484,7 +484,7 @@ class TestMatrixTuple:
         """A PyPy marker adds an ``implementation_name`` clause."""
         t = MatrixTuple(
             python_version="3.11",
-            platform_id="linux_x86_64",
+            platform_spec=PlatformSpec("linux_x86_64"),
             environment={
                 "sys_platform": "linux",
                 "platform_machine": "x86_64",

--- a/nab-python/tests/universal/test_matrix.py
+++ b/nab-python/tests/universal/test_matrix.py
@@ -107,6 +107,16 @@ class TestMatrixExpand:
         with pytest.raises(ValueError, match="Unknown platform"):
             matrix.expand()
 
+    def test_unknown_platform_id_wins_over_the_free_threaded_rule(self) -> None:
+        """A bad id is the error to report; the rest of the target is moot."""
+        matrix = Matrix(
+            python=">=3.13",
+            platforms=(PlatformSpec("freebsd_amd64", free_threaded=True),),
+            implementations=("pypy",),
+        )
+        with pytest.raises(ValueError, match="Unknown platform"):
+            matrix.expand()
+
     def test_empty_python_range_raises(self) -> None:
         """A python spec satisfied by no known minor is a user error."""
         matrix = Matrix(python=">=4.0", platforms=(PlatformSpec("linux_x86_64"),))

--- a/nab-python/tests/universal/test_matrix.py
+++ b/nab-python/tests/universal/test_matrix.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import pytest
 
 from nab_python._vendor.packaging.markers import Marker
+from nab_python.tags import PlatformSpec
 from nab_python.universal.matrix import (
     _IMPLEMENTATION_DEFAULTS,
     _KNOWN_PYTHON_MINORS,
@@ -17,7 +18,6 @@ from nab_python.universal.matrix import (
     MatrixTuple,
     _pythons_in_range,
 )
-from nab_python.universal.wheel_selection import PlatformSpec
 
 
 class TestPythonsInRange:

--- a/nab-python/tests/universal/test_matrix.py
+++ b/nab-python/tests/universal/test_matrix.py
@@ -47,7 +47,9 @@ class TestMatrixExpand:
 
     def test_simple_range_expands_to_known_minors(self) -> None:
         """A python range maps to the union of known minors that satisfy it."""
-        matrix = Matrix(python=">=3.11, <3.13", platforms=("linux_x86_64",))
+        matrix = Matrix(
+            python=">=3.11, <3.13", platforms=(PlatformSpec("linux_x86_64"),)
+        )
         tuples = matrix.expand()
         assert [t.python_version for t in tuples] == ["3.11", "3.12"]
         assert all(t.platform_id == "linux_x86_64" for t in tuples)
@@ -56,7 +58,11 @@ class TestMatrixExpand:
         """All (python, platform) pairs are present in the cross-product."""
         matrix = Matrix(
             python=">=3.10, <3.12",
-            platforms=("linux_x86_64", "macos_arm64", "windows_amd64"),
+            platforms=(
+                PlatformSpec("linux_x86_64"),
+                PlatformSpec("macos_arm64"),
+                PlatformSpec("windows_amd64"),
+            ),
         )
         tuples = matrix.expand()
         expected_count = 6
@@ -73,7 +79,7 @@ class TestMatrixExpand:
 
     def test_environment_has_all_required_pep508_keys(self) -> None:
         """Every PEP 508 marker variable must be set per tuple."""
-        matrix = Matrix(python="==3.12", platforms=("macos_arm64",))
+        matrix = Matrix(python="==3.12", platforms=(PlatformSpec("macos_arm64"),))
         tuples = matrix.expand()
         assert len(tuples) == 1
         env = tuples[0].environment
@@ -97,22 +103,22 @@ class TestMatrixExpand:
 
     def test_unknown_platform_id_raises(self) -> None:
         """An unknown platform id is a user error, raised eagerly."""
-        matrix = Matrix(python=">=3.11", platforms=("freebsd_amd64",))
+        matrix = Matrix(python=">=3.11", platforms=(PlatformSpec("freebsd_amd64"),))
         with pytest.raises(ValueError, match="Unknown platform"):
             matrix.expand()
 
     def test_empty_python_range_raises(self) -> None:
         """A python spec satisfied by no known minor is a user error."""
-        matrix = Matrix(python=">=4.0", platforms=("linux_x86_64",))
+        matrix = Matrix(python=">=4.0", platforms=(PlatformSpec("linux_x86_64"),))
         with pytest.raises(ValueError, match="No known Python"):
             matrix.expand()
 
     def test_python_order_desc_reverses_iteration(self) -> None:
         """``python_order='desc'`` yields tuples in reversed Python order."""
-        asc = Matrix(python=">=3.10, <3.13", platforms=("linux_x86_64",))
+        asc = Matrix(python=">=3.10, <3.13", platforms=(PlatformSpec("linux_x86_64"),))
         desc = Matrix(
             python=">=3.10, <3.13",
-            platforms=("linux_x86_64",),
+            platforms=(PlatformSpec("linux_x86_64"),),
             python_order="desc",
         )
         assert [t.python_version for t in asc.expand()] == ["3.10", "3.11", "3.12"]
@@ -123,7 +129,7 @@ class TestMatrixExpand:
         with pytest.raises(ValueError, match="python_order"):
             Matrix(
                 python=">=3.10",
-                platforms=("linux_x86_64",),
+                platforms=(PlatformSpec("linux_x86_64"),),
                 python_order="banana",
             ).expand()
 
@@ -131,7 +137,7 @@ class TestMatrixExpand:
         """``python_patches`` sets ``python_full_version`` per minor."""
         matrix = Matrix(
             python=">=3.11, <3.13",
-            platforms=("linux_x86_64",),
+            platforms=(PlatformSpec("linux_x86_64"),),
             python_patches={"3.11": "3.11.4", "3.12": "3.12.1"},
         )
         tuples = matrix.expand()
@@ -143,7 +149,7 @@ class TestMatrixExpand:
 
     def test_python_patches_default_to_zero(self) -> None:
         """When patches not declared, ``.0`` is used."""
-        matrix = Matrix(python="==3.11", platforms=("linux_x86_64",))
+        matrix = Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),))
         tuples = matrix.expand()
         assert tuples[0].environment["python_full_version"] == "3.11.0"
 
@@ -151,7 +157,7 @@ class TestMatrixExpand:
         """A partial mapping uses overrides for declared minors only."""
         matrix = Matrix(
             python=">=3.11, <3.13",
-            platforms=("linux_x86_64",),
+            platforms=(PlatformSpec("linux_x86_64"),),
             python_patches={"3.11": "3.11.4"},
         )
         tuples = matrix.expand()
@@ -164,7 +170,7 @@ class TestMatrixExpand:
         """A patches key that is not a known ``major.minor`` is a user error."""
         matrix = Matrix(
             python="==3.11",
-            platforms=("linux_x86_64",),
+            platforms=(PlatformSpec("linux_x86_64"),),
             python_patches={"3.11.0": "3.11.9"},
         )
         with pytest.raises(ValueError, match="python_patches"):
@@ -176,7 +182,7 @@ class TestMatrixExpand:
 
         matrix = Matrix(
             python="==3.11",
-            platforms=("linux_x86_64",),
+            platforms=(PlatformSpec("linux_x86_64"),),
             python_patches={"3.11": "3.11.5"},
         )
         env = matrix.expand()[0].environment
@@ -185,7 +191,7 @@ class TestMatrixExpand:
 
     def test_platform_release_default_is_empty_string(self) -> None:
         """Without a user declaration, ``platform_release`` is ``""``."""
-        matrix = Matrix(python="==3.11", platforms=("linux_x86_64",))
+        matrix = Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),))
         env = matrix.expand()[0].environment
         assert env["platform_release"] == ""
         assert env["platform_version"] == ""
@@ -212,7 +218,7 @@ class TestMatrixExpand:
         """A real PEP 508 marker should evaluate against the tuple's env."""
         matrix = Matrix(
             python=">=3.11, <3.12",
-            platforms=("windows_amd64", "linux_x86_64"),
+            platforms=(PlatformSpec("windows_amd64"), PlatformSpec("linux_x86_64")),
         )
         tuples = matrix.expand()
         win_env = next(
@@ -236,7 +242,7 @@ class TestImplementationAxis:
 
     def test_default_is_cpython_only(self) -> None:
         """Without declaring implementations, every tuple is CPython."""
-        matrix = Matrix(python="==3.11", platforms=("linux_x86_64",))
+        matrix = Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),))
         tuples = matrix.expand()
         assert len(tuples) == 1
         env = tuples[0].environment
@@ -248,7 +254,7 @@ class TestImplementationAxis:
         """The implementation axis multiplies the tuple count."""
         matrix = Matrix(
             python=">=3.11, <3.13",
-            platforms=("linux_x86_64", "macos_arm64"),
+            platforms=(PlatformSpec("linux_x86_64"), PlatformSpec("macos_arm64")),
             implementations=("cpython", "pypy"),
         )
         tuples = matrix.expand()
@@ -258,7 +264,7 @@ class TestImplementationAxis:
         """A PyPy tuple sets the PyPy interpreter-identity markers."""
         matrix = Matrix(
             python="==3.11",
-            platforms=("linux_x86_64",),
+            platforms=(PlatformSpec("linux_x86_64"),),
             implementations=("pypy",),
         )
         env = matrix.expand()[0].environment
@@ -271,7 +277,7 @@ class TestImplementationAxis:
         """An unknown implementation is a user error, raised eagerly."""
         matrix = Matrix(
             python="==3.11",
-            platforms=("linux_x86_64",),
+            platforms=(PlatformSpec("linux_x86_64"),),
             implementations=("jython",),
         )
         with pytest.raises(ValueError, match="Unknown implementations"):
@@ -493,7 +499,7 @@ class TestMatrixTuple:
         ``implementation_name`` so it no longer matches a PyPy environment."""
         matrix = Matrix(
             python="==3.11",
-            platforms=("linux_x86_64",),
+            platforms=(PlatformSpec("linux_x86_64"),),
             implementations=("cpython", "pypy"),
         )
         tuples = matrix.expand()

--- a/nab-python/tests/universal/test_reresolve.py
+++ b/nab-python/tests/universal/test_reresolve.py
@@ -15,6 +15,7 @@ from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._testing.overrides import pkg_override
 from nab_python._vendor.packaging.version import Version
 from nab_python.provider import BuildPolicy, DistPolicy
+from nab_python.tags import PlatformSpec
 from nab_python.universal import reresolve as reresolve_module
 from nab_python.universal.matrix import MatrixTuple
 from nab_python.universal.reresolve import (
@@ -24,7 +25,6 @@ from nab_python.universal.reresolve import (
 )
 from nab_python.universal.resolve import TupleResult, UniversalResult
 from nab_python.universal.validate import PinValidation, ValidationReport
-from nab_python.universal.wheel_selection import PlatformSpec
 
 
 def _wheel(filename: str) -> WheelFile:

--- a/nab-python/tests/universal/test_reresolve.py
+++ b/nab-python/tests/universal/test_reresolve.py
@@ -55,7 +55,6 @@ def _make_coordinator(
 def _linux_311(full_version: str = "3.11.0") -> MatrixTuple:
     return MatrixTuple(
         python_version="3.11",
-        platform_id="linux_x86_64",
         environment={
             "python_version": "3.11",
             "python_full_version": full_version,

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -1281,8 +1281,8 @@ class TestMergeUniversalLockInputs:
         matrix = Matrix(
             python="==3.11",
             platforms=(
-                PlatformSpec("linux_x86_64", manylinux_floor=(2, 17)),
-                PlatformSpec("linux_x86_64", manylinux_floor=(2, 34)),
+                PlatformSpec("linux_x86_64", libc_version=(2, 17)),
+                PlatformSpec("linux_x86_64", libc_version=(2, 34)),
             ),
         )
         older, newer = matrix.expand()

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -299,7 +299,7 @@ class TestConflictForkResolve:
         )
 
     def _one_tuple_matrix(self) -> Matrix:
-        return Matrix(python="==3.11", platforms=("linux_x86_64",))
+        return Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),))
 
     def _black_forks(self) -> list:
         return [
@@ -444,7 +444,7 @@ class TestConflictForkBaseNames:
         )
 
     def _matrix(self) -> Matrix:
-        return Matrix(python="==3.11", platforms=("linux_x86_64",))
+        return Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),))
 
     def _forks(self) -> list[ResolveFork]:
         # cpu and gpu both pull in accel; the base has only ``base``.
@@ -1066,7 +1066,7 @@ class TestVcsConfigPlumbing:
             name="pkg",
             url=f"git+https://example.com/pkg.git@{_FORTY_SHA}",
         )
-        matrix = Matrix(python="==3.11", platforms=("linux_x86_64",))
+        matrix = Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),))
         with pytest.raises(ValueError, match="vcs_sources require VcsPolicy.ALLOW"):
             resolve_with_coordinator(
                 coordinator,
@@ -1197,11 +1197,11 @@ class TestUniversalResult:
         ok = TupleResult(tuple_=_linux_311(), success=True)
         bad = TupleResult(tuple_=_windows_311(), success=False)
         assert UniversalResult(
-            matrix=Matrix(python="==3.11", platforms=("linux_x86_64",)),
+            matrix=Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),)),
             tuple_results=[ok, ok],
         ).success
         assert not UniversalResult(
-            matrix=Matrix(python="==3.11", platforms=("linux_x86_64",)),
+            matrix=Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),)),
             tuple_results=[ok, bad],
         ).success
 
@@ -1220,7 +1220,7 @@ class TestUniversalResult:
         result = UniversalResult(
             matrix=Matrix(
                 python="==3.11",
-                platforms=("linux_x86_64", "windows_amd64"),
+                platforms=(PlatformSpec("linux_x86_64"), PlatformSpec("windows_amd64")),
             ),
             tuple_results=[ok, bad],
         )
@@ -1261,7 +1261,7 @@ class TestMergeUniversalLockInputs:
         result = UniversalResult(
             matrix=Matrix(
                 python="==3.11",
-                platforms=("linux_x86_64", "windows_amd64"),
+                platforms=(PlatformSpec("linux_x86_64"), PlatformSpec("windows_amd64")),
             ),
             tuple_results=[ok_with_lock, ok_without_lock],
         )
@@ -1319,7 +1319,7 @@ class TestResolveWithCoordinator:
     def test_first_pass_returns_pins(self) -> None:
         """Single-tuple resolve produces a UniversalResult with pins."""
         coordinator = _make_coordinator({"pkg": [_make_wheel("1.0", package="pkg")]})
-        matrix = Matrix(python="==3.11", platforms=("linux_x86_64",))
+        matrix = Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),))
         result = resolve_with_coordinator(
             coordinator,
             matrix,
@@ -1336,7 +1336,7 @@ class TestResolveWithCoordinator:
         rather than a silent drop.
         """
         coordinator = _make_coordinator({"pkg": [_make_wheel("1.0", package="pkg")]})
-        matrix = Matrix(python="==3.11", platforms=("linux_x86_64",))
+        matrix = Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),))
         with pytest.raises(MissingExtraError):
             resolve_with_coordinator(coordinator, matrix, ["pkg[missing]"])
 
@@ -1350,7 +1350,7 @@ class TestResolveWithCoordinator:
                 ]
             }
         )
-        matrix = Matrix(python="==3.11", platforms=("linux_x86_64",))
+        matrix = Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),))
         result = resolve_with_coordinator(
             coordinator,
             matrix,
@@ -1383,7 +1383,9 @@ class TestResolveUniversalWrapper:
                 ) as inner,
             ):
                 result = resolve_mod.resolve_universal(
-                    matrix=Matrix(python="==3.11", platforms=("linux_x86_64",)),
+                    matrix=Matrix(
+                        python="==3.11", platforms=(PlatformSpec("linux_x86_64"),)
+                    ),
                     requirements=["pkg"],
                 )
         assert result is sentinel
@@ -1414,7 +1416,9 @@ class TestResolveUniversalWrapper:
             fetch_cls.return_value.__enter__.return_value = "COORD"
             fetch_cls.return_value.__exit__.return_value = False
             resolve_mod.resolve_universal(
-                matrix=Matrix(python="==3.11", platforms=("linux_x86_64",)),
+                matrix=Matrix(
+                    python="==3.11", platforms=(PlatformSpec("linux_x86_64"),)
+                ),
                 requirements=["pkg"],
                 indexes=custom,
             )
@@ -1442,7 +1446,7 @@ class TestLocalVcsRequiresPython:
         coord = make_coordinator([], package="foo")
         result = resolve_with_coordinator(
             coord,
-            Matrix(python="==3.10", platforms=("linux_x86_64",)),
+            Matrix(python="==3.10", platforms=(PlatformSpec("linux_x86_64"),)),
             ["foo"],
             local_sources=[local],
         )
@@ -1464,7 +1468,7 @@ class TestLocalVcsRequiresPython:
         )
         result = resolve_with_coordinator(
             coord,
-            Matrix(python="==3.10", platforms=("linux_x86_64",)),
+            Matrix(python="==3.10", platforms=(PlatformSpec("linux_x86_64"),)),
             ["foo"],
             local_sources=[local],
         )
@@ -1478,7 +1482,7 @@ class TestLocalVcsRequiresPython:
         coord = make_coordinator([], package="foo")
         result = resolve_with_coordinator(
             coord,
-            Matrix(python="==3.10", platforms=("linux_x86_64",)),
+            Matrix(python="==3.10", platforms=(PlatformSpec("linux_x86_64"),)),
             ["foo"],
             local_sources=[local],
         )
@@ -1495,7 +1499,7 @@ class TestLocalVcsRequiresPython:
             coord,
             Matrix(
                 python="==3.13",
-                platforms=("linux_x86_64",),
+                platforms=(PlatformSpec("linux_x86_64"),),
                 python_patches={"3.13": "3.13.4"},
             ),
             ["foo"],
@@ -1514,7 +1518,7 @@ class TestLocalVcsRequiresPython:
             coord,
             Matrix(
                 python="==3.13",
-                platforms=("linux_x86_64",),
+                platforms=(PlatformSpec("linux_x86_64"),),
                 python_patches={"3.13": "3.13.4"},
             ),
             ["foo"],
@@ -1566,7 +1570,7 @@ class TestArchiveSourceUniversal:
 
         result = resolve_with_coordinator(
             coord,
-            Matrix(python=">=3.11, <3.13", platforms=("linux_x86_64",)),
+            Matrix(python=">=3.11, <3.13", platforms=(PlatformSpec("linux_x86_64"),)),
             ["foo"],
             archive_sources=[source],
             archive_cache_dir=tmp_path / "arch",
@@ -1594,7 +1598,7 @@ class TestArchiveSourceUniversal:
 
         result = resolve_with_coordinator(
             coord,
-            Matrix(python="==3.10", platforms=("linux_x86_64",)),
+            Matrix(python="==3.10", platforms=(PlatformSpec("linux_x86_64"),)),
             ["foo"],
             archive_sources=[source],
             archive_cache_dir=tmp_path / "arch",

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -56,6 +56,7 @@ from nab_python.requirements_file import (
     read_pyproject_name,
     read_pyproject_optional_dependencies,
 )
+from nab_python.tags import PlatformSpec
 from nab_python.universal import resolve as resolve_mod
 from nab_python.universal.matrix import Matrix, MatrixTuple
 from nab_python.universal.resolve import (
@@ -71,7 +72,6 @@ from nab_python.universal.resolve import (
     merge_universal_lock_inputs,
     resolve_with_coordinator,
 )
-from nab_python.universal.wheel_selection import PlatformSpec
 from nab_resolver.errors import ResolutionError
 
 if TYPE_CHECKING:

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -103,7 +103,7 @@ def _make_coordinator(listings: dict[str, list[WheelFile]]) -> MagicMock:
 def _linux_311() -> MatrixTuple:
     return MatrixTuple(
         python_version="3.11",
-        platform_id="linux_x86_64",
+        platform_spec=PlatformSpec("linux_x86_64"),
         environment={
             "python_version": "3.11",
             "python_full_version": "3.11.0",
@@ -123,7 +123,7 @@ def _linux_311() -> MatrixTuple:
 def _windows_311() -> MatrixTuple:
     return MatrixTuple(
         python_version="3.11",
-        platform_id="windows_amd64",
+        platform_spec=PlatformSpec("windows_amd64"),
         environment={
             "python_version": "3.11",
             "python_full_version": "3.11.0",

--- a/nab-python/tests/universal/test_universal_provider.py
+++ b/nab-python/tests/universal/test_universal_provider.py
@@ -585,7 +585,7 @@ class TestWheelTagFiltering:
         provider = UniversalProvider(
             _index_with_files(wheels),
             marker_environment=_LINUX_ENV,
-            platform_spec=PlatformSpec("linux_x86_64", manylinux_floor=(2, 17)),
+            platform_spec=PlatformSpec("linux_x86_64", libc_version=(2, 17)),
             build_policy=BuildPolicy.NEVER,
         )
         result = provider.filter_distributions("pkg", wheels)
@@ -600,7 +600,7 @@ class TestWheelTagFiltering:
         provider = UniversalProvider(
             _index_with_files(wheels),
             marker_environment=_LINUX_ENV,
-            platform_spec=PlatformSpec("linux_x86_64", manylinux_floor=(2, 34)),
+            platform_spec=PlatformSpec("linux_x86_64", libc_version=(2, 34)),
         )
         result = provider.filter_distributions("pkg", wheels)
         assert [v for v, _ in result] == [Version("1.0")]

--- a/nab-python/tests/universal/test_universal_provider.py
+++ b/nab-python/tests/universal/test_universal_provider.py
@@ -29,8 +29,8 @@ from nab_python.provider import (
     VcsPolicy,
     VcsSource,
 )
+from nab_python.tags import PlatformSpec
 from nab_python.universal.provider import UniversalProvider
-from nab_python.universal.wheel_selection import PlatformSpec
 from nab_resolver.resolver import Resolver
 
 if TYPE_CHECKING:

--- a/nab-python/tests/universal/test_validate.py
+++ b/nab-python/tests/universal/test_validate.py
@@ -104,7 +104,6 @@ def _wheel(filename: str) -> WheelFile:
 def _linux_311() -> MatrixTuple:
     return MatrixTuple(
         python_version="3.11",
-        platform_id="linux_x86_64",
         environment={
             "python_version": "3.11",
             "python_full_version": "3.11.0",
@@ -125,7 +124,6 @@ def _linux_311() -> MatrixTuple:
 def _windows_311() -> MatrixTuple:
     return MatrixTuple(
         python_version="3.11",
-        platform_id="windows_amd64",
         environment={
             "python_version": "3.11",
             "python_full_version": "3.11.0",

--- a/nab-python/tests/universal/test_validate.py
+++ b/nab-python/tests/universal/test_validate.py
@@ -22,6 +22,7 @@ from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._testing.overrides import pkg_override
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.version import Version
+from nab_python.tags import PlatformSpec
 from nab_python.universal.matrix import MatrixTuple
 from nab_python.universal.resolve import TupleResult, UniversalResult
 from nab_python.universal.validate import (
@@ -32,7 +33,6 @@ from nab_python.universal.validate import (
     _requirement_key,
     validate_lock,
 )
-from nab_python.universal.wheel_selection import PlatformSpec
 
 _BASE_METADATA = (
     "Metadata-Version: 2.1\n"

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -44,7 +44,6 @@ from nab_python.requirements_file import (
     read_pyproject_groups,
     read_pyproject_optional_dependencies,
 )
-from nab_python.tags import platform_label
 
 from . import cli as _cli
 from .cli import (
@@ -789,7 +788,7 @@ def _build_provenance(
     platforms: tuple[str, ...]
     if config.mode is ResolveMode.UNIVERSAL and config.matrix is not None:
         python_specifier = config.matrix.python
-        platforms = tuple(platform_label(p) for p in config.matrix.platforms)
+        platforms = tuple(p.label for p in config.matrix.platforms)
     else:
         python_specifier = config.requires_python
         platforms = ()

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -44,6 +44,7 @@ from nab_python.requirements_file import (
     read_pyproject_groups,
     read_pyproject_optional_dependencies,
 )
+from nab_python.tags import platform_label
 
 from . import cli as _cli
 from .cli import (
@@ -788,7 +789,7 @@ def _build_provenance(
     platforms: tuple[str, ...]
     if config.mode is ResolveMode.UNIVERSAL and config.matrix is not None:
         python_specifier = config.matrix.python
-        platforms = tuple(config.matrix.platforms)
+        platforms = tuple(platform_label(p) for p in config.matrix.platforms)
     else:
         python_specifier = config.requires_python
         platforms = ()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -151,7 +151,6 @@ def _universal_result(*, success: bool, error: str | None = None) -> UniversalRe
     matrix = Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),))
     tup = MatrixTuple(
         python_version="3.11",
-        platform_id="linux_x86_64",
         environment=dict(_LINUX_311_ENV),
         platform_spec=PlatformSpec("linux_x86_64"),
     )
@@ -175,7 +174,6 @@ def _multi_tuple_universal_result() -> UniversalResult:
         env = {**_LINUX_311_ENV, "python_version": py_minor}
         tup = MatrixTuple(
             python_version=py_minor,
-            platform_id="linux_x86_64",
             environment=env,
             platform_spec=PlatformSpec("linux_x86_64"),
         )
@@ -1039,7 +1037,6 @@ class TestLockCommandUniversal:
         for member, version in (("cpu", "1.0"), ("gpu", "2.0")):
             tup = MatrixTuple(
                 python_version="3.11",
-                platform_id="linux_x86_64",
                 environment=dict(_LINUX_311_ENV),
                 platform_spec=PlatformSpec("linux_x86_64"),
                 selection=(("extra", member),),
@@ -1291,13 +1288,11 @@ class TestLockCommandUniversal:
         pyproject = _universal_pyproject(tmp_path)
         ok_tuple = MatrixTuple(
             python_version="3.11",
-            platform_id="linux_x86_64",
             environment=dict(_LINUX_311_ENV),
             platform_spec=PlatformSpec("linux_x86_64"),
         )
         bad_tuple = MatrixTuple(
             python_version="3.11",
-            platform_id="windows_amd64",
             environment=dict(_LINUX_311_ENV),
             platform_spec=PlatformSpec("windows_amd64"),
         )
@@ -1341,13 +1336,11 @@ class TestLockCommandUniversal:
         pyproject = _universal_pyproject(tmp_path)
         env_a = MatrixTuple(
             python_version="3.11",
-            platform_id="linux_x86_64",
             environment=dict(_LINUX_311_ENV),
             platform_spec=PlatformSpec("linux_x86_64"),
         )
         env_b = MatrixTuple(
             python_version="3.12",
-            platform_id="linux_x86_64",
             environment={**_LINUX_311_ENV, "python_version": "3.12"},
             platform_spec=PlatformSpec("linux_x86_64"),
         )
@@ -1465,7 +1458,6 @@ class TestLockCommandUniversal:
             env = {**_LINUX_311_ENV, "python_version": "3.11"}
             tup = MatrixTuple(
                 python_version="3.11",
-                platform_id=platform_id,
                 environment=env,
                 platform_spec=PlatformSpec(platform_id),
             )
@@ -1596,13 +1588,11 @@ class TestLockCommandUniversal:
         # Build a mixed matrix: 3.11 succeeds, 3.12 fails.
         good_tup = MatrixTuple(
             python_version="3.11",
-            platform_id="linux_x86_64",
             environment={**_LINUX_311_ENV, "python_version": "3.11"},
             platform_spec=PlatformSpec("linux_x86_64"),
         )
         bad_tup = MatrixTuple(
             python_version="3.12",
-            platform_id="linux_x86_64",
             environment={**_LINUX_311_ENV, "python_version": "3.12"},
             platform_spec=PlatformSpec("linux_x86_64"),
         )
@@ -1660,7 +1650,6 @@ class TestNoEmitWorkspace:
         matrix = Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),))
         tup = MatrixTuple(
             python_version="3.11",
-            platform_id="linux_x86_64",
             environment=dict(_LINUX_311_ENV),
             platform_spec=PlatformSpec("linux_x86_64"),
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,9 +62,9 @@ from nab_python.provider import (
 )
 from nab_python.requirements_file import InvalidProjectRequirementError
 from nab_python.resolve import ResolutionResult
+from nab_python.tags import PlatformSpec
 from nab_python.universal.matrix import Matrix, MatrixTuple
 from nab_python.universal.resolve import TupleResult, UniversalResult
-from nab_python.universal.wheel_selection import PlatformSpec
 from nab_resolver.resolver import ResolutionError
 
 V = Version

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -148,7 +148,7 @@ def _workspace_pyproject(tmp_path: Path, *, universal: bool = False) -> Path:
 
 def _universal_result(*, success: bool, error: str | None = None) -> UniversalResult:
     """Build a real :class:`UniversalResult` with one matrix tuple."""
-    matrix = Matrix(python="==3.11", platforms=("linux_x86_64",))
+    matrix = Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),))
     tup = MatrixTuple(
         python_version="3.11",
         platform_id="linux_x86_64",
@@ -168,7 +168,7 @@ def _universal_result(*, success: bool, error: str | None = None) -> UniversalRe
 
 def _multi_tuple_universal_result() -> UniversalResult:
     """Build a successful UniversalResult with two tuples (3.11 and 3.12)."""
-    matrix = Matrix(python=">=3.11,<3.13", platforms=("linux_x86_64",))
+    matrix = Matrix(python=">=3.11,<3.13", platforms=(PlatformSpec("linux_x86_64"),))
     tuples = []
     results = []
     for py_minor in ("3.11", "3.12"):
@@ -1034,7 +1034,7 @@ class TestLockCommandUniversal:
             'platforms = ["linux_x86_64"]\n',
         )
 
-        matrix = Matrix(python="==3.11", platforms=("linux_x86_64",))
+        matrix = Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),))
         results: list[TupleResult] = []
         for member, version in (("cpu", "1.0"), ("gpu", "2.0")):
             tup = MatrixTuple(
@@ -1317,7 +1317,7 @@ class TestLockCommandUniversal:
         mixed = UniversalResult(
             matrix=Matrix(
                 python="==3.11",
-                platforms=("linux_x86_64", "windows_amd64"),
+                platforms=(PlatformSpec("linux_x86_64"), PlatformSpec("windows_amd64")),
             ),
             tuple_results=[ok_tr, bad_tr],
         )
@@ -1372,7 +1372,9 @@ class TestLockCommandUniversal:
             error="ResolutionError: base unresolvable\nDiagnostics: missing",
         )
         mixed = UniversalResult(
-            matrix=Matrix(python=">=3.11,<3.13", platforms=("linux_x86_64",)),
+            matrix=Matrix(
+                python=">=3.11,<3.13", platforms=(PlatformSpec("linux_x86_64"),)
+            ),
             tuple_results=[ok_tr, bad_tr],
             base_results=[ok_base, bad_base],
         )
@@ -1454,7 +1456,10 @@ class TestLockCommandUniversal:
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
         """A template missing ``{platform_id}`` on a multi-platform matrix exits 1."""
-        matrix = Matrix(python="==3.11", platforms=("linux_x86_64", "windows_amd64"))
+        matrix = Matrix(
+            python="==3.11",
+            platforms=(PlatformSpec("linux_x86_64"), PlatformSpec("windows_amd64")),
+        )
         tuples_results = []
         for platform_id in ("linux_x86_64", "windows_amd64"):
             env = {**_LINUX_311_ENV, "python_version": "3.11"}
@@ -1616,7 +1621,9 @@ class TestLockCommandUniversal:
             lock_input=None,
         )
         mixed = UniversalResult(
-            matrix=Matrix(python=">=3.11,<3.13", platforms=("linux_x86_64",)),
+            matrix=Matrix(
+                python=">=3.11,<3.13", platforms=(PlatformSpec("linux_x86_64"),)
+            ),
             tuple_results=[good_tr, bad_tr],
         )
         out = tmp_path / "constraints-{python_version}.txt"
@@ -1650,7 +1657,7 @@ class TestNoEmitWorkspace:
     @staticmethod
     def _alpha_and_foo_universal() -> UniversalResult:
         """A universal result with alpha + foo on a single tuple."""
-        matrix = Matrix(python="==3.11", platforms=("linux_x86_64",))
+        matrix = Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),))
         tup = MatrixTuple(
             python_version="3.11",
             platform_id="linux_x86_64",


### PR DESCRIPTION
A Linux target emitted both manylinux and musllinux tags at once, and its manylinux floor was applied as a ceiling. `PlatformSpec` carried a `manylinux_floor` and a `musllinux_floor` side by side and expanded both, so a declared `linux_x86_64` target rejected numpy's `manylinux_2_28` wheel (above the 2.17 floor) and selected its `musllinux_1_2` wheel instead. A machine links one C library, so `PlatformSpec` now takes `libc` and `libc_version`, a target emits exactly one family's tags, and the glibc default is 2.28, below which numpy, pandas and scipy publish no wheel at all. A libc version outside its family's only major (glibc 3.x, musl 2.x) names platform tags nothing is built for, so it is a config error rather than a target that silently matches nothing.

The ABI axis had no free-threaded value: every CPython target got `cpXY` plus `abi3`, which a free-threaded interpreter cannot load. `PlatformSpec.free_threaded` now names the `cpXYt` ABI, with `abi3t` in place of `abi3`. That build starts at CPython 3.13, so a free-threaded target under a matrix that admits an older minor, or a non-CPython implementation, is rejected up front.

None of these knobs were reachable from config, which took bare platform ids, so `[tool.nab.matrix].platforms` now accepts a table form alongside the id:

```toml
platforms = ["windows_amd64", { id = "linux_x86_64", libc = "musl", libc-version = "1.2" }]
```

An id may appear once. A lockfile entry is selected by a PEP 508 marker, and PEP 508 has no variable for the libc family or the free-threaded build, so two targets sharing an id would render the same marker and the lock could not tell their pins apart. Locking a second libc family is a second run with its own config and output file.

The machinery itself moves from `universal/wheel_selection.py` to a public `nab_python.tags`. It was the only importer of `packaging.tags` outside the vendored copy, and it sat inside the package the docs call experimental, so the default resolve path had no way to reach it. That is the root of `nab lock` on Linux pinning `pywin32`: specific mode has no concept of a wheel tag anywhere. `compatible_tags_for_tuple` becomes `tags_for_target` and `select_wheel_for_tuple` becomes `select_wheel` (the old names were about matrix tuples, and the module is about to serve the default path), `wheel_tag_set` joins `__all__` because `universal/provider.py` was importing it while it was private, and `wheel_compatible_with_tuple` goes, having had no caller.

Both model fixes change universal-mode wheel selection, which is why they ride with the move rather than landing on top of a default path that already depends on them. Universal mode is experimental. Specific mode is unchanged here and gains the tag filter in a follow-up.