### PR TITLE
share the base listing filter across universal matrix tuples

### DIFF
--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -8,6 +8,7 @@ already-cached metadata where possible.
 from __future__ import annotations
 
 from datetime import datetime
+from functools import partial
 from typing import TYPE_CHECKING
 
 from nab_index.client import SdistFile, WheelFile
@@ -288,6 +289,49 @@ def filter_distributions(
     so the resolver can read whichever source is cheapest at the
     chosen version.  The wheels are dropped later, at lock
     construction time, so only the sdist ends up pinned.
+
+    The filter runs in two passes.  :func:`base_distributions` applies
+    everything that has no platform axis (dist policy, Requires-Python,
+    upload cutoff, sort order), and is memoised per (package, Python)
+    across the targets of one resolve when the provider carries a
+    :class:`~nab_python.provider.ListingFilterCache`.  The wheel-tag
+    pass then runs per target on top of that shared list, so a
+    linux-only wheel still stays off the Windows target.
+    """
+    base = base_distributions(provider, normalized, files)
+    return _apply_wheel_tags(provider, normalized, base)
+
+
+def base_distributions(
+    provider: Provider,
+    normalized: str,
+    files: Sequence[WheelFile | SdistFile],
+) -> list[tuple[Version, DistFile]]:
+    """Return the pre-tag filter result, through the shared memo when there is one."""
+    cache = provider.listing_filter_cache
+    if cache is None:
+        return _filter_base(provider, normalized, files)
+
+    return cache.filtered(
+        normalized,
+        provider.python_version,
+        provider.stats,
+        partial(_filter_base, provider, normalized, files),
+    )
+
+
+def _filter_base(
+    provider: Provider,
+    normalized: str,
+    files: Sequence[WheelFile | SdistFile],
+) -> list[tuple[Version, DistFile]]:
+    """Filter and sort the listing by everything but the target's wheel tags.
+
+    Reads only the listing, the resolve-wide policy config, and the
+    target Python, so two targets that differ only by platform get the
+    same list back.  Not canonicalized: the tag pass drops artifacts,
+    and the representative version of an equal group is chosen from
+    what survives it.
     """
     # Late import: ``provider`` imports this module at module load.
     from ..provider import DistPolicy
@@ -299,12 +343,8 @@ def filter_distributions(
         provider.uploaded_prior_to is not None or provider.overrides_set_time
     )
 
-    # Bound once outside the loop: this runs for every wheel of every package.
-    tags = provider.wheel_tags
-
     result: list[tuple[Version, DistFile]] = []
     sort_with_wheel_first = False
-    tag_rejected_versions: set[Version] = set()
     for dist in files:
         provider.stats.distributions_seen += 1
         if isinstance(dist, WheelFile):
@@ -338,12 +378,39 @@ def filter_distributions(
             time_filter_active=time_filter_active,
         ):
             continue
-        if tags is not None and excluded_by_wheel_tags(
-            provider, normalized, dist, tags
-        ):
+
+        result.append((version, dist))
+
+    if sort_with_wheel_first:
+        result.sort(
+            key=lambda pair: (pair[0], isinstance(pair[1], WheelFile)),
+            reverse=True,
+        )
+    else:
+        result.sort(key=lambda pair: pair[0], reverse=True)
+    return result
+
+
+def _apply_wheel_tags(
+    provider: Provider,
+    normalized: str,
+    base: list[tuple[Version, DistFile]],
+) -> list[tuple[Version, DistFile]]:
+    """Drop the wheels this target cannot install, and the versions they leave empty.
+
+    Runs per target: the tags are the one axis of the filter the targets
+    of a matrix do not share.
+    """
+    tags = provider.wheel_tags
+    if tags is None:
+        return _canonicalize_equal_versions(base)
+
+    result: list[tuple[Version, DistFile]] = []
+    tag_rejected_versions: set[Version] = set()
+    for version, dist in base:
+        if excluded_by_wheel_tags(provider, normalized, dist, tags):
             tag_rejected_versions.add(version)
             continue
-
         result.append((version, dist))
 
     if tag_rejected_versions:
@@ -354,13 +421,6 @@ def filter_distributions(
             tag_rejected_versions - kept
         )
 
-    if sort_with_wheel_first:
-        result.sort(
-            key=lambda pair: (pair[0], isinstance(pair[1], WheelFile)),
-            reverse=True,
-        )
-    else:
-        result.sort(key=lambda pair: pair[0], reverse=True)
     return _canonicalize_equal_versions(result)
 
 

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -12,7 +12,7 @@ import enum
 import logging
 import re
 from collections import defaultdict, deque
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import TYPE_CHECKING, cast
 
 from nab_index.client import (
@@ -62,6 +62,7 @@ __all__ = [
     "DistPolicy",
     "ExtrasMode",
     "InvalidUploadTimeError",
+    "ListingFilterCache",
     "LocalSource",
     "MetadataError",
     "MissingExtraError",
@@ -323,6 +324,65 @@ class ProviderStats:
 DistFile = WheelFile | SdistFile
 
 
+_STAT_FIELDS = tuple(stat.name for stat in fields(ProviderStats))
+
+
+def _counters(stats: ProviderStats) -> tuple[int, ...]:
+    """Return every counter of ``stats``, in ``_STAT_FIELDS`` order."""
+    return tuple(getattr(stats, name) for name in _STAT_FIELDS)
+
+
+class ListingFilterCache:
+    """Base listing-filter results shared across the targets of one resolve.
+
+    The pre-tag half of the listing filter (see
+    :func:`nab_python._provider.listing.base_distributions`) reads the
+    listing's files, the policy config, and the target Python, and has no
+    platform axis, so targets that differ only by platform recompute an
+    identical list.  Memoising it per (package, Python) leaves only the
+    wheel-tag pass to run per target.
+
+    One instance is only valid across providers that share a coordinator
+    and a policy config, as the targets of one resolve do.
+    """
+
+    def __init__(self) -> None:
+        """Create an empty cache."""
+        self._entries: dict[
+            tuple[str, str | None],
+            tuple[list[tuple[Version, DistFile]], tuple[int, ...]],
+        ] = {}
+
+    def filtered(
+        self,
+        package: str,
+        python_version: str | None,
+        stats: ProviderStats,
+        compute: Callable[[], list[tuple[Version, DistFile]]],
+    ) -> list[tuple[Version, DistFile]]:
+        """Return the filter result for ``package``, running ``compute`` once.
+
+        A memo hit replays the counters the filter raised onto ``stats``, so
+        every target still reports the files it would have walked.
+        """
+        entry = self._entries.get((package, python_version))
+        if entry is not None:
+            result, delta = entry
+            for name, count in zip(_STAT_FIELDS, delta, strict=True):
+                if count:
+                    setattr(stats, name, getattr(stats, name) + count)
+            return list(result)
+
+        before = _counters(stats)
+        result = compute()
+
+        delta = tuple(
+            now - was for now, was in zip(_counters(stats), before, strict=True)
+        )
+        self._entries[(package, python_version)] = (list(result), delta)
+        return result
+
+
 # Sentinel for "this override does not set the field".  Distinct from
 # ``None``, which is a real value (a disabled upload-time cutoff).
 _UNSET = object()
@@ -362,6 +422,10 @@ class Provider:
     first when they are usable here.  The universal path passes the pins
     of an already-resolved tuple, which aligns the matrix on one version
     where every tuple can take it.
+
+    ``listing_filter_cache`` shares the platform-independent half of the
+    listing filter with the other targets of the same resolve; see
+    :class:`ListingFilterCache`.
     """
 
     # Drives two prefetch paths: the speculative root-batch prefetch
@@ -439,6 +503,7 @@ class Provider:
         resolution_strategy: ResolutionStrategy | str = ResolutionStrategy.HIGHEST,
         direct_packages: frozenset[str] | None = None,
         preferences: Mapping[str, Version] | None = None,
+        listing_filter_cache: ListingFilterCache | None = None,
         *,
         trust_unverified_sdist_deps: bool = False,
     ) -> None:
