### PR TITLE
warn when a default tag ceiling drops a version's last wheel

### DIFF
--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -424,10 +424,18 @@ def _apply_wheel_tags(
 
     result: list[tuple[Version, DistFile]] = []
     tag_rejected_versions: set[Version] = set()
+    kept_wheel_versions: set[Version] = set()
+    ceiling_drops: dict[Version, tuple[WheelFile, tuple[str, tuple[int, int]]]] = {}
     for version, dist in base:
         if excluded_by_wheel_tags(provider, normalized, dist, tags):
             tag_rejected_versions.add(version)
+            if version not in ceiling_drops and isinstance(dist, WheelFile):
+                admitting = provider.ceiling_would_admit(dist.filename)
+                if admitting is not None:
+                    ceiling_drops[version] = (dist, admitting)
             continue
+        if isinstance(dist, WheelFile):
+            kept_wheel_versions.add(version)
         result.append((version, dist))
 
     if tag_rejected_versions:
@@ -437,6 +445,12 @@ def _apply_wheel_tags(
         provider.stats.excluded_versions_no_compatible_wheel += len(
             tag_rejected_versions - kept
         )
+
+    # Warn only where an unset default ceiling took a version's last wheel: a
+    # release that also ships an in-ceiling wheel keeps it and stays silent.
+    for version, (wheel, (knob, raise_to)) in ceiling_drops.items():
+        if version not in kept_wheel_versions:
+            provider.warn_ceiling_drop(normalized, version, wheel, knob, raise_to)
 
     return result
 

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -37,6 +37,7 @@ from ._vcs_admission import (
 from ._vendor.packaging.ranges import VersionRange
 from ._vendor.packaging.utils import canonicalize_name
 from .metadata import WheelMetadata
+from .tags import default_ceiling_admitting
 from .target import host_environment
 
 if TYPE_CHECKING:
@@ -614,6 +615,10 @@ class Provider:
         # whole package failed on wheel tags alone.
         self.base_filtered_packages: set[str] = set()
 
+        # (package, version) pairs already warned about losing their last wheel
+        # to an unset default tag ceiling, so the warning fires once per drop.
+        self._warned_ceiling_versions: set[tuple[str, Version]] = set()
+
         self.root_requirements = root_requirements or {}
         self.versions_cache: dict[str, list[tuple[Version, DistFile]]] = {}
         self.deps_cache: dict[tuple[str, Version], dict[str, VersionRange]] = {}
@@ -1144,6 +1149,50 @@ class Provider:
     ) -> list[tuple[Version, DistFile]]:
         """See :func:`nab_python._provider.listing.filter_distributions`."""
         return _listing.filter_distributions(self, normalized, files)
+
+    def ceiling_would_admit(
+        self, wheel_filename: str
+    ) -> tuple[str, tuple[int, int]] | None:
+        """Return the unset default ceiling that alone drops ``wheel_filename``.
+
+        Delegates to :func:`nab_python.tags.default_ceiling_admitting` for a
+        declared target; a host target names no platform_spec and never has a
+        raisable ceiling, so it returns ``None``.
+        """
+        if self.target is None or self.target.platform_spec is None:
+            return None
+        return default_ceiling_admitting(
+            self.target.platform_spec,
+            python_version=self.target.python_version,
+            implementation=self.target.implementation,
+            wheel_filename=wheel_filename,
+        )
+
+    def warn_ceiling_drop(
+        self,
+        normalized: str,
+        version: Version,
+        wheel: WheelFile,
+        knob: str,
+        raise_to: tuple[int, int],
+    ) -> None:
+        """Warn once that an unset default ceiling dropped a version's last wheel."""
+        key = (normalized, version)
+        if key in self._warned_ceiling_versions:
+            return
+        self._warned_ceiling_versions.add(key)
+        logger.warning(
+            "%s %s: wheel %s is above the default %s ceiling and was"
+            " dropped, leaving the version with no installable wheel;"
+            " set %s to %s.%s to keep it",
+            normalized,
+            version,
+            wheel.filename,
+            knob,
+            knob,
+            raise_to[0],
+            raise_to[1],
+        )
 
     def pick_best_candidate(
         self,

--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Callable, Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from functools import cache, cached_property, lru_cache
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Literal
@@ -47,6 +47,7 @@ __all__ = [
     "PlatformSpec",
     "TagSet",
     "TagsSource",
+    "default_ceiling_admitting",
     "platform_kind",
     "supports_free_threading",
     "wheel_tag_set",
@@ -285,6 +286,87 @@ def _check_version_cap(key: str, version: tuple[int, int]) -> None:
 def platform_kind(platform_id: str) -> str | None:
     """Return a platform id's kind, or ``None`` if nab does not know the id."""
     return _PLATFORM_KIND.get(platform_id)
+
+
+# The libc/OS version a versioned platform tag carries, which the target reads
+# as a ceiling.  Used to pull the ``(major, minor)`` back out of a wheel's tag
+# when deciding whether raising an unset default ceiling would admit it.
+_MACOS_PLATFORM_RE = re.compile(r"^macosx_(\d+)_(\d+)_")
+_MANYLINUX_PLATFORM_RE = re.compile(r"^manylinux_(\d+)_(\d+)_")
+_MUSLLINUX_PLATFORM_RE = re.compile(r"^musllinux_(\d+)_(\d+)_")
+
+
+def _platform_versions(
+    wheel_filename: str, pattern: re.Pattern[str]
+) -> list[tuple[int, int]]:
+    """Return the ``(major, minor)`` pairs ``pattern`` matches in a wheel's tags."""
+    wheel_tags = wheel_tag_set(wheel_filename)
+    if wheel_tags is None:
+        return []
+    out: list[tuple[int, int]] = []
+    for tag in wheel_tags:
+        match = pattern.match(tag.platform)
+        if match is not None:
+            out.append((int(match.group(1)), int(match.group(2))))
+    return out
+
+
+def default_ceiling_admitting(
+    spec: PlatformSpec,
+    *,
+    python_version: str,
+    implementation: str,
+    wheel_filename: str,
+) -> tuple[str, tuple[int, int]] | None:
+    """Return the unset default ceiling that alone keeps a wheel out, or ``None``.
+
+    A macOS or Linux target reads its OS/libc version as a ceiling on the
+    wheels it accepts.  When that version is a default the caller never set,
+    an incompatible wheel might be one the target would install if the
+    ceiling were raised.  This returns ``(knob, raise_to)`` naming the knob
+    (``macos-min`` or ``libc-version``) and the lowest version it would need
+    to be raised to, but only when raising it is enough: the result is
+    confirmed by rebuilding the target's tags at ``raise_to`` and rechecking
+    acceptance, so an arch, Python, ABI, or libc-family mismatch (which no
+    ceiling change fixes) yields ``None``.  A ceiling the caller set, and any
+    non-macOS/Linux target, also yield ``None``.
+    """
+    kind = platform_kind(spec.platform_id)
+    if kind == "macos" and spec.macos_min is None:
+        knob = "macos-min"
+        current = _DEFAULT_MACOS_MIN[spec.arch]
+        candidates = _platform_versions(wheel_filename, _MACOS_PLATFORM_RE)
+        field = "macos_min"
+    elif kind == "linux" and spec.libc_version is None:
+        knob = "libc-version"
+        current = _DEFAULT_LIBC_VERSION[spec.libc]
+        pattern = (
+            _MUSLLINUX_PLATFORM_RE if spec.libc == "musl" else _MANYLINUX_PLATFORM_RE
+        )
+        candidates = _platform_versions(wheel_filename, pattern)
+        field = "libc_version"
+    else:
+        return None
+
+    higher = [version for version in candidates if version > current]
+    if not higher:
+        return None
+    raise_to = min(higher)
+
+    try:
+        raised = TagSet.for_spec(
+            python_version=python_version,
+            spec=replace(spec, **{field: raise_to}),
+            implementation=implementation,
+        )
+    except ValueError:
+        # A tag naming a version past the knob's cap (or below its floor) is
+        # not a ceiling nab can raise to, so it is not the sole cause.
+        return None
+
+    if raised.accepts(wheel_filename):
+        return knob, raise_to
+    return None
 
 
 def _version_tag(version: tuple[int, int] | None) -> str:

--- a/nab-python/tests/test_provider_declared_target.py
+++ b/nab-python/tests/test_provider_declared_target.py
@@ -11,6 +11,7 @@ through a matrix.
 
 from __future__ import annotations
 
+import logging
 import threading
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
@@ -736,6 +737,135 @@ class TestEqualVersionCanonicalization:
         assert windows.fetch_versions("pkg") == []
         assert windows.stats.excluded_by_wheel_tags == 2
         assert windows.stats.excluded_versions_no_compatible_wheel == 1
+
+
+class TestDefaultCeilingWarning:
+    """A version losing its last wheel to an unset default ceiling is announced."""
+
+    @staticmethod
+    def _macos_provider(
+        files: Sequence[WheelFile | SdistFile], spec: PlatformSpec
+    ) -> Provider:
+        return Provider(
+            _index_with_files(files),
+            ResolveTarget.for_declared(python_version="3.11", spec=spec),
+            build_policy=BuildPolicy.NEVER,
+        )
+
+    def test_default_macos_ceiling_drop_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A version whose only wheel needs a newer macOS is named in a warning."""
+        files = [_platform_wheel("2.0", "cp311-cp311-macosx_14_0_arm64")]
+        provider = self._macos_provider(files, PlatformSpec("macos_arm64"))
+        with caplog.at_level(logging.WARNING, logger="nab_python.provider"):
+            provider.filter_distributions("pkg", files)
+        assert len(caplog.records) == 1
+        message = caplog.records[0].getMessage()
+        assert "pkg" in message
+        assert "2.0" in message
+        assert "pkg-2.0-cp311-cp311-macosx_14_0_arm64.whl" in message
+        assert "macos-min" in message
+        assert "14.0" in message
+
+    def test_explicit_macos_min_does_not_warn(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A user-set ceiling is the user's own choice, so no warning fires."""
+        files = [_platform_wheel("2.0", "cp311-cp311-macosx_14_0_arm64")]
+        provider = self._macos_provider(
+            files, PlatformSpec("macos_arm64", macos_min=(12, 0))
+        )
+        with caplog.at_level(logging.WARNING, logger="nab_python.provider"):
+            provider.filter_distributions("pkg", files)
+        assert caplog.records == []
+
+    def test_in_ceiling_wheel_kept_does_not_warn(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A release that also ships an installable wheel stays silent."""
+        files = [
+            _platform_wheel("2.0", "cp311-cp311-macosx_14_0_arm64"),
+            _platform_wheel("2.0", "cp311-cp311-macosx_12_0_arm64"),
+        ]
+        provider = self._macos_provider(files, PlatformSpec("macos_arm64"))
+        with caplog.at_level(logging.WARNING, logger="nab_python.provider"):
+            result = provider.filter_distributions("pkg", files)
+        assert Version("2.0") in {v for v, _ in result}
+        assert caplog.records == []
+
+    def test_default_linux_ceiling_drop_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A manylinux wheel above the default glibc names the libc knob."""
+        files = [_platform_wheel("2.0", "cp311-cp311-manylinux_2_34_x86_64")]
+        provider = Provider(
+            _index_with_files(files),
+            _linux_target(PlatformSpec("linux_x86_64")),
+            build_policy=BuildPolicy.NEVER,
+        )
+        with caplog.at_level(logging.WARNING, logger="nab_python.provider"):
+            provider.filter_distributions("pkg", files)
+        assert len(caplog.records) == 1
+        message = caplog.records[0].getMessage()
+        assert "libc-version" in message
+        assert "2.34" in message
+
+    def test_ordinary_platform_mismatch_does_not_warn(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A win wheel on a linux target is a mismatch no ceiling change fixes."""
+        files = [_platform_wheel("2.0", "cp311-cp311-win_amd64")]
+        provider = Provider(
+            _index_with_files(files),
+            _linux_target(PlatformSpec("linux_x86_64")),
+            build_policy=BuildPolicy.NEVER,
+        )
+        with caplog.at_level(logging.WARNING, logger="nab_python.provider"):
+            provider.filter_distributions("pkg", files)
+        assert caplog.records == []
+
+    def test_arch_mismatch_does_not_warn(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A macOS x86_64 wheel on an arm64 target is an arch mismatch, not a ceiling."""
+        files = [_platform_wheel("2.0", "cp311-cp311-macosx_14_0_x86_64")]
+        provider = self._macos_provider(files, PlatformSpec("macos_arm64"))
+        with caplog.at_level(logging.WARNING, logger="nab_python.provider"):
+            provider.filter_distributions("pkg", files)
+        assert caplog.records == []
+
+    def test_warns_once_per_version(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A second filter pass over the same drop does not warn again."""
+        files = [_platform_wheel("2.0", "cp311-cp311-macosx_14_0_arm64")]
+        provider = self._macos_provider(files, PlatformSpec("macos_arm64"))
+        with caplog.at_level(logging.WARNING, logger="nab_python.provider"):
+            provider.filter_distributions("pkg", files)
+            provider.filter_distributions("pkg", files)
+        assert len(caplog.records) == 1
+
+    def test_two_dropped_wheels_warn_once(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A version with two above-ceiling wheels is recorded once, warned once."""
+        files = [
+            _platform_wheel("2.0", "cp311-cp311-macosx_14_0_arm64"),
+            _platform_wheel("2.0", "cp311-cp311-macosx_15_0_arm64"),
+        ]
+        provider = self._macos_provider(files, PlatformSpec("macos_arm64"))
+        with caplog.at_level(logging.WARNING, logger="nab_python.provider"):
+            provider.filter_distributions("pkg", files)
+        assert len(caplog.records) == 1
+
+    def test_host_target_never_warns(self) -> None:
+        """A host provider has no platform_spec, so the ceiling check is skipped."""
+        provider = Provider(_index_with_files([]), ResolveTarget.for_host())
+        assert provider.ceiling_would_admit("pkg-2.0-py3-none-any.whl") is None
+
+    def test_no_target_has_no_ceiling(self) -> None:
+        """With no target there is nothing to raise, so the check is skipped."""
+        provider = Provider(_index_with_files([]))
+        assert provider.ceiling_would_admit("pkg-2.0-py3-none-any.whl") is None
 
 
 class TestRequiresPythonPatch:

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -26,6 +26,7 @@ from nab_python.tags import (
     _ordered_tags_for_spec,
     _parse_tag_str,
     _platform_tags_for_spec,
+    default_ceiling_admitting,
     wheel_tag_set,
 )
 
@@ -1067,3 +1068,67 @@ class TestLinuxPlatformOrderMatchesSysTags:
         many = Tag("cp311", "cp311", "manylinux_2_28_x86_64")
         assert host.rank[plain] < host.rank[many]
         assert declared.rank[plain] < declared.rank[many]
+
+
+class TestDefaultCeilingAdmitting:
+    """``default_ceiling_admitting`` names an unset default ceiling, or nothing."""
+
+    def test_musl_default_ceiling_named(self) -> None:
+        """A musllinux wheel above the 1.2 default names the raise-to version."""
+        got = default_ceiling_admitting(
+            PlatformSpec("linux_x86_64", libc="musl"),
+            python_version="3.11",
+            implementation="cpython",
+            wheel_filename="pkg-2.0-cp311-cp311-musllinux_1_3_x86_64.whl",
+        )
+        assert got == ("libc-version", (1, 3))
+
+    def test_python_mismatch_is_not_a_ceiling(self) -> None:
+        """A cp312 wheel on a 3.11 target is not admitted by any ceiling change."""
+        got = default_ceiling_admitting(
+            PlatformSpec("macos_arm64"),
+            python_version="3.11",
+            implementation="cpython",
+            wheel_filename="pkg-2.0-cp312-cp312-macosx_14_0_arm64.whl",
+        )
+        assert got is None
+
+    def test_windows_target_has_no_ceiling(self) -> None:
+        """Windows names no versioned platform tag, so there is no ceiling."""
+        got = default_ceiling_admitting(
+            PlatformSpec("windows_amd64"),
+            python_version="3.11",
+            implementation="cpython",
+            wheel_filename="pkg-2.0-cp311-cp311-manylinux_2_34_x86_64.whl",
+        )
+        assert got is None
+
+    def test_non_wheel_filename_has_no_ceiling(self) -> None:
+        """A filename that is not a parseable wheel yields no candidate versions."""
+        got = default_ceiling_admitting(
+            PlatformSpec("macos_arm64"),
+            python_version="3.11",
+            implementation="cpython",
+            wheel_filename="pkg-2.0.tar.gz",
+        )
+        assert got is None
+
+    def test_below_ceiling_tag_is_not_a_ceiling(self) -> None:
+        """A manylinux 2.17 wheel is at or below the default, so nothing is raised."""
+        got = default_ceiling_admitting(
+            PlatformSpec("linux_x86_64"),
+            python_version="3.11",
+            implementation="cpython",
+            wheel_filename="pkg-2.0-cp311-cp311-manylinux_2_17_x86_64.whl",
+        )
+        assert got is None
+
+    def test_version_past_the_cap_is_not_raisable(self) -> None:
+        """A tag naming a version past the knob cap is not a ceiling nab can raise to."""
+        got = default_ceiling_admitting(
+            PlatformSpec("macos_arm64"),
+            python_version="3.11",
+            implementation="cpython",
+            wheel_filename="pkg-2.0-cp311-cp311-macosx_100_0_arm64.whl",
+        )
+        assert got is None


### PR DESCRIPTION
When you declare a platform target and do not set an OS or libc floor, nab applies a conservative default ceiling (macOS 12.0 on arm64, macOS 10.13 on x86_64, glibc 2.28, musl 1.2). A wheel that needs a newer floor is dropped for not matching the target's tags, and if it was the version's only wheel the whole version goes with it. nab then quietly pins an older version, or falls to an sdist, with no signal that a ceiling the user never touched cost them the newest release. Today that drop is only surfaced when a package has zero surviving versions, so the common "silently resolved to an older version" case says nothing.

This adds a warning that fires once per (package, version) when an unset default ceiling is the sole reason a version loses its last compatible wheel. It confirms the ceiling really is the sole cause by rebuilding the target's tags with the ceiling raised and rechecking acceptance, so an arch, Python, ABI, or libc-family mismatch (which no ceiling change fixes) stays silent. A release that also ships an in-ceiling wheel keeps it and stays silent too. The defaults are unchanged.

Repro, macOS arm64 target at the default 12.0 ceiling with BuildPolicy.NEVER:

    target = ResolveTarget.for_declared(python_version="3.11", spec=PlatformSpec("macos_arm64"))
    prov = Provider(index([wheel("2.0", "cp311-cp311-macosx_14_0_arm64"),
                           wheel("1.0", "cp311-cp311-macosx_12_0_arm64")]),
                    target, build_policy=BuildPolicy.NEVER)
    prov.filter_distributions("pkg", files)

Before, 2.0 is dropped and 1.0 is pinned with nothing logged. After, nab warns that pkg 2.0's only wheel is above the default macos-min ceiling and names the value (14.0) that would keep it.

Alternative: warn on every ceiling-dropped wheel rather than only when the version loses its last wheel; louder, but it fires on releases that also ship an in-ceiling wheel, so left out.
