### PR TITLE
catch zlib.error when reading a corrupt wheel or sdist

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -12,6 +12,7 @@ import io
 import re
 import sys
 import tarfile
+import zlib
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING
@@ -533,7 +534,7 @@ def _extract_sdist_files(data: bytes) -> tuple[str | None, str | None]:
     """Extract PKG-INFO and pyproject.toml from a .tar.gz sdist archive.
 
     Returns ``(pkg_info, pyproject_toml)``. Either may be ``None`` if
-    the archive cannot be opened or the file is absent. PEP 643 static
+    the archive cannot be read or the file is absent. PEP 643 static
     metadata detection requires both: PKG-INFO carries the ``Dynamic``
     field that says which values are not authoritative, and
     pyproject.toml's ``[project].dynamic`` is the static-metadata
@@ -543,7 +544,14 @@ def _extract_sdist_files(data: bytes) -> tuple[str | None, str | None]:
     """
     try:
         return _read_tar_sdist_files(data)
-    except (tarfile.TarError, OSError, UnicodeDecodeError, KeyError, EOFError):
+    except (
+        tarfile.TarError,
+        OSError,
+        UnicodeDecodeError,
+        KeyError,
+        EOFError,
+        zlib.error,
+    ):
         return (None, None)
 
 
@@ -637,9 +645,10 @@ def extract_sdist_archive(data: bytes, target_dir: Path) -> Path:
     except KeyError as exc:
         msg = f"broken link in sdist member: {exc}"
         raise ValueError(msg) from exc
-    except (tarfile.TarError, OSError, EOFError) as exc:
-        # gzip raises BadGzipFile (an OSError) on a bad header, and a bare
-        # EOFError on a truncated stream; neither is a TarError.
+    except (tarfile.TarError, OSError, EOFError, zlib.error) as exc:
+        # gzip raises BadGzipFile (an OSError) on a bad header, a bare EOFError on
+        # a truncated stream, and zlib.error on a corrupt deflate block; none of
+        # them is a TarError.
         msg = f"unreadable sdist archive: {exc}"
         raise ValueError(msg) from exc
 

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import re
 import zipfile
+import zlib
 from email.parser import BytesParser, Parser
 from html.parser import HTMLParser
 from pathlib import Path
@@ -279,7 +280,7 @@ def _read_wheel_requires_python(wheel_path: Path, expected: str) -> str | None:
             if member is None:
                 return None
             raw = archive.read(member)
-    except (zipfile.BadZipFile, OSError, UnsupportedWheelError):
+    except (zipfile.BadZipFile, OSError, UnsupportedWheelError, zlib.error):
         return None
 
     value = BytesParser().parsebytes(raw, headersonly=True).get("Requires-Python")
@@ -353,7 +354,7 @@ def read_wheel_metadata(wheel_path: Path) -> str | None:
             if member is None:
                 return None
             return zf.read(member).decode("utf-8")
-    except (zipfile.BadZipFile, OSError, UnicodeDecodeError):
+    except (zipfile.BadZipFile, OSError, UnicodeDecodeError, zlib.error):
         return None
 
 

--- a/nab-python/tests/test_archive.py
+++ b/nab-python/tests/test_archive.py
@@ -12,6 +12,7 @@ import gzip
 import hashlib
 import io
 import tarfile
