### PR TITLE
report a bad --python value as a flag error, not a [tool.nab] one

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -1125,7 +1125,12 @@ def with_python_override(
         )
         raise ConfigError(msg)
 
-    _validate_environment_values({"python": python})
+    try:
+        Version(python)
+    except InvalidVersion as exc:
+        msg = f"--python must be a version like '3.12' or '3.12.4', got {python!r}"
+        raise ConfigError(msg) from exc
+
     environment = (
         EnvironmentConfig(python=python)
         if config.environment is None
@@ -1508,9 +1513,9 @@ def _environment_platform_spec(value: object) -> PlatformSpec:
 def _validate_environment_values(environment: Mapping[str, Any]) -> None:
     """Validate the value of every environment axis the table names.
 
-    Shared by the ``[tool.nab.environment]`` parse, the
-    ``[tool.nab.marker-environment]`` translation, and the ``--python``
-    override, so all three reject the same bad values with one message.
+    Shared by the ``[tool.nab.environment]`` parse and the
+    ``[tool.nab.marker-environment]`` translation, so both reject the
+    same bad values with one message.
     """
     python = environment.get("python")
     if python is not None:

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -244,10 +244,11 @@ def resolve_for_targets(  # noqa: PLR0913 - the surface mirrors the CLI; bundlin
 
     ``config`` defaults to :func:`read_pyproject_config(path)`.  The
     caller supplies ``transport`` so the HTTP library choice stays
-    outside nab-python.  ``cache_dir``, ``offline`` and ``python_version``
-    are runtime overrides from the CLI; ``python_version`` backs
-    ``--python`` and moves the resolve target onto that Python, leaving
-    the rest of the environment alone.
+    outside nab-python.  ``cache_dir`` and ``offline`` are runtime
+    overrides from the CLI; ``python_version`` applies
+    :func:`~nab_python.config.with_python_override`, moving the resolve
+    target onto that Python and leaving the rest of the environment
+    alone.
 
     ``groups`` and ``extras`` name PEP 735 groups and
     ``[project.optional-dependencies]`` keys to fold in;

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -803,6 +803,17 @@ class TestRequiresPython:
         ):
             plan_targets(config)
 
+    def test_python_override_error_names_the_flag(self, tmp_path: Path) -> None:
+        """The override is the flag's value, so the error names --python."""
+        path = write(tmp_path, '[project]\nname = "x"\nversion = "0"\n')
+        config = read_pyproject_config(path)
+        with pytest.raises(
+            ConfigError,
+            match=r"--python must be a version like '3\.12' or '3\.12\.4',"
+            r" got '3\.12\.x'",
+        ):
+            with_python_override(config, "3.12.x")
+
     def test_python_cannot_retarget_a_matrix(self, tmp_path: Path) -> None:
         """The matrix names the python axis of every target it declares."""
         path = write(

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -31,6 +31,7 @@ from nab_python.config import (
     NabProjectConfig,
     ResolveMode,
     read_pyproject_config,
+    with_python_override,
 )
 from nab_python.config_sources import (
     OPTIONS,
@@ -469,6 +470,21 @@ def _reject_python_override_in_universal(
         sys.exit(1)
 
 
+def _python_override_or_exit(
+    config: NabProjectConfig, python: str | None
+) -> NabProjectConfig:
+    """Retarget ``config`` onto the ``--python`` value, exiting 1 on a bad one.
+
+    Applied here rather than forwarded to the resolve, so the error reads
+    as a flag error, not a ``[tool.nab]`` one.
+    """
+    try:
+        return with_python_override(config, python)
+    except ConfigError as e:
+        sys.stderr.write(f"Error: {e}\n")
+        sys.exit(1)
+
+
 def _resolve(  # noqa: PLR0913, C901 - one wrapper per resolve_for_targets kwarg / exit-mapped error
     path: Path,
     *,
@@ -488,6 +504,7 @@ def _resolve(  # noqa: PLR0913, C901 - one wrapper per resolve_for_targets kwarg
     resolve is reported (one line for a single environment, a per-tuple
     block for a matrix) and the process exits 1.
     """
+    config = _python_override_or_exit(config, python)
     try:
         result = resolve_for_targets(
             path,
@@ -495,7 +512,6 @@ def _resolve(  # noqa: PLR0913, C901 - one wrapper per resolve_for_targets kwarg
             config=config,
             cache_dir=cache_dir,
             offline=offline,
-            python_version=python,
             groups=groups,
             extras=extras,
             resolution_strategy=resolution_strategy,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -951,7 +951,8 @@ class TestPythonFlag:
             "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
         ) as mock_resolve:
             lock(pyproject, output=out, python="3.11")
-        assert mock_resolve.call_args.kwargs["python_version"] == "3.11"
+        config = mock_resolve.call_args.kwargs["config"]
+        assert config.environment.python == "3.11"
 
     def test_absent_flag_leaves_the_host_target(self, tmp_path: Path) -> None:
         pyproject = _make_pyproject(tmp_path)
@@ -960,7 +961,35 @@ class TestPythonFlag:
             "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
         ) as mock_resolve:
             lock(pyproject, output=out)
-        assert mock_resolve.call_args.kwargs["python_version"] is None
+        assert mock_resolve.call_args.kwargs["config"].environment is None
+
+    def test_invalid_value_is_a_flag_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A bad value names the flag; there is no [tool.nab] table to fix."""
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with pytest.raises(SystemExit) as exc:
+            lock(pyproject, output=out, python="3.12.x")
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert (
+            "Error: --python must be a version like '3.12' or '3.12.4',"
+            " got '3.12.x'" in err
+        )
+        assert "[tool.nab]" not in err
+        assert not out.exists()
+
+    def test_download_invalid_value_is_a_flag_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        with pytest.raises(SystemExit) as exc:
+            download(pyproject, output=tmp_path / "wheels", python="3.12.x")
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "Error: --python must be a version like" in err
+        assert "[tool.nab]" not in err
 
     def test_rejected_in_universal_mode(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -987,7 +1016,8 @@ class TestPythonFlag:
             ),
         ):
             download(pyproject, output=out, python="3.11")
-        assert mock_resolve.call_args.kwargs["python_version"] == "3.11"
+        config = mock_resolve.call_args.kwargs["config"]
+        assert config.environment.python == "3.11"
 
     def test_download_rejects_it_in_universal_mode(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
`nab lock --python 3.12.x` failed with `Error in [tool.nab]: environment.python must be a version like '3.12' or '3.12.4', got '3.12.x'`. The message sent the user to a pyproject table they never touched when the bad value was on the command line.

The CLI forwarded the flag into `resolve_for_targets`, so the failure came back through the generic ConfigError handler that adds the `[tool.nab]` prefix. The CLI now applies `with_python_override` itself before the resolve, and a bad value reports as `Error: --python must be a version like '3.12' or '3.12.4', got '3.12.x'`. The matrix rejection for `--python` takes the same path, so it drops the misleading prefix as well. `download` behaves the same as `lock`.
