### PR TITLE
key the PEP 658 metadata cache by artifact

### DIFF
--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -9,7 +9,7 @@ Layout under ``root``:
 
     simple-v0/<index>/<package>.json       <- raw PyPI JSON body
     simple-v0/<index>/<package>.policy     <- {fetched_at, max_age, etag}
-    metadata-v0/<index>/<package>/<version>.metadata
+    metadata-v1/<index>/<package>/<url digest>.metadata
     sdist-v1/<index>/<package>/<version>.json  <- {pkg_info, pyproject}
 
 A versioned bucket name (``simple-v0``) gives zero-cost schema
@@ -39,7 +39,7 @@ __all__ = [
 
 
 CACHE_VERSION_SIMPLE = "v0"
-CACHE_VERSION_METADATA = "v0"
+CACHE_VERSION_METADATA = "v1"
 CACHE_VERSION_SDIST = "v1"
 
 DEFAULT_PYPI_URLS = frozenset(
@@ -142,6 +142,19 @@ class OnDiskCache:
         version_segment = _require_single_segment(version)
         return base / package_segment / f"{version_segment}{suffix}"
 
+    def _metadata_path(self, package: str, metadata_url: str) -> Path:
+        """Return the file holding the sidecar published at ``metadata_url``.
+
+        Keyed by the URL rather than by version: :pep:`658` attaches a
+        sidecar to one file, so the wheels of a single version each have
+        their own, and per-platform wheels can declare different
+        dependencies. The URL is digested because an index may serve
+        artifacts from any path shape, while the key must be one segment.
+        """
+        package_segment = _require_single_segment(package)
+        digest = hashlib.sha256(metadata_url.encode("utf-8")).hexdigest()
+        return self._metadata_dir / package_segment / f"{digest}.metadata"
+
     def get_simple(self, package: str) -> tuple[bytes, CachePolicy] | None:
         """Return ``(body_bytes, policy)`` if cached, else ``None``."""
         body_path, policy_path = self._simple_paths(package)
@@ -176,18 +189,13 @@ class OnDiskCache:
         _, policy_path = self._simple_paths(package)
         _atomic_write(policy_path, _encode_policy(policy))
 
-    def get_metadata(self, package: str, version: str) -> str | None:
-        """Return cached PEP 658 metadata text, or ``None`` on miss."""
-        return _read_text(
-            self._entry_path(self._metadata_dir, package, version, ".metadata")
-        )
+    def get_metadata(self, package: str, metadata_url: str) -> str | None:
+        """Return the cached sidecar text for ``metadata_url``, or ``None``."""
+        return _read_text(self._metadata_path(package, metadata_url))
 
-    def put_metadata(self, package: str, version: str, text: str) -> None:
-        """Write PEP 658 metadata text. Treated as immutable."""
-        _atomic_write(
-            self._entry_path(self._metadata_dir, package, version, ".metadata"),
-            text.encode("utf-8"),
-        )
+    def put_metadata(self, package: str, metadata_url: str, text: str) -> None:
+        """Write the sidecar text served at ``metadata_url``. Immutable."""
+        _atomic_write(self._metadata_path(package, metadata_url), text.encode("utf-8"))
 
     def get_sdist_files(
         self, package: str, version: str
@@ -248,12 +256,12 @@ class CacheBackend(Protocol):
         """Update the policy for an existing entry without rewriting the body."""
         ...
 
-    def get_metadata(self, package: str, version: str) -> str | None:
-        """Return cached PEP 658 metadata text, or ``None`` on miss."""
+    def get_metadata(self, package: str, metadata_url: str) -> str | None:
+        """Return the cached sidecar text for ``metadata_url``, or ``None``."""
         ...
 
-    def put_metadata(self, package: str, version: str, text: str) -> None:
-        """Store PEP 658 metadata text. Treated as immutable."""
+    def put_metadata(self, package: str, metadata_url: str, text: str) -> None:
+        """Store the sidecar text served at ``metadata_url``. Immutable."""
         ...
 
     def get_sdist_files(
@@ -292,10 +300,10 @@ class NullCache:
     def refresh_simple_policy(self, package: str, policy: CachePolicy) -> None:
         """Discard the policy refresh."""
 
-    def get_metadata(self, package: str, version: str) -> str | None:
+    def get_metadata(self, package: str, metadata_url: str) -> str | None:
         """Return ``None`` (always a miss)."""
 
-    def put_metadata(self, package: str, version: str, text: str) -> None:
+    def put_metadata(self, package: str, metadata_url: str, text: str) -> None:
         """Discard the entry."""
 
     def get_sdist_files(

--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -137,19 +137,17 @@ class OnDiskCache:
         policy = self._simple_dir / f"{segment}.policy"
         return (body, policy)
 
-    def _entry_path(self, base: Path, package: str, version: str, suffix: str) -> Path:
+    def _sdist_path(self, package: str, version: str) -> Path:
         package_segment = _require_single_segment(package)
         version_segment = _require_single_segment(version)
-        return base / package_segment / f"{version_segment}{suffix}"
+        return self._sdist_dir / package_segment / f"{version_segment}.json"
 
     def _metadata_path(self, package: str, metadata_url: str) -> Path:
         """Return the file holding the sidecar published at ``metadata_url``.
 
-        Keyed by the URL rather than by version: :pep:`658` attaches a
-        sidecar to one file, so the wheels of a single version each have
-        their own, and per-platform wheels can declare different
-        dependencies. The URL is digested because an index may serve
-        artifacts from any path shape, while the key must be one segment.
+        :pep:`658` attaches a sidecar to one file, so the wheels of a version
+        each have their own. The URL is digested to keep the key a single
+        path segment whatever path shape the index serves.
         """
         package_segment = _require_single_segment(package)
         digest = hashlib.sha256(metadata_url.encode("utf-8")).hexdigest()
@@ -206,7 +204,7 @@ class OnDiskCache:
         whose ``pyproject_toml`` is ``None`` means the sdist ships no
         pyproject.toml, which is not the same as a miss.
         """
-        text = _read_text(self._entry_path(self._sdist_dir, package, version, ".json"))
+        text = _read_text(self._sdist_path(package, version))
         if text is None:
             return None
         try:
@@ -224,7 +222,7 @@ class OnDiskCache:
     ) -> None:
         """Write the ``(pkg_info, pyproject_toml)`` pair as one record."""
         _atomic_write(
-            self._entry_path(self._sdist_dir, package, version, ".json"),
+            self._sdist_path(package, version),
             json.dumps({"pkg_info": pkg_info, "pyproject": pyproject_toml}).encode(
                 "utf-8"
             ),

--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -72,9 +72,10 @@ def _header(response: HttpResponse, key: str) -> str | None:
 class CachedAsyncSimpleClient:
     """Async PyPI Simple API client with on-disk caching.
 
-    Distinct from :class:`AsyncSimpleClient`: the metadata methods
-    take ``(package, version)`` so the cache can key by package
-    coordinate rather than URL. The interface mirrors what
+    Distinct from :class:`AsyncSimpleClient`: its methods take the
+    ``(package, version)`` coordinate alongside the artifact URL, so the
+    cache can key sdist records by coordinate and offline misses can name
+    what was being resolved. The interface mirrors what
     :class:`FetchCoordinator` actually needs.
     """
 
@@ -203,7 +204,13 @@ class CachedAsyncSimpleClient:
         metadata_url: str,
         metadata_hash: tuple[str, str] | None = None,
     ) -> str:
-        """Return PEP 658 metadata text for ``(package, version)``.
+        """Return the PEP 658 metadata text published at ``metadata_url``.
+
+        The cache entry stands for the sidecar at that URL, not for the
+        ``(package, version)`` coordinate: a version's wheels each publish
+        their own sidecar, and per-platform wheels can declare different
+        dependencies, so keying by version would serve one wheel's METADATA
+        for another.  ``version`` names the coordinate being resolved.
 
         Treated as immutable: cached forever, never revalidated.  A
         cache hit is returned without re-checking, since it was
@@ -217,7 +224,7 @@ class CachedAsyncSimpleClient:
         the response Content-Type charset. This keeps the parsed text
         tied to the bytes the hash covers.
         """
-        cached = self._cache.get_metadata(package, version)
+        cached = self._cache.get_metadata(package, metadata_url)
         if cached is not None:
             return cached
 
@@ -231,7 +238,7 @@ class CachedAsyncSimpleClient:
         if metadata_hash is not None:
             _verify_metadata_hash(content, metadata_hash)
         text = content.decode("utf-8")
-        self._cache.put_metadata(package, version, text)
+        self._cache.put_metadata(package, metadata_url, text)
         return text
 
     async def get_sdist_files(

--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -72,11 +72,8 @@ def _header(response: HttpResponse, key: str) -> str | None:
 class CachedAsyncSimpleClient:
     """Async PyPI Simple API client with on-disk caching.
 
-    Distinct from :class:`AsyncSimpleClient`: its methods take the
-    ``(package, version)`` coordinate alongside the artifact URL, so the
-    cache can key sdist records by coordinate and offline misses can name
-    what was being resolved. The interface mirrors what
-    :class:`FetchCoordinator` actually needs.
+    Distinct from :class:`AsyncSimpleClient`: the interface mirrors what
+    :class:`FetchCoordinator` actually needs rather than the Simple API.
     """
 
     def __init__(
@@ -206,11 +203,8 @@ class CachedAsyncSimpleClient:
     ) -> str:
         """Return the PEP 658 metadata text published at ``metadata_url``.
 
-        The cache entry stands for the sidecar at that URL, not for the
-        ``(package, version)`` coordinate: a version's wheels each publish
-        their own sidecar, and per-platform wheels can declare different
-        dependencies, so keying by version would serve one wheel's METADATA
-        for another.  ``version`` names the coordinate being resolved.
+        ``version`` names the coordinate being resolved; the cache entry
+        stands for the sidecar at the URL.
 
         Treated as immutable: cached forever, never revalidated.  A
         cache hit is returned without re-checking, since it was

--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -558,11 +558,11 @@ def prefetch_walk_ahead(
             continue
         if _has_complete_override(provider, normalized, version):
             continue
-        if coordinator_index.has_metadata(normalized, wheel.version):
-            continue
         # ``_first_wheel_per_version`` filters out wheels without metadata_url.
         metadata_url = wheel.metadata_url
         assert metadata_url is not None
+        if coordinator_index.has_metadata_for(normalized, wheel.version, metadata_url):
+            continue
         items.append((normalized, wheel.version, metadata_url, wheel.metadata_hash))
     if items:
         provider.coordinator.request_metadata_batch(items)

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -116,6 +116,15 @@ class _Pending:
     result: Any = None
 
 
+def _metadata_key(package: str, version: str, metadata_url: str | None) -> str:
+    """Return the pending key for one sidecar fetch.
+
+    The URL is in the key so two wheels of a version do not share a request:
+    a waiter is released by the artifact it asked for.
+    """
+    return f"metadata:{package}:{version}:{metadata_url}"
+
+
 class InMemoryIndex:
     """Thread-safe storage for fetched package data.
 
@@ -130,6 +139,10 @@ class InMemoryIndex:
         self._listing_indexes: dict[str, str] = {}
         self._metadata: dict[tuple[str, str], str | None] = {}
         self._metadata_errors: dict[tuple[str, str], BaseException] = {}
+        # The sidecar URL whose bytes fill each ``_metadata`` slot, or None
+        # when the slot stands for the version rather than for one artifact
+        # (sdist PKG-INFO, an injected override).
+        self._metadata_source: dict[tuple[str, str], str | None] = {}
         # Keys whose ``_metadata`` slot was last written from an sdist
         # PKG-INFO rather than a wheel METADATA; readers need the
         # origin because only sdist deps go through the PEP 643 gate.
@@ -216,13 +229,37 @@ class InMemoryIndex:
         with self._lock:
             return (package, version) in self._metadata
 
-    def store_metadata(self, package: str, version: str, data: str | None) -> None:
+    def has_metadata_for(self, package: str, version: str, metadata_url: str) -> bool:
+        """Return ``True`` when the slot already answers for ``metadata_url``.
+
+        A slot filled from a sidecar answers only for that sidecar; one with
+        no artifact behind it (sdist PKG-INFO, an injected override) stands
+        for the version itself and answers for any.
+        """
+        with self._lock:
+            slot = (package, version)
+            if slot not in self._metadata:
+                return False
+            source = self._metadata_source[slot]
+            return source is None or source == metadata_url
+
+    def store_metadata(
+        self,
+        package: str,
+        version: str,
+        data: str | None,
+        metadata_url: str | None = None,
+    ) -> None:
         """Cache metadata text (or ``None`` for a failed fetch).
 
-        ``None`` means no PEP 658 sidecar arrived and readers fall back to
-        the sdist, so it never overwrites sdist PKG-INFO already in the slot.
+        ``metadata_url`` is the sidecar the text came from; ``None`` marks
+        the slot as standing for the version rather than for one artifact.
+
+        A ``data`` of ``None`` means no PEP 658 sidecar arrived and readers
+        fall back to the sdist, so it never overwrites sdist PKG-INFO
+        already in the slot.
         """
-        key = f"metadata:{package}:{version}"
+        key = _metadata_key(package, version, metadata_url)
         slot = (package, version)
         with self._lock:
             keep_sdist_text = (
@@ -232,6 +269,7 @@ class InMemoryIndex:
             )
             if not keep_sdist_text:
                 self._metadata[slot] = data
+                self._metadata_source[slot] = metadata_url
                 self._metadata_from_sdist.discard(slot)
 
             # the waiter gets whatever the slot holds, which may be kept text
@@ -242,7 +280,11 @@ class InMemoryIndex:
             pending.event.set()
 
     def store_metadata_error(
-        self, package: str, version: str, error: BaseException
+        self,
+        package: str,
+        version: str,
+        error: BaseException,
+        metadata_url: str | None = None,
     ) -> None:
         """Record an integrity failure for a metadata fetch and unblock waiters.
 
@@ -250,7 +292,7 @@ class InMemoryIndex:
         sidecar arrived and the resolver may fall back to the sdist, while an
         error means the sidecar was served but failed its published hash.
         """
-        key = f"metadata:{package}:{version}"
+        key = _metadata_key(package, version, metadata_url)
         with self._lock:
             self._metadata_errors[(package, version)] = error
             pending = self._pending.get(key)
@@ -276,6 +318,7 @@ class InMemoryIndex:
         key = f"sdist:{package}:{version}"
         with self._lock:
             self._metadata[(package, version)] = data
+            self._metadata_source[(package, version)] = None
             self._metadata_from_sdist.add((package, version))
             pending = self._pending.get(key)
         if pending is not None:
@@ -584,7 +627,9 @@ class FetchCoordinator:
                 continue
             assert req.version is not None
             if req.kind is FetchKind.METADATA:
-                self.index.store_metadata_error(req.package, req.version, error)
+                self.index.store_metadata_error(
+                    req.package, req.version, error, req.url
+                )
             elif req.kind is FetchKind.SDIST:
                 self.index.store_sdist_metadata_error(req.package, req.version, error)
             else:
@@ -615,13 +660,13 @@ class FetchCoordinator:
         url: str,
         metadata_hash: tuple[str, str] | None = None,
     ) -> threading.Event:
-        """Request a wheel-metadata fetch for ``(package, version)``."""
+        """Request the sidecar at ``url`` as the metadata for ``(package, version)``."""
         self._check_alive()
-        if self.index.has_metadata(package, version):
+        if self.index.has_metadata_for(package, version, url):
             done = threading.Event()
             done.set()
             return done
-        key = f"metadata:{package}:{version}"
+        key = _metadata_key(package, version, url)
         pending, existed = self.index.get_or_create_pending(key)
         if not existed:
             self._submit(
@@ -735,12 +780,12 @@ class FetchCoordinator:
         results: list[tuple[str, str, threading.Event]] = []
         batch: list[FetchRequest] = []
         for package, version, url, metadata_hash in items:
-            if self.index.has_metadata(package, version):
+            if self.index.has_metadata_for(package, version, url):
                 done = threading.Event()
                 done.set()
                 results.append((package, version, done))
                 continue
-            key = f"metadata:{package}:{version}"
+            key = _metadata_key(package, version, url)
             pending, existed = self.index.get_or_create_pending(key)
             if not existed:
                 batch.append(
@@ -919,9 +964,9 @@ class FetchCoordinator:
         assert req.version is not None
         if req.kind is FetchKind.METADATA:
             if isinstance(exc, MetadataHashMismatchError):
-                self.index.store_metadata_error(req.package, req.version, exc)
+                self.index.store_metadata_error(req.package, req.version, exc, req.url)
             else:
-                self.index.store_metadata(req.package, req.version, None)
+                self.index.store_metadata(req.package, req.version, None, req.url)
         elif req.kind is FetchKind.SDIST:
             if isinstance(exc, SdistHashMismatchError):
                 self.index.store_sdist_metadata_error(req.package, req.version, exc)
@@ -945,13 +990,16 @@ class FetchCoordinator:
         self._record_serving_index(client, req.package)
         self.index.store_listing(req.package, files)
 
-        # auto-prefetch metadata for newest candidates (files are oldest-first)
-        wheels_with_meta: list[tuple[WheelFile, str]] = [
-            (f, f.metadata_url)
-            for f in files
-            if isinstance(f, WheelFile) and f.metadata_url is not None
-        ]
-        for w, metadata_url in wheels_with_meta[-self.PREFETCH_METADATA_COUNT :]:
+        # Auto-prefetch metadata for the newest candidates (files are
+        # oldest-first). One wheel per version: the first with a sidecar is the
+        # one the provider picks for that version's metadata.
+        first_wheel: dict[str, tuple[WheelFile, str]] = {}
+        for f in files:
+            if isinstance(f, WheelFile) and f.metadata_url is not None:
+                first_wheel.setdefault(f.version, (f, f.metadata_url))
+
+        newest = list(first_wheel.values())[-self.PREFETCH_METADATA_COUNT :]
+        for w, metadata_url in newest:
             self.request_metadata(req.package, w.version, metadata_url, w.metadata_hash)
 
     def _record_serving_index(
@@ -987,7 +1035,7 @@ class FetchCoordinator:
         text = await client.get_metadata_text(
             req.package, req.version, req.url, req.metadata_hash
         )
-        self.index.store_metadata(req.package, req.version, text)
+        self.index.store_metadata(req.package, req.version, text, req.url)
 
     async def _fetch_sdist(
         self,

--- a/nab-python/tests/property_python/test_cached_client_equiv.py
+++ b/nab-python/tests/property_python/test_cached_client_equiv.py
@@ -103,11 +103,11 @@ class DictCache:
         body, _ = self.simple[package]
         self.simple[package] = (body, policy)
 
-    def get_metadata(self, package: str, version: str) -> str | None:
-        return self.metadata.get((package, version))
+    def get_metadata(self, package: str, metadata_url: str) -> str | None:
+        return self.metadata.get((package, metadata_url))
 
-    def put_metadata(self, package: str, version: str, text: str) -> None:
-        self.metadata[(package, version)] = text
+    def put_metadata(self, package: str, metadata_url: str, text: str) -> None:
+        self.metadata[(package, metadata_url)] = text
 
     def get_sdist_files(
         self, package: str, version: str
@@ -297,7 +297,7 @@ def test_metadata_hash_gate_and_immutability(
         with pytest.raises(MetadataHashMismatchError):
             run(client.get_metadata_text(package, version, murl, ("sha256", bad)))
         # Mismatch must not poison the cache.
-        assert cache.get_metadata(package, version) is None
+        assert cache.get_metadata(package, murl) is None
         out = run(client.get_metadata_text(package, version, murl, ("sha256", good)))
         assert out == text
 

--- a/nab-python/tests/property_python/test_fetch_coordinator.py
+++ b/nab-python/tests/property_python/test_fetch_coordinator.py
@@ -60,6 +60,11 @@ def _wheel(pkg: str, version: str, *, has_metadata: bool) -> WheelFile:
     )
 
 
+def _metadata_url(pkg: str, version: str) -> str:
+    """The sidecar URL the listing publishes for ``(pkg, version)``."""
+    return _wheel(pkg, version, has_metadata=True).metadata_url or ""
+
+
 def _sdist(pkg: str, version: str) -> SdistFile:
     return SdistFile(
         filename=f"{pkg}-{version}.tar.gz",
@@ -80,10 +85,18 @@ class FakeClient:
         self.calls_lock = threading.Lock()
         self.closed = False
 
-    async def _common(self, key: Key) -> None:
+    async def _common(self, key: Key, plan_key: Key | None = None) -> None:
+        """Count one call against ``key``; take its outcome from ``plan_key``.
+
+        Metadata calls count against the sidecar URL, since two wheels of
+        one version publish two sidecars and so are two logical fetches,
+        while the plan still injects errors per ``(package, version)``.
+        """
         with self.calls_lock:
             self.calls[key] += 1
-        mode, delay = self.plan.get(key, ("ok", 0.0))
+        mode, delay = self.plan.get(
+            plan_key if plan_key is not None else key, ("ok", 0.0)
+        )
         if delay:
             await asyncio.sleep(delay)
         if mode == "err":
@@ -106,7 +119,9 @@ class FakeClient:
         url: str,
         metadata_hash: tuple[str, str] | None = None,
     ) -> str:
-        await self._common(("metadata", package, version))
+        await self._common(
+            ("metadata", package, version, url), ("metadata", package, version)
+        )
         return f"META:{package}:{version}"
 
     async def get_sdist_files(
@@ -185,9 +200,7 @@ def test_every_request_gets_exactly_one_correct_reply(
                 ev = coord.request_listing(pkg)
                 requested.append((("listing", pkg), ev))
             elif kind == "metadata":
-                ev = coord.request_metadata(
-                    pkg, ver, f"https://example.invalid/{pkg}-{ver}.whl.metadata"
-                )
+                ev = coord.request_metadata(pkg, ver, _metadata_url(pkg, ver))
                 requested.append((("metadata", pkg, ver), ev))
             elif kind == "sdist":
                 ev = coord.request_sdist(
@@ -201,8 +214,8 @@ def test_every_request_gets_exactly_one_correct_reply(
                 requested.append((("sdist-archive", pkg, ver), ev))
             else:  # batch: include a duplicate pair on purpose
                 items: list[tuple[str, str, str, tuple[str, str] | None]] = [
-                    (pkg, ver, "https://example.invalid/u.metadata", None),
-                    (pkg, ver, "https://example.invalid/u.metadata", None),
+                    (pkg, ver, _metadata_url(pkg, ver), None),
+                    (pkg, ver, _metadata_url(pkg, ver), None),
                 ]
                 for bpkg, bver, bev in coord.request_metadata_batch(items):
                     requested.append((("metadata", bpkg, bver), bev))

--- a/nab-python/tests/test_cache.py
+++ b/nab-python/tests/test_cache.py
@@ -249,7 +249,7 @@ class TestOnDiskCache:
 
     def test_sdist_corrupt_record_is_a_miss(self, tmp_path: Path) -> None:
         cache = self._make(tmp_path)
-        path = cache._entry_path(cache._sdist_dir, "foo", "1.0", ".json")
+        path = cache._sdist_path("foo", "1.0")
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("not-json", encoding="utf-8")
         assert cache.get_sdist_files("foo", "1.0") is None

--- a/nab-python/tests/test_cache.py
+++ b/nab-python/tests/test_cache.py
@@ -18,6 +18,12 @@ from nab_index.cache import (
     _index_dirname,
 )
 
+# Two wheels of one version, each with its own PEP 658 sidecar.
+METADATA_URLS = (
+    "https://f.example/foo-1.0-cp311-manylinux_2_17_x86_64.whl.metadata",
+    "https://f.example/foo-1.0-cp311-win_amd64.whl.metadata",
+)
+
 
 class TestCachePolicy:
     def test_is_fresh_within_window(self) -> None:
@@ -206,21 +212,26 @@ class TestOnDiskCache:
 
     def test_metadata_round_trip(self, tmp_path: Path) -> None:
         cache = self._make(tmp_path)
-        cache.put_metadata("foo", "1.0", "Metadata-Version: 2.1\nName: foo\n")
-        assert cache.get_metadata("foo", "1.0") == (
+        cache.put_metadata(
+            "foo", METADATA_URLS[0], "Metadata-Version: 2.1\nName: foo\n"
+        )
+        assert cache.get_metadata("foo", METADATA_URLS[0]) == (
             "Metadata-Version: 2.1\nName: foo\n"
         )
 
     def test_metadata_miss(self, tmp_path: Path) -> None:
         cache = self._make(tmp_path)
-        assert cache.get_metadata("foo", "1.0") is None
+        assert cache.get_metadata("foo", METADATA_URLS[0]) is None
 
-    def test_metadata_per_version(self, tmp_path: Path) -> None:
+    def test_metadata_per_artifact(self, tmp_path: Path) -> None:
+        """Each wheel of a version gets its own entry, keyed by sidecar URL."""
         cache = self._make(tmp_path)
-        cache.put_metadata("foo", "1.0", "v1")
-        cache.put_metadata("foo", "2.0", "v2")
-        assert cache.get_metadata("foo", "1.0") == "v1"
-        assert cache.get_metadata("foo", "2.0") == "v2"
+        linux_url, win_url = METADATA_URLS
+        cache.put_metadata("foo", linux_url, "linux")
+        cache.put_metadata("foo", win_url, "win")
+        assert cache.get_metadata("foo", linux_url) == "linux"
+        assert cache.get_metadata("foo", win_url) == "win"
+        assert len(list((tmp_path / "metadata-v1" / "pypi" / "foo").iterdir())) == 2
 
     def test_sdist_round_trip(self, tmp_path: Path) -> None:
         cache = self._make(tmp_path)
@@ -243,31 +254,38 @@ class TestOnDiskCache:
         path.write_text("not-json", encoding="utf-8")
         assert cache.get_sdist_files("foo", "1.0") is None
 
-    def test_put_metadata_rejects_multi_segment_sentinel(self, tmp_path: Path) -> None:
+    def test_put_metadata_rejects_multi_segment_package(self, tmp_path: Path) -> None:
         cache = self._make(tmp_path)
-        sentinel = "1.0#foo-1.0-py3-none-any/../../elsewhere.whl"
         with pytest.raises(ValueError, match="not a single path segment"):
-            cache.put_metadata("foo", sentinel, "text")
-        assert list(tmp_path.rglob("elsewhere.whl.metadata")) == []
+            cache.put_metadata("foo/../../elsewhere", METADATA_URLS[0], "text")
+        assert list(tmp_path.rglob("*.metadata")) == []
 
-    def test_sentinel_version_round_trips(self, tmp_path: Path) -> None:
+    def test_put_sdist_rejects_multi_segment_version(self, tmp_path: Path) -> None:
         cache = self._make(tmp_path)
-        sentinel = "1.0#foo-1.0-py3-none-any.whl"
-        cache.put_metadata("foo", sentinel, "META")
-        assert cache.get_metadata("foo", sentinel) == "META"
+        with pytest.raises(ValueError, match="not a single path segment"):
+            cache.put_sdist_files("foo", "1.0/../../elsewhere", "Name: foo\n", None)
+        assert list(tmp_path.rglob("*.json")) == []
+
+    def test_metadata_url_cannot_escape_the_package_dir(self, tmp_path: Path) -> None:
+        cache = self._make(tmp_path)
+        cache.put_metadata("foo", "https://f.example/../../../etc/passwd.metadata", "T")
+        written = list(tmp_path.rglob("*.metadata"))
+        assert [p.parent for p in written] == [
+            tmp_path / "metadata-v1" / "pypi" / "foo"
+        ]
 
 
 class TestNullCache:
     def test_get_returns_none_and_put_is_noop(self) -> None:
         cache = NullCache()
         assert cache.get_simple("foo") is None
-        assert cache.get_metadata("foo", "1.0") is None
+        assert cache.get_metadata("foo", METADATA_URLS[0]) is None
         assert cache.get_sdist_files("foo", "1.0") is None
         # Puts must be no-ops with no return value.
         policy = CachePolicy(fetched_at=0, max_age=0, etag=None)
         assert cache.put_simple("foo", b"", policy) is None
         assert cache.refresh_simple_policy("foo", policy) is None
-        assert cache.put_metadata("foo", "1.0", "x") is None
+        assert cache.put_metadata("foo", METADATA_URLS[0], "x") is None
         assert cache.put_sdist_files("foo", "1.0", "x", None) is None
         # And subsequent gets still miss.
         assert cache.get_simple("foo") is None

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -1049,11 +1049,11 @@ class TestGetMetadataText:
 
         text = asyncio.run(go())
         assert text == "Metadata-Version: 2.1\n"
-        assert cache.get_metadata("pkg", "1.0") == text
+        assert cache.get_metadata("pkg", "https://x/pkg.metadata") == text
 
     def test_warm_cache_skips_network(self, tmp_path: Path) -> None:
         cache = _make_cache(tmp_path)
-        cache.put_metadata("pkg", "1.0", "stored")
+        cache.put_metadata("pkg", "https://x/pkg.metadata", "stored")
         transport = _FakeTransport()
 
         async def go() -> str:
@@ -1067,6 +1067,36 @@ class TestGetMetadataText:
 
         assert asyncio.run(go()) == "stored"
         assert transport.calls == []
+
+    def test_sibling_wheel_of_same_version_is_not_served(self, tmp_path: Path) -> None:
+        """A cached sidecar is not reused for another wheel of the same version.
+
+        PEP 658 publishes a sidecar per file, and per-platform wheels of one
+        version can declare different dependencies, so the second wheel must
+        be fetched and verified against its own digest.
+        """
+        linux_url = "https://f.example/foo-1.0-cp311-manylinux_2_17_x86_64.whl.metadata"
+        win_url = "https://f.example/foo-1.0-cp311-win_amd64.whl.metadata"
+        linux_body = b"Metadata-Version: 2.1\nRequires-Dist: linux-only-dep\n"
+        win_body = b"Metadata-Version: 2.1\nRequires-Dist: windows-only-dep\n"
+        transport = _FakeTransport([_FakeResponse(linux_body), _FakeResponse(win_body)])
+        win_digest = hashlib.sha256(win_body).hexdigest()
+
+        async def go() -> str:
+            warm = CachedAsyncSimpleClient(transport, _make_cache(tmp_path))
+            await warm.get_metadata_text("foo", "1.0", linux_url)
+            await warm.aclose()
+            # A later process reading the same cache root.
+            client = CachedAsyncSimpleClient(transport, _make_cache(tmp_path))
+            try:
+                return await client.get_metadata_text(
+                    "foo", "1.0", win_url, ("sha256", win_digest)
+                )
+            finally:
+                await client.aclose()
+
+        assert asyncio.run(go()) == win_body.decode()
+        assert [url for url, _ in transport.calls] == [linux_url, win_url]
 
     def test_offline_miss_raises(self, tmp_path: Path) -> None:
         cache = _make_cache(tmp_path)
@@ -1101,7 +1131,7 @@ class TestGetMetadataText:
 
         text = asyncio.run(go())
         assert text == body.decode()
-        assert cache.get_metadata("pkg", "1.0") == text
+        assert cache.get_metadata("pkg", "https://x/pkg.metadata") == text
 
     def test_mismatching_hash_raises_and_skips_cache(self, tmp_path: Path) -> None:
         cache = _make_cache(tmp_path)
@@ -1120,7 +1150,7 @@ class TestGetMetadataText:
 
         with pytest.raises(MetadataHashMismatchError):
             asyncio.run(go())
-        assert cache.get_metadata("pkg", "1.0") is None
+        assert cache.get_metadata("pkg", "https://x/pkg.metadata") is None
 
     def test_returns_utf8_decode_of_verified_bytes(self, tmp_path: Path) -> None:
         """The result is the utf-8 decode of the hash-verified bytes.
@@ -1147,7 +1177,7 @@ class TestGetMetadataText:
 
         text = asyncio.run(go())
         assert text == body.decode("utf-8")
-        assert cache.get_metadata("foo", "1.0") == text
+        assert cache.get_metadata("foo", "https://x/foo.metadata") == text
         parsed = parse_metadata(text)
         assert [str(req) for req in parsed.requires_dist] == ["bar>=2"]
 

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -1071,9 +1071,7 @@ class TestGetMetadataText:
     def test_sibling_wheel_of_same_version_is_not_served(self, tmp_path: Path) -> None:
         """A cached sidecar is not reused for another wheel of the same version.
 
-        PEP 658 publishes a sidecar per file, and per-platform wheels of one
-        version can declare different dependencies, so the second wheel must
-        be fetched and verified against its own digest.
+        The second wheel is fetched and verified against its own digest.
         """
         linux_url = "https://f.example/foo-1.0-cp311-manylinux_2_17_x86_64.whl.metadata"
         win_url = "https://f.example/foo-1.0-cp311-win_amd64.whl.metadata"

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -1294,6 +1294,45 @@ class TestFetchCoordinatorCache:
             assert listing == []
         assert not coord._crashed
 
+    @respx.mock
+    def test_warm_cache_keeps_sibling_wheels_apart(self, tmp_path: Path) -> None:
+        """One wheel's METADATA is never served for a sibling wheel of that version.
+
+        PEP 658 attaches a sidecar to a file, so per-platform wheels of one
+        version can declare different dependencies. A run whose compatible
+        wheel differs from an earlier run's must fetch its own sidecar.
+        """
+        linux_url = "https://f.example/foo-1.0-cp311-manylinux_2_17_x86_64.whl.metadata"
+        win_url = "https://f.example/foo-1.0-cp311-win_amd64.whl.metadata"
+        linux_body = (
+            b"Metadata-Version: 2.1\nName: foo\nRequires-Dist: linux-only-dep\n"
+        )
+        win_body = (
+            b"Metadata-Version: 2.1\nName: foo\nRequires-Dist: windows-only-dep\n"
+        )
+        linux_route = respx.get(linux_url).mock(
+            return_value=httpx.Response(200, content=linux_body)
+        )
+        win_route = respx.get(win_url).mock(
+            return_value=httpx.Response(200, content=win_body)
+        )
+        linux_hash = ("sha256", hashlib.sha256(linux_body).hexdigest())
+        win_hash = ("sha256", hashlib.sha256(win_body).hexdigest())
+
+        with _coord(cache_dir=tmp_path) as coord:
+            coord.request_metadata("foo", "1.0", linux_url, linux_hash).wait(timeout=5)
+            assert coord.index.get_metadata("foo", "1.0") == linux_body.decode()
+
+        # A later run over the same cache dir, in an environment whose
+        # compatible wheel is the win_amd64 one.
+        with _coord(cache_dir=tmp_path) as coord:
+            coord.request_metadata("foo", "1.0", win_url, win_hash).wait(timeout=5)
+            assert coord.index.get_metadata_error("foo", "1.0") is None
+            assert coord.index.get_metadata("foo", "1.0") == win_body.decode()
+
+        assert linux_route.call_count == 1
+        assert win_route.call_count == 1
+
     def test_explicit_cache_backend_takes_precedence(self) -> None:
         """A passed-in cache_backend wins over cache_dir."""
         from nab_index.cache import NullCache

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -86,8 +86,10 @@ class TestInMemoryIndex:
 
     def test_store_metadata_error_fires_metadata_pending(self) -> None:
         idx = InMemoryIndex()
-        pending, _ = idx.get_or_create_pending("metadata:foo:1.0")
-        idx.store_metadata_error("foo", "1.0", MetadataHashMismatchError("bad"))
+        pending, _ = idx.get_or_create_pending("metadata:foo:1.0:https://f/a.metadata")
+        idx.store_metadata_error(
+            "foo", "1.0", MetadataHashMismatchError("bad"), "https://f/a.metadata"
+        )
         assert pending.event.is_set()
 
     def test_store_metadata_error_without_pending(self) -> None:
@@ -108,11 +110,26 @@ class TestInMemoryIndex:
 
     def test_pending_event_set_on_metadata(self) -> None:
         idx = InMemoryIndex()
-        pending, existed = idx.get_or_create_pending("metadata:foo:1.0")
+        pending, existed = idx.get_or_create_pending("metadata:foo:1.0:https://f/a.md")
         assert not existed
-        idx.store_metadata("foo", "1.0", "text")
+        idx.store_metadata("foo", "1.0", "text", "https://f/a.md")
         assert pending.event.is_set()
         assert pending.result == "text"
+
+    def test_sidecar_slot_answers_only_for_its_own_artifact(self) -> None:
+        idx = InMemoryIndex()
+        idx.store_metadata("foo", "1.0", "linux", "https://f/linux.whl.metadata")
+        assert idx.has_metadata_for("foo", "1.0", "https://f/linux.whl.metadata")
+        assert not idx.has_metadata_for("foo", "1.0", "https://f/win.whl.metadata")
+
+    def test_version_level_slot_answers_for_any_artifact(self) -> None:
+        idx = InMemoryIndex()
+        idx.store_sdist_metadata("foo", "1.0", "PKG-INFO\n")
+        assert idx.has_metadata_for("foo", "1.0", "https://f/win.whl.metadata")
+
+    def test_has_metadata_for_is_false_on_an_empty_slot(self) -> None:
+        idx = InMemoryIndex()
+        assert not idx.has_metadata_for("foo", "1.0", "https://f/a.whl.metadata")
 
     def test_get_or_create_existing(self) -> None:
         idx = InMemoryIndex()
@@ -163,12 +180,14 @@ class TestInMemoryIndex:
     def test_metadata_none_keeps_stored_sdist_pkg_info(self) -> None:
         """A failed sidecar fetch must not erase stored sdist PKG-INFO."""
         idx = InMemoryIndex()
-        pending, _ = idx.get_or_create_pending("metadata:foo:1.0")
+        pending, _ = idx.get_or_create_pending("metadata:foo:1.0:https://f/a.md")
         idx.store_sdist_metadata("foo", "1.0", "PKG-INFO\n")
-        idx.store_metadata("foo", "1.0", None)
+        idx.store_metadata("foo", "1.0", None, "https://f/a.md")
         assert pending.event.is_set()
         assert idx.get_metadata("foo", "1.0") == "PKG-INFO\n"
         assert idx.metadata_from_sdist("foo", "1.0")
+        # The kept text still stands for the version, not for the sidecar.
+        assert idx.has_metadata_for("foo", "1.0", "https://f/other.md")
 
     def test_metadata_none_after_sdist_none_stays_none(self) -> None:
         idx = InMemoryIndex()
@@ -544,14 +563,15 @@ class TestFetchCoordinator:
             assert sdist_event.wait(timeout=5)
 
             # queue the request directly: request_metadata would short-circuit
-            # on has_metadata, but a prefetch already in flight still lands
-            pending, _ = coord.index.get_or_create_pending("metadata:pkg:1.0")
+            # on the stored PKG-INFO, but a prefetch already in flight lands
+            url = "https://files.example.com/pkg-1.0.whl.metadata"
+            pending, _ = coord.index.get_or_create_pending(f"metadata:pkg:1.0:{url}")
             coord._submit(
                 FetchRequest(
                     kind=FetchKind.METADATA,
                     package="pkg",
                     version="1.0",
-                    url="https://files.example.com/pkg-1.0.whl.metadata",
+                    url=url,
                 )
             )
 
@@ -877,7 +897,7 @@ class TestFetchCoordinator:
         respx.get(url__regex=r".*").mock(return_value=httpx.Response(200, text="meta"))
         with _coord() as coord:
             # Pre-create a pending so the second request finds it.
-            coord.index.get_or_create_pending("metadata:pkg:1.0")
+            coord.index.get_or_create_pending("metadata:pkg:1.0:https://f.com/m")
             e = coord.request_metadata("pkg", "1.0", "https://f.com/m")
             # Should reuse the existing pending (existed=True path).
             e.wait(timeout=5)
@@ -1216,7 +1236,7 @@ class TestFetchCoordinator:
         respx.get(url__regex=r".*").mock(return_value=httpx.Response(200, text="meta"))
         with _coord() as coord:
             # Pre-create a pending for one of the batch items.
-            coord.index.get_or_create_pending("metadata:a:1.0")
+            coord.index.get_or_create_pending("metadata:a:1.0:https://f.com/a")
             results = coord.request_metadata_batch(
                 [
                     ("a", "1.0", "https://f.com/a", None),
@@ -1298,9 +1318,8 @@ class TestFetchCoordinatorCache:
     def test_warm_cache_keeps_sibling_wheels_apart(self, tmp_path: Path) -> None:
         """One wheel's METADATA is never served for a sibling wheel of that version.
 
-        PEP 658 attaches a sidecar to a file, so per-platform wheels of one
-        version can declare different dependencies. A run whose compatible
-        wheel differs from an earlier run's must fetch its own sidecar.
+        A run whose compatible wheel differs from an earlier run's must fetch
+        its own sidecar.
         """
         linux_url = "https://f.example/foo-1.0-cp311-manylinux_2_17_x86_64.whl.metadata"
         win_url = "https://f.example/foo-1.0-cp311-win_amd64.whl.metadata"
@@ -1668,3 +1687,97 @@ class TestMultiIndexCoordinator:
                 coord._build_client()
         finally:
             coord.shutdown()
+
+
+_SIBLING_LINUX = "foo-1.0-cp311-cp311-manylinux_2_17_x86_64.whl"
+_SIBLING_WIN = "foo-1.0-cp311-cp311-win_amd64.whl"
+_SIBLING_LINUX_BODY = b"Metadata-Version: 2.1\nName: foo\nRequires-Dist: linux-dep\n"
+_SIBLING_WIN_BODY = b"Metadata-Version: 2.1\nName: foo\nRequires-Dist: windows-dep\n"
+
+
+def _sibling_wheel_listing() -> dict:
+    """A listing whose one version has more sidecar wheels than the prefetch takes.
+
+    Ordered so the prefetch window would cut past the first wheel if it counted
+    wheels rather than versions.
+    """
+    fillers = [f"foo-1.0-cp3{n}-cp3{n}-macosx_11_0_arm64.whl" for n in range(3, 3 + 9)]
+    names = [_SIBLING_LINUX, "foo-1.0-py3-none-any.whl", _SIBLING_WIN, *fillers]
+    return {
+        "meta": {"api-version": "1.0"},
+        "name": "foo",
+        "files": [
+            {
+                "filename": name,
+                "url": f"https://f.example/{name}",
+                "core-metadata": True,
+            }
+            for name in names
+        ],
+    }
+
+
+class TestSiblingWheelMetadata:
+    """The metadata a version's slot holds belongs to the wheel that was asked for."""
+
+    def _routes(self) -> tuple[respx.Route, respx.Route]:
+        linux = respx.get(f"https://f.example/{_SIBLING_LINUX}.metadata").mock(
+            return_value=httpx.Response(200, content=_SIBLING_LINUX_BODY)
+        )
+        win = respx.get(f"https://f.example/{_SIBLING_WIN}.metadata").mock(
+            return_value=httpx.Response(200, content=_SIBLING_WIN_BODY)
+        )
+        respx.get("https://pypi.org/simple/foo/").mock(
+            return_value=httpx.Response(200, json=_sibling_wheel_listing())
+        )
+        respx.get(url__regex=r".*\.whl\.metadata$").mock(
+            return_value=httpx.Response(200, content=b"Metadata-Version: 2.1\n")
+        )
+        return linux, win
+
+    def _await_metadata(self, coord: FetchCoordinator) -> None:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and not coord.index.has_metadata(
+            "foo", "1.0"
+        ):
+            time.sleep(0.01)
+
+    @respx.mock
+    def test_listing_prefetch_takes_the_wheel_the_provider_will_pick(self) -> None:
+        """The prefetch fetches one wheel per version: the first with a sidecar."""
+        linux, win = self._routes()
+        with _coord() as coord:
+            coord.request_listing("foo").wait(timeout=5)
+            self._await_metadata(coord)
+            assert (
+                coord.index.get_metadata("foo", "1.0") == _SIBLING_LINUX_BODY.decode()
+            )
+        assert linux.call_count == 1
+        assert win.call_count == 0
+
+    @respx.mock
+    def test_sibling_wheel_is_not_served_from_a_prefetched_listing(
+        self, tmp_path: Path
+    ) -> None:
+        """A run whose compatible wheel is not the prefetched one gets its own.
+
+        The listing prefetch has already filled the version's slot, and a
+        second run over the warm cache dir refills it with no network at all,
+        so nothing but the artifact identity keeps the two wheels apart.
+        """
+        linux, win = self._routes()
+        with _coord(cache_dir=tmp_path) as coord:
+            coord.request_listing("foo").wait(timeout=5)
+            self._await_metadata(coord)
+
+        win_hash = ("sha256", hashlib.sha256(_SIBLING_WIN_BODY).hexdigest())
+        win_url = f"https://f.example/{_SIBLING_WIN}.metadata"
+        with _coord(cache_dir=tmp_path) as coord:
+            coord.request_listing("foo").wait(timeout=5)
+            self._await_metadata(coord)
+            coord.request_metadata("foo", "1.0", win_url, win_hash).wait(timeout=5)
+            assert coord.index.get_metadata_error("foo", "1.0") is None
+            assert coord.index.get_metadata("foo", "1.0") == _SIBLING_WIN_BODY.decode()
+
+        assert linux.call_count == 1
+        assert win.call_count == 1


### PR DESCRIPTION
A version's wheels each publish their own PEP 658 sidecar, and wheels built for different platforms can declare different dependencies. The on-disk entry was keyed by (package, version), so a warm `~/.cache/nab` could hand back one wheel's METADATA as another wheel's in a later process, with no fetch. Nothing catches it on the way out: a cached sidecar is treated as immutable, so a hit is returned without consulting the published hash. On a machine whose compatible wheel is not the one that filled the cache, the resolve runs against the wrong dependency list.

Key the entry by the sidecar URL and bump the bucket to `metadata-v1` so existing entries are ignored. The in-memory metadata slot and the fetch dedup key now carry the artifact too, so two wheels of one version no longer share a request or release each other's waiters. A slot with no artifact behind it (sdist PKG-INFO, an injected override) still keys on the version alone and answers for any wheel.

The listing prefetch changes with it: it now takes the first sidecar wheel of each of the newest versions, which is the wheel the provider goes on to ask for, rather than the newest wheels regardless of version. Otherwise it would fill a version's slot from whichever wheel happened to land in the window and force a second fetch.
