### PR TITLE
exit 1 instead of a traceback when a requested extra does not exist

### DIFF
--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -60,7 +60,11 @@ from nab_python.lockfile import (
     write_requirements_with_hashes,  # noqa: F401 - re-exported for tests
     write_requirements_without_hashes,  # noqa: F401 - re-exported for tests
 )
-from nab_python.provider import InvalidUploadTimeError, UnsupportedVcsError
+from nab_python.provider import (
+    InvalidUploadTimeError,
+    MissingExtraError,
+    UnsupportedVcsError,
+)
 from nab_python.requirements_file import (
     InvalidProjectRequirementError,
     InvalidProjectTableError,
@@ -513,7 +517,7 @@ def _resolve(  # noqa: PLR0913, C901 - one wrapper per resolve_for_targets kwarg
     except InvalidProjectRequirementError as e:
         sys.stderr.write(f"Error: {e}\n")
         sys.exit(1)
-    except LookupError as e:
+    except (MissingExtraError, LookupError) as e:
         sys.stderr.write(f"Error: {e}\n")
         sys.exit(1)
     except (MissingHashError, MissingSdistError) as e:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,6 +59,7 @@ from nab_python.lockfile import (
 )
 from nab_python.provider import (
     InvalidUploadTimeError,
+    MissingExtraError,
     ResolutionStrategy,
     UnsupportedVcsError,
 )
@@ -597,6 +598,25 @@ class TestLockCommandSpecific:
         ):
             lock(pyproject)
         assert "unknown group" in capsys.readouterr().err
+
+    def test_missing_extra_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A root extra the package does not declare exits 1, not a traceback."""
+        pyproject = _make_pyproject(tmp_path)
+        with (
+            patch(
+                "nab.cli.resolve_for_targets",
+                side_effect=MissingExtraError(
+                    "foo==1.0 does not provide extra 'nonexistent'"
+                ),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject)
+        err = capsys.readouterr().err
+        assert "does not provide extra 'nonexistent'" in err
+        assert "Traceback" not in err
 
     def test_missing_file_exits(self, tmp_path: Path) -> None:
         """Exit 1 when pyproject.toml doesn't exist."""
@@ -1354,6 +1374,25 @@ class TestLockCommandUniversal:
         err = capsys.readouterr().err
         assert "Cannot lock" in err
         assert "503" in err
+
+    def test_missing_extra_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A root extra the package does not declare exits 1, not a traceback."""
+        pyproject = _universal_pyproject(tmp_path)
+        with (
+            patch(
+                "nab.cli.resolve_for_targets",
+                side_effect=MissingExtraError(
+                    "foo==1.0 does not provide extra 'nonexistent'"
+                ),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, format="requirements-without-hashes")
+        err = capsys.readouterr().err
+        assert "does not provide extra 'nonexistent'" in err
+        assert "Traceback" not in err
 
     def test_malformed_simple_response_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -3292,6 +3331,25 @@ class TestDownloadCommand:
         ):
             download(pyproject)
         assert "Resolution failed" in capsys.readouterr().err
+
+    def test_missing_extra_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A root extra the package does not declare exits 1, not a traceback."""
+        pyproject = _make_pyproject(tmp_path)
+        with (
+            patch(
+                "nab.cli.resolve_for_targets",
+                side_effect=MissingExtraError(
+                    "foo==1.0 does not provide extra 'nonexistent'"
+                ),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            download(pyproject)
+        err = capsys.readouterr().err
+        assert "does not provide extra 'nonexistent'" in err
+        assert "Traceback" not in err
 
     def test_missing_dependencies_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
Under the default `extras_mode = "error_user"`, requesting an extra a package does not declare (`foo[nonexistent]` in `[project].dependencies`) makes the provider raise `MissingExtraError`. `nab lock` and `nab download` translate the errors out of `resolve_for_targets` into an `Error: ...` message and exit 1, but `MissingExtraError` is not one of them, so it escapes as a raw traceback.

`MissingExtraError` subclasses `Exception`, not `LookupError`, so the existing `except LookupError` never covered it. Catch it alongside `LookupError` in `_resolve`, which both the specific and universal paths go through.
