### PR TITLE
apply a workspace declared in nab.toml

### DIFF
--- a/docs/how-to/workspaces.md
+++ b/docs/how-to/workspaces.md
@@ -46,15 +46,13 @@ Every listed member must contain a `pyproject.toml` with a
 
 The project being locked declares the workspace, in either of its two
 config files, and its `members` are read relative to that project's
-directory. Running `nab lock` at the root activates discovery that
-way.
+directory. That is the path `nab lock` takes at a workspace root.
 
 When `nab lock <member>/pyproject.toml` is invoked and the member
 declares no workspace of its own, nab walks upwards from the member's
-directory looking for the first ancestor `pyproject.toml` that carries
-a `[tool.nab.workspace]` table. The walk only looks at
-`pyproject.toml`, so a root that declares its workspace in `nab.toml`
-is found when it is the project being locked, not from a member.
+directory for the first ancestor that declares one, in either file:
+`[tool.nab.workspace]` in its `pyproject.toml`, or `[workspace]` in
+its `nab.toml`. The `pyproject.toml` is checked first.
 
 Each member of the matched workspace contributes a local source. The
 provider prefers those local sources over PyPI for any requirement
@@ -81,13 +79,12 @@ alone.
 ## Scope of `[tool.nab]` keys
 
 Workspace discovery flows these from the root into the file being
-locked: the member entries from `[tool.nab.workspace].members`
-(merged into `local-sources`), and the build-policy floor described
-above. Everything else under `[tool.nab]` is scoped to the
-pyproject being locked: `conflicts`, `default-groups`, `constraints`,
-`matrix`, `mode`, `requires-python`, `uploaded-prior-to`,
-`build-policy` itself, `dist-policy`, `vcs`, `indexes`, and
-`environment`. Locking a member with `nab lock
+locked: the workspace `members` (merged into `local-sources`), and
+the build-policy floor described above. Everything else under
+`[tool.nab]` is scoped to the pyproject being locked: `conflicts`,
+`default-groups`, `constraints`, `matrix`, `mode`, `requires-python`,
+`uploaded-prior-to`, `build-policy` itself, `dist-policy`, `vcs`,
+`indexes`, and `environment`. Locking a member with `nab lock
 packages/core/pyproject.toml` reads only that file's keys; the
 root's are ignored.
 

--- a/docs/how-to/workspaces.md
+++ b/docs/how-to/workspaces.md
@@ -4,11 +4,10 @@
 > Workspace support is experimental. Discovery rules, member
 > validation, and the auto-promoted build policy may change.
 
-A workspace is a parent project whose `pyproject.toml` declares one
-or more in-tree members. When `nab lock` runs against a member (or
-the root itself), the resolver prefers the in-tree members over PyPI
-for any package whose canonical name matches a member's
-`[project].name`.
+A workspace is a parent project that declares one or more in-tree
+members. When `nab lock` runs against a member (or the root itself),
+the resolver prefers the in-tree members over PyPI for any package
+whose canonical name matches a member's `[project].name`.
 
 ## Declaring a workspace
 
@@ -24,6 +23,16 @@ members = [
 ]
 ```
 
+`workspace` is a project-scope key like any other, so the same table
+can be written at the top level of the project-directory `nab.toml`
+instead:
+
+```toml
+# /repo/nab.toml
+[workspace]
+members = ["packages/core", "packages/extras", "tools/cli"]
+```
+
 `members` is a list of literal directory paths relative to the
 workspace root. Globs (`*`, `?`, `[`) are rejected; spell out each
 member.
@@ -35,15 +44,21 @@ Every listed member must contain a `pyproject.toml` with a
 
 ## How discovery works
 
-When `nab lock <member>/pyproject.toml` is invoked, nab walks
-upwards from the member's directory looking for the first ancestor
-`pyproject.toml` that carries a `[tool.nab.workspace]` table. The
-member's own pyproject also counts: running `nab lock` at the root
-activates discovery the same way.
+The project being locked declares the workspace, in either of its two
+config files, and its `members` are read relative to that project's
+directory. Running `nab lock` at the root activates discovery that
+way.
 
