### PR TITLE
note that nab download also fetches direct-URL archives

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -112,10 +112,10 @@ prints a notice naming the cutoff it dropped.
 
 ## `nab download`
 
-Resolve and download every wheel and sdist into a local
-directory. The download is idempotent: files whose recorded
-sha256 matches a local file are left alone. Local and VCS pins
-are skipped.
+Resolve and download every wheel, sdist, and direct-URL
+archive into a local directory. The download is idempotent:
+files whose recorded sha256 matches a local file are left
+alone. Local and VCS pins are skipped.
 
 Universal mode (`[tool.nab].mode = "universal"`) re-resolves
 across the matrix and downloads the union of every tuple's

--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -246,12 +246,12 @@ single-environment mode.
 
 ## `nab download`
 
-`nab download` resolves the project again, then fetches every wheel
-and sdist on the resulting pins into the `--output` directory
-(defaults to `wheels/`), verifying each file's `sha256` against the
-digest the index published. Local and VCS pins are skipped. The
-download is idempotent: a file whose digest already matches a local
-copy is left alone.
+`nab download` resolves the project again, then fetches every wheel,
+sdist, and direct-URL archive on the resulting pins into the
+`--output` directory (defaults to `wheels/`), verifying each file's
+`sha256` against the digest recorded on the pin. Local and VCS pins
+are skipped. The download is idempotent: a file whose digest already
+matches a local copy is left alone.
 
 The result is a per-resolve directory of artefacts that any
 installer can consume offline:

--- a/nab-python/src/nab_python/download.py
+++ b/nab-python/src/nab_python/download.py
@@ -85,10 +85,12 @@ class DownloadResult:
 
 
 def iter_artifacts(lock_input: LockInput) -> Iterable[DownloadEntry]:
-    """Yield every wheel/sdist artefact referenced by ``lock_input``.
+    """Yield every downloadable artefact referenced by ``lock_input``.
 
-    The union across the targets the resolve ran against, deduplicated
-    by URL so a wheel shared by several of them is downloaded once.
+    A wheel, sdist, or direct-URL archive for each pin, deduplicated
+    by URL across the targets the resolve ran against so an artefact
+    shared by several of them is downloaded once.  Local and VCS pins
+    carry no downloadable URL and are skipped.
     """
     seen: set[str] = set()
     for label in sorted(lock_input.targets):

--- a/src/nab/_download.py
+++ b/src/nab/_download.py
@@ -1,9 +1,9 @@
 """``nab download`` subcommand.
 
-Resolves a project and fetches every wheel and sdist into a local
-directory: the union of every target's artefacts, deduplicated by URL,
-which for a declared matrix pre-populates a directory for offline
-deployment across platforms.
+Resolves a project and fetches every wheel, sdist, and direct-URL
+archive into a local directory: the union of every target's
+artefacts, deduplicated by URL, which for a declared matrix
+pre-populates a directory for offline deployment across platforms.
 
 External callers (the resolver entry point and the download
 helper) are accessed through :mod:`nab.cli` so the test suite's
@@ -60,7 +60,7 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
     project_constraint: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
     project_default_group: Annotated[tuple[str, ...], tyro.conf.UseAppendAction] = (),
 ) -> None:
-    """Resolve and download every wheel/sdist into a local directory.
+    """Resolve and download every wheel, sdist, and direct-URL archive.
 
     Output files are named after the recorded artefact filename.  The
     download is idempotent: files whose sha256 already matches are


### PR DESCRIPTION
The `nab download` reference and the download docstrings claimed it fetches only wheels and sdists. A resolve can also pin a package to a direct-URL archive, and `nab download` already fetches those alongside the index artefacts. Only the wording was out of date.

This updates both reference pages and the download docstrings to list wheels, sdists, and direct-URL archives, and to note that local and VCS pins are skipped.
