### PR TITLE
warn once per run instead of once per target on a dropped root marker

### DIFF
--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -477,6 +477,10 @@ class _EngineSettings:
     # Shared by every target of every pass: the coordinator and the policy
     # config the pre-tag half of the listing filter reads are both fixed here.
     listing_filter_cache: ListingFilterCache = field(default_factory=ListingFilterCache)
+    # The root requirements already reported by _warn_dropped_root_marker. The
+    # same roots are read once per target per fork plus once in the base pass,
+    # and one mistaken requirement is worth one warning.
+    warned_root_markers: set[str] = field(default_factory=set)
 
 
 @dataclass(frozen=True, slots=True)
@@ -540,10 +544,17 @@ def _resolve_one_target(
     environment = target.marker_env
     try:
         resolver_requirements, root_extras = _build_resolver_inputs(
-            requirements, config, environment=environment
+            requirements,
+            config,
+            environment=environment,
+            warned=settings.warned_root_markers,
         )
         resolver_constraints, _ = _build_resolver_inputs(
-            constraints, config, environment=environment, kind="constraint"
+            constraints,
+            config,
+            environment=environment,
+            kind="constraint",
+            warned=settings.warned_root_markers,
         )
     except ResolutionError as exc:
         return TargetResult(target=target, success=False, error=exc)
@@ -1030,21 +1041,28 @@ def _check_group_disjointness(
     raise ResolutionError("; ".join(clauses))
 
 
-def _warn_dropped_root_marker(req: Requirement) -> None:
+def _warn_dropped_root_marker(req: Requirement, warned: set[str]) -> None:
     """Warn when a dropped root requirement tests an extra/group membership.
 
     A root marker testing ``extra``, ``extras``, or ``dependency_groups``
     evaluates False at resolve time (root activates no extra or group), so the
-    dep would otherwise be dropped silently.
+    dep would otherwise be dropped silently.  ``warned`` carries the
+    requirements already reported in this run, so one mistaken requirement is
+    reported once rather than once per target per fork.
     """
     marker_text = str(req.marker)
-    if "extra ==" in marker_text or membership_set_in_marker(marker_text):
-        _logger.warning(
-            "Root requirement %r tests an extra or dependency-group membership "
-            "marker; the dep is dropped because root activates no extra or group "
-            "at resolve time. For an extra, use pkg[extra] (extras-of-package).",
-            str(req),
-        )
+    if "extra ==" not in marker_text and not membership_set_in_marker(marker_text):
+        return
+    text = str(req)
+    if text in warned:
+        return
+    warned.add(text)
+    _logger.warning(
+        "Root requirement %r tests an extra or dependency-group membership "
+        "marker; the dep is dropped because root activates no extra or group "
+        "at resolve time. For an extra, use pkg[extra] (extras-of-package).",
+        text,
+    )
 
 
 def _build_resolver_inputs(
@@ -1053,6 +1071,7 @@ def _build_resolver_inputs(
     *,
     environment: Mapping[str, str],
     kind: str = "requirement",
+    warned: set[str] | None = None,
 ) -> tuple[dict[str, VersionRange], set[tuple[str, str]]]:
     """Convert PEP 508 requirements to the resolver's input shape.
 
@@ -1066,10 +1085,15 @@ def _build_resolver_inputs(
     ``kind`` is ``"requirement"`` or ``"constraint"``.  A constraint may
     not carry extras, and shapes the error wording; the returned extras
     set is empty for one.
+
+    ``warned`` is the run's set of already-reported extra/group root
+    markers (see :func:`_warn_dropped_root_marker`); a caller that does
+    not share one gets a fresh set, so it warns per call.
     """
     resolver_requirements: dict[str, VersionRange] = {}
     sources: defaultdict[str, list[str]] = defaultdict(list)
     root_extras: set[tuple[str, str]] = set()
+    already_warned = set() if warned is None else warned
     for req in requirements:
         if kind == "constraint" and req.extras:
             msg = f"Constraints cannot have extras: {req}"
@@ -1077,7 +1101,7 @@ def _build_resolver_inputs(
         if req.marker is not None and not dependency_marker_holds(
             req.marker, environment
         ):
-            _warn_dropped_root_marker(req)
+            _warn_dropped_root_marker(req, already_warned)
             continue
         if req.url is not None:
             admit_vcs_url(req.url, config.vcs)

--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -604,6 +604,63 @@ class TestConflictForkBaseNames:
         assert any("Base attribution skipped" in rec.message for rec in caplog.records)
 
 
+class TestDroppedRootMarkerWarnedOnce:
+    """One mistaken root requirement is reported once per run, however
+    many targets, forks and base passes read it."""
+
+    def _coordinator(self) -> MagicMock:
+        return _make_coordinator({"base": [_make_wheel("1.0", package="base")]})
+
+    def _two_targets(self) -> list[ResolveTarget]:
+        return Matrix(
+            python="==3.11",
+            platforms=(PlatformSpec("linux_x86_64"), PlatformSpec("windows_amd64")),
+        ).expand()
+
+    def _forks(self) -> list[ResolveFork]:
+        reqs = tuple(_reqs("base", 'gated ; extra == "test"'))
+        return [
+            ResolveFork((("extra", "cpu"),), reqs),
+            ResolveFork((("extra", "gpu"),), reqs),
+        ]
+
+    def test_warned_once_across_targets_forks_and_base_pass(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.WARNING, logger="nab_python.resolve"):
+            result = resolve_with_coordinator(
+                self._coordinator(),
+                self._two_targets(),
+                forks=self._forks(),
+                base_requirements=_reqs("base", 'gated ; extra == "test"'),
+                config=_no_build(),
+            )
+        assert result.success
+        warnings = [rec for rec in caplog.records if "membership marker" in rec.message]
+        assert len(warnings) == 1
+
+    def test_two_offending_requirements_each_warn_once(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        reqs = _reqs("base", 'gated ; extra == "test"', 'other ; "dev" in extras')
+        with caplog.at_level(logging.WARNING, logger="nab_python.resolve"):
+            result = resolve_with_coordinator(
+                self._coordinator(),
+                self._two_targets(),
+                reqs,
+                config=_no_build(),
+            )
+        assert result.success
+        warned = [
+            rec.getMessage()
+            for rec in caplog.records
+            if "membership marker" in rec.message
+        ]
+        assert len(warned) == 2
+        assert sum('gated; extra == "test"' in msg for msg in warned) == 1
+        assert sum('other; "dev" in extras' in msg for msg in warned) == 1
+
+
 class TestDirectPackages:
     """The direct set handed to the provider: the canonical names of the
     root requirements this target kept."""


### PR DESCRIPTION
A root requirement whose marker tests an extra or a dependency group is dropped, and nab warns about it. Since the engine collapse that warning is emitted once per target per fork, plus once more in the base pass, so one mistaken requirement produces a wall of identical warnings that grows with the matrix.

With dependencies ["packaging", "tomli ; extra == \"test\""] and a matrix of python >=3.11,<3.14 crossed with [linux_x86_64, macos_arm64], the same warning is printed 6 times.

The engine now carries a run-scoped set of the root requirements it has already reported, threaded into both `_build_resolver_inputs` calls, and `_warn_dropped_root_marker` returns early on a repeat. The check stays where it is, inside the per-target builder, so it keeps evaluating the marker against the target environment rather than matching on marker text; only the repetition is suppressed. Two distinct offending requirements still get one warning each.