### PR TITLE
NO_VERSIONS reason claims no sdist when a present sdist was filtered

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -1575,9 +1575,11 @@ class Provider:
         wheel-tag filter, requires-python, dist-policy, or the upload-time
         cutoff.  The raw listing tells absence from incompatibility apart.
         The wheel-tag case (a Windows-only package on a Linux target) is
-        named only when nothing else dropped a file: a version the base
-        pass filtered out, even alongside a tag-rejected wheel on another
-        version, reports the base-filter reason instead.
+        named only when the base pass dropped nothing, or when the file
+        it dropped was an sdist: there the reason names both the rejected
+        tags and the filtered sdist, because the sdist is what the user
+        can bring back.  A base-filtered wheel alongside a tag-rejected
+        wheel on another version reports the base-filter reason alone.
 
         A look-ahead rejection emits a clause that removes the rejected
         versions from the range, so the resolver asks again over a range
@@ -1595,6 +1597,16 @@ class Provider:
                     f"found on index but none of the wheel's tags are compatible"
                     f" with the resolve target ({tag_excluded} wheels rejected),"
                     f" and no sdist is available to build from"
+                )
+            elif tag_excluded and any(isinstance(f, SdistFile) for f in raw_listing):
+                # A present sdist beside tag-rejected wheels was dropped by
+                # the base pass (it would otherwise keep its version alive),
+                # so name both causes rather than the base filter alone.
+                reason = (
+                    f"found on index but none of the wheel's tags are compatible"
+                    f" with the resolve target ({tag_excluded} wheels rejected),"
+                    f" and the sdist was filtered by requires-python,"
+                    f" dist-policy, or upload-time"
                 )
             else:
                 reason = (

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -983,7 +983,7 @@ class TestNoVersionsReasons:
         ``foo`` 2.0 ships only a Windows wheel the Linux target refuses,
         and ``foo`` 1.0 ships an sdist dropped by its ``requires-python``.
         The reason must not claim "no sdist is available" when one is on
-        the index.
+        the index: it names the rejected tags and the filtered sdist.
         """
         listing = [
             WheelFile(
@@ -1004,10 +1004,10 @@ class TestNoVersionsReasons:
             ),
         )
         provider.choose_version("foo", SpecifierSet("").to_range())
-        assert (
-            provider.get_no_versions_reason("foo")
-            == "found on index but no distribution is compatible "
-            "(all filtered by requires-python, dist-policy, or upload-time)"
+        assert provider.get_no_versions_reason("foo") == (
+            "found on index but none of the wheel's tags are compatible with"
+            " the resolve target (1 wheels rejected), and the sdist was"
+            " filtered by requires-python, dist-policy, or upload-time"
         )
 
     def test_present_but_dist_policy_filtered_reports_incompatible(self) -> None:
@@ -1019,6 +1019,45 @@ class TestNoVersionsReasons:
             provider.get_no_versions_reason("foo")
             == "found on index but no distribution is compatible "
             "(all filtered by requires-python, dist-policy, or upload-time)"
+        )
+
+    def test_tag_excluded_wheel_with_filtered_sdist_keeps_the_sdist(self) -> None:
+        """A tag-excluded wheel beside a filtered sdist must not deny the sdist.
+
+        The sdist is on the index, dropped only by requires-python, so the
+        reason may not claim ``no sdist is available to build from``: it has
+        to read present-but-filtered like the no-tag-excluded branch does.
+        """
+        wheel = WheelFile(
+            filename="foo-1.0-cp311-cp311-win_amd64.whl",
+            url="https://example.com/foo-1.0-cp311-cp311-win_amd64.whl",
+            version="1.0",
+            requires_python=None,
+            has_metadata=True,
+            upload_time=None,
+        )
+        sdist = SdistFile(
+            filename="foo-1.0.tar.gz",
+            url="https://example.com/foo-1.0.tar.gz",
+            version="1.0",
+            requires_python=">=3.13",
+            upload_time=None,
+        )
+        coordinator = make_coordinator([wheel, sdist], package="foo")
+        provider = Provider(
+            coordinator,
+            target=ResolveTarget.for_declared(
+                python_version="3.11", spec=PlatformSpec("linux_x86_64")
+            ),
+        )
+        provider.choose_version("foo", SpecifierSet("").to_range())
+        reason = provider.get_no_versions_reason("foo")
+        assert reason is not None
+        assert "no sdist is available" not in reason
+        assert reason == (
+            "found on index but none of the wheel's tags are compatible with"
+            " the resolve target (1 wheels rejected), and the sdist was"
+            " filtered by requires-python, dist-policy, or upload-time"
         )
 
     def test_get_reason_returns_none_for_unknown_package(self) -> None:


### PR DESCRIPTION
When a package offers only tag-incompatible wheels beside an sdist that requires-python, the dist-policy, or the upload-time cutoff filtered out, the NO_VERSIONS reason is the generic "no distribution is compatible (all filtered by requires-python, dist-policy, or upload-time)". The tag rejections are real and worth naming, and the filtered sdist is the file the user can bring back by loosening a setting, so the generic line undersells what happened.

The tag-excluded branch now names both causes when the raw listing still holds an sdist: "none of the wheel's tags are compatible with the resolve target (N wheels rejected), and the sdist was filtered by requires-python, dist-policy, or upload-time". A base-filtered wheel beside a tag-rejected wheel keeps the generic message, since there is no sdist to point at.