### PR TITLE
stop a transient index 503 from downgrading the lock

### DIFF
--- a/nab-index/src/nab_index/httpx_async_transport.py
+++ b/nab-index/src/nab_index/httpx_async_transport.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import ssl
 from typing import TYPE_CHECKING, Any
 
 import httpx
 import truststore
 
+from .retry import MAX_RETRIES, RETRY_STATUSES, next_delay
 from .transport import HttpError
 
 if TYPE_CHECKING:
@@ -75,15 +77,39 @@ class HttpxAsyncTransport:
     async def get(
         self, url: str, *, headers: dict[str, str] | None = None
     ) -> _HttpxResponse:
-        """Send a GET request."""
-        try:
-            response = await self._client.get(url, headers=headers)
-        except Exception as exc:
-            # httpx raises InvalidURL and lets idna hostname errors escape its
-            # HTTPError hierarchy, so wrap every failure to issue the request.
-            msg = f"GET {url} failed: {exc}"
-            raise HttpError(msg) from exc
-        return _HttpxResponse(response)
+        """Send a GET request, retrying a blip.
+
+        httpx has no retry machinery beyond reconnecting, so the shared policy
+        runs in this loop rather than in the client.
+        """
+        failures = 0
+
+        while True:
+            try:
+                response = await self._client.get(url, headers=headers)
+            except httpx.HTTPError as exc:
+                failures += 1
+                if failures > MAX_RETRIES:
+                    msg = f"GET {url} failed: {exc}"
+                    raise HttpError(msg) from exc
+                delay = next_delay(failures)
+            except Exception as exc:
+                # httpx raises InvalidURL and lets idna hostname errors escape
+                # its HTTPError hierarchy.  A URL httpx cannot even issue is not
+                # a blip, so it is wrapped and raised rather than retried.
+                msg = f"GET {url} failed: {exc}"
+                raise HttpError(msg) from exc
+            else:
+                if response.status_code not in RETRY_STATUSES:
+                    return _HttpxResponse(response)
+                failures += 1
+                # Out of budget: hand back the status the index served, which is
+                # what the urllib3 backend does with raise_on_status=False.
+                if failures > MAX_RETRIES:
+                    return _HttpxResponse(response)
+                delay = next_delay(failures, response.headers.get("Retry-After"))
+
+            await asyncio.sleep(delay)
 
     async def aclose(self) -> None:
         """Close the underlying client."""

--- a/nab-index/src/nab_index/retry.py
+++ b/nab-index/src/nab_index/retry.py
@@ -1,0 +1,72 @@
+"""Retry policy for index GETs, shared by the async transports.
+
+An index GET is idempotent, and a 5xx, a 429, or a dropped connection is
+usually a blip rather than the index's answer.
+
+urllib3's default retries a connection error but retries a 413, 429, or 503
+only when the response carries ``Retry-After``; httpx retries nothing. Both
+transports take the policy here instead of their library's default.
+"""
+
+from __future__ import annotations
+
+import urllib3
+from urllib3.exceptions import InvalidHeader
+
+__all__ = [
+    "GET_RETRY",
+    "MAX_RETRIES",
+    "RETRY_STATUSES",
+    "next_delay",
+]
+
+MAX_RETRIES = 3
+"""Retries after the first attempt, so at most four requests per URL."""
+
+RETRY_STATUSES = frozenset({429, 500, 502, 503, 504})
+"""Statuses that are retried; any other status is served to the caller."""
+
+_BACKOFF_FACTOR = 0.25
+
+# Unbounded, a "Retry-After: 3600" would park the resolve for an hour.
+_RETRY_AFTER_MAX_SECONDS = 10.0
+
+_RETRY_AFTER_PARSER = urllib3.Retry()
+
+
+def _retry_after_seconds(value: str) -> float | None:
+    """Bounded Retry-After in seconds; None when the header does not parse."""
+    try:
+        seconds = _RETRY_AFTER_PARSER.parse_retry_after(value)
+    except InvalidHeader:
+        return None
+    return min(seconds, _RETRY_AFTER_MAX_SECONDS)
+
+
+class _BoundedRetry(urllib3.Retry):
+    """Retry that bounds the Retry-After wait and ignores a malformed one."""
+
+    def get_retry_after(self, response: urllib3.BaseHTTPResponse) -> float | None:
+        value = response.headers.get("Retry-After")
+        return None if value is None else _retry_after_seconds(value)
+
+
+GET_RETRY = _BoundedRetry(
+    total=MAX_RETRIES,
+    status_forcelist=RETRY_STATUSES,
+    backoff_factor=_BACKOFF_FACTOR,
+    # Once the budget is spent, hand the response back so the caller sees the
+    # status the index served rather than a retry error.
+    raise_on_status=False,
+)
+
+
+def next_delay(failures: int, retry_after: str | None = None) -> float:
+    """Seconds to wait after ``failures`` attempts, on urllib3's schedule."""
+    if retry_after is not None:
+        seconds = _retry_after_seconds(retry_after)
+        if seconds is not None:
+            return seconds
+    if failures <= 1:
+        return 0.0
+    return _BACKOFF_FACTOR * 2 ** (failures - 1)

