### PR TITLE
model an empty metadata fetch in the coordinator test fake

### DIFF
--- a/nab-python/src/nab_python/_testing/coordinator_fake.py
+++ b/nab-python/src/nab_python/_testing/coordinator_fake.py
@@ -93,9 +93,10 @@ def _wire_metadata_side_effects(
         # The fetcher skips a sidecar the index already answers for.
         if index.has_metadata(pkg, ver, url):
             return
+        # Store even when the sidecar returns nothing: an empty fetch still
+        # marks the slot fetched, as real _fetch_metadata does.
         text = resolve_metadata(pkg, ver, url)
-        if text is not None:
-            index.store_metadata(pkg, ver, text, url)
+        index.store_metadata(pkg, ver, text, url)
 
     def _request_metadata(
         pkg: str, ver: str, url: str, _hash: tuple[str, str] | None = None
@@ -172,7 +173,9 @@ def make_coordinator(  # noqa: PLR0913 - one keyword per index slot a test pre-l
       ``metadata_text`` (or the entry from ``metadata_by_url``, or from
       ``metadata_by_version``, or auto-generated minimal METADATA when
       ``auto_metadata`` is true) under the requested sidecar URL, as the
-      fetcher does.  ``metadata_by_url`` is how sibling wheels of one
+      fetcher does.  When nothing resolves, ``None`` lands in the sidecar
+      slot, so the fetched-but-empty slot reads back the way it would in
+      production.  ``metadata_by_url`` is how sibling wheels of one
       version are given different dependencies.
     * ``request_sdist`` writes ``sdist_pkg_info`` and, if not ``None``,
       ``sdist_pyproject_toml``.

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -5536,7 +5536,9 @@ class TestPrefetchWalkAhead:
         coordinator.reset_mock()
         provider.prefetch_walk_ahead("foo")
         items = coordinator.request_metadata_batch.call_args[0][0]
-        assert len(items) == provider.DEEP_PREFETCH_COUNT
+        # fetch_versions already prefetched the newest version; it fills a
+        # window slot but is skipped as already-held.
+        assert len(items) == provider.DEEP_PREFETCH_COUNT - 1
 
     def test_skips_versions_with_cached_deps(self) -> None:
         """Versions already in ``deps_cache`` are excluded from the batch."""
@@ -5550,15 +5552,19 @@ class TestPrefetchWalkAhead:
         items = coordinator.request_metadata_batch.call_args[0][0]
         versions = [ver for _, ver, _, _ in items]
         assert "2.0" not in versions
-        assert "3.0" in versions
+        # fetch_versions already prefetched the newest version.
+        assert "3.0" not in versions
         assert "1.0" in versions
 
     def test_dedupes_repeated_versions(self) -> None:
         """A wheel and a sdist for the same version count as one slot."""
+        # 3.0 is the newest, so fetch_versions prefetches and skips it; the
+        # wheel and sdist for 2.0 collapse to the single 2.0 slot.
         wheels: list[WheelFile | SdistFile] = [
             make_wheel("3.0"),
-            make_sdist("3.0"),
             make_wheel("2.0"),
+            make_sdist("2.0"),
+            make_wheel("1.0"),
         ]
         coordinator = make_coordinator(wheels, package="foo")
         provider = Provider(coordinator)
@@ -5567,7 +5573,24 @@ class TestPrefetchWalkAhead:
         provider.prefetch_walk_ahead("foo")
         items = coordinator.request_metadata_batch.call_args[0][0]
         versions = [ver for _, ver, _, _ in items]
-        assert versions == ["3.0", "2.0"]
+        assert versions == ["2.0", "1.0"]
+
+    def test_skips_version_whose_empty_fetch_the_coordinator_holds(self) -> None:
+        """An already-fetched sidecar, even an empty one, is not re-requested."""
+        wheels = [make_wheel("3.0"), make_wheel("2.0"), make_wheel("1.0")]
+        coordinator = make_coordinator(wheels, package="foo")
+        provider = Provider(coordinator)
+        provider.fetch_versions("foo")
+        # An empty fetch (no sidecar served) still marks the slot fetched.
+        two = make_wheel("2.0")
+        assert two.metadata_url is not None
+        coordinator.request_metadata("foo", "2.0", two.metadata_url)
+        coordinator.reset_mock()
+        provider.prefetch_walk_ahead("foo")
+        items = coordinator.request_metadata_batch.call_args[0][0]
+        versions = [ver for _, ver, _, _ in items]
+        assert "2.0" not in versions
+        assert "1.0" in versions
 
     def test_picks_wheel_when_both_present(self) -> None:
         """A version with both a wheel and a sdist still prefetches the wheel."""


### PR DESCRIPTION
The shared make_coordinator fake diverged from the real FetchCoordinator._fetch_metadata on one point: when a sidecar returns nothing, the real coordinator still calls store_metadata(pkg, ver, None, url), which marks the slot fetched (has_metadata() true), while the fake skipped the store and left the slot never-fetched.

That gap left the has_metadata skip in prefetch_walk_ahead with no test guard. In production fetch_versions speculatively prefetches the newest version, so prefetch_walk_ahead always sees it already held and skips it. Under the old fake nothing was stored, so three TestPrefetchWalkAhead tests asserted the newest version being re-requested, which production never does, and dropping the skip in prefetch_walk_ahead would still have passed every test.

The fake now calls store_metadata unconditionally, so an unserved sidecar leaves a fetched-but-empty slot. The three tests are reworked to the real prefetch-then-skip behaviour, and a new test pins the skip directly: it pre-fetches one version and asserts that version is absent from the batch.