### PR TITLE
assert exact resolve stat counts in test_success_returns_pins

### DIFF
--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -919,8 +919,8 @@ class TestResolveOneTarget:
         assert tr.target.platform_id == "linux_x86_64"
         assert tr.conflicts == 0
         assert tr.backjumps == 0
-        assert tr.metadata_fetched >= 0
-        assert tr.distributions_seen >= 0
+        assert tr.metadata_fetched == 1
+        assert tr.distributions_seen == 1
 
     def test_failure_returns_error(self) -> None:
         """A resolve with no candidate version reports failure."""


### PR DESCRIPTION
The success path in `test_success_returns_pins` asserted `metadata_fetched >= 0` and `distributions_seen >= 0`. Both are non-negative counters, so those checks hold no matter what the resolve does and catch nothing if the accounting drifts.

The single-wheel resolve in that test fetches one distribution's metadata and sees one distribution, so pin both to 1. A miscount now fails the test instead of passing silently.
