### PR TITLE
Introduce ResolveTarget as the unit of resolution

### DIFF
--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -53,6 +53,7 @@ from nab_python.provider import (
     VcsPolicy,
     split_extra,
 )
+from nab_python.target import ResolveTarget
 from nab_resolver.resolver import Resolver
 
 BENCHMARKS_DIR = Path(__file__).parent
@@ -178,6 +179,14 @@ def _full_marker_environment(
 _PYTHON_VERSION_PARTS = 2
 
 
+def _resolve_target(
+    python_version: str,
+    marker_environment: dict[str, str] | None,
+) -> ResolveTarget:
+    target = ResolveTarget.for_host_python(python_version)
+    return target.with_marker_overrides(marker_environment or {})
+
+
 def _scenario_marker_env(
     python_version: str,
     overlay: dict[str, str],
@@ -240,14 +249,13 @@ def run_one(  # noqa: PLR0913 - one wrapper per scenario knob
     ) as coordinator:
         provider = Provider(
             coordinator,
-            python_version=python_version,
+            target=_resolve_target(python_version, marker_environment),
             root_requirements=requirements,
             uploaded_prior_to=uploaded_prior_to,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.NEVER,
             package_overrides=package_overrides,
             trust_unverified_sdist_deps=trust_unverified_sdist_deps,
-            marker_environment=marker_environment,
         )
         resolver = Resolver(
             provider,

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -51,6 +51,7 @@ from nab_python.provider import (
     VcsPolicy,
     split_extra,
 )
+from nab_python.target import ResolveTarget
 from nab_resolver.resolver import Resolver
 
 BENCHMARKS_DIR = Path(__file__).parent
@@ -184,6 +185,15 @@ def scenario_marker_env(
     return env
 
 
+def resolve_target(
+    python_version: str,
+    marker_environment: dict[str, str] | None,
+) -> ResolveTarget:
+    """Build the scenario's resolve target: host machine, scenario Python."""
+    target = ResolveTarget.for_host_python(python_version)
+    return target.with_marker_overrides(marker_environment or {})
+
+
 def parse_datetime(value: str) -> datetime:
     """Parse an ISO 8601 datetime string to a timezone-aware datetime."""
     dt = datetime.fromisoformat(value)
@@ -245,14 +255,13 @@ def resolve_scenario(  # noqa: PLR0913 - one wrapper per scenario knob
     ) as coordinator:
         provider = Provider(
             coordinator,
-            python_version=python_version,
+            target=resolve_target(python_version, marker_environment),
             root_requirements=requirements,
             uploaded_prior_to=uploaded_prior_to,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.NEVER,
             package_overrides=package_overrides,
             trust_unverified_sdist_deps=trust_unverified_sdist_deps,
-            marker_environment=marker_environment,
             resolution_strategy=resolution_strategy,
             direct_packages=direct_packages,
         )

--- a/nab-python/benchmarks/strategy_sweep.py
+++ b/nab-python/benchmarks/strategy_sweep.py
@@ -105,13 +105,12 @@ def _resolve_one(  # noqa: PLR0913 - one kwarg per knob; bundling hides the surf
     ) as coordinator:
         provider = Provider(
             coordinator,
-            python_version=python_version,
+            target=_scenarios.resolve_target(python_version, marker_environment),
             root_requirements=requirements,
             uploaded_prior_to=uploaded_prior_to,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.NEVER,
             package_overrides=package_overrides,
-            marker_environment=marker_environment,
             resolution_strategy=strategy,
             direct_packages=direct_packages,
             extras_mode=extras_mode,

--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -380,17 +380,17 @@ def excluded_by_python(
     A per-package ``requires-python`` override substitutes for
     ``dist.requires_python`` and goes through the same cached comparison,
     keyed by the specifier string; the verdict depends only on that string
-    and the fixed ``provider.python_version``.
+    and the fixed ``provider.python_release``.
     """
     override_rp = provider.effective_requires_python(normalized, version)
     effective = override_rp if override_rp is not None else dist.requires_python
-    if not effective or not provider.python_version:
+    if not effective or provider.python_release is None:
         return False
     cached = provider.requires_python_cache.get(effective)
     if cached is None:
         try:
             spec = SpecifierSet(effective)
-            cached = Version(provider.python_version) not in spec
+            cached = provider.python_release not in spec
         except InvalidSpecifier:
             # Malformed Requires-Python on the dist: treat as
             # not-excluded, let downstream logic decide.  Our own

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -477,6 +477,7 @@ class Provider:
         # the Python a candidate could be rejecting (see _provider.listing).
         if target is None:
             self.python_version: str | None = None
+            self.python_release: Version | None = None
             self.environment: dict[str, str] = host_environment()
             self.env_with_extra: dict[str, str | frozenset[str]] = {
                 **self.environment,
@@ -484,6 +485,7 @@ class Provider:
             }
         else:
             self.python_version = target.python_full_version
+            self.python_release = target.python_release
             self.environment = dict(target.marker_env)
             self.env_with_extra = target.env_with_membership()
 

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -34,11 +34,10 @@ from ._vcs_admission import (
     VcsConfig,
     VcsPolicy,
 )
-from ._vendor.packaging.markers import default_environment
 from ._vendor.packaging.ranges import VersionRange
 from ._vendor.packaging.utils import canonicalize_name
-from ._vendor.packaging.version import InvalidVersion, Version
 from .metadata import WheelMetadata
+from .target import host_environment
 
 if TYPE_CHECKING:
     import threading
@@ -49,8 +48,10 @@ if TYPE_CHECKING:
     from nab_resolver.types import Incompatibility, RangeProtocol
 
     from ._vendor.packaging.requirements import Requirement
+    from ._vendor.packaging.version import Version
     from .config import IndexOverride, NabProjectConfig, PackageOverride
     from .fetch import FetchCoordinator
+    from .target import ResolveTarget
 
 __all__ = [
     "ArchiveSource",
@@ -70,9 +71,7 @@ __all__ = [
     "VcsConfig",
     "VcsPolicy",
     "VcsSource",
-    "apply_python_axis_overlay",
     "join_extra",
-    "python_axis_environment",
     "split_extra",
 ]
 
@@ -80,71 +79,6 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 _EXTRA_RE = re.compile(r"^(?P<base>[^\[]+)\[(?P<extra>[^\]]+)\]$")
-
-
-# PEP 508 ``python_version`` is the ``major.minor`` pair;
-# ``python_full_version`` is the full ``major.minor.micro`` release.
-_PYTHON_VERSION_PARTS = 2
-_PYTHON_FULL_VERSION_PARTS = 3
-
-
-def python_axis_environment(python_version: str) -> dict[str, str]:
-    """Map an explicit Python version to its PEP 508 marker keys.
-
-    ``python_version`` is padded to two components and
-    ``python_full_version`` to three so patch-precision markers evaluate
-    the same here as in the universal matrix. Raises ``InvalidVersion``
-    if the input is not a version.
-    """
-    try:
-        parsed = Version(python_version)
-    except InvalidVersion:
-        msg = f"python_version {python_version!r} is not a valid version"
-        raise InvalidVersion(msg) from None
-    release = parsed.release
-    minor = ".".join(str(part) for part in (*release, 0)[:_PYTHON_VERSION_PARTS])
-    if len(release) >= _PYTHON_FULL_VERSION_PARTS:
-        full = python_version
-    else:
-        # Pad the release to three components, keeping the epoch and any
-        # prerelease/post/dev/local tag, which live outside ``release``.
-        epoch = f"{parsed.epoch}!" if parsed.epoch else ""
-        padded = ".".join(
-            str(part) for part in (*release, 0, 0)[:_PYTHON_FULL_VERSION_PARTS]
-        )
-        suffix = str(parsed)[len(parsed.base_version) :]
-        full = f"{epoch}{padded}{suffix}"
-    return {"python_version": minor, "python_full_version": full}
-
-
-def apply_python_axis_overlay(
-    environment: dict[str, str], overlay: Mapping[str, str]
-) -> None:
-    """Merge ``overlay`` into ``environment``, keeping the python axis in sync.
-
-    When the overlay moves only ``python_version`` (or only
-    ``python_full_version``) the untouched key would keep the host patch
-    level and the two would describe different interpreters. Re-derive both
-    from whichever axis key the overlay supplies (``python_full_version``
-    wins when both are present), so an overlay of ``python_version`` ``3.8``
-    yields ``python_full_version`` ``3.8.0`` like the universal matrix. On
-    CPython ``implementation_version`` equals ``python_full_version``, so move
-    it with the axis; other implementations version separately and keep their
-    host value unless the overlay sets it. Non-axis keys the overlay sets are
-    kept verbatim; the ``python_version``/``python_full_version`` pair is always
-    the derived one, so a patch-precision ``python_version`` (e.g. ``3.10.5``)
-    normalizes to major.minor.
-    """
-    source = overlay.get("python_full_version") or overlay.get("python_version")
-    if source is None:
-        environment.update(overlay)
-        return
-
-    axis = python_axis_environment(source)
-    if environment.get("implementation_name") == "cpython":
-        environment["implementation_version"] = axis["python_full_version"]
-    environment.update(overlay)
-    environment.update(axis)
 
 
 def _normalize_extra(extra: str) -> str:
@@ -411,6 +345,12 @@ class Provider:
     A thread pool submits listing fetches in the background so
     transitive deps are fetched concurrently with resolution.
     The HTTP connection pool is shared across threads for reuse.
+
+    ``target`` is the environment the resolve is for: its markers gate
+    every dependency and its Python filters candidates by
+    Requires-Python.  Left unset, markers evaluate against the host and
+    no candidate is filtered by Requires-Python, since nothing has said
+    which Python the resolve targets.
     """
 
     # Drives two prefetch paths: the speculative root-batch prefetch
@@ -469,7 +409,7 @@ class Provider:
     def __init__(  # noqa: PLR0913, PLR0915 - resolver config is wide; bundling all flags into one bag is worse for callers
         self,
         coordinator: FetchCoordinator,
-        python_version: str | None = None,
+        target: ResolveTarget | None = None,
         root_requirements: dict[str, VersionRange] | None = None,
         uploaded_prior_to: datetime | None = None,
         extras_mode: ExtrasMode = ExtrasMode.ERROR_USER,
@@ -479,7 +419,6 @@ class Provider:
         package_overrides: Sequence[PackageOverride] = (),
         index_overrides: Mapping[str, IndexOverride] | None = None,
         vcs_config: VcsConfig | None = None,
-        marker_environment: dict[str, str] | None = None,
         local_sources: list[LocalSource] | None = None,
         vcs_sources: list[VcsSource] | None = None,
         vcs_cache_dir: Path | None = None,
@@ -493,21 +432,7 @@ class Provider:
     ) -> None:
         """Construct the provider; see the class docstring for parameters."""
         self.coordinator = coordinator
-        self.python_version = python_version
-        if marker_environment:
-            # The Requires-Python candidate filter reads self.python_version, so
-            # an impersonated target Python in the overlay must move it too,
-            # keeping the filter aligned with marker evaluation. It parses a
-            # full Version, so pad to the full release like the environment does
-            # (overlay python_version "3.8" gives "3.8.0", not the host patch
-            # level). Mirrors UniversalProvider.
-            overlay_python = marker_environment.get(
-                "python_full_version"
-            ) or marker_environment.get("python_version")
-            if overlay_python is not None:
-                self.python_version = python_axis_environment(overlay_python)[
-                    "python_full_version"
-                ]
+        self.target = target
         self.uploaded_prior_to = uploaded_prior_to
 
         # Passed through to the build env when extract_source_metadata
@@ -534,9 +459,6 @@ class Provider:
             for o in self._index_overrides.values()
         )
 
-        if marker_environment:
-            self._check_marker_overlay_build_policy(build_policy)
-
         self.vcs_config = vcs_config or VcsConfig()
         self.local_sources = _sources.index_local_sources(self, local_sources or [])
         self.vcs_cache_dir = vcs_cache_dir
@@ -547,21 +469,23 @@ class Provider:
             self, archive_sources or []
         )
 
-        # default_environment() returns a TypedDict whose ``.items()`` view
-        # widens values to ``object``; rebuild as a concrete ``dict[str, str]``
-        # so mutations and the env_with_extra copy below stay typed.
-        env_init: dict[str, str] = {
-            key: value
-            for key, value in default_environment().items()
-            if isinstance(value, str)
-        }
-        self.environment: dict[str, str] = env_init
-        if python_version is not None:
-            apply_python_axis_overlay(
-                self.environment, python_axis_environment(python_version)
-            )
-        if marker_environment:
-            apply_python_axis_overlay(self.environment, marker_environment)
+        # ``environment`` backs every marker evaluation; ``env_with_extra``
+        # is the reused per-evaluation copy of it, seeded with the empty
+        # lockfile-only set variables (see EMPTY_MEMBERSHIP_SETS).  Without a
+        # target both come from the host and ``python_version`` stays None,
+        # which turns the Requires-Python filter off: nothing has declared
+        # the Python a candidate could be rejecting (see _provider.listing).
+        if target is None:
+            self.python_version: str | None = None
+            self.environment: dict[str, str] = host_environment()
+            self.env_with_extra: dict[str, str | frozenset[str]] = {
+                **self.environment,
+                **EMPTY_MEMBERSHIP_SETS,
+            }
+        else:
+            self.python_version = target.python_full_version
+            self.environment = dict(target.marker_env)
+            self.env_with_extra = target.env_with_membership()
 
         self.root_requirements = root_requirements or {}
         self.versions_cache: dict[str, list[tuple[Version, DistFile]]] = {}
@@ -605,13 +529,6 @@ class Provider:
         self.marker_extra_cache: dict[int, dict[str, bool]] = {}
         # Memoised str(marker) for the cheap "extra" in marker_text gate.
         self.marker_text_cache: dict[int, str] = {}
-        # Reused per-evaluation environment dict (avoids a copy per requirement),
-        # seeded with the empty lockfile-only set variables (see
-        # EMPTY_MEMBERSHIP_SETS) so a marker testing one evaluates False.
-        self.env_with_extra: dict[str, str | frozenset[str]] = {
-            **self.environment,
-            **EMPTY_MEMBERSHIP_SETS,
-        }
 
         # (base, extra, normalized_name) per input package string.
         self._package_parts: dict[str, tuple[str, str | None, str]] = {}
@@ -701,39 +618,6 @@ class Provider:
                 ):
                     continue
                 self.coordinator.request_listing(normalized)
-
-    def _check_marker_overlay_build_policy(self, build_policy: BuildPolicy) -> None:
-        """Reject a non-``NEVER`` build policy under a marker overlay.
-
-        Backends run on the host, so invoking one under a marker overlay
-        would produce metadata that does not match the impersonated
-        target.  The guard inspects both override surfaces as well as the
-        global so a single build override cannot quietly opt out of the
-        soundness check.
-        """
-        offending: list[tuple[str, BuildPolicy]] = []
-        if build_policy is not BuildPolicy.NEVER:
-            offending.append(("<global>", build_policy))
-        offending.extend(
-            (o.name, o.build_policy)
-            for o in self._package_overrides
-            if o.build_policy not in (None, BuildPolicy.NEVER)
-        )
-        offending.extend(
-            (f"index:{name}", o.build_policy)
-            for name, o in self._index_overrides.items()
-            if o.build_policy not in (None, BuildPolicy.NEVER)
-        )
-        if not offending:
-            return
-        rendered = ", ".join(f"{name}={policy.value}" for name, policy in offending)
-        msg = (
-            "marker_environment overlay requires BuildPolicy.NEVER globally"
-            " and in every override that sets build-policy; got"
-            f" {rendered}.  Backends run on the host and report metadata for"
-            " the host, not the impersonated target."
-        )
-        raise ValueError(msg)
 
     def fetch_versions(self, package: str) -> list[tuple[Version, DistFile]]:
         """See :func:`nab_python._provider.listing.fetch_versions`."""

--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -255,7 +255,7 @@ def expand_self_extras(
     optional_deps: Mapping[str, Sequence[str]],
     project_name: str | None,
     selected: Sequence[str],
-    environment: dict[str, str] | None = None,
+    environment: Mapping[str, str] | None = None,
 ) -> list[str]:
     """Return ``selected`` plus every extra reachable through self-references.
 

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -18,7 +18,6 @@ from nab_resolver.resolver import (
 
 from ._conflict_kind import dependency_marker_holds, membership_set_in_marker
 from ._vcs_admission import admit_vcs_url
-from ._vendor.packaging.markers import default_environment
 from ._vendor.packaging.ranges import VersionRange
 from ._vendor.packaging.requirements import Requirement
 from ._vendor.packaging.specifiers import SpecifierSet
@@ -41,11 +40,10 @@ from .config import (
 from .fetch import FetchCoordinator
 from .lockfile import LockInput, build_lock_input_from_provider
 from .provider import (
+    BuildPolicy,
     Provider,
     ResolutionStrategy,
-    apply_python_axis_overlay,
     join_extra,
-    python_axis_environment,
     split_extra,
 )
 from .requirements_file import (
@@ -60,6 +58,7 @@ from .requirements_file import (
     resolve_groups_to_requirements,
     select_optional_dependencies,
 )
+from .target import ResolveTarget
 from .universal.matrix import Matrix
 from .universal.resolve import (
     ResolveFork,
@@ -72,8 +71,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from nab_index.transport import AsyncHttpTransport
-
-    from .universal.matrix import MatrixTuple
 
 
 __all__ = [
@@ -149,17 +146,16 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
     effective_groups = tuple(dict.fromkeys((*groups, *config.default_groups)))
 
     if python_version is not None:
-        effective_python = python_version
+        target = ResolveTarget.for_host_python(python_version)
     elif config.requires_python is not None:
-        effective_python = _resolve_target_python(config.requires_python)
+        target = ResolveTarget.for_host_python(
+            _resolve_target_python(config.requires_python)
+        )
     else:
-        vi = sys.version_info
-        effective_python = f"{vi.major}.{vi.minor}.{vi.micro}"
-
-    marker_environment = _build_marker_environment(
-        python_version=effective_python,
-        overrides=config.marker_environment,
-    )
+        target = ResolveTarget.for_host()
+    _check_marker_overlay_build_policy(config)
+    target = target.with_marker_overrides(config.marker_environment)
+    marker_environment = target.marker_env
 
     if config.conflicts:
         # Read each table once and reuse it across the existence check
@@ -209,7 +205,7 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
     ) as coordinator:
         provider = Provider(
             coordinator,
-            python_version=marker_environment["python_full_version"],
+            target=target,
             root_requirements=resolver_requirements,
             uploaded_prior_to=config.uploaded_prior_to,
             root_extras=root_extras,
@@ -219,7 +215,6 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
             index_overrides=config.index_overrides,
             trust_unverified_sdist_deps=config.trust_unverified_sdist_deps,
             vcs_config=config.vcs,
-            marker_environment=dict(config.marker_environment) or None,
             local_sources=list(config.local_sources) or None,
             vcs_sources=list(config.vcs_sources) or None,
             vcs_cache_dir=cache_dir / "vcs" if cache_dir is not None else None,
@@ -245,7 +240,7 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
         pins = {k: v for k, v in raw.items() if split_extra(k)[1] is None}
         if config.local_sources or config.vcs_sources or config.archive_sources:
             _raise_for_source_python(
-                provider, pins, Version(marker_environment["python_full_version"])
+                provider, pins, Version(target.python_full_version)
             )
         lock_input = build_lock_input_from_provider(
             provider,
@@ -324,7 +319,7 @@ def _group_requirements_by_group_from_table(
 
 
 def _group_package_ranges(
-    requirements: list[Requirement], environment: dict[str, str]
+    requirements: list[Requirement], environment: Mapping[str, str]
 ) -> tuple[dict[str, VersionRange], dict[str, list[str]]]:
     """Fold one group's direct requirements into per-package ranges.
 
@@ -373,7 +368,7 @@ class _GroupConflict:
 
 def _find_group_conflicts(
     per_group: Mapping[str, list[Requirement]],
-    environment: dict[str, str],
+    environment: Mapping[str, str],
 ) -> list[_GroupConflict]:
     """Return the direct group-vs-group conflicts under ``environment``.
 
@@ -419,7 +414,7 @@ def _find_group_conflicts(
 def _check_group_disjointness(
     per_group: Mapping[str, list[Requirement]],
     *,
-    environment: dict[str, str],
+    environment: Mapping[str, str],
 ) -> None:
     """Raise on the first direct conflict between two groups, naming them.
 
@@ -437,7 +432,7 @@ def _check_group_disjointness(
 
 def _check_group_disjointness_across_tuples(
     per_group: Mapping[str, list[Requirement]],
-    tuples: Sequence[MatrixTuple],
+    tuples: Sequence[ResolveTarget],
 ) -> None:
     """Raise if a direct group conflict holds on any targeted tuple.
 
@@ -446,7 +441,7 @@ def _check_group_disjointness_across_tuples(
     """
     affected: dict[_GroupConflict, set[str]] = defaultdict(set)
     for t in tuples:
-        for conflict in _find_group_conflicts(per_group, t.environment):
+        for conflict in _find_group_conflicts(per_group, t.marker_env):
             affected[conflict].add(t.label)
     if not affected:
         return
@@ -469,7 +464,7 @@ def _check_group_disjointness_across_tuples(
 def _load_extra_requirements(
     path: Path,
     selected: Sequence[str],
-    environment: dict[str, str] | None = None,
+    environment: Mapping[str, str] | None = None,
 ) -> list[Requirement]:
     """Read [project.optional-dependencies] from ``path`` and expand ``selected``.
 
@@ -496,7 +491,7 @@ def _extra_requirements_from_table(
     selected: Sequence[str],
     *,
     path: Path,
-    environment: dict[str, str] | None = None,
+    environment: Mapping[str, str] | None = None,
 ) -> list[Requirement]:
     """Expand ``selected`` extras from an already-read optional-deps table.
 
@@ -678,7 +673,7 @@ def _build_resolver_inputs(
     requirements: list[Requirement],
     config: NabProjectConfig,
     *,
-    environment: dict[str, str],
+    environment: Mapping[str, str],
 ) -> tuple[dict[str, VersionRange], set[tuple[str, str]]]:
     """Convert PEP 508 ``Requirement`` objects to the resolver's input shape.
 
@@ -722,27 +717,40 @@ def _build_resolver_inputs(
     return resolver_requirements, root_extras
 
 
-def _build_marker_environment(
-    *,
-    python_version: str,
-    overrides: Mapping[str, str],
-) -> dict[str, str]:
-    """Return the merged PEP 508 environment used for root-marker evaluation.
+def _check_marker_overlay_build_policy(config: NabProjectConfig) -> None:
+    """Reject a non-``NEVER`` build policy under a marker-environment overlay.
 
-    Mirrors :class:`Provider`: defaults from
-    :func:`default_environment`, then ``python_version`` /
-    ``python_full_version`` rewritten from the effective Python, then
-    user overrides. An overlay touching one python-axis key re-derives the
-    other through :func:`apply_python_axis_overlay` so they stay in sync.
+    Backends run on the host, so invoking one under an overlay would
+    produce metadata that does not match the impersonated target.  The
+    guard inspects both override surfaces as well as the global, so a
+    single build override cannot quietly opt out of the soundness check.
+    A config with no overlay resolves against the host and builds freely.
     """
-    env: dict[str, str] = {
-        key: value
-        for key, value in default_environment().items()
-        if isinstance(value, str)
-    }
-    apply_python_axis_overlay(env, python_axis_environment(python_version))
-    apply_python_axis_overlay(env, overrides)
-    return env
+    if not config.marker_environment:
+        return
+    offending: list[tuple[str, BuildPolicy]] = []
+    if config.build_policy is not BuildPolicy.NEVER:
+        offending.append(("<global>", config.build_policy))
+    offending.extend(
+        (o.name, o.build_policy)
+        for o in config.package_overrides
+        if o.build_policy not in (None, BuildPolicy.NEVER)
+    )
+    offending.extend(
+        (f"index:{name}", o.build_policy)
+        for name, o in config.index_overrides.items()
+        if o.build_policy not in (None, BuildPolicy.NEVER)
+    )
+    if not offending:
+        return
+    rendered = ", ".join(f"{name}={policy.value}" for name, policy in offending)
+    msg = (
+        "marker_environment overlay requires BuildPolicy.NEVER globally"
+        " and in every override that sets build-policy; got"
+        f" {rendered}.  Backends run on the host and report metadata for"
+        " the host, not the impersonated target."
+    )
+    raise ValueError(msg)
 
 
 def _raise_for_source_python(
@@ -780,7 +788,7 @@ def _validate_universal_conflict_minimums(
     tables: _ForkTables,
     selected_extras: Sequence[str],
     active_groups: Sequence[str],
-    tuples: Sequence[MatrixTuple],
+    tuples: Sequence[ResolveTarget],
 ) -> None:
     """Run the require-one minimums check per tuple, marker-aware.
 
@@ -792,7 +800,7 @@ def _validate_universal_conflict_minimums(
     """
     for t in tuples:
         active_extras = expand_self_extras(
-            tables.optional, tables.project_name, selected_extras, t.environment
+            tables.optional, tables.project_name, selected_extras, t.marker_env
         )
         try:
             validate_conflict_minimums(conflicts, active_extras, active_groups)
@@ -806,7 +814,7 @@ def _validate_universal_conflict_exclusions(
     tables: _ForkTables,
     active_extras: Sequence[str],
     active_groups: Sequence[str],
-    tuples: Sequence[MatrixTuple],
+    tuples: Sequence[ResolveTarget],
 ) -> None:
     """Run the at-most-one exclusion check per tuple, marker-aware.
 
@@ -818,7 +826,7 @@ def _validate_universal_conflict_exclusions(
     expanded_groups = expand_group_includes(tables.groups, active_groups)
     for t in tuples:
         expanded_extras = expand_self_extras(
-            tables.optional, tables.project_name, active_extras, t.environment
+            tables.optional, tables.project_name, active_extras, t.marker_env
         )
         try:
             validate_conflict_exclusions(conflicts, expanded_extras, expanded_groups)
@@ -1028,7 +1036,7 @@ def _resolve_target_python(specifier: str) -> str:
 
 
 def _build_constraints(
-    config: NabProjectConfig, *, environment: dict[str, str]
+    config: NabProjectConfig, *, environment: Mapping[str, str]
 ) -> dict[str, VersionRange]:
     """Parse constraint strings from config into resolver-input ranges.
 

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -239,9 +239,7 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
             raise
         pins = {k: v for k, v in raw.items() if split_extra(k)[1] is None}
         if config.local_sources or config.vcs_sources or config.archive_sources:
-            _raise_for_source_python(
-                provider, pins, Version(target.python_full_version)
-            )
+            _raise_for_source_python(provider, pins, target.python_release)
         lock_input = build_lock_input_from_provider(
             provider,
             pins,

--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -46,8 +46,12 @@ __all__ = [
     "TagSet",
     "TagsSource",
     "platform_kind",
+    "supports_free_threading",
     "wheel_tag_set",
 ]
+
+# The free-threaded build ships from CPython 3.13 (PEP 703).
+FREE_THREADED_MIN_PYTHON = (3, 13)
 
 Libc = Literal["glibc", "musl"]
 
@@ -578,13 +582,19 @@ class TagSet:
             if host[0].interpreter.startswith(_PYPY_INTERPRETER_PREFIX)
             else "cpython"
         )
+        # The host's free-threaded ABI only carries to a Python that has one:
+        # ``cp310t`` has never existed, and a target advertising it matches no
+        # wheel at all.  The declared-target path refuses the same combination.
+        free_threaded = host[0].abi.endswith(
+            _FREE_THREADED_ABI_SUFFIX
+        ) and supports_free_threading(python)
         return cls(
             tuple(
                 _tags_in_order(
                     python,
                     platforms,
                     implementation,
-                    free_threaded=host[0].abi.endswith(_FREE_THREADED_ABI_SUFFIX),
+                    free_threaded=free_threaded,
                 )
             )
         )
@@ -615,6 +625,11 @@ def _python_pair(python_version: str) -> tuple[int, int]:
     release = Version(python_version).release
     major, minor = (*release, 0)[:2]
     return major, minor
+
+
+def supports_free_threading(python_version: str) -> bool:
+    """Whether ``python_version`` has a free-threaded build at all (:pep:`703`)."""
+    return _python_pair(python_version) >= FREE_THREADED_MIN_PYTHON
 
 
 def _tags_in_order(

--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -50,9 +50,6 @@ __all__ = [
     "wheel_tag_set",
 ]
 
-# The free-threaded build ships from CPython 3.13 (PEP 703).
-FREE_THREADED_MIN_PYTHON = (3, 13)
-
 Libc = Literal["glibc", "musl"]
 
 # The free-threaded build ships from CPython 3.13 (PEP 703).
@@ -392,7 +389,11 @@ _PYMALLOC_LAST_VERSION = (3, 7)
 # PEP 425 interpreter short code for PyPy, and the abi suffix CPython's
 # free-threaded build carries (``cp313t``).  Both are read back off a
 # host tag set to name the interpreter a bare ``sys_tags()`` came from.
-_PYPY_INTERPRETER_PREFIX = "pp"
+# The PEP 425 interpreter prefix each implementation names itself with.
+_IMPLEMENTATION_FOR_PREFIX: Mapping[str, str] = MappingProxyType(
+    {"cp": "cpython", "pp": "pypy"}
+)
+_INTERPRETER_PREFIX_LEN = 2
 _FREE_THREADED_ABI_SUFFIX = "t"
 
 # The platform tag of an interpreter-agnostic wheel.  It is not a
@@ -577,11 +578,7 @@ class TagSet:
         ]
         # sys_tags yields the most specific tag first, so the running
         # interpreter names itself in the first entry.
-        implementation = (
-            "pypy"
-            if host[0].interpreter.startswith(_PYPY_INTERPRETER_PREFIX)
-            else "cpython"
-        )
+        implementation = _host_implementation(host[0].interpreter)
         # The host's free-threaded ABI only carries to a Python that has one:
         # ``cp310t`` has never existed, and a target advertising it matches no
         # wheel at all.  The declared-target path refuses the same combination.
@@ -625,6 +622,23 @@ def _python_pair(python_version: str) -> tuple[int, int]:
     release = Version(python_version).release
     major, minor = (*release, 0)[:2]
     return major, minor
+
+
+def _host_implementation(interpreter: str) -> str:
+    """Name the implementation a PEP 425 interpreter tag belongs to.
+
+    An interpreter nab has no tag rules for cannot be resolved for: guessing
+    CPython would hand it a ``cpXY`` tag set it can load none of.
+    """
+    prefix = interpreter[:_INTERPRETER_PREFIX_LEN]
+    implementation = _IMPLEMENTATION_FOR_PREFIX.get(prefix)
+    if implementation is None:
+        msg = (
+            f"unsupported interpreter {interpreter!r}:"
+            f" nab resolves for CPython and PyPy"
+        )
+        raise ValueError(msg)
+    return implementation
 
 
 def supports_free_threading(python_version: str) -> bool:

--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -1,29 +1,36 @@
 """Predict which wheel a target environment would install.
 
 Resolution needs the install-time wheel selection answer without a
-live interpreter, so the tag set is computed from :class:`PlatformSpec`
-and the implementation name directly, never from the interpreter
-running nab. CPython tags come from ``packaging.tags.cpython_tags``;
-PyPy tags are emitted directly (interpreter ``ppXY``, abi
-``pypyXY_pp73``). Both add interpreter-agnostic tags from
-``packaging.tags.compatible_tags``. Platform tags use ``mac_platforms``
-for macOS and expand the declared libc family's tags on Linux. A wheel
-matches the target iff its parsed tags share a member with the target's
-accepted tag set.
+live interpreter, so a declared target's tag set is computed from
+:class:`PlatformSpec` and the implementation name directly, never from
+the interpreter running nab. CPython tags come from
+``packaging.tags.cpython_tags``; PyPy tags are emitted directly
+(interpreter ``ppXY``, abi ``pypyXY_pp73``). Both add
+interpreter-agnostic tags from ``packaging.tags.compatible_tags``.
+Platform tags use ``mac_platforms`` for macOS and expand the declared
+libc family's tags on Linux. A wheel matches the target iff its parsed
+tags share a member with the target's accepted tag set.
+
+:class:`TagSet` is that accepted set, in install-preference order. The
+host builds one from ``packaging.tags.sys_tags``; a target Python on
+the host machine keeps the host's platform axis and moves only the
+interpreter and abi, which is what pip's ``--python-version`` does.
 """
 
 from __future__ import annotations
 
 import re
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
-from functools import cache, lru_cache
+from functools import cache, cached_property, lru_cache
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Literal
 
 from ._vendor.packaging import tags as ptags
+from ._vendor.packaging.version import Version
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping
+    from collections.abc import Mapping, Sequence
 
     from nab_index.client import WheelFile
 
@@ -36,9 +43,9 @@ __all__ = [
     "LIBC_MAJOR",
     "Libc",
     "PlatformSpec",
+    "TagSet",
+    "TagsSource",
     "platform_kind",
-    "select_wheel",
-    "tags_for_target",
     "wheel_tag_set",
 ]
 
@@ -46,6 +53,10 @@ Libc = Literal["glibc", "musl"]
 
 # The free-threaded build ships from CPython 3.13 (PEP 703).
 FREE_THREADED_MIN_PYTHON = (3, 13)
+
+# Where a host tag set comes from.  Injected so a caller (and every
+# test) can name the interpreter it means instead of the one running.
+TagsSource = Callable[[], "Iterable[Tag]"]
 
 
 # PEP 427: a wheel filename has at least 5 dash-separated segments
@@ -374,23 +385,15 @@ _PYPY_SOABI = "73"
 _PYMALLOC_ABI_SUFFIX = "m"
 _PYMALLOC_LAST_VERSION = (3, 7)
 
+# PEP 425 interpreter short code for PyPy, and the abi suffix CPython's
+# free-threaded build carries (``cp313t``).  Both are read back off a
+# host tag set to name the interpreter a bare ``sys_tags()`` came from.
+_PYPY_INTERPRETER_PREFIX = "pp"
+_FREE_THREADED_ABI_SUFFIX = "t"
 
-@cache
-def tags_for_target(
-    *,
-    python_version: str,
-    spec: PlatformSpec,
-    implementation: str = "cpython",
-) -> frozenset[Tag]:
-    """Return the full set of tags ``(python_version, spec, impl)`` accepts.
-
-    Builds the same ordered tags as :func:`_tags_in_order` and returns
-    them as a frozenset.  Cached on the three immutable inputs (str,
-    frozen dataclass, str): the resulting set is identical across every
-    wheel-compatibility check for the same target, so the cache skips
-    rebuilding the same :class:`Tag` set per call.
-    """
-    return frozenset(_tags_in_order(python_version, spec, implementation))
+# The platform tag of an interpreter-agnostic wheel.  It is not a
+# machine, so it never seeds the platform axis of another target.
+_ANY_PLATFORM = "any"
 
 
 @lru_cache(maxsize=4096)
@@ -444,43 +447,6 @@ def wheel_tag_set(filename: str) -> frozenset[Tag] | None:
     return _parse_tag_str("-".join(parts[-3:]))
 
 
-def select_wheel(
-    wheels: Iterable[WheelFile],
-    *,
-    python_version: str,
-    spec: PlatformSpec,
-    implementation: str = "cpython",
-) -> WheelFile | None:
-    """Pick the most-specific compatible wheel for the target, or None.
-
-    Implements PEP 425 preference: wheels matching earlier
-    (more-specific) tags in :func:`tags_for_target` win over those
-    matching later (more-generic) tags.  Within the same tag rank, the
-    wheel with the highest PEP 427 build tag wins (an absent tag sorts
-    lowest); exact ties keep input order.
-    """
-    compat_list = list(_tags_in_order(python_version, spec, implementation))
-    rank: dict[Tag, int] = {tag: i for i, tag in enumerate(compat_list)}
-
-    best: tuple[int, tuple[int, str], WheelFile] | None = None
-    for wheel in wheels:
-        wheel_tags = wheel_tag_set(wheel.filename)
-        if not wheel_tags:
-            continue
-        # Lowest rank index wins (most-specific tag).
-        wheel_rank = min((rank[t] for t in wheel_tags if t in rank), default=None)
-        if wheel_rank is None:
-            continue
-        build_key = _build_tag_sort_key(wheel.filename)
-        if (
-            best is None
-            or wheel_rank < best[0]
-            or (wheel_rank == best[0] and build_key > best[1])
-        ):
-            best = (wheel_rank, build_key, wheel)
-    return best[2] if best is not None else None
-
-
 def _build_tag_sort_key(filename: str) -> tuple[int, str]:
     """Return a PEP 427 build-tag sort key; an absent tag sorts lowest.
 
@@ -500,14 +466,163 @@ def _cpython_abi(py_version: tuple[int, int], *, free_threaded: bool) -> str:
     """Name the ABI a CPython target loads."""
     abi = f"cp{py_version[0]}{py_version[1]}"
     if free_threaded:
-        return abi + "t"
+        return abi + _FREE_THREADED_ABI_SUFFIX
     if py_version <= _PYMALLOC_LAST_VERSION:
         return abi + _PYMALLOC_ABI_SUFFIX
     return abi
 
 
+@dataclass(frozen=True)
+class TagSet:
+    """The wheel tags one target accepts, in install-preference order.
+
+    ``ordered`` is PEP 425 preference order, most specific first, so a
+    tag's index in it is the target's preference for the wheels
+    carrying it.
+    """
+
+    ordered: tuple[Tag, ...]
+
+    @cached_property
+    def members(self) -> frozenset[Tag]:
+        """The accepted tags as a set, for compatibility tests."""
+        return frozenset(self.ordered)
+
+    @cached_property
+    def rank(self) -> Mapping[Tag, int]:
+        """Preference index per accepted tag; the lowest index wins."""
+        return {tag: i for i, tag in enumerate(self.ordered)}
+
+    def accepts(self, wheel_filename: str) -> bool:
+        """Return True when the target can install ``wheel_filename``.
+
+        A filename that is not a parseable wheel is never accepted.
+        """
+        wheel_tags = wheel_tag_set(wheel_filename)
+        return wheel_tags is not None and not wheel_tags.isdisjoint(self.members)
+
+    def pick(self, wheels: Iterable[WheelFile]) -> WheelFile | None:
+        """Pick the most-specific compatible wheel for the target, or None.
+
+        Implements PEP 425 preference: wheels matching earlier
+        (more-specific) tags in :attr:`ordered` win over those matching
+        later (more-generic) tags.  Within the same tag rank, the wheel
+        with the highest PEP 427 build tag wins (an absent tag sorts
+        lowest); exact ties keep input order.
+        """
+        rank = self.rank
+        best: tuple[int, tuple[int, str], WheelFile] | None = None
+        for wheel in wheels:
+            wheel_tags = wheel_tag_set(wheel.filename)
+            if not wheel_tags:
+                continue
+            # Lowest rank index wins (most-specific tag).
+            wheel_rank = min((rank[t] for t in wheel_tags if t in rank), default=None)
+            if wheel_rank is None:
+                continue
+            build_key = _build_tag_sort_key(wheel.filename)
+            if (
+                best is None
+                or wheel_rank < best[0]
+                or (wheel_rank == best[0] and build_key > best[1])
+            ):
+                best = (wheel_rank, build_key, wheel)
+        return best[2] if best is not None else None
+
+    @classmethod
+    def for_spec(
+        cls,
+        *,
+        python_version: str,
+        spec: PlatformSpec,
+        implementation: str = "cpython",
+    ) -> TagSet:
+        """Return the tags a declared (python, platform, impl) target accepts."""
+        return cls(_ordered_tags_for_spec(python_version, spec, implementation))
+
+    @classmethod
+    def for_host(cls, *, tags_source: TagsSource = ptags.sys_tags) -> TagSet:
+        """Return the tags the running interpreter accepts.
+
+        ``packaging.tags.sys_tags`` already answers this for the live
+        machine, libc probing and all, so nothing is re-derived here.
+        """
+        return cls(tuple(tags_source()))
+
+    @classmethod
+    def for_host_python(
+        cls, python: str, *, tags_source: TagsSource = ptags.sys_tags
+    ) -> TagSet:
+        """Return the host's tags with the interpreter moved to ``python``.
+
+        The machine is still the host, so its platform tags carry over
+        unchanged (the ``any`` platform is not a machine and is
+        re-derived with the rest of the interpreter-agnostic tags); only
+        the interpreter and abi axes move.  This is what pip's
+        ``--python-version`` targets.  The host's implementation and
+        free-threaded build are read back off its own tags.
+        """
+        host = tuple(tags_source())
+        if not host:
+            msg = "tags_source yielded no tags, so the host platform is unknown"
+            raise ValueError(msg)
+        platforms = [
+            platform
+            for platform in dict.fromkeys(tag.platform for tag in host)
+            if platform != _ANY_PLATFORM
+        ]
+        # sys_tags yields the most specific tag first, so the running
+        # interpreter names itself in the first entry.
+        implementation = (
+            "pypy"
+            if host[0].interpreter.startswith(_PYPY_INTERPRETER_PREFIX)
+            else "cpython"
+        )
+        return cls(
+            tuple(
+                _tags_in_order(
+                    python,
+                    platforms,
+                    implementation,
+                    free_threaded=host[0].abi.endswith(_FREE_THREADED_ABI_SUFFIX),
+                )
+            )
+        )
+
+
+@cache
+def _ordered_tags_for_spec(
+    python_version: str, spec: PlatformSpec, implementation: str
+) -> tuple[Tag, ...]:
+    """Build a declared target's ordered tags.
+
+    Cached on the three immutable inputs (str, frozen dataclass, str):
+    the matrix rebuilds a target's tags per resolve pass, and the tag
+    list is identical every time.
+    """
+    return tuple(
+        _tags_in_order(
+            python_version,
+            _platform_tags_for_spec(spec),
+            implementation,
+            free_threaded=spec.free_threaded,
+        )
+    )
+
+
+def _python_pair(python_version: str) -> tuple[int, int]:
+    """Return ``(major, minor)`` for a ``3.12`` or ``3.12.5`` version."""
+    release = Version(python_version).release
+    major, minor = (*release, 0)[:2]
+    return major, minor
+
+
 def _tags_in_order(
-    python_version: str, spec: PlatformSpec, implementation: str = "cpython"
+    python_version: str,
+    platforms: Sequence[str],
+    implementation: str,
+    *,
+    free_threaded: bool,
 ) -> Iterable[Tag]:
     """Yield the tags a target accepts in install preference order.
 
@@ -520,9 +635,8 @@ def _tags_in_order(
     directly.  Both then add the interpreter-agnostic tags (pyXY-none-any,
     py3-none-any, ...).
     """
-    major, minor = (int(p) for p in python_version.split("."))
-    py_version = (major, minor)
-    platforms = _platform_tags_for_spec(spec)
+    py_version = _python_pair(python_version)
+    major, minor = py_version
     if implementation == "pypy":
         interpreter = f"pp{major}{minor}"
         abi = f"pypy{major}{minor}_pp{_PYPY_SOABI}"
@@ -532,7 +646,7 @@ def _tags_in_order(
             yield ptags.Tag(interpreter, "none", platform_)
     else:
         interpreter = f"cp{major}{minor}"
-        abi = _cpython_abi(py_version, free_threaded=spec.free_threaded)
+        abi = _cpython_abi(py_version, free_threaded=free_threaded)
         yield from ptags.cpython_tags(
             python_version=py_version, abis=[abi], platforms=platforms
         )

--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -1,0 +1,447 @@
+"""The environment one resolve runs against.
+
+A :class:`ResolveTarget` is a complete PEP 508 marker environment plus
+the wheel tags that environment accepts.  Specific mode resolves
+against one, built from the host interpreter; universal mode builds one
+per (python, platform, implementation) point of the declared matrix.
+Both feed the same provider, so the resolver has a single notion of
+"the environment we are resolving for".
+
+A declared target synthesizes its markers from the platform and
+implementation it names, never from the interpreter running nab: a
+matrix that models linux/3.11 must answer the same way on a macOS host.
+A host target takes them from ``packaging.markers.default_environment``
+untouched, and says so through :attr:`ResolveTarget.host_faithful`,
+which is what tells a caller whether running a build backend here would
+report metadata for the target or for someone else.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field, replace
+from typing import TYPE_CHECKING
+
+from ._conflict_kind import EMPTY_MEMBERSHIP_SETS, MARKER_VARIABLE_FOR_KIND
+from ._vendor.packaging import tags as ptags
+from ._vendor.packaging.markers import default_environment
+from ._vendor.packaging.version import InvalidVersion, Version
+from .tags import TagSet
+
+if TYPE_CHECKING:
+    from .tags import PlatformSpec, TagsSource
+
+
+__all__ = [
+    "IMPLEMENTATION_MARKERS",
+    "PLATFORM_MARKERS",
+    "EnvironmentSource",
+    "ResolveTarget",
+    "apply_python_axis_overlay",
+    "declared_environment",
+    "host_environment",
+    "python_axis_environment",
+]
+
+
+# Where a host marker environment comes from.  Injected so a caller
+# (and every test) can name the interpreter it means instead of the one
+# running.
+EnvironmentSource = Callable[[], Mapping[str, object]]
+
+
+# The OS/arch PEP 508 marker values per matrix platform id.  These are
+# the most common values for the named machine; they drive marker
+# evaluation only, never the resolver's own constraints.
+PLATFORM_MARKERS: dict[str, dict[str, str]] = {
+    "linux_x86_64": {
+        "sys_platform": "linux",
+        "platform_system": "Linux",
+        "platform_machine": "x86_64",
+        "os_name": "posix",
+    },
+    "linux_aarch64": {
+        "sys_platform": "linux",
+        "platform_system": "Linux",
+        "platform_machine": "aarch64",
+        "os_name": "posix",
+    },
+    "macos_arm64": {
+        "sys_platform": "darwin",
+        "platform_system": "Darwin",
+        "platform_machine": "arm64",
+        "os_name": "posix",
+    },
+    "macos_x86_64": {
+        "sys_platform": "darwin",
+        "platform_system": "Darwin",
+        "platform_machine": "x86_64",
+        "os_name": "posix",
+    },
+    "windows_amd64": {
+        "sys_platform": "win32",
+        "platform_system": "Windows",
+        "platform_machine": "AMD64",
+        "os_name": "nt",
+    },
+}
+
+
+# The interpreter-identity PEP 508 marker values per implementation.
+IMPLEMENTATION_MARKERS: dict[str, dict[str, str]] = {
+    "cpython": {
+        "platform_python_implementation": "CPython",
+        "implementation_name": "cpython",
+    },
+    "pypy": {
+        "platform_python_implementation": "PyPy",
+        "implementation_name": "pypy",
+    },
+}
+
+
+# PEP 425 interpreter short tag per implementation, used in the label so
+# targets differing only by implementation stay distinct.
+_IMPLEMENTATION_PREFIX: dict[str, str] = {"cpython": "py", "pypy": "pp"}
+_DEFAULT_IMPLEMENTATION_PREFIX = "py"
+
+# The platform half of a label naming the machine nab itself runs on.
+_HOST_PLATFORM_LABEL = "host"
+
+# PEP 508 ``python_version`` is the ``major.minor`` pair;
+# ``python_full_version`` is the full ``major.minor.micro`` release.
+_PYTHON_VERSION_PARTS = 2
+_PYTHON_FULL_VERSION_PARTS = 3
+
+
+def host_environment(
+    env_source: EnvironmentSource = default_environment,
+) -> dict[str, str]:
+    """Return the host's PEP 508 marker environment as a plain string dict.
+
+    ``default_environment`` returns a TypedDict whose ``.items()`` view
+    widens the values to ``object``, so rebuild it as ``dict[str, str]``
+    the callers can overlay onto.
+    """
+    return {key: value for key, value in env_source().items() if isinstance(value, str)}
+
+
+def python_axis_environment(python_version: str) -> dict[str, str]:
+    """Map an explicit Python version to its PEP 508 marker keys.
+
+    ``python_version`` is padded to two components and
+    ``python_full_version`` to three so patch-precision markers evaluate
+    the same here as in the universal matrix. Raises ``InvalidVersion``
+    if the input is not a version.
+    """
+    try:
+        parsed = Version(python_version)
+    except InvalidVersion:
+        msg = f"python_version {python_version!r} is not a valid version"
+        raise InvalidVersion(msg) from None
+    release = parsed.release
+    minor = ".".join(str(part) for part in (*release, 0)[:_PYTHON_VERSION_PARTS])
+    if len(release) >= _PYTHON_FULL_VERSION_PARTS:
+        full = python_version
+    else:
+        # Pad the release to three components, keeping the epoch and any
+        # prerelease/post/dev/local tag, which live outside ``release``.
+        epoch = f"{parsed.epoch}!" if parsed.epoch else ""
+        padded = ".".join(
+            str(part) for part in (*release, 0, 0)[:_PYTHON_FULL_VERSION_PARTS]
+        )
+        suffix = str(parsed)[len(parsed.base_version) :]
+        full = f"{epoch}{padded}{suffix}"
+    return {"python_version": minor, "python_full_version": full}
+
+
+def apply_python_axis_overlay(
+    environment: dict[str, str], overlay: Mapping[str, str]
+) -> None:
+    """Merge ``overlay`` into ``environment``, keeping the python axis in sync.
+
+    When the overlay moves only ``python_version`` (or only
+    ``python_full_version``) the untouched key would keep the host patch
+    level and the two would describe different interpreters. Re-derive both
+    from whichever axis key the overlay supplies (``python_full_version``
+    wins when both are present), so an overlay of ``python_version`` ``3.8``
+    yields ``python_full_version`` ``3.8.0`` like the universal matrix. On
+    CPython ``implementation_version`` equals ``python_full_version``, so move
+    it with the axis; other implementations version separately and keep their
+    host value unless the overlay sets it. Non-axis keys the overlay sets are
+    kept verbatim; the ``python_version``/``python_full_version`` pair is always
+    the derived one, so a patch-precision ``python_version`` (e.g. ``3.10.5``)
+    normalizes to major.minor.
+    """
+    source = overlay.get("python_full_version") or overlay.get("python_version")
+    if source is None:
+        environment.update(overlay)
+        return
+
+    axis = python_axis_environment(source)
+    if environment.get("implementation_name") == "cpython":
+        environment["implementation_version"] = axis["python_full_version"]
+    environment.update(overlay)
+    environment.update(axis)
+
+
+@dataclass(frozen=True)
+class ResolveTarget:
+    """One environment a resolve runs against: markers, wheel tags, a name.
+
+    ``label`` names the target (``host``, ``py312-linux_x86_64``) and is
+    the key a universal lock records its pins under, so it carries every
+    axis that makes one target differ from another, including the
+    conflict-fork ``selection``.
+
+    ``selection`` is the conflict-fork this target belongs to: the
+    ``(kind, name)`` members (``kind`` is ``"extra"`` or ``"group"``)
+    active in this fork's resolve, empty for an unforked one.  When set,
+    it adds a ``'name' in extras`` / ``'name' in dependency_groups``
+    clause to :attr:`marker_string` so the lockfile entry fires only
+    when the user selects that member.
+
+    ``platform_spec`` is set on a declared (matrix) target and names the
+    tag knobs it was expanded from; a host target has none.
+    ``multi_implementation`` says the matrix models more than one
+    implementation, which pins ``implementation_name`` on
+    :attr:`environment_marker_string` so the CPython and PyPy entries
+    for one python/platform stay mutually exclusive.
+    """
+
+    label: str
+    marker_env: Mapping[str, str] = field(compare=False)
+    tags: TagSet = field(compare=False)
+    host_faithful: bool = field(compare=False)
+    selection: tuple[tuple[str, str], ...] = ()
+    platform_spec: PlatformSpec | None = field(default=None, compare=False)
+    multi_implementation: bool = field(default=False, compare=False)
+
+    @property
+    def python_version(self) -> str:
+        """The PEP 508 ``python_version``: the target's ``major.minor``."""
+        return self.marker_env["python_version"]
+
+    @property
+    def python_full_version(self) -> str:
+        """The PEP 508 ``python_full_version``: the target's full release."""
+        return self.marker_env["python_full_version"]
+
+    @property
+    def implementation(self) -> str:
+        """The target's interpreter implementation (``cpython``, ``pypy``)."""
+        return self.marker_env["implementation_name"]
+
+    @property
+    def platform_id(self) -> str:
+        """The matrix platform this target names, or ``host`` for the host."""
+        if self.platform_spec is None:
+            return _HOST_PLATFORM_LABEL
+        return self.platform_spec.platform_id
+
+    def env_with_membership(self) -> dict[str, str | frozenset[str]]:
+        """Return the marker env seeded with the empty membership sets.
+
+        ``extras`` and ``dependency_groups`` are defined only when
+        consuming a lockfile, so a dependency marker that tests one
+        evaluates False here rather than raising (see
+        :data:`~nab_python._conflict_kind.EMPTY_MEMBERSHIP_SETS`).
+        """
+        return {**self.marker_env, **EMPTY_MEMBERSHIP_SETS}
+
+    @property
+    def environment_marker_string(self) -> str:
+        """Return the PEP 508 marker for this target's environment only.
+
+        Combines ``python_version``, ``sys_platform`` and
+        ``platform_machine``, plus ``implementation_name`` when the
+        matrix models more than one implementation.  It carries no
+        conflict-fork ``selection``, so it is what the lockfile's
+        top-level ``environments`` list declares: the platform/Python
+        universe, not which extras or groups are active.
+        """
+        env = self.marker_env
+        marker = (
+            f'python_version == "{self.python_version}"'
+            f' and sys_platform == "{env["sys_platform"]}"'
+            f' and platform_machine == "{env["platform_machine"]}"'
+        )
+        if self.multi_implementation or self.implementation != "cpython":
+            marker += f' and implementation_name == "{self.implementation}"'
+        return marker
+
+    @property
+    def marker_string(self) -> str:
+        """Return the per-package PEP 508 marker that selects this target.
+
+        This is :attr:`environment_marker_string` plus a bare membership
+        clause per active conflict-fork member.  The emit-time
+        disjointness validator prunes the install contexts that activate
+        two members of one declared conflict, so the bare clause needs no
+        ``not in`` negation against the other members.
+        """
+        marker = self.environment_marker_string
+        for kind, name in sorted(self.selection):
+            variable = MARKER_VARIABLE_FOR_KIND[kind]
+            marker += f' and "{name}" in {variable}'
+        return marker
+
+    def with_marker_overrides(self, overrides: Mapping[str, str]) -> ResolveTarget:
+        """Return this target with ``overrides`` merged into its marker env.
+
+        The python axis is re-derived when the overlay moves it, so
+        ``python_version`` and ``python_full_version`` never describe two
+        different interpreters.  The tag set does not move with it: an
+        overlay names no libc floor or macOS deployment target, so it
+        cannot rebuild the wheel-tag axis.  The result is no longer
+        host-faithful; a build backend run under it reports the host's
+        metadata, not the impersonated target's.
+        """
+        if not overrides:
+            return self
+        env = dict(self.marker_env)
+        apply_python_axis_overlay(env, overrides)
+        return replace(self, marker_env=env, host_faithful=False)
+
+    def with_selection(self, selection: tuple[tuple[str, str], ...]) -> ResolveTarget:
+        """Return this target under a conflict fork's active members.
+
+        The label gains one ``kind-name`` clause per member, joined by
+        ``.`` in sorted order, so the forks of one target stay distinct:
+        ``py311-linux_x86_64-group-black22.group-isort5``.  The ``.``
+        separator and the ``kind`` prefix keep it unambiguous, since
+        canonical member names are ``[a-z0-9-]`` only: two selections
+        that differ in how their names split on ``-`` (or an extra and a
+        group of the same name) cannot collide onto one label and
+        silently overwrite each other's pins.
+        """
+        base = self.label
+        if self.selection:
+            base = base[: -len(_selection_suffix(self.selection))]
+        return replace(
+            self,
+            label=base + _selection_suffix(selection),
+            selection=selection,
+        )
+
+    @classmethod
+    def for_host(
+        cls,
+        *,
+        env_source: EnvironmentSource = default_environment,
+        tags_source: TagsSource = ptags.sys_tags,
+    ) -> ResolveTarget:
+        """Return the target the running interpreter is.
+
+        Both sources are injected so a caller can model an interpreter
+        other than the one running, and so tests do not have to resolve
+        against whatever machine they happen to be on.
+        """
+        return cls(
+            label=_HOST_PLATFORM_LABEL,
+            marker_env=host_environment(env_source),
+            tags=TagSet.for_host(tags_source=tags_source),
+            host_faithful=True,
+        )
+
+    @classmethod
+    def for_host_python(
+        cls,
+        python: str,
+        *,
+        env_source: EnvironmentSource = default_environment,
+        tags_source: TagsSource = ptags.sys_tags,
+    ) -> ResolveTarget:
+        """Return the host with its interpreter moved to ``python``.
+
+        The machine stays the host: its markers and platform tags carry
+        over, and only the python axis (``python_version``,
+        ``python_full_version``, and the tags' interpreter/abi) moves.
+        This is what pip's ``--python-version`` targets.
+        """
+        env = host_environment(env_source)
+        apply_python_axis_overlay(env, python_axis_environment(python))
+        return cls(
+            label=_python_label(env["python_version"], env["implementation_name"])
+            + f"-{_HOST_PLATFORM_LABEL}",
+            marker_env=env,
+            tags=TagSet.for_host_python(python, tags_source=tags_source),
+            host_faithful=False,
+        )
+
+    @classmethod
+    def for_declared(
+        cls,
+        *,
+        python_version: str,
+        spec: PlatformSpec,
+        implementation: str = "cpython",
+        python_full_version: str | None = None,
+        multi_implementation: bool = False,
+    ) -> ResolveTarget:
+        """Return a target declared as (python, platform, implementation).
+
+        ``python_full_version`` overrides the default ``{minor}.0``
+        patch release, which makes a marker like ``python_full_version >=
+        "3.11.4"`` evaluate against the user's actual deployment.
+        """
+        return cls(
+            label=_python_label(python_version, implementation) + f"-{spec.label}",
+            marker_env=declared_environment(
+                python_version, spec, implementation, python_full_version
+            ),
+            tags=TagSet.for_spec(
+                python_version=python_version,
+                spec=spec,
+                implementation=implementation,
+            ),
+            host_faithful=False,
+            platform_spec=spec,
+            multi_implementation=multi_implementation,
+        )
+
+
+def declared_environment(
+    python_version: str,
+    spec: PlatformSpec,
+    implementation: str,
+    python_full_version: str | None = None,
+) -> dict[str, str]:
+    """Build a complete PEP 508 marker environment for a declared target.
+
+    Combines the platform's OS/arch markers and the implementation's
+    interpreter-identity markers with the python-axis values derived from
+    ``python_version``.  ``platform_release`` and ``platform_version``
+    come from the :class:`~nab_python.tags.PlatformSpec`; both default to
+    ``""`` so kernel-conditioned markers evaluate False unless the user
+    declares a target kernel or OS version.
+
+    ``implementation_version`` is set to the Python version for every
+    implementation; for non-CPython this is the interpreter's Python
+    level, not its own release (PyPy 7.3.x), so the rare
+    ``implementation_version`` marker on PyPy may misevaluate.
+    """
+    full = python_full_version or f"{python_version}.0"
+    return {
+        **PLATFORM_MARKERS[spec.platform_id],
+        **IMPLEMENTATION_MARKERS[implementation],
+        "python_version": python_version,
+        "python_full_version": full,
+        "implementation_version": full,
+        "platform_release": spec.platform_release,
+        "platform_version": spec.platform_version,
+    }
+
+
+def _python_label(python_version: str, implementation: str) -> str:
+    """Render the interpreter half of a label, e.g. ``py311`` or ``pp311``."""
+    prefix = _IMPLEMENTATION_PREFIX.get(implementation, _DEFAULT_IMPLEMENTATION_PREFIX)
+    return prefix + python_version.replace(".", "")
+
+
+def _selection_suffix(selection: tuple[tuple[str, str], ...]) -> str:
+    """Render a conflict-fork selection as a label suffix, empty when unforked."""
+    if not selection:
+        return ""
+    members = ".".join(f"{kind}-{name}" for kind, name in sorted(selection))
+    return f"-{members}"

--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -217,6 +217,22 @@ class ResolveTarget:
     platform_spec: PlatformSpec | None = field(default=None, compare=False)
     multi_implementation: bool = field(default=False, compare=False)
 
+    def __post_init__(self) -> None:
+        """Reject a python the resolve cannot compare Requires-Python against.
+
+        Every candidate's ``Requires-Python`` is tested against this target,
+        so an unparseable version has to fail here, naming itself, rather than
+        as an ``InvalidVersion`` raised per candidate deep in the listing.
+        """
+        try:
+            Version(self.python_full_version)
+        except InvalidVersion as exc:
+            msg = (
+                f"target {self.label!r} names python_full_version"
+                f" {self.python_full_version!r}, which is not a PEP 440 version"
+            )
+            raise ValueError(msg) from exc
+
     @property
     def python_version(self) -> str:
         """The PEP 508 ``python_version``: the target's ``major.minor``."""
@@ -226,6 +242,18 @@ class ResolveTarget:
     def python_full_version(self) -> str:
         """The PEP 508 ``python_full_version``: the target's full release."""
         return self.marker_env["python_full_version"]
+
+    @property
+    def python_release(self) -> Version:
+        """The release a ``Requires-Python`` specifier is compared against.
+
+        ``python_full_version`` is the PEP 508 marker value, so on a release
+        candidate it carries the ``rc``.  A specifier admits no prerelease
+        unless it names one, so comparing that value directly would exclude
+        every distribution requiring the very release the interpreter is a
+        candidate for.  pip compares ``sys.version_info``, and so does this.
+        """
+        return Version(Version(self.python_full_version).base_version)
 
     @property
     def implementation(self) -> str:

--- a/nab-python/src/nab_python/universal/matrix.py
+++ b/nab-python/src/nab_python/universal/matrix.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 
 from .._vendor.packaging.specifiers import SpecifierSet
 from .._vendor.packaging.version import Version
-from ..tags import FREE_THREADED_MIN_PYTHON
+from ..tags import FREE_THREADED_MIN_PYTHON, supports_free_threading
 from ..target import IMPLEMENTATION_MARKERS, PLATFORM_MARKERS, ResolveTarget
 
 if TYPE_CHECKING:
@@ -148,7 +148,7 @@ class Matrix:
         too_old = [
             py
             for py in _pythons_in_range(self.python)
-            if tuple(int(p) for p in py.split(".")) < FREE_THREADED_MIN_PYTHON
+            if not supports_free_threading(py)
         ]
         if too_old:
             msg = (

--- a/nab-python/src/nab_python/universal/matrix.py
+++ b/nab-python/src/nab_python/universal/matrix.py
@@ -1,22 +1,22 @@
 """Matrix expansion for user-declared universal resolution.
 
 Expands a python version range, a platform list, and an implementation
-list into a finite list of tuples, each a complete PEP 508 marker
-environment the single-environment resolver can run against. Every PEP
-508 variable appearing in any marker on the dep graph must have a value
-in every tuple. Wheel-tag and ``Requires-Python`` filtering happens
-elsewhere.
+list into a finite list of :class:`~nab_python.target.ResolveTarget`,
+each a complete PEP 508 marker environment the single-environment
+resolver can run against. Every PEP 508 variable appearing in any marker
+on the dep graph must have a value in every target. ``Requires-Python``
+filtering happens elsewhere.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from .._conflict_kind import MARKER_VARIABLE_FOR_KIND
 from .._vendor.packaging.specifiers import SpecifierSet
 from .._vendor.packaging.version import Version
 from ..tags import FREE_THREADED_MIN_PYTHON
+from ..target import IMPLEMENTATION_MARKERS, PLATFORM_MARKERS, ResolveTarget
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -27,7 +27,6 @@ if TYPE_CHECKING:
 # user range raises.
 __all__ = [
     "Matrix",
-    "MatrixTuple",
 ]
 
 
@@ -42,164 +41,12 @@ _KNOWN_PYTHON_MINORS: tuple[str, ...] = (
 )
 
 
-# Defaults filled in for marker keys the user did not specify.  These
-# come from the most common PEP 508 environment values for the named
-# OS/arch.  They are used only for marker *evaluation*; the resolver
-# does not consume them as constraints on its own.
-_PLATFORM_DEFAULTS: dict[str, dict[str, str]] = {
-    "linux_x86_64": {
-        "sys_platform": "linux",
-        "platform_system": "Linux",
-        "platform_machine": "x86_64",
-        "os_name": "posix",
-    },
-    "linux_aarch64": {
-        "sys_platform": "linux",
-        "platform_system": "Linux",
-        "platform_machine": "aarch64",
-        "os_name": "posix",
-    },
-    "macos_arm64": {
-        "sys_platform": "darwin",
-        "platform_system": "Darwin",
-        "platform_machine": "arm64",
-        "os_name": "posix",
-    },
-    "macos_x86_64": {
-        "sys_platform": "darwin",
-        "platform_system": "Darwin",
-        "platform_machine": "x86_64",
-        "os_name": "posix",
-    },
-    "windows_amd64": {
-        "sys_platform": "win32",
-        "platform_system": "Windows",
-        "platform_machine": "AMD64",
-        "os_name": "nt",
-    },
-}
-
-
-# The implementation-axis PEP 508 marker values per known
-# implementation.
-_IMPLEMENTATION_DEFAULTS: dict[str, dict[str, str]] = {
-    "cpython": {
-        "platform_python_implementation": "CPython",
-        "implementation_name": "cpython",
-    },
-    "pypy": {
-        "platform_python_implementation": "PyPy",
-        "implementation_name": "pypy",
-    },
-}
-
-# PEP 425 interpreter short tag per implementation, used in the tuple
-# label so tuples differing only by implementation stay distinct.
-_IMPLEMENTATION_PREFIX: dict[str, str] = {"cpython": "py", "pypy": "pp"}
-
-
-@dataclass(frozen=True)
-class MatrixTuple:
-    """A single point in the universal-resolution matrix.
-
-    ``selection`` records the conflict-fork this tuple belongs to: a
-    tuple of ``(kind, name)`` members (``kind`` is ``"extra"`` or
-    ``"group"``) that are active in this fork's resolve.  It is empty
-    for an unforked resolve.  When set, it both disambiguates the
-    label and adds an ``'name' in extras`` / ``'name' in
-    dependency_groups`` clause to the marker so the lockfile entry
-    fires only when the user selects that member.
-    """
-
-    python_version: str
-    platform_spec: PlatformSpec
-    environment: dict[str, str] = field(hash=False, compare=False)
-    implementation: str = "cpython"
-    multi_implementation: bool = field(default=False, hash=False, compare=False)
-    selection: tuple[tuple[str, str], ...] = ()
-
-    @property
-    def platform_id(self) -> str:
-        """The platform this tuple models, as the spec declares it."""
-        return self.platform_spec.platform_id
-
-    @property
-    def label(self) -> str:
-        """Return a short human-readable id like ``py311-linux_x86_64``.
-
-        Uses the interpreter prefix (``py`` for CPython, ``pp`` for
-        PyPy) so tuples that differ only by implementation get distinct
-        labels, and appends the platform spec's knob discriminator so a
-        spec off the platform defaults keeps its own label.  A
-        conflict-fork ``selection`` then appends each active member as
-        ``kind-name``, joined by ``.``, in sorted order so the forks of
-        one python/platform stay distinct, e.g.
-        ``py311-linux_x86_64-group-black22.group-isort5``.  The ``.``
-        separator and the ``kind`` prefix keep the label unambiguous:
-        canonical member names are ``[a-z0-9-]`` only, so a name can
-        never introduce a ``.``, and two selections that differ only in
-        how their names split on ``-`` (or an extra versus a group of
-        the same name) cannot collide into one label and silently
-        overwrite each other's pins when the label is used as a dict
-        key.
-        """
-        prefix = _IMPLEMENTATION_PREFIX[self.implementation]
-        base = (
-            f"{prefix}{self.python_version.replace('.', '')}-{self.platform_spec.label}"
-        )
-        if not self.selection:
-            return base
-        suffix = ".".join(f"{kind}-{name}" for kind, name in sorted(self.selection))
-        return f"{base}-{suffix}"
-
-    @property
-    def environment_marker_string(self) -> str:
-        """Return the PEP 508 marker for this tuple's environment only.
-
-        Combines ``python_version``, ``sys_platform``, and
-        ``platform_machine``.  In a multi-implementation matrix every
-        tuple also constrains ``implementation_name`` so the CPython and
-        PyPy entries for the same python/platform stay mutually
-        exclusive; a sole-CPython matrix omits the clause.
-
-        This carries no conflict-fork ``selection``, so it is what the
-        lockfile's top-level ``environments`` list declares: the
-        platform/Python universe, not which extras or groups are active.
-        """
-        env = self.environment
-        marker = (
-            f'python_version == "{self.python_version}"'
-            f' and sys_platform == "{env["sys_platform"]}"'
-            f' and platform_machine == "{env["platform_machine"]}"'
-        )
-        if self.multi_implementation or self.implementation != "cpython":
-            marker += f' and implementation_name == "{env["implementation_name"]}"'
-        return marker
-
-    @property
-    def marker_string(self) -> str:
-        """Return the per-package PEP 508 marker that selects this tuple.
-
-        This is :attr:`environment_marker_string` plus a bare membership
-        clause per active conflict-fork member (``'name' in extras`` for
-        an extra, ``'name' in dependency_groups`` for a group).  The
-        emit-time disjointness validator prunes the install contexts
-        that activate two members of one declared conflict, so the bare
-        clause needs no ``not in`` negation against the other members.
-        """
-        marker = self.environment_marker_string
-        for kind, name in sorted(self.selection):
-            variable = MARKER_VARIABLE_FOR_KIND[kind]
-            marker += f' and "{name}" in {variable}'
-        return marker
-
-
 @dataclass
 class Matrix:
     """User-declared universal resolution matrix.
 
     ``python_order``: ``"asc"`` (default, 3.9 first) or ``"desc"`` (3.13
-    first).  Combined with cross-tuple alignment in the resolver this
+    first).  Combined with cross-target alignment in the resolver this
     selects between ``fork-strategy=fewest`` (asc: oldest-Python pin
     propagates forward, the lowest common version wins) and
     ``fork-strategy=requires-python`` (desc: newest-Python pin
@@ -207,16 +54,16 @@ class Matrix:
     incompatible).
 
     ``python_patches``: optional ``{minor: full_version}`` mapping that
-    sets the per-tuple ``python_full_version`` marker.  Defaults to
-    ``{minor}.0`` per tuple, which makes markers like
+    sets the per-target ``python_full_version`` marker.  Defaults to
+    ``{minor}.0`` per target, which makes markers like
     ``python_full_version >= "3.11.4"`` evaluate to False on a 3.11
-    tuple.  Users with deployments on later patch releases should
+    target.  Users with deployments on later patch releases should
     declare them here so marker evaluation matches reality.  Example:
     ``python_patches={"3.11": "3.11.4", "3.12": "3.12.1"}``.
 
     ``implementations``: the interpreter implementations to model
     (``"cpython"``, ``"pypy"``).  Defaults to ``("cpython",)``.  Each
-    multiplies the tuple count; markers and wheel tags resolve per
+    multiplies the target count; markers and wheel tags resolve per
     implementation.
     """
 
@@ -226,8 +73,8 @@ class Matrix:
     python_patches: dict[str, str] | None = None
     implementations: tuple[str, ...] = ("cpython",)
 
-    def expand(self) -> list[MatrixTuple]:
-        """Expand the matrix into concrete tuples.
+    def expand(self) -> list[ResolveTarget]:
+        """Expand the matrix into concrete targets.
 
         Validates inputs eagerly: unknown platform ids, unknown
         implementations, ``python_patches`` keys that are not known
@@ -241,13 +88,13 @@ class Matrix:
         unknown = [
             s.platform_id
             for s in self.platforms
-            if s.platform_id not in _PLATFORM_DEFAULTS
+            if s.platform_id not in PLATFORM_MARKERS
         ]
         if unknown:
             msg = f"Unknown platform ids: {unknown!r}"
             raise ValueError(msg)
         unknown_impl = [
-            i for i in self.implementations if i not in _IMPLEMENTATION_DEFAULTS
+            i for i in self.implementations if i not in IMPLEMENTATION_MARKERS
         ]
         if unknown_impl:
             msg = f"Unknown implementations: {unknown_impl!r}"
@@ -269,11 +116,11 @@ class Matrix:
             py_versions.reverse()
         multi_impl = len(self.implementations) > 1
         return [
-            MatrixTuple(
+            ResolveTarget.for_declared(
                 python_version=py,
-                platform_spec=spec,
-                environment=_build_environment(py, spec, impl, patches.get(py)),
+                spec=spec,
                 implementation=impl,
+                python_full_version=patches.get(py),
                 multi_implementation=multi_impl,
             )
             for py in py_versions
@@ -309,43 +156,6 @@ class Matrix:
                 f" but matrix.python admits {too_old!r}"
             )
             raise ValueError(msg)
-
-
-def _build_environment(
-    python_version: str,
-    spec: PlatformSpec,
-    implementation: str,
-    python_full_version: str | None = None,
-) -> dict[str, str]:
-    """Build a complete PEP 508 marker environment for one tuple.
-
-    Combines the platform's OS/arch defaults and the implementation's
-    interpreter-identity defaults with python-axis values derived from
-    ``python_version``.  ``platform_release`` and ``platform_version``
-    come from the :class:`PlatformSpec`; both default to ``""`` so
-    kernel-conditioned markers evaluate False unless the user declares a
-    target kernel/OS version.
-
-    ``python_full_version`` overrides the default ``{minor}.0`` value.
-    Used when the matrix declares ``python_patches`` to make
-    patch-bound markers (``python_full_version >= "3.11.4"``) evaluate
-    against the user's actual deployment patch release.
-
-    ``implementation_version`` is set to the Python version for every
-    implementation; for non-CPython this is the interpreter's Python
-    level, not its own release (PyPy 7.3.x), so the rare
-    ``implementation_version`` marker on PyPy may misevaluate.
-    """
-    full = python_full_version or f"{python_version}.0"
-    return {
-        **_PLATFORM_DEFAULTS[spec.platform_id],
-        **_IMPLEMENTATION_DEFAULTS[implementation],
-        "python_version": python_version,
-        "python_full_version": full,
-        "implementation_version": full,
-        "platform_release": spec.platform_release,
-        "platform_version": spec.platform_version,
-    }
 
 
 def _pythons_in_range(spec: str) -> Iterable[str]:

--- a/nab-python/src/nab_python/universal/provider.py
+++ b/nab-python/src/nab_python/universal/provider.py
@@ -1,25 +1,20 @@
-"""Provider subclass that accepts a full PEP 508 marker environment.
+"""Provider subclass for one point of the universal matrix.
 
-The stock :class:`nab_python.provider.Provider` only accepts a
-``python_version`` override and inherits everything else from
-``default_environment()`` (the host environment).  Universal resolution
-needs to swap the entire environment per tuple, so this subclass
-overlays a user-supplied dict on top.
-
-Also adds a ``preferences`` knob: a ``{package_name: Version}`` dict
-tried first when choosing a version.  Used for cross-tuple alignment
-("if tuple A picked numpy 2.2.6, ask tuple B to try 2.2.6 first").
+Adds a ``preferences`` knob to the stock
+:class:`nab_python.provider.Provider`: a ``{package_name: Version}``
+dict tried first when choosing a version.  Used for cross-target
+alignment ("if target A picked numpy 2.2.6, ask target B to try 2.2.6
+first").
 
 Resolution strategy (``highest``/``lowest``/``lowest-direct``) is
 inherited from :class:`Provider` and threaded through via the
 parent's ``resolution_strategy`` and ``direct_packages`` kwargs.
 
-When ``platform_spec`` is supplied, the provider also filters wheel
-candidates by tag compatibility at resolve time.  Versions whose only
-wheels are for another libc family, or above the spec's libc/macOS
-version, become unavailable unless an sdist is present, which keeps the
-version alive at every ``build_policy`` level (look-ahead rejects an
-unreadable sdist).
+With ``filter_by_wheel_tags`` the provider also filters wheel candidates
+by tag compatibility at resolve time.  Versions whose only wheels are for
+another libc family, or above the target's libc/macOS version, become
+unavailable unless an sdist is present, which keeps the version alive at
+every ``build_policy`` level (look-ahead rejects an unreadable sdist).
 """
 
 from __future__ import annotations
@@ -28,9 +23,7 @@ from typing import TYPE_CHECKING
 
 from nab_index.client import SdistFile, WheelFile
 
-from .._conflict_kind import EMPTY_MEMBERSHIP_SETS
 from .._provider.extras import version_provides_extra
-from .._vendor.packaging.markers import default_environment
 from .._vendor.packaging.ranges import VersionRange
 from .._vendor.packaging.utils import canonicalize_name
 from ..provider import (
@@ -44,7 +37,6 @@ from ..provider import (
     VcsConfig,
     VcsSource,
 )
-from ..tags import tags_for_target, wheel_tag_set
 
 __all__ = [
     "DistFile",
@@ -64,16 +56,17 @@ if TYPE_CHECKING:
     from .._vendor.packaging.version import Version
     from ..config import IndexOverride, NabProjectConfig, PackageOverride
     from ..fetch import FetchCoordinator
-    from ..tags import PlatformSpec
+    from ..tags import TagSet
+    from ..target import ResolveTarget
 
 
 class UniversalProvider(Provider):
-    """Provider with a user-supplied marker environment + preferences."""
+    """Provider for one resolve target, with uv-style version preferences."""
 
     def __init__(  # noqa: PLR0913 - matches Provider signature
         self,
         coordinator: FetchCoordinator,
-        marker_environment: dict[str, str],
+        target: ResolveTarget,
         *,
         root_requirements: dict[str, VersionRange] | None = None,
         uploaded_prior_to: datetime | None = None,
@@ -93,9 +86,9 @@ class UniversalProvider(Provider):
         preferences: dict[str, Version] | None = None,
         resolution_strategy: ResolutionStrategy | str = ResolutionStrategy.HIGHEST,
         direct_packages: frozenset[str] | None = None,
-        platform_spec: PlatformSpec | None = None,
+        filter_by_wheel_tags: bool = False,
     ) -> None:
-        """Create a provider with overlay environment + uv-style preferences."""
+        """Create a provider for ``target`` with uv-style preferences."""
         if isinstance(resolution_strategy, str):
             try:
                 resolution_strategy = ResolutionStrategy(resolution_strategy)
@@ -113,13 +106,7 @@ class UniversalProvider(Provider):
         )
         super().__init__(
             coordinator,
-            # Use the full patch version for Requires-Python evaluation;
-            # python_version only carries major.minor, so patch-level
-            # specifiers (e.g. >=3.13.1) require python_full_version.
-            python_version=(
-                marker_environment.get("python_full_version")
-                or marker_environment.get("python_version")
-            ),
+            target=target,
             root_requirements=root_requirements,
             uploaded_prior_to=uploaded_prior_to,
             extras_mode=extras_mode,
@@ -139,22 +126,12 @@ class UniversalProvider(Provider):
             resolution_strategy=resolution_strategy,
             direct_packages=direct_packages,
         )
-        merged: dict[str, str] = {
-            key: value
-            for key, value in default_environment().items()
-            if isinstance(value, str)
-        }
-        merged.update(marker_environment)
-        self.environment = merged
-        self.env_with_extra = {**merged, **EMPTY_MEMBERSHIP_SETS}
         # Normalize preferences keys so lookup matches the provider's
         # canonical naming scheme.
         self._preferences: dict[str, Version] = {
             canonicalize_name(k): v for k, v in (preferences or {}).items()
         }
-        self._platform_spec = platform_spec
-        self._py_minor = marker_environment.get("python_version")
-        self._implementation = marker_environment.get("implementation_name", "cpython")
+        self._wheel_tags: TagSet | None = target.tags if filter_by_wheel_tags else None
         self.excluded_by_wheel_tags = 0
         self.excluded_versions_no_compatible_wheel = 0
 
@@ -198,9 +175,8 @@ class UniversalProvider(Provider):
         """Filter parent's result by wheel-tag compatibility.
 
         A version is unavailable to the resolver if its only wheels are
-        tag-incompatible with this tuple's ``platform_spec``.  Sdists
-        keep the version alive at every
-        :class:`BuildPolicy` level because static PKG-INFO and the
+        tag-incompatible with the target.  Sdists keep the version alive at
+        every :class:`BuildPolicy` level because static PKG-INFO and the
         bundled ``pyproject.toml`` fallback are read unconditionally;
         ``BUILD_LOCAL`` adds backend invocation on local checkouts and
         ``BUILD_REMOTE`` adds it on VCS clones and remote sdists.  The
@@ -208,29 +184,22 @@ class UniversalProvider(Provider):
         extraction actually fails (e.g. dynamic deps with no static
         fallback under :attr:`BuildPolicy.NEVER`).
 
-        When ``platform_spec`` is unset (legacy callers) the override
-        is a no-op.
+        Without ``filter_by_wheel_tags`` the override is a no-op.
         """
         base = super().filter_distributions(normalized, files)
-        if self._platform_spec is None or self._py_minor is None:
+        # Bound once outside the per-wheel loop: this runs for every wheel
+        # of every package on every target, so the hoist matters on large
+        # workloads.
+        tags = self._wheel_tags
+        if tags is None:
             return base
 
-        spec = self._platform_spec
-        py_minor = self._py_minor
-        # Look up the per-tuple accepted tag set once outside the per-wheel
-        # loop and inline the membership check; this loop runs for every
-        # wheel of every package on every tuple, so the hoist matters on
-        # large workloads.
-        accepted = tags_for_target(
-            python_version=py_minor, spec=spec, implementation=self._implementation
-        )
         kept: list[tuple[Version, DistFile]] = []
         versions_with_wheel: set[Version] = set()
         versions_with_sdist: set[Version] = set()
         for version, dist in base:
             if isinstance(dist, WheelFile):
-                wheel_tags = wheel_tag_set(dist.filename)
-                if wheel_tags is not None and not wheel_tags.isdisjoint(accepted):
+                if tags.accepts(dist.filename):
                     kept.append((version, dist))
                     versions_with_wheel.add(version)
                 else:

--- a/nab-python/src/nab_python/universal/reresolve.py
+++ b/nab-python/src/nab_python/universal/reresolve.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 
     from ..config import IndexOverride, NabProjectConfig, PackageOverride
     from ..fetch import FetchCoordinator
-    from .matrix import MatrixTuple
+    from ..target import ResolveTarget
     from .resolve import UniversalResult
     from .validate import PinValidation, ValidationReport
 
@@ -199,7 +199,7 @@ def _reresolve_one_step(  # noqa: PLR0913
 
 def _resolve_one_tuple_with_overrides(  # noqa: PLR0913
     coordinator: FetchCoordinator,
-    tup: MatrixTuple,
+    tup: ResolveTarget,
     requirements: list[str],
     wheel_metadata: dict[tuple[str, str], str],
     *,
@@ -219,12 +219,14 @@ def _resolve_one_tuple_with_overrides(  # noqa: PLR0913
     resolution_strategy: str,
 ) -> dict[str, str]:
     """Re-resolve ``tup`` with the given metadata overrides; return pins."""
-    # Carry the original tuple's patch release so markers gated on
+    # Carry the original target's patch release so markers gated on
     # python_full_version evaluate the same in both passes.
+    spec = tup.platform_spec
+    assert spec is not None  # every matrix target declares one
     one_tuple_matrix = _Matrix(
         python=f"=={tup.python_version}",
-        platforms=(tup.platform_spec,),
-        python_patches={tup.python_version: tup.environment["python_full_version"]},
+        platforms=(spec,),
+        python_patches={tup.python_version: tup.python_full_version},
         implementations=(tup.implementation,),
     )
     with _override_metadata(coordinator, wheel_metadata):

--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -25,7 +25,6 @@ from .._vendor.packaging.markers import Marker
 from .._vendor.packaging.ranges import VersionRange
 from .._vendor.packaging.requirements import InvalidRequirement, Requirement
 from .._vendor.packaging.utils import canonicalize_name
-from .._vendor.packaging.version import Version
 from ..config import ConfigError, IndexOverride, PackageOverride
 from ..fetch import (
     DEFAULT_INDEX_NAME,
@@ -76,6 +75,7 @@ if TYPE_CHECKING:
 
     from nab_index.transport import AsyncHttpTransport
 
+    from .._vendor.packaging.version import Version
     from ..config import ConflictSet, NabProjectConfig
     from ..target import ResolveTarget
     from .matrix import Matrix
@@ -671,7 +671,7 @@ def _raise_for_source_python(
     )
     if not managed:
         return
-    target = Version(t.python_full_version)
+    target = t.python_release
     for name, version in pins.items():
         normalized = canonicalize_name(name)
         if normalized not in managed:

--- a/nab-python/src/nab_python/universal/resolve.py
+++ b/nab-python/src/nab_python/universal/resolve.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 import time
 from collections import defaultdict
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from nab_index.multi_index import IndexConfig
@@ -77,14 +77,15 @@ if TYPE_CHECKING:
     from nab_index.transport import AsyncHttpTransport
 
     from ..config import ConflictSet, NabProjectConfig
-    from .matrix import Matrix, MatrixTuple
+    from ..target import ResolveTarget
+    from .matrix import Matrix
 
 
 @dataclass
 class TupleResult:
     """Result of one specific resolve."""
 
-    tuple_: MatrixTuple
+    tuple_: ResolveTarget
     success: bool
     pins: dict[str, Version] = field(default_factory=dict)
     error: str | None = None
@@ -205,7 +206,7 @@ def merge_universal_lock_inputs(
         label = tr.tuple_.label
         per_tuple_pins[label] = dict(tr.lock_input.pins)
         tuple_markers[label] = Marker(tr.tuple_.marker_string)
-        tuple_environments[label] = dict(tr.tuple_.environment)
+        tuple_environments[label] = dict(tr.tuple_.marker_env)
 
         env_marker = tr.tuple_.environment_marker_string
         parsed = env_marker_cache.get(env_marker)
@@ -371,7 +372,7 @@ def resolve_with_coordinator(  # noqa: PLR0913 - mirrors resolve_universal's sur
 
     def run_pass(
         reqs: list[str],
-        tuples: list[MatrixTuple],
+        tuples: list[ResolveTarget],
         prefs: dict[str, Version],
     ) -> list[TupleResult]:
         return _run_pass(
@@ -403,7 +404,7 @@ def resolve_with_coordinator(  # noqa: PLR0913 - mirrors resolve_universal's sur
         tuples = (
             base_tuples
             if not fork.selection
-            else [replace(t, selection=fork.selection) for t in base_tuples]
+            else [t.with_selection(fork.selection) for t in base_tuples]
         )
         results = run_pass(list(fork.requirements), tuples, accumulated)
         out.extend(results)
@@ -423,7 +424,7 @@ def resolve_with_coordinator(  # noqa: PLR0913 - mirrors resolve_universal's sur
         )
         for tr in base_results:
             if tr.success:
-                signature = tuple(sorted(tr.tuple_.environment.items()))
+                signature = tuple(sorted(tr.tuple_.marker_env.items()))
                 env_base_names[signature] = frozenset(
                     canonicalize_name(name) for name in tr.pins
                 )
@@ -443,7 +444,7 @@ def resolve_with_coordinator(  # noqa: PLR0913 - mirrors resolve_universal's sur
 
 
 def _run_pass(  # noqa: PLR0913
-    tuples: list[MatrixTuple],
+    tuples: list[ResolveTarget],
     requirements: list[str],
     constraints: list[str] | None,
     *,
@@ -472,10 +473,10 @@ def _run_pass(  # noqa: PLR0913
     where the matrix admits it.
     """
 
-    def resolve(t: MatrixTuple, current_prefs: dict[str, Version]) -> TupleResult:
+    def resolve(t: ResolveTarget, current_prefs: dict[str, Version]) -> TupleResult:
         try:
             tuple_requirements, tuple_constraints = _parse_tuple_inputs(
-                requirements, constraints, t.environment, vcs_config or VcsConfig()
+                requirements, constraints, t.marker_env, vcs_config or VcsConfig()
             )
         except ResolutionError as exc:
             return TupleResult(
@@ -563,7 +564,7 @@ def _direct_package_names(requirements: list[str]) -> set[str]:
 
 def _parse_requirements(
     reqs: list[str],
-    environment: dict[str, str],
+    environment: Mapping[str, str],
     *,
     vcs_config: VcsConfig | None = None,
     kind: str = "requirement",
@@ -632,7 +633,7 @@ def _root_extras(requirements: dict[str, VersionRange]) -> set[tuple[str, str]]:
 def _parse_tuple_inputs(
     requirements: list[str],
     constraints: list[str] | None,
-    environment: dict[str, str],
+    environment: Mapping[str, str],
     vcs_config: VcsConfig,
 ) -> tuple[dict[str, VersionRange], dict[str, VersionRange] | None]:
     """Parse a tuple's root requirements and constraints for its env.
@@ -654,7 +655,7 @@ def _parse_tuple_inputs(
 
 def _raise_for_source_python(
     provider: UniversalProvider,
-    t: MatrixTuple,
+    t: ResolveTarget,
     pins: Mapping[str, Version],
 ) -> None:
     """Reject a local, VCS, or archive pin whose Requires-Python excludes the tuple.
@@ -670,7 +671,7 @@ def _raise_for_source_python(
     )
     if not managed:
         return
-    target = Version(t.environment["python_full_version"])
+    target = Version(t.python_full_version)
     for name, version in pins.items():
         normalized = canonicalize_name(name)
         if normalized not in managed:
@@ -700,7 +701,7 @@ def _tuple_stats(
 
 def _resolve_one_tuple(  # noqa: PLR0913
     coordinator: FetchCoordinator,
-    t: MatrixTuple,
+    t: ResolveTarget,
     requirements: dict[str, VersionRange],
     constraints: dict[str, VersionRange] | None,
     *,
@@ -723,7 +724,7 @@ def _resolve_one_tuple(  # noqa: PLR0913
     """Run one single-environment resolve for ``t``."""
     provider = UniversalProvider(
         coordinator,
-        marker_environment=t.environment,
+        t,
         root_requirements=requirements,
         root_extras=_root_extras(requirements),
         uploaded_prior_to=uploaded_prior_to,
@@ -741,7 +742,7 @@ def _resolve_one_tuple(  # noqa: PLR0913
         preferences=preferences,
         resolution_strategy=resolution_strategy,
         direct_packages=direct_packages,
-        platform_spec=t.platform_spec,
+        filter_by_wheel_tags=True,
     )
     resolver: Resolver[str, Version] = Resolver(
         provider,

--- a/nab-python/src/nab_python/universal/validate.py
+++ b/nab-python/src/nab_python/universal/validate.py
@@ -30,14 +30,13 @@ from .._vendor.packaging.requirements import (
 from .._vendor.packaging.utils import canonicalize_name, canonicalize_version
 from .._vendor.packaging.version import Version
 from ..metadata import load_static_project, metadata_deps_are_static, parse_metadata
-from ..tags import select_wheel
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
 
     from ..config import PackageOverride
     from ..fetch import FetchCoordinator
-    from .matrix import MatrixTuple
+    from ..target import ResolveTarget
     from .resolve import UniversalResult
 
 
@@ -200,7 +199,7 @@ def _dependencies_override_for(
 
 def _validate_pin(  # noqa: PLR0911 - one return per outcome reads cleaner here
     coordinator: FetchCoordinator,
-    tup: MatrixTuple,
+    tup: ResolveTarget,
     package: str,
     version: Version,
     package_overrides: Sequence[PackageOverride] = (),
@@ -227,12 +226,7 @@ def _validate_pin(  # noqa: PLR0911 - one return per outcome reads cleaner here
             status="sdist_only",
             detail="no wheels at this version; install requires building from sdist",
         )
-    chosen = select_wheel(
-        wheels_at_version,
-        python_version=tup.python_version,
-        spec=tup.platform_spec,
-        implementation=tup.implementation,
-    )
+    chosen = tup.tags.pick(wheels_at_version)
     if chosen is None:
         status = (
             "no_compatible_wheel_with_sdist" if has_sdist else "no_compatible_wheel"
@@ -293,11 +287,11 @@ def _validate_pin(  # noqa: PLR0911 - one return per outcome reads cleaner here
         )
     try:
         chosen_by_extra = _evaluate_metadata_deps_by_extra(
-            metadata_text, tup.environment
+            metadata_text, tup.marker_env
         )
         listing_text = coordinator.index.get_metadata(normalized, str(version))
         listing_by_extra: dict[str | None, set[str]] = (
-            _evaluate_metadata_deps_by_extra(listing_text, tup.environment)
+            _evaluate_metadata_deps_by_extra(listing_text, tup.marker_env)
             if listing_text is not None
             else {None: set()}
         )
@@ -490,7 +484,7 @@ def _fetch_wheel_metadata(
 
 def _evaluate_metadata_deps_by_extra(
     metadata_text: str,
-    environment: dict[str, str],
+    environment: Mapping[str, str],
 ) -> dict[str | None, set[str]]:
     """Return deps grouped by extra: ``{None: base_deps, "extra": deps_for_extra}``.
 

--- a/nab-python/tests/property_python/test_build_policy_never.py
+++ b/nab-python/tests/property_python/test_build_policy_never.py
@@ -35,6 +35,7 @@ from nab_python.provider import (
     Provider,
     UnsupportedSdistError,
 )
+from nab_python.target import ResolveTarget
 
 from .strategies import PROPERTY_SETTINGS
 
@@ -126,7 +127,7 @@ def _run_case(
     )
     provider = Provider(
         coordinator,
-        python_version="3.12.0",
+        target=ResolveTarget.for_host_python("3.12.0"),
         dist_policy=DistPolicy.WHEEL_OR_SDIST,
         build_policy=policy,
     )

--- a/nab-python/tests/property_python/test_extras_pep685.py
+++ b/nab-python/tests/property_python/test_extras_pep685.py
@@ -28,6 +28,7 @@ from nab_python.provider import (
     join_extra,
     split_extra,
 )
+from nab_python.target import ResolveTarget
 
 from .strategies import PROPERTY_SETTINGS
 
@@ -96,7 +97,11 @@ def _make_extras_provider(
     # Pre-store metadata so the resolver short-circuits on the
     # has_metadata cache hit before the side effects fire.
     coordinator.index.store_metadata("testpkg", "1.0", metadata_text)
-    return Provider(coordinator, python_version="3.12.0", extras_mode=extras_mode)
+    return Provider(
+        coordinator,
+        target=ResolveTarget.for_host_python("3.12.0"),
+        extras_mode=extras_mode,
+    )
 
 
 class TestQuoteExtraNameNormalization:

--- a/nab-python/tests/property_python/test_marker_overlay.py
+++ b/nab-python/tests/property_python/test_marker_overlay.py
@@ -1,12 +1,11 @@
-"""Property tests for :func:`nab_python.resolve._build_marker_environment`.
+"""Property tests for :class:`nab_python.target.ResolveTarget`'s marker env.
 
-The marker-environment builder merges a fixed defaults dict (the
-host machine's PEP 508 environment), a ``python_version`` override
-derived from the requested interpreter, and a user-supplied
-overrides mapping.  The PubGrub provider evaluates root markers
-against the resulting dict, so the merge must be deterministic in
-the algebraic sense: empty overrides leave the result untouched,
-and disjoint overrides commute.
+A host-python target merges a fixed defaults dict (the host machine's
+PEP 508 environment), a ``python_version`` override derived from the
+requested interpreter, and a user-supplied overrides mapping.  The
+PubGrub provider evaluates root markers against the resulting dict, so
+the merge must be deterministic in the algebraic sense: empty overrides
+leave the result untouched, and disjoint overrides commute.
 
 Reference: https://peps.python.org/pep-0508/#environment-markers
 """
@@ -16,15 +15,26 @@ Reference: https://peps.python.org/pep-0508/#environment-markers
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 from hypothesis import assume, given
 from hypothesis import strategies as st
 
-from nab_python.resolve import _build_marker_environment
+from nab_python.target import ResolveTarget
 
 from .strategies import PROPERTY_SETTINGS
 
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
 pytestmark = pytest.mark.property
+
+
+def _marker_env(python_version: str, overrides: dict[str, str]) -> Mapping[str, str]:
+    """The marker env a host target for ``python_version`` resolves against."""
+    target = ResolveTarget.for_host_python(python_version)
+    return target.with_marker_overrides(overrides).marker_env
 
 
 # Marker keys whose values are stable strings on every supported
@@ -93,12 +103,8 @@ class TestEmptyOverrideIsIdentity:
     @PROPERTY_SETTINGS
     def test_empty_overlay_is_identity(self, python_version: str) -> None:
         """Empty overrides reproduce the unmodified default environment."""
-        baseline = _build_marker_environment(
-            python_version=python_version, overrides={}
-        )
-        repeated = _build_marker_environment(
-            python_version=python_version, overrides={}
-        )
+        baseline = _marker_env(python_version, {})
+        repeated = _marker_env(python_version, {})
         assert baseline == repeated
 
 
@@ -126,10 +132,6 @@ class TestDisjointOverlaysCommute:
     ) -> None:
         """``base ∪ A ∪ B == base ∪ B ∪ A`` for disjoint ``A`` and ``B``."""
         assume(set(overlay_a).isdisjoint(set(overlay_b)))
-        a_then_b = _build_marker_environment(
-            python_version=python_version, overrides={**overlay_a, **overlay_b}
-        )
-        b_then_a = _build_marker_environment(
-            python_version=python_version, overrides={**overlay_b, **overlay_a}
-        )
+        a_then_b = _marker_env(python_version, {**overlay_a, **overlay_b})
+        b_then_a = _marker_env(python_version, {**overlay_b, **overlay_a})
         assert a_then_b == b_then_a

--- a/nab-python/tests/property_python/test_tags_differential.py
+++ b/nab-python/tests/property_python/test_tags_differential.py
@@ -5,14 +5,15 @@ top of the vendored ``packaging.tags``.
 Each test here re-derives one layer with the upstream ``packaging``
 distribution as the oracle and requires agreement:
 
-1. The tag order built by ``_tags_in_order`` must match the same
-   order rebuilt with upstream ``cpython_tags``/``compatible_tags``.
+1. The tag order a :class:`TagSet` builds for a declared target must
+   match the same order rebuilt with upstream
+   ``cpython_tags``/``compatible_tags``.
 2. The vendored ``mac_platforms`` must match upstream for identical
    inputs.
 3. ``parse_tag`` must expand compressed tag sets identically.
 4. ``wheel_tag_set`` must agree with upstream
    ``parse_wheel_filename`` on every spec-valid filename.
-5. ``select_wheel`` must pick a wheel whose best upstream rank is
+5. ``TagSet.pick`` must choose a wheel whose best upstream rank is
    the minimum over all candidate wheels.
 
 .. _PEP 425: https://peps.python.org/pep-0425/
@@ -34,9 +35,8 @@ from nab_python.tags import (
     _MACOS_TAG_FLOOR,
     _PLATFORM_ARCH,
     PlatformSpec,
+    TagSet,
     _platform_tags_for_spec,
-    _tags_in_order,
-    select_wheel,
     wheel_tag_set,
 )
 
@@ -105,7 +105,7 @@ def _oracle_tags_in_order(
     *,
     free_threaded: bool,
 ) -> list[tuple[str, str, str]]:
-    """Rebuild ``tags._tags_in_order`` with upstream ``packaging.tags``."""
+    """Rebuild a declared target's tag order with upstream ``packaging.tags``."""
     major, minor = (int(p) for p in python_version.split("."))
     py = (major, minor)
     out: list[tuple[str, str, str]] = []
@@ -131,7 +131,7 @@ def _oracle_tags_in_order(
 
 
 class TestTagOrderMatchesUpstream:
-    """``_tags_in_order`` defines the install-preference ranking every
+    """``TagSet.for_spec`` defines the install-preference ranking every
     wheel choice hangs off.  Rebuilding the same order with upstream
     ``cpython_tags``/``compatible_tags`` over the same platform list
     must agree exactly: a divergence reorders wheel preference.
@@ -148,7 +148,11 @@ class TestTagOrderMatchesUpstream:
     ) -> None:
         """Vendored tag order equals the upstream-rebuilt order."""
         platforms = _platform_tags_for_spec(spec)
-        got = _triples(_tags_in_order(python_version, spec, implementation))
+        got = _triples(
+            TagSet.for_spec(
+                python_version=python_version, spec=spec, implementation=implementation
+            ).ordered
+        )
         expected = _oracle_tags_in_order(
             python_version,
             platforms,
@@ -344,12 +348,9 @@ class TestSelectWheelMinimizesUpstreamRank:
             return min(ranks) if ranks else None
 
         oracle_ranks = [r for w in wheels if (r := best_rank(w)) is not None]
-        chosen = select_wheel(
-            wheels,
-            python_version=python_version,
-            spec=spec,
-            implementation=implementation,
-        )
+        chosen = TagSet.for_spec(
+            python_version=python_version, spec=spec, implementation=implementation
+        ).pick(wheels)
         if not oracle_ranks:
             assert chosen is None
             return

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -76,6 +76,7 @@ from nab_python.provider import (
     VcsPolicy,
     VcsSource,
 )
+from nab_python.target import ResolveTarget
 
 
 def _wheel(name: str = "foo", version: str = "1.0") -> WheelArtifact:
@@ -2388,7 +2389,7 @@ class TestBuildLockInputFromProvider:
         coordinator = make_coordinator([_sdist_file("pkg", "2.0")], package="pkg")
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=ResolveTarget.for_host_python("3.12.0"),
             build_policy=BuildPolicy.NEVER,
             package_overrides=(
                 pkg_override("pkg", dependencies=(Requirement("dep-a>=1"),)),

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -31,7 +31,6 @@ from nab_python._provider.metadata_resolver import (
 )
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._testing.overrides import pkg_override
-from nab_python._vendor.packaging.markers import Marker
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.specifiers import SpecifierSet
@@ -59,14 +58,18 @@ from nab_python.provider import (
     VcsConfig,
     VcsPolicy,
     VcsSource,
-    apply_python_axis_overlay,
-    python_axis_environment,
 )
 from nab_python.resolve import _build_resolver_inputs, _raise_for_source_python
+from nab_python.target import ResolveTarget
 from nab_resolver.resolver import ResolutionError, Resolver
 from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
 
 V = Version
+
+# The target most tests resolve against: the host machine, impersonating
+# CPython 3.12.0.  Shared because it is frozen and building one walks the
+# host's whole tag set.
+_PY312 = ResolveTarget.for_host_python("3.12.0")
 
 
 def make_wheel(
@@ -131,9 +134,7 @@ class TestPrefetchListings:
         """Root requirement listings are fetched in background on init."""
         coordinator = make_coordinator([make_wheel("1.0")], package="foo")
         root_reqs = {"foo": SpecifierSet(">=1.0").to_range()}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         result = provider.fetch_versions("foo")
         assert len(result) == 1
 
@@ -141,9 +142,7 @@ class TestPrefetchListings:
         """``prefetch_new_deps`` doesn't overwrite already-cached listings."""
         coordinator = make_coordinator([make_wheel("2.0")], package="foo")
         root_reqs = {"foo": SpecifierSet(">=1.0").to_range()}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         provider.fetch_versions("foo")
         provider.versions_cache["foo"] = [(V("1.0"), make_wheel("1.0"))]
         provider.prefetch_new_deps({"foo": SpecifierSet(">=1.0").to_range()})
@@ -187,9 +186,7 @@ class TestSpeculativePrefetch:
             package="foo",
         )
         root_reqs = {"foo": SpecifierSet("<3.0").to_range()}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         provider.fetch_versions("foo")
         # Should have submitted a batch prefetch within the root range
         assert (
@@ -234,9 +231,7 @@ class TestSpeculativePrefetch:
         """No prefetch when root range excludes all versions."""
         coordinator = make_coordinator([make_wheel("1.0")], package="foo")
         root_reqs = {"foo": SpecifierSet(">=5.0").to_range()}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         provider.fetch_versions("foo")
         coordinator.request_metadata_batch.assert_not_called()
 
@@ -317,7 +312,7 @@ class TestFetchVersions:
         coordinator = make_coordinator(
             [make_wheel("1.0", requires_python=">=3.12")], package="foo"
         )
-        provider = Provider(coordinator, python_version="3.10.0")
+        provider = Provider(coordinator, target=ResolveTarget.for_host_python("3.10.0"))
         assert provider.fetch_versions("foo") == []
 
     def test_keeps_matching_requires_python(self) -> None:
@@ -325,7 +320,7 @@ class TestFetchVersions:
         coordinator = make_coordinator(
             [make_wheel("1.0", requires_python=">=3.10")], package="foo"
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         assert len(provider.fetch_versions("foo")) == 1
 
     def test_invalid_requires_python_keeps_package(self) -> None:
@@ -333,7 +328,7 @@ class TestFetchVersions:
         coordinator = make_coordinator(
             [make_wheel("1.0", requires_python=">>>invalid")], package="foo"
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         assert len(provider.fetch_versions("foo")) == 1
 
     def test_non_string_requires_python_admitted_without_crash(self) -> None:
@@ -355,7 +350,7 @@ class TestFetchVersions:
         files = _parse_files(data, "https://example.com/", "foo")
         assert files[0].requires_python is None
         coordinator = make_coordinator(files, package="foo")
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         assert len(provider.fetch_versions("foo")) == 1
 
     def test_requires_python_cache_hit_exercises_cached_branch(self) -> None:
@@ -373,7 +368,7 @@ class TestFetchVersions:
             ],
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.10.0")
+        provider = Provider(coordinator, target=ResolveTarget.for_host_python("3.10.0"))
         # Two wheels, same requires-python string, both excluded.
         assert provider.fetch_versions("foo") == []
         # Cache should have one entry: the parsed exclusion verdict.
@@ -384,7 +379,7 @@ class TestFetchVersions:
         coordinator = make_coordinator(
             [make_wheel("1.0", requires_python=">=99.0")], package="foo"
         )
-        provider = Provider(coordinator, python_version=None)
+        provider = Provider(coordinator, target=None)
         assert len(provider.fetch_versions("foo")) == 1
 
     def test_requires_python_filter_honors_python_overlay(self) -> None:
@@ -403,12 +398,10 @@ class TestFetchVersions:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312.with_marker_overrides(
+                {"python_version": "3.8", "python_full_version": "3.8.0"}
+            ),
             build_policy=BuildPolicy.NEVER,
-            marker_environment={
-                "python_version": "3.8",
-                "python_full_version": "3.8.0",
-            },
         )
         versions = [v for v, _ in provider.fetch_versions("foo")]
         assert versions == [V("1.0")]
@@ -428,7 +421,7 @@ class TestFetchVersions:
                 )
         records = asyncio.run(LocalIndexClient(tmp_path.as_uri()).get_files("foo"))
         coordinator = make_coordinator([], package="foo")
-        provider = Provider(coordinator, python_version="3.8.0")
+        provider = Provider(coordinator, target=ResolveTarget.for_host_python("3.8.0"))
         versions = [v for v, _ in provider.filter_distributions("foo", records)]
         assert versions == [V("1.0")]
 
@@ -449,7 +442,7 @@ class TestFetchVersions:
             (tmp_path / f"foo-{version}.tar.gz").write_bytes(buf.getvalue())
         records = asyncio.run(LocalIndexClient(tmp_path.as_uri()).get_files("foo"))
         coordinator = make_coordinator([], package="foo")
-        provider = Provider(coordinator, python_version="3.8.0")
+        provider = Provider(coordinator, target=ResolveTarget.for_host_python("3.8.0"))
         versions = [v for v, _ in provider.filter_distributions("foo", records)]
         assert versions == [V("1.0")]
 
@@ -469,9 +462,10 @@ class TestFetchVersions:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.3",
+            target=ResolveTarget.for_host_python("3.12.3").with_marker_overrides(
+                {"python_version": "3.8"}
+            ),
             build_policy=BuildPolicy.NEVER,
-            marker_environment={"python_version": "3.8"},
         )
         assert provider.environment["python_version"] == "3.8"
         assert provider.environment["python_full_version"] == "3.8.0"
@@ -663,7 +657,7 @@ class TestResolutionStrategy:
         root_reqs = {"bar": SpecifierSet("<2.0").to_range()}
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             root_requirements=root_reqs,
             resolution_strategy=ResolutionStrategy.LOWEST,
         )
@@ -689,7 +683,7 @@ class TestEqualVersionDifferentStrings:
 
     def test_listing_collapses_to_one_logical_version(self) -> None:
         coordinator = make_coordinator(self._files(), package="pkg")
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         version_list = provider.fetch_versions("pkg")
         versions = provider.versions_only("pkg", version_list)
         assert versions == [V("1.0")]
@@ -697,7 +691,7 @@ class TestEqualVersionDifferentStrings:
 
     def test_wheel_not_evicted_by_same_version_sdist(self) -> None:
         coordinator = make_coordinator(self._files(), package="pkg")
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         version_list = provider.fetch_versions("pkg")
         mapping = provider._wheel_by_version("pkg", version_list)
         assert len(mapping) == 1
@@ -711,7 +705,7 @@ class TestEqualVersionDifferentStrings:
             coordinator = make_coordinator(self._files(), package="pkg")
             provider = Provider(
                 coordinator,
-                python_version="3.12.0",
+                target=_PY312,
                 resolution_strategy=strategy,
             )
             chosen[strategy] = provider.choose_version(
@@ -727,8 +721,8 @@ class TestEqualVersionDifferentStrings:
         forward = make_coordinator(self._files(), package="pkg")
         reverse_files = list(reversed(self._files()))
         backward = make_coordinator(reverse_files, package="pkg")
-        p_forward = Provider(forward, python_version="3.12.0")
-        p_backward = Provider(backward, python_version="3.12.0")
+        p_forward = Provider(forward, target=_PY312)
+        p_backward = Provider(backward, target=_PY312)
         v_forward = p_forward.choose_version("pkg", SpecifierSet(">=1.0").to_range())
         v_backward = p_backward.choose_version("pkg", SpecifierSet(">=1.0").to_range())
         assert v_forward is not None
@@ -837,9 +831,7 @@ class TestPrereleaseAdmission:
             "foo": VersionRange.full(admit_arbitrary=False),
             "bar": SpecifierSet("==5.0").to_range(),
         }
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         resolver = Resolver(provider, range_type=VersionRange, root_version="0")
         pins = resolver.resolve(root_reqs)
         assert pins["foo"] == V("2.0rc1")
@@ -878,7 +870,7 @@ class TestNoVersionsReasons:
             ],
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.9.0")
+        provider = Provider(coordinator, target=ResolveTarget.for_host_python("3.9.0"))
         provider.choose_version("foo", SpecifierSet("").to_range())
         assert (
             provider.get_no_versions_reason("foo")
@@ -927,7 +919,7 @@ class TestNoVersionsReasons:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             root_requirements={"foo": VersionRange.full(admit_arbitrary=False)},
         )
         # Pretend the resolver decided bar==1.0 already.
@@ -954,7 +946,7 @@ class TestNoVersionsReasons:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.BUILD_LOCAL,
             root_requirements={"pkg": VersionRange.full(admit_arbitrary=False)},
@@ -1014,7 +1006,7 @@ class TestNoVersionsReasons:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             root_requirements={
                 "foo": VersionRange.full(admit_arbitrary=False),
                 "bar": SpecifierSet("==1.0").to_range(),
@@ -1046,7 +1038,7 @@ class TestNoVersionsReasons:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             root_requirements={"foo": VersionRange.full(admit_arbitrary=False)},
         )
         pos_range = SpecifierSet("<2.0").to_range()
@@ -1077,7 +1069,7 @@ class TestGetDependencies:
             ),
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         deps = provider.get_dependencies("foo", V("1.0"))
         assert "bar" in deps
         assert "baz" in deps
@@ -1095,7 +1087,7 @@ class TestGetDependencies:
             ),
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         deps = provider.get_dependencies("foo", V("1.0"))
         assert V("3.0") in deps["bar"]
         assert V("1.0") not in deps["bar"]
@@ -1108,7 +1100,7 @@ class TestGetDependencies:
             metadata_text="Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n",
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         provider.get_dependencies("foo", V("1.0"))
         provider.get_dependencies("foo", V("1.0"))
         # Metadata should only be requested once (via speculative prefetch
@@ -1131,7 +1123,7 @@ class TestGetDependencies:
         coordinator.index.store_metadata_error(
             "foo", "1.0", MetadataHashMismatchError("metadata sha256 mismatch")
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         with pytest.raises(MetadataHashMismatchError):
             provider.get_dependencies("foo", V("1.0"))
         assert ("foo", V("1.0")) not in provider.deps_cache
@@ -1161,7 +1153,7 @@ class TestGetDependencies:
             return _done_event()
 
         coordinator.request_sdist.side_effect = _poisoned_request_sdist
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         with pytest.raises(SdistHashMismatchError):
             provider.get_dependencies("foo", V("1.0"))
         assert ("foo", V("1.0")) not in provider.deps_cache
@@ -1191,7 +1183,7 @@ class TestGetDependencies:
         coordinator = make_coordinator(
             [make_wheel("1.0")], metadata_text=bad_metadata, package="foo"
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         with pytest.raises(MetadataError, match="Invalid metadata"):
             provider.get_dependencies("foo", V("1.0"))
 
@@ -1211,7 +1203,7 @@ class TestGetDependencies:
         coordinator = make_coordinator(
             [make_wheel("1.0")], metadata_text=bad_metadata, package="foo"
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         with pytest.raises(MetadataError, match="invalid Requires-Python"):
             provider.get_dependencies("foo", V("1.0"))
 
@@ -1235,7 +1227,7 @@ class TestGetDependencies:
         coordinator = make_coordinator(
             [make_wheel("1.0")], metadata_text=bad_metadata, package="foo"
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         with pytest.raises(MetadataError, match="Invalid metadata"):
             provider.get_dependencies("foo", V("1.0"))
         # Make the underlying parse blow up if we go through it again --
@@ -1262,7 +1254,7 @@ class TestGetDependencies:
         coordinator = make_coordinator(
             [make_wheel("1.0")], metadata_text=bad_metadata, package="foo"
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         with caplog.at_level("WARNING", logger="nab_python.provider"):
             with pytest.raises(MetadataError):
                 provider.get_dependencies("foo", V("1.0"))
@@ -1298,7 +1290,7 @@ class TestGetDependencies:
             [make_wheel("1.0", has_metadata=False, local_path=wheel_path)],
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         deps = provider.get_dependencies("foo", V("1.0"))
         assert "bar" in deps
         assert V("2.0") in deps["bar"]
@@ -1318,7 +1310,7 @@ class TestGetDependencies:
             [make_wheel("1.0", has_metadata=False, local_path=wheel_path)],
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         with pytest.raises(MetadataError):
             provider.get_dependencies("foo", V("1.0"))
 
@@ -1335,7 +1327,7 @@ class TestGetDependencies:
             ),
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         deps = provider.get_dependencies("foo", V("1.0"))
         assert "bar" not in deps
         assert "baz" in deps
@@ -1356,7 +1348,7 @@ class TestGetDependencies:
             ),
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.11")
+        provider = Provider(coordinator, target=ResolveTarget.for_host_python("3.11"))
         deps = provider.get_dependencies("foo", V("1.0"))
         assert "only313" not in deps
         assert "only311" in deps
@@ -1367,7 +1359,7 @@ class TestGetDependencies:
         """
         coordinator = make_coordinator([make_wheel("1.0")], package="foo")
         with pytest.raises(InvalidVersion, match="'not-a-version'"):
-            Provider(coordinator, python_version="not-a-version")
+            Provider(coordinator, target=ResolveTarget.for_host_python("not-a-version"))
 
     def test_arbitrary_equality_dep_is_literal_range(self) -> None:
         """``===`` deps round-trip as a literal-only range.
@@ -1388,7 +1380,7 @@ class TestGetDependencies:
             ),
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         deps = provider.get_dependencies("foo", V("1.0"))
         assert "bar" in deps
         assert "custom-build" in deps["bar"]
@@ -1417,7 +1409,7 @@ class TestTransitiveDirectUrlDep:
             ),
             package="foo",
         )
-        return Provider(coordinator, python_version="3.12.0", vcs_config=vcs_config)
+        return Provider(coordinator, target=_PY312, vcs_config=vcs_config)
 
     def test_plain_url_dep_refused(self) -> None:
         """A non-VCS direct-URL dep raises rather than pinning from the index."""
@@ -1458,7 +1450,7 @@ class TestTransitiveDirectUrlDep:
             ),
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         deps = provider.get_dependencies("foo", V("1.0"))
         assert "bar" not in deps
         assert "baz" in deps
@@ -1484,7 +1476,7 @@ class TestTransitiveDirectUrlDep:
         )
         return Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             root_extras=root_extras,
             vcs_config=vcs_config,
         )
@@ -1862,16 +1854,18 @@ class TestLocalSources:
 
 class TestMarkerEnvironment:
     def test_overlay_overrides_host(self) -> None:
-        """Keys in ``marker_environment`` overlay the host environment."""
+        """Keys in the target's marker overrides overlay the host environment."""
         coordinator = make_coordinator([make_wheel("1.0")], package="foo")
         provider = Provider(
             coordinator,
+            target=ResolveTarget.for_host().with_marker_overrides(
+                {
+                    "platform_system": "Windows",
+                    "sys_platform": "win32",
+                    "platform_machine": "AMD64",
+                }
+            ),
             build_policy=BuildPolicy.NEVER,
-            marker_environment={
-                "platform_system": "Windows",
-                "sys_platform": "win32",
-                "platform_machine": "AMD64",
-            },
         )
         assert provider.environment["platform_system"] == "Windows"
         assert provider.environment["sys_platform"] == "win32"
@@ -1882,8 +1876,10 @@ class TestMarkerEnvironment:
         coordinator = make_coordinator([make_wheel("1.0")], package="foo")
         provider = Provider(
             coordinator,
+            target=ResolveTarget.for_host().with_marker_overrides(
+                {"platform_system": "Darwin"}
+            ),
             build_policy=BuildPolicy.NEVER,
-            marker_environment={"platform_system": "Darwin"},
         )
         assert "os_name" in provider.environment
         assert provider.environment["platform_system"] == "Darwin"
@@ -1903,22 +1899,24 @@ class TestMarkerEnvironment:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12",
+            target=ResolveTarget.for_host_python("3.12").with_marker_overrides(
+                {"sys_platform": "win32"}
+            ),
             build_policy=BuildPolicy.NEVER,
-            marker_environment={"sys_platform": "win32"},
         )
         deps = provider.get_dependencies("foo", V("1.0"))
         assert "pywin32" in deps
         assert "only-linux" not in deps
 
     def test_python_version_overlay_runs_after_python_version_arg(self) -> None:
-        """``marker_environment`` overlay applies after ``python_version``."""
+        """The marker overrides apply after the target Python."""
         coordinator = make_coordinator([make_wheel("1.0")], package="foo")
         provider = Provider(
             coordinator,
-            python_version="3.11.5",
+            target=ResolveTarget.for_host_python("3.11.5").with_marker_overrides(
+                {"python_version": "3.13"}
+            ),
             build_policy=BuildPolicy.NEVER,
-            marker_environment={"python_version": "3.13"},
         )
         assert provider.environment["python_version"] == "3.13"
 
@@ -1926,7 +1924,9 @@ class TestMarkerEnvironment:
         """A 2-part python_version yields a 3-part python_full_version."""
         coordinator = make_coordinator([make_wheel("1.0")], package="foo")
         provider = Provider(
-            coordinator, python_version="3.10", build_policy=BuildPolicy.NEVER
+            coordinator,
+            target=ResolveTarget.for_host_python("3.10"),
+            build_policy=BuildPolicy.NEVER,
         )
         assert provider.environment["python_version"] == "3.10"
         assert provider.environment["python_full_version"] == "3.10.0"
@@ -1935,175 +1935,33 @@ class TestMarkerEnvironment:
         """A 3-part python_version keeps its patch component."""
         coordinator = make_coordinator([make_wheel("1.0")], package="foo")
         provider = Provider(
-            coordinator, python_version="3.11.5", build_policy=BuildPolicy.NEVER
+            coordinator,
+            target=ResolveTarget.for_host_python("3.11.5"),
+            build_policy=BuildPolicy.NEVER,
         )
         assert provider.environment["python_full_version"] == "3.11.5"
 
-    def test_overlay_with_never_override_passes(self) -> None:
-        """Overrides at ``NEVER`` skip the guard's offending branch.
 
-        Covers the loop's skip-iteration path: a build override whose
-        policy is ``NEVER`` must not contribute to the guard's offending
-        list.
-        """
-        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
+class TestTargetEnvironment:
+    def test_target_python_moves_implementation_version(self) -> None:
+        """A target Python moves implementation_version too."""
         provider = Provider(
-            coordinator,
-            build_policy=BuildPolicy.NEVER,
-            package_overrides=(
-                pkg_override("quarantined", build_policy=BuildPolicy.NEVER),
-            ),
-            marker_environment={"platform_system": "Windows"},
+            make_coordinator(), target=ResolveTarget.for_host_python("3.9.0")
         )
-        assert (
-            provider.effective_build_policy("quarantined", V("1.0"))
-            is BuildPolicy.NEVER
-        )
-
-    def test_default_policy_blocked_when_overlay_used(self) -> None:
-        """The default ``BUILD_LOCAL`` is rejected with a marker overlay.
-
-        Users who want a marker overlay must opt into ``never`` explicitly,
-        since a host-side backend cannot reflect the impersonated target.
-        """
-        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
-        with pytest.raises(ValueError, match="marker_environment overlay requires"):
-            Provider(
-                coordinator,
-                marker_environment={"platform_system": "Windows"},
-            )
-
-    def test_overlay_with_build_remote_policy_raises(self) -> None:
-        """Non-``NEVER`` global + ``marker_environment`` is rejected."""
-        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
-        with pytest.raises(ValueError, match="marker_environment overlay requires"):
-            Provider(
-                coordinator,
-                build_policy=BuildPolicy.BUILD_REMOTE,
-                marker_environment={"platform_system": "Windows"},
-            )
-
-    def test_overlay_with_build_remote_override_raises(self) -> None:
-        """A build override that escapes ``NEVER`` also fails the guard."""
-        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
-        with pytest.raises(ValueError, match="marker_environment overlay requires"):
-            Provider(
-                coordinator,
-                build_policy=BuildPolicy.NEVER,
-                package_overrides=(
-                    pkg_override("foo", build_policy=BuildPolicy.BUILD_REMOTE),
-                ),
-                marker_environment={"platform_system": "Windows"},
-            )
-
-    def test_overlay_with_build_remote_index_override_raises(self) -> None:
-        """A per-index build override that escapes ``NEVER`` fails the guard."""
-        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
-        with pytest.raises(ValueError, match="marker_environment overlay requires"):
-            Provider(
-                coordinator,
-                build_policy=BuildPolicy.NEVER,
-                index_overrides={
-                    "internal": IndexOverride(build_policy=BuildPolicy.BUILD_REMOTE)
-                },
-                marker_environment={"platform_system": "Windows"},
-            )
-
-    def test_no_overlay_no_constraint(self) -> None:
-        """Without ``marker_environment``, looser ``BuildPolicy`` works."""
-        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
-        provider = Provider(coordinator, build_policy=BuildPolicy.BUILD_REMOTE)
-        assert provider.build_policy is BuildPolicy.BUILD_REMOTE
-
-    def test_empty_overlay_no_constraint(self) -> None:
-        """An empty overlay does not trigger the BuildPolicy check."""
-        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
-        provider = Provider(
-            coordinator,
-            build_policy=BuildPolicy.BUILD_REMOTE,
-            marker_environment={},
-        )
-        assert provider.build_policy is BuildPolicy.BUILD_REMOTE
-
-
-class TestPythonAxisEnvironment:
-    def test_single_component_version_pads_python_version(self) -> None:
-        """``python_version`` is padded to major.minor like full to three."""
-        env = python_axis_environment("3")
-        assert env == {"python_version": "3.0", "python_full_version": "3.0.0"}
-
-    def test_unparseable_version_raises_named_error(self) -> None:
-        """The error names the bad ``python_version`` input."""
-        with pytest.raises(InvalidVersion, match="python_version 'not-a-version'"):
-            python_axis_environment("not-a-version")
-
-    def test_two_component_prerelease_keeps_tag(self) -> None:
-        """A 2-release-component prerelease keeps its tag in full version."""
-        env = python_axis_environment("3.14a1")
-        assert env["python_version"] == "3.14"
-        assert Version(env["python_full_version"]) == Version("3.14a1")
-
-    def test_two_component_prerelease_not_treated_as_final(self) -> None:
-        """A prerelease target must not satisfy a final-release marker."""
-        env = python_axis_environment("3.14rc1")
-        assert Marker('python_full_version >= "3.14.0"').evaluate(env) is False
-        assert Marker('python_full_version == "3.14.0"').evaluate(env) is False
-
-
-class TestApplyPythonAxisOverlay:
-    def test_cpython_moves_implementation_version_with_axis(self) -> None:
-        """On CPython the axis move drags implementation_version along."""
-        env = {
-            "implementation_name": "cpython",
-            "python_version": "3.11",
-            "python_full_version": "3.11.5",
-            "implementation_version": "3.11.5",
-        }
-        apply_python_axis_overlay(env, {"python_version": "3.8"})
-        assert env["python_full_version"] == "3.8.0"
-        assert env["implementation_version"] == "3.8.0"
-
-    def test_non_cpython_keeps_its_implementation_version(self) -> None:
-        """A PyPy axis move keeps the interpreter's own release version."""
-        env = {
-            "implementation_name": "pypy",
-            "python_version": "3.9",
-            "python_full_version": "3.9.18",
-            "implementation_version": "7.3.13",
-        }
-        apply_python_axis_overlay(env, {"python_version": "3.10"})
-        assert env["python_full_version"] == "3.10.0"
-        assert env["implementation_version"] == "7.3.13"
-
-    def test_provider_target_python_moves_implementation_version(self) -> None:
-        """A Provider target Python moves implementation_version too."""
-        provider = Provider(make_coordinator(), python_version="3.9.0")
         assert provider.environment["implementation_version"] == "3.9.0"
         assert (
             provider.environment["implementation_version"]
             == provider.environment["python_full_version"]
         )
 
-    def test_patch_precision_python_version_normalizes_to_minor(self) -> None:
-        """A patch-precision python_version overlay normalizes to major.minor."""
-        env = {
-            "implementation_name": "cpython",
-            "python_version": "3.11",
-            "python_full_version": "3.11.5",
-            "implementation_version": "3.11.5",
-        }
-        apply_python_axis_overlay(env, {"python_version": "3.10.5"})
-        assert env["python_version"] == "3.10"
-        assert env["python_full_version"] == "3.10.5"
-        assert Marker('python_version == "3.10"').evaluate(env) is True
-
-    def test_provider_marker_env_patch_python_version_normalizes(self) -> None:
-        """A marker-env python_version like 3.10.5 normalizes to major.minor."""
+    def test_marker_env_patch_python_version_normalizes(self) -> None:
+        """A marker-override python_version like 3.10.5 normalizes to major.minor."""
         provider = Provider(
             make_coordinator(),
-            python_version="3.12.3",
+            target=ResolveTarget.for_host_python("3.12.3").with_marker_overrides(
+                {"python_version": "3.10.5"}
+            ),
             build_policy=BuildPolicy.NEVER,
-            marker_environment={"python_version": "3.10.5"},
         )
         assert provider.environment["python_version"] == "3.10"
         assert provider.environment["python_full_version"] == "3.10.5"
@@ -2126,9 +1984,7 @@ class TestLookAhead:
         )
 
         root_reqs = {"bar": SpecifierSet("<2.0").to_range()}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         spec = SpecifierSet("")
         assert provider.choose_version("foo", spec.to_range()) == V("1.0")
 
@@ -2150,9 +2006,7 @@ class TestLookAhead:
             package="foo",
         )
         root_reqs = {"bar": SpecifierSet(">=1.0").to_range()}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         spec = SpecifierSet("")
         assert provider.choose_version("foo", spec.to_range()) == V("1.0")
 
@@ -2167,9 +2021,7 @@ class TestLookAhead:
             package="foo",
         )
         root_reqs = {"bar": SpecifierSet("<2.0").to_range()}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         spec = SpecifierSet("")
         assert provider.choose_version("foo", spec.to_range()) is None
 
@@ -2184,9 +2036,7 @@ class TestLookAhead:
             package="foo",
         )
         root_reqs = {"bar": SpecifierSet("<2.0").to_range()}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         provider.get_dependencies("foo", V("1.0"))
         spec = SpecifierSet("")
         assert provider.choose_version("foo", spec.to_range()) is None
@@ -2209,9 +2059,7 @@ class TestLookAhead:
             package="foo",
         )
         root_reqs = {"bar": SpecifierSet("<2.0").to_range()}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         spec = SpecifierSet("")
         # v2.0 conflicts with root, v1.0 has no metadata_url and is
         # skipped; choose_version returns ``None`` instead of raising.
@@ -2228,9 +2076,7 @@ class TestLookAhead:
             package="foo",
         )
         root_reqs = {"bar": SpecifierSet("<2.0").to_range()}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         provider.deps_cache[("foo", V("1.0"))] = {}
         spec = SpecifierSet("")
         assert provider.choose_version("foo", spec.to_range()) == V("1.0")
@@ -2286,9 +2132,7 @@ class TestLookAhead:
 
         coordinator.request_metadata_batch.side_effect = _request_metadata_batch
 
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
 
         spec = SpecifierSet("")
         assert provider.choose_version("foo", spec.to_range()) == V("1.0")
@@ -2311,9 +2155,7 @@ class TestLookAhead:
         )
 
         root_reqs = {"bar": SpecifierSet("<2.0").to_range()}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         spec = SpecifierSet("")
         assert provider.choose_version("foo", spec.to_range()) == V("1.0")
 
@@ -2359,9 +2201,7 @@ class TestDecisionLookAhead:
         # Root requirements are unused for the rejection itself, but they
         # have to be non-empty so that look-ahead is enabled.
         root_reqs = {"baz": SpecifierSet(">=1.0").to_range()}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         provider.receive_partial_solution_hint({}, {"bar": V("3.0")})
         spec = SpecifierSet("")
         # foo==2.0 conflicts with bar==3.0 (needs >=5.0); foo==1.0 is compatible.
@@ -2400,9 +2240,7 @@ class TestDecisionLookAhead:
         )
         coordinator = make_coordinator(wheels, metadata_text=meta, package="foo")
         root_reqs = {"baz": SpecifierSet(">=1.0").to_range()}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         provider.receive_partial_solution_hint({}, {"bar": V("3.0")})
         # check_decisions=False ignores the bar==3.0 conflict.
         assert provider._look_ahead_ok("foo", V("1.0"), check_decisions=False)
@@ -2417,9 +2255,7 @@ class TestDecisionLookAhead:
         )
         coordinator = make_coordinator(wheels, metadata_text=meta, package="foo")
         root_reqs = {"baz": SpecifierSet(">=1.0").to_range()}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         provider.receive_partial_solution_hint({}, {"bar": V("3.0")})
         spec = SpecifierSet("")
         assert provider.choose_version("foo", spec.to_range()) is None
@@ -2436,9 +2272,7 @@ class TestDecisionLookAhead:
         )
         coordinator = make_coordinator(wheels, metadata_text=meta, package="foo")
         root_reqs = {"baz": SpecifierSet(">=1.0").to_range()}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         # bar has a positive range that doesn't intersect bar>=5.0 (the dep)
         # but is not decided yet.
         provider.receive_partial_solution_hint(
@@ -2495,9 +2329,7 @@ class TestDecisionLookAhead:
             "foo": VersionRange.full(admit_arbitrary=False),
             "app": VersionRange.full(admit_arbitrary=False),
         }
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         resolver = Resolver(provider, range_type=VersionRange, root_version="0")
         with pytest.raises(ResolutionError) as exc_info:
             resolver.resolve(dict(root_reqs))
@@ -2612,9 +2444,7 @@ class TestLookAheadAbort:
             package="foo",
         )
         root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         provider.receive_partial_solution_hint({}, {"bar": V("3.0")})
         provider._LOOKAHEAD_ABORT_THRESHOLD = 2  # type: ignore[misc]
         chosen = provider.choose_version("foo", VersionRange.full())
@@ -2638,9 +2468,7 @@ class TestLookAheadAbort:
             package="foo",
         )
         root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         provider.receive_partial_solution_hint({}, {"bar": V("3.0")})
         provider._LOOKAHEAD_ABORT_THRESHOLD = 64  # type: ignore[misc]
         # Only 2 candidates so we never cross 64; the scan returns None.
@@ -2665,9 +2493,7 @@ class TestLookAheadAbort:
             package="foo",
         )
         root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         provider.receive_partial_solution_hint({}, {"bar": V("3.0")})
         provider._LOOKAHEAD_ABORT_THRESHOLD = 2  # type: ignore[misc]
         assert provider.choose_version("foo", VersionRange.full()) == V("3.0")
@@ -2690,9 +2516,7 @@ class TestLookAheadAbort:
             package="foo",
         )
         root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         provider.receive_partial_solution_hint({}, {"bar": V("3.0")})
         provider._LOOKAHEAD_ABORT_THRESHOLD = 2  # type: ignore[misc]
         provider.choose_version("foo", VersionRange.full())
