### PR TITLE
name the knob that moves an excluded resolve target

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -654,7 +654,11 @@ error.  See [Build policy](build-policy.md).
   range the project supports.  A declaration.  It is recorded as the
   lockfile's top-level `requires-python` and checked against the resolve
   target; it does not choose that target.  A declaration that excludes
-  the target is a config error naming `[tool.nab.environment] python`.
+  the target is a config error naming the knob that moves it:
+  `[tool.nab.environment] python` for a single-environment resolve,
+  `[tool.nab.matrix].python` and `[tool.nab.matrix.python-patches]` for a
+  matrix target, since neither `--python` nor `[tool.nab.environment]` is
+  allowed alongside a matrix.
 * `[tool.nab.environment].python`: the Python to resolve for, defaulting
   to the host's.  A single version, not a specifier.  `--python X.Y`
   overrides it for one run.

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -134,6 +134,12 @@ _PEP508_MARKER_VARIABLES = frozenset(
 # Marker variables whose values must parse as PEP 440 versions.
 _VERSION_MARKER_VARIABLES = frozenset({"python_version", "python_full_version"})
 
+# How a ``requires-python`` declaration is named back to the user.  The
+# [tool.nab] key stays bare because the CLI's error prefix already names that
+# table; the [project] fallback has to name its own.
+_TOOL_NAB_REQUIRES_PYTHON = "requires-python"
+_PROJECT_REQUIRES_PYTHON = "[project] requires-python"
+
 
 @dataclass(frozen=True, slots=True)
 class MatrixConfig:
@@ -416,6 +422,9 @@ class NabProjectConfig:
     # top-level ``requires-python`` and checked against the resolve target.
     # It does not choose the target; ``environment`` does.
     requires_python: str | None = None
+    # The surface ``requires_python`` was read from, named by the error when
+    # the declaration excludes a target.
+    requires_python_source: str = _TOOL_NAB_REQUIRES_PYTHON
     uploaded_prior_to: datetime | None = None
     dist_policy: DistPolicy = DistPolicy.WHEEL_OR_SDIST
     build_policy: BuildPolicy = BuildPolicy.BUILD_LOCAL
@@ -710,8 +719,10 @@ def _config_from_effective(
     )
 
     requires_python = effective["requires-python"].value
-    if requires_python is None:
+    requires_python_source = _TOOL_NAB_REQUIRES_PYTHON
+    if requires_python is None and project_requires_python is not None:
         requires_python = project_requires_python
+        requires_python_source = _PROJECT_REQUIRES_PYTHON
 
     default_groups = effective["default-groups"].value
     conflicts = effective["conflicts"].value
@@ -728,6 +739,7 @@ def _config_from_effective(
         constraints=effective["constraints"].value,
         default_groups=default_groups,
         requires_python=requires_python,
+        requires_python_source=requires_python_source,
         uploaded_prior_to=effective["uploaded-prior-to"].value,
         dist_policy=dist_policy,
         build_policy=build_policy,
@@ -887,7 +899,12 @@ def plan_targets(config: NabProjectConfig) -> tuple[ResolveTarget, ...]:
     """
     targets = _plan_targets(config.matrix, config.environment)
     for target in targets:
-        _check_requires_python_admits_target(config.requires_python, target)
+        _check_requires_python_admits_target(
+            config.requires_python,
+            target,
+            source=config.requires_python_source,
+            matrix=config.matrix is not None,
+        )
     return targets
 
 
@@ -1076,14 +1093,17 @@ def with_python_override(
     )
 
     retargeted = replace(config, environment=environment, build_policy=build_policy)
-    _check_requires_python_admits_target(
-        retargeted.requires_python, plan_targets(retargeted)[0]
-    )
+    # Called for the check it runs: the declaration must admit the moved target.
+    plan_targets(retargeted)
     return retargeted
 
 
 def _check_requires_python_admits_target(
-    requires_python: str | None, target: ResolveTarget
+    requires_python: str | None,
+    target: ResolveTarget,
+    *,
+    source: str,
+    matrix: bool,
 ) -> None:
     """Reject a ``requires-python`` declaration that excludes the resolve target.
 
@@ -1091,6 +1111,12 @@ def _check_requires_python_admits_target(
     does not steer the resolve.  Resolving for a Python the project says it
     does not support would produce a lock the project's own metadata
     rejects, so it fails loud and names the knob that moves the target.
+
+    Which knob that is depends on the target.  A matrix declares the python
+    axis of every target it expands, and both ``--python`` and
+    ``[tool.nab.environment]`` are themselves errors alongside one, so a
+    matrix target is moved by ``matrix.python`` and
+    ``[tool.nab.matrix.python-patches]`` instead.
     """
     if requires_python is None:
         return
@@ -1099,13 +1125,24 @@ def _check_requires_python_admits_target(
     # This is the comparison every candidate's Requires-Python takes too.
     if target.python_release in SpecifierSet(requires_python):
         return
-    msg = (
-        f"requires-python = {requires_python!r} excludes the resolve target"
-        f" Python {target.python_full_version} ({target.label}).  nab resolves"
-        " for the host interpreter unless told otherwise; pass --python with a"
-        " version the declaration admits, set [tool.nab.environment] python to one, or"
-        " widen requires-python."
+    excludes = (
+        f"{source} = {requires_python!r} excludes the resolve target"
+        f" Python {target.python_full_version} ({target.label})."
     )
+    if matrix:
+        msg = (
+            f"{excludes}  [tool.nab.matrix] declares the python axis of every"
+            " target it expands, and a matrix minor resolves at patch 0 unless"
+            " [tool.nab.matrix.python-patches] names a patch: pin"
+            f" {target.python_version} there if only its patch level is excluded,"
+            " narrow matrix.python to drop the version, or widen requires-python."
+        )
+    else:
+        msg = (
+            f"{excludes}  nab resolves for the host interpreter unless told"
+            " otherwise; pass --python with a version the declaration admits, set"
+            " [tool.nab.environment] python to one, or widen requires-python."
+        )
     raise ConfigError(msg)
 
 

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -826,7 +826,12 @@ class TestRequiresPython:
             },
         )
         assert target.python_release in SpecifierSet(">=3.14")
-        _check_requires_python_admits_target(config.requires_python, target)
+        _check_requires_python_admits_target(
+            config.requires_python,
+            target,
+            source=config.requires_python_source,
+            matrix=False,
+        )
 
     def test_a_python_override_rescues_a_declaration_the_host_fails(
         self, tmp_path: Path
@@ -863,6 +868,54 @@ class TestRequiresPython:
             '[tool.nab]\nrequires-python = ">=3.9"\n',
         )
         assert read_pyproject_config(path).requires_python == ">=3.9"
+
+    def test_matrix_target_message_names_the_matrix_knobs(self, tmp_path: Path) -> None:
+        """A matrix target is moved by the matrix, not by --python.
+
+        A minor expands at patch 0 unless ``python-patches`` names a patch,
+        so a micro-level floor excludes the target the matrix plans.  Both
+        knobs the host wording names are hard errors under a matrix, so the
+        message may not name either.
+        """
+        path = write(
+            tmp_path,
+            '[tool.nab]\nmode = "universal"\nrequires-python = ">=3.11.4"\n'
+            '[tool.nab.matrix]\npython = ">=3.11,<3.12"\n'
+            'platforms = ["linux_x86_64"]\n',
+        )
+        config = read_pyproject_config(path)
+        with pytest.raises(ConfigError) as exc:
+            plan_targets(config)
+        message = str(exc.value)
+        assert "excludes the resolve target Python 3.11.0" in message
+        assert "[tool.nab.matrix.python-patches]" in message
+        assert "--python" not in message
+        assert "[tool.nab.environment]" not in message
+
+    def test_python_patches_admits_the_matrix_target(self, tmp_path: Path) -> None:
+        """The knob the matrix message names has to clear the error."""
+        path = write(
+            tmp_path,
+            '[tool.nab]\nmode = "universal"\nrequires-python = ">=3.11.4"\n'
+            '[tool.nab.matrix]\npython = ">=3.11,<3.12"\n'
+            'platforms = ["linux_x86_64"]\n'
+            '[tool.nab.matrix.python-patches]\n"3.11" = "3.11.4"\n',
+        )
+        (target,) = plan_targets(read_pyproject_config(path))
+        assert target.python_full_version == "3.11.4"
+
+    def test_project_table_declaration_names_its_table(self, tmp_path: Path) -> None:
+        """A [project] value is not a [tool.nab] one; the error says so."""
+        path = write(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "0"\nrequires-python = "<3"\n',
+        )
+        config = read_pyproject_config(path)
+        with pytest.raises(
+            ConfigError,
+            match=r"\[project\] requires-python = '<3' excludes the resolve target",
+        ):
+            plan_targets(config)
 
     def test_project_table_specifier_is_validated(self, tmp_path: Path) -> None:
         """A malformed [project].requires-python fails loud, not silently."""


### PR DESCRIPTION
When a `requires-python` declaration excludes the resolve target, the error is host-shaped in two ways it should not be. It tells the user to pass `--python` or set `[tool.nab.environment] python`, but both of those are themselves hard errors alongside `[tool.nab.matrix]`, and it never names the knob that actually works. It also opens with a bare `requires-python = ...`, which under the CLI's `Error in [tool.nab]: ` prefix reads as a `[tool.nab]` value even when it was read from `[project]`.

A matrix minor resolves at patch 0 unless `[tool.nab.matrix.python-patches]` names a patch, so a micro-level floor excludes the target the matrix plans:

```toml
[tool.nab]
mode = "universal"
requires-python = ">=3.11.4"

[tool.nab.matrix]
python = ">=3.11,<3.12"
platforms = ["linux_x86_64"]
```

```
Error in [tool.nab]: requires-python = '>=3.11.4' excludes the resolve target Python 3.11.0 (py311-linux_x86_64).  nab resolves for the host interpreter unless told otherwise; pass --python with a version the declaration admits, set [tool.nab.environment] python to one, or widen requires-python.
```

Adding `python-patches = { "3.11" = "3.11.4" }` locks cleanly, but the message never says so.

The check now takes the declaration's source and whether a matrix is in play. A matrix target gets a message naming `[tool.nab.matrix.python-patches]` for the excluded patch level, narrowing `matrix.python` to drop the version, or widening `requires-python`. A host or environment target keeps the existing wording. The message opens with the surface the value was read from, so a `[project]` declaration says `[project] requires-python`. No behaviour changes: the check still fails closed on a target the declaration excludes, and the planner still expands a matrix minor at patch 0.