--- a/nab-index/src/nab_index/urllib3_async_transport.py
+++ b/nab-index/src/nab_index/urllib3_async_transport.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 import truststore
 import urllib3
 
+from .retry import GET_RETRY
 from .transport import HttpError
 
 if TYPE_CHECKING:
@@ -130,7 +131,13 @@ class Urllib3AsyncTransport:
         return pool
 
     def _request(self, url: str, headers: dict[str, str]) -> urllib3.BaseHTTPResponse:
-        return self._pool().request("GET", url, headers=headers, timeout=self._timeout)
+        return self._pool().request(
+            "GET",
+            url,
+            headers=headers,
+            timeout=self._timeout,
+            retries=GET_RETRY,
+        )
 
     async def get(
         self, url: str, *, headers: dict[str, str] | None = None

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -21,12 +21,7 @@ from urllib.parse import urlsplit
 
 from nab_index.cache import CacheBackend, NullCache, OfflineError, OnDiskCache
 from nab_index.cached_client import CachedAsyncSimpleClient
-from nab_index.client import (
-    MetadataHashMismatchError,
-    SdistFile,
-    SdistHashMismatchError,
-    WheelFile,
-)
+from nab_index.client import SdistFile, WheelFile
 from nab_index.local_index import LocalIndexClient, parse_file_url
 from nab_index.multi_index import IndexConfig, MultiIndexClient
 
@@ -337,11 +332,12 @@ class InMemoryIndex:
         error: BaseException,
         metadata_url: str | None = None,
     ) -> None:
-        """Record an integrity failure for a metadata fetch and unblock waiters.
+        """Record a failed metadata fetch and unblock waiters.
 
         Distinct from ``store_metadata(None)``: ``None`` means no PEP 658
-        sidecar arrived and the resolver may fall back to the sdist, while an
-        error means the sidecar was served but failed its published hash.
+        sidecar arrived and the resolver may fall back to the sdist; an error
+        means an advertised sidecar could not be fetched or failed its published
+        hash, so the resolve must not fall through.
         """
         key = _metadata_key(package, version, metadata_url)
         with self._lock:
@@ -353,7 +349,7 @@ class InMemoryIndex:
     def get_metadata_error(
         self, package: str, version: str, metadata_url: str | None = None
     ) -> BaseException | None:
-        """Return a recorded metadata integrity error, or ``None``.
+        """Return a recorded metadata fetch error, or ``None``.
 
         The artifact's own error wins; a version-level error (a tampered
         sdist archive) answers for any artifact, as the version-level text
@@ -389,11 +385,12 @@ class InMemoryIndex:
     def store_sdist_metadata_error(
         self, package: str, version: str, error: BaseException
     ) -> None:
-        """Record an sdist integrity failure and unblock the sdist waiter.
+        """Record a failed sdist fetch and unblock the sdist waiter.
 
-        A recorded error is distinct from ``store_sdist_metadata(None)``: None
-        means the archive yielded no PKG-INFO, an error means the archive
-        failed its published hash and the resolve must abort, not fall through.
+        Distinct from ``store_sdist_metadata(None)``: ``None`` means the archive
+        yielded no PKG-INFO; an error means the archive could not be fetched or
+        failed its published hash, so the resolve must abort rather than fall
+        through.
         """
         key = f"sdist:{package}:{version}"
         with self._lock:
@@ -449,11 +446,12 @@ class InMemoryIndex:
     def store_sdist_archive_error(
         self, package: str, version: str, error: BaseException
     ) -> None:
-        """Record an sdist-archive integrity failure and unblock the waiter.
+        """Record a failed sdist-archive fetch and unblock the waiter.
 