@@ -2717,9 +2541,7 @@ class TestLookAheadAbort:
             package="foo",
         )
         root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         provider.receive_partial_solution_hint({}, {"bar": V("3.0")})
         provider._LOOKAHEAD_ABORT_THRESHOLD = 2  # type: ignore[misc]
         provider._MAX_FORCE_BACKTRACKS_PER_PKG = 3  # type: ignore[misc]
@@ -2746,9 +2568,7 @@ class TestLookAheadAbort:
             [make_wheel("1.0")], metadata_text=meta, package="foo"
         )
         root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         # bar=3.0 conflicts with foo's bar<2.0 dep, the same
         # state that would have triggered the abort in the first place.
         provider.receive_partial_solution_hint({}, {"bar": V("3.0")})
@@ -2775,9 +2595,7 @@ class TestLookAheadAbort:
             [make_wheel("1.0")], metadata_text=meta, package="foo"
         )
         root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         provider.receive_partial_solution_hint({}, {"bar": V("3.0")})
         provider._lookahead_aborted["foo"] = ("bar", V("3.0"))
         # No pre-warm; cold cache. The safety look-ahead fetches the
@@ -2802,9 +2620,7 @@ class TestLookAheadAbort:
             package="foo",
         )
         root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         provider.receive_partial_solution_hint({}, {"bar": V("3.0")})
         # Skip is recorded, but foo==1.0 has bad metadata so the
         # safety check rejects and the scan proceeds.
