### PR TITLE
gate extra-only and group-only packages behind membership markers

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -52,9 +52,11 @@ Extras selection:
   array.
 * `--all-extras` selects every declared extra.
 
-Both `--groups` and `--extras` produce a single union resolve;
-the lockfile records the selection but does not emit per-package
-`'X' in extras` or `'X' in dependency_groups` markers.
+Both `--groups` and `--extras` produce a single union resolve. A
+package that only a selected extra or group reaches is emitted with
+a `'X' in extras` or `'X' in dependency_groups` marker, so an
+installer given neither leaves it out; see
+[Lockfiles](lockfile.md).
 
 `--output` defaults to `pylock.toml` for `pylock` and
 `requirements.txt` for the two requirements formats. Pass

--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -90,6 +90,48 @@ size = 286433
   requires at least one of the three so the lockfile is
   consumable by pip's hash-checking mode.
 
+### Extras and dependency groups
+
+`nab lock --extras cli --groups dev` resolves the project, the `cli`
+extra and the `dev` group together, and records the selection in the
+top-level `extras` and `dependency-groups` keys. PEP 751 has an
+installer read those keys as what the lock offers, and install with
+no extras and only the `default-groups` unless it is asked for more.
+So a package that only `cli` or only `dev` reaches is emitted with a
+marker naming the selection that brought it in:
+
+```toml
+[[packages]]
+name = "mytool"
+version = "2.0.0"
+marker = "\"cli\" in extras"
+
+[[packages]]
+name = "mydev"
+version = "3.0.0"
+marker = "\"dev\" in dependency_groups"
+```
+
+Reachability is what decides: a package the project's own
+dependencies pull in is unconditional even when a selected extra
+also asks for it, and a package that two selections reach disjoins
+both (`"cli" in extras or "dev" in dependency_groups`). A group
+named in `[tool.nab].default-groups` still installs by default,
+because PEP 751 seeds `dependency_groups` from `default-groups`
+when the installer is given no group selection.
+
+The gate is a property of the install context, not of the platform.
+A matrix folds the selection into every target, so an extra that
+reaches a package on every target gives it the bare membership
+clause; one that reaches it on only some targets gets that clause
+joined by `and` onto those targets' environment markers.
+
+The versions are one joint resolution, so an extra's constraints
+shape the pins of the packages it shares with the project. A
+conflict between two selections is a resolution failure, not two
+lockfiles, unless it is declared; see
+[Conflicting extras and groups](../explanation/conflicts.md).
+
 ### Portable paths
 
 A lockfile can reference content on disk: a `LocalPin`'s

--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -247,6 +247,8 @@ def build_target_lock(
     *,
     indexes: Sequence[IndexConfig] = (),
     resolved_keys: Iterable[str] = (),
+    base_roots: Iterable[str] | None = None,
+    selector_roots: Mapping[tuple[str, str], Iterable[str]] | None = None,
 ) -> TargetLock:
     """Build one target's :class:`~nab_python.lockfile.TargetLock`.
 
@@ -260,10 +262,28 @@ def build_target_lock(
     ``name[extra]`` proxies; it is read to find which extras activated
     so their edges join the forward dependency graph.
 
+    ``base_roots`` and ``selector_roots`` are the resolver keys each
+    install context requires directly: the project's own dependencies,
+    and those of each selected extra and each selected group, keyed by
+    its ``(kind, name)`` member.  :func:`_membership_gates` walks the
+    resolve from them to find the packages only a selection reaches.  An
+    empty ``base_roots`` is a project with no dependencies of its own, so
+    it does not stand in for ``None``: omitting it while passing selector
+    roots raises.
+
     Every wheel the target can install, plus the sdist, is recorded for
     each pinned version.
     """
     from ..lockfile import LocalPin, TargetLock
+
+    if base_roots is None:
+        if selector_roots:
+            msg = (
+                "selector_roots need base_roots:"
+                " without them every package looks selector-only"
+            )
+            raise ValueError(msg)
+        base_roots = ()
 
     lock_pins: dict[str, PinShape] = {}
     for raw_name, version in pins.items():
@@ -305,7 +325,86 @@ def build_target_lock(
         pins=lock_pins,
         dependencies=dependencies,
         base_dependencies=base_dependencies,
+        package_gates=_membership_gates(
+            provider,
+            pins,
+            base_roots=base_roots,
+            selector_roots=selector_roots or {},
+        ),
     )
