### PR TITLE
Evaluate extra markers against the active set

### DIFF
--- a/nab-python/src/nab_python/_conflict_kind.py
+++ b/nab-python/src/nab_python/_conflict_kind.py
@@ -11,8 +11,11 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
+from ._vendor.packaging.markersets import MarkerSet
+
 if TYPE_CHECKING:
     from collections.abc import Mapping
+    from collections.abc import Set as AbstractSet
 
     from ._vendor.packaging.markers import Marker
 
@@ -31,8 +34,9 @@ MARKER_VARIABLE_FOR_KIND = {
 # packaging only defines when consuming a lockfile.  At resolve time no
 # conflict-fork member is active as a marker-set member (forks fold their
 # members into requirements, not the environment), so both are empty.  Seeding
-# them keeps a dependency marker that tests one from raising a raw KeyError at
-# evaluation; the membership simply tests False and the dep is dropped.
+# them keeps a dependency marker that tests one from raising an
+# UndefinedEnvironmentName at evaluation; the membership tests False and
+# the dep is dropped.
 EMPTY_MEMBERSHIP_SETS: dict[str, frozenset[str]] = {
     variable: frozenset() for variable in MARKER_VARIABLE_FOR_KIND.values()
 }
@@ -53,10 +57,22 @@ def membership_set_in_marker(marker_text: str) -> str | None:
     return match.group(1) if match else None
 
 
-def dependency_marker_holds(marker: Marker, environment: Mapping[str, str]) -> bool:
+def dependency_marker_holds(
+    marker: Marker, environment: Mapping[str, str | AbstractSet[str]]
+) -> bool:
     """Evaluate a dependency marker for a resolve-time ``environment``.
 
-    Seeds the empty lockfile-only set variables so a marker that tests one
-    evaluates cleanly to False instead of raising a raw KeyError.
+    ``extra`` is set-valued: bound to the active extra names, ``extra == "x"``
+    tests membership and ``extra != "x"`` non-membership, both PEP 685
+    normalised.  It defaults to the empty set when ``environment`` omits it.
+
+    A standard variable a marker names but ``environment`` omits raises
+    ``UndefinedEnvironmentName``; callers pass a complete
+    ``ResolveTarget.marker_env``.  The lockfile-only set variables are seeded
+    empty, so a marker that tests one evaluates to False rather than raising.
     """
-    return bool(marker.evaluate({**environment, **EMPTY_MEMBERSHIP_SETS}))
+    env: dict[str, str | AbstractSet[str]] = {"extra": frozenset()}
+    env.update(environment)
+    env.update(EMPTY_MEMBERSHIP_SETS)
+
+    return MarkerSet.from_marker(marker).evaluate(env)

--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -228,11 +228,11 @@ def expand_self_extras(
 
     A self-reference carrying a PEP 508 marker (``{name}[fast];
     python_version < "3.10"``) activates its extra only when the marker
-    evaluates true under ``environment``.  ``extra`` is bound to the
-    extra being walked so a marker like ``extra == "all"`` resolves
-    against it.  ``environment`` ``None`` skips that check and walks
-    every self-reference, which is what a caller that defers marker
-    evaluation to each target wants.
+    evaluates true under ``environment``.  ``extra`` binds to the
+    one-name set of the extra being walked, so ``extra == "all"``
+    resolves against it.  ``environment`` ``None`` skips that check and
+    walks every self-reference, which is what a caller that defers
+    marker evaluation to each target wants.
 
     The original ``selected`` order is preserved at the front of the
     result; reachable extras are appended in BFS order without
@@ -266,7 +266,7 @@ def expand_self_extras(
                 environment is not None
                 and req.marker is not None
                 and not dependency_marker_holds(
-                    req.marker, {**environment, "extra": extra}
+                    req.marker, {**environment, "extra": frozenset({extra})}
                 )
             ):
                 continue

--- a/nab-python/tests/test_conflict_kind.py
+++ b/nab-python/tests/test_conflict_kind.py
@@ -1,0 +1,98 @@
+"""Set-valued extra evaluation for dependency markers.
+
+``dependency_marker_holds`` binds ``extra`` to the full set of active extras, so
+a dep gated ``extra != "cpu"`` drops for a selection including ``cpu`` and one
+gated ``extra == "a"`` activates for ``[a, b]``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Set as AbstractSet
+
+import pytest
+
+from nab_python._conflict_kind import dependency_marker_holds
+from nab_python._vendor.packaging.markers import Marker
+
+_ENV: dict[str, str] = {
+    "python_version": "3.11",
+    "python_full_version": "3.11.2",
+    "sys_platform": "linux",
+    "os_name": "posix",
+    "platform_machine": "x86_64",
+    "implementation_name": "cpython",
+}
+
+
+def _holds(marker_text: str, extras: AbstractSet[str]) -> bool:
+    return dependency_marker_holds(Marker(marker_text), {**_ENV, "extra": extras})
+
+
+class TestDependencyMarkerHoldsSetExtra:
+    def test_negated_extra_dropped_for_that_selection(self) -> None:
+        """``extra != "cpu"`` must not hold for a ``[cpu]`` selection."""
+        assert _holds('extra != "cpu"', frozenset({"cpu"})) is False
+
+    def test_negated_extra_holds_for_other_selection(self) -> None:
+        assert _holds('extra != "cpu"', frozenset({"gpu"})) is True
+
+    def test_negated_extra_holds_for_base(self) -> None:
+        """No extras active: ``extra != "cpu"`` is a base dependency."""
+        assert _holds('extra != "cpu"', frozenset()) is True
+
+    def test_positive_extra_activates_for_multi_selection(self) -> None:
+        """``extra == "a"`` activates for ``pkg[a, b]``."""
+        assert _holds('extra == "a"', frozenset({"a", "b"})) is True
+
+    def test_positive_extra_inactive_when_not_selected(self) -> None:
+        assert _holds('extra == "a"', frozenset({"b"})) is False
+
+    def test_pep685_normalisation_both_sides(self) -> None:
+        """The marker name and the active names both normalise before matching."""
+        assert _holds('extra == "Fast.Path"', frozenset({"fast-path"})) is True
+        assert _holds('extra != "Fast.Path"', frozenset({"fast_path"})) is False
+
+    def test_env_atom_combined_with_extra(self) -> None:
+        """A marker mixing an environment atom with a negated extra holds only
+        where both do."""
+        assert _holds('sys_platform == "linux" and extra != "cpu"', frozenset({"gpu"}))
+        assert not _holds(
+            'sys_platform == "linux" and extra != "cpu"', frozenset({"cpu"})
+        )
+        assert not _holds(
+            'sys_platform == "win32" and extra != "cpu"', frozenset({"gpu"})
+        )
+
+    def test_extra_defaults_to_empty_when_unbound(self) -> None:
+        """A marker evaluated with no ``extra`` binding sees no extras active."""
+        assert dependency_marker_holds(Marker('extra != "cpu"'), _ENV) is True
+        assert dependency_marker_holds(Marker('extra == "cpu"'), _ENV) is False
+
+    def test_membership_set_variables_empty_at_resolve_time(self) -> None:
+        """The lockfile-only set variables stay seeded empty, so a marker that
+        tests ``extras`` evaluates False rather than raising."""
+        assert _holds('"docs" not in extras', frozenset({"cpu"})) is True
+        assert _holds('"docs" in extras', frozenset({"cpu"})) is False
+
+
+class TestDependencyMarkerHoldsScalarExtra:
+    def test_scalar_extra_binding(self) -> None:
+        """A single extra name bound as a string is read as its one-name set."""
+        env: dict[str, str] = {**_ENV, "extra": "cpu"}
+        assert dependency_marker_holds(Marker('extra == "cpu"'), env) is True
+        assert dependency_marker_holds(Marker('extra != "cpu"'), env) is False
+
+    @pytest.mark.parametrize(
+        ("marker_text", "want"),
+        [
+            ('python_version < "3.10"', False),
+            ('python_version >= "3.11"', True),
+            ('sys_platform == "linux"', True),
+            ('sys_platform == "win32"', False),
+        ],
+    )
+    def test_environment_only_markers_unaffected(
+        self, marker_text: str, want: bool
+    ) -> None:
+        """A marker naming no extra evaluates against the environment alone."""
+        assert dependency_marker_holds(Marker(marker_text), _ENV) is want

--- a/nab-python/tests/test_lockfile_validate.py
+++ b/nab-python/tests/test_lockfile_validate.py
@@ -378,6 +378,26 @@ def test_direct_indeterminate_form_skipped() -> None:
     )
 
 
+def test_direct_undefined_variable_skipped() -> None:
+    """A marker naming a variable the environment omits is indeterminate.
+
+    ``extras`` and the other lockfile-only set variables are seeded empty,
+    so they evaluate to False rather than raising. A standard variable the
+    environment does not supply still raises
+    :class:`UndefinedEnvironmentName`, and an item nab cannot decide for is
+    skipped rather than reported as unsatisfied.
+    """
+    committed = pylock_of()
+    assert (
+        check_direct_requirements(
+            committed,
+            [root('bar>=1; python_version >= "3.12"')],
+            marker_env={"sys_platform": "linux"},
+        )
+        is None
+    )
+
+
 def test_direct_no_requirements_returns_none() -> None:
     assert check_direct_requirements(pylock_of(), [], marker_env=LINUX_ENV) is None
 

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -503,6 +503,25 @@ class TestExpandSelfExtras:
         env = {"python_version": "3.11", "python_full_version": "3.11.0"}
         assert expand_self_extras(opt, "mypkg", ["all"], env) == ["all"]
 
+    def test_self_reference_negated_extra_skips_own_extra(self) -> None:
+        """A self-ref gated ``extra != "<own-extra>"`` does not activate for it."""
+        opt = {
+            "cpu": ['mypkg[fast]; extra != "cpu"'],
+            "fast": ["some-dep"],
+        }
+        env = {"python_version": "3.11", "python_full_version": "3.11.0"}
+        assert expand_self_extras(opt, "mypkg", ["cpu"], env) == ["cpu"]
+
+    def test_self_reference_negated_extra_walks_other_extra(self) -> None:
+        """A self-ref gated ``extra != "cpu"`` activates when walked from
+        another extra."""
+        opt = {
+            "gpu": ['mypkg[fast]; extra != "cpu"'],
+            "fast": ["some-dep"],
+        }
+        env = {"python_version": "3.11", "python_full_version": "3.11.0"}
+        assert expand_self_extras(opt, "mypkg", ["gpu"], env) == ["gpu", "fast"]
+
 
 class TestExpandExtraRequirements:
     def test_empty_selection_returns_empty(self) -> None:

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -2225,9 +2225,10 @@ class TestBuildResolverInputs:
     def test_env_gated_drop_is_silent(self, caplog: pytest.LogCaptureFixture) -> None:
         """A requirement dropped by a plain env marker stays silent."""
         reqs = [Requirement('foo ; python_version < "3.0"')]
+        env = {"python_version": "3.11", "python_full_version": "3.11.2"}
         with caplog.at_level("WARNING", logger="nab_python.resolve"):
             resolver_requirements, _ = _build_resolver_inputs(
-                reqs, NabProjectConfig(), environment={}
+                reqs, NabProjectConfig(), environment=env
             )
         assert "foo" not in resolver_requirements
         assert not caplog.records


### PR DESCRIPTION
Route dependency-marker evaluation through the marker algebra and bind extra to the set of active extras. A single extra name or an unbound extra keeps its previous result; set-valued bindings are accepted for callers that pass more than one active extra.

Stacked on #475.