@@ -2826,9 +2642,7 @@ class TestLookAheadAbort:
         )
         coordinator = make_coordinator(wheels, metadata_text=meta, package="foo")
         root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         # Recorded state names bar==3.0, but the current decisions have
         # bar==2.0, so the recorded state is stale.
         provider.receive_partial_solution_hint({}, {"bar": V("2.0")})
@@ -3268,7 +3082,7 @@ class TestDependenciesOverride:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             extras_mode=ExtrasMode.ERROR_USER,
             root_extras={("foo", "security")},
             package_overrides=(
@@ -3546,7 +3360,7 @@ class TestRequiresPythonListingGate:
         )
         provider = Provider(
             coordinator,
-            python_version="3.9.0",
+            target=ResolveTarget.for_host_python("3.9.0"),
             package_overrides=(pkg_override("foo", requires_python=">=3.9"),),
         )
         assert [v for v, _ in provider.fetch_versions("foo")] == [V("1.0")]
@@ -3559,7 +3373,7 @@ class TestRequiresPythonListingGate:
         )
         provider = Provider(
             coordinator,
-            python_version="3.10.0",
+            target=ResolveTarget.for_host_python("3.10.0"),
             package_overrides=(pkg_override("foo", requires_python=">=3.11"),),
         )
         assert provider.fetch_versions("foo") == []
