### PR TITLE
don't overwrite earlier requirements files when a later tuple fails

### DIFF
--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -12,12 +12,17 @@ working after the per-command split.
 
 from __future__ import annotations
 
+import contextlib
+import errno
+import os
+import stat
 import sys
+import tempfile
 from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 from string import Formatter
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, NamedTuple
 
 import tomli
 import tomli_w
@@ -488,11 +493,15 @@ def _emit_requirements(
 
     A plain path with several targets errors clearly: there is no
     one-file shape that pip can install from across all of them.
+
+    The templated shape is all-or-nothing: every tuple is rendered and
+    staged before any file is moved into place.
     """
     with_hashes = format == "requirements"
     multi_target = len(lock_input.targets) > 1
     if _cli.is_stdout(output) or (output is None and multi_target):
-        sys.stdout.write(_render_requirements_or_exit(lock_input, with_hashes))
+        text, _ = _render_requirements_or_exit(lock_input, with_hashes)
+        sys.stdout.write(text)
         return
 
     target = output if output is not None else Path(_cli._DEFAULT_OUTPUT[format])  # noqa: SLF001
@@ -507,17 +516,23 @@ def _emit_requirements(
                 "  --output 'constraints-{python_version}.txt'\n"
             )
             sys.exit(1)
-        _write_target_requirements(lock_input, target, with_hashes=with_hashes)
+        text, count = _render_requirements_or_exit(lock_input, with_hashes)
+        target.write_text(text, encoding="utf-8")
+        sys.stderr.write(f"Wrote {target} ({count} packages)\n")
         return
 
     _check_output_template(target, template)
+
+    rendered: list[_RenderedFile] = []
     for label, path in _substituted_paths(lock_input, target, template).items():
-        _write_target_requirements(
-            _for_target(lock_input, label),
-            path,
-            with_hashes=with_hashes,
-            label=label,
+        text, count = _render_requirements_or_exit(
+            _for_target(lock_input, label), with_hashes
         )
+        rendered.append(
+            _RenderedFile(path=path, label=label, text=text, pin_count=count)
+        )
+
+    _write_requirements_files(rendered)
 
 
 def _substituted_paths(
@@ -550,35 +565,92 @@ def _for_target(lock_input: LockInput, label: str) -> LockInput:
     return replace(lock_input, targets={label: lock_input.targets[label]})
 
 
-def _write_target_requirements(
-    lock_input: LockInput,
-    output: Path,
-    *,
-    with_hashes: bool,
-    label: str | None = None,
-) -> None:
-    """Write one target's pins to ``output``.
+class _RenderedFile(NamedTuple):
+    """One tuple's requirements text and the file it belongs in."""
 
-    ``label`` names the tuple in the report line, for the templated
-    shape that writes one file per tuple.  Without it the file is the
-    whole lock and there is no other tuple to tell it apart from.
+    path: Path
+    label: str
+    text: str
+    pin_count: int
+
+
+def _write_requirements_files(rendered: list[_RenderedFile]) -> None:
+    """Write every rendered tuple to its path, or none of them.
+
+    Each text is staged beside its destination and moved into place only
+    once every stage is on disk, so an unwritable path fails before any
+    file has been replaced.
     """
-    text = _render_requirements_or_exit(lock_input, with_hashes)
-    output.write_text(text, encoding="utf-8")
-    count = sum(len(lock.pins) for lock in lock_input.targets.values())
-    named = f", tuple {label}" if label is not None else ""
-    sys.stderr.write(f"Wrote {output} ({count} packages{named})\n")
+    staged: list[tuple[Path, _RenderedFile]] = []
+    try:
+        for item in rendered:
+            tmp = _stage_path(item.path)
+            staged.append((tmp, item))
+            tmp.write_text(item.text, encoding="utf-8")
+            tmp.chmod(_destination_mode(item.path))
+    except OSError:
+        for tmp, _ in staged:
+            _discard(tmp)
+        raise
+
+    for tmp, item in staged:
+        tmp.replace(item.path)
+        sys.stderr.write(
+            f"Wrote {item.path} ({item.pin_count} packages, tuple {item.label})\n"
+        )
 
 
-def _render_requirements_or_exit(lock_input: LockInput, with_hashes: bool) -> str:  # noqa: FBT001 - internal, one call shape
-    """Render the pins as requirements text, exiting on a missing hash."""
+def _stage_path(output: Path) -> Path:
+    """Create an empty file beside ``output`` to stage its text in.
+
+    Staging in the destination's directory keeps the later rename on one
+    filesystem, so it is atomic.  A directory at ``output`` is refused
+    here because the rename would only refuse it once earlier files had
+    already been replaced.
+    """
+    if output.is_dir():
+        raise IsADirectoryError(errno.EISDIR, os.strerror(errno.EISDIR), str(output))
+    fd, name = tempfile.mkstemp(
+        dir=output.parent, prefix=f"{output.name}.", suffix=".tmp"
+    )
+    os.close(fd)
+    return Path(name)
+
+
+def _destination_mode(output: Path) -> int:
+    """Permissions to give a staged file before it replaces ``output``.
+
+    ``mkstemp`` creates at 0600, so a staged file needs the mode the
+    destination already has, or the one a fresh write would have given it.
+    """
+    try:
+        return stat.S_IMODE(output.stat().st_mode)
+    except FileNotFoundError:
+        umask = os.umask(0)
+        os.umask(umask)
+        return 0o666 & ~umask
+
+
+def _discard(staged: Path) -> None:
+    """Remove a staged file, ignoring a failure to remove it."""
+    with contextlib.suppress(OSError):
+        staged.unlink()
+
+
+def _render_requirements_or_exit(
+    lock_input: LockInput,
+    with_hashes: bool,  # noqa: FBT001 - internal, one call shape
+) -> tuple[str, int]:
+    """Render the requirements text and pin count, exiting on a missing hash."""
     try:
         if with_hashes:
-            return _cli.write_requirements_with_hashes(lock_input)
-        return _cli.write_requirements_without_hashes(lock_input)
+            text = _cli.write_requirements_with_hashes(lock_input)
+        else:
+            text = _cli.write_requirements_without_hashes(lock_input)
     except _cli.MissingHashError as e:
         sys.stderr.write(f"Cannot lock: {e}\n")
         sys.exit(1)
+    return text, sum(len(lock.pins) for lock in lock_input.targets.values())
 
 
 def resolve_group_selection(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ import contextlib
 import importlib
 import io
 import runpy
+import stat
 import sys
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError
@@ -237,6 +238,42 @@ def _multi_tuple_universal_result() -> ResolveResult:
     return ResolveResult(
         targets=tuples,
         target_results=[_resolved(tup, {"foo": V("1.0")}) for tup in tuples],
+    )
+
+
+def _late_hashless_universal_result() -> ResolveResult:
+    """Two tuples, where only the second one pins a hashless artefact.
+
+    A marker-gated dependency produces this shape.
+    """
+    first, second = (_target(py_minor) for py_minor in ("3.11", "3.12"))
+    hashless = IndexPin(
+        name="priv",
+        version="1.0",
+        index="pypi",
+        wheels=(
+            WheelArtifact(
+                filename="priv-1.0-py3-none-any.whl",
+                url="https://example.com/priv-1.0-py3-none-any.whl",
+                hashes=(),
+            ),
+        ),
+    )
+    return ResolveResult(
+        targets=(first, second),
+        target_results=[
+            _resolved(first, {"foo": V("1.0")}),
+            TargetResult(
+                target=second,
+                success=True,
+                pins={"foo": V("1.0"), "priv": V("1.0")},
+                lock=TargetLock(
+                    target=second,
+                    pins={"foo": _foo_index_pin(), "priv": hashless},
+                    dependencies={},
+                ),
+            ),
+        ],
     )
 
 
@@ -1641,6 +1678,78 @@ class TestLockCommandUniversal:
         ):
             lock(pyproject, format="requirements", output=out)
         assert "Cannot lock" in capsys.readouterr().err
+
+    def test_template_missing_hash_writes_no_file(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A refusal on the second tuple leaves the first tuple's file alone.
+
+        The hashless pin is reachable only from the 3.12 tuple, so the run
+        must refuse before req-3.11.txt has been rewritten.
+        """
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "req-{python_version}.txt"
+        first = tmp_path / "req-3.11.txt"
+        first.write_text("stale==0.1\n")
+        with (
+            patch(
+                "nab.cli.resolve_for_targets",
+                return_value=_late_hashless_universal_result(),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, format="requirements", output=out)
+        err = capsys.readouterr().err
+        assert "no acceptable hash" in err
+        assert "Wrote" not in err
+        assert first.read_text() == "stale==0.1\n"
+        assert not (tmp_path / "req-3.12.txt").exists()
+
+    def test_template_unwritable_path_writes_no_file(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An unwritable path on the second tuple leaves the first alone.
+
+        A directory sits where req-3.12.txt would go, so the first tuple's
+        file keeps its contents and no stage is left behind.
+        """
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "req-{python_version}.txt"
+        first = tmp_path / "req-3.11.txt"
+        first.write_text("stale==0.1\n")
+        (tmp_path / "req-3.12.txt").mkdir()
+        with (
+            patch(
+                "nab.cli.resolve_for_targets",
+                return_value=_multi_tuple_universal_result(),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, format="requirements-without-hashes", output=out)
+        err = capsys.readouterr().err
+        assert "cannot write output" in err
+        assert "Wrote" not in err
+        assert first.read_text() == "stale==0.1\n"
+        assert not list(tmp_path.glob("*.tmp"))
+
+    def test_template_files_keep_the_permissions_a_write_would_give(
+        self, tmp_path: Path
+    ) -> None:
+        """Staged files carry the mode a direct write would have left."""
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "req-{python_version}.txt"
+        first = tmp_path / "req-3.11.txt"
+        first.write_text("stale==0.1\n")
+        before = stat.S_IMODE(first.stat().st_mode)
+        with patch(
+            "nab.cli.resolve_for_targets",
+            return_value=_multi_tuple_universal_result(),
+        ):
+            lock(pyproject, format="requirements-without-hashes", output=out)
+        assert first.read_text().strip() == "foo==1.0"
+        assert stat.S_IMODE(first.stat().st_mode) == before
+        fresh = stat.S_IMODE((tmp_path / "req-3.12.txt").stat().st_mode)
+        assert fresh == before
 
     def test_failed_tuples_are_skipped_in_template_emit(self, tmp_path: Path) -> None:
         """Only successful tuples produce a file."""


### PR DESCRIPTION
`nab lock --format requirements` with a `--output` template writes one file per tuple, in order. If a later tuple fails, because one of its pins has no acceptable hash or because its path is not writable, the command exits 1 having already overwritten the earlier tuples' files. The files left on disk mix pins from the old run with pins from the new one, and nothing marks which is which.

The templated emit is now all-or-nothing. Every tuple is rendered before any file is touched, so a missing hash is refused up front. Each rendered file is staged next to its destination, and the stages are renamed into place only once all of them are written. A staged file takes the mode of the destination it replaces, or the mode a plain write would give a new file, so permissions are unchanged. Stages left behind by a failure are removed.
