### PR TITLE
drop synthetic implementation_version from non-cpython locks

### DIFF
--- a/docs/explanation/universal.md
+++ b/docs/explanation/universal.md
@@ -150,7 +150,10 @@ puts `implementation_name` on every tuple's marker and on the
 `(python, platform)` point stay mutually exclusive, and a PyPy-only
 lock refuses CPython. PyPy's `implementation_version` is modelled as
 the Python level, not PyPy's own release, so the rare marker comparing
-`implementation_version` against a PyPy version misevaluates.
+`implementation_version` against a PyPy version misevaluates during the
+resolve. The lockfile does not carry that synthetic value: a non-CPython
+`environments` entry leaves `implementation_version` open, so a real PyPy
+still accepts the lock (a dep gated on the axis may be missed at install).
 
 ## Trade-offs versus marker-fork PubGrub
 

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -443,7 +443,10 @@ def _declared_environments(
     A marker on an axis the lock cannot bound (see
     :data:`~nab_python.target.UNBOUNDABLE_MARKER_VARIABLES`) is reported:
     the lock stays open on it, so an installer whose kernel differs will
-    still accept the lock, with the dep that marker gated missing.
+    still accept the lock, with the dep that marker gated missing.  A marker
+    on ``implementation_version`` under a non-CPython target is reported the
+    same way (see :func:`~nab_python.target.unboundable_variables`): the
+    value there is synthetic, so the lock leaves the axis open.
     """
     variables: set[str] = set()
     for markers in consulted.values():
@@ -459,6 +462,22 @@ def _declared_environments(
             " miss the dependencies that marker gates.",
             ", ".join(unboundable),
         )
+    for target in declaring:
+        if target.implementation == "cpython":
+            continue
+        consulted_names: set[str] = set()
+        for marker in consulted[env_signature(target)]:
+            consulted_names |= marker_variables(str(marker))
+        if "implementation_version" in consulted_names:
+            _logger.warning(
+                "A marker in this resolve consults implementation_version on a"
+                " non-CPython target; the value nab uses there is the Python"
+                " level, not the interpreter's release, so the lockfile leaves"
+                " that axis open and an installer whose value differs will"
+                " still accept this lock and miss the dependencies that marker"
+                " gates."
+            )
+            break
     return [
         Marker(environment_declaration(target, consulted[env_signature(target)]))
         for target in declaring

--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -57,6 +57,7 @@ __all__ = [
     "host_environment",
     "marker_variables",
     "python_axis_environment",
+    "unboundable_variables",
 ]
 
 
@@ -184,6 +185,22 @@ UNBOUNDABLE_MARKER_VARIABLES: frozenset[str] = frozenset(
     {"platform_release", "platform_version"}
 )
 
+
+def unboundable_variables(target: ResolveTarget) -> frozenset[str]:
+    """Return the variables the lock cannot bound for ``target``.
+
+    Always the kernel axes.  On a non-CPython target ``implementation_version``
+    joins them: :func:`declared_environment` sets it to the target's Python
+    level, but a released PyPy reports its own release (7.3.x) there, so a
+    clause bounded on the synthetic value would refuse the very interpreter
+    the lock was resolved for.  CPython's ``implementation_version`` is its
+    Python micro, so it stays declarable by constraint.
+    """
+    if target.implementation == "cpython":
+        return UNBOUNDABLE_MARKER_VARIABLES
+    return UNBOUNDABLE_MARKER_VARIABLES | {"implementation_version"}
+
+
 # Declared whether or not a marker consults them: these are the axes the
 # package set was chosen for, so a lock that leaves them open is one any
 # environment would accept.
@@ -266,8 +283,13 @@ def environment_declaration(target: ResolveTarget, consulted: Iterable[Marker]) 
     pins the OS.  The variables in :data:`_BY_CONSTRAINT` are declared by
     constraint (see :func:`_version_clauses`), because a lock that pinned
     the micro release would refuse the very interpreters it resolved for.
-    Variables in :data:`UNBOUNDABLE_MARKER_VARIABLES` are dropped (see
-    there).
+    The variables :func:`unboundable_variables` names for the target are
+    dropped: the kernel axes always, and ``implementation_version`` on a
+    non-CPython target, whose value is the target's Python level rather than
+    the interpreter's own release.  Dropping it leaves the lock open on that
+    axis, so a dependency the resolve gated on ``implementation_version``
+    under PyPy may still be missed at install; the resolve's own use of the
+    synthetic value stays a known limitation (a real axis is needed).
     """
     texts = sorted({str(marker) for marker in consulted})
     variables: set[str] = set()
@@ -279,7 +301,7 @@ def environment_declaration(target: ResolveTarget, consulted: Iterable[Marker]) 
         always.append("implementation_name")
     names = [
         *always,
-        *sorted(variables - set(always) - UNBOUNDABLE_MARKER_VARIABLES),
+        *sorted(variables - set(always) - unboundable_variables(target)),
     ]
     declaring = _Declaring(
         marker_env=target.marker_env,
@@ -894,7 +916,9 @@ def declared_environment(
     ``implementation_version`` is set to the Python version for every
     implementation; for non-CPython this is the interpreter's Python
     level, not its own release (PyPy 7.3.x), so the rare
-    ``implementation_version`` marker on PyPy may misevaluate.
+    ``implementation_version`` marker on PyPy may misevaluate during the
+    resolve.  The lock does not carry the synthetic value: see
+    :func:`unboundable_variables`.
     """
     full = python_full_version or f"{python_version}.0"
     return {

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -3401,6 +3401,58 @@ class TestLockDeclaresItsEnvironment:
         assert "platform_release" not in str(environment)
         assert "platform_release" in caplog.text
 
+    def test_pypy_implementation_version_marker_warns_and_stays_undeclared(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """PyPy reports 7.3.x there, not its Python level, so the synthetic
+        value cannot be bounded; the lock leaves the axis open and warns.
+        """
+        body = self._PYPROJECT.replace(
+            'platform = "linux_x86_64"\n',
+            'platform = "linux_x86_64"\nimplementation = "pypy"\n',
+        )
+        with caplog.at_level(logging.WARNING, logger="nab_python.resolve"):
+            lock_input = self._resolve(
+                tmp_path,
+                body,
+                self._coordinator(
+                    'Requires-Dist: bar ; implementation_version >= "7.3"\n'
+                ),
+            )
+        (environment,) = lock_input.environments
+        assert "implementation_version" not in str(environment)
+        assert "bar" not in _locked(lock_input)
+        assert "implementation_version" in caplog.text
+        real_pypy = {
+            **_PY312_ENV,
+            "implementation_name": "pypy",
+            "platform_python_implementation": "PyPy",
+            "implementation_version": "7.3.17",
+            "python_full_version": "3.12.9",
+        }
+        assert Marker(str(environment)).evaluate(real_pypy)
+
+    def test_a_pypy_target_without_the_axis_declares_and_does_not_warn(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A non-CPython resolve that never reads implementation_version keeps
+        its ordinary declaration and raises no axis warning.
+        """
+        body = self._PYPROJECT.replace(
+            'platform = "linux_x86_64"\n',
+            'platform = "linux_x86_64"\nimplementation = "pypy"\n',
+        )
+        with caplog.at_level(logging.WARNING, logger="nab_python.resolve"):
+            lock_input = self._resolve(
+                tmp_path,
+                body,
+                self._coordinator('Requires-Dist: bar ; sys_platform == "win32"\n'),
+            )
+        (environment,) = lock_input.environments
+        assert 'sys_platform == "linux"' in str(environment)
+        assert "bar" not in _locked(lock_input)
+        assert "implementation_version" not in caplog.text
+
     def test_a_full_version_marker_declares_how_it_read_not_the_micro(
         self, tmp_path: Path
     ) -> None:

--- a/nab-python/tests/test_target.py
+++ b/nab-python/tests/test_target.py
@@ -18,6 +18,7 @@ from nab_python.target import (
     IMPLEMENTATION_MARKERS,
     PEP508_MARKER_VARIABLES,
     PLATFORM_MARKERS,
+    UNBOUNDABLE_MARKER_VARIABLES,
     Matrix,
     ResolveTarget,
     apply_python_axis_overlay,
@@ -26,6 +27,7 @@ from nab_python.target import (
     host_environment,
     marker_variables,
     python_axis_environment,
+    unboundable_variables,
 )
 
 _HOST_ENV: dict[str, str] = {
@@ -691,6 +693,27 @@ class TestEnvironmentDeclaration:
         assert Marker(pypy).evaluate(on_pypy)
         assert not Marker(cpython).evaluate(on_pypy)
 
+    def test_a_pypy_target_drops_the_implementation_version_clause(self) -> None:
+        """PyPy 3.11 reports 7.3.x, not 3.11.0, so a bound on the synthetic
+        3.11.0 would refuse the very interpreter the lock targets.
+        """
+        target = ResolveTarget.for_declared(
+            python_version="3.11",
+            spec=PlatformSpec("linux_x86_64"),
+            implementation="pypy",
+        )
+        declaration = environment_declaration(
+            target, [Marker('implementation_version < "7.3"')]
+        )
+        assert "implementation_version" not in declaration
+
+        real_pypy = {
+            **declared_environment("3.11", PlatformSpec("linux_x86_64"), "pypy"),
+            "implementation_version": "7.3.17",
+            "python_full_version": "3.11.9",
+        }
+        assert Marker(declaration).evaluate(real_pypy)
+
 
 class TestFullVersionDeclaration:
     """``python_full_version`` is declared by constraint, not by value: the
@@ -827,6 +850,31 @@ class TestFullVersionDeclaration:
             self._target("3.13.0rc1"), [Marker('python_full_version < "3.13.0"')]
         )
         assert declaration.endswith('and python_full_version == "3.13.0rc1"')
+
+
+class TestUnboundableVariables:
+    """CPython carries ``implementation_version`` as its own micro release;
+    a non-CPython target's value there is synthetic, so the lock cannot
+    bound it.
+    """
+
+    def test_cpython_names_only_the_kernel_axes(self) -> None:
+        target = ResolveTarget.for_declared(
+            python_version="3.11",
+            spec=PlatformSpec("linux_x86_64"),
+            implementation="cpython",
+        )
+        assert unboundable_variables(target) == UNBOUNDABLE_MARKER_VARIABLES
+
+    def test_pypy_adds_implementation_version(self) -> None:
+        target = ResolveTarget.for_declared(
+            python_version="3.11",
+            spec=PlatformSpec("linux_x86_64"),
+            implementation="pypy",
+        )
+        assert unboundable_variables(target) == (
+            UNBOUNDABLE_MARKER_VARIABLES | {"implementation_version"}
+        )
 
 
 class TestDecidingClauses:


### PR DESCRIPTION
A PyPy (or any non-CPython) lock is uninstallable on the interpreter it targets. nab models `implementation_version` as the target's Python level, so a declared PyPy 3.11 target reports `implementation_version == "3.11.0"`, but real PyPy 3.11 reports 7.3.x. When a dependency marker consults `implementation_version`, the lock's `environments` entry declares that clause against the synthetic value. Real PyPy fails the clause, its half of the environment declaration evaluates False, and the installer refuses the lock.

This treats `implementation_version` as unboundable for a non-CPython target, the same way the kernel axes (`platform_release`, `platform_version`) already are, so the clause is dropped and the lock stays open on that axis. CPython, whose `implementation_version` is its own Python micro, is unchanged. `_declared_environments` warns once when a non-CPython resolve consulted `implementation_version`, so the open axis is visible.

Before, a declared PyPy target rendered `... and implementation_name == "pypy" and implementation_version < "7.3"`, and a real PyPy 7.3.17 environment evaluated that to False. After, the clause is gone and real PyPy accepts the lock:

    t = ResolveTarget.for_declared(python_version="3.11", spec=PlatformSpec("linux_x86_64"), implementation="pypy")
    decl = environment_declaration(t, [Marker('implementation_version < "7.3"')])
    # decl no longer names implementation_version
    Marker(decl).evaluate({..., "implementation_name": "pypy", "implementation_version": "7.3.17"})  # True

The resolve itself still uses the synthetic value to decide which deps an `implementation_version` marker gates, so a dep gated on that axis under PyPy can be included wrongly during the resolve. That stays a known limitation and needs a real implementation-version axis.

Alternative: drop the clause only when the value is synthetic (equal to the target's Python level), which keeps a real PyPy host resolve declaring its genuine 7.3.x value; more precise on the host case for one extra condition.