@@ -3571,7 +3385,7 @@ class TestRequiresPythonListingGate:
         )
         provider = Provider(
             coordinator,
-            python_version="3.9.0",
+            target=ResolveTarget.for_host_python("3.9.0"),
             package_overrides=(pkg_override("foo", requires_python=""),),
         )
         assert [v for v, _ in provider.fetch_versions("foo")] == [V("1.0")]
@@ -3589,7 +3403,7 @@ class TestRequiresPythonListingGate:
         )
         provider = Provider(
             coordinator,
-            python_version="3.10.0",
+            target=ResolveTarget.for_host_python("3.10.0"),
             package_overrides=(pkg_override("foo", requires_python=">=3.0"),),
         )
         assert [v for v, _ in provider.fetch_versions("foo")] == [V("1.0")]
@@ -3602,7 +3416,7 @@ class TestRequiresPythonListingGate:
         coordinator = make_coordinator([make_wheel("1.0")], package="foo")
         provider = Provider(
             coordinator,
-            python_version=None,
+            target=None,
             package_overrides=(pkg_override("foo", requires_python=">=3.11"),),
         )
         assert len(provider.fetch_versions("foo")) == 1
@@ -3617,7 +3431,7 @@ class TestSkipFetch:
         coordinator = make_coordinator([make_wheel("1.0")], package="foo")
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             package_overrides=(
                 pkg_override("foo", dependencies=(Requirement("dep-a>=1"),)),
             ),
@@ -3629,7 +3443,7 @@ class TestSkipFetch:
         coordinator = make_coordinator([make_wheel("1.0")], package="foo")
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             package_overrides=(pkg_override("foo", dependencies=()),),
         )
         assert provider.get_dependencies("foo", V("1.0")) == {}
@@ -3640,7 +3454,7 @@ class TestSkipFetch:
         coordinator = make_coordinator([make_wheel("1.0")], package="foo")
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             package_overrides=(
                 pkg_override("foo", dependencies=(Requirement("dep-a>=1"),)),
             ),
@@ -3654,7 +3468,7 @@ class TestSkipFetch:
         coordinator = make_coordinator([make_wheel("1.0")], package="foo")
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             package_overrides=(pkg_override("foo", requires_python=">=3.0"),),
         )
         with pytest.raises(MetadataError):
@@ -3672,7 +3486,7 @@ class TestSkipFetch:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.NEVER,
             root_requirements={"pkg": VersionRange.full(admit_arbitrary=False)},
@@ -3702,7 +3516,7 @@ class TestSkipFetch:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             root_requirements={"pkg": VersionRange.full(admit_arbitrary=False)},
             package_overrides=(
                 pkg_override("pkg == 2.0", dependencies=(Requirement("dep-a>=1"),)),
@@ -3722,7 +3536,7 @@ class TestSkipFetch:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             package_overrides=(
                 pkg_override("pkg", dependencies=(Requirement("dep-a"),)),
             ),
@@ -3742,7 +3556,7 @@ class TestSkipFetch:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             root_requirements={"pkg": SpecifierSet(">=1.0").to_range()},
             package_overrides=(
                 pkg_override("pkg == 2.0", dependencies=(Requirement("dep-a"),)),
@@ -3762,7 +3576,7 @@ class TestSkipFetch:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             package_overrides=(
                 pkg_override("pkg", dependencies=(Requirement("dep-a"),)),
             ),
@@ -3779,7 +3593,7 @@ class TestSkipFetch:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             package_overrides=(
                 pkg_override("pkg == 2.0", dependencies=(Requirement("dep-a"),)),
             ),
@@ -3810,7 +3624,7 @@ class TestLocalVcsPythonGuardOverride:
         coordinator = make_coordinator([], package="foo")
         provider = Provider(
             coordinator,
-            python_version="3.9.0",
+            target=ResolveTarget.for_host_python("3.9.0"),
             local_sources=[LocalSource("foo", str(tmp_path))],
             build_policy=BuildPolicy.NEVER,
             package_overrides=(pkg_override("foo", requires_python=override_rp),),
@@ -4241,7 +4055,7 @@ class TestExtras:
             metadata_text=EXTRA_METADATA,
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         deps = provider.get_dependencies("foo[security]", V("1.0"))
         assert "cryptography" in deps
         assert "foo" in deps
@@ -4254,7 +4068,7 @@ class TestExtras:
             metadata_text=WHITESPACE_EXTRA_METADATA,
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         deps = provider.get_dependencies("foo[security]", V("1.0"))
         assert "cryptography" in deps
 
@@ -4378,7 +4192,7 @@ class TestExtras:
             metadata_text=EXTRA_METADATA,
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         base_deps = provider.get_dependencies("foo", V("1.0"))
         assert "bar" in base_deps
         extra_deps = provider.get_dependencies("foo[security]", V("1.0"))
@@ -4391,7 +4205,7 @@ class TestExtras:
             metadata_text=EXTRA_METADATA,
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         provider.get_dependencies("foo[security]", V("1.0"))
         provider.get_dependencies("foo[security]", V("1.0"))
         assert ("foo[security]", V("1.0")) in provider.deps_cache
@@ -4409,7 +4223,7 @@ class TestExtras:
     def test_marker_cache_hits_on_repeat(self) -> None:
         """Reclassifying the same Requirement hits the marker caches."""
         coordinator = make_coordinator([make_wheel("1.0")], package="foo")
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         base_req = Requirement('bar; python_version >= "3.7"')
         extra_req = Requirement('qux; extra == "security"')
 
@@ -4436,7 +4250,7 @@ class TestExtras:
             metadata_text=metadata,
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         base_deps = provider.get_dependencies("foo", V("1.0"))
         sec_deps = provider.get_dependencies("foo[security]", V("1.0"))
         assert "cryptography" not in base_deps
@@ -4458,7 +4272,7 @@ class TestExtras:
             metadata_text=metadata,
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         sec_deps = provider.get_dependencies("foo[security]", V("1.0"))
         socks_deps = provider.get_dependencies("foo[socks]", V("1.0"))
         assert "cryptography" in sec_deps
@@ -4483,7 +4297,7 @@ class TestExtras:
             metadata_text=metadata,
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         base_deps = provider.get_dependencies("foo", V("1.0"))
         assert "bar" in base_deps
         extra_deps = provider.get_dependencies("foo[dev]", V("1.0"))
@@ -4503,7 +4317,7 @@ class TestExtras:
             metadata_text=metadata,
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         deps = provider.get_dependencies("foo", V("1.0"))
         assert "bar" in deps
         assert "bar[baz]" in deps
@@ -4522,7 +4336,7 @@ class TestExtras:
             metadata_text=metadata,
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         deps = provider.get_dependencies("foo[all]", V("1.0"))
         assert "bar" in deps
         assert "bar[http]" in deps
@@ -4543,7 +4357,7 @@ class TestExtras:
             metadata_text=metadata,
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         base_deps = provider.get_dependencies("foo", V("1.0"))
         assert "bar[http]" in base_deps
         extra_deps = provider.get_dependencies("foo[all]", V("1.0"))
@@ -4564,7 +4378,7 @@ class TestExtras:
             metadata_text=metadata,
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         extra_deps = provider.get_dependencies("foo[tight]", V("1.0"))
         assert "bar" in extra_deps
         assert V("1.5") not in extra_deps["bar"]
@@ -4589,7 +4403,7 @@ class TestExtras:
             metadata_text=metadata,
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         deps = provider.get_dependencies("foo[bar]", V("1.0"))
         assert deps["foo"].is_empty
 
@@ -4607,7 +4421,7 @@ class TestExtras:
             metadata_text=metadata,
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         deps = provider.get_dependencies("foo[bar]", V("1.0"))
         assert deps["foo"] == VersionRange.singleton(V("1.0"))
 
@@ -4626,7 +4440,7 @@ class TestExtras:
             metadata_text=metadata,
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         base_deps = provider.get_dependencies("foo", V("1.0"))
         assert "bar" in base_deps
         assert "bar[http]" not in base_deps  # base doesn't have the extra
@@ -4646,7 +4460,7 @@ class TestExtras:
             metadata_text=metadata,
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         deps = provider.get_dependencies("foo", V("1.0"))
         assert "bar" in deps
         assert "bar[http]" in deps
@@ -4666,7 +4480,7 @@ class TestExtras:
             metadata_text=metadata,
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         deps = provider.get_dependencies("foo[all]", V("1.0"))
         assert "bar" in deps
         assert "bar[http]" in deps
@@ -4680,9 +4494,7 @@ class TestExtras:
             metadata_text=NO_EXTRA_METADATA,
             package="foo",
         )
-        provider = Provider(
-            coordinator, python_version="3.12.0", extras_mode=ExtrasMode.WARN
-        )
+        provider = Provider(coordinator, target=_PY312, extras_mode=ExtrasMode.WARN)
         deps = provider.get_dependencies("foo[nonexistent]", V("1.0"))
         assert deps == {"foo": VersionRange.singleton(V("1.0"))}
 
@@ -4695,7 +4507,7 @@ class TestExtras:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             extras_mode=ExtrasMode.ERROR_USER,
             root_extras={("foo", "nonexistent")},
         )
@@ -4711,7 +4523,7 @@ class TestExtras:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             extras_mode=ExtrasMode.ERROR_USER,
         )
         deps = provider.get_dependencies("foo[nonexistent]", V("1.0"))
@@ -4748,9 +4560,7 @@ class TestExtras:
             "Requires-Dist: alpha[ext-one]\n",
         )
         roots = {"gamma": VersionRange.full(admit_arbitrary=False)}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=roots
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=roots)
         resolver: Resolver[str, Version] = Resolver(
             provider, range_type=VersionRange, root_version="0"
         )
@@ -4767,7 +4577,7 @@ class TestExtras:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             extras_mode=ExtrasMode.BACKTRACK,
             root_extras={("foo", "nonexistent")},
         )
@@ -4791,7 +4601,7 @@ class TestExtras:
 
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             extras_mode=ExtrasMode.BACKTRACK,
         )
         spec = SpecifierSet("")
@@ -4853,7 +4663,7 @@ class TestExtras:
             metadata_text=metadata,
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         deps = provider.get_dependencies("foo[dev]", V("1.0"))
         assert "good" in deps
         assert "broken" in deps
@@ -4874,7 +4684,7 @@ class TestExtras:
             metadata_text=metadata,
             package="foo",
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         provider.versions_cache["cryptography"] = [(V("1.0"), make_wheel("1.0"))]
         deps = provider.get_dependencies("foo[security]", V("1.0"))
         assert "cryptography" in deps
@@ -4891,7 +4701,7 @@ class TestExtras:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             extras_mode=ExtrasMode.BACKTRACK,
         )
         spec = SpecifierSet("")
@@ -4921,7 +4731,7 @@ class TestExtrasPrereleaseAdmission:
         )
         provider = Provider(
             self._coordinator_for_c(),
-            python_version="3.12.0",
+            target=_PY312,
             root_requirements=root_reqs,
             root_extras=root_extras,
         )
@@ -4988,9 +4798,7 @@ class TestExtrasPrereleaseAdmission:
             "a": VersionRange.full(admit_arbitrary=False),
             "b": VersionRange.full(admit_arbitrary=False),
         }
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         resolver = Resolver(provider, range_type=VersionRange, root_version="0")
         pins = resolver.resolve(root_reqs)
         assert resolver.stats.backjumps > 0
@@ -5043,7 +4851,7 @@ class TestExtrasPrereleaseBaseRangeBlocks:
         root_reqs = {"r": VersionRange.full(admit_arbitrary=False)}
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             extras_mode=ExtrasMode.BACKTRACK,
             root_requirements=root_reqs,
         )
