### PR TITLE
Reject a pylock passed where a pyproject belongs

### DIFF
--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -25,18 +25,20 @@ Each pinned package carries:
   index), a `LocalPin` (a directory on disk), a `VcsPin` (a
   git URL with a commit pin), or an `ArchivePin` (a `.tar.gz` URL
   content-pinned by a required `sha256`),
-* every artefact downloaded for that pin (`sdist` and `wheels`),
-  each with its filename, URL, `sha256`, and optional size.
+* every artefact the index listed at that pinned version (`sdist`
+  and `wheels`), each with its filename, URL, `sha256`, and optional
+  size.
 
-The resolver records exactly what it considered, so
-`nab download` can fetch the same files back without consulting
-the index again.
+Nothing is fetched to build a lock: the digests come from the index
+listing, so a resolve reads metadata and never a wheel body.
 
 ## PEP 751 `pylock.toml`
 
 The PEP 751 lockfile is the format for cross-tool Python
-lockfiles. It is what `nab lock --format pylock` produces and
-what `nab download` consumes when handed a lockfile.
+lockfiles. It is what `nab lock --format pylock` produces, and what
+`nab lock --locked` checks against. It is an output. `nab download`
+resolves from project inputs, so hand it a `pyproject.toml`, not a
+lockfile.
 
 A trimmed example, after resolving the
 [getting-started](../tutorial/getting-started.md) project:
@@ -166,11 +168,12 @@ single-environment mode.
 
 ## `nab download`
 
-`nab download` walks the same pin set, fetches every wheel and
-sdist into the `--output` directory (defaults to `wheels/`), and
-verifies each file's `sha256` against the recorded digest. Local
-and VCS pins are skipped. The download is idempotent: a file
-whose digest already matches a local copy is left alone.
+`nab download` resolves the project again, then fetches every wheel
+and sdist on the resulting pins into the `--output` directory
+(defaults to `wheels/`), verifying each file's `sha256` against the
+digest the index published. Local and VCS pins are skipped. The
+download is idempotent: a file whose digest already matches a local
+copy is left alone.
 
 The result is a per-resolve directory of artefacts that any
 installer can consume offline:
@@ -181,8 +184,9 @@ pip install --no-index --find-links wheels/ -r requirements.txt
 ```
 
 This pairs naturally with `--require-hashes`: hashes are baked
-into the requirements file, the artefacts on disk are the exact
-ones verified during resolve, and pip refuses anything else.
+into the requirements file, the artefacts on disk are verified
+against those same digests on the way down, and pip refuses
+anything else.
 
 [PEP 751]: https://peps.python.org/pep-0751/
 [hash-checking]: https://pip.pypa.io/en/stable/topics/secure-installs/#hash-checking-mode

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -19,6 +19,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Literal, NoReturn
 
+import tomli
 import tyro
 from tyro.extras import SubcommandApp
 
@@ -388,6 +389,20 @@ def _fail_config(exc: SourceConfigError) -> NoReturn:
     sys.exit(1)
 
 
+def _is_pylock(path: Path) -> bool:
+    """Whether ``path`` holds a PEP 751 lock rather than a pyproject.
+
+    ``lock-version`` is the one required key PEP 751 gives a lock and a
+    pyproject never carries.  An unreadable or malformed file is left for
+    the pyproject parser to report.
+    """
+    try:
+        data = tomli.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, tomli.TOMLDecodeError):
+        return False
+    return "lock-version" in data and "project" not in data
+
+
 def _require_pyproject_file(path: Path) -> None:
     """Exit 1 if ``path`` is not a readable pyproject file.
 
@@ -398,6 +413,12 @@ def _require_pyproject_file(path: Path) -> None:
     if not path.is_file():
         reason = "is a directory" if path.is_dir() else "not found"
         sys.stderr.write(f"Error: {path} {reason}\n")
+        sys.exit(1)
+    if _is_pylock(path):
+        sys.stderr.write(
+            f"Error: {path} is a PEP 751 lockfile, not a pyproject.  nab resolves"
+            f" from project inputs, so pass the pyproject.toml instead.\n"
+        )
         sys.exit(1)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -588,6 +588,19 @@ class TestLockCommandSpecific:
             lock(pyproject, output=Path("-"))
         assert "is not valid TOML" in capsys.readouterr().err
 
+    def test_pylock_passed_as_the_project_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A PEP 751 lock handed in where a pyproject belongs says so."""
+        pylock = tmp_path / "pylock.toml"
+        pylock.write_text(
+            'lock-version = "1.0"\ncreated-by = "nab"\n\n'
+            '[[packages]]\nname = "idna"\nversion = "3.10"\n'
+        )
+        with pytest.raises(SystemExit, match="1"):
+            lock(pylock)
+        assert "is a PEP 751 lockfile" in capsys.readouterr().err
+
     def test_output_is_directory_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
`docs/reference/lockfile.md` said the pylock is "what `nab download` consumes when handed a lockfile". It is not: `download` resolves from project inputs and has no lockfile path. Following the docs produces this, on nab's own output:

```
$ nab download pylock.toml --output wheels/
Error in [tool.nab]: unknown [tool.nab] keys: ['command-line', 'created-at', 'input-path', 'nab-version']; expected one of [...]
```

nab rejects its own lockfile by naming its own provenance keys as unknown configuration, which is a dead end for anyone who hits it. The path guard now recognises a PEP 751 file where a project belongs and says so:

```
Error: pylock.toml is a PEP 751 lockfile, not a pyproject.  nab resolves from project inputs, so pass the pyproject.toml instead.
```

`lock-version` is the one required key PEP 751 gives a lock and a pyproject never carries, so that is the test; a malformed or unreadable file still falls through to the parser that already reports it properly.

The two other claims on that page were also false and are corrected. Nothing is fetched to build a lock (digests come from the index listing, so a resolve reads metadata and never a wheel body), and `nab download` re-resolves rather than replaying a recorded file set, so "fetch the same files back without consulting the index again" and "the exact ones verified during resolve" both overstated what happens.