### PR TITLE
document the matrix implementations axis

### DIFF
--- a/docs/explanation/universal.md
+++ b/docs/explanation/universal.md
@@ -99,12 +99,12 @@ numpy==2.1.3
 ...
 ```
 
-One block per `(python, platform)` cell. Pip cannot install a
-single requirements.txt across multiple tuples in hash-checking
-mode, so the per-tuple block format is for inspection or for
-tools that consume one block at a time. When a tuple fails
-resolution, the line reads `# <label>: FAILED` followed by the
-indented error and the process exits 1.
+One block per tuple. Pip cannot install a single requirements.txt
+across multiple tuples in hash-checking mode, so the per-tuple
+block format is for inspection or for tools that consume one block
+at a time. When a tuple fails resolution, the line reads
+`# <label>: FAILED` followed by the indented error and the process
+exits 1.
 
 ## Patch-release markers
 
@@ -142,15 +142,15 @@ implementations). A PyPy tuple sets `platform_python_implementation =
 accepts `ppXY-pypyXY_pp73` wheel tags instead of `cpXY`. Labels use the
 `pp` interpreter prefix (`pp311-linux_x86_64`).
 
-A matrix modelling one implementation leaves the axis open: its
-lockfile markers carry `python_version`, `sys_platform` and
-`platform_machine` only. Declaring a second one puts
-`implementation_name` on every tuple's marker, and on the
-`environments` entry it declares, so the CPython and PyPy entries for
-one `(python, platform)` point stay mutually exclusive. PyPy's
-`implementation_version` is modelled as the Python level, not PyPy's
-own release, so the rare marker comparing `implementation_version`
-against a PyPy version misevaluates.
+A CPython-only matrix leaves the axis open: its lockfile markers carry
+`python_version`, `sys_platform` and `platform_machine` only. Any other
+matrix, whether it names two implementations or one non-CPython one,
+puts `implementation_name` on every tuple's marker and on the
+`environments` entry it declares. The CPython and PyPy entries for one
+`(python, platform)` point stay mutually exclusive, and a PyPy-only
+lock refuses CPython. PyPy's `implementation_version` is modelled as
+the Python level, not PyPy's own release, so the rare marker comparing
+`implementation_version` against a PyPy version misevaluates.
 
 ## Trade-offs versus marker-fork PubGrub
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,9 +73,10 @@ contributing
 * Direct-URL `.tar.gz` archive sources, hash-verified and pinned as
   PEP 751 `packages.archive`
 * PEP 751 lockfile emission via the upstream `packaging` library
-* Universal resolution across a user-declared `(python, platform)`
-  matrix.  Opt-in via `[tool.nab].mode = "universal"`; the API and
-  output format are still subject to change.
+* Universal resolution across a user-declared
+  `(python, platform, implementation)` matrix.  Opt-in via
+  `[tool.nab].mode = "universal"`; the API and output format are still
+  subject to change.
 * Mutually-exclusive extras and dependency groups via
   `[tool.nab].conflicts`: fail fast in specific mode, fork the resolve
   in universal mode.  See [conflicts](explanation/conflicts.md).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -70,15 +70,18 @@ all three formats:
 
 * `pylock` produces one PEP 751 file with per-tuple `Package`
   entries gated by markers (`python_version`, `sys_platform`,
-  `platform_machine`). Versions agreed across every tuple appear
-  once without a marker; divergent versions appear once per
-  `(version, source)` group with the matching tuples disjoined.
+  `platform_machine`, plus `implementation_name` when the matrix
+  declares a non-CPython implementation or more than one). Versions
+  agreed across every tuple appear once without a marker; divergent
+  versions appear once per `(version, source)` group with the
+  matching tuples disjoined.
 * `requirements` and `requirements-without-hashes` emit a
   sequence of `# label` comment blocks, one per
-  `(python, platform)` tuple, followed by that tuple's pins. Pip's
-  hash-checking mode cannot install a single requirements.txt
-  across multiple tuples, so the per-tuple block format is for
-  inspection or for tools that consume one block at a time.
+  `(python, platform, implementation)` tuple, followed by that
+  tuple's pins. Pip's hash-checking mode cannot install a single
+  requirements.txt across multiple tuples, so the per-tuple block
+  format is for inspection or for tools that consume one block at
+  a time.
 
 Failed tuples render as `# {label}: FAILED` followed by the
 indented error and exit `1`.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -537,9 +537,9 @@ over HTTP.
 ## Universal mode (experimental)
 
 Universal resolution runs the single-environment resolver once per
