### PR TITLE
map non-UTF-8 PEP 658 metadata sidecar to HttpError

### DIFF
--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -224,7 +224,9 @@ class CachedAsyncSimpleClient:
         Metadata is decoded from the hash-verified bytes as utf-8 rather
         than the transport's ``.text``, which a backend may decode under
         the response Content-Type charset. This keeps the parsed text
-        tied to the bytes the hash covers.
+        tied to the bytes the hash covers.  A body that is not valid utf-8
+        raises :class:`MalformedSimpleResponseError` (an :class:`HttpError`
+        subclass) rather than a raw :class:`UnicodeDecodeError`.
         """
         cached = self._cache.get_metadata(package, metadata_url)
         if cached is not None:
@@ -239,7 +241,14 @@ class CachedAsyncSimpleClient:
         content = response.content
         if metadata_hash is not None:
             _verify_metadata_hash(content, metadata_hash)
-        text = content.decode("utf-8")
+        try:
+            text = content.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            msg = (
+                f"{metadata_url} served a malformed PEP 658 metadata sidecar "
+                f"for {package}=={version}: body is not valid UTF-8"
+            )
+            raise MalformedSimpleResponseError(msg) from exc
         self._cache.put_metadata(package, metadata_url, text)
         return text
 

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -56,10 +56,11 @@ _SUPPORTS_DATA_FILTER = hasattr(tarfile, "data_filter")
 
 
 class MalformedSimpleResponseError(HttpError):
-    """The index served a 200 response that is not a usable Simple-API listing.
+    """The index served a 200 response that is not a usable Simple-API body.
 
-    Subclasses :class:`HttpError` so a broken listing is caught alongside
-    transport and 4xx/5xx failures.
+    Covers a listing that is not valid JSON and a PEP 658 metadata sidecar
+    that is not valid UTF-8. Subclasses :class:`HttpError` so a broken body
+    is caught alongside transport and 4xx/5xx failures.
     """
 
 

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -1422,6 +1422,61 @@ class TestGetMetadataText:
         assert [str(req) for req in parsed.requires_dist] == ["bar>=2"]
 
 
+class TestNonUtf8MetadataSidecar:
+    """A hash-valid but non-UTF-8 PEP 658 sidecar raises a clean HttpError.
+
+    The bytes pass the published hash, then fail to decode as utf-8. Like
+    ``TestNonUtf8ListingBody`` on the listing path, a body that cannot be
+    decoded surfaces as an :class:`HttpError` subclass, not a raw
+    :class:`UnicodeDecodeError`.
+    """
+
+    _LATIN1_SIDECAR = "Metadata-Version: 2.1\nName: pkg\nSummary: café\n".encode(
+        "latin-1"
+    )
+
+    def test_hash_valid_non_utf8_raises_http_error_and_skips_cache(
+        self, tmp_path: Path
+    ) -> None:
+        cache = _make_cache(tmp_path)
+        digest = hashlib.sha256(self._LATIN1_SIDECAR).hexdigest()
+        transport = _FakeTransport([_FakeResponse(self._LATIN1_SIDECAR)])
+
+        async def go() -> str:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_metadata_text(
+                    "pkg", "1.0", "https://x/pkg.metadata", ("sha256", digest)
+                )
+            finally:
+                await client.aclose()
+
+        with pytest.raises(MalformedSimpleResponseError, match="metadata") as caught:
+            asyncio.run(go())
+        assert isinstance(caught.value, HttpError)
+        assert cache.get_metadata("pkg", "https://x/pkg.metadata") is None
+
+    def test_unhashed_non_utf8_raises_http_error_and_skips_cache(
+        self, tmp_path: Path
+    ) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport([_FakeResponse(self._LATIN1_SIDECAR)])
+
+        async def go() -> str:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_metadata_text(
+                    "pkg", "1.0", "https://x/pkg.metadata"
+                )
+            finally:
+                await client.aclose()
+
+        with pytest.raises(MalformedSimpleResponseError, match="metadata") as caught:
+            asyncio.run(go())
+        assert isinstance(caught.value, HttpError)
+        assert cache.get_metadata("pkg", "https://x/pkg.metadata") is None
+
+
 class TestGetSdistFiles:
     def test_cold_cache_fetches_and_stores_both(self, tmp_path: Path) -> None:
         cache = _make_cache(tmp_path)


### PR DESCRIPTION
A PEP 658 metadata sidecar that isn't valid UTF-8 crashed the resolve with a raw UnicodeDecodeError. The listing path already turns a non-UTF-8 body into a MalformedSimpleResponseError, but get_metadata_text decoded the sidecar bytes with a bare content.decode("utf-8"), so a bad body escaped as a decode error the resolver never expects to see.

Wrap that decode and raise MalformedSimpleResponseError (an HttpError subclass) naming the URL and coordinate, so a broken sidecar is caught alongside the other index failures. Nothing is written to the cache when the decode fails.
