### PR TITLE
fork conflicts in specific mode, not only with a matrix

### DIFF
--- a/docs/explanation/conflicts.md
+++ b/docs/explanation/conflicts.md
@@ -1,14 +1,13 @@
 # Conflicting extras and groups
 
 > [!WARNING]
-> Conflict declarations are tied to universal mode, which is
-> experimental. The lockfile shape may change.
+> The lockfile shape for conflicts may still change.
 
 Some optional dependency sets are mutually exclusive: a CPU build and a
 GPU build of the same stack, or testing variants pinned to different
 tool versions. nab cannot put two such sets in one resolution, and a
-universal lock that tried to would fail the emit-time disjointness
-check. Declaring the conflict tells nab to keep them apart.
+lock that tried to would fail the emit-time disjointness check.
+Declaring the conflict tells nab to keep them apart.
 
 ## Declaring a conflict
 
@@ -60,27 +59,15 @@ Declaring conflicts in the workspace root does not propagate to a
 its own. See [Lock a workspace](../how-to/workspaces.md) for the full
 list of keys that flow vs stay local.
 
-## Specific mode: fail fast
+## Forking co-selected members
 
-A single-environment resolve cannot serve two exclusive members at
-once. Selecting both is rejected before any network work:
-
-```console
-$ nab lock --extras cpu gpu
-Error in [tool.nab]: extra 'cpu', extra 'gpu' cannot be selected
-together: declared mutually exclusive (at-most-one) in
-[tool.nab].conflicts
-```
-
-`exactly-one` and `at-least-one` additionally reject selecting none.
-
-## Universal mode: fork the resolve
-
-In universal mode nab does not reject co-selected members: it forks the
-resolve. When the selection activates two or more members of a set (for
-example `nab lock --all-groups` over the `black*` groups above), nab
-resolves each member separately and writes every result into one
-lockfile. Each fork's pins carry a marker selecting that member:
+When the selection activates two or more members of a set, nab does not
+reject it: it forks the resolve. For example `nab lock --extras cpu gpu`,
+or `nab lock --all-groups` over the `black*` groups above, resolves each
+member separately and writes every result into one lockfile. This is the
+same in specific and universal mode; the resolve mode does not change how
+a conflict is handled. Each fork's pins carry a marker selecting that
+member:
 
 ```toml
 [[packages]]
@@ -106,16 +93,23 @@ stay active in every fork.
 
 Forking needs one member per fork. If a single selection forces two
 members of one set together, no fork can separate them, so the resolve
-is refused. This happens when an umbrella extra self-references both
-members (`all = ["proj[cpu]", "proj[gpu]"]`) or an umbrella group
-includes both member groups. Co-selecting the members directly still
-forks; only the all-in-one umbrella, which cannot resolve disjointly,
-is rejected.
+is refused before any network work:
 
-The require-one check is not skipped in universal mode. Declaring
-`exactly-one` or `at-least-one` and selecting none of its members still
-raises before the resolve, the same as in specific mode. Only the
-co-selection case differs: universal mode forks instead of rejecting.
+```console
+$ nab lock --extras all
+Error in [tool.nab]: extra 'cpu', extra 'gpu' cannot be selected
+together: declared mutually exclusive (at-most-one) in
+[tool.nab].conflicts
+```
+
+This happens when an umbrella extra self-references both members
+(`all = ["proj[cpu]", "proj[gpu]"]`) or an umbrella group includes both
+member groups. Co-selecting the members directly still forks; only the
+all-in-one umbrella, which cannot resolve disjointly, is rejected.
+
+The require-one policies still raise. Declaring `exactly-one` or
+`at-least-one` and selecting none of its members is rejected before the
+resolve, regardless of mode; only the co-selection case forks.
 
 Groups named in `[tool.nab].default-groups` count as part of the
 selection for every conflict check. A project with
@@ -123,8 +117,7 @@ selection for every conflict check. A project with
 groups `a` and `b`
 satisfies the minimum without passing `--groups`, and a `--groups b`
 on top of that default activates two members of an exclusive set,
-which the exclusion check then catches (specific mode) or which
-universal mode forks into two.
+which then forks into two.
 
 A dependency required by every member of a set but not by the base
 keeps its membership marker, so it does not install when no member is

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,5 +78,5 @@ contributing
   `[tool.nab].mode = "universal"`; the API and output format are still
   subject to change.
 * Mutually-exclusive extras and dependency groups via
-  `[tool.nab].conflicts`: fail fast in specific mode, fork the resolve
-  in universal mode.  See [conflicts](explanation/conflicts.md).
+  `[tool.nab].conflicts`: co-selected members fork the resolve, in
+  specific and universal mode.  See [conflicts](explanation/conflicts.md).

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -664,16 +664,17 @@ def _plan_forks(
 ) -> tuple[list[ResolveFork], list[Requirement] | None]:
     """Plan the resolves a selection needs, and the base pass they need.
 
-    A declared matrix forks an engaged conflict: one resolve per choice
-    of member, each carrying its own requirements.  Without one there is
-    a single unforked resolve, and the exclusion check below is what
-    refuses a selection that engages a conflict at all: with nowhere to
-    fork to, two co-selected members cannot both be locked.
+    An engaged conflict forks whether or not a matrix is declared: one
+    resolve per choice of member, each carrying its own requirements,
+    with the member stamped onto the selection so its pins land under a
+    membership-gated marker.  The exclusion check below still refuses a
+    selection that reaches two members of a set without directly
+    selecting either (an umbrella extra or group), since a fork can only
+    carry a directly-selected member.
 
     The second element is the no-member requirement list, needed only
     when the plan actually forked; see :func:`resolve_with_coordinator`.
     """
-    fork_conflicts = config.matrix is not None
     if config.conflicts:
         _validate_conflict_members_exist(
             config.conflicts, tables.optional, tables.groups
@@ -686,7 +687,7 @@ def _plan_forks(
             targets,
         )
 
-    plan = conflict_forks(extras, groups, config.conflicts if fork_conflicts else ())
+    plan = conflict_forks(extras, groups, config.conflicts)
     forks: list[ResolveFork] = []
     # Forks of an extra-based conflict share a group selection, so the
     # (group, group) -> target scan runs once per distinct one.
@@ -885,11 +886,12 @@ def _check_conflict_exclusions(
     never share a target and pass; two that co-activate on one target
     fail.
 
-    A matrix runs this once per fork, where each fork holds at most one
-    member of an engaged set, so it only catches the members an umbrella
-    selection reaches transitively.  Without a matrix there is one fork
-    carrying the whole selection, so this is also what refuses two
-    co-selected members outright.
+    This runs once per fork, where each fork holds at most one member of
+    an engaged set, so it only catches co-selection an umbrella extra or
+    group reaches transitively: a member not directly selected cannot be
+    assigned to a fork, so ``conflict_forks`` leaves it in the shared
+    base where two of them meet.  Directly co-selecting two members forks
+    instead of raising here.
     """
     expanded_groups = expand_group_includes(tables.groups, active_groups)
     for target in targets:

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -129,9 +129,14 @@ def _build_constraints(
 
 
 class TestSpecificModeConflictValidation:
-    """A declared conflict fails fast in specific mode, before any network."""
+    """Conflict handling in specific mode: direct co-selection forks, an
+    umbrella that reaches two members without selecting either fails fast."""
 
-    def test_co_selecting_conflicting_extras_raises(self, tmp_path: Path) -> None:
+    @patch("nab_python.resolve.resolve_with_coordinator")
+    def test_co_selecting_conflicting_extras_forks(
+        self, mock_engine: MagicMock, tmp_path: Path
+    ) -> None:
+        """Two directly co-selected conflicting extras fork, matrix or not."""
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text(
             '[project]\nname = "x"\nversion = "0"\n'
@@ -142,15 +147,20 @@ class TestSpecificModeConflictValidation:
             "[tool.nab]\n"
             'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
         )
-        # No FetchCoordinator patch: the validation must raise before any
-        # network work is attempted.
-        with pytest.raises(ConflictSelectionError, match="cannot be selected together"):
-            _resolved(
-                pyproject,
-                _FAKE_TRANSPORT,
-                extras=("cpu", "gpu"),
-                python_version="3.12.0",
-            )
+        _resolved(
+            pyproject,
+            _FAKE_TRANSPORT,
+            extras=("cpu", "gpu"),
+            python_version="3.12.0",
+        )
+        forks = mock_engine.call_args.kwargs["forks"]
+        assert {f.selection for f in forks} == {
+            (("extra", "cpu"),),
+            (("extra", "gpu"),),
+        }
+        by_selection = {f.selection: f.requirements for f in forks}
+        assert [str(r) for r in by_selection[(("extra", "cpu"),)]] == ["numpy==2.1.2"]
+        assert [str(r) for r in by_selection[(("extra", "gpu"),)]] == ["numpy==2.0.0"]
 
     def test_single_extra_under_conflict_resolves(self, tmp_path: Path) -> None:
         pyproject = tmp_path / "pyproject.toml"
@@ -184,6 +194,39 @@ class TestSpecificModeConflictValidation:
         assert V("1.0") in root_reqs["foo"]
         assert V("2.0") not in root_reqs["foo"]
         assert _pins(result) == {"foo": V("1.0")}
+
+    def test_direct_co_selection_forks_and_locks(self, tmp_path: Path) -> None:
+        """A real specific-mode co-selection resolves to two forks, each
+        pinning its own member's version under a distinct selection."""
+        coordinator = make_coordinator(
+            listings={"numpy": _index_wheels("numpy", "2.0.0", "2.1.2")},
+            auto_metadata=True,
+        )
+        path = tmp_path / "pyproject.toml"
+        path.write_text(
+            '[project]\nname = "proj"\nversion = "0"\ndependencies = []\n'
+            "[project.optional-dependencies]\n"
+            'cpu = ["numpy==2.1.2"]\n'
+            'gpu = ["numpy==2.0.0"]\n'
+            "[tool.nab]\n"
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n',
+            encoding="utf-8",
+        )
+        with patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda _self: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            result = _resolved(
+                path, _FAKE_TRANSPORT, extras=("cpu", "gpu"), python_version="3.12.0"
+            )
+        label_for = {v: label for v, label in result.merged_pins()["numpy"]}
+        assert set(label_for) == {"2.0.0", "2.1.2"}
+        assert label_for["2.1.2"].endswith("-extra-cpu")
+        assert label_for["2.0.0"].endswith("-extra-gpu")
+        # Both forks land in the lock under their own selection.
+        lock_input = build_lock_input(
+            result, config=read_pyproject_config(path), extras=("cpu", "gpu")
+        )
+        assert len(lock_input.targets) == 2
 
     def test_unknown_conflict_member_raises(self, tmp_path: Path) -> None:
         pyproject = tmp_path / "pyproject.toml"
@@ -528,9 +571,12 @@ class TestSpecificModeConflictValidation:
         root_reqs = mock_provider_cls.call_args.kwargs["root_requirements"]
         assert "bar" in root_reqs
 
-    def test_default_groups_plus_cli_violate_exclusion(self, tmp_path: Path) -> None:
-        # ``default-groups = ["a"]`` plus ``--groups b`` activates both
-        # members of an at-most-one set, so the exclusion check trips.
+    @patch("nab_python.resolve.resolve_with_coordinator")
+    def test_default_groups_plus_cli_fork_exclusion(
+        self, mock_engine: MagicMock, tmp_path: Path
+    ) -> None:
+        # ``default-groups = ["a"]`` plus ``--groups b`` directly selects
+        # both members of an at-most-one set, so the resolve forks.
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text(
             '[project]\nname = "x"\nversion = "0"\n'
@@ -542,13 +588,17 @@ class TestSpecificModeConflictValidation:
             'default-groups = ["a"]\n'
             'conflicts = [[{ group = "a" }, { group = "b" }]]\n'
         )
-        with pytest.raises(ConflictSelectionError, match="cannot be selected together"):
-            _resolved(
-                pyproject,
-                _FAKE_TRANSPORT,
-                groups=("b",),
-                python_version="3.12.0",
-            )
+        _resolved(
+            pyproject,
+            _FAKE_TRANSPORT,
+            groups=("b",),
+            python_version="3.12.0",
+        )
+        forks = mock_engine.call_args.kwargs["forks"]
+        assert {f.selection for f in forks} == {
+            (("group", "a"),),
+            (("group", "b"),),
+        }
 
 
 class TestResolvePyproject:


### PR DESCRIPTION
Declaring `[tool.nab].conflicts` and then selecting two members of a set only forked the resolve when a `[tool.nab.matrix]` was also declared. Without a matrix the same selection was rejected outright, so an identical project errored in specific mode but locked cleanly as a one-target matrix. The gate was an accident of the old two-engine split, not a real limitation: a fork is a selection dimension, and `conflict_forks`, the membership markers, and the emit-time disjointness validator all work with a single target.

Two projects, identical except one adds a one-target matrix, with `cpu = ["idna==3.7"]`, `gpu = ["idna==3.6"]` and `conflicts = [[{extra="cpu"}, {extra="gpu"}]]`, run with `nab lock <pyproject> --extras cpu gpu`:

Specific (no matrix) errored:
```
Error in [tool.nab]: extra 'cpu', extra 'gpu' cannot be selected together: declared mutually exclusive (at-most-one) in [tool.nab].conflicts
```

Universal (one-target matrix, same `--extras`) locked idna 3.6 under a `"gpu" in extras` marker and idna 3.7 under `"cpu" in extras`.

This drops the `config.matrix is not None` gate in `_plan_forks` and passes the declared conflicts to `conflict_forks` unconditionally, so directly co-selecting two members forks in both modes and emits one lockfile with disjoint membership markers. The exclusion check still refuses an umbrella extra or group that reaches two members without directly selecting either, since a fork can only carry a directly-selected member, and `exactly-one` / `at-least-one` still raise when a selection names none of a set's members.

Alternative: keep the gate and replace the error with a message telling the user to declare a matrix or narrow the selection, preserving the old asymmetry.
