### PR TITLE
fix no-versions reason blaming wheel tags over other filters

### DIFF
--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -309,7 +309,13 @@ def filter_distributions(
     linux-only wheel still stays off the Windows target.
     """
     base = base_distributions(provider, normalized, files)
-    return _apply_wheel_tags(provider, normalized, base)
+    result = _apply_wheel_tags(provider, normalized, base)
+
+    if not result and len(base) < len(files):
+        # The base pass (dist-policy, requires-python, upload cutoff) dropped a
+        # file, so an empty result is not the tag pass alone.
+        provider.base_filtered_packages.add(normalized)
+    return result
 
 
 def base_distributions(

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -606,6 +606,12 @@ class Provider:
         # than blame requires-python or the cutoff.
         self.tag_excluded_wheels: dict[str, int] = {}
 
+        # Canonical names whose listing lost a file to requires-python,
+        # dist-policy, or the upload cutoff before the tag pass ran.  A
+        # tag-rejected wheel on some other version must not then claim the
+        # whole package failed on wheel tags alone.
+        self.base_filtered_packages: set[str] = set()
+
         self.root_requirements = root_requirements or {}
         self.versions_cache: dict[str, list[tuple[Version, DistFile]]] = {}
         self.deps_cache: dict[tuple[str, Version], dict[str, VersionRange]] = {}
@@ -1513,9 +1519,11 @@ class Provider:
         ``all_versions`` is post-filter, so an empty one means either the
         index served no files or every file it served was dropped by the
         wheel-tag filter, requires-python, dist-policy, or the upload-time
-        cutoff.  The raw listing tells absence from incompatibility apart,
-        and the tag filter's own tally names the wheel-tag case, which is
-        what a Windows-only package on a Linux target hits.
+        cutoff.  The raw listing tells absence from incompatibility apart.
+        The wheel-tag case (a Windows-only package on a Linux target) is
+        named only when nothing else dropped a file: a version the base
+        pass filtered out, even alongside a tag-rejected wheel on another
+        version, reports the base-filter reason instead.
 
         A look-ahead rejection emits a clause that removes the rejected
         versions from the range, so the resolver asks again over a range
@@ -1526,19 +1534,19 @@ class Provider:
             _, _, normalized = self.split_and_normalize(package)
             raw_listing = self.coordinator.index.get_listing(normalized)
             tag_excluded = self.tag_excluded_wheels.get(normalized, 0)
-            if tag_excluded:
+            if not raw_listing:
+                reason = "package not found on any configured index"
+            elif tag_excluded and normalized not in self.base_filtered_packages:
                 reason = (
                     f"found on index but none of the wheel's tags are compatible"
                     f" with the resolve target ({tag_excluded} wheels rejected),"
                     f" and no sdist is available to build from"
                 )
-            elif raw_listing:
+            else:
                 reason = (
                     "found on index but no distribution is compatible "
                     "(all filtered by requires-python, dist-policy, or upload-time)"
                 )
-            else:
-                reason = "package not found on any configured index"
         elif blockers:
             # Look-ahead rejection: candidates DID match the range but
             # were rejected.  Naming the blocker is more useful than

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -942,6 +942,74 @@ class TestNoVersionsReasons:
             " available to build from"
         )
 
+    def test_tag_rejected_wheel_does_not_hijack_requires_python_reason(self) -> None:
+        """A tag-rejected wheel must not mask a requires-python exclusion.
+
+        ``foo`` 2.0 ships only a Windows wheel the Linux target refuses,
+        and ``foo`` 1.0 ships a ``py3-none-any`` wheel the target could
+        install but for its ``requires-python``.  The wheel-tag tally is
+        package-global, so the 2.0 rejection must not make the reason
+        blame wheel tags and claim no sdist when 1.0 was really dropped
+        by requires-python.
+        """
+        listing = [
+            WheelFile(
+                filename="foo-2.0-cp311-cp311-win_amd64.whl",
+                url="https://example.com/foo-2.0-cp311-cp311-win_amd64.whl",
+                version="2.0",
+                requires_python=None,
+                has_metadata=True,
+                upload_time=None,
+            ),
+            make_wheel("1.0", requires_python=">=3.13"),
+        ]
+        coordinator = make_coordinator(listing, package="foo")
+        provider = Provider(
+            coordinator,
+            target=ResolveTarget.for_declared(
+                python_version="3.11", spec=PlatformSpec("linux_x86_64")
+            ),
+        )
+        provider.choose_version("foo", SpecifierSet("").to_range())
+        assert (
+            provider.get_no_versions_reason("foo")
+            == "found on index but no distribution is compatible "
+            "(all filtered by requires-python, dist-policy, or upload-time)"
+        )
+
+    def test_tag_rejected_wheel_does_not_deny_a_filtered_sdist(self) -> None:
+        """A tag-rejected wheel must not deny an sdist that was filtered.
+
+        ``foo`` 2.0 ships only a Windows wheel the Linux target refuses,
+        and ``foo`` 1.0 ships an sdist dropped by its ``requires-python``.
+        The reason must not claim "no sdist is available" when one is on
+        the index.
+        """
+        listing = [
+            WheelFile(
+                filename="foo-2.0-cp311-cp311-win_amd64.whl",
+                url="https://example.com/foo-2.0-cp311-cp311-win_amd64.whl",
+                version="2.0",
+                requires_python=None,
+                has_metadata=True,
+                upload_time=None,
+            ),
+            make_sdist("1.0", requires_python=">=3.13"),
+        ]
+        coordinator = make_coordinator(listing, package="foo")
+        provider = Provider(
+            coordinator,
+            target=ResolveTarget.for_declared(
+                python_version="3.11", spec=PlatformSpec("linux_x86_64")
+            ),
+        )
+        provider.choose_version("foo", SpecifierSet("").to_range())
+        assert (
+            provider.get_no_versions_reason("foo")
+            == "found on index but no distribution is compatible "
+            "(all filtered by requires-python, dist-policy, or upload-time)"
+        )
+
     def test_present_but_dist_policy_filtered_reports_incompatible(self) -> None:
         """A dist-policy-filtered package reports incompatible, not absent."""
         coordinator = make_coordinator([make_sdist("1.0")], package="foo")


### PR DESCRIPTION
When a package resolves to no versions, nab reports why. If one version shipped a wheel rejected only on its tags (say a Windows-only wheel on a Linux target) while another version was actually dropped by requires-python, dist-policy, or the upload-time cutoff, the reason blamed the wheel tags and claimed no sdist was available to build from. That points at the wrong version and the wrong cause, and it can deny an sdist that is sitting on the index.

The wheel-tag tally is package-global, so a single tag-rejected wheel anywhere in the listing was enough to hijack the message. This tracks whether the base pass (requires-python, dist-policy, upload cutoff) dropped a file, and reports the wheel-tag reason only when nothing else did.
