### PR TITLE
stop a generic no-match reason overwriting the look-ahead blocker

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -1448,6 +1448,11 @@ class Provider:
         cutoff.  The raw listing tells absence from incompatibility apart,
         and the tag filter's own tally names the wheel-tag case, which is
         what a Windows-only package on a Linux target hits.
+
+        A look-ahead rejection emits a clause that removes the rejected
+        versions from the range, so the resolver asks again over a range
+        nothing falls in.  That second ask has no blockers of its own, so
+        its no-match reason must not overwrite the one naming the blocker.
         """
         if not all_versions:
             _, _, normalized = self.split_and_normalize(package)
@@ -1474,6 +1479,9 @@ class Provider:
             # versions inside ``version_range``.
             joined = "; ".join(blockers)
             reason = f"every version in range was rejected: {joined}"
+        elif package in self._no_versions_reasons:
+            # The weakest reason: keep whatever is already recorded.
+            return
         else:
             reason = "no version matches the requirement"
         self._no_versions_reasons[package] = reason

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -966,6 +966,39 @@ class TestNoVersionsReasons:
         assert "bar" in reason
         assert "every version in range was rejected" in reason
 
+    def test_blocker_reason_outlives_a_later_empty_range(self) -> None:
+        """A later ask over an empty range keeps the blocker reason.
+
+        ``foo`` 1.0 requires ``bar==2.0`` and the resolver has already
+        decided ``bar==1.0``, so the reason naming bar must survive a
+        second ask that finds no candidate at all.
+        """
+        coordinator = make_coordinator(
+            [make_wheel("1.0")],
+            metadata_text=(
+                "Metadata-Version: 2.1\n"
+                "Name: foo\n"
+                "Version: 1.0\n"
+                "Requires-Dist: bar==2.0\n"
+            ),
+            package="foo",
+        )
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            root_requirements={"foo": VersionRange.full(admit_arbitrary=False)},
+        )
+        provider.solution_decisions["bar"] = V("1.0")
+        assert provider.choose_version("foo", VersionRange.full()) is None
+
+        # Nothing falls in this range, so the second ask has no blockers.
+        assert provider.choose_version("foo", SpecifierSet(">=5.0").to_range()) is None
+
+        assert (
+            provider.get_no_versions_reason("foo")
+            == "every version in range was rejected: requires bar != 1.0"
+        )
+
     def test_sdist_only_under_dynamic_local_names_build_policy(self) -> None:
         """When every candidate is rejected because the package is
         sdist-only with dynamic deps and the build policy refuses to

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -2712,6 +2712,46 @@ class TestAugmentResolutionError:
         assert "Diagnostics:" in str(info.value)
         assert "foo: package not found on any configured index" in str(info.value)
 
+    def test_transitive_conflict_reports_the_blocker(self, tmp_path: Path) -> None:
+        """A transitive conflict names the blocker instead of a bare no-match.
+
+        ``foo`` needs ``bar>=2`` and ``baz`` needs ``bar==1.0``, so
+        look-ahead rejects every ``foo`` candidate.  The project wrote no
+        specifier on ``foo``, so "no version matches the requirement"
+        would point the user at a fix that does not exist.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\ndependencies = ["foo", "baz"]\n',
+            encoding="utf-8",
+        )
+
+        coordinator = make_coordinator(
+            listings={
+                "foo": _index_wheels("foo", "3.0", "3.1"),
+                "bar": _index_wheels("bar", "1.0", "2.0"),
+                "baz": _index_wheels("baz", "5.0"),
+            },
+            metadata_by_version={
+                "3.0": _metadata("foo", "3.0", "bar>=2"),
+                "3.1": _metadata("foo", "3.1", "bar>=2"),
+                "1.0": _metadata("bar", "1.0"),
+                "2.0": _metadata("bar", "2.0"),
+                "5.0": _metadata("baz", "5.0", "bar==1.0"),
+            },
+        )
+
+        with patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda _self: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            with pytest.raises(ResolutionError) as info:
+                _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
+
+        diagnostics = str(info.value).split("Diagnostics:")[1]
+        assert "foo: every version in range was rejected" in diagnostics
+        assert "bar" in diagnostics
+        assert "foo: no version matches the requirement" not in diagnostics
+
 
 def _tuple_for_python(python_version: str) -> ResolveTarget:
     """Build a linux_x86_64 target for ``python_version``.
@@ -3096,6 +3136,12 @@ class TestLocalVcsRequiresPython:
             mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
             result = _resolved(root, _FAKE_TRANSPORT)
         assert _pins(result)["foo"] == V("1.0")
+
+
+def _metadata(name: str, version: str, *requires: str) -> str:
+    """METADATA text for ``name`` ``version`` with one Requires-Dist per entry."""
+    body = "".join(f"Requires-Dist: {req}\n" for req in requires)
+    return f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n{body}\n"
 
 
 def _index_wheels(name: str, *versions: str) -> list[WheelFile]:


### PR DESCRIPTION
A transitive conflict reports the wrong cause. Resolving a project that depends on foo and baz, where foo needs bar>=2 and baz needs bar==1.0, prints:

```
foo: no version matches the requirement
```

Nothing is wrong with foo, and the project wrote no specifier on it to loosen, so that hint points at a fix that does not exist. The blocker is bar.

The provider does compute the right reason: when look-ahead rejects every foo candidate it records "every version in range was rejected: requires bar != 1.0". But the rejection also emits a clause that removes those versions from foo's range, so the resolver asks for foo again over a range nothing falls in. The second ask has no blockers of its own, so the generic fallback fires and overwrites the reason naming bar.

The fallback now leaves an already-recorded reason in place, so the error names bar instead of foo.
