### PR TITLE
fix documented requirements.txt hash line count and order

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -29,8 +29,8 @@ Resolve and emit a lockfile or pin list. Three formats:
 
 * `--format pylock` (default) writes a [PEP 751] `pylock.toml`.
 * `--format requirements` writes a pip-compatible
-  `requirements.txt` with one `--hash=sha256:...` line per
-  recorded artefact.
+  `requirements.txt` with one `--hash=<algo>:<digest>` line per
+  recorded digest.
 * `--format requirements-without-hashes` writes a sorted
   `name==version` list with no hashes.
 

--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -10,7 +10,7 @@ result:
 
 * `--format pylock` (default): a [PEP 751] `pylock.toml`.
 * `--format requirements`: a pip-compatible `requirements.txt`
-  with `--hash=sha256:...` per recorded artefact.
+  with one `--hash=<algo>:<digest>` line per recorded digest.
 * `--format requirements-without-hashes`: a sorted
   `name==version` list with no hashes.
 
@@ -183,10 +183,15 @@ starlette==0.36.0 \
     --hash=sha256:...
 ```
 
-The hash count per package equals the number of artefacts
-recorded in the resolve. An sdist hash, when present, comes
-first; wheel hashes follow. The continuation backslashes match
-what pip-compile emits.
+A package carries one `--hash` line per recorded digest, not one
+per artefact. Only `sha256`, `sha384`, and `sha512` are recorded,
+so a wheel the index publishes with an `md5` and a `sha256`
+contributes one line, and one published with a `sha256` and a
+`sha512` contributes two. The lines are sorted by algorithm then
+digest rather than grouped by artefact, so an sdist hash lands
+wherever its digest sorts and the output does not depend on the
+order the artefacts were found in. The continuation backslashes
+match what pip-compile emits.
 
 Local and VCS pins are rendered without hashes, mirroring pip's
 behaviour. An editable local pin becomes a `-e` line and a

--- a/nab-python/src/nab_python/_lockfile/requirements.py
+++ b/nab-python/src/nab_python/_lockfile/requirements.py
@@ -33,16 +33,16 @@ def write_requirements_with_hashes(
 ) -> str:
     """Render ``lock_input`` as a pip-compatible requirements.txt.
 
-    Each line is ``name==version`` followed by one ``--hash=sha256:...``
-    per recorded artefact, in the format pip's hash-checking mode
-    accepts.  Local and VCS pins are emitted as ``name @ <url>`` lines
-    without hashes (pip does not hash-check those forms); an editable
-    local pin renders as ``-e <url>`` and a ``subdirectory`` as a
-    ``#subdirectory=`` fragment.  An archive pin is a third form, ``name @
-    <url>#sha256=...``, carrying its hash in the fragment;
-    :func:`require_artifact_hashes` skips it because that hash is guaranteed
-    at config parse.  Returns the text and, when ``output_path`` is provided,
-    atomically writes it.
+    Each line is ``name==version`` followed by one ``--hash=<algo>:<digest>``
+    per recorded digest, in the format pip's hash-checking mode accepts.  The
+    hash lines are sorted, so the output does not depend on artefact order.
+    Local and VCS pins are emitted as ``name @ <url>`` lines without hashes
+    (pip does not hash-check those forms); an editable local pin renders as
+    ``-e <url>`` and a ``subdirectory`` as a ``#subdirectory=`` fragment.  An
+    archive pin is a third form, ``name @ <url>#sha256=...``, carrying its hash
+    in the fragment; :func:`require_artifact_hashes` skips it because that hash
+    is guaranteed at config parse.  Returns the text and, when ``output_path``
+    is provided, atomically writes it.
     """
     require_artifact_hashes(lock_input)
     return _render_requirements(lock_input, with_hashes=True, output_path=output_path)

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -3017,6 +3017,27 @@ class TestBuildTargetLock:
         }
         assert pin.wheels[0].primary_digest == ("sha384", "d" * 96)
 
+    def test_md5_dropped_when_sha256_present(self) -> None:
+        wheel = WheelFile(
+            filename="foo-1.0-py3-none-any.whl",
+            url="https://pypi.org/simple/foo/foo-1.0-py3-none-any.whl",
+            version="1.0",
+            requires_python=">=3.10",
+            has_metadata=False,
+            upload_time=None,
+            hashes=(("md5", "0" * 32), ("sha256", "a" * 64)),
+            size=1234,
+        )
+        provider = _FakeProvider(listings={"foo": [(Version("1.0"), wheel)]})
+        lock = build_target_lock(provider, _HOST, {"foo": Version("1.0")})
+
+        pin = lock.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.wheels[0].hashes == (("sha256", "a" * 64),)
+
+        text = write_requirements_with_hashes(_lock_from(lock))
+        assert text == f"foo==1.0 \\\n    --hash=sha256:{'a' * 64}\n"
+
     def test_diverging_requires_python_drops_field(self) -> None:
         wheel_a = _wheel_file(requires_python=">=3.10")
         wheel_b = WheelFile(
@@ -3520,6 +3541,29 @@ class TestWriteRequirementsWithHashes:
             LockInput(targets=_one({"foo": reverse}))
         )
         assert text_forward == text_reverse
+
+    def test_hash_lines_sorted_across_sdist_and_wheel(self) -> None:
+        sdist = SdistArtifact(
+            filename="foo-1.0.tar.gz",
+            url="https://example.com/foo-1.0.tar.gz",
+            hashes=(("sha256", "f" * 64),),
+        )
+        wheel = WheelArtifact(
+            filename="foo-1.0-py3-none-any.whl",
+            url="https://example.com/foo-1.0-py3-none-any.whl",
+            hashes=(("sha256", "0" * 64), ("sha512", "9" * 128)),
+        )
+        pin = IndexPin(
+            name="foo", version="1.0", index="pypi", sdist=sdist, wheels=(wheel,)
+        )
+
+        text = write_requirements_with_hashes(LockInput(targets=_one({"foo": pin})))
+        assert text == (
+            "foo==1.0 \\\n"
+            f"    --hash=sha256:{'0' * 64} \\\n"
+            f"    --hash=sha256:{'f' * 64} \\\n"
+            f"    --hash=sha512:{'9' * 128}\n"
+        )
 
     def test_local_pin_uses_file_url(self, tmp_path: Path) -> None:
         text = write_requirements_with_hashes(


### PR DESCRIPTION
The `--format requirements` docs said each package gets one `--hash` line per recorded artefact, with the sdist hash first and the wheel hashes after. Neither holds. The emitter gathers every recorded digest from the sdist and the wheels and sorts them by algorithm then digest, so the sdist hash lands wherever its digest sorts, and the output does not depend on the order the artefacts were found in.

The count is per digest, not per artefact. Only sha256, sha384 and sha512 are recorded, so a wheel the index publishes with an md5 and a sha256 contributes one line, and one published with a sha256 and a sha512 contributes two.

Corrects the wording in `docs/reference/lockfile.md`, `docs/reference/cli.md` and the `write_requirements_with_hashes` docstring, and adds tests pinning the sorted order and the md5 drop.