-declared `(python, platform)` tuple, sharing one fetcher so metadata
-is fetched at most once per package.  Output and API are still subject
-to change.
+declared `(python, platform, implementation)` tuple, sharing one
+fetcher so metadata is fetched at most once per package.  Output and
+API are still subject to change.
 
 ```toml
 [tool.nab]
@@ -548,14 +548,33 @@ mode = "universal"
 [tool.nab.matrix]
 python = ">=3.11,<3.14"
 platforms = ["linux_x86_64", "macos_arm64"]
-python-order = "asc"            # "asc" | "desc"
+implementations = ["cpython", "pypy"]   # default ["cpython"]
+python-order = "asc"                    # "asc" | "desc"
 python-patches = { "3.11" = "3.11.4" }
 ```
 
-`python-order` controls cross-tuple alignment direction (`asc` mirrors
-uv's `fork-strategy=fewest`; `desc` mirrors `fork-strategy=
-requires-python`).  `python-patches` overrides the per-minor
-`python_full_version` marker value for marker evaluation.
+The matrix has three axes, and nab resolves the full cross product:
+the example above declares 3 pythons, 2 platforms and 2
+implementations, so it plans 12 tuples.
+
+| Key | Default | Meaning |
+| --- | --- | --- |
+| `python` | required | A PEP 440 range like `>=3.11,<3.14`, expanded into one tuple per minor |
+| `platforms` | required | The platforms to model; a bare id, or a table of the tag knobs below |
+| `implementations` | `["cpython"]` | The interpreter implementations to model: `"cpython"`, `"pypy"` |
+| `python-order` | `"asc"` | Cross-tuple alignment direction |
+| `python-patches` | per-minor `.0` | Overrides the `python_full_version` marker value for a minor |
+
+`python-order` sets the alignment direction: `asc` mirrors uv's
+`fork-strategy=fewest`, `desc` mirrors `fork-strategy=requires-python`.
+
+### Interpreter implementations
+
+`implementations` names the interpreters to model, and each entry
+multiplies the tuple count.  An unknown implementation, a duplicate,
+and an empty list are each a config error.  See
+[Universal resolution](../explanation/universal.md) for how the axis is
+modelled and what it puts on the lockfile markers.
 
 ### Platform tag knobs
 
@@ -614,8 +633,8 @@ target that does run that kernel has to say so.
 free-threaded wheels and neither the ordinary `cp3XX` ones nor `abi3`
 (a free-threaded interpreter cannot load either).  It needs CPython
 3.13 or newer, the first release with a free-threaded build; a matrix
-that admits an older minor, or a non-CPython implementation, is a
-config error.
+whose `python` admits an older minor, or whose `implementations` names
+anything but `cpython`, is a config error.
 
 An id may appear once.  A lockfile entry is selected by a PEP 508
 marker, and PEP 508 has no variable for the libc family or the
@@ -641,9 +660,9 @@ error.  See [Build policy](build-policy.md).
   overrides it for one run.
 * `[tool.nab.matrix].python`: a range like `>=3.11,<3.14`, expanded into
   one tuple per minor version.  Used only by universal mode.  Pair with
-  `[tool.nab.matrix].platforms` and (optionally)
-  `[tool.nab.matrix].python-patches` to control the resolve and marker
-  shape across all tuples.
+  `[tool.nab.matrix].platforms`, `[tool.nab.matrix].implementations` and
+  (optionally) `[tool.nab.matrix].python-patches` to control the resolve
+  and marker shape across all tuples.
 
 Declaring a `[tool.nab.matrix]` table while `mode` is `specific` is an
 error: the matrix is the universal resolver's input, so leaving mode

--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -157,12 +157,13 @@ the target's Python. It bounds what the project supports; the
 ### Universal mode
 
 Under `[tool.nab].mode = "universal"`, `nab lock --format pylock`
-writes a single file covering every `(python, platform)` tuple
-in the matrix. Packages whose pinned version is identical across
-every tuple appear once with no marker; packages that diverge
-appear as multiple `Package` entries with PEP 508 markers built
-from each tuple's `python_version`, `sys_platform`, and
-`platform_machine`.
+writes a single file covering every
+`(python, platform, implementation)` tuple in the matrix. Packages
+whose pinned version is identical across every tuple appear once with
+no marker; packages that diverge appear as multiple `Package` entries
+with PEP 508 markers built from each tuple's `python_version`,
+`sys_platform` and `platform_machine`, plus `implementation_name` on
+the same terms as the `environments` declarations above.
 
 `environments` carries one declaration per tuple, built the same way
 a single-environment lock builds its one: from the markers that

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -2856,21 +2856,26 @@ def _parse_major_minor(key: str, value: object) -> tuple[int, int] | None:
     return (release[0], release[1])
 
 
-def _parse_matrix(value: object) -> MatrixConfig | None:
-    if not isinstance(value, dict):
-        msg = f"[tool.nab.matrix] must be a table, got {type(value).__name__}"
-        raise ConfigError(msg)
-    allowed = {
+_MATRIX_KEYS = frozenset(
+    {
         "python",
         "platforms",
         "python-order",
         "python-patches",
         "implementations",
     }
-    unknown = sorted(set(value) - allowed)
+)
+
+
+def _parse_matrix(value: object) -> MatrixConfig | None:
+    if not isinstance(value, dict):
+        msg = f"[tool.nab.matrix] must be a table, got {type(value).__name__}"
+        raise ConfigError(msg)
+    unknown = sorted(set(value) - _MATRIX_KEYS)
     if unknown:
         msg = (
-            f"unknown [tool.nab.matrix] keys: {unknown!r}; expected {sorted(allowed)!r}"
+            f"unknown [tool.nab.matrix] keys: {unknown!r};"
+            f" expected {sorted(_MATRIX_KEYS)!r}"
         )
         raise ConfigError(msg)
     try:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -12,6 +12,7 @@ from nab_python._vendor.packaging.markers import default_environment
 from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.version import Version
 from nab_python.config import (
+    _MATRIX_KEYS,
     ConfigError,
     ConflictKind,
     ConflictMember,
@@ -74,6 +75,17 @@ def first_tool_nab_example() -> str:
         if block.lstrip().startswith("[tool.nab]"):
             return block
     raise AssertionError("no [tool.nab] example block in configuration.md")
+
+
+def universal_mode_section() -> str:
+    """Return the universal-mode section of the config reference."""
+    text = DOCS_CONFIGURATION.read_text()
+    match = re.search(
+        r"^## Universal mode.*?(?=^## )", text, flags=re.DOTALL | re.MULTILINE
+    )
+    if match is None:
+        raise AssertionError("no universal-mode section in configuration.md")
+    return match.group(0)
 
 
 class TestCliOverridesFold:
@@ -887,7 +899,7 @@ class TestRequiresPython:
             read_pyproject_config(path)
 
     def test_top_level_doc_example_is_a_valid_specifier(self, tmp_path: Path) -> None:
-        """The config guide's top-level example must parse as a valid specifier."""
+        """The config reference's top-level example must parse as a valid specifier."""
         block = first_tool_nab_example()
         match = re.search(r'^requires-python = "([^"]*)"', block, re.MULTILINE)
         assert match is not None, "top-level example dropped requires-python"
@@ -2951,6 +2963,16 @@ class TestIndexOverrides:
         with pytest.raises(ConfigError, match="are not supported") as excinfo:
             read_pyproject_config(path, discover_workspace=False)
         assert "flat body keys" not in str(excinfo.value)
+
+
+class TestMatrixReferenceDocs:
+    def test_reference_documents_every_matrix_key(self) -> None:
+        """Every key the matrix parser accepts is named in the config reference."""
+        section = universal_mode_section()
+        undocumented = sorted(key for key in _MATRIX_KEYS if f"`{key}`" not in section)
+        assert not undocumented, (
+            f"[tool.nab.matrix] keys the config reference never names: {undocumented}"
+        )
 
 
 class TestMatrix:


### PR DESCRIPTION
`[tool.nab.matrix]` accepts an `implementations` key, but the config reference never named it, and index.md, cli.md, lockfile.md and the universal explanation all described the matrix as a `(python, platform)` tuple. Nothing in the docs tells you the third axis exists, or that declaring it multiplies the number of tuples nab resolves.

The reference now lists every key the matrix parser accepts and its default, and a short section says what `implementations` does to the tuple count and to the lockfile markers. The pages that spelled the tuple out now name all three axes, and the free-threading note points at the key that expresses the CPython-only constraint.

A test checks the parser's key set against the reference, so a new matrix key fails the suite until it is documented.
