### PR TITLE
resolve build requirements for the host interpreter

### DIFF
--- a/nab-python/src/nab_python/_build/env.py
+++ b/nab-python/src/nab_python/_build/env.py
@@ -112,6 +112,12 @@ class NabBuildEnv:
     marker overlay) before the inner resolve so the build env is
     computed against PyPI alone.
 
+    The venv is created from the host interpreter and the PEP 517
+    hooks run in it, so the build requirements resolve for the host
+    and not for any ``--python`` retarget: a wheel for another
+    Python's ABI would not import, and a build requirement the host
+    needs would be dropped by its marker.
+
     Construction is cheap; the work happens in ``__enter__``.
     """
 
@@ -120,13 +126,11 @@ class NabBuildEnv:
         requires: list[str],
         *,
         config: NabProjectConfig,
-        python_version: str | None = None,
         transport_factory: Callable[[], AsyncHttpTransport] = Urllib3AsyncTransport,
     ) -> None:
         """Capture inputs; the venv and inner resolve happen in __enter__."""
         self._requires = list(requires)
         self._config = config
-        self._python_version = python_version
         self._transport_factory = transport_factory
 
         self._tmpdir: tempfile.TemporaryDirectory[str] | None = None
@@ -284,7 +288,6 @@ class NabBuildEnv:
                 synthetic,
                 transport,
                 config=inner_config,
-                python_version=self._python_version,
             )
             # The build env resolves for the host alone, so its one
             # target's failure is the whole resolve's.

--- a/nab-python/src/nab_python/_build/runner.py
+++ b/nab-python/src/nab_python/_build/runner.py
@@ -62,7 +62,6 @@ def run_build_backend(
     source_dir: Path,
     *,
     config: NabProjectConfig,
-    python_version: str | None = None,
 ) -> WheelMetadata:
     """Extract wheel metadata for ``source_dir`` via the build backend.
 