-        Kept in its own slot rather than ``store_sdist_archive(None)`` so
-        the ``BUILD_REMOTE`` path can tell a failed fetch (skip the
-        version) from a tampered archive (abort the resolve).
+        Kept in its own slot rather than ``store_sdist_archive(None)`` so the
+        ``BUILD_REMOTE`` path can tell an archive the index never offered (skip
+        the version) from one it advertised and then failed to serve (abort the
+        resolve).
         """
         key = f"sdist-archive:{package}:{version}"
         with self._lock:
@@ -465,7 +463,7 @@ class InMemoryIndex:
     def get_sdist_archive_error(
         self, package: str, version: str
     ) -> BaseException | None:
-        """Return a recorded sdist-archive integrity error, or ``None``."""
+        """Return a recorded sdist-archive fetch error, or ``None``."""
         with self._lock:
             return self._sdist_archive_errors.get((package, version))
 
@@ -1001,13 +999,18 @@ class FetchCoordinator:
         req: FetchRequest,
         exc: Exception,
     ) -> None:
-        """Record a failed fetch so any waiter unblocks (else a deadlock)."""
+        """Record a failed fetch so any waiter unblocks (else a deadlock).
+
+        Offline with a cold cache is the one deliberate degradation: the
+        artifact is recorded absent and the resolver works with what the cache
+        holds. Any other failure is recorded as an error, because a file the
+        listing advertised and the index then failed to serve is not the same as
+        a file that does not exist.
+        """
+        offline = isinstance(exc, OfflineError)
+
         if req.kind is FetchKind.LISTING:
-            # Offline + cold cache is a deliberate empty listing (the
-            # resolver proceeds with no candidates); any other failure is
-            # stored as an error so fetch_versions can surface it instead of
-            # reporting no candidates.
-            if isinstance(exc, OfflineError):
+            if offline:
                 # Record the serving index before the empty listing fires the
                 # pending event (see _fetch_listing).
                 self._record_serving_index(client, req.package)
@@ -1015,21 +1018,23 @@ class FetchCoordinator:
             else:
                 self.index.store_listing_error(req.package, exc)
             return
+
         assert req.version is not None
+
         if req.kind is FetchKind.METADATA:
-            if isinstance(exc, MetadataHashMismatchError):
-                self.index.store_metadata_error(req.package, req.version, exc, req.url)
-            else:
+            if offline:
                 self.index.store_metadata(req.package, req.version, None, req.url)
-        elif req.kind is FetchKind.SDIST:
-            if isinstance(exc, SdistHashMismatchError):
-                self.index.store_sdist_metadata_error(req.package, req.version, exc)
             else:
+                self.index.store_metadata_error(req.package, req.version, exc, req.url)
+        elif req.kind is FetchKind.SDIST:
+            if offline:
                 self.index.store_sdist_metadata(req.package, req.version, None)
-        elif isinstance(exc, SdistHashMismatchError):
-            self.index.store_sdist_archive_error(req.package, req.version, exc)
-        else:
+            else:
+                self.index.store_sdist_metadata_error(req.package, req.version, exc)
+        elif offline:
             self.index.store_sdist_archive(req.package, req.version, None)
+        else:
+            self.index.store_sdist_archive_error(req.package, req.version, exc)
 
     async def _fetch_listing(
         self,

--- a/nab-python/tests/property_python/test_fetch_coordinator.py
+++ b/nab-python/tests/property_python/test_fetch_coordinator.py
@@ -226,37 +226,55 @@ def test_every_request_gets_exactly_one_correct_reply(
 
         index = coord.index
 
-        # Routing + error-as-reply checks per key.
+        # Routing + error-as-reply checks per key.  A fetch that failed replies
+        # in the error slot, so the metadata slot holds only what a fetch that
+        # succeeded wrote.
         meta_keys = {k for k, _ in requested if k[0] == "metadata"}
         sdist_keys = {k for k, _ in requested if k[0] == "sdist"}
         for key in meta_keys | sdist_keys:
-            _, pkg, ver = key
-            # Metadata is keyed by the artifact it came from, so read back the
-            # slot the request was for: a metadata request asks about one
-            # sidecar, an sdist request about the version.  The listing
-            # prefetch writes that same sidecar slot from the same plan entry,
-            # so it can only produce text the sidecar request already allows.
-            asked_for_sidecar = ("metadata", pkg, ver) in meta_keys
-            sidecar = _metadata_url(pkg, ver) if asked_for_sidecar else None
-            assert index.has_metadata(pkg, ver, sidecar), f"no metadata slot for {key}"
-            value = index.get_metadata(pkg, ver, sidecar)
-            allowed: set[str | None] = set()
+            kind, pkg, ver = key
             base_ver = ver.split("#", 1)[0]
-            if asked_for_sidecar:
+            # Metadata is keyed by the artifact it came from, so read back the
+            # slot the request was for: a metadata request asks about its own
+            # sidecar, an sdist request about the version.
+            if kind == "metadata":
+                sidecar = _metadata_url(pkg, ver)
                 mode, _ = client.plan.get(("metadata", pkg, ver), ("ok", 0.0))
-                allowed.add(f"META:{pkg}:{ver}" if mode == "ok" else None)
-            if ("sdist", pkg, ver) in sdist_keys:
+                expected = f"META:{pkg}:{ver}"
+            else:
+                sidecar = None
                 mode, _ = client.plan.get(("sdist", pkg, base_ver), ("ok", 0.0))
-                allowed.add(f"PKGINFO:{pkg}:{ver}" if mode == "ok" else None)
-            assert value in allowed, f"cross-talk at {key}: {value!r} not in {allowed}"
+                expected = f"PKGINFO:{pkg}:{ver}"
+
+            if mode == "ok":
+                # A served fetch wrote its own slot, and it holds only its own
+                # text: no cross-talk from another key.
+                assert index.has_metadata(pkg, ver, sidecar), (
+                    f"no metadata slot for {key}"
+                )
+                got = index.get_metadata(pkg, ver, sidecar)
+                assert got == expected, f"cross-talk at {key}: {got!r} != {expected!r}"
+            else:
+                # A failed advertised fetch is recorded as an error, not an empty
+                # slot, so the resolve surfaces it instead of falling through.
+                assert isinstance(
+                    index.get_metadata_error(pkg, ver, sidecar), RuntimeError
+                ), f"no error for {key}"
 
         for key, _ in requested:
             if key[0] == "sdist-archive":
                 _, pkg, ver = key
                 mode, _delay = client.plan.get(key, ("ok", 0.0))
                 got = index.get_sdist_archive(pkg, ver)
-                expected = f"BYTES:{pkg}:{ver}".encode() if mode == "ok" else None
-                assert got == expected, f"archive mismatch for {key}"
+                if mode == "ok":
+                    assert got == f"BYTES:{pkg}:{ver}".encode(), (
+                        f"archive mismatch for {key}"
+                    )
+                else:
+                    assert got is None, f"archive bytes for a failed {key}"
+                    assert isinstance(
+                        index.get_sdist_archive_error(pkg, ver), RuntimeError
+                    ), f"no archive error for {key}"
 
         for key, _ in requested:
             if key[0] == "listing":

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -7,7 +7,10 @@ import io
 import json
 import ssl
 import tarfile
-from collections.abc import Mapping
+import threading
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -19,6 +22,7 @@ import urllib3
 
 from nab_index.client import AsyncSimpleClient, _extract_sdist_files
 from nab_index.httpx_async_transport import HttpxAsyncTransport, _HttpxResponse
+from nab_index.retry import GET_RETRY, MAX_RETRIES, RETRY_STATUSES, next_delay
 from nab_index.transport import HttpError
 from nab_index.urllib3_async_transport import (
     Urllib3AsyncTransport,
@@ -38,6 +42,113 @@ LISTING_JSON = {
         },
     ],
 }
+
+
+class _StubIndex(ThreadingHTTPServer):
+    """Loopback index that serves each queued status once, then 200."""
+
+    statuses: list[int]
+    seen: list[str]
+
+
+class _StubIndexHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        assert isinstance(self.server, _StubIndex)
+        self.server.seen.append(self.path)
+        status = self.server.statuses.pop(0) if self.server.statuses else 200
+
+        body = b"ok"
+        self.send_response(status)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        """Drop the handler's stderr access log."""
+
+
+@contextmanager
+def _stub_index(statuses: list[int]) -> Iterator[_StubIndex]:
+    server = _StubIndex(("127.0.0.1", 0), _StubIndexHandler)
+    server.statuses = list(statuses)
+    server.seen = []
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.fixture
+def slept(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Record the httpx transport's backoff sleeps instead of taking them."""
+    delays: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    monkeypatch.setattr(
+        "nab_index.httpx_async_transport.asyncio.sleep",
+        fake_sleep,
+    )
+    return delays
+
+
+class TestRetryPolicy:
+    """The retry policy both transports share."""
+
+    def test_transient_status_is_retried_without_retry_after(self) -> None:
+        """A bare 5xx/429 is retried; urllib3's default only retries with Retry-After."""
+        assert all(
+            GET_RETRY.is_retry("GET", status, has_retry_after=False)
+            for status in RETRY_STATUSES
+        )
+
+    def test_client_error_is_not_retried(self) -> None:
+        """A 404 (absent package) and a 403 are the index's answer."""
+        assert not GET_RETRY.is_retry("GET", 404, has_retry_after=False)
+        assert not GET_RETRY.is_retry("GET", 403, has_retry_after=False)
+
+    def test_budget_is_bounded(self) -> None:
+        assert GET_RETRY.total == MAX_RETRIES
+
+    def test_exhausted_status_retries_keep_the_response(self) -> None:
+        """A persistent 503 surfaces as HTTP 503, not as a retry error."""
+        assert GET_RETRY.raise_on_status is False
+
+    def test_backoff_grows_between_attempts(self) -> None:
+        """The first retry is immediate, then urllib3's exponential schedule."""
+        assert [next_delay(n) for n in (1, 2, 3)] == [0.0, 0.5, 1.0]
+
+    def test_retry_after_overrides_backoff(self) -> None:
+        assert next_delay(1, "2") == 2.0
+
+    def test_retry_after_is_bounded(self) -> None:
+        """A long Retry-After cannot park the resolve."""
+        assert next_delay(1, "3600") == 10.0
+        assert GET_RETRY.get_retry_after(_urllib3_response(503, "3600")) == 10.0
+
+    def test_unparseable_retry_after_falls_back_to_backoff(self) -> None:
+        assert next_delay(2, "soon") == 0.5
+        assert GET_RETRY.get_retry_after(_urllib3_response(503, "soon")) is None
+
+    def test_absent_retry_after_falls_back_to_backoff(self) -> None:
+        assert GET_RETRY.get_retry_after(_urllib3_response(503, None)) is None
+
+    def test_bound_survives_urllib3s_retry_copies(self) -> None:
+        """urllib3 clones the policy per attempt, so the bound must clone with it."""
+        retry = GET_RETRY.increment(method="GET", url="/pkg/", error=OSError("boom"))
+        assert retry.get_retry_after(_urllib3_response(503, "3600")) == 10.0
+
+
+def _urllib3_response(status: int, retry_after: str | None) -> urllib3.BaseHTTPResponse:
+    response = MagicMock(spec=urllib3.BaseHTTPResponse)
+    response.status = status
+    response.headers = {} if retry_after is None else {"Retry-After": retry_after}
+    return response
 
 
 class TestFetchCoordinatorTransport:
@@ -141,12 +252,19 @@ class TestHttpxAsyncTransport:
     def test_get_wraps_non_httperror_from_request(
         self, raised: Exception, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A non-HTTPError raised while issuing the request maps to HttpError."""
+        """A non-HTTPError raised while issuing the request maps to HttpError.
+
+        A URL httpx cannot even issue is not a blip, so it is raised on the
+        first attempt rather than spending the retry budget on it.
+        """
+        attempts = 0
 
         async def go() -> None:
             transport = HttpxAsyncTransport(http2=False)
 
             async def boom(*args: object, **kwargs: object) -> object:
+                nonlocal attempts
+                attempts += 1
                 raise raised
 
             monkeypatch.setattr(transport._client, "get", boom)
@@ -160,6 +278,8 @@ class TestHttpxAsyncTransport:
         ):
             asyncio.run(go())
 
+        assert attempts == 1
+
     def test_uses_truststore_ssl_context(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """AsyncClient gets a truststore SSLContext via verify=."""
         cls = MagicMock()
@@ -167,6 +287,124 @@ class TestHttpxAsyncTransport:
         HttpxAsyncTransport()
         verify = cls.call_args.kwargs["verify"]
         assert isinstance(verify, truststore.SSLContext)
+
+    @respx.mock
+    def test_get_retries_a_transient_status(self, slept: list[float]) -> None:
+        """A bare 503 is a blip, so ask again before believing it."""
+        route = respx.get("https://example.com/pkg").mock(
+            side_effect=[httpx.Response(503), httpx.Response(200, json={"ok": True})]
+        )
+
+        async def go() -> _HttpxResponse:
+            transport = HttpxAsyncTransport(http2=False)
+            try:
+                return await transport.get("https://example.com/pkg")
+            finally:
+                await transport.aclose()
+
+        resp = asyncio.run(go())
+        resp.raise_for_status()
+        assert resp.status_code == 200
+        assert route.call_count == 2
+        assert slept == [0.0]
+
+    @respx.mock
+    def test_get_retries_a_transport_error(self, slept: list[float]) -> None:
+        """A dropped connection is retried, as it is on the urllib3 backend."""
+        route = respx.get("https://example.com/pkg").mock(
+            side_effect=[httpx.ConnectError("boom"), httpx.Response(200)]
+        )
+
+        async def go() -> _HttpxResponse:
+            transport = HttpxAsyncTransport(http2=False)
+            try:
+                return await transport.get("https://example.com/pkg")
+            finally:
+                await transport.aclose()
+
+        assert asyncio.run(go()).status_code == 200
+        assert route.call_count == 2
+        assert slept == [0.0]
+
+    @respx.mock
+    def test_get_honours_a_bounded_retry_after(self, slept: list[float]) -> None:
+        route = respx.get("https://example.com/pkg").mock(
+            side_effect=[
+                httpx.Response(429, headers={"Retry-After": "3600"}),
+                httpx.Response(200),
+            ]
+        )
+
+        async def go() -> _HttpxResponse:
+            transport = HttpxAsyncTransport(http2=False)
+            try:
+                return await transport.get("https://example.com/pkg")
+            finally:
+                await transport.aclose()
+
+        assert asyncio.run(go()).status_code == 200
+        assert route.call_count == 2
+        assert slept == [10.0]
+
+    @respx.mock
+    def test_get_gives_up_on_a_persistent_transient_status(
+        self, slept: list[float]
+    ) -> None:
+        """The budget is bounded, and the caller still sees the 503."""
+        route = respx.get("https://example.com/pkg").mock(
+            side_effect=[httpx.Response(503)] * (MAX_RETRIES + 1)
+        )
+
+        async def go() -> _HttpxResponse:
+            transport = HttpxAsyncTransport(http2=False)
+            try:
+                return await transport.get("https://example.com/pkg")
+            finally:
+                await transport.aclose()
+
+        resp = asyncio.run(go())
+        assert route.call_count == MAX_RETRIES + 1
+        assert slept == [0.0, 0.5, 1.0]
+        with pytest.raises(HttpError, match="503"):
+            resp.raise_for_status()
+
+    @respx.mock
+    def test_get_gives_up_on_a_persistent_transport_error(
+        self, slept: list[float]
+    ) -> None:
+        route = respx.get("https://example.com/pkg").mock(
+            side_effect=httpx.ConnectError("boom")
+        )
+
+        async def go() -> None:
+            transport = HttpxAsyncTransport(http2=False)
+            try:
+                await transport.get("https://example.com/pkg")
+            finally:
+                await transport.aclose()
+
+        with pytest.raises(HttpError, match="GET https://example.com/pkg failed"):
+            asyncio.run(go())
+        assert route.call_count == MAX_RETRIES + 1
+        assert slept == [0.0, 0.5, 1.0]
+
+    @respx.mock
+    def test_get_does_not_retry_a_client_error(self, slept: list[float]) -> None:
+        """A 404 is the index's answer, so it is fetched once."""
+        route = respx.get("https://example.com/missing").mock(
+            return_value=httpx.Response(404)
+        )
+
+        async def go() -> _HttpxResponse:
+            transport = HttpxAsyncTransport(http2=False)
+            try:
+                return await transport.get("https://example.com/missing")
+            finally:
+                await transport.aclose()
+
+        assert asyncio.run(go()).status_code == 404
+        assert route.call_count == 1
+        assert slept == []
 
 
 class TestUrllib3AsyncTransport:
@@ -205,6 +443,7 @@ class TestUrllib3AsyncTransport:
             "https://example.com/",
             headers={"Accept-Encoding": "gzip", "k": "v"},
             timeout=5.0,
+            retries=GET_RETRY,
         )
         pool.clear.assert_called_once()
 
@@ -255,6 +494,7 @@ class TestUrllib3AsyncTransport:
             "https://example.com/",
             headers={"Accept-Encoding": "gzip"},
             timeout=5.0,
+            retries=GET_RETRY,
         )
 
     def test_get_lets_caller_override_accept_encoding(
@@ -282,6 +522,7 @@ class TestUrllib3AsyncTransport:
             "https://example.com/",
             headers={"Accept-Encoding": "identity"},
             timeout=5.0,
+            retries=GET_RETRY,
         )
 
     def test_get_applies_bounded_default_timeout(
@@ -321,6 +562,55 @@ class TestUrllib3AsyncTransport:
 
         asyncio.run(go())
         assert pool.request.call_args.kwargs["timeout"] == 1.5
+
+    def test_get_retries_a_bare_transient_status(self) -> None:
+        """One 503 with no Retry-After must not read as the index's answer."""
+        with _stub_index([503]) as index:
+            url = f"http://127.0.0.1:{index.server_port}/pkg/pkg-1.0.whl.metadata"
+
+            async def go() -> _Urllib3Response:
+                transport = Urllib3AsyncTransport()
+                try:
+                    return await transport.get(url)
+                finally:
+                    await transport.aclose()
+
+            resp = asyncio.run(go())
+            resp.raise_for_status()
+            assert resp.status_code == 200
+            assert len(index.seen) == 2
+
+    def test_get_gives_up_on_a_persistent_transient_status(self) -> None:
+        """The budget is bounded, and the caller still sees the 503."""
+        with _stub_index([503] * (MAX_RETRIES + 1)) as index:
+            url = f"http://127.0.0.1:{index.server_port}/pkg/"
+
+            async def go() -> _Urllib3Response:
+                transport = Urllib3AsyncTransport()
+                try:
+                    return await transport.get(url)
+                finally:
+                    await transport.aclose()
+
+            resp = asyncio.run(go())
+            assert len(index.seen) == MAX_RETRIES + 1
+            with pytest.raises(HttpError, match="HTTP 503"):
+                resp.raise_for_status()
+
+    def test_get_does_not_retry_a_client_error(self) -> None:
+        """A 404 is the index's answer, so it is fetched once."""
+        with _stub_index([404]) as index:
+            url = f"http://127.0.0.1:{index.server_port}/pkg/"
+
+            async def go() -> _Urllib3Response:
+                transport = Urllib3AsyncTransport()
+                try:
+                    return await transport.get(url)
+                finally:
+                    await transport.aclose()
+
+            assert asyncio.run(go()).status_code == 404
+            assert len(index.seen) == 1
 
     def test_response_json(self) -> None:
         fake = MagicMock(spec=urllib3.BaseHTTPResponse)

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -28,6 +28,7 @@ from nab_index.client import (
 from nab_index.httpx_async_transport import HttpxAsyncTransport
 from nab_index.local_index import LocalIndexClient
 from nab_index.multi_index import IndexConfig, MultiIndexClient
+from nab_index.transport import HttpError
 from nab_python.fetch import (
     FetchCoordinator,
     FetchKind,
@@ -36,6 +37,12 @@ from nab_python.fetch import (
     InMemoryIndex,
     _resolve_routes,
 )
+
+
+@pytest.fixture
+def no_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exhaust the transport's retry budget on the first attempt, so no backoff."""
+    monkeypatch.setattr("nab_index.httpx_async_transport.MAX_RETRIES", 0)
 
 
 def _coord(**kwargs: object) -> FetchCoordinator:
@@ -603,9 +610,8 @@ class TestFetchCoordinator:
             assert coord.index.get_listing_error("bad") is not None
 
     @respx.mock
-    def test_sdist_fetch_failure_records_empty(self) -> None:
-        """When sdist extraction errors, store_sdist_metadata(None) unblocks
-        any waiter and the coordinator does not crash."""
+    def test_sdist_fetch_failure_records_error(self, no_retries: None) -> None:
+        """A 5xx on an sdist records an error, not an archive without PKG-INFO."""
         respx.get("https://files.example.com/broken.tar.gz").mock(
             return_value=httpx.Response(500)
         )
@@ -615,23 +621,22 @@ class TestFetchCoordinator:
             )
             event.wait(timeout=5)
             assert not coord._crashed
-            # store_sdist_metadata(None) was called via the failure handler.
             assert coord.index.get_metadata("broken", "1.0") is None
+            error = coord.index.get_metadata_error("broken", "1.0")
+            assert isinstance(error, HttpError)
 
     @respx.mock
-    def test_metadata_fetch_failure_records_empty(self) -> None:
-        """When metadata fetch errors, store_metadata(None) unblocks the
-        waiter and the coordinator does not crash."""
-        respx.get("https://files.example.com/broken-1.0.whl.metadata").mock(
-            return_value=httpx.Response(500)
-        )
+    def test_metadata_fetch_failure_records_error(self, no_retries: None) -> None:
+        """A 5xx on a sidecar records an error, not an absent sidecar."""
+        sidecar = "https://files.example.com/broken-1.0.whl.metadata"
+        respx.get(sidecar).mock(return_value=httpx.Response(500))
         with _coord() as coord:
-            event = coord.request_metadata(
-                "broken", "1.0", "https://files.example.com/broken-1.0.whl.metadata"
-            )
+            event = coord.request_metadata("broken", "1.0", sidecar)
             event.wait(timeout=5)
             assert not coord._crashed
             assert coord.index.get_metadata("broken", "1.0") is None
+            error = coord.index.get_metadata_error("broken", "1.0", sidecar)
+            assert isinstance(error, HttpError)
 
     @respx.mock
     def test_late_sidecar_failure_keeps_stored_sdist_pkg_info(self) -> None:
@@ -1258,8 +1263,8 @@ class TestFetchCoordinator:
             event.wait(timeout=5)
 
     @respx.mock
-    def test_request_sdist_archive_404_stores_none(self) -> None:
-        """A 404 leaves the archive slot at ``None`` so the waiter unblocks."""
+    def test_request_sdist_archive_404_records_error(self) -> None:
+        """A 404 on an archive records an error and unblocks the waiter."""
         respx.get(url__regex=r".*").mock(return_value=httpx.Response(404))
         with _coord() as coord:
             event = coord.request_sdist_archive(
@@ -1267,6 +1272,8 @@ class TestFetchCoordinator:
             )
             event.wait(timeout=5)
             assert coord.index.get_sdist_archive("pkg", "1.0") is None
+            error = coord.index.get_sdist_archive_error("pkg", "1.0")
+            assert isinstance(error, HttpError)
 
     def test_request_direct_archive_deduplicates(self, tmp_path: Path) -> None:
         """A direct archive already in flight hands back its pending event."""
@@ -1449,6 +1456,41 @@ class TestFetchCoordinatorCache:
 
         assert linux_route.call_count == 1
         assert win_route.call_count == 1
+
+    @respx.mock
+    def test_offline_with_cold_cache_records_absent_artifacts(
+        self, tmp_path: Path
+    ) -> None:
+        """Offline with a cache miss records the artifact absent, not as an error.
+
+        Offline is the one failure the resolver works around: it resolves from
+        what the cache holds, so an uncached artifact is skipped.
+        """
+        with FetchCoordinator(
+            transport=HttpxAsyncTransport(),
+            cache_dir=tmp_path,
+            offline=True,
+        ) as coord:
+            meta = coord.request_metadata(
+                "pkg", "1.0", "https://files.example.com/pkg-1.0.whl.metadata"
+            )
+            sdist = coord.request_sdist(
+                "pkg", "2.0", "https://files.example.com/pkg-2.0.tar.gz"
+            )
+            archive = coord.request_sdist_archive(
+                "pkg", "3.0", "https://files.example.com/pkg-3.0.tar.gz"
+            )
+            assert meta.wait(timeout=5)
+            assert sdist.wait(timeout=5)
+            assert archive.wait(timeout=5)
+
+            assert coord.index.get_metadata("pkg", "1.0") is None
+            assert coord.index.get_metadata_error("pkg", "1.0") is None
+            assert coord.index.get_metadata("pkg", "2.0") is None
+            assert coord.index.get_metadata_error("pkg", "2.0") is None
+            assert coord.index.get_sdist_archive("pkg", "3.0") is None
+            assert coord.index.get_sdist_archive_error("pkg", "3.0") is None
+        assert not coord._crashed
 
     def test_explicit_cache_backend_takes_precedence(self) -> None:
         """A passed-in cache_backend wins over cache_dir."""

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import sys
 from pathlib import Path
 from typing import ClassVar
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
+import respx
 
 from nab_index.client import WheelFile
+from nab_index.httpx_async_transport import HttpxAsyncTransport
+from nab_index.transport import HttpError
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.markers import Marker, default_environment
 from nab_python._vendor.packaging.pylock import Pylock
@@ -3734,3 +3739,56 @@ class TestExtraAndGroupMembershipMarkers:
             "mytool": '"cli" in extras',
             "subtool": '"cli" in extras',
         }
+
+
+class TestSidecarFetchFailure:
+    """An advertised sidecar the index fails to serve fails the resolve."""
+
+    @staticmethod
+    def _wheel_only_listing(*versions: str) -> dict[str, object]:
+        return {
+            "meta": {"api-version": "1.0"},
+            "name": "pkg",
+            "files": [
+                {
+                    "filename": f"pkg-{v}-py3-none-any.whl",
+                    "url": f"https://files.example.com/pkg-{v}-py3-none-any.whl",
+                    "core-metadata": True,
+                }
+                for v in versions
+            ],
+        }
+
+    @respx.mock
+    def test_persistent_503_on_a_sidecar_does_not_pin_an_older_version(
+        self, tmp_path: Path
+    ) -> None:
+        """A 503 that outlives the retries must not read as "no sidecar here".
+
+        pkg 2.0 is wheel-only, so a sidecar recorded absent leaves the version
+        with no metadata source: the resolver would drop 2.0 and quietly pin 1.0.
+        """
+        respx.get("https://pypi.org/simple/pkg/").mock(
+            return_value=httpx.Response(
+                200, json=self._wheel_only_listing("1.0", "2.0")
+            )
+        )
+        respx.get("https://files.example.com/pkg-1.0-py3-none-any.whl.metadata").mock(
+            return_value=httpx.Response(
+                200, text="Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n"
+            )
+        )
+        respx.get("https://files.example.com/pkg-2.0-py3-none-any.whl.metadata").mock(
+            return_value=httpx.Response(503)
+        )
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\nversion = "0"\ndependencies = ["pkg"]\n'
+        )
+        transport = HttpxAsyncTransport()
+        try:
+            with pytest.raises(HttpError, match="503"):
+                _resolved(pyproject, transport, python_version="3.12.0")
+        finally:
+            asyncio.run(transport.aclose())


### PR DESCRIPTION
A transient 503 or 429 from an index could quietly change the result of a resolve. Neither async transport retried a bare 5xx or 429 on an index GET, and the fetch coordinator treated any failure other than a hash mismatch as "this artifact does not exist". For a wheel-only version, a failed PEP 658 sidecar then leaves no metadata source at all, so the resolver drops that version, pins an older one, and writes the lockfile with exit 0.

Both transports now take a shared retry policy from `nab_index.retry`: at most three retries of a 429, 500, 502, 503 or 504, and of a dropped connection, on urllib3's backoff schedule, obeying `Retry-After` but capping the wait at 10 seconds. urllib3's default retried those statuses only when the response carried `Retry-After`, and httpx retried nothing.

Once the retries are spent, the coordinator records the failure as an error rather than an absent artifact, so the resolve stops with the HTTP error instead of falling through. Offline with a cold cache is unchanged: the artifact is recorded absent and the resolver works with what the cache holds.
