### PR TITLE
fix nab lock crash on a control char in build-system.requires

### DIFF
--- a/nab-python/src/nab_python/_build/env.py
+++ b/nab-python/src/nab_python/_build/env.py
@@ -40,6 +40,7 @@ from nab_index.urllib3_async_transport import Urllib3AsyncTransport
 from .._vcs_admission import UnsupportedVcsError
 from ..config import NabProjectConfig
 from ..download import download_lock
+from ..requirements_file import InvalidProjectRequirementError
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
@@ -289,10 +290,14 @@ class NabBuildEnv:
             # The build env resolves for the host alone, so its one
             # target's failure is the whole resolve's.
             result.raise_for_failure()
-        except (UnsupportedVcsError, NotImplementedError) as exc:
-            # A direct-URL/VCS build requirement means nab cannot build this
-            # sdist. Report it as a build-env failure so the outer resolve
-            # skips the version instead of aborting on the raw error.
+        except (
+            UnsupportedVcsError,
+            NotImplementedError,
+            InvalidProjectRequirementError,
+        ) as exc:
+            # A build requirement nab cannot resolve: a direct-URL/VCS pin, or
+            # a string that is not valid PEP 508. Wrap it so the outer resolve
+            # skips this sdist rather than aborting on the raw error.
             msg = f"build env resolve failed: {exc}"
             raise BuildEnvError(msg) from exc
 
@@ -397,6 +402,20 @@ def _render_synthetic_pyproject(requires: list[str]) -> str:
 
 
 def _toml_str(value: str) -> str:
-    """Single-line TOML string literal escape."""
-    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
-    return f'"{escaped}"'
+    """Escape a string as a single-line TOML basic-string literal.
+
+    Backslash, double-quote, and the control characters TOML forbids bare in a
+    basic string (below U+0020, plus U+007F) are escaped, so a requirement
+    carrying a newline stays valid TOML instead of splitting across a line.
+    """
+    out: list[str] = []
+    for ch in value:
+        if ch == "\\":
+            out.append("\\\\")
+        elif ch == '"':
+            out.append('\\"')
+        elif ch < "\x20" or ch == "\x7f":
+            out.append(f"\\u{ord(ch):04x}")
+        else:
+            out.append(ch)
+    return '"' + "".join(out) + '"'

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -832,6 +832,22 @@ class TestResolveAndDownload:
         with pytest.raises(BuildEnvError, match="build env resolve"):
             env._resolve_and_download(wheel_dir)
 
+    def test_control_char_build_requirement_wrapped(self, tmp_path: Path) -> None:
+        """A control character makes a build requirement invalid PEP 508, so
+        _resolve_and_download raises BuildEnvError rather than a raw error.
+        """
+        env = NabBuildEnv(
+            requires=["setuptools\n>=61"],
+            config=NabProjectConfig(),
+        )
+        env._tmpdir = MagicMock()  # type: ignore[attr-defined]
+        env._venv_path = tmp_path / "venv"  # type: ignore[attr-defined]
+        env._python_executable = tmp_path / "venv" / "bin" / "python"  # type: ignore[attr-defined]
+        wheel_dir = tmp_path / "wheels"
+        wheel_dir.mkdir()
+        with pytest.raises(BuildEnvError, match="build env resolve"):
+            env._resolve_and_download(wheel_dir)
+
 
 class TestNabBuildEnvLifecycle:
     """Edge cases of the context-manager lifecycle that fall outside
@@ -855,6 +871,18 @@ class TestNabBuildEnvLifecycle:
 
         text = _render_synthetic_pyproject([])
         assert "dependencies = []" in text
+
+    def test_render_synthetic_pyproject_escapes_control_chars(self) -> None:
+        """Control characters, quotes, and backslashes in a requirement
+        round-trip through the synthetic pyproject as valid TOML.
+        """
+        import tomli
+
+        from nab_python._build.env import _render_synthetic_pyproject
+
+        requires = ["a\nb", 'c"d\\e', "f\x00g", "h\x7fi", "plain>=1"]
+        rendered = _render_synthetic_pyproject(requires)
+        assert tomli.loads(rendered)["project"]["dependencies"] == requires
 
 
 class TestNabBuildEnvEnterInstall:


### PR DESCRIPTION
A source whose build-system.requires holds a string with a control character (say a stray newline) made nab lock crash with a raw TOMLDecodeError.

nab writes a source's build requirements into a synthetic pyproject.toml and reads it back to resolve the build environment. The writer only escaped backslashes and double quotes, so a bare control character landed in the TOML unescaped and the read-back rejected the file.

The writer now also escapes the control characters TOML forbids in a basic string (below U+0020, plus U+007F), so the synthetic file always parses. Such a requirement is still not valid PEP 508, so the inner resolve now raises InvalidProjectRequirementError, which is wrapped as a BuildEnvError so the outer resolve skips that sdist version instead of aborting.
