### PR TITLE
canonicalize equal versions before the wheel-tag pass

### DIFF
--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -302,8 +302,9 @@ def filter_distributions(
 
     The filter runs in two passes.  :func:`base_distributions` applies
     everything that has no platform axis (dist policy, Requires-Python,
-    upload cutoff, sort order), and is memoised per (package, Python)
-    across the targets of one resolve when the provider carries a
+    upload cutoff, sort order, equal-version canonicalization), and is
+    memoised per (package, Python) across the targets of one resolve
+    when the provider carries a
     :class:`~nab_python.provider.ListingFilterCache`.  The wheel-tag
     pass then runs per target on top of that shared list, so a
     linux-only wheel still stays off the Windows target.
@@ -339,9 +340,9 @@ def _filter_base(
 
     Reads only the listing, the resolve-wide policy config, and the
     target Python, so two targets that differ only by platform get the
-    same list back.  Not canonicalized: the tag pass drops artifacts,
-    and the representative version of an equal group is chosen from
-    what survives it.
+    same list back.  Canonicalized here, ahead of the tag pass, so the
+    representative version of an equal group is picked from the whole
+    listing and does not vary with what a target's tags keep.
     """
     # Late import: ``provider`` imports this module at module load.
     from ..provider import DistPolicy
@@ -398,7 +399,7 @@ def _filter_base(
         )
     else:
         result.sort(key=lambda pair: pair[0], reverse=True)
-    return result
+    return _canonicalize_equal_versions(result)
 
 
 def _apply_wheel_tags(
@@ -413,7 +414,7 @@ def _apply_wheel_tags(
     """
     tags = provider.wheel_tags
     if tags is None:
-        return _canonicalize_equal_versions(base)
+        return base
 
     result: list[tuple[Version, DistFile]] = []
     tag_rejected_versions: set[Version] = set()
@@ -431,7 +432,7 @@ def _apply_wheel_tags(
             tag_rejected_versions - kept
         )
 
-    return _canonicalize_equal_versions(result)
+    return result
 
 
 def _excluded_by_python_or_time(

--- a/nab-python/tests/test_provider_declared_target.py
+++ b/nab-python/tests/test_provider_declared_target.py
@@ -29,6 +29,7 @@ from nab_python.fetch import InMemoryIndex
 from nab_python.provider import (
     BuildPolicy,
     DistPolicy,
+    ListingFilterCache,
     Provider,
     VcsConfig,
     VcsPolicy,
@@ -679,6 +680,62 @@ class TestWheelTagFiltering:
         result = provider.fetch_versions("pkg")
         assert result == []
         assert provider.stats.excluded_versions_no_compatible_wheel == 1
+
+
+class TestEqualVersionCanonicalization:
+    """One release pins under one version string, whatever the target's tags drop."""
+
+    @staticmethod
+    def _files() -> list[WheelFile | SdistFile]:
+        """A release whose wheel says ``1.0`` and whose sdist says ``1.0.0``."""
+        return [
+            _platform_wheel("1.0", "cp311-cp311-manylinux_2_17_x86_64"),
+            _sdist("1.0.0"),
+        ]
+
+    def _provider(self, spec: PlatformSpec, cache: ListingFilterCache) -> Provider:
+        return Provider(
+            _index_with_files(self._files()),
+            _linux_target(spec),
+            listing_filter_cache=cache,
+        )
+
+    def test_pin_string_does_not_vary_with_the_tag_pass(self) -> None:
+        """The linux target keeps the wheel, the windows target drops it.
+
+        The representative of the equal group is picked over the whole
+        listing, so both targets pin the release as ``1.0``.  Picking it
+        from the tag survivors would pin it as ``1.0.0`` on windows,
+        where only the sdist is left.
+        """
+        cache = ListingFilterCache()
+        linux = self._provider(PlatformSpec("linux_x86_64"), cache)
+        windows = self._provider(PlatformSpec("windows_amd64"), cache)
+
+        linux_pins = {str(v) for v, _ in linux.fetch_versions("pkg")}
+        windows_pins = {str(v) for v, _ in windows.fetch_versions("pkg")}
+
+        assert linux_pins == {"1.0"}
+        assert windows_pins == {"1.0"}
+
+    def test_equal_group_left_wheel_less_is_counted_once(self) -> None:
+        """An equal group whose every wheel the target refuses is one lost version.
+
+        Both wheels spell the one release, so the two tag rejections leave
+        a single uninstallable version behind, not two.
+        """
+        wheels = [
+            _platform_wheel("1.0", "cp311-cp311-manylinux_2_17_x86_64"),
+            _platform_wheel("1.0.0", "cp311-cp311-manylinux_2_17_aarch64"),
+        ]
+        windows = Provider(
+            _index_with_files(wheels),
+            _linux_target(PlatformSpec("windows_amd64")),
+            listing_filter_cache=ListingFilterCache(),
+        )
+        assert windows.fetch_versions("pkg") == []
+        assert windows.stats.excluded_by_wheel_tags == 2
+        assert windows.stats.excluded_versions_no_compatible_wheel == 1
 
 
 class TestRequiresPythonPatch:


### PR DESCRIPTION
A release that spells its version two ways (a wheel filename saying `1.0` and an sdist saying `1.0.0`) can pin under two different strings in one lock, and shows up as two `[[packages]]` entries for the one release. Equal-version canonicalization runs at the end of the per-target wheel-tag filter, so the representative Version of an equal group is picked from whatever that target's PEP 425 tags happened to keep. A linux target keeps the wheel and pins `1.0`; a windows target drops it, is left with the sdist, and pins `1.0.0`.

With `pkg-1.0-cp312-cp312-manylinux_2_17_x86_64.whl` and `pkg-1.0.0.tar.gz` in the listing, `fetch_versions("pkg")` gives `1.0` for py312-linux_x86_64 and `1.0.0` for py312-windows_amd64, and a lock over both targets carries both entries pointing at the same sdist.

This moves the canonicalization into the base pass, which has no platform axis, so the representative is chosen over the whole listing before any target's tags drop anything. The tag pass now only drops artifacts, which is what its docstring already said it did. The base pass is memoised per (package, Python) through `ListingFilterCache`, so every target of a resolve shares the one representative.

Before the specific/universal collapse the base filter canonicalized the full listing and the tag pass ran on top of it, so this restores that ordering.