### PR TITLE
add windows_arm64 and linux_i686 platform ids

### DIFF
--- a/docs/explanation/universal.md
+++ b/docs/explanation/universal.md
@@ -51,8 +51,9 @@ python-order = "asc"
 
 `python` is a PEP 440 specifier expanded into one tuple per
 minor version. `platforms` is a list of platform ids
-(`linux_x86_64`, `linux_aarch64`, `macos_x86_64`, `macos_arm64`,
-`windows_amd64`), each optionally written as a table to declare its
+(`linux_x86_64`, `linux_aarch64`, `linux_i686`, `macos_x86_64`,
+`macos_arm64`, `windows_amd64`, `windows_arm64`), each optionally
+written as a table to declare its
 wheel-tag knobs (libc family and version, macOS deployment target,
 free-threaded build).  See
 [Configuration](../reference/configuration.md).

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -615,7 +615,7 @@ platforms = [
 
 | Key | Default | Meaning |
 | --- | --- | --- |
-| `id` | required | `linux_x86_64`, `linux_aarch64`, `macos_arm64`, `macos_x86_64`, or `windows_amd64` |
+| `id` | required | `linux_x86_64`, `linux_aarch64`, `linux_i686`, `macos_arm64`, `macos_x86_64`, `windows_amd64`, or `windows_arm64` |
 | `libc` | `"glibc"` | The Linux C library: `"glibc"` or `"musl"` |
 | `libc-version` | glibc `2.28`, musl `1.2` | The libc version the target runs |
 | `macos-min` | arm64 `12.0`, x86_64 `10.13` | The macOS deployment target |

--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -259,6 +259,8 @@ _PLATFORM_ARCH: dict[str, str] = {
     "macos_arm64": "arm64",
     "macos_x86_64": "x86_64",
     "windows_amd64": "amd64",
+    "windows_arm64": "arm64",
+    "linux_i686": "i686",
 }
 
 # The kind behind :func:`platform_kind`, which both tag generation and the
@@ -269,6 +271,8 @@ _PLATFORM_KIND: dict[str, str] = {
     "macos_arm64": "macos",
     "macos_x86_64": "macos",
     "windows_amd64": "windows",
+    "windows_arm64": "windows",
+    "linux_i686": "linux",
 }
 
 

--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -100,6 +100,18 @@ PLATFORM_MARKERS: dict[str, dict[str, str]] = {
         "platform_machine": "AMD64",
         "os_name": "nt",
     },
+    "windows_arm64": {
+        "sys_platform": "win32",
+        "platform_system": "Windows",
+        "platform_machine": "ARM64",
+        "os_name": "nt",
+    },
+    "linux_i686": {
+        "sys_platform": "linux",
+        "platform_system": "Linux",
+        "platform_machine": "i686",
+        "os_name": "posix",
+    },
 }
 
 

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -1344,6 +1344,35 @@ class TestEnvironment:
         assert target.implementation == "pypy"
         assert target.platform_id == "macos_arm64"
 
+    def test_windows_arm64_bare_id_declares_a_target(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab.environment]\npython = "3.12"\nplatform = "windows_arm64"\n'
+            '[tool.nab]\nbuild-policy = "never"\n',
+        )
+        config = read_pyproject_config(path)
+        assert config.environment == EnvironmentConfig(
+            python="3.12", platform=PlatformSpec("windows_arm64")
+        )
+        (target,) = plan_targets(config)
+        assert target.marker_env["platform_machine"] == "ARM64"
+        assert target.tags.accepts("somepkg-1.0-cp312-cp312-win_arm64.whl")
+
+    def test_linux_i686_table_declares_a_target(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab.environment]\npython = "3.12"\n'
+            'platform = { id = "linux_i686" }\n'
+            '[tool.nab]\nbuild-policy = "never"\n',
+        )
+        config = read_pyproject_config(path)
+        assert config.environment == EnvironmentConfig(
+            python="3.12", platform=PlatformSpec("linux_i686")
+        )
+        (target,) = plan_targets(config)
+        assert target.marker_env["platform_machine"] == "i686"
+        assert target.tags.accepts("somepkg-1.0-cp312-cp312-manylinux2014_i686.whl")
+
     def test_platform_without_python_takes_the_host_python(
         self, tmp_path: Path
     ) -> None:
@@ -1445,10 +1474,10 @@ class TestEnvironment:
 
     def test_unknown_platform_id_in_a_table_rejected(self, tmp_path: Path) -> None:
         path = write(
-            tmp_path, '[tool.nab.environment]\nplatform = { id = "linux_i686" }\n'
+            tmp_path, '[tool.nab.environment]\nplatform = { id = "freebsd_amd64" }\n'
         )
         with pytest.raises(
-            ConfigError, match="unknown environment.platform 'linux_i686'"
+            ConfigError, match="unknown environment.platform 'freebsd_amd64'"
         ):
             read_pyproject_config(path)
 
