### PR TITLE
render readable ranges in resolution-failure reports

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -2034,6 +2034,29 @@ class Provider:
             return VersionRange.full(admit_arbitrary=False)
         return constraint.snap_bounds(universe)
 
+    def format_range(self, constraint: RangeProtocol[Version]) -> str:
+        """Render ``constraint`` for a failure report.
+
+        ``VersionRange`` has no ``__str__``, so interpolating one gives the
+        debug repr, including the internal boundary-kind sentinels.  A range a
+        specifier set can spell reads as that specifier set, so ``==3.0.0``
+        shows the way a user would have written it.
+
+        An unconstrained range renders as nothing, leaving the package name to
+        carry the line, and the empty range gets a phrase rather than the
+        ``<0`` a specifier set spells it with.  A range with no specifier
+        spelling, such as a disjunction, keeps the range's own rendering.
+        """
+        assert isinstance(constraint, VersionRange)
+        if constraint.is_empty:
+            return "no version"
+        if (~constraint).is_empty:
+            return ""
+        specifier_set = constraint.to_specifier_set()
+        if specifier_set is None:
+            return str(constraint)
+        return str(specifier_set)
+
     def get_dependencies(
         self, package: str, version: Version
     ) -> dict[str, VersionRange]:

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -1773,8 +1773,8 @@ class Provider:
                 (cand, blocker_pkg, pos_range)
             ].union
             out.append(
-                f"requires {blocker_pkg} in {dep_range}"
-                f" but solution has it in {pos_range}"
+                f"requires {blocker_pkg} in {self.format_range(dep_range)}"
+                f" but solution has it in {self.format_range(pos_range)}"
             )
 
         for (
@@ -1786,7 +1786,8 @@ class Provider:
             if cand != normalized:
                 continue
             out.append(
-                f"requires {blocker_pkg} in {dep_range} but root has it in {root_range}"
+                f"requires {blocker_pkg} in {self.format_range(dep_range)}"
+                f" but root has it in {self.format_range(root_range)}"
             )
 
         # Collapse repeated metadata-error blockers (one per version) into

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -795,8 +795,8 @@ class Provider:
 
         # The dep range each rejected candidate declared for the blocker,
         # unioned per group.  Feeds the membership widening of the flushed
-        # blocker term; the range-keyed union also feeds the no-versions
-        # message.
+        # blocker term, and the no-versions message, which names the range the
+        # candidate declared rather than negating the blocker it hit.
         self.pending_decision_dep_ranges: defaultdict[
             tuple[str, str, Version], _lookahead.DepRangeUnion
         ] = defaultdict(_lookahead.DepRangeUnion.zero)
@@ -1764,7 +1764,15 @@ class Provider:
         for cand, blocker_pkg, blocker_version in self.pending_blocks:
             if cand != normalized:
                 continue
-            out.append(f"requires {blocker_pkg} != {blocker_version}")
+            dep_range = self.pending_decision_dep_ranges[
+                (cand, blocker_pkg, blocker_version)
+            ].union
+            # The blocker is decided, so the line names that version rather
+            # than a singleton range, which has no specifier spelling.
+            out.append(
+                f"requires {blocker_pkg} in {self.format_range(dep_range)}"
+                f" but solution has it at {blocker_version}"
+            )
 
         for cand, blocker_pkg, pos_range in self.pending_range_blocks:
             if cand != normalized:

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -970,7 +970,11 @@ def _resolve_one_target(
     )
     observer = _ResolveObserver(settings.progress)
     resolver: Resolver[str, Version] = Resolver(
-        provider, observer=observer, range_type=VersionRange, root_version="0"
+        provider,
+        observer=observer,
+        range_type=VersionRange,
+        root_version="0",
+        format_range=provider.format_range,
     )
 
     _logger.debug("resolving %s", target.label)

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -4326,6 +4326,57 @@ class TestDecisionLookAhead:
 
         assert "exceeded" not in str(exc_info.value)
 
+    def test_full_resolve_report_spells_ranges_as_requirements(self) -> None:
+        """A real failure report spells a dependency the way a user wrote it.
+
+        The resolver runs with ``range_type=VersionRange``, which has no
+        ``__str__``, so without the hook a ``==V`` dependency shows the debug
+        repr and its internal ``AFTER_LOCALS`` boundary sentinel, and an
+        unconstrained root requirement shows ``(-inf, +inf)``.
+        """
+
+        def named_wheel(pkg: str, version: str) -> WheelFile:
+            return WheelFile(
+                filename=f"{pkg}-{version}-py3-none-any.whl",
+                url=f"https://example.com/{pkg}-{version}.whl",
+                version=version,
+                requires_python=None,
+                has_metadata=True,
+                upload_time=None,
+                local_path=None,
+            )
+
+        coordinator = make_coordinator(
+            listings={
+                "foo": [named_wheel("foo", "1.0")],
+                "app": [named_wheel("app", "3.0")],
+                "lib": [named_wheel("lib", "5.0"), named_wheel("lib", "9.0")],
+            },
+            metadata_by_version={
+                "1.0": make_metadata("foo", "1.0", "lib==9.0"),
+                "3.0": make_metadata("app", "3.0", "lib==5.0"),
+                "5.0": make_metadata("lib", "5.0"),
+                "9.0": make_metadata("lib", "9.0"),
+            },
+        )
+        root_reqs = {
+            "foo": VersionRange.full(admit_arbitrary=False),
+            "app": VersionRange.full(admit_arbitrary=False),
+        }
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
+        resolver = Resolver(
+            provider,
+            range_type=VersionRange,
+            root_version="0",
+            format_range=provider.format_range,
+        )
+        with pytest.raises(ResolutionError) as exc_info:
+            resolver.resolve(dict(root_reqs))
+
+        lines = str(exc_info.value).splitlines()
+        assert "because all versions of foo depend on lib ==9.0" in lines
+        assert "because your project depends on foo" in lines
+
 
 class TestLookAheadAbort:
     """Look-ahead abort path: when the scan rejects ``_LOOKAHEAD_ABORT_THRESHOLD``

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -1824,8 +1824,8 @@ class TestNoVersionsReasons:
         assert result is None
         reason = provider.get_no_versions_reason("foo")
         assert reason is not None
-        assert "bar" in reason
-        assert "root has it in" in reason
+        assert "<VersionRange" not in reason
+        assert "requires bar in [2.0, 2.0] but root has it in [1.0, 1.0]" in reason
 
     def test_range_block_rejection_names_the_blocker(self) -> None:
         """Same as above but the blocker is a positive-range constraint
@@ -1850,17 +1850,49 @@ class TestNoVersionsReasons:
             root_requirements={"foo": VersionRange.full(admit_arbitrary=False)},
         )
         pos_range = SpecifierSet("<2.0").to_range()
