### PR TITLE
refuse VCS URLs that name no repository

### DIFF
--- a/docs/how-to/vcs.md
+++ b/docs/how-to/vcs.md
@@ -43,6 +43,11 @@ Three layers, each AND-checked:
    commit SHA after `@`.  Branch and tag references are rejected
    because they are mutable.
 
+Everything after the final `@` is the ref, so the URL has to name a
+repository ahead of it: `git+https://github.com` and
+`git+https://github.com@<sha>` are both refused;
+`git+https://github.com/myorg/pkg@<sha>` is not.
+
 ## Pinned VCS sources
 
 The supported entry point is `[[tool.nab.vcs-sources]]`:

--- a/nab-python/src/nab_python/_vcs_admission.py
+++ b/nab-python/src/nab_python/_vcs_admission.py
@@ -127,6 +127,17 @@ def _without_userinfo(url: str) -> str:
     return urlunsplit(parts._replace(netloc=host))
 
 
+def _repo_path(inner_url: str) -> str:
+    """Return the path of ``inner_url`` with any trailing ``@<ref>`` dropped.
+
+    The ref is whatever follows the last ``@`` of the path component, the
+    same split :class:`nab_index.vcs.VcsRequest` makes at clone time.  An
+    empty result means the URL names no repo.
+    """
+    path = urlsplit(inner_url).path
+    return path.rpartition("@")[0] if "@" in path else path
+
+
 _REPO_BOUNDARY_CHARS: frozenset[str] = frozenset({"/", "@", "#"})
 
 
@@ -218,6 +229,32 @@ def admit_vcs_url(url: str, config: VcsConfig) -> str:
                 f'\n    note: "{scheme}" is unauthenticated;'
                 " consider an https/ssh variant."
             )
+        raise UnsupportedVcsError(msg)
+
+    try:
+        repo_path = _repo_path(inner_url)
+    except ValueError:
+        # urlsplit raises on an authority it cannot parse (an unclosed IPv6
+        # bracket), which ingestion reports as a refusal, not a traceback.
+        msg = (
+            "refusing malformed VCS URL\n"
+            f"    {url}\n"
+            "    reason: the URL does not parse."
+        )
+        raise UnsupportedVcsError(msg) from None
+
+    # Without a repo path there is nothing to clone, and an appended pin's
+    # "@" lands in the netloc instead of the path, where urlsplit reads
+    # "host@<sha>" as userinfo "host" and host "<sha>".  Requiring a path
+    # leaves the checks below a real host and a real repo to look at.
+    if not repo_path.strip("/"):
+        msg = (
+            "refusing VCS URL that names no repository\n"
+            f"    {url}\n"
+            "    reason: the URL has no repository path.\n"
+            "    note: everything after the final @ is the ref, so a repo URL\n"
+            "          looks like git+https://host/org/repo.git@<ref>."
+        )
         raise UnsupportedVcsError(msg)
 
     # An empty allowed-repos denies every repo (deny-all), matching

--- a/nab-python/tests/property_python/test_vcs_admission.py
+++ b/nab-python/tests/property_python/test_vcs_admission.py
@@ -10,6 +10,9 @@ Invariants:
 * fragment irrelevance: appending a ``#fragment`` never changes the
   decision (``has_full_commit_sha`` strips fragments; prefix checks
   are on the head of the URL);
+* repo path required: a URL whose path names no repository (nothing
+  before the final ``@``) is refused, so the ref of an appended pin
+  can never land in the authority;
 * pin monotonicity: a URL admitted under ``require_pin=False`` is
   admitted under ``require_pin=True`` once ``@<40-hex-sha>`` is
   appended;
@@ -167,7 +170,12 @@ def _oracle(url: str, config: VcsConfig) -> str:
         return "refuse"
     if scheme not in config.allowed_schemes:
         return "refuse"
-    inner = _drop_login(url[len("git+") :])
+    inner = url[len("git+") :]
+    path = urlsplit(inner).path
+    repo_path = path.rpartition("@")[0] if "@" in path else path
+    if not repo_path.strip("/"):
+        return "refuse"
+    inner = _drop_login(inner)
     if not any(_prefix_under_repo(inner, _drop_login(p)) for p in config.allowed_repos):
         return "refuse"
     if config.require_pin:

--- a/nab-python/tests/test_vcs_admission.py
+++ b/nab-python/tests/test_vcs_admission.py
@@ -447,7 +447,7 @@ class TestAdmitVcsUrlRequirePin:
 
     def test_sha_in_authority_refused_when_pin_required(self) -> None:
         """The clone parser sees no ref here, so admission must refuse."""
-        with pytest.raises(UnsupportedVcsError, match="vcs.require-pin"):
+        with pytest.raises(UnsupportedVcsError, match="names no repository"):
             admit_vcs_url(
                 f"git+https://github.com@{_FORTY}",
                 _allow_https(),
@@ -507,3 +507,185 @@ class TestAdmitVcsUrlNonVcsRefusal:
                 "bzr+https://bzr.example.com/r",
                 _allow_https(),
             )
+
+
+class TestAdmitVcsUrlRepoPath:
+    def test_pathless_url_refused(self) -> None:
+        """A URL with no path names no repository, so it is refused."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://",),
+            require_pin=False,
+        )
+        with pytest.raises(UnsupportedVcsError, match="names no repository"):
+            admit_vcs_url("git+https://github.com", config)
+
+    def test_pathless_url_with_login_refused(self) -> None:
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+ssh"}),
+            allowed_repos=("ssh://",),
+            require_pin=False,
+        )
+        with pytest.raises(UnsupportedVcsError, match="names no repository"):
+            admit_vcs_url("git+ssh://git@github.com", config)
+
+    def test_pathless_url_with_sha_appended_refused(self) -> None:
+        """The ``@<sha>`` here is userinfo, not a ref: still no repository."""
+        with pytest.raises(UnsupportedVcsError, match="names no repository"):
+            admit_vcs_url(f"git+https://github.com@{_FORTY}", _allow_https())
+
+    def test_root_path_only_refused(self) -> None:
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://",),
+            require_pin=False,
+        )
+        with pytest.raises(UnsupportedVcsError, match="names no repository"):
+            admit_vcs_url("git+https://github.com/", config)
+
+    def test_ref_only_path_refused(self) -> None:
+        """Everything after the final ``@`` is the ref, leaving no repo path."""
+        with pytest.raises(UnsupportedVcsError, match="names no repository"):
+            admit_vcs_url(f"git+https://github.com/@{_FORTY}", _allow_https())
+
+    def test_repo_path_with_ref_admitted(self) -> None:
+        scheme = admit_vcs_url(
+            f"git+https://github.com/foo/bar.git@{_FORTY}",
+            _allow_https(),
+        )
+        assert scheme == "git+https"
+
+
+class TestPinAppendMonotonicity:
+    """Appending a pin must never turn an admit into a refuse."""
+
+    URLS = (
+        "git+https://github.com",
+        "git+https://github.com/",
+        "git+https://github.com/foo",
+        "git+https://github.com/foo/bar.git",
+        "git+https://github.com/foo/bar.git@main",
+        "git+https://user:pass@github.com/foo/bar.git",
+    )
+
+    def _config(self, *, require_pin: bool) -> VcsConfig:
+        return VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("",),
+            require_pin=require_pin,
+        )
+
+    def _admits(self, url: str, config: VcsConfig) -> bool:
+        try:
+            admit_vcs_url(url, config)
+        except UnsupportedVcsError:
+            return False
+        return True
+
+    @pytest.mark.parametrize("url", URLS)
+    def test_pin_append_never_turns_admit_into_refuse(self, url: str) -> None:
+        if not self._admits(url, self._config(require_pin=False)):
+            return
+        assert self._admits(f"{url}@{_FORTY}", self._config(require_pin=True))
+
+
+class TestAdmitVcsUrlUserinfoPosition:
+    def test_allowed_prefix_in_userinfo_position_refused(self) -> None:
+        """An allowed host sitting in the userinfo is not the host cloned from."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com",),
+            require_pin=False,
+        )
+        with pytest.raises(UnsupportedVcsError, match="not in vcs.allowed-repos"):
+            admit_vcs_url("git+https://github.com@elsewhere.example/foo", config)
+
+
+class TestAdmitVcsUrlMalformed:
+    def test_unparseable_authority_refused(self) -> None:
+        """An unclosed IPv6 bracket is refused, not raised through."""
+        with pytest.raises(UnsupportedVcsError, match="does not parse"):
+            admit_vcs_url("git+https://[/org/repo", _allow_https())
+
+    def test_unparseable_authority_refused_with_empty_allowed_repos(self) -> None:
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=(),
+        )
+        with pytest.raises(UnsupportedVcsError, match="does not parse"):
+            admit_vcs_url("git+https://[/org/repo", config)
+
+
+class TestAdmitVcsUrlRealWorldShapes:
+    """Shapes a user actually writes still admit."""
+
+    def test_ssh_login_unpinned(self) -> None:
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+ssh"}),
+            allowed_repos=("ssh://github.com/org",),
+            require_pin=False,
+        )
+        assert admit_vcs_url("git+ssh://git@github.com/org/repo", config) == "git+ssh"
+
+    def test_ssh_login_with_pin(self) -> None:
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+ssh"}),
+            allowed_repos=("ssh://git@github.com/org/repo.git",),
+        )
+        scheme = admit_vcs_url(
+            f"git+ssh://git@github.com/org/repo.git@{_FORTY}",
+            config,
+        )
+        assert scheme == "git+ssh"
+
+    def test_port_and_fragment_with_pin(self) -> None:
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com:8443/org",),
+        )
+        scheme = admit_vcs_url(
+            f"git+https://github.com:8443/org/repo.git@{_FORTY}#subdirectory=pkg",
+            config,
+        )
+        assert scheme == "git+https"
+
+    def test_repo_path_containing_at_sign_with_pin(self) -> None:
+        """Only the final ``@`` is the ref, so an ``@`` in the path survives."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://example.org/org",),
+        )
+        scheme = admit_vcs_url(
+            f"git+https://example.org/org/re@po@{_FORTY}",
+            config,
+        )
+        assert scheme == "git+https"
+
+    def test_branch_ref_admitted_when_pin_not_required(self) -> None:
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com/org",),
+            require_pin=False,
+        )
+        scheme = admit_vcs_url("git+https://github.com/org/repo@main", config)
+        assert scheme == "git+https"
+
+    def test_file_url_with_pin(self) -> None:
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+file"}),
+            allowed_repos=("file:///srv/repos",),
+        )
+        scheme = admit_vcs_url(f"git+file:///srv/repos/pkg@{_FORTY}", config)
+        assert scheme == "git+file"


### PR DESCRIPTION
A VCS URL that names no repository, such as `git+https://github.com`, is admitted today. It has nothing to clone, and worse, the pin separator collides with the authority: appending `@<sha>` puts the `@` in the netloc, so `urlsplit` reads `github.com@<sha>` as userinfo `github.com` and host `<sha>`. The path stays empty, `has_full_commit_sha` sees no ref, and admission refuses the pinned URL while admitting the unpinned one. Pinning a URL should never be what gets it refused.

```python
sha = "a" * 40
admit_vcs_url("git+https://github.com", cfg_unpinned)        # admitted
admit_vcs_url(f"git+https://github.com@{sha}", cfg_pinned)   # refused
```

`admit_vcs_url` now requires a repo path, checked after the scheme allowlist and before the repo allowlist. The path is taken with `urlsplit` and any trailing `@<ref>` dropped, the same last-`@`-in-path split `nab_index.vcs` makes at clone time, so admission and clone agree on what the repo is. Anything that gets past the gate has a real path, so an appended pin always lands in the path component and can never reach the netloc. `git+https://github.com`, `git+https://github.com/`, `git+ssh://git@github.com` and both `@<sha>` variants are now refused with a diagnostic. The gate parses the authority, so a URL that `urlsplit` rejects (an unclosed IPv6 bracket) is now refused as malformed rather than escaping ingestion as a `ValueError`.

This is pre-existing, not a regression. The property suite already encodes pin monotonicity, but Hypothesis only reaches the pathless URL on some seeds and not within the default example budget, so it was also sitting there as a latent CI flake. The oracle in the property test gained the repo-path rule alongside the implementation, and the documented rule in `docs/how-to/vcs.md` was updated to match.
