### PR TITLE
exit cleanly on a non-UTF-8 Simple-API listing instead of crashing

### DIFF
--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -128,13 +128,15 @@ class CachedAsyncSimpleClient:
     def _parse_listing(self, body: bytes, package: str) -> list[WheelFile | SdistFile]:
         """Parse a Simple-API listing body.
 
-        A non-JSON body raises the same
+        A body that is not valid JSON raises the same
         :class:`MalformedSimpleResponseError` as a valid-JSON body of the
-        wrong shape, not a raw :class:`json.JSONDecodeError`.
+        wrong shape, not a raw decode error. ``json.loads`` on non-UTF-8
+        bytes raises :class:`UnicodeDecodeError`, not
+        :class:`json.JSONDecodeError`, so both are caught.
         """
         try:
             data = json.loads(body)
-        except json.JSONDecodeError as exc:
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
             msg = (
                 f"{self._index_url} served a malformed Simple-API response for "
                 f"{package!r}: body is not valid JSON"

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -1033,6 +1033,64 @@ class TestNonJsonListingBody:
         assert body == LISTING_BYTES
 
 
+class TestNonUtf8ListingBody:
+    """A 200 body that is not decodable text must raise a clean error, not crash.
+
+    ``json.loads`` on non-UTF-8 bytes raises :class:`UnicodeDecodeError`,
+    not :class:`json.JSONDecodeError`, so it has to be caught too.
+    """
+
+    _LATIN1_BODY = '{"files": [], "meta": {"author": "François"}}'.encode("latin-1")
+
+    def test_cold_non_utf8_body_raises_http_error_and_skips_cache(
+        self, tmp_path: Path
+    ) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport([_FakeResponse(self._LATIN1_BODY, status=200)])
+
+        async def go() -> list:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_files("foo")
+            finally:
+                await client.aclose()
+
+        with pytest.raises(
+            MalformedSimpleResponseError, match="malformed Simple-API"
+        ) as caught:
+            asyncio.run(go())
+        assert isinstance(caught.value, HttpError)
+        assert cache.get_simple("foo") is None
+
+    def test_revalidate_non_utf8_body_preserves_good_cache(
+        self, tmp_path: Path
+    ) -> None:
+        cache = _make_cache(tmp_path)
+        cache.put_simple(
+            "pkg",
+            LISTING_BYTES,
+            CachePolicy(fetched_at=0, max_age=1, etag="old"),
+        )
+        transport = _FakeTransport([_FakeResponse(self._LATIN1_BODY, status=200)])
+
+        async def go() -> list:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_files("pkg")
+            finally:
+                await client.aclose()
+
+        with pytest.raises(
+            MalformedSimpleResponseError, match="malformed Simple-API"
+        ) as caught:
+            asyncio.run(go())
+        assert isinstance(caught.value, HttpError)
+        cached = cache.get_simple("pkg")
+        assert cached is not None
+        body, _ = cached
+        assert body == LISTING_BYTES
+
+
 class TestGetMetadataText:
     def test_cold_cache_fetches_and_stores(self, tmp_path: Path) -> None:
         cache = _make_cache(tmp_path)


### PR DESCRIPTION
When a remote index serves a 200 listing whose body is not valid UTF-8, `nab lock` and `nab download` crashed with a raw `UnicodeDecodeError` traceback instead of reporting the bad response and exiting 1.

`_parse_listing` caught `json.JSONDecodeError`, but `json.loads` on non-UTF-8 bytes raises `UnicodeDecodeError` before it gets as far as decoding the JSON, so that path escaped. Catch both, so a non-decodable body raises `MalformedSimpleResponseError` like any other malformed listing and the CLI turns it into a clean error message.
