### PR TITLE
Move the nab override out of the NAB_ namespace

### DIFF
--- a/tasks/refresh-locks.sh
+++ b/tasks/refresh-locks.sh
@@ -11,9 +11,11 @@ set -euo pipefail
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
+# NAB_* is nab's own settings namespace and it rejects any variable in it that
+# is not a setting, so the override for which nab to run lives outside it.
 NAB=(.venv/bin/python -m nab)
-if [[ -n "${NAB_BIN:-}" ]]; then
-    read -ra NAB <<<"${NAB_BIN}"
+if [[ -n "${REFRESH_NAB_BIN:-}" ]]; then
+    read -ra NAB <<<"${REFRESH_NAB_BIN}"
 fi
 
 EXTRA_ARGS=("$@")


### PR DESCRIPTION
`tasks/refresh-locks.sh` lets you point it at a different nab with `NAB_BIN`, and that override cannot work: `NAB_*` is nab's own settings namespace and nab rejects any variable in it that is not a setting, so every lock the script then runs dies before it starts.

```
$ NAB_BIN="../other/.venv/bin/python -m nab" tasks/refresh-locks.sh
==> Locking group: tests
Config error: NAB_BIN is not a valid nab setting; the known NAB_* variables are ['NAB_CACHE_DIR', 'NAB_HTTP_BACKEND', 'NAB_MAX_CONCURRENCY', 'NAB_OFFLINE'].
```

The rejection is right and worth keeping, since a mistyped `NAB_OFLINE` should fail rather than be ignored. The variable is what has to move, so the override is now `REFRESH_NAB_BIN`. Found by trying to use it.