### PR TITLE
fix archive cache corruption on concurrent extraction

### DIFF
--- a/nab-python/src/nab_python/_provider/sources.py
+++ b/nab-python/src/nab_python/_provider/sources.py
@@ -10,6 +10,8 @@ downloads and hash-verifies a ``.tar.gz`` and extracts it; both reuse the
 from __future__ import annotations
 
 import shutil
+import tempfile
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -23,6 +25,8 @@ if TYPE_CHECKING:
     from .._vendor.packaging.version import Version
     from ..metadata import WheelMetadata
     from ..provider import ArchiveSource, LocalSource, Provider, VcsSource
+
+_EXTRACTED_MARKER = ".nab-extracted"
 
 
 def index_local_sources(
@@ -346,38 +350,52 @@ def _extract_archive(
 
     Idempotent, like :func:`prepare_clone`: a digest already extracted in a
     prior resolve is reused rather than re-extracted, since the tree is
-    content-addressed by its verified hash.  The completion marker also
-    distinguishes a finished tree from a partial one left by a crashed run,
-    which is discarded and redone.
+    content-addressed by its verified hash.  A fresh extraction lands in a
+    temporary sibling and is renamed into place once its completion marker is
+    written, so the cache path never holds a partial tree.
     """
     from ..provider import UnsupportedSdistError
 
     target = cache_dir / digest
-    marker = target / ".nab-extracted"
+    marker = target / _EXTRACTED_MARKER
 
-    # Reuse a tree a prior resolve already extracted for this digest.
-    if marker.is_file():
-        root_name = marker.read_text(encoding="utf-8").strip()
-        # Resolve to match the fresh-extract branch, so the file URI works
-        # even for a relative cache dir.
-        base = target / root_name if root_name else target
-        return base.resolve()
+    if not marker.is_file():
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        tmp = Path(tempfile.mkdtemp(dir=cache_dir, prefix=f"{digest}.", suffix=".tmp"))
 
-    # Discard any partial tree left by a crashed run, then extract afresh.
-    if target.exists():
-        shutil.rmtree(target)
-    target.mkdir(parents=True)
-    try:
-        root = extract_sdist_archive(data, target)
-    except ValueError as exc:
-        shutil.rmtree(target, ignore_errors=True)
-        msg = f"archive could not be extracted: {exc}"
-        raise UnsupportedSdistError(msg) from exc
+        try:
+            try:
+                root = extract_sdist_archive(data, tmp)
+            except ValueError as exc:
+                msg = f"archive could not be extracted: {exc}"
+                raise UnsupportedSdistError(msg) from exc
 
-    # Record the root name (empty for a flat archive) so the next resolve
-    # reuses the tree without re-reading the bytes.  Compare against the
-    # resolved target since extract_sdist_archive resolves symlinks and
-    # relative cache dirs, which would otherwise misrecord a flat root.
-    root_name = root.name if root != target.resolve() else ""
-    marker.write_text(root_name, encoding="utf-8")
-    return root
+            # An empty root name means a flat archive.  Compare against the
+            # resolved temp dir, since extract_sdist_archive resolves symlinks
+            # and relative cache dirs.
+            root_name = root.name if root != tmp.resolve() else ""
+            (tmp / _EXTRACTED_MARKER).write_text(root_name, encoding="utf-8")
+
+            try:
+                tmp.rename(target)
+            except OSError as exc:
+                # The cache path is taken.  A marker there means another run
+                # got there first, so keep its tree; without one it is a partial
+                # left by an interrupted run, so wipe it and retry the rename.
+                if not marker.is_file():
+                    shutil.rmtree(target, ignore_errors=True)
+                    with suppress(OSError):
+                        tmp.rename(target)
+                if not marker.is_file():
+                    msg = f"extracted archive could not be moved into place: {exc}"
+                    raise UnsupportedSdistError(msg) from exc
+        finally:
+            # A successful rename leaves nothing here; any other exit, an
+            # interrupt included, would leak the temp tree.
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    root_name = marker.read_text(encoding="utf-8").strip()
+
+    # Resolve so the file URI works even for a relative cache dir.
+    base = target / root_name if root_name else target
+    return base.resolve()

--- a/nab-python/tests/test_archive.py
+++ b/nab-python/tests/test_archive.py
@@ -24,6 +24,7 @@ from nab_index.archive import ArchiveRequest, ArchiveRequestError
 from nab_index.client import SdistHashMismatchError, extract_sdist_archive
 from nab_index.httpx_async_transport import HttpxAsyncTransport
 from nab_index.multi_index import IndexConfig
+from nab_python._provider import sources
 from nab_python._provider.sources import _fetch_archive_bytes
 from nab_python.download import (
     DownloadError,
@@ -299,6 +300,7 @@ class TestArchiveMaterialize:
         provider.coordinator.index.store_sdist_archive("foo", digest, data)
         with pytest.raises(UnsupportedSdistError, match="could not be extracted"):
             provider.fetch_versions("foo")
+        assert list((tmp_path / "arch").iterdir()) == []
 
     def test_truncated_archive_raises(self, tmp_path: Path) -> None:
         # The hash covers the truncated bytes, so this fails in extraction
@@ -312,6 +314,7 @@ class TestArchiveMaterialize:
         provider.coordinator.index.store_sdist_archive("foo", digest, data)
         with pytest.raises(UnsupportedSdistError, match="could not be extracted"):
             provider.fetch_versions("foo")
+        assert list((tmp_path / "arch").iterdir()) == []
 
     @requires_data_filter
     def test_reextraction_replaces_stale_partial_tree(self, tmp_path: Path) -> None:
@@ -355,6 +358,100 @@ class TestArchiveMaterialize:
 
         assert str(versions[0][0]) == "1.0.0"
         assert sentinel.exists()
+
+    @requires_data_filter
+    def test_partial_tree_never_visible_at_cache_path(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # The marker is the only completeness signal, so a concurrent run would
+        # read a half-written tree at the cache path as its own to wipe or to
+        # mark complete.  Nothing may appear there until extraction is done.
+        data = _make_sdist("foo", "1.0.0", _PYPROJECT)
+        digest = hashlib.sha256(data).hexdigest()
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
+        )
+        cache = tmp_path / "arch"
+        target = cache / digest
+        seen_mid_extract: list[bool] = []
+
+        def watching_extract(payload: bytes, target_dir: Path) -> Path:
+            seen_mid_extract.append(target.exists())
+            return extract_sdist_archive(payload, target_dir)
+
+        monkeypatch.setattr(sources, "extract_sdist_archive", watching_extract)
+        provider = _provider([source], cache)
+        provider.coordinator.index.store_sdist_archive("foo", digest, data)
+
+        versions = provider.fetch_versions("foo")
+
+        assert seen_mid_extract == [False]
+        assert str(versions[0][0]) == "1.0.0"
+        assert (target / "foo-1.0.0" / "pyproject.toml").is_file()
+        assert (target / ".nab-extracted").read_text(encoding="utf-8") == "foo-1.0.0"
+
+    @requires_data_filter
+    def test_lost_publish_race_uses_the_finished_tree(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # When a concurrent run publishes its own finished tree first, that tree
+        # is used as-is and the temporary one is dropped.
+        data = _make_sdist("foo", "1.0.0", _PYPROJECT)
+        digest = hashlib.sha256(data).hexdigest()
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
+        )
+        cache = tmp_path / "arch"
+        target = cache / digest
+        seen_mid_extract: list[bool] = []
+
+        def racing_extract(payload: bytes, target_dir: Path) -> Path:
+            seen_mid_extract.append(target.exists())
+            root = extract_sdist_archive(payload, target_dir)
+            winner = target / "foo-1.0.0"
+            winner.mkdir(parents=True, exist_ok=True)
+            (winner / "pyproject.toml").write_text(_PYPROJECT, encoding="utf-8")
+            (winner / "WINNER").write_text("", encoding="utf-8")
+            (target / ".nab-extracted").write_text("foo-1.0.0", encoding="utf-8")
+            return root
+
+        monkeypatch.setattr(sources, "extract_sdist_archive", racing_extract)
+        provider = _provider([source], cache)
+        provider.coordinator.index.store_sdist_archive("foo", digest, data)
+
+        versions = provider.fetch_versions("foo")
+
+        assert seen_mid_extract == [False]
+        assert str(versions[0][0]) == "1.0.0"
+        assert (target / "foo-1.0.0" / "WINNER").is_file()
+        assert list(cache.iterdir()) == [target]
+
+    @requires_data_filter
+    def test_interrupted_extraction_leaves_no_temp_tree(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # An interrupt lands after the bytes are on disk but before the rename.
+        # Nothing sweeps the cache later, so the temp tree has to go now.
+        data = _make_sdist("foo", "1.0.0", _PYPROJECT)
+        digest = hashlib.sha256(data).hexdigest()
+        cache = tmp_path / "arch"
+
+        def interrupted_extract(payload: bytes, target_dir: Path) -> Path:
+            extract_sdist_archive(payload, target_dir)
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(sources, "extract_sdist_archive", interrupted_extract)
+
+        with pytest.raises(KeyboardInterrupt):
+            sources._extract_archive(cache, digest, data)
+
+        assert list(cache.iterdir()) == []
 
     @requires_data_filter
     def test_flat_archive_without_root_dir(self, tmp_path: Path) -> None:


### PR DESCRIPTION
`_extract_archive` wiped `<cache>/<digest>`, extracted into it, then wrote the `.nab-extracted` marker. Two runs extracting the same sdist at once step on each other: the second wipes the tree the first is still writing into, and the first then writes its marker over whatever is left. The marker is the only completeness signal, so every later run reuses that half-written tree, and the resolve keeps failing on missing files until the cache is cleared by hand.

Extraction now lands in a `tempfile.mkdtemp` sibling inside the cache dir, writes its marker there, and is renamed into place, the same shape `prepare_clone` already uses for VCS checkouts. If the rename finds the path taken, a marker there means another run got there first and its tree is kept; without one the leftover is a partial from an interrupted run, so it is replaced. The temp dir is removed in a `finally`, so an interrupt between extraction and the rename leaves nothing behind.
