### PR TITLE
Record the program name in lock provenance

### DIFF
--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -668,7 +668,8 @@ def _build_provenance(
     return Provenance(
         nab_version=__version__,
         created_at=anchor,
-        command_line=tuple(sys.argv),
+        # argv[0] is a path into the checkout or venv, not the program name.
+        command_line=("nab", *sys.argv[1:]),
         input_path=str(path),
         mode=config.mode.value,
         python_specifier=python_specifier,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2563,6 +2563,18 @@ class TestLockProvenanceCliOverrides:
         block = tomli.loads(out.read_text())["tool"]["nab"]
         assert "cli-project-overrides" not in block
 
+    def test_command_line_records_the_program_name(self, tmp_path: Path) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        argv = ["/somewhere/on/this/machine/src/nab/__main__.py", "lock", "--offline"]
+        with (
+            patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
+            patch.object(sys, "argv", argv),
+        ):
+            app.cli(args=["lock", str(pyproject), "--output", str(out)], prog="nab")
+        recorded = tomli.loads(out.read_text())["tool"]["nab"]["command-line"]
+        assert recorded == ["nab", "lock", "--offline"]
+
 
 class TestGroupAndExtraSelection:
     """Selection guards for ``--all-groups`` / ``--all-extras``.


### PR DESCRIPTION
`_build_provenance` records `tuple(sys.argv)`, and `argv[0]` is the interpreter's resolved path to the entry point rather than the program name. Every lock nab writes therefore carries an absolute path from the machine that wrote it, and every lock committed here carries mine:

```toml
[tool.nab]
command-line = [
    "/home/damian/opensource/remote/projects/resolver/nab/src/nab/__main__.py",
    "lock", "--groups", "tests", ...
]
```

It does not break `--locked`, which drops the `[tool]` block before comparing, so the effect is confined to the provenance record. Still, a committed lock should not depend on where the resolver happened to live, and a local filesystem layout has no business riding along in a published artefact. The fix substitutes `nab` for `argv[0]` and passes the remaining arguments through untouched.

The existing provenance tests construct `command_line=("nab", "lock", ...)`, so they already encode the intended shape; they never caught this because they build `Provenance` directly instead of driving the CLI. The new test goes through `app.cli` with a patched `sys.argv` and asserts on what actually lands in the file.

The second commit regenerates the six locks under `.github/requirements/` so they stop shipping my checkout path. That refresh also picks up the current nab version in the provenance block, one dependency bump (z3-solver 4.15.4.0 to 4.16.0.0 in the crosshair lock), and a reordering of the wheel entries, which is where the bulk of the diff comes from. The wheel sets themselves are unchanged.