@@ -5088,7 +4896,7 @@ class TestExtrasPrereleaseBaseRangeBlocks:
         }
         coordinator = make_coordinator(listings=listings, metadata_by_version=metadata)
         provider = Provider(
-            coordinator, python_version="3.12.0", extras_mode=ExtrasMode.BACKTRACK
+            coordinator, target=_PY312, extras_mode=ExtrasMode.BACKTRACK
         )
         # Base decided to the final 1.0.0, which does not provide x, so the
         # proxy has no candidate; the pre-release 2.0.0a1 is excluded only
@@ -5197,7 +5005,7 @@ class TestDistPolicy:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.SDIST_INSTALL,
         )
         deps = provider.get_dependencies("pkg", V("1.0"))
@@ -5214,7 +5022,7 @@ class TestDistPolicy:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         deps = provider.get_dependencies("pkg", V("1.0"))
@@ -5232,7 +5040,7 @@ class TestDistPolicy:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.NEVER,
         )
@@ -5249,7 +5057,7 @@ class TestDistPolicy:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.NEVER,
             trust_unverified_sdist_deps=True,
@@ -5268,7 +5076,7 @@ class TestDistPolicy:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.NEVER,
             trust_unverified_sdist_deps=True,
@@ -5286,7 +5094,7 @@ class TestDistPolicy:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.NEVER,
             trust_unverified_sdist_deps=True,
@@ -5304,7 +5112,7 @@ class TestDistPolicy:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.NEVER,
             package_overrides=(pkg_override("pkg", dist_trust_unverified_deps=True),),
@@ -5324,7 +5132,7 @@ class TestDistPolicy:
         coordinator.index.store_listing_index("pkg", "internal")
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.NEVER,
             index_overrides={
@@ -5346,7 +5154,7 @@ class TestDistPolicy:
         coordinator.index.store_listing_index("pkg", "pypi")
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.NEVER,
             index_overrides={
@@ -5367,7 +5175,7 @@ class TestDistPolicy:
         coordinator.index.store_listing_index("pkg", "internal")
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.NEVER,
             package_overrides=(pkg_override("pkg", dist_trust_unverified_deps=True),),
@@ -5387,7 +5195,7 @@ class TestDistPolicy:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         with pytest.raises(MetadataError):
@@ -5426,7 +5234,7 @@ class TestDistPolicy:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         provider.fetch_versions("pkg")
@@ -5453,7 +5261,7 @@ class TestDistPolicy:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         with pytest.raises(MetadataError):
@@ -5508,9 +5316,7 @@ class TestSpeculativePrefetchBatchLimit:
             package="foo",
         )
         root_reqs = {"foo": SpecifierSet(">=1.0").to_range()}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         provider.fetch_versions("foo")
         # request_metadata_batch should have been called with at most
         # PREFETCH_BATCH items.
@@ -5528,9 +5334,7 @@ class TestSpeculativePrefetchBatchLimit:
             package="foo",
         )
         root_reqs = {"foo": SpecifierSet(">=1.0").to_range()}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         # Pre-cache deps for v2.0 so it gets skipped during prefetch.
         provider.deps_cache[("foo", V("2.0"))] = {}
         provider.fetch_versions("foo")
@@ -5670,9 +5474,7 @@ class TestPrefetchWalkAhead:
             package="foo",
         )
         root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         provider.receive_partial_solution_hint({}, {"bar": V("3.0")})
         with patch.object(
             provider, "prefetch_walk_ahead", wraps=provider.prefetch_walk_ahead
@@ -5689,9 +5491,7 @@ class TestPrefetchWalkAhead:
             package="foo",
         )
         root_reqs = {"foo": SpecifierSet(">=1.0").to_range()}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         with patch.object(
             provider, "prefetch_walk_ahead", wraps=provider.prefetch_walk_ahead
         ) as spy:
@@ -5705,9 +5505,7 @@ class TestPickBestCandidateNone:
         wheels = [make_wheel("1.0")]
         coordinator = make_coordinator(wheels, package="foo")
         root_reqs = {"foo": SpecifierSet(">=5.0").to_range()}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         versions = provider.fetch_versions("foo")
         result = provider.pick_best_candidate("foo", versions)
         assert result is None
@@ -5715,16 +5513,14 @@ class TestPickBestCandidateNone:
     def test_returns_none_on_empty_versions(self) -> None:
         """pick_best_candidate returns None when versions list is empty."""
         coordinator = make_coordinator([make_wheel("1.0")], package="foo")
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         assert provider.pick_best_candidate("foo", []) is None
 
     def test_returns_none_on_empty_versions_with_root_range(self) -> None:
         """Empty versions list returns None even when name is a root requirement."""
         coordinator = make_coordinator([make_wheel("1.0")], package="foo")
         root_reqs = {"foo": SpecifierSet(">=1.0").to_range()}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         assert provider.pick_best_candidate("foo", []) is None
 
     def test_root_requirement_returns_first_match(self) -> None:
@@ -5732,9 +5528,7 @@ class TestPickBestCandidateNone:
         wheels = [make_wheel("3.0"), make_wheel("2.0"), make_wheel("1.0")]
         coordinator = make_coordinator(wheels, package="foo")
         root_reqs = {"foo": SpecifierSet("<3.0").to_range()}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         versions = provider.fetch_versions("foo")
         result = provider.pick_best_candidate("foo", versions)
         assert result is not None
@@ -5791,9 +5585,7 @@ class TestAwaitMetadataBatchEdgeCases:
             package="foo",
         )
         root_reqs = {"bar": SpecifierSet("<2.0").to_range()}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         spec = SpecifierSet("")
         result = provider.choose_version("foo", spec.to_range())
         assert result == V("1.0")
@@ -5821,9 +5613,7 @@ class TestAwaitMetadataBatchEdgeCases:
             package="foo",
         )
         root_reqs = {"bar": SpecifierSet("<2.0").to_range()}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         spec = SpecifierSet("")
         result = provider.choose_version("foo", spec.to_range())
         assert result == V("1.0")
@@ -5837,7 +5627,7 @@ class TestAwaitMetadataBatchEdgeCases:
         coordinator.index.store_metadata_error(
             "foo", "1.0", MetadataHashMismatchError("metadata sha256 mismatch")
         )
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         with pytest.raises(MetadataHashMismatchError):
             provider._await_metadata_batch(
                 "foo",
@@ -5857,7 +5647,7 @@ class TestAwaitMetadataBatchEdgeCases:
         """
         dists = [make_sdist("1.0"), make_wheel("1.0")]
         coordinator = make_coordinator(dists, sdist_pkg_info=PKG_INFO_PRE_PEP643_DEPS)
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         with pytest.raises(UnsupportedSdistError):
             provider.get_dependencies("pkg", V("1.0"))
 
@@ -5919,7 +5709,7 @@ class TestSpeculativePrefetchSkipsNonWheelDists:
         root_reqs = {"foo": SpecifierSet(">=1.0").to_range()}
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             root_requirements=root_reqs,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
@@ -5955,7 +5745,7 @@ class TestChooseVersionBatchLoop:
         root_reqs = {"bar": SpecifierSet("<2.0").to_range()}
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             root_requirements=root_reqs,
         )
         # Use a small batch size to force multiple iterations.
@@ -5993,7 +5783,7 @@ class TestChooseVersionBatchLoop:
         root_reqs = {"bar": SpecifierSet("<2.0").to_range()}
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             root_requirements=root_reqs,
         )
         provider._BROAD_LA_REJECT_CAP = 1
@@ -6137,12 +5927,12 @@ class TestSharedSlotProvenance:
         the pre-PEP-643 deps.
         """
         coordinator = make_coordinator(None, sdist_pkg_info=PKG_INFO_PRE_PEP643_DEPS)
-        first = Provider(coordinator, python_version="3.12.0")
+        first = Provider(coordinator, target=_PY312)
         first.versions_cache["pkg"] = [(V("1.0"), make_sdist("1.0"))]
         with pytest.raises(UnsupportedSdistError):
             first.get_dependencies("pkg", V("1.0"))
 
-        second = Provider(coordinator, python_version="3.12.0")
+        second = Provider(coordinator, target=_PY312)
         second.versions_cache["pkg"] = [
             (V("1.0"), make_wheel("1.0")),
             (V("1.0"), make_sdist("1.0")),
@@ -6163,11 +5953,11 @@ class TestSharedSlotProvenance:
             "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\nRequires-Dist: dep-a\n"
         )
         coordinator = make_coordinator(None, metadata_text=metadata)
-        first = Provider(coordinator, python_version="3.12.0")
+        first = Provider(coordinator, target=_PY312)
         first.versions_cache["pkg"] = [(V("1.0"), make_wheel("1.0"))]
         assert "dep-a" in first.get_dependencies("pkg", V("1.0"))
 
-        second = Provider(coordinator, python_version="3.12.0")
+        second = Provider(coordinator, target=_PY312)
         second.versions_cache["pkg"] = [(V("1.0"), make_sdist("1.0"))]
         assert "dep-a" in second.get_dependencies("pkg", V("1.0"))
 
@@ -6388,7 +6178,7 @@ class TestEffectiveBuildPolicy:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.BUILD_LOCAL,
             package_overrides=(
@@ -6460,7 +6250,7 @@ class TestEffectiveBuildPolicy:
         from nab_python._vendor.packaging.version import Version as _Version
 
         coordinator = make_coordinator([make_sdist("1.0")], package="pkg")
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         cached_meta = WheelMetadata(
             name="pkg",
             version=_Version("1.0"),
@@ -6493,7 +6283,7 @@ class TestStaticSdistMetadata:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         with pytest.raises(UnsupportedSdistError):
@@ -6508,7 +6298,7 @@ class TestStaticSdistMetadata:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         with pytest.raises(UnsupportedSdistError):
@@ -6534,7 +6324,7 @@ class TestStaticSdistMetadata:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         deps = provider.get_dependencies("pkg", V("1.0"))
@@ -6554,7 +6344,7 @@ class TestStaticSdistMetadata:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         with pytest.raises(UnsupportedSdistError):
@@ -6575,7 +6365,7 @@ class TestStaticSdistMetadata:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         with pytest.raises(UnsupportedSdistError):
@@ -6598,7 +6388,7 @@ class TestStaticSdistMetadata:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         deps = provider.get_dependencies("pkg", V("1.0"))
@@ -6617,7 +6407,7 @@ class TestStaticSdistMetadata:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         with pytest.raises(UnsupportedSdistError):
@@ -6632,7 +6422,7 @@ class TestStaticSdistMetadata:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         with pytest.raises(UnsupportedSdistError):
@@ -6647,7 +6437,7 @@ class TestStaticSdistMetadata:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         with pytest.raises(UnsupportedSdistError):
@@ -6669,7 +6459,7 @@ class TestStaticSdistMetadata:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         deps = provider.get_dependencies("pkg", V("1.0"))
@@ -6685,7 +6475,7 @@ class TestStaticSdistMetadata:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         with pytest.raises(MetadataError, match="must be an array of strings"):
@@ -6707,7 +6497,7 @@ class TestStaticSdistMetadata:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         with pytest.raises(MetadataError, match="must be a table"):
@@ -6729,7 +6519,7 @@ class TestStaticSdistMetadata:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         deps = provider.get_dependencies("pkg", V("1.0"))
@@ -6753,7 +6543,7 @@ class TestStaticSdistMetadata:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         with pytest.raises(MetadataError, match="extra 'bad' must be an array"):
@@ -6774,7 +6564,7 @@ class TestStaticSdistMetadata:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         with pytest.raises(MetadataError, match="must be an array of strings"):
@@ -6795,7 +6585,7 @@ class TestStaticSdistMetadata:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         with pytest.raises(MetadataError, match="invalid requirement"):
@@ -6818,7 +6608,7 @@ class TestStaticSdistMetadata:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         with pytest.raises(MetadataError, match="invalid requirement"):
@@ -6841,7 +6631,7 @@ class TestStaticSdistMetadata:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         with pytest.raises(MetadataError, match="extra 'foo' must be an array"):
@@ -6884,7 +6674,7 @@ class TestStaticSdistMetadata:
 
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.BUILD_REMOTE,
         )
@@ -6916,7 +6706,7 @@ class TestStaticSdistMetadata:
 
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.BUILD_REMOTE,
         )
@@ -6962,7 +6752,7 @@ class TestStaticSdistMetadata:
 
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.BUILD_REMOTE,
         )
@@ -7001,7 +6791,7 @@ class TestStaticSdistMetadata:
         root_reqs = {"pkg": SpecifierSet(">=0").to_range()}
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             root_requirements=root_reqs,
         )
@@ -7027,7 +6817,7 @@ class TestBuildRemoteFailureModes:
         coordinator = make_coordinator(files, package="pkg")
         return Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.BUILD_REMOTE,
             package_overrides=overrides,
@@ -7317,7 +7107,7 @@ class TestPublicAccessors:
         local = LocalSource(name="My-Lib", path="/tmp/my-lib")
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             local_sources=[local],
             build_policy=BuildPolicy.NEVER,
         )
@@ -7333,7 +7123,7 @@ class TestPublicAccessors:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             vcs_sources=[vcs],
             vcs_config=VcsConfig(
                 policy=VcsPolicy.ALLOW,
@@ -7350,7 +7140,7 @@ class TestPublicAccessors:
         coordinator = make_coordinator(wheels, package="pkg")
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             root_requirements={"pkg": SpecifierSet(">=0").to_range()},
         )
         # Force the listing into the cache by asking for a version
@@ -7361,7 +7151,7 @@ class TestPublicAccessors:
 
     def test_dist_files_for_unlisted_returns_empty(self) -> None:
         coordinator = make_coordinator(package="pkg")
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=_PY312)
         assert provider.dist_files_for("unknown", V("1.0")) == []
 
 
@@ -7399,9 +7189,7 @@ class TestExtrasInvalidMetadata:
             metadata_by_version={"2.0": EXTRA_METADATA, "1.0": EXTRA_METADATA},
             package="foo",
         )
-        provider = Provider(
-            coordinator, python_version="3.12.0", extras_mode=ExtrasMode.WARN
-        )
+        provider = Provider(coordinator, target=_PY312, extras_mode=ExtrasMode.WARN)
         provider._invalid_metadata[("foo", V("2.0"))] = "stub"
         version = provider.choose_version("foo[security]", VersionRange.full())
         assert version == V("1.0")
@@ -7414,9 +7202,7 @@ class TestExtrasInvalidMetadata:
             metadata_by_version={"2.0": self.BAD_META, "1.0": EXTRA_METADATA},
             package="foo",
         )
-        provider = Provider(
-            coordinator, python_version="3.12.0", extras_mode=ExtrasMode.WARN
-        )
+        provider = Provider(coordinator, target=_PY312, extras_mode=ExtrasMode.WARN)
         version = provider.choose_version("foo[security]", VersionRange.full())
         assert version == V("1.0")
 
@@ -7435,7 +7221,7 @@ class TestExtrasInvalidMetadata:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             extras_mode=ExtrasMode.WARN,
             root_extras={("foo", "security")},
         )
@@ -7461,7 +7247,7 @@ class TestExtrasInvalidMetadata:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             root_extras={("foo", "security")},
         )
         version = provider.choose_version("foo[security]", VersionRange.full())
@@ -7481,7 +7267,7 @@ class TestExtrasInvalidMetadata:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             extras_mode=ExtrasMode.WARN,
             root_extras={("foo", "security")},
         )
@@ -7503,7 +7289,7 @@ class TestExtrasInvalidMetadata:
         )
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             root_extras={("foo", "security")},
         )
         version = provider.choose_version("foo[security]", VersionRange.full())
@@ -7529,7 +7315,7 @@ class TestExtrasInvalidMetadata:
         }
         provider = Provider(
             coordinator,
-            python_version="3.12.0",
+            target=_PY312,
             root_requirements=root_reqs,
             root_extras={("pkg", "feature")},
         )
@@ -7554,9 +7340,7 @@ class TestScanBatchNoFirstCandidate:
             wheels, metadata_by_version=meta_by_version, package="foo"
         )
         root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
-        provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
-        )
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         provider.receive_partial_solution_hint({}, {"bar": V("1")})
         provider._LOOKAHEAD_ABORT_THRESHOLD = 2  # type: ignore[misc]
         wheel_by = {V(str(i)): wheels[20 - i] for i in range(20, 0, -1)}

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -9,11 +9,14 @@ import pytest
 
 from nab_index.client import WheelFile
 from nab_python._testing.coordinator_fake import make_coordinator
