### PR TITLE
scope the universal experimental warning to the lockfile format

### DIFF
--- a/docs/explanation/universal.md
+++ b/docs/explanation/universal.md
@@ -1,8 +1,9 @@
 # Universal resolution
 
 > [!WARNING]
-> Universal mode is experimental. The resolver loop and the PEP
-> 751 lockfile shape it produces are subject to change.
+> Universal mode runs the same resolver as a specific resolve. The
+> multi-target PEP 751 lockfile format it produces is experimental
+> and may change without notice.
 
 A specific resolve pins one version per package for one marker
 environment. A universal resolve produces a single artefact
@@ -85,7 +86,7 @@ nab lock --format requirements-without-hashes --output - pyproject.toml
 ```
 
 ```
-warning: mode = 'universal' is experimental; output format may change without notice
+warning: the multi-target ('universal') lockfile format is experimental and may change without notice
 # py311-linux_x86_64
 fastapi==0.115.2
 numpy==2.0.2

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -10,7 +10,8 @@ single run with a `--project-<key>` flag.
 
 ```toml
 [tool.nab]
-# "specific" (default) or "universal" (experimental, opt-in).
+# "specific" (default) or "universal" (opt-in; its multi-target
+# lockfile format is experimental).
 mode = "specific"
 
 # PEP 508 constraint strings.  Bound versions but never pull packages
@@ -554,13 +555,13 @@ The URL is read by its own scheme, whatever the configured indexes use:
 a `file://` archive is read from disk, and any other archive is fetched
 over HTTP.
 
-## Universal mode (experimental)
+## Universal mode
 
 Universal resolution resolves one target per declared
 `(python, platform, implementation)` tuple, on the same engine a
 single-environment resolve uses, sharing one fetcher so metadata is
-fetched at most once per package.  Output and API are still subject to
-change.
+fetched at most once per package.  The multi-target lockfile format it
+produces is experimental and may change without notice.
 
 ```toml
 [tool.nab]

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -693,8 +693,8 @@ def _config_from_effective(
             msg = (
                 "[tool.nab.matrix] is set but mode is 'specific'; set"
                 " mode = 'universal' to resolve for every target the matrix"
-                " declares, or remove the table. Universal mode is"
-                " experimental."
+                " declares, or remove the table. The multi-target lockfile"
+                " format universal mode produces is experimental."
             )
             raise ConfigError(msg)
         # A higher-precedence source (--project-mode) selected a

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -132,9 +132,10 @@ class ResolveMode(enum.Enum):
     ``SPECIFIC`` resolves one target, the host or an impersonated
     marker environment.  ``UNIVERSAL`` resolves one target per tuple
     declared in ``[tool.nab.matrix]``.  Both run the same engine over a
-    list of targets.  ``UNIVERSAL`` is *experimental*: users must opt in
-    by setting ``[tool.nab].mode = "universal"`` and declaring
-    ``[tool.nab.matrix]``.
+    list of targets.  ``UNIVERSAL``'s multi-target lockfile format is
+    *experimental* and may change; the resolver itself is the same one
+    ``SPECIFIC`` runs.  Users opt in by setting
+    ``[tool.nab].mode = "universal"`` and declaring ``[tool.nab.matrix]``.
     """
 
     SPECIFIC = "specific"

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -208,8 +208,8 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
 
     if config.mode is ResolveMode.UNIVERSAL:
         sys.stderr.write(
-            "warning: mode = 'universal' is experimental; output format may"
-            " change without notice\n"
+            "warning: the multi-target ('universal') lockfile format is"
+            " experimental and may change without notice\n"
         )
 
     transport = _cli._make_transport(settings.http_backend)  # noqa: SLF001

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1329,6 +1329,8 @@ class TestLockCommandUniversal:
             lock(pyproject, format="requirements-without-hashes")
         captured = capsys.readouterr()
         assert "experimental" in captured.err
+        assert "lockfile format" in captured.err
+        assert "resolver loop" not in captured.err
         assert "# py311-linux_x86_64" in captured.out
         assert "# py312-linux_x86_64" in captured.out
         assert "foo==1.0" in captured.out


### PR DESCRIPTION
Since the two resolution engines collapsed into one, universal mode runs the same resolver loop as a specific resolve; it just resolves a list of targets longer than one. But the stderr warning, the ConfigError hint, the ResolveMode docstring, and the docs still call universal mode (and its resolver loop) experimental, which now reads as disclaiming the same resolver a specific resolve uses. The clearest overclaim was the universal.md warning: "The resolver loop and the PEP 751 lockfile shape it produces are subject to change", but the resolver loop is not subject to change.

This rewords all eight sites so the experimental disclaimer points at the thing that really is still evolving, the multi-target lockfile output format, while stating that the resolver is the same one specific mode runs. The emitted warning now reads:

    warning: the multi-target ('universal') lockfile format is experimental and may change without notice

The wording deliberately does not claim the format is stable; the multi-target format is still evolving, so the at-emit-time heads-up stays.

Alternative: replace "experimental" with softer "not yet stable" wording, which is arguably more precise but drops the established term.
