### PR TITLE
exit cleanly when a forbidden build blocks dynamic metadata

### DIFF
--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -62,6 +62,7 @@ from nab_python.lockfile import (
 )
 from nab_python.provider import (
     InvalidUploadTimeError,
+    MetadataError,
     MissingExtraError,
     UnsupportedVcsError,
 )
@@ -520,7 +521,7 @@ def _resolve(  # noqa: PLR0913, C901 - one wrapper per resolve_for_targets kwarg
     except (MissingExtraError, LookupError) as e:
         sys.stderr.write(f"Error: {e}\n")
         sys.exit(1)
-    except (MissingHashError, MissingSdistError) as e:
+    except (MissingHashError, MissingSdistError, MetadataError) as e:
         sys.stderr.write(f"{failure_prefix}: {e}\n")
         sys.exit(1)
     except NotImplementedError as e:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -655,6 +655,36 @@ class TestLockCommandSpecific:
         assert "does not provide extra 'nonexistent'" in err
         assert "Traceback" not in err
 
+    def test_dynamic_local_source_forbidden_build_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A local source needing a forbidden build exits 1, not a traceback.
+
+        Dynamic metadata under build-policy never raises
+        ``UnsupportedSdistError``, a ``MetadataError`` subclass.
+        """
+        member = tmp_path / "mylocal"
+        member.mkdir()
+        (member / "pyproject.toml").write_text(
+            '[project]\nname = "mylocal"\nversion = "1.0"\ndynamic = ["dependencies"]\n'
+        )
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\nname = "root"\nversion = "0"\n'
+            'dependencies = ["mylocal"]\n'
+            "[tool.nab]\n"
+            'build-policy = "never"\n'
+            "[[tool.nab.local-sources]]\n"
+            'name = "mylocal"\n'
+            'path = "mylocal"\n',
+        )
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, offline=True, output=Path("-"), cache=False)
+        err = capsys.readouterr().err
+        assert "Cannot lock" in err
+        assert "has dynamic metadata" in err
+        assert "Traceback" not in err
+
     def test_missing_file_exits(self, tmp_path: Path) -> None:
         """Exit 1 when pyproject.toml doesn't exist."""
         with pytest.raises(SystemExit, match="1"):


### PR DESCRIPTION
`nab lock` and `nab download` printed a raw traceback when a source needed a build the effective build policy forbids, for example a local source with dynamic dependencies under `build-policy = "never"`. The provider raises `UnsupportedSdistError` there, which the resolve wrapper did not catch, so it escaped instead of being reported.

Add its base class `MetadataError` to the handler that already covers `MissingSdistError`, so these commands print a one-line `Cannot lock` or `Cannot download` message and exit 1.