+from nab_python._testing.overrides import pkg_override
+from nab_python._vendor.packaging.markers import default_environment
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.version import InvalidVersion, Version
 from nab_python.config import (
     ConfigError,
     ConflictSelectionError,
+    IndexOverride,
     MatrixConfig,
     NabProjectConfig,
     ResolveMode,
@@ -30,10 +33,10 @@ from nab_python.resolve import (
     UnsupportedModeError,
     _augment_resolution_error,
     _build_constraints,
-    _build_marker_environment,
     _build_resolver_inputs,
     _check_group_disjointness,
     _check_group_disjointness_across_tuples,
+    _check_marker_overlay_build_policy,
     _find_group_conflicts,
     _load_extra_requirements,
     _load_group_requirements,
@@ -45,7 +48,7 @@ from nab_python.resolve import (
     resolve_universal_pyproject,
 )
 from nab_python.tags import PlatformSpec
-from nab_python.universal.matrix import MatrixTuple
+from nab_python.target import ResolveTarget
 from nab_resolver.ranges import Range
 from nab_resolver.resolver import (
     Incompatibility,
@@ -535,14 +538,9 @@ class TestResolvePyproject:
 
             resolve_pyproject(pyproject, _FAKE_TRANSPORT)
 
-        call_kwargs = mock_provider_cls.call_args
-        pv = call_kwargs.kwargs.get("python_version") or call_kwargs[1].get(
-            "python_version"
-        )
-        assert pv is not None
-        parts = pv.split(".")
-        assert len(parts) == 3
-        assert all(p.isdigit() for p in parts)
+        target = mock_provider_cls.call_args.kwargs["target"]
+        assert target.host_faithful
+        assert target.marker_env == default_environment()
 
     def test_indexes_from_config_passed_to_coordinator(self, tmp_path: Path) -> None:
         """[tool.nab.indexes] reaches FetchCoordinator as the indexes list."""
@@ -747,6 +745,7 @@ class TestResolvePyproject:
         pyproject.write_text(
             "[project]\n"
             'dependencies = ["foo", "windows-only; sys_platform == \'win32\'"]\n'
+            '[tool.nab]\nbuild-policy = "never"\n'
             "[tool.nab.marker-environment]\n"
             'sys_platform = "linux"\n',
         )
@@ -818,6 +817,7 @@ class TestResolvePyproject:
         pyproject.write_text(
             "[project]\n"
             'dependencies = ["foo", "linux-only; sys_platform == \'linux\'"]\n'
+            '[tool.nab]\nbuild-policy = "never"\n'
             "[tool.nab.marker-environment]\n"
             'sys_platform = "linux"\n',
         )
@@ -902,7 +902,8 @@ class TestResolvePyproject:
 
         resolve_pyproject(pyproject, _FAKE_TRANSPORT)
 
-        assert mock_provider_cls.call_args.kwargs["python_version"] == "3.10.5"
+        target = mock_provider_cls.call_args.kwargs["target"]
+        assert target.python_full_version == "3.10.5"
 
     @patch("nab_python.resolve.build_lock_input_from_provider")
     @patch("nab_python.resolve.Resolver")
@@ -929,7 +930,8 @@ class TestResolvePyproject:
 
         resolve_pyproject(pyproject, _FAKE_TRANSPORT, python_version="3.12.4")
 
-        assert mock_provider_cls.call_args.kwargs["python_version"] == "3.12.4"
+        target = mock_provider_cls.call_args.kwargs["target"]
+        assert target.python_full_version == "3.12.4"
 
     def test_universal_mode_rejected(self, tmp_path: Path) -> None:
         """resolve_pyproject refuses to handle mode = 'universal'."""
@@ -2547,104 +2549,93 @@ class TestAugmentResolutionError:
         assert "foo: package not found on any configured index" in str(info.value)
 
 
-def _tuple_for_python(python_version: str) -> MatrixTuple:
-    """Build a linux_x86_64 tuple for ``python_version``.
+def _tuple_for_python(python_version: str) -> ResolveTarget:
+    """Build a linux_x86_64 target for ``python_version``.
 
     Only the marker environment matters for the group pre-pass, so the
     platform axis is held constant and the python axis varies; the
     label encodes the python version so a conflict message can be
     asserted against it.
     """
-    return MatrixTuple(
+    return ResolveTarget.for_declared(
         python_version=python_version,
-        platform_spec=PlatformSpec("linux_x86_64"),
-        environment={
-            "python_version": python_version,
-            "python_full_version": f"{python_version}.0",
-            "implementation_name": "cpython",
-            "implementation_version": f"{python_version}.0",
-            "os_name": "posix",
-            "platform_machine": "x86_64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "",
-            "platform_system": "Linux",
-            "platform_version": "",
-            "sys_platform": "linux",
-        },
+        spec=PlatformSpec("linux_x86_64"),
     )
 
 
-class TestBuildMarkerEnvironment:
-    def test_two_part_python_version_expands_full_version(self) -> None:
-        """python_full_version pads to three components, matching the matrix."""
-        env = _build_marker_environment(python_version="3.10", overrides={})
-        assert env["python_version"] == "3.10"
-        assert env["python_full_version"] == "3.10.0"
+class TestCheckMarkerOverlayBuildPolicy:
+    """A marker overlay forces ``BuildPolicy.NEVER`` everywhere it can build."""
 
-    def test_full_python_version_preserved(self) -> None:
-        env = _build_marker_environment(python_version="3.11.5", overrides={})
-        assert env["python_full_version"] == "3.11.5"
+    def test_default_policy_blocked_when_overlay_used(self) -> None:
+        """The default ``BUILD_LOCAL`` is rejected with a marker overlay.
 
-    def test_overlay_python_version_alone_syncs_full_version(self) -> None:
-        """An overlay python_version drives python_full_version too.
-
-        Setting only ``python_version`` moves ``python_full_version`` off
-        the host patch level to ``{minor}.0``, so a
-        ``python_full_version``-gated marker no longer reads the host
-        interpreter.
+        Users who want a marker overlay must opt into ``never`` explicitly,
+        since a host-side backend cannot reflect the impersonated target.
         """
-        env = _build_marker_environment(
-            python_version="3.12.3", overrides={"python_version": "3.8"}
+        config = NabProjectConfig(
+            marker_environment={"platform_system": "Windows"},
         )
-        assert env["python_version"] == "3.8"
-        assert env["python_full_version"] == "3.8.0"
+        with pytest.raises(ValueError, match="marker_environment overlay requires"):
+            _check_marker_overlay_build_policy(config)
 
-    def test_overlay_full_version_alone_syncs_minor(self) -> None:
-        """An overlay python_full_version drives python_version too."""
-        env = _build_marker_environment(
-            python_version="3.12.3", overrides={"python_full_version": "3.8.7"}
+    def test_overlay_with_build_remote_policy_raises(self) -> None:
+        """Non-``NEVER`` global + a marker overlay is rejected."""
+        config = NabProjectConfig(
+            build_policy=BuildPolicy.BUILD_REMOTE,
+            marker_environment={"platform_system": "Windows"},
         )
-        assert env["python_version"] == "3.8"
-        assert env["python_full_version"] == "3.8.7"
+        with pytest.raises(ValueError, match="marker_environment overlay requires"):
+            _check_marker_overlay_build_policy(config)
 
-    def test_overlay_both_axis_values_respected(self) -> None:
-        """When the overlay sets both axis keys, both win verbatim."""
-        env = _build_marker_environment(
-            python_version="3.12.3",
-            overrides={"python_version": "3.8", "python_full_version": "3.8.7"},
+    def test_overlay_with_build_remote_override_raises(self) -> None:
+        """A build override that escapes ``NEVER`` also fails the guard."""
+        config = NabProjectConfig(
+            build_policy=BuildPolicy.NEVER,
+            package_overrides=(
+                pkg_override("foo", build_policy=BuildPolicy.BUILD_REMOTE),
+            ),
+            marker_environment={"platform_system": "Windows"},
         )
-        assert env["python_version"] == "3.8"
-        assert env["python_full_version"] == "3.8.7"
+        with pytest.raises(ValueError, match="marker_environment overlay requires"):
+            _check_marker_overlay_build_policy(config)
 
-    def test_overlay_without_python_keeps_host_axis(self) -> None:
-        """A non-python overlay leaves both python-axis values alone."""
-        env = _build_marker_environment(
-            python_version="3.12.3", overrides={"sys_platform": "win32"}
+    def test_overlay_with_build_remote_index_override_raises(self) -> None:
+        """A per-index build override that escapes ``NEVER`` fails the guard."""
+        config = NabProjectConfig(
+            build_policy=BuildPolicy.NEVER,
+            index_overrides={
+                "internal": IndexOverride(build_policy=BuildPolicy.BUILD_REMOTE)
+            },
+            marker_environment={"platform_system": "Windows"},
         )
-        assert env["python_version"] == "3.12"
-        assert env["python_full_version"] == "3.12.3"
-        assert env["sys_platform"] == "win32"
+        with pytest.raises(ValueError, match="marker_environment overlay requires"):
+            _check_marker_overlay_build_policy(config)
 
-    def test_target_python_moves_implementation_version(self) -> None:
-        """implementation_version follows a non-host target on CPython."""
-        env = _build_marker_environment(python_version="3.9.0", overrides={})
-        assert env["implementation_version"] == "3.9.0"
-        assert env["implementation_version"] == env["python_full_version"]
-
-    def test_overlay_python_moves_implementation_version(self) -> None:
-        """An overlay python-axis move drags implementation_version along."""
-        env = _build_marker_environment(
-            python_version="3.12.3", overrides={"python_version": "3.8"}
+    def test_overlay_with_never_override_passes(self) -> None:
+        """An override already at ``NEVER`` is not offending."""
+        config = NabProjectConfig(
+            build_policy=BuildPolicy.NEVER,
+            package_overrides=(
+                pkg_override("quarantined", build_policy=BuildPolicy.NEVER),
+            ),
+            marker_environment={"platform_system": "Windows"},
         )
-        assert env["implementation_version"] == "3.8.0"
+        _check_marker_overlay_build_policy(config)
 
-    def test_explicit_implementation_version_override_wins(self) -> None:
-        """An explicit implementation_version override is kept verbatim."""
-        env = _build_marker_environment(
-            python_version="3.9.0",
-            overrides={"implementation_version": "3.9.7"},
+    def test_no_overlay_no_constraint(self) -> None:
+        """Without an overlay, a looser ``BuildPolicy`` is fine."""
+        _check_marker_overlay_build_policy(
+            NabProjectConfig(build_policy=BuildPolicy.BUILD_REMOTE)
         )
-        assert env["implementation_version"] == "3.9.7"
+
+    def test_empty_overlay_no_constraint(self) -> None:
+        """An empty overlay does not trigger the build-policy check."""
+        _check_marker_overlay_build_policy(
+            NabProjectConfig(
+                build_policy=BuildPolicy.BUILD_REMOTE,
+                marker_environment={},
+            )
+        )
 
 
 class TestCheckGroupDisjointnessAcrossTuples:
@@ -2889,8 +2880,8 @@ class TestLocalVcsRequiresPython:
         coordinator = make_coordinator([], package="foo")
         provider = Provider(
             coordinator,
+            target=ResolveTarget.for_host_python(python_version),
             local_sources=[LocalSource("foo", str(tmp_path))],
-            python_version=python_version,
             build_policy=BuildPolicy.NEVER,
         )
         provider.fetch_versions("foo")

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 import pytest
 
 from nab_index.client import WheelFile
+from nab_python._vendor.packaging.tags import Tag
 from nab_python.tags import (
     _PLATFORM_ARCH,
     _PLATFORM_KIND,
@@ -904,3 +905,82 @@ class TestPyPyTags:
         assert pp_native
         assert cp_native.isdisjoint(pp)
         assert pp_native.isdisjoint(cp)
+
+
+class TestTagSetHostConstructors:
+    """The host constructors take their tags from an injected source."""
+
+    _HOST = (
+        Tag("cp313", "cp313", "manylinux_2_39_x86_64"),
+        Tag("cp313", "cp313", "linux_x86_64"),
+        Tag("py3", "none", "any"),
+    )
+
+    def _host_tags(self) -> tuple[Tag, ...]:
+        return self._HOST
+
+    def test_for_host_takes_the_source_verbatim(self) -> None:
+        """packaging already answers this for the live machine."""
+        tags = TagSet.for_host(tags_source=self._host_tags)
+        assert tags.ordered == self._HOST
+        assert tags.members == frozenset(self._HOST)
+
+    def test_for_host_defaults_to_sys_tags(self) -> None:
+        """Without a source, the running interpreter's tags are used."""
+        assert TagSet.for_host().ordered
+
+    def test_for_host_python_keeps_the_host_platform_order(self) -> None:
+        """The platform axis carries over, in the host's own preference order."""
+        tags = TagSet.for_host_python("3.11", tags_source=self._host_tags)
+        platforms = [t.platform for t in tags.ordered if t.interpreter == "cp311"]
+        assert platforms[:2] == ["manylinux_2_39_x86_64", "linux_x86_64"]
+
+    def test_for_host_python_drops_the_any_platform(self) -> None:
+        """``any`` is not a machine, so it never seeds the platform axis."""
+        tags = TagSet.for_host_python("3.11", tags_source=self._host_tags)
+        assert Tag("cp311", "cp311", "any") not in tags.members
+        assert Tag("py3", "none", "any") in tags.members
+
+    def test_for_host_python_needs_a_non_empty_source(self) -> None:
+        with pytest.raises(ValueError, match="no tags"):
+            TagSet.for_host_python("3.11", tags_source=tuple)
+
+    def _free_threaded_host(self) -> tuple[Tag, ...]:
+        return (
+            Tag("cp314", "cp314t", "manylinux_2_39_x86_64"),
+            Tag("py3", "none", "any"),
+        )
+
+    def test_free_threaded_host_does_not_carry_to_an_older_python(self) -> None:
+        """``cp310t`` never existed, so a target naming it matches no wheel."""
+        tags = TagSet.for_host_python("3.10", tags_source=self._free_threaded_host)
+        assert {t.abi for t in tags.ordered if t.interpreter == "cp310"} == {
+            "cp310",
+            "abi3",
+            "none",
+        }
+
+    def test_free_threaded_host_carries_to_a_python_that_has_it(self) -> None:
+        tags = TagSet.for_host_python("3.13", tags_source=self._free_threaded_host)
+        assert "cp313t" in {t.abi for t in tags.ordered}
+
+
+class TestTagSetAccepts:
+    """``accepts`` answers wheel compatibility from the filename alone."""
+
+    _TAGS = TagSet.for_spec(python_version="3.11", spec=PlatformSpec("linux_x86_64"))
+
+    def test_compatible_wheel_accepted(self) -> None:
+        assert self._TAGS.accepts("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl")
+
+    def test_incompatible_wheel_rejected(self) -> None:
+        assert not self._TAGS.accepts("pkg-1.0-cp311-cp311-win_amd64.whl")
+
+    def test_unparseable_filename_rejected(self) -> None:
+        assert not self._TAGS.accepts("pkg-1.0.tar.gz")
+
+    def test_rank_orders_specific_before_generic(self) -> None:
+        """The rank drives the install pick: lowest index wins."""
+        specific = Tag("cp311", "cp311", "manylinux_2_28_x86_64")
+        generic = Tag("py3", "none", "any")
+        assert self._TAGS.rank[specific] < self._TAGS.rank[generic]

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -951,6 +951,18 @@ class TestTagSetHostConstructors:
             Tag("py3", "none", "any"),
         )
 
+    def test_an_unknown_host_interpreter_raises(self) -> None:
+        """Guessing CPython would hand the host a tag set it can load none of."""
+
+        def graalpy_tags() -> tuple[Tag, ...]:
+            return (
+                Tag("graalpy311", "graalpy311_native", "manylinux_2_39_x86_64"),
+                Tag("py3", "none", "any"),
+            )
+
+        with pytest.raises(ValueError, match="unsupported interpreter"):
+            TagSet.for_host_python("3.11", tags_source=graalpy_tags)
+
     def test_free_threaded_host_does_not_carry_to_an_older_python(self) -> None:
         """``cp310t`` never existed, so a target naming it matches no wheel."""
         tags = TagSet.for_host_python("3.10", tags_source=self._free_threaded_host)

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -21,11 +21,10 @@ from nab_python.tags import (
     _PLATFORM_ARCH,
     _PLATFORM_KIND,
     PlatformSpec,
+    TagSet,
+    _ordered_tags_for_spec,
     _parse_tag_str,
     _platform_tags_for_spec,
-    _tags_in_order,
-    select_wheel,
-    tags_for_target,
     wheel_tag_set,
 )
 
@@ -58,12 +57,9 @@ def _compatible(
     implementation: str = "cpython",
 ) -> bool:
     """True iff the target would install ``wheel``, given only that wheel."""
-    chosen = select_wheel(
-        [wheel],
-        python_version=python_version,
-        spec=spec,
-        implementation=implementation,
-    )
+    chosen = TagSet.for_spec(
+        python_version=python_version, spec=spec, implementation=implementation
+    ).pick([wheel])
     return chosen is not None
 
 
@@ -268,7 +264,7 @@ class TestLibcFamilyExclusivity:
         """Given numpy's full wheel list, the glibc target picks the glibc wheel."""
         spec = PlatformSpec("linux_x86_64")
         wheels = [_wheel(NUMPY_MUSLLINUX), _wheel(NUMPY_MANYLINUX)]
-        chosen = select_wheel(wheels, python_version="3.13", spec=spec)
+        chosen = TagSet.for_spec(python_version="3.13", spec=spec).pick(wheels)
         assert chosen is not None
         assert chosen.filename == NUMPY_MANYLINUX
 
@@ -303,7 +299,9 @@ class TestFreeThreadedTarget:
     def test_free_threaded_target_keeps_abi3t_and_pure_python(self) -> None:
         """The stable free-threaded ABI and the pure-Python fallback remain."""
         spec = PlatformSpec("linux_x86_64", free_threaded=True)
-        tag_strs = {str(t) for t in tags_for_target(python_version="3.13", spec=spec)}
+        tag_strs = {
+            str(t) for t in TagSet.for_spec(python_version="3.13", spec=spec).members
+        }
         assert "cp313-abi3t-manylinux_2_28_x86_64" in tag_strs
         assert "py3-none-any" in tag_strs
 
@@ -326,21 +324,17 @@ class TestPymallocAbi:
     def test_a_37_target_names_the_m_abi(self) -> None:
         """Every 3.7 wheel is tagged cp37m, so a cp37 target matches none."""
         spec = PlatformSpec("linux_x86_64")
-        tags = tags_for_target(python_version="3.7", spec=spec)
-        assert "cp37m" in {t.abi for t in tags}
-        wheel = wheel_tag_set(
+        tags = TagSet.for_spec(python_version="3.7", spec=spec)
+        assert "cp37m" in {t.abi for t in tags.ordered}
+        assert tags.accepts(
             "numpy-1.21.6-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
         )
-        assert wheel is not None
-        assert wheel & tags
 
     def test_38_dropped_the_flag(self) -> None:
         spec = PlatformSpec("linux_x86_64")
-        tags = tags_for_target(python_version="3.8", spec=spec)
-        assert "cp38m" not in {t.abi for t in tags}
-        wheel = wheel_tag_set("numpy-1.24.4-cp38-cp38-manylinux_2_17_x86_64.whl")
-        assert wheel is not None
-        assert wheel & tags
+        tags = TagSet.for_spec(python_version="3.8", spec=spec)
+        assert "cp38m" not in {t.abi for t in tags.ordered}
+        assert tags.accepts("numpy-1.24.4-cp38-cp38-manylinux_2_17_x86_64.whl")
 
 
 class TestAbiIsHostIndependent:
@@ -356,7 +350,7 @@ class TestAbiIsHostIndependent:
         """A declared GIL target keeps its cp313 and abi3 tags on such a host."""
         spec = PlatformSpec("linux_x86_64")
         with _free_threaded_host():
-            tag_strs = {str(t) for t in _tags_in_order("3.13", spec)}
+            tag_strs = {str(t) for t in _ordered_tags_for_spec("3.13", spec, "cpython")}
         assert "cp313-cp313-manylinux_2_28_x86_64" in tag_strs
         assert "cp313-abi3-manylinux_2_28_x86_64" in tag_strs
         assert not any("cp313t" in t for t in tag_strs)
@@ -375,36 +369,44 @@ class TestAbiIsHostIndependent:
     def test_free_threaded_target_reachable_from_any_host(self) -> None:
         """A declared free-threaded target gets its cp313t tag with no host help."""
         spec = PlatformSpec("linux_x86_64", free_threaded=True)
-        tag_strs = {str(t) for t in _tags_in_order("3.13", spec)}
+        tag_strs = {str(t) for t in _ordered_tags_for_spec("3.13", spec, "cpython")}
         assert "cp313-cp313t-manylinux_2_28_x86_64" in tag_strs
 
 
 class TestTagsForTarget:
-    """``tags_for_target`` produces the full PEP 425 tag set."""
+    """``TagSet.for_spec`` produces the full PEP 425 tag set."""
 
     def test_linux_includes_manylinux_at_or_below_libc_version(self) -> None:
         """A glibc 2.17 target admits manylinux_2_17 and below."""
         spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
-        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
+        tag_strs = {
+            str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
+        }
         assert "cp311-cp311-manylinux_2_17_x86_64" in tag_strs
         assert "cp311-cp311-manylinux_2_5_x86_64" in tag_strs
 
     def test_linux_excludes_manylinux_above_libc_version(self) -> None:
         """manylinux_2_28 needs glibc 2.28; a 2.17 target cannot run it."""
         spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
-        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
+        tag_strs = {
+            str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
+        }
         assert "cp311-cp311-manylinux_2_28_x86_64" not in tag_strs
 
     def test_default_linux_admits_manylinux_2_28(self) -> None:
         """The default glibc version admits manylinux_2_28."""
         spec = PlatformSpec("linux_x86_64")
-        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
+        tag_strs = {
+            str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
+        }
         assert "cp311-cp311-manylinux_2_28_x86_64" in tag_strs
 
     def test_linux_includes_legacy_aliases(self) -> None:
         """manylinux1, manylinux2010, manylinux2014 aliases are included."""
         spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
-        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
+        tag_strs = {
+            str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
+        }
         assert "cp311-cp311-manylinux1_x86_64" in tag_strs
         assert "cp311-cp311-manylinux2010_x86_64" in tag_strs
         assert "cp311-cp311-manylinux2014_x86_64" in tag_strs
@@ -412,14 +414,18 @@ class TestTagsForTarget:
     def test_linux_excludes_aliases_above_libc_version(self) -> None:
         """manylinux2014 means glibc 2.17; a 2.12 target excludes it."""
         spec = PlatformSpec("linux_x86_64", libc_version=(2, 12))
-        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
+        tag_strs = {
+            str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
+        }
         assert "cp311-cp311-manylinux2014_x86_64" not in tag_strs
         assert "cp311-cp311-manylinux2010_x86_64" in tag_strs
 
     def test_aarch64_manylinux_stops_at_2_17(self) -> None:
         """aarch64 does not descend below glibc 2.17 (PEP 599)."""
         spec = PlatformSpec("linux_aarch64", libc_version=(2, 17))
-        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
+        tag_strs = {
+            str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
+        }
         assert "cp311-cp311-manylinux_2_17_aarch64" in tag_strs
         assert "cp311-cp311-manylinux2014_aarch64" in tag_strs
         assert "cp311-cp311-manylinux_2_16_aarch64" not in tag_strs
@@ -437,21 +443,27 @@ class TestTagsForTarget:
     def test_x86_64_keeps_legacy_alias_range(self) -> None:
         """x86_64 still descends to manylinux1 (glibc 2.5)."""
         spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
-        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
+        tag_strs = {
+            str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
+        }
         assert "cp311-cp311-manylinux1_x86_64" in tag_strs
         assert "cp311-cp311-manylinux_2_5_x86_64" in tag_strs
 
     def test_musl_includes_musllinux_at_or_below_version(self) -> None:
         """A musl 1.2 target admits musllinux_1_2 and below."""
         spec = PlatformSpec("linux_x86_64", libc="musl", libc_version=(1, 2))
-        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
+        tag_strs = {
+            str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
+        }
         assert "cp311-cp311-musllinux_1_2_x86_64" in tag_strs
         assert "cp311-cp311-musllinux_1_0_x86_64" in tag_strs
 
     def test_macos_arm64_default_accepts_modern_wheels(self) -> None:
         """The default ``macos_arm64`` admits ``macosx_11_0`` and ``macosx_12_0``."""
         spec = PlatformSpec("macos_arm64")
-        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
+        tag_strs = {
+            str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
+        }
         # mac_platforms yields versions <= the declared one
         assert "cp311-cp311-macosx_11_0_arm64" in tag_strs
         assert "cp311-cp311-macosx_12_0_arm64" in tag_strs
@@ -461,25 +473,33 @@ class TestTagsForTarget:
     def test_macos_x86_64_uses_default_min(self) -> None:
         """``macos_x86_64`` defaults to macOS 10.13 (x86_64-era)."""
         spec = PlatformSpec("macos_x86_64")
-        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
+        tag_strs = {
+            str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
+        }
         assert "cp311-cp311-macosx_10_13_x86_64" in tag_strs
 
     def test_macos_explicit_min(self) -> None:
         """An explicit ``macos_min`` overrides the default."""
         spec = PlatformSpec("macos_arm64", macos_min=(14, 0))
-        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
+        tag_strs = {
+            str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
+        }
         assert "cp311-cp311-macosx_14_0_arm64" in tag_strs
 
     def test_windows_amd64(self) -> None:
         """Windows amd64 generates ``win_amd64`` tags."""
         spec = PlatformSpec("windows_amd64")
-        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
+        tag_strs = {
+            str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
+        }
         assert "cp311-cp311-win_amd64" in tag_strs
 
     def test_includes_universal_tags(self) -> None:
         """``py3-none-any`` and ``cp311-none-any`` are always in the set."""
         spec = PlatformSpec("linux_x86_64")
-        tag_strs = {str(t) for t in tags_for_target(python_version="3.11", spec=spec)}
+        tag_strs = {
+            str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
+        }
         assert "py3-none-any" in tag_strs
         assert "cp311-none-any" in tag_strs
 
@@ -634,13 +654,13 @@ class TestSelectWheel:
         """No compatible wheel -> None."""
         spec = PlatformSpec("linux_x86_64")
         wheels = [_wheel("pkg-1.0-cp311-cp311-win_amd64.whl")]
-        assert select_wheel(wheels, python_version="3.11", spec=spec) is None
+        assert TagSet.for_spec(python_version="3.11", spec=spec).pick(wheels) is None
 
     def test_default_macos_arm64_selects_modern_only_wheel(self) -> None:
         """A version shipping only a ``macosx_12_0`` arm64 wheel is selectable."""
         spec = PlatformSpec("macos_arm64")
         wheels = [_wheel("pkg-2.2.0-cp312-cp312-macosx_12_0_arm64.whl")]
-        chosen = select_wheel(wheels, python_version="3.12", spec=spec)
+        chosen = TagSet.for_spec(python_version="3.12", spec=spec).pick(wheels)
         assert chosen is not None
         assert chosen.filename == "pkg-2.2.0-cp312-cp312-macosx_12_0_arm64.whl"
 
@@ -651,7 +671,7 @@ class TestSelectWheel:
             _wheel("pkg-2.2.0-py3-none-any.whl"),
             _wheel("pkg-2.2.0-cp312-cp312-macosx_12_0_arm64.whl"),
         ]
-        chosen = select_wheel(wheels, python_version="3.12", spec=spec)
+        chosen = TagSet.for_spec(python_version="3.12", spec=spec).pick(wheels)
         assert chosen is not None
         assert chosen.filename == "pkg-2.2.0-cp312-cp312-macosx_12_0_arm64.whl"
 
@@ -662,7 +682,7 @@ class TestSelectWheel:
             _wheel("pkg-1.0-py3-none-any.whl"),
             _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl"),
         ]
-        chosen = select_wheel(wheels, python_version="3.11", spec=spec)
+        chosen = TagSet.for_spec(python_version="3.11", spec=spec).pick(wheels)
         assert chosen is not None
         assert "manylinux" in chosen.filename
 
@@ -670,7 +690,7 @@ class TestSelectWheel:
         """When only py3-none-any is compatible, it wins."""
         spec = PlatformSpec("linux_x86_64")
         wheels = [_wheel("pkg-1.0-py3-none-any.whl")]
-        chosen = select_wheel(wheels, python_version="3.11", spec=spec)
+        chosen = TagSet.for_spec(python_version="3.11", spec=spec).pick(wheels)
         assert chosen is not None
         assert chosen.filename == "pkg-1.0-py3-none-any.whl"
 
@@ -689,7 +709,7 @@ class TestSelectWheel:
             ),
             good,
         ]
-        chosen = select_wheel(wheels, python_version="3.11", spec=spec)
+        chosen = TagSet.for_spec(python_version="3.11", spec=spec).pick(wheels)
         assert chosen is good
 
     def test_higher_glibc_wheel_wins_over_lower(self) -> None:
@@ -704,7 +724,7 @@ class TestSelectWheel:
             _wheel("pkg-1.0-cp311-cp311-manylinux_2_5_x86_64.whl"),
             _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl"),
         ]
-        chosen = select_wheel(wheels, python_version="3.11", spec=spec)
+        chosen = TagSet.for_spec(python_version="3.11", spec=spec).pick(wheels)
         assert chosen is not None
         assert "manylinux_2_17" in chosen.filename
 
@@ -721,7 +741,7 @@ class TestSelectWheel:
             _wheel("pkg-1.0-cp311-cp311-manylinux_2_5_x86_64.whl"),
             _wheel("pkg-1.0-cp311-cp311-manylinux2014_x86_64.whl"),
         ]
-        chosen = select_wheel(wheels, python_version="3.11", spec=spec)
+        chosen = TagSet.for_spec(python_version="3.11", spec=spec).pick(wheels)
         assert chosen is not None
         assert "manylinux2014" in chosen.filename
 
@@ -737,7 +757,7 @@ class TestSelectWheel:
             _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl"),
             _wheel("pkg-1.0-cp311-cp311-manylinux_2_5_x86_64.whl"),
         ]
-        chosen = select_wheel(wheels, python_version="3.11", spec=spec)
+        chosen = TagSet.for_spec(python_version="3.11", spec=spec).pick(wheels)
         assert chosen is not None
         assert "manylinux_2_17" in chosen.filename
 
@@ -746,7 +766,9 @@ class TestSelectWheel:
         spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
         build1 = _wheel("pkg-1.0-1-cp311-cp311-manylinux_2_17_x86_64.whl")
         build5 = _wheel("pkg-1.0-5-cp311-cp311-manylinux_2_17_x86_64.whl")
-        chosen = select_wheel([build1, build5], python_version="3.11", spec=spec)
+        chosen = TagSet.for_spec(python_version="3.11", spec=spec).pick(
+            [build1, build5]
+        )
         assert chosen is build5
 
     def test_build_tag_selection_is_order_independent(self) -> None:
@@ -754,8 +776,12 @@ class TestSelectWheel:
         spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
         build1 = _wheel("pkg-1.0-1-cp311-cp311-manylinux_2_17_x86_64.whl")
         build5 = _wheel("pkg-1.0-5-cp311-cp311-manylinux_2_17_x86_64.whl")
-        forward = select_wheel([build1, build5], python_version="3.11", spec=spec)
-        reverse = select_wheel([build5, build1], python_version="3.11", spec=spec)
+        forward = TagSet.for_spec(python_version="3.11", spec=spec).pick(
+            [build1, build5]
+        )
+        reverse = TagSet.for_spec(python_version="3.11", spec=spec).pick(
+            [build5, build1]
+        )
         assert forward is build5
         assert reverse is build5
 
@@ -764,7 +790,9 @@ class TestSelectWheel:
         spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
         untagged = _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl")
         build3 = _wheel("pkg-1.0-3-cp311-cp311-manylinux_2_17_x86_64.whl")
-        chosen = select_wheel([untagged, build3], python_version="3.11", spec=spec)
+        chosen = TagSet.for_spec(python_version="3.11", spec=spec).pick(
+            [untagged, build3]
+        )
         assert chosen is build3
 
     def test_an_absurd_build_number_is_malformed(self) -> None:
@@ -772,7 +800,9 @@ class TestSelectWheel:
         spec = PlatformSpec("linux_x86_64")
         build5 = _wheel("pkg-1.0-5-cp311-cp311-manylinux_2_17_x86_64.whl")
         absurd = _wheel(f"pkg-1.0-{'9' * 5000}-cp311-cp311-manylinux_2_17_x86_64.whl")
-        chosen = select_wheel([absurd, build5], python_version="3.11", spec=spec)
+        chosen = TagSet.for_spec(python_version="3.11", spec=spec).pick(
+            [absurd, build5]
+        )
         assert chosen is build5
 
     def test_malformed_build_tag_treated_as_absent(self) -> None:
@@ -780,7 +810,9 @@ class TestSelectWheel:
         spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
         malformed = _wheel("pkg-1.0-x-cp311-cp311-manylinux_2_17_x86_64.whl")
         build5 = _wheel("pkg-1.0-5-cp311-cp311-manylinux_2_17_x86_64.whl")
-        chosen = select_wheel([malformed, build5], python_version="3.11", spec=spec)
+        chosen = TagSet.for_spec(python_version="3.11", spec=spec).pick(
+            [malformed, build5]
+        )
         assert chosen is build5
 
 
@@ -855,20 +887,17 @@ class TestPyPyTags:
         """The PyPy-specific wheel outranks the pure-Python fallback."""
         pure = _wheel("numpy-1.0-py3-none-any.whl")
         native = _wheel("numpy-1.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.whl")
-        chosen = select_wheel(
-            [pure, native],
-            python_version="3.11",
-            spec=self.SPEC,
-            implementation="pypy",
-        )
+        chosen = TagSet.for_spec(
+            python_version="3.11", spec=self.SPEC, implementation="pypy"
+        ).pick([pure, native])
         assert chosen is native
 
     def test_compat_tag_sets_differ_by_implementation(self) -> None:
         """The CPython and PyPy tuples accept disjoint native-tag sets."""
-        cp = tags_for_target(python_version="3.11", spec=self.SPEC)
-        pp = tags_for_target(
+        cp = TagSet.for_spec(python_version="3.11", spec=self.SPEC).members
+        pp = TagSet.for_spec(
             python_version="3.11", spec=self.SPEC, implementation="pypy"
-        )
+        ).members
         cp_native = {t for t in cp if t.abi.startswith("cp")}
         pp_native = {t for t in pp if t.abi.startswith("pypy")}
         assert cp_native

--- a/nab-python/tests/test_target.py
+++ b/nab-python/tests/test_target.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import pytest
 
 from nab_python._vendor.packaging.markers import Marker
+from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.tags import Tag
 from nab_python._vendor.packaging.version import InvalidVersion, Version
 from nab_python.tags import PlatformSpec
@@ -88,6 +89,41 @@ class TestForHost:
         assert target.host_faithful
         assert Version(target.python_full_version)
         assert target.tags.ordered
+
+
+class TestPythonRelease:
+    """``Requires-Python`` names a release, so a prerelease host is one."""
+
+    def test_a_release_candidate_host_is_its_release(self) -> None:
+        """A 3.15 candidate satisfies ``>=3.15``, as it does under pip.
+
+        The PEP 508 marker value keeps the ``rc``, but a specifier admits no
+        prerelease unless it names one, so comparing that value would drop
+        every distribution requiring the release the host is a candidate for.
+        """
+        target = ResolveTarget.for_host(
+            env_source=lambda: {**_HOST_ENV, "python_full_version": "3.15.0rc1"},
+            tags_source=_host_tags,
+        )
+        assert target.python_full_version == "3.15.0rc1"
+        assert target.python_release == Version("3.15.0")
+        assert target.python_release in SpecifierSet(">=3.15")
+
+    def test_a_final_release_is_itself(self) -> None:
+        target = ResolveTarget.for_host(env_source=_host_env, tags_source=_host_tags)
+        assert target.python_release == Version(_HOST_ENV["python_full_version"])
+
+
+class TestTargetPythonIsComparable:
+    """Every candidate's Requires-Python is tested against this target."""
+
+    def test_an_unparseable_python_names_itself(self) -> None:
+        """A local-build version fails here, not once per candidate."""
+        with pytest.raises(ValueError, match="not a PEP 440 version"):
+            ResolveTarget.for_host(
+                env_source=lambda: {**_HOST_ENV, "python_full_version": "3.11.2+"},
+                tags_source=_host_tags,
+            )
 
 
 class TestForHostPython:

--- a/nab-python/tests/test_target.py
+++ b/nab-python/tests/test_target.py
@@ -1,0 +1,498 @@
+"""Tests for :class:`nab_python.target.ResolveTarget`.
+
+The host constructors take their environment and tag sources as
+arguments, so every test here names the interpreter it means instead of
+the one running the suite.  One smoke test uses the live sources.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nab_python._vendor.packaging.markers import Marker
+from nab_python._vendor.packaging.tags import Tag
+from nab_python._vendor.packaging.version import InvalidVersion, Version
+from nab_python.tags import PlatformSpec
+from nab_python.target import (
+    IMPLEMENTATION_MARKERS,
+    PLATFORM_MARKERS,
+    ResolveTarget,
+    apply_python_axis_overlay,
+    declared_environment,
+    host_environment,
+    python_axis_environment,
+)
+
+_HOST_ENV: dict[str, str] = {
+    "implementation_name": "cpython",
+    "implementation_version": "3.13.2",
+    "os_name": "posix",
+    "platform_machine": "x86_64",
+    "platform_python_implementation": "CPython",
+    "platform_release": "6.8.0",
+    "platform_system": "Linux",
+    "platform_version": "#1 SMP",
+    "python_full_version": "3.13.2",
+    "python_version": "3.13",
+    "sys_platform": "linux",
+}
+
+_HOST_TAGS: tuple[Tag, ...] = (
+    Tag("cp313", "cp313", "manylinux_2_39_x86_64"),
+    Tag("cp313", "cp313", "linux_x86_64"),
+    Tag("cp313", "abi3", "manylinux_2_39_x86_64"),
+    Tag("py3", "none", "any"),
+)
+
+
+def _host_env() -> dict[str, str]:
+    return dict(_HOST_ENV)
+
+
+def _host_tags() -> tuple[Tag, ...]:
+    return _HOST_TAGS
+
+
+class TestHostEnvironment:
+    def test_drops_non_string_values(self) -> None:
+        """A source yielding a non-string value contributes nothing for it."""
+        env = host_environment(lambda: {"os_name": "posix", "extras": frozenset()})
+        assert env == {"os_name": "posix"}
+
+    def test_defaults_to_the_live_interpreter(self) -> None:
+        """With no source, the host's own PEP 508 environment is returned."""
+        env = host_environment()
+        assert env["python_version"].count(".") == 1
+        assert Version(env["python_full_version"])
+        assert env["sys_platform"]
+
+
+class TestForHost:
+    def test_marker_env_is_the_untouched_host(self) -> None:
+        target = ResolveTarget.for_host(env_source=_host_env, tags_source=_host_tags)
+        assert target.marker_env == _HOST_ENV
+        assert target.host_faithful
+
+    def test_label_names_the_host(self) -> None:
+        target = ResolveTarget.for_host(env_source=_host_env, tags_source=_host_tags)
+        assert target.label == "host"
+        assert target.platform_id == "host"
+
+    def test_tags_are_the_hosts(self) -> None:
+        target = ResolveTarget.for_host(env_source=_host_env, tags_source=_host_tags)
+        assert target.tags.ordered == _HOST_TAGS
+
+    def test_live_sources_smoke(self) -> None:
+        """The default sources answer for the interpreter running the suite."""
+        target = ResolveTarget.for_host()
+        assert target.host_faithful
+        assert Version(target.python_full_version)
+        assert target.tags.ordered
+
+
+class TestForHostPython:
+    def test_python_axis_moves(self) -> None:
+        target = ResolveTarget.for_host_python(
+            "3.10.5", env_source=_host_env, tags_source=_host_tags
+        )
+        assert target.python_version == "3.10"
+        assert target.python_full_version == "3.10.5"
+        assert not target.host_faithful
+
+    def test_machine_stays_the_host(self) -> None:
+        """Only the python axis moves; the machine's markers carry over."""
+        target = ResolveTarget.for_host_python(
+            "3.10", env_source=_host_env, tags_source=_host_tags
+        )
+        assert target.marker_env["platform_machine"] == "x86_64"
+        assert target.marker_env["platform_release"] == "6.8.0"
+
+    def test_label_names_the_python_and_the_host(self) -> None:
+        target = ResolveTarget.for_host_python(
+            "3.10.5", env_source=_host_env, tags_source=_host_tags
+        )
+        assert target.label == "py310-host"
+
+    def test_tags_keep_the_host_platforms(self) -> None:
+        """The host's platform tags carry over, in the host's own order."""
+        target = ResolveTarget.for_host_python(
+            "3.10", env_source=_host_env, tags_source=_host_tags
+        )
+        tag_strs = {str(t) for t in target.tags.ordered}
+        assert "cp310-cp310-manylinux_2_39_x86_64" in tag_strs
+        assert "cp310-cp310-linux_x86_64" in tag_strs
+        assert not any("cp313" in t for t in tag_strs)
+
+    def test_pypy_host_keeps_its_interpreter(self) -> None:
+        """A PyPy host yields PyPy tags for the target Python."""
+
+        def pypy_tags() -> tuple[Tag, ...]:
+            return (
+                Tag("pp311", "pypy311_pp73", "manylinux_2_39_x86_64"),
+                Tag("py3", "none", "any"),
+            )
+
+        target = ResolveTarget.for_host_python(
+            "3.10", env_source=_host_env, tags_source=pypy_tags
+        )
+        tag_strs = {str(t) for t in target.tags.ordered}
+        assert "pp310-pypy310_pp73-manylinux_2_39_x86_64" in tag_strs
+
+    def test_free_threaded_host_keeps_its_abi(self) -> None:
+        """A free-threaded host targets the ``cpXYt`` ABI at the new Python."""
+
+        def free_threaded_tags() -> tuple[Tag, ...]:
+            return (
+                Tag("cp313", "cp313t", "manylinux_2_39_x86_64"),
+                Tag("py3", "none", "any"),
+            )
+
+        target = ResolveTarget.for_host_python(
+            "3.14", env_source=_host_env, tags_source=free_threaded_tags
+        )
+        tag_strs = {str(t) for t in target.tags.ordered}
+        assert "cp314-cp314t-manylinux_2_39_x86_64" in tag_strs
+
+    def test_invalid_python_raises(self) -> None:
+        with pytest.raises(InvalidVersion, match="python_version 'not-a-version'"):
+            ResolveTarget.for_host_python(
+                "not-a-version", env_source=_host_env, tags_source=_host_tags
+            )
+
+    def test_live_sources_smoke(self) -> None:
+        """The default sources are the running interpreter's."""
+        target = ResolveTarget.for_host_python("3.10")
+        assert target.python_full_version == "3.10.0"
+        assert target.tags.ordered
+
+
+class TestForDeclared:
+    def test_environment_has_all_eleven_pep508_variables(self) -> None:
+        target = ResolveTarget.for_declared(
+            python_version="3.12", spec=PlatformSpec("macos_arm64")
+        )
+        assert set(target.marker_env) == {
+            "implementation_name",
+            "implementation_version",
+            "os_name",
+            "platform_machine",
+            "platform_python_implementation",
+            "platform_release",
+            "platform_system",
+            "platform_version",
+            "python_full_version",
+            "python_version",
+            "sys_platform",
+        }
+        assert target.marker_env["sys_platform"] == "darwin"
+        assert target.python_full_version == "3.12.0"
+
+    def test_patch_release_overrides_the_default(self) -> None:
+        target = ResolveTarget.for_declared(
+            python_version="3.11",
+            spec=PlatformSpec("linux_x86_64"),
+            python_full_version="3.11.4",
+        )
+        assert target.python_full_version == "3.11.4"
+        assert target.marker_env["implementation_version"] == "3.11.4"
+
+    def test_is_not_host_faithful(self) -> None:
+        """A declared target impersonates a machine, so a build here lies."""
+        target = ResolveTarget.for_declared(
+            python_version="3.11", spec=PlatformSpec("linux_x86_64")
+        )
+        assert not target.host_faithful
+
+    def test_platform_id_and_spec_are_kept(self) -> None:
+        spec = PlatformSpec("linux_x86_64", libc="musl")
+        target = ResolveTarget.for_declared(python_version="3.11", spec=spec)
+        assert target.platform_spec == spec
+        assert target.platform_id == "linux_x86_64"
+
+    def test_tags_come_from_the_spec(self) -> None:
+        target = ResolveTarget.for_declared(
+            python_version="3.11", spec=PlatformSpec("linux_x86_64", libc="musl")
+        )
+        tag_strs = {str(t) for t in target.tags.ordered}
+        assert "cp311-cp311-musllinux_1_2_x86_64" in tag_strs
+        assert not any("manylinux" in t for t in tag_strs)
+
+
+class TestLabels:
+    def test_label_is_short_and_stable(self) -> None:
+        """``label`` is a short id suitable for filenames and logs."""
+        target = ResolveTarget.for_declared(
+            python_version="3.11", spec=PlatformSpec("linux_x86_64")
+        )
+        assert target.label == "py311-linux_x86_64"
+
+    def test_pypy_label_uses_pp_prefix(self) -> None:
+        target = ResolveTarget.for_declared(
+            python_version="3.11",
+            spec=PlatformSpec("linux_x86_64"),
+            implementation="pypy",
+        )
+        assert target.label == "pp311-linux_x86_64"
+
+    def test_spec_knobs_add_a_discriminator(self) -> None:
+        target = ResolveTarget.for_declared(
+            python_version="3.11",
+            spec=PlatformSpec("linux_x86_64", libc="musl"),
+        )
+        assert target.label == "py311-linux_x86_64-musl"
+
+    def test_selection_appends_sorted_member_suffix(self) -> None:
+        """A conflict-fork selection appends sorted ``kind-name`` members."""
+        target = ResolveTarget.for_declared(
+            python_version="3.11", spec=PlatformSpec("linux_x86_64")
+        ).with_selection((("group", "isort5"), ("group", "black22")))
+        assert target.label == "py311-linux_x86_64-group-black22.group-isort5"
+
+    def test_mixed_extra_and_group_selection_label_format(self) -> None:
+        """Mixed selections sort ``extra-`` before ``group-`` lexically.
+
+        Pins the exact byte-stable label shape so renaming
+        :data:`KIND_EXTRA` / :data:`KIND_GROUP` cannot silently flip the
+        sort order and rewrite every label dict key.
+        """
+        target = ResolveTarget.for_declared(
+            python_version="3.11", spec=PlatformSpec("linux_x86_64")
+        ).with_selection((("group", "isort5"), ("extra", "cpu")))
+        assert target.label == "py311-linux_x86_64-extra-cpu.group-isort5"
+
+    def test_label_distinguishes_selections_that_split_on_hyphen(self) -> None:
+        """Names containing ``-`` cannot collide two selections into one label.
+
+        Canonical names collapse ``[-_.]`` runs to a single ``-``, so a
+        ``-`` joiner is ambiguous: ``a-b`` plus ``c`` and ``a`` plus
+        ``b-c`` would both read as ``a-b-c``.  The ``.`` separator keeps
+        the two selections on distinct labels.
+        """
+        base = ResolveTarget.for_declared(
+            python_version="3.11", spec=PlatformSpec("linux_x86_64")
+        )
+        first = base.with_selection((("extra", "a-b"), ("extra", "c")))
+        second = base.with_selection((("extra", "a"), ("extra", "b-c")))
+        assert first.label != second.label
+
+    def test_label_distinguishes_extra_from_group_of_same_name(self) -> None:
+        base = ResolveTarget.for_declared(
+            python_version="3.11", spec=PlatformSpec("linux_x86_64")
+        )
+        as_extra = base.with_selection((("extra", "cpu"),))
+        as_group = base.with_selection((("group", "cpu"),))
+        assert as_extra.label != as_group.label
+
+    def test_reselecting_replaces_the_previous_suffix(self) -> None:
+        """A target already under a fork takes the new fork's label."""
+        forked = ResolveTarget.for_declared(
+            python_version="3.11", spec=PlatformSpec("linux_x86_64")
+        ).with_selection((("extra", "cpu"),))
+        assert forked.with_selection((("extra", "gpu"),)).label == (
+            "py311-linux_x86_64-extra-gpu"
+        )
+        assert forked.with_selection(()).label == "py311-linux_x86_64"
+
+
+class TestMarkerStrings:
+    @staticmethod
+    def _linux_311() -> ResolveTarget:
+        return ResolveTarget.for_declared(
+            python_version="3.11", spec=PlatformSpec("linux_x86_64")
+        )
+
+    def test_extra_selection_adds_extras_marker_clause(self) -> None:
+        target = self._linux_311().with_selection((("extra", "cpu"),))
+        assert target.marker_string.endswith('and "cpu" in extras')
+
+    def test_group_selection_adds_dependency_groups_clause(self) -> None:
+        target = self._linux_311().with_selection((("group", "black22"),))
+        assert target.marker_string.endswith('and "black22" in dependency_groups')
+
+    def test_selection_clauses_are_sorted(self) -> None:
+        target = self._linux_311().with_selection(
+            (("group", "isort5"), ("extra", "cpu"))
+        )
+        # sorted by (kind, name): ("extra", "cpu") < ("group", "isort5")
+        assert target.marker_string.endswith(
+            'and "cpu" in extras and "isort5" in dependency_groups'
+        )
+
+    def test_environment_marker_string_omits_selection(self) -> None:
+        target = self._linux_311().with_selection((("group", "black22"),))
+        assert "in dependency_groups" not in target.environment_marker_string
+        assert target.environment_marker_string.endswith('platform_machine == "x86_64"')
+        assert '"black22" in dependency_groups' in target.marker_string
+
+    def test_empty_selection_leaves_marker_and_label_unchanged(self) -> None:
+        target = self._linux_311()
+        assert target.label == "py311-linux_x86_64"
+        assert "in extras" not in target.marker_string
+        assert "in dependency_groups" not in target.marker_string
+
+    def test_cpython_marker_omits_implementation(self) -> None:
+        assert "implementation_name" not in self._linux_311().marker_string
+
+    def test_pypy_marker_constrains_implementation(self) -> None:
+        target = ResolveTarget.for_declared(
+            python_version="3.11",
+            spec=PlatformSpec("linux_x86_64"),
+            implementation="pypy",
+        )
+        assert target.marker_string.endswith('and implementation_name == "pypy"')
+
+    def test_multi_implementation_cpython_marker_pins_implementation(self) -> None:
+        target = ResolveTarget.for_declared(
+            python_version="3.11",
+            spec=PlatformSpec("linux_x86_64"),
+            multi_implementation=True,
+        )
+        assert target.marker_string.endswith('and implementation_name == "cpython"')
+
+
+class TestEnvWithMembership:
+    def test_membership_sets_are_seeded_empty(self) -> None:
+        """A marker testing ``extras`` evaluates False instead of raising."""
+        target = ResolveTarget.for_declared(
+            python_version="3.11", spec=PlatformSpec("linux_x86_64")
+        )
+        env = target.env_with_membership()
+        assert env["extras"] == frozenset()
+        assert env["dependency_groups"] == frozenset()
+        assert env["sys_platform"] == "linux"
+
+
+class TestWithMarkerOverrides:
+    def test_empty_overrides_keep_the_target(self) -> None:
+        target = ResolveTarget.for_host(env_source=_host_env, tags_source=_host_tags)
+        assert target.with_marker_overrides({}) is target
+
+    def test_override_replaces_the_host_value(self) -> None:
+        target = ResolveTarget.for_host(
+            env_source=_host_env, tags_source=_host_tags
+        ).with_marker_overrides({"sys_platform": "win32"})
+        assert target.marker_env["sys_platform"] == "win32"
+        assert target.marker_env["os_name"] == "posix"
+        assert not target.host_faithful
+
+    def test_python_axis_override_syncs_the_full_version(self) -> None:
+        target = ResolveTarget.for_host(
+            env_source=_host_env, tags_source=_host_tags
+        ).with_marker_overrides({"python_version": "3.8"})
+        assert target.python_full_version == "3.8.0"
+
+    def test_tags_do_not_move_with_the_overlay(self) -> None:
+        """An overlay names no libc floor, so it cannot rebuild the tag axis."""
+        base = ResolveTarget.for_host(env_source=_host_env, tags_source=_host_tags)
+        overlaid = base.with_marker_overrides({"sys_platform": "win32"})
+        assert overlaid.tags == base.tags
+
+
+class TestDeclaredEnvironment:
+    def test_kernel_markers_evaluate_against_the_declared_release(self) -> None:
+        env = declared_environment(
+            "3.11",
+            PlatformSpec("linux_x86_64", platform_release="5.10.0"),
+            "cpython",
+        )
+        assert Marker('platform_release >= "5.10"').evaluate(env)
+
+
+class TestMarkerTables:
+    def test_each_implementation_sets_the_interpreter_markers(self) -> None:
+        required = {"platform_python_implementation", "implementation_name"}
+        for impl, env in IMPLEMENTATION_MARKERS.items():
+            assert required == env.keys(), impl
+
+    def test_each_platform_sets_the_os_and_arch_markers(self) -> None:
+        required = {"sys_platform", "platform_system", "platform_machine", "os_name"}
+        for platform_id, env in PLATFORM_MARKERS.items():
+            missing = required - env.keys()
+            assert not missing, f"{platform_id} missing {missing}"
+
+
+class TestPythonAxisEnvironment:
+    def test_single_component_version_pads_python_version(self) -> None:
+        """``python_version`` is padded to major.minor like full to three."""
+        env = python_axis_environment("3")
+        assert env == {"python_version": "3.0", "python_full_version": "3.0.0"}
+
+    def test_unparseable_version_raises_named_error(self) -> None:
+        """The error names the bad ``python_version`` input."""
+        with pytest.raises(InvalidVersion, match="python_version 'not-a-version'"):
+            python_axis_environment("not-a-version")
+
+    def test_two_component_prerelease_keeps_tag(self) -> None:
+        """A 2-release-component prerelease keeps its tag in full version."""
+        env = python_axis_environment("3.14a1")
+        assert env["python_version"] == "3.14"
+        assert Version(env["python_full_version"]) == Version("3.14a1")
+
+    def test_two_component_prerelease_not_treated_as_final(self) -> None:
+        """A prerelease target must not satisfy a final-release marker."""
+        env = python_axis_environment("3.14rc1")
+        assert Marker('python_full_version >= "3.14.0"').evaluate(env) is False
+        assert Marker('python_full_version == "3.14.0"').evaluate(env) is False
+
+    def test_epoch_is_kept_when_padding(self) -> None:
+        """The epoch survives the pad to three release components."""
+        env = python_axis_environment("1!3.9")
+        assert env["python_full_version"] == "1!3.9.0"
+
+
+class TestApplyPythonAxisOverlay:
+    def test_cpython_moves_implementation_version_with_axis(self) -> None:
+        """On CPython the axis move drags implementation_version along."""
+        env = {
+            "implementation_name": "cpython",
+            "python_version": "3.11",
+            "python_full_version": "3.11.5",
+            "implementation_version": "3.11.5",
+        }
+        apply_python_axis_overlay(env, {"python_version": "3.8"})
+        assert env["python_full_version"] == "3.8.0"
+        assert env["implementation_version"] == "3.8.0"
+
+    def test_non_cpython_keeps_its_implementation_version(self) -> None:
+        """A PyPy axis move keeps the interpreter's own release version."""
+        env = {
+            "implementation_name": "pypy",
+            "python_version": "3.9",
+            "python_full_version": "3.9.18",
+            "implementation_version": "7.3.13",
+        }
+        apply_python_axis_overlay(env, {"python_version": "3.10"})
+        assert env["python_full_version"] == "3.10.0"
+        assert env["implementation_version"] == "7.3.13"
+
+    def test_patch_precision_python_version_normalizes_to_minor(self) -> None:
+        """A patch-precision python_version overlay normalizes to major.minor."""
+        env = {
+            "implementation_name": "cpython",
+            "python_version": "3.11",
+            "python_full_version": "3.11.5",
+            "implementation_version": "3.11.5",
+        }
+        apply_python_axis_overlay(env, {"python_version": "3.10.5"})
+        assert env["python_version"] == "3.10"
+        assert env["python_full_version"] == "3.10.5"
+        assert Marker('python_version == "3.10"').evaluate(env) is True
+
+    def test_overlay_without_the_axis_is_a_plain_merge(self) -> None:
+        env = {"python_version": "3.11", "python_full_version": "3.11.5"}
+        apply_python_axis_overlay(env, {"sys_platform": "win32"})
+        assert env["sys_platform"] == "win32"
+        assert env["python_full_version"] == "3.11.5"
+
+    def test_explicit_implementation_version_override_wins(self) -> None:
+        """An explicit implementation_version override is kept verbatim."""
+        env = {
+            "implementation_name": "cpython",
+            "python_version": "3.9",
+            "python_full_version": "3.9.0",
+            "implementation_version": "3.9.0",
+        }
+        apply_python_axis_overlay(
+            env, {"python_version": "3.9", "implementation_version": "3.9.7"}
+        )
+        assert env["implementation_version"] == "3.9.7"

--- a/nab-python/tests/test_widen_decision.py
+++ b/nab-python/tests/test_widen_decision.py
@@ -24,6 +24,7 @@ from nab_python.provider import (
     Provider,
     VcsSource,
 )
+from nab_python.target import ResolveTarget
 from nab_resolver.resolver import Resolver
 from nab_resolver.root import ROOT
 
@@ -71,7 +72,7 @@ def _graph_coordinator(graph: dict[str, dict[str, list[str]]]) -> MagicMock:
 def _listing_provider(package: str, versions: list[str]) -> Provider:
     """Provider with ``package``'s listing already fetched into the cache."""
     coordinator = _graph_coordinator({package: {v: [] for v in versions}})
-    provider = Provider(coordinator, python_version="3.12.0")
+    provider = Provider(coordinator, target=ResolveTarget.for_host_python("3.12.0"))
     provider.fetch_versions(package)
     return provider
 
@@ -79,7 +80,7 @@ def _listing_provider(package: str, versions: list[str]) -> Provider:
 class TestWidenDecision:
     def test_none_before_listing_is_cached(self) -> None:
         coordinator = _graph_coordinator({"p": {"1.0": []}})
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=ResolveTarget.for_host_python("3.12.0"))
         assert provider.widen_decision("p", V("1.0")) is None
 
     def test_universe_includes_prereleases(self) -> None:
@@ -139,7 +140,7 @@ class TestWidenDecision:
 
     def test_none_for_vcs_source(self) -> None:
         coordinator = make_coordinator([], package="bar")
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=ResolveTarget.for_host_python("3.12.0"))
         provider.vcs_sources["bar"] = VcsSource(
             "bar", "git+https://example.com/bar.git@abc123"
         )
@@ -148,7 +149,7 @@ class TestWidenDecision:
 
     def test_none_for_archive_source(self) -> None:
         coordinator = make_coordinator([], package="baz")
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=ResolveTarget.for_host_python("3.12.0"))
         provider.archive_sources["baz"] = ArchiveSource(
             "baz", "https://example.com/baz-1.0.tar.gz#sha256=00"
         )
