### PR TITLE
derive sidecar metadata URLs only for prefetched wheels

### DIFF
--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -1060,14 +1060,16 @@ class FetchCoordinator:
         # Auto-prefetch metadata for the newest candidates (files are
         # oldest-first). One wheel per version: the first with a sidecar is the
         # one the provider picks for that version's metadata.
-        first_wheel: dict[str, tuple[WheelFile, str]] = {}
+        first_wheel: dict[str, WheelFile] = {}
         for f in files:
-            if isinstance(f, WheelFile) and (url := f.metadata_url) is not None:
-                first_wheel.setdefault(f.version, (f, url))
+            if isinstance(f, WheelFile) and f.has_metadata:
+                first_wheel.setdefault(f.version, f)
 
         newest = list(first_wheel.values())[-self.PREFETCH_METADATA_COUNT :]
-        for w, metadata_url in newest:
-            self.request_metadata(req.package, w.version, metadata_url, w.metadata_hash)
+        for w in newest:
+            url = w.metadata_url
+            assert url is not None
+            self.request_metadata(req.package, w.version, url, w.metadata_hash)
 
     def _record_serving_index(
         self,

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -588,6 +588,53 @@ class TestFetchCoordinator:
             assert coord.index.has_metadata("pkg", "3.0", sidecar)
 
     @respx.mock
+    def test_listing_prefetch_derives_urls_only_for_submitted_wheels(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The sidecar URL is derived only for the wheels the prefetch submits."""
+        listing = {
+            "meta": {"api-version": "1.0"},
+            "name": "pkg",
+            "files": [
+                {
+                    "filename": f"pkg-{n}.0-py3-none-any.whl",
+                    "url": f"https://f.com/pkg-{n}.0-py3-none-any.whl",
+                    "core-metadata": True,
+                }
+                for n in range(1, 16)
+            ],
+        }
+        respx.get("https://pypi.org/simple/pkg/").mock(
+            return_value=httpx.Response(200, json=listing)
+        )
+        respx.get(url__regex=r".*\.whl\.metadata$").mock(
+            return_value=httpx.Response(200, text="Metadata-Version: 2.1\n")
+        )
+
+        derived: list[str] = []
+        original = WheelFile.metadata_url.fget
+        assert original is not None
+
+        def counting(wheel: WheelFile) -> str | None:
+            derived.append(wheel.filename)
+            return original(wheel)
+
+        monkeypatch.setattr(WheelFile, "metadata_url", property(counting))
+
+        sidecar = "https://f.com/pkg-15.0-py3-none-any.whl.metadata"
+        with _coord() as coord:
+            coord.request_listing("pkg").wait(timeout=5)
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline and not coord.index.has_metadata(
+                "pkg", "15.0", sidecar
+            ):
+                time.sleep(0.01)
+            assert coord.index.has_metadata("pkg", "15.0", sidecar)
+
+        # The newest PREFETCH_METADATA_COUNT wheels, not all 15.
+        assert derived == [f"pkg-{n}.0-py3-none-any.whl" for n in range(6, 16)]
+
+    @respx.mock
     def test_fetch_error_logged_not_raised(self) -> None:
         respx.get("https://pypi.org/simple/bad/").mock(return_value=httpx.Response(500))
         with _coord() as coord:


### PR DESCRIPTION
When a listing comes back, the metadata auto-prefetch built the PEP 658 sidecar URL for every wheel that advertised one, then kept only the newest 10 versions. The URL is derived with urlsplit and urlunsplit, so on packages with many releases most of that string work was thrown away, and it all ran on the fetcher thread.

Filter on the has_metadata flag instead, slice down to the newest PREFETCH_METADATA_COUNT wheels first, and derive the URL only for the ones submitted for prefetch.
