### PR TITLE
Exit 1 on a missing requested extra instead of a traceback

### DIFF
--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -60,7 +60,11 @@ from nab_python.lockfile import (
     write_requirements_with_hashes,  # noqa: F401 - re-exported for tests
     write_requirements_without_hashes,  # noqa: F401 - re-exported for tests
 )
-from nab_python.provider import InvalidUploadTimeError, UnsupportedVcsError
+from nab_python.provider import (
+    InvalidUploadTimeError,
+    MissingExtraError,
+    UnsupportedVcsError,
+)
 from nab_python.requirements_file import (
     InvalidProjectRequirementError,
     InvalidProjectTableError,
@@ -498,7 +502,7 @@ def _resolve(  # noqa: PLR0913, C901 - one wrapper per resolve_for_targets kwarg
     except ResolutionError as e:
         sys.stderr.write(f"Resolution failed: {e}\n")
         sys.exit(1)
-    except UnsupportedVcsError as e:
+    except (UnsupportedVcsError, MissingExtraError) as e:
         sys.stderr.write(f"{failure_prefix}: {e}\n")
         sys.exit(1)
     except InvalidUploadTimeError as e:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,6 +59,7 @@ from nab_python.lockfile import (
 )
 from nab_python.provider import (
     InvalidUploadTimeError,
+    MissingExtraError,
     ResolutionStrategy,
     UnsupportedVcsError,
 )
@@ -578,6 +579,27 @@ class TestLockCommandSpecific:
         ):
             lock(pyproject)
         assert "Cannot lock" in capsys.readouterr().err
+
+    def test_missing_extra_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """MissingExtraError exits 1 with the message instead of a traceback."""
+        pyproject = _make_pyproject(tmp_path)
+        with (
+            patch(
+                "nab.cli.resolve_for_targets",
+                side_effect=MissingExtraError(
+                    "pkg==1.0 does not provide extra 'bogus'"
+                ),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject)
+
+        err = capsys.readouterr().err
+        assert "Cannot lock" in err
+        assert "does not provide extra 'bogus'" in err
+        assert "Traceback" not in err
 
     def test_lookup_error_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
`nab lock` on a project that requests an extra the package does not provide crashes with a `MissingExtraError` traceback instead of an error message.

The provider raises `MissingExtraError` when a root-requested extra is not in `Provides-Extra`, which is the default error-user mode. The CLI's `_resolve` wrapper maps every expected failure to a message and exit 1, but it never listed this one, so the exception escaped unhandled.

Catch it with the other resolve failures. The error now comes out as `Cannot lock: pkg==1.0 does not provide extra 'bogus'` with exit 1. `nab download` shares the same wrapper, so it gets the same handling, prefixed `Cannot download`.
