### PR TITLE
treat a non-UTF-8 project TOML as invalid TOML

### DIFF
--- a/nab-python/src/nab_python/_build/runner.py
+++ b/nab-python/src/nab_python/_build/runner.py
@@ -80,7 +80,7 @@ def run_build_backend(
     if pyproject.is_file():
         try:
             data = tomli.loads(pyproject.read_text(encoding="utf-8"))
-        except (OSError, tomli.TOMLDecodeError) as exc:
+        except (OSError, UnicodeDecodeError, tomli.TOMLDecodeError) as exc:
             msg = f"could not read pyproject.toml at {source_dir}: {exc}"
             raise BuildBackendError(msg) from exc
     elif (source_dir / "setup.py").is_file():

--- a/nab-python/src/nab_python/build_backend.py
+++ b/nab-python/src/nab_python/build_backend.py
@@ -78,6 +78,9 @@ def extract_static_metadata(source_dir: Path) -> WheelMetadata | None:
         # ``is_file`` is racy: the file may vanish or become unreadable
         # between the check and the read.  Treat it the same as missing.
         return None
+    except UnicodeDecodeError:
+        # TOML is UTF-8, so a file that will not decode has no static metadata.
+        return None
     project = load_static_project(text)
     if project is None:
         return None

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -848,7 +848,7 @@ def _reject_unknown_pyproject_keys(path: Path) -> None:
     try:
         with path.open("rb") as f:
             data = tomli.load(f)
-    except tomli.TOMLDecodeError as exc:
+    except (UnicodeDecodeError, tomli.TOMLDecodeError) as exc:
         msg = f"{path} is not valid TOML: {exc}"
         raise ConfigError(msg) from exc
     raw = tool_nab_section(data)

--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -1319,10 +1319,11 @@ def _gate_reason(spec: OptionSpec, kind: SourceKind) -> str:
 
 
 def _read_raw_table(path: Path, kind: SourceKind) -> Mapping[str, Any]:
+    # TOML is UTF-8, so a file that will not decode is invalid TOML.
     try:
         with path.open("rb") as f:
             data = tomli.load(f)
-    except tomli.TOMLDecodeError as exc:
+    except (UnicodeDecodeError, tomli.TOMLDecodeError) as exc:
         msg = f"{path} is not valid TOML: {exc}"
         raise SourceConfigError(msg) from exc
     if kind is SourceKind.PYPROJECT:

--- a/nab-python/src/nab_python/workspace.py
+++ b/nab-python/src/nab_python/workspace.py
@@ -64,7 +64,7 @@ def _load_member_toml(pyproject: Path) -> dict[str, Any]:
     try:
         with pyproject.open("rb") as f:
             return tomli.load(f)
-    except tomli.TOMLDecodeError as exc:
+    except (UnicodeDecodeError, tomli.TOMLDecodeError) as exc:
         msg = f"{pyproject} is not valid TOML: {exc}"
         raise WorkspaceDiscoveryError(msg) from exc
 
@@ -103,7 +103,7 @@ def discover_workspace_root(member_pyproject: Path) -> Path | None:
         try:
             with candidate.open("rb") as f:
                 data = tomli.load(f)
-        except (OSError, tomli.TOMLDecodeError):
+        except (OSError, UnicodeDecodeError, tomli.TOMLDecodeError):
             continue
         nab = tool_nab_section(data)
         if isinstance(nab, dict) and "workspace" in nab:

--- a/nab-python/tests/test_build_backend.py
+++ b/nab-python/tests/test_build_backend.py
@@ -85,6 +85,12 @@ class TestExtractStaticMetadata:
         _write_pyproject(tmp_path, "this is not toml [")
         assert extract_static_metadata(tmp_path) is None
 
+    def test_non_utf8_toml_returns_none(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_bytes(
+            b'[project]\nname = "foo"\nversion = "1.0"\ndescription = "\xe9"\n'
+        )
+        assert extract_static_metadata(tmp_path) is None
+
     def test_no_project_table_returns_none(self, tmp_path: Path) -> None:
         _write_pyproject(tmp_path, '[build-system]\nrequires = ["setuptools"]\n')
         assert extract_static_metadata(tmp_path) is None

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -283,6 +283,13 @@ class TestRunBuildBackend:
         with pytest.raises(BuildBackendError, match="could not read"):
             run_build_backend(tmp_path, config=config)
 
+    def test_non_utf8_pyproject(self, tmp_path: Path, config: NabProjectConfig) -> None:
+        (tmp_path / "pyproject.toml").write_bytes(
+            b"[build-system]\nrequires = []\n# \xe9\n"
+        )
+        with pytest.raises(BuildBackendError, match="could not read"):
+            run_build_backend(tmp_path, config=config)
+
     def test_backend_metadata_missing_version_raises(
         self, tmp_path: Path, config: NabProjectConfig
     ) -> None:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -221,6 +221,13 @@ class TestTopLevelKeys:
         with pytest.raises(ConfigError, match="not valid TOML"):
             read_pyproject_config(path)
 
+    def test_non_utf8_rejected(self, tmp_path: Path) -> None:
+        # TOML is UTF-8, so a latin-1 byte makes the file invalid TOML.
+        path = tmp_path / "pyproject.toml"
+        path.write_bytes(b'[project]\nname = "demo"\ndescription = "\xe9"\n')
+        with pytest.raises(ConfigError, match="not valid TOML"):
+            read_pyproject_config(path)
+
     @pytest.mark.parametrize("user_key", ["offline = true", 'cache-dir = "x"'])
     def test_user_scope_key_in_pyproject_rejected(
         self, tmp_path: Path, user_key: str

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -549,6 +549,19 @@ class TestLoadTomlLayerDirect:
         with pytest.raises(SourceConfigError, match="not valid TOML"):
             _load_toml_layer(path, SourceKind.USER_TOML)
 
+    def test_non_utf8_nab_toml_errors(self, tmp_path: Path) -> None:
+        # TOML is UTF-8, so a latin-1 byte makes the file invalid TOML.
+        path = tmp_path / "nab.toml"
+        path.write_bytes(b'cache-dir = "\xe9"\n')
+        with pytest.raises(SourceConfigError, match="not valid TOML"):
+            _load_toml_layer(path, SourceKind.USER_TOML)
+
+    def test_non_utf8_pyproject_errors(self, tmp_path: Path) -> None:
+        path = tmp_path / "pyproject.toml"
+        path.write_bytes(b'[project]\ndescription = "\xe9"\n')
+        with pytest.raises(SourceConfigError, match="not valid TOML"):
+            _load_toml_layer(path, SourceKind.PYPROJECT)
+
     def test_pyproject_without_tool_nab_is_empty(self, tmp_path: Path) -> None:
         path = _write(tmp_path / "pyproject.toml", '[project]\nname = "x"\n')
         layer = _load_toml_layer(path, SourceKind.PYPROJECT)

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -1817,6 +1817,25 @@ class TestLocalSources:
         with pytest.raises(UnsupportedSdistError, match="BUILD_LOCAL"):
             provider.fetch_versions("foo")
 
+    def test_non_utf8_pyproject_raises_unsupported(self, tmp_path: Path) -> None:
+        """A local source with a non-UTF-8 ``pyproject.toml`` is unbuildable.
+
+        Neither the static read nor the backend can read the file, so it is
+        reported as an unsupported source, not as a decode traceback.
+        """
+        (tmp_path / "pyproject.toml").write_bytes(
+            b'[project]\nname = "foo"\nversion = "1.0"\ndescription = "\xe9"\n'
+        )
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(
+            coordinator,
+            local_sources=[LocalSource("foo", str(tmp_path))],
+            build_policy=BuildPolicy.BUILD_LOCAL,
+            build_config=NabProjectConfig(),
+        )
+        with pytest.raises(UnsupportedSdistError, match="could not read pyproject"):
+            provider.fetch_versions("foo")
+
     def test_local_source_under_never_reads_statically(self, tmp_path: Path) -> None:
         """NEVER admits ``LocalSource`` declarations and reads them statically.
 

--- a/nab-python/tests/test_workspace.py
+++ b/nab-python/tests/test_workspace.py
@@ -74,6 +74,21 @@ class TestDiscoverWorkspaceRoot:
         )
         assert discover_workspace_root(member) == (tmp_path / "ws" / "pyproject.toml")
 
+    def test_skips_non_utf8_intermediate_pyprojects(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "ws" / "pyproject.toml",
+            '[project]\nname = "ws"\nversion = "0"\n'
+            "[tool.nab.workspace]\nmembers = []\n",
+        )
+        broken = tmp_path / "ws" / "broken" / "pyproject.toml"
+        broken.parent.mkdir(parents=True)
+        broken.write_bytes(b'[project]\nname = "\xe9"\n')
+        member = _write(
+            tmp_path / "ws" / "broken" / "pkg" / "pyproject.toml",
+            '[project]\nname = "pkg"\nversion = "0"\n',
+        )
+        assert discover_workspace_root(member) == (tmp_path / "ws" / "pyproject.toml")
+
     def test_walks_past_pyproject_without_workspace_table(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "outer" / "pyproject.toml",
@@ -286,6 +301,22 @@ class TestReadWorkspaceMembers:
         )
         with pytest.raises(
             WorkspaceDiscoveryError, match=rf"{re.escape(str(root))} is not valid TOML"
+        ):
+            read_workspace_members(root)
+
+    def test_member_non_utf8_raises(self, tmp_path: Path) -> None:
+        root = _write(
+            tmp_path / "pyproject.toml",
+            '[project]\nname = "ws"\nversion = "0"\n'
+            "[tool.nab.workspace]\n"
+            'members = ["pkg"]\n',
+        )
+        member = tmp_path / "pkg" / "pyproject.toml"
+        member.parent.mkdir(parents=True)
+        member.write_bytes(b'[project]\nname = "pkg"\ndescription = "\xe9"\n')
+        with pytest.raises(
+            WorkspaceDiscoveryError,
+            match=rf"{re.escape(str(member))} is not valid TOML",
         ):
             read_workspace_members(root)
 

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -581,6 +581,29 @@ def _render_requirements_or_exit(lock_input: LockInput, with_hashes: bool) -> st
         sys.exit(1)
 
 
+def _read_selection_table_or_exit(
+    path: Path,
+    reader: Callable[[Path], Mapping[str, object]],
+) -> Mapping[str, object]:
+    """Read the table a selection flag expands over, exiting 1 on a bad file.
+
+    ``nab download`` selects groups and extras before it loads the config, so
+    this read is the first to touch the pyproject and reports a bad file itself.
+    """
+    try:
+        return reader(path)
+    except OSError:
+        reason = "is a directory" if path.is_dir() else "not found"
+        sys.stderr.write(f"Error: {path} {reason}\n")
+        sys.exit(1)
+    except (UnicodeDecodeError, tomli.TOMLDecodeError) as e:
+        sys.stderr.write(f"Error: {path} is not valid TOML: {e}\n")
+        sys.exit(1)
+    except TypeError as e:
+        sys.stderr.write(f"Error in {path}: {e}\n")
+        sys.exit(1)
+
+
 def resolve_group_selection(
     path: Path,
     *,
@@ -602,15 +625,7 @@ def resolve_group_selection(
     if not (all_groups or groups):
         return ()
 
-    try:
-        defined = read_pyproject_groups(path)
-    except OSError:
-        reason = "is a directory" if path.is_dir() else "not found"
-        sys.stderr.write(f"Error: {path} {reason}\n")
-        sys.exit(1)
-    except TypeError as e:
-        sys.stderr.write(f"Error in {path}: {e}\n")
-        sys.exit(1)
+    defined = _read_selection_table_or_exit(path, read_pyproject_groups)
     return tuple(defined.keys()) if all_groups else tuple(dict.fromkeys(groups))
 
 
@@ -627,15 +642,7 @@ def resolve_extra_selection(
     if not (all_extras or extras):
         return ()
 
-    try:
-        defined = read_pyproject_optional_dependencies(path)
-    except OSError:
-        reason = "is a directory" if path.is_dir() else "not found"
-        sys.stderr.write(f"Error: {path} {reason}\n")
-        sys.exit(1)
-    except TypeError as e:
-        sys.stderr.write(f"Error in {path}: {e}\n")
-        sys.exit(1)
+    defined = _read_selection_table_or_exit(path, read_pyproject_optional_dependencies)
     return tuple(defined.keys()) if all_extras else tuple(dict.fromkeys(extras))
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -621,6 +621,16 @@ class TestLockCommandSpecific:
             lock(pyproject, output=Path("-"))
         assert "is not valid TOML" in capsys.readouterr().err
 
+    def test_non_utf8_toml_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A byte that will not decode reports a clean message, not a traceback."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_bytes(b'[project]\ndescription = "\xe9"\ndependencies = []\n')
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, output=Path("-"))
+        assert "is not valid TOML" in capsys.readouterr().err
+
     def test_pylock_passed_as_the_project_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -2717,6 +2727,44 @@ class TestGroupAndExtraSelection:
         with pytest.raises(SystemExit, match="1"):
             resolve_group_selection(pyproject, groups=(), all_groups=True)
         assert "[dependency-groups] must be a table" in capsys.readouterr().err
+
+    def test_all_groups_malformed_toml_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("[project]\nname = 'x'\n[dependency-groups]\ndev = ['a'\n")
+        with pytest.raises(SystemExit, match="1"):
+            resolve_group_selection(pyproject, groups=(), all_groups=True)
+        assert "is not valid TOML" in capsys.readouterr().err
+
+    def test_all_groups_non_utf8_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_bytes(b"[project]\nname = '\xe9'\n[dependency-groups]\n")
+        with pytest.raises(SystemExit, match="1"):
+            resolve_group_selection(pyproject, groups=(), all_groups=True)
+        assert "is not valid TOML" in capsys.readouterr().err
+
+    def test_all_extras_malformed_toml_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            "[project]\nname = 'x'\n[project.optional-dependencies]\ntest = ['a'\n"
+        )
+        with pytest.raises(SystemExit, match="1"):
+            resolve_extra_selection(pyproject, extras=(), all_extras=True)
+        assert "is not valid TOML" in capsys.readouterr().err
+
+    def test_all_extras_non_utf8_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_bytes(b"[project]\nname = '\xe9'\n")
+        with pytest.raises(SystemExit, match="1"):
+            resolve_extra_selection(pyproject, extras=(), all_extras=True)
+        assert "is not valid TOML" in capsys.readouterr().err
 
     def test_explicit_groups_non_table_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
A `pyproject.toml` or `nab.toml` containing a byte that is not valid UTF-8 let `UnicodeDecodeError` escape the reader, so any command that touched the file ended in a raw traceback instead of the usual "is not valid TOML" message and exit 1.

TOML is UTF-8, so a file that will not decode is invalid TOML. The pyproject, nab.toml, workspace, and build-backend readers now catch `UnicodeDecodeError` alongside `TOMLDecodeError` and report it the same way. Static metadata extraction treats an undecodable file as having no static metadata, the same as an unreadable one.

In `nab download`, the `--all-groups` and `--all-extras` selection reads happen before the config load, so a bad file got no error at all rather than the malformed-TOML one. They now share one helper that exits 1 with the same message.