@@ -457,6 +522,9 @@ class Provider:
         self.coordinator = coordinator
         self.target = target
         self.uploaded_prior_to = uploaded_prior_to
+        # The pre-tag half of the listing filter, shared with the other
+        # targets of this resolve.  ``None`` computes it here instead.
+        self.listing_filter_cache = listing_filter_cache
 
         # Passed through to the build env when extract_source_metadata
         # falls through to a PEP 517 backend; static-only callers leave None.

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -57,6 +57,7 @@ from .config import (
 from .fetch import FetchCoordinator
 from .lockfile import LockInput, TargetLock, build_target_lock
 from .provider import (
+    ListingFilterCache,
     Provider,
     ResolutionStrategy,
     join_extra,
@@ -473,6 +474,9 @@ class _EngineSettings:
     cache_dir: Path | None
     align: bool
     resolution: ResolutionStrategy
+    # Shared by every target of every pass: the coordinator and the policy
+    # config the pre-tag half of the listing filter reads are both fixed here.
+    listing_filter_cache: ListingFilterCache = field(default_factory=ListingFilterCache)
 
 
 @dataclass(frozen=True, slots=True)
@@ -568,6 +572,7 @@ def _resolve_one_target(
             name for name in resolver_requirements if split_extra(name)[1] is None
         ),
         preferences=dict(preferences),
+        listing_filter_cache=settings.listing_filter_cache,
     )
     resolver: Resolver[str, Version] = Resolver(
         provider, range_type=VersionRange, root_version="0"

--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -19,6 +19,7 @@ import pytest
 
 from nab_index.client import WheelFile
 from nab_python import resolve as resolve_mod
+from nab_python._provider import listing as listing_mod
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.requirements import Requirement
@@ -46,9 +47,11 @@ from nab_python.lockfile import (
 from nab_python.provider import (
     ArchiveSource,
     BuildPolicy,
+    DistFile,
     DistPolicy,
     LocalSource,
     MissingExtraError,
+    Provider,
     ResolutionStrategy,
     UnsupportedSdistError,
     UnsupportedVcsError,
@@ -78,6 +81,7 @@ from nab_python.target import Matrix, ResolveTarget
 from nab_resolver.errors import ResolutionError
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
 
 
@@ -1505,3 +1509,122 @@ class TestArchiveSourceAcrossTargets:
         error = result.target_results[0].error
         assert error is not None
         assert "foo 1.0 requires Python" in str(error)
+
+
+class TestSharedListingFilter:
+    """The base listing filter is computed once per (package, Python)."""
+
+    def _wheel(
+        self,
+        version: str,
+        *,
+        requires_python: str | None = None,
+        tag: str = "py3-none-any",
+    ) -> WheelFile:
+        return WheelFile(
+            filename=f"pkg-{version}-{tag}.whl",
+            url=f"https://example.com/pkg-{version}.whl",
+            version=version,
+            requires_python=requires_python,
+            has_metadata=True,
+            upload_time=None,
+            hashes=(("sha256", "a" * 64),),
+        )
+
+    def _coordinator(self, wheels: list[WheelFile]) -> MagicMock:
+        return _make_coordinator({"pkg": wheels})
+
+    def _targets(self, python: str) -> list[ResolveTarget]:
+        return Matrix(
+            python=python,
+            platforms=(PlatformSpec("linux_x86_64"), PlatformSpec("windows_amd64")),
+        ).expand()
+
+    def _count_base_filters(self) -> tuple[list[str], object]:
+        calls: list[str] = []
+        real = listing_mod._filter_base
+
+        def counting(
+            provider: Provider, normalized: str, files: Sequence[WheelFile]
+        ) -> list[tuple[Version, DistFile]]:
+            calls.append(f"{normalized}@{provider.python_version}")
+            return real(provider, normalized, files)
+
+        return calls, counting
+
+    def test_platform_targets_share_one_base_filter(self) -> None:
+        """Targets differing only by platform reuse the base filter result."""
+        wheels = [self._wheel("1.0"), self._wheel("2.0")]
+        calls, counting = self._count_base_filters()
+
+        with patch.object(listing_mod, "_filter_base", counting):
+            result = resolve_with_coordinator(
+                self._coordinator(wheels),
+                self._targets("==3.11"),
+                _reqs("pkg"),
+                config=_no_build(),
+            )
+
+        assert result.success
+        assert len(result.target_results) == 2
+        assert calls == ["pkg@3.11.0"]
+
+    def test_shared_filter_runs_before_the_wheel_tag_pass(self) -> None:
+        """Only the pre-tag list is shared: a linux-only wheel stays off Windows."""
+        wheels = [
+            self._wheel("1.0"),
+            self._wheel("2.0", tag="cp311-cp311-manylinux_2_17_x86_64"),
+        ]
+        calls, counting = self._count_base_filters()
+
+        with patch.object(listing_mod, "_filter_base", counting):
+            result = resolve_with_coordinator(
+                self._coordinator(wheels),
+                self._targets("==3.11"),
+                _reqs("pkg"),
+                config=_no_build(),
+            )
+
+        assert result.success
+        assert calls == ["pkg@3.11.0"]
+        pinned = {
+            tr.target.platform_id: str(tr.pins["pkg"]) for tr in result.target_results
+        }
+        assert pinned == {"linux_x86_64": "2.0", "windows_amd64": "1.0"}
+
+    def test_each_python_filters_the_listing_once(self) -> None:
+        """The memo is keyed by Python: a Requires-Python bound still applies."""
+        wheels = [self._wheel("1.0"), self._wheel("2.0", requires_python=">=3.12")]
+        calls, counting = self._count_base_filters()
+
+        with patch.object(listing_mod, "_filter_base", counting):
+            result = resolve_with_coordinator(
+                self._coordinator(wheels),
+                self._targets(">=3.11,<3.13"),
+                _reqs("pkg"),
+                config=_no_build(),
+                align_across_targets=False,
+            )
+
+        assert result.success
+        assert len(result.target_results) == 4
+        assert sorted(calls) == ["pkg@3.11.0", "pkg@3.12.0"]
+        pinned = {
+            tr.target.python_version: str(tr.pins["pkg"])
+            for tr in result.target_results
+        }
+        assert pinned == {"3.11": "1.0", "3.12": "2.0"}
+
+    def test_reused_filter_still_counts_distributions_per_target(self) -> None:
+        """Every target reports the files it saw, memo hit or not."""
+        wheels = [self._wheel("1.0"), self._wheel("2.0")]
+
+        result = resolve_with_coordinator(
+            self._coordinator(wheels),
+            self._targets("==3.11"),
+            _reqs("pkg"),
+            config=_no_build(),
+        )
+
+        assert result.success
+        assert [tr.distributions_seen for tr in result.target_results] == [2, 2]


### PR DESCRIPTION
A universal resolve re-runs the base Simple-API listing filter once per matrix tuple, so a matrix with several platforms per Python rebuilds the same candidate list over and over. That filter only reads the listing's files, the policy config, and the target Python. It has no platform axis, so the work is identical for every tuple that shares a Python, and on a warm cache it is a large share of the resolve's time.

Memoise the filter per (package, Python) for the length of one universal resolve. The per-tuple wheel-tag pass still runs on top of the shared result, so a linux-only wheel stays off the Windows tuple. A memo hit replays the counters the filter raised, so each tuple still reports the distributions it walked.

Warm wall time on the tuple-heavy universal benchmark scenarios: starlette-fastapi -34%, top88-parallel -30%, top88-pypi-stress -29%, scientific-python-multi -43%, max-25-tuples -44%, transformers-cpu-multi-python -21%. Single-tuple scenarios are unchanged, and pins are identical across the suite.
