### PR TITLE
stop describing universal mode as a separate resolver engine

### DIFF
--- a/docs/explanation/conflicts.md
+++ b/docs/explanation/conflicts.md
@@ -118,8 +118,8 @@ selection for every conflict check. A project with
 groups `a` and `b`
 satisfies the minimum without passing `--groups`, and a `--groups b`
 on top of that default activates two members of an exclusive set,
-which the exclusion check then catches (specific mode) or the
-universal resolver forks into two.
+which the exclusion check then catches (specific mode) or which
+universal mode forks into two.
 
 A dependency required by every member of a set but not by the base
 keeps its membership marker, so it does not install when no member is

--- a/docs/explanation/universal.md
+++ b/docs/explanation/universal.md
@@ -156,8 +156,8 @@ the Python level, not PyPy's own release, so the rare marker comparing
 
 | Property | Matrix (nab) | Marker-fork (uv) |
 | --- | --- | --- |
-| Resolver core | Untouched. Universal is a per-tuple loop on top of the existing single-env resolver. | Forks pervade the resolver state. |
+| Resolver core | Untouched. A matrix is a longer target list, not extra solver state. | Forks pervade the resolver state. |
 | Universe | Exactly what the user declared. | All of PEP 508, narrowed by `tool.uv.environments`. |
 | Errors | "no wheel for python 3.11 on macos arm64" - actionable. | "no wheel for some marker environment the resolver cared about" - less actionable. |
-| Wasted work | High: 90% of resolver state is identical across tuples; not shared. | Low: shared whenever markers don't fork. |
-| Implementation cost | Small. Promotes a working PoC. | Large. Conflict explanations and lockfile shape are research-grade work. |
+| Wasted work | High: solver state is rebuilt per target. Only the fetcher and its metadata cache are shared. | Low: shared whenever markers don't fork. |
+| Implementation cost | Small. One engine over a target list. | Large. Conflict explanations and lockfile shape are research-grade work. |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -536,10 +536,11 @@ over HTTP.
 
 ## Universal mode (experimental)
 
-Universal resolution runs the single-environment resolver once per
-declared `(python, platform, implementation)` tuple, sharing one
-fetcher so metadata is fetched at most once per package.  Output and
-API are still subject to change.
+Universal resolution resolves one target per declared
+`(python, platform, implementation)` tuple, on the same engine a
+single-environment resolve uses, sharing one fetcher so metadata is
+fetched at most once per package.  Output and API are still subject to
+change.
 
 ```toml
 [tool.nab]
@@ -665,7 +666,7 @@ error.  See [Build policy](build-policy.md).
   and marker shape across all tuples.
 
 Declaring a `[tool.nab.matrix]` table while `mode` is `specific` is an
-error: the matrix is the universal resolver's input, so leaving mode
+error: the matrix is the list of targets to resolve, so leaving mode
 behind is almost always an oversight rather than an intent.
 
 The one exception is an explicit `--project-mode specific` on the

--- a/nab-python/benchmarks/README.md
+++ b/nab-python/benchmarks/README.md
@@ -1,7 +1,7 @@
 # Benchmarks
 
-nab ships two benchmark suites that exercise the single-environment
-and the universal resolver against real-world scenarios.
+nab ships two benchmark suites that exercise single-environment and
+universal resolves against real-world scenarios.
 
 ## Single-environment scenarios
 

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -668,8 +668,9 @@ def _config_from_effective(
         if not mode_value.origin.outranks(matrix_value.origin):
             msg = (
                 "[tool.nab.matrix] is set but mode is 'specific'; set"
-                " mode = 'universal' to opt in to the experimental"
-                " matrix-based resolver"
+                " mode = 'universal' to resolve for every target the matrix"
+                " declares, or remove the table. Universal mode is"
+                " experimental."
             )
             raise ConfigError(msg)
         # A higher-precedence source (--project-mode) selected a

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -128,11 +128,12 @@ class ExtrasMode(enum.Enum):
 class ResolveMode(enum.Enum):
     """How the resolver interprets the project.
 
-    ``SPECIFIC`` runs the single-environment resolver against one
-    marker environment (host or impersonated).  ``UNIVERSAL`` runs the
-    matrix-based per-tuple resolver and is *experimental*: users
-    must opt in by setting ``[tool.nab].mode = "universal"`` and
-    declaring ``[tool.nab.matrix]``.
+    ``SPECIFIC`` resolves one target, the host or an impersonated
+    marker environment.  ``UNIVERSAL`` resolves one target per tuple
+    declared in ``[tool.nab.matrix]``.  Both run the same engine over a
+    list of targets.  ``UNIVERSAL`` is *experimental*: users must opt in
+    by setting ``[tool.nab].mode = "universal"`` and declaring
+    ``[tool.nab.matrix]``.
     """
 
     SPECIFIC = "specific"

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -173,8 +173,12 @@ class TestMode:
             tmp_path,
             '[tool.nab.matrix]\npython = ">=3.11"\nplatforms = ["linux_x86_64"]\n',
         )
-        with pytest.raises(ConfigError, match="set mode = 'universal'"):
+        with pytest.raises(ConfigError) as excinfo:
             read_pyproject_config(path)
+        message = str(excinfo.value)
+        assert "set mode = 'universal'" in message
+        assert "resolve for every target the matrix declares" in message
+        assert "matrix-based resolver" not in message
 
     def test_matrix_with_specific_mode_in_same_file_rejected(
         self, tmp_path: Path


### PR DESCRIPTION
Since the two paths collapsed there is one engine: a resolve is a list of targets, and a host resolve is a list of length 1. Several user-facing texts still say a matrix engages a second, experimental "matrix-based resolver" layered on the single-environment one. The error every user hits on the matrix surface is the worst of them:

```toml
[tool.nab]
mode = "specific"

[tool.nab.matrix]
python = ">=3.11"
platforms = ["linux_x86_64"]
```

```
ConfigError: [tool.nab.matrix] is set but mode is 'specific'; set mode = 'universal' to opt in to the experimental matrix-based resolver
```

This reworks that message, the ResolveMode docstring, the configuration reference, the universal and conflicts explanations, and the benchmarks README to describe one engine over a target list. Universal mode is still called experimental everywhere it was, and the lock warning is untouched. The universal trade-off table also loses an unsourced "90% of resolver state" figure and a line about promoting a PoC that no longer exists.

Prose only, no behaviour change.