### PR TITLE
Emit negated markers for conflict forks

### DIFF
--- a/docs/explanation/conflicts.md
+++ b/docs/explanation/conflicts.md
@@ -73,12 +73,12 @@ member:
 [[packages]]
 name = "black"
 version = "22.1.0"
-marker = "... and \"black22\" in dependency_groups"
+marker = "... and \"black22\" in dependency_groups and \"black23\" not in dependency_groups and \"black24\" not in dependency_groups"
 
 [[packages]]
 name = "black"
 version = "23.12.0"
-marker = "... and \"black23\" in dependency_groups"
+marker = "... and \"black23\" in dependency_groups and \"black22\" not in dependency_groups and \"black24\" not in dependency_groups"
 ```
 
 The requirements formats name a fork with the `{selection}` variable in
@@ -131,11 +131,14 @@ conjunction across those sets; this stays correct for one set, the
 common case.
 
 The lockfile stays within PEP 751: the membership markers use the
-standard `extras` and `dependency_groups` variables, and the install
-context that would activate two members of one set is pruned by the
-declared conflict, so the two entries never collide for a reader. A
-collision that is *not* covered by a declared conflict still raises a
-`DisjointnessError`, now with a hint pointing at the `conflicts` key.
+standard `extras` and `dependency_groups` variables, and each fork's
+marker negates the co-members of every conflict set it draws from
+(`"cpu" in extras and "gpu" not in extras`), so the forks are mutually
+exclusive in the markers themselves. A PEP 751 consumer that never
+reads `[tool.nab].conflicts` still installs at most one fork; the two
+entries cannot collide for a reader. A collision that is *not* covered
+by a declared conflict still raises a `DisjointnessError`, with a hint
+pointing at the `conflicts` key.
 
 ## Trade-offs
 

--- a/nab-python/src/nab_python/_lockfile/disjointness.py
+++ b/nab-python/src/nab_python/_lockfile/disjointness.py
@@ -98,8 +98,8 @@ def validate_marker_disjointness(
     ``[tool.nab].conflicts``: each entry is a set of ``(kind, name)``
     members (``kind`` is ``"extra"`` or ``"group"``) of which at most
     one may be active.  Their co-selection points are removed from the
-    universe, so a universal lock can carry one fork per conflicting
-    extra/group under bare ``'name' in extras`` markers.  A collision
+    universe, so a same-name pair that can fire together only at a
+    forbidden co-selection is not counted as a collision.  A collision
     outside every pruned point still raises, hinting at the
     ``conflicts`` key when extras or groups drive the colliding markers.
 
@@ -289,10 +289,10 @@ def _pair_collision(
     fold to constants, leaving the membership residual).  Each
     conflict-respecting selection binds the membership variables, so the
     pair collides in that environment when both bound residuals stay
-    non-empty together.  On a collision the label, the
-    environment, and a concrete satisfying assignment (the selection
-    merged with :meth:`MarkerSet.witness`) are returned; the witness is
-    ``None`` when the first colliding selection is an opaque-``contains``
+    non-empty together.  On a collision the label, the environment, and a
+    concrete satisfying assignment (the selection merged with
+    :meth:`MarkerSet.witness`) are returned; the witness is ``None`` when
+    the first colliding selection is an opaque-``contains``
     over-approximation the algebra cannot reduce to a point.
     """
     for label, env in distinct_environments:

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -39,6 +39,7 @@ from .disjointness import validate_marker_disjointness
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
+    from collections.abc import Set as AbstractSet
 
     from ..lockfile import (
         LockInput,
@@ -47,6 +48,7 @@ if TYPE_CHECKING:
         TargetLock,
         WheelArtifact,
     )
+    from ..target import ResolveTarget
 
 
 __all__ = [
@@ -124,14 +126,15 @@ def build_pylock(lock_input: LockInput, *, lock_dir: Path | None = None) -> Pylo
     from ..lockfile import LOCK_VERSION
 
     base = (lock_dir if lock_dir is not None else Path.cwd()).resolve()
-    package_records = _build_packages(lock_input, base)
+    exclusion_groups = conflict_exclusion_groups(lock_input.conflicts)
+    package_records = _build_packages(lock_input, base, exclusion_groups)
     package_records.sort(key=_package_sort_key)
     validate_marker_disjointness(
         package_records,
         environments=lock_input.marker_envs,
         extras=lock_input.extras,
         groups=lock_input.active_groups,
-        exclusive_groups=conflict_exclusion_groups(lock_input.conflicts),
+        exclusive_groups=exclusion_groups,
         declared_groups=conflict_member_groups(lock_input.conflicts),
     )
     tool: dict[str, Any] | None = (
@@ -332,7 +335,11 @@ def _sdist_to_package(sdist: SdistArtifact, *, lock_dir: Path) -> PackageSdist:
     )
 
 
-def _build_packages(lock_input: LockInput, lock_dir: Path) -> list[Package]:
+def _build_packages(
+    lock_input: LockInput,
+    lock_dir: Path,
+    exclusion_groups: Sequence[AbstractSet[tuple[str, str]]],
+) -> list[Package]:
     """Collapse the per-target pins into Package entries with markers.
 
     For each canonical package name:
@@ -379,6 +386,11 @@ def _build_packages(lock_input: LockInput, lock_dir: Path) -> list[Package]:
     base_names = _close_base_names(
         targets, env_signatures, env_fork_counts, lock_input.env_base_names
     )
+    # One selection marker per label; it does not vary by package.
+    selection_markers = {
+        label: _selection_marker(lock.target, exclusion_groups)
+        for label, lock in targets.items()
+    }
 
     for canonical_name, per_target in by_name.items():
         groups = _group_pins_by_pin(per_target)
@@ -399,6 +411,7 @@ def _build_packages(lock_input: LockInput, lock_dir: Path) -> list[Package]:
                 env_signatures,
                 env_fork_counts,
                 base_names,
+                selection_markers,
             )
             out.append(
                 _pin_to_package(
@@ -641,6 +654,7 @@ def _build_marker(
     env_signatures: Mapping[str, tuple[tuple[str, str], ...]],
     env_fork_counts: Mapping[tuple[tuple[str, str], ...], int],
     env_base_names: Mapping[tuple[tuple[str, str], ...], frozenset[str]],
+    selection_markers: Mapping[str, str],
 ) -> Marker | None:
     """Return the marker selecting ``labels``, or ``None`` if unconditional.
 
@@ -658,6 +672,13 @@ def _build_marker(
     membership OR and does not install when no member is selected.
     An environment with no base-name set (no conflict fork ran) leaves
     the gate open.
+
+    A membership contribution carries the fork's positive selection AND
+    the negation of every co-member of the conflict sets it selects from
+    (``"cpu" in extras and "gpu" not in extras``), so the forks are
+    mutually exclusive in the marker itself: a PEP 751 consumer that never
+    reads ``[tool.nab].conflicts`` still installs at most one fork.  See
+    :func:`_selection_marker`.
 
     A package a selected extra or group reaches while the project's own
     dependencies do not carries that selection's gate (see
@@ -701,7 +722,7 @@ def _build_marker(
             )
         else:
             contributions.extend(
-                Marker(_with_gate(targets[label].target.marker_string, gates[label]))
+                Marker(_with_gate(selection_markers[label], gates[label]))
                 for label in env_labels
             )
             unconditional = False
@@ -718,6 +739,33 @@ def _build_marker(
     if len(common) == 1:
         return Marker(_gate_clause(next(iter(common))))
     return _or_markers(contributions)
+
+
+def _selection_marker(
+    target: ResolveTarget,
+    exclusion_groups: Sequence[AbstractSet[tuple[str, str]]],
+) -> str:
+    """Return the fork's per-package marker with its co-members negated.
+
+    Starts from the target's
+    :attr:`~nab_python.target.ResolveTarget.marker_string` and conjoins
+    ``'name' not in <variable>`` for every other member of every conflict
+    set the selection draws from, so at most one fork installs.  A
+    selection drawing from no exclusion group returns ``marker_string``
+    unchanged.
+    """
+    selected = set(target.selection)
+
+    co_members: set[tuple[str, str]] = set()
+    for group in exclusion_groups:
+        if group & selected:
+            co_members |= group - selected
+
+    marker = target.marker_string
+    for kind, name in sorted(co_members):
+        variable = MARKER_VARIABLE_FOR_KIND[kind]
+        marker += f' and "{name}" not in {variable}'
+    return marker
 
 
 def _gate_clause(gate: Sequence[tuple[str, str]]) -> str:

--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -660,8 +660,9 @@ class ResolveTarget:
     ``(kind, name)`` members (``kind`` is ``"extra"`` or ``"group"``)
     active in this fork's resolve, empty for an unforked one.  When set,
     it adds a ``'name' in extras`` / ``'name' in dependency_groups``
-    clause to :attr:`marker_string` so the lockfile entry fires only
-    when the user selects that member.
+    clause to :attr:`marker_string`; the lockfile emitter derives the
+    per-package marker, which also negates the co-members of the conflict
+    sets that forbid co-selection, from it.
 
     ``platform_spec`` is set on a declared (matrix) target and names the
     tag knobs it was expanded from; a host target has none.
@@ -836,13 +837,15 @@ class ResolveTarget:
 
     @property
     def marker_string(self) -> str:
-        """Return the per-package PEP 508 marker that selects this target.
+        """Return :attr:`environment_marker_string` plus a bare membership clause.
 
-        This is :attr:`environment_marker_string` plus a bare membership
-        clause per active conflict-fork member.  The emit-time
-        disjointness validator prunes the install contexts that activate
-        two members of one declared conflict, so the bare clause needs no
-        ``not in`` negation against the other members.
+        Each ``(kind, name)`` member of :attr:`selection` adds
+        ``'name' in extras`` / ``'name' in dependency_groups`` in sorted
+        order.  The clause is bare: it names the members this fork
+        selects, not the co-members it excludes.  The lockfile emitter
+        derives the mutually-exclusive per-package marker, which also
+        negates the co-members of the conflict sets that forbid
+        co-selection, from the target's environment and selection.
         """
         marker = self.environment_marker_string
         for kind, name in sorted(self.selection):

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -35,7 +35,7 @@ from nab_python._lockfile.pylock import (
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._testing.overrides import pkg_override
 from nab_python._vendor.packaging.markers import Marker
-from nab_python._vendor.packaging.markersets import IntractableMarkerSet
+from nab_python._vendor.packaging.markersets import IntractableMarkerSet, MarkerSet
 from nab_python._vendor.packaging.pylock import Package, PackageWheel, Pylock
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.utils import canonicalize_name
@@ -1976,6 +1976,43 @@ class TestMarkerDisjointness:
                 extras=("cpu", "fast-io"),
                 groups=(),
             )
+
+    def test_large_conflict_fork_negation_stays_within_budget(self) -> None:
+        # A fork that negates every co-member of three declared 5-member
+        # sets carries 15 membership atoms.  The conflict-respecting
+        # selection binds all of them, so the pair is decided without
+        # the unrestricted membership powerset that would overrun the
+        # cell budget.
+        envs = {
+            "linux": {
+                "python_version": "3.11",
+                "sys_platform": "linux",
+                "platform_machine": "x86_64",
+            },
+        }
+
+        sets = [tuple(f"{letter}{i}" for i in range(5)) for letter in ("a", "b", "c")]
+        all_names = tuple(name for members in sets for name in members)
+
+        def _fork_marker(picks: tuple[str, ...]) -> str:
+            clauses = [f"'{name}' in extras" for name in picks]
+            for members in sets:
+                clauses += [
+                    f"'{name}' not in extras" for name in members if name not in picks
+                ]
+            return " and ".join(clauses)
+
+        exclusive = [frozenset(("extra", name) for name in members) for members in sets]
+        validate_marker_disjointness(
+            [
+                self._pkg("foo", "1.0", _fork_marker(("a0", "b0", "c0"))),
+                self._pkg("foo", "2.0", _fork_marker(("a1", "b1", "c1"))),
+            ],
+            environments=envs,
+            extras=all_names,
+            groups=(),
+            exclusive_groups=exclusive,
+        )
 
     def test_unreferenced_groups_add_no_membership_axis(self) -> None:
         # Symmetric behaviour for ``dependency_groups``: a project with
@@ -4926,3 +4963,291 @@ class TestLockPruneObservability:
         with caplog.at_level(logging.DEBUG, logger=_BUILDER_LOGGER):
             build_target_lock(provider, _HOST, {"foo": Version("1.0")})
         assert not [r for r in caplog.records if r.name == _BUILDER_LOGGER]
+
+
+def _selection_pin(name: str, version: str) -> IndexPin:
+    # PEP 427 escapes ``-`` to ``_`` in the wheel filename's name field.
+    escaped = canonicalize_name(name).replace("-", "_")
+    return IndexPin(
+        name=name,
+        version=version,
+        index="pypi",
+        wheels=(
+            WheelArtifact(
+                filename=f"{escaped}-{version}-py3-none-any.whl",
+                url=f"https://example.com/{escaped}-{version}-py3-none-any.whl",
+                hashes=(("sha256", "a" * 64),),
+            ),
+        ),
+    )
+
+
+class TestConflictForkNegatedEmission:
+    """A conflict fork's per-package marker negates its conflict co-members.
+
+    nab emits ``"cpu" in extras and "gpu" not in extras`` for the cpu
+    fork, not the bare positive clause, so a PEP 751 consumer that never
+    reads ``[tool.nab].conflicts`` still installs at most one fork.  Built
+    and emitted through nab's own ``write_lock``, then read back by
+    packaging's reference consumer ``Pylock.select``.
+    """
+
+    _BASE: ClassVar[ResolveTarget] = _target(python_version="3.12")
+    _ENV: ClassVar[dict[str, str]] = dict(_target(python_version="3.12").marker_env)
+    _CPU: ClassVar[tuple[tuple[str, str], ...]] = (("extra", "cpu"),)
+    _GPU: ClassVar[tuple[tuple[str, str], ...]] = (("extra", "gpu"),)
+
+    def _lock(self) -> Pylock:
+        cpu = self._BASE.with_selection(self._CPU)
+        gpu = self._BASE.with_selection(self._GPU)
+
+        targets = {
+            cpu.label: TargetLock(
+                target=cpu,
+                pins={
+                    "onnxruntime": _selection_pin("onnxruntime", "1.20.0"),
+                    "torch": _selection_pin("torch", "2.5.0"),
+                },
+            ),
+            gpu.label: TargetLock(
+                target=gpu,
+                pins={
+                    "onnxruntime-gpu": _selection_pin("onnxruntime-gpu", "1.20.0"),
+                    "torch": _selection_pin("torch", "2.6.0"),
+                },
+            ),
+        }
+
+        conflicts = (
+            ConflictSet(
+                members=(
+                    ConflictMember(ConflictKind.EXTRA, "cpu"),
+                    ConflictMember(ConflictKind.EXTRA, "gpu"),
+                ),
+                policy=ConflictPolicy.AT_MOST_ONE,
+            ),
+        )
+
+        text = write_lock(
+            LockInput(
+                targets=targets,
+                env_base_names={_env_signature(cpu): frozenset()},
+                extras=("cpu", "gpu"),
+                conflicts=conflicts,
+            )
+        )
+        return Pylock.from_dict(tomllib.loads(text))
+
+    def _select(self, pylock: Pylock, extras: list[str]) -> set[str]:
+        return {
+            str(pkg.name)
+            for pkg, _ in pylock.select(
+                environment=self._ENV,  # type: ignore[arg-type]
+                extras=extras,
+                dependency_groups=(),
+            )
+        }
+
+    def test_emitted_markers_carry_the_negation(self) -> None:
+        pylock = self._lock()
+        by_name = {str(p.name): str(p.marker) for p in pylock.packages}
+        assert '"cpu" in extras and "gpu" not in extras' in by_name["onnxruntime"]
+        assert '"gpu" in extras and "cpu" not in extras' in by_name["onnxruntime-gpu"]
+
+    def test_select_both_extras_installs_neither_conflicting_name(self) -> None:
+        # {cpu, gpu} together matches neither fork's pin.
+        pylock = self._lock()
+        assert self._select(pylock, ["cpu", "gpu"]) == set()
+
+    def test_single_extra_selection_unchanged(self) -> None:
+        pylock = self._lock()
+        assert self._select(pylock, ["cpu"]) == {"onnxruntime", "torch"}
+        assert self._select(pylock, ["gpu"]) == {"onnxruntime-gpu", "torch"}
+
+    def test_empty_extras_selects_nothing(self) -> None:
+        pylock = self._lock()
+        assert self._select(pylock, []) == set()
+
+    def test_same_name_fork_no_double_select(self) -> None:
+        # Both torch entries share a name; {cpu, gpu} selects neither.
+        pylock = self._lock()
+        assert "torch" not in self._select(pylock, ["cpu", "gpu"])
+
+    def test_partitions_are_disjoint_without_the_conflict_universe(self) -> None:
+        # The emitted markers are disjoint with no conflict-declaration
+        # universe; the constraint lives in the marker.
+        pylock = self._lock()
+        by_name = {str(p.name): p.marker for p in pylock.packages}
+        left = MarkerSet.from_marker(str(by_name["onnxruntime"]))
+        right = MarkerSet.from_marker(str(by_name["onnxruntime-gpu"]))
+        assert left.is_disjoint(right)
+
+        torch_markers = [
+            MarkerSet.from_marker(str(p.marker))
+            for p in pylock.packages
+            if str(p.name) == "torch"
+        ]
+        assert len(torch_markers) == 2
+        assert torch_markers[0].is_disjoint(torch_markers[1])
+
+    def test_gate_accepts_partitions_without_the_conflict_universe(self) -> None:
+        # The torch pair passes the gate with empty ``exclusive_groups``;
+        # the negation in the markers makes the entries disjoint.
+        pylock = self._lock()
+        validate_marker_disjointness(
+            pylock.packages,
+            environments={"env": self._ENV},
+            extras=("cpu", "gpu"),
+            groups=(),
+            exclusive_groups=(),
+        )
+
+    def test_two_conflict_sets_negate_only_within_set(self) -> None:
+        # A member is negated only within its own conflict set: cpu
+        # excludes gpu, mkl excludes openblas, never across sets.
+        cpu_mkl = self._BASE.with_selection((("extra", "cpu"), ("extra", "mkl")))
+        gpu_blas = self._BASE.with_selection((("extra", "gpu"), ("extra", "openblas")))
+
+        targets = {
+            cpu_mkl.label: TargetLock(
+                target=cpu_mkl, pins={"fast": _selection_pin("fast", "1.0")}
+            ),
+            gpu_blas.label: TargetLock(
+                target=gpu_blas, pins={"slow": _selection_pin("slow", "1.0")}
+            ),
+        }
+
+        conflicts = (
+            ConflictSet(
+                members=(
+                    ConflictMember(ConflictKind.EXTRA, "cpu"),
+                    ConflictMember(ConflictKind.EXTRA, "gpu"),
+                ),
+                policy=ConflictPolicy.AT_MOST_ONE,
+            ),
+            ConflictSet(
+                members=(
+                    ConflictMember(ConflictKind.EXTRA, "mkl"),
+                    ConflictMember(ConflictKind.EXTRA, "openblas"),
+                ),
+                policy=ConflictPolicy.AT_MOST_ONE,
+            ),
+        )
+
+        text = write_lock(
+            LockInput(
+                targets=targets,
+                env_base_names={_env_signature(cpu_mkl): frozenset()},
+                extras=("cpu", "gpu", "mkl", "openblas"),
+                conflicts=conflicts,
+            )
+        )
+        pylock = Pylock.from_dict(tomllib.loads(text))
+
+        fast = next(str(p.marker) for p in pylock.packages if str(p.name) == "fast")
+        assert '"cpu" in extras' in fast
+        assert '"mkl" in extras' in fast
+        assert '"gpu" not in extras' in fast
+        assert '"openblas" not in extras' in fast
+
+    def test_single_set_draw_negates_only_that_set(self) -> None:
+        # Drawing from one of two sets negates that set's co-members
+        # alone; the other set stays open, so {cpu, mkl} installs cpu.
+        cpu = self._BASE.with_selection((("extra", "cpu"),))
+        gpu = self._BASE.with_selection((("extra", "gpu"),))
+
+        targets = {
+            cpu.label: TargetLock(
+                target=cpu,
+                pins={"onnxruntime": _selection_pin("onnxruntime", "1.20.0")},
+            ),
+            gpu.label: TargetLock(
+                target=gpu,
+                pins={"onnxruntime-gpu": _selection_pin("onnxruntime-gpu", "1.20.0")},
+            ),
+        }
+
+        conflicts = (
+            ConflictSet(
+                members=(
+                    ConflictMember(ConflictKind.EXTRA, "cpu"),
+                    ConflictMember(ConflictKind.EXTRA, "gpu"),
+                ),
+                policy=ConflictPolicy.AT_MOST_ONE,
+            ),
+            ConflictSet(
+                members=(
+                    ConflictMember(ConflictKind.EXTRA, "mkl"),
+                    ConflictMember(ConflictKind.EXTRA, "openblas"),
+                ),
+                policy=ConflictPolicy.AT_MOST_ONE,
+            ),
+        )
+
+        text = write_lock(
+            LockInput(
+                targets=targets,
+                env_base_names={_env_signature(cpu): frozenset()},
+                extras=("cpu", "gpu", "mkl", "openblas"),
+                conflicts=conflicts,
+            )
+        )
+        pylock = Pylock.from_dict(tomllib.loads(text))
+
+        cpu_marker = next(
+            str(p.marker) for p in pylock.packages if str(p.name) == "onnxruntime"
+        )
+        assert '"gpu" not in extras' in cpu_marker
+        assert '"mkl" not in extras' not in cpu_marker
+        assert '"openblas" not in extras' not in cpu_marker
+        assert self._select(pylock, ["cpu", "mkl"]) == {"onnxruntime"}
+
+    def test_three_large_sets_write_lock_within_budget(self) -> None:
+        # Three declared 5-member at-most-one sets, each fork drawing one
+        # member per set, so every per-package marker negates 12
+        # co-members.  The disjointness gate binds them through the
+        # selection instead of the full membership powerset, so the lock
+        # is written rather than raising IntractableMarkerSet.
+        sets = [tuple(f"{letter}{i}" for i in range(5)) for letter in ("a", "b", "c")]
+        all_names = tuple(name for members in sets for name in members)
+
+        fork_one = self._BASE.with_selection(
+            (("extra", "a0"), ("extra", "b0"), ("extra", "c0"))
+        )
+        fork_two = self._BASE.with_selection(
+            (("extra", "a1"), ("extra", "b1"), ("extra", "c1"))
+        )
+
+        targets = {
+            fork_one.label: TargetLock(
+                target=fork_one, pins={"torch": _selection_pin("torch", "2.5.0")}
+            ),
+            fork_two.label: TargetLock(
+                target=fork_two, pins={"torch": _selection_pin("torch", "2.6.0")}
+            ),
+        }
+
+        conflicts = tuple(
+            ConflictSet(
+                members=tuple(
+                    ConflictMember(ConflictKind.EXTRA, name) for name in members
+                ),
+                policy=ConflictPolicy.AT_MOST_ONE,
+            )
+            for members in sets
+        )
+
+        text = write_lock(
+            LockInput(
+                targets=targets,
+                env_base_names={_env_signature(fork_one): frozenset()},
+                extras=all_names,
+                conflicts=conflicts,
+            )
+        )
+        pylock = Pylock.from_dict(tomllib.loads(text))
+
+        torch_versions = {
+            str(p.version) for p in pylock.packages if str(p.name) == "torch"
+        }
+        assert torch_versions == {"2.5.0", "2.6.0"}


### PR DESCRIPTION
Conflict-fork lock entries carry the full mutual-exclusion condition in their markers. An installer that selects a conflicting extras combination matches no entry instead of installing both sides of the conflict. The constraint travels in the lockfile itself, so no extra installer logic is needed.

Stacked on #479.
