### PR TITLE
refuse VCS URL whose authority only breaks after userinfo strip

### DIFF
--- a/nab-python/src/nab_python/_vcs_admission.py
+++ b/nab-python/src/nab_python/_vcs_admission.py
@@ -188,6 +188,13 @@ def has_full_commit_sha(url: str) -> bool:
     return bool(FULL_GIT_SHA_RE.match(ref))
 
 
+def _malformed_vcs_error(url: str) -> UnsupportedVcsError:
+    """Refusal for a URL whose authority ``urlsplit`` cannot parse."""
+    return UnsupportedVcsError(
+        f"refusing malformed VCS URL\n    {url}\n    reason: the URL does not parse."
+    )
+
+
 def admit_vcs_url(url: str, config: VcsConfig) -> str:
     """Admit a direct-URL requirement, or raise :class:`UnsupportedVcsError`.
 
@@ -234,14 +241,7 @@ def admit_vcs_url(url: str, config: VcsConfig) -> str:
     try:
         repo_path = _repo_path(inner_url)
     except ValueError:
-        # urlsplit raises on an authority it cannot parse (an unclosed IPv6
-        # bracket), which ingestion reports as a refusal, not a traceback.
-        msg = (
-            "refusing malformed VCS URL\n"
-            f"    {url}\n"
-            "    reason: the URL does not parse."
-        )
-        raise UnsupportedVcsError(msg) from None
+        raise _malformed_vcs_error(url) from None
 
     # Without a repo path there is nothing to clone, and an appended pin's
     # "@" lands in the netloc instead of the path, where urlsplit reads
@@ -257,13 +257,22 @@ def admit_vcs_url(url: str, config: VcsConfig) -> str:
         )
         raise UnsupportedVcsError(msg)
 
+    # Stripping userinfo can unbalance an IPv6 bracket, so the match may raise
+    # on a netloc that parsed whole above.
+    try:
+        repo_admitted = any(
+            _repo_prefix_matches(
+                _without_userinfo(inner_url), _without_userinfo(prefix)
+            )
+            for prefix in config.allowed_repos
+        )
+    except ValueError:
+        raise _malformed_vcs_error(url) from None
+
     # An empty allowed-repos denies every repo (deny-all), matching
     # allowed-schemes: under policy = "allow" the user must list at least
     # one repo prefix.
-    if not any(
-        _repo_prefix_matches(_without_userinfo(inner_url), _without_userinfo(prefix))
-        for prefix in config.allowed_repos
-    ):
+    if not repo_admitted:
         allowed_str = ", ".join(sorted(config.allowed_repos)) or "<empty>"
         msg = (
             "refusing VCS repo\n"

--- a/nab-python/tests/test_vcs_admission.py
+++ b/nab-python/tests/test_vcs_admission.py
@@ -621,6 +621,22 @@ class TestAdmitVcsUrlMalformed:
         with pytest.raises(UnsupportedVcsError, match="does not parse"):
             admit_vcs_url("git+https://[/org/repo", config)
 
+    def test_authority_malformed_only_after_userinfo_strip_refused(self) -> None:
+        """A netloc that parses whole but not once its userinfo is stripped.
+
+        ``[::1]@[::2`` balances its brackets across the whole netloc, so the
+        first urlsplit accepts it. Dropping ``[::1]@`` leaves ``[::2``, an
+        unclosed bracket that the allowed-repos match rejects.
+        """
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com/ok/repo",),
+            require_pin=False,
+        )
+        with pytest.raises(UnsupportedVcsError, match="does not parse"):
+            admit_vcs_url("git+https://[::1]@[::2/ok/repo", config)
+
 
 class TestAdmitVcsUrlRealWorldShapes:
     """Shapes a user actually writes still admit."""


### PR DESCRIPTION
Admitting a URL like `git+https://[::1]@[::2/ok/repo` crashed with a raw ValueError instead of a clean refusal. The netloc balances its brackets across the whole authority, so the first urlsplit accepts it, but the allowed-repos check strips the userinfo (`[::1]@`) and leaves `[::2`, an unclosed IPv6 bracket that urlsplit then rejects. That match ran outside the guard that turns a parse failure into a refusal, so the exception escaped admission.

The allowed-repos match now runs under the same guard, so a URL that only becomes malformed once its userinfo is stripped is refused with the same "does not parse" message as one that fails to parse up front. The refusal message is pulled into a small helper so both call sites share it.
