### PR TITLE
keep stored max-age on a 304 without a Cache-Control header

### DIFF
--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -151,9 +151,15 @@ class CachedAsyncSimpleClient:
             headers["If-None-Match"] = policy.etag
         response = await self._transport.get(url, headers=headers)
         if response.status_code == _HTTP_NOT_MODIFIED:
+            # A 304 without cache-control keeps the stored max-age.
+            cache_control = _header(response, "cache-control")
             new_policy = CachePolicy(
                 fetched_at=int(time.time()),
-                max_age=_parse_max_age(_header(response, "cache-control")),
+                max_age=(
+                    _parse_max_age(cache_control)
+                    if cache_control is not None
+                    else policy.max_age
+                ),
                 etag=_header(response, "etag") or policy.etag,
             )
             self._cache.refresh_simple_policy(package, new_policy)

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -705,6 +705,60 @@ class TestGetFiles:
         assert new_policy.etag == "old-etag"
         assert new_policy.max_age == 600
 
+    def test_bare_304_retains_stored_max_age(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        cache.put_simple(
+            "pkg",
+            LISTING_BYTES,
+            CachePolicy(fetched_at=0, max_age=60, etag="v1"),
+        )
+        transport = _FakeTransport(
+            [_FakeResponse(b"", status=304, headers={"etag": "v1"})]
+        )
+
+        async def go() -> list:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_files("pkg")
+            finally:
+                await client.aclose()
+
+        asyncio.run(go())
+        cached = cache.get_simple("pkg")
+        assert cached is not None
+        _, new_policy = cached
+        assert new_policy.max_age == 60
+
+    def test_304_cache_control_overrides_stored_max_age(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        cache.put_simple(
+            "pkg",
+            LISTING_BYTES,
+            CachePolicy(fetched_at=0, max_age=60, etag="v1"),
+        )
+        transport = _FakeTransport(
+            [
+                _FakeResponse(
+                    b"",
+                    status=304,
+                    headers={"etag": "v1", "cache-control": "max-age=120"},
+                )
+            ]
+        )
+
+        async def go() -> list:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_files("pkg")
+            finally:
+                await client.aclose()
+
+        asyncio.run(go())
+        cached = cache.get_simple("pkg")
+        assert cached is not None
+        _, new_policy = cached
+        assert new_policy.max_age == 120
+
     def test_stale_revalidates_304_with_new_etag_replaces_etag(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
When a stale Simple-API listing is revalidated and the index replies with a bare 304 (no Cache-Control header), nab reset the cache entry's freshness window to the 600s default instead of keeping the max-age the origin sent with the original 200. On an index that only puts a longer max-age on the full response, that made listings look stale far sooner than they should and forced extra conditional requests.

The 304 path always ran the response's Cache-Control through `_parse_max_age`, which falls back to the 600s default when the header is missing, so a bare 304 clobbered the stored value. Now a 304 recomputes max-age only when it actually carries a Cache-Control header; otherwise it retains the max-age already stored for the listing. A 304 that does send Cache-Control still overrides, as before.
