### PR TITLE
add linux_armv7l id with a per-arch glibc floor

### DIFF
--- a/docs/explanation/universal.md
+++ b/docs/explanation/universal.md
@@ -51,9 +51,9 @@ python-order = "asc"
 
 `python` is a PEP 440 specifier expanded into one tuple per
 minor version. `platforms` is a list of platform ids
-(`linux_x86_64`, `linux_aarch64`, `linux_i686`, `macos_x86_64`,
-`macos_arm64`, `windows_amd64`, `windows_arm64`), each optionally
-written as a table to declare its
+(`linux_x86_64`, `linux_aarch64`, `linux_i686`, `linux_armv7l`,
+`macos_x86_64`, `macos_arm64`, `windows_amd64`, `windows_arm64`), each
+optionally written as a table to declare its
 wheel-tag knobs (libc family and version, macOS deployment target,
 free-threaded build).  See
 [Configuration](../reference/configuration.md).

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -615,9 +615,9 @@ platforms = [
 
 | Key | Default | Meaning |
 | --- | --- | --- |
-| `id` | required | `linux_x86_64`, `linux_aarch64`, `linux_i686`, `macos_arm64`, `macos_x86_64`, `windows_amd64`, or `windows_arm64` |
+| `id` | required | `linux_x86_64`, `linux_aarch64`, `linux_i686`, `linux_armv7l`, `macos_arm64`, `macos_x86_64`, `windows_amd64`, or `windows_arm64` |
 | `libc` | `"glibc"` | The Linux C library: `"glibc"` or `"musl"` |
-| `libc-version` | glibc `2.28`, musl `1.2` | The libc version the target runs |
+| `libc-version` | glibc `2.28` (armv7l `2.31`), musl `1.2` | The libc version the target runs |
 | `macos-min` | arm64 `12.0`, x86_64 `10.13` | The macOS deployment target |
 | `platform-release` | `""` | The `platform_release` marker value |
 | `platform-version` | `""` | The `platform_version` marker value |

--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -87,6 +87,14 @@ DEFAULT_LIBC: Libc = "glibc"
 _DEFAULT_LIBC_VERSION: Mapping[Libc, tuple[int, int]] = MappingProxyType(
     {"glibc": (2, 28), "musl": (1, 2)}
 )
+# A glibc default the arch raises above the family's.  armv7l's current PyPI
+# wheels are built at manylinux_2_31 (Debian bullseye / Raspberry Pi OS is glibc
+# 2.31), and a 2.28 floor would reject every one of them.  The floor stays a
+# ceiling on the tag, so this only holds where armv7l machines run 2.31 or newer;
+# an older one has to declare its libc-version.  musl armv7l keeps the 1.2 default.
+_ARCH_DEFAULT_GLIBC: Mapping[str, tuple[int, int]] = MappingProxyType(
+    {"armv7l": (2, 31)}
+)
 # The only major each family has shipped.  Tags expand within the declared
 # major, so a foreign major names platform tags no wheel is built for.
 LIBC_MAJOR: Mapping[Libc, int] = MappingProxyType({"glibc": 2, "musl": 1})
@@ -221,10 +229,14 @@ class PlatformSpec:
 
     @property
     def effective_libc_version(self) -> tuple[int, int]:
-        """The declared libc version, or this family's default."""
-        if self.libc_version is None:
-            return _DEFAULT_LIBC_VERSION[self.libc]
-        return self.libc_version
+        """The declared libc version, or the arch/family default."""
+        if self.libc_version is not None:
+            return self.libc_version
+        if self.libc == "glibc":
+            arch_default = _ARCH_DEFAULT_GLIBC.get(self.arch)
+            if arch_default is not None:
+                return arch_default
+        return _DEFAULT_LIBC_VERSION[self.libc]
 
     @property
     def label(self) -> str:
@@ -261,6 +273,7 @@ _PLATFORM_ARCH: dict[str, str] = {
     "windows_amd64": "amd64",
     "windows_arm64": "arm64",
     "linux_i686": "i686",
+    "linux_armv7l": "armv7l",
 }
 
 # The kind behind :func:`platform_kind`, which both tag generation and the
@@ -273,6 +286,7 @@ _PLATFORM_KIND: dict[str, str] = {
     "windows_amd64": "windows",
     "windows_arm64": "windows",
     "linux_i686": "linux",
+    "linux_armv7l": "linux",
 }
 
 

--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -112,6 +112,12 @@ PLATFORM_MARKERS: dict[str, dict[str, str]] = {
         "platform_machine": "i686",
         "os_name": "posix",
     },
+    "linux_armv7l": {
+        "sys_platform": "linux",
+        "platform_system": "Linux",
+        "platform_machine": "armv7l",
+        "os_name": "posix",
+    },
 }
 
 

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -1373,6 +1373,23 @@ class TestEnvironment:
         assert target.marker_env["platform_machine"] == "i686"
         assert target.tags.accepts("somepkg-1.0-cp312-cp312-manylinux2014_i686.whl")
 
