### PR TITLE
Use marker algebra for reduction and variables

### DIFF
--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
@@ -14,6 +13,7 @@ from ._conflict_kind import dependency_marker_holds
 from ._vendor.packaging.dependency_groups import resolve_dependency_groups
 from ._vendor.packaging.errors import ExceptionGroup
 from ._vendor.packaging.markers import Marker
+from ._vendor.packaging.markersets import MarkerSet
 from ._vendor.packaging.requirements import InvalidRequirement, Requirement
 from ._vendor.packaging.utils import InvalidName, canonicalize_name
 
@@ -285,161 +285,32 @@ def _and_markers(marker: Marker | None, gates: frozenset[str]) -> Marker:
     return Marker(" and ".join(f"({p})" for p in parts))
 
 
-def _decide_extra_conjunct(conjunct: str, extra: str) -> bool:
-    """Evaluate a single ``extra`` comparison under the bound value.
-
-    The caller only passes a lone comparison that references ``extra`` (and so
-    no environment variable), so packaging's public ``Marker.evaluate`` decides
-    it outright.
-    """
-    return Marker(conjunct).evaluate({"extra": extra})
-
-
-def _split_top_level(text: str, op: str) -> list[str]:
-    """Split ``text`` on its top-level `` op `` (quote- and paren-aware).
-
-    The scan skips the operator inside quoted operands (e.g. ``"android"``
-    contains ``and``) and inside parenthesised groups, so only the outermost
-    ``and`` / ``or`` operands split.
-    """
-    sep = f" {op} "
-    parts: list[str] = []
-    depth = 0
-    quote = ""
-    start = 0
-    i = 0
-    while i < len(text):
-        ch = text[i]
-        if quote:
-            if ch == quote:
-                quote = ""
-        elif ch in "'\"":
-            quote = ch
-        elif ch == "(":
-            depth += 1
-        elif ch == ")":
-            depth -= 1
-        elif depth == 0 and text.startswith(sep, i):
-            parts.append(text[start:i].strip())
-            i += len(sep)
-            start = i
-            continue
-        i += 1
-    parts.append(text[start:].strip())
-    return parts
-
-
-def _strip_wrapping_parens(text: str) -> str:
-    """Remove parentheses that wrap the whole expression, repeatedly."""
-    while text.startswith("(") and text.endswith(")"):
-        depth = 0
-        quote = ""
-        wraps = True
-        for i, ch in enumerate(text):
-            if quote:
-                if ch == quote:
-                    quote = ""
-            elif ch in "'\"":
-                quote = ch
-            elif ch == "(":
-                depth += 1
-            elif ch == ")":
-                depth -= 1
-                if depth == 0 and i != len(text) - 1:
-                    wraps = False
-                    break
-        if not wraps:
-            break
-        text = text[1:-1].strip()
-    return text
-
-
-def _wrap_for_and(text: str) -> str:
-    """Parenthesise ``text`` when it is a top-level ``or`` (precedence)."""
-    return f"({text})" if len(_split_top_level(text, "or")) > 1 else text
-
-
-_QUOTED_LITERAL = re.compile(r"'[^']*'|\"[^\"]*\"")
-_EXTRA_VARIABLE = re.compile(r"\bextra\b")
-
-
-def _references_extra_variable(text: str) -> bool:
-    """Whether ``text`` uses the ``extra`` marker variable.
-
-    Quoted values are dropped and a word boundary applied so neither a value
-    that contains ``extra`` (``sys_platform == "extraos"``) nor the distinct
-    ``extras`` set variable is mistaken for it.
-    """
-    return bool(_EXTRA_VARIABLE.search(_QUOTED_LITERAL.sub("", text)))
-
-
-def _reduce_conjunct(conjunct: str, extra: str) -> str | bool:
-    """Reduce one ``and`` conjunct under a bound ``extra``.
-
-    Returns ``True`` when the conjunct is satisfied (and drops out), ``False``
-    for a contradiction, or a residual string of environment conditions.
-    """
-    inner = _strip_wrapping_parens(conjunct)
-    references_extra = _references_extra_variable(inner)
-    is_group = len(_split_top_level(inner, "or")) > 1 or (
-        references_extra and len(_split_top_level(inner, "and")) > 1
-    )
-    if is_group:
-        reduced = _reduce_marker_string(inner, extra)
-        return reduced if isinstance(reduced, bool) else _wrap_for_and(reduced)
-    if not references_extra:
-        return inner
-    return _decide_extra_conjunct(inner, extra)
-
-
-def _reduce_marker_string(text: str, extra: str) -> str | bool:
-    """Reduce a marker string under a bound ``extra`` (interim, string-based).
-
-    Returns ``True`` (tautology), ``False`` (contradiction), or a residual
-    marker string of the surviving environment conditions.  Handles a
-    top-level ``or`` of ``and`` groups and recurses into parenthesised
-    subgroups; each conjunct that references only ``extra`` is decided
-    through packaging's public ``Marker.evaluate``.
-
-    This should move to a public packaging marker-reduction API once one
-    exists; nab deliberately does not reach into ``Marker._markers`` (see the
-    rejected-precedent note in :mod:`nab_python._lockfile.disjointness`).
-    """
-    text = _strip_wrapping_parens(text)
-    disjuncts = _split_top_level(text, "or")
-    if len(disjuncts) > 1:
-        surviving: list[str] = []
-        for disjunct in disjuncts:
-            reduced = _reduce_marker_string(disjunct, extra)
-            if reduced is True:
-                return True
-            if isinstance(reduced, str):
-                surviving.append(reduced)
-        if not surviving:
-            return False
-        return " or ".join(surviving)
-    residual: list[str] = []
-    for conjunct in _split_top_level(text, "and"):
-        reduced = _reduce_conjunct(conjunct, extra)
-        if reduced is False:
-            return False
-        if isinstance(reduced, str):
-            residual.append(reduced)
-    if not residual:
-        return True
-    return " and ".join(residual)
-
-
 def _environment_residual(marker: Marker, extra: str) -> str | bool:
     """Reduce a self-ref activation marker against a bound ``extra``.
 
     A self-reference is reached only because its extra is selected, so its
-    ``extra == "<extra>"`` clause is already decided at expansion.  Delegates
-    to :func:`_reduce_marker_string` over ``str(marker)``: returns ``True``
-    (tautology, a bare dep), ``False`` (contradiction, does not activate), or
-    a residual string of the surviving environment conditions.
+    ``extra == "<extra>"`` clause is already decided at expansion.  Restricts
+    the marker's environment set with ``extra`` bound to that one name and
+    reads off what survives: ``True`` (tautology, a bare dep), ``False``
+    (contradiction, does not activate), or a residual marker string of the
+    surviving environment conditions.
+
+    ``extra`` binds as a one-name set, the PEP 685 set model the algebra
+    evaluates ``extra ==`` / ``extra !=`` under.  Environment variables the
+    binding leaves untouched stay in the residual, so a
+    variable-vs-variable clause naming ``extra`` (``sys_platform ==
+    extra``) is kept as a residual atom over the target's own value rather
+    than decided against the machine running nab.
     """
