### PR TITLE
fix RecursionError when reporting a deeply backtracked failure

### DIFF
--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -1165,23 +1165,31 @@ def _augment_resolution_error(exc: ResolutionError, provider: Provider) -> None:
 def _walk_no_versions_packages(
     incompatibility: Incompatibility[Any, Any],
 ) -> list[str]:
-    """Return package names from every NO_VERSIONS clause in the tree."""
+    """Return package names from every NO_VERSIONS clause in the tree.
+
+    The walk is iterative: the tree gains a level per conflict, so a deeply
+    backtracked resolve overflows the recursion limit.
+    """
     out: list[str] = []
     seen_ids: set[int] = set()
+    stack: list[Incompatibility[Any, Any]] = [incompatibility]
 
-    def visit(node: Incompatibility[Any, Any]) -> None:
+    while stack:
+        node = stack.pop()
         if id(node) in seen_ids:
-            return
+            continue
         seen_ids.add(id(node))
+
         if node.cause is IncompatibilityCause.NO_VERSIONS:
             for term in node.terms:
                 pkg = term.package
                 if isinstance(pkg, str):
                     out.append(pkg)
-        if node.cause_left is not None:
-            visit(node.cause_left)
-        if node.cause_right is not None:
-            visit(node.cause_right)
 
-    visit(incompatibility)
+        # Right before left, so the left cause pops first and names keep their order.
+        if node.cause_right is not None:
+            stack.append(node.cause_right)
+        if node.cause_left is not None:
+            stack.append(node.cause_left)
+
     return out

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -2687,6 +2688,19 @@ class TestAugmentResolutionError:
         # Walk should record ``shared`` exactly once even though ``leaf``
         # is reachable from two branches of the derivation DAG.
         assert _walk_no_versions_packages(top) == ["shared"]
+
+    def test_walks_a_chain_deeper_than_the_recursion_limit(self) -> None:
+        """A derivation longer than the recursion limit is still walked."""
+        node: Incompatibility = self._no_versions_clause("buried-pkg")
+        for _ in range(sys.getrecursionlimit() + 100):
+            node = Incompatibility(
+                [Term("buried-pkg", Range.full(), positive=True)],
+                cause=IncompatibilityCause.DERIVED,
+                cause_left=node,
+                cause_right=None,
+            )
+
+        assert _walk_no_versions_packages(node) == ["buried-pkg"]
 
     def test_resolve_pyproject_re_raises_with_diagnostic(self, tmp_path: Path) -> None:
         """``resolve_pyproject`` re-raises the augmented ResolutionError."""

--- a/nab-resolver/src/nab_resolver/report.py
+++ b/nab-resolver/src/nab_resolver/report.py
@@ -56,22 +56,32 @@ def explain_incompatibility(
     visited_ids: set[int],
     narrow: _NarrowFn | None = None,
 ) -> None:
-    """Walk the cause tree appending one explanatory line per node."""
-    if id(incompatibility) in visited_ids:
-        return
-    visited_ids.add(id(incompatibility))
+    """Walk the cause tree appending one explanatory line per node.
 
-    if incompatibility.cause == IncompatibilityCause.DERIVED:
-        if incompatibility.cause_left:
-            explain_incompatibility(
-                incompatibility.cause_left, lines, visited_ids, narrow
-            )
-        if incompatibility.cause_right:
-            explain_incompatibility(
-                incompatibility.cause_right, lines, visited_ids, narrow
-            )
+    The walk is iterative: the tree gains a level per conflict, so a deeply
+    backtracked resolve overflows the recursion limit.
+    """
+    # The flag marks a node whose children are already pushed: it renders after them.
+    stack: list[tuple[Incompatibility[Any, Any], bool]] = [(incompatibility, False)]
 
-    lines.append(_render_line(incompatibility, narrow))
+    while stack:
+        node, expanded = stack.pop()
+        if expanded:
+            lines.append(_render_line(node, narrow))
+            continue
+
+        if id(node) in visited_ids:
+            continue
+        visited_ids.add(id(node))
+
+        stack.append((node, True))
+
+        # Right before left, so the left cause pops first and lines keep their order.
+        if node.cause == IncompatibilityCause.DERIVED:
+            if node.cause_right:
+                stack.append((node.cause_right, False))
+            if node.cause_left:
+                stack.append((node.cause_left, False))
 
 
 def _narrow_positive(term: Term[Any, Any], narrow: _NarrowFn) -> Term[Any, Any]:

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -3,6 +3,7 @@ and end-to-end resolution with a simple in-memory provider."""
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Mapping
 from typing import Any
 
@@ -1853,6 +1854,37 @@ class TestErrorMessages:
         negative = format_term(Term("a", Range.at_least(1), positive=False))
         assert positive == "a [1, +inf)"
         assert negative == "not a [1, +inf)"
+
+    def test_derivation_deeper_than_the_recursion_limit_renders(self) -> None:
+        """A chain longer than the recursion limit renders instead of overflowing."""
+        depth = sys.getrecursionlimit() + 100
+        node = Incompatibility(
+            [Term("tail", Range.at_least(1), positive=True)],
+            cause=IncompatibilityCause.NO_VERSIONS,
+        )
+        for index in range(depth):
+            satisfier = Incompatibility(
+                [
+                    Term(f"p{index}", Range.singleton(1), positive=True),
+                    Term("tail", Range.at_least(1), positive=False),
+                ],
+                cause=IncompatibilityCause.DEPENDENCY,
+            )
+            node = Incompatibility(
+                [Term(f"p{index}", Range.singleton(1), positive=True)],
+                cause=IncompatibilityCause.DERIVED,
+                cause_left=node,
+                cause_right=satisfier,
+            )
+
+        lines = format_error(node).splitlines()
+
+        assert len(lines) == 2 * depth + 1
+        assert lines[0] == "because no versions of tail [1, +inf) are available"
+        assert lines[1] == "because p0 1 depends on tail [1, +inf)"
+        assert lines[2] == "so p0 1"
+        assert lines[-2] == f"because p{depth - 1} 1 depends on tail [1, +inf)"
+        assert lines[-1] == f"so p{depth - 1} 1"
 
 
 class TestConstraints:


### PR DESCRIPTION
A resolve that backtracks deeply fails with a raw RecursionError raised from the error path itself, so you get a traceback instead of the derivation tree. On the default recursion limit it takes around 950 conflicts to hit.

The derivation tree gains a level per conflict, and `explain_incompatibility` recursed once per node. It now walks the tree with an explicit stack. `_walk_no_versions_packages`, which augments the resolution error on the Python side, has the same shape and is now iterative too.

Rendered lines and reported package names keep their existing order.
