### PR TITLE
write downloaded artefacts atomically

### DIFF
--- a/nab-python/src/nab_python/download.py
+++ b/nab-python/src/nab_python/download.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
+from nab_index.atomic import atomic_write
 from nab_index.client import AsyncSimpleClient
 from nab_index.local_index import parse_file_url
 from nab_index.transport import HttpError
@@ -236,7 +237,7 @@ async def _run_downloads(
                     f"  expected: {entry.digest}\n  actual:   {actual}"
                 )
                 raise DownloadError(msg)
-            target.write_bytes(data)
+            atomic_write(target, data)
             written.append(target)
             logger.info("wrote %s", target)
 

--- a/nab-python/tests/test_download.py
+++ b/nab-python/tests/test_download.py
@@ -295,6 +295,29 @@ class TestDownloadLock:
         assert (tmp_path / "foo-1.0-py3-none-any.whl").read_bytes() == wheel_bytes
         assert len(result.written) == 1
 
+    def test_interrupted_write_leaves_no_partial_at_target(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        wheel_bytes = b"WHEELDATA" * 64
+        wheel_sha = hashlib.sha256(wheel_bytes).hexdigest()
+        pin = _index_pin(wheel_sha=wheel_sha)
+        transport = _FakeTransport({"https://example.com/foo-1.0.whl": wheel_bytes})
+
+        def crash(_src: object, _dst: object) -> None:
+            msg = "interrupted mid-write"
+            raise OSError(msg)
+
+        monkeypatch.setattr("nab_index.atomic.os.replace", crash)
+
+        with pytest.raises(OSError, match="interrupted mid-write"):
+            download_lock(
+                LockInput(targets=_one({"foo": pin})),
+                transport,  # type: ignore[arg-type]
+                tmp_path,
+            )
+        assert not (tmp_path / "foo-1.0-py3-none-any.whl").exists()
+        assert list(tmp_path.iterdir()) == []
+
     def test_uppercase_recorded_digest_verifies(self, tmp_path: Path) -> None:
         wheel_bytes = b"WHEELDATA"
         wheel_sha = hashlib.sha256(wheel_bytes).hexdigest().upper()


### PR DESCRIPTION
`nab download` wrote each wheel and sdist with `target.write_bytes(data)`, a single non-atomic write straight to the final path. If that write was interrupted, by the process being killed or the disk filling, the output directory was left holding a truncated file under the real artefact name, and a later run would treat it as a complete download.

This routes the write through the existing `atomic_write` helper, which stages the bytes in a temp file beside the target and renames it into place. An interrupted write now leaves the target absent rather than truncated.
