### PR TITLE
sort flat wheelhouse listings instead of using readdir order

### DIFF
--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -216,10 +216,14 @@ def _scan_flat_wheelhouse(
     root: Path,
     package: str,
 ) -> list[WheelFile | SdistFile]:
-    """Find all dists for ``package`` in a flat directory of files."""
+    """Find all dists for ``package`` in a flat directory of files.
+
+    Entries are sorted because the listing order breaks ties between dists at
+    one version, and ``iterdir`` order comes from the filesystem.
+    """
     canonical = _canonical(package)
     files: list[WheelFile | SdistFile] = []
-    for entry in root.iterdir():
+    for entry in sorted(root.iterdir()):
         if not entry.is_file():
             continue
         if _FLAT_EXTS.search(entry.name) is None:

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -22,7 +22,7 @@ from nab_index.local_index import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Coroutine
+    from collections.abc import Coroutine, Iterator
     from typing import Any
 
 _T = TypeVar("_T")
@@ -153,6 +153,31 @@ class TestFlatWheelhouse:
         missing = tmp_path / "does-not-exist"
         client = LocalIndexClient(missing.as_uri())
         assert run(client.get_files("foo")) == []
+
+    def test_listing_order_independent_of_readdir_order(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # These dists tie on every ordering rule, so only the directory-entry
+        # order can separate them.
+        names = [
+            "foo-1.0-py3-none-any.whl",
+            "foo-1.0-py2.py3-none-any.whl",
+            "foo-1.0.tar.gz",
+        ]
+        for name in names:
+            (tmp_path / name).write_bytes(b"")
+
+        client = LocalIndexClient(tmp_path.as_uri())
+        real_iterdir = Path.iterdir
+
+        def listing(*, reverse: bool) -> list[str]:
+            def fake_iterdir(self: Path) -> Iterator[Path]:
+                return iter(sorted(real_iterdir(self), reverse=reverse))
+
+            monkeypatch.setattr(Path, "iterdir", fake_iterdir)
+            return [f.filename for f in run(client.get_files("foo"))]
+
+        assert listing(reverse=False) == listing(reverse=True) == sorted(names)
 
     def test_requires_python_read_from_wheel_metadata(self, tmp_path: Path) -> None:
         # Requires-Python is absent from the filename; it comes from METADATA.


### PR DESCRIPTION
A flat wheelhouse (a directory of `.whl` and `.tar.gz` files used as a local index, pip's `--find-links ./wheels` shape) was scanned with a bare `Path.iterdir()`, so the files came back in whatever order the filesystem gave them. That is the listing order the provider sees, and listing order breaks ties between dists at the same version. When a release has more than one usable dist, say `foo-1.0-py3-none-any.whl` alongside `foo-1.0-py2.py3-none-any.whl`, or a wheel next to an sdist, directory order alone decided which one was picked, and so which METADATA drove the resolve and which URL was written to the lockfile.

The same wheelhouse can therefore produce a different lock on a different machine or filesystem, or after being copied, with no change to its contents.

Sort the entries before building the records, so the listing depends only on the wheelhouse contents.
