### PR TITLE
read archive sources by their own URL scheme

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -494,6 +494,10 @@ package below the archive root, for monorepo layouts.  Reading static
 dependencies works at any `build-policy`; dynamic dependencies require
 `build-policy = "build-remote"`, like a remote sdist.
 
+The URL is read by its own scheme, whatever the configured indexes use:
+a `file://` archive is read from disk, and any other archive is fetched
+over HTTP.
+
 ## Universal mode (experimental)
 
 Universal resolution runs the single-environment resolver once per

--- a/nab-index/src/nab_index/archive.py
+++ b/nab-index/src/nab_index/archive.py
@@ -4,9 +4,9 @@ Parses a pip-style archive URL such as
 ``https://example.com/foo-1.0.tar.gz#sha256=<hex>&subdirectory=pkg`` into
 its bare URL, the declared hashes, and any subdirectory.
 
-The download and hash verification happen in the fetch coordinator (the
-same path a remote sdist takes); which archives are permitted is a
-policy decision in :mod:`nab_python.config`.
+The download happens in the fetch coordinator, which reads the URL by its
+own scheme; which archives are permitted is a policy decision in
+:mod:`nab_python.config`.
 """
 
 from __future__ import annotations

--- a/nab-python/src/nab_python/_provider/sources.py
+++ b/nab-python/src/nab_python/_provider/sources.py
@@ -269,9 +269,8 @@ def _fetch_archive_bytes(
     """Return ``(cache_dir, request, digest, data)`` for a verified archive.
 
     Raises before returning if the cache dir is missing, the download failed,
