### PR TITLE
fix a base dep's transitive dep gated behind a conflict-extra marker

### DIFF
--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -297,10 +297,14 @@ def build_target_lock(
             provider, canonical, version, indexes
         )
 
+    dependencies, base_dependencies = _forward_dependency_graph(
+        provider, pins, resolved_keys
+    )
     return TargetLock(
         target=target,
         pins=lock_pins,
-        dependencies=_forward_dependency_graph(provider, pins, resolved_keys),
+        dependencies=dependencies,
+        base_dependencies=base_dependencies,
     )
 
 
@@ -308,15 +312,18 @@ def _forward_dependency_graph(
     provider: LockInputProvider,
     pins: Mapping[str, Version],
     resolved_keys: Iterable[str],
-) -> dict[str, tuple[str, ...]]:
+) -> tuple[dict[str, tuple[str, ...]], dict[str, tuple[str, ...]]]:
     """Build the forward dependency graph among the locked packages.
 
-    Each pinned package maps to the canonical names of its direct
-    dependencies that are themselves pinned.  Base dependencies come
-    from ``deps_cache``; an activated extra (a ``name[extra]`` key in
-    ``resolved_keys``) folds that extra's dependencies in too.  Names
-    not in ``pins`` are dropped so every edge points at a real
-    ``[[packages]]`` entry.
+    Returns ``(full, base)``.  ``full`` maps each pinned package to the
+    canonical names of its direct dependencies that are themselves
+    pinned; an activated extra (a ``name[extra]`` key in
+    ``resolved_keys``) folds that extra's dependencies in.  ``base`` is
+    the subset from each package's own metadata (``deps_cache``), before
+    any extra is folded in, so it holds only the edges that fire
+    regardless of which extra was activated.  Names not in ``pins`` are
+    dropped from both so every edge points at a real ``[[packages]]``
+    entry.
     """
     from ..provider import split_extra
 