+
+
+def _membership_gates(
+    provider: LockInputProvider,
+    pins: Mapping[str, Version],
+    *,
+    base_roots: Iterable[str],
+    selector_roots: Mapping[tuple[str, str], Iterable[str]],
+) -> dict[str, tuple[tuple[str, str], ...]]:
+    """Name the selections that gate each package no base dependency reaches.
+
+    A selected extra or group is folded into the resolve that produces
+    the lock, so its requirements pin packages a default install must not
+    receive.  PEP 751 defaults an install to no extras and to
+    ``default-groups``, and decides per package from ``packages.marker``,
+    so a package only a selection reaches has to name every selection
+    that reaches it; the writer turns each ``(kind, name)`` member into
+    ``'name' in extras`` / ``'name' in dependency_groups``.  A package
+    the project's own dependencies reach is unconditional.
+
+    Reachability is over this target's resolved graph, so an extras proxy
+    (an extra requiring ``pkg[fancy]`` while the project requires plain
+    ``pkg``) gates what ``fancy`` adds without gating ``pkg``.
+    """
+    if not selector_roots:
+        return {}
+
+    pinned = {canonicalize_name(name): version for name, version in pins.items()}
+    base_reachable = _reachable_names(provider, pinned, base_roots)
+
+    gates: defaultdict[str, list[tuple[str, str]]] = defaultdict(list)
+    for member in sorted(selector_roots):
+        gated = _reachable_names(provider, pinned, selector_roots[member])
+        for name in gated - base_reachable:
+            gates[name].append(member)
+    return {name: tuple(members) for name, members in gates.items()}
+
+
+def _reachable_names(
+    provider: LockInputProvider,
+    pinned: Mapping[str, Version],
+    roots: Iterable[str],
+) -> set[str]:
+    """Return the pinned names reachable from ``roots`` at their pinned versions.
+
+    The walk is over resolver keys, so a ``name[extra]`` root pulls in
+    that extra's dependencies on top of the package's own.
+    """
+    from ..provider import split_extra
+
+    reached: set[str] = set()
+    seen: set[str] = set()
+    stack = list(roots)
+
+    while stack:
+        key = stack.pop()
+        if key in seen:
+            continue
+        seen.add(key)
+
+        raw_name, extra = split_extra(key)
+        canonical = canonicalize_name(raw_name)
+        version = pinned.get(canonical)
+        if version is None:
+            continue
+        reached.add(canonical)
+
+        cache_key = (canonical, version)
+        stack.extend(provider.deps_cache.get(cache_key, {}))
+        if extra is not None:
+            stack.extend(provider.extra_deps_map.get(cache_key, {}).get(extra, {}))
+
+    return reached
 
 
 def _forward_dependency_graph(

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 
 import tomli_w
 
+from .._conflict_kind import MARKER_VARIABLE_FOR_KIND
 from .._vendor.packaging.markers import Marker
 from .._vendor.packaging.pylock import (
     Package,
@@ -345,6 +346,11 @@ def _build_packages(lock_input: LockInput, lock_dir: Path) -> list[Package]:
     The emitted marker is the raw OR of the per-target marker
     expressions; no Boolean minimisation runs.
 
+    A package a selected extra or group reaches while the project's own
+    dependencies do not is gated on that selection, so a default install
+    (no extras, the default groups) leaves it out.  See
+    :func:`_build_marker`.
+
     A conflict fork injects a membership clause into every target's
     marker, including the forks' base dependencies.  A base dependency
     present in every fork of an environment must install regardless of
@@ -649,10 +655,22 @@ def _build_marker(
     membership OR and does not install when no member is selected.
     An environment with no base-name set (no conflict fork ran) leaves
     the gate open.
+
+    A package a selected extra or group reaches while the project's own
+    dependencies do not carries that selection's gate (see
+    :attr:`~nab_python.lockfile.TargetLock.package_gates`), which is
+    joined by ``and`` onto each contribution.  An env collapses only when
+    its forks agree on the gate, since one entry cannot carry two.  When the
+    package covers every target, every env collapsed, and every target
+    gates it the same way, the env clauses are dropped and the gate
+    stands alone: a selection is a property of the install context, not
+    of the platform, so ``"cli" in extras`` is the whole marker.
     """
     by_env: defaultdict[tuple[tuple[str, str], ...], list[str]] = defaultdict(list)
     for label in labels:
         by_env[env_signatures[label]].append(label)
+
+    gates = {label: targets[label].package_gates.get(name, ()) for label in labels}
 
     # The package is unconditional only when it covers every target AND
     # every environment collapsed to its env-only marker. A member-only
@@ -672,18 +690,53 @@ def _build_marker(
             if base_names is not None
             else (env_fork_counts[signature] == 1)
         )
-        if len(env_labels) >= env_fork_counts[signature] and is_base:
+        agreed_gate = len({gates[label] for label in env_labels}) == 1
+        if len(env_labels) >= env_fork_counts[signature] and is_base and agreed_gate:
             head = targets[env_labels[0]].target
-            contributions.append(Marker(head.environment_marker_string))
+            contributions.append(
+                Marker(_with_gate(head.environment_marker_string, gates[env_labels[0]]))
+            )
         else:
             contributions.extend(
-                Marker(targets[label].target.marker_string) for label in env_labels
+                Marker(_with_gate(targets[label].target.marker_string, gates[label]))
+                for label in env_labels
             )
             unconditional = False
 
-    if unconditional:
+    if not unconditional:
+        return _or_markers(contributions)
+
+    # Every env collapsed at full coverage: the environment is not what
+    # selects this package, so only the gate can, and only when every
+    # target agrees on it.
+    common = set(gates.values())
+    if common == {()}:
         return None
+    if len(common) == 1:
+        return Marker(_gate_clause(next(iter(common))))
     return _or_markers(contributions)
+
+
+def _gate_clause(gate: Sequence[tuple[str, str]]) -> str:
+    """Render a package's membership gate as a PEP 508 clause.
+
+    Each ``(kind, name)`` member becomes ``'name' in extras`` or
+    ``'name' in dependency_groups``; a package two selections reach
+    disjoins them, since either one installs it.
+    """
+    return " or ".join(
+        f'"{name}" in {MARKER_VARIABLE_FOR_KIND[kind]}' for kind, name in sorted(gate)
+    )
+
+
+def _with_gate(marker: str, gate: Sequence[tuple[str, str]]) -> str:
+    """AND a package's membership gate onto the marker of one target."""
+    if not gate:
+        return marker
+    clause = _gate_clause(gate)
+    if len(gate) > 1:
+        clause = f"({clause})"
+    return f"{marker} and {clause}"
 
 
 def _env_signatures(

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -353,12 +353,23 @@ class TargetLock:
     its markers (see :attr:`~nab_python.target.ResolveTarget.marker_string`)
     rather than being handed a projection of them, so a lock entry and
     the environment it was resolved for cannot drift apart.
+
+    ``package_gates`` maps a package this target locked to the selected
+    extras and groups that reach it while the project's own dependencies
+    do not, as ``(kind, name)`` members.  The writer emits each one as a
+    ``'name' in extras`` / ``'name' in dependency_groups`` clause on that
+    package's marker, so a default install (no extras, the default
+    groups) leaves it out.  A package the project's dependencies reach is
+    absent from the map and stays unconditional.
     """
 
     target: ResolveTarget
     pins: Mapping[str, PinShape]
     dependencies: Mapping[str, tuple[str, ...]] = field(default_factory=dict)
     base_dependencies: Mapping[str, tuple[str, ...]] = field(default_factory=dict)
+    package_gates: Mapping[str, tuple[tuple[str, str], ...]] = field(
+        default_factory=dict
+    )
 
 
 @dataclass

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -91,6 +91,7 @@ if TYPE_CHECKING:
 
 
 __all__ = [
+    "InstallContexts",
     "ResolveFork",
     "ResolveResult",
     "TargetResult",
@@ -108,6 +109,27 @@ EnvSignature = tuple[tuple[str, str], ...]
 
 
 @dataclass(frozen=True, slots=True)
+class InstallContexts:
+    """A fork's requirements, split back into the contexts PEP 751 installs.
+
+    ``project`` is the project's own dependencies, and ``selectors``
+    holds one requirement list per active extra and group, keyed by its
+    ``(kind, name)`` member.  The lock writer walks the resolved graph
+    from each of them, so a package only a selection reaches is gated on
+    it (see :attr:`~nab_python.lockfile.TargetLock.package_gates`) and a
+    default install leaves it out.
+
+    A member of the fork's own ``selection`` is not a selector here: its
+    clause is already on every pin of the fork.
+    """
+
+    project: tuple[Requirement, ...] = ()
+    selectors: Mapping[tuple[str, str], tuple[Requirement, ...]] = field(
+        default_factory=dict
+    )
+
+
+@dataclass(frozen=True, slots=True)
 class ResolveFork:
     """A conflict fork's resolver input: a selection and its requirements.
 
@@ -117,10 +139,16 @@ class ResolveFork:
     selection activates).  Each fork runs against every target, with its
     ``selection`` stamped onto each so the pins land under a distinct
     label and a membership-gated marker.
+
+    ``contexts`` is that same requirement list split into the install
+    contexts the lock has to distinguish; ``None`` for a caller that
+    resolves a bare requirement list and has no project to split it
+    into, which leaves every package unconditional.
     """
 
     selection: tuple[tuple[str, str], ...]
     requirements: tuple[Requirement, ...]
+    contexts: InstallContexts | None = None
 
 
 @dataclass
@@ -333,7 +361,12 @@ def resolve_with_coordinator(  # noqa: PLR0913 - the knobs a caller drives a bar
             t.with_selection(fork.selection) if fork.selection else t for t in targets
         ]
         pass_results = _run_pass(
-            fork_targets, fork.requirements, constraints, settings, accumulated
+            fork_targets,
+            fork.requirements,
+            constraints,
+            settings,
+            accumulated,
+            fork.contexts,
         )
         results.extend(pass_results)
         accumulated = _threaded_preferences(
@@ -533,18 +566,22 @@ def _run_pass(
     constraints: Sequence[Requirement],
     settings: _EngineSettings,
     preferences: Mapping[str, Version],
+    contexts: InstallContexts | None = None,
 ) -> list[TargetResult]:
     """Resolve every target in ``targets`` once, in order.
 
     With alignment on, each target's pins are threaded forward as
     preferences for the next, so the pins stay aligned across targets
     wherever the environments admit it.
+
+    ``contexts`` splits ``requirements`` into the install contexts the
+    lock gates its packages on; see :class:`InstallContexts`.
     """
     results: list[TargetResult] = []
     accumulated = dict(preferences)
     for target in targets:
         tr = _resolve_one_target(
-            target, requirements, constraints, settings, accumulated
+            target, requirements, constraints, settings, accumulated, contexts
         )
         results.append(tr)
         accumulated = _threaded_preferences(accumulated, [tr], align=settings.align)
@@ -557,6 +594,7 @@ def _resolve_one_target(
     constraints: Sequence[Requirement],
     settings: _EngineSettings,
     preferences: Mapping[str, Version],
+    contexts: InstallContexts | None = None,
 ) -> TargetResult:
     """Run one single-environment resolve for ``target``."""
     config = settings.config
@@ -623,6 +661,7 @@ def _resolve_one_target(
             **_target_stats(resolver, provider),
         )
     elapsed = time.monotonic() - start
+    base_roots, selector_roots = _install_context_roots(contexts, environment)
     return TargetResult(
         target=target,
         success=True,
@@ -634,10 +673,54 @@ def _resolve_one_target(
             pins,
             indexes=settings.coordinator.indexes,
             resolved_keys=raw,
+            base_roots=base_roots,
+            selector_roots=selector_roots,
         ),
         wall_time=elapsed,
         **_target_stats(resolver, provider),
     )
+
+
+def _install_context_roots(
+    contexts: InstallContexts | None, environment: Mapping[str, str]
+) -> tuple[frozenset[str] | None, dict[tuple[str, str], frozenset[str]] | None]:
+    """Return the lock writer's install-context roots for one target.
+
+    ``(None, None)`` when there is no selection to attribute packages to,
+    which leaves every package unconditional.  A requirement whose marker
+    this target's environment fails is dropped, exactly as the resolve
+    dropped it, so it gates nothing.
+    """
+    if contexts is None or not contexts.selectors:
+        return None, None
+    return (
+        _root_keys(contexts.project, environment),
+        {
+            member: _root_keys(requirements, environment)
+            for member, requirements in contexts.selectors.items()
+        },
+    )
+
+
+def _root_keys(
+    requirements: Sequence[Requirement], environment: Mapping[str, str]
+) -> frozenset[str]:
+    """Return the resolver keys ``requirements`` names directly.
+
+    The same shape :func:`_build_resolver_inputs` feeds the resolver: a
+    canonical name per requirement, plus a ``name[extra]`` proxy key per
+    requested extra, with marker-excluded requirements dropped.
+    """
+    keys: set[str] = set()
+    for req in requirements:
+        if req.marker is not None and not dependency_marker_holds(
+            req.marker, environment
+        ):
+            continue
+        name = str(canonicalize_name(req.name))
+        keys.add(name)
+        keys.update(join_extra(name, extra) for extra in req.extras)
+    return frozenset(keys)
 
 
 def _consulted_markers(
@@ -735,6 +818,10 @@ def _plan_forks(
             ResolveFork(
                 selection=fork.selection,
                 requirements=tuple(_fork_requirements(path, tables, fork)),
+                contexts=InstallContexts(
+                    project=tuple(tables.dependencies),
+                    selectors=_selector_requirements(path, tables, fork),
+                ),
             )
         )
 
@@ -745,6 +832,34 @@ def _plan_forks(
     if len(plan) > 1:
         base_requirements = _fork_requirements(path, tables, _base_fork(plan[0]))
     return forks, base_requirements
+
+
+def _selector_requirements(
+    path: Path, tables: _ProjectTables, fork: ConflictFork
+) -> dict[tuple[str, str], tuple[Requirement, ...]]:
+    """Split a fork's selection into one requirement list per member.
+
+    The lock writer walks the resolved graph from each of them to gate
+    the packages only that extra or group reaches.  A member of the
+    fork's own ``selection`` is left out: every pin of the fork already
+    carries its clause, so gating it again would only repeat it.
+
+    A group named in ``default-groups`` is here like any other: PEP 751
+    seeds ``dependency_groups`` from ``default-groups`` when the
+    installer selects none, so the gate still holds for a default
+    install.
+    """
+    chosen = set(fork.selection)
+    selectors: dict[tuple[str, str], tuple[Requirement, ...]] = {}
+    for extra in fork.active_extras:
+        member = (ConflictKind.EXTRA.value, str(canonicalize_name(extra)))
+        if member not in chosen:
+            selectors[member] = tuple(_extra_requirements(tables, [extra], path))
+    for group in fork.active_groups:
+        member = (ConflictKind.GROUP.value, str(canonicalize_name(group)))
+        if member not in chosen:
+            selectors[member] = tuple(_group_requirements(tables.groups, [group], path))
+    return selectors
 
 
 def _fork_requirements(

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import ClassVar, cast
@@ -4102,3 +4102,250 @@ class TestDependencyGraph:
         data = tomllib.loads(text)
         by_name = {p["name"]: p for p in data["packages"]}
         assert by_name["foo"]["dependencies"] == [{"name": "bar"}, {"name": "baz"}]
+
+
+class TestMembershipGates:
+    """Only-an-extra / only-a-group packages carry a membership marker.
+
+    The lock declares its ``extras`` and ``dependency-groups``, and PEP
+    751 has an installer default to no extras and to ``default-groups``,
+    so every package the selection alone reaches has to say so in its
+    own ``packages.marker``.
+    """
+
+    @staticmethod
+    def _provider(
+        names: Sequence[str],
+        deps_cache: dict[tuple[str, Version], dict[str, object]] | None = None,
+        extra_deps_map: dict[tuple[str, Version], dict[str, dict[str, object]]]
+        | None = None,
+    ) -> _FakeProvider:
+        return _FakeProvider(
+            listings={name: [(Version("1.0"), _wheel_file(name))] for name in names},
+            deps_cache=deps_cache,
+            extra_deps_map=extra_deps_map,
+        )
+
+    def test_extra_only_package_and_its_transitive_dep_are_gated(self) -> None:
+        provider = self._provider(
+            ("core", "mytool", "subtool"),
+            deps_cache={
+                ("core", Version("1.0")): {},
+                ("mytool", Version("1.0")): dict.fromkeys(["subtool"]),
+                ("subtool", Version("1.0")): {},
+            },
+        )
+        lock = build_target_lock(
+            provider,
+            _HOST,
+            dict.fromkeys(("core", "mytool", "subtool"), Version("1.0")),
+            base_roots=frozenset({"core"}),
+            selector_roots={("extra", "cli"): frozenset({"mytool"})},
+        )
+        assert lock.package_gates == {
+            "mytool": (("extra", "cli"),),
+            "subtool": (("extra", "cli"),),
+        }
+
+    def test_group_only_package_gates_on_dependency_groups(self) -> None:
+        provider = self._provider(
+            ("core", "mydev"),
+            deps_cache={
+                ("core", Version("1.0")): {},
+                ("mydev", Version("1.0")): {},
+            },
+        )
+        lock = build_target_lock(
+            provider,
+            _HOST,
+            dict.fromkeys(("core", "mydev"), Version("1.0")),
+            base_roots=frozenset({"core"}),
+            selector_roots={("group", "dev"): frozenset({"mydev"})},
+        )
+        pylock = build_pylock(_lock_from(lock))
+        assert {
+            str(pkg.name): str(pkg.marker) if pkg.marker else None
+            for pkg in pylock.packages
+        } == {"core": None, "mydev": '"dev" in dependency_groups'}
+
+    def test_package_two_selectors_reach_disjoins_both(self) -> None:
+        """Reached by an extra and a group: either selection installs it."""
+        provider = self._provider(
+            ("shared",), deps_cache={("shared", Version("1.0")): {}}
+        )
+        lock = build_target_lock(
+            provider,
+            _HOST,
+            {"shared": Version("1.0")},
+            base_roots=frozenset(),
+            selector_roots={
+                ("extra", "cli"): frozenset({"shared"}),
+                ("group", "dev"): frozenset({"shared"}),
+            },
+        )
+        pylock = build_pylock(_lock_from(lock))
+        (package,) = pylock.packages
+        assert str(package.marker) == ('"cli" in extras or "dev" in dependency_groups')
+
+    def test_extras_proxy_gates_only_what_the_extra_adds(self) -> None:
+        """The project requires ``foo``; the extra requires ``foo[fancy]``.
+
+        ``foo`` itself installs unconditionally; only what ``fancy``
+        adds on top of it is gated.
+        """
+        provider = self._provider(
+            ("foo", "fancy-lib"),
+            deps_cache={
+                ("foo", Version("1.0")): {},
+                ("fancy-lib", Version("1.0")): {},
+            },
+            extra_deps_map={
+                ("foo", Version("1.0")): {"fancy": dict.fromkeys(["fancy-lib"])}
+            },
+        )
+        lock = build_target_lock(
+            provider,
+            _HOST,
+            dict.fromkeys(("foo", "fancy-lib"), Version("1.0")),
+            base_roots=frozenset({"foo"}),
+            selector_roots={("extra", "cli"): frozenset({"foo", "foo[fancy]"})},
+        )
+        assert lock.package_gates == {"fancy-lib": (("extra", "cli"),)}
+
+    def test_base_dependency_reached_through_a_cycle_is_not_gated(self) -> None:
+        """A dependency cycle in the base closure terminates the walk."""
+        provider = self._provider(
+            ("core", "loop", "mytool"),
+            deps_cache={
+                ("core", Version("1.0")): dict.fromkeys(["loop"]),
+                ("loop", Version("1.0")): dict.fromkeys(["core"]),
+                ("mytool", Version("1.0")): dict.fromkeys(["loop"]),
+            },
+        )
+        lock = build_target_lock(
+            provider,
+            _HOST,
+            dict.fromkeys(("core", "loop", "mytool"), Version("1.0")),
+            base_roots=frozenset({"core"}),
+            selector_roots={("extra", "cli"): frozenset({"mytool"})},
+        )
+        assert lock.package_gates == {"mytool": (("extra", "cli"),)}
+
+    def test_unpinned_dependency_is_skipped(self) -> None:
+        """A dep name the resolve did not pin cannot be gated."""
+        provider = self._provider(
+            ("mytool",),
+            deps_cache={("mytool", Version("1.0")): dict.fromkeys(["ghost"])},
+        )
+        lock = build_target_lock(
+            provider,
+            _HOST,
+            {"mytool": Version("1.0")},
+            base_roots=frozenset(),
+            selector_roots={("extra", "cli"): frozenset({"mytool"})},
+        )
+        assert set(lock.package_gates) == {"mytool"}
+
+    def test_no_selection_leaves_the_map_empty(self) -> None:
+        provider = self._provider(("core",), deps_cache={("core", Version("1.0")): {}})
+        lock = build_target_lock(
+            provider, _HOST, {"core": Version("1.0")}, base_roots=frozenset({"core"})
+        )
+        assert lock.package_gates == {}
+
+    def test_selector_roots_without_base_roots_are_refused(self) -> None:
+        """Omitting ``base_roots`` would gate the base packages too.
+
+        An empty ``base_roots`` is a project with no dependencies of its
+        own, so it cannot double as "the caller did not say".
+        """
+        provider = self._provider(("core",), deps_cache={("core", Version("1.0")): {}})
+        with pytest.raises(ValueError, match="need base_roots"):
+            build_target_lock(
+                provider,
+                _HOST,
+                {"core": Version("1.0")},
+                selector_roots={("extra", "cli"): frozenset({"core"})},
+            )
+
+    def test_gate_stands_alone_when_every_target_agrees(self) -> None:
+        """The selection, not the platform, is what selects the package."""
+        provider = self._provider(
+            ("core", "mytool"),
+            deps_cache={
+                ("core", Version("1.0")): {},
+                ("mytool", Version("1.0")): {},
+            },
+        )
+        pins = dict.fromkeys(("core", "mytool"), Version("1.0"))
+        roots: dict[tuple[str, str], frozenset[str]] = {
+            ("extra", "cli"): frozenset({"mytool"})
+        }
+        py310 = _target("3.10")
+        py311 = _target("3.11")
+        lock_input = LockInput(
+            targets={
+                t.label: build_target_lock(
+                    provider,
+                    t,
+                    pins,
+                    base_roots=frozenset({"core"}),
+                    selector_roots=roots,
+                )
+                for t in (py310, py311)
+            },
+            extras=("cli",),
+        )
+        pylock = build_pylock(lock_input)
+        assert {
+            str(pkg.name): str(pkg.marker) if pkg.marker else None
+            for pkg in pylock.packages
+        } == {"core": None, "mytool": '"cli" in extras'}
+
+    def test_target_specific_gate_keeps_its_environment_clause(self) -> None:
+        """Only one target's extra reaches the package, so the env stays.
+
+        The gate is joined by and onto that target's own marker, so an installer
+        on the other target leaves the package out however it selects.
+        """
+        provider = self._provider(
+            ("core", "mytool"),
+            deps_cache={
+                ("core", Version("1.0")): {},
+                ("mytool", Version("1.0")): {},
+            },
+        )
+        pins = dict.fromkeys(("core", "mytool"), Version("1.0"))
+        py310 = _target("3.10")
+        py311 = _target("3.11")
+        lock_input = LockInput(
+            targets={
+                py310.label: build_target_lock(
+                    provider,
+                    py310,
+                    pins,
+                    base_roots=frozenset({"core"}),
+                    selector_roots={("extra", "cli"): frozenset({"mytool"})},
+                ),
+                py311.label: build_target_lock(
+                    provider,
+                    py311,
+                    pins,
+                    base_roots=frozenset({"core", "mytool"}),
+                    selector_roots={("extra", "cli"): frozenset()},
+                ),
+            },
+            extras=("cli",),
+        )
+        pylock = build_pylock(lock_input)
+        markers = {
+            str(pkg.name): str(pkg.marker) if pkg.marker else None
+            for pkg in pylock.packages
+        }
+        assert markers["core"] is None
+        assert markers["mytool"] == (
+            '(python_version == "3.10" and sys_platform == "linux"'
+            ' and platform_machine == "x86_64" and "cli" in extras)'
+            ' or (python_version == "3.11" and sys_platform == "linux"'
+            ' and platform_machine == "x86_64")'
+        )

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import sys
 from pathlib import Path
+from typing import ClassVar
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -12,6 +13,7 @@ import pytest
 from nab_index.client import WheelFile
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.markers import Marker, default_environment
+from nab_python._vendor.packaging.pylock import Pylock
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.version import Version
 from nab_python.config import (
@@ -22,7 +24,7 @@ from nab_python.config import (
     ResolveMode,
     read_pyproject_config,
 )
-from nab_python.lockfile import LockInput, PinShape
+from nab_python.lockfile import LockInput, PinShape, build_pylock
 from nab_python.provider import (
     BuildPolicy,
     LocalSource,
@@ -3541,3 +3543,194 @@ class TestLockDeclaresItsEnvironment:
         assert not Marker(str(environment)).evaluate(
             {**_PY312_ENV, "python_full_version": "3.12.5"}
         )
+
+
+class TestExtraAndGroupMembershipMarkers:
+    """A selected extra or group gates the packages only it reaches.
+
+    End to end from ``pyproject.toml`` to the emitted lock.  PEP 751
+    defaults an install to no extras and to ``default-groups``, so a
+    package a selection alone pulls in has to carry ``'name' in extras``
+    / ``'name' in dependency_groups``.
+    """
+
+    _MEMBERS: ClassVar[dict[str, str]] = {
+        "core": '[project]\nname = "core"\nversion = "1.0"\n',
+        "mytool": '[project]\nname = "mytool"\nversion = "2.0"\n'
+        'dependencies = ["subtool"]\n',
+        "mydev": '[project]\nname = "mydev"\nversion = "3.0"\n',
+        "subtool": '[project]\nname = "subtool"\nversion = "4.0"\n',
+    }
+
+    _ROOT = (
+        '[project]\nname = "app"\nversion = "1.0"\ndependencies = ["core"]\n'
+        '[project.optional-dependencies]\ncli = ["mytool"]\n'
+        '[dependency-groups]\ndev = ["mydev"]\n'
+        + "".join(
+            f'[[tool.nab.local-sources]]\nname = "{name}"\npath = "{name}"\n'
+            for name in ("core", "mytool", "mydev", "subtool")
+        )
+    )
+
+    @staticmethod
+    def _lock(
+        tmp_path: Path,
+        *,
+        extras: tuple[str, ...] = (),
+        groups: tuple[str, ...] = (),
+        root: str | None = None,
+        members: dict[str, str] | None = None,
+    ) -> Pylock:
+        (tmp_path / "pyproject.toml").write_text(
+            root if root is not None else TestExtraAndGroupMembershipMarkers._ROOT,
+            encoding="utf-8",
+        )
+        bodies = (
+            members
+            if members is not None
+            else TestExtraAndGroupMembershipMarkers._MEMBERS
+        )
+        for name, body in bodies.items():
+            member = tmp_path / name
+            member.mkdir()
+            (member / "pyproject.toml").write_text(body, encoding="utf-8")
+        with patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda _self: make_coordinator([])
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            path = tmp_path / "pyproject.toml"
+            config = read_pyproject_config(path)
+            result = _resolved(
+                path,
+                _FAKE_TRANSPORT,
+                config=config,
+                extras=extras,
+                groups=groups,
+            )
+        pylock = build_pylock(
+            build_lock_input(
+                result,
+                config=config,
+                extras=extras,
+                dependency_groups=groups,
+            ),
+            lock_dir=tmp_path,
+        )
+        pylock.validate()
+        return pylock
+
+    @staticmethod
+    def _markers(pylock: Pylock) -> dict[str, str | None]:
+        return {
+            str(pkg.name): str(pkg.marker) if pkg.marker else None
+            for pkg in pylock.packages
+        }
+
+    @staticmethod
+    def _selected(pylock: Pylock, **kwargs: list[str]) -> set[str]:
+        return {str(pkg.name) for pkg, _ in pylock.select(**kwargs)}
+
+    def test_extra_only_package_carries_extras_membership(self, tmp_path: Path) -> None:
+        pylock = self._lock(tmp_path, extras=("cli",), groups=("dev",))
+
+        assert self._markers(pylock) == {
+            "core": None,
+            "mydev": '"dev" in dependency_groups',
+            "mytool": '"cli" in extras',
+            "subtool": '"cli" in extras',
+        }
+
+    def test_default_install_skips_extra_and_group_packages(
+        self, tmp_path: Path
+    ) -> None:
+        """The spec's default install context: no extras, no groups."""
+        pylock = self._lock(tmp_path, extras=("cli",), groups=("dev",))
+
+        assert self._selected(pylock) == {"core"}
+        assert self._selected(pylock, extras=["cli"]) == {"core", "mytool", "subtool"}
+        assert self._selected(pylock, dependency_groups=["dev"]) == {"core", "mydev"}
+        assert self._selected(pylock, extras=["cli"], dependency_groups=["dev"]) == {
+            "core",
+            "mydev",
+            "mytool",
+            "subtool",
+        }
+
+    def test_package_reached_by_base_and_extra_is_unconditional(
+        self, tmp_path: Path
+    ) -> None:
+        """An extra re-requiring a project dependency does not gate it."""
+        root = self._ROOT.replace('cli = ["mytool"]', 'cli = ["mytool", "core"]')
+        pylock = self._lock(tmp_path, extras=("cli",), root=root)
+
+        assert self._selected(pylock) == {"core"}
+
+    def test_default_group_still_installs_by_default(self, tmp_path: Path) -> None:
+        """A ``default-groups`` member gates on the group but installs by default.
+
+        PEP 751 seeds ``dependency_groups`` from ``default-groups`` when
+        the installer is given no group selection, so the membership
+        marker holds; an installer that explicitly selects no group
+        (``dependency_groups=[]``) drops it.
+        """
+        root = self._ROOT + '[tool.nab]\ndefault-groups = ["dev"]\n'
+        pylock = self._lock(tmp_path, root=root)
+
+        assert pylock.default_groups == ("dev",)
+        assert self._selected(pylock) == {"core", "mydev"}
+        assert self._selected(pylock, dependency_groups=[]) == {"core"}
+
+    def test_no_selection_leaves_every_package_unmarked(self, tmp_path: Path) -> None:
+        pylock = self._lock(tmp_path)
+
+        assert [pkg.marker for pkg in pylock.packages] == [None]
+        assert self._selected(pylock) == {"core"}
+
+    def test_marker_excluded_extra_requirement_is_not_locked(
+        self, tmp_path: Path
+    ) -> None:
+        """A requirement the target Python excludes is in no install context."""
+        root = self._ROOT.replace(
+            'cli = ["mytool"]',
+            'cli = ["mytool", "mydev ; python_version < \'3.9\'"]',
+        )
+        pylock = self._lock(tmp_path, extras=("cli",), root=root)
+
+        assert set(self._markers(pylock)) == {"core", "mytool", "subtool"}
+
+    def test_extra_requiring_an_extra_of_a_base_package(self, tmp_path: Path) -> None:
+        """``cli = ["core[fancy]"]``: core stays unconditional, fancy's dep is gated."""
+        root = self._ROOT.replace('cli = ["mytool"]', 'cli = ["core[fancy]"]')
+        pylock = self._lock(
+            tmp_path,
+            extras=("cli",),
+            root=root,
+            members={
+                "core": '[project]\nname = "core"\nversion = "1.0"\n'
+                '[project.optional-dependencies]\nfancy = ["subtool"]\n',
+                "subtool": TestExtraAndGroupMembershipMarkers._MEMBERS["subtool"],
+                "mytool": TestExtraAndGroupMembershipMarkers._MEMBERS["mytool"],
+                "mydev": TestExtraAndGroupMembershipMarkers._MEMBERS["mydev"],
+            },
+        )
+
+        assert self._markers(pylock) == {"core": None, "subtool": '"cli" in extras'}
+
+    def test_matrix_gates_the_extra_on_every_target(self, tmp_path: Path) -> None:
+        """A matrix folds the extra into every target, and gates it there too.
+
+        The gate is a property of the install context, not of the
+        platform, so an extra every target reaches the same way carries
+        the bare membership clause.
+        """
+        root = self._ROOT + (
+            '[tool.nab]\nmode = "universal"\n'
+            '[tool.nab.matrix]\npython = ">=3.11,<3.13"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+        pylock = self._lock(tmp_path, extras=("cli",), root=root)
+
+        assert self._markers(pylock) == {
+            "core": None,
+            "mytool": '"cli" in extras',
+            "subtool": '"cli" in extras',
+        }

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -251,8 +251,8 @@ def _drop_workspace_pins(
     ``workspace_to_drop`` holds canonical workspace member names; pin
     keys are already canonical.  An empty set returns ``lock_input``
     unchanged.  Each target's pins are filtered, and its forward
-    dependency graph with them, so no edge points at a dropped member
-    with no ``[[packages]]`` entry.
+    dependency graph and membership gates with them, so no edge or gate
+    names a dropped member with no ``[[packages]]`` entry.
     """
     if not workspace_to_drop:
         return lock_input
@@ -268,6 +268,9 @@ def _drop_workspace_pins(
                 name: kept
                 for name, deps in lock.dependencies.items()
                 if keep(name) and (kept := tuple(dep for dep in deps if keep(dep)))
+            },
+            package_gates={
+                name: gate for name, gate in lock.package_gates.items() if keep(name)
             },
         )
         for label, lock in lock_input.targets.items()


### PR DESCRIPTION
`nab lock --extras cli --groups dev` records the selection in the lockfile's `extras` and `dependency-groups` keys, but every package comes out unconditional. Under PEP 751 an installer defaults to no extras and only the default groups, and decides per package from `packages.marker`, so a conforming installer reading one of our locks pulls the extra-only and group-only packages into a plain install.

The selections are folded into the single resolve that produces the lock, and nothing afterwards recorded which packages arrived that way. The writer now walks the resolved graph from each install context's roots. A package that no base dependency reaches gets a `"cli" in extras` or `"dev" in dependency_groups` marker, disjoining the clauses when more than one selection reaches it. A package the project's own dependencies already pull in stays unconditional, even when a selected extra also asks for it.

Universal mode has no equivalent gate: a plain extra or group is folded into every tuple and its packages carry no membership marker. The reference docs described that as a design choice; it is a PEP 751 gap, and they now say so, with a test pinning the current behaviour.