@@ -1517,9 +1546,9 @@ class TestEnvironment:
             read_pyproject_config(path)
 
     def test_unknown_platform_rejected(self, tmp_path: Path) -> None:
-        path = write(tmp_path, '[tool.nab.environment]\nplatform = "linux_i686"\n')
+        path = write(tmp_path, '[tool.nab.environment]\nplatform = "freebsd_amd64"\n')
         with pytest.raises(
-            ConfigError, match="unknown environment.platform 'linux_i686'"
+            ConfigError, match="unknown environment.platform 'freebsd_amd64'"
         ):
             read_pyproject_config(path)
 
@@ -3391,6 +3420,18 @@ class TestMatrix:
         assert matrix.platforms == (
             PlatformSpec("macos_arm64"),
             PlatformSpec("linux_x86_64", libc="musl", libc_version=(1, 2)),
+        )
+
+    def test_windows_arm64_and_linux_i686_are_known_ids(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            self._platforms_body('["windows_arm64", "linux_i686"]'),
+        )
+        matrix = read_pyproject_config(path).matrix
+        assert matrix is not None
+        assert matrix.platforms == (
+            PlatformSpec("windows_arm64"),
+            PlatformSpec("linux_i686"),
         )
 
     @pytest.mark.parametrize(

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -28,6 +28,7 @@ from nab_python.tags import (
     _platform_tags_for_spec,
     wheel_tag_set,
 )
+from nab_python.target import PLATFORM_MARKERS
 
 # numpy 2.5.1 ships one manylinux wheel (tagged 2.27 and 2.28, no older),
 # one musllinux wheel, and one free-threaded wheel per platform.
@@ -86,7 +87,9 @@ class TestPlatformSpecKnobsBelongToTheirPlatform:
     a machine that was never modelled.
     """
 
-    @pytest.mark.parametrize("platform_id", ["macos_arm64", "windows_amd64"])
+    @pytest.mark.parametrize(
+        "platform_id", ["macos_arm64", "windows_amd64", "windows_arm64"]
+    )
     def test_libc_outside_linux_raises(self, platform_id: str) -> None:
         """Only a Linux target links a C library."""
         with pytest.raises(ValueError, match="libc is a Linux knob"):
@@ -196,6 +199,14 @@ class TestPlatformSpec:
         """``macos_arm64`` arch is ``arm64``."""
         spec = PlatformSpec("macos_arm64")
         assert spec.arch == "arm64"
+
+    def test_windows_arm64_arch(self) -> None:
+        """``windows_arm64`` wheel-tag arch is the lowercase ``arm64``."""
+        assert PlatformSpec("windows_arm64").arch == "arm64"
+
+    def test_linux_i686_arch(self) -> None:
+        """``linux_i686`` carries the ``i686`` arch."""
+        assert PlatformSpec("linux_i686").arch == "i686"
 
     def test_label_distinguishes_space_from_underscore(self) -> None:
         """Whitespace and ``_`` in ``platform_release`` encode differently.
@@ -372,6 +383,52 @@ class TestAbiIsHostIndependent:
         spec = PlatformSpec("linux_x86_64", free_threaded=True)
         tag_strs = {str(t) for t in _ordered_tags_for_spec("3.13", spec, "cpython")}
         assert "cp313-cp313t-manylinux_2_28_x86_64" in tag_strs
+
+
+class TestPlatformIdTableParity:
+    """The three id-keyed platform tables must name the same ids.
+
+    ``Matrix.expand`` validates a declared id against ``PLATFORM_MARKERS``
+    only, while ``PlatformSpec.arch`` and ``platform_kind`` read the other
+    two.  An id in one table but not the others would pass validation and
+    then ``KeyError`` deep in tag building.
+    """
+
+    def test_the_three_tables_agree(self) -> None:
+        assert set(PLATFORM_MARKERS) == set(_PLATFORM_ARCH) == set(_PLATFORM_KIND)
+
+
+class TestWindowsArm64:
+    """``windows_arm64`` names the ``win_arm64`` wheel tag."""
+
+    def test_platform_tag_is_win_arm64(self) -> None:
+        assert _platform_tags_for_spec(PlatformSpec("windows_arm64")) == ["win_arm64"]
+
+    def test_accepts_a_win_arm64_wheel(self) -> None:
+        spec = PlatformSpec("windows_arm64")
+        wheel = _wheel("foo-1.0-cp312-cp312-win_arm64.whl")
+        assert _compatible(wheel, python_version="3.12", spec=spec)
+
+    def test_free_threaded_target_takes_the_cp313t_wheel(self) -> None:
+        spec = PlatformSpec("windows_arm64", free_threaded=True)
+        wheel = _wheel("foo-1.0-cp313-cp313t-win_arm64.whl")
+        assert _compatible(wheel, python_version="3.13", spec=spec)
+
+
+class TestLinuxI686:
+    """``linux_i686`` emits the i686 manylinux family down to glibc 2.5."""
+
+    def test_default_target_emits_manylinux_i686(self) -> None:
+        platforms = _platform_tags_for_spec(PlatformSpec("linux_i686"))
+        assert platforms[0] == "linux_i686"
+        assert "manylinux_2_28_i686" in platforms
+        assert "manylinux_2_5_i686" in platforms
+        assert not any(p.startswith("musllinux") for p in platforms)
+
+    def test_accepts_a_manylinux2014_i686_wheel(self) -> None:
+        spec = PlatformSpec("linux_i686")
+        wheel = _wheel("foo-1.0-cp312-cp312-manylinux2014_i686.whl")
+        assert _compatible(wheel, python_version="3.12", spec=spec)
 
 
 class TestTagsForTarget:

--- a/nab-python/tests/test_target.py
+++ b/nab-python/tests/test_target.py
@@ -281,6 +281,26 @@ class TestLabels:
         )
         assert target.label == "py311-linux_x86_64-musl"
 
