### PR TITLE
httpx backend: don't retry a redirect loop as a transient blip

### DIFF
--- a/nab-index/src/nab_index/httpx_async_transport.py
+++ b/nab-index/src/nab_index/httpx_async_transport.py
@@ -88,6 +88,10 @@ class HttpxAsyncTransport:
         while True:
             try:
                 response = await self._client.get(url, headers=headers)
+            except httpx.TooManyRedirects as exc:
+                # A redirect loop is persistent, so it is raised rather than retried.
+                msg = f"GET {url} failed: {exc}"
+                raise HttpError(msg) from exc
             except httpx.HTTPError as exc:
                 failures += 1
                 if failures > MAX_RETRIES:

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -272,6 +272,25 @@ class TestHttpxAsyncTransport:
         resp.raise_for_status()
         assert resp.status_code == 200
 
+    @respx.mock
+    def test_get_gives_up_on_a_redirect_loop(self, slept: list[float]) -> None:
+        """A redirect loop raises rather than being retried."""
+        route = respx.get("https://example.com/loop").mock(
+            return_value=httpx.Response(302, headers={"Location": "/loop"})
+        )
+
+        async def go() -> None:
+            transport = HttpxAsyncTransport(http2=False)
+            try:
+                await transport.get("https://example.com/loop")
+            finally:
+                await transport.aclose()
+
+        with pytest.raises(HttpError, match="redirects"):
+            asyncio.run(go())
+        assert route.call_count == MAX_REDIRECTS + 1
+        assert slept == []
+
     def test_client_takes_the_shared_redirect_budget(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
A redirect loop makes httpx raise TooManyRedirects, which is a subclass of httpx.HTTPError. The get() retry loop caught it as a generic HTTP error and retried it like a transient blip, re-issuing the whole redirect chain on every attempt (four passes in all, since MAX_RETRIES is 3) before finally giving up.

Catch TooManyRedirects ahead of the generic HTTPError handler and wrap it in an HttpError straight away. A redirect loop is persistent, so the request now fails on the first pass instead of hammering the server three more times.
