### PR TITLE
read each target's own wheel metadata in a matrix resolve

### DIFF
--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -649,8 +649,8 @@ def prefetch_batch(
     Uses request_metadata_batch so all requests reach the fetcher
     as a single queue item and are processed concurrently.
     Returns list of (version, ver_str, metadata_url, event) for submitted
-    requests; the sidecar URL is what the await reads the metadata back by,
-    since sibling wheels of one version hold their own texts.
+    requests.  Sibling wheels of one version hold their own texts, so the
+    await reads the metadata back by the sidecar URL submitted here.
     """
     items: list[tuple[str, str, str, tuple[str, str] | None]] = []
     version_map: list[tuple[Version, str, str]] = []
@@ -705,10 +705,9 @@ def await_metadata_batch(
             # refuses it) rather than pinning it as dependency-free.
             continue
         if from_sdist:
-            # The wheel has no sidecar of its own and the version-level slot
-            # holds sdist PKG-INFO from an earlier fallback; caching it here
-            # would skip the PEP 643 gate that get_dependencies applies on
-            # the from_sdist path.
+            # The sidecar served nothing and the read fell back to sdist
+            # PKG-INFO; caching it here would skip the PEP 643 gate that
+            # get_dependencies applies on the from_sdist path.
             continue
         try:
             provider.parse_and_cache_metadata(cache_key, text)

--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -631,7 +631,7 @@ def prefetch_walk_ahead(
         # ``_first_wheel_per_version`` filters out wheels without metadata_url.
         metadata_url = wheel.metadata_url
         assert metadata_url is not None
-        if coordinator_index.has_metadata_for(normalized, wheel.version, metadata_url):
+        if coordinator_index.has_metadata(normalized, wheel.version, metadata_url):
             continue
         items.append((normalized, wheel.version, metadata_url, wheel.metadata_hash))
     if items:
@@ -643,15 +643,17 @@ def prefetch_batch(
     package: str,
     versions: list[Version],
     wheel_by_version_map: dict[Version, DistFile],
-) -> list[tuple[Version, str, threading.Event]]:
+) -> list[tuple[Version, str, str, threading.Event]]:
     """Submit metadata fetches for a batch of candidates.
 
     Uses request_metadata_batch so all requests reach the fetcher
     as a single queue item and are processed concurrently.
-    Returns list of (version, ver_str, event) for submitted requests.
+    Returns list of (version, ver_str, metadata_url, event) for submitted
+    requests; the sidecar URL is what the await reads the metadata back by,
+    since sibling wheels of one version hold their own texts.
     """
     items: list[tuple[str, str, str, tuple[str, str] | None]] = []
-    version_map: list[tuple[Version, str]] = []
+    version_map: list[tuple[Version, str, str]] = []
     for v in versions:
         if (package, v) in provider.deps_cache or v not in wheel_by_version_map:
             continue
@@ -664,36 +666,38 @@ def prefetch_batch(
             items.append(
                 (package, wheel.version, wheel.metadata_url, wheel.metadata_hash)
             )
-            version_map.append((v, wheel.version))
+            version_map.append((v, wheel.version, wheel.metadata_url))
 
     if not items:
         return []
 
     raw = provider.coordinator.request_metadata_batch(items)
     submitted = []
-    for (_pkg, _ver, ev), (version, ver_str) in zip(raw, version_map, strict=True):
-        submitted.append((version, ver_str, ev))
+    for (_pkg, _ver, ev), (version, ver_str, metadata_url) in zip(
+        raw, version_map, strict=True
+    ):
+        submitted.append((version, ver_str, metadata_url, ev))
     return submitted
 
 
 def await_metadata_batch(
     provider: Provider,
     package: str,
-    submitted: list[tuple[Version, str, threading.Event]],
+    submitted: list[tuple[Version, str, str, threading.Event]],
 ) -> None:
     """Wait for all submitted metadata to arrive, then parse into cache."""
-    for version, ver_str, event in submitted:
+    for version, ver_str, metadata_url, event in submitted:
         cache_key = (package, version)
         if cache_key in provider.deps_cache:
             continue
         event.wait()
         integrity_error = provider.coordinator.index.get_metadata_error(
-            package, ver_str
+            package, ver_str, metadata_url
         )
         if integrity_error is not None:
             raise integrity_error
         text, from_sdist = provider.coordinator.index.get_metadata_with_origin(
-            package, ver_str
+            package, ver_str, metadata_url
         )
         if text is None:
             # No PEP 658 text arrived: leave the version un-cached so
@@ -701,9 +705,10 @@ def await_metadata_batch(
             # refuses it) rather than pinning it as dependency-free.
             continue
         if from_sdist:
-            # The shared slot holds sdist PKG-INFO from an earlier
-            # fallback; caching it here would skip the PEP 643 gate
-            # that get_dependencies applies on the from_sdist path.
+            # The wheel has no sidecar of its own and the version-level slot
+            # holds sdist PKG-INFO from an earlier fallback; caching it here
+            # would skip the PEP 643 gate that get_dependencies applies on
+            # the from_sdist path.
             continue
         try:
             provider.parse_and_cache_metadata(cache_key, text)

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -61,9 +61,9 @@ def resolve_metadata(
     ver_str = str(version)
     index = provider.coordinator.index
 
-    # Sibling wheels of one version can declare different dependencies, so
-    # every read is keyed by the artifact this target would install.  ``dist``
-    # is picked from the target's own tag-filtered listing.
+    # Sibling wheels of one version can declare different dependencies, so the
+    # read is keyed by the artifact this target would install.  ``versions`` is
+    # the target's own tag-filtered listing, so the pick is per-target.
     dist = pick_dist_for_metadata(versions, version)
     metadata_url = dist.metadata_url if isinstance(dist, WheelFile) else None
 

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -59,16 +59,18 @@ def resolve_metadata(
 
     _, _, normalized = provider.split_and_normalize(package)
     ver_str = str(version)
+    index = provider.coordinator.index
 
-    # Wheel METADATA and sdist PKG-INFO share the slot; the origin of the
-    # last write comes back with the text it wrote.
-    text, from_sdist = provider.coordinator.index.get_metadata_with_origin(
-        normalized, ver_str
-    )
+    # Sibling wheels of one version can declare different dependencies, so
+    # every read is keyed by the artifact this target would install.  ``dist``
+    # is picked from the target's own tag-filtered listing.
+    dist = pick_dist_for_metadata(versions, version)
+    metadata_url = dist.metadata_url if isinstance(dist, WheelFile) else None
+
+    text, from_sdist = index.get_metadata_with_origin(normalized, ver_str, metadata_url)
     if text is not None:
         return (text, from_sdist)
 
-    dist = pick_dist_for_metadata(versions, version)
     if dist is None:
         msg = f"Version {version} of {package} not found in listing"
         raise MetadataError(msg)
@@ -79,13 +81,13 @@ def resolve_metadata(
             normalized, ver_str, dist.metadata_url, dist.metadata_hash
         )
         event.wait()
-        integrity_error = provider.coordinator.index.get_metadata_error(
-            normalized, ver_str
+        integrity_error = index.get_metadata_error(
+            normalized, ver_str, dist.metadata_url
         )
         if integrity_error is not None:
             raise integrity_error
-        metadata_text, from_sdist = provider.coordinator.index.get_metadata_with_origin(
-            normalized, ver_str
+        metadata_text, from_sdist = index.get_metadata_with_origin(
+            normalized, ver_str, dist.metadata_url
         )
     elif isinstance(dist, WheelFile) and dist.local_path is not None:
         try:
@@ -315,9 +317,10 @@ def fetch_sdist_metadata(
 ) -> tuple[str | None, bool]:
     """Block until the coordinator returns sdist PKG-INFO text.
 
-    Returns ``(metadata_text, from_sdist)``: a wheel's PEP 658 sidecar can
-    land on the shared slot while the sdist fetch is in flight, so the text
-    read back is not necessarily the sdist's.
+    Returns ``(metadata_text, from_sdist)``: the origin comes back with the
+    text, so text that landed in the version-level slot from somewhere other
+    than the sdist is not put through the :pep:`643` gate as if it were the
+    sdist's own PKG-INFO.
 
     The archive is verified against ``sdist.hashes`` before its PKG-INFO is
     read. A hash mismatch is recorded as an integrity error and re-raised here.
@@ -426,8 +429,8 @@ def parse_and_cache_metadata(
     :class:`~nab_python.fetch.InMemoryIndex` so that universal-mode
     resolves only run :func:`parse_metadata` once per
     ``(package, version)`` regardless of how many tuples ask for it.  The
-    cache is keyed on ``metadata_text`` as well, so a tuple holding the
-    other artifact's text out of the shared slot parses it itself.
+    cache is keyed on ``metadata_text`` as well, so a tuple holding another
+    artifact's text for that version parses it itself.
     Per-tuple classification (marker evaluation, extras admission)
     still runs locally in :func:`cache_deps_from_metadata`.  The
     sdist-dynamic-deps reconciliation in

--- a/nab-python/src/nab_python/_testing/coordinator_fake.py
+++ b/nab-python/src/nab_python/_testing/coordinator_fake.py
@@ -60,11 +60,14 @@ def _make_metadata_resolver(
     *,
     metadata_text: str | None,
     metadata_by_version: Mapping[str, str | None] | None,
+    metadata_by_url: Mapping[str, str | None] | None,
     auto_metadata: bool,
-) -> Callable[[str, str], str | None]:
-    """Return a callable that picks metadata text for ``(pkg, version)``."""
+) -> Callable[[str, str, str], str | None]:
+    """Return a callable that picks metadata text for one sidecar."""
 
-    def _resolve(pkg: str, ver: str) -> str | None:
+    def _resolve(pkg: str, ver: str, url: str) -> str | None:
+        if metadata_by_url is not None:
+            return metadata_by_url.get(url)
         if metadata_by_version is not None:
             return metadata_by_version.get(ver)
         if metadata_text is not None:
@@ -79,7 +82,7 @@ def _make_metadata_resolver(
 def _wire_metadata_side_effects(
     coordinator: MagicMock,
     index: InMemoryIndex,
-    resolve_metadata: Callable[[str, str], str | None],
+    resolve_metadata: Callable[[str, str, str], str | None],
 ) -> None:
     """Attach ``request_listing``/``request_metadata``/batch side effects."""
 
@@ -87,21 +90,21 @@ def _wire_metadata_side_effects(
         return _done_event()
 
     def _request_metadata(
-        pkg: str, ver: str, _url: str, _hash: tuple[str, str] | None = None
+        pkg: str, ver: str, url: str, _hash: tuple[str, str] | None = None
     ) -> threading.Event:
-        text = resolve_metadata(pkg, ver)
+        text = resolve_metadata(pkg, ver, url)
         if text is not None:
-            index.store_metadata(pkg, ver, text)
+            index.store_metadata(pkg, ver, text, url)
         return _done_event()
 
     def _request_metadata_batch(
         items: list[tuple[str, str, str, tuple[str, str] | None]],
     ) -> list[tuple[str, str, threading.Event]]:
         results: list[tuple[str, str, threading.Event]] = []
-        for pkg, ver, _url, _hash in items:
-            text = resolve_metadata(pkg, ver)
+        for pkg, ver, url, _hash in items:
+            text = resolve_metadata(pkg, ver, url)
             if text is not None:
-                index.store_metadata(pkg, ver, text)
+                index.store_metadata(pkg, ver, text, url)
             results.append((pkg, ver, _done_event()))
         return results
 
@@ -136,13 +139,14 @@ def _wire_sdist_side_effects(
     coordinator.request_sdist.side_effect = _request_sdist
 
 
-def make_coordinator(
+def make_coordinator(  # noqa: PLR0913 - one keyword per index slot a test pre-loads
     wheels: Sequence[WheelFile | SdistFile] | None = None,
     *,
     package: str = "pkg",
     listings: Mapping[str, Sequence[WheelFile | SdistFile]] | None = None,
     metadata_text: str | None = None,
     metadata_by_version: Mapping[str, str | None] | None = None,
+    metadata_by_url: Mapping[str, str | None] | None = None,
     auto_metadata: bool = False,
     sdist_pkg_info: str | None = None,
     sdist_pyproject_toml: str | None = None,
@@ -161,8 +165,11 @@ def make_coordinator(
 
     * ``request_listing`` always returns a set event.
     * ``request_metadata`` and ``request_metadata_batch`` write
-      ``metadata_text`` (or the entry from ``metadata_by_version``, or
-      auto-generated minimal METADATA when ``auto_metadata`` is true).
+      ``metadata_text`` (or the entry from ``metadata_by_url``, or from
+      ``metadata_by_version``, or auto-generated minimal METADATA when
+      ``auto_metadata`` is true) under the requested sidecar URL, as the
+      fetcher does.  ``metadata_by_url`` is how sibling wheels of one
+      version are given different dependencies.
     * ``request_sdist`` writes ``sdist_pkg_info`` and, if not ``None``,
       ``sdist_pyproject_toml``.
 
@@ -183,6 +190,7 @@ def make_coordinator(
     resolve_metadata = _make_metadata_resolver(
         metadata_text=metadata_text,
         metadata_by_version=metadata_by_version,
+        metadata_by_url=metadata_by_url,
         auto_metadata=auto_metadata,
     )
     _wire_metadata_side_effects(coordinator, index, resolve_metadata)

--- a/nab-python/src/nab_python/_testing/coordinator_fake.py
+++ b/nab-python/src/nab_python/_testing/coordinator_fake.py
@@ -89,12 +89,18 @@ def _wire_metadata_side_effects(
     def _request_listing(_pkg: str) -> threading.Event:
         return _done_event()
 
-    def _request_metadata(
-        pkg: str, ver: str, url: str, _hash: tuple[str, str] | None = None
-    ) -> threading.Event:
+    def _fetch_metadata(pkg: str, ver: str, url: str) -> None:
+        # The fetcher skips a sidecar the index already answers for.
+        if index.has_metadata(pkg, ver, url):
+            return
         text = resolve_metadata(pkg, ver, url)
         if text is not None:
             index.store_metadata(pkg, ver, text, url)
+
+    def _request_metadata(
+        pkg: str, ver: str, url: str, _hash: tuple[str, str] | None = None
+    ) -> threading.Event:
+        _fetch_metadata(pkg, ver, url)
         return _done_event()
 
     def _request_metadata_batch(
@@ -102,9 +108,7 @@ def _wire_metadata_side_effects(
     ) -> list[tuple[str, str, threading.Event]]:
         results: list[tuple[str, str, threading.Event]] = []
         for pkg, ver, url, _hash in items:
-            text = resolve_metadata(pkg, ver, url)
-            if text is not None:
-                index.store_metadata(pkg, ver, text, url)
+            _fetch_metadata(pkg, ver, url)
             results.append((pkg, ver, _done_event()))
         return results
 

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -137,15 +137,16 @@ class InMemoryIndex:
         self._listings: dict[str, list[WheelFile | SdistFile]] = {}
         self._listing_errors: dict[str, BaseException] = {}
         self._listing_indexes: dict[str, str] = {}
-        self._metadata: dict[tuple[str, str], str | None] = {}
-        self._metadata_errors: dict[tuple[str, str], BaseException] = {}
-        # The sidecar URL whose bytes fill each ``_metadata`` slot, or None
-        # when the slot stands for the version rather than for one artifact
-        # (sdist PKG-INFO, an injected override).
-        self._metadata_source: dict[tuple[str, str], str | None] = {}
-        # Keys whose ``_metadata`` slot was last written from an sdist
-        # PKG-INFO rather than a wheel METADATA; readers need the
-        # origin because only sdist deps go through the PEP 643 gate.
+        # Metadata text is keyed by the artifact it came from: the sidecar URL
+        # for a wheel's METADATA, or None for text that stands for the version
+        # itself (sdist PKG-INFO, an injected override).  Two wheels of one
+        # version can declare different dependencies, so a reader asks for the
+        # artifact its own target would install.
+        self._metadata: dict[tuple[str, str, str | None], str | None] = {}
+        self._metadata_errors: dict[tuple[str, str, str | None], BaseException] = {}
+        # Versions whose version-level slot was written from an sdist PKG-INFO;
+        # readers need the origin because only sdist deps go through the
+        # PEP 643 gate.
         self._metadata_from_sdist: set[tuple[str, str]] = set()
         self._sdist_pyproject: dict[tuple[str, str], str | None] = {}
         self._sdist_archives: dict[tuple[str, str], bytes | None] = {}
@@ -154,8 +155,9 @@ class InMemoryIndex:
 
         # Parsed metadata is a pure function of the underlying text, so it
         # is shared across the per-target providers of one resolve.  Entries
-        # are ``(source_text, parsed)``: a wheel and an sdist share one
-        # ``_metadata`` slot, so a parse only answers for the text it parsed.
+        # are ``(source_text, parsed)``: one version can have several texts
+        # (sibling wheels, an sdist), so a parse only answers for the text it
+        # parsed.
         self._parsed_metadata: dict[tuple[str, str], tuple[str, Any]] = {}
 
         # Post-reconciliation sdist metadata: the result after
@@ -218,73 +220,81 @@ class InMemoryIndex:
         with self._lock:
             return self._listing_indexes.get(package)
 
-    def get_metadata(self, package: str, version: str) -> str | None:
+    def _read_metadata(
+        self, package: str, version: str, metadata_url: str | None
+    ) -> tuple[str | None, bool]:
+        """Return the text answering for ``metadata_url`` and its origin.
+
+        Caller holds the lock.  The artifact's own slot wins; the
+        version-level slot (sdist PKG-INFO, an injected override) answers when
+        that artifact has nothing, which is how a wheel with no sidecar, or
+        one whose sidecar fetch came back empty, reaches the sdist's text.
+        """
+        if metadata_url is not None:
+            text = self._metadata.get((package, version, metadata_url))
+            if text is not None:
+                return (text, False)
+        version_level = self._metadata.get((package, version, None))
+        return (version_level, (package, version) in self._metadata_from_sdist)
+
+    def get_metadata(
+        self, package: str, version: str, metadata_url: str | None = None
+    ) -> str | None:
         """Return cached metadata text, or ``None`` if not yet stored."""
         with self._lock:
-            key = (package, version)
-            if key in self._metadata:
-                return self._metadata[key]
-            return None
+            return self._read_metadata(package, version, metadata_url)[0]
 
-    def has_metadata(self, package: str, version: str) -> bool:
-        """Return ``True`` once a metadata fetch has resolved (any value)."""
-        with self._lock:
-            return (package, version) in self._metadata
+    def has_metadata(
+        self, package: str, version: str, metadata_url: str | None = None
+    ) -> bool:
+        """Return ``True`` once a fetch answering for ``metadata_url`` resolved.
 
-    def has_metadata_for(self, package: str, version: str, metadata_url: str) -> bool:
-        """Return ``True`` when the slot already answers for ``metadata_url``.
-
-        A slot filled from a sidecar answers only for that sidecar; one with
-        no artifact behind it (sdist PKG-INFO, an injected override) stands
-        for the version itself and answers for any.
+        Any value counts, including the ``None`` of a sidecar that was not
+        served.  A slot filled from a sidecar answers only for that sidecar;
+        the version-level slot answers for any artifact.
         """
         with self._lock:
-            slot = (package, version)
-            if slot not in self._metadata:
-                return False
-            source = self._metadata_source[slot]
-            return source is None or source == metadata_url
+            if (
+                metadata_url is not None
+                and (package, version, metadata_url) in self._metadata
+            ):
+                return True
+            return (package, version, None) in self._metadata
 
     def get_metadata_with_origin(
-        self, package: str, version: str
+        self, package: str, version: str, metadata_url: str | None = None
     ) -> tuple[str | None, bool]:
-        """Return the metadata text and whether it came from an sdist.
+        """Return the metadata text for ``metadata_url`` and its sdist origin.
 
-        Wheel METADATA and sdist PKG-INFO share the slot, so a write landing
-        between two separate lookups can pair one artifact's text with the
-        other's origin.  Only sdist text goes through the :pep:`643`
-        dynamic-deps gate, so the two are read under one lock.
+        A wheel's METADATA and an sdist's PKG-INFO can both stand for one
+        version, and only sdist text goes through the :pep:`643` dynamic-deps
+        gate, so text and origin are read together under one lock.
         """
         with self._lock:
-            slot = (package, version)
-            return self._metadata.get(slot), slot in self._metadata_from_sdist
+            return self._read_metadata(package, version, metadata_url)
 
     def _write_metadata_slot(
         self,
-        slot: tuple[str, str],
+        slot: tuple[str, str, str | None],
         data: str | None,
         *,
-        source: str | None,
         from_sdist: bool,
     ) -> None:
-        """Write the shared metadata slot. Caller holds the lock.
+        """Write one metadata slot. Caller holds the lock.
 
-        ``source`` is the sidecar URL the text came from, or ``None`` when
-        the slot stands for the version rather than for one artifact.
-
-        Reconciled sdist metadata is derived from the text in the slot, so
-        replacing the text drops it.  The parsed cache carries the text it
+        Reconciled sdist metadata is derived from the version-level text, so
+        replacing that text drops it.  The parsed cache carries the text it
         parsed and needs no eviction.
         """
-        if self._metadata.get(slot) != data:
-            self._resolved_sdist_metadata.pop(slot, None)
-
+        package, version, metadata_url = slot
+        if metadata_url is None:
+            if self._metadata.get(slot) != data:
+                self._resolved_sdist_metadata.pop((package, version), None)
+            if from_sdist:
+                self._metadata_from_sdist.add((package, version))
+            else:
+                self._metadata_from_sdist.discard((package, version))
         self._metadata[slot] = data
-        self._metadata_source[slot] = source
-        if from_sdist:
-            self._metadata_from_sdist.add(slot)
-        else:
-            self._metadata_from_sdist.discard(slot)
 
     def store_metadata(
         self,
@@ -295,31 +305,20 @@ class InMemoryIndex:
     ) -> None:
         """Cache metadata text (or ``None`` for a failed fetch).
 
-        ``metadata_url`` is the sidecar the text came from; ``None`` marks
-        the slot as standing for the version rather than for one artifact.
+        ``metadata_url`` is the sidecar the text came from; ``None`` stores the
+        text as standing for the version rather than for one artifact.
 
         A ``data`` of ``None`` means no PEP 658 sidecar arrived and readers
-        fall back to the sdist, so it never overwrites sdist PKG-INFO
-        already in the slot.
+        fall back to the sdist.  It lands in the sidecar's own slot, so it
+        cannot erase sdist PKG-INFO the version-level slot already holds.
         """
         key = _metadata_key(package, version, metadata_url)
-        slot = (package, version)
+        slot = (package, version, metadata_url)
         with self._lock:
-            keep_sdist_text = (
-                data is None
-                and slot in self._metadata_from_sdist
-                and self._metadata[slot] is not None
-            )
-            if not keep_sdist_text:
-                self._write_metadata_slot(
-                    slot, data, source=metadata_url, from_sdist=False
-                )
-
-            # the waiter gets whatever the slot holds, which may be kept text
-            result = self._metadata[slot]
+            self._write_metadata_slot(slot, data, from_sdist=False)
             pending = self._pending.get(key)
         if pending is not None:
-            pending.result = result
+            pending.result = data
             pending.event.set()
 
     def store_metadata_error(
@@ -337,32 +336,43 @@ class InMemoryIndex:
         """
         key = _metadata_key(package, version, metadata_url)
         with self._lock:
-            self._metadata_errors[(package, version)] = error
+            self._metadata_errors[(package, version, metadata_url)] = error
             pending = self._pending.get(key)
         if pending is not None:
             pending.event.set()
 
-    def get_metadata_error(self, package: str, version: str) -> BaseException | None:
-        """Return a recorded metadata integrity error, or ``None``."""
+    def get_metadata_error(
+        self, package: str, version: str, metadata_url: str | None = None
+    ) -> BaseException | None:
+        """Return a recorded metadata integrity error, or ``None``.
+
+        The artifact's own error wins; a version-level error (a tampered
+        sdist archive) stands for the version and answers for any artifact,
+        since no dist of that version can be trusted once one was tampered
+        with.
+        """
         with self._lock:
-            return self._metadata_errors.get((package, version))
+            if metadata_url is not None:
+                error = self._metadata_errors.get((package, version, metadata_url))
+                if error is not None:
+                    return error
+            return self._metadata_errors.get((package, version, None))
 
     def store_sdist_metadata(
         self, package: str, version: str, data: str | None
     ) -> None:
-        """Store sdist-derived PKG-INFO under the same metadata key.
+        """Store sdist-derived PKG-INFO in the version-level metadata slot.
 
-        Wheel and sdist results land in the same ``_metadata`` slot
-        because PKG-INFO is core-metadata-equivalent. The pending
-        keys differ so a sdist request can run in parallel with (or
-        after) a failed wheel metadata request.
-        :meth:`metadata_from_sdist` reports which kind the slot holds.
+        PKG-INFO is core-metadata-equivalent, so it stands for the version
+        rather than for one artifact and answers for a wheel with no sidecar
+        of its own.  The pending key differs from a wheel's so an sdist
+        request can run in parallel with (or after) a failed wheel metadata
+        request.  :meth:`metadata_from_sdist` reports which kind the
+        version-level slot holds.
         """
         key = f"sdist:{package}:{version}"
         with self._lock:
-            self._write_metadata_slot(
-                (package, version), data, source=None, from_sdist=True
-            )
+            self._write_metadata_slot((package, version, None), data, from_sdist=True)
             pending = self._pending.get(key)
         if pending is not None:
             pending.result = data
@@ -379,13 +389,13 @@ class InMemoryIndex:
         """
         key = f"sdist:{package}:{version}"
         with self._lock:
-            self._metadata_errors[(package, version)] = error
+            self._metadata_errors[(package, version, None)] = error
             pending = self._pending.get(key)
         if pending is not None:
             pending.event.set()
 
     def metadata_from_sdist(self, package: str, version: str) -> bool:
-        """Return ``True`` when the metadata slot was last written from an sdist.
+        """Return ``True`` when the version-level slot was written from an sdist.
 
         The slot itself cannot distinguish wheel METADATA from sdist
         PKG-INFO; readers that apply the :pep:`643` dynamic-deps gate
@@ -698,7 +708,7 @@ class FetchCoordinator:
     ) -> threading.Event:
         """Request the sidecar at ``url`` as the metadata for ``(package, version)``."""
         self._check_alive()
-        if self.index.has_metadata_for(package, version, url):
+        if self.index.has_metadata(package, version, url):
             done = threading.Event()
             done.set()
             return done
@@ -816,7 +826,7 @@ class FetchCoordinator:
         results: list[tuple[str, str, threading.Event]] = []
         batch: list[FetchRequest] = []
         for package, version, url, metadata_hash in items:
-            if self.index.has_metadata_for(package, version, url):
+            if self.index.has_metadata(package, version, url):
                 done = threading.Event()
                 done.set()
                 results.append((package, version, done))

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -225,15 +225,21 @@ class InMemoryIndex:
     ) -> tuple[str | None, bool]:
         """Return the text answering for ``metadata_url`` and its origin.
 
-        Caller holds the lock.  The artifact's own slot wins; the
-        version-level slot (sdist PKG-INFO, an injected override) answers when
-        that artifact has nothing, which is how a wheel with no sidecar, or
-        one whose sidecar fetch came back empty, reaches the sdist's text.
+        Caller holds the lock.  The artifact's own slot wins, then the
+        version-level one.  An sdist's PKG-INFO answers for an artifact with
+        no text of its own, but not for a sidecar nobody has fetched yet:
+        lending it there would give a wheel that declares its own dependencies
+        the sdist's.  An injected override has no artifact behind it and
+        answers for any.  A wheel with no sidecar asks with ``None``.
         """
         if metadata_url is not None:
-            text = self._metadata.get((package, version, metadata_url))
-            if text is not None:
-                return (text, False)
+            slot = (package, version, metadata_url)
+            if slot in self._metadata:
+                text = self._metadata[slot]
+                if text is not None:
+                    return (text, False)
+            elif (package, version) in self._metadata_from_sdist:
+                return (None, False)
         version_level = self._metadata.get((package, version, None))
         return (version_level, (package, version) in self._metadata_from_sdist)
 
@@ -250,8 +256,8 @@ class InMemoryIndex:
         """Return ``True`` once a fetch answering for ``metadata_url`` resolved.
 
         Any value counts, including the ``None`` of a sidecar that was not
-        served.  A slot filled from a sidecar answers only for that sidecar;
-        the version-level slot answers for any artifact.
+        served.  It tracks :meth:`_read_metadata`, so a fetch skipped on the
+        strength of it leaves the reader the same text a fetch would have.
         """
         with self._lock:
             if (
@@ -259,7 +265,10 @@ class InMemoryIndex:
                 and (package, version, metadata_url) in self._metadata
             ):
                 return True
-            return (package, version, None) in self._metadata
+            return (package, version, None) in self._metadata and (
+                metadata_url is None
+                or (package, version) not in self._metadata_from_sdist
+            )
 
     def get_metadata_with_origin(
         self, package: str, version: str, metadata_url: str | None = None
@@ -347,9 +356,8 @@ class InMemoryIndex:
         """Return a recorded metadata integrity error, or ``None``.
 
         The artifact's own error wins; a version-level error (a tampered
-        sdist archive) stands for the version and answers for any artifact,
-        since no dist of that version can be trusted once one was tampered
-        with.
+        sdist archive) answers for any artifact, as the version-level text
+        does.
         """
         with self._lock:
             if metadata_url is not None:

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -1353,7 +1353,7 @@ class Provider:
 
         starts_iter = iter(range(0, len(remaining), self.PREFETCH_BATCH))
         in_flight: deque[
-            tuple[list[Version], list[tuple[Version, str, threading.Event]]]
+            tuple[list[Version], list[tuple[Version, str, str, threading.Event]]]
         ] = deque()
         for _ in range(self.PREFETCH_DEPTH):
             start = next(starts_iter, None)
@@ -1617,14 +1617,14 @@ class Provider:
         package: str,
         versions: list[Version],
         wheel_by_version: dict[Version, DistFile],
-    ) -> list[tuple[Version, str, threading.Event]]:
+    ) -> list[tuple[Version, str, str, threading.Event]]:
         """See :func:`nab_python._provider.listing.prefetch_batch`."""
         return _listing.prefetch_batch(self, package, versions, wheel_by_version)
 
     def _await_metadata_batch(
         self,
         package: str,
-        submitted: list[tuple[Version, str, threading.Event]],
+        submitted: list[tuple[Version, str, str, threading.Event]],
     ) -> None:
         """See :func:`nab_python._provider.listing.await_metadata_batch`."""
         _listing.await_metadata_batch(self, package, submitted)

--- a/nab-python/tests/property_python/test_fetch_coordinator.py
+++ b/nab-python/tests/property_python/test_fetch_coordinator.py
@@ -231,18 +231,18 @@ def test_every_request_gets_exactly_one_correct_reply(
         sdist_keys = {k for k, _ in requested if k[0] == "sdist"}
         for key in meta_keys | sdist_keys:
             _, pkg, ver = key
-            # Metadata is keyed by the artifact it came from, so a reader names
-            # the sidecar it asked for; an sdist's PKG-INFO answers for any.
-            sidecar = _metadata_url(pkg, ver)
+            # Metadata is keyed by the artifact it came from, so read back the
+            # slot the request was for: a metadata request asks about one
+            # sidecar, an sdist request about the version.  The listing
+            # prefetch writes that same sidecar slot from the same plan entry,
+            # so it can only produce text the sidecar request already allows.
+            asked_for_sidecar = ("metadata", pkg, ver) in meta_keys
+            sidecar = _metadata_url(pkg, ver) if asked_for_sidecar else None
             assert index.has_metadata(pkg, ver, sidecar), f"no metadata slot for {key}"
             value = index.get_metadata(pkg, ver, sidecar)
             allowed: set[str | None] = set()
             base_ver = ver.split("#", 1)[0]
-            if ("metadata", pkg, ver) in meta_keys:
-                mode, _ = client.plan.get(("metadata", pkg, ver), ("ok", 0.0))
-                allowed.add(f"META:{pkg}:{ver}" if mode == "ok" else None)
-            # The listing prefetch can also have written META for this slot.
-            if has_meta.get(pkg) and "#" not in ver:
+            if asked_for_sidecar:
                 mode, _ = client.plan.get(("metadata", pkg, ver), ("ok", 0.0))
                 allowed.add(f"META:{pkg}:{ver}" if mode == "ok" else None)
             if ("sdist", pkg, ver) in sdist_keys:

--- a/nab-python/tests/property_python/test_fetch_coordinator.py
+++ b/nab-python/tests/property_python/test_fetch_coordinator.py
@@ -231,8 +231,11 @@ def test_every_request_gets_exactly_one_correct_reply(
         sdist_keys = {k for k, _ in requested if k[0] == "sdist"}
         for key in meta_keys | sdist_keys:
             _, pkg, ver = key
-            assert index.has_metadata(pkg, ver), f"no metadata slot for {key}"
-            value = index.get_metadata(pkg, ver)
+            # Metadata is keyed by the artifact it came from, so a reader names
+            # the sidecar it asked for; an sdist's PKG-INFO answers for any.
+            sidecar = _metadata_url(pkg, ver)
+            assert index.has_metadata(pkg, ver, sidecar), f"no metadata slot for {key}"
+            value = index.get_metadata(pkg, ver, sidecar)
             allowed: set[str | None] = set()
             base_ver = ver.split("#", 1)[0]
             if ("metadata", pkg, ver) in meta_keys:

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -135,16 +135,28 @@ class TestInMemoryIndex:
         assert idx.get_metadata("foo", "1.0", win_url) == "win"
         assert idx.get_metadata("foo", "1.0") is None
 
-    def test_version_level_slot_answers_for_any_artifact(self) -> None:
+    def test_an_injected_override_answers_for_any_artifact(self) -> None:
         idx = InMemoryIndex()
-        idx.store_sdist_metadata("foo", "1.0", "PKG-INFO\n")
+        idx.store_metadata("foo", "1.0", "override\n")
         assert idx.has_metadata("foo", "1.0", "https://f/win.whl.metadata")
         assert idx.get_metadata_with_origin(
             "foo", "1.0", "https://f/win.whl.metadata"
-        ) == (
-            "PKG-INFO\n",
-            True,
-        )
+        ) == ("override\n", False)
+
+    def test_sdist_pkg_info_does_not_answer_for_an_unfetched_sidecar(self) -> None:
+        """A wheel that declares its own dependencies must fetch them.
+
+        The sdist is a fallback for an artifact with no text of its own, so
+        lending its PKG-INFO to a sidecar nobody has fetched yet would give
+        the wheel the sdist's dependencies instead of the wheel's.
+        """
+        idx = InMemoryIndex()
+        idx.store_sdist_metadata("foo", "1.0", "PKG-INFO\n")
+        assert not idx.has_metadata("foo", "1.0", "https://f/win.whl.metadata")
+        assert idx.get_metadata_with_origin(
+            "foo", "1.0", "https://f/win.whl.metadata"
+        ) == (None, False)
+        assert idx.get_metadata_with_origin("foo", "1.0") == ("PKG-INFO\n", True)
 
     def test_a_sidecar_that_was_not_served_falls_back_to_the_sdist(self) -> None:
         """An empty sidecar slot does not shadow the version-level text."""
@@ -230,8 +242,11 @@ class TestInMemoryIndex:
         assert pending.event.is_set()
         assert idx.get_metadata("foo", "1.0") == "PKG-INFO\n"
         assert idx.metadata_from_sdist("foo", "1.0")
-        # The kept text stands for the version, so it answers for any sidecar.
-        assert idx.has_metadata("foo", "1.0", "https://f/other.md")
+        # The sidecar that resolved to nothing reads the kept text.
+        assert idx.get_metadata_with_origin("foo", "1.0", "https://f/a.md") == (
+            "PKG-INFO\n",
+            True,
+        )
 
     def test_metadata_none_after_sdist_none_stays_none(self) -> None:
         idx = InMemoryIndex()

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -117,19 +117,63 @@ class TestInMemoryIndex:
         assert pending.result == "text"
 
     def test_sidecar_slot_answers_only_for_its_own_artifact(self) -> None:
+        linux_url = "https://f/linux.whl.metadata"
+        win_url = "https://f/win.whl.metadata"
         idx = InMemoryIndex()
-        idx.store_metadata("foo", "1.0", "linux", "https://f/linux.whl.metadata")
-        assert idx.has_metadata_for("foo", "1.0", "https://f/linux.whl.metadata")
-        assert not idx.has_metadata_for("foo", "1.0", "https://f/win.whl.metadata")
+        idx.store_metadata("foo", "1.0", "linux", linux_url)
+        assert idx.has_metadata("foo", "1.0", linux_url)
+        assert not idx.has_metadata("foo", "1.0", win_url)
+
+    def test_sibling_sidecars_keep_their_own_text(self) -> None:
+        """Two wheels of one version can declare different dependencies."""
+        linux_url = "https://f/linux.whl.metadata"
+        win_url = "https://f/win.whl.metadata"
+        idx = InMemoryIndex()
+        idx.store_metadata("foo", "1.0", "linux", linux_url)
+        idx.store_metadata("foo", "1.0", "win", win_url)
+        assert idx.get_metadata("foo", "1.0", linux_url) == "linux"
+        assert idx.get_metadata("foo", "1.0", win_url) == "win"
+        assert idx.get_metadata("foo", "1.0") is None
 
     def test_version_level_slot_answers_for_any_artifact(self) -> None:
         idx = InMemoryIndex()
         idx.store_sdist_metadata("foo", "1.0", "PKG-INFO\n")
-        assert idx.has_metadata_for("foo", "1.0", "https://f/win.whl.metadata")
+        assert idx.has_metadata("foo", "1.0", "https://f/win.whl.metadata")
+        assert idx.get_metadata_with_origin(
+            "foo", "1.0", "https://f/win.whl.metadata"
+        ) == (
+            "PKG-INFO\n",
+            True,
+        )
 
-    def test_has_metadata_for_is_false_on_an_empty_slot(self) -> None:
+    def test_a_sidecar_that_was_not_served_falls_back_to_the_sdist(self) -> None:
+        """An empty sidecar slot does not shadow the version-level text."""
+        url = "https://f/a.whl.metadata"
         idx = InMemoryIndex()
-        assert not idx.has_metadata_for("foo", "1.0", "https://f/a.whl.metadata")
+        idx.store_metadata("foo", "1.0", None, url)
+        idx.store_sdist_metadata("foo", "1.0", "PKG-INFO\n")
+        assert idx.has_metadata("foo", "1.0", url)
+        assert idx.get_metadata_with_origin("foo", "1.0", url) == ("PKG-INFO\n", True)
+
+    def test_has_metadata_is_false_on_an_empty_slot(self) -> None:
+        idx = InMemoryIndex()
+        assert not idx.has_metadata("foo", "1.0", "https://f/a.whl.metadata")
+
+    def test_a_sidecars_integrity_error_answers_only_for_that_sidecar(self) -> None:
+        linux_url = "https://f/linux.whl.metadata"
+        win_url = "https://f/win.whl.metadata"
+        idx = InMemoryIndex()
+        error = MetadataHashMismatchError("metadata sha256 mismatch")
+        idx.store_metadata_error("foo", "1.0", error, linux_url)
+        assert idx.get_metadata_error("foo", "1.0", linux_url) is error
+        assert idx.get_metadata_error("foo", "1.0", win_url) is None
+        assert idx.get_metadata_error("foo", "1.0") is None
+
+    def test_a_version_level_integrity_error_answers_for_any_artifact(self) -> None:
+        idx = InMemoryIndex()
+        error = SdistHashMismatchError("boom")
+        idx.store_sdist_metadata_error("foo", "1.0", error)
+        assert idx.get_metadata_error("foo", "1.0", "https://f/a.whl.metadata") is error
 
     def test_get_or_create_existing(self) -> None:
         idx = InMemoryIndex()
@@ -186,8 +230,8 @@ class TestInMemoryIndex:
         assert pending.event.is_set()
         assert idx.get_metadata("foo", "1.0") == "PKG-INFO\n"
         assert idx.metadata_from_sdist("foo", "1.0")
-        # The kept text still stands for the version, not for the sidecar.
-        assert idx.has_metadata_for("foo", "1.0", "https://f/other.md")
+        # The kept text stands for the version, so it answers for any sidecar.
+        assert idx.has_metadata("foo", "1.0", "https://f/other.md")
 
     def test_metadata_none_after_sdist_none_stays_none(self) -> None:
         idx = InMemoryIndex()
@@ -356,7 +400,7 @@ class TestFetchCoordinator:
         with coord:
             event = coord.request_metadata("second", "1.0", "https://f.com/second")
             assert event.wait(timeout=5)
-        assert coord.index.get_metadata("second", "1.0") == "ok"
+        assert coord.index.get_metadata("second", "1.0", "https://f.com/second") == "ok"
 
     @respx.mock
     def test_request_listing(self) -> None:
@@ -405,7 +449,9 @@ class TestFetchCoordinator:
                 "testpkg", "1.0", "https://files.example.com/testpkg-1.0.whl.metadata"
             )
             event.wait(timeout=5)
-            text = coord.index.get_metadata("testpkg", "1.0")
+            text = coord.index.get_metadata(
+                "testpkg", "1.0", "https://files.example.com/testpkg-1.0.whl.metadata"
+            )
             assert text == METADATA_TEXT
 
     @respx.mock
@@ -450,8 +496,14 @@ class TestFetchCoordinator:
             assert len(results) == 2
             for _pkg, _ver, event in results:
                 event.wait(timeout=5)
-            assert coord.index.get_metadata("pkg-a", "1.0") == "meta-a"
-            assert coord.index.get_metadata("pkg-b", "2.0") == "meta-b"
+            a_meta = coord.index.get_metadata(
+                "pkg-a", "1.0", "https://f.com/a.metadata"
+            )
+            b_meta = coord.index.get_metadata(
+                "pkg-b", "2.0", "https://f.com/b.metadata"
+            )
+            assert a_meta == "meta-a"
+            assert b_meta == "meta-b"
 
     @respx.mock
     def test_batch_skips_cached(self) -> None:
@@ -504,12 +556,13 @@ class TestFetchCoordinator:
             # Give them a moment to complete
             import time
 
+            sidecar = "https://f.com/pkg-3.0-py3-none-any.whl.metadata"
             deadline = time.monotonic() + 5
             while time.monotonic() < deadline:
-                if coord.index.has_metadata("pkg", "3.0"):
+                if coord.index.has_metadata("pkg", "3.0", sidecar):
                     break
                 time.sleep(0.01)
-            assert coord.index.has_metadata("pkg", "3.0")
+            assert coord.index.has_metadata("pkg", "3.0", sidecar)
 
     @respx.mock
     def test_fetch_error_logged_not_raised(self) -> None:
@@ -625,8 +678,9 @@ class TestFetchCoordinator:
             )
             event.wait(timeout=5)
             assert not coord._crashed
-            assert coord.index.get_metadata("tampered", "1.0") is None
-            error = coord.index.get_metadata_error("tampered", "1.0")
+            sidecar = "https://files.example.com/tampered-1.0.whl.metadata"
+            assert coord.index.get_metadata("tampered", "1.0", sidecar) is None
+            error = coord.index.get_metadata_error("tampered", "1.0", sidecar)
             assert isinstance(error, MetadataHashMismatchError)
 
     def test_crashed_raises(self) -> None:
@@ -650,9 +704,9 @@ class TestFetchCoordinator:
             e1.wait(timeout=5)
             for _, _, ev in results:
                 ev.wait(timeout=5)
-            assert coord.index.get_metadata("a", "1") == "ok"
-            assert coord.index.get_metadata("b", "1") == "ok"
-            assert coord.index.get_metadata("c", "1") == "ok"
+            assert coord.index.get_metadata("a", "1", "https://f.com/a") == "ok"
+            assert coord.index.get_metadata("b", "1", "https://f.com/b") == "ok"
+            assert coord.index.get_metadata("c", "1", "https://f.com/c") == "ok"
 
     def test_shutdown_when_never_started(self) -> None:
         """shutdown() is a no-op when the coordinator was never started."""
@@ -751,10 +805,12 @@ class TestFetchCoordinator:
         assert archive.is_set()
         assert batch[0][2].is_set()
 
-        assert isinstance(coord.index.get_metadata_error("a", "1.0"), RuntimeError)
+        meta_error = coord.index.get_metadata_error("a", "1.0", "https://f.com/a")
+        batch_error = coord.index.get_metadata_error("d", "1.0", "https://f.com/d")
+        assert isinstance(meta_error, RuntimeError)
         assert isinstance(coord.index.get_metadata_error("b", "1.0"), RuntimeError)
         assert isinstance(coord.index.get_sdist_archive_error("c", "1.0"), RuntimeError)
-        assert isinstance(coord.index.get_metadata_error("d", "1.0"), RuntimeError)
+        assert isinstance(batch_error, RuntimeError)
 
     @respx.mock
     def test_drain_queue_empty_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -893,8 +949,8 @@ class TestFetchCoordinator:
         coord._thread = None
         coord._started = False
         assert not coord._crashed
-        assert coord.index.get_metadata("first", "1.0") == "slow"
-        assert coord.index.get_metadata("drain", "1.0") == "slow"
+        assert coord.index.get_metadata("first", "1.0", "https://f.com/first") == "slow"
+        assert coord.index.get_metadata("drain", "1.0", "https://f.com/drain") == "slow"
 
     @respx.mock
     def test_drain_shutdown_replies_to_inflight_requests(self) -> None:
@@ -915,7 +971,7 @@ class TestFetchCoordinator:
         event = coord.request_metadata("pkg", "1.0", "https://f.com/pkg")
         coord.shutdown()
         assert event.wait(timeout=2)
-        assert coord.index.get_metadata("pkg", "1.0") == "slow"
+        assert coord.index.get_metadata("pkg", "1.0", "https://f.com/pkg") == "slow"
 
     @respx.mock
     def test_request_metadata_deduplicates(self) -> None:
@@ -1366,14 +1422,15 @@ class TestFetchCoordinatorCache:
 
         with _coord(cache_dir=tmp_path) as coord:
             coord.request_metadata("foo", "1.0", linux_url, linux_hash).wait(timeout=5)
-            assert coord.index.get_metadata("foo", "1.0") == linux_body.decode()
+            linux_text = coord.index.get_metadata("foo", "1.0", linux_url)
+            assert linux_text == linux_body.decode()
 
         # A later run over the same cache dir, in an environment whose
         # compatible wheel is the win_amd64 one.
         with _coord(cache_dir=tmp_path) as coord:
             coord.request_metadata("foo", "1.0", win_url, win_hash).wait(timeout=5)
-            assert coord.index.get_metadata_error("foo", "1.0") is None
-            assert coord.index.get_metadata("foo", "1.0") == win_body.decode()
+            assert coord.index.get_metadata_error("foo", "1.0", win_url) is None
+            assert coord.index.get_metadata("foo", "1.0", win_url) == win_body.decode()
 
         assert linux_route.call_count == 1
         assert win_route.call_count == 1
@@ -1762,9 +1819,10 @@ class TestSiblingWheelMetadata:
         return linux, win
 
     def _await_metadata(self, coord: FetchCoordinator) -> None:
+        """Wait for the prefetch of the wheel the listing publishes first."""
         deadline = time.monotonic() + 5
         while time.monotonic() < deadline and not coord.index.has_metadata(
-            "foo", "1.0"
+            "foo", "1.0", f"https://f.example/{_SIBLING_LINUX}.metadata"
         ):
             time.sleep(0.01)
 
@@ -1775,9 +1833,10 @@ class TestSiblingWheelMetadata:
         with _coord() as coord:
             coord.request_listing("foo").wait(timeout=5)
             self._await_metadata(coord)
-            assert (
-                coord.index.get_metadata("foo", "1.0") == _SIBLING_LINUX_BODY.decode()
+            text = coord.index.get_metadata(
+                "foo", "1.0", f"https://f.example/{_SIBLING_LINUX}.metadata"
             )
+            assert text == _SIBLING_LINUX_BODY.decode()
         assert linux.call_count == 1
         assert win.call_count == 0
 
@@ -1802,8 +1861,9 @@ class TestSiblingWheelMetadata:
             coord.request_listing("foo").wait(timeout=5)
             self._await_metadata(coord)
             coord.request_metadata("foo", "1.0", win_url, win_hash).wait(timeout=5)
-            assert coord.index.get_metadata_error("foo", "1.0") is None
-            assert coord.index.get_metadata("foo", "1.0") == _SIBLING_WIN_BODY.decode()
+            assert coord.index.get_metadata_error("foo", "1.0", win_url) is None
+            win_text = coord.index.get_metadata("foo", "1.0", win_url)
+            assert win_text == _SIBLING_WIN_BODY.decode()
 
         assert linux.call_count == 1
         assert win.call_count == 1

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -5771,6 +5771,29 @@ class TestAwaitMetadataBatchEdgeCases:
         with pytest.raises(UnsupportedSdistError):
             provider.get_dependencies("pkg", V("1.0"))
 
+    def test_batch_leaves_an_empty_sidecar_on_the_sdists_terms(self) -> None:
+        """A sidecar that served no text reads PKG-INFO, and stays gated.
+
+        The fetcher records a sidecar that served nothing as the ``None`` of
+        its own slot, so the batch read falls back to the sdist's PKG-INFO.
+        Caching that as wheel METADATA would bypass the PEP 643 gate.
+        """
+        wheel = make_wheel("1.0")
+        assert wheel.metadata_url is not None
+        dists = [make_sdist("1.0"), wheel]
+        coordinator = make_coordinator(dists, sdist_pkg_info=PKG_INFO_PRE_PEP643_DEPS)
+        provider = Provider(coordinator, target=_PY312)
+        with pytest.raises(UnsupportedSdistError):
+            provider.get_dependencies("pkg", V("1.0"))
+        coordinator.index.store_metadata("pkg", "1.0", None, wheel.metadata_url)
+
+        version_list = provider.fetch_versions("pkg")
+        wheel_map = provider._wheel_by_version("pkg", version_list)
+        submitted = provider._prefetch_batch("pkg", [V("1.0")], wheel_map)
+        provider._await_metadata_batch("pkg", submitted)
+
+        assert ("pkg", V("1.0")) not in provider.deps_cache
+
 
 class TestIsReady:
     def test_extras_cached_base(self) -> None:

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -5647,6 +5647,11 @@ class TestPickBestCandidateNone:
         coordinator.request_metadata.assert_not_called()
 
 
+# The sidecar of ``make_wheel("1.0")``: the batch path reads the metadata
+# back by the artifact it submitted.
+_SIDECAR_URL = "https://example.com/pkg-1.0-py3-none-any.whl.metadata"
+
+
 class TestAwaitMetadataBatchEdgeCases:
     def test_skips_versions_already_in_deps_cache(self) -> None:
         """Submitted entries already in ``deps_cache`` short-circuit the wait.
@@ -5662,7 +5667,7 @@ class TestAwaitMetadataBatchEdgeCases:
         provider.deps_cache[("foo", V("1.0"))] = {"bar": VersionRange.full()}
         provider._await_metadata_batch(
             "foo",
-            [(V("1.0"), "1.0", _done_event())],
+            [(V("1.0"), "1.0", _SIDECAR_URL, _done_event())],
         )
         assert provider.deps_cache[("foo", V("1.0"))] == {"bar": VersionRange.full()}
 
@@ -5728,13 +5733,16 @@ class TestAwaitMetadataBatchEdgeCases:
         wheels = [make_wheel("1.0")]
         coordinator = make_coordinator(wheels, package="foo")
         coordinator.index.store_metadata_error(
-            "foo", "1.0", MetadataHashMismatchError("metadata sha256 mismatch")
+            "foo",
+            "1.0",
+            MetadataHashMismatchError("metadata sha256 mismatch"),
+            _SIDECAR_URL,
         )
         provider = Provider(coordinator, target=_PY312)
         with pytest.raises(MetadataHashMismatchError):
             provider._await_metadata_batch(
                 "foo",
-                [(V("1.0"), "1.0", _done_event())],
+                [(V("1.0"), "1.0", _SIDECAR_URL, _done_event())],
             )
         assert ("foo", V("1.0")) not in provider.deps_cache
 
@@ -6043,26 +6051,31 @@ class TestSharedSlotProvenance:
         with pytest.raises(UnsupportedSdistError):
             second.get_dependencies("pkg", V("1.0"))
 
-    def test_wheel_metadata_stays_trusted_for_sdist_only_view(self) -> None:
-        """Wheel METADATA in the slot is trusted whatever the reader's view.
+    def test_an_sdist_only_view_reads_the_sdists_own_pkg_info(self) -> None:
+        """A wheel's METADATA does not answer for a tuple that installs the sdist.
 
-        The reverse ordering: a provider with the wheel in view stores
-        METADATA text, then a provider whose view is sdist-only reads
-        it. Inferring the origin from the reader's listing would
-        mislabel the text as PKG-INFO and spuriously reject the
-        version under the PEP 643 gate.
+        The reverse ordering: a provider with the wheel in view stores its
+        METADATA, then a provider whose view is sdist-only reads.  The two
+        artifacts can declare different dependencies, and the origin travels
+        with the text, so the sdist's PEP 643 static PKG-INFO is trusted on
+        its own terms rather than replaced by the wheel's deps.
         """
         metadata = (
             "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\nRequires-Dist: dep-a\n"
         )
-        coordinator = make_coordinator(None, metadata_text=metadata)
+        pkg_info = (
+            "Metadata-Version: 2.2\nName: pkg\nVersion: 1.0\nRequires-Dist: dep-b\n"
+        )
+        coordinator = make_coordinator(
+            None, metadata_text=metadata, sdist_pkg_info=pkg_info
+        )
         first = Provider(coordinator, target=_PY312)
         first.versions_cache["pkg"] = [(V("1.0"), make_wheel("1.0"))]
         assert "dep-a" in first.get_dependencies("pkg", V("1.0"))
 
         second = Provider(coordinator, target=_PY312)
         second.versions_cache["pkg"] = [(V("1.0"), make_sdist("1.0"))]
-        assert "dep-a" in second.get_dependencies("pkg", V("1.0"))
+        assert "dep-b" in second.get_dependencies("pkg", V("1.0"))
 
 
 class TestPickDistForMetadata:

--- a/nab-python/tests/test_provider_declared_target.py
+++ b/nab-python/tests/test_provider_declared_target.py
@@ -987,3 +987,35 @@ class TestSiblingWheelDependencies:
         linux._await_metadata_batch("pkg", submitted)
 
         assert set(linux.deps_cache[("pkg", Version("1.0"))]) == {"linuxdep"}
+
+    def test_an_sdists_pkg_info_does_not_supply_a_wheels_dependencies(self) -> None:
+        """A target with a wheel reads its sidecar even after the sdist landed.
+
+        A target with no wheel of its own resolves the version through the
+        sdist, filling the version-level slot.  That text is a fallback for an
+        artifact with nothing of its own, so it must not stand in for a
+        sidecar the Windows target has yet to fetch.
+        """
+        coordinator = make_coordinator(
+            [_WIN_WHEEL, _sdist("1.0")],
+            package="pkg",
+            metadata_by_url={_sidecar(_WIN_WHEEL): _WIN_WHEEL_METADATA},
+            sdist_pkg_info=(
+                "Metadata-Version: 2.2\nName: pkg\nVersion: 1.0\n"
+                "Requires-Dist: sdistdep\n\n"
+            ),
+        )
+        macos = Provider(
+            coordinator,
+            ResolveTarget.for_declared(
+                python_version="3.11", spec=PlatformSpec("macos_arm64")
+            ),
+        )
+        windows = Provider(
+            coordinator,
+            ResolveTarget.for_declared(
+                python_version="3.11", spec=PlatformSpec("windows_amd64")
+            ),
+        )
+        assert set(macos.get_dependencies("pkg", Version("1.0"))) == {"sdistdep"}
+        assert set(windows.get_dependencies("pkg", Version("1.0"))) == {"windep"}

--- a/nab-python/tests/test_provider_declared_target.py
+++ b/nab-python/tests/test_provider_declared_target.py
@@ -907,3 +907,83 @@ class TestSharedMetadataSlot:
         monkeypatch.setattr(index, "get_metadata_error", _land_sidecar_then_report)
 
         assert set(macos.get_dependencies("pkg", Version("1.0"))) == {"dep-from-wheel"}
+
+
+_LINUX_WHEEL = _platform_wheel("1.0", "cp311-cp311-manylinux_2_17_x86_64")
+_WIN_WHEEL = _platform_wheel("1.0", "cp311-cp311-win_amd64")
+
+_LINUX_WHEEL_METADATA = (
+    "Metadata-Version: 2.4\nName: pkg\nVersion: 1.0\nRequires-Dist: linuxdep\n\n"
+)
+_WIN_WHEEL_METADATA = (
+    "Metadata-Version: 2.4\nName: pkg\nVersion: 1.0\nRequires-Dist: windep\n\n"
+)
+
+
+def _sidecar(wheel: WheelFile) -> str:
+    """The sidecar URL of a wheel that advertises PEP 658 metadata."""
+    url = wheel.metadata_url
+    assert url is not None
+    return url
+
+
+def _sibling_wheel_targets() -> tuple[MagicMock, Provider, Provider]:
+    """Two targets over one version published as a Linux wheel and a Windows one.
+
+    The two wheels declare different dependencies, so each target must read
+    the METADATA of the wheel it would install.
+    """
+    coordinator = make_coordinator(
+        [_LINUX_WHEEL, _WIN_WHEEL],
+        package="pkg",
+        metadata_by_url={
+            _sidecar(_LINUX_WHEEL): _LINUX_WHEEL_METADATA,
+            _sidecar(_WIN_WHEEL): _WIN_WHEEL_METADATA,
+        },
+    )
+    linux = Provider(coordinator, _LINUX_TARGET)
+    windows = Provider(
+        coordinator,
+        ResolveTarget.for_declared(
+            python_version="3.11", spec=PlatformSpec("windows_amd64")
+        ),
+    )
+    return coordinator, linux, windows
+
+
+class TestSiblingWheelDependencies:
+    """Sibling wheels of one version keep their own Requires-Dist per target."""
+
+    def test_a_siblings_metadata_is_not_served_to_another_target(self) -> None:
+        """Each target reads the METADATA of the wheel it would install.
+
+        Both targets prefetch their own wheel's sidecar, so the version's
+        metadata is fetched twice; the later fetch must not answer for the
+        target whose wheel was fetched first.
+        """
+        _coordinator, linux, windows = _sibling_wheel_targets()
+        linux.fetch_versions("pkg")
+        assert set(windows.get_dependencies("pkg", Version("1.0"))) == {"windep"}
+        assert set(linux.get_dependencies("pkg", Version("1.0"))) == {"linuxdep"}
+
+    def test_the_reverse_fetch_order_gives_the_same_deps(self) -> None:
+        _coordinator, linux, windows = _sibling_wheel_targets()
+        windows.fetch_versions("pkg")
+        assert set(linux.get_dependencies("pkg", Version("1.0"))) == {"linuxdep"}
+        assert set(windows.get_dependencies("pkg", Version("1.0"))) == {"windep"}
+
+    def test_the_batch_await_reads_back_the_wheel_it_submitted(self) -> None:
+        """The batch prefetch path keys its read by artifact too.
+
+        Another target's batch can land its own wheel's METADATA between this
+        target's submit and its await.
+        """
+        _coordinator, linux, windows = _sibling_wheel_targets()
+        linux_wheels = linux._wheel_by_version("pkg", linux.fetch_versions("pkg"))
+        win_wheels = windows._wheel_by_version("pkg", windows.fetch_versions("pkg"))
+
+        submitted = linux._prefetch_batch("pkg", [Version("1.0")], linux_wheels)
+        windows._prefetch_batch("pkg", [Version("1.0")], win_wheels)
+        linux._await_metadata_batch("pkg", submitted)
+
+        assert set(linux.deps_cache[("pkg", Version("1.0"))]) == {"linuxdep"}


### PR DESCRIPTION
When one version publishes several wheels, a matrix lock recorded one wheel's Requires-Dist for every target. The metadata cache in `InMemoryIndex` was keyed `(package, version)`, so whichever artifact's METADATA landed in that slot last supplied every target's dependencies, and the reader returned that text before it looked at which dist its own target would install. The result depends on fetch order, and the missing dependency is left out of the lock entirely.

With a local index where pkg 1.0 publishes a manylinux wheel requiring linuxdep and a win_amd64 wheel requiring windep, locking for platforms `["linux_x86_64", "windows_amd64"]` gives pkg a single dependency on linuxdep, with windep absent from the lock even though the win_amd64 wheel is locked for the Windows environment. Flipping the platform order flips the answer to windep, and linuxdep vanishes.

Metadata text, its sdist origin and its integrity error are now keyed by the artifact they came from: the wheel's PEP 658 sidecar URL, or `None` for text that stands for the version itself (sdist PKG-INFO, an injected override). A read asks for the artifact its own target would install; the version-level text answers when that artifact has nothing of its own, but it is not lent to a sidecar nobody has fetched yet, since a wheel that declares its own dependencies must fetch them. `resolve_metadata` now picks the dist for the target first (its listing is already tag-filtered per target) and reads that artifact's slot, and the batch prefetch reads back by the sidecar URL it submitted.