@@ -328,26 +335,32 @@ def _forward_dependency_graph(
 
     pinned = {canonicalize_name(name) for name in pins}
     graph: dict[str, tuple[str, ...]] = {}
+    base_graph: dict[str, tuple[str, ...]] = {}
     for raw_name, version in pins.items():
         canonical = canonicalize_name(raw_name)
         cache_key = (canonical, version)
-        dep_names = {
+        base_deps = {
             canonicalize_name(split_extra(dep)[0])
             for dep in provider.deps_cache.get(cache_key, {})
         }
+        all_deps = set(base_deps)
         extra_map = provider.extra_deps_map.get(cache_key, {})
         for extra in activated_extras.get(canonical, ()):
-            dep_names.update(
+            all_deps.update(
                 canonicalize_name(split_extra(dep)[0])
                 for dep in extra_map.get(extra, {})
             )
-        dep_names &= pinned
+        base_deps &= pinned
+        all_deps &= pinned
         # An umbrella extra (pkg[all] pulling pkg[graphviz]) can name its own
         # package; drop it so pkg is never an edge to itself.
-        dep_names.discard(canonical)
-        if dep_names:
-            graph[canonical] = tuple(sorted(dep_names))
-    return graph
+        base_deps.discard(canonical)
+        all_deps.discard(canonical)
+        if all_deps:
+            graph[canonical] = tuple(sorted(all_deps))
+        if base_deps:
+            base_graph[canonical] = tuple(sorted(base_deps))
+    return graph, base_graph
 
 
 def _index_pin_from_listing(

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -525,11 +525,9 @@ def _close_base_names(
     a package the forks pull in through the base dep is missing from
     ``env_base_names`` and would keep its membership clause, so it drops
     out of the no-member install context even though the base dep that
-    requires it installs there.  Following the edges present in every
-    fork of the environment restores the closure, keeping the no-member
-    context closed under the lock's own dependency graph.  An edge only
-    some forks carry (a member activating an extra on a base dep) is left
-    out, so a member-only dep is not promoted to base.
+    requires it installs there.  Following the base (unconditional) edges
+    present in every fork of the environment restores the closure, keeping
+    the no-member context closed under the lock's own dependency graph.
 
     Preserves the missing-signature contract: only signatures present in
     ``env_base_names`` appear in the result, so an env with no base pass
@@ -558,18 +556,21 @@ def _shared_fork_edges(
     env_signatures: Mapping[str, tuple[tuple[str, str], ...]],
     env_fork_counts: Mapping[tuple[tuple[str, str], ...], int],
 ) -> dict[tuple[tuple[str, str], ...], dict[str, list[str]]]:
-    """Per-env adjacency of the edges present in every fork of the env.
+    """Per-env adjacency of the base edges present in every fork of the env.
 
-    An edge a member adds in only some forks (an extra it activates on a
-    base dep) is dropped, so following these edges never promotes a
-    member-only dep to base.
+    Walks ``base_dependencies`` (a package's unconditional edges), never
+    the extra-folded ``dependencies``, so a dep a conflict member pulls in
+    through an extra is not an edge here even when every fork activates
+    that extra.  A base edge only some forks carry (a base dep pinned to a
+    version whose deps differ) is dropped too.  Following these edges thus
+    never promotes a member-only dep to base.
     """
     edge_counts: defaultdict[tuple[tuple[str, str], ...], Counter[tuple[str, str]]] = (
         defaultdict(Counter)
     )
     for label, lock in targets.items():
         counter = edge_counts[env_signatures[label]]
-        for source, deps in lock.dependencies.items():
+        for source, deps in lock.base_dependencies.items():
             for dep in dict.fromkeys(deps):
                 counter[source, dep] += 1
 

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -11,7 +11,7 @@ disjointness validation lives in
 from __future__ import annotations
 
 import os
-from collections import defaultdict
+from collections import Counter, defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -355,15 +355,21 @@ def _build_packages(lock_input: LockInput, lock_dir: Path) -> list[Package]:
     but not by the base is absent from that set, so it keeps the
     membership clause and does not install when no member is selected.
     See :class:`LockInput.env_base_names` for the missing-signature
-    contract.  Forks of one environment that disagree on a base
-    dependency's pin raise :class:`DivergentBaseDependencyError`
-    instead of emitting a lock whose no-member context misses it.
+    contract.  The base-name set is first closed under the emitted
+    dependency edges (:func:`_close_base_names`) so a transitive dep the
+    forks pull in through a base dep counts as base too.  Forks of one
+    environment that disagree on a base dependency's pin raise
+    :class:`DivergentBaseDependencyError` instead of emitting a lock
+    whose no-member context misses it.
     """
     out: list[Package] = []
     targets = lock_input.targets
     by_name = _group_by_name(targets)
     env_signatures = _env_signatures(targets)
     env_fork_counts = _count(env_signatures.values())
+    base_names = _close_base_names(
+        targets, env_signatures, env_fork_counts, lock_input.env_base_names
+    )
 
     for canonical_name, per_target in by_name.items():
         groups = _group_pins_by_pin(per_target)
@@ -373,7 +379,7 @@ def _build_packages(lock_input: LockInput, lock_dir: Path) -> list[Package]:
             groups,
             env_signatures,
             env_fork_counts,
-            lock_input.env_base_names,
+            base_names,
         )
 
         for pins, labels in groups:
@@ -383,7 +389,7 @@ def _build_packages(lock_input: LockInput, lock_dir: Path) -> list[Package]:
                 targets,
                 env_signatures,
                 env_fork_counts,
-                lock_input.env_base_names,
+                base_names,
             )
             out.append(
                 _pin_to_package(
@@ -502,6 +508,80 @@ def _merge_pins_in_group(pins: list[PinShape]) -> PinShape:
         wheels=tuple(sorted(seen_wheels.values(), key=_wheel_sort_key)),
         requires_python=requires_python,
     )
+
+
+def _close_base_names(
+    targets: Mapping[str, TargetLock],
+    env_signatures: Mapping[str, tuple[tuple[str, str], ...]],
+    env_fork_counts: Mapping[tuple[tuple[str, str], ...], int],
+    env_base_names: Mapping[tuple[tuple[str, str], ...], frozenset[str]],
+) -> dict[tuple[tuple[str, str], ...], frozenset[str]]:
+    """Close each env's base-name set under the emitted dependency edges.
+
+    ``env_base_names`` records the names an independent base pass
+    resolved, at that pass's versions, which emission discards in favour
+    of the conflict-fork versions.  When the forks pin a base dependency
+    lower than the base pass did, its emitted transitive closure differs:
+    a package the forks pull in through the base dep is missing from
+    ``env_base_names`` and would keep its membership clause, so it drops
+    out of the no-member install context even though the base dep that
+    requires it installs there.  Following the edges present in every
+    fork of the environment restores the closure, keeping the no-member
+    context closed under the lock's own dependency graph.  An edge only
+    some forks carry (a member activating an extra on a base dep) is left
+    out, so a member-only dep is not promoted to base.
+
+    Preserves the missing-signature contract: only signatures present in
+    ``env_base_names`` appear in the result, so an env with no base pass
+    stays absent and its base status stays unknowable.
+    """
+    if not env_base_names:
+        return dict(env_base_names)
+
+    shared = _shared_fork_edges(targets, env_signatures, env_fork_counts)
+    closed: dict[tuple[tuple[str, str], ...], frozenset[str]] = {}
+    for signature, base in env_base_names.items():
+        adjacency = shared.get(signature, {})
+        reachable = set(base)
+        stack = list(base)
+        while stack:
+            for dep in adjacency.get(stack.pop(), ()):
+                if dep not in reachable:
+                    reachable.add(dep)
+                    stack.append(dep)
+        closed[signature] = frozenset(reachable)
+    return closed
+
+
+def _shared_fork_edges(
+    targets: Mapping[str, TargetLock],
+    env_signatures: Mapping[str, tuple[tuple[str, str], ...]],
+    env_fork_counts: Mapping[tuple[tuple[str, str], ...], int],
+) -> dict[tuple[tuple[str, str], ...], dict[str, list[str]]]:
+    """Per-env adjacency of the edges present in every fork of the env.
+
+    An edge a member adds in only some forks (an extra it activates on a
+    base dep) is dropped, so following these edges never promotes a
+    member-only dep to base.
+    """
+    edge_counts: defaultdict[tuple[tuple[str, str], ...], Counter[tuple[str, str]]] = (
+        defaultdict(Counter)
+    )
+    for label, lock in targets.items():
+        counter = edge_counts[env_signatures[label]]
+        for source, deps in lock.dependencies.items():
+            for dep in dict.fromkeys(deps):
+                counter[source, dep] += 1
+
+    shared: dict[tuple[tuple[str, str], ...], dict[str, list[str]]] = {}
+    for signature, counter in edge_counts.items():
+        count = env_fork_counts[signature]
+        adjacency: defaultdict[str, list[str]] = defaultdict(list)
+        for (source, dep), seen in counter.items():
+            if seen == count:
+                adjacency[source].append(dep)
+        shared[signature] = adjacency
+    return shared
 
 
 def _check_base_fork_agreement(

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -344,7 +344,10 @@ class TargetLock:
     ``pins`` is keyed by canonical package name; each value is the pin
     that target resolved to.  ``dependencies`` is the forward edge set
     among those pins, keyed the same way, which the writer emits as
-    PEP 751 ``packages.dependencies``.
+    PEP 751 ``packages.dependencies``.  ``base_dependencies`` is its
+    unconditional subset: the edges from each package's own metadata,
+    before any activated extra folds its deps in.  The writer closes a
+    conflict environment's no-member base-name set over these edges only.
 
     ``target`` is the environment the pins hold for.  The writer reads
     its markers (see :attr:`~nab_python.target.ResolveTarget.marker_string`)
@@ -355,6 +358,7 @@ class TargetLock:
     target: ResolveTarget
     pins: Mapping[str, PinShape]
     dependencies: Mapping[str, tuple[str, ...]] = field(default_factory=dict)
+    base_dependencies: Mapping[str, tuple[str, ...]] = field(default_factory=dict)
 
 
 @dataclass

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -942,29 +942,14 @@ class TestConflictForkBaseDepDivergentClosure:
             "baz": _index_pin(name="baz", version="1.0"),
         }
         fork_deps = {"foo": ("baz",)}
-        cpu = self._LINUX.with_selection(self._CPU)
-        gpu = self._LINUX.with_selection(self._GPU)
-        targets = {
-            cpu.label: TargetLock(
-                target=cpu, pins=dict(fork_pins), dependencies=dict(fork_deps)
-            ),
-            gpu.label: TargetLock(
-                target=gpu, pins=dict(fork_pins), dependencies=dict(fork_deps)
-            ),
-        }
-        return LockInput(
-            targets=targets,
-            env_base_names={_env_signature(self._LINUX): frozenset({"foo", "bar"})},
-            extras=("cpu", "gpu"),
-            conflicts=(
-                ConflictSet(
-                    members=(
-                        ConflictMember(ConflictKind.EXTRA, "cpu"),
-                        ConflictMember(ConflictKind.EXTRA, "gpu"),
-                    ),
-                    policy=ConflictPolicy.AT_MOST_ONE,
-                ),
-            ),
+        return self._lock_input_with(
+            cpu_pins=fork_pins,
+            cpu_deps=fork_deps,
+            cpu_base_deps=fork_deps,
+            gpu_pins=fork_pins,
+            gpu_deps=fork_deps,
+            gpu_base_deps=fork_deps,
+            base_names=frozenset({"foo", "bar"}),
         )
 
     def test_transitive_dep_of_base_dep_installs_with_no_member(self) -> None:
@@ -983,8 +968,10 @@ class TestConflictForkBaseDepDivergentClosure:
         self,
         cpu_pins: Mapping[str, PinShape],
         cpu_deps: Mapping[str, tuple[str, ...]],
+        cpu_base_deps: Mapping[str, tuple[str, ...]],
         gpu_pins: Mapping[str, PinShape],
         gpu_deps: Mapping[str, tuple[str, ...]],
+        gpu_base_deps: Mapping[str, tuple[str, ...]],
         base_names: frozenset[str],
     ) -> LockInput:
         cpu = self._LINUX.with_selection(self._CPU)
@@ -992,10 +979,16 @@ class TestConflictForkBaseDepDivergentClosure:
         return LockInput(
             targets={
                 cpu.label: TargetLock(
-                    target=cpu, pins=dict(cpu_pins), dependencies=dict(cpu_deps)
+                    target=cpu,
+                    pins=dict(cpu_pins),
+                    dependencies=dict(cpu_deps),
+                    base_dependencies=dict(cpu_base_deps),
                 ),
                 gpu.label: TargetLock(
-                    target=gpu, pins=dict(gpu_pins), dependencies=dict(gpu_deps)
+                    target=gpu,
+                    pins=dict(gpu_pins),
+                    dependencies=dict(gpu_deps),
+                    base_dependencies=dict(gpu_base_deps),
                 ),
             },
             env_base_names={_env_signature(self._LINUX): base_names},
@@ -1011,10 +1004,70 @@ class TestConflictForkBaseDepDivergentClosure:
             ),
         )
 
-    def test_extra_only_dep_of_base_dep_stays_member_gated(self) -> None:
-        # ``cudalib`` is pulled in only by the cpu fork (a member activates
-        # an extra on the base dep foo), so the edge is not shared by every
-        # fork and cudalib must not be promoted to base.
+    def test_shared_extra_activated_dep_stays_member_gated(self) -> None:
+        # foo is the only base dep; every fork installs it as plain foo.
+        # Both members activate foo[telemetry], so ``telemetrylib`` is a
+        # foo -> telemetrylib edge in every fork's full graph, but it is
+        # extra-activated (absent from ``base_dependencies``).  It must
+        # not be promoted to base: plain foo does not pull it in the
+        # no-member context.
+        cpu_pins: dict[str, PinShape] = {
+            "foo": _index_pin(name="foo", version="1.0"),
+            "telemetrylib": _index_pin(name="telemetrylib", version="1.0"),
+            "torch-cpu": _index_pin(name="torch-cpu", version="1.0"),
+        }
+        gpu_pins: dict[str, PinShape] = {
+            "foo": _index_pin(name="foo", version="1.0"),
+            "telemetrylib": _index_pin(name="telemetrylib", version="1.0"),
+            "torch-gpu": _index_pin(name="torch-gpu", version="1.0"),
+        }
+        lock_input = self._lock_input_with(
+            cpu_pins=cpu_pins,
+            cpu_deps={"foo": ("telemetrylib",)},
+            cpu_base_deps={},
+            gpu_pins=gpu_pins,
+            gpu_deps={"foo": ("telemetrylib",)},
+            gpu_base_deps={},
+            base_names=frozenset({"foo"}),
+        )
+        pylock = build_pylock(lock_input)
+        by_name = {str(p.name): p for p in pylock.packages}
+
+        assert '"cpu" in extras' in str(by_name["telemetrylib"].marker)
+
+    def test_divergent_extra_activated_dep_emits_cleanly(self) -> None:
+        # Same shape, but the extra-activated telemetrylib pins diverge
+        # across the forks.  It is member-gated, not base, so the two
+        # entries stay disjoint and no DivergentBaseDependencyError fires.
+        cpu_pins: dict[str, PinShape] = {
+            "foo": _index_pin(name="foo", version="1.0"),
+            "telemetrylib": _index_pin(name="telemetrylib", version="1.0"),
+        }
+        gpu_pins: dict[str, PinShape] = {
+            "foo": _index_pin(name="foo", version="1.0"),
+            "telemetrylib": _index_pin(name="telemetrylib", version="2.0"),
+        }
+        lock_input = self._lock_input_with(
+            cpu_pins=cpu_pins,
+            cpu_deps={"foo": ("telemetrylib",)},
+            cpu_base_deps={},
+            gpu_pins=gpu_pins,
+            gpu_deps={"foo": ("telemetrylib",)},
+            gpu_base_deps={},
+            base_names=frozenset({"foo"}),
+        )
+        pylock = build_pylock(lock_input)
+        markers = [
+            str(p.marker) for p in pylock.packages if str(p.name) == "telemetrylib"
+        ]
+        assert len(markers) == 2
+        assert all("in extras" in marker for marker in markers)
+
+    def test_base_edge_only_some_forks_carry_stays_member_gated(self) -> None:
+        # cudalib is a base dep of foo, but only the cpu fork pins it, so
+        # foo -> cudalib is a base edge one fork carries and the other
+        # drops.  An edge not shared by every fork must not promote
+        # cudalib to base.
         lock_input = self._lock_input_with(
             cpu_pins={
                 "foo": _index_pin(name="foo", version="2.0"),
@@ -1022,11 +1075,13 @@ class TestConflictForkBaseDepDivergentClosure:
                 "cudalib": _index_pin(name="cudalib", version="1.0"),
             },
             cpu_deps={"foo": ("baz", "cudalib")},
+            cpu_base_deps={"foo": ("baz", "cudalib")},
             gpu_pins={
                 "foo": _index_pin(name="foo", version="2.0"),
                 "baz": _index_pin(name="baz", version="1.0"),
             },
             gpu_deps={"foo": ("baz",)},
+            gpu_base_deps={"foo": ("baz",)},
             base_names=frozenset({"foo"}),
         )
         pylock = build_pylock(lock_input)
@@ -1045,8 +1100,10 @@ class TestConflictForkBaseDepDivergentClosure:
         lock_input = self._lock_input_with(
             cpu_pins=pins,
             cpu_deps=deps,
+            cpu_base_deps=deps,
             gpu_pins=pins,
             gpu_deps=deps,
+            gpu_base_deps=deps,
             base_names=frozenset({"foo"}),
         )
         pylock = build_pylock(lock_input)
@@ -3913,8 +3970,10 @@ class TestDependencyGraph:
             resolved_keys=("foo", "bar", "baz"),
         )
         # ``missing`` is not locked, so it is dropped; bar and baz have no
-        # locked dependencies, so they are absent from the graph.
+        # locked dependencies, so they are absent from the graph.  These
+        # are all base (unconditional) edges, so both graphs agree.
         assert lock.dependencies == {"foo": ("bar",)}
+        assert lock.base_dependencies == {"foo": ("bar",)}
 
     def test_activated_extra_edges_join_graph(self) -> None:
         provider = _FakeProvider(
@@ -3934,6 +3993,8 @@ class TestDependencyGraph:
             resolved_keys=("foo", "foo[cli]", "foo[doc]", "plugin"),
         )
         assert lock.dependencies == {"foo": ("plugin",)}
+        # plugin is pulled only by the cli extra, so it is not a base edge.
+        assert lock.base_dependencies == {}
 
     def test_umbrella_extra_drops_self_edge(self) -> None:
         # ``all`` pulls ``mypkg[graphviz]`` and ``mypkg[otel]``, so its recorded
@@ -3970,6 +4031,9 @@ class TestDependencyGraph:
             ),
         )
         assert lock.dependencies == {"mypkg": ("graphviz-lib", "otel-lib")}
+        # Both transitive deps arrive through extras, so neither is a base
+        # edge and mypkg has no base dependencies.
+        assert lock.base_dependencies == {}
 
     def test_emitted_as_pep751_dependencies(self) -> None:
         text = write_lock(

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -921,6 +921,144 @@ class TestConflictForkBaseDepDivergence:
         assert '"cpu" in extras' in str(shared.marker)
 
 
+class TestConflictForkBaseDepDivergentClosure:
+    """A base dep is agreed across the conflict forks, but the forks pin
+    it lower than the independent base pass, so its emitted transitive
+    dep is absent from ``env_base_names``.  That dep installs whenever the
+    unconditional base dep does, so it must drop its membership clause
+    too, or the no-member context installs the base dep without a
+    dependency it declares."""
+
+    _LINUX: ClassVar[ResolveTarget] = _target()
+    _CPU: ClassVar[tuple[tuple[str, str], ...]] = (("extra", "cpu"),)
+    _GPU: ClassVar[tuple[tuple[str, str], ...]] = (("extra", "gpu"),)
+
+    def _lock_input(self) -> LockInput:
+        # Both forks pin foo==2.0 (foo -> baz) and baz==1.0.  The base
+        # pass independently resolved foo==3.0 (foo -> bar), so
+        # ``env_base_names`` names foo and bar but never baz.
+        fork_pins: dict[str, PinShape] = {
+            "foo": _index_pin(name="foo", version="2.0"),
+            "baz": _index_pin(name="baz", version="1.0"),
+        }
+        fork_deps = {"foo": ("baz",)}
+        cpu = self._LINUX.with_selection(self._CPU)
+        gpu = self._LINUX.with_selection(self._GPU)
+        targets = {
+            cpu.label: TargetLock(
+                target=cpu, pins=dict(fork_pins), dependencies=dict(fork_deps)
+            ),
+            gpu.label: TargetLock(
+                target=gpu, pins=dict(fork_pins), dependencies=dict(fork_deps)
+            ),
+        }
+        return LockInput(
+            targets=targets,
+            env_base_names={_env_signature(self._LINUX): frozenset({"foo", "bar"})},
+            extras=("cpu", "gpu"),
+            conflicts=(
+                ConflictSet(
+                    members=(
+                        ConflictMember(ConflictKind.EXTRA, "cpu"),
+                        ConflictMember(ConflictKind.EXTRA, "gpu"),
+                    ),
+                    policy=ConflictPolicy.AT_MOST_ONE,
+                ),
+            ),
+        )
+
+    def test_transitive_dep_of_base_dep_installs_with_no_member(self) -> None:
+        pylock = build_pylock(self._lock_input())
+        by_name = {str(p.name): p for p in pylock.packages}
+        no_member = self._LINUX.env_with_membership()
+
+        foo = by_name["foo"]
+        assert foo.marker is None or foo.marker.evaluate(no_member)
+
+        baz = by_name["baz"]
+        assert "in extras" not in str(baz.marker)
+        assert baz.marker is None or baz.marker.evaluate(no_member)
+
+    def _lock_input_with(
+        self,
+        cpu_pins: Mapping[str, PinShape],
+        cpu_deps: Mapping[str, tuple[str, ...]],
+        gpu_pins: Mapping[str, PinShape],
+        gpu_deps: Mapping[str, tuple[str, ...]],
+        base_names: frozenset[str],
+    ) -> LockInput:
+        cpu = self._LINUX.with_selection(self._CPU)
+        gpu = self._LINUX.with_selection(self._GPU)
+        return LockInput(
+            targets={
+                cpu.label: TargetLock(
+                    target=cpu, pins=dict(cpu_pins), dependencies=dict(cpu_deps)
+                ),
+                gpu.label: TargetLock(
+                    target=gpu, pins=dict(gpu_pins), dependencies=dict(gpu_deps)
+                ),
+            },
+            env_base_names={_env_signature(self._LINUX): base_names},
+            extras=("cpu", "gpu"),
+            conflicts=(
+                ConflictSet(
+                    members=(
+                        ConflictMember(ConflictKind.EXTRA, "cpu"),
+                        ConflictMember(ConflictKind.EXTRA, "gpu"),
+                    ),
+                    policy=ConflictPolicy.AT_MOST_ONE,
+                ),
+            ),
+        )
+
+    def test_extra_only_dep_of_base_dep_stays_member_gated(self) -> None:
+        # ``cudalib`` is pulled in only by the cpu fork (a member activates
+        # an extra on the base dep foo), so the edge is not shared by every
+        # fork and cudalib must not be promoted to base.
+        lock_input = self._lock_input_with(
+            cpu_pins={
+                "foo": _index_pin(name="foo", version="2.0"),
+                "baz": _index_pin(name="baz", version="1.0"),
+                "cudalib": _index_pin(name="cudalib", version="1.0"),
+            },
+            cpu_deps={"foo": ("baz", "cudalib")},
+            gpu_pins={
+                "foo": _index_pin(name="foo", version="2.0"),
+                "baz": _index_pin(name="baz", version="1.0"),
+            },
+            gpu_deps={"foo": ("baz",)},
+            base_names=frozenset({"foo"}),
+        )
+        pylock = build_pylock(lock_input)
+        by_name = {str(p.name): p for p in pylock.packages}
+
+        assert "in extras" not in str(by_name["baz"].marker)
+        assert '"cpu" in extras' in str(by_name["cudalib"].marker)
+
+    def test_diamond_closure_promotes_shared_dep_once(self) -> None:
+        pins: dict[str, PinShape] = {
+            "foo": _index_pin(name="foo", version="2.0"),
+            "baz": _index_pin(name="baz", version="1.0"),
+            "qux": _index_pin(name="qux", version="1.0"),
+        }
+        deps = {"foo": ("baz", "qux"), "baz": ("qux",)}
+        lock_input = self._lock_input_with(
+            cpu_pins=pins,
+            cpu_deps=deps,
+            gpu_pins=pins,
+            gpu_deps=deps,
+            base_names=frozenset({"foo"}),
+        )
+        pylock = build_pylock(lock_input)
+        by_name = {str(p.name): p for p in pylock.packages}
+        no_member = self._LINUX.env_with_membership()
+
+        for name in ("baz", "qux"):
+            marker = by_name[name].marker
+            assert "in extras" not in str(marker)
+            assert marker is None or marker.evaluate(no_member)
+
+
 class TestConflictForksWithoutBaseAttribution:
     """When conflict forks ran but the caller did not supply base
     requirements, ``env_base_names`` is empty.  Base status is unknowable,


### PR DESCRIPTION
A lock with mutually exclusive conflict extras (say torch-cpu against torch-gpu) emits a package unconditionally when it installs no matter which extra is selected, and gates it behind a marker like `"cpu" in extras` when it belongs to one member. Which packages count as base was decided against the names an independent base pass resolved.

That check was version-blind. When the conflict forks agree on a base dependency but pin it lower than the base pass did, the base dep pulls in a different transitive dep than the base pass saw. That transitive dep is missing from the base-pass names, so it kept its conflict marker and dropped out of the no-member install even though the base dep that requires it installs there. The emitted lock's own dependency graph was then unsatisfiable: with no extra selected the base dep installs without a dependency it declares.

The fix closes each environment's base-name set over the lock's own dependency edges before gating, following only the unconditional edges present in every fork. `TargetLock` now carries a `base_dependencies` field recording each package's edges from its own metadata, before any activated extra folds its deps in, so a dep reached only through an extra is never promoted to base.