@@ -97,11 +96,7 @@ def run_build_backend(
     skip_prepare = _should_skip_prepare(backend, data)
 
     try:
-        with NabBuildEnv(
-            requires=list(requires),
-            config=config,
-            python_version=python_version,
-        ) as env:
+        with NabBuildEnv(requires=list(requires), config=config) as env:
             project = build.ProjectBuilder.from_isolated_env(
                 env,
                 source_dir=str(source_dir),

--- a/nab-python/src/nab_python/_provider/build_remote.py
+++ b/nab-python/src/nab_python/_provider/build_remote.py
@@ -93,7 +93,6 @@ def build_remote_sdist(
             built = build_backend.extract_metadata(
                 source_dir,
                 config=provider.build_config,
-                python_version=provider.python_version,
             )
         except BuildBackendError as exc:
             msg = f"{package}=={version} build-remote backend failed: {exc}"

--- a/nab-python/src/nab_python/_provider/sources.py
+++ b/nab-python/src/nab_python/_provider/sources.py
@@ -116,11 +116,7 @@ def extract_source_metadata(
         )
         raise UnsupportedSdistError(msg)
     try:
-        return build_backend.extract_metadata(
-            path,
-            config=provider.build_config,
-            python_version=provider.python_version,
-        )
+        return build_backend.extract_metadata(path, config=provider.build_config)
     except BuildBackendError as exc:
         msg = f"{descriptor}: {exc}"
         raise UnsupportedSdistError(msg) from exc

--- a/nab-python/src/nab_python/build_backend.py
+++ b/nab-python/src/nab_python/build_backend.py
@@ -199,7 +199,6 @@ def extract_metadata(
     source_dir: Path,
     *,
     config: NabProjectConfig | None = None,
-    python_version: str | None = None,
 ) -> WheelMetadata:
     """Extract metadata for a source directory.
 
@@ -229,8 +228,4 @@ def extract_metadata(
     # which we should not pay for in static-only callers.
     from ._build.runner import run_build_backend  # noqa: PLC0415
 
-    return run_build_backend(
-        source_dir,
-        config=config,
-        python_version=python_version,
-    )
+    return run_build_backend(source_dir, config=config)

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -814,6 +814,54 @@ class TestResolveAndDownload:
             with pytest.raises(BuildEnvError, match="sdist-only"):
                 env._resolve_and_download(wheel_dir)
 
+    def test_inner_resolve_runs_for_the_host(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The inner resolve gets no Python override.
+
+        The venv is built from the host interpreter, so a target
+        Python would pick wheels for another ABI and evaluate the
+        build requirements' markers against the wrong interpreter.
+        """
+        from nab_python.lockfile import TargetLock
+        from nab_python.resolve import ResolveResult, TargetResult
+        from nab_python.target import ResolveTarget
+
+        env = NabBuildEnv(requires=["foo"], config=NabProjectConfig())
+        env._tmpdir = MagicMock()  # type: ignore[attr-defined]
+        env._venv_path = tmp_path / "venv"  # type: ignore[attr-defined]
+        env._python_executable = tmp_path / "venv" / "bin" / "python"  # type: ignore[attr-defined]
+        target = ResolveTarget.for_host()
+        fake_result = ResolveResult(
+            targets=(target,),
+            target_results=[
+                TargetResult(
+                    target=target,
+                    success=True,
+                    pins={},
+                    lock=TargetLock(target=target, pins={}),
+                )
+            ],
+        )
+        captured: dict[str, object] = {}
+
+        def fake_resolve(
+            _path: Path, _transport: object, **kwargs: object
+        ) -> ResolveResult:
+            captured.update(kwargs)
+            return fake_result
+
+        monkeypatch.setattr("nab_python.resolve.resolve_for_targets", fake_resolve)
+        monkeypatch.setattr(
+            "nab_python._build.env.download_lock",
+            lambda *_a, **_k: MagicMock(written=[], skipped=[]),
+        )
+        wheel_dir = tmp_path / "wheels"
+        wheel_dir.mkdir()
+
+        assert env._resolve_and_download(wheel_dir) == []
+        assert "python_version" not in captured
+
     def test_url_build_requirement_wrapped(self, tmp_path: Path) -> None:
         """A direct-URL build requirement the inner resolve refuses is
         wrapped as BuildEnvError, so the outer resolve skips the

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -1900,6 +1900,50 @@ class TestLocalSources:
         with pytest.raises(UnsupportedSdistError, match="backend exploded"):
             provider.fetch_versions("foo")
 
+    def test_local_source_build_is_not_retargeted(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A ``--python`` retarget does not reach the build env.
+
+        The backend runs in a venv made from the host interpreter, so
+        a target Python would pick wheels for the wrong ABI and drop
+        build requirements the host needs.
+        """
+        self._write_local(
+            tmp_path,
+            """
+            [project]
+            name = "foo"
+            version = "1.0"
+            dynamic = ["dependencies"]
+            """,
+        )
+        built = WheelMetadata(
+            name="foo",
+            version=V("1.0"),
+            requires_python=None,
+            requires_dist=[],
+            provides_extra=[],
+        )
+        captured: dict[str, object] = {}
+
+        def fake_build(_path: Path, **kwargs: object) -> WheelMetadata:
+            captured.update(kwargs)
+            return built
+
+        monkeypatch.setattr("nab_python.build_backend.extract_metadata", fake_build)
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            local_sources=[LocalSource("foo", str(tmp_path))],
+            build_policy=BuildPolicy.BUILD_LOCAL,
+        )
+        assert len(provider.fetch_versions("foo")) == 1
+        assert captured == {"config": provider.build_config}
+
     def test_priority_does_not_shadow_local_source_with_pypi_listing(
         self,
         tmp_path: Path,
@@ -6317,11 +6361,8 @@ class TestEffectiveBuildPolicy:
             provides_extra=[],
         )
 
-        def fake_build(
-            _path: object, *, config: object, python_version: object
-        ) -> WheelMetadata:
-            captured["config"] = config
-            captured["python_version"] = python_version
+        def fake_build(_path: object, **kwargs: object) -> WheelMetadata:
+            captured["kwargs"] = kwargs
             return built_meta
 
         monkeypatch.setattr(build_remote, "extract_sdist_archive", fake_extract)
@@ -6340,7 +6381,9 @@ class TestEffectiveBuildPolicy:
         )
         assert out is built_meta
         assert captured["bytes"] == archive_bytes
-        assert captured["python_version"] == "3.12.0"
+        # The backend runs on the host interpreter, so the resolve
+        # target's Python must not reach the build env.
+        assert captured["kwargs"] == {"config": provider.build_config}
 
     def test_resolve_dynamic_sdist_reuses_cross_tuple_cache(self) -> None:
         """A second call for the same sdist returns the cached metadata.
@@ -6839,9 +6882,7 @@ class TestStaticSdistMetadata:
 
         coordinator.request_sdist_archive.side_effect = _request_archive
 
-        def _naive_build(
-            _path: object, *, config: object, python_version: object
-        ) -> WheelMetadata:
+        def _naive_build(_path: object, *, config: object) -> WheelMetadata:
             raise InvalidUploadTimeError(
                 "setuptools 68.0.0 has a timezone-naive upload time"
                 " '2025-06-01T00:00:00'; the Simple API requires"


### PR DESCRIPTION
Under a `--python` retarget, `nab lock --python 3.9` on a 3.14 host, the build environment resolved its `[build-system].requires` for the target Python while the venv the PEP 517 hooks actually run in is created from the host interpreter. So a cp39 wheel gets installed into a cp314 venv and cannot be imported, and a build requirement gated on the running interpreter (`tomli; python_version >= "3.11"`) is dropped because its marker is evaluated against 3.9. Either way the backend fails, the sdist is rejected and the version is skipped, purely because of the retarget.

On main, with a 3.14 host:

```python
with NabBuildEnv(requires=["cffi"], config=NabProjectConfig(), python_version="3.9") as e:
    subprocess.run([e.python_executable, "-c", "import cffi; cffi.FFI()"])
# ModuleNotFoundError: No module named '_cffi_backend'
```

nab does not discover or download interpreters, and `enforce_build_policy_for_targets` already permits a host build under a python-axis retarget (it only warns that the build reports the host interpreter's metadata). What a backend needs from its build environment is code the interpreter running the hook can import, so the build requirements now resolve for the host. The target Python is no longer threaded from the provider through `extract_metadata` and `run_build_backend` into `NabBuildEnv`, which also makes the code agree with the comment already sitting next to it. `Provider.python_version` is unchanged and still drives the Requires-Python filter and the built-sdist Requires-Python check.

This drops the `python_version` keyword from the public `nab_python.build_backend.extract_metadata`; it existed only to feed the build environment.
