### PR TITLE
Resolve for the host, not the requires-python floor

### DIFF
--- a/docs/how-to/workspaces.md
+++ b/docs/how-to/workspaces.md
@@ -72,7 +72,7 @@ above. Everything else under `[tool.nab]` is scoped to the
 pyproject being locked: `conflicts`, `default-groups`, `constraints`,
 `matrix`, `mode`, `requires-python`, `uploaded-prior-to`,
 `build-policy` itself, `dist-policy`, `vcs`, `indexes`, and
-`marker-environment`. Locking a member with `nab lock
+`environment`. Locking a member with `nab lock
 packages/core/pyproject.toml` reads only that file's keys; the
 root's are ignored.
 

--- a/docs/reference/build-policy.md
+++ b/docs/reference/build-policy.md
@@ -133,16 +133,26 @@ resolved, so a version-scoped per-package override (a quoted
 and per-index overrides do not apply to sources (a local source has no
 serving index).  Use a bare-name key to govern a source build.
 
-## Platform impersonation forbids host builds
+## A declared platform forbids host builds
 
 A PEP 517 backend always runs on the host nab runs on, so it reports the
 host's dependencies.  That is correct when you resolve for the host, but
-wrong when you resolve *as if* you were on another platform.  nab refuses
-the combination in both places it can impersonate a platform:
+wrong when you resolve *as if* you were on another machine.  Every target
+that moves the platform axis therefore forbids host builds:
+`build-policy` is forced to `never`, and an explicit non-`never` value
+(global or in any override) is a config error, checked before the resolve
+starts.  That covers both surfaces that declare a machine:
 
-* With `[tool.nab.marker-environment]` set, `build-policy` must be `never`
-  at the global level and in every override that sets it.  A non-`never`
-  value is rejected before the resolve starts.
-* Under `mode = "universal"`, `build-policy` defaults to `never` and
-  cannot be raised.  An explicit non-`never` value, global or in any
-  override, is a config error.
+* `[tool.nab.environment]` with a `platform` or an `implementation`.
+* `mode = "universal"`, where every matrix tuple declares one.
+
+This matches pip, which requires `--only-binary=:all:` under `--platform`,
+`--abi`, or `--implementation`.
+
+A retarget of the **python axis alone** (`[tool.nab.environment].python`,
+or `--python X.Y`) is different: the machine is still the host.  nab warns
+that a build would report the host interpreter's metadata, and permits it.
+This is a deliberate deviation from pip: the workspace `build-local` floor
+exists for members with dynamic metadata, and forbidding a build here would
+break every workspace that also pins a Python.  Set `build-policy = "never"`
+to forbid it.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -80,6 +80,11 @@ all three formats:
 Failed tuples render as `# {label}: FAILED` followed by the
 indented error and exit `1`.
 
+`--python X.Y` resolves for that Python on this machine instead of the
+running interpreter, like pip's `--python-version`; it moves only the
+python axis, so a declared `[tool.nab.environment].platform` stays. It is
+rejected in universal mode, where the matrix declares the Python axis.
+
 A project option can be overridden for one run with a `--project-<key>`
 flag: `--project-resolution`, `--project-mode`, `--project-requires-python`,
 `--project-uploaded-prior-to`, `--project-dist-policy`,

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -73,12 +73,18 @@ implementation = "cpython"  # "cpython" (default) or "pypy"
   which is what pip's `--python-version` does.  `nab lock --python 3.10`
   is the same thing for one run.
 * `platform` (with or without `implementation`) declares the machine, so
-  the markers and the wheel tags are synthesized from the platform id
-  rather than read off the host.  `implementation` needs a `platform`:
-  an interpreter is modelled on a declared machine, never on the host's.
+  the PEP 508 markers are synthesized from the platform id rather than
+  read off the host.  `implementation` needs a `platform`: an interpreter
+  is modelled on a declared machine, never on the host's.
 * A declared platform forbids host builds, so `build-policy` must be
   `never`.  A python-only retarget warns and permits.  See
   [Build policy](build-policy.md).
+
+A declared platform moves the markers only.  Candidate selection does not
+yet reject a version that ships no wheel for it, and the lockfile records
+every wheel the pinned version publishes, so a single-environment lock is
+not a cross-platform wheel lock.  Use `mode = "universal"`, which does
+filter candidates by wheel tag, to lock for machines you are not on.
 
 `[tool.nab.environment]` and `[tool.nab.matrix]` cannot both be set: the
 matrix already declares one environment per tuple.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -21,10 +21,11 @@ constraints = ["urllib3<2"]
 # default-groups array.
 default-groups = ["dev"]
 
-# Override the host's Python for a single-environment resolve.
-# A PEP 440 specifier, not a bare version; for multi-Python
-# locking use the [tool.nab.matrix] table below.
-requires-python = "==3.12.0"
+# The Python range this project supports.  A declaration: it is
+# recorded in the lockfile and checked against the resolve target,
+# and it does not choose that target.  Falls back to
+# [project].requires-python.  A PEP 440 specifier, not a bare version.
+requires-python = ">=3.10"
 
 # Reproducibility cutoff.  Distributions uploaded after this timestamp
 # are ignored.  Accepts ISO 8601 strings, native TOML datetimes, or a
@@ -52,24 +53,45 @@ PKG-INFO dependencies skips the dynamic-metadata path):
 dist-policy = { policy = "wheel-or-sdist", trust-unverified-deps = false }
 ```
 
-## Marker environment overlay
+## The resolve environment
 
-`[tool.nab.marker-environment]` impersonates a non-host environment
-for a single-environment resolve.  Each key overrides the corresponding
-PEP 508 marker variable; keys not listed keep their host value.
+nab resolves for the interpreter it is running on.  The host is the
+target, like pip: the same lock command on a Python 3.14 machine
+resolves the markers a Python 3.14 install evaluates.
+
+`[tool.nab.environment]` retargets it.  The table is one cell of a
+matrix, and every axis it leaves out keeps the host's value:
 
 ```toml
-[tool.nab.marker-environment]
-platform_system = "Linux"
-sys_platform = "linux"
-platform_machine = "x86_64"
+[tool.nab.environment]
+python = "3.10"             # a version, not a specifier ("3.10" or "3.10.5")
+platform = "linux_x86_64"   # a matrix platform id
+implementation = "cpython"  # "cpython" (default) or "pypy"
 ```
 
-Setting this overlay requires `build-policy = "never"` at the global
-level and in every override that sets `build-policy`: a PEP 517 backend
-runs on the host, so a build cannot reflect the impersonated target.
-See [Build policy](build-policy.md) for the same rule under universal
-mode.
+* `python` alone keeps the host machine and moves only the interpreter,
+  which is what pip's `--python-version` does.  `nab lock --python 3.10`
+  is the same thing for one run.
+* `platform` (with or without `implementation`) declares the machine, so
+  the markers and the wheel tags are synthesized from the platform id
+  rather than read off the host.  `implementation` needs a `platform`:
+  an interpreter is modelled on a declared machine, never on the host's.
+* A declared platform forbids host builds, so `build-policy` must be
+  `never`.  A python-only retarget warns and permits.  See
+  [Build policy](build-policy.md).
+
+`[tool.nab.environment]` and `[tool.nab.matrix]` cannot both be set: the
+matrix already declares one environment per tuple.
+
+### `[tool.nab.marker-environment]` (deprecated)
+
+The old overlay set PEP 508 marker variables one at a time, so a partial
+declaration (`sys_platform` alone) left the rest of the machine on the
+host and resolved for a machine that does not exist.  It is translated
+to `[tool.nab.environment]` with a warning, and a key that names no
+environment axis, or a `(sys_platform, platform_machine)` pair that names
+no platform nab models, is a config error.  Declare the environment
+instead.
 
 ## Indexes
 
@@ -593,20 +615,21 @@ the host: `build-policy` defaults to `never` and cannot be raised.  An
 explicit non-`never` value (global or in any override) is a config
 error.  See [Build policy](build-policy.md).
 
-### `requires-python` vs `[tool.nab.matrix].python`
+### The three `python` knobs
 
-The two `python` knobs cover different shapes of resolve:
-
-* `[tool.nab].requires-python`: a PEP 440 specifier like `==3.12.0`
-  or `>=3.12`.  Treated as a host-environment
-  override for a single-environment resolve.  Mostly useful when
-  you need to lock against a different Python than the one running
-  nab and you only need one lock.
-* `[tool.nab.matrix].python`: a range like `>=3.11,<3.14`, expanded
-  into one tuple per minor version.  Used only by universal mode.
-  Pair with `[tool.nab.matrix].platforms` and (optionally)
-  `[tool.nab.matrix].python-patches` to control the resolve and
-  marker shape across all tuples.
+* `[tool.nab].requires-python` (or `[project].requires-python`): the
+  range the project supports.  A declaration.  It is recorded as the
+  lockfile's top-level `requires-python` and checked against the resolve
+  target; it does not choose that target.  A declaration that excludes
+  the target is a config error naming `[tool.nab.environment] python`.
+* `[tool.nab.environment].python`: the Python to resolve for, defaulting
+  to the host's.  A single version, not a specifier.  `--python X.Y`
+  overrides it for one run.
+* `[tool.nab.matrix].python`: a range like `>=3.11,<3.14`, expanded into
+  one tuple per minor version.  Used only by universal mode.  Pair with
+  `[tool.nab.matrix].platforms` and (optionally)
+  `[tool.nab.matrix].python-patches` to control the resolve and marker
+  shape across all tuples.
 
 Declaring a `[tool.nab.matrix]` table while `mode` is `specific` is an
 error: the matrix is the universal resolver's input, so leaving mode
@@ -615,12 +638,11 @@ behind is almost always an oversight rather than an intent.
 The one exception is an explicit `--project-mode specific` on the
 command line.  A CLI override outranks the `[tool.nab]` table, so it
 selects a single-environment resolve for that run and the declared
-matrix does not apply; `requires-python` then chooses the Python to
-resolve against.  This is how a universal project takes one
+matrix does not apply.  This is how a universal project takes one
 single-environment lock without editing its `pyproject.toml`:
 
 ```bash
