### PR TITLE
clarify --project-mode universal error when no file matrix exists

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -674,10 +674,19 @@ def _config_from_effective(
     mode: ResolveMode = mode_value.value
     matrix: MatrixConfig | None = matrix_value.value
     if mode is ResolveMode.UNIVERSAL and matrix is None:
-        msg = (
-            "mode = 'universal' requires a [tool.nab.matrix] table"
-            " declaring python and platforms"
-        )
+        if mode_value.origin.kind is SourceKind.CLI:
+            msg = (
+                "--project-mode universal needs a [tool.nab.matrix] table, but"
+                " a matrix can only be declared in the project file (there is"
+                " no --project-matrix flag). Add [tool.nab.matrix] to the"
+                " project's pyproject.toml or nab.toml, or drop --project-mode"
+                " universal."
+            )
+        else:
+            msg = (
+                "mode = 'universal' requires a [tool.nab.matrix] table"
+                " declaring python and platforms"
+            )
         raise ConfigError(msg)
     if mode is ResolveMode.SPECIFIC and matrix is not None:
         if not mode_value.origin.outranks(matrix_value.origin):

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -115,10 +115,13 @@ class TestCliOverridesFold:
 
     def test_cli_mode_universal_requires_matrix(self, tmp_path: Path) -> None:
         path = write(tmp_path, '[project]\nname = "x"\nversion = "0"\n')
-        with pytest.raises(ConfigError, match=r"requires a \[tool.nab.matrix\]"):
+        with pytest.raises(ConfigError) as excinfo:
             read_pyproject_config(
                 path, discover_workspace=False, cli_overrides={"mode": "universal"}
             )
+        message = str(excinfo.value)
+        assert "[tool.nab.matrix]" in message
+        assert "there is no --project-matrix" in message
 
     def test_cli_mode_specific_shadows_declared_matrix(self, tmp_path: Path) -> None:
         path = write(
@@ -165,8 +168,11 @@ class TestMode:
 
     def test_universal_requires_matrix(self, tmp_path: Path) -> None:
         path = write(tmp_path, '[tool.nab]\nmode = "universal"\n')
-        with pytest.raises(ConfigError, match="requires a \\[tool.nab.matrix\\]"):
+        with pytest.raises(ConfigError) as excinfo:
             read_pyproject_config(path)
+        message = str(excinfo.value)
+        assert "requires a [tool.nab.matrix]" in message
+        assert "--project-matrix" not in message
 
     def test_matrix_without_universal_mode_rejected(self, tmp_path: Path) -> None:
         path = write(


### PR DESCRIPTION
Running `nab lock --project-mode universal` on a project with no [tool.nab.matrix] gives "mode = 'universal' requires a [tool.nab.matrix] table declaring python and platforms". That message is fine when mode came from the project file, but a user who reached it through the CLI flag may go looking for a --project-matrix flag that does not exist, since a matrix can only be declared in the project file.

When the universal mode came from --project-mode, the error now says so: it names the matrix as file-only and points the user at pyproject.toml or nab.toml, or at dropping the flag. The file-declared case keeps the original message.

  $ nab lock --project-mode universal path/to/pyproject.toml   # no [tool.nab.matrix]
  Error in [tool.nab]: --project-mode universal needs a [tool.nab.matrix] table, but a matrix can only be declared in the project file (there is no --project-matrix flag). Add [tool.nab.matrix] to the project's pyproject.toml or nab.toml, or drop --project-mode universal.

Erroring when no matrix exists anywhere is correct; --project-mode universal still works when the project declares a matrix.

Alternative: add a real --project-matrix CLI override so universal is fully CLI-drivable without a file. Much larger, and it cuts against the file-only project-config design, so not done here.