### PR TITLE
check default groups in the lock disjointness validator

### DIFF
--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -126,7 +126,7 @@ def build_pylock(lock_input: LockInput, *, lock_dir: Path | None = None) -> Pylo
         package_records,
         environments=lock_input.marker_envs,
         extras=lock_input.extras,
-        groups=lock_input.dependency_groups,
+        groups=lock_input.active_groups,
         exclusive_groups=conflict_exclusion_groups(lock_input.conflicts),
         declared_groups=conflict_member_groups(lock_input.conflicts),
     )

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -2554,9 +2554,11 @@ def _validate_default_groups_against_conflicts(
     """Reject default-groups that co-activate an exclusive conflict set.
 
     A default install activates every default group with no user
-    selection, so the emit-time disjointness validator never sees them.
-    Two default groups in the same at-most-one or exactly-one set would
-    silently violate the declared conflict; catch it at parse time.
+    selection, but the emit-time disjointness validator prunes any
+    context that activates two members of an exclusive set, so it never
+    enumerates that install.  Two default groups in the same at-most-one
+    or exactly-one set would silently violate the declared conflict;
+    catch it at parse time.
     """
     active = {canonicalize_name(g) for g in default_groups}
     for group in conflict_exclusion_groups(conflicts):

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -411,6 +411,17 @@ class LockInput:
     per mutually-exclusive extra/group) validates."""
 
     @property
+    def active_groups(self) -> tuple[str, ...]:
+        """Every group an install context can activate.
+
+        PEP 751 keeps the ``default-groups`` names out of
+        ``dependency-groups``, and an installer that selects nothing
+        still activates the defaults, so the group axis of an install
+        context is the union of the two arrays.
+        """
+        return tuple(dict.fromkeys((*self.dependency_groups, *self.default_groups)))
+
+    @property
     def marker_envs(self) -> dict[str, Mapping[str, str]]:
         """The PEP 508 marker environment each target resolved under."""
         return {label: lock.target.marker_env for label, lock in self.targets.items()}

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -1456,6 +1456,14 @@ class TestDependencyGroups:
         assert "dependency-groups" not in data
         assert "default-groups" not in data
 
+    def test_active_groups_unions_selection_and_defaults(self) -> None:
+        lock_input = LockInput(
+            targets=_one({"foo": _index_pin()}),
+            dependency_groups=("docs", "dev"),
+            default_groups=("dev", "lint"),
+        )
+        assert lock_input.active_groups == ("docs", "dev", "lint")
+
     def test_group_names_normalized(self) -> None:
         text = write_lock(
             LockInput(

--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -369,6 +369,23 @@ class TestConflictForkResolve:
         with pytest.raises(DisjointnessError, match="black"):
             build_pylock(lock_input)
 
+    def test_default_groups_collision_is_ambiguous(self) -> None:
+        # The same undeclared collision, but the groups come from
+        # default-groups rather than the CLI selection.  A default
+        # install activates both, so the validator must still see it.
+        result = resolve_with_coordinator(
+            self._black_coordinator(),
+            _one_target(),
+            forks=self._black_forks(),
+            config=_no_build(),
+        )
+        lock_input = build_lock_input(
+            result,
+            config=_no_build(default_groups=("black22", "black23")),
+        )
+        with pytest.raises(DisjointnessError, match="black"):
+            build_pylock(lock_input)
+
     def test_top_level_environments_drop_membership_and_dedupe(self) -> None:
         # Two forks of the one (python, platform) target must collapse to
         # a single top-level environment with no membership clause: that


### PR DESCRIPTION
The lock's emit-time disjointness check only enumerates install contexts built from the groups a user selected on the CLI, so it is blind over the lock's own default install. A package entry whose marker is `"<group>" in dependency_groups` for a group that comes from `[tool.nab].default-groups` is False at every enumerated point, so an ambiguous pair of entries that both fire in a plain `pip install` of the lock passes the check silently. The same lock shape is validated when the group arrives via `--group`.

`resolve.py` already folds `default-groups` into the effective group set that drives the fork plan and the resolves; only the validator axis was missing them. `LockInput` grows an `active_groups` property, the ordered union of the CLI selection and the default groups, and `build_pylock` hands that to `validate_marker_disjointness` instead of `dependency_groups`. Widening the axis is safe in one direction: exclusive-set pruning still drops any context activating two members of a conflict set, so no new false positive is introduced.

The emitted `dependency-groups` and `default-groups` arrays are unchanged. PEP 751 says default group names must not be repeated in `dependency-groups`, and installers seed the selection from the defaults themselves.

Repro: two entries for the same package, markers `python_version == "3.12" and "t20" in dependency_groups` and `python_version >= "3.12" and "t20" in dependency_groups`, with `t20` in `default-groups`. Both fire in a default install, but the lock is emitted without a `DisjointnessError`.