+import zlib
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
@@ -76,6 +77,29 @@ _PYPROJECT = '[project]\nname = "foo"\nversion = "1.0.0"\ndependencies = ["bar>=
 def _half(data: bytes) -> bytes:
     """Return the leading half of ``data``, as a cut-short download leaves it."""
     return data[: len(data) // 2]
+
+
+_CLEAN_PREFIX = 1 << 20
+_INVALID_DEFLATE_BLOCK = b"\x07" * 8
+
+
+def _corrupt_deflate_sdist() -> bytes:
+    """Return ``.tar.gz`` bytes whose member data is behind a corrupt deflate block.
+
+    The clean prefix is longer than the reader's decompression buffer, so the
+    archive opens and its tar headers read; only reading a member's data hits the
+    reserved block type zlib rejects.
+    """
+    body = (_PYPROJECT + "# filler\n" * (2 * _CLEAN_PREFIX // 9)).encode("utf-8")
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        info = tarfile.TarInfo("foo-1.0.0/pyproject.toml")
+        info.size = len(body)
+        tar.addfile(info, io.BytesIO(body))
+
+    deflate = zlib.compressobj(9, zlib.DEFLATED, zlib.MAX_WBITS | 16)
+    clean = deflate.compress(buf.getvalue()[:_CLEAN_PREFIX])
+    return clean + deflate.flush(zlib.Z_SYNC_FLUSH) + _INVALID_DEFLATE_BLOCK
 
 
 def _provider(archive_sources: list[ArchiveSource], cache_dir: Path | None) -> Provider:
@@ -687,8 +711,9 @@ class TestExtractArchive:
             b"not a gzip stream",
             gzip.compress(b"not a tar"),
             _half(_make_sdist("foo", "1.0.0", _PYPROJECT)),
+            _corrupt_deflate_sdist(),
         ],
-        ids=["empty", "not-gzip", "gzip-not-tar", "truncated"],
+        ids=["empty", "not-gzip", "gzip-not-tar", "truncated", "corrupt-deflate"],
     )
     def test_unreadable_archive_raises_value_error(
         self, data: bytes, tmp_path: Path

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -6,6 +6,7 @@ import asyncio
 import io
 import tarfile
 import zipfile
+import zlib
 from pathlib import Path
 from typing import TYPE_CHECKING, TypeVar
 
@@ -73,6 +74,32 @@ def _write_sdist(
             info.size = len(body)
             tar.addfile(info, io.BytesIO(body))
     path.write_bytes(buf.getvalue())
+
+
+_CLEAN_PREFIX = 1 << 20
+_INVALID_DEFLATE_BLOCK = b"\x07" * 8
+
+
+def _write_corrupt_sdist(path: Path, name: str, version: str) -> None:
+    """Write an sdist whose PKG-INFO body is behind a corrupt deflate block.
+
+    The clean prefix is longer than the reader's decompression buffer, so the
+    archive opens and its tar headers read; only reading PKG-INFO's body hits the
+    reserved block type zlib rejects.
+    """
+    body = (
+        f"Metadata-Version: 2.2\nName: {name}\nVersion: {version}\n\n"
+        + "filler\n" * (2 * _CLEAN_PREFIX // 7)
+    ).encode()
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        info = tarfile.TarInfo(name=f"{name}-{version}/PKG-INFO")
+        info.size = len(body)
+        tar.addfile(info, io.BytesIO(body))
+
+    deflate = zlib.compressobj(9, zlib.DEFLATED, zlib.MAX_WBITS | 16)
+    clean = deflate.compress(buf.getvalue()[:_CLEAN_PREFIX])
+    path.write_bytes(clean + deflate.flush(zlib.Z_SYNC_FLUSH) + _INVALID_DEFLATE_BLOCK)
 
 
 class TestParseFileUrl:
@@ -267,6 +294,17 @@ class TestFlatWheelhouse:
         _write_sdist(path, "foo", "1.0", ">=3.12")
         whole = path.read_bytes()
         path.write_bytes(whole[: len(whole) // 2])
+        client = LocalIndexClient(tmp_path.as_uri())
+        files = run(client.get_files("foo"))
+        assert len(files) == 1
+        assert files[0].requires_python is None
+
+    def test_sdist_requires_python_none_for_corrupt_archive(
+        self, tmp_path: Path
+    ) -> None:
+        # A flat-wheelhouse sdist carries no published hash, so a corrupt one
+        # reaches the reader.
+        _write_corrupt_sdist(tmp_path / "foo-1.0.tar.gz", "foo", "1.0")
         client = LocalIndexClient(tmp_path.as_uri())
         files = run(client.get_files("foo"))
         assert len(files) == 1

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import io
+import struct
 import tarfile
 import zipfile
 import zlib
@@ -77,7 +78,34 @@ def _write_sdist(
 
 
 _CLEAN_PREFIX = 1 << 20
-_INVALID_DEFLATE_BLOCK = b"\x07" * 8
+_RESERVED_BLOCK_TYPE = b"\x07"
+_INVALID_DEFLATE_BLOCK = _RESERVED_BLOCK_TYPE * 8
+
+
+def _write_corrupt_wheel(path: Path, name: str, version: str) -> None:
+    """Write a wheel whose METADATA holds a corrupt deflate stream.
+
+    The zip's central directory is left intact, so the archive opens and lists its
+    members; only reading METADATA hits the reserved block type zlib rejects.
+    """
+    member = f"{name}-{version}.dist-info/METADATA"
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            member,
+            f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n"
+            "Requires-Python: >=3.12\n",
+        )
+    with zipfile.ZipFile(path) as zf:
+        info = zf.getinfo(member)
+
+    # A local file header is 30 fixed bytes, then the name and extra fields, then
+    # the member's compressed data.
+    raw = bytearray(path.read_bytes())
+    name_len, extra_len = struct.unpack_from("<HH", raw, info.header_offset + 26)
+    start = info.header_offset + 30 + name_len + extra_len
+
+    raw[start : start + info.compress_size] = _RESERVED_BLOCK_TYPE * info.compress_size
+    path.write_bytes(bytes(raw))
 
 
 def _write_corrupt_sdist(path: Path, name: str, version: str) -> None:
@@ -230,6 +258,15 @@ class TestFlatWheelhouse:
 
     def test_requires_python_none_for_unreadable_zip(self, tmp_path: Path) -> None:
         (tmp_path / "foo-1.0-py3-none-any.whl").write_bytes(b"not a zip")
+        client = LocalIndexClient(tmp_path.as_uri())
+        files = run(client.get_files("foo"))
+        assert len(files) == 1
+        assert files[0].requires_python is None
+
+    def test_requires_python_none_for_corrupt_zip(self, tmp_path: Path) -> None:
+        # A flat-wheelhouse wheel carries no published hash, so a corrupt one
+        # reaches the reader.
+        _write_corrupt_wheel(tmp_path / "foo-1.0-py3-none-any.whl", "foo", "1.0")
         client = LocalIndexClient(tmp_path.as_uri())
         files = run(client.get_files("foo"))
         assert len(files) == 1
@@ -657,6 +694,11 @@ class TestReadWheelMetadata:
         not_a_wheel = tmp_path / "foo-1.0-py3-none-any.whl"
         not_a_wheel.write_bytes(b"not a zip archive")
         assert read_wheel_metadata(not_a_wheel) is None
+
+    def test_returns_none_for_corrupt_zip(self, tmp_path: Path) -> None:
+        wheel = tmp_path / "foo-1.0-py3-none-any.whl"
+        _write_corrupt_wheel(wheel, "foo", "1.0")
+        assert read_wheel_metadata(wheel) is None
 
     def test_returns_none_for_non_wheel_filename(self, tmp_path: Path) -> None:
         assert read_wheel_metadata(tmp_path / "notes.txt") is None


### PR DESCRIPTION
A corrupt sdist or wheel in a local wheelhouse crashes `nab lock` with a raw zlib.error traceback. The archive readers in nab-index catch tarfile.TarError, OSError, EOFError and zipfile.BadZipFile, which covers a bad gzip header and a truncated stream. A corrupt deflate block is neither: gzip and zipfile raise zlib.error, and none of the catch tuples list it. A flat wheelhouse publishes no hashes, so a damaged file reaches the reader.

Add zlib.error to the catch tuples in the sdist and wheel readers. A corrupt file is skipped like any other unreadable one, and extract_sdist_archive raises the same ValueError it already raises for a truncated archive.
