### PR TITLE
name a conflict fork in requirements output with {selection}

### DIFF
--- a/docs/explanation/conflicts.md
+++ b/docs/explanation/conflicts.md
@@ -94,6 +94,11 @@ version = "23.12.0"
 marker = "... and \"black23\" in dependency_groups"
 ```
 
+The requirements formats name a fork with the `{selection}` variable in
+an `--output` template (`--output 'req-{selection}.txt'` writes
+`req-extra-cpu.txt` and `req-extra-gpu.txt`), since two forks of one
+tuple share every other axis and would otherwise collide onto one file.
+
 When several sets are engaged at once, the forks are the cartesian
 product across them (one member chosen per set), so `black{22,23,24}`
 crossed with `isort{5,6,7}` is nine forks. Non-conflicting selections

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -61,6 +61,21 @@ requirements file: no one file can carry every tuple's pins (see
 below), so the requirements formats print to stdout unless `--output`
 names a template.
 
+A requirements `--output` template writes one file per tuple. The
+variables are `{python_version}`, `{platform_id}`, and `{selection}`,
+which names the conflict fork a tuple belongs to (`extra-cpu`,
+`group-black22.group-isort5`, empty when the resolve did not fork):
+
+```console
+$ nab lock --format requirements-without-hashes --extras cpu gpu \
+    --output 'req-{python_version}-{selection}.txt'
+Wrote req-3.12-extra-cpu.txt (12 packages, tuple py312-linux_x86_64-extra-cpu)
+Wrote req-3.12-extra-gpu.txt (14 packages, tuple py312-linux_x86_64-extra-gpu)
+```
+
+A template that maps two tuples onto one path is rejected, naming the
+variable that would separate them.
+
 Exits non-zero on resolution failure; the message starts with
 `Resolution failed:` followed by a derivation tree, and any
 captured diagnostics are appended under a `Diagnostics:` section.

--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -514,6 +514,16 @@ class ResolveTarget:
         return self.marker_env["implementation_name"]
 
     @property
+    def selection_slug(self) -> str:
+        """The conflict fork this target belongs to, as a label slug.
+
+        ``extra-cpu``, ``group-black22.group-isort5``, empty when
+        unforked.  It is the tail of :attr:`label` without the leading
+        separator.
+        """
+        return _selection_slug(self.selection)
+
+    @property
     def platform_id(self) -> str:
         """The matrix platform this target names, or ``host`` for the host."""
         if self.platform_spec is None:
@@ -891,9 +901,12 @@ def _python_label(python_version: str, implementation: str) -> str:
     return prefix + python_version.replace(".", "")
 
 
+def _selection_slug(selection: tuple[tuple[str, str], ...]) -> str:
+    """Render a conflict-fork selection as a slug, empty when unforked."""
+    return ".".join(f"{kind}-{name}" for kind, name in sorted(selection))
+
+
 def _selection_suffix(selection: tuple[tuple[str, str], ...]) -> str:
     """Render a conflict-fork selection as a label suffix, empty when unforked."""
-    if not selection:
-        return ""
-    members = ".".join(f"{kind}-{name}" for kind, name in sorted(selection))
-    return f"-{members}"
+    slug = _selection_slug(selection)
+    return f"-{slug}" if slug else ""

--- a/nab-python/tests/test_target.py
+++ b/nab-python/tests/test_target.py
@@ -333,6 +333,16 @@ class TestLabels:
         )
         assert forked.with_selection(()).label == "py311-linux_x86_64"
 
+    def test_selection_slug_names_the_fork(self) -> None:
+        """The slug is the label suffix without its leading separator."""
+        base = ResolveTarget.for_declared(
+            python_version="3.11", spec=PlatformSpec("linux_x86_64")
+        )
+        assert base.selection_slug == ""
+        forked = base.with_selection((("group", "isort5"), ("extra", "cpu")))
+        assert forked.selection_slug == "extra-cpu.group-isort5"
+        assert forked.label.endswith(f"-{forked.selection_slug}")
+
 
 class TestMarkerStrings:
     @staticmethod

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -22,7 +22,7 @@ from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 from string import Formatter
-from typing import TYPE_CHECKING, Annotated, NamedTuple
+from typing import TYPE_CHECKING, Annotated, NamedTuple, NoReturn
 
 import tomli
 import tomli_w
@@ -65,7 +65,9 @@ from .cli import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable, Mapping, Sequence
+
+    from nab_python.target import ResolveTarget
 
 
 def _emit_or_exit(emit: Callable[[], None]) -> None:
@@ -119,7 +121,8 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
 
     Universal mode (``[tool.nab].mode = "universal"``) supports all
     three formats.  For requirements formats, an ``--output`` template
-    containing ``{python_version}`` or ``{platform_id}`` writes one
+    containing ``{python_version}``, ``{platform_id}`` or
+    ``{selection}`` (the conflict fork a tuple belongs to) writes one
     file per matrix tuple; a plain path is rejected when multiple
     tuples would collide.
 
@@ -424,10 +427,44 @@ def _diff_summary(
     return f": {', '.join(parts)}" if parts else ""
 
 
+def _template_values(target: ResolveTarget) -> dict[str, str]:
+    """Return the value each ``--output`` template variable takes on ``target``.
+
+    ``selection`` is empty on an unforked target, so a template naming it
+    on a resolve with no conflict fork renders the empty string.
+    """
+    return {
+        "python_version": target.python_version,
+        "platform_id": target.platform_id,
+        "selection": target.selection_slug,
+    }
+
+
+def _varying_vars(targets: Sequence[ResolveTarget]) -> list[str]:
+    """Return the template variables whose value differs across ``targets``.
+
+    These are the variables an ``--output`` template has to name to give
+    each tuple its own file.  The list can be empty: two tuples can
+    differ in a tag knob no variable names (a musl and a glibc target
+    share one ``platform_id``), and then no template separates them.
+    """
+    values = [_template_values(target) for target in targets]
+    first = values[0]
+    return [
+        name for name in first if any(other[name] != first[name] for other in values)
+    ]
+
+
+def _and_list(names: Sequence[str]) -> str:
+    """Render ``names`` as ``a``, ``a and b``, or ``a, b and c``."""
+    *rest, last = names
+    return f"{', '.join(rest)} and {last}" if rest else last
+
+
 def _check_output_template(output: Path, template: str) -> None:
     """Reject an --output template that ``str.format`` cannot render.
 
-    Only bare ``{python_version}`` and ``{platform_id}`` fields are
+    Only the bare :data:`~nab.cli.TUPLE_TEMPLATE_VARS` fields are
     accepted. An unbalanced brace, an unknown field name, or a field
     carrying a format spec (``{platform_id:d}``) or conversion
     (``{python_version!r}``) is rejected here.
@@ -448,7 +485,7 @@ def _check_output_template(output: Path, template: str) -> None:
     except ValueError as e:
         sys.stderr.write(f"Error: --output {output} is not a valid template: {e}\n")
         sys.exit(1)
-    supported = " and ".join(allowed_vars)
+    supported = _and_list(allowed_vars)
     unknown = sorted(f"{{{name}}}" for name, _, _ in fields if name not in allowed)
     if unknown:
         sys.stderr.write(
@@ -485,10 +522,12 @@ def _emit_requirements(
       file to fall back to: there is no one file to write.
     * ``output`` is unset and the lock covers one target: write
       ``requirements.txt``.
-    * ``output`` contains ``{python_version}`` or ``{platform_id}``:
+    * ``output`` names a :data:`~nab.cli.TUPLE_TEMPLATE_VARS` variable:
       write one file per target, substituting the target's values into
       the template.  This is the constraints-per-Python-version shape
-      (e.g. ``constraints-{python_version}.txt``).
+      (e.g. ``constraints-{python_version}.txt``), and
+      ``{selection}`` names the conflict fork a target belongs to
+      (``req-{selection}.txt`` -> ``req-extra-cpu.txt``).
     * ``output`` is a plain path: write the lock's one target there.
 
     A plain path with several targets errors clearly: there is no
@@ -508,14 +547,7 @@ def _emit_requirements(
     template = str(target)
     if not any(var in template for var in _cli.TUPLE_TEMPLATE_VARS):
         if multi_target:
-            sys.stderr.write(
-                "Error: universal mode produced multiple tuples but"
-                f" --output {target} has no template variable to"
-                " disambiguate.  Use {python_version} and/or"
-                " {platform_id} in the path, e.g.:\n"
-                "  --output 'constraints-{python_version}.txt'\n"
-            )
-            sys.exit(1)
+            _refuse_untemplated(lock_input, target)
         text, count = _render_requirements_or_exit(lock_input, with_hashes)
         target.write_text(text, encoding="utf-8")
         sys.stderr.write(f"Wrote {target} ({count} packages)\n")
@@ -535,27 +567,78 @@ def _emit_requirements(
     _write_requirements_files(rendered)
 
 
+def _refuse_untemplated(lock_input: LockInput, output: Path) -> NoReturn:
+    """Exit 1: several tuples, and one plain ``--output`` path for them all.
+
+    Names the variables that actually vary across the tuples, which for a
+    resolve forked by ``[tool.nab].conflicts`` is ``{selection}`` alone:
+    the fork is a dimension of its own, and the tuples it produces can
+    share every other axis.
+    """
+    targets = [lock.target for lock in lock_input.targets.values()]
+    count = len(targets)
+    varying = _varying_vars(targets)
+    if not varying:
+        sys.stderr.write(
+            f"Error: the resolve produced {count} tuples and no --output template"
+            f" variable tells them apart, so {output} cannot hold them."
+            "  Emit pylock output instead.\n"
+        )
+        sys.exit(1)
+    placeholders = _and_list([f"{{{name}}}" for name in varying])
+    example = "constraints" + "".join(f"-{{{name}}}" for name in varying) + ".txt"
+    sys.stderr.write(
+        f"Error: the resolve produced {count} tuples but --output {output} has no"
+        f" template variable to disambiguate.  Use {placeholders} in the path,"
+        f" e.g.:\n  --output '{example}'\n"
+    )
+    sys.exit(1)
+
+
+def _refuse_collision(
+    first: TargetLock, second: TargetLock, *, output: Path, template: str, path: str
+) -> NoReturn:
+    """Exit 1: two tuples render one path under this template."""
+    missing = [
+        name
+        for name in _varying_vars([first.target, second.target])
+        if f"{{{name}}}" not in template
+    ]
+    head = (
+        f"Error: tuples {first.target.label!r} and {second.target.label!r}"
+        f" both map to {path!r};"
+    )
+    if not missing:
+        sys.stderr.write(
+            f"{head} no --output template variable tells them apart."
+            "  Emit pylock output instead.\n"
+        )
+        sys.exit(1)
+    placeholders = _and_list([f"{{{name}}}" for name in missing])
+    sys.stderr.write(
+        f"{head} --output {output} is missing a template variable to"
+        f" disambiguate.  Add {placeholders} to the path.\n"
+    )
+    sys.exit(1)
+
+
 def _substituted_paths(
     lock_input: LockInput, output: Path, template: str
 ) -> dict[str, Path]:
     """Render the per-target output paths, refusing a template that collides."""
-    by_path: dict[str, str] = {}
+    by_path: dict[str, TargetLock] = {}
     paths: dict[str, Path] = {}
     for label, lock in lock_input.targets.items():
-        substituted = template.format(
-            python_version=lock.target.python_version,
-            platform_id=lock.target.platform_id,
-        )
+        substituted = template.format(**_template_values(lock.target))
         if substituted in by_path:
-            sys.stderr.write(
-                "Error: tuples"
-                f" {by_path[substituted]!r} and {label!r}"
-                f" both map to {substituted!r}; --output {output} is missing"
-                " a template variable to disambiguate.  Use both"
-                " {python_version} and {platform_id} in the path.\n"
+            _refuse_collision(
+                by_path[substituted],
+                lock,
+                output=output,
+                template=template,
+                path=substituted,
             )
-            sys.exit(1)
-        by_path[substituted] = label
+        by_path[substituted] = lock
         paths[label] = Path(substituted)
     return paths
 

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -120,7 +120,7 @@ _DEFAULT_OUTPUT: dict[str, str] = {
     "requirements-without-hashes": "requirements.txt",
 }
 
-TUPLE_TEMPLATE_VARS = ("{python_version}", "{platform_id}")
+TUPLE_TEMPLATE_VARS = ("{python_version}", "{platform_id}", "{selection}")
 
 # Conventional KeyboardInterrupt exit code: 128 + SIGINT(2).
 _SIGINT_EXIT_CODE = 130

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -242,6 +242,30 @@ def _multi_tuple_universal_result() -> ResolveResult:
     )
 
 
+def _forked_universal_result() -> ResolveResult:
+    """One matrix tuple that ``[tool.nab].conflicts`` forked into two."""
+    tuples = tuple(_target(selection=(("extra", extra),)) for extra in ("cpu", "gpu"))
+    return ResolveResult(
+        targets=tuples,
+        target_results=[_resolved(tup, {"foo": V("1.0")}) for tup in tuples],
+    )
+
+
+def _two_libc_universal_result() -> ResolveResult:
+    """Two tuples on one platform_id, differing only in their libc."""
+    tuples = tuple(
+        ResolveTarget.for_declared(
+            python_version="3.11",
+            spec=PlatformSpec("linux_x86_64", libc=libc),
+        )
+        for libc in ("glibc", "musl")
+    )
+    return ResolveResult(
+        targets=tuples,
+        target_results=[_resolved(tup, {"foo": V("1.0")}) for tup in tuples],
+    )
+
+
 def _late_hashless_universal_result() -> ResolveResult:
     """Two tuples, where only the second one pins a hashless artefact.
 
@@ -1577,7 +1601,11 @@ class TestLockCommandUniversal:
     def test_multi_tuple_without_template_errors(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """Multiple tuples + plain --output fails with a clear message."""
+        """Multiple tuples + plain --output fails with a clear message.
+
+        The two tuples differ only in their Python, so the remedy names
+        ``{python_version}`` and not the variables that would add nothing.
+        """
         pyproject = _universal_pyproject(tmp_path)
         out = tmp_path / "requirements.txt"
         with (
@@ -1589,9 +1617,9 @@ class TestLockCommandUniversal:
         ):
             lock(pyproject, format="requirements-without-hashes", output=out)
         err = capsys.readouterr().err
-        assert "produced multiple tuples" in err
+        assert "produced 2 tuples" in err
         assert "{python_version}" in err
-        assert "{platform_id}" in err
+        assert "{platform_id}" not in err
         # No partial output written.
         assert not out.exists()
 
@@ -1697,6 +1725,100 @@ class TestLockCommandUniversal:
         ):
             lock(pyproject, format="requirements-without-hashes", output=out)
         assert (tmp_path / "constraints-3.11.txt").read_text().strip() == "foo==1.0"
+
+    def test_template_with_selection_writes_one_file_per_fork(
+        self, tmp_path: Path
+    ) -> None:
+        """``{selection}`` in --output expands to one file per conflict fork."""
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "req-{selection}.txt"
+        with patch(
+            "nab.cli.resolve_for_targets",
+            return_value=_forked_universal_result(),
+        ):
+            lock(pyproject, format="requirements-without-hashes", output=out)
+        assert (tmp_path / "req-extra-cpu.txt").read_text().strip() == "foo==1.0"
+        assert (tmp_path / "req-extra-gpu.txt").read_text().strip() == "foo==1.0"
+
+    def test_forked_collision_points_at_selection(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Two forks of one tuple collide; the message names ``{selection}``."""
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "req-{python_version}-{platform_id}.txt"
+        with (
+            patch(
+                "nab.cli.resolve_for_targets",
+                return_value=_forked_universal_result(),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, format="requirements-without-hashes", output=out)
+        err = capsys.readouterr().err
+        assert "both map to" in err
+        assert "{selection}" in err
+        assert not (tmp_path / "req-3.11-linux_x86_64.txt").exists()
+
+    def test_forked_plain_output_points_at_selection(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A plain --output over a forked resolve names ``{selection}`` only."""
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "requirements.txt"
+        with (
+            patch(
+                "nab.cli.resolve_for_targets",
+                return_value=_forked_universal_result(),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, format="requirements-without-hashes", output=out)
+        err = capsys.readouterr().err
+        assert "2 tuples" in err
+        assert "{selection}" in err
+        assert "{python_version}" not in err
+        assert not out.exists()
+
+    def test_collision_with_no_variable_to_add_says_so(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Tuples differing only in a knob no variable names cannot be written.
+
+        A musl and a glibc target share one ``platform_id`` and one
+        ``python_version``, so no template can tell them apart.
+        """
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "req-{python_version}-{platform_id}-{selection}.txt"
+        with (
+            patch(
+                "nab.cli.resolve_for_targets",
+                return_value=_two_libc_universal_result(),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, format="requirements-without-hashes", output=out)
+        err = capsys.readouterr().err
+        assert "both map to" in err
+        assert "tells them apart" in err
+        assert list(tmp_path.glob("req-*.txt")) == []
+
+    def test_plain_output_with_no_variable_to_add_says_so(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A plain --output over indistinguishable tuples says no variable helps."""
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "requirements.txt"
+        with (
+            patch(
+                "nab.cli.resolve_for_targets",
+                return_value=_two_libc_universal_result(),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, format="requirements-without-hashes", output=out)
+        err = capsys.readouterr().err
+        assert "tells them apart" in err
+        assert not out.exists()
 
     def test_template_missing_hash_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
When `[tool.nab].conflicts` forks a tuple, the requirements formats cannot write the result under any `--output` shape, and both refusal messages misdiagnose why. The two forks of one tuple share their `python_version` and `platform_id`, so a template collides and the collision message tells you to use the two variables you already passed; a plain path is refused with "universal mode produced multiple tuples" when the matrix has exactly one tuple and the multiplicity is the fork. The same resolve emits fine as pylock.

With a project whose `cpu` and `gpu` extras are declared conflicting and pin different versions of `idna`:

```console
$ nab lock --extras cpu gpu --format requirements-without-hashes --output 'req-{python_version}-{platform_id}.txt'
Error: tuples 'py312-linux_x86_64-extra-cpu' and 'py312-linux_x86_64-extra-gpu' both map to 'req-3.12-linux_x86_64.txt'; --output req-{python_version}-{platform_id}.txt is missing a template variable to disambiguate.  Use both {python_version} and {platform_id} in the path.
```

This adds `{selection}` as a third `--output` template variable, holding the conflict fork a tuple belongs to (`extra-cpu`, `group-black22.group-isort5`, empty when the resolve did not fork), so `--output 'req-{selection}.txt'` writes `req-extra-cpu.txt` and `req-extra-gpu.txt`. Both refusals now compute which variables actually differ across the colliding tuples and name only those, and are honest about the case where no variable separates them (a musl and a glibc target share one `platform_id`), pointing at pylock instead of repeating advice the user already followed.

The `ResolveTarget` fork slug is exposed as a public `selection_slug` property rather than reaching into `target.py`'s private label helper.
