### PR TITLE
exit 1 instead of crashing when lock --output has no file name

### DIFF
--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -927,15 +927,25 @@ def _validate_pylock_output_name(
 
     A pylock-format lockfile must be ``pylock.toml`` or match
     ``pylock.<name>.toml`` (dot separators).  stdout (``-``) and the
-    requirements formats are exempt; exits 1 on a bad name with a
-    suggested correction.
+    requirements formats are exempt; a directory-like output (no file
+    name) and a bad name both exit 1, the latter with a suggested
+    correction.
     """
     if format != "pylock" or output is None or _cli.is_stdout(output):
         return
     if is_valid_pylock_path(output):
         return
-    dotted = output.with_name(output.name.replace("-", "."))
-    suggestion = dotted.name if is_valid_pylock_path(dotted) else "pylock.toml"
+    if not output.name:
+        _cli.printer().error(
+            f"--output {str(output)!r} names a directory, not a file; the"
+            " pylock output must be a file named 'pylock.toml' or"
+            " 'pylock.<name>.toml'."
+        )
+        sys.exit(1)
+    # Path(name), not output.with_name(name): with_name raises on names its
+    # dotted form can produce, such as '.' from a bare '-'.
+    dotted = output.name.replace("-", ".")
+    suggestion = dotted if is_valid_pylock_path(Path(dotted)) else "pylock.toml"
     _cli.printer().error(
         f"output file name {output.name!r} must match 'pylock.toml'"
         " or 'pylock.<name>.toml' per PEP 751 (note the dot separator,"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2518,6 +2518,30 @@ class TestPylockOutputNameValidation:
             lock(pyproject, output=tmp_path / "lock.toml")
         assert "pylock.toml" in capsys.readouterr().err
 
+    @pytest.mark.parametrize("raw", [".", "/", ""])
+    def test_empty_name_rejected_cleanly(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], raw: str
+    ) -> None:
+        """A directory-like ``--output`` has no file name, so it exits 1."""
+        pyproject = _make_pyproject(tmp_path)
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, output=Path(raw))
+        err = capsys.readouterr().err
+        assert "names a directory, not a file" in err
+        assert "pylock.toml" in err
+
+    @pytest.mark.parametrize("raw", ["sub/-", "a/b/-"])
+    def test_hyphen_name_rejected_cleanly(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], raw: str
+    ) -> None:
+        """A non-stdout ``-`` component whose dotted form is invalid still exits 1."""
+        pyproject = _make_pyproject(tmp_path)
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, output=tmp_path / raw)
+        err = capsys.readouterr().err
+        assert "PEP 751" in err
+        assert "pylock.toml" in err
+
     def test_stdout_skips_validation(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
`nab lock --output .` (also `/` or an empty string) points at a directory, so the output path has no file name. That case is meant to be rejected with exit 1, but the validation crashed first: it built a suggested name with `Path.with_name`, which raises `ValueError` on an empty name.

A directory-like output now gets its own exit-1 error naming the actual mistake ("names a directory, not a file"), instead of falling through to the wrong-file-name message with an empty string in it. The suggested-name check for genuinely wrong names is built from a plain `Path` rather than `with_name`, which also raises on names the dotted form can produce (a bare `-` becomes `.`).
