### PR TITLE
sort dep extras so ResolutionError text is reproducible

### DIFF
--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -595,11 +595,11 @@ def add_classified_dep(
 
     if not req_extras:
         base_deps[name] = base_deps.get(name, VersionRange.full()) & vi
-        for re in dep_extras:
+        for re in sorted(dep_extras):
             base_deps[join_extra(name, re)] = VersionRange.full(admit_arbitrary=False)
     else:
         for extra_name in req_extras:
             edeps = extra_deps_map[extra_name]
             edeps[name] = edeps.get(name, VersionRange.full()) & vi
-            for re in dep_extras:
+            for re in sorted(dep_extras):
                 edeps[join_extra(name, re)] = VersionRange.full(admit_arbitrary=False)

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -1793,6 +1793,26 @@ class TestAddClassifiedDep:
         assert "bar[a-x]" in base
         assert "bar[b-y]" in base
 
+    def test_base_multi_extra_proxy_keys_sorted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Base-dep proxy keys come out sorted regardless of extras set order."""
+        req = Requirement("bar[x,y,z]")
+        monkeypatch.setattr(req, "extras", ["z", "y", "x"])
+        base: dict[str, VersionRange] = {}
+        add_classified_dep(req, set(), base, {})
+        assert list(base) == ["bar", "bar[x]", "bar[y]", "bar[z]"]
+
+    def test_extra_gated_multi_extra_proxy_keys_sorted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Extra-gated proxy keys come out sorted regardless of extras set order."""
+        req = Requirement("bar[x,y,z]")
+        monkeypatch.setattr(req, "extras", ["z", "y", "x"])
+        extra_map: dict[str, dict[str, VersionRange]] = {"g": {}}
+        add_classified_dep(req, {"g"}, {}, extra_map)
+        assert list(extra_map["g"]) == ["bar", "bar[x]", "bar[y]", "bar[z]"]
+
 
 class TestLocalSources:
     def _write_local(


### PR DESCRIPTION
A Requires-Dist entry naming several extras, e.g. `bar[x,y]`, inserted its extras-proxy keys into the dep dict in set iteration order, which varies with the hash seed. A failing resolve could then report the same conflict with the proxy keys in a different order on each run. Sorting the extras before insertion makes the order deterministic.
