### PR TITLE
fix metadata sha256 mismatch when a wheel URL has a hash fragment

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -16,7 +16,7 @@ import zlib
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlsplit, urlunsplit
 
 from packaging.utils import (
     InvalidSdistFilename,
@@ -204,8 +204,17 @@ class WheelFile:
 
     @property
     def metadata_url(self) -> str | None:
-        """Return the PEP 658/714 metadata URL, or None when unsupported."""
-        return self.url + ".metadata" if self.has_metadata else None
+        """Return the PEP 658/714 metadata URL, or None when unsupported.
+
+        The ``.metadata`` suffix goes on the path, so a PEP 503
+        ``#<algo>=<digest>`` fragment carried by the file URL is dropped
+        first: appended to the fragment it would never reach the wire,
+        and the request would fetch the wheel itself.
+        """
+        if not self.has_metadata:
+            return None
+        parts = urlsplit(self.url)
+        return urlunsplit(parts._replace(path=parts.path + ".metadata", fragment=""))
 
 
 @dataclass(frozen=True, slots=True)

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -206,13 +206,11 @@ class WheelFile:
     def metadata_url(self) -> str | None:
         """Return the PEP 658/714 metadata URL, or None when unsupported.
 
-        The ``.metadata`` suffix goes on the path, so a PEP 503
-        ``#<algo>=<digest>`` fragment carried by the file URL is dropped
-        first: appended to the fragment it would never reach the wire,
-        and the request would fetch the wheel itself.
+        The suffix goes on the path, so a PEP 503 hash fragment is dropped.
         """
         if not self.has_metadata:
             return None
+
         parts = urlsplit(self.url)
         return urlunsplit(parts._replace(path=parts.path + ".metadata", fragment=""))
 

--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -144,7 +144,7 @@ def _prefer_metadata_source(current: DistFile | None, candidate: DistFile) -> Di
 def _metadata_rank(dist: DistFile) -> int:
     """Rank a dist by metadata-fetch cost (lower is cheaper)."""
     if isinstance(dist, WheelFile):
-        return 0 if dist.metadata_url is not None else 1
+        return 0 if dist.has_metadata else 1
     return 2
 
 
@@ -209,10 +209,8 @@ def prefetch_root_batch(
             continue
         if _has_complete_override(provider, normalized, version):
             continue
-        if isinstance(dist, WheelFile) and dist.metadata_url is not None:
-            items.append(
-                (normalized, dist.version, dist.metadata_url, dist.metadata_hash)
-            )
+        if isinstance(dist, WheelFile) and (url := dist.metadata_url) is not None:
+            items.append((normalized, dist.version, url, dist.metadata_hash))
     if items:
         provider.coordinator.request_metadata_batch(items)
 
@@ -236,10 +234,10 @@ def prefetch_transitive_best(
     if (
         cache_key not in provider.deps_cache
         and isinstance(dist, WheelFile)
-        and dist.metadata_url is not None
+        and (url := dist.metadata_url) is not None
     ):
         provider.coordinator.request_metadata(
-            normalized, dist.version, dist.metadata_url, dist.metadata_hash
+            normalized, dist.version, url, dist.metadata_hash
         )
 
 
@@ -609,7 +607,7 @@ def _first_wheel_per_version(
     """First wheel-with-PEP-658-metadata per unique version, in list order."""
     out: dict[Version, WheelFile] = {}
     for version, dist in versions_list:
-        if isinstance(dist, WheelFile) and dist.metadata_url is not None:
+        if isinstance(dist, WheelFile) and dist.has_metadata:
             out.setdefault(version, dist)
     return out
 
@@ -649,7 +647,7 @@ def prefetch_walk_ahead(
             continue
         if _has_complete_override(provider, normalized, version):
             continue
-        # ``_first_wheel_per_version`` filters out wheels without metadata_url.
+        # ``_first_wheel_per_version`` keeps only wheels with a sidecar.
         metadata_url = wheel.metadata_url
         assert metadata_url is not None
         if coordinator_index.has_metadata(normalized, wheel.version, metadata_url):
@@ -683,11 +681,9 @@ def prefetch_batch(
         if _has_complete_override(provider, package, v):
             continue
         wheel = wheel_by_version_map[v]
-        if isinstance(wheel, WheelFile) and wheel.metadata_url is not None:
-            items.append(
-                (package, wheel.version, wheel.metadata_url, wheel.metadata_hash)
-            )
-            version_map.append((v, wheel.version, wheel.metadata_url))
+        if isinstance(wheel, WheelFile) and (url := wheel.metadata_url) is not None:
+            items.append((package, wheel.version, url, wheel.metadata_hash))
+            version_map.append((v, wheel.version, url))
 
     if not items:
         return []

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -76,9 +76,9 @@ def resolve_metadata(
         raise MetadataError(msg)
 
     from_sdist = False
-    if isinstance(dist, WheelFile) and dist.metadata_url is not None:
+    if isinstance(dist, WheelFile) and (url := dist.metadata_url) is not None:
         event = provider.coordinator.request_metadata(
-            normalized, ver_str, dist.metadata_url, dist.metadata_hash
+            normalized, ver_str, url, dist.metadata_hash
         )
         event.wait()
         integrity_error = index.get_metadata_error(
@@ -140,7 +140,7 @@ def pick_dist_for_metadata(
         if v != version:
             continue
         if isinstance(d, WheelFile):
-            if d.metadata_url is not None:
+            if d.has_metadata:
                 if wheel_with_meta is None:
                     wheel_with_meta = d
             elif wheel_without_meta is None:

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -1049,8 +1049,8 @@ class FetchCoordinator:
         # one the provider picks for that version's metadata.
         first_wheel: dict[str, tuple[WheelFile, str]] = {}
         for f in files:
-            if isinstance(f, WheelFile) and f.metadata_url is not None:
-                first_wheel.setdefault(f.version, (f, f.metadata_url))
+            if isinstance(f, WheelFile) and (url := f.metadata_url) is not None:
+                first_wheel.setdefault(f.version, (f, url))
 
         newest = list(first_wheel.values())[-self.PREFETCH_METADATA_COUNT :]
         for w, metadata_url in newest:

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -10,7 +10,7 @@ import tarfile
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlsplit
 
 import pytest
 
@@ -98,6 +98,29 @@ class _FakeTransport:
             msg = f"unexpected request to {url}"
             raise AssertionError(msg)
         return self._responses.pop(0)
+
+    async def aclose(self) -> None:
+        return None
+
+
+class _PathRoutingTransport:
+    """Serves bodies by URL path, as a server does.
+
+    RFC 3986 keeps the fragment off the wire, so a request whose
+    ``.metadata`` suffix landed inside the fragment reaches the wheel's
+    own path and is served the wheel.
+    """
+
+    def __init__(self, bodies: dict[str, bytes]) -> None:
+        self._bodies = bodies
+        self.paths: list[str] = []
+
+    async def get(
+        self, url: str, *, headers: dict[str, str] | None = None
+    ) -> _FakeResponse:
+        path = urlsplit(url).path
+        self.paths.append(path)
+        return _FakeResponse(self._bodies[path])
 
     async def aclose(self) -> None:
         return None
@@ -515,6 +538,99 @@ class TestRelativeUrlResolution:
         data = {"files": [{"filename": "foo-1.0-py3-none-any.whl", "url": raw}]}
         files = _parse_files(data, "https://example.com/simple/", "foo")
         assert files[0].url == urljoin(base, raw) != raw
+
+
+class TestMetadataUrl:
+    """PEP 658/714 sidecar URL derived from the PEP 691 file URL."""
+
+    def _wheel(self, url: str, *, has_metadata: bool = True) -> WheelFile:
+        return WheelFile(
+            filename="foo-1.0-py3-none-any.whl",
+            url=url,
+            version="1.0",
+            requires_python=None,
+            has_metadata=has_metadata,
+            upload_time=None,
+        )
+
+    def test_suffix_appended_to_path(self) -> None:
+        wheel = self._wheel("https://files.example.com/foo-1.0-py3-none-any.whl")
+        assert (
+            wheel.metadata_url
+            == "https://files.example.com/foo-1.0-py3-none-any.whl.metadata"
+        )
+
+    def test_hash_fragment_dropped(self) -> None:
+        wheel = self._wheel(
+            "https://files.example.com/foo-1.0-py3-none-any.whl#sha256=" + "a" * 64
+        )
+        assert (
+            wheel.metadata_url
+            == "https://files.example.com/foo-1.0-py3-none-any.whl.metadata"
+        )
+
+    def test_query_string_preserved(self) -> None:
+        wheel = self._wheel(
+            "https://files.example.com/foo-1.0-py3-none-any.whl?token=x#sha256=abc"
+        )
+        assert (
+            wheel.metadata_url
+            == "https://files.example.com/foo-1.0-py3-none-any.whl.metadata?token=x"
+        )
+
+    def test_file_url(self) -> None:
+        wheel = self._wheel("file:///srv/wheels/foo-1.0-py3-none-any.whl")
+        assert (
+            wheel.metadata_url == "file:///srv/wheels/foo-1.0-py3-none-any.whl.metadata"
+        )
+
+    def test_no_sidecar_yields_none(self) -> None:
+        wheel = self._wheel(
+            "https://files.example.com/foo-1.0-py3-none-any.whl", has_metadata=False
+        )
+        assert wheel.metadata_url is None
+
+
+class TestFragmentedUrlSidecarFetch:
+    """A PEP 503 hash fragment on the file URL must not divert the sidecar fetch."""
+
+    def test_sidecar_fetched_and_verified(self, tmp_path: Path) -> None:
+        wheel_bytes = b"PK\x03\x04 not really a wheel"
+        sidecar = b"Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n"
+        wheel_path = "/packages/foo-1.0-py3-none-any.whl"
+        data = {
+            "files": [
+                {
+                    "filename": "foo-1.0-py3-none-any.whl",
+                    "url": (
+                        f"https://files.example.com{wheel_path}"
+                        f"#sha256={hashlib.sha256(wheel_bytes).hexdigest()}"
+                    ),
+                    "core-metadata": {
+                        "sha256": hashlib.sha256(sidecar).hexdigest(),
+                    },
+                },
+            ],
+        }
+        files = _parse_files(data, "https://example.com/simple/", "foo")
+        wheel = files[0]
+        assert isinstance(wheel, WheelFile)
+        transport = _PathRoutingTransport(
+            {wheel_path: wheel_bytes, wheel_path + ".metadata": sidecar}
+        )
+
+        async def go() -> str:
+            client = CachedAsyncSimpleClient(transport, _make_cache(tmp_path))
+            try:
+                assert wheel.metadata_url is not None
+                return await client.get_metadata_text(
+                    "foo", "1.0", wheel.metadata_url, wheel.metadata_hash
+                )
+            finally:
+                await client.aclose()
+
+        assert asyncio.run(go()) == sidecar.decode()
+        assert transport.paths == [wheel_path + ".metadata"]
 
 
 class TestParseHashes:

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -104,12 +104,7 @@ class _FakeTransport:
 
 
 class _PathRoutingTransport:
-    """Serves bodies by URL path, as a server does.
-
-    RFC 3986 keeps the fragment off the wire, so a request whose
-    ``.metadata`` suffix landed inside the fragment reaches the wheel's
-    own path and is served the wheel.
-    """
+    """Serves bodies by URL path, as a server does: the fragment is not sent."""
 
     def __init__(self, bodies: dict[str, bytes]) -> None:
         self._bodies = bodies
@@ -612,9 +607,11 @@ class TestFragmentedUrlSidecarFetch:
                 },
             ],
         }
+
         files = _parse_files(data, "https://example.com/simple/", "foo")
         wheel = files[0]
         assert isinstance(wheel, WheelFile)
+
         transport = _PathRoutingTransport(
             {wheel_path: wheel_bytes, wheel_path + ".metadata": sidecar}
         )


### PR DESCRIPTION
Against an index whose PEP 691 JSON puts a PEP 503 hash fragment on the file URL (`https://.../foo-1.0-py3-none-any.whl#sha256=...`), every resolve fails. `WheelFile.metadata_url` built the PEP 658 sidecar URL by appending `.metadata` to the raw URL, so the suffix landed inside the fragment instead of on the path. The server never sees the fragment, so the sidecar request re-downloaded the wheel itself, and nab then hashed those wheel bytes against the sidecar's `core-metadata` digest and aborted with a misleading `metadata sha256 mismatch`.

The URL is now split with `urlsplit`, the suffix appended to the path, and the fragment dropped. The query string is kept, since an index that needs a token to serve the wheel needs it to serve the sidecar too. Callers that only wanted to know whether a sidecar was advertised now check `has_metadata` instead of deriving a URL and comparing it to `None`.
