### PR TITLE
fix stale parsed metadata when a wheel and sdist share one slot

### DIFF
--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -691,13 +691,15 @@ def await_metadata_batch(
         )
         if integrity_error is not None:
             raise integrity_error
-        text = provider.coordinator.index.get_metadata(package, ver_str)
+        text, from_sdist = provider.coordinator.index.get_metadata_with_origin(
+            package, ver_str
+        )
         if text is None:
             # No PEP 658 text arrived: leave the version un-cached so
             # look-ahead's get_dependencies runs the sdist fallback (or
             # refuses it) rather than pinning it as dependency-free.
             continue
-        if provider.coordinator.index.metadata_from_sdist(package, ver_str):
+        if from_sdist:
             # The shared slot holds sdist PKG-INFO from an earlier
             # fallback; caching it here would skip the PEP 643 gate
             # that get_dependencies applies on the from_sdist path.

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -60,13 +60,14 @@ def resolve_metadata(
     _, _, normalized = provider.split_and_normalize(package)
     ver_str = str(version)
 
-    text = provider.coordinator.index.get_metadata(normalized, ver_str)
+    # Wheel METADATA and sdist PKG-INFO share the slot, so the text and the
+    # kind of the last write come back together.  Inferring the kind from the
+    # listing instead would mislabel the text whenever this provider's view
+    # differs from the one that stored it.
+    text, from_sdist = provider.coordinator.index.get_metadata_with_origin(
+        normalized, ver_str
+    )
     if text is not None:
-        # Wheel METADATA and sdist PKG-INFO share the slot; the index
-        # records which kind the last write was.  Inferring from the
-        # listing instead would mislabel the text whenever this
-        # provider's view differs from the one that stored it.
-        from_sdist = provider.coordinator.index.metadata_from_sdist(normalized, ver_str)
         return (text, from_sdist)
 
     dist = pick_dist_for_metadata(versions, version)
@@ -417,7 +418,9 @@ def parse_and_cache_metadata(
     The parsed :class:`WheelMetadata` is shared via the
     :class:`~nab_python.fetch.InMemoryIndex` so that universal-mode
     resolves only run :func:`parse_metadata` once per
-    ``(package, version)`` regardless of how many tuples ask for it.
+    ``(package, version)`` regardless of how many tuples ask for it.  The
+    cache answers for ``metadata_text`` alone, so a tuple that reads the
+    other artifact's metadata out of the shared slot parses it itself.
     Per-tuple classification (marker evaluation, extras admission)
     still runs locally in :func:`cache_deps_from_metadata`.  The
     sdist-dynamic-deps reconciliation in
@@ -427,10 +430,14 @@ def parse_and_cache_metadata(
     """
     package, version = cache_key
     version_str = str(version)
-    metadata = provider.coordinator.index.get_parsed_metadata(package, version_str)
+    metadata = provider.coordinator.index.get_parsed_metadata(
+        package, version_str, metadata_text
+    )
     if metadata is None:
         metadata = parse_metadata(metadata_text)
-        provider.coordinator.index.store_parsed_metadata(package, version_str, metadata)
+        provider.coordinator.index.store_parsed_metadata(
+            package, version_str, metadata, metadata_text
+        )
     if from_sdist and _sdist_deps_need_dynamic(
         metadata,
         trust_unverified=provider.effective_trust_unverified(

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -60,10 +60,8 @@ def resolve_metadata(
     _, _, normalized = provider.split_and_normalize(package)
     ver_str = str(version)
 
-    # Wheel METADATA and sdist PKG-INFO share the slot, so the text and the
-    # kind of the last write come back together.  Inferring the kind from the
-    # listing instead would mislabel the text whenever this provider's view
-    # differs from the one that stored it.
+    # Wheel METADATA and sdist PKG-INFO share the slot; the origin of the
+    # last write comes back with the text it wrote.
     text, from_sdist = provider.coordinator.index.get_metadata_with_origin(
         normalized, ver_str
     )
@@ -75,6 +73,7 @@ def resolve_metadata(
         msg = f"Version {version} of {package} not found in listing"
         raise MetadataError(msg)
 
+    from_sdist = False
     if isinstance(dist, WheelFile) and dist.metadata_url is not None:
         event = provider.coordinator.request_metadata(
             normalized, ver_str, dist.metadata_url, dist.metadata_hash
@@ -85,7 +84,9 @@ def resolve_metadata(
         )
         if integrity_error is not None:
             raise integrity_error
-        metadata_text = provider.coordinator.index.get_metadata(normalized, ver_str)
+        metadata_text, from_sdist = provider.coordinator.index.get_metadata_with_origin(
+            normalized, ver_str
+        )
     elif isinstance(dist, WheelFile) and dist.local_path is not None:
         try:
             metadata_text = read_wheel_metadata(dist.local_path)
@@ -96,13 +97,15 @@ def resolve_metadata(
         metadata_text = None
 
     if metadata_text is not None:
-        return (metadata_text, False)
+        return (metadata_text, from_sdist)
 
     sdist = find_sdist(versions, version)
     if sdist is not None:
-        metadata_text = fetch_sdist_metadata(provider, normalized, ver_str, sdist)
+        metadata_text, from_sdist = fetch_sdist_metadata(
+            provider, normalized, ver_str, sdist
+        )
     if metadata_text is not None:
-        return (metadata_text, True)
+        return (metadata_text, from_sdist)
 
     msg = (
         f"No metadata for {package}=={version}: "
@@ -309,8 +312,12 @@ def find_sdist(
 
 def fetch_sdist_metadata(
     provider: Provider, package: str, version: str, sdist: SdistFile
-) -> str | None:
+) -> tuple[str | None, bool]:
     """Block until the coordinator returns sdist PKG-INFO text.
+
+    Returns ``(metadata_text, from_sdist)``: a wheel's PEP 658 sidecar can
+    land on the shared slot while the sdist fetch is in flight, so the text
+    read back is not necessarily the sdist's.
 
     The archive is verified against ``sdist.hashes`` before its PKG-INFO is
     read. A hash mismatch is recorded as an integrity error and re-raised here.
@@ -323,7 +330,7 @@ def fetch_sdist_metadata(
     integrity_error = provider.coordinator.index.get_metadata_error(package, version)
     if integrity_error is not None:
         raise integrity_error
-    return provider.coordinator.index.get_metadata(package, version)
+    return provider.coordinator.index.get_metadata_with_origin(package, version)
 
 
 def classify_requirement(
@@ -419,8 +426,8 @@ def parse_and_cache_metadata(
     :class:`~nab_python.fetch.InMemoryIndex` so that universal-mode
     resolves only run :func:`parse_metadata` once per
     ``(package, version)`` regardless of how many tuples ask for it.  The
-    cache answers for ``metadata_text`` alone, so a tuple that reads the
-    other artifact's metadata out of the shared slot parses it itself.
+    cache is keyed on ``metadata_text`` as well, so a tuple holding the
+    other artifact's text out of the shared slot parses it itself.
     Per-tuple classification (marker evaluation, extras admission)
     still runs locally in :func:`cache_deps_from_metadata`.  The
     sdist-dynamic-deps reconciliation in
@@ -430,6 +437,7 @@ def parse_and_cache_metadata(
     """
     package, version = cache_key
     version_str = str(version)
+
     metadata = provider.coordinator.index.get_parsed_metadata(
         package, version_str, metadata_text
     )
@@ -438,6 +446,7 @@ def parse_and_cache_metadata(
         provider.coordinator.index.store_parsed_metadata(
             package, version_str, metadata, metadata_text
         )
+
     if from_sdist and _sdist_deps_need_dynamic(
         metadata,
         trust_unverified=provider.effective_trust_unverified(
@@ -445,6 +454,7 @@ def parse_and_cache_metadata(
         ),
     ):
         metadata = resolve_dynamic_sdist(provider, cache_key, metadata)
+
     cache_deps_from_metadata(provider, cache_key, metadata)
 
 

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -153,9 +153,9 @@ class InMemoryIndex:
         self._pending: dict[str, _Pending] = {}
 
         # Parsed metadata is a pure function of the underlying text, so it
-        # is shared across the per-target providers of one resolve.  Each
-        # entry is ``(source_text, parsed)``: the two artifact kinds share
-        # one ``_metadata`` slot, so a parse only answers for its own text.
+        # is shared across the per-target providers of one resolve.  Entries
+        # are ``(source_text, parsed)``: a wheel and an sdist share one
+        # ``_metadata`` slot, so a parse only answers for the text it parsed.
         self._parsed_metadata: dict[tuple[str, str], tuple[str, Any]] = {}
 
         # Post-reconciliation sdist metadata: the result after
@@ -250,11 +250,10 @@ class InMemoryIndex:
     ) -> tuple[str | None, bool]:
         """Return the metadata text and whether it came from an sdist.
 
-        Read together under one lock.  Wheel METADATA and sdist PKG-INFO
-        share the slot and a fetch can land between two lookups, so taking
-        the text and its origin separately can pair one artifact's text
-        with the other's origin.  Only sdist text goes through the
-        :pep:`643` dynamic-deps gate, so the pair has to be coherent.
+        Wheel METADATA and sdist PKG-INFO share the slot, so a write landing
+        between two separate lookups can pair one artifact's text with the
+        other's origin.  Only sdist text goes through the :pep:`643`
+        dynamic-deps gate, so the two are read under one lock.
         """
         with self._lock:
             slot = (package, version)
@@ -279,6 +278,7 @@ class InMemoryIndex:
         """
         if self._metadata.get(slot) != data:
             self._resolved_sdist_metadata.pop(slot, None)
+
         self._metadata[slot] = data
         self._metadata_source[slot] = source
         if from_sdist:
@@ -468,9 +468,9 @@ class InMemoryIndex:
         Unlike :meth:`get_metadata` (which returns the raw text), this
         returns the already-parsed dataclass.  A parse of any other text is
         a miss: wheel METADATA and sdist PKG-INFO share one
-        ``(package, version)`` slot and either can replace the other while
-        a resolve is in flight, so a hit on the key alone would hand back
-        the deps of the artifact the caller is not holding.
+        ``(package, version)`` slot and either can replace the other
+        mid-resolve, so a hit on the key alone could hand back the deps of
+        the artifact the caller is not holding.
         """
         with self._lock:
             entry = self._parsed_metadata.get((package, version))

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -153,8 +153,10 @@ class InMemoryIndex:
         self._pending: dict[str, _Pending] = {}
 
         # Parsed metadata is a pure function of the underlying text, so it
-        # is shared across the per-target providers of one resolve.
-        self._parsed_metadata: dict[tuple[str, str], Any] = {}
+        # is shared across the per-target providers of one resolve.  Each
+        # entry is ``(source_text, parsed)``: the two artifact kinds share
+        # one ``_metadata`` slot, so a parse only answers for its own text.
+        self._parsed_metadata: dict[tuple[str, str], tuple[str, Any]] = {}
 
         # Post-reconciliation sdist metadata: the result after
         # PEP 643 dynamic deps have been resolved via the bundled
@@ -243,6 +245,47 @@ class InMemoryIndex:
             source = self._metadata_source[slot]
             return source is None or source == metadata_url
 
+    def get_metadata_with_origin(
+        self, package: str, version: str
+    ) -> tuple[str | None, bool]:
+        """Return the metadata text and whether it came from an sdist.
+
+        Read together under one lock.  Wheel METADATA and sdist PKG-INFO
+        share the slot and a fetch can land between two lookups, so taking
+        the text and its origin separately can pair one artifact's text
+        with the other's origin.  Only sdist text goes through the
+        :pep:`643` dynamic-deps gate, so the pair has to be coherent.
+        """
+        with self._lock:
+            slot = (package, version)
+            return self._metadata.get(slot), slot in self._metadata_from_sdist
+
+    def _write_metadata_slot(
+        self,
+        slot: tuple[str, str],
+        data: str | None,
+        *,
+        source: str | None,
+        from_sdist: bool,
+    ) -> None:
+        """Write the shared metadata slot. Caller holds the lock.
+
+        ``source`` is the sidecar URL the text came from, or ``None`` when
+        the slot stands for the version rather than for one artifact.
+
+        Reconciled sdist metadata is derived from the text in the slot, so
+        replacing the text drops it.  The parsed cache carries the text it
+        parsed and needs no eviction.
+        """
+        if self._metadata.get(slot) != data:
+            self._resolved_sdist_metadata.pop(slot, None)
+        self._metadata[slot] = data
+        self._metadata_source[slot] = source
+        if from_sdist:
+            self._metadata_from_sdist.add(slot)
+        else:
+            self._metadata_from_sdist.discard(slot)
+
     def store_metadata(
         self,
         package: str,
@@ -268,9 +311,9 @@ class InMemoryIndex:
                 and self._metadata[slot] is not None
             )
             if not keep_sdist_text:
-                self._metadata[slot] = data
-                self._metadata_source[slot] = metadata_url
-                self._metadata_from_sdist.discard(slot)
+                self._write_metadata_slot(
+                    slot, data, source=metadata_url, from_sdist=False
+                )
 
             # the waiter gets whatever the slot holds, which may be kept text
             result = self._metadata[slot]
@@ -317,9 +360,9 @@ class InMemoryIndex:
         """
         key = f"sdist:{package}:{version}"
         with self._lock:
-            self._metadata[(package, version)] = data
-            self._metadata_source[(package, version)] = None
-            self._metadata_from_sdist.add((package, version))
+            self._write_metadata_slot(
+                (package, version), data, source=None, from_sdist=True
+            )
             pending = self._pending.get(key)
         if pending is not None:
             pending.result = data
@@ -417,42 +460,35 @@ class InMemoryIndex:
             self._pending[key] = pending
             return pending, False
 
-    def get_parsed_metadata(self, package: str, version: str) -> Any | None:
-        """Return the cached parsed :class:`WheelMetadata` or ``None``.
+    def get_parsed_metadata(
+        self, package: str, version: str, source_text: str
+    ) -> Any | None:
+        """Return the cached parse of ``source_text``, or ``None``.
 
-        Unlike :meth:`get_metadata` (which returns the raw text),
-        this returns the already-parsed dataclass.  Callers populate
-        the cache by calling :meth:`store_parsed_metadata` after
-        parsing the text once.
+        Unlike :meth:`get_metadata` (which returns the raw text), this
+        returns the already-parsed dataclass.  A parse of any other text is
+        a miss: wheel METADATA and sdist PKG-INFO share one
+        ``(package, version)`` slot and either can replace the other while
+        a resolve is in flight, so a hit on the key alone would hand back
+        the deps of the artifact the caller is not holding.
         """
         with self._lock:
-            return self._parsed_metadata.get((package, version))
+            entry = self._parsed_metadata.get((package, version))
+            if entry is None or entry[0] != source_text:
+                return None
+            return entry[1]
 
-    def store_parsed_metadata(self, package: str, version: str, metadata: Any) -> None:
-        """Cache a parsed :class:`WheelMetadata` for future tuple lookups.
+    def store_parsed_metadata(
+        self, package: str, version: str, metadata: Any, source_text: str
+    ) -> None:
+        """Cache the parse of ``source_text`` for future tuple lookups.
 
         Safe across tuples because the parsed object is read-only and
-        a pure function of the underlying text.  Per-tuple
-        classification (marker eval, extras admission) happens
-        above this cache.
+        a pure function of ``source_text``.  Per-tuple classification
+        (marker eval, extras admission) happens above this cache.
         """
         with self._lock:
-            self._parsed_metadata[(package, version)] = metadata
-
-    def pop_parsed_metadata(self, package: str, version: str) -> Any | None:
-        """Remove and return the cached parsed metadata for one key.
-
-        Returns ``None`` when no entry was present.  Used by the
-        re-resolve path so that overriding the raw text invalidates
-        the parsed view that downstream metadata classification reads.
-        """
-        with self._lock:
-            popped = self._parsed_metadata.pop((package, version), None)
-            # An override invalidates the reconciled view too: the
-            # post-augment / post-build metadata is downstream of the
-            # raw parse and must not survive when the parse is replaced.
-            self._resolved_sdist_metadata.pop((package, version), None)
-            return popped
+            self._parsed_metadata[(package, version)] = (source_text, metadata)
 
     def get_resolved_sdist_metadata(self, package: str, version: str) -> Any | None:
         """Return cached post-reconciliation sdist metadata or ``None``.

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -230,17 +230,38 @@ class TestInMemoryIndex:
         """``store_parsed_metadata`` and ``get_parsed_metadata`` round-trip."""
         idx = InMemoryIndex()
         sentinel = object()
-        assert idx.get_parsed_metadata("foo", "1.0") is None
-        idx.store_parsed_metadata("foo", "1.0", sentinel)
-        assert idx.get_parsed_metadata("foo", "1.0") is sentinel
+        assert idx.get_parsed_metadata("foo", "1.0", "METADATA") is None
+        idx.store_parsed_metadata("foo", "1.0", sentinel, "METADATA")
+        assert idx.get_parsed_metadata("foo", "1.0", "METADATA") is sentinel
 
     def test_parsed_metadata_per_version(self) -> None:
         """Each ``(package, version)`` pair has its own slot."""
         idx = InMemoryIndex()
-        idx.store_parsed_metadata("foo", "1.0", "v1")
-        idx.store_parsed_metadata("foo", "2.0", "v2")
-        assert idx.get_parsed_metadata("foo", "1.0") == "v1"
-        assert idx.get_parsed_metadata("foo", "2.0") == "v2"
+        idx.store_parsed_metadata("foo", "1.0", "v1", "TEXT-1")
+        idx.store_parsed_metadata("foo", "2.0", "v2", "TEXT-2")
+        assert idx.get_parsed_metadata("foo", "1.0", "TEXT-1") == "v1"
+        assert idx.get_parsed_metadata("foo", "2.0", "TEXT-2") == "v2"
+
+    def test_parsed_metadata_answers_only_for_its_own_text(self) -> None:
+        """The sdist's parse is not served to a reader holding wheel METADATA.
+
+        Both kinds write one ``(package, version)`` slot, so the wheel's
+        PEP 658 sidecar can replace PKG-INFO a previous tuple already parsed.
+        """
+        idx = InMemoryIndex()
+        idx.store_sdist_metadata("foo", "1.0", "PKG-INFO")
+        idx.store_parsed_metadata("foo", "1.0", "sdist-parse", "PKG-INFO")
+        idx.store_metadata("foo", "1.0", "METADATA")
+        assert idx.get_parsed_metadata("foo", "1.0", "METADATA") is None
+
+    def test_get_metadata_with_origin_reports_the_last_write(self) -> None:
+        """Text and origin come back together, from whichever kind wrote last."""
+        idx = InMemoryIndex()
+        assert idx.get_metadata_with_origin("foo", "1.0") == (None, False)
+        idx.store_sdist_metadata("foo", "1.0", "PKG-INFO")
+        assert idx.get_metadata_with_origin("foo", "1.0") == ("PKG-INFO", True)
+        idx.store_metadata("foo", "1.0", "METADATA")
+        assert idx.get_metadata_with_origin("foo", "1.0") == ("METADATA", False)
 
     def test_resolved_sdist_metadata_roundtrip(self) -> None:
         """``store_resolved_sdist_metadata`` round-trips through ``get``."""
@@ -250,20 +271,25 @@ class TestInMemoryIndex:
         idx.store_resolved_sdist_metadata("foo", "1.0", sentinel)
         assert idx.get_resolved_sdist_metadata("foo", "1.0") is sentinel
 
-    def test_pop_parsed_metadata_invalidates_resolved(self) -> None:
-        """Popping the raw parse drops the post-reconciliation entry too.
+    def test_metadata_rewrite_drops_the_reconciled_sdist_view(self) -> None:
+        """Replacing the raw text drops the post-reconciliation entry too.
 
-        Downstream code reads the reconciled value when raising the
-        bundled-pyproject fallback or after a PEP 517 build; if the
-        raw text is replaced (re-resolve), the reconciliation must be
-        recomputed against the new text.
+        The reconciled record is the PKG-INFO in the slot plus the bundled
+        pyproject.toml or a PEP 517 build, so it cannot outlive that text.
         """
         idx = InMemoryIndex()
-        idx.store_parsed_metadata("foo", "1.0", "raw")
+        idx.store_sdist_metadata("foo", "1.0", "PKG-INFO")
         idx.store_resolved_sdist_metadata("foo", "1.0", "resolved")
-        idx.pop_parsed_metadata("foo", "1.0")
-        assert idx.get_parsed_metadata("foo", "1.0") is None
+        idx.store_metadata("foo", "1.0", "METADATA")
         assert idx.get_resolved_sdist_metadata("foo", "1.0") is None
+
+    def test_restoring_the_same_text_keeps_the_reconciled_sdist_view(self) -> None:
+        """Re-storing identical text is not a rewrite, so the entry survives."""
+        idx = InMemoryIndex()
+        idx.store_sdist_metadata("foo", "1.0", "PKG-INFO")
+        idx.store_resolved_sdist_metadata("foo", "1.0", "resolved")
+        idx.store_sdist_metadata("foo", "1.0", "PKG-INFO")
+        assert idx.get_resolved_sdist_metadata("foo", "1.0") == "resolved"
 
     def test_listing_index_roundtrip(self) -> None:
         """``store_listing_index`` records the serving index name, and

--- a/nab-python/tests/test_provider_declared_target.py
+++ b/nab-python/tests/test_provider_declared_target.py
@@ -788,3 +788,111 @@ class TestVcsConfigPlumbing:
             build_policy=BuildPolicy.NEVER,
         )
         assert provider.vcs_cache_dir is None
+
+
+_WHEEL_METADATA = (
+    "Metadata-Version: 2.4\nName: pkg\nVersion: 1.0\nRequires-Dist: dep-from-wheel\n\n"
+)
+
+# Metadata-Version 2.1 keeps these Requires-Dist lines outside the PEP 643
+# static guarantee, so the sdist's deps come from its pyproject.toml instead.
+_SDIST_PKG_INFO = (
+    "Metadata-Version: 2.1\n"
+    "Name: pkg\n"
+    "Version: 1.0\n"
+    "Requires-Dist: dep-from-untrusted-pkginfo\n"
+    "\n"
+)
+
+_SDIST_PYPROJECT = """
+[project]
+name = "pkg"
+version = "1.0"
+dependencies = ["dep-from-static-pyproject"]
+"""
+
+
+def _wheel_and_sdist_targets() -> tuple[MagicMock, Provider, Provider]:
+    """Two targets over one (pkg, 1.0) published as a manylinux wheel and an sdist.
+
+    The macOS target has no compatible wheel and takes the sdist path; the
+    Linux target takes the wheel.  Both share one coordinator, so both
+    artifacts of (pkg, 1.0) write one metadata slot.
+    """
+    coordinator = make_coordinator(
+        [
+            _platform_wheel("1.0", "cp311-cp311-manylinux_2_17_x86_64"),
+            _sdist("1.0"),
+        ],
+        package="pkg",
+        metadata_text=_WHEEL_METADATA,
+        sdist_pkg_info=_SDIST_PKG_INFO,
+        sdist_pyproject_toml=_SDIST_PYPROJECT,
+    )
+    macos = Provider(
+        coordinator,
+        ResolveTarget.for_declared(
+            python_version="3.11", spec=PlatformSpec("macos_arm64")
+        ),
+    )
+    linux = Provider(coordinator, _LINUX_TARGET)
+    return coordinator, macos, linux
+
+
+class TestSharedMetadataSlot:
+    """Wheel METADATA and sdist PKG-INFO share one slot across the targets."""
+
+    def test_late_wheel_sidecar_supersedes_the_sdist_parse(self) -> None:
+        """A sidecar landing after the sdist gives the wheel's deps, not the sdist's.
+
+        The listing prefetch is not tag-filtered, so the wheel's PEP 658
+        sidecar for (pkg, 1.0) is in flight while the macOS target fetches the
+        same version's sdist.  Whichever lands last owns the slot, and every
+        later reader has to resolve against that text.
+        """
+        coordinator, macos, linux = _wheel_and_sdist_targets()
+        assert set(macos.get_dependencies("pkg", Version("1.0"))) == {
+            "dep-from-static-pyproject"
+        }
+        coordinator.index.store_metadata("pkg", "1.0", _WHEEL_METADATA)
+        assert set(linux.get_dependencies("pkg", Version("1.0"))) == {"dep-from-wheel"}
+
+    def test_deps_do_not_depend_on_which_fetch_lands_first(self) -> None:
+        """The same sidecar landing first gives the Linux target the same deps."""
+        coordinator, macos, linux = _wheel_and_sdist_targets()
+        coordinator.index.store_metadata("pkg", "1.0", _WHEEL_METADATA)
+        assert set(macos.get_dependencies("pkg", Version("1.0"))) == {"dep-from-wheel"}
+        assert set(linux.get_dependencies("pkg", Version("1.0"))) == {"dep-from-wheel"}
+
+    def test_sidecar_landing_between_lookups_keeps_the_origin_with_the_text(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A reader takes the text and its origin from one write, so the gate holds.
+
+        The fetcher writes the slot from its own thread, so an in-flight
+        sidecar can land between a reader's two lookups.  Landing it from
+        inside the origin lookup pins that interleave: pairing the sdist's
+        PKG-INFO with the wheel's origin skips the PEP 643 gate and resolves
+        the untrusted Requires-Dist lines, which neither artifact declares.
+        """
+        coordinator, macos, linux = _wheel_and_sdist_targets()
+        # The wheel's sidecar is still in flight, so the sdist is the only
+        # metadata of (pkg, 1.0) that has reached the slot.
+        coordinator.request_metadata.side_effect = lambda *_args: _done_event()
+        coordinator.request_metadata_batch.side_effect = lambda items: [
+            (pkg, ver, _done_event()) for pkg, ver, _url, _hash in items
+        ]
+        assert set(macos.get_dependencies("pkg", Version("1.0"))) == {
+            "dep-from-static-pyproject"
+        }
+        index = coordinator.index
+        reported_origin = index.metadata_from_sdist
+
+        def _land_sidecar_then_report(package: str, version: str) -> bool:
+            index.store_metadata(package, version, _WHEEL_METADATA)
+            return reported_origin(package, version)
+
+        monkeypatch.setattr(index, "metadata_from_sdist", _land_sidecar_then_report)
+        assert set(linux.get_dependencies("pkg", Version("1.0"))) == {
+            "dep-from-static-pyproject"
+        }

--- a/nab-python/tests/test_provider_declared_target.py
+++ b/nab-python/tests/test_provider_declared_target.py
@@ -794,6 +794,12 @@ _WHEEL_METADATA = (
     "Metadata-Version: 2.4\nName: pkg\nVersion: 1.0\nRequires-Dist: dep-from-wheel\n\n"
 )
 
+# Metadata-Version 2.1 predates PEP 643, so this text read as an sdist's
+# PKG-INFO fails the static gate and its deps are treated as dynamic.
+_LEGACY_WHEEL_METADATA = (
+    "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\nRequires-Dist: dep-from-wheel\n\n"
+)
+
 # Metadata-Version 2.1 keeps these Requires-Dist lines outside the PEP 643
 # static guarantee, so the sdist's deps come from its pyproject.toml instead.
 _SDIST_PKG_INFO = (
@@ -812,7 +818,9 @@ dependencies = ["dep-from-static-pyproject"]
 """
 
 
-def _wheel_and_sdist_targets() -> tuple[MagicMock, Provider, Provider]:
+def _wheel_and_sdist_targets(
+    *, wheel_metadata: str = _WHEEL_METADATA
+) -> tuple[MagicMock, Provider, Provider]:
     """Two targets over one (pkg, 1.0) published as a manylinux wheel and an sdist.
 
     The macOS target has no compatible wheel and takes the sdist path; the
@@ -825,7 +833,7 @@ def _wheel_and_sdist_targets() -> tuple[MagicMock, Provider, Provider]:
             _sdist("1.0"),
         ],
         package="pkg",
-        metadata_text=_WHEEL_METADATA,
+        metadata_text=wheel_metadata,
         sdist_pkg_info=_SDIST_PKG_INFO,
         sdist_pyproject_toml=_SDIST_PYPROJECT,
     )
@@ -854,6 +862,7 @@ class TestSharedMetadataSlot:
         assert set(macos.get_dependencies("pkg", Version("1.0"))) == {
             "dep-from-static-pyproject"
         }
+
         coordinator.index.store_metadata("pkg", "1.0", _WHEEL_METADATA)
         assert set(linux.get_dependencies("pkg", Version("1.0"))) == {"dep-from-wheel"}
 
@@ -864,35 +873,37 @@ class TestSharedMetadataSlot:
         assert set(macos.get_dependencies("pkg", Version("1.0"))) == {"dep-from-wheel"}
         assert set(linux.get_dependencies("pkg", Version("1.0"))) == {"dep-from-wheel"}
 
-    def test_sidecar_landing_between_lookups_keeps_the_origin_with_the_text(
+    def test_sidecar_landing_before_the_sdist_read_keeps_the_origin_with_the_text(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A reader takes the text and its origin from one write, so the gate holds.
+        """The sdist waiter reads back the origin of the text it was handed.
 
-        The fetcher writes the slot from its own thread, so an in-flight
-        sidecar can land between a reader's two lookups.  Landing it from
-        inside the origin lookup pins that interleave: pairing the sdist's
-        PKG-INFO with the wheel's origin skips the PEP 643 gate and resolves
-        the untrusted Requires-Dist lines, which neither artifact declares.
+        The listing prefetch fires the wheel's sidecar without waiting on it,
+        so the sidecar can land on the shared slot between the sdist write and
+        the waiter's read.  The waiter reads the slot, not its own result, so
+        assuming the sdist still owns it puts a wheel's METADATA through the
+        PEP 643 gate, where a Metadata-Version 2.1 wheel is judged dynamic and
+        its deps are replaced by the sdist's pyproject.
         """
-        coordinator, macos, linux = _wheel_and_sdist_targets()
-        # The wheel's sidecar is still in flight, so the sdist is the only
-        # metadata of (pkg, 1.0) that has reached the slot.
+        coordinator, macos, _linux = _wheel_and_sdist_targets(
+            wheel_metadata=_LEGACY_WHEEL_METADATA
+        )
         coordinator.request_metadata.side_effect = lambda *_args: _done_event()
         coordinator.request_metadata_batch.side_effect = lambda items: [
             (pkg, ver, _done_event()) for pkg, ver, _url, _hash in items
         ]
-        assert set(macos.get_dependencies("pkg", Version("1.0"))) == {
-            "dep-from-static-pyproject"
-        }
+
         index = coordinator.index
-        reported_origin = index.metadata_from_sdist
+        recorded_error = index.get_metadata_error
 
-        def _land_sidecar_then_report(package: str, version: str) -> bool:
-            index.store_metadata(package, version, _WHEEL_METADATA)
-            return reported_origin(package, version)
+        # The waiter's own error check is the last thing it does before reading
+        # the slot, so landing the sidecar here lands it inside the window.
+        def _land_sidecar_then_report(
+            package: str, version: str
+        ) -> BaseException | None:
+            index.store_metadata(package, version, _LEGACY_WHEEL_METADATA)
+            return recorded_error(package, version)
 
-        monkeypatch.setattr(index, "metadata_from_sdist", _land_sidecar_then_report)
-        assert set(linux.get_dependencies("pkg", Version("1.0"))) == {
-            "dep-from-static-pyproject"
-        }
+        monkeypatch.setattr(index, "get_metadata_error", _land_sidecar_then_report)
+
+        assert set(macos.get_dependencies("pkg", Version("1.0"))) == {"dep-from-wheel"}


### PR DESCRIPTION
Wheel METADATA and sdist PKG-INFO write the same (package, version) slot in the in-memory index, and the listing prefetch is not tag filtered. A wheel's PEP 658 sidecar can therefore land on a slot another tuple already filled from the sdist, and the other way round.

The parsed-metadata cache that universal mode shares across tuple providers was keyed on (package, version) alone, so a rewrite of the text left the earlier parse in place and a later tuple could resolve the package from the artifact it was not holding. The origin flag was also read separately from the text, so sdist PKG-INFO could come back marked as wheel METADATA and have its Requires-Dist lines used with the PEP 643 dynamic-deps gate skipped.

Each parse is now cached against the text it parsed, so a slot rewrite is a miss and the tuple parses what it is actually holding. Text and origin come back together from one lock through get_metadata_with_origin, and the readers that used to pair them from two separate lookups (the sdist waiter, the re-resolve override, the validator's static-deps route) take the pair.