-        dep_range = SpecifierSet("==2.0").to_range()
         provider.solution_ranges["bar"] = pos_range
         result = provider.choose_version("foo", VersionRange.full())
         assert result is None
         reason = provider.get_no_versions_reason("foo")
         assert reason is not None
         # foo requires bar==2.0; the message must name that, not the solution range.
+        assert "<VersionRange" not in reason
+        assert "AFTER_LOCALS" not in reason
         assert (
-            f"requires bar in {dep_range} but solution has it in {pos_range}" in reason
+            "requires bar in [2.0, 2.0]"
+            " but solution has it in (-inf, 2.0.dev0)" in reason
         )
         assert "disjoint with current solution range" not in reason
+
+    def test_post_release_pin_blocker_renders_post_excluding_bound(self) -> None:
+        """``bar>2.0`` excludes 2.0's post releases, so it is disjoint with
+        ``==2.0.post1``. The lower bound must render as ``(2.0.post*``; a bare
+        ``(2.0`` would make the two reported intervals look overlapping.
+        """
+        coordinator = make_coordinator(
+            [make_wheel("1.0")],
+            metadata_text=(
+                "Metadata-Version: 2.1\n"
+                "Name: foo\n"
+                "Version: 1.0\n"
+                "Requires-Dist: bar>2.0\n"
+            ),
+            package="foo",
+        )
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            root_requirements={"foo": VersionRange.full(admit_arbitrary=False)},
+        )
+        provider.solution_ranges["bar"] = SpecifierSet("==2.0.post1").to_range()
+        result = provider.choose_version("foo", VersionRange.full())
+        assert result is None
+        reason = provider.get_no_versions_reason("foo")
+        assert reason is not None
+        assert (
+            "requires bar in (2.0.post*, +inf)"
+            " but solution has it in [2.0.post1, 2.0.post1]" in reason
+        )
 
 
 def _sdist_entry(version: str) -> dict[str, object]:

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -1731,9 +1731,9 @@ class TestNoVersionsReasons:
         # Nothing falls in this range, so the second ask has no blockers.
         assert provider.choose_version("foo", SpecifierSet(">=5.0").to_range()) is None
 
