### PR TITLE
let environment.platform carry the wheel-tag knobs

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -80,6 +80,21 @@ implementation = "cpython"  # "cpython" (default) or "pypy"
   `never`.  A python-only retarget warns and permits.  See
   [Build policy](build-policy.md).
 
+`platform` takes the two shapes a `[tool.nab.matrix]` platform takes: a
+bare id at that platform's default tag knobs, or a table declaring them.
+
+```toml
+[tool.nab.environment]
+python = "3.13"
+platform = { id = "macos_arm64", macos-min = "14.0" }
+```
+
+The knobs, their defaults and their rules are the ones the matrix's
+"Platform tag knobs" section below lists.  A bare id keeps the default
+macOS deployment target (12.0 on arm64), so a wheel tagged
+`macosx_14_0_arm64` is not accepted until the target says it runs macOS
+14.
+
 The target declares both halves of the environment: its PEP 508 markers
 gate every dependency, and its PEP 425 wheel tags gate every candidate.
 A version whose only wheels the target cannot install, and which ships no
@@ -106,6 +121,11 @@ to `[tool.nab.environment]` with a warning, and a key that names no
 environment axis, or a `(sys_platform, platform_machine)` pair that names
 no platform nab models, is a config error.  Declare the environment
 instead.
+
+`platform_release` and `platform_version` are knobs of the machine the
+pair names, so they translate into the platform table
+(`platform-release`, `platform-version`) and need the pair alongside
+them.
 
 ## Indexes
 
@@ -634,7 +654,9 @@ free-threaded wheels and neither the ordinary `cp3XX` ones nor `abi3`
 (a free-threaded interpreter cannot load either).  It needs CPython
 3.13 or newer, the first release with a free-threaded build; a matrix
 whose `python` admits an older minor, or whose `implementations` names
-anything but `cpython`, is a config error.
+anything but `cpython`, is a config error, and so is a
+`[tool.nab.environment]` whose `python` or `implementation` says the
+same.
 
 An id may appear once.  A lockfile entry is selected by a PEP 508
 marker, and PEP 508 has no variable for the libc family or the

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -64,6 +64,7 @@ from .target import (
     PLATFORM_MARKERS,
     Matrix,
     ResolveTarget,
+    check_free_threaded,
     host_environment,
     python_axis_environment,
 )
@@ -153,10 +154,15 @@ class EnvironmentConfig:
     One cell of a matrix: the axes a target is made of.  An unset axis
     takes the host's value, so an empty table is the host and a table
     naming only ``python`` is the host machine running another Python.
+
+    ``platform`` is the same :class:`~nab_python.tags.PlatformSpec` a
+    ``matrix.platforms`` entry parses to, so the wheel-tag knobs (the libc
+    family and version, the macOS deployment target, the kernel marker
+    values, the free-threaded build) are declarable here too.
     """
 
     python: str | None = None
-    platform: str | None = None
+    platform: PlatformSpec | None = None
     implementation: str | None = None
 
 
@@ -923,10 +929,20 @@ def _declared_target(environment: EnvironmentConfig) -> ResolveTarget:
     assert environment.platform is not None  # the caller checked
     python = environment.python or host_environment()["python_full_version"]
     axis = python_axis_environment(python)
+    implementation = environment.implementation or "cpython"
+    try:
+        check_free_threaded(
+            platforms=(environment.platform,),
+            implementations=(implementation,),
+            python_versions=(axis["python_version"],),
+        )
+    except ValueError as exc:
+        msg = f"invalid [tool.nab.environment]: {exc}"
+        raise ConfigError(msg) from exc
     return ResolveTarget.for_declared(
         python_version=axis["python_version"],
-        spec=PlatformSpec(environment.platform),
-        implementation=environment.implementation or "cpython",
+        spec=environment.platform,
+        implementation=implementation,
         python_full_version=axis["python_full_version"],
     )
 
@@ -1373,18 +1389,17 @@ def _parse_marker_environment(value: object) -> dict[str, str]:
 _ENVIRONMENT_KEYS = frozenset({"python", "platform", "implementation"})
 
 
-def _parse_environment(value: object) -> dict[str, str]:
+def _parse_environment(value: object) -> dict[str, Any]:
     """Parse ``[tool.nab.environment]``: the one environment to resolve for.
 
