### PR TITLE
Add timeouts to the git ls-remote and fetch calls

### DIFF
--- a/nab-index/src/nab_index/vcs.py
+++ b/nab-index/src/nab_index/vcs.py
@@ -52,6 +52,16 @@ _VCS_PREFIX_RE = re.compile(r"^git\+")
 # before the fetch, so the directory alone cannot prove a finished clone.
 _COMPLETE_MARKER = "nab-complete"
 
+# git applies no read timeout, so a remote that goes quiet after the handshake
+# blocks forever.  git's own knobs are per-transport (``http.lowSpeed*`` is
+# libcurl-only, ``GIT_SSH_COMMAND`` ssh-only) and neither reaches the ``git://``
+# daemon protocol, so the bound goes on the subprocess.
+_LS_REMOTE_TIMEOUT_SECONDS = 120
+
+# A fetch gets the wider bound: a server can send nothing for minutes while it
+# builds a large repo's pack.
+_FETCH_TIMEOUT_SECONDS = 1800
+
 
 class VcsCloneError(Exception):
     """Raised when a clone or ref resolution fails."""
@@ -231,8 +241,13 @@ def _resolve_sha(request: VcsRequest, *, require_pin: bool) -> str:
             capture_output=True,
             text=True,
             env=_git_env(),
+            timeout=_LS_REMOTE_TIMEOUT_SECONDS,
         )
-    except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+    except (
+        FileNotFoundError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+    ) as exc:
         msg = f"git ls-remote {request.repo_url} {target}: {exc}"
         raise VcsCloneError(msg) from exc
 
@@ -284,6 +299,7 @@ def _shallow_clone(repo_url: str, sha: str, dest: Path) -> None:
             check=True,
             cwd=dest,
             env=_git_env(),
+            timeout=_FETCH_TIMEOUT_SECONDS,
         )
         subprocess.run(  # noqa: S603 - git is a runtime dep
             checkout_args,
@@ -292,7 +308,11 @@ def _shallow_clone(repo_url: str, sha: str, dest: Path) -> None:
             env=_git_env(),
         )
         (dest / ".git" / _COMPLETE_MARKER).touch()
-    except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+    except (
+        FileNotFoundError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+    ) as exc:
         # Roll back the partial clone so the cache stays clean.
         shutil.rmtree(dest, ignore_errors=True)
         msg = f"failed to clone {repo_url} @ {sha}: {exc}"

--- a/nab-python/tests/test_vcs.py
+++ b/nab-python/tests/test_vcs.py
@@ -42,6 +42,29 @@ def _mark_complete(clone_dir: Path) -> None:
     (clone_dir / ".git" / _COMPLETE_MARKER).touch()
 
 
+# One per transport git can speak, including the ``git://`` daemon protocol
+# that no client-side git config reaches.
+_STALLED_REPO_URLS = [
+    "https://example.invalid/x/y.git",
+    "ssh://git@example.invalid/x/y.git",
+    "git://example.invalid/x/y.git",
+]
+
+
+def _stalled_remote(cmd: list[str], **kwargs: object) -> object:
+    """Stand in for git talking to a remote that goes quiet after the handshake."""
+    if cmd[1] in {"ls-remote", "fetch"}:
+        timeout = kwargs.get("timeout")
+        if not isinstance(timeout, (int, float)):
+            msg = f"unbounded git {cmd[1]} hangs on a stalled remote"
+            raise AssertionError(msg)
+        raise subprocess.TimeoutExpired(cmd, float(timeout))
+
+    if cmd[1] == "init":
+        (Path(str(kwargs["cwd"])) / ".git").mkdir(exist_ok=True)
+    return type("P", (), {"returncode": 0})()
+
+
 class TestVcsRequestParse:
     def test_https_with_sha(self) -> None:
         req = VcsRequest.parse("git+https://github.com/x/y.git@" + "a" * 40)
@@ -270,6 +293,58 @@ class TestResolveShaAnnotatedTag:
         assert "v1^{}" in queried
 
 
+class TestStalledRemote:
+    """A remote that accepts the connection and then goes quiet must not hang."""
+
+    @pytest.mark.parametrize("repo_url", _STALLED_REPO_URLS)
+    def test_ls_remote_gives_up(
+        self,
+        repo_url: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(subprocess, "run", _stalled_remote)
+        req = VcsRequest("git", repo_url, "main", "")
+        with pytest.raises(VcsCloneError, match="ls-remote"):
+            _resolve_sha(req, require_pin=False)
+
+    @pytest.mark.parametrize("repo_url", _STALLED_REPO_URLS)
+    def test_fetch_gives_up_and_rolls_back(
+        self,
+        repo_url: str,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(subprocess, "run", _stalled_remote)
+        req = VcsRequest("git", repo_url, "a" * 40, "")
+        with pytest.raises(VcsCloneError, match="failed to clone"):
+            prepare_clone(tmp_path, req, require_pin=True)
+
+        repo_dir = next((tmp_path / "vcs").iterdir())
+        assert list(repo_dir.iterdir()) == []
+
+    def test_fetch_bound_outlasts_a_quiet_pack_build(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A big repo sends nothing but keepalives while the server packs it."""
+        bounds: dict[str, float] = {}
+
+        def fake_run(cmd: list[str], **kwargs: object) -> object:
+            timeout = kwargs.get("timeout")
+            if isinstance(timeout, (int, float)):
+                bounds[cmd[1]] = float(timeout)
+            if cmd[1] == "init":
+                (Path(str(kwargs["cwd"])) / ".git").mkdir(exist_ok=True)
+            return type("P", (), {"returncode": 0})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        req = VcsRequest("git", "https://example.invalid/x/y.git", "a" * 40, "")
+        prepare_clone(tmp_path, req, require_pin=True)
+
+        assert bounds["fetch"] >= 15 * 60
+
+
 class TestPrepareClone:
     def test_idempotent_when_marked_complete(
         self,
@@ -335,7 +410,7 @@ class TestPrepareClone:
         sha = "e" * 40
 
         def fake_run(cmd: list[str], **_kwargs: object) -> object:
-            if "fetch" in cmd:
+            if cmd[:2] == ["git", "fetch"]:
                 raise subprocess.CalledProcessError(128, cmd)
             return type("P", (), {"returncode": 0})()
 


### PR DESCRIPTION
A `git+` requirement shells out to `git ls-remote` and `git fetch` with no timeout. If a remote completes the handshake and then goes quiet, git blocks on the read indefinitely and the resolve blocks with it. The HTTP transport is bounded at 5 seconds; the git path was not bounded at all.

Both calls now pass a `timeout`, and `subprocess.TimeoutExpired` is handled alongside the other git failures, so a stall surfaces as a `VcsCloneError` naming the repo. `ls-remote` gets 120 seconds, since it is only a ref advertisement. `fetch` gets 30 minutes, because a server can send nothing for minutes while it builds the pack for a large repo, and a tighter bound would break clones that work today. The fetch path already removes the partial clone on failure, so a timed-out clone leaves no half-written cache entry.

Git's own settings don't cover this: `http.lowSpeedLimit` and `http.lowSpeedTime` apply only to the libcurl transport and `GIT_SSH_COMMAND` only to ssh, and neither reaches the `git://` daemon protocol, so the bound has to sit on the subprocess.
