### PR TITLE
fix cli.md claim that --groups populates the lockfile default-groups array

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -39,7 +39,9 @@ Dependency-group selection (PEP 735):
 * `--groups foo bar` folds the named groups from the project's
   `[dependency-groups]` table into the resolve. The selected
   group names land in the lockfile's top-level
-  `dependency-groups` and `default-groups` arrays.
+  `dependency-groups` array. The separate `default-groups` array
+  records the `[tool.nab].default-groups` project setting, not
+  this run's selection.
 * `--all-groups` selects every group defined in the project.
 
 Extras selection:


### PR DESCRIPTION
The CLI reference said a `--groups foo bar` selection lands in both the lockfile's top-level `dependency-groups` and `default-groups` arrays. That is wrong for `default-groups`.

Only `dependency-groups` records this run's `--groups` selection. The `default-groups` array records the `[tool.nab].default-groups` project setting, which is a separate value. Reworded the bullet so each array is tied to its actual source.

Docs only, no behavior change.
