### PR TITLE
docs: name archive sources in the never and build-local policies

### DIFF
--- a/docs/reference/build-policy.md
+++ b/docs/reference/build-policy.md
@@ -37,6 +37,10 @@ Static metadata only, from any source:
 * VCS clones declared via `[[tool.nab.vcs-sources]]`: the clone
   is fetched and its `pyproject.toml` is read statically.  Same
   skip behaviour for dynamic deps.
+* Archive sources declared via `[[tool.nab.archive-sources]]`:
+  the `.tar.gz` is downloaded, hash-verified, and extracted, then
+  its `pyproject.toml` is read statically.  Same skip behaviour
+  for dynamic deps.
 
 Picks the most reproducible posture: every input to the SAT
 problem is a file read, not a sandboxed subprocess.  Use `never`
@@ -50,8 +54,8 @@ Adds PEP 517 backend invocation on local checkouts.  When a
 `dynamic = ["dependencies"]`, the project's
 `[build-system].build-backend` runs inside an isolated venv via
 `nab_python._build.runner` and the
-resulting wheel `METADATA` is used.  Remote PyPI sdists and VCS
-clones remain static-only.
+resulting wheel `METADATA` is used.  Remote PyPI sdists, VCS
+clones, and archive sources remain static-only.
 
 ## `build-remote`
 


### PR DESCRIPTION
The build-policy reference lists every source type nab reads statically under `never`, but archive sources declared via `[[tool.nab.archive-sources]]` were missing, even though they are read the same way as local checkouts and VCS clones. `build-remote` already documented them, so the two lower levels read as if they did not handle archive sources at all.

Add the archive-sources bullet to `never`, and name them alongside the remote PyPI sdists and VCS clones that stay static-only under `build-local`.