+    def test_windows_arm64_label(self) -> None:
+        target = ResolveTarget.for_declared(
+            python_version="3.12", spec=PlatformSpec("windows_arm64")
+        )
+        assert target.label == "py312-windows_arm64"
+
+    def test_linux_i686_label(self) -> None:
+        target = ResolveTarget.for_declared(
+            python_version="3.12", spec=PlatformSpec("linux_i686")
+        )
+        assert target.label == "py312-linux_i686"
+
+    def test_free_threaded_windows_arm64_label(self) -> None:
+        target = ResolveTarget.for_declared(
+            python_version="3.13",
+            spec=PlatformSpec("windows_arm64", free_threaded=True),
+        )
+        assert target.label == "py313-windows_arm64-ft"
+        assert "cp313t" in {t.abi for t in target.tags.ordered}
+
     def test_selection_appends_sorted_member_suffix(self) -> None:
         """A conflict-fork selection appends sorted ``kind-name`` members."""
         target = ResolveTarget.for_declared(
@@ -488,6 +508,21 @@ class TestMarkerTables:
         for platform_id, env in PLATFORM_MARKERS.items():
             missing = required - env.keys()
             assert not missing, f"{platform_id} missing {missing}"
+
+
+class TestNewPlatformIdsExpand:
+    """The added ids expand from a matrix like any other platform."""
+
+    def test_windows_arm64_and_linux_i686_expand_to_targets(self) -> None:
+        matrix = Matrix(
+            python="==3.12",
+            platforms=(
+                PlatformSpec("windows_arm64"),
+                PlatformSpec("linux_i686"),
+            ),
+        )
+        labels = {t.label for t in matrix.expand()}
+        assert labels == {"py312-windows_arm64", "py312-linux_i686"}
 
 
 class TestPythonAxisEnvironment:


### PR DESCRIPTION
nab modeled five matrix platform ids. This adds two common targets with real PyPI wheel support that could not be named from `[tool.nab.matrix].platforms` or `[tool.nab.environment].platform`: `windows_arm64` and `linux_i686`.

The tag generators are already arch-generic, so the change is three data-table entries per id (marker env in `PLATFORM_MARKERS`, wheel-tag arch in `_PLATFORM_ARCH`, kind in `_PLATFORM_KIND`) plus a parity test that pins the three id-keyed tables to the same key set. That test closes a latent path where an id added to one table but not the others passes matrix validation and then KeyErrors during tag building.

`windows_arm64` carries `platform_machine` "ARM64" (the value packaging reports on that machine) and emits the `win_arm64` wheel tag. `linux_i686` carries `platform_machine` "i686" and, because i686 is a manylinux1/2010 arch, emits the i686 manylinux family down to glibc 2.5.

An alternative the maintainer may prefer: also add `linux_armv7l`, `ppc64le`, and `s390x`. Held back here because their real PyPI wheels are built above nab's shared default glibc floor of 2.28 (armv7l wheels target glibc 2.31, for instance), so a default target would reject every real wheel and fall back to sdist. Offering them correctly needs a per-arch default libc floor, which is a design change beyond this data-table addition.