-    return _reduce_marker_string(str(marker), extra)
+    residual = MarkerSet.from_marker(marker).restrict(
+        {"extra": frozenset({extra})}, on_unknown_variable="residual"
+    )
+
+    if residual.is_empty():
+        return False
+
+    text = residual.to_marker_string()
+    return True if text is None else text
 
 
 def expand_extra_requirements(

--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING
 from ._conflict_kind import EMPTY_MEMBERSHIP_SETS, MARKER_VARIABLE_FOR_KIND
 from ._vendor.packaging import tags as ptags
 from ._vendor.packaging.markers import Marker, default_environment
+from ._vendor.packaging.markersets import variable_names
 from ._vendor.packaging.specifiers import SpecifierSet
 from ._vendor.packaging.version import InvalidVersion, Version
 from .tags import (
@@ -232,10 +233,6 @@ _ALWAYS_DECLARED: tuple[str, ...] = (
     "platform_machine",
 )
 
-_MARKER_VARIABLE_RE = re.compile(
-    r"\b(" + "|".join(sorted(PEP508_MARKER_VARIABLES)) + r")\b"
-)
-
 # The variables a lock never declares by value: their bounds come only from a
 # slice's ``python_full_version`` clauses (see :func:`slices_from_points`).
 # Both carry a micro release, and on CPython they carry the same one
@@ -261,13 +258,24 @@ _MARKER_CLAUSE_RE = re.compile(
 def marker_variables(marker_text: str) -> frozenset[str]:
     """Return the PEP 508 environment variables ``marker_text`` names.
 
-    Matches the spec's names as whole words against the marker's string
-    form.  A name inside a string literal (``sys_platform ==
-    "python_version"``) counts, so the result over-approximates; a
-    declaration built from too many variables is narrower than one built
-    from too few, which is the safe direction to be wrong in.
+    Parses the marker and reads the variables its operands name, keeping
+    only the PEP 508 environment variables: the set variables ``extra`` /
+    ``extras`` / ``dependency_groups`` are not lock-environment axes (a lock
+    cannot pin them), so they drop out.  A quoted name on the right of a
+    variable comparison (``sys_platform == "python_version"``) is a value the
+    marker compares against, not a variable it reads, and is not returned; but
+    packaging reads the right operand of a literal-only comparison
+    (``"3.9" == "python_version"``) as an environment key, so that name is
+    returned.  The result is an
+    over-approximation of semantic support: a tautology such as
+    ``python_version >= "0"`` still reports ``python_version``.
+    Over-declaring narrows the lock, which is the safe direction to be
+    wrong in.
+
+    Every call site passes a serialised :class:`Marker`; an input that is not
+    a valid marker raises :class:`InvalidMarker`.
     """
-    return frozenset(_MARKER_VARIABLE_RE.findall(marker_text))
+    return variable_names(marker_text) & PEP508_MARKER_VARIABLES
 
 
 def environment_declaration(target: ResolveTarget, consulted: Iterable[Marker]) -> str:

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -919,6 +919,50 @@ class TestExpandExtraRequirements:
         names = {r.name for r in expand_extra_requirements(opt, "mypkg", ["a"])}
         assert {"depA", "depB"} <= names
 
+    def test_self_ref_var_vs_var_extra_gate_kept_as_target_residual(self) -> None:
+        """A variable-vs-variable self-ref gate naming ``extra``
+        (``sys_platform == extra``) survives as a residual atom over the
+        target's ``sys_platform``, not decided against the machine running nab.
+        """
+        opt = {
+            "all": ["mypkg[fast]; sys_platform == extra"],
+            "fast": ["some-dep"],
+        }
+        dep = next(
+            r
+            for r in expand_extra_requirements(opt, "mypkg", ["all"])
+            if r.name == "some-dep"
+        )
+        assert dep.marker is not None
+        # packaging reads the RHS variable name as a literal, so the residual
+        # sys_platform == "extra" fires only where sys_platform is that string.
+        assert dep.marker.evaluate({"sys_platform": "extra"})
+        assert not dep.marker.evaluate({"sys_platform": "linux"})
+
+    def test_self_ref_negated_extra_gate_for_walked_extra_drops(self) -> None:
+        """``extra != "all"`` on the walked extra ``all`` is a contradiction,
+        so the reached dep never activates through that path."""
+        opt = {
+            "all": ['mypkg[fast]; extra != "all"'],
+            "fast": ["some-dep"],
+        }
+        names = {r.name for r in expand_extra_requirements(opt, "mypkg", ["all"])}
+        assert "some-dep" not in names
+
+    def test_self_ref_negated_other_extra_gate_is_unconditional(self) -> None:
+        """``extra != "other"`` on the walked extra ``all`` is a tautology, so
+        the reached dep is bare (activates on every target)."""
+        opt = {
+            "all": ['mypkg[fast]; extra != "other"'],
+            "fast": ["some-dep"],
+        }
+        dep = next(
+            r
+            for r in expand_extra_requirements(opt, "mypkg", ["all"])
+            if r.name == "some-dep"
+        )
+        assert dep.marker is None
+
 
 class TestExpandGroupIncludes:
     def test_no_include_returns_input(self) -> None:

--- a/nab-python/tests/test_target.py
+++ b/nab-python/tests/test_target.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import pytest
 
-from nab_python._vendor.packaging.markers import Marker
+from nab_python._vendor.packaging.markers import InvalidMarker, Marker
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.tags import Tag
@@ -719,14 +719,37 @@ class TestMarkerVariables:
         }
 
     def test_a_marker_naming_nothing_yields_nothing(self) -> None:
+        """``extra`` is not a lock-environment axis, so it is filtered out."""
         assert marker_variables('extra == "docs"') == frozenset()
 
-    def test_a_name_in_a_string_literal_counts(self) -> None:
-        """Over-approximating narrows the declaration, which is the safe way."""
-        assert marker_variables('os_name == "platform_machine"') == {
-            "os_name",
-            "platform_machine",
+    def test_set_variables_are_not_environment_axes(self) -> None:
+        """The set variables never enter the ``environments`` declaration:
+        a lock cannot pin ``extras`` / ``dependency_groups``."""
+        assert marker_variables('"docs" in extras') == frozenset()
+        assert marker_variables('"g" in dependency_groups') == frozenset()
+
+    def test_a_name_in_a_string_literal_is_not_a_referenced_variable(self) -> None:
+        """A quoted value on the right of a variable comparison is not a variable
+        the marker reads, so parsing reports only the bare variable.
+        """
+        assert marker_variables('os_name == "platform_machine"') == {"os_name"}
+
+    def test_unparseable_marker_raises(self) -> None:
+        """A string that is not a valid marker raises InvalidMarker."""
+        with pytest.raises(InvalidMarker):
+            marker_variables("this is not a marker")
+
+    def test_arbitrary_equality_still_yields_the_variable_name(self) -> None:
+        """A ``===`` marker names a variable even though the algebra rejects it
+        at construction: extracting names does not build atoms.
+        """
+        assert marker_variables('python_full_version === "3.13.5"') == {
+            "python_full_version"
         }
+        assert marker_variables('implementation_version === "3.13.5"') == {
+            "implementation_version"
+        }
+        assert marker_variables('platform_release === "6.8.0"') == {"platform_release"}
 
     def test_every_declared_variable_is_a_marker_environment_key(self) -> None:
         target = ResolveTarget.for_host(env_source=_host_env, tags_source=_host_tags)
@@ -758,6 +781,18 @@ class TestEnvironmentDeclaration:
         )
         assert declaration.endswith('and platform_system == "Linux"')
         assert Marker(declaration).evaluate(_HOST_ENV)
+
+    def test_an_arbitrary_equality_marker_adds_no_full_version_clause(self) -> None:
+        """A consulted ``===`` on the version axis names the axis (the scrape
+        collects it) but the algebra rejects the ``===`` atom, so it yields no
+        boundary: a whole target adds no ``python_full_version`` clause and the
+        declaration still holds on the target.
+        """
+        declaration = environment_declaration(
+            self._target(), [Marker('python_full_version === "3.13.5"')]
+        )
+        assert "python_full_version" not in declaration
+        assert Marker(declaration).evaluate(self._target().marker_env)
 
     def test_consulted_variables_are_declared_in_sorted_order(self) -> None:
         declaration = environment_declaration(
@@ -888,6 +923,22 @@ class TestVersionEmission:
         slice's upper bound stays release form."""
         below, above = slices_from_points(self._minor(), [Version("3.12.4")])
         consulted = [Marker('python_full_version >= "3.12.4"')]
+        assert 'python_full_version < "3.12.4"' in environment_declaration(
+            below, consulted
+        )
+        assert 'python_full_version >= "3.12.4.dev0"' in environment_declaration(
+            above, consulted
+        )
+
+    def test_a_consulted_marker_without_the_axis_adds_no_clause(self) -> None:
+        """A consulted marker that never reads ``python_full_version`` does not
+        disturb the slice bounds; only the markers that read the axis split it,
+        so an off-axis ``os_name`` clause leaves the split untouched."""
+        below, above = slices_from_points(self._minor(), [Version("3.12.4")])
+        consulted = [
+            Marker('python_full_version >= "3.12.4"'),
+            Marker('os_name == "posix"'),
+        ]
         assert 'python_full_version < "3.12.4"' in environment_declaration(
             below, consulted
         )


### PR DESCRIPTION
Replaces the string-based marker reducer and the marker-variable regex with the marker algebra. This fixes the reducer evaluating host-machine values for variable-vs-variable comparisons and makes variable extraction structural.

Stacked on #473.
