### PR TITLE
memoize wheel_tag_set on the wheel filename

### DIFF
--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -543,7 +543,7 @@ def _parse_tag_str(tag_str: str) -> frozenset[Tag] | None:
     return frozenset(_intern_tag(t) for t in raw)
 
 
-@cache
+@lru_cache(maxsize=65536)
 def wheel_tag_set(filename: str) -> frozenset[Tag] | None:
     """Parse a wheel filename into the set of tags it advertises.
 

--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -543,16 +543,20 @@ def _parse_tag_str(tag_str: str) -> frozenset[Tag] | None:
     return frozenset(_intern_tag(t) for t in raw)
 
 
+@cache
 def wheel_tag_set(filename: str) -> frozenset[Tag] | None:
     """Parse a wheel filename into the set of tags it advertises.
 
     Per PEP 427 the filename's last three dash-separated segments
     are ``python-abi-platform``; per PEP 425 each can be a
     dot-separated compressed set.  Returns ``None`` for a non-wheel
-    filename or one with too few segments.  The expensive work
-    (``parse_tag`` + Tag interning) lives in :func:`_parse_tag_str`,
-    which is cached on the suffix so wheels that share it
-    short-circuit.
+    filename or one with too few segments.
+
+    The tag set is a pure function of the filename, so the whole
+    result is memoized on it, and a repeated filename skips the string
+    splitting.  The parse and Tag interning are shared further across
+    distinct filenames by :func:`_parse_tag_str`, keyed on the tag
+    suffix.
     """
     if not filename.endswith(".whl"):
         return None

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -648,6 +648,20 @@ class TestWheelCompatibility:
         finally:
             _parse_tag_str.cache_clear()
 
+    def test_repeated_filename_is_decomposed_once(self) -> None:
+        """A repeated wheel filename is parsed once, not once per lookup."""
+        filename = "starlette-1.3.1-py3-none-any.whl"
+        if hasattr(wheel_tag_set, "cache_clear"):
+            wheel_tag_set.cache_clear()
+
+        with patch("nab_python.tags._parse_tag_str", wraps=_parse_tag_str) as parse:
+            first = wheel_tag_set(filename)
+            repeats = [wheel_tag_set(filename) for _ in range(8)]
+
+        assert first == _parse_tag_str("py3-none-any")
+        assert all(result is first for result in repeats)
+        assert parse.call_count == 1
+
     def test_accepts_manylinux_at_libc_version(self) -> None:
         """A manylinux_2_17 wheel matches a glibc 2.17 target."""
         spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))


### PR DESCRIPTION
A universal resolve tests every candidate wheel against each matrix tuple, so wheel_tag_set is called on the same filename once per tuple. On multi-tuple resolves that made it the top CPU function. Only the tag-suffix parse (_parse_tag_str) was cached, so the endswith check plus the filename split and rejoin ran again on every call, even for a filename already seen.

Memoize wheel_tag_set on the filename with a bounded lru_cache. A repeated filename now returns the cached tag set and skips the string work, while the suffix cache still shares the parse across distinct filenames. The cache is capped at 65536 entries to keep memory bounded on large resolves.
