### PR TITLE
fix lowest-direct flooring a marker-excluded root in universal mode

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -419,9 +419,10 @@ class Provider:
     resolve targets.
 
     ``preferences`` are versions another resolve already decided, tried
-    first when they are usable here.  The universal path passes the pins
-    of an already-resolved tuple, which aligns the matrix on one version
-    where every tuple can take it.
+    first when they are usable here.  A multi-target resolve passes the
+    pins of an already-resolved target, which aligns the matrix on one
+    version where every target can take it.  A package the strategy wants
+    lowest for ignores the preference and takes its own floor.
 
     ``listing_filter_cache`` shares the platform-independent half of the
     listing filter with the other targets of the same resolve; see
@@ -1204,10 +1205,12 @@ class Provider:
 
         A preference is honored only when it is in range and usable here: a
         base version needs extractable metadata, an extras proxy
-        additionally needs to declare the extra.
+        additionally needs to declare the extra.  A package the strategy
+        wants lowest for keeps its own floor, so alignment cannot make the
+        result depend on the order the targets resolve in.
         """
         preferred = self._preferences.get(normalized)
-        if preferred is None:
+        if preferred is None or self.wants_lowest(normalized):
             return None
 
         all_versions = self.versions_only(normalized, self.fetch_versions(package))

--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -646,6 +646,81 @@ class TestDirectPackages:
         assert self._direct_packages("pkg[foo]") == {"pkg"}
 
 
+class TestLowestDirectAcrossTargets:
+    """``lowest-direct`` reads the direct set per target, after markers,
+    and the floor it gives a direct package survives cross-target alignment.
+
+    ``foo`` is a root gated on windows and a dependency of ``bar``
+    everywhere.  A target whose markers drop the root treats ``foo`` as
+    transitive; a target that keeps it floors it, whichever target
+    resolves first.
+    """
+
+    def _coordinator(self) -> MagicMock:
+        return make_coordinator(
+            listings={
+                "bar": [_make_wheel("5.0", package="bar")],
+                "foo": [
+                    _make_wheel("1.0", package="foo"),
+                    _make_wheel("2.0", package="foo"),
+                ],
+            },
+            metadata_by_version={
+                "5.0": (
+                    "Metadata-Version: 2.1\nName: bar\nVersion: 5.0\n"
+                    "Requires-Dist: foo>=1\n\n"
+                ),
+                "1.0": "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n\n",
+                "2.0": "Metadata-Version: 2.1\nName: foo\nVersion: 2.0\n\n",
+            },
+        )
+
+    def _pins(self, *platform_ids: str) -> dict[str, dict[str, Version]]:
+        targets = Matrix(
+            python="==3.11",
+            platforms=tuple(PlatformSpec(p) for p in platform_ids),
+        ).expand()
+        result = resolve_with_coordinator(
+            self._coordinator(),
+            targets,
+            _reqs('foo; sys_platform == "win32"', "bar"),
+            config=_no_build(),
+            resolution_strategy=ResolutionStrategy.LOWEST_DIRECT,
+        )
+        assert result.success
+        return {
+            tr.target.platform_spec.platform_id: tr.pins
+            for tr in result.target_results
+            if tr.target.platform_spec is not None
+        }
+
+    def test_marker_excluded_root_takes_the_transitive_newest(self) -> None:
+        """On linux ``foo`` reaches the graph only through ``bar``."""
+        assert self._pins("linux_x86_64") == {
+            "linux_x86_64": {"bar": Version("5.0"), "foo": Version("2.0")},
+        }
+
+    def test_marker_included_root_still_takes_its_floor(self) -> None:
+        """On windows the same ``foo`` requirement is direct, so it floors."""
+        assert self._pins("windows_amd64") == {
+            "windows_amd64": {"bar": Version("5.0"), "foo": Version("1.0")},
+        }
+
+    def test_floor_survives_a_leading_transitive_target(self) -> None:
+        """Linux pins the newest first; windows still floors its direct ``foo``."""
+        assert self._pins("linux_x86_64", "windows_amd64") == {
+            "linux_x86_64": {"bar": Version("5.0"), "foo": Version("2.0")},
+            "windows_amd64": {"bar": Version("5.0"), "foo": Version("1.0")},
+        }
+
+    def test_leading_floor_aligns_the_transitive_target(self) -> None:
+        """Windows floors first, and linux takes that pin as its preference."""
+        assert self._pins("windows_amd64", "linux_x86_64") == {
+            "windows_amd64": {"bar": Version("5.0"), "foo": Version("1.0")},
+            "linux_x86_64": {"bar": Version("5.0"), "foo": Version("1.0")},
+        }
+
+
 _FORTY_SHA = "0123456789abcdef0123456789abcdef01234567"
 
 


### PR DESCRIPTION
Universal mode built the set of direct packages for lowest-direct from the raw requirement strings, before markers were applied, so a root like `foo; sys_platform == "win32"` counted as direct on every tuple in the matrix. On a linux tuple, where foo reaches the graph only as another package's dependency, it was still pinned to its floor instead of the newest version the transitive requirement allows. Resolving for a single environment gets this right because it parses requirements against the environment first.

The direct set now comes from each tuple's own parsed requirements, so a root whose marker is false on that tuple is treated as transitive there.

Serial alignment could undo the floor from the other side: once a tuple pinned foo to its newest version, that pin was threaded forward as a preference, and a later tuple where foo really is direct took the preference instead of its floor. A package the strategy wants at its lowest now ignores the preference, so the pins no longer depend on the order the tuples resolve in.
