### PR TITLE
include python 3.15 in matrix range expansion

### DIFF
--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -154,6 +154,7 @@ KNOWN_PYTHON_MINORS: tuple[str, ...] = (
     "3.12",
     "3.13",
     "3.14",
+    "3.15",
 )
 
 

--- a/nab-python/tests/test_matrix.py
+++ b/nab-python/tests/test_matrix.py
@@ -47,6 +47,14 @@ class TestMatrixExpand:
         assert [t.python_version for t in tuples] == ["3.11", "3.12"]
         assert all(t.platform_id == "linux_x86_64" for t in tuples)
 
+    def test_range_expands_to_python_315(self) -> None:
+        """A range spanning 3.15 includes it, matching the ``--python`` path."""
+        matrix = Matrix(
+            python=">=3.14, <3.16", platforms=(PlatformSpec("linux_x86_64"),)
+        )
+        tuples = matrix.expand()
+        assert [t.python_version for t in tuples] == ["3.14", "3.15"]
+
     def test_cross_product_pythons_and_platforms(self) -> None:
         """All (python, platform) pairs are present in the cross-product."""
         matrix = Matrix(

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -377,6 +377,18 @@ class TestAbiIsHostIndependent:
 class TestTagsForTarget:
     """``TagSet.for_spec`` produces the full PEP 425 tag set."""
 
+    def test_python_315_emits_cp315_tags(self) -> None:
+        """A 3.15 target builds cp315 interpreter tags."""
+        spec = PlatformSpec("linux_x86_64")
+        members = TagSet.for_spec(python_version="3.15", spec=spec).members
+        assert any(t.interpreter == "cp315" for t in members)
+
+    def test_python_315_free_threaded_emits_cp315t_abi(self) -> None:
+        """A free-threaded 3.15 target builds the cp315t ABI tag."""
+        spec = PlatformSpec("linux_x86_64", free_threaded=True)
+        members = TagSet.for_spec(python_version="3.15", spec=spec).members
+        assert any(t.abi == "cp315t" for t in members)
+
     def test_linux_includes_manylinux_at_or_below_libc_version(self) -> None:
         """A glibc 2.17 target admits manylinux_2_17 and below."""
         spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))


### PR DESCRIPTION
A matrix `python` range that spans 3.15 silently dropped it, while the `--python` path resolved 3.15 fine, so the two surfaces disagreed. `KNOWN_PYTHON_MINORS` in nab-python/src/nab_python/target.py is the only list the matrix expansion consults, and it topped out at 3.14. `TagSet.for_spec` builds cp315/cp315t tags directly from vendored packaging, so `--python 3.15` already worked.

    from nab_python.target import Matrix
    from nab_python.tags import PlatformSpec
    m = Matrix(python=">=3.14,<3.16", platforms=(PlatformSpec("linux_x86_64"),))
    print([t.python_version for t in m.expand()])   # was ['3.14'], now ['3.14', '3.15']

Adding 3.15 to the tuple makes the grid reach it. Vendored packaging emits cp315 and cp315t tags correctly, and the free-threaded floor (3.13) covers 3.15.

Alternative: derive the known-minors range from vendored packaging so 3.16+ needs no edit; larger, depends on packaging internals, and the explicit list stays greppable, so it is left as a one-liner here.