-    Kept as the raw ``key -> str`` table so the registry merges it sub-key
-    by sub-key across the config sources; :func:`_environment_from_effective`
-    turns the merged whole into an :class:`EnvironmentConfig`.
+    Kept as the raw table so the registry merges it sub-key by sub-key
+    across the config sources; :func:`_environment_from_effective` turns the
+    merged whole into an :class:`EnvironmentConfig`.  ``platform`` takes the
+    two shapes a ``matrix.platforms`` entry takes, a bare id or a table of
+    the wheel-tag knobs, so a dict value passes through here.
     """
     if not isinstance(value, dict):
-        msg = (
-            "[tool.nab.environment] must be a table of string -> string,"
-            f" got {type(value).__name__}"
-        )
+        msg = f"[tool.nab.environment] must be a table, got {type(value).__name__}"
         raise ConfigError(msg)
     unknown = sorted(set(value) - _ENVIRONMENT_KEYS)
     if unknown:
@@ -1393,15 +1408,33 @@ def _parse_environment(value: object) -> dict[str, str]:
             f" expected {sorted(_ENVIRONMENT_KEYS)!r}"
         )
         raise ConfigError(msg)
-    out = {
-        key: _parse_string_value(f"environment.{key}", item)
+    out: dict[str, Any] = {
+        key: item
+        if key == "platform"
+        else _parse_string_value(f"environment.{key}", item)
         for key, item in value.items()
     }
     _validate_environment_values(out)
     return out
 
 
-def _validate_environment_values(environment: Mapping[str, str]) -> None:
+def _environment_platform_spec(value: object) -> PlatformSpec:
+    """Build the :class:`PlatformSpec` ``[tool.nab.environment].platform`` names.
+
+    The same two shapes ``matrix.platforms`` entries take, parsed by the same
+    code: a bare id at the platform's default tag knobs, or a table declaring
+    them.
+    """
+    where = "environment.platform"
+    if isinstance(value, str):
+        return _platform_spec(where, platform_id=value)
+    if isinstance(value, dict):
+        return _parse_platform_table(where, cast("dict[str, Any]", value))
+    msg = f"{where} must be a platform id or a table, got {type(value).__name__}"
+    raise ConfigError(msg)
+
+
+def _validate_environment_values(environment: Mapping[str, Any]) -> None:
     """Validate the value of every environment axis the table names.
 
     Shared by the ``[tool.nab.environment]`` parse, the
@@ -1419,10 +1452,15 @@ def _validate_environment_values(environment: Mapping[str, str]) -> None:
             )
             raise ConfigError(msg) from exc
     platform = environment.get("platform")
-    if platform is not None and platform not in PLATFORM_MARKERS:
-        valid = sorted(PLATFORM_MARKERS)
-        msg = f"unknown environment.platform {platform!r}; expected one of {valid!r}"
-        raise ConfigError(msg)
+    if platform is not None:
+        platform_id = _environment_platform_spec(platform).platform_id
+        if platform_id not in PLATFORM_MARKERS:
+            valid = sorted(PLATFORM_MARKERS)
+            msg = (
+                f"unknown environment.platform {platform_id!r};"
+                f" expected one of {valid!r}"
+            )
+            raise ConfigError(msg)
     implementation = environment.get("implementation")
     if implementation is not None and implementation not in _KNOWN_IMPLEMENTATIONS:
         valid = list(_KNOWN_IMPLEMENTATIONS)
@@ -1441,6 +1479,11 @@ _MARKER_PLATFORM_KEYS = ("sys_platform", "platform_machine")
 # The platform id names these too, so an overlay may repeat them as long as it
 # agrees with the machine the pair identifies.
 _MARKER_PLATFORM_IMPLIED_KEYS = ("platform_system", "os_name")