-The matched root's `members` list is then read and each member
-contributes a local source. The provider prefers those local
-sources over PyPI for any requirement whose canonical name matches.
+When `nab lock <member>/pyproject.toml` is invoked and the member
+declares no workspace of its own, nab walks upwards from the member's
+directory looking for the first ancestor `pyproject.toml` that carries
+a `[tool.nab.workspace]` table. The walk only looks at
+`pyproject.toml`, so a root that declares its workspace in `nab.toml`
+is found when it is the project being locked, not from a member.
+
+Each member of the matched workspace contributes a local source. The
+provider prefers those local sources over PyPI for any requirement
+whose canonical name matches.
 
 ## Interaction with `[[tool.nab.local-sources]]`
 

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -582,11 +582,11 @@ def read_pyproject_config(
     Unknown keys at the top level are rejected so typos fail loud.
 
     When ``discover_workspace`` is true (the default), the merged
-    ``workspace`` table drives discovery: its members resolve against the
-    project directory.  A project declaring no workspace of its own walks
-    up from ``path`` for the first ancestor ``pyproject.toml`` whose
-    ``[tool.nab.workspace]`` table is present.  Either way every member
-    is materialised as an additional :class:`LocalSource` (explicit
+    ``workspace`` table drives discovery and its members resolve against
+    the project directory.  A project that declares no workspace of its
+    own walks up from ``path`` for the first ancestor project file that
+    declares one.  Either way every member is materialised as an
+    additional :class:`LocalSource` (explicit
     ``[[tool.nab.local-sources]]`` entries win on collision) and the
     effective ``build-policy`` is floored at
     :attr:`BuildPolicy.BUILD_LOCAL`, except under ``mode = "universal"``,
@@ -830,10 +830,10 @@ def _apply_workspace_discovery(
     """Materialise the workspace members and floor the build policy.
 
     The project's own ``workspace`` table wins, whichever project file
-    declared it (``declared_in`` names that file), and its members resolve
-    against the project directory.  A project that declares none walks up
-    for an ancestor ``pyproject.toml`` that does, which is what makes
-    ``nab lock <member>`` resolve against the workspace root.
+    declared it (``declared_in`` names that file), and its members
+    resolve against the project directory.  A project that declares none
+    walks up for an ancestor project file that does, so ``nab lock
+    <member>`` still resolves against the workspace root.
     """
     if config.workspace is not None:
         root_label = declared_in
@@ -843,13 +843,15 @@ def _apply_workspace_discovery(
             declared_in=declared_in,
         )
     else:
-        root_pyproject = discover_workspace_root(path)
-        if root_pyproject is None:
+        root_file = discover_workspace_root(path)
+        if root_file is None:
             return config
-        root_label = str(root_pyproject)
-        discovered = read_workspace_members(root_pyproject)
+        root_label = str(root_file)
+        discovered = read_workspace_members(root_file)
+
     if not discovered:
         return config
+
     merged = merge_workspace_local_sources(config.local_sources, discovered)
     _reject_duplicate_source_names(merged, config.vcs_sources, config.archive_sources)
     explicit_names = {canonicalize_name(src.name) for src in config.local_sources}
@@ -2611,7 +2613,7 @@ def _parse_workspace(value: object) -> WorkspaceConfig | None:
 
     Schema today is a single ``members`` field listing literal paths.
     Globs and member-existence checks happen in
-    :func:`nab_python.workspace.read_workspace_members`; this layer only
+    :func:`nab_python.workspace.workspace_local_sources`; this layer only
     validates the table shape so typos like ``member = ...`` (missing
     the ``s``) fail loud at config-parse time.
     """

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -74,6 +74,7 @@ from .workspace import (
     discover_workspace_root,
     merge_workspace_local_sources,
     read_workspace_members,
+    workspace_local_sources,
 )
 
 if TYPE_CHECKING:
@@ -580,16 +581,18 @@ def read_pyproject_config(
     Returns the default ``NabProjectConfig`` when the table is absent.
     Unknown keys at the top level are rejected so typos fail loud.
 
-    When ``discover_workspace`` is true (the default), this function
-    also walks up from ``path`` looking for a ``pyproject.toml`` whose
-    ``[tool.nab.workspace]`` table is present.  If found, every member
+    When ``discover_workspace`` is true (the default), the merged
+    ``workspace`` table drives discovery: its members resolve against the
+    project directory.  A project declaring no workspace of its own walks
+    up from ``path`` for the first ancestor ``pyproject.toml`` whose
+    ``[tool.nab.workspace]`` table is present.  Either way every member
     is materialised as an additional :class:`LocalSource` (explicit
     ``[[tool.nab.local-sources]]`` entries win on collision) and the
     effective ``build-policy`` is floored at
     :attr:`BuildPolicy.BUILD_LOCAL`, except under ``mode = "universal"``,
     where ``build-policy`` stays at ``never`` (host builds are forbidden)
     and the floor is not applied.  Pass ``discover_workspace=False``
-    to skip the walk; useful for tests or for callers that layer their
+    to skip discovery; useful for tests or for callers that layer their
     own workspace logic on top of a base config.
 
     The ``[tool.nab]``-config portion is sourced from the registry merged
@@ -641,7 +644,9 @@ def read_pyproject_config(
         project_requires_python=project_requires_python,
     )
     if discover_workspace:
-        config = _apply_workspace_discovery(path, config)
+        config = _apply_workspace_discovery(
+            path, config, declared_in=effective["workspace"].origin.label
+        )
     return config
 
 
@@ -820,12 +825,29 @@ _logger = logging.getLogger(__name__)
 
 
 def _apply_workspace_discovery(
-    path: Path, config: NabProjectConfig
+    path: Path, config: NabProjectConfig, *, declared_in: str
 ) -> NabProjectConfig:
-    root_pyproject = discover_workspace_root(path)
-    if root_pyproject is None:
-        return config
-    discovered = read_workspace_members(root_pyproject)
+    """Materialise the workspace members and floor the build policy.
+
+    The project's own ``workspace`` table wins, whichever project file
+    declared it (``declared_in`` names that file), and its members resolve
+    against the project directory.  A project that declares none walks up
+    for an ancestor ``pyproject.toml`` that does, which is what makes
+    ``nab lock <member>`` resolve against the workspace root.
+    """
+    if config.workspace is not None:
+        root_label = declared_in
+        discovered = workspace_local_sources(
+            config.workspace.members,
+            root_dir=path.parent.resolve(),
+            declared_in=declared_in,
+        )
+    else:
+        root_pyproject = discover_workspace_root(path)
+        if root_pyproject is None:
+            return config
+        root_label = str(root_pyproject)
+        discovered = read_workspace_members(root_pyproject)
     if not discovered:
         return config
     merged = merge_workspace_local_sources(config.local_sources, discovered)
@@ -847,7 +869,7 @@ def _apply_workspace_discovery(
             " (workspace root: %s)",
             config.build_policy.value,
             promoted_policy.value,
-            root_pyproject,
+            root_label,
         )
     return replace(
         config,

--- a/nab-python/src/nab_python/workspace.py
+++ b/nab-python/src/nab_python/workspace.py
@@ -1,12 +1,16 @@
 """Workspace discovery for member ``pyproject.toml`` files.
 
-A "workspace" here is the ``[tool.nab.workspace]`` table on a parent
-``pyproject.toml``.  When ``nab lock`` is invoked against a member, this
-module walks up to the root, reads the members, and synthesises a
-:class:`~nab_python.provider.LocalSource` per member.  The provider then
-prefers those local sources over PyPI by canonical name, so a member
-package resolves against its in-tree source instead of being fetched
-from the index.
+A "workspace" is a table of members declared by a project: either
+``[tool.nab.workspace]`` in its ``pyproject.toml`` or ``[workspace]`` in
+the project-dir ``nab.toml``.  Every member is synthesised into a
+:class:`~nab_python.provider.LocalSource`.  The provider then prefers
+those local sources over PyPI by canonical name, so a member package
+resolves against its in-tree source instead of being fetched from the
+index.
+
+A project that declares no workspace of its own walks up to an ancestor
+``pyproject.toml`` that does, so ``nab lock`` invoked against a member
+still resolves against the root's members.
 
 Members are listed literally; globs are refused with an error.  Users
 coming from other tools that allow globs get a clear migration
@@ -37,6 +41,7 @@ __all__ = [
     "discover_workspace_root",
     "merge_workspace_local_sources",
     "read_workspace_members",
+    "workspace_local_sources",
 ]
 
 
@@ -111,15 +116,19 @@ def discover_workspace_root(member_pyproject: Path) -> Path | None:
     return None
 
 
-def read_workspace_members(root_pyproject: Path) -> tuple[LocalSource, ...]:
-    """Synthesise :class:`LocalSource` entries from a workspace root.
+def workspace_local_sources(
+    members: Iterable[str], *, root_dir: Path, declared_in: str
+) -> tuple[LocalSource, ...]:
+    """Synthesise a :class:`LocalSource` per declared workspace member.
 
-    Reads ``[tool.nab.workspace].members`` from ``root_pyproject``.  Each
-    entry must be a literal path; any entry containing ``*``, ``?`` or
-    ``[`` raises :class:`WorkspaceDiscoveryError` with a message naming
-    the offending entry.  For every member directory the function opens
-    ``<member>/pyproject.toml`` and requires ``[project].name``;
-    missing pyproject or missing name is a hard error.
+    ``members`` are the paths the workspace declared, resolved against
+    ``root_dir``; ``declared_in`` names the file that declared them and
+    prefixes the errors.  Each entry must be a literal path; any entry
+    containing ``*``, ``?`` or ``[`` raises
+    :class:`WorkspaceDiscoveryError` with a message naming the offending
+    entry.  For every member directory the function opens
+    ``<member>/pyproject.toml`` and requires ``[project].name``; missing
+    pyproject or missing name is a hard error.
 
     Two members declaring the same canonical name raises
     :class:`WorkspaceDiscoveryError`.  The returned tuple preserves
@@ -130,43 +139,21 @@ def read_workspace_members(root_pyproject: Path) -> tuple[LocalSource, ...]:
     editably by default, matching uv.  Explicit
     ``[[tool.nab.local-sources]]`` entries default to non-editable.
     """
-    root_data = _load_member_toml(root_pyproject)
-    raw_workspace = root_data.get("tool", {}).get("nab", {}).get("workspace")
-    if not isinstance(raw_workspace, dict):
-        msg = (
-            f"{root_pyproject}: [tool.nab.workspace] must be a table,"
-            f" got {type(raw_workspace).__name__}"
-        )
-        raise WorkspaceDiscoveryError(msg)
-    raw_members = raw_workspace.get("members")
-    if not isinstance(raw_members, list):
-        msg = (
-            f"{root_pyproject}: [tool.nab.workspace].members must be a list of"
-            f" strings, got {type(raw_members).__name__}"
-        )
-        raise WorkspaceDiscoveryError(msg)
-
     sources: list[LocalSource] = []
     seen: dict[str, str] = {}
-    for entry in raw_members:
-        if not isinstance(entry, str):
-            msg = (
-                f"{root_pyproject}: [tool.nab.workspace].members entries must be"
-                f" strings, got {type(entry).__name__}: {entry!r}"
-            )
-            raise WorkspaceDiscoveryError(msg)
+    for entry in members:
         if any(ch in entry for ch in "*?["):
             msg = (
-                f"{root_pyproject}: globs in [tool.nab.workspace].members are not"
-                f" supported in nab; list members literally."
+                f"{declared_in}: globs in workspace members are not supported"
+                f" in nab; list members literally."
                 f"  Offending entry: {entry!r}"
             )
             raise WorkspaceDiscoveryError(msg)
-        member_dir = (root_pyproject.parent / entry).resolve()
+        member_dir = (root_dir / entry).resolve()
         member_pyproject = member_dir / "pyproject.toml"
         if not member_pyproject.is_file():
             msg = (
-                f"{root_pyproject}: workspace member {entry!r} has no"
+                f"{declared_in}: workspace member {entry!r} has no"
                 f" pyproject.toml at {member_pyproject}"
             )
             raise WorkspaceDiscoveryError(msg)
@@ -188,7 +175,7 @@ def read_workspace_members(root_pyproject: Path) -> tuple[LocalSource, ...]:
         canonical = canonicalize_name(name)
         if canonical in seen:
             msg = (
-                f"{root_pyproject}: workspace members declare duplicate"
+                f"{declared_in}: workspace members declare duplicate"
                 f" canonical name {canonical!r} via entries {seen[canonical]!r}"
                 f" and {entry!r}"
             )
@@ -196,6 +183,46 @@ def read_workspace_members(root_pyproject: Path) -> tuple[LocalSource, ...]:
         seen[canonical] = entry
         sources.append(LocalSource(name=name, path=str(member_dir), editable=True))
     return tuple(sources)
+
+
+def read_workspace_members(root_pyproject: Path) -> tuple[LocalSource, ...]:
+    """Synthesise :class:`LocalSource` entries from a workspace root.
+
+    Reads ``[tool.nab.workspace].members`` from ``root_pyproject`` and
+    materialises them with :func:`workspace_local_sources`, resolving each
+    member path against the root's directory.  Used for the root an
+    ancestor walk finds, which is read straight off disk rather than
+    through the config registry.
+    """
+    root_data = _load_member_toml(root_pyproject)
+    raw_workspace = root_data.get("tool", {}).get("nab", {}).get("workspace")
+    if not isinstance(raw_workspace, dict):
+        msg = (
+            f"{root_pyproject}: [tool.nab.workspace] must be a table,"
+            f" got {type(raw_workspace).__name__}"
+        )
+        raise WorkspaceDiscoveryError(msg)
+    raw_members = raw_workspace.get("members")
+    if not isinstance(raw_members, list):
+        msg = (
+            f"{root_pyproject}: [tool.nab.workspace].members must be a list of"
+            f" strings, got {type(raw_members).__name__}"
+        )
+        raise WorkspaceDiscoveryError(msg)
+    members: list[str] = []
+    for entry in raw_members:
+        if not isinstance(entry, str):
+            msg = (
+                f"{root_pyproject}: [tool.nab.workspace].members entries must be"
+                f" strings, got {type(entry).__name__}: {entry!r}"
+            )
+            raise WorkspaceDiscoveryError(msg)
+        members.append(entry)
+    return workspace_local_sources(
+        members,
+        root_dir=root_pyproject.parent,
+        declared_in=str(root_pyproject),
+    )
 
 
 def merge_workspace_local_sources(

--- a/nab-python/src/nab_python/workspace.py
+++ b/nab-python/src/nab_python/workspace.py
@@ -9,8 +9,8 @@ resolves against its in-tree source instead of being fetched from the
 index.
 
 A project that declares no workspace of its own walks up to an ancestor
-``pyproject.toml`` that does, so ``nab lock`` invoked against a member
-still resolves against the root's members.
+project file that does, in either spelling, so ``nab lock`` invoked
+against a member still resolves against the root's members.
 
 Members are listed literally; globs are refused with an error.  Users
 coming from other tools that allow globs get a clear migration
@@ -59,6 +59,9 @@ class WorkspaceDiscoveryError(ValueError):
     """Raised when a workspace member or root is structurally invalid."""
 
 
+_PROJECT_TOML = "nab.toml"
+
+
 def _load_member_toml(pyproject: Path) -> dict[str, Any]:
     """Parse ``pyproject``, raising :class:`WorkspaceDiscoveryError` on bad TOML.
 
@@ -74,45 +77,60 @@ def _load_member_toml(pyproject: Path) -> dict[str, Any]:
         raise WorkspaceDiscoveryError(msg) from exc
 
 
+def _workspace_declaration(data: dict[str, Any], project_file: Path) -> tuple[Any, str]:
+    """Return the workspace table ``project_file`` declares, and its name.
+
+    A ``pyproject.toml`` spells it ``[tool.nab.workspace]``; the
+    project-dir ``nab.toml`` spells it as a top-level ``[workspace]``.
+    The value is returned unvalidated, so a malformed table still counts
+    as a declaration and errors when its members are read.  ``None``
+    means the file declares no workspace.
+    """
+    if project_file.name == _PROJECT_TOML:
+        return data.get("workspace"), "[workspace]"
+    nab = tool_nab_section(data)
+    label = "[tool.nab.workspace]"
+    if not isinstance(nab, dict):
+        return None, label
+    return nab.get("workspace"), label
+
+
 @dataclass(frozen=True, slots=True)
 class WorkspaceConfig:
-    """Parsed ``[tool.nab.workspace]`` table.
+    """Parsed workspace table.
 
     ``members`` is the literal list of paths declared at the workspace
     root.  No globs, no path resolution; those happen later in
-    :func:`read_workspace_members`.
+    :func:`workspace_local_sources`.
     """
 
     members: tuple[str, ...]
 
 
 def discover_workspace_root(member_pyproject: Path) -> Path | None:
-    """Return the workspace root pyproject for ``member_pyproject``.
+    """Return the project file declaring the workspace for ``member_pyproject``.
 
-    Walks from ``member_pyproject``'s directory upwards looking for the
-    first ``pyproject.toml`` whose ``[tool.nab.workspace]`` table is
-    present.  Returns that pyproject's path, or ``None`` when no such
-    ancestor (or self) exists.
+    Walks upwards from ``member_pyproject``'s directory for the first
+    project file that declares a workspace, checking ``pyproject.toml``
+    before ``nab.toml`` in each directory.  Returns that file's path, or
+    ``None`` when nothing on the walk declares one.
 
-    The input ``member_pyproject`` is itself considered: a user invoking
-    ``nab lock`` on a workspace root sees discovery activate.
-    Filesystem-level errors and TOML parse errors during the walk are
-    swallowed: a malformed sibling pyproject should not prevent
-    discovery from finding a valid root above it.
+    The starting directory counts, so ``nab lock`` on a workspace root
+    activates discovery too.  Filesystem-level errors and TOML parse
+    errors during the walk are swallowed: a malformed sibling should not
+    prevent discovery from finding a valid root above it.
     """
     start_dir = member_pyproject.resolve().parent
     for parent in (start_dir, *start_dir.parents):
-        candidate = parent / "pyproject.toml"
-        if not candidate.is_file():
-            continue
-        try:
-            with candidate.open("rb") as f:
-                data = tomli.load(f)
-        except (OSError, UnicodeDecodeError, tomli.TOMLDecodeError):
-            continue
-        nab = tool_nab_section(data)
-        if isinstance(nab, dict) and "workspace" in nab:
-            return candidate
+        for candidate in (parent / "pyproject.toml", parent / _PROJECT_TOML):
+            try:
+                with candidate.open("rb") as f:
+                    data = tomli.load(f)
+            except (OSError, UnicodeDecodeError, tomli.TOMLDecodeError):
+                continue
+            declared, _label = _workspace_declaration(data, candidate)
+            if declared is not None:
+                return candidate
     return None
 
 
@@ -121,14 +139,13 @@ def workspace_local_sources(
 ) -> tuple[LocalSource, ...]:
     """Synthesise a :class:`LocalSource` per declared workspace member.
 
-    ``members`` are the paths the workspace declared, resolved against
-    ``root_dir``; ``declared_in`` names the file that declared them and
-    prefixes the errors.  Each entry must be a literal path; any entry
-    containing ``*``, ``?`` or ``[`` raises
-    :class:`WorkspaceDiscoveryError` with a message naming the offending
-    entry.  For every member directory the function opens
-    ``<member>/pyproject.toml`` and requires ``[project].name``; missing
-    pyproject or missing name is a hard error.
+    ``members`` are the declared paths, resolved against ``root_dir``;
+    ``declared_in`` names the declaring file and prefixes the errors.
+    Each entry must be a literal path; any entry containing ``*``, ``?``
+    or ``[`` raises :class:`WorkspaceDiscoveryError` with a message
+    naming the offending entry.  For every member directory the function
+    opens ``<member>/pyproject.toml`` and requires ``[project].name``;
+    missing pyproject or missing name is a hard error.
 
     Two members declaring the same canonical name raises
     :class:`WorkspaceDiscoveryError`.  The returned tuple preserves
@@ -141,6 +158,7 @@ def workspace_local_sources(
     """
     sources: list[LocalSource] = []
     seen: dict[str, str] = {}
+
     for entry in members:
         if any(ch in entry for ch in "*?["):
             msg = (
@@ -149,6 +167,7 @@ def workspace_local_sources(
                 f"  Offending entry: {entry!r}"
             )
             raise WorkspaceDiscoveryError(msg)
+
         member_dir = (root_dir / entry).resolve()
         member_pyproject = member_dir / "pyproject.toml"
         if not member_pyproject.is_file():
@@ -157,6 +176,7 @@ def workspace_local_sources(
                 f" pyproject.toml at {member_pyproject}"
             )
             raise WorkspaceDiscoveryError(msg)
+
         member_data = _load_member_toml(member_pyproject)
         project_table = member_data.get("project", {})
         if not isinstance(project_table, dict):
@@ -165,6 +185,7 @@ def workspace_local_sources(
                 f" table, got {type(project_table).__name__}"
             )
             raise WorkspaceDiscoveryError(msg)
+
         name = project_table.get("name")
         if not isinstance(name, str) or not name:
             msg = (
@@ -172,6 +193,7 @@ def workspace_local_sources(
                 f" [project].name (got {name!r})"
             )
             raise WorkspaceDiscoveryError(msg)
+
         canonical = canonicalize_name(name)
         if canonical in seen:
             msg = (
@@ -180,48 +202,52 @@ def workspace_local_sources(
                 f" and {entry!r}"
             )
             raise WorkspaceDiscoveryError(msg)
+
         seen[canonical] = entry
         sources.append(LocalSource(name=name, path=str(member_dir), editable=True))
+
     return tuple(sources)
 
 
-def read_workspace_members(root_pyproject: Path) -> tuple[LocalSource, ...]:
+def read_workspace_members(root_file: Path) -> tuple[LocalSource, ...]:
     """Synthesise :class:`LocalSource` entries from a workspace root.
 
-    Reads ``[tool.nab.workspace].members`` from ``root_pyproject`` and
-    materialises them with :func:`workspace_local_sources`, resolving each
-    member path against the root's directory.  Used for the root an
-    ancestor walk finds, which is read straight off disk rather than
-    through the config registry.
+    Reads the members ``root_file`` declares, in the spelling its name
+    calls for, and resolves each member path against the root's
+    directory.  This is the path taken for a root the ancestor walk
+    found, which is read off disk rather than through the config
+    registry.
     """
-    root_data = _load_member_toml(root_pyproject)
-    raw_workspace = root_data.get("tool", {}).get("nab", {}).get("workspace")
+    root_data = _load_member_toml(root_file)
+    raw_workspace, label = _workspace_declaration(root_data, root_file)
     if not isinstance(raw_workspace, dict):
         msg = (
-            f"{root_pyproject}: [tool.nab.workspace] must be a table,"
-            f" got {type(raw_workspace).__name__}"
+            f"{root_file}: {label} must be a table, got {type(raw_workspace).__name__}"
         )
         raise WorkspaceDiscoveryError(msg)
+
     raw_members = raw_workspace.get("members")
     if not isinstance(raw_members, list):
         msg = (
-            f"{root_pyproject}: [tool.nab.workspace].members must be a list of"
+            f"{root_file}: {label}.members must be a list of"
             f" strings, got {type(raw_members).__name__}"
         )
         raise WorkspaceDiscoveryError(msg)
+
     members: list[str] = []
     for entry in raw_members:
         if not isinstance(entry, str):
             msg = (
-                f"{root_pyproject}: [tool.nab.workspace].members entries must be"
+                f"{root_file}: {label}.members entries must be"
                 f" strings, got {type(entry).__name__}: {entry!r}"
             )
             raise WorkspaceDiscoveryError(msg)
         members.append(entry)
+
     return workspace_local_sources(
         members,
-        root_dir=root_pyproject.parent,
-        declared_in=str(root_pyproject),
+        root_dir=root_file.parent,
+        declared_in=str(root_file),
     )
 
 

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -4074,6 +4074,27 @@ class TestWorkspaceDiscoveryIntegration:
         assert config.constraints == ()
         assert config.conflicts == ()
 
+    def test_workspace_in_non_pyproject_project_file(self, tmp_path: Path) -> None:
+        # ``nab lock alt.toml`` reads [tool.nab] from that file, so the
+        # workspace it declares drives discovery even though the walk-up
+        # would never consider a file by that name.
+        alt = tmp_path / "alt.toml"
+        alt.write_text(
+            '[project]\nname = "ws"\nversion = "0"\n'
+            "[tool.nab.workspace]\n"
+            'members = ["pkg"]\n',
+        )
+        member_dir = tmp_path / "pkg"
+        member_dir.mkdir()
+        (member_dir / "pyproject.toml").write_text(
+            '[project]\nname = "alpha"\nversion = "0"\n',
+        )
+        config = read_pyproject_config(alt)
+        assert config.local_sources == (
+            LocalSource(name="alpha", path=str(member_dir), editable=True),
+        )
+        assert config.workspace_member_names == frozenset({"alpha"})
+
 
 def _inspect(path: Path, key: str) -> str:
     """Render ``nab config get <key>`` the way the inspector would.
@@ -4244,6 +4265,27 @@ class TestProjectNabTomlConfiguresResolve:
         anchor = datetime(2024, 1, 5, tzinfo=timezone.utc)
         config = read_pyproject_config(path, discover_workspace=False, anchor=anchor)
         assert config.uploaded_prior_to == datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    def test_table_workspace(self, tmp_path: Path) -> None:
+        member_dir = tmp_path / "libs" / "foo"
+        member_dir.mkdir(parents=True)
+        (member_dir / "pyproject.toml").write_text(
+            '[project]\nname = "foo"\nversion = "1.0"\n',
+        )
+        path = self._write(
+            tmp_path,
+            '[project]\nname = "root"\nversion = "0"\n'
+            "[tool.nab]\n"
+            'build-policy = "never"\n',
+            '[workspace]\nmembers = ["libs/foo"]\n',
+        )
+        config = read_pyproject_config(path)
+        assert config.local_sources == (
+            LocalSource(name="foo", path=str(member_dir), editable=True),
+        )
+        assert config.workspace_member_names == frozenset({"foo"})
+        assert config.build_policy is BuildPolicy.BUILD_LOCAL
+        assert "members=['libs/foo']" in _inspect(path, "workspace")
 
 
 class TestProjectNabTomlGateAndConflict:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -4075,25 +4075,53 @@ class TestWorkspaceDiscoveryIntegration:
         assert config.conflicts == ()
 
     def test_workspace_in_non_pyproject_project_file(self, tmp_path: Path) -> None:
-        # ``nab lock alt.toml`` reads [tool.nab] from that file, so the
-        # workspace it declares drives discovery even though the walk-up
-        # would never consider a file by that name.
+        # ``nab lock alt.toml`` reads [tool.nab] from that file, so its
+        # workspace drives discovery even though the walk-up would never
+        # consider a file by that name.
         alt = tmp_path / "alt.toml"
         alt.write_text(
             '[project]\nname = "ws"\nversion = "0"\n'
             "[tool.nab.workspace]\n"
             'members = ["pkg"]\n',
         )
+
         member_dir = tmp_path / "pkg"
         member_dir.mkdir()
         (member_dir / "pyproject.toml").write_text(
             '[project]\nname = "alpha"\nversion = "0"\n',
         )
+
         config = read_pyproject_config(alt)
+
         assert config.local_sources == (
             LocalSource(name="alpha", path=str(member_dir), editable=True),
         )
         assert config.workspace_member_names == frozenset({"alpha"})
+
+    def test_member_lock_finds_root_workspace_in_nab_toml(self, tmp_path: Path) -> None:
+        # The root declares its workspace in nab.toml, so locking a member
+        # has to walk up to it: members and build-policy floor included.
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "ws"\nversion = "0"\n',
+        )
+        (tmp_path / "nab.toml").write_text('[workspace]\nmembers = ["pkg"]\n')
+
+        member_dir = tmp_path / "pkg"
+        member_dir.mkdir()
+        member = member_dir / "pyproject.toml"
+        member.write_text(
+            '[project]\nname = "alpha"\nversion = "0"\n'
+            "[tool.nab]\n"
+            'build-policy = "never"\n',
+        )
+
+        config = read_pyproject_config(member)
+
+        assert config.local_sources == (
+            LocalSource(name="alpha", path=str(member_dir), editable=True),
+        )
+        assert config.workspace_member_names == frozenset({"alpha"})
+        assert config.build_policy is BuildPolicy.BUILD_LOCAL
 
 
 def _inspect(path: Path, key: str) -> str:

--- a/nab-python/tests/test_workspace.py
+++ b/nab-python/tests/test_workspace.py
@@ -125,6 +125,37 @@ class TestDiscoverWorkspaceRoot:
             tmp_path / "outer" / "pyproject.toml"
         )
 
+    def test_walks_up_to_root_declaring_workspace_in_nab_toml(
+        self, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "ws"
+        _write(
+            root / "pyproject.toml",
+            '[project]\nname = "ws"\nversion = "0"\n',
+        )
+        _write(root / "nab.toml", '[workspace]\nmembers = ["pkg"]\n')
+        member = _write(
+            root / "pkg" / "pyproject.toml",
+            '[project]\nname = "pkg"\nversion = "0"\n',
+        )
+        assert discover_workspace_root(member) == (root / "nab.toml")
+
+    def test_root_pyproject_workspace_wins_over_sibling_nab_toml(
+        self, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "ws"
+        _write(
+            root / "pyproject.toml",
+            '[project]\nname = "ws"\nversion = "0"\n'
+            "[tool.nab.workspace]\nmembers = []\n",
+        )
+        _write(root / "nab.toml", '[workspace]\nmembers = ["pkg"]\n')
+        member = _write(
+            root / "pkg" / "pyproject.toml",
+            '[project]\nname = "pkg"\nversion = "0"\n',
+        )
+        assert discover_workspace_root(member) == (root / "pyproject.toml")
+
     def test_walks_past_non_table_tool_nab(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "outer" / "pyproject.toml",
@@ -165,6 +196,23 @@ class TestReadWorkspaceMembers:
             LocalSource(name="alpha", path=str(tmp_path / "a"), editable=True),
             LocalSource(name="beta", path=str(tmp_path / "sub" / "b"), editable=True),
         )
+
+    def test_nab_toml_root_members_become_local_sources(self, tmp_path: Path) -> None:
+        root = _write(tmp_path / "nab.toml", '[workspace]\nmembers = ["a"]\n')
+        _write(
+            tmp_path / "a" / "pyproject.toml",
+            '[project]\nname = "alpha"\nversion = "0"\n',
+        )
+        assert read_workspace_members(root) == (
+            LocalSource(name="alpha", path=str(tmp_path / "a"), editable=True),
+        )
+
+    def test_nab_toml_root_non_list_members_raises(self, tmp_path: Path) -> None:
+        root = _write(tmp_path / "nab.toml", '[workspace]\nmembers = "not-a-list"\n')
+        with pytest.raises(
+            WorkspaceDiscoveryError, match=re.escape("[workspace].members must be")
+        ):
+            read_workspace_members(root)
 
     def test_members_default_to_editable(self, tmp_path: Path) -> None:
         # Workspace members install editably by default, matching uv.


### PR DESCRIPTION
A `[workspace]` table at the top level of a project's `nab.toml` parses, and `nab config get workspace` reports it, but the resolve behaved as if it were not there: the members never became local sources, so they were fetched from PyPI, and the build-policy floor never applied. The same held for a workspace declared in a project file not named `pyproject.toml`, such as `nab lock alt.toml`.

Discovery never looked at the merged config. It only walked up for an ancestor `pyproject.toml` carrying `[tool.nab.workspace]`, so a workspace the project itself declared in another config file was invisible to it.

Members now come from the merged `workspace` table whenever the project declares one, resolved against the project directory. A project that declares no workspace still walks up for an ancestor that does. That walk now recognises `[workspace]` in an ancestor `nab.toml` alongside `[tool.nab.workspace]` in a `pyproject.toml`, checking the pyproject first, so locking a member of such a root picks up the root's members and the floor.