@@ -178,7 +179,7 @@ class TestNarrowForDisplay:
 
     def test_never_triggers_a_fetch(self) -> None:
         coordinator = _graph_coordinator({"p": {"3.0": [], "2.0": [], "1.0": []}})
-        provider = Provider(coordinator, python_version="3.12.0")
+        provider = Provider(coordinator, target=ResolveTarget.for_host_python("3.12.0"))
         provider.fetch_versions("p")
         coordinator.request_listing.side_effect = AssertionError(
             "narrow_for_display fetched a listing"
@@ -212,7 +213,9 @@ class TestWideningRegressionGraphs:
     ) -> dict[str, Version]:
         coordinator = _graph_coordinator(graph)
         provider = Provider(
-            coordinator, python_version="3.12.0", root_requirements=root_reqs
+            coordinator,
+            target=ResolveTarget.for_host_python("3.12.0"),
+            root_requirements=root_reqs,
         )
         resolver = Resolver(provider, range_type=VersionRange, root_version="0")
         return resolver.resolve(root_reqs)

--- a/nab-python/tests/universal/property_universal/strategies.py
+++ b/nab-python/tests/universal/property_universal/strategies.py
@@ -6,6 +6,9 @@ import os
 
 from hypothesis import HealthCheck, settings
 
+from nab_python.tags import PlatformSpec
+from nab_python.target import ResolveTarget
+
 _DEEP = os.environ.get("HYPOTHESIS_PROFILE") == "deep"
 
 PROPERTY_SETTINGS = settings(
@@ -26,16 +29,7 @@ DEEP_SETTINGS = settings(
 )
 """Heavier settings for properties that benefit from more examples."""
 
-LINUX_ENV: dict[str, str] = {
-    "python_version": "3.11",
-    "python_full_version": "3.11.0",
-    "implementation_name": "cpython",
-    "implementation_version": "3.11.0",
-    "os_name": "posix",
-    "platform_machine": "x86_64",
-    "platform_python_implementation": "CPython",
-    "platform_release": "",
-    "platform_system": "Linux",
-    "platform_version": "",
-    "sys_platform": "linux",
-}
+LINUX_TARGET = ResolveTarget.for_declared(
+    python_version="3.11", spec=PlatformSpec("linux_x86_64")
+)
+"""The CPython 3.11 linux_x86_64 target the property fixtures resolve against."""

--- a/nab-python/tests/universal/property_universal/test_alignment.py
+++ b/nab-python/tests/universal/property_universal/test_alignment.py
@@ -23,7 +23,8 @@ from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.version import Version
 from nab_python.lockfile import IndexPin, LockInput
 from nab_python.tags import PlatformSpec
-from nab_python.universal.matrix import Matrix, MatrixTuple
+from nab_python.target import ResolveTarget
+from nab_python.universal.matrix import Matrix
 from nab_python.universal.resolve import (
     TupleResult,
     UniversalResult,
@@ -33,18 +34,14 @@ from nab_python.universal.resolve import (
 )
 from nab_resolver.errors import ResolutionError
 
-from .strategies import LINUX_ENV, PROPERTY_SETTINGS
+from .strategies import LINUX_TARGET, PROPERTY_SETTINGS
 
 pytestmark = pytest.mark.property
 
 
-def _fake_tuple() -> MatrixTuple:
-    """Build a minimal linux/3.11 ``MatrixTuple`` for property fixtures."""
-    return MatrixTuple(
-        python_version="3.11",
-        platform_spec=PlatformSpec("linux_x86_64"),
-        environment=LINUX_ENV,
-    )
+def _fake_tuple() -> ResolveTarget:
+    """Build a minimal linux/3.11 target for property fixtures."""
+    return LINUX_TARGET
 
 
 @st.composite
@@ -131,7 +128,7 @@ class TestMarkerFiltering:
         self, reqs: list[str]
     ) -> None:
         """Requirements with non-matching markers are absent from the parsed dict."""
-        linux_env = _fake_tuple().environment
+        linux_env = _fake_tuple().marker_env
         try:
             out = _parse_requirements(reqs, linux_env)
         except ResolutionError:
@@ -165,8 +162,8 @@ _PLATFORM_POOL: tuple[str, ...] = (
 @st.composite
 def tuple_lock_inputs(
     draw: st.DrawFn,
-) -> list[tuple[MatrixTuple, dict[str, IndexPin]]]:
-    """Draw N ``(MatrixTuple, pin_map)`` pairs with unique labels."""
+) -> list[tuple[ResolveTarget, dict[str, IndexPin]]]:
+    """Draw N ``(ResolveTarget, pin_map)`` pairs with unique labels."""
     size = draw(st.integers(min_value=1, max_value=3))
     chosen_platforms = draw(
         st.lists(
@@ -176,12 +173,10 @@ def tuple_lock_inputs(
             unique=True,
         )
     )
-    pairs: list[tuple[MatrixTuple, dict[str, IndexPin]]] = []
+    pairs: list[tuple[ResolveTarget, dict[str, IndexPin]]] = []
     for platform in chosen_platforms:
-        tup = MatrixTuple(
-            python_version="3.11",
-            platform_spec=PlatformSpec(platform),
-            environment={**LINUX_ENV, "sys_platform": platform.split("_", 1)[0]},
+        tup = ResolveTarget.for_declared(
+            python_version="3.11", spec=PlatformSpec(platform)
         )
         pairs.append((tup, draw(pin_maps())))
     return pairs
@@ -203,7 +198,7 @@ class TestMergeUniversalLockInputs:
     @given(pairs=tuple_lock_inputs())
     @PROPERTY_SETTINGS
     def test_merge_preserves_per_tuple_pins(
-        self, pairs: list[tuple[MatrixTuple, dict[str, IndexPin]]]
+        self, pairs: list[tuple[ResolveTarget, dict[str, IndexPin]]]
     ) -> None:
         """Every input ``(name, version)`` reappears under the source tuple's label."""
         matrix = Matrix(

--- a/nab-python/tests/universal/property_universal/test_matrix.py
+++ b/nab-python/tests/universal/property_universal/test_matrix.py
@@ -24,9 +24,9 @@ from nab_python._vendor.packaging.markers import Marker
 from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.version import Version
 from nab_python.tags import PlatformSpec
+from nab_python.target import PLATFORM_MARKERS
 from nab_python.universal.matrix import (
     _KNOWN_PYTHON_MINORS,
-    _PLATFORM_DEFAULTS,
     Matrix,
     _pythons_in_range,
 )
@@ -35,7 +35,7 @@ from .strategies import PROPERTY_SETTINGS
 
 pytestmark = pytest.mark.property
 
-PLATFORM_IDS = tuple(_PLATFORM_DEFAULTS)
+PLATFORM_IDS = tuple(PLATFORM_MARKERS)
 
 
 @st.composite
@@ -139,7 +139,7 @@ class TestExpansionDeterminism:
         second = matrix.expand()
         assert len(first) == len(second)
         for tup_a, tup_b in zip(first, second, strict=True):
-            assert tup_a.environment == tup_b.environment
+            assert tup_a.marker_env == tup_b.marker_env
 
 
 class TestPythonOrderingFlip:
@@ -255,7 +255,7 @@ class TestQuotePEP508MarkerKeys:
             "sys_platform",
         }
         for tup in Matrix(python=spec, platforms=platforms).expand():
-            missing = required - tup.environment.keys()
+            missing = required - tup.marker_env.keys()
             assert not missing, f"{tup.label} missing {missing}"
 
 
@@ -268,7 +268,7 @@ class TestQuoteSysPlatformConsistency:
 
     The ``environment`` dict's ``sys_platform`` must be consistent
     with the tuple's ``platform_id``.  A regression in
-    ``_PLATFORM_DEFAULTS`` (e.g. setting ``sys_platform`` to
+    ``PLATFORM_MARKERS`` (e.g. setting ``sys_platform`` to
     ``"Darwin"`` for a macOS id) would mis-evaluate platform-gated
     markers.
 
@@ -289,9 +289,9 @@ class TestQuoteSysPlatformConsistency:
             is_linux = tup.platform_id.startswith("linux_")
             is_win = tup.platform_id.startswith("windows_")
             is_mac = tup.platform_id.startswith("macos_")
-            assert linux_marker.evaluate(tup.environment) is is_linux
-            assert win_marker.evaluate(tup.environment) is is_win
-            assert darwin_marker.evaluate(tup.environment) is is_mac
+            assert linux_marker.evaluate(tup.marker_env) is is_linux
+            assert win_marker.evaluate(tup.marker_env) is is_win
+            assert darwin_marker.evaluate(tup.marker_env) is is_mac
 
     @given(spec=python_specs_admitting_some_minor(), platforms=platform_subsets())
     @PROPERTY_SETTINGS
@@ -302,4 +302,4 @@ class TestQuoteSysPlatformConsistency:
         matrix = Matrix(python=spec, platforms=platforms)
         for tup in matrix.expand():
             marker = Marker(f"python_version == '{tup.python_version}'")
-            assert marker.evaluate(tup.environment) is True
+            assert marker.evaluate(tup.marker_env) is True

--- a/nab-python/tests/universal/property_universal/test_matrix.py
+++ b/nab-python/tests/universal/property_universal/test_matrix.py
@@ -1,12 +1,12 @@
 """Property tests for the matrix-expansion logic in :mod:`nab_python.universal.matrix`.
 
-The matrix expansion produces one ``MatrixTuple`` per
+The matrix expansion produces one ``ResolveTarget`` per
 ``(python_version, platform_id)`` pair admitted by a PEP 440
 specifier.  This file walks the relevant clauses of `PEP 440`_,
 `PEP 425`_, and `PEP 508`_ paragraph by paragraph and adds a
 property test for each one.  PEP 508 specifies the
 environment-marker variables every tool must provide; the matrix's
-per-tuple ``environment`` dict must include every PEP 508 key so
+per-tuple ``marker_env`` dict must include every PEP 508 key so
 that subsequent ``Marker.evaluate`` calls do not raise.
 
 .. _PEP 440: https://peps.python.org/pep-0440/
@@ -125,7 +125,7 @@ class TestExpansionDeterminism:
     def test_expand_environment_dict_stable(
         self, spec: str, platforms: tuple[PlatformSpec, ...]
     ) -> None:
-        """The per-tuple ``environment`` dict is identical across calls.
+        """The per-tuple ``marker_env`` dict is identical across calls.
 
         The label/identity check in :meth:`test_expand_is_idempotent`
         confirms tuple ordering is deterministic.  Downstream marker
@@ -266,7 +266,7 @@ class TestQuoteSysPlatformConsistency:
     > ``linux``, ``linux2``, ``darwin``, ``java1.8.0_51`` (note
     > that ``linux`` is from Python3 and ``linux2`` from Python2).
 
-    The ``environment`` dict's ``sys_platform`` must be consistent
+    The ``marker_env`` dict's ``sys_platform`` must be consistent
     with the tuple's ``platform_id``.  A regression in
     ``PLATFORM_MARKERS`` (e.g. setting ``sys_platform`` to
     ``"Darwin"`` for a macOS id) would mis-evaluate platform-gated

--- a/nab-python/tests/universal/property_universal/test_matrix_labels.py
+++ b/nab-python/tests/universal/property_universal/test_matrix_labels.py
@@ -22,10 +22,9 @@ from nab_python.tags import (
     LIBC_MAJOR,
     PlatformSpec,
 )
+from nab_python.target import IMPLEMENTATION_MARKERS, PLATFORM_MARKERS
 from nab_python.universal.matrix import (
-    _IMPLEMENTATION_DEFAULTS,
     _KNOWN_PYTHON_MINORS,
-    _PLATFORM_DEFAULTS,
     Matrix,
 )
 
@@ -33,8 +32,8 @@ from .strategies import PROPERTY_SETTINGS
 
 pytestmark = pytest.mark.property
 
-PLATFORM_IDS = sorted(_PLATFORM_DEFAULTS)
-IMPLS = sorted(_IMPLEMENTATION_DEFAULTS)
+PLATFORM_IDS = sorted(PLATFORM_MARKERS)
+IMPLS = sorted(IMPLEMENTATION_MARKERS)
 
 python_specs = st.one_of(
     st.sampled_from(_KNOWN_PYTHON_MINORS).map(lambda v: f"=={v}"),
@@ -147,8 +146,8 @@ class TestExpansionExactCoverage:
         assert len(got) == len(expected)
         assert set(got) == expected
         again = matrix.expand()
-        assert [(t.label, t.environment) for t in again] == [
-            (t.label, t.environment) for t in tuples
+        assert [(t.label, t.marker_env) for t in again] == [
+            (t.label, t.marker_env) for t in tuples
         ]
         labels = [t.label for t in tuples]
         assert len(set(labels)) == len(labels), labels
@@ -196,7 +195,7 @@ class TestPythonPatchesEnvironment:
             python_patches={minor: full},
         )
         (tup,) = matrix.expand()
-        env = tup.environment
+        env = tup.marker_env
         assert env["python_full_version"] == full
         assert env["python_version"] == minor
         assert env["implementation_version"] == full

--- a/nab-python/tests/universal/property_universal/test_provider_pep425.py
+++ b/nab-python/tests/universal/property_universal/test_provider_pep425.py
@@ -20,17 +20,18 @@ from hypothesis import strategies as st
 from nab_index.client import SdistFile, WheelFile
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python.provider import BuildPolicy, DistPolicy
-from nab_python.tags import PlatformSpec, select_wheel
+from nab_python.tags import PlatformSpec, TagSet
+from nab_python.target import ResolveTarget
 from nab_python.universal.provider import UniversalProvider
 
-from .strategies import LINUX_ENV, PROPERTY_SETTINGS
+from .strategies import LINUX_TARGET, PROPERTY_SETTINGS
 
 pytestmark = pytest.mark.property
 
 
 def compatible(wheel: WheelFile, spec: PlatformSpec) -> bool:
     """True iff a CPython 3.11 target on ``spec`` would install ``wheel``."""
-    return select_wheel([wheel], python_version="3.11", spec=spec) is not None
+    return TagSet.for_spec(python_version="3.11", spec=spec).pick([wheel]) is not None
 
 
 _PLATFORM_TAGS = (
@@ -93,8 +94,8 @@ def coordinator(files: list[WheelFile | SdistFile]) -> MagicMock:
     return make_coordinator(files, package="pkg")
 
 
-class TestNoPlatformSpecIsNoOp:
-    """When ``platform_spec=None`` the universal provider must return
+class TestNoTagFilterIsNoOp:
+    """Without ``filter_by_wheel_tags`` the universal provider must return
     the parent provider's full listing unchanged.
 
     The override delegates to ``super().filter_distributions`` and
@@ -105,11 +106,11 @@ class TestNoPlatformSpecIsNoOp:
 
     @given(files=listing())
     @PROPERTY_SETTINGS
-    def test_no_platform_spec_is_noop(self, files: list[WheelFile | SdistFile]) -> None:
-        """Without ``platform_spec`` the override matches super()'s output."""
+    def test_no_tag_filter_is_noop(self, files: list[WheelFile | SdistFile]) -> None:
+        """Without the tag filter the override matches super()'s output."""
         provider = UniversalProvider(
             coordinator(files),
-            marker_environment=LINUX_ENV,
+            LINUX_TARGET,
         )
         super_out = UniversalProvider.__mro__[1].filter_distributions(
             provider, "pkg", files
@@ -135,8 +136,8 @@ class TestFilterIsSubsetOfParent:
         """The override never adds entries; it only removes."""
         provider = UniversalProvider(
             coordinator(files),
-            marker_environment=LINUX_ENV,
-            platform_spec=PlatformSpec("linux_x86_64"),
+            LINUX_TARGET,
+            filter_by_wheel_tags=True,
             build_policy=BuildPolicy.NEVER,
         )
         super_out = UniversalProvider.__mro__[1].filter_distributions(
@@ -169,8 +170,8 @@ class TestOnlyCompatibleWheelsKept:
         spec = PlatformSpec("linux_x86_64")
         provider = UniversalProvider(
             coordinator(files),
-            marker_environment=LINUX_ENV,
-            platform_spec=spec,
+            ResolveTarget.for_declared(python_version="3.11", spec=spec),
+            filter_by_wheel_tags=True,
             build_policy=BuildPolicy.BUILD_REMOTE,
         )
         out = provider.filter_distributions("pkg", files)
@@ -199,8 +200,8 @@ class TestVersionAdmissionPolicy:
         spec = PlatformSpec("linux_x86_64")
         provider = UniversalProvider(
             coordinator(files),
-            marker_environment=LINUX_ENV,
-            platform_spec=spec,
+            ResolveTarget.for_declared(python_version="3.11", spec=spec),
+            filter_by_wheel_tags=True,
             build_policy=BuildPolicy.BUILD_REMOTE,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
@@ -231,8 +232,8 @@ class TestVersionAdmissionPolicy:
         spec = PlatformSpec("linux_x86_64")
         provider = UniversalProvider(
             coordinator(files),
-            marker_environment=LINUX_ENV,
-            platform_spec=spec,
+            ResolveTarget.for_declared(python_version="3.11", spec=spec),
+            filter_by_wheel_tags=True,
             build_policy=BuildPolicy.NEVER,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )

--- a/nab-python/tests/universal/property_universal/test_validate.py
+++ b/nab-python/tests/universal/property_universal/test_validate.py
@@ -27,7 +27,7 @@ from nab_python.universal.validate import (
     _per_extra_divergence,
 )
 
-from .strategies import LINUX_ENV, PROPERTY_SETTINGS
+from .strategies import LINUX_TARGET, PROPERTY_SETTINGS
 
 pytestmark = pytest.mark.property
 
@@ -89,7 +89,7 @@ class TestEvaluateGroupsByExtra:
     ) -> None:
         """Computed buckets equal the buckets we encoded in the METADATA."""
         text, expected = payload
-        out = _evaluate_metadata_deps_by_extra(text, LINUX_ENV)
+        out = _evaluate_metadata_deps_by_extra(text, LINUX_TARGET.marker_env)
         assert out == expected
 
 

--- a/nab-python/tests/universal/test_matrix.py
+++ b/nab-python/tests/universal/test_matrix.py
@@ -11,11 +11,8 @@ import pytest
 from nab_python._vendor.packaging.markers import Marker
 from nab_python.tags import PlatformSpec
 from nab_python.universal.matrix import (
-    _IMPLEMENTATION_DEFAULTS,
     _KNOWN_PYTHON_MINORS,
-    _PLATFORM_DEFAULTS,
     Matrix,
-    MatrixTuple,
     _pythons_in_range,
 )
 
@@ -43,7 +40,7 @@ class TestPythonsInRange:
 
 
 class TestMatrixExpand:
-    """``Matrix.expand`` builds tuples and validates inputs."""
+    """``Matrix.expand`` builds targets and validates inputs."""
 
     def test_simple_range_expands_to_known_minors(self) -> None:
         """A python range maps to the union of known minors that satisfy it."""
@@ -82,7 +79,7 @@ class TestMatrixExpand:
         matrix = Matrix(python="==3.12", platforms=(PlatformSpec("macos_arm64"),))
         tuples = matrix.expand()
         assert len(tuples) == 1
-        env = tuples[0].environment
+        env = tuples[0].marker_env
         required_keys = {
             "python_version",
             "python_full_version",
@@ -153,15 +150,15 @@ class TestMatrixExpand:
         tuples = matrix.expand()
         py311 = next(t for t in tuples if t.python_version == "3.11")
         py312 = next(t for t in tuples if t.python_version == "3.12")
-        assert py311.environment["python_full_version"] == "3.11.4"
-        assert py312.environment["python_full_version"] == "3.12.1"
-        assert py311.environment["implementation_version"] == "3.11.4"
+        assert py311.marker_env["python_full_version"] == "3.11.4"
+        assert py312.marker_env["python_full_version"] == "3.12.1"
+        assert py311.marker_env["implementation_version"] == "3.11.4"
 
     def test_python_patches_default_to_zero(self) -> None:
         """When patches not declared, ``.0`` is used."""
         matrix = Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),))
         tuples = matrix.expand()
-        assert tuples[0].environment["python_full_version"] == "3.11.0"
+        assert tuples[0].marker_env["python_full_version"] == "3.11.0"
 
     def test_python_patches_partial_mapping(self) -> None:
         """A partial mapping uses overrides for declared minors only."""
@@ -173,8 +170,8 @@ class TestMatrixExpand:
         tuples = matrix.expand()
         py311 = next(t for t in tuples if t.python_version == "3.11")
         py312 = next(t for t in tuples if t.python_version == "3.12")
-        assert py311.environment["python_full_version"] == "3.11.4"
-        assert py312.environment["python_full_version"] == "3.12.0"
+        assert py311.marker_env["python_full_version"] == "3.11.4"
+        assert py312.marker_env["python_full_version"] == "3.12.0"
 
     def test_python_patches_unknown_minor_key_raises(self) -> None:
         """A patches key that is not a known ``major.minor`` is a user error."""
@@ -195,14 +192,14 @@ class TestMatrixExpand:
             platforms=(PlatformSpec("linux_x86_64"),),
             python_patches={"3.11": "3.11.5"},
         )
-        env = matrix.expand()[0].environment
+        env = matrix.expand()[0].marker_env
         assert Marker('python_full_version >= "3.11.4"').evaluate(env)
         assert not Marker('python_full_version >= "3.11.6"').evaluate(env)
 
     def test_platform_release_default_is_empty_string(self) -> None:
         """Without a user declaration, ``platform_release`` is ``""``."""
         matrix = Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),))
-        env = matrix.expand()[0].environment
+        env = matrix.expand()[0].marker_env
         assert env["platform_release"] == ""
         assert env["platform_version"] == ""
 
@@ -212,7 +209,7 @@ class TestMatrixExpand:
             "linux_x86_64", platform_release="5.10.0", platform_version="#1 SMP"
         )
         matrix = Matrix(python="==3.11", platforms=(spec,))
-        env = matrix.expand()[0].environment
+        env = matrix.expand()[0].marker_env
         assert env["platform_release"] == "5.10.0"
         assert env["platform_version"] == "#1 SMP"
 
@@ -220,7 +217,7 @@ class TestMatrixExpand:
         """Kernel-conditioned markers fire when the user declares a target."""
         spec = PlatformSpec("linux_x86_64", platform_release="5.10.0")
         matrix = Matrix(python="==3.11", platforms=(spec,))
-        env = matrix.expand()[0].environment
+        env = matrix.expand()[0].marker_env
         assert Marker('platform_release >= "5.10"').evaluate(env)
         assert not Marker('platform_release >= "6.0"').evaluate(env)
 
@@ -231,11 +228,9 @@ class TestMatrixExpand:
             platforms=(PlatformSpec("windows_amd64"), PlatformSpec("linux_x86_64")),
         )
         tuples = matrix.expand()
-        win_env = next(
-            t.environment for t in tuples if t.platform_id == "windows_amd64"
-        )
+        win_env = next(t.marker_env for t in tuples if t.platform_id == "windows_amd64")
         linux_env = next(
-            t.environment for t in tuples if t.platform_id == "linux_x86_64"
+            t.marker_env for t in tuples if t.platform_id == "linux_x86_64"
         )
 
         win_marker = Marker("sys_platform == 'win32'")
@@ -255,7 +250,7 @@ class TestImplementationAxis:
         matrix = Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),))
         tuples = matrix.expand()
         assert len(tuples) == 1
-        env = tuples[0].environment
+        env = tuples[0].marker_env
         assert tuples[0].implementation == "cpython"
         assert env["implementation_name"] == "cpython"
         assert env["platform_python_implementation"] == "CPython"
@@ -277,7 +272,7 @@ class TestImplementationAxis:
             platforms=(PlatformSpec("linux_x86_64"),),
             implementations=("pypy",),
         )
-        env = matrix.expand()[0].environment
+        env = matrix.expand()[0].marker_env
         assert env["implementation_name"] == "pypy"
         assert env["platform_python_implementation"] == "PyPy"
         assert Marker('platform_python_implementation == "PyPy"').evaluate(env)
@@ -294,167 +289,8 @@ class TestImplementationAxis:
             matrix.expand()
 
 
-class TestMatrixTuple:
-    """``MatrixTuple`` is a lightweight value object."""
-
-    def test_label_is_short_and_stable(self) -> None:
-        """``label`` is a short id suitable for filenames and logs."""
-        t = MatrixTuple(
-            python_version="3.11",
-            platform_spec=PlatformSpec("linux_x86_64"),
-            environment={},
-        )
-        assert t.label == "py311-linux_x86_64"
-
-    def test_pypy_label_uses_pp_prefix(self) -> None:
-        """A PyPy tuple's label uses the ``pp`` interpreter prefix."""
-        t = MatrixTuple(
-            python_version="3.11",
-            platform_spec=PlatformSpec("linux_x86_64"),
-            environment={},
-            implementation="pypy",
-        )
-        assert t.label == "pp311-linux_x86_64"
-
-    def test_selection_appends_member_suffix_to_label(self) -> None:
-        """A conflict-fork selection appends sorted ``kind-name`` members."""
-        t = MatrixTuple(
-            python_version="3.11",
-            platform_spec=PlatformSpec("linux_x86_64"),
-            environment={},
-            selection=(("group", "isort5"), ("group", "black22")),
-        )
-        assert t.label == "py311-linux_x86_64-group-black22.group-isort5"
-
-    def test_mixed_extra_and_group_selection_label_format(self) -> None:
-        """Mixed selections sort ``extra-`` before ``group-`` lexically.
-
-        Pins the exact byte-stable label shape so renaming
-        :data:`KIND_EXTRA` / :data:`KIND_GROUP` cannot silently flip the
-        sort order and rewrite every label dict key.
-        """
-        t = MatrixTuple(
-            python_version="3.11",
-            platform_spec=PlatformSpec("linux_x86_64"),
-            environment={},
-            selection=(("group", "isort5"), ("extra", "cpu")),
-        )
-        assert t.label == "py311-linux_x86_64-extra-cpu.group-isort5"
-
-    def test_label_distinguishes_selections_that_split_on_hyphen(self) -> None:
-        """Names containing ``-`` cannot collide two selections into one label.
-
-        Canonical names collapse ``[-_.]`` runs to a single ``-``, so a
-        ``-`` joiner is ambiguous: ``a-b`` plus ``c`` and ``a`` plus
-        ``b-c`` would both read as ``a-b-c``.  The ``.`` separator keeps
-        the two selections on distinct labels.
-        """
-        first = MatrixTuple(
-            python_version="3.11",
-            platform_spec=PlatformSpec("linux_x86_64"),
-            environment={},
-            selection=(("extra", "a-b"), ("extra", "c")),
-        )
-        second = MatrixTuple(
-            python_version="3.11",
-            platform_spec=PlatformSpec("linux_x86_64"),
-            environment={},
-            selection=(("extra", "a"), ("extra", "b-c")),
-        )
-        assert first.label != second.label
-
-    def test_label_distinguishes_extra_from_group_of_same_name(self) -> None:
-        """An extra and a group of the same name get distinct labels."""
-        as_extra = MatrixTuple(
-            python_version="3.11",
-            platform_spec=PlatformSpec("linux_x86_64"),
-            environment={},
-            selection=(("extra", "cpu"),),
-        )
-        as_group = MatrixTuple(
-            python_version="3.11",
-            platform_spec=PlatformSpec("linux_x86_64"),
-            environment={},
-            selection=(("group", "cpu"),),
-        )
-        assert as_extra.label != as_group.label
-
-    def test_extra_selection_adds_extras_marker_clause(self) -> None:
-        """An extra member adds a bare ``in extras`` clause to the marker."""
-        t = MatrixTuple(
-            python_version="3.11",
-            platform_spec=PlatformSpec("linux_x86_64"),
-            environment={
-                "sys_platform": "linux",
-                "platform_machine": "x86_64",
-                "implementation_name": "cpython",
-            },
-            selection=(("extra", "cpu"),),
-        )
-        assert t.marker_string.endswith('and "cpu" in extras')
-
-    def test_group_selection_adds_dependency_groups_clause(self) -> None:
-        """A group member adds a bare ``in dependency_groups`` clause."""
-        t = MatrixTuple(
-            python_version="3.11",
-            platform_spec=PlatformSpec("linux_x86_64"),
-            environment={
-                "sys_platform": "linux",
-                "platform_machine": "x86_64",
-                "implementation_name": "cpython",
-            },
-            selection=(("group", "black22"),),
-        )
-        assert t.marker_string.endswith('and "black22" in dependency_groups')
-
-    def test_selection_clauses_are_sorted(self) -> None:
-        """Selection clauses emit in sorted order for byte-stable output."""
-        t = MatrixTuple(
-            python_version="3.11",
-            platform_spec=PlatformSpec("linux_x86_64"),
-            environment={
-                "sys_platform": "linux",
-                "platform_machine": "x86_64",
-                "implementation_name": "cpython",
-            },
-            selection=(("group", "isort5"), ("extra", "cpu")),
-        )
-        # sorted by (kind, name): ("extra", "cpu") < ("group", "isort5")
-        assert t.marker_string.endswith(
-            'and "cpu" in extras and "isort5" in dependency_groups'
-        )
-
-    def test_environment_marker_string_omits_selection(self) -> None:
-        """The env-only marker drops the conflict membership clause."""
-        t = MatrixTuple(
-            python_version="3.11",
-            platform_spec=PlatformSpec("linux_x86_64"),
-            environment={
-                "sys_platform": "linux",
-                "platform_machine": "x86_64",
-                "implementation_name": "cpython",
-            },
-            selection=(("group", "black22"),),
-        )
-        assert "in dependency_groups" not in t.environment_marker_string
-        assert t.environment_marker_string.endswith('platform_machine == "x86_64"')
-        # The full per-package marker still carries the membership clause.
-        assert '"black22" in dependency_groups' in t.marker_string
-
-    def test_empty_selection_leaves_marker_and_label_unchanged(self) -> None:
-        """The default empty selection is a no-op (back-compat)."""
-        t = MatrixTuple(
-            python_version="3.11",
-            platform_spec=PlatformSpec("linux_x86_64"),
-            environment={
-                "sys_platform": "linux",
-                "platform_machine": "x86_64",
-                "implementation_name": "cpython",
-            },
-        )
-        assert t.label == "py311-linux_x86_64"
-        assert "in extras" not in t.marker_string
-        assert "in dependency_groups" not in t.marker_string
+class TestTargetLabels:
+    """Expansion gives each target a distinct label."""
 
     def test_duplicate_platform_id_specs_get_distinct_labels(self) -> None:
         """Two specs sharing a platform_id but differing in a knob stay distinct.
@@ -477,33 +313,6 @@ class TestMatrixTuple:
             "py311-linux_x86_64-musl",
         ]
 
-    def test_cpython_marker_omits_implementation(self) -> None:
-        """The default CPython marker keeps its three-clause form."""
-        t = MatrixTuple(
-            python_version="3.11",
-            platform_spec=PlatformSpec("linux_x86_64"),
-            environment={
-                "sys_platform": "linux",
-                "platform_machine": "x86_64",
-                "implementation_name": "cpython",
-            },
-        )
-        assert "implementation_name" not in t.marker_string
-
-    def test_pypy_marker_constrains_implementation(self) -> None:
-        """A PyPy marker adds an ``implementation_name`` clause."""
-        t = MatrixTuple(
-            python_version="3.11",
-            platform_spec=PlatformSpec("linux_x86_64"),
-            environment={
-                "sys_platform": "linux",
-                "platform_machine": "x86_64",
-                "implementation_name": "pypy",
-            },
-            implementation="pypy",
-        )
-        assert t.marker_string.endswith('and implementation_name == "pypy"')
-
     def test_multi_implementation_cpython_marker_excludes_pypy(self) -> None:
         """In a multi-implementation matrix the CPython tuple constrains
         ``implementation_name`` so it no longer matches a PyPy environment."""
@@ -516,8 +325,8 @@ class TestMatrixTuple:
         cpython = next(t for t in tuples if t.implementation == "cpython")
         pypy = next(t for t in tuples if t.implementation == "pypy")
         assert cpython.marker_string.endswith('and implementation_name == "cpython"')
-        assert not Marker(cpython.marker_string).evaluate(pypy.environment)
-        assert not Marker(pypy.marker_string).evaluate(cpython.environment)
+        assert not Marker(cpython.marker_string).evaluate(pypy.marker_env)
+        assert not Marker(pypy.marker_string).evaluate(cpython.marker_env)
 
 
 class TestKnownConstants:
@@ -529,21 +338,3 @@ class TestKnownConstants:
             tuple(int(part) for part in m.split(".")) for m in _KNOWN_PYTHON_MINORS
         ]
         assert as_versions == sorted(as_versions)
-
-    def test_each_implementation_default_has_interpreter_markers(self) -> None:
-        """Every implementation default sets the two interpreter markers."""
-        required = {"platform_python_implementation", "implementation_name"}
-        for impl, env in _IMPLEMENTATION_DEFAULTS.items():
-            assert required == env.keys(), impl
-
-    def test_each_platform_default_has_required_keys(self) -> None:
-        """Every platform default must define the OS/arch markers."""
-        required = {
-            "sys_platform",
-            "platform_system",
-            "platform_machine",
-            "os_name",
-        }
-        for platform_id, env in _PLATFORM_DEFAULTS.items():
-            missing = required - env.keys()
-            assert not missing, f"{platform_id} missing {missing}"

--- a/nab-python/tests/universal/test_reresolve.py
+++ b/nab-python/tests/universal/test_reresolve.py
@@ -16,8 +16,8 @@ from nab_python._testing.overrides import pkg_override
 from nab_python._vendor.packaging.version import Version
 from nab_python.provider import BuildPolicy, DistPolicy
 from nab_python.tags import PlatformSpec
+from nab_python.target import ResolveTarget
 from nab_python.universal import reresolve as reresolve_module
-from nab_python.universal.matrix import MatrixTuple
 from nab_python.universal.reresolve import (
     _diff_pins,
     _resolve_one_tuple_with_overrides,
@@ -52,23 +52,11 @@ def _make_coordinator(
     )
 
 
-def _linux_311(full_version: str = "3.11.0") -> MatrixTuple:
-    return MatrixTuple(
+def _linux_311(full_version: str = "3.11.0") -> ResolveTarget:
+    return ResolveTarget.for_declared(
         python_version="3.11",
-        environment={
-            "python_version": "3.11",
-            "python_full_version": full_version,
-            "implementation_name": "cpython",
-            "implementation_version": full_version,
-            "os_name": "posix",
-            "platform_machine": "x86_64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "",
-            "platform_system": "Linux",
-            "platform_version": "",
-            "sys_platform": "linux",
-        },
-        platform_spec=PlatformSpec("linux_x86_64"),
+        spec=PlatformSpec("linux_x86_64"),
+        python_full_version=full_version,
     )
 
 
@@ -474,7 +462,7 @@ class TestResolveOneTupleWithOverrides:
                 resolution_strategy="highest",
             )
         matrix = inner.call_args.args[1]
-        env = matrix.expand()[0].environment
+        env = matrix.expand()[0].marker_env
         assert env["python_full_version"] == "3.11.9"
         assert env["implementation_version"] == "3.11.9"
 

--- a/nab-python/tests/universal/test_resolve.py
+++ b/nab-python/tests/universal/test_resolve.py
@@ -57,8 +57,9 @@ from nab_python.requirements_file import (
     read_pyproject_optional_dependencies,
 )
 from nab_python.tags import PlatformSpec
+from nab_python.target import ResolveTarget
 from nab_python.universal import resolve as resolve_mod
-from nab_python.universal.matrix import Matrix, MatrixTuple
+from nab_python.universal.matrix import Matrix
 from nab_python.universal.resolve import (
     ResolveFork,
     TupleResult,
@@ -100,43 +101,15 @@ def _make_coordinator(listings: dict[str, list[WheelFile]]) -> MagicMock:
     return make_coordinator(listings=listings, auto_metadata=True)
 
 
-def _linux_311() -> MatrixTuple:
-    return MatrixTuple(
-        python_version="3.11",
-        platform_spec=PlatformSpec("linux_x86_64"),
-        environment={
-            "python_version": "3.11",
-            "python_full_version": "3.11.0",
-            "implementation_name": "cpython",
-            "implementation_version": "3.11.0",
-            "os_name": "posix",
-            "platform_machine": "x86_64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "",
-            "platform_system": "Linux",
-            "platform_version": "",
-            "sys_platform": "linux",
-        },
+def _linux_311() -> ResolveTarget:
+    return ResolveTarget.for_declared(
+        python_version="3.11", spec=PlatformSpec("linux_x86_64")
     )
 
 
-def _windows_311() -> MatrixTuple:
-    return MatrixTuple(
-        python_version="3.11",
-        platform_spec=PlatformSpec("windows_amd64"),
-        environment={
-            "python_version": "3.11",
-            "python_full_version": "3.11.0",
-            "implementation_name": "cpython",
-            "implementation_version": "3.11.0",
-            "os_name": "nt",
-            "platform_machine": "AMD64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "",
-            "platform_system": "Windows",
-            "platform_version": "",
-            "sys_platform": "win32",
-        },
+def _windows_311() -> ResolveTarget:
+    return ResolveTarget.for_declared(
+        python_version="3.11", spec=PlatformSpec("windows_amd64")
     )
 
 
@@ -481,7 +454,7 @@ class TestConflictForkBaseNames:
         )
         pylock = build_pylock(lock_input)
         by_name = {str(p.name): p for p in pylock.packages}
-        env = dict(result.tuple_results[0].tuple_.environment)
+        env = dict(result.tuple_results[0].tuple_.marker_env)
         neither = {**env, "extras": frozenset()}
         cpu = {**env, "extras": frozenset({"cpu"})}
 
@@ -550,7 +523,7 @@ class TestConflictForkBaseNames:
         ):
             assert clause in marker_text
 
-        env = dict(result.tuple_results[0].tuple_.environment)
+        env = dict(result.tuple_results[0].tuple_.marker_env)
         none = {**env, "extras": frozenset(), "dependency_groups": frozenset()}
         assert crossdep.marker is not None
         assert not crossdep.marker.evaluate(none)
@@ -662,25 +635,25 @@ class TestParseRequirements:
 
     def test_marker_true_keeps_requirement(self) -> None:
         """A requirement whose marker matches the env is kept."""
-        env = _linux_311().environment
+        env = _linux_311().marker_env
         out = _parse_requirements(['pkg; sys_platform == "linux"'], env)
         assert "pkg" in out
 
     def test_marker_false_drops_requirement(self) -> None:
         """A requirement whose marker excludes the env is dropped."""
-        env = _linux_311().environment
+        env = _linux_311().marker_env
         out = _parse_requirements(['pkg; sys_platform == "win32"'], env)
         assert out == {}
 
     def test_set_marker_drops_without_crash(self) -> None:
         """A lockfile-only set marker is empty at resolve time, so the dep drops."""
-        env = _linux_311().environment
+        env = _linux_311().marker_env
         out = _parse_requirements(['pkg ; "x" in extras'], env)
         assert out == {}
 
     def test_extras_get_separate_entries(self) -> None:
         """Extras become ``name[extra]`` entries with any-version range."""
-        env = _linux_311().environment
+        env = _linux_311().marker_env
         out = _parse_requirements(["pkg[foo,bar]"], env)
         assert "pkg" in out
         assert "pkg[foo]" in out
@@ -695,7 +668,7 @@ class TestParseRequirements:
         the insertion order of the proxy keys becomes the resolver's root
         package order. A reversed extras order must still give the sorted keys.
         """