+# The kernel markers, which are knobs of the platform the pair names.
+_MARKER_PLATFORM_KNOBS = {
+    "platform_release": "platform-release",
+    "platform_version": "platform-version",
+}
 
 # The platform id each (sys_platform, platform_machine) pair names.
 _PLATFORM_ID_BY_MARKERS: dict[tuple[str, str], str] = {
@@ -1451,7 +1494,7 @@ _PLATFORM_ID_BY_MARKERS: dict[tuple[str, str], str] = {
 
 def _environment_from_marker_environment(
     marker_environment: Mapping[str, str],
-) -> dict[str, str]:
+) -> dict[str, Any]:
     """Translate the deprecated ``[tool.nab.marker-environment]`` overlay.
 
     The overlay set PEP 508 marker variables one by one, which let a
@@ -1459,7 +1502,9 @@ def _environment_from_marker_environment(
     environment on the host and resolve for a machine that does not exist.
     The replacement declares whole axes, so every overlay key must name one:
     an unmappable ``(sys_platform, platform_machine)`` pair, or a key no
-    axis can carry, is an error rather than a silently-wrong resolve.
+    axis can carry, is an error rather than a silently-wrong resolve.  The
+    kernel markers name no axis of their own; they are knobs of the platform
+    the pair names, and translate into its table.
     """
     _logger.warning(
         "[tool.nab.marker-environment] is deprecated and will be removed;"
@@ -1472,6 +1517,7 @@ def _environment_from_marker_environment(
         *_MARKER_IMPLEMENTATION_KEYS,
         *_MARKER_PLATFORM_KEYS,
         *_MARKER_PLATFORM_IMPLIED_KEYS,
+        *_MARKER_PLATFORM_KNOBS,
     }
     untranslatable = sorted(set(marker_environment) - translatable)
     if untranslatable:
@@ -1483,7 +1529,7 @@ def _environment_from_marker_environment(
         )
         raise ConfigError(msg)
 
-    environment: dict[str, str] = {}
+    environment: dict[str, Any] = {}
     for key in _MARKER_PYTHON_KEYS:
         if key in marker_environment:
             environment["python"] = marker_environment[key]
@@ -1494,10 +1540,16 @@ def _environment_from_marker_environment(
             environment["implementation"] = marker_environment[key].lower()
             break
 
-    implied = [k for k in _MARKER_PLATFORM_IMPLIED_KEYS if k in marker_environment]
-    if implied and not any(k in marker_environment for k in _MARKER_PLATFORM_KEYS):
+    needs_platform = [
+        k
+        for k in (*_MARKER_PLATFORM_IMPLIED_KEYS, *_MARKER_PLATFORM_KNOBS)
+        if k in marker_environment
+    ]
+    if needs_platform and not any(
+        k in marker_environment for k in _MARKER_PLATFORM_KEYS
+    ):
         msg = (
-            f"[tool.nab.marker-environment] sets {implied!r} without"
+            f"[tool.nab.marker-environment] sets {needs_platform!r} without"
             " (sys_platform, platform_machine), which is the pair that names"
             " the machine.  Declare [tool.nab.environment] platform instead:"
             " half a machine would keep the other half of the host's."
@@ -1521,7 +1573,14 @@ def _environment_from_marker_environment(
             )
             raise ConfigError(msg)
         _check_implied_platform_markers(marker_environment, platform_id)
-        environment["platform"] = platform_id
+        environment["platform"] = {
+            "id": platform_id,
+            **{
+                knob: marker_environment[key]
+                for key, knob in _MARKER_PLATFORM_KNOBS.items()
+                if key in marker_environment
+            },
+        }
     _validate_environment_values(environment)
     return environment
 
@@ -1563,7 +1622,7 @@ def _environment_from_effective(
     replacement removes.  Returns ``None`` when neither is declared, which
     is the host.
     """
-    declared: Mapping[str, str] = effective["environment"].value
+    declared: Mapping[str, Any] = effective["environment"].value
     marker_environment: Mapping[str, str] = effective["marker-environment"].value
     if marker_environment:
         if declared:
@@ -1576,9 +1635,10 @@ def _environment_from_effective(
         declared = _environment_from_marker_environment(marker_environment)
     if not declared:
         return None
+    platform = declared.get("platform")
     environment = EnvironmentConfig(
         python=declared.get("python"),
-        platform=declared.get("platform"),
+        platform=None if platform is None else _environment_platform_spec(platform),
         implementation=declared.get("implementation"),
     )
     if environment.implementation is not None and environment.platform is None:

--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -480,10 +480,11 @@ def _parse_marker_environment(value: Any, where: str) -> Mapping[str, str]:
     return _delegate(lambda: _impl(value))
 
 
-def _parse_environment(value: Any, where: str) -> Mapping[str, str]:
-    # Name-keyed table (python/platform/implementation -> str), one cell of
-    # a matrix.  A mapping row, so the axes merge sub-key by sub-key across
-    # the ladder and a ``--python`` override moves only the python axis.
+def _parse_environment(value: Any, where: str) -> Mapping[str, Any]:
+    # Name-keyed table (python/platform/implementation), one cell of a
+    # matrix; platform is an id or a table of tag knobs.  A mapping row, so
+    # the axes merge sub-key by sub-key across the ladder and a ``--python``
+    # override moves only the python axis.
     del where
     from .config import (  # noqa: PLC0415 (config import cycle)
         _parse_environment as _impl,
@@ -782,10 +783,21 @@ def _render_marker_environment(value: Mapping[str, str]) -> str:
     return ", ".join(f"{k}={v}" for k, v in sorted(value.items()))
 
 
-def _render_environment(value: Mapping[str, str]) -> str:
+def _render_environment(value: Mapping[str, Any]) -> str:
     if not value:
         return "<host>"
-    return ", ".join(f"{k}={v}" for k, v in sorted(value.items()))
+    return ", ".join(
+        f"{k}={_render_environment_axis(v)}" for k, v in sorted(value.items())
+    )
+
+
+def _render_environment_axis(value: Any) -> str:
+    """Render one axis, the platform table as ``id[knob=value, ...]``."""
+    if not isinstance(value, dict):
+        return str(value)
+    knobs = ", ".join(f"{k}={v}" for k, v in sorted(value.items()) if k != "id")
+    platform_id = value["id"]
+    return f"{platform_id}[{knobs}]" if knobs else str(platform_id)
 
 
 def _render_vcs(value: Any) -> str:
@@ -916,7 +928,7 @@ OPTIONS: tuple[OptionSpec, ...] = (
     OptionSpec(
         key="environment",
         scope=Scope.PROJECT,
-        type_label="table(python,platform,implementation)",
+        type_label="table(python,platform[,knobs],implementation)",
         default=_EMPTY_MAPPING,
         env_var=None,
         cli_flag=None,

--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -50,6 +50,7 @@ __all__ = [
     "Matrix",
     "ResolveTarget",
     "apply_python_axis_overlay",
+    "check_free_threaded",
     "declared_environment",
     "environment_declaration",
     "host_environment",
@@ -817,7 +818,11 @@ class Matrix:
             )
             raise ValueError(msg)
 
-        self._check_free_threaded()
+        check_free_threaded(
+            platforms=self.platforms,
+            implementations=self.implementations,
+            python_versions=tuple(_pythons_in_range(self.python)),
+        )
 
         py_versions = list(_pythons_in_range(self.python))
         if not py_versions:
@@ -840,36 +845,38 @@ class Matrix:
             for impl in self.implementations
         ]
 
-    def _check_free_threaded(self) -> None:
-        """Reject a free-threaded platform no interpreter build can satisfy.
 
-        The ``cpXYt`` ABI ships only from CPython 3.13, and only the matrix
-        sees both axes the rule needs: the platform carries the flag, and the
-        implementation and the python range live here.
-        """
-        if not any(spec.free_threaded for spec in self.platforms):
-            return
+def check_free_threaded(
+    *,
+    platforms: Sequence[PlatformSpec],
+    implementations: Sequence[str],
+    python_versions: Sequence[str],
+) -> None:
+    """Reject a free-threaded platform no interpreter build can satisfy.
 
-        foreign = [i for i in self.implementations if i != "cpython"]
-        if foreign:
-            msg = (
-                f"a free-threaded platform needs CPython, not {foreign!r};"
-                f" only CPython has a free-threaded build"
-            )
-            raise ValueError(msg)
+    The ``cpXYt`` ABI ships only from CPython 3.13, and the rule needs all
+    three axes: the platform carries the flag, and only the declaration
+    around it knows the implementation and the python versions.  Both
+    declaring surfaces (the matrix and the single environment) call this.
+    """
+    if not any(spec.free_threaded for spec in platforms):
+        return
 
-        floor = ".".join(str(p) for p in FREE_THREADED_MIN_PYTHON)
-        too_old = [
-            py
-            for py in _pythons_in_range(self.python)
-            if not supports_free_threading(py)
-        ]
-        if too_old:
-            msg = (
-                f"a free-threaded platform needs CPython {floor} or newer,"
-                f" but matrix.python admits {too_old!r}"
-            )
-            raise ValueError(msg)
+    foreign = [i for i in implementations if i != "cpython"]
+    if foreign:
+        msg = (
+            f"a free-threaded platform needs CPython, not {foreign!r};"
+            f" only CPython has a free-threaded build"
+        )
+        raise ValueError(msg)
+
+    floor = ".".join(str(p) for p in FREE_THREADED_MIN_PYTHON)
+    too_old = [py for py in python_versions if not supports_free_threading(py)]
+    if too_old:
+        msg = (
+            f"a free-threaded platform needs CPython {floor} or newer, not {too_old!r}"
+        )
+        raise ValueError(msg)
 
 
 def _pythons_in_range(spec: str) -> Iterable[str]:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -1271,7 +1271,9 @@ class TestEnvironment:
         )
         config = read_pyproject_config(path)
         assert config.environment == EnvironmentConfig(
-            python="3.11", platform="macos_arm64", implementation="pypy"
+            python="3.11",
+            platform=PlatformSpec("macos_arm64"),
+            implementation="pypy",
         )
         (target,) = plan_targets(config)
         assert target.marker_env["sys_platform"] == "darwin"
@@ -1290,6 +1292,139 @@ class TestEnvironment:
         host = ResolveTarget.for_host()
         assert target.python_full_version == host.python_full_version
         assert target.platform_id == "linux_x86_64"
+
+    def test_platform_table_declares_the_tag_knobs(self, tmp_path: Path) -> None:
+        """The table form of matrix.platforms works on the one environment too."""
+        path = write(
+            tmp_path,
+            "[tool.nab.environment]\n"
+            'python = "3.12"\n'
+            'platform = { id = "macos_arm64", macos-min = "14.0" }\n'
+            '[tool.nab]\nbuild-policy = "never"\n',
+        )
+        config = read_pyproject_config(path)
+        assert config.environment == EnvironmentConfig(
+            python="3.12", platform=PlatformSpec("macos_arm64", macos_min=(14, 0))
+        )
+        (target,) = plan_targets(config)
+        wheel = "somepkg-1.0-cp312-cp312-macosx_14_0_arm64.whl"
+        assert target.tags.accepts(wheel)
+        assert "platform=macos_arm64[macos-min=14.0]" in _inspect(path, "environment")
+
+    def test_the_inspector_renders_a_knobless_table(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab.environment]\nplatform = { id = "linux_x86_64" }\n'
+            '[tool.nab]\nbuild-policy = "never"\n',
+        )
+        assert "platform=linux_x86_64" in _inspect(path, "environment")
+
+    def test_bare_platform_id_keeps_the_default_knobs(self, tmp_path: Path) -> None:
+        """Without macos-min the deployment target is the arch default (12.0)."""
+        path = write(
+            tmp_path,
+            "[tool.nab.environment]\n"
+            'python = "3.12"\n'
+            'platform = "macos_arm64"\n'
+            '[tool.nab]\nbuild-policy = "never"\n',
+        )
+        (target,) = plan_targets(read_pyproject_config(path))
+        wheel = "somepkg-1.0-cp312-cp312-macosx_14_0_arm64.whl"
+        assert not target.tags.accepts(wheel)
+
+    def test_platform_table_rejects_a_foreign_knob(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab.environment]\n"
+            'platform = { id = "linux_x86_64", macos-min = "14.0" }\n',
+        )
+        with pytest.raises(
+            ConfigError,
+            match=r"environment.platform declares \['macos-min'\]",
+        ):
+            read_pyproject_config(path)
+
+    def test_platform_table_needs_an_id(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path, '[tool.nab.environment]\nplatform = { macos-min = "14.0" }\n'
+        )
+        with pytest.raises(
+            ConfigError, match="environment.platform missing required key 'id'"
+        ):
+            read_pyproject_config(path)
+
+    def test_platform_table_rejects_a_bad_knob_value(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab.environment]\nplatform = { id = "linux_x86_64", libc = 1 }\n',
+        )
+        with pytest.raises(ConfigError, match="environment.platform.libc must be a"):
+            read_pyproject_config(path)
+
+    def test_platform_table_rejects_an_unknown_knob(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab.environment]\nplatform = { id = "linux_x86_64", cpu = "8" }\n',
+        )
+        with pytest.raises(
+            ConfigError, match=r"unknown environment.platform keys: \['cpu'\]"
+        ):
+            read_pyproject_config(path)
+
+    def test_platform_must_be_an_id_or_a_table(self, tmp_path: Path) -> None:
+        path = write(tmp_path, "[tool.nab.environment]\nplatform = 3\n")
+        with pytest.raises(
+            ConfigError,
+            match="environment.platform must be a platform id or a table, got int",
+        ):
+            read_pyproject_config(path)
+
+    def test_unknown_platform_id_in_a_table_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path, '[tool.nab.environment]\nplatform = { id = "linux_i686" }\n'
+        )
+        with pytest.raises(
+            ConfigError, match="unknown environment.platform 'linux_i686'"
+        ):
+            read_pyproject_config(path)
+
+    def test_free_threaded_platform_takes_the_t_abi(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab.environment]\n"
+            'python = "3.13"\n'
+            'platform = { id = "linux_x86_64", free-threaded = true }\n'
+            '[tool.nab]\nbuild-policy = "never"\n',
+        )
+        (target,) = plan_targets(read_pyproject_config(path))
+        assert target.tags.accepts("somepkg-1.0-cp313-cp313t-manylinux_2_28_x86_64.whl")
+        assert not target.tags.accepts(
+            "somepkg-1.0-cp313-cp313-manylinux_2_28_x86_64.whl"
+        )
+
+    def test_free_threaded_rejects_python_below_3_13(self, tmp_path: Path) -> None:
+        """3.12 has no free-threaded build, so its cp312t ABI matches nothing."""
+        path = write(
+            tmp_path,
+            "[tool.nab.environment]\n"
+            'python = "3.12"\n'
+            'platform = { id = "linux_x86_64", free-threaded = true }\n'
+            '[tool.nab]\nbuild-policy = "never"\n',
+        )
+        with pytest.raises(ConfigError, match="needs CPython 3.13 or newer"):
+            read_pyproject_config(path)
+
+    def test_free_threaded_rejects_pypy(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab.environment]\n"
+            'python = "3.13"\n'
+            'implementation = "pypy"\n'
+            'platform = { id = "linux_x86_64", free-threaded = true }\n'
+            '[tool.nab]\nbuild-policy = "never"\n',
+        )
+        with pytest.raises(ConfigError, match="needs CPython, not"):
+            read_pyproject_config(path)
 
     def test_must_be_table(self, tmp_path: Path) -> None:
         path = write(tmp_path, '[tool.nab]\nenvironment = "no"\n')
@@ -1391,7 +1526,7 @@ class TestMarkerEnvironmentDeprecation:
         )
         config = read_pyproject_config(path)
         assert config.environment == EnvironmentConfig(
-            platform="windows_amd64", implementation="cpython"
+            platform=PlatformSpec("windows_amd64"), implementation="cpython"
         )
 
     def test_the_platform_id_carries_the_markers_it_implies(
@@ -1407,7 +1542,9 @@ class TestMarkerEnvironmentDeprecation:
             'platform_machine = "x86_64"\n',
         )
         config = read_pyproject_config(path)
-        assert config.environment == EnvironmentConfig(platform="linux_x86_64")
+        assert config.environment == EnvironmentConfig(
+            platform=PlatformSpec("linux_x86_64")
+        )
 
     def test_an_implied_marker_that_contradicts_the_platform_is_an_error(
         self, tmp_path: Path
@@ -1456,11 +1593,40 @@ class TestMarkerEnvironmentDeprecation:
         """A variable no environment axis carries cannot be translated."""
         path = write(
             tmp_path,
-            '[tool.nab.marker-environment]\nplatform_release = "6.8.0"\n',
+            '[tool.nab.marker-environment]\nimplementation_version = "3.12.4"\n',
         )
         with pytest.raises(
-            ConfigError, match=r"variable\(s\) \['platform_release'\] cannot be"
+            ConfigError, match=r"variable\(s\) \['implementation_version'\] cannot be"
         ):
+            read_pyproject_config(path)
+
+    def test_kernel_markers_translate_to_platform_knobs(self, tmp_path: Path) -> None:
+        """The kernel markers are platform knobs, so the platform table carries them."""
+        path = write(
+            tmp_path,
+            '[tool.nab]\nbuild-policy = "never"\n'
+            "[tool.nab.marker-environment]\n"
+            'sys_platform = "linux"\n'
+            'platform_machine = "x86_64"\n'
+            'platform_release = "6.8.0"\n'
+            'platform_version = "#1 SMP"\n',
+        )
+        config = read_pyproject_config(path)
+        assert config.environment == EnvironmentConfig(
+            platform=PlatformSpec(
+                "linux_x86_64", platform_release="6.8.0", platform_version="#1 SMP"
+            )
+        )
+        (target,) = plan_targets(config)
+        assert target.marker_env["platform_release"] == "6.8.0"
+
+    def test_a_kernel_marker_alone_is_an_error(self, tmp_path: Path) -> None:
+        """A kernel marker is a knob of a machine, so it needs the pair that names one."""
+        path = write(
+            tmp_path,
+            '[tool.nab.marker-environment]\nplatform_release = "6.8.0"\n',
+        )
+        with pytest.raises(ConfigError, match="which is the pair that names"):
             read_pyproject_config(path)
 
     def test_unknown_implementation_is_an_error(self, tmp_path: Path) -> None:


### PR DESCRIPTION
`[tool.nab.matrix].platforms` lets a platform entry declare the wheel-tag knobs (libc, libc-version, macos-min, platform-release, platform-version, free-threaded), but `[tool.nab.environment].platform` took only a bare id, so a single-environment project could not reach them. That is functional, not cosmetic: a bare `macos_arm64` keeps the default 12.0 deployment target, so a wheel tagged `macosx_14_0_arm64` is not accepted, and a version whose only wheels are tag-incompatible is dropped with no sdist fallback because a declared target forces `build-policy = never`.

```toml
[tool.nab.environment]
python = "3.12"
platform = { id = "macos_arm64", macos-min = "14.0" }
```

On main that is `environment.platform must be a string, got dict`.

`environment.platform` now takes the same two shapes a matrix platform entry takes, a bare id or a table of the knobs, parsed by the matrix's own table parser, so the unknown-key, missing-id, foreign-knob and bad-value errors are the same words under the label `environment.platform`. `Matrix._check_free_threaded` moves to a module-level `check_free_threaded()` that both surfaces call, so `free-threaded = true` on Python 3.12 or on PyPy is rejected here too rather than synthesizing `cpXYt` tags nothing builds.

The deprecated `[tool.nab.marker-environment]` keys `platform_release` and `platform_version` get the migration path they lacked: they are knobs of the machine `(sys_platform, platform_machine)` names, so they now translate into that platform's table instead of hard-erroring as untranslatable.