+    def test_linux_armv7l_table_with_libc_version_override(
+        self, tmp_path: Path
+    ) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab.environment]\npython = "3.12"\n'
+            'platform = { id = "linux_armv7l", libc-version = "2.34" }\n'
+            '[tool.nab]\nbuild-policy = "never"\n',
+        )
+        config = read_pyproject_config(path)
+        assert config.environment == EnvironmentConfig(
+            python="3.12", platform=PlatformSpec("linux_armv7l", libc_version=(2, 34))
+        )
+        (target,) = plan_targets(config)
+        assert target.marker_env["platform_machine"] == "armv7l"
+        assert target.tags.accepts("somepkg-1.0-cp312-cp312-manylinux_2_34_armv7l.whl")
+
     def test_platform_without_python_takes_the_host_python(
         self, tmp_path: Path
     ) -> None:
@@ -3433,6 +3450,15 @@ class TestMatrix:
             PlatformSpec("windows_arm64"),
             PlatformSpec("linux_i686"),
         )
+
+    def test_linux_armv7l_is_a_known_matrix_id(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            self._platforms_body('["linux_armv7l"]'),
+        )
+        matrix = read_pyproject_config(path).matrix
+        assert matrix is not None
+        assert matrix.platforms == (PlatformSpec("linux_armv7l"),)
 
     @pytest.mark.parametrize(
         ("entry", "message"),

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -208,6 +208,35 @@ class TestPlatformSpec:
         """``linux_i686`` carries the ``i686`` arch."""
         assert PlatformSpec("linux_i686").arch == "i686"
 
+    def test_linux_armv7l_arch(self) -> None:
+        """``linux_armv7l`` carries the ``armv7l`` arch."""
+        assert PlatformSpec("linux_armv7l").arch == "armv7l"
+
+    def test_armv7l_default_glibc_is_2_31(self) -> None:
+        """An undeclared armv7l target floors at glibc 2.31, not 2.28.
+
+        Current armv7l wheels on PyPI (cryptography 46+) are built at
+        manylinux_2_31; a 2.28 floor would reject every one of them.
+        """
+        spec = PlatformSpec("linux_armv7l")
+        assert spec.libc == "glibc"
+        assert spec.effective_libc_version == (2, 31)
+
+    def test_armv7l_musl_keeps_the_family_default(self) -> None:
+        """The armv7l glibc floor does not move its musl default."""
+        spec = PlatformSpec("linux_armv7l", libc="musl")
+        assert spec.effective_libc_version == (1, 2)
+
+    def test_armv7l_declared_libc_version_wins(self) -> None:
+        """An explicit ``libc_version`` still overrides the armv7l default."""
+        spec = PlatformSpec("linux_armv7l", libc_version=(2, 17))
+        assert spec.effective_libc_version == (2, 17)
+
+    def test_other_arches_keep_glibc_2_28_default(self) -> None:
+        """The armv7l floor is a pure addition; every other arch stays 2.28."""
+        for platform_id in ("linux_x86_64", "linux_aarch64", "linux_i686"):
+            assert PlatformSpec(platform_id).effective_libc_version == (2, 28)
+
     def test_label_distinguishes_space_from_underscore(self) -> None:
         """Whitespace and ``_`` in ``platform_release`` encode differently.
 
@@ -429,6 +458,30 @@ class TestLinuxI686:
         spec = PlatformSpec("linux_i686")
         wheel = _wheel("foo-1.0-cp312-cp312-manylinux2014_i686.whl")
         assert _compatible(wheel, python_version="3.12", spec=spec)
+
+
+class TestLinuxArmv7l:
+    """``linux_armv7l`` emits the armv7l manylinux family from glibc 2.31 down."""
+
+    def test_default_target_emits_manylinux_armv7l(self) -> None:
+        platforms = _platform_tags_for_spec(PlatformSpec("linux_armv7l"))
+        assert platforms[0] == "linux_armv7l"
+        assert "manylinux_2_31_armv7l" in platforms
+        assert "manylinux_2_17_armv7l" in platforms
+        assert "manylinux2014_armv7l" in platforms
+        assert "manylinux_2_5_armv7l" not in platforms
+        assert not any(p.startswith("musllinux") for p in platforms)
+
+    def test_accepts_a_manylinux_2_31_armv7l_wheel(self) -> None:
+        spec = PlatformSpec("linux_armv7l")
+        wheel = _wheel("foo-1.0-cp312-cp312-manylinux_2_31_armv7l.whl")
+        assert _compatible(wheel, python_version="3.12", spec=spec)
+
+    def test_rejects_a_manylinux_2_34_armv7l_wheel(self) -> None:
+        """A wheel above the default floor needs an explicit libc-version."""
+        spec = PlatformSpec("linux_armv7l")
+        wheel = _wheel("foo-1.0-cp312-cp312-manylinux_2_34_armv7l.whl")
+        assert not _compatible(wheel, python_version="3.12", spec=spec)
 
 
 class TestTagsForTarget:

--- a/nab-python/tests/test_target.py
+++ b/nab-python/tests/test_target.py
@@ -293,6 +293,12 @@ class TestLabels:
         )
         assert target.label == "py312-linux_i686"
 
+    def test_linux_armv7l_label(self) -> None:
+        target = ResolveTarget.for_declared(
+            python_version="3.12", spec=PlatformSpec("linux_armv7l")
+        )
+        assert target.label == "py312-linux_armv7l"
+
     def test_free_threaded_windows_arm64_label(self) -> None:
         target = ResolveTarget.for_declared(
             python_version="3.13",
@@ -509,6 +515,11 @@ class TestMarkerTables:
             missing = required - env.keys()
             assert not missing, f"{platform_id} missing {missing}"
 
+    def test_linux_armv7l_marker_machine(self) -> None:
+        env = declared_environment("3.12", PlatformSpec("linux_armv7l"), "cpython")
+        assert env["platform_machine"] == "armv7l"
+        assert env["sys_platform"] == "linux"
+
 
 class TestNewPlatformIdsExpand:
     """The added ids expand from a matrix like any other platform."""
@@ -523,6 +534,14 @@ class TestNewPlatformIdsExpand:
         )
         labels = {t.label for t in matrix.expand()}
         assert labels == {"py312-windows_arm64", "py312-linux_i686"}
+
+    def test_linux_armv7l_expands_to_a_target(self) -> None:
+        matrix = Matrix(
+            python="==3.12",
+            platforms=(PlatformSpec("linux_armv7l"),),
+        )
+        labels = {t.label for t in matrix.expand()}
+        assert labels == {"py312-linux_armv7l"}
 
 
 class TestPythonAxisEnvironment:


### PR DESCRIPTION
Builds on #459 (retargets to main once that merges).

nab's default glibc floor is one value per family, glibc 2.28. The manylinux tag generator emits tags from that floor downward, never above it, so a 2.28 default admits manylinux_2_28 down to manylinux_2_17 for a non-x86 arch and nothing newer. armv7l is the arch where that default is wrong: every armv7l wheel cryptography ships on PyPI is built at manylinux_2_31, from 46.0.4 through 49.0.0.

```
cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl
cryptography-48.0.1-cp39-abi3-manylinux_2_31_armv7l.whl
cryptography-47.0.0-cp38-abi3-manylinux_2_31_armv7l.whl
cryptography-46.0.4-...-manylinux_2_31_armv7l.whl
```

A default armv7l target at glibc 2.28 rejects all of them and, since a declared target forbids host builds, falls through to an sdist or fails.

This makes the default floor arch-aware. A small override table raises armv7l to glibc 2.31; every other arch stays at 2.28 and musl stays at 1.2. The floor is still a ceiling on the emitted tag, so raising it is only right where armv7l machines run 2.31 or newer, which Debian bullseye and Raspberry Pi OS do. An older board declares its own libc-version, and an explicit libc-version still wins over the default. It also adds the linux_armv7l platform id (sys_platform linux, platform_machine armv7l), reachable from both the environment and matrix config.

x86_64, aarch64 and i686 keep manylinux_2_28 as their standard image, so they need no override. ppc64le and s390x also resolve fine at 2.28; once this per-arch mechanism exists, adding either is a one-line data-table entry.

Alternative: keep every arch at 2.28 and require the armv7l user to set libc-version = "2.31" by hand. Simpler code, but it makes the common armv7l case fail by default with a non-obvious fix.