-        assert (
-            provider.get_no_versions_reason("foo")
-            == "every version in range was rejected: requires bar != 1.0"
+        assert provider.get_no_versions_reason("foo") == (
+            "every version in range was rejected:"
+            " requires bar in ==2.0 but solution has it at 1.0"
         )
 
     def test_sdist_only_under_dynamic_local_names_build_policy(self) -> None:
@@ -1825,7 +1825,7 @@ class TestNoVersionsReasons:
         reason = provider.get_no_versions_reason("foo")
         assert reason is not None
         assert "<VersionRange" not in reason
-        assert "requires bar in [2.0, 2.0] but root has it in [1.0, 1.0]" in reason
+        assert "requires bar in ==2.0 but root has it in ==1.0" in reason
 
     def test_range_block_rejection_names_the_blocker(self) -> None:
         """Same as above but the blocker is a positive-range constraint
@@ -1858,16 +1858,13 @@ class TestNoVersionsReasons:
         # foo requires bar==2.0; the message must name that, not the solution range.
         assert "<VersionRange" not in reason
         assert "AFTER_LOCALS" not in reason
-        assert (
-            "requires bar in [2.0, 2.0]"
-            " but solution has it in (-inf, 2.0.dev0)" in reason
-        )
+        assert "requires bar in ==2.0 but solution has it in <2.0" in reason
         assert "disjoint with current solution range" not in reason
 
-    def test_post_release_pin_blocker_renders_post_excluding_bound(self) -> None:
+    def test_post_release_pin_blocker_spells_both_sides_as_specifiers(self) -> None:
         """``bar>2.0`` excludes 2.0's post releases, so it is disjoint with
-        ``==2.0.post1``. The lower bound must render as ``(2.0.post*``; a bare
-        ``(2.0`` would make the two reported intervals look overlapping.
+        ``==2.0.post1``.  Both sides read as the specifiers a user would write,
+        so the reader can see why they do not overlap.
         """
         coordinator = make_coordinator(
             [make_wheel("1.0")],
@@ -1889,10 +1886,43 @@ class TestNoVersionsReasons:
         assert result is None
         reason = provider.get_no_versions_reason("foo")
         assert reason is not None
-        assert (
-            "requires bar in (2.0.post*, +inf)"
-            " but solution has it in [2.0.post1, 2.0.post1]" in reason
+        assert "requires bar in >2.0 but solution has it in ==2.0.post1" in reason
+
+    def test_decision_block_rejection_names_the_requirement(self) -> None:
+        """The decision-block diagnostic names the candidate's real
+        requirement, mirroring the range-block path.  ``foo`` 1.0 requires
+        ``bar==2.0`` and the resolver has already decided ``bar==1.0``, so
+        every ``foo`` candidate is rejected.  The message must name the
+        ``bar==2.0`` foo needs, not ``requires bar != 1.0`` (which wrongly
+        implies any bar other than 1.0 would satisfy foo).
+
+        The ranges are spelled out rather than interpolated, so the
+        assertion fails if the message ever prints the debug repr again.
+        """
+        coordinator = make_coordinator(
+            [make_wheel("1.0")],
+            metadata_text=(
+                "Metadata-Version: 2.1\n"
+                "Name: foo\n"
+                "Version: 1.0\n"
+                "Requires-Dist: bar==2.0\n"
+            ),
+            package="foo",
         )
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            root_requirements={"foo": VersionRange.full(admit_arbitrary=False)},
+        )
+        provider.solution_decisions["bar"] = V("1.0")
+        result = provider.choose_version("foo", VersionRange.full())
+        assert result is None
+        reason = provider.get_no_versions_reason("foo")
+        assert reason is not None
+        assert "<VersionRange" not in reason
+        assert "AFTER_LOCALS" not in reason
+        assert "requires bar in ==2.0 but solution has it at 1.0" in reason
+        assert "requires bar != 1.0" not in reason
 
 
 def _sdist_entry(version: str) -> dict[str, object]:

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -3361,10 +3361,12 @@ class TestAugmentResolutionError:
                 _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
 
         diagnostics = str(info.value).split("Diagnostics:")[1]
+        assert "<VersionRange" not in diagnostics
         assert (
-            "foo: every version in range was rejected: requires lib != 9.0"
-            in diagnostics
+            "foo: every version in range was rejected:"
+            " requires lib in ==5.0 but solution has it at 9.0" in diagnostics
         )
+        assert "requires lib != 9.0" not in diagnostics
         assert "foo: no version matches the requirement" not in diagnostics
 
     def test_cutoff_filtered_sdist_is_not_reported_as_never_published(
@@ -3450,7 +3452,7 @@ class TestAugmentResolutionError:
         assert "AFTER_LOCALS" not in diagnostics
         assert (
             "c: every version in range was rejected:"
-            " requires b in [1.0, 1.0] but root has it in [2, +inf)"
+            " requires b in ==1.0 but root has it in >=2"
         ) in diagnostics
 
 

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -3414,6 +3414,45 @@ class TestAugmentResolutionError:
             " dist-policy, or upload-time" in diagnostics
         )
 
+    def test_blocker_diagnostics_render_readable_ranges(self, tmp_path: Path) -> None:
+        """Blocker diagnostics render declared ranges, not the debug repr.
+
+        ``c`` declares ``b==1.0`` while the project requires ``b>=2``, so
+        look-ahead rejects every ``c`` candidate against the root requirement.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\ndependencies = ["b>=2", "c"]\n',
+            encoding="utf-8",
+        )
+
+        coordinator = make_coordinator(
+            listings={
+                "b": _index_wheels("b", "1.0", "2.0"),
+                "c": _index_wheels("c", "5.0", "6.0"),
+            },
+            metadata_by_version={
+                "1.0": _metadata("b", "1.0"),
+                "2.0": _metadata("b", "2.0"),
+                "5.0": _metadata("c", "5.0", "b==1.0"),
+                "6.0": _metadata("c", "6.0", "b==1.0"),
+            },
+        )
+
+        with patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda _self: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            with pytest.raises(ResolutionError) as info:
+                _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
+
+        diagnostics = str(info.value).split("Diagnostics:")[1]
+        assert "<VersionRange" not in diagnostics
+        assert "AFTER_LOCALS" not in diagnostics
+        assert (
+            "c: every version in range was rejected:"
+            " requires b in [1.0, 1.0] but root has it in [2, +inf)"
+        ) in diagnostics
+
 
 class TestConflictingRootRequirements:
     def test_both_requirements_are_named(self, tmp_path: Path) -> None:

--- a/nab-python/tests/test_widen_decision.py
+++ b/nab-python/tests/test_widen_decision.py
@@ -670,6 +670,40 @@ class TestNarrowForDisplay:
         coordinator.request_listing.assert_not_called()
 
 
+class TestFormatRange:
+    """``format_range`` prefers the specifier spelling of a range."""
+
+    def test_bounded_range_reads_as_its_specifiers(self) -> None:
+        provider = _listing_provider("p", ["1.0"])
+        assert provider.format_range(SpecifierSet(">=1,<2").to_range()) == "<2,>=1"
+
+    def test_equality_range_drops_the_boundary_sentinel(self) -> None:
+        """``==V`` carries an ``AFTER_LOCALS`` upper bound in its repr."""
+        provider = _listing_provider("p", ["1.0"])
+        constraint = SpecifierSet("==9.0").to_range()
+        assert "AFTER_LOCALS" in repr(constraint)
+        assert provider.format_range(constraint) == "==9.0"
+
+    def test_unconstrained_range_reads_as_nothing(self) -> None:
+        """Neither unconstrained form adds anything a reader needs."""
+        provider = _listing_provider("p", ["1.0"])
+        assert provider.format_range(VersionRange.full(admit_arbitrary=False)) == ""
+        assert provider.format_range(VersionRange.full(admit_arbitrary=True)) == ""
+
+    def test_empty_range_reads_as_no_version(self) -> None:
+        """The empty range spells as ``<0``, which says the wrong thing."""
+        provider = _listing_provider("p", ["1.0"])
+        assert str(VersionRange.empty().to_specifier_set()) == "<0"
+        assert provider.format_range(VersionRange.empty()) == "no version"
+
+    def test_unspellable_range_keeps_the_range_rendering(self) -> None:
+        """A disjunction has no specifier set, so the range renders itself."""
+        provider = _listing_provider("p", ["1.0"])
+        constraint = SpecifierSet("<5.0").to_range() | SpecifierSet(">=9.0").to_range()
+        assert constraint.to_specifier_set() is None
+        assert provider.format_range(constraint) == str(constraint)
+
+
 class TestPackagingProviderHooks:
     def test_widen_decision_returns_none(self) -> None:
         provider = PackagingProvider({"a": {V("1.0"): {}}})

--- a/nab-resolver/src/nab_resolver/conflict.py
+++ b/nab-resolver/src/nab_resolver/conflict.py
@@ -89,6 +89,7 @@ def conflict_resolution(
                 format_error(
                     current_incompatibility,
                     narrow=resolver.provider.narrow_for_display,
+                    format_range=resolver.format_range,
                 ),
                 incompatibility=current_incompatibility,
             )
@@ -150,6 +151,7 @@ def conflict_resolution(
                     format_error(
                         current_incompatibility,
                         narrow=resolver.provider.narrow_for_display,
+                        format_range=resolver.format_range,
                     ),
                     incompatibility=current_incompatibility,
                 )

--- a/nab-resolver/src/nab_resolver/report.py
+++ b/nab-resolver/src/nab_resolver/report.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from .types import Incompatibility
 
     _NarrowFn: TypeAlias = Callable[[Any, Any], Any]  # (package, constraint) -> shown
+    _FormatFn: TypeAlias = Callable[[Any], str]  # constraint -> display string
 
 __all__ = [
     "explain_incompatibility",
@@ -33,6 +34,7 @@ __all__ = [
 def format_error(
     root_incompatibility: Incompatibility[Any, Any],
     narrow: _NarrowFn | None = None,
+    format_range: _FormatFn = str,
 ) -> str:
     """Format a human-readable error from an incompatibility derivation tree.
 
@@ -46,9 +48,14 @@ def format_error(
     ``NO_VERSIONS`` line a narrowing to the full range is ignored, since the
     range is what keeps the sentence true.  Narrowing happens at render time
     only, never mutating the derivation tree.
+
+    ``format_range`` renders a constraint for display and defaults to ``str``,
+    which reads well for the resolver's own ``Range``.  A range type whose
+    ``str`` is a debug repr passes its own.  Rendering a constraint as the
+    empty string drops it from the line along with its separating space.
     """
     lines: list[str] = []
-    explain_incompatibility(root_incompatibility, lines, set(), narrow)
+    explain_incompatibility(root_incompatibility, lines, set(), narrow, format_range)
     return "\n".join(lines) if lines else "Resolution impossible"
 
 
@@ -68,6 +75,7 @@ def explain_incompatibility(
     lines: list[str],
     visited_ids: set[int],
     narrow: _NarrowFn | None = None,
+    format_range: _FormatFn = str,
 ) -> None:
     """Walk the cause tree appending one explanatory line per node.
 
@@ -87,10 +95,9 @@ def explain_incompatibility(
             for package in needed.get(id(node), ()):
                 gap = unstated.pop(package, None)
                 if gap is not None:
-                    lines.append(
-                        f"because no versions of {package} {gap} are available"
-                    )
-            lines.append(_render_line(node, narrow))
+                    subject = _with_range(str(package), format_range(gap))
+                    lines.append(f"because no versions of {subject} are available")
+            lines.append(_render_line(node, narrow, format_range))
             continue
 
         if id(node) in visited_ids:
@@ -237,6 +244,7 @@ def _narrowed_away(
 def _render_line(
     incompatibility: Incompatibility[Any, Any],
     narrow: _NarrowFn | None,
+    format_range: _FormatFn = str,
 ) -> str:
     """Render a single incompatibility as one explanation line."""
     cause = incompatibility.cause
@@ -258,30 +266,32 @@ def _render_line(
         if dep.is_positive():
             verb = "are" if plural else "is"
             return (
-                f"because {format_term(parent)} {verb} incompatible with "
-                f"{format_term(dep)}"
+                f"because {format_term(parent, format_range)} {verb} "
+                f"incompatible with {format_term(dep, format_range)}"
             )
         verb = "depend on" if plural else "depends on"
-        requirement = _format_requirement(dep.negate())
-        return f"because {format_term(parent)} {verb} {requirement}"
+        requirement = _format_requirement(dep.negate(), format_range)
+        return f"because {format_term(parent, format_range)} {verb} {requirement}"
 
     if cause is IncompatibilityCause.ROOT and len(terms) == _ATTRIBUTION_CLAUSE_TERMS:
         _, dep = terms
         positive_dep = dep if dep.is_positive() else dep.negate()
-        return f"because your project depends on {_format_requirement(positive_dep)}"
+        requirement = _format_requirement(positive_dep, format_range)
+        return f"because your project depends on {requirement}"
 
     if cause is IncompatibilityCause.CONSTRAINT:
         (term,) = terms
-        return (
-            f"because the user constrained "
-            f"{term.package} {incompatibility.constraint_range}"
-        )
+        shown = format_range(incompatibility.constraint_range)
+        subject = _with_range(str(term.package), shown)
+        return f"because the user constrained {subject}"
 
-    return _render_prefix_line(cause, terms)
+    return _render_prefix_line(cause, terms, format_range)
 
 
 def _render_prefix_line(
-    cause: IncompatibilityCause, terms: Sequence[Term[Any, Any]]
+    cause: IncompatibilityCause,
+    terms: Sequence[Term[Any, Any]],
+    format_range: _FormatFn = str,
 ) -> str:
     """Render a clause that has no attribution form as a prefix and a body."""
     # The virtual root is always selected, so naming it says nothing; a line
@@ -297,7 +307,7 @@ def _render_prefix_line(
         IncompatibilityCause.DERIVED: "so",
     }.get(cause, "")
     render = _format_requirement if cause in _REQUIREMENT_PREFIX_CAUSES else format_term
-    body = " and ".join(render(term) for term in stated)
+    body = " and ".join(render(term, format_range) for term in stated)
 
     if cause is IncompatibilityCause.NO_VERSIONS:
         return f"{prefix} {body} are available"
@@ -309,17 +319,26 @@ def _is_full(term: Term[Any, Any]) -> bool:
     return term.is_positive() and (~term.constraint).is_empty
 
 
-def _format_requirement(term: Term[Any, Any]) -> str:
+def _with_range(subject: str, shown: str) -> str:
+    """Join a subject to its rendered range, omitting an empty one.
+
+    An unconstrained range renders as the empty string, and a bare space
+    before nothing would trail the line.
+    """
+    return f"{subject} {shown}" if shown else subject
+
+
+def _format_requirement(term: Term[Any, Any], format_range: _FormatFn = str) -> str:
     """Render a term in object position ("depends on b").
 
     A full term there is the package name alone.
     """
     if _is_full(term):
         return str(term.package)
-    return format_term(term)
+    return format_term(term, format_range)
 
 
-def format_term(term: Term[Any, Any]) -> str:
+def format_term(term: Term[Any, Any], format_range: _FormatFn = str) -> str:
     """Render a single term as ``[not ]package range``.
 
     A full term reads as "all versions of package"; :func:`_format_requirement`
@@ -328,7 +347,7 @@ def format_term(term: Term[Any, Any]) -> str:
     if _is_full(term):
         return f"all versions of {term.package}"
     sign = "" if term.is_positive() else "not "
-    return f"{sign}{term.package} {term.constraint}"
+    return _with_range(f"{sign}{term.package}", format_range(term.constraint))
 
 
 def prior_cause(

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -21,7 +21,7 @@ Rust implementation: https://github.com/pubgrub-rs/pubgrub
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Generic, Protocol
 
@@ -413,6 +413,7 @@ class Resolver(Generic[PackageType, VersionType]):
         max_iterations: int = DEFAULT_MAX_ITERATIONS,
         range_type: type[RangeProtocol[Any]] = Range,
         root_version: Any = 1,
+        format_range: Callable[[Any], str] = str,
     ) -> None:
         """Create a resolver with the given provider and optional observer.
 
@@ -422,6 +423,11 @@ class Resolver(Generic[PackageType, VersionType]):
         comparable type) but a PEP 440 range type such as
         :class:`packaging.ranges.VersionRange` requires a parseable
         version string or :class:`~packaging.version.Version` here.
+
+        ``format_range`` renders a constraint in a failure report.  It travels
+        with ``range_type``: the default ``str`` reads well for
+        :class:`~nab_resolver.ranges.Range`, while a range type whose ``str``
+        is a debug representation needs its own.
         """
         self.provider = provider
         self.observer: ResolverObserver[PackageType, VersionType] = (
@@ -430,6 +436,7 @@ class Resolver(Generic[PackageType, VersionType]):
         self.max_iterations = max_iterations
         self.range_type = range_type
         self.root_version = root_version
+        self.format_range = format_range
 
         self.incompatibilities: list[Incompatibility[Any, Any]] = []
         self.package_to_incompatibilities: defaultdict[Any, list[int]] = defaultdict(

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -2049,6 +2049,61 @@ class TestErrorMessages:
         assert negative == "not a [1, +inf)"
 
 
+class TestFormatRangeHook:
+    """``format_range`` renders every constraint a report line shows.
+
+    A range type whose ``str`` is a debug representation supplies its own; the
+    default is ``str``, which reads well for :class:`Range`.
+    """
+
+    @staticmethod
+    def _shown(_constraint: object) -> str:
+        return "SHOWN"
+
+    @staticmethod
+    def _blank(_constraint: object) -> str:
+        return ""
+
+    def test_hook_renders_terms_on_both_sides_of_a_dependency(self) -> None:
+        dependency = Incompatibility(
+            [
+                Term("a", Range.at_least(1), positive=True),
+                Term("b", Range.at_least(3), positive=False),
+            ],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+        assert (
+            format_error(dependency, format_range=self._shown)
+            == "because a SHOWN depends on b SHOWN"
+        )
+
+    def test_hook_renders_the_user_constraint_line(self) -> None:
+        constrained = Incompatibility(
+            [Term("a", Range.at_least(1), positive=True)],
+            cause=IncompatibilityCause.CONSTRAINT,
+            constraint_range=Range.less_than(2),
+        )
+        assert (
+            format_error(constrained, format_range=self._shown)
+            == "because the user constrained a SHOWN"
+        )
+
+    def test_a_range_rendered_as_nothing_leaves_no_trailing_space(self) -> None:
+        """An unconstrained range renders empty, so the name carries the line."""
+        term = Term("a", Range.at_least(1), positive=False)
+        assert format_term(term, self._blank) == "not a"
+
+        constrained = Incompatibility(
+            [Term("a", Range.at_least(1), positive=True)],
+            cause=IncompatibilityCause.CONSTRAINT,
+            constraint_range=Range.full(),
+        )
+        assert (
+            format_error(constrained, format_range=self._blank)
+            == "because the user constrained a"
+        )
+
+
 class TestFullRangeWording:
     """A term admitting every version reads as prose, not as an interval.
 

--- a/nab-resolver/tests/test_widen_hook.py
+++ b/nab-resolver/tests/test_widen_hook.py
@@ -554,6 +554,15 @@ class TestUnstatedVersions:
             message
         )
 
+    def test_states_the_gap_through_the_format_range_hook(self) -> None:
+        """The stated listing is a range too, so it renders like every other."""
+        with pytest.raises(ResolutionError) as exc_info:
+            Resolver(
+                _SnappingProvider(_REJECTED_RUN),
+                format_range=lambda _constraint: "SHOWN",
+            ).resolve({"a": Range.at_least(2)})
+        assert "because no versions of a SHOWN are available" in str(exc_info.value)
+
     def test_states_the_gap_a_resolved_requirement_leaves(self) -> None:
         """The requirement runs past the exclusion that resolves it."""
         packages = {"a": {1: {}, 2: {"py": Range.at_least(11)}, 3: {}}, "py": {9: {}}}


### PR DESCRIPTION
Asking for `paddlex==3.0.0` and hitting a conflict printed this:

```
paddlex <VersionRange '[3.0.0, 3.0.0[AFTER_LOCALS]]'>
```

`AFTER_LOCALS` is an internal boundary sentinel for "just past every local version of 3.0.0". It cannot be written as a requirement and means nothing to whoever is reading the failure. Every range in a failure report came out this way, since the formatter interpolates the constraint and `VersionRange` defines `__repr__` and no `__str__`.

The formatter now takes a `format_range` hook. It defaults to `str`, so the resolver's own `Range` renders as it did, and the provider supplies one that prefers the specifier-set spelling:

- A range a specifier set can spell reads as that specifier set, so the line above becomes `paddlex ==3.0.0`.
- An unconstrained range renders as nothing, so a bare requirement reads "because your project depends on foo" instead of carrying `(-inf, +inf)`.
- The empty range reads "no version", where a specifier set spells it `<0`.
- A range with no specifier spelling, such as a disjunction, keeps the range's own rendering.

`VersionRange.to_specifier_set` came in with the vendored packaging pin in #732. The diagnostics lines are composed inside the provider before the formatter sees them, so this hook cannot reach them; #472 extends it to those.
