### PR TITLE
don't abort resolve on a corrupt sidecar for a non-selected candidate

### DIFF
--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -678,8 +678,8 @@ def prefetch_batch(
     for v in versions:
         if (package, v) in provider.deps_cache or v not in wheel_by_version_map:
             continue
-        # On a corrupt-metadata wheel ``await_metadata_batch`` would otherwise
-        # raise on the very metadata this override replaces.
+        # A complete override supplies the deps, so fetching this version's
+        # metadata is wasted work.
         if _has_complete_override(provider, package, v):
             continue
         wheel = wheel_by_version_map[v]
@@ -716,7 +716,10 @@ def await_metadata_batch(
             package, ver_str, metadata_url
         )
         if integrity_error is not None:
-            raise integrity_error
+            # Leave the version un-cached instead of aborting the batch.
+            # The error stays recorded, so get_dependencies re-raises it
+            # only if the scan actually selects this version.
+            continue
         text, from_sdist = provider.coordinator.index.get_metadata_with_origin(
             package, ver_str, metadata_url
         )

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -3739,9 +3739,9 @@ class TestSkipFetch:
         assert "dep-a" in provider.deps_cache[("pkg", V("2.0"))]
 
     def test_corrupt_wheel_resolves_via_scan(self) -> None:
-        # A corrupt-metadata wheel would make await_metadata_batch raise in
-        # the prefetch path.  A complete override short-circuits submission,
-        # so the scan reaches get_dependencies (skip-fetch) and resolves.
+        # A complete override short-circuits batch submission for the corrupt
+        # wheel, so the scan reaches get_dependencies (skip-fetch) and resolves
+        # from the override's deps rather than the corrupt metadata.
         coordinator = make_coordinator(
             [make_wheel("3.0"), make_wheel("2.0")],
             metadata_by_version={
@@ -5881,9 +5881,10 @@ class TestAwaitMetadataBatchEdgeCases:
         assert result == V("1.0")
         assert ("foo", V("2.0")) not in provider.deps_cache
 
-    def test_batch_metadata_hash_mismatch_aborts(self) -> None:
-        """A recorded integrity failure in the batch path aborts the wait
-        rather than leaving the version un-cached for an sdist fallback."""
+    def test_batch_metadata_hash_mismatch_defers_to_get_dependencies(self) -> None:
+        """A recorded integrity failure in the batch path leaves the version
+        un-cached without aborting; get_dependencies re-raises it when the
+        resolver actually selects this version."""
         wheels = [make_wheel("1.0")]
         coordinator = make_coordinator(wheels, package="foo")
         coordinator.index.store_metadata_error(
@@ -5893,12 +5894,44 @@ class TestAwaitMetadataBatchEdgeCases:
             _SIDECAR_URL,
         )
         provider = Provider(coordinator, target=_PY312)
-        with pytest.raises(MetadataHashMismatchError):
-            provider._await_metadata_batch(
-                "foo",
-                [(V("1.0"), "1.0", _SIDECAR_URL, _done_event())],
-            )
+        provider._await_metadata_batch(
+            "foo",
+            [(V("1.0"), "1.0", _SIDECAR_URL, _done_event())],
+        )
         assert ("foo", V("1.0")) not in provider.deps_cache
+        with pytest.raises(MetadataHashMismatchError):
+            provider.get_dependencies("foo", V("1.0"))
+
+    def test_batch_hash_mismatch_on_non_selected_candidate_resolves(self) -> None:
+        """A corrupt sidecar on a candidate the scan never selects must not abort.
+
+        v3.0's deps conflict with a decision, so the scan prefetches the
+        [v2.0, v1.0] batch.  v2.0 is clean and selected first; v1.0's sidecar
+        is corrupt but never examined.  Integrity-checking it in the batch
+        would crash the resolve over a version not in the solution.
+        """
+        wheels = [make_wheel("3.0"), make_wheel("2.0"), make_wheel("1.0")]
+        coordinator = make_coordinator(
+            wheels,
+            metadata_by_version={
+                "3.0": "Metadata-Version: 2.1\nName: pkg\nVersion: 3.0\nRequires-Dist: bar==2.0\n",
+                "2.0": "Metadata-Version: 2.1\nName: pkg\nVersion: 2.0\n",
+            },
+            package="pkg",
+        )
+        corrupt = make_wheel("1.0")
+        assert corrupt.metadata_url is not None
+        coordinator.index.store_metadata_error(
+            "pkg",
+            "1.0",
+            MetadataHashMismatchError("metadata sha256 mismatch"),
+            corrupt.metadata_url,
+        )
+        provider = Provider(coordinator, target=_PY312)
+        provider.solution_decisions["bar"] = V("1.0")
+        assert provider.choose_version("pkg", VersionRange.full()) == V("2.0")
+        assert provider.deps_cache[("pkg", V("2.0"))] == {}
+        assert ("pkg", V("1.0")) not in provider.deps_cache
 
     def test_batch_does_not_parse_sdist_pkg_info_as_wheel_metadata(self) -> None:
         """Sdist PKG-INFO in the shared slot is not cached by the batch path.


### PR DESCRIPTION
The batch prefetch raised as soon as it saw a recorded integrity error on any speculatively fetched candidate. When a clean higher-preference version was there to be selected, a corrupt PEP 658 sidecar on a lower version the scan never examines would still crash choose_version, failing a resolve that should have succeeded.

await_metadata_batch now leaves the version un-cached instead of raising, the same way it already handles missing, sdist-sourced, and malformed metadata. The error stays recorded, so get_dependencies re-raises it only when the resolver actually selects that version.