-    or the bytes fail their hash.  The hash is re-checked here rather than
-    trusted to the serving client: a ``file://`` index reads archive bytes
-    without verifying them, so this is the one place the check always runs.
+    or the bytes fail their hash.  The coordinator reads the declared URL
+    without verifying it, so every declared hash is checked here.
     """
     from ..provider import UnsupportedSdistError
 
@@ -291,24 +290,13 @@ def _fetch_archive_bytes(
     # only carries accepted algorithms, so every pair is verifiable.
     digest = request.hashes[0][1]
 
-    # Fetch through the shared coordinator; a recorded integrity error or an
-    # absent download both fail the resolve here.
-    event = provider.coordinator.request_sdist_archive(
-        canonical, digest, request.url, request.hashes
-    )
+    event = provider.coordinator.request_direct_archive(canonical, digest, request.url)
     event.wait()
-    error = provider.coordinator.index.get_sdist_archive_error(canonical, digest)
-    if error is not None:
-        raise error
     data = provider.coordinator.index.get_sdist_archive(canonical, digest)
     if data is None:
         msg = f"archive source {source.name!r}: download from {request.url} failed"
         raise UnsupportedSdistError(msg)
 
-    # Verify every declared hash rather than trust the serving client, so a
-    # file:// index (which does not check) cannot slip an unverified archive
-    # through, and so this layer never disagrees with a client that verified a
-    # different algorithm.
     for pinned_hash in request.hashes:
         _verify_sdist_hash(data, pinned_hash)
     return cache_dir, request, digest, data

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -17,16 +17,18 @@ import logging
 import threading
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
 
 from nab_index.cache import CacheBackend, NullCache, OfflineError, OnDiskCache
 from nab_index.cached_client import CachedAsyncSimpleClient
 from nab_index.client import (
+    AsyncSimpleClient,
     MetadataHashMismatchError,
     SdistFile,
     SdistHashMismatchError,
     WheelFile,
 )
-from nab_index.local_index import LocalIndexClient
+from nab_index.local_index import LocalIndexClient, parse_file_url
 from nab_index.multi_index import IndexConfig, MultiIndexClient
 
 from ._vendor.packaging.utils import canonicalize_name
@@ -63,12 +65,13 @@ logger = logging.getLogger(__name__)
 
 
 class FetchKind(enum.Enum):
-    """Distinguishes the four kinds of fetches the coordinator handles."""
+    """Distinguishes the kinds of fetches the coordinator handles."""
 
     LISTING = "listing"
     METADATA = "metadata"
     SDIST = "sdist"
     SDIST_ARCHIVE = "sdist-archive"
+    DIRECT_ARCHIVE = "direct-archive"
 
 
 @dataclass(frozen=True, slots=True)
@@ -730,6 +733,33 @@ class FetchCoordinator:
             )
         return pending.event
 
+    def request_direct_archive(
+        self,
+        package: str,
+        version: str,
+        url: str,
+    ) -> threading.Event:
+        """Request the bytes of an archive named by URL rather than by an index.
+
+        Used by ``[[tool.nab.archive-sources]]``, whose URL is declared
+        independently of every index, so the URL's own scheme decides how it is
+        read.  The bytes land unverified in the same slot as
+        :meth:`request_sdist_archive`; the caller checks the declared hashes.
+        """
+        self._check_alive()
+        key = f"sdist-archive:{package}:{version}"
+        pending, existed = self.index.get_or_create_pending(key)
+        if not existed:
+            self._submit(
+                FetchRequest(
+                    kind=FetchKind.DIRECT_ARCHIVE,
+                    package=package,
+                    version=version,
+                    url=url,
+                )
+            )
+        return pending.event
+
     def request_metadata_batch(
         self, items: list[tuple[str, str, str, tuple[str, str] | None]]
     ) -> list[tuple[str, str, threading.Event]]:
@@ -892,8 +922,10 @@ class FetchCoordinator:
                     await self._fetch_metadata(client, req)
                 elif req.kind is FetchKind.SDIST:
                     await self._fetch_sdist(client, req)
-                else:
+                elif req.kind is FetchKind.SDIST_ARCHIVE:
                     await self._fetch_sdist_archive(client, req)
+                else:
+                    await self._fetch_direct_archive(req)
             except Exception as exc:
                 logger.exception("Fetch failed: %s %s", req.kind.value, req.package)
                 self._record_fetch_failure(client, req, exc)
@@ -1020,4 +1052,19 @@ class FetchCoordinator:
         data = await client.get_sdist_archive(
             req.package, req.version, req.url, req.sdist_hashes
         )
+        self.index.store_sdist_archive(req.package, req.version, data)
+
+    async def _fetch_direct_archive(self, req: FetchRequest) -> None:
+        """Read an archive declared by URL, by that URL's own scheme."""
+        assert req.version is not None
+        assert req.url is not None
+
+        if urlsplit(req.url).scheme == "file":
+            data = parse_file_url(req.url).read_bytes()
+        else:
+            if self._offline:
+                msg = f"archive fetch unavailable in offline mode ({req.url})"
+                raise OfflineError(msg)
+            data = await AsyncSimpleClient(self._transport).download(req.url)
+
         self.index.store_sdist_archive(req.package, req.version, data)

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -22,7 +22,6 @@ from urllib.parse import urlsplit
 from nab_index.cache import CacheBackend, NullCache, OfflineError, OnDiskCache
 from nab_index.cached_client import CachedAsyncSimpleClient
 from nab_index.client import (
-    AsyncSimpleClient,
     MetadataHashMismatchError,
     SdistFile,
     SdistHashMismatchError,
@@ -890,6 +889,10 @@ class FetchCoordinator:
         finally:
             await client.aclose()
 
+            # A file:// index client owns no transport, but a direct archive
+            # fetch can still have opened one.  aclose is idempotent.
+            await self._transport.aclose()
+
     def _dispatch(
         self,
         item: FetchRequest | list[FetchRequest],
@@ -1065,6 +1068,8 @@ class FetchCoordinator:
             if self._offline:
                 msg = f"archive fetch unavailable in offline mode ({req.url})"
                 raise OfflineError(msg)
-            data = await AsyncSimpleClient(self._transport).download(req.url)
+            response = await self._transport.get(req.url)
+            response.raise_for_status()
+            data = response.content
 
         self.index.store_sdist_archive(req.package, req.version, data)

--- a/nab-python/tests/test_archive.py
+++ b/nab-python/tests/test_archive.py
@@ -1,9 +1,9 @@
 """Tests for direct-URL archive sources (``[[tool.nab.archive-sources]]``).
 
-The download itself goes through the fetch coordinator, so these tests
-pre-seed the in-memory index with the archive bytes (or an error) rather
-than hitting the network, and exercise the extract-then-materialise path
-on real ``.tar.gz`` bytes.
+Most tests pre-seed the in-memory index with the archive bytes rather than
+hitting the network, and exercise the extract-then-materialise path on real
+``.tar.gz`` bytes.  The fetch tests drive a real coordinator, so the download
+itself is under test.
 """
 
 from __future__ import annotations
@@ -15,17 +15,22 @@ import tarfile
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
+import httpx
 import pytest
+import respx
 
 from nab_index._subdir import subdirectory_escapes
 from nab_index.archive import ArchiveRequest, ArchiveRequestError
 from nab_index.client import SdistHashMismatchError, extract_sdist_archive
+from nab_index.httpx_async_transport import HttpxAsyncTransport
+from nab_index.multi_index import IndexConfig
+from nab_python._provider.sources import _fetch_archive_bytes
 from nab_python.download import (
     DownloadError,
     _reject_colliding_targets,
     iter_artifacts,
 )
-from nab_python.fetch import InMemoryIndex
+from nab_python.fetch import FetchCoordinator, InMemoryIndex
 from nab_python.lockfile import ArchivePin, LockInput
 from nab_python.provider import (
     ArchiveSource,
@@ -74,6 +79,18 @@ def _provider(archive_sources: list[ArchiveSource], cache_dir: Path | None) -> P
     return Provider(
         coordinator,
         archive_sources=archive_sources,
+        archive_cache_dir=cache_dir,
+        build_policy=BuildPolicy.NEVER,
+    )
+
+
+def _fetching_provider(
+    coordinator: FetchCoordinator, source: ArchiveSource, cache_dir: Path
+) -> Provider:
+    """Provider wired to a real coordinator, so the archive is really fetched."""
+    return Provider(
+        coordinator,
+        archive_sources=[source],
         archive_cache_dir=cache_dir,
         build_policy=BuildPolicy.NEVER,
     )
@@ -239,20 +256,6 @@ class TestArchiveMaterialize:
         assert len(versions) == 1
         assert str(versions[0][0]) == "1.0.0"
 
-    def test_hash_mismatch_is_hard_error(self, tmp_path: Path) -> None:
-        digest = "a" * 64
-        source = ArchiveSource(
-            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
-        )
-        provider = _provider([source], tmp_path / "arch")
-        provider.coordinator.index.store_sdist_archive_error(
-            "foo", digest, SdistHashMismatchError("sha256 mismatch")
-        )
-        # A tampered archive fails the resolve loudly; it is not swallowed
-        # as an UnsupportedSdistError the look-ahead would treat as a skip.
-        with pytest.raises(SdistHashMismatchError):
-            provider.fetch_versions("foo")
-
     def test_missing_cache_dir_raises(self) -> None:
         digest = "a" * 64
         source = ArchiveSource(
@@ -268,14 +271,13 @@ class TestArchiveMaterialize:
             name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
         )
         provider = _provider([source], tmp_path / "arch")
-        # No bytes stored and no error recorded: the fetch produced nothing.
+        # No bytes stored: the fetch produced nothing.
         with pytest.raises(UnsupportedSdistError, match="download.*failed"):
             provider.fetch_versions("foo")
 
-    def test_local_source_hash_verified(self, tmp_path: Path) -> None:
-        # A file:// index reads bytes without verifying, so materialisation
-        # re-checks the hash: tampered bytes present (and no recorded error)
-        # still fail the resolve loudly.
+    def test_tampered_archive_is_hard_error(self, tmp_path: Path) -> None:
+        # Tampered bytes fail the resolve loudly, not as an UnsupportedSdistError
+        # the look-ahead would treat as a skippable version.
         digest = "a" * 64
         source = ArchiveSource(
             name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
@@ -393,6 +395,73 @@ class TestArchiveMaterialize:
         second.coordinator.index.store_sdist_archive("foo", digest, data)
         versions = second.fetch_versions("foo")
         assert str(versions[0][0]) == "1.0.0"
+
+
+class TestArchiveFetch:
+    """An archive URL is read by its own scheme, whatever the index speaks."""
+
+    def test_file_archive_read_from_disk_under_https_index(
+        self, tmp_path: Path
+    ) -> None:
+        data = _make_sdist("foo", "1.0.0", _PYPROJECT)
+        archive = tmp_path / "foo-1.0.0.tar.gz"
+        archive.write_bytes(data)
+        digest = hashlib.sha256(data).hexdigest()
+        source = ArchiveSource(name="foo", url=f"{archive.as_uri()}#sha256={digest}")
+
+        with FetchCoordinator(transport=HttpxAsyncTransport()) as coordinator:
+            provider = _fetching_provider(coordinator, source, tmp_path / "arch")
+            _, _, key, fetched = _fetch_archive_bytes(provider, source)
+
+        assert key == digest
+        assert fetched == data
+
+    @respx.mock
+    def test_https_archive_fetched_over_http_under_file_index(
+        self, tmp_path: Path
+    ) -> None:
+        wheelhouse = tmp_path / "wheelhouse"
+        wheelhouse.mkdir()
+        data = _make_sdist("foo", "1.0.0", _PYPROJECT)
+        digest = hashlib.sha256(data).hexdigest()
+        url = "https://ex.invalid/foo-1.0.0.tar.gz"
+        respx.get(url).mock(return_value=httpx.Response(200, content=data))
+        source = ArchiveSource(name="foo", url=f"{url}#sha256={digest}")
+
+        with FetchCoordinator(
+            transport=HttpxAsyncTransport(),
+            indexes=[IndexConfig("local", wheelhouse.as_uri())],
+        ) as coordinator:
+            provider = _fetching_provider(coordinator, source, tmp_path / "arch")
+            _, _, _, fetched = _fetch_archive_bytes(provider, source)
+
+        assert fetched == data
+
+    @respx.mock
+    def test_offline_https_archive_is_not_fetched(self, tmp_path: Path) -> None:
+        data = _make_sdist("foo", "1.0.0", _PYPROJECT)
+        digest = hashlib.sha256(data).hexdigest()
+        url = "https://ex.invalid/foo-1.0.0.tar.gz"
+        route = respx.get(url).mock(return_value=httpx.Response(200, content=data))
+        source = ArchiveSource(name="foo", url=f"{url}#sha256={digest}")
+
+        with FetchCoordinator(
+            transport=HttpxAsyncTransport(), offline=True
+        ) as coordinator:
+            provider = _fetching_provider(coordinator, source, tmp_path / "arch")
+            with pytest.raises(UnsupportedSdistError, match="download.*failed"):
+                _fetch_archive_bytes(provider, source)
+
+        assert not route.called
+
+    def test_missing_file_archive_fails_the_resolve(self, tmp_path: Path) -> None:
+        absent = tmp_path / "absent-1.0.0.tar.gz"
+        source = ArchiveSource(name="foo", url=f"{absent.as_uri()}#sha256={'a' * 64}")
+
+        with FetchCoordinator(transport=HttpxAsyncTransport()) as coordinator:
+            provider = _fetching_provider(coordinator, source, tmp_path / "arch")
+            with pytest.raises(UnsupportedSdistError, match="download.*failed"):
+                _fetch_archive_bytes(provider, source)
 
 
 class TestArchiveDownload:

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -1211,6 +1211,17 @@ class TestFetchCoordinator:
             event.wait(timeout=5)
             assert coord.index.get_sdist_archive("pkg", "1.0") is None
 
+    def test_request_direct_archive_deduplicates(self, tmp_path: Path) -> None:
+        """A direct archive already in flight hands back its pending event."""
+        archive = tmp_path / "pkg-1.0.tar.gz"
+        archive.write_bytes(b"archive")
+        with _coord() as coord:
+            pending, _ = coord.index.get_or_create_pending("sdist-archive:pkg:digest")
+            event = coord.request_direct_archive("pkg", "digest", archive.as_uri())
+
+            assert event is pending.event
+            assert coord.index.get_sdist_archive("pkg", "digest") is None
+
     def test_fetch_sdist_archive_null_url_stores_none(self) -> None:
         """A ``FetchRequest`` with ``url=None`` short-circuits to ``None``.
 

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -1222,6 +1222,25 @@ class TestFetchCoordinator:
             assert event is pending.event
             assert coord.index.get_sdist_archive("pkg", "digest") is None
 
+    def test_file_index_still_closes_the_transport(self, tmp_path: Path) -> None:
+        """A file:// index client owns no transport; a direct archive fetch may."""
+        closed = threading.Event()
+
+        class RecordingTransport(HttpxAsyncTransport):
+            async def aclose(self) -> None:
+                closed.set()
+                await super().aclose()
+
+        wheelhouse = tmp_path / "wheelhouse"
+        wheelhouse.mkdir()
+        with FetchCoordinator(
+            transport=RecordingTransport(),  # type: ignore[arg-type]
+            indexes=[IndexConfig("local", wheelhouse.as_uri())],
+        ):
+            pass
+
+        assert closed.is_set()
+
     def test_fetch_sdist_archive_null_url_stores_none(self) -> None:
         """A ``FetchRequest`` with ``url=None`` short-circuits to ``None``.
 


### PR DESCRIPTION
An `[[tool.nab.archive-sources]]` entry declares its own URL, but the download was dispatched through the routed index client, so the archive's scheme had to match the index's. A `file://` archive failed against an HTTPS index, and an HTTPS archive failed against a `file://` index.

The fetch coordinator now reads an archive source by the scheme of the URL it was given: `file://` from disk, anything else over HTTP. Hash checking is unchanged: the provider still verifies every declared hash on the bytes it gets back.

The second commit closes the HTTP transport on shutdown whichever index client is configured. A `file://` index owns no transport, but an archive source can open one, and that transport was left dangling.