-nab lock --project-mode specific --project-requires-python "==3.13.*"
+nab lock --project-mode specific --python 3.13
 ```
 
 ## CLI flags
@@ -632,6 +654,7 @@ nab lock [PATH]
   --cache-dir PATH             # override on-disk cache location
   --no-cache                   # disable cache for this run
   --offline True|False         # use cache only, no network (or bare --offline / --no-offline)
+  --python X.Y                 # resolve for this Python on this machine
   --http-backend X             # urllib3 (default) | httpx (layered)
   --locked                     # verify the committed pylock is current; write nothing
   --upgrade                    # re-anchor the P<n>D window to now
@@ -659,7 +682,7 @@ scope that fixes where it may come from:
 * Project-scope options describe the resolve itself, so they live with
   the project. Every `[tool.nab]` key is project-scope (`mode`,
   `indexes`, `constraints`, `vcs`, `workspace`, `dist-policy`,
-  `build-policy`, `marker-environment`, `conflicts`, `matrix`,
+  `build-policy`, `environment`, `conflicts`, `matrix`,
   `packages`, `resolution`, and the rest), and each may be set in
   either `pyproject.toml`'s `[tool.nab]` or a project-directory
   `nab.toml`. They are never read from a user/system file or an

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -709,8 +709,6 @@ def _config_from_effective(
     requires_python = effective["requires-python"].value
     if requires_python is None:
         requires_python = project_requires_python
-    if matrix is None:
-        _check_requires_python_admits_target(requires_python, targets[0])
 
     default_groups = effective["default-groups"].value
     conflicts = effective["conflicts"].value
@@ -871,8 +869,15 @@ def plan_targets(config: NabProjectConfig) -> tuple[ResolveTarget, ...]:
     host machine on another Python when it names only ``python``), and a
     project that declares neither resolves against the running interpreter,
     like pip.
+
+    The ``requires-python`` declaration is checked here rather than at parse
+    time because ``--python`` moves the target after the config is read, and
+    it is the flag that rescues a project whose declaration excludes the host.
     """
-    return _plan_targets(config.matrix, config.environment)
+    targets = _plan_targets(config.matrix, config.environment)
+    if config.matrix is None:
+        _check_requires_python_admits_target(config.requires_python, targets[0])
+    return targets
 
 
 def _plan_targets(
@@ -1072,9 +1077,9 @@ def _check_requires_python_admits_target(
     msg = (
         f"requires-python = {requires_python!r} excludes the resolve target"
         f" Python {version} ({target.label}).  nab resolves for the host"
-        " interpreter unless told otherwise; set [tool.nab.environment]"
-        " python to a version the declaration admits, or widen"
-        " requires-python."
+        " interpreter unless told otherwise; pass --python with a version the"
+        " declaration admits, set [tool.nab.environment] python to one, or"
+        " widen requires-python."
     )
     raise ConfigError(msg)
 

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -804,8 +804,11 @@ def _apply_workspace_discovery(
     # workspace BUILD_LOCAL floor does not apply there: keep never.  A
     # python-only retarget stays on the host machine, so the floor still
     # applies and a workspace member with dynamic metadata still builds.
+    #
+    # The planner without the requires-python check: the config is still
+    # being read, and --python has not moved the target yet.
     promoted_policy = config.build_policy
-    if not _forbids_host_builds(plan_targets(config)):
+    if not _forbids_host_builds(_plan_targets(config.matrix, config.environment)):
         promoted_policy = auto_promote_build_policy_for_workspace(config.build_policy)
     if promoted_policy is not config.build_policy:
         _logger.info(
@@ -1069,16 +1072,16 @@ def _check_requires_python_admits_target(
     """
     if requires_python is None:
         return
-    version = Version(target.python_full_version)
-    # Accept a prerelease host (3.14.0rc1): the declaration is about the
-    # release line, and a specifier only admits prereleases when asked.
-    if SpecifierSet(requires_python).contains(version, prereleases=True):
+    # The release, not the marker value: a specifier admits no prerelease
+    # unless it names one, so ">=3.14" has to admit a 3.14 candidate host.
+    # This is the comparison every candidate's Requires-Python takes too.
+    if target.python_release in SpecifierSet(requires_python):
         return
     msg = (
         f"requires-python = {requires_python!r} excludes the resolve target"
-        f" Python {version} ({target.label}).  nab resolves for the host"
-        " interpreter unless told otherwise; pass --python with a version the"
-        " declaration admits, set [tool.nab.environment] python to one, or"
+        f" Python {target.python_full_version} ({target.label}).  nab resolves"
+        " for the host interpreter unless told otherwise; pass --python with a"
+        " version the declaration admits, set [tool.nab.environment] python to one, or"
         " widen requires-python."
     )
     raise ConfigError(msg)
@@ -1415,6 +1418,9 @@ def _validate_environment_values(environment: Mapping[str, str]) -> None:
 _MARKER_PYTHON_KEYS = ("python_full_version", "python_version")
 _MARKER_IMPLEMENTATION_KEYS = ("implementation_name", "platform_python_implementation")
 _MARKER_PLATFORM_KEYS = ("sys_platform", "platform_machine")
+# The platform id names these too, so an overlay may repeat them as long as it
+# agrees with the machine the pair identifies.
+_MARKER_PLATFORM_IMPLIED_KEYS = ("platform_system", "os_name")
 
 # The platform id each (sys_platform, platform_machine) pair names.
 _PLATFORM_ID_BY_MARKERS: dict[tuple[str, str], str] = {
@@ -1444,6 +1450,7 @@ def _environment_from_marker_environment(
         *_MARKER_PYTHON_KEYS,
         *_MARKER_IMPLEMENTATION_KEYS,
         *_MARKER_PLATFORM_KEYS,
+        *_MARKER_PLATFORM_IMPLIED_KEYS,
     }
     untranslatable = sorted(set(marker_environment) - translatable)
     if untranslatable:
@@ -1465,6 +1472,15 @@ def _environment_from_marker_environment(
             # platform_python_implementation is title-cased ("CPython").
             environment["implementation"] = marker_environment[key].lower()
             break
+    implied = [k for k in _MARKER_PLATFORM_IMPLIED_KEYS if k in marker_environment]
+    if implied and not any(k in marker_environment for k in _MARKER_PLATFORM_KEYS):
+        msg = (
+            f"[tool.nab.marker-environment] sets {implied!r} without"
+            " (sys_platform, platform_machine), which is the pair that names"
+            " the machine.  Declare [tool.nab.environment] platform instead:"
+            " half a machine would keep the other half of the host's."
+        )
+        raise ConfigError(msg)
     if any(key in marker_environment for key in _MARKER_PLATFORM_KEYS):
         pair = (
             marker_environment.get("sys_platform", ""),
@@ -1481,9 +1497,35 @@ def _environment_from_marker_environment(
                 " a machine would keep the other half of the host's."
             )
             raise ConfigError(msg)
+        _check_implied_platform_markers(marker_environment, platform_id)
         environment["platform"] = platform_id
     _validate_environment_values(environment)
     return environment
+
+
+def _check_implied_platform_markers(
+    marker_environment: Mapping[str, str], platform_id: str
+) -> None:
+    """Reject an overlay whose implied markers contradict the platform it names.
+
+    The platform id carries ``platform_system`` and ``os_name``, so an overlay
+    that repeats them is translatable; one that disagrees with them names two
+    machines at once.
+    """
+    declared = PLATFORM_MARKERS[platform_id]
+    conflicting = {
+        key: marker_environment[key]
+        for key in _MARKER_PLATFORM_IMPLIED_KEYS
+        if key in marker_environment and marker_environment[key] != declared[key]
+    }
+    if conflicting:
+        expected = {key: declared[key] for key in conflicting}
+        msg = (
+            f"[tool.nab.marker-environment] sets {conflicting!r}, which"
+            f" contradicts platform {platform_id!r}, where they are"
+            f" {expected!r}.  One overlay names one machine."
+        )
+        raise ConfigError(msg)
 
 
 def _environment_from_effective(

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -59,6 +59,12 @@ from .provider import (
     _normalize_extra,
 )
 from .tags import DEFAULT_LIBC, LIBC_MAJOR, Libc, PlatformSpec, platform_kind
+from .target import (
+    PLATFORM_MARKERS,
+    ResolveTarget,
+    host_environment,
+    python_axis_environment,
+)
 from .universal.matrix import Matrix
 from .workspace import (
     WorkspaceConfig,
@@ -83,6 +89,7 @@ __all__ = [
     "ConflictPolicy",
     "ConflictSelectionError",
     "ConflictSet",
+    "EnvironmentConfig",
     "IndexOverride",
     "MatrixConfig",
     "NabProjectConfig",
@@ -92,10 +99,14 @@ __all__ = [
     "conflict_exclusion_groups",
     "conflict_forks",
     "conflict_member_groups",
+    "enforce_build_policy_for_targets",
     "index_routes_from_config",
+    "matrix_from_config",
+    "plan_targets",
     "read_pyproject_config",
     "validate_conflict_exclusions",
     "validate_conflict_minimums",
+    "with_python_override",
 ]
 
 
@@ -132,6 +143,20 @@ class MatrixConfig:
     python_order: str = "asc"
     python_patches: Mapping[str, str] | None = None
     implementations: tuple[str, ...] = ("cpython",)
+
+
+@dataclass(frozen=True, slots=True)
+class EnvironmentConfig:
+    """The single environment ``[tool.nab.environment]`` declares.
+
+    One cell of a matrix: the axes a target is made of.  An unset axis
+    takes the host's value, so an empty table is the host and a table
+    naming only ``python`` is the host machine running another Python.
+    """
+
+    python: str | None = None
+    platform: str | None = None
+    implementation: str | None = None
 
 
 class ConflictPolicy(enum.Enum):
@@ -386,12 +411,17 @@ class NabProjectConfig:
     mode: ResolveMode = ResolveMode.SPECIFIC
     constraints: tuple[str, ...] = ()
     default_groups: tuple[str, ...] = ()
+    # The project's declared Python support range: recorded as the lock's
+    # top-level ``requires-python`` and checked against the resolve target.
+    # It does not choose the target; ``environment`` does.
     requires_python: str | None = None
     uploaded_prior_to: datetime | None = None
     dist_policy: DistPolicy = DistPolicy.WHEEL_OR_SDIST
     build_policy: BuildPolicy = BuildPolicy.BUILD_LOCAL
     trust_unverified_sdist_deps: bool = False
-    marker_environment: Mapping[str, str] = field(default_factory=dict)
+    # The declared resolve environment from ``[tool.nab.environment]``, or
+    # ``None`` for the host.  Mutually exclusive with ``matrix``.
+    environment: EnvironmentConfig | None = None
     indexes: tuple[IndexConfig, ...] = (
         IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL),
     )
@@ -571,6 +601,7 @@ def read_pyproject_config(
         anchor = datetime.now(timezone.utc)
     pyproject_dir = path.parent.resolve()
     _reject_unknown_pyproject_keys(path)
+    project_requires_python = _read_project_requires_python(path)
     # Point the pyproject root at ``pyproject_dir / path.name`` (not
     # ``path.resolve()``) so the registry's declaring directory is the
     # symlink's own directory, matching the historical local-sources base
@@ -586,7 +617,10 @@ def read_pyproject_config(
         cli_layer = build_cli_layer(cli_overrides or {})
         effective = resolve_config(layers, read_env_layer({}), cli_layer)
     config = _config_from_effective(
-        effective, anchor=anchor, pyproject_dir=pyproject_dir
+        effective,
+        anchor=anchor,
+        pyproject_dir=pyproject_dir,
+        project_requires_python=project_requires_python,
     )
     if discover_workspace:
         config = _apply_workspace_discovery(path, config)
@@ -598,6 +632,7 @@ def _config_from_effective(
     *,
     anchor: datetime,
     pyproject_dir: Path,
+    project_requires_python: str | None = None,
 ) -> NabProjectConfig:
     """Assemble :class:`NabProjectConfig` from the registry merged ladder.
 
@@ -606,11 +641,14 @@ def _config_from_effective(
     cross-file conflict rule, and the category gate.  The cross-field
     transforms the single-key rows deliberately defer (mode/matrix mutual
     requirement, declared-index references for routing and per-index
-    overrides, the cross-surface package-override overlap, universal
-    build-policy enforcement and the marker-environment ban, the
+    overrides, the cross-surface package-override overlap, the resolve-target
+    plan and the build-policy enforcement it drives, the
     default-groups-vs-conflicts check, and source-name uniqueness) then run
     here over the merged whole.  Workspace discovery is applied by the
     caller afterwards.
+
+    ``project_requires_python`` is ``[project].requires-python``, the
+    fallback source for the declaration when ``[tool.nab]`` sets none.
     """
     del anchor  # P<n>D durations are already anchored in the effective map.
     mode_value = effective["mode"]
@@ -649,24 +687,30 @@ def _config_from_effective(
     index_overrides: Mapping[str, IndexOverride] = effective["index"].value
     _validate_index_overrides_declared(index_overrides, declared_index_names)
 
-    marker_environment = effective["marker-environment"].value
-    build_policy: BuildPolicy = effective["build-policy"].value
-    if mode is ResolveMode.UNIVERSAL:
-        build_policy = _enforce_universal_build_policy(
-            build_policy_set=effective["build-policy"].origin.kind
-            is not SourceKind.DEFAULT,
-            build_policy=build_policy,
-            package_overrides=package_overrides,
-            index_overrides=index_overrides,
+    environment = _environment_from_effective(effective)
+    if matrix is not None and environment is not None:
+        msg = (
+            "[tool.nab.matrix] and [tool.nab.environment] cannot both be set:"
+            " the matrix declares one environment per tuple, so a single"
+            " declared environment would contradict it.  Drop one."
         )
-        if marker_environment:
-            msg = (
-                "mode = 'universal' does not support"
-                " [tool.nab.marker-environment]: the matrix defines each"
-                " environment, so a global overlay would conflict with the"
-                " per-tuple values. Drop it or use mode = 'specific'."
-            )
-            raise ConfigError(msg)
+        raise ConfigError(msg)
+
+    targets = _plan_targets(matrix, environment)
+    build_policy = enforce_build_policy_for_targets(
+        targets=targets,
+        build_policy=effective["build-policy"].value,
+        build_policy_set=effective["build-policy"].origin.kind
+        is not SourceKind.DEFAULT,
+        package_overrides=package_overrides,
+        index_overrides=index_overrides,
+    )
+
+    requires_python = effective["requires-python"].value
+    if requires_python is None:
+        requires_python = project_requires_python
+    if matrix is None:
+        _check_requires_python_admits_target(requires_python, targets[0])
 
     default_groups = effective["default-groups"].value
     conflicts = effective["conflicts"].value
@@ -682,12 +726,12 @@ def _config_from_effective(
         mode=mode,
         constraints=effective["constraints"].value,
         default_groups=default_groups,
-        requires_python=effective["requires-python"].value,
+        requires_python=requires_python,
         uploaded_prior_to=effective["uploaded-prior-to"].value,
         dist_policy=dist_policy,
         build_policy=build_policy,
         trust_unverified_sdist_deps=trust_unverified,
-        marker_environment=marker_environment,
+        environment=environment,
         indexes=indexes,
         vcs=effective["vcs"].value,
         local_sources=local_sources,
@@ -758,13 +802,12 @@ def _apply_workspace_discovery(
     merged = merge_workspace_local_sources(config.local_sources, discovered)
     _reject_duplicate_source_names(merged, config.vcs_sources, config.archive_sources)
     explicit_names = {canonicalize_name(src.name) for src in config.local_sources}
-    # A universal matrix or a marker-environment overlay both forbid host
-    # builds, so the workspace BUILD_LOCAL floor does not apply: keep never.
-    forbids_host_builds = config.mode is ResolveMode.UNIVERSAL or bool(
-        config.marker_environment
-    )
+    # A target that impersonates a machine forbids host builds, so the
+    # workspace BUILD_LOCAL floor does not apply there: keep never.  A
+    # python-only retarget stays on the host machine, so the floor still
+    # applies and a workspace member with dynamic metadata still builds.
     promoted_policy = config.build_policy
-    if not forbids_host_builds:
+    if not _forbids_host_builds(plan_targets(config)):
         promoted_policy = auto_promote_build_policy_for_workspace(config.build_policy)
     if promoted_policy is not config.build_policy:
         _logger.info(
@@ -819,20 +862,146 @@ def _reject_unknown_pyproject_keys(path: Path) -> None:
         raise ConfigError(msg)
 
 
-def _enforce_universal_build_policy(
+def plan_targets(config: NabProjectConfig) -> tuple[ResolveTarget, ...]:
+    """Return every environment ``config`` resolves against, in matrix order.
+
+    The host is the target unless the project says otherwise: a declared
+    matrix expands to one target per tuple, ``[tool.nab.environment]``
+    names a single target (declared when it moves the platform axis, the
+    host machine on another Python when it names only ``python``), and a
+    project that declares neither resolves against the running interpreter,
+    like pip.
+    """
+    return _plan_targets(config.matrix, config.environment)
+
+
+def _plan_targets(
+    matrix: MatrixConfig | None, environment: EnvironmentConfig | None
+) -> tuple[ResolveTarget, ...]:
+    """Plan the targets from the two declaring surfaces, pre-assembly.
+
+    Takes the pieces rather than a :class:`NabProjectConfig` so the config
+    parse can plan (and enforce the build policy) while it is still
+    assembling one.
+    """
+    if matrix is not None:
+        return tuple(matrix_from_config(matrix).expand())
+    if environment is None:
+        return (ResolveTarget.for_host(),)
+    if environment.platform is not None:
+        return (_declared_target(environment),)
+    # An implementation without a platform is rejected at parse, so a
+    # remaining environment declares the python axis and nothing else.
+    assert environment.python is not None
+    return (ResolveTarget.for_host_python(environment.python),)
+
+
+def _declared_target(environment: EnvironmentConfig) -> ResolveTarget:
+    """Build the one target ``[tool.nab.environment]`` declares.
+
+    The platform is named, so the target's markers and wheel tags are
+    synthesized from it rather than read off the host.  An unset ``python``
+    takes the host's release, and an unset ``implementation`` is CPython,
+    matching the matrix default.
+    """
+    assert environment.platform is not None  # the caller checked
+    python = environment.python or host_environment()["python_full_version"]
+    axis = python_axis_environment(python)
+    return ResolveTarget.for_declared(
+        python_version=axis["python_version"],
+        spec=PlatformSpec(environment.platform),
+        implementation=environment.implementation or "cpython",
+        python_full_version=axis["python_full_version"],
+    )
+
+
+def matrix_from_config(matrix: MatrixConfig) -> Matrix:
+    """Build the expandable :class:`Matrix` from its parsed config table."""
+    return Matrix(
+        python=matrix.python,
+        platforms=matrix.platforms,
+        python_order=matrix.python_order,
+        python_patches=(
+            dict(matrix.python_patches) if matrix.python_patches is not None else None
+        ),
+        implementations=matrix.implementations,
+    )
+
+
+def _forbids_host_builds(targets: Sequence[ResolveTarget]) -> bool:
+    """Whether any target impersonates a machine other than the host's.
+
+    A declared target (a matrix tuple, or an environment naming a platform
+    or implementation) carries a :class:`PlatformSpec`; the host and a
+    host-python retarget do not.
+    """
+    return any(target.platform_spec is not None for target in targets)
+
+
+def enforce_build_policy_for_targets(
+    *,
+    targets: Sequence[ResolveTarget],
+    build_policy: BuildPolicy,
+    build_policy_set: bool,
+    package_overrides: Sequence[PackageOverride],
+    index_overrides: Mapping[str, IndexOverride],
+) -> BuildPolicy:
+    """Return the build policy the planned targets permit, or raise.
+
+    A PEP 517 backend only ever runs on the host interpreter, so what a
+    build reports is the host's metadata.  Two tiers follow:
+
+    * A target that moves the platform axis (a matrix, or an environment
+      naming a ``platform`` or ``implementation``) forbids host builds:
+      ``build-policy`` is forced to ``never`` and an explicit non-``never``
+      value, global or in any override, is an error.  This matches pip,
+      which requires ``--only-binary=:all:`` under ``--platform``.
+    * A python-axis-only retarget on the host machine warns and permits:
+      the workspace ``build-local`` floor exists for members with dynamic
+      metadata, and forbidding a build here would break every workspace
+      that also pins a Python.  A deliberate deviation from pip.
+
+    The host target permits, so the default case builds freely.
+    """
+    if _forbids_host_builds(targets):
+        offending = _explicit_host_builds(
+            build_policy_set=build_policy_set,
+            build_policy=build_policy,
+            package_overrides=package_overrides,
+            index_overrides=index_overrides,
+        )
+        if offending:
+            msg = (
+                "a declared target cannot build on the host, so build-policy"
+                f" must be 'never'; got {', '.join(offending)}.  A PEP 517"
+                " backend runs on the host and reports the host's metadata,"
+                " not the target's.  Remove the setting (it defaults to"
+                " 'never' for a declared target) or set it to 'never'."
+            )
+            raise ConfigError(msg)
+        return BuildPolicy.NEVER
+    if not all(target.host_faithful for target in targets):
+        _logger.warning(
+            "the resolve targets Python %s but a build would run on the host"
+            " interpreter and report its metadata; set build-policy = 'never'"
+            " to forbid builds",
+            targets[0].python_full_version,
+        )
+    return build_policy
+
+
+def _explicit_host_builds(
     *,
     build_policy_set: bool,
     build_policy: BuildPolicy,
-    package_overrides: tuple[PackageOverride, ...],
+    package_overrides: Sequence[PackageOverride],
     index_overrides: Mapping[str, IndexOverride],
-) -> BuildPolicy:
-    """Force ``never`` under universal mode and reject explicit host builds.
+) -> list[str]:
+    """Name every surface that explicitly asks for a non-``never`` build.
 
-    Universal resolution impersonates one platform per matrix tuple, but a
-    PEP 517 backend only ever runs on the host, so a build cannot reflect a
-    non-host target.  ``build-policy`` therefore defaults to ``never`` under
-    ``mode = "universal"``; an explicit non-``never`` value, global or in any
-    override, is an error.
+    An unset global is not offending: ``build-policy`` defaults to
+    ``never`` for a target that forbids host builds rather than failing a
+    project that never mentioned it.
     """
     offending: list[str] = []
     if build_policy_set and build_policy is not BuildPolicy.NEVER:
@@ -845,14 +1014,69 @@ def _enforce_universal_build_policy(
         bp = index_override.build_policy
         if bp is not None and bp is not BuildPolicy.NEVER:
             offending.append(f"index.{name} build-policy = {bp.value!r}")
-    if offending:
-        msg = (
-            "mode = 'universal' cannot build on the host, so build-policy must"
-            f" be 'never'; got {', '.join(offending)}.  Remove the setting (it"
-            " defaults to 'never' under universal mode) or set it to 'never'."
-        )
-        raise ConfigError(msg)
-    return BuildPolicy.NEVER
+    return offending
+
+
+def with_python_override(
+    config: NabProjectConfig, python: str | None
+) -> NabProjectConfig:
+    """Return ``config`` with its resolve target moved onto ``python``.
+
+    The ``--python`` flag (and the ``python_version`` argument of
+    :func:`~nab_python.resolve.resolve_pyproject`) retargets the python
+    axis for one run, leaving any declared platform in place.  The
+    build-policy guard runs again over the new plan, so a runtime retarget
+    is held to the same rule as a declared one.  ``None`` is a no-op.
+    """
+    if python is None:
+        return config
+    _validate_environment_values({"python": python})
+    environment = (
+        EnvironmentConfig(python=python)
+        if config.environment is None
+        else replace(config.environment, python=python)
+    )
+    build_policy = enforce_build_policy_for_targets(
+        targets=_plan_targets(config.matrix, environment),
+        build_policy=config.build_policy,
+        # The policy here is the effective one, so any non-``never`` value
+        # that survived the parse is an explicit host-build request.
+        build_policy_set=True,
+        package_overrides=config.package_overrides,
+        index_overrides=config.index_overrides,
+    )
+    retargeted = replace(config, environment=environment, build_policy=build_policy)
+    _check_requires_python_admits_target(
+        retargeted.requires_python, plan_targets(retargeted)[0]
+    )
+    return retargeted
+
+
+def _check_requires_python_admits_target(
+    requires_python: str | None, target: ResolveTarget
+) -> None:
+    """Reject a ``requires-python`` declaration that excludes the resolve target.
+
+    ``requires-python`` declares the Python range the project supports; it
+    does not steer the resolve.  Resolving for a Python the project says it
+    does not support would produce a lock the project's own metadata
+    rejects, so it fails loud and names the knob that moves the target.
+    """
+    if requires_python is None:
+        return
+    version = Version(target.python_full_version)
+    # Accept a prerelease host (3.14.0rc1): the declaration is about the
+    # release line, and a specifier only admits prereleases when asked.
+    if SpecifierSet(requires_python).contains(version, prereleases=True):
+        return
+    msg = (
+        f"requires-python = {requires_python!r} excludes the resolve target"
+        f" Python {version} ({target.label}).  nab resolves for the host"
+        " interpreter unless told otherwise; set [tool.nab.environment]"
+        " python to a version the declaration admits, or widen"
+        " requires-python."
+    )
+    raise ConfigError(msg)
 
 
 def _parse_mode(value: object) -> ResolveMode:
@@ -914,12 +1138,14 @@ def _parse_string_value(key: str, value: object) -> str:
 def _parse_requires_python(value: object) -> str | None:
     """Parse ``[tool.nab].requires-python`` as a PEP 440 specifier.
 
-    Stored as the raw specifier string so the lockfile writer can pass
-    it straight to :class:`SpecifierSet`.  The resolve path later
-    derives a concrete Python version target from the same specifier.
-    Raises :class:`ConfigError` for invalid specifiers and for
-    well-meaning bare versions like ``"3.13"``; those are not valid
-    specifiers and must be written ``"==3.13"`` or ``">=3.13,<3.14"``.
+    A declaration, not a target: it is recorded as the lock's top-level
+    ``requires-python`` and checked against the resolve target, and the
+    target itself comes from ``[tool.nab.environment]`` (the host by
+    default).  Stored as the raw specifier string so the lockfile writer
+    can pass it straight to :class:`SpecifierSet`.  Raises
+    :class:`ConfigError` for invalid specifiers and for well-meaning bare
+    versions like ``"3.13"``; those are not valid specifiers and must be
+    written ``"==3.13"`` or ``">=3.13,<3.14"``.
     """
     raw = _parse_string_value("requires-python", value)
     try:
@@ -931,6 +1157,23 @@ def _parse_requires_python(value: object) -> str | None:
         )
         raise ConfigError(msg) from exc
     return raw
+
+
+def _read_project_requires_python(path: Path) -> str | None:
+    """Read ``[project].requires-python``, the fallback declaration source.
+
+    ``[tool.nab].requires-python`` (and ``--project-requires-python``) wins
+    when set; otherwise the project's own declaration is what the lock
+    records.  The file has already been parsed as TOML by
+    :func:`_reject_unknown_pyproject_keys`, so a decode error cannot reach
+    here.
+    """
+    with path.open("rb") as f:
+        data = tomli.load(f)
+    project = data.get("project")
+    if not isinstance(project, dict) or "requires-python" not in project:
+        return None
+    return _parse_requires_python(project["requires-python"])
 
 
 def index_routes_from_config(config: NabProjectConfig) -> list[IndexRoute]:
@@ -1097,6 +1340,186 @@ def _parse_marker_environment(value: object) -> dict[str, str]:
                 raise ConfigError(msg) from exc
         out[k] = v
     return out
+
+
+_ENVIRONMENT_KEYS = frozenset({"python", "platform", "implementation"})
+
+
+def _parse_environment(value: object) -> dict[str, str]:
+    """Parse ``[tool.nab.environment]``: the one environment to resolve for.
+
+    Kept as the raw ``key -> str`` table so the registry merges it sub-key
+    by sub-key across the config sources; :func:`_environment_from_effective`
+    turns the merged whole into an :class:`EnvironmentConfig`.
+    """
+    if not isinstance(value, dict):
+        msg = (
+            "[tool.nab.environment] must be a table of string -> string,"
+            f" got {type(value).__name__}"
+        )
+        raise ConfigError(msg)
+    unknown = sorted(set(value) - _ENVIRONMENT_KEYS)
+    if unknown:
+        msg = (
+            f"unknown [tool.nab.environment] keys: {unknown!r};"
+            f" expected {sorted(_ENVIRONMENT_KEYS)!r}"
+        )
+        raise ConfigError(msg)
+    out = {
+        key: _parse_string_value(f"environment.{key}", item)
+        for key, item in value.items()
+    }
+    _validate_environment_values(out)
+    return out
+
+
+def _validate_environment_values(environment: Mapping[str, str]) -> None:
+    """Validate the value of every environment axis the table names.
+
+    Shared by the ``[tool.nab.environment]`` parse, the
+    ``[tool.nab.marker-environment]`` translation, and the ``--python``
+    override, so all three reject the same bad values with one message.
+    """
+    python = environment.get("python")
+    if python is not None:
+        try:
+            Version(python)
+        except InvalidVersion as exc:
+            msg = (
+                "environment.python must be a version like '3.12' or"
+                f" '3.12.4', got {python!r}"
+            )
+            raise ConfigError(msg) from exc
+    platform = environment.get("platform")
+    if platform is not None and platform not in PLATFORM_MARKERS:
+        valid = sorted(PLATFORM_MARKERS)
+        msg = f"unknown environment.platform {platform!r}; expected one of {valid!r}"
+        raise ConfigError(msg)
+    implementation = environment.get("implementation")
+    if implementation is not None and implementation not in _KNOWN_IMPLEMENTATIONS:
+        valid = list(_KNOWN_IMPLEMENTATIONS)
+        msg = (
+            f"unknown environment.implementation {implementation!r};"
+            f" expected one of {valid!r}"
+        )
+        raise ConfigError(msg)
+
+
+# The deprecated marker-environment keys, per environment axis, in the
+# order they are read: the more precise key wins.
+_MARKER_PYTHON_KEYS = ("python_full_version", "python_version")
+_MARKER_IMPLEMENTATION_KEYS = ("implementation_name", "platform_python_implementation")
+_MARKER_PLATFORM_KEYS = ("sys_platform", "platform_machine")
+
+# The platform id each (sys_platform, platform_machine) pair names.
+_PLATFORM_ID_BY_MARKERS: dict[tuple[str, str], str] = {
+    (markers["sys_platform"], markers["platform_machine"]): platform_id
+    for platform_id, markers in PLATFORM_MARKERS.items()
+}
+
+
+def _environment_from_marker_environment(
+    marker_environment: Mapping[str, str],
+) -> dict[str, str]:
+    """Translate the deprecated ``[tool.nab.marker-environment]`` overlay.
+
+    The overlay set PEP 508 marker variables one by one, which let a
+    partial declaration (``sys_platform`` alone) leave the rest of the
+    environment on the host and resolve for a machine that does not exist.
+    The replacement declares whole axes, so every overlay key must name one:
+    an unmappable ``(sys_platform, platform_machine)`` pair, or a key no
+    axis can carry, is an error rather than a silently-wrong resolve.
+    """
+    _logger.warning(
+        "[tool.nab.marker-environment] is deprecated and will be removed;"
+        " declare [tool.nab.environment] with python/platform/implementation"
+        " instead.  Translating the overlay for this run."
+    )
+    translatable = {
+        *_MARKER_PYTHON_KEYS,
+        *_MARKER_IMPLEMENTATION_KEYS,
+        *_MARKER_PLATFORM_KEYS,
+    }
+    untranslatable = sorted(set(marker_environment) - translatable)
+    if untranslatable:
+        msg = (
+            f"[tool.nab.marker-environment] variable(s) {untranslatable!r} cannot"
+            " be translated to [tool.nab.environment], whose axes are"
+            f" {sorted(_ENVIRONMENT_KEYS)!r}.  The platform id carries the"
+            " OS and machine markers; declare it as environment.platform."
+        )
+        raise ConfigError(msg)
+
+    environment: dict[str, str] = {}
+    for key in _MARKER_PYTHON_KEYS:
+        if key in marker_environment:
+            environment["python"] = marker_environment[key]
+            break
+    for key in _MARKER_IMPLEMENTATION_KEYS:
+        if key in marker_environment:
+            # platform_python_implementation is title-cased ("CPython").
+            environment["implementation"] = marker_environment[key].lower()
+            break
+    if any(key in marker_environment for key in _MARKER_PLATFORM_KEYS):
+        pair = (
+            marker_environment.get("sys_platform", ""),
+            marker_environment.get("platform_machine", ""),
+        )
+        platform_id = _PLATFORM_ID_BY_MARKERS.get(pair)
+        if platform_id is None:
+            valid = sorted(PLATFORM_MARKERS)
+            msg = (
+                "[tool.nab.marker-environment] sets (sys_platform,"
+                f" platform_machine) = {pair!r}, which names no platform nab"
+                f" models.  Declare [tool.nab.environment] platform = one of"
+                f" {valid!r}; both markers must name one machine, because half"
+                " a machine would keep the other half of the host's."
+            )
+            raise ConfigError(msg)
+        environment["platform"] = platform_id
+    _validate_environment_values(environment)
+    return environment
+
+
+def _environment_from_effective(
+    effective: Mapping[str, EffectiveValue],
+) -> EnvironmentConfig | None:
+    """Fold the environment surfaces into the one declared environment.
+
+    ``[tool.nab.environment]`` is the surface;
+    ``[tool.nab.marker-environment]`` is its deprecated predecessor and is
+    translated into it.  Declaring both is an error: the two would have to
+    agree, and a silent precedence between them is exactly the ambiguity the
+    replacement removes.  Returns ``None`` when neither is declared, which
+    is the host.
+    """
+    declared: Mapping[str, str] = effective["environment"].value
+    marker_environment: Mapping[str, str] = effective["marker-environment"].value
+    if marker_environment:
+        if declared:
+            msg = (
+                "[tool.nab.environment] and the deprecated"
+                " [tool.nab.marker-environment] are both set; drop the"
+                " marker-environment table."
+            )
+            raise ConfigError(msg)
+        declared = _environment_from_marker_environment(marker_environment)
+    if not declared:
+        return None
+    environment = EnvironmentConfig(
+        python=declared.get("python"),
+        platform=declared.get("platform"),
+        implementation=declared.get("implementation"),
+    )
+    if environment.implementation is not None and environment.platform is None:
+        valid = sorted(PLATFORM_MARKERS)
+        msg = (
+            "[tool.nab.environment].implementation needs a platform: an"
+            " interpreter is modelled on a declared machine, not on the host's."
+            f"  Add platform = one of {valid!r}."
+        )
+        raise ConfigError(msg)
+    return environment
 
 
 _INDEX_KEYS = frozenset({"name", "url"})
@@ -2416,15 +2839,7 @@ def _parse_matrix(value: object) -> MatrixConfig | None:
 
 def _validate_matrix_axes(config: MatrixConfig) -> None:
     """Expand the matrix eagerly to catch bad axes at parse time."""
-    matrix = Matrix(
-        python=config.python,
-        platforms=config.platforms,
-        python_order=config.python_order,
-        python_patches=dict(config.python_patches)
-        if config.python_patches is not None
-        else None,
-        implementations=config.implementations,
-    )
+    matrix = matrix_from_config(config)
     try:
         matrix.expand()
     except ValueError as exc:

--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -245,7 +245,7 @@ class OptionSpec:
     ``env_var`` is the ``NAB_*`` name or ``None`` (not env-settable).
     ``cli_flag`` is the tyro flag spelling the conformance test checks,
     or ``None`` for a file-only row (a structured PROJECT table with no
-    bare CLI flag, e.g. ``vcs``/``workspace``/``marker-environment``);
+    bare CLI flag, e.g. ``vcs``/``workspace``/``environment``);
     ``cli_param`` is the tyro function-parameter name backing the flag,
     also ``None`` for a file-only row.  ``type_label`` is shown by
     ``nab config``.
@@ -475,6 +475,18 @@ def _parse_marker_environment(value: Any, where: str) -> Mapping[str, str]:
     del where
     from .config import (  # noqa: PLC0415 (config import cycle)
         _parse_marker_environment as _impl,
+    )
+
+    return _delegate(lambda: _impl(value))
+
+
+def _parse_environment(value: Any, where: str) -> Mapping[str, str]:
+    # Name-keyed table (python/platform/implementation -> str), one cell of
+    # a matrix.  A mapping row, so the axes merge sub-key by sub-key across
+    # the ladder and a ``--python`` override moves only the python axis.
+    del where
+    from .config import (  # noqa: PLC0415 (config import cycle)
+        _parse_environment as _impl,
     )
 
     return _delegate(lambda: _impl(value))
@@ -770,6 +782,12 @@ def _render_marker_environment(value: Mapping[str, str]) -> str:
     return ", ".join(f"{k}={v}" for k, v in sorted(value.items()))
 
 
+def _render_environment(value: Mapping[str, str]) -> str:
+    if not value:
+        return "<host>"
+    return ", ".join(f"{k}={v}" for k, v in sorted(value.items()))
+
+
 def _render_vcs(value: Any) -> str:
     parts = [f"policy={value.policy.value}"]
     if value.allowed_schemes:
@@ -896,9 +914,21 @@ OPTIONS: tuple[OptionSpec, ...] = (
         render=lambda v: v.value,
     ),
     OptionSpec(
+        key="environment",
+        scope=Scope.PROJECT,
+        type_label="table(python,platform,implementation)",
+        default=_EMPTY_MAPPING,
+        env_var=None,
+        cli_flag=None,
+        cli_param=None,
+        parse=_parse_environment,
+        render=_render_environment,
+        is_mapping=True,
+    ),
+    OptionSpec(
         key="marker-environment",
         scope=Scope.PROJECT,
-        type_label="table(marker-var=str)",
+        type_label="table(marker-var=str) [deprecated]",
         default=_EMPTY_MAPPING,
         env_var=None,
         cli_flag=None,

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -20,7 +20,6 @@ from ._vcs_admission import admit_vcs_url
 from ._vendor.packaging.ranges import VersionRange
 from ._vendor.packaging.requirements import Requirement
 from ._vendor.packaging.utils import canonicalize_name
-from ._vendor.packaging.version import Version
 from .config import (
     ConfigError,
     ConflictFork,
@@ -70,6 +69,7 @@ if TYPE_CHECKING:
 
     from nab_index.transport import AsyncHttpTransport
 
+    from ._vendor.packaging.version import Version
     from .target import ResolveTarget
 
 

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import itertools
 import logging
-import sys
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -20,7 +19,6 @@ from ._conflict_kind import dependency_marker_holds, membership_set_in_marker
 from ._vcs_admission import admit_vcs_url
 from ._vendor.packaging.ranges import VersionRange
 from ._vendor.packaging.requirements import Requirement
-from ._vendor.packaging.specifiers import SpecifierSet
 from ._vendor.packaging.utils import canonicalize_name
 from ._vendor.packaging.version import Version
 from .config import (
@@ -33,14 +31,16 @@ from .config import (
     ResolveMode,
     conflict_forks,
     index_routes_from_config,
+    matrix_from_config,
+    plan_targets,
     read_pyproject_config,
     validate_conflict_exclusions,
     validate_conflict_minimums,
+    with_python_override,
 )
 from .fetch import FetchCoordinator
 from .lockfile import LockInput, build_lock_input_from_provider
 from .provider import (
-    BuildPolicy,
     Provider,
     ResolutionStrategy,
     join_extra,
@@ -58,8 +58,6 @@ from .requirements_file import (
     resolve_groups_to_requirements,
     select_optional_dependencies,
 )
-from .target import ResolveTarget
-from .universal.matrix import Matrix
 from .universal.resolve import (
     ResolveFork,
     UniversalResult,
@@ -71,6 +69,8 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from nab_index.transport import AsyncHttpTransport
+
+    from .target import ResolveTarget
 
 
 __all__ = [
@@ -119,7 +119,9 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
     ``config`` defaults to :func:`read_pyproject_config(path)`. The
     caller supplies ``transport`` so the HTTP library choice stays
     outside nab-python. ``cache_dir``, ``offline`` and
-    ``python_version`` are runtime overrides from the CLI.
+    ``python_version`` are runtime overrides from the CLI;
+    ``python_version`` backs ``--python`` and moves the resolve target
+    onto that Python, leaving the rest of the environment alone.
 
     ``groups`` and ``extras`` name PEP 735 groups and
     ``[project.optional-dependencies]`` keys to fold in.
@@ -145,16 +147,10 @@ def resolve_pyproject(  # noqa: PLR0913 - the surface mirrors the CLI; bundling 
     # into the active group set alongside the CLI selection.
     effective_groups = tuple(dict.fromkeys((*groups, *config.default_groups)))
 
-    if python_version is not None:
-        target = ResolveTarget.for_host_python(python_version)
-    elif config.requires_python is not None:
-        target = ResolveTarget.for_host_python(
-            _resolve_target_python(config.requires_python)
-        )
-    else:
-        target = ResolveTarget.for_host()
-    _check_marker_overlay_build_policy(config)
-    target = target.with_marker_overrides(config.marker_environment)
+    # The host is the target unless the project (or --python) says
+    # otherwise; specific mode carries no matrix, so the plan is one target.
+    config = with_python_override(config, python_version)
+    (target,) = plan_targets(config)
     marker_environment = target.marker_env
 
     if config.conflicts:
@@ -715,42 +711,6 @@ def _build_resolver_inputs(
     return resolver_requirements, root_extras
 
 
-def _check_marker_overlay_build_policy(config: NabProjectConfig) -> None:
-    """Reject a non-``NEVER`` build policy under a marker-environment overlay.
-
-    Backends run on the host, so invoking one under an overlay would
-    produce metadata that does not match the impersonated target.  The
-    guard inspects both override surfaces as well as the global, so a
-    single build override cannot quietly opt out of the soundness check.
-    A config with no overlay resolves against the host and builds freely.
-    """
-    if not config.marker_environment:
-        return
-    offending: list[tuple[str, BuildPolicy]] = []
-    if config.build_policy is not BuildPolicy.NEVER:
-        offending.append(("<global>", config.build_policy))
-    offending.extend(
-        (o.name, o.build_policy)
-        for o in config.package_overrides
-        if o.build_policy not in (None, BuildPolicy.NEVER)
-    )
-    offending.extend(
-        (f"index:{name}", o.build_policy)
-        for name, o in config.index_overrides.items()
-        if o.build_policy not in (None, BuildPolicy.NEVER)
-    )
-    if not offending:
-        return
-    rendered = ", ".join(f"{name}={policy.value}" for name, policy in offending)
-    msg = (
-        "marker_environment overlay requires BuildPolicy.NEVER globally"
-        " and in every override that sets build-policy; got"
-        f" {rendered}.  Backends run on the host and report metadata for"
-        " the host, not the impersonated target."
-    )
-    raise ValueError(msg)
-
-
 def _raise_for_source_python(
     provider: Provider,
     pins: Mapping[str, Version],
@@ -869,17 +829,7 @@ def resolve_universal_pyproject(
         raise UnsupportedModeError(msg)
 
     base_dependencies = read_pyproject_dependencies(path)
-    matrix = Matrix(
-        python=config.matrix.python,
-        platforms=config.matrix.platforms,
-        python_order=config.matrix.python_order,
-        python_patches=(
-            dict(config.matrix.python_patches)
-            if config.matrix.python_patches is not None
-            else None
-        ),
-        implementations=config.matrix.implementations,
-    )
+    matrix = matrix_from_config(config.matrix)
     expanded_tuples = matrix.expand()
     group_table = read_pyproject_groups(path)
     tables = _ForkTables(
@@ -982,55 +932,6 @@ def resolve_universal_pyproject(
         index_routes=index_routes_from_config(config) or None,
         resolution_strategy=effective_strategy.value,
     )
-
-
-_PYTHON_CANDIDATE_MAJORS = (3, 4)
-_PYTHON_CANDIDATE_MINORS = range(30)
-_PYTHON_CANDIDATE_PATCHES = range(30)
-
-
-def _resolve_target_python(specifier: str) -> str:
-    """Pick a concrete Python version that satisfies ``specifier``.
-
-    ``specifier`` is a PEP 440 specifier set (already validated at
-    config-parse time, see :func:`_parse_requires_python`).  The
-    resolve target is the lowest enumerated ``M.N.P`` release that the
-    specifier admits: deterministic regardless of host, and matches
-    the user's written intent ("lock for >=3.13" -> "use 3.13.0
-    markers"; "lock for ==3.10.5" -> "use 3.10.5 markers").
-
-    Falls back to the host Python when no enumerated candidate
-    satisfies (e.g. an open-ended ``<X.Y`` specifier with no lower
-    bound, or a range that admits only versions outside the candidate
-    grid).  The host fallback warns via the logger so the operator can
-    notice when their lockfile's ``requires-python`` field implies a
-    target the resolve could not actually impersonate.
-    """
-    spec_set = SpecifierSet(specifier)
-
-    # M.N.0 first so >=3.13 resolves to 3.13.0 (not 3.13.<something>).
-    # filter() preserves input order, so the first match is the lowest.
-    candidates: list[Version] = []
-    for major in _PYTHON_CANDIDATE_MAJORS:
-        for minor in _PYTHON_CANDIDATE_MINORS:
-            candidates.append(Version(f"{major}.{minor}.0"))
-            for patch in _PYTHON_CANDIDATE_PATCHES:
-                if patch == 0:
-                    continue
-                candidates.append(Version(f"{major}.{minor}.{patch}"))
-
-    matches = [str(v) for v in spec_set.filter(candidates)]
-    if matches:
-        return matches[0]
-    vi = sys.version_info
-    host = f"{vi.major}.{vi.minor}.{vi.micro}"
-    _logger.warning(
-        "requires-python = %r matches no enumerated CPython release;"
-        " falling back to host Python %s for the resolve target",
-        specifier,
-        host,
-    )
-    return host
 
 
 def _build_constraints(

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+from nab_python._vendor.packaging.markers import default_environment
+from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.version import Version
 from nab_python.config import (
     ConfigError,
@@ -20,6 +22,7 @@ from nab_python.config import (
     MatrixConfig,
     NabProjectConfig,
     ResolveMode,
+    _check_requires_python_admits_target,
     conflict_exclusion_groups,
     conflict_forks,
     index_routes_from_config,
@@ -753,6 +756,42 @@ class TestRequiresPython:
         ):
             plan_targets(config)
 
+    def test_a_matrix_declares_its_own_pythons(self, tmp_path: Path) -> None:
+        """The matrix names the targets, so requires-python does not gate them.
+
+        The declaration is about the project, and a matrix that admits a
+        Python the project excludes is caught where the matrix is parsed.
+        """
+        path = write(
+            tmp_path,
+            '[tool.nab]\nmode = "universal"\nrequires-python = "==3.9.*"\n'
+            '[tool.nab.matrix]\npython = "==3.12"\n'
+            'platforms = ["linux_x86_64"]\n',
+        )
+        config = read_pyproject_config(path)
+        (target,) = plan_targets(config)
+        assert target.python_version == "3.12"
+
+    def test_a_release_candidate_host_satisfies_its_own_release(
+        self, tmp_path: Path
+    ) -> None:
+        """``>=3.14`` has to admit a 3.14 candidate, as it does under pip.
+
+        A specifier admits no prerelease unless it names one, so comparing the
+        marker value would refuse to lock at all on a release candidate.
+        """
+        path = write(tmp_path, '[tool.nab]\nrequires-python = ">=3.14"\n')
+        config = read_pyproject_config(path)
+        target = ResolveTarget.for_host(
+            env_source=lambda: {
+                **default_environment(),
+                "python_version": "3.14",
+                "python_full_version": "3.14.0rc1",
+            },
+        )
+        assert target.python_release in SpecifierSet(">=3.14")
+        _check_requires_python_admits_target(config.requires_python, target)
+
     def test_a_python_override_rescues_a_declaration_the_host_fails(
         self, tmp_path: Path
     ) -> None:
@@ -1312,6 +1351,36 @@ class TestMarkerEnvironmentDeprecation:
             platform="windows_amd64", implementation="cpython"
         )
 
+    def test_the_platform_id_carries_the_markers_it_implies(
+        self, tmp_path: Path
+    ) -> None:
+        """The overlay nab shipped named platform_system, so it has to translate."""
+        path = write(
+            tmp_path,
+            '[tool.nab]\nbuild-policy = "never"\n'
+            "[tool.nab.marker-environment]\n"
+            'platform_system = "Linux"\n'
+            'sys_platform = "linux"\n'
+            'platform_machine = "x86_64"\n',
+        )
+        config = read_pyproject_config(path)
+        assert config.environment == EnvironmentConfig(platform="linux_x86_64")
+
+    def test_an_implied_marker_that_contradicts_the_platform_is_an_error(
+        self, tmp_path: Path
+    ) -> None:
+        """One overlay names one machine."""
+        path = write(
+            tmp_path,
+            '[tool.nab]\nbuild-policy = "never"\n'
+            "[tool.nab.marker-environment]\n"
+            'platform_system = "Windows"\n'
+            'sys_platform = "linux"\n'
+            'platform_machine = "x86_64"\n',
+        )
+        with pytest.raises(ConfigError, match="contradicts platform"):
+            read_pyproject_config(path)
+
     def test_half_a_platform_is_an_error(self, tmp_path: Path) -> None:
         """``sys_platform`` alone used to keep the host's machine."""
         path = write(
@@ -1331,14 +1400,23 @@ class TestMarkerEnvironmentDeprecation:
         with pytest.raises(ConfigError, match="names no platform nab models"):
             read_pyproject_config(path)
 
-    def test_untranslatable_variable_is_an_error(self, tmp_path: Path) -> None:
-        """``platform_system`` carries no axis: the platform id implies it."""
+    def test_an_implied_marker_alone_is_an_error(self, tmp_path: Path) -> None:
+        """``platform_system`` names no machine without the pair that does."""
         path = write(
             tmp_path,
             '[tool.nab.marker-environment]\nplatform_system = "Linux"\n',
         )
+        with pytest.raises(ConfigError, match="which is the pair that names"):
+            read_pyproject_config(path)
+
+    def test_untranslatable_variable_is_an_error(self, tmp_path: Path) -> None:
+        """A variable no environment axis carries cannot be translated."""
+        path = write(
+            tmp_path,
+            '[tool.nab.marker-environment]\nplatform_release = "6.8.0"\n',
+        )
         with pytest.raises(
-            ConfigError, match=r"variable\(s\) \['platform_system'\] cannot be"
+            ConfigError, match=r"variable\(s\) \['platform_release'\] cannot be"
         ):
             read_pyproject_config(path)
 

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -16,12 +16,14 @@ from nab_python.config import (
     ConflictPolicy,
     ConflictSelectionError,
     ConflictSet,
+    EnvironmentConfig,
     MatrixConfig,
     NabProjectConfig,
     ResolveMode,
     conflict_exclusion_groups,
     conflict_forks,
     index_routes_from_config,
+    plan_targets,
     read_pyproject_config,
     validate_conflict_minimums,
 )
@@ -46,6 +48,7 @@ from nab_python.provider import (
     VcsSource,
 )
 from nab_python.tags import PlatformSpec
+from nab_python.target import ResolveTarget
 from nab_python.workspace import WorkspaceConfig
 
 
@@ -710,15 +713,71 @@ class TestDefaultGroups:
 
 
 class TestRequiresPython:
+    """``requires-python`` declares the supported range; it is not a target.
+
+    The resolve target is the host (or ``[tool.nab.environment]``), so a
+    specifier finer than the host's Python is paired with the environment
+    that satisfies it; one that admits no target at all is an error.
+    """
+
     def test_round_trip_specifier(self, tmp_path: Path) -> None:
         """A valid PEP 440 specifier round-trips as the raw string."""
-        path = write(tmp_path, '[tool.nab]\nrequires-python = "==3.12.0"\n')
+        path = write(
+            tmp_path,
+            '[tool.nab]\nrequires-python = "==3.12.0"\n'
+            '[tool.nab.environment]\npython = "3.12.0"\n',
+        )
         assert read_pyproject_config(path).requires_python == "==3.12.0"
 
     def test_range_specifier_round_trips(self, tmp_path: Path) -> None:
         """A range specifier (``>=X,<Y``) round-trips as written."""
-        path = write(tmp_path, '[tool.nab]\nrequires-python = ">=3.13,<3.14"\n')
+        path = write(
+            tmp_path,
+            '[tool.nab]\nrequires-python = ">=3.13,<3.14"\n'
+            '[tool.nab.environment]\npython = "3.13"\n',
+        )
         assert read_pyproject_config(path).requires_python == ">=3.13,<3.14"
+
+    def test_excluding_the_resolve_target_is_an_error(self, tmp_path: Path) -> None:
+        """A declaration the target Python fails names the knob that moves it."""
+        path = write(
+            tmp_path,
+            '[tool.nab]\nrequires-python = "==3.9.*"\n'
+            '[tool.nab.environment]\npython = "3.12"\n',
+        )
+        with pytest.raises(
+            ConfigError,
+            match=r"excludes the resolve target Python 3.12.*tool.nab.environment",
+        ):
+            read_pyproject_config(path)
+
+    def test_project_table_is_the_fallback_source(self, tmp_path: Path) -> None:
+        """``[project].requires-python`` is recorded when [tool.nab] sets none."""
+        path = write(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "0"\nrequires-python = ">=3.8"\n',
+        )
+        assert read_pyproject_config(path).requires_python == ">=3.8"
+
+    def test_tool_nab_wins_over_the_project_table(self, tmp_path: Path) -> None:
+        """The nab key overrides the project's own declaration."""
+        path = write(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "0"\nrequires-python = ">=3.8"\n'
+            '[tool.nab]\nrequires-python = ">=3.9"\n',
+        )
+        assert read_pyproject_config(path).requires_python == ">=3.9"
+
+    def test_project_table_specifier_is_validated(self, tmp_path: Path) -> None:
+        """A malformed [project].requires-python fails loud, not silently."""
+        path = write(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "0"\nrequires-python = "3.9"\n',
+        )
+        with pytest.raises(
+            ConfigError, match="requires-python must be a PEP 440 specifier"
+        ):
+            read_pyproject_config(path)
 
     def test_bare_version_rejected(self, tmp_path: Path) -> None:
         """A bare version is not a valid specifier; reject with guidance."""
@@ -750,7 +809,13 @@ class TestRequiresPython:
         assert match is not None, "top-level example dropped requires-python"
         value = match.group(1)
 
-        path = write(tmp_path, f'[tool.nab]\nrequires-python = "{value}"\n')
+        # The declaration is checked against the resolve target, so pin one
+        # the example admits rather than the Python the tests happen to run.
+        path = write(
+            tmp_path,
+            f'[tool.nab]\nrequires-python = "{value}"\n'
+            '[tool.nab.environment]\npython = "3.13"\n',
+        )
         assert read_pyproject_config(path).requires_python == value
 
 
@@ -993,7 +1058,7 @@ class TestUniversalBuildPolicy:
             '[tool.nab]\nmode = "universal"\nbuild-policy = "build-local"\n'
             + _UNIVERSAL_MATRIX,
         )
-        with pytest.raises(ConfigError, match="universal.*build-policy.*never"):
+        with pytest.raises(ConfigError, match="declared target.*build-policy.*never"):
             read_pyproject_config(path)
 
     def test_explicit_build_remote_rejected(self, tmp_path: Path) -> None:
@@ -1002,7 +1067,7 @@ class TestUniversalBuildPolicy:
             '[tool.nab]\nmode = "universal"\nbuild-policy = "build-remote"\n'
             + _UNIVERSAL_MATRIX,
         )
-        with pytest.raises(ConfigError, match="universal.*build-policy.*never"):
+        with pytest.raises(ConfigError, match="declared target.*build-policy.*never"):
             read_pyproject_config(path)
 
     def test_package_override_build_policy_rejected(self, tmp_path: Path) -> None:
@@ -1075,16 +1140,210 @@ class TestResolution:
             read_pyproject_config(path)
 
 
-class TestMarkerEnvironment:
-    def test_round_trip(self, tmp_path: Path) -> None:
+class TestEnvironment:
+    """``[tool.nab.environment]``: the one environment to resolve for."""
+
+    def test_absent_is_the_host(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab]\nresolution = "highest"\n')
+        config = read_pyproject_config(path)
+        assert config.environment is None
+        assert plan_targets(config) == (ResolveTarget.for_host(),)
+
+    def test_python_only_retargets_the_host_python(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab.environment]\npython = "3.10"\n')
+        config = read_pyproject_config(path)
+        assert config.environment == EnvironmentConfig(python="3.10")
+        (target,) = plan_targets(config)
+        assert target.python_full_version == "3.10.0"
+        assert target.platform_id == "host"
+
+    def test_platform_declares_a_target(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab.environment]\n"
+            'python = "3.11"\n'
+            'platform = "macos_arm64"\n'
+            'implementation = "pypy"\n'
+            '[tool.nab]\nbuild-policy = "never"\n',
+        )
+        config = read_pyproject_config(path)
+        assert config.environment == EnvironmentConfig(
+            python="3.11", platform="macos_arm64", implementation="pypy"
+        )
+        (target,) = plan_targets(config)
+        assert target.marker_env["sys_platform"] == "darwin"
+        assert target.implementation == "pypy"
+        assert target.platform_id == "macos_arm64"
+
+    def test_platform_without_python_takes_the_host_python(
+        self, tmp_path: Path
+    ) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab.environment]\nplatform = "linux_x86_64"\n'
+            '[tool.nab]\nbuild-policy = "never"\n',
+        )
+        (target,) = plan_targets(read_pyproject_config(path))
+        host = ResolveTarget.for_host()
+        assert target.python_full_version == host.python_full_version
+        assert target.platform_id == "linux_x86_64"
+
+    def test_must_be_table(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab]\nenvironment = "no"\n')
+        with pytest.raises(
+            ConfigError, match=r"\[tool.nab.environment\] must be a table"
+        ):
+            read_pyproject_config(path)
+
+    def test_unknown_key_rejected(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab.environment]\nlibc = "musl"\n')
+        with pytest.raises(
+            ConfigError, match=r"unknown \[tool.nab.environment\] keys: \['libc'\]"
+        ):
+            read_pyproject_config(path)
+
+    def test_value_must_be_string(self, tmp_path: Path) -> None:
+        path = write(tmp_path, "[tool.nab.environment]\npython = 3\n")
+        with pytest.raises(ConfigError, match="environment.python must be a string"):
+            read_pyproject_config(path)
+
+    def test_python_must_be_a_version(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab.environment]\npython = ">=3.12"\n')
+        with pytest.raises(
+            ConfigError, match="environment.python must be a version like"
+        ):
+            read_pyproject_config(path)
+
+    def test_unknown_platform_rejected(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[tool.nab.environment]\nplatform = "linux_i686"\n')
+        with pytest.raises(
+            ConfigError, match="unknown environment.platform 'linux_i686'"
+        ):
+            read_pyproject_config(path)
+
+    def test_unknown_implementation_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab.environment]\nplatform = "linux_x86_64"\n'
+            'implementation = "jython"\n',
+        )
+        with pytest.raises(
+            ConfigError, match="unknown environment.implementation 'jython'"
+        ):
+            read_pyproject_config(path)
+
+    def test_implementation_without_platform_rejected(self, tmp_path: Path) -> None:
+        """An interpreter is modelled on a declared machine, not the host's."""
+        path = write(tmp_path, '[tool.nab.environment]\nimplementation = "pypy"\n')
+        with pytest.raises(
+            ConfigError,
+            match=r"\[tool.nab.environment\].implementation needs a platform",
+        ):
+            read_pyproject_config(path)
+
+    def test_rejected_alongside_a_matrix(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab]\nmode = "universal"\n'
+            + _UNIVERSAL_MATRIX
+            + '[tool.nab.environment]\npython = "3.12"\n',
+        )
+        with pytest.raises(
+            ConfigError,
+            match=r"\[tool.nab.matrix\] and \[tool.nab.environment\] cannot both",
+        ):
+            read_pyproject_config(path)
+
+
+class TestMarkerEnvironmentDeprecation:
+    """``[tool.nab.marker-environment]`` translates to the environment table.
+
+    The overlay set marker variables one at a time, so a partial platform
+    left the rest of the machine on the host.  Every key must now name an
+    environment axis; one that cannot is an error, not a wrong resolve.
+    """
+
+    def test_python_version_translates(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
         path = write(
             tmp_path,
             "[tool.nab.marker-environment]\n"
-            'platform_system = "Linux"\n'
-            'sys_platform = "linux"\n',
+            'python_version = "3.12"\n'
+            'python_full_version = "3.12.4"\n',
         )
-        env = read_pyproject_config(path).marker_environment
-        assert env == {"platform_system": "Linux", "sys_platform": "linux"}
+        with caplog.at_level("WARNING", logger="nab_python.config"):
+            config = read_pyproject_config(path)
+        assert config.environment == EnvironmentConfig(python="3.12.4")
+        assert any("deprecated" in rec.message for rec in caplog.records)
+
+    def test_platform_pair_translates_to_a_platform_id(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab]\nbuild-policy = "never"\n'
+            "[tool.nab.marker-environment]\n"
+            'sys_platform = "win32"\n'
+            'platform_machine = "AMD64"\n'
+            'platform_python_implementation = "CPython"\n',
+        )
+        config = read_pyproject_config(path)
+        assert config.environment == EnvironmentConfig(
+            platform="windows_amd64", implementation="cpython"
+        )
+
+    def test_half_a_platform_is_an_error(self, tmp_path: Path) -> None:
+        """``sys_platform`` alone used to keep the host's machine."""
+        path = write(
+            tmp_path,
+            '[tool.nab.marker-environment]\nsys_platform = "linux"\n',
+        )
+        with pytest.raises(ConfigError, match="names no platform nab models"):
+            read_pyproject_config(path)
+
+    def test_unmappable_pair_is_an_error(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab.marker-environment]\n"
+            'sys_platform = "linux"\n'
+            'platform_machine = "ppc64le"\n',
+        )
+        with pytest.raises(ConfigError, match="names no platform nab models"):
+            read_pyproject_config(path)
+
+    def test_untranslatable_variable_is_an_error(self, tmp_path: Path) -> None:
+        """``platform_system`` carries no axis: the platform id implies it."""
+        path = write(
+            tmp_path,
+            '[tool.nab.marker-environment]\nplatform_system = "Linux"\n',
+        )
+        with pytest.raises(
+            ConfigError, match=r"variable\(s\) \['platform_system'\] cannot be"
+        ):
+            read_pyproject_config(path)
+
+    def test_unknown_implementation_is_an_error(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab]\nbuild-policy = "never"\n'
+            "[tool.nab.marker-environment]\n"
+            'sys_platform = "linux"\n'
+            'platform_machine = "x86_64"\n'
+            'implementation_name = "jython"\n',
+        )
+        with pytest.raises(
+            ConfigError, match="unknown environment.implementation 'jython'"
+        ):
+            read_pyproject_config(path)
+
+    def test_both_surfaces_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab.environment]\npython = "3.12"\n'
+            "[tool.nab.marker-environment]\n"
+            'python_version = "3.11"\n',
+        )
+        with pytest.raises(ConfigError, match="are both set"):
+            read_pyproject_config(path)
 
     def test_must_be_table(self, tmp_path: Path) -> None:
         path = write(tmp_path, '[tool.nab]\nmarker-environment = "no"\n')
@@ -1105,16 +1364,6 @@ class TestMarkerEnvironment:
         )
         with pytest.raises(ConfigError, match="unknown marker-environment variable"):
             read_pyproject_config(path)
-
-    def test_version_value_round_trip(self, tmp_path: Path) -> None:
-        path = write(
-            tmp_path,
-            "[tool.nab.marker-environment]\n"
-            'python_version = "3.12"\n'
-            'python_full_version = "3.12.4"\n',
-        )
-        env = read_pyproject_config(path).marker_environment
-        assert env == {"python_version": "3.12", "python_full_version": "3.12.4"}
 
     def test_python_version_must_be_pep440(self, tmp_path: Path) -> None:
         path = write(
@@ -1147,10 +1396,11 @@ class TestMarkerEnvironment:
             'python = ">=3.11"\n'
             'platforms = ["linux_x86_64"]\n'
             "[tool.nab.marker-environment]\n"
-            'platform_system = "Windows"\n',
+            'python_version = "3.11"\n',
         )
         with pytest.raises(
-            ConfigError, match="does not support .tool.nab.marker-environment."
+            ConfigError,
+            match=r"\[tool.nab.matrix\] and \[tool.nab.environment\] cannot both",
         ):
             read_pyproject_config(path)
 
@@ -3279,22 +3529,40 @@ class TestWorkspaceDiscoveryIntegration:
         config = read_pyproject_config(member)
         assert config.build_policy is BuildPolicy.NEVER
 
-    def test_marker_environment_member_not_promoted(self, tmp_path: Path) -> None:
-        """A marker overlay keeps never; discovery does not promote it.
+    def test_declared_platform_member_not_promoted(self, tmp_path: Path) -> None:
+        """A declared platform keeps never; discovery does not promote it.
 
-        A host build cannot reflect the impersonated marker target, so the
-        BUILD_LOCAL floor applied to workspace members is skipped.
+        A host build cannot reflect the declared machine, so the BUILD_LOCAL
+        floor applied to workspace members is skipped.
         """
         member = self._ws(tmp_path)
         member.write_text(
             '[project]\nname = "alpha"\nversion = "0"\n'
             "[tool.nab]\n"
             'build-policy = "never"\n'
-            "[tool.nab.marker-environment]\n"
-            'python_version = "3.9"\n',
+            "[tool.nab.environment]\n"
+            'platform = "linux_x86_64"\n',
         )
         config = read_pyproject_config(member)
         assert config.build_policy is BuildPolicy.NEVER
+
+    def test_declared_python_member_still_promoted(self, tmp_path: Path) -> None:
+        """A python-only retarget keeps the BUILD_LOCAL floor.
+
+        The machine is still the host, and a workspace member with dynamic
+        metadata has to build, so the floor applies and the build is
+        permitted (with a warning).  A deliberate deviation from pip.
+        """
+        member = self._ws(tmp_path)
+        member.write_text(
+            '[project]\nname = "alpha"\nversion = "0"\n'
+            "[tool.nab]\n"
+            'build-policy = "never"\n'
+            "[tool.nab.environment]\n"
+            'python = "3.9"\n',
+        )
+        config = read_pyproject_config(member)
+        assert config.build_policy is BuildPolicy.BUILD_LOCAL
 
     def test_no_discovery_skips_walk(self, tmp_path: Path) -> None:
         member = self._ws(tmp_path)
@@ -3421,15 +3689,15 @@ class TestProjectNabTomlConfiguresResolve:
         assert config.vcs.allowed_schemes == frozenset({"git+https"})
         assert "policy=allow" in _inspect(path, "vcs")
 
-    def test_table_marker_environment(self, tmp_path: Path) -> None:
+    def test_table_environment(self, tmp_path: Path) -> None:
         path = self._write(
             tmp_path,
             '[project]\nname = "x"\nversion = "0"\n',
-            '[marker-environment]\nsys_platform = "linux"\n',
+            '[environment]\npython = "3.12"\n',
         )
         config = read_pyproject_config(path, discover_workspace=False)
-        assert config.marker_environment == {"sys_platform": "linux"}
-        assert "sys_platform=linux" in _inspect(path, "marker-environment")
+        assert config.environment == EnvironmentConfig(python="3.12")
+        assert "python=3.12" in _inspect(path, "environment")
 
     def test_list_constraints(self, tmp_path: Path) -> None:
         path = self._write(

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -758,17 +758,19 @@ class TestRequiresPython:
     ) -> None:
         """``--python`` is the knob the error names, so it has to work.
 
-        The check runs against the target the resolve actually uses, which
-        ``--python`` moves after the config is read.  A library capped below
-        the host (``>=3.9,<3.13`` on 3.14) is otherwise unlockable.
+        The check runs against the target the resolve actually uses, and
+        ``--python`` moves that target after the config is read.  Without it a
+        library capped below the interpreter locking it could not be locked at
+        all.  nab itself needs 3.10, so a project declaring only 3.9 is never
+        the host, whatever runs the suite.
         """
-        path = write(tmp_path, '[tool.nab]\nrequires-python = ">=3.9,<3.13"\n')
+        path = write(tmp_path, '[tool.nab]\nrequires-python = "==3.9.*"\n')
         config = read_pyproject_config(path)
         with pytest.raises(ConfigError, match="excludes the resolve target"):
             plan_targets(config)
 
-        (target,) = plan_targets(with_python_override(config, "3.12"))
-        assert target.python_version == "3.12"
+        (target,) = plan_targets(with_python_override(config, "3.9"))
+        assert target.python_version == "3.9"
 
     def test_project_table_is_the_fallback_source(self, tmp_path: Path) -> None:
         """``[project].requires-python`` is recorded when [tool.nab] sets none."""

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -26,6 +26,7 @@ from nab_python.config import (
     plan_targets,
     read_pyproject_config,
     validate_conflict_minimums,
+    with_python_override,
 )
 from nab_python.config_sources import (
     SourceConfigError,
@@ -739,17 +740,35 @@ class TestRequiresPython:
         assert read_pyproject_config(path).requires_python == ">=3.13,<3.14"
 
     def test_excluding_the_resolve_target_is_an_error(self, tmp_path: Path) -> None:
-        """A declaration the target Python fails names the knob that moves it."""
+        """A declaration the target Python fails names the knobs that move it."""
         path = write(
             tmp_path,
             '[tool.nab]\nrequires-python = "==3.9.*"\n'
             '[tool.nab.environment]\npython = "3.12"\n',
         )
+        config = read_pyproject_config(path)
         with pytest.raises(
             ConfigError,
-            match=r"excludes the resolve target Python 3.12.*tool.nab.environment",
+            match=r"excludes the resolve target Python 3.12.*--python",
         ):
-            read_pyproject_config(path)
+            plan_targets(config)
+
+    def test_a_python_override_rescues_a_declaration_the_host_fails(
+        self, tmp_path: Path
+    ) -> None:
+        """``--python`` is the knob the error names, so it has to work.
+
+        The check runs against the target the resolve actually uses, which
+        ``--python`` moves after the config is read.  A library capped below
+        the host (``>=3.9,<3.13`` on 3.14) is otherwise unlockable.
+        """
+        path = write(tmp_path, '[tool.nab]\nrequires-python = ">=3.9,<3.13"\n')
+        config = read_pyproject_config(path)
+        with pytest.raises(ConfigError, match="excludes the resolve target"):
+            plan_targets(config)
+
+        (target,) = plan_targets(with_python_override(config, "3.12"))
+        assert target.python_version == "3.12"
 
     def test_project_table_is_the_fallback_source(self, tmp_path: Path) -> None:
         """``[project].requires-python`` is recorded when [tool.nab] sets none."""

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -784,6 +784,7 @@ class TestParserFoldHelpers:
                 "uploaded-prior-to",
                 "dist-policy",
                 "build-policy",
+                "environment",
                 "marker-environment",
                 "vcs",
                 "workspace",

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -9,14 +9,12 @@ import pytest
 
 from nab_index.client import WheelFile
 from nab_python._testing.coordinator_fake import make_coordinator
-from nab_python._testing.overrides import pkg_override
 from nab_python._vendor.packaging.markers import default_environment
 from nab_python._vendor.packaging.requirements import Requirement
-from nab_python._vendor.packaging.version import InvalidVersion, Version
+from nab_python._vendor.packaging.version import Version
 from nab_python.config import (
     ConfigError,
     ConflictSelectionError,
-    IndexOverride,
     MatrixConfig,
     NabProjectConfig,
     ResolveMode,
@@ -36,13 +34,11 @@ from nab_python.resolve import (
     _build_resolver_inputs,
     _check_group_disjointness,
     _check_group_disjointness_across_tuples,
-    _check_marker_overlay_build_policy,
     _find_group_conflicts,
     _load_extra_requirements,
     _load_group_requirements,
     _load_group_requirements_by_group,
     _raise_for_source_python,
-    _resolve_target_python,
     _walk_no_versions_packages,
     resolve_pyproject,
     resolve_universal_pyproject,
@@ -746,8 +742,8 @@ class TestResolvePyproject:
             "[project]\n"
             'dependencies = ["foo", "windows-only; sys_platform == \'win32\'"]\n'
             '[tool.nab]\nbuild-policy = "never"\n'
-            "[tool.nab.marker-environment]\n"
-            'sys_platform = "linux"\n',
+            "[tool.nab.environment]\n"
+            'platform = "linux_x86_64"\n',
         )
         mock_coord_cls.return_value.__enter__ = lambda s: s
         mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
@@ -771,12 +767,12 @@ class TestResolvePyproject:
         mock_build_lock: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """A python_full_version-gated dep follows the impersonated Python.
+        """A python_full_version-gated dep follows the declared Python.
 
-        Overlaying only ``python_version = "3.8"`` on a 3.12 host must keep
-        ``legacy; python_full_version < '3.10'``: the user is impersonating
-        Python 3.8, so the marker holds. The host patch level must not leak
-        in through ``python_full_version``.
+        Declaring only ``python = "3.8"`` on a 3.12 host must keep
+        ``legacy; python_full_version < '3.10'``: the resolve targets Python
+        3.8, so the marker holds. The host patch level must not leak in
+        through ``python_full_version``.
         """
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text(
@@ -784,8 +780,8 @@ class TestResolvePyproject:
             "dependencies = ["
             '"foo", "legacy; python_full_version < \'3.10\'"]\n'
             '[tool.nab]\nbuild-policy = "never"\n'
-            "[tool.nab.marker-environment]\n"
-            'python_version = "3.8"\n',
+            "[tool.nab.environment]\n"
+            'python = "3.8"\n',
         )
         mock_coord_cls.return_value.__enter__ = lambda s: s
         mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
@@ -794,7 +790,7 @@ class TestResolvePyproject:
             "legacy": V("1.0"),
         }
 
-        resolve_pyproject(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
+        resolve_pyproject(pyproject, _FAKE_TRANSPORT)
 
         requirements = mock_resolver_cls.return_value.resolve.call_args.args[0]
         assert "foo" in requirements
@@ -818,8 +814,8 @@ class TestResolvePyproject:
             "[project]\n"
             'dependencies = ["foo", "linux-only; sys_platform == \'linux\'"]\n'
             '[tool.nab]\nbuild-policy = "never"\n'
-            "[tool.nab.marker-environment]\n"
-            'sys_platform = "linux"\n',
+            "[tool.nab.environment]\n"
+            'platform = "linux_x86_64"\n',
         )
         mock_coord_cls.return_value.__enter__ = lambda s: s
         mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
@@ -867,7 +863,7 @@ class TestResolvePyproject:
         pyproject.write_text(
             '[project]\ndependencies = ["foo"]\n',
         )
-        with pytest.raises(InvalidVersion, match="'not-a-version'"):
+        with pytest.raises(ConfigError, match="'not-a-version'"):
             resolve_pyproject(
                 pyproject, _FAKE_TRANSPORT, python_version="not-a-version"
             )
@@ -876,7 +872,7 @@ class TestResolvePyproject:
     @patch("nab_python.resolve.Resolver")
     @patch("nab_python.resolve.Provider")
     @patch("nab_python.resolve.FetchCoordinator")
-    def test_config_requires_python_used_when_set(
+    def test_python_version_arg_retargets_the_python_axis(
         self,
         mock_coord_cls: MagicMock,
         mock_provider_cls: MagicMock,
@@ -884,45 +880,16 @@ class TestResolvePyproject:
         mock_build_lock: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """[tool.nab].requires-python derives the resolve target Python.
+        """The ``python_version`` arg (``--python``) sets the target Python.
 
-        ``==3.10.5`` is a single-version specifier, so the resolve
-        target is exactly 3.10.5; ``>=3.10`` would resolve to 3.10.0
-        (the lowest enumerated candidate the specifier admits).
+        ``requires-python`` is only a declaration, so it neither steers the
+        target nor conflicts with an override it admits.
         """
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text(
             '[project]\ndependencies = ["foo"]\n'
             "[tool.nab]\n"
-            'requires-python = "==3.10.5"\n',
-        )
-        mock_coord_cls.return_value.__enter__ = lambda s: s
-        mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
-        mock_resolver_cls.return_value.resolve.return_value = {}
-
-        resolve_pyproject(pyproject, _FAKE_TRANSPORT)
-
-        target = mock_provider_cls.call_args.kwargs["target"]
-        assert target.python_full_version == "3.10.5"
-
-    @patch("nab_python.resolve.build_lock_input_from_provider")
-    @patch("nab_python.resolve.Resolver")
-    @patch("nab_python.resolve.Provider")
-    @patch("nab_python.resolve.FetchCoordinator")
-    def test_cli_python_overrides_config(
-        self,
-        mock_coord_cls: MagicMock,
-        mock_provider_cls: MagicMock,
-        mock_resolver_cls: MagicMock,
-        mock_build_lock: MagicMock,
-        tmp_path: Path,
-    ) -> None:
-        """An explicit python_version arg wins over the config value."""
-        pyproject = tmp_path / "pyproject.toml"
-        pyproject.write_text(
-            '[project]\ndependencies = ["foo"]\n'
-            "[tool.nab]\n"
-            'requires-python = "==3.10.5"\n',
+            'requires-python = ">=3.10"\n',
         )
         mock_coord_cls.return_value.__enter__ = lambda s: s
         mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
@@ -932,6 +899,19 @@ class TestResolvePyproject:
 
         target = mock_provider_cls.call_args.kwargs["target"]
         assert target.python_full_version == "3.12.4"
+
+    def test_python_version_arg_outside_requires_python_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """A retarget the declaration excludes fails loud, not silently."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\ndependencies = ["foo"]\n'
+            "[tool.nab]\n"
+            'requires-python = ">=3.11"\n',
+        )
+        with pytest.raises(ConfigError, match="excludes the resolve target"):
+            resolve_pyproject(pyproject, _FAKE_TRANSPORT, python_version="3.9")
 
     def test_universal_mode_rejected(self, tmp_path: Path) -> None:
         """resolve_pyproject refuses to handle mode = 'universal'."""
@@ -1805,54 +1785,153 @@ class TestResolvePyprojectLockShape:
         assert tuple(ix.url for ix in passed) == ("https://custom.index/simple/",)
 
 
-class TestResolveTargetPython:
-    """``_resolve_target_python`` derives a concrete Python version."""
+class TestSpecificModeTargetPlan:
+    """The resolve target: the host, or the environment the project declares."""
 
-    def test_exact_specifier(self) -> None:
-        """``==3.10.5`` resolves to exactly 3.10.5."""
-        assert _resolve_target_python("==3.10.5") == "3.10.5"
+    @staticmethod
+    def _mock_resolve(coord: MagicMock, resolver: MagicMock) -> None:
+        coord.return_value.__enter__ = lambda s: s
+        coord.return_value.__exit__ = MagicMock(return_value=False)
+        resolver.return_value.resolve.return_value = {}
 
-    def test_lower_bound_only(self) -> None:
-        """``>=3.13`` resolves to 3.13.0 (the lowest enumerated match)."""
-        assert _resolve_target_python(">=3.13") == "3.13.0"
-
-    def test_range(self) -> None:
-        """``>=3.13,<3.14`` resolves to 3.13.0."""
-        assert _resolve_target_python(">=3.13,<3.14") == "3.13.0"
-
-    def test_excluded_minor(self) -> None:
-        """``>=3.10,!=3.12,<3.15`` skips the excluded minor."""
-        # 3.10.0 is the lowest enumerated match; the !=3.12 hole only
-        # matters when the lower bound forces the search past 3.12.
-        assert _resolve_target_python(">=3.10,!=3.12,<3.15") == "3.10.0"
-
-    def test_unbounded_below_falls_back_to_host(
-        self, caplog: pytest.LogCaptureFixture
+    @patch("nab_python.resolve.build_lock_input_from_provider")
+    @patch("nab_python.resolve.Resolver")
+    @patch("nab_python.resolve.Provider")
+    @patch("nab_python.resolve.FetchCoordinator")
+    def test_host_is_the_default_target(
+        self,
+        mock_coord_cls: MagicMock,
+        mock_provider_cls: MagicMock,
+        mock_resolver_cls: MagicMock,
+        mock_build_lock: MagicMock,
+        tmp_path: Path,
     ) -> None:
-        """Open-ended ``<X.Y`` falls back to the host Python with a warning."""
-        with caplog.at_level("WARNING", logger="nab_python.resolve"):
-            target = _resolve_target_python("<3.14")
-        # ``<3.14`` admits ``3.0.0`` (the lowest enumerated candidate),
-        # so the helper returns 3.0.0; fallback only fires when the
-        # specifier admits *nothing* in the candidate grid.  We verify
-        # that with a separate impossible-range case below.
-        assert target == "3.0.0"
-        assert not caplog.records
+        """A project that declares no environment resolves for the host."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text('[project]\ndependencies = ["foo"]\n')
+        self._mock_resolve(mock_coord_cls, mock_resolver_cls)
 
-    def test_no_match_falls_back_to_host(
-        self, caplog: pytest.LogCaptureFixture
+        resolve_pyproject(pyproject, _FAKE_TRANSPORT)
+
+        target = mock_provider_cls.call_args.kwargs["target"]
+        assert target == ResolveTarget.for_host()
+        assert target.host_faithful
+
+    @patch("nab_python.resolve.build_lock_input_from_provider")
+    @patch("nab_python.resolve.Resolver")
+    @patch("nab_python.resolve.Provider")
+    @patch("nab_python.resolve.FetchCoordinator")
+    def test_requires_python_does_not_steer_the_target(
+        self,
+        mock_coord_cls: MagicMock,
+        mock_provider_cls: MagicMock,
+        mock_resolver_cls: MagicMock,
+        mock_build_lock: MagicMock,
+        tmp_path: Path,
     ) -> None:
-        """A specifier that admits nothing in the grid logs and falls back."""
-        with caplog.at_level("WARNING", logger="nab_python.resolve"):
-            target = _resolve_target_python(">=99.0")
-        # The candidate grid stops at major 4, so ``>=99.0`` admits
-        # nothing and the helper falls back to the host (whatever the
-        # test runner is using).  We check the warning was emitted.
-        assert target  # non-empty
-        assert any(
-            "matches no enumerated CPython release" in rec.message
-            for rec in caplog.records
+        """``requires-python`` is a declaration: the host stays the target.
+
+        It is recorded as the lock's ``requires-python`` and nothing else,
+        so a project supporting 3.9 and up still resolves for the host.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\ndependencies = ["foo"]\n[tool.nab]\nrequires-python = ">=3.9"\n'
         )
+        self._mock_resolve(mock_coord_cls, mock_resolver_cls)
+
+        resolve_pyproject(pyproject, _FAKE_TRANSPORT)
+
+        target = mock_provider_cls.call_args.kwargs["target"]
+        assert target == ResolveTarget.for_host()
+        assert mock_build_lock.call_args.kwargs["requires_python"] == ">=3.9"
+
+    @patch("nab_python.resolve.build_lock_input_from_provider")
+    @patch("nab_python.resolve.Resolver")
+    @patch("nab_python.resolve.Provider")
+    @patch("nab_python.resolve.FetchCoordinator")
+    def test_environment_python_retargets_the_host(
+        self,
+        mock_coord_cls: MagicMock,
+        mock_provider_cls: MagicMock,
+        mock_resolver_cls: MagicMock,
+        mock_build_lock: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """``[tool.nab.environment].python`` moves the python axis only."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\ndependencies = ["foo"]\n'
+            "[tool.nab.environment]\n"
+            'python = "3.10.5"\n'
+        )
+        self._mock_resolve(mock_coord_cls, mock_resolver_cls)
+
+        resolve_pyproject(pyproject, _FAKE_TRANSPORT)
+
+        target = mock_provider_cls.call_args.kwargs["target"]
+        assert target.python_full_version == "3.10.5"
+        assert target.platform_id == "host"
+
+    @patch("nab_python.resolve.build_lock_input_from_provider")
+    @patch("nab_python.resolve.Resolver")
+    @patch("nab_python.resolve.Provider")
+    @patch("nab_python.resolve.FetchCoordinator")
+    def test_environment_platform_declares_the_target(
+        self,
+        mock_coord_cls: MagicMock,
+        mock_provider_cls: MagicMock,
+        mock_resolver_cls: MagicMock,
+        mock_build_lock: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """A declared platform builds a synthesized (non-host) target."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\ndependencies = ["foo"]\n'
+            "[tool.nab.environment]\n"
+            'python = "3.11"\n'
+            'platform = "windows_amd64"\n'
+        )
+        self._mock_resolve(mock_coord_cls, mock_resolver_cls)
+
+        resolve_pyproject(pyproject, _FAKE_TRANSPORT)
+
+        target = mock_provider_cls.call_args.kwargs["target"]
+        assert target.platform_id == "windows_amd64"
+        assert target.marker_env["sys_platform"] == "win32"
+        assert target.python_version == "3.11"
+        assert not target.host_faithful
+
+    @patch("nab_python.resolve.build_lock_input_from_provider")
+    @patch("nab_python.resolve.Resolver")
+    @patch("nab_python.resolve.Provider")
+    @patch("nab_python.resolve.FetchCoordinator")
+    def test_python_override_wins_over_the_environment(
+        self,
+        mock_coord_cls: MagicMock,
+        mock_provider_cls: MagicMock,
+        mock_resolver_cls: MagicMock,
+        mock_build_lock: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """``--python`` moves the python axis of a declared environment."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\ndependencies = ["foo"]\n'
+            "[tool.nab]\n"
+            'build-policy = "never"\n'
+            "[tool.nab.environment]\n"
+            'python = "3.11"\n'
+            'platform = "linux_aarch64"\n'
+        )
+        self._mock_resolve(mock_coord_cls, mock_resolver_cls)
+
+        resolve_pyproject(pyproject, _FAKE_TRANSPORT, python_version="3.12.4")
+
+        target = mock_provider_cls.call_args.kwargs["target"]
+        assert target.python_full_version == "3.12.4"
+        assert target.platform_id == "linux_aarch64"
 
 
 class TestLoadGroupRequirements:
@@ -2563,81 +2642,6 @@ def _tuple_for_python(python_version: str) -> ResolveTarget:
     )
 
 
-class TestCheckMarkerOverlayBuildPolicy:
-    """A marker overlay forces ``BuildPolicy.NEVER`` everywhere it can build."""
-
-    def test_default_policy_blocked_when_overlay_used(self) -> None:
-        """The default ``BUILD_LOCAL`` is rejected with a marker overlay.
-
-        Users who want a marker overlay must opt into ``never`` explicitly,
-        since a host-side backend cannot reflect the impersonated target.
-        """
-        config = NabProjectConfig(
-            marker_environment={"platform_system": "Windows"},
-        )
-        with pytest.raises(ValueError, match="marker_environment overlay requires"):
-            _check_marker_overlay_build_policy(config)
-
-    def test_overlay_with_build_remote_policy_raises(self) -> None:
-        """Non-``NEVER`` global + a marker overlay is rejected."""
-        config = NabProjectConfig(
-            build_policy=BuildPolicy.BUILD_REMOTE,
-            marker_environment={"platform_system": "Windows"},
-        )
-        with pytest.raises(ValueError, match="marker_environment overlay requires"):
-            _check_marker_overlay_build_policy(config)
-
-    def test_overlay_with_build_remote_override_raises(self) -> None:
-        """A build override that escapes ``NEVER`` also fails the guard."""
-        config = NabProjectConfig(
-            build_policy=BuildPolicy.NEVER,
-            package_overrides=(
-                pkg_override("foo", build_policy=BuildPolicy.BUILD_REMOTE),
-            ),
-            marker_environment={"platform_system": "Windows"},
-        )
-        with pytest.raises(ValueError, match="marker_environment overlay requires"):
-            _check_marker_overlay_build_policy(config)
-
-    def test_overlay_with_build_remote_index_override_raises(self) -> None:
-        """A per-index build override that escapes ``NEVER`` fails the guard."""
-        config = NabProjectConfig(
-            build_policy=BuildPolicy.NEVER,
-            index_overrides={
-                "internal": IndexOverride(build_policy=BuildPolicy.BUILD_REMOTE)
-            },
-            marker_environment={"platform_system": "Windows"},
-        )
-        with pytest.raises(ValueError, match="marker_environment overlay requires"):
-            _check_marker_overlay_build_policy(config)
-
-    def test_overlay_with_never_override_passes(self) -> None:
-        """An override already at ``NEVER`` is not offending."""
-        config = NabProjectConfig(
-            build_policy=BuildPolicy.NEVER,
-            package_overrides=(
-                pkg_override("quarantined", build_policy=BuildPolicy.NEVER),
-            ),
-            marker_environment={"platform_system": "Windows"},
-        )
-        _check_marker_overlay_build_policy(config)
-
-    def test_no_overlay_no_constraint(self) -> None:
-        """Without an overlay, a looser ``BuildPolicy`` is fine."""
-        _check_marker_overlay_build_policy(
-            NabProjectConfig(build_policy=BuildPolicy.BUILD_REMOTE)
-        )
-
-    def test_empty_overlay_no_constraint(self) -> None:
-        """An empty overlay does not trigger the build-policy check."""
-        _check_marker_overlay_build_policy(
-            NabProjectConfig(
-                build_policy=BuildPolicy.BUILD_REMOTE,
-                marker_environment={},
-            )
-        )
-
-
 class TestCheckGroupDisjointnessAcrossTuples:
     """``_check_group_disjointness_across_tuples`` runs the per-group
     range check under each tuple's marker environment and raises early
@@ -2940,13 +2944,13 @@ class TestLocalVcsRequiresPython:
             with pytest.raises(ResolutionError, match="foo 1.0 requires Python"):
                 resolve_pyproject(root, _FAKE_TRANSPORT, python_version="3.10.0")
 
-    def test_resolve_pyproject_overlay_target_satisfies_local(
+    def test_resolve_pyproject_declared_target_satisfies_local(
         self, tmp_path: Path
     ) -> None:
-        """A marker overlay's impersonated Python is the local-source target.
+        """The declared environment's Python is the local-source target.
 
-        A source valid only for the impersonated Python must not be refused
-        for failing the host Python. Mirrors the universal per-tuple check.
+        A source valid only for the declared Python must not be refused for
+        failing the host Python. Mirrors the universal per-tuple check.
         """
         member = tmp_path / "foo"
         member.mkdir()
@@ -2958,8 +2962,8 @@ class TestLocalVcsRequiresPython:
         root.write_text(
             '[project]\nname = "proj"\ndependencies = ["foo"]\n'
             '[tool.nab]\nbuild-policy = "never"\n'
-            "[tool.nab.marker-environment]\n"
-            'python_version = "3.12"\npython_full_version = "3.12.1"\n'
+            "[tool.nab.environment]\n"
+            'python = "3.12.1"\n'
             '[[tool.nab.local-sources]]\nname = "foo"\npath = "foo"\n',
             encoding="utf-8",
         )
@@ -2970,15 +2974,15 @@ class TestLocalVcsRequiresPython:
         ):
             mock_coord_cls.return_value.__enter__ = lambda _self: fake
             mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
-            result = resolve_pyproject(root, _FAKE_TRANSPORT, python_version="3.10.0")
+            result = resolve_pyproject(root, _FAKE_TRANSPORT)
         assert result.pins["foo"] == V("1.0")
 
-    def test_resolve_pyproject_overlay_target_satisfies_index(
+    def test_resolve_pyproject_declared_target_satisfies_index(
         self, tmp_path: Path
     ) -> None:
-        """The overlay's impersonated Python also gates index candidates.
+        """The declared environment's Python also gates index candidates.
 
-        An index candidate whose Requires-Python admits only the overlaid
+        An index candidate whose Requires-Python admits only the declared
         Python must survive the listing filter, matching the local-source
         check so both judge the same Requires-Python identically.
         """
@@ -2994,8 +2998,8 @@ class TestLocalVcsRequiresPython:
         root.write_text(
             '[project]\nname = "proj"\ndependencies = ["foo"]\n'
             '[tool.nab]\nbuild-policy = "never"\n'
-            "[tool.nab.marker-environment]\n"
-            'python_version = "3.12"\npython_full_version = "3.12.1"\n',
+            "[tool.nab.environment]\n"
+            'python = "3.12.1"\n',
             encoding="utf-8",
         )
         fake = make_coordinator([wheel], package="foo", auto_metadata=True)
@@ -3005,7 +3009,7 @@ class TestLocalVcsRequiresPython:
         ):
             mock_coord_cls.return_value.__enter__ = lambda _self: fake
             mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
-            result = resolve_pyproject(root, _FAKE_TRANSPORT, python_version="3.10.0")
+            result = resolve_pyproject(root, _FAKE_TRANSPORT)
         assert result.pins["foo"] == V("1.0")
 
 

--- a/src/nab/_download.py
+++ b/src/nab/_download.py
@@ -47,6 +47,7 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
     cache_dir: Path | None = None,
     cache: bool = True,
     offline: OfflineFlag = None,
+    python: str | None = None,
     max_concurrency: int | None = None,
     workspace_discovery: bool = True,
     groups: tuple[str, ...] = (),
@@ -72,6 +73,9 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
     mirror ``nab lock``: a project declaring an ``exactly-one`` or
     ``at-least-one`` conflict needs at least one member selected for
     the resolve to start, so these flags also gate the download.
+
+    ``--python X.Y`` resolves for that Python on this machine instead of
+    the running interpreter, as on ``nab lock``.
 
     ``--offline``, ``--cache-dir``, ``--http-backend``,
     ``--max-concurrency`` and ``--project-resolution`` flow through the
@@ -111,6 +115,7 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
     effective_cache_dir = _cli._resolve_effective_cache_dir(  # noqa: SLF001
         settings.cache_dir, cache=cache
     )
+    _cli._reject_python_override_in_universal(config, python)  # noqa: SLF001
     transport = _cli._make_transport(settings.http_backend)  # noqa: SLF001
     if config.mode is ResolveMode.UNIVERSAL:
         universal = _cli._resolve_universal(  # noqa: SLF001
@@ -132,6 +137,7 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
             offline=settings.offline,
             transport=transport,
             failure_prefix="Cannot download",
+            python=python,
             groups=selected_groups,
             extras=selected_extras,
             resolution_strategy=settings.resolution,

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -87,6 +87,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     cache_dir: Path | None = None,
     cache: bool = True,
     offline: OfflineFlag = None,
+    python: str | None = None,
     groups: tuple[str, ...] = (),
     all_groups: bool = False,
     extras: tuple[str, ...] = (),
@@ -127,6 +128,10 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     with ``pip install --no-deps -e <member>`` when consuming the
     lockfile via pip's PEP 751 install or ``--require-hashes``: both
     refuse directory entries because they cannot be hashed.
+
+    ``--python X.Y`` resolves for that Python on this machine instead of
+    the running interpreter, like pip's ``--python-version``.  It is
+    rejected in universal mode, where the matrix declares the Python axis.
 
     ``--project-resolution`` overrides ``[tool.nab].resolution`` for this
     run (a PROJECT-scope override, so it is layered through the config
@@ -176,6 +181,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     if locked and config.mode is ResolveMode.UNIVERSAL:
         sys.stderr.write("Error: --locked is not supported in universal mode.\n")
         sys.exit(1)
+    _cli._reject_python_override_in_universal(config, python)  # noqa: SLF001
     settings = _cli._layered_run_settings_or_exit(path, overrides)  # noqa: SLF001
     effective_cache_dir = _cli._resolve_effective_cache_dir(  # noqa: SLF001
         settings.cache_dir, cache=cache
@@ -224,6 +230,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
         offline=settings.offline,
         transport=transport,
         failure_prefix="Cannot lock",
+        python=python,
         groups=selected_groups,
         extras=selected_extras,
         resolution_strategy=settings.resolution,

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -29,6 +29,7 @@ from nab_index.urllib3_async_transport import Urllib3AsyncTransport
 from nab_python.config import (
     ConfigError,
     NabProjectConfig,
+    ResolveMode,
     read_pyproject_config,
 )
 from nab_python.config_sources import (
@@ -450,6 +451,23 @@ def is_stdout(output: Path | None) -> bool:
     return output is not None and str(output) == "-"
 
 
+def _reject_python_override_in_universal(
+    config: NabProjectConfig, python: str | None
+) -> None:
+    """Exit 1 when ``--python`` is passed to a matrix-declaring project.
+
+    The matrix declares the python axis itself, so a single Python for the
+    run has nowhere to land; silently ignoring the flag would lock a set
+    the user did not ask for.
+    """
+    if python is not None and config.mode is ResolveMode.UNIVERSAL:
+        sys.stderr.write(
+            "Error: --python is not supported in universal mode;"
+            " [tool.nab.matrix].python declares the Python axis.\n"
+        )
+        sys.exit(1)
+
+
 def _resolve_specific(  # noqa: PLR0913, C901 - one wrapper per resolve_pyproject kwarg / exit-mapped error
     path: Path,
     *,
@@ -458,6 +476,7 @@ def _resolve_specific(  # noqa: PLR0913, C901 - one wrapper per resolve_pyprojec
     offline: bool,
     transport: AsyncHttpTransport,
     failure_prefix: str,
+    python: str | None = None,
     groups: tuple[str, ...] = (),
     extras: tuple[str, ...] = (),
     resolution_strategy: ResolutionStrategy | None = None,
@@ -470,6 +489,7 @@ def _resolve_specific(  # noqa: PLR0913, C901 - one wrapper per resolve_pyprojec
             config=config,
             cache_dir=cache_dir,
             offline=offline,
+            python_version=python,
             groups=groups,
             extras=extras,
             resolution_strategy=resolution_strategy,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -760,6 +760,64 @@ class TestLockCommandSpecific:
         assert "typoo" in err
 
 
+class TestPythonFlag:
+    """``--python`` retargets the resolve for one run."""
+
+    def test_threads_the_python_version_to_the_resolver(self, tmp_path: Path) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with patch(
+            "nab.cli.resolve_pyproject", return_value=_stub_resolution_result()
+        ) as mock_resolve:
+            lock(pyproject, output=out, python="3.11")
+        assert mock_resolve.call_args.kwargs["python_version"] == "3.11"
+
+    def test_absent_flag_leaves_the_host_target(self, tmp_path: Path) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with patch(
+            "nab.cli.resolve_pyproject", return_value=_stub_resolution_result()
+        ) as mock_resolve:
+            lock(pyproject, output=out)
+        assert mock_resolve.call_args.kwargs["python_version"] is None
+
+    def test_rejected_in_universal_mode(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The matrix declares the python axis, so the flag has nowhere to land."""
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with pytest.raises(SystemExit) as exc:
+            lock(pyproject, output=out, python="3.11")
+        assert exc.value.code == 1
+        assert "--python is not supported in universal mode" in capsys.readouterr().err
+        assert not out.exists()
+
+    def test_download_threads_the_python_version(self, tmp_path: Path) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "wheels"
+        with (
+            patch(
+                "nab.cli.resolve_pyproject", return_value=_stub_resolution_result()
+            ) as mock_resolve,
+            patch(
+                "nab.cli.download_lock",
+                return_value=MagicMock(written=(out / "x.whl",), skipped=()),
+            ),
+        ):
+            download(pyproject, output=out, python="3.11")
+        assert mock_resolve.call_args.kwargs["python_version"] == "3.11"
+
+    def test_download_rejects_it_in_universal_mode(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _universal_pyproject(tmp_path)
+        with pytest.raises(SystemExit) as exc:
+            download(pyproject, output=tmp_path / "wheels", python="3.11")
+        assert exc.value.code == 1
+        assert "--python is not supported in universal mode" in capsys.readouterr().err
+
+
 class TestLockCommandUniversal:
     """Tests for `nab lock` in universal mode."""
 


### PR DESCRIPTION
Breaking. `_resolve_target_python` returned the lowest release the `requires-python` specifier admits, so nab resolved for that release rather than for the interpreter it was running on. A project declaring `requires-python = ">=3.8"` on a Python 3.14 host resolved as 3.8 and pinned `importlib-metadata` and `zipp` behind `python_version < "3.10"`; pip installs neither. `>=3.9`, the commonest declaration in the ecosystem, therefore locked as 3.9 forever, and `_resolve_target_python("<3.13")` returned `3.0.0`.

The host is now the target, which is pip's rule (`sys.version_info` unless `--python-version` says otherwise). `[tool.nab].requires-python` and `[project].requires-python` become what PEP 621 says they are: a declaration, recorded as the lock's top-level `requires-python` and checked against the target rather than choosing it. A declaration that excludes the target is a config error rather than a lock for a Python the project says it does not support.

Retargeting is now explicit. A new `[tool.nab.environment]` table takes `python`, `platform` and `implementation`, and `--python X.Y` retargets the interpreter axis for one run. Together they replace `[tool.nab.marker-environment]`, which is deprecated and translated with a warning: its partial declarations could describe a machine that does not exist, because naming `sys_platform` alone kept the host's `platform_machine`, and that is now an error rather than a silently wrong resolve.

The two build-policy guards become one, at config time. Any target that declares a platform forbids host builds, which is pip's rule under `--platform` and `--abi` (it requires `--only-binary=:all:`). A python-only retarget on the host platform warns and permits, because the workspace build-policy floor exists for members with dynamic metadata and refusing it would stop a workspace from pinning a Python. That is a deliberate deviation from pip and it is documented as one. It also closes a real hole: `requires-python` used to retarget the resolve without populating the marker environment, so the old guard never fired and a resolve impersonating another Python still ran host build backends.

The wheel-tag filter is not here. A declared `platform` still moves only the markers, so candidate selection does not yet reject a version that ships no wheel for it. That is the next change, and the docs say so rather than letting the new table imply more than it does.