### PR TITLE
parse upload-time with any fractional-seconds width on Python 3.10

### DIFF
--- a/nab-python/src/nab_python/_iso8601.py
+++ b/nab-python/src/nab_python/_iso8601.py
@@ -1,0 +1,34 @@
+"""Shared parsing for the ISO 8601 timestamps that indexes and pylock files carry."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+_FRACTIONAL_SECONDS = re.compile(r"\.(\d+)")
+
+
+def parse_iso_datetime(raw: str) -> datetime:
+    """Parse an ISO 8601 datetime, raising ``ValueError`` when it cannot be read.
+
+    The offset in ``raw`` is preserved, and the result is naive when there is
+    none, so each caller decides what a missing offset means.
+    """
+    return datetime.fromisoformat(_to_isoformat(raw))
+
+
+def _to_isoformat(raw: str) -> str:
+    """Rewrite ``raw`` into the shape ``datetime.isoformat`` emits.
+
+    Before Python 3.11, ``datetime.fromisoformat`` parses only that shape: an
+    explicit ``+HH:MM`` offset rather than ``Z``, and a fraction of exactly 3 or
+    6 digits. PEP 700 serves ``Z`` and permits 0 through 6, so those are the two
+    parts normalized here; the rest is left for ``fromisoformat`` to judge.
+    """
+    iso = f"{raw[:-1]}+00:00" if raw.endswith("Z") else raw
+    return _FRACTIONAL_SECONDS.sub(_microseconds, iso)
+
+
+def _microseconds(match: re.Match[str]) -> str:
+    # A datetime holds microseconds, so digits past the sixth are dropped.
+    return "." + match.group(1)[:6].ljust(6, "0")

--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -19,6 +19,7 @@ import tomli
 
 from nab_index.client import SdistFile, WheelFile
 
+from .._iso8601 import parse_iso_datetime
 from .._toml import tool_nab_section
 from .._vendor.packaging.pylock import Pylock, PylockValidationError
 from .._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
@@ -187,10 +188,8 @@ def read_lockfile_anchor(path: Path) -> datetime | None:
     if isinstance(raw, datetime):
         return raw if raw.tzinfo else raw.replace(tzinfo=timezone.utc)
     if isinstance(raw, str):
-        # Python 3.10's fromisoformat rejects a trailing 'Z'; 3.11+ accept it.
-        iso = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
         try:
-            dt = datetime.fromisoformat(iso)
+            dt = parse_iso_datetime(raw)
         except ValueError:
             return None
         return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
@@ -470,7 +469,7 @@ def _parse_upload_time(raw: str | None) -> datetime | None:
     if raw is None:
         return None
     try:
-        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        parsed = parse_iso_datetime(raw)
     except ValueError:
         return None
     if parsed.tzinfo is None:

--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -7,12 +7,12 @@ already-cached metadata where possible.
 
 from __future__ import annotations
 
-from datetime import datetime
 from functools import partial
 from typing import TYPE_CHECKING
 
 from nab_index.client import SdistFile, WheelFile
 
+from .._iso8601 import parse_iso_datetime
 from .._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from .._vendor.packaging.version import InvalidVersion, Version
 from ..metadata import intern_version as _intern_version
@@ -20,6 +20,7 @@ from ..metadata import intern_version as _intern_version
 if TYPE_CHECKING:
     import threading
     from collections.abc import Mapping, Sequence
+    from datetime import datetime
 
     from nab_resolver.types import RangeProtocol
 
@@ -558,7 +559,7 @@ def excluded_by_time(
         provider.stats.excluded_by_time += 1
         return True
     try:
-        upload_dt = datetime.fromisoformat(dist.upload_time.replace("Z", "+00:00"))
+        upload_dt = parse_iso_datetime(dist.upload_time)
     except ValueError:
         provider.stats.excluded_by_time += 1
         return True

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -26,6 +26,7 @@ from nab_index.archive import ArchiveRequest, ArchiveRequestError
 from nab_index.multi_index import IndexConfig
 
 from ._conflict_kind import KIND_EXTRA, KIND_GROUP
+from ._iso8601 import parse_iso_datetime
 from ._toml import tool_nab_section
 from ._vcs_admission import known_vcs_schemes
 from ._vendor.packaging.requirements import InvalidRequirement, Requirement
@@ -1255,10 +1256,8 @@ def _parse_uploaded_prior_to(value: object, *, anchor: datetime) -> datetime:
         except OverflowError:
             msg = f"uploaded-prior-to duration is too large: {value!r}"
             raise ConfigError(msg) from None
-    # Python 3.10's fromisoformat rejects a trailing 'Z'; 3.11+ accept it.
-    iso_value = f"{value[:-1]}+00:00" if value.endswith("Z") else value
     try:
-        dt = datetime.fromisoformat(iso_value)
+        dt = parse_iso_datetime(value)
     except ValueError as exc:
         msg = (
             "uploaded-prior-to must be an ISO 8601 datetime with"

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -922,6 +922,13 @@ class TestUploadedPriorTo:
         # Equivalent to 00:00 UTC.
         assert dt.astimezone(timezone.utc) == datetime(2026, 5, 1, tzinfo=timezone.utc)
 
+    def test_iso_string_with_fractional_seconds(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path, '[tool.nab]\nuploaded-prior-to = "2026-05-01T00:00:00.5Z"\n'
+        )
+        dt = read_pyproject_config(path).uploaded_prior_to
+        assert dt == datetime(2026, 5, 1, 0, 0, 0, 500000, tzinfo=timezone.utc)
+
     def test_naive_iso_string_rejected(self, tmp_path: Path) -> None:
         path = write(
             tmp_path, '[tool.nab]\nuploaded-prior-to = "2026-05-01T00:00:00"\n'

--- a/nab-python/tests/test_iso8601.py
+++ b/nab-python/tests/test_iso8601.py
@@ -1,0 +1,73 @@
+"""Tests for the shared ISO 8601 datetime parser."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from nab_python._iso8601 import _to_isoformat, parse_iso_datetime
+
+# PEP 700 serves upload-time as an ISO 8601 UTC timestamp, so an index may use
+# any fractional-seconds width from 0 through 6 digits.
+PEP_700_WIDTHS = [
+    ("2024-01-15T12:30:45Z", 0),
+    ("2024-01-15T12:30:45.1Z", 100000),
+    ("2024-01-15T12:30:45.12Z", 120000),
+    ("2024-01-15T12:30:45.123Z", 123000),
+    ("2024-01-15T12:30:45.1234Z", 123400),
+    ("2024-01-15T12:30:45.12345Z", 123450),
+    ("2024-01-15T12:30:45.123456Z", 123456),
+]
+
+
+@pytest.mark.parametrize(("raw", "microsecond"), PEP_700_WIDTHS)
+def test_parses_every_pep700_fraction_width(raw: str, microsecond: int) -> None:
+    assert parse_iso_datetime(raw) == datetime(
+        2024, 1, 15, 12, 30, 45, microsecond, tzinfo=timezone.utc
+    )
+
+
+@pytest.mark.parametrize("raw", [raw for raw, _ in PEP_700_WIDTHS])
+def test_normal_form_is_what_isoformat_emits(raw: str) -> None:
+    """Python 3.10 reads back only what ``isoformat`` writes, so pin that shape."""
+    iso = _to_isoformat(raw)
+    assert datetime.fromisoformat(iso).isoformat() == iso
+
+
+def test_offset_is_preserved() -> None:
+    parsed = parse_iso_datetime("2024-01-15T12:30:45.5+05:30")
+    assert parsed.utcoffset() == timedelta(hours=5, minutes=30)
+    assert parsed.astimezone(timezone.utc) == datetime(
+        2024, 1, 15, 7, 0, 45, 500000, tzinfo=timezone.utc
+    )
+
+
+def test_missing_offset_parses_naive() -> None:
+    """A missing offset is left for the caller to reject or coerce."""
+    parsed = parse_iso_datetime("2024-01-15T12:30:45.5")
+    assert parsed.tzinfo is None
+    assert parsed.isoformat() == "2024-01-15T12:30:45.500000"
+
+
+def test_sub_microsecond_digits_truncated() -> None:
+    assert parse_iso_datetime("2024-01-15T12:30:45.1234567Z") == datetime(
+        2024, 1, 15, 12, 30, 45, 123456, tzinfo=timezone.utc
+    )
+
+
+def test_fraction_with_no_digits_raises_value_error() -> None:
+    """A trailing dot is not a fraction, so it must not be padded into one."""
+    with pytest.raises(ValueError, match="2024-01-15T12:30:45."):
+        parse_iso_datetime("2024-01-15T12:30:45.")
+
+
+def test_offset_fraction_is_widened_too() -> None:
+    """A fractional offset also has to reach ``fromisoformat`` in normal form."""
+    iso = _to_isoformat("2024-01-15T12:30:45.5+05:30:00.5")
+    assert datetime.fromisoformat(iso).isoformat() == iso
+
+
+def test_non_datetime_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="not-a-date"):
+        parse_iso_datetime("not-a-date")

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -1336,6 +1336,15 @@ class TestReadLockfileAnchor:
         )
         assert read_lockfile_anchor(path) == datetime(2026, 5, 1, tzinfo=timezone.utc)
 
+    def test_reads_iso_string_with_fractional_seconds(self, tmp_path: Path) -> None:
+        path = tmp_path / "pylock.toml"
+        path.write_text(
+            '[tool.nab]\ncreated-at = "2026-05-01T00:00:00.5+00:00"\n',
+        )
+        assert read_lockfile_anchor(path) == datetime(
+            2026, 5, 1, 0, 0, 0, 500000, tzinfo=timezone.utc
+        )
+
     def test_naive_datetime_coerced_to_utc(self, tmp_path: Path) -> None:
         path = tmp_path / "pylock.toml"
         path.write_text(
@@ -2911,6 +2920,40 @@ class TestBuildTargetLock:
         assert pin.sdist is not None
         assert pin.sdist.upload_time == datetime(
             2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc
+        )
+
+    @pytest.mark.parametrize(
+        ("fraction", "microsecond"),
+        [
+            ("", 0),
+            (".1", 100000),
+            (".12", 120000),
+            (".123", 123000),
+            (".1234", 123400),
+            (".12345", 123450),
+            (".123456", 123456),
+        ],
+    )
+    def test_wheel_upload_time_keeps_every_pep700_fraction_width(
+        self, fraction: str, microsecond: int
+    ) -> None:
+        """PEP 700 permits 0 through 6 fractional digits; all reach the lock."""
+        wheel = WheelFile(
+            filename="foo-1.0-py3-none-any.whl",
+            url="https://pypi.org/simple/foo/foo-1.0-py3-none-any.whl",
+            version="1.0",
+            requires_python=">=3.10",
+            has_metadata=False,
+            upload_time=f"2026-05-01T12:00:00{fraction}Z",
+            hashes=(("sha256", "a" * 64),),
+            size=1234,
+        )
+        provider = _FakeProvider(listings={"foo": [(Version("1.0"), wheel)]})
+        lock = build_target_lock(provider, _HOST, {"foo": Version("1.0")})
+        pin = lock.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.wheels[0].upload_time == datetime(
+            2026, 5, 1, 12, 0, 0, microsecond, tzinfo=timezone.utc
         )
 
     def test_upload_time_none_when_index_omits_it(self) -> None:

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -2907,16 +2907,20 @@ class TestUploadedPriorTo:
         provider = Provider(coordinator, uploaded_prior_to=cutoff)
         assert provider.fetch_versions("foo") == []
 
-    def test_fractional_seconds(self) -> None:
-        """Upload times with fractional seconds are parsed correctly."""
+    @pytest.mark.parametrize(
+        "fraction", ["", ".1", ".12", ".123", ".1234", ".12345", ".123456"]
+    )
+    def test_fractional_seconds(self, fraction: str) -> None:
+        """PEP 700 permits 0 through 6 fractional digits, and all of them parse."""
         wheels = [
-            make_wheel("1.0", upload_time="2024-01-15T12:30:45.123456Z"),
+            make_wheel("1.0", upload_time=f"2024-01-15T12:30:45{fraction}Z"),
         ]
         coordinator = make_coordinator(wheels, package="foo")
         cutoff = datetime(2024, 3, 1, tzinfo=timezone.utc)
         provider = Provider(coordinator, uploaded_prior_to=cutoff)
         versions = [v for v, _ in provider.fetch_versions("foo")]
         assert versions == [V("1.0")]
+        assert provider.stats.excluded_by_time == 0
 
     def test_invalid_upload_time_excluded(self) -> None:
         """Wheels with unparseable upload-time are excluded."""
@@ -2927,6 +2931,15 @@ class TestUploadedPriorTo:
         cutoff = datetime(2024, 3, 1, tzinfo=timezone.utc)
         provider = Provider(coordinator, uploaded_prior_to=cutoff)
         assert provider.fetch_versions("foo") == []
+
+    def test_malformed_fraction_excluded_not_fatal(self) -> None:
+        """An empty fraction is malformed, so the wheel is skipped, not fatal."""
+        wheels = [make_wheel("1.0", upload_time="2024-01-15T12:30:45.")]
+        coordinator = make_coordinator(wheels, package="foo")
+        cutoff = datetime(2024, 3, 1, tzinfo=timezone.utc)
+        provider = Provider(coordinator, uploaded_prior_to=cutoff)
+        assert provider.fetch_versions("foo") == []
+        assert provider.stats.excluded_by_time == 1
 
     def test_naive_upload_time_raises_when_cutoff_active(self) -> None:
         """A timezone-naive upload-time violates PEP 700, so it is a hard error."""


### PR DESCRIPTION
PEP 700 lets an index serve upload-time with 0 to 6 fractional digits, but Python 3.10's `datetime.fromisoformat` reads back only what `isoformat` writes: a fraction of exactly 3 or 6 digits, and no trailing `Z`. So on 3.10 a spec-valid timestamp like `2024-01-01T00:00:00.1Z` fails to parse. Under an `uploaded-prior-to` cutoff that silently drops the artifact from the listing, and when writing a lock it drops the upload-time field, so the resolve and the emitted pylock both depend on the interpreter nab runs under. The same inputs parse on 3.11+.

Four places parsed one of these timestamps, each with its own `Z` rewrite. They now go through one helper that widens the fraction to microseconds before handing it to `fromisoformat`, so every supported Python reads the same timestamps. A dot with no digits after it is still a parse error rather than being padded into a valid fraction.
