### PR TITLE
clear the static-analysis errors and recover a dead lock test

### DIFF
--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -12,7 +12,8 @@ Pins:
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from contextlib import AbstractContextManager
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -42,7 +43,7 @@ NUMPY_FREETHREADED = (
 CRYPTOGRAPHY_ABI3 = "cryptography-44.0.0-cp37-abi3-manylinux_2_28_x86_64.whl"
 
 
-def _free_threaded_host() -> object:
+def _free_threaded_host() -> AbstractContextManager[MagicMock]:
     """Patch the config vars packaging reads to fake a free-threaded host."""
     return patch(
         "nab_python.tags.ptags._get_config_var",

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -518,7 +518,7 @@ def _resolve(  # noqa: PLR0913, C901 - one wrapper per resolve_for_targets kwarg
     except InvalidProjectRequirementError as e:
         sys.stderr.write(f"Error: {e}\n")
         sys.exit(1)
-    except (MissingExtraError, LookupError) as e:
+    except LookupError as e:
         sys.stderr.write(f"Error: {e}\n")
         sys.exit(1)
     except (MissingHashError, MissingSdistError, MetadataError) as e:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -641,27 +641,6 @@ class TestLockCommandSpecific:
             lock(pyproject)
         assert "Cannot lock" in capsys.readouterr().err
 
-    def test_missing_extra_exits(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """MissingExtraError exits 1 with the message instead of a traceback."""
-        pyproject = _make_pyproject(tmp_path)
-        with (
-            patch(
-                "nab.cli.resolve_for_targets",
-                side_effect=MissingExtraError(
-                    "pkg==1.0 does not provide extra 'bogus'"
-                ),
-            ),
-            pytest.raises(SystemExit, match="1"),
-        ):
-            lock(pyproject)
-
-        err = capsys.readouterr().err
-        assert "Cannot lock" in err
-        assert "does not provide extra 'bogus'" in err
-        assert "Traceback" not in err
-
     def test_lookup_error_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -697,6 +676,7 @@ class TestLockCommandSpecific:
         ):
             lock(pyproject)
         err = capsys.readouterr().err
+        assert "Cannot lock" in err
         assert "does not provide extra 'nonexistent'" in err
         assert "Traceback" not in err
 


### PR DESCRIPTION
ruff check flags three static-analysis errors, and one of them hides a test that never runs.

TestLockCommandSpecific defined test_missing_extra_exits twice, so Python kept the second and the first never ran (F811). The dead copy asserted the lock path prefixes the message with "Cannot lock"; this folds that assertion into the live test and deletes the shadow.

In cli.py the lock helper's try/except listed MissingExtraError in two clauses (B025). The first, `except (UnsupportedVcsError, MissingExtraError)`, always wins, so the later `except (MissingExtraError, LookupError)` was unreachable for it. Narrowing the second to `except LookupError` is behavior-preserving and clears B025.

test_tags.py annotated `_free_threaded_host` as returning `object` while it returns a `patch(...)` context manager, so pyright rejected `with _free_threaded_host():`. It is now annotated `AbstractContextManager[MagicMock]`.

These are not CI failures; CI runs its type checkers on nab-resolver/src only and ruff is not in CI. But ruff-check and ruff-format run in pre-commit, so the F811 and B025 block a local commit that touches these files.