-        env = _linux_311().environment
+        env = _linux_311().marker_env
         real_requirement = resolve_mod.Requirement
 
         def reversed_extras(req_str: str) -> object:
@@ -710,13 +683,13 @@ class TestParseRequirements:
 
     def test_no_specifier_yields_any(self) -> None:
         """An unconstrained requirement gets the any() range."""
-        env = _linux_311().environment
+        env = _linux_311().marker_env
         out = _parse_requirements(["pkg"], env)
         assert out["pkg"] == VersionRange.full(admit_arbitrary=False)
 
     def test_specifier_yields_intervals(self) -> None:
         """A bounded specifier produces the corresponding interval."""
-        env = _linux_311().environment
+        env = _linux_311().marker_env
         out = _parse_requirements(["pkg>=1.0,<2.0"], env)
         # The specifier should be stricter than unbounded; we check
         # by confirming a known-out-of-range version is excluded.
@@ -730,7 +703,7 @@ class TestParseRequirements:
         requirement on its own without any special-casing here.
         Declared extras still flow through.
         """
-        env = _linux_311().environment
+        env = _linux_311().marker_env
         out = _parse_requirements(["pkg[ext]===1.0.special"], env)
         assert "pkg" in out
         assert "1.0.special" in out["pkg"]
@@ -739,7 +712,7 @@ class TestParseRequirements:
 
     def test_duplicate_name_intersects(self) -> None:
         """Two requirements for one package combine to their overlap."""
-        env = _linux_311().environment
+        env = _linux_311().marker_env
         out = _parse_requirements(["pkg>=2.0", "pkg<3.0"], env)
         assert Version("2.5") in out["pkg"]
         assert Version("1.0") not in out["pkg"]
@@ -747,13 +720,13 @@ class TestParseRequirements:
 
     def test_conflicting_names_raise(self) -> None:
         """Contradictory pins for one package raise ResolutionError."""
-        env = _linux_311().environment
+        env = _linux_311().marker_env
         with pytest.raises(ResolutionError, match="pkg==1.0"):
             _parse_requirements(["pkg==1.0", "pkg==2.0"], env)
 
     def test_constraint_extras_rejected(self) -> None:
         """A constraint carrying extras is rejected, matching pip."""
-        env = _linux_311().environment
+        env = _linux_311().marker_env
         with pytest.raises(ConfigError, match="extras"):
             _parse_requirements(["pkg[dev]<2.0"], env, kind="constraint")
 
@@ -765,7 +738,7 @@ class TestParseRequirements:
         single-env path once enforced such constraints unconditionally
         (issue #38).
         """
-        env = _linux_311().environment
+        env = _linux_311().marker_env
         out = _parse_requirements(
             ['pkg<2.0 ; sys_platform == "win32"'], env, kind="constraint"
         )
@@ -773,7 +746,7 @@ class TestParseRequirements:
 
     def test_marker_true_keeps_constraint(self) -> None:
         """A constraint whose marker matches the env binds its range."""
-        env = _linux_311().environment
+        env = _linux_311().marker_env
         out = _parse_requirements(
             ['pkg<2.0 ; sys_platform == "linux"'], env, kind="constraint"
         )
@@ -782,19 +755,19 @@ class TestParseRequirements:
 
     def test_extra_proxy_key_normalized(self) -> None:
         """The proxy key is PEP 685 normalized, matching the single-env path."""
-        env = _linux_311().environment
+        env = _linux_311().marker_env
         out = _parse_requirements(["pkg[My_Extra]"], env)
         assert "pkg[my-extra]" in out
 
     def test_plain_url_requirement_refused(self) -> None:
         """A plain archive URL is refused as an unsupported scheme."""
-        env = _linux_311().environment
+        env = _linux_311().marker_env
         with pytest.raises(UnsupportedVcsError, match="not a recognized VCS scheme"):
             _parse_requirements(["pkg @ https://example.com/pkg.whl"], env)
 
     def test_vcs_url_refused_by_default_policy(self) -> None:
         """A git+https requirement is refused under the default BLOCK policy."""
-        env = _linux_311().environment
+        env = _linux_311().marker_env
         with pytest.raises(UnsupportedVcsError, match='vcs.policy is "block"'):
             _parse_requirements(
                 [f"pkg @ git+https://example.com/pkg.git@{_FORTY_SHA}"], env
@@ -802,7 +775,7 @@ class TestParseRequirements:
 
     def test_url_constraint_refused(self) -> None:
         """A direct-URL constraint is refused the same way as a requirement."""
-        env = _linux_311().environment
+        env = _linux_311().marker_env
         with pytest.raises(UnsupportedVcsError, match='vcs.policy is "block"'):
             _parse_requirements(
                 [f"pkg @ git+https://example.com/pkg.git@{_FORTY_SHA}"],
@@ -812,7 +785,7 @@ class TestParseRequirements:
 
     def test_admitted_vcs_url_raises_not_implemented(self) -> None:
         """An admitted VCS requirement still has no universal resolve path."""
-        env = _linux_311().environment
+        env = _linux_311().marker_env
         vcs_config = VcsConfig(
             policy=VcsPolicy.ALLOW,
             allowed_schemes=frozenset({"git+https"}),
@@ -847,9 +820,9 @@ class TestUniversalSelfRefMarker:
             )
         )
         strings = [str(r) for r in reqs]
-        assert "some-dep" not in _parse_requirements(strings, _linux_311().environment)
+        assert "some-dep" not in _parse_requirements(strings, _linux_311().marker_env)
         included = {
-            **_linux_311().environment,
+            **_linux_311().marker_env,
             "python_version": "3.9",
             "python_full_version": "3.9.0",
         }
@@ -860,7 +833,7 @@ class TestRootExtras:
     """``_root_extras`` recovers requested extras from the proxy keys."""
 
     def test_recovers_and_normalizes_extras(self) -> None:
-        env = _linux_311().environment
+        env = _linux_311().marker_env
         out = _parse_requirements(["pkg[My_Extra]", "other"], env)
         assert _root_extras(out) == {("pkg", "my-extra")}
 

--- a/nab-python/tests/universal/test_universal_provider.py
+++ b/nab-python/tests/universal/test_universal_provider.py
@@ -30,6 +30,7 @@ from nab_python.provider import (
     VcsSource,
 )
 from nab_python.tags import PlatformSpec
+from nab_python.target import ResolveTarget
 from nab_python.universal.provider import UniversalProvider
 from nab_resolver.resolver import Resolver
 
@@ -69,30 +70,18 @@ def _make_coordinator(
     return make_coordinator(wheels, package=package, auto_metadata=True)
 
 
-_LINUX_ENV: dict[str, str] = {
-    "python_version": "3.11",
-    "python_full_version": "3.11.0",
-    "implementation_name": "cpython",
-    "implementation_version": "3.11.0",
-    "os_name": "posix",
-    "platform_machine": "x86_64",
-    "platform_python_implementation": "CPython",
-    "platform_release": "",
-    "platform_system": "Linux",
-    "platform_version": "",
-    "sys_platform": "linux",
-}
+_LINUX_TARGET = ResolveTarget.for_declared(
+    python_version="3.11", spec=PlatformSpec("linux_x86_64")
+)
+
+
+def _linux_target(spec: PlatformSpec) -> ResolveTarget:
+    """A 3.11 linux target with declared tag knobs."""
+    return ResolveTarget.for_declared(python_version="3.11", spec=spec)
 
 
 class TestPerTupleRequiresPythonOverride:
     """A requires-python override participates in per-tuple python filtering."""
-
-    @staticmethod
-    def _env(py: str) -> dict[str, str]:
-        env = dict(_LINUX_ENV)
-        env["python_version"] = py
-        env["python_full_version"] = f"{py}.0"
-        return env
 
     def _provider(self, py: str) -> UniversalProvider:
         coordinator = make_coordinator(
@@ -102,7 +91,9 @@ class TestPerTupleRequiresPythonOverride:
         )
         return UniversalProvider(
             coordinator,
-            marker_environment=self._env(py),
+            ResolveTarget.for_declared(
+                python_version=py, spec=PlatformSpec("linux_x86_64")
+            ),
             package_overrides=(pkg_override("pkg", requires_python=">=3.11"),),
         )
 
@@ -127,7 +118,7 @@ class TestProvidesExtraDependenciesOverride:
         )
         return UniversalProvider(
             coordinator,
-            marker_environment=_LINUX_ENV,
+            _LINUX_TARGET,
             package_overrides=(
                 pkg_override(
                     "pkg",
@@ -155,11 +146,13 @@ class TestEnvironmentOverlay:
     """The provider overlays user-supplied marker keys on the host env."""
 
     def test_user_keys_override_host_defaults(self) -> None:
-        """``marker_environment`` keys take precedence over ``default_environment()``."""
+        """The target's marker overrides take precedence over the host env."""
         coordinator = _make_coordinator([])
         provider = UniversalProvider(
             coordinator,
-            marker_environment={"sys_platform": "win32", "python_version": "3.12"},
+            ResolveTarget.for_host().with_marker_overrides(
+                {"sys_platform": "win32", "python_version": "3.12"}
+            ),
         )
         assert provider.environment["sys_platform"] == "win32"
         assert provider.environment["python_version"] == "3.12"
@@ -169,7 +162,7 @@ class TestEnvironmentOverlay:
         coordinator = _make_coordinator([])
         provider = UniversalProvider(
             coordinator,
-            marker_environment={"python_version": "3.11"},
+            ResolveTarget.for_host().with_marker_overrides({"python_version": "3.11"}),
         )
         # implementation_name is not in our supplied dict; the host
         # default fills it in (cpython on standard CPython runs).
@@ -180,7 +173,7 @@ class TestEnvironmentOverlay:
         coordinator = _make_coordinator([])
         provider = UniversalProvider(
             coordinator,
-            marker_environment={"sys_platform": "win32"},
+            ResolveTarget.for_host().with_marker_overrides({"sys_platform": "win32"}),
         )
         assert provider.env_with_extra["sys_platform"] == "win32"
 
@@ -190,14 +183,14 @@ class TestTrustUnverifiedSdistDeps:
 
     def test_defaults_false_without_build_config(self) -> None:
         coordinator = _make_coordinator([])
-        provider = UniversalProvider(coordinator, marker_environment=_LINUX_ENV)
+        provider = UniversalProvider(coordinator, _LINUX_TARGET)
         assert provider.trust_unverified_sdist_deps is False
 
     def test_taken_from_build_config(self) -> None:
         coordinator = _make_coordinator([])
         provider = UniversalProvider(
             coordinator,
-            marker_environment=_LINUX_ENV,
+            _LINUX_TARGET,
             build_config=NabProjectConfig(trust_unverified_sdist_deps=True),
         )
         assert provider.trust_unverified_sdist_deps is True
@@ -212,7 +205,7 @@ class TestStrategyValidation:
         with pytest.raises(ValueError, match="resolution_strategy"):
             UniversalProvider(
                 coordinator,
-                marker_environment=_LINUX_ENV,
+                _LINUX_TARGET,
                 resolution_strategy="middle",
             )
 
@@ -225,7 +218,7 @@ class TestPreferences:
         coordinator = _make_coordinator([])
         provider = UniversalProvider(
             coordinator,
-            marker_environment=_LINUX_ENV,
+            _LINUX_TARGET,
             preferences={"My-Cool_Pkg": Version("1.0")},
         )
         assert "my-cool-pkg" in provider._preferences
@@ -236,7 +229,7 @@ class TestPreferences:
         coordinator = _make_coordinator(wheels)
         provider = UniversalProvider(
             coordinator,
-            marker_environment=_LINUX_ENV,
+            _LINUX_TARGET,
             preferences={"pkg": Version("2.0")},
         )
         chosen = provider.choose_version("pkg", VersionRange.full())
@@ -248,7 +241,7 @@ class TestPreferences:
         coordinator = _make_coordinator(wheels)
         provider = UniversalProvider(
             coordinator,
-            marker_environment=_LINUX_ENV,
+            _LINUX_TARGET,
             preferences={"pkg": Version("5.0")},
         )
         result = provider.choose_version("pkg", VersionRange.full())
@@ -279,7 +272,7 @@ class TestExtrasProxyPreference:
         )
         return UniversalProvider(
             coordinator,
-            marker_environment=_LINUX_ENV,
+            _LINUX_TARGET,
             root_extras={("foo", "bar")},
             preferences={"foo": Version(preferred)},
         )
@@ -344,7 +337,7 @@ class TestExtrasProxyPreferenceAdmission:
         )
         return UniversalProvider(
             coordinator,
-            marker_environment=_LINUX_ENV,
+            _LINUX_TARGET,
             root_extras={("foo", "bar")},
             preferences={"foo": Version(preferred)},
         )
@@ -396,7 +389,7 @@ class TestCrossTupleProxyAlignment:
         root_reqs = {"a": VersionRange.full(admit_arbitrary=False)}
         provider = UniversalProvider(
             coordinator,
-            marker_environment=_LINUX_ENV,
+            _LINUX_TARGET,
             root_requirements=root_reqs,
             preferences=preferences,
         )
@@ -420,7 +413,7 @@ class TestStrategyChoiceVersion:
         coordinator = _make_coordinator(wheels)
         provider = UniversalProvider(
             coordinator,
-            marker_environment=_LINUX_ENV,
+            _LINUX_TARGET,
             resolution_strategy="lowest",
         )
         chosen = provider.choose_version("pkg", VersionRange.full())
@@ -431,7 +424,7 @@ class TestStrategyChoiceVersion:
         coordinator = _make_coordinator([])
         provider = UniversalProvider(
             coordinator,
-            marker_environment=_LINUX_ENV,
+            _LINUX_TARGET,
             resolution_strategy="lowest",
         )
         assert provider.choose_version("pkg", VersionRange.full()) is None
@@ -442,7 +435,7 @@ class TestStrategyChoiceVersion:
         coordinator = _make_coordinator(wheels)
         provider = UniversalProvider(
             coordinator,
-            marker_environment=_LINUX_ENV,
+            _LINUX_TARGET,
             resolution_strategy="lowest-direct",
             direct_packages=frozenset({"pkg"}),
         )
@@ -455,7 +448,7 @@ class TestStrategyChoiceVersion:
         coordinator = _make_coordinator(wheels)
         provider = UniversalProvider(
             coordinator,
-            marker_environment=_LINUX_ENV,
+            _LINUX_TARGET,
             resolution_strategy="lowest-direct",
             direct_packages=frozenset(),
         )
@@ -503,12 +496,12 @@ def _index_with_files(
 class TestWheelTagFiltering:
     """Resolve-time wheel-tag filtering (hole 2 plug)."""
 
-    def test_no_platform_spec_keeps_legacy_behavior(self) -> None:
-        """Without ``platform_spec`` the override is a no-op."""
+    def test_no_tag_filter_keeps_every_wheel(self) -> None:
+        """Without ``filter_by_wheel_tags`` the override is a no-op."""
         wheels = [_platform_wheel("1.0", "cp311-cp311-win_amd64")]
         provider = UniversalProvider(
             _index_with_files(wheels),
-            marker_environment=_LINUX_ENV,
+            _LINUX_TARGET,
         )
         result = provider.filter_distributions("pkg", wheels)
         assert [v for v, _ in result] == [Version("1.0")]
@@ -521,8 +514,8 @@ class TestWheelTagFiltering:
         ]
         provider = UniversalProvider(
             _index_with_files(wheels),
-            marker_environment=_LINUX_ENV,
-            platform_spec=PlatformSpec("linux_x86_64"),
+            _linux_target(PlatformSpec("linux_x86_64")),
+            filter_by_wheel_tags=True,
         )
         result = provider.filter_distributions("pkg", wheels)
         kept_filenames = {dist.filename for _, dist in result}
@@ -537,8 +530,8 @@ class TestWheelTagFiltering:
         ]
         provider = UniversalProvider(
             _index_with_files(wheels),
-            marker_environment=_LINUX_ENV,
-            platform_spec=PlatformSpec("linux_x86_64"),
+            _linux_target(PlatformSpec("linux_x86_64")),
+            filter_by_wheel_tags=True,
             build_policy=BuildPolicy.NEVER,
         )
         result = provider.filter_distributions("pkg", wheels)
@@ -554,8 +547,8 @@ class TestWheelTagFiltering:
         ]
         provider = UniversalProvider(
             _index_with_files(files),
-            marker_environment=_LINUX_ENV,
-            platform_spec=PlatformSpec("linux_x86_64"),
+            _linux_target(PlatformSpec("linux_x86_64")),
+            filter_by_wheel_tags=True,
             build_policy=BuildPolicy.BUILD_REMOTE,
         )
         result = provider.filter_distributions("pkg", files)
@@ -570,8 +563,8 @@ class TestWheelTagFiltering:
         wheels = [_platform_wheel("1.0", "py3-none-any")]
         provider = UniversalProvider(
             _index_with_files(wheels),
-            marker_environment=_LINUX_ENV,
-            platform_spec=PlatformSpec("linux_x86_64"),
+            _linux_target(PlatformSpec("linux_x86_64")),
+            filter_by_wheel_tags=True,
         )
         result = provider.filter_distributions("pkg", wheels)
         assert [v for v, _ in result] == [Version("1.0")]
@@ -584,8 +577,8 @@ class TestWheelTagFiltering:
         ]
         provider = UniversalProvider(
             _index_with_files(wheels),
-            marker_environment=_LINUX_ENV,
-            platform_spec=PlatformSpec("linux_x86_64", libc_version=(2, 17)),
+            _linux_target(PlatformSpec("linux_x86_64", libc_version=(2, 17))),
+            filter_by_wheel_tags=True,
             build_policy=BuildPolicy.NEVER,
         )
         result = provider.filter_distributions("pkg", wheels)
@@ -599,8 +592,8 @@ class TestWheelTagFiltering:
         ]
         provider = UniversalProvider(
             _index_with_files(wheels),
-            marker_environment=_LINUX_ENV,
-            platform_spec=PlatformSpec("linux_x86_64", libc_version=(2, 34)),
+            _linux_target(PlatformSpec("linux_x86_64", libc_version=(2, 34))),
+            filter_by_wheel_tags=True,
         )
         result = provider.filter_distributions("pkg", wheels)
         assert [v for v, _ in result] == [Version("1.0")]
@@ -614,8 +607,8 @@ class TestWheelTagFiltering:
         ]
         provider = UniversalProvider(
             _index_with_files(files),
-            marker_environment=_LINUX_ENV,
-            platform_spec=PlatformSpec("linux_x86_64"),
+            _linux_target(PlatformSpec("linux_x86_64")),
+            filter_by_wheel_tags=True,
             dist_policy=DistPolicy.WHEEL_ONLY,
             build_policy=BuildPolicy.BUILD_REMOTE,
         )
@@ -637,8 +630,8 @@ class TestWheelTagFiltering:
         ]
         provider = UniversalProvider(
             _index_with_files(files),
-            marker_environment=_LINUX_ENV,
-            platform_spec=PlatformSpec("linux_x86_64"),
+            _linux_target(PlatformSpec("linux_x86_64")),
+            filter_by_wheel_tags=True,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.NEVER,
         )
@@ -663,8 +656,8 @@ class TestWheelTagFiltering:
         ]
         provider = UniversalProvider(
             _index_with_files(files),
-            marker_environment=_LINUX_ENV,
-            platform_spec=PlatformSpec("linux_x86_64"),
+            _linux_target(PlatformSpec("linux_x86_64")),
+            filter_by_wheel_tags=True,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         result = provider.fetch_versions("pkg")
@@ -677,20 +670,24 @@ class TestRequiresPythonPatch:
 
     def test_dist_kept_when_patch_satisfies_requires_python(self) -> None:
         """python_full_version 3.13.4 keeps a dist that requires >=3.13.1."""
-        env = {**_LINUX_ENV, "python_version": "3.13", "python_full_version": "3.13.4"}
         provider = UniversalProvider(
             _make_coordinator([_make_wheel("1.0", requires_python=">=3.13.1")]),
-            marker_environment=env,
+            ResolveTarget.for_declared(
+                python_version="3.13",
+                spec=PlatformSpec("linux_x86_64"),
+                python_full_version="3.13.4",
+            ),
         )
         result = provider.fetch_versions("pkg")
         assert [v for v, _ in result] == [Version("1.0")]
 
     def test_dist_excluded_when_patch_below_requires_python(self) -> None:
         """A tuple targeting 3.13.0 excludes a >=3.13.1 dist."""
-        env = {**_LINUX_ENV, "python_version": "3.13", "python_full_version": "3.13.0"}
         provider = UniversalProvider(
             _make_coordinator([_make_wheel("1.0", requires_python=">=3.13.1")]),
-            marker_environment=env,
+            ResolveTarget.for_declared(
+                python_version="3.13", spec=PlatformSpec("linux_x86_64")
+            ),
         )
         assert provider.fetch_versions("pkg") == []
 
@@ -716,7 +713,7 @@ class TestVcsConfigPlumbing:
         with pytest.raises(ValueError, match="vcs_sources require VcsPolicy.ALLOW"):
             UniversalProvider(
                 coordinator,
-                marker_environment=_LINUX_ENV,
+                _LINUX_TARGET,
                 vcs_config=VcsConfig(policy=VcsPolicy.BLOCK),
                 vcs_sources=[source],
                 build_policy=BuildPolicy.NEVER,
@@ -736,7 +733,7 @@ class TestVcsConfigPlumbing:
         )
         provider = UniversalProvider(
             coordinator,
-            marker_environment=_LINUX_ENV,
+            _LINUX_TARGET,
             vcs_config=VcsConfig(
                 policy=VcsPolicy.ALLOW,
                 allowed_schemes=frozenset({"git+https"}),
@@ -760,7 +757,7 @@ class TestVcsConfigPlumbing:
         cache = tmp_path / "vcs"
         provider = UniversalProvider(
             coordinator,
-            marker_environment=_LINUX_ENV,
+            _LINUX_TARGET,
             vcs_cache_dir=cache,
             build_policy=BuildPolicy.NEVER,
         )
@@ -771,7 +768,7 @@ class TestVcsConfigPlumbing:
         coordinator = _make_coordinator([])
         provider = UniversalProvider(
             coordinator,
-            marker_environment=_LINUX_ENV,
+            _LINUX_TARGET,
             build_policy=BuildPolicy.NEVER,
         )
         assert provider.vcs_cache_dir is None

--- a/nab-python/tests/universal/test_validate.py
+++ b/nab-python/tests/universal/test_validate.py
@@ -23,7 +23,7 @@ from nab_python._testing.overrides import pkg_override
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.version import Version
 from nab_python.tags import PlatformSpec
-from nab_python.universal.matrix import MatrixTuple
+from nab_python.target import ResolveTarget
 from nab_python.universal.resolve import TupleResult, UniversalResult
 from nab_python.universal.validate import (
     PinValidation,
@@ -101,43 +101,15 @@ def _wheel(filename: str) -> WheelFile:
     )
 
 
-def _linux_311() -> MatrixTuple:
-    return MatrixTuple(
-        python_version="3.11",
-        environment={
-            "python_version": "3.11",
-            "python_full_version": "3.11.0",
-            "implementation_name": "cpython",
-            "implementation_version": "3.11.0",
-            "os_name": "posix",
-            "platform_machine": "x86_64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "",
-            "platform_system": "Linux",
-            "platform_version": "",
-            "sys_platform": "linux",
-        },
-        platform_spec=PlatformSpec("linux_x86_64"),
+def _linux_311() -> ResolveTarget:
+    return ResolveTarget.for_declared(
+        python_version="3.11", spec=PlatformSpec("linux_x86_64")
     )
 
 
-def _windows_311() -> MatrixTuple:
-    return MatrixTuple(
-        python_version="3.11",
-        environment={
-            "python_version": "3.11",
-            "python_full_version": "3.11.0",
-            "implementation_name": "cpython",
-            "implementation_version": "3.11.0",
-            "os_name": "nt",
-            "platform_machine": "AMD64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "",
-            "platform_system": "Windows",
-            "platform_version": "",
-            "sys_platform": "win32",
-        },
-        platform_spec=PlatformSpec("windows_amd64"),
+def _windows_311() -> ResolveTarget:
+    return ResolveTarget.for_declared(
+        python_version="3.11", spec=PlatformSpec("windows_amd64")
     )
 
 
@@ -1024,7 +996,7 @@ class TestPerExtraDivergence:
 
     def test_evaluate_metadata_deps_by_extra_groups_correctly(self) -> None:
         """``_evaluate_metadata_deps_by_extra`` returns base + per-extra buckets."""
-        env = _linux_311().environment
+        env = _linux_311().marker_env
         out = _evaluate_metadata_deps_by_extra(_BASE_EXTRA_METADATA, env)
         assert out[None] == {"requests>=2"}
         assert out["redis"] == {"redis>=5"}
@@ -1046,7 +1018,7 @@ class TestPerExtraDivergence:
             'Requires-Dist: somedep; "docs" in extras\n'
             'Requires-Dist: devdep; "dev" in dependency_groups\n'
         )
-        env = _linux_311().environment
+        env = _linux_311().marker_env
         out = _evaluate_metadata_deps_by_extra(meta, env)
         assert out[None] == {"realdep>=1"}
         assert out["docs"] == set()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,17 +63,24 @@ from nab_python.provider import (
 from nab_python.requirements_file import InvalidProjectRequirementError
 from nab_python.resolve import ResolutionResult
 from nab_python.tags import PlatformSpec
-from nab_python.universal.matrix import Matrix, MatrixTuple
+from nab_python.target import ResolveTarget
+from nab_python.universal.matrix import Matrix
 from nab_python.universal.resolve import TupleResult, UniversalResult
 from nab_resolver.resolver import ResolutionError
 
 V = Version
 
-_LINUX_311_ENV = {
-    "python_version": "3.11",
-    "sys_platform": "linux",
-    "platform_machine": "x86_64",
-}
+
+def _target(
+    py_minor: str = "3.11",
+    platform_id: str = "linux_x86_64",
+    selection: tuple[tuple[str, str], ...] = (),
+) -> ResolveTarget:
+    """A declared CPython target for the universal-result fixtures."""
+    target = ResolveTarget.for_declared(
+        python_version=py_minor, spec=PlatformSpec(platform_id)
+    )
+    return target.with_selection(selection)
 
 
 def _foo_index_pin(version: str = "1.0", name: str = "foo") -> IndexPin:
@@ -149,11 +156,7 @@ def _workspace_pyproject(tmp_path: Path, *, universal: bool = False) -> Path:
 def _universal_result(*, success: bool, error: str | None = None) -> UniversalResult:
     """Build a real :class:`UniversalResult` with one matrix tuple."""
     matrix = Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),))
-    tup = MatrixTuple(
-        python_version="3.11",
-        environment=dict(_LINUX_311_ENV),
-        platform_spec=PlatformSpec("linux_x86_64"),
-    )
+    tup = _target()
     lock_input = LockInput(pins={"foo": _foo_index_pin()}) if success else None
     tr = TupleResult(
         tuple_=tup,
@@ -171,12 +174,7 @@ def _multi_tuple_universal_result() -> UniversalResult:
     tuples = []
     results = []
     for py_minor in ("3.11", "3.12"):
-        env = {**_LINUX_311_ENV, "python_version": py_minor}
-        tup = MatrixTuple(
-            python_version=py_minor,
-            environment=env,
-            platform_spec=PlatformSpec("linux_x86_64"),
-        )
+        tup = _target(py_minor)
         tuples.append(tup)
         results.append(
             TupleResult(
@@ -1035,12 +1033,7 @@ class TestLockCommandUniversal:
         matrix = Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),))
         results: list[TupleResult] = []
         for member, version in (("cpu", "1.0"), ("gpu", "2.0")):
-            tup = MatrixTuple(
-                python_version="3.11",
-                environment=dict(_LINUX_311_ENV),
-                platform_spec=PlatformSpec("linux_x86_64"),
-                selection=(("extra", member),),
-            )
+            tup = _target(selection=(("extra", member),))
             results.append(
                 TupleResult(
                     tuple_=tup,
@@ -1286,16 +1279,8 @@ class TestLockCommandUniversal:
         each successful tuple's ``# label`` + pins block.
         """
         pyproject = _universal_pyproject(tmp_path)
-        ok_tuple = MatrixTuple(
-            python_version="3.11",
-            environment=dict(_LINUX_311_ENV),
-            platform_spec=PlatformSpec("linux_x86_64"),
-        )
-        bad_tuple = MatrixTuple(
-            python_version="3.11",
-            environment=dict(_LINUX_311_ENV),
-            platform_spec=PlatformSpec("windows_amd64"),
-        )
+        ok_tuple = _target()
+        bad_tuple = _target(platform_id="windows_amd64")
         ok_tr = TupleResult(
             tuple_=ok_tuple,
             success=True,
@@ -1334,16 +1319,8 @@ class TestLockCommandUniversal:
         # failed one renders a ``base/<label>: FAILED`` block.  One
         # tuple has to fail so ``_print_universal_blocks`` runs at all.
         pyproject = _universal_pyproject(tmp_path)
-        env_a = MatrixTuple(
-            python_version="3.11",
-            environment=dict(_LINUX_311_ENV),
-            platform_spec=PlatformSpec("linux_x86_64"),
-        )
-        env_b = MatrixTuple(
-            python_version="3.12",
-            environment={**_LINUX_311_ENV, "python_version": "3.12"},
-            platform_spec=PlatformSpec("linux_x86_64"),
-        )
+        env_a = _target()
+        env_b = _target("3.12")
         bad_tr = TupleResult(
             tuple_=env_b,
             success=False,
@@ -1455,12 +1432,7 @@ class TestLockCommandUniversal:
         )
         tuples_results = []
         for platform_id in ("linux_x86_64", "windows_amd64"):
-            env = {**_LINUX_311_ENV, "python_version": "3.11"}
-            tup = MatrixTuple(
-                python_version="3.11",
-                environment=env,
-                platform_spec=PlatformSpec(platform_id),
-            )
+            tup = _target(platform_id=platform_id)
             tuples_results.append(
                 TupleResult(
                     tuple_=tup,
@@ -1586,16 +1558,8 @@ class TestLockCommandUniversal:
         """Only successful tuples produce a file."""
         pyproject = _universal_pyproject(tmp_path)
         # Build a mixed matrix: 3.11 succeeds, 3.12 fails.
-        good_tup = MatrixTuple(
-            python_version="3.11",
-            environment={**_LINUX_311_ENV, "python_version": "3.11"},
-            platform_spec=PlatformSpec("linux_x86_64"),
-        )
-        bad_tup = MatrixTuple(
-            python_version="3.12",
-            environment={**_LINUX_311_ENV, "python_version": "3.12"},
-            platform_spec=PlatformSpec("linux_x86_64"),
-        )
+        good_tup = _target()
+        bad_tup = _target("3.12")
         good_tr = TupleResult(
             tuple_=good_tup,
             success=True,
@@ -1648,11 +1612,7 @@ class TestNoEmitWorkspace:
     def _alpha_and_foo_universal() -> UniversalResult:
         """A universal result with alpha + foo on a single tuple."""
         matrix = Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),))
-        tup = MatrixTuple(
-            python_version="3.11",
-            environment=dict(_LINUX_311_ENV),
-            platform_spec=PlatformSpec("linux_x86_64"),
-        )
+        tup = _target()
         pins = {"alpha": V("0"), "foo": V("1.0")}
         lock_input = LockInput(
             pins={


### PR DESCRIPTION
Groundwork, no behaviour change. Specific mode and universal mode each carry their own idea of what they are resolving for: specific builds a marker environment in `resolve.py` and has no tag concept at all, universal builds a `MatrixTuple` per cell. Two environment types, two code paths, and the tag machinery reachable from only one of them. That split is why the default mode records the index's entire wheel list and happily pins `pywin32` on Linux.

`ResolveTarget` is now the one environment type: a frozen marker environment plus a `TagSet`, with three constructors. `for_host` reads the live interpreter, `for_host_python` keeps the host's platform tags and swaps only the interpreter axis (which is what pip's `--python-version` does), and `for_declared` builds one from a declared platform, which is what a matrix cell was. `MatrixTuple` is gone and `Matrix.expand()` returns targets. `Provider` takes a target instead of a loose `python_version` and `marker_environment`, so the overlay repoint and the second environment build go with it.

`TagSet` lands in `tags.py` with `ordered`, `members`, `rank`, `accepts` and `pick`. It is built for every target and unit-tested, and nothing reads it yet: the filter that makes the default mode tag-aware is the next change, and it needs to be revertable on its own.

The host constructors take injected environment and tag sources so the coverage gate is not a lottery across runners, and two smoke tests use the live ones.

Deliberately preserved, so the flip is its own reviewable change: `_resolve_target_python` still picks the lowest release the `requires-python` specifier admits, which means a project declaring `>=3.9` still resolves as Python 3.9 on a 3.14 host.

Locking the same project against this branch and its base produces byte-identical output in specific mode, and in universal mode over nine tuples the pylock differs only in `created-at` and the recorded argv.