### PR TITLE
Split CI/CD pipeline per workspace

### DIFF
--- a/.github/requirements/pylock.nox.toml
+++ b/.github/requirements/pylock.nox.toml
@@ -1,0 +1,932 @@
+lock-version = "1.0"
+environments = [
+    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+]
+requires-python = ">=3.10"
+dependency-groups = [
+    "nox",
+]
+default-groups = [
+    "nox",
+]
+created-by = "nab"
+
+[[packages]]
+name = "argcomplete"
+version = "3.7.0"
+marker = "\"nox\" in dependency_groups"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "argcomplete-3.7.0.tar.gz"
+upload-time = 2026-06-30 22:28:22.249666+00:00
+url = "https://files.pythonhosted.org/packages/95/c0/c8e94135e66fabf89a120d9b4b123fe6993506beca6c1938a74c24cfa5fd/argcomplete-3.7.0.tar.gz"
+size = 73284
+
+[packages.sdist.hashes]
+sha256 = "afde224f753f874807b1dc1414e883ab8fe0cda9c04807b6047dcb8e1ac23913"
+
+[[packages.wheels]]
+name = "argcomplete-3.7.0-py3-none-any.whl"
+upload-time = 2026-06-30 22:28:20.547827+00:00
+url = "https://files.pythonhosted.org/packages/12/f6/5b8ec087cd9cfa9449491ec83f76fb6b7006b4dff57d2ba8aaab330fe8e4/argcomplete-3.7.0-py3-none-any.whl"
+size = 42575
+
+[packages.wheels.hashes]
+sha256 = "d8f0f22d2a8a7caa383be1e22b6caf1ecaf0ebd10d8f83cc125e36540c95830c"
+
+[[packages]]
+name = "attrs"
+version = "26.1.0"
+marker = "\"nox\" in dependency_groups"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "attrs-26.1.0.tar.gz"
+upload-time = 2026-03-19 14:22:25.026315+00:00
+url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz"
+size = 952055
+
+[packages.sdist.hashes]
+sha256 = "d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32"
+
+[[packages.wheels]]
+name = "attrs-26.1.0-py3-none-any.whl"
+upload-time = 2026-03-19 14:22:23.645947+00:00
+url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl"
+size = 67548
+
+[packages.wheels.hashes]
+sha256 = "c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309"
+
+[[packages]]
+name = "build"
+version = "1.5.0"
+requires-python = ">=3.10"
+dependencies = [
+    { name = "colorama" },
+    { name = "importlib-metadata" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+    { name = "tomli" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "build-1.5.0.tar.gz"
+upload-time = 2026-04-30 03:18:25.170465+00:00
+url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz"
+size = 89796
+
+[packages.sdist.hashes]
+sha256 = "302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647"
+
+[[packages.wheels]]
+name = "build-1.5.0-py3-none-any.whl"
+upload-time = 2026-04-30 03:18:23.644906+00:00
+url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl"
+size = 26018
+
+[packages.wheels.hashes]
+sha256 = "13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f"
+
+[[packages]]
+name = "colorama"
+version = "0.4.6"
+marker = "(python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version >= \"3.10.2.dev0\") or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+requires-python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "colorama-0.4.6.tar.gz"
+upload-time = 2022-10-25 02:36:22.414799+00:00
+url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz"
+size = 27697
+
+[packages.sdist.hashes]
+sha256 = "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+
+[[packages.wheels]]
+name = "colorama-0.4.6-py2.py3-none-any.whl"
+upload-time = 2022-10-25 02:36:20.889702+00:00
+url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl"
+size = 25335
+
+[packages.wheels.hashes]
+sha256 = "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+
+[[packages]]
+name = "colorlog"
+version = "6.10.1"
+marker = "\"nox\" in dependency_groups"
+requires-python = ">=3.6"
+dependencies = [
+    { name = "colorama" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "colorlog-6.10.1.tar.gz"
+upload-time = 2025-10-16 16:14:11.978851+00:00
+url = "https://files.pythonhosted.org/packages/a2/61/f083b5ac52e505dfc1c624eafbf8c7589a0d7f32daa398d2e7590efa5fda/colorlog-6.10.1.tar.gz"
+size = 17162
+
+[packages.sdist.hashes]
+sha256 = "eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321"
+
+[[packages.wheels]]
+name = "colorlog-6.10.1-py3-none-any.whl"
+upload-time = 2025-10-16 16:14:10.512866+00:00
+url = "https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl"
+size = 11743
+
+[packages.wheels.hashes]
+sha256 = "2d7e8348291948af66122cff006c9f8da6255d224e7cf8e37d8de2df3bad8c9c"
+
+[[packages]]
+name = "dependency-groups"
+version = "1.3.1"
+marker = "\"nox\" in dependency_groups"
+requires-python = ">=3.8"
+dependencies = [
+    { name = "packaging" },
+    { name = "tomli" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "dependency_groups-1.3.1.tar.gz"
+upload-time = 2025-05-02 00:34:29.452155+00:00
+url = "https://files.pythonhosted.org/packages/62/55/f054de99871e7beb81935dea8a10b90cd5ce42122b1c3081d5282fdb3621/dependency_groups-1.3.1.tar.gz"
+size = 10093
+
+[packages.sdist.hashes]
+sha256 = "78078301090517fd938c19f64a53ce98c32834dfe0dee6b88004a569a6adfefd"
+
+[[packages.wheels]]
+name = "dependency_groups-1.3.1-py3-none-any.whl"
+upload-time = 2025-05-02 00:34:27.085036+00:00
+url = "https://files.pythonhosted.org/packages/99/c7/d1ec24fb280caa5a79b6b950db565dab30210a66259d17d5bb2b3a9f878d/dependency_groups-1.3.1-py3-none-any.whl"
+size = 8664
+
+[packages.wheels.hashes]
+sha256 = "51aeaa0dfad72430fcfb7bcdbefbd75f3792e5919563077f30bc0d73f4493030"
+
+[[packages]]
+name = "distlib"
+version = "0.4.3"
+marker = "\"nox\" in dependency_groups"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "distlib-0.4.3.tar.gz"
+upload-time = 2026-06-12 08:04:52.847314+00:00
+url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz"
+size = 615141
+
+[packages.sdist.hashes]
+sha256 = "f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed"
+
+[[packages.wheels]]
+name = "distlib-0.4.3-py2.py3-none-any.whl"
+upload-time = 2026-06-12 08:04:50.506662+00:00
+url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl"
+size = 470628
+
+[packages.wheels.hashes]
+sha256 = "4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b"
+
+[[packages]]
+name = "docstring-parser"
+version = "0.18.0"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "docstring_parser-0.18.0.tar.gz"
+upload-time = 2026-04-14 04:09:19.867229+00:00
+url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz"
+size = 29341
+
+[packages.sdist.hashes]
+sha256 = "292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015"
+
+[[packages.wheels]]
+name = "docstring_parser-0.18.0-py3-none-any.whl"
+upload-time = 2026-04-14 04:09:18.638975+00:00
+url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl"
+size = 22484
+
+[packages.wheels.hashes]
+sha256 = "b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b"
+
+[[packages]]
+name = "filelock"
+version = "3.29.7"
+marker = "\"nox\" in dependency_groups"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "filelock-3.29.7.tar.gz"
+upload-time = 2026-07-08 05:46:58.716948+00:00
+url = "https://files.pythonhosted.org/packages/35/94/00f2059e4835eace3ae8fde680b932c496f8ec7bdc99168dfa53fb2e6b79/filelock-3.29.7.tar.gz"
+size = 71521
+
+[packages.sdist.hashes]
+sha256 = "5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d"
+
+[[packages.wheels]]
+name = "filelock-3.29.7-py3-none-any.whl"
+upload-time = 2026-07-08 05:46:57.530856+00:00
+url = "https://files.pythonhosted.org/packages/60/02/be4a57b60c7149b55b9e3b3c13f609cd8eb5307c751f22bd8fb8d262e75b/filelock-3.29.7-py3-none-any.whl"
+size = 46036
+
+[packages.wheels.hashes]
+sha256 = "987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51"
+
+[[packages]]
+name = "humanize"
+version = "4.16.0"
+marker = "\"nox\" in dependency_groups"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "humanize-4.16.0.tar.gz"
+upload-time = 2026-06-30 16:17:29.859993+00:00
+url = "https://files.pythonhosted.org/packages/0a/ea/13a1ef3c12d12662905801495283530251918b70d62d368f1d2e0272c70d/humanize-4.16.0.tar.gz"
+size = 89515
+
+[packages.sdist.hashes]
+sha256 = "7dc2244a2f84a4bfb1d36c37bac80cd78e35cdc5c119206d87b018e1445f3a3f"
+
+[[packages.wheels]]
+name = "humanize-4.16.0-py3-none-any.whl"
+upload-time = 2026-06-30 16:17:28.360556+00:00
+url = "https://files.pythonhosted.org/packages/b0/aa/0b7365d30fed43e7a3449aba1fe20a0a7174d9cf13e282af4e69ac825441/humanize-4.16.0-py3-none-any.whl"
+size = 137209
+
+[packages.wheels.hashes]
+sha256 = "353eb2f34c09d098b2880eee8bef21832eae6d174f48c5762fff7e5fcb74d01d"
+
+[[packages]]
+name = "importlib-metadata"
+version = "9.0.0"
+marker = "(python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\")"
+requires-python = ">=3.10"
+dependencies = [
+    { name = "zipp" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "importlib_metadata-9.0.0.tar.gz"
+upload-time = 2026-03-20 06:42:56.999805+00:00
+url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz"
+size = 56405
+
+[packages.sdist.hashes]
+sha256 = "a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc"
+
+[[packages.wheels]]
+name = "importlib_metadata-9.0.0-py3-none-any.whl"
+upload-time = 2026-03-20 06:42:55.665400+00:00
+url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl"
+size = 27789
+
+[packages.wheels.hashes]
+sha256 = "2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7"
+
+[[packages]]
+name = "installer"
+version = "1.0.1"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "installer-1.0.1.tar.gz"
+upload-time = 2026-05-11 18:13:28.158660+00:00
+url = "https://files.pythonhosted.org/packages/06/fe/b9f481cf0cc867958a21338baa900357b7b7d86cac9b025948049d77923c/installer-1.0.1.tar.gz"
+size = 481132
+
+[packages.sdist.hashes]
+sha256 = "052c7fc3721d54c696e2dea019be67539d7b144e924f559f54beb3121831c364"
+
+[[packages.wheels]]
+name = "installer-1.0.1-py3-none-any.whl"
+upload-time = 2026-05-11 18:13:26.252723+00:00
+url = "https://files.pythonhosted.org/packages/26/48/bedf3ba4163e7db392c9d4cbdfc8217423196c8fccbe5a404a0f094fde63/installer-1.0.1-py3-none-any.whl"
+size = 464455
+
+[packages.wheels.hashes]
+sha256 = "011d045df8b954ced7dde3a7e42ae4418da40ecda7990f2d11d5ed7c146fd98b"
+
+[[packages]]
+name = "nox"
+version = "2026.4.10"
+marker = "\"nox\" in dependency_groups"
+requires-python = ">=3.9"
+dependencies = [
+    { name = "argcomplete" },
+    { name = "attrs" },
+    { name = "colorlog" },
+    { name = "dependency-groups" },
+    { name = "humanize" },
+    { name = "packaging" },
+    { name = "tomli" },
+    { name = "virtualenv" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "nox-2026.4.10.tar.gz"
+upload-time = 2026-04-10 17:42:42.209122+00:00
+url = "https://files.pythonhosted.org/packages/e7/6b/e672c862a43cfca704d32359221fa3780226daa1e5db5dfc401bcc8be9c9/nox-2026.4.10.tar.gz"
+size = 4034839
+
+[packages.sdist.hashes]
+sha256 = "2d0af5374f3f37a295428c927d1b04a8182aa01762897d172446dda2f1ce9692"
+
+[[packages.wheels]]
+name = "nox-2026.4.10-py3-none-any.whl"
+upload-time = 2026-04-10 17:42:40.664366+00:00
+url = "https://files.pythonhosted.org/packages/7f/95/4df134a100b5a9a12378d5301b934366686ef6fbdaffcd21211d5654970e/nox-2026.4.10-py3-none-any.whl"
+size = 75536
+
+[packages.wheels.hashes]
+sha256 = "082c117627590d9b90aa21f86df89b310b07c5842539524203bcb3c719f116c1"
+
+[[packages]]
+name = "packaging"
+version = "26.2"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "packaging-26.2.tar.gz"
+upload-time = 2026-04-24 20:15:23.917886+00:00
+url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz"
+size = 228134
+
+[packages.sdist.hashes]
+sha256 = "ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"
+
+[[packages.wheels]]
+name = "packaging-26.2-py3-none-any.whl"
+upload-time = 2026-04-24 20:15:22.081511+00:00
+url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl"
+size = 100195
+
+[packages.wheels.hashes]
+sha256 = "5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"
+
+[[packages]]
+name = "platformdirs"
+version = "4.10.0"
+marker = "\"nox\" in dependency_groups"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "platformdirs-4.10.0.tar.gz"
+upload-time = 2026-05-28 03:32:53.587772+00:00
+url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz"
+size = 31224
+
+[packages.sdist.hashes]
+sha256 = "31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7"
+
+[[packages.wheels]]
+name = "platformdirs-4.10.0-py3-none-any.whl"
+upload-time = 2026-05-28 03:32:52.175593+00:00
+url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl"
+size = 22743
+
+[packages.wheels.hashes]
+sha256 = "fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a"
+
+[[packages]]
+name = "pyproject-hooks"
+version = "1.2.0"
+requires-python = ">=3.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pyproject_hooks-1.2.0.tar.gz"
+upload-time = 2024-09-29 09:24:13.293934+00:00
+url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz"
+size = 19228
+
+[packages.sdist.hashes]
+sha256 = "1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8"
+
+[[packages.wheels]]
+name = "pyproject_hooks-1.2.0-py3-none-any.whl"
+upload-time = 2024-09-29 09:24:11.978642+00:00
+url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl"
+size = 10216
+
+[packages.wheels.hashes]
+sha256 = "9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913"
+
+[[packages]]
+name = "python-discovery"
+version = "1.4.4"
+marker = "\"nox\" in dependency_groups"
+requires-python = ">=3.8"
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "python_discovery-1.4.4.tar.gz"
+upload-time = 2026-07-08 23:06:50.691727+00:00
+url = "https://files.pythonhosted.org/packages/4c/81/58c70036dffeccb7fe7d79d6260c69f7a28272bbd3909c29a01ea9422744/python_discovery-1.4.4.tar.gz"
+size = 72212
+
+[packages.sdist.hashes]
+sha256 = "5cad33982d412c1f3ffb8f9ca4ea292c9680bca3942451d30b69c37fce53a4a3"
+
+[[packages.wheels]]
+name = "python_discovery-1.4.4-py3-none-any.whl"
+upload-time = 2026-07-08 23:06:49.402423+00:00
+url = "https://files.pythonhosted.org/packages/9d/ae/84bc0d2440c95772272bb6f4b3d09ccf08b2898fce89b3d4f969a9fc74e9/python_discovery-1.4.4-py3-none-any.whl"
+size = 34181
+
+[packages.wheels.hashes]
+sha256 = "abebe9120b43453b68c908acfb1e72a19d1a959ed2cb620ad38fc57d08056dbe"
+
+[[packages]]
+name = "tomli"
+version = "2.4.1"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "tomli-2.4.1.tar.gz"
+upload-time = 2026-03-25 20:22:03.828102+00:00
+url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz"
+size = 17543
+
+[packages.sdist.hashes]
+sha256 = "7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
+upload-time = 2026-03-25 20:21:10.473841+00:00
+url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
+size = 154704
+
+[packages.wheels.hashes]
+sha256 = "f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl"
+upload-time = 2026-03-25 20:21:12.036923+00:00
+url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl"
+size = 149454
+
+[packages.wheels.hashes]
+sha256 = "4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:13.098441+00:00
+url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 237561
+
+[packages.wheels.hashes]
+sha256 = "96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:14.569419+00:00
+url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 243824
+
+[packages.wheels.hashes]
+sha256 = "5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-win_amd64.whl"
+upload-time = 2026-03-25 20:21:18.978514+00:00
+url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl"
+size = 108084
+
+[packages.wheels.hashes]
+sha256 = "5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2026-03-25 20:21:21.626567+00:00
+url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 155924
+
+[packages.wheels.hashes]
+sha256 = "c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl"
+upload-time = 2026-03-25 20:21:23.002533+00:00
+url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl"
+size = 150018
+
+[packages.wheels.hashes]
+sha256 = "7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:24.040813+00:00
+url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 244948
+
+[packages.wheels.hashes]
+sha256 = "ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:25.177901+00:00
+url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 253341
+
+[packages.wheels.hashes]
+sha256 = "136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-win_amd64.whl"
+upload-time = 2026-03-25 20:21:29.386807+00:00
+url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl"
+size = 108847
+
+[packages.wheels.hashes]
+sha256 = "52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2026-03-25 20:21:31.650748+00:00
+url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 155866
+
+[packages.wheels.hashes]
+sha256 = "36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl"
+upload-time = 2026-03-25 20:21:33.028949+00:00
+url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl"
+size = 149887
+
+[packages.wheels.hashes]
+sha256 = "eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:34.510750+00:00
+url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 243704
+
+[packages.wheels.hashes]
+sha256 = "c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:36.012836+00:00
+url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 251628
+
+[packages.wheels.hashes]
+sha256 = "f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-win_amd64.whl"
+upload-time = 2026-03-25 20:21:40.248121+00:00
+url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl"
+size = 108755
+
+[packages.wheels.hashes]
+sha256 = "8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl"
+upload-time = 2026-03-25 20:21:42.230154+00:00
+url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl"
+size = 155726
+
+[packages.wheels.hashes]
+sha256 = "fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl"
+upload-time = 2026-03-25 20:21:43.386384+00:00
+url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl"
+size = 149859
+
+[packages.wheels.hashes]
+sha256 = "a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:44.474645+00:00
+url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 244713
+
+[packages.wheels.hashes]
+sha256 = "559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:45.620261+00:00
+url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 252084
+
+[packages.wheels.hashes]
+sha256 = "01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-win_amd64.whl"
+upload-time = 2026-03-25 20:21:50.506850+00:00
+url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl"
+size = 109082
+
+[packages.wheels.hashes]
+sha256 = "88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-py3-none-any.whl"
+upload-time = 2026-03-25 20:22:03.012768+00:00
+url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl"
+size = 14583
+
+[packages.wheels.hashes]
+sha256 = "0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe"
+
+[[packages]]
+name = "tomli-w"
+version = "1.2.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "tomli_w-1.2.0.tar.gz"
+upload-time = 2025-01-15 12:07:24.262974+00:00
+url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz"
+size = 7184
+
+[packages.sdist.hashes]
+sha256 = "2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021"
+
+[[packages.wheels]]
+name = "tomli_w-1.2.0-py3-none-any.whl"
+upload-time = 2025-01-15 12:07:22.074224+00:00
+url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl"
+size = 6675
+
+[packages.wheels.hashes]
+sha256 = "188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90"
+
+[[packages]]
+name = "truststore"
+version = "0.10.4"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "truststore-0.10.4.tar.gz"
+upload-time = 2025-08-12 18:49:02.730234+00:00
+url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz"
+size = 26169
+
+[packages.sdist.hashes]
+sha256 = "9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301"
+
+[[packages.wheels]]
+name = "truststore-0.10.4-py3-none-any.whl"
+upload-time = 2025-08-12 18:49:01.460601+00:00
+url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl"
+size = 18660
+
+[packages.wheels.hashes]
+sha256 = "adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"
+
+[[packages]]
+name = "typeguard"
+version = "4.5.2"
+requires-python = ">=3.9"
+dependencies = [
+    { name = "typing-extensions" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "typeguard-4.5.2.tar.gz"
+upload-time = 2026-05-14 12:59:40.857502+00:00
+url = "https://files.pythonhosted.org/packages/67/1c/dfba5c4633cafc4c701f237d2ba63b416805047fd6d96aab4cfc40969f98/typeguard-4.5.2.tar.gz"
+size = 80240
+
+[packages.sdist.hashes]
+sha256 = "5a16dcac23502039299c97c8941651bc33d7ea8cc4b2f7d6bbb1b528f6eea423"
+
+[[packages.wheels]]
+name = "typeguard-4.5.2-py3-none-any.whl"
+upload-time = 2026-05-14 12:59:39.473017+00:00
+url = "https://files.pythonhosted.org/packages/5b/29/74eeb4d3f3ae61ca096b018ad486b3b3c74b17bec09ab4edab721cbefec3/typeguard-4.5.2-py3-none-any.whl"
+size = 36748
+
+[packages.wheels.hashes]
+sha256 = "fcf9de18bd945cdb4c7b996e12b4c51ce83f92f191314a6d7cf1739586ec98cf"
+
+[[packages]]
+name = "typing-extensions"
+version = "4.16.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "typing_extensions-4.16.0.tar.gz"
+upload-time = 2026-07-02 08:40:05.920538+00:00
+url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz"
+size = 113555
+
+[packages.sdist.hashes]
+sha256 = "dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5"
+
+[[packages.wheels]]
+name = "typing_extensions-4.16.0-py3-none-any.whl"
+upload-time = 2026-07-02 08:40:04.659120+00:00
+url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl"
+size = 45571
+
+[packages.wheels.hashes]
+sha256 = "481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8"
+
+[[packages]]
+name = "tyro"
+version = "1.0.15"
+requires-python = ">=3.8"
+dependencies = [
+    { name = "docstring-parser" },
+    { name = "typeguard" },
+    { name = "typing-extensions" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "tyro-1.0.15.tar.gz"
+upload-time = 2026-06-20 08:48:28.364151+00:00
+url = "https://files.pythonhosted.org/packages/12/78/a5749a6c1ee9abc2999e294f339f8f72476d1a60bb95fc0e86156aafed3b/tyro-1.0.15.tar.gz"
+size = 593822
+
+[packages.sdist.hashes]
+sha256 = "3f1d60887723eecb9c489f195d11f079c4a1f33df74b723552ad31ec57c667bb"
+
+[[packages.wheels]]
+name = "tyro-1.0.15-py3-none-any.whl"
+upload-time = 2026-06-20 08:48:27.104712+00:00
+url = "https://files.pythonhosted.org/packages/5d/28/d607636187cf6c18eb72efb5d65c1d1b9e451db03d84676f835dd488fdbd/tyro-1.0.15-py3-none-any.whl"
+size = 215045
+
+[packages.wheels.hashes]
+sha256 = "982da1d566005f1b2a6b56f6be6c6929c96f0e5fab9d61bc6097573ddfaf8d13"
+
+[[packages]]
+name = "urllib3"
+version = "2.7.0"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "urllib3-2.7.0.tar.gz"
+upload-time = 2026-05-07 16:13:18.596909+00:00
+url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz"
+size = 433602
+
+[packages.sdist.hashes]
+sha256 = "231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"
+
+[[packages.wheels]]
+name = "urllib3-2.7.0-py3-none-any.whl"
+upload-time = 2026-05-07 16:13:17.151740+00:00
+url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl"
+size = 131087
+
+[packages.wheels.hashes]
+sha256 = "9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
+
+[[packages]]
+name = "virtualenv"
+version = "21.6.1"
+marker = "\"nox\" in dependency_groups"
+requires-python = ">=3.9"
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+    { name = "typing-extensions" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "virtualenv-21.6.1.tar.gz"
+upload-time = 2026-07-10 19:33:53.312699+00:00
+url = "https://files.pythonhosted.org/packages/34/d9/b477fddb68840b570af8b22afe9b035cbc277b5fb7b33dea390617a8b10f/virtualenv-21.6.1.tar.gz"
+size = 5526620
+
+[packages.sdist.hashes]
+sha256 = "15f978b7cd329f24855ff4a0c4b4899cc7678589f49adbdcbbb4d3232e641128"
+
+[[packages.wheels]]
+name = "virtualenv-21.6.1-py3-none-any.whl"
+upload-time = 2026-07-10 19:33:51.629569+00:00
+url = "https://files.pythonhosted.org/packages/c1/7c/4e7225d46d634a0d8d534dd8a6ce0c319d09b4d0cf0337eb314ca4789d8c/virtualenv-21.6.1-py3-none-any.whl"
+size = 5506392
+
+[packages.wheels.hashes]
+sha256 = "afe991df855715a2b2f60edfcc0107ef95a79fdfd8cb4cdaa71603d1c12e463b"
+
+[[packages]]
+name = "zipp"
+version = "4.1.0"
+marker = "(python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\")"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "zipp-4.1.0.tar.gz"
+upload-time = 2026-05-18 20:08:57.967214+00:00
+url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz"
+size = 26214
+
+[packages.sdist.hashes]
+sha256 = "4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602"
+
+[[packages.wheels]]
+name = "zipp-4.1.0-py3-none-any.whl"
+upload-time = 2026-05-18 20:08:57.045692+00:00
+url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl"
+size = 10238
+
+[packages.wheels.hashes]
+sha256 = "25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f"
+
+[tool.nab]
+nab-version = "0.0.10.dev0"
+created-at = 2026-07-18 20:36:13.161143+00:00
+command-line = [
+    "nab",
+    "lock",
+    "--groups",
+    "nox",
+    "--project-default-group",
+    "nox",
+    "--no-emit-workspace",
+    "--output",
+    ".github/requirements/pylock.nox.toml",
+]
+input-path = "pyproject.toml"
+mode = "universal"
+python-specifier = ">=3.10,<3.15"
+platforms = [
+    "linux_x86_64",
+    "linux_aarch64",
+    "macos_arm64",
+    "macos_x86_64",
+    "windows_amd64",
+]
+cli-project-overrides = [
+    "--project-default-group=nox",
+]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -103,27 +103,19 @@ jobs:
         with:
           python-version: "3.13"
           cache: pip
-          cache-dependency-path: .github/requirements/pylock.types.toml
+          cache-dependency-path: |
+            .github/requirements/pylock.nox.toml
+            .github/requirements/pylock.types.toml
 
       - name: Upgrade pip to PEP 751 install support
         run: python -m pip install --upgrade "pip>=26.1"
 
-      - name: Install type-checking deps
-        run: pip install -r .github/requirements/pylock.types.toml
+      - name: Install nox
+        run: pip install -r .github/requirements/pylock.nox.toml
 
-      - name: Install workspace packages
-        run: pip install --no-deps -e nab-resolver -e nab-python -e nab-index -e .
-
+      # Type-check logic lives in noxfile.py. The checker goes through env,
+      # not inline ${{ }}, for zizmor.
       - name: Run ${{ matrix.checker }}
-        # Pyright needs --pythonpath to discover the venv; the other
-        # checkers find it via sys.executable or PATH.
-        run: |
-          case "${CHECKER}" in
-            mypy)    python -m mypy nab-resolver/src ;;
-            pyright) python -m pyright --pythonpath "$(which python)" ;;
-            ty)      ty check nab-resolver/src ;;
-            pyrefly) pyrefly check nab-resolver/src ;;
-            zuban)   zuban check nab-resolver/src ;;
-          esac
+        run: nox -s "types(checker='${CHECKER}')"
         env:
           CHECKER: ${{ matrix.checker }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   test:
-    name: ${{ matrix.os }} / ${{ matrix.python-version }}
+    name: ${{ matrix.workspace }} / ${{ matrix.os }} / ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}-latest
     timeout-minutes: 30
     strategy:
@@ -26,6 +26,8 @@ jobs:
       matrix:
         os: [ubuntu, windows, macos]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        # noxfile.py maps each workspace to its tests and coverage gates.
+        workspace: [resolver, python, umbrella]
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -38,23 +40,24 @@ jobs:
           python-version: ${{ matrix.python-version }}
           check-latest: true
           cache: pip
-          cache-dependency-path: .github/requirements/pylock.tests.toml
+          cache-dependency-path: |
+            .github/requirements/pylock.nox.toml
+            .github/requirements/pylock.tests.toml
           allow-prereleases: true
 
       - name: Upgrade pip to PEP 751 install support
         run: python -m pip install --upgrade "pip>=26.1"
 
-      - name: Install third-party deps
-        run: pip install -r .github/requirements/pylock.tests.toml
+      - name: Install nox
+        run: pip install -r .github/requirements/pylock.nox.toml
 
-      - name: Install workspace packages
-        run: pip install --no-deps -e nab-resolver -e nab-python -e nab-index -e .
-
-      - name: Run tests with coverage
-        run: |
-          python -m coverage run -m pytest
-          python -m coverage combine
-          python -m coverage report
+      # Test and coverage logic lives in noxfile.py. The workspace goes through
+      # env, not inline ${{ }}, for zizmor; shell: bash expands it on Windows.
+      - name: Test the ${{ matrix.workspace }} workspace
+        run: nox -s "tests(workspace='${WORKSPACE}')"
+        shell: bash
+        env:
+          WORKSPACE: ${{ matrix.workspace }}
 
   property-tests:
     name: Property tests

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build/
 .coverage*
 .ruff_cache/
 .hatch/
+.nox/
 docs/_build/
 
 *token*.txt

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -24,11 +24,20 @@ docs, and types groups available via `hatch run`.
 ## Running the tests
 
 The default suite is fast (under a minute) and covers every module
-under `nab_resolver`, `nab_python`, and `nab`:
+under `nab_resolver`, `nab_python`, `nab_index`, and `nab`:
 
 ```bash
 .venv/bin/python -m pytest                # default selection (no markers)
 .venv/bin/python -m pytest --cov          # with branch coverage
+```
+
+CI gates each workspace's coverage on its own tests through nox (see
+`noxfile.py`). With nox installed (`pip install nox`), reproduce a single
+workspace, or all of them, with:
+
+```bash
+nox -s tests                              # every workspace, each gated
+nox -s "tests(workspace='python')"        # just one workspace
 ```
 
 Property-based tests are opt-in via marker:
@@ -68,9 +77,13 @@ the floor.
 ## Coverage policy
 
 The `pyproject.toml` `[tool.coverage.report] fail_under = 100`
-setting requires `pytest --cov` to report 100 percent branch
-coverage on `nab_resolver`, `nab_python`, and `nab`. When code is
-genuinely unreachable from the default suite, prefer:
+setting requires 100 percent branch coverage on every workspace
+package: `nab_resolver`, `nab_python`, `nab_index`, and `nab`. The
+full local suite (`pytest --cov`) checks all four together; nox splits
+them per workspace in CI so each workspace's tests cover only its own
+package, with `nab_index` gated alongside `nab_python`, whose tests
+exercise it. When code is genuinely unreachable from the default
+suite, prefer:
 
 * `# pragma: no cover` for a platform-specific or defensively
   unreachable line.

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -623,7 +623,14 @@ def _sdist_member_top_level(name: str) -> tuple[int, str, str]:
     return (len(parts) - 1, top_dir, parts[-1])
 
 
-def extract_sdist_archive(data: bytes, target_dir: Path) -> Path:
+# The tar data filter (PEP 706) this extraction requires ships in 3.10.12 /
+# 3.11.4 / 3.12. The guard below raises on older patch releases and never
+# extracts, so the CI cell still on 3.10.11 exercises only one side of it and
+# cannot reach the extraction path. Drop the pragma when that cell moves to a
+# build carrying the filter or 3.10 reaches EOL (2026-10).
+def extract_sdist_archive(
+    data: bytes, target_dir: Path
+) -> Path:  # pragma: no cover (tar data filter)
     """Extract a .tar.gz sdist into ``target_dir`` and return the source root.
 
     Anything the extractor cannot read raises :class:`ValueError`: a corrupt or

--- a/nab-index/tests/__init__.py
+++ b/nab-index/tests/__init__.py
@@ -1,0 +1,1 @@
+"""nab-index test suite."""

--- a/nab-index/tests/ruff.toml
+++ b/nab-index/tests/ruff.toml
@@ -1,0 +1,30 @@
+extend = "../../pyproject.toml"
+
+[lint]
+extend-ignore = [
+    # Tests don't need full docstrings or rigid docstring style.
+    "D100", "D101", "D102", "D103", "D104", "D107",
+    "D202", "D205", "D209", "D301", "D400", "D401", "D403",
+    # Test fixtures and mock callables routinely accept-but-ignore args.
+    "ARG001", "ARG002", "ARG005",
+    # Tests construct exceptions inline.
+    "EM101", "TRY003",
+    # Tests use /tmp paths.
+    "S108",
+    # Loose-ends commonly hit by test data setup.
+    "B007", "C901", "C416", "FBT001", "FBT002",
+    "FURB171",
+    "PLR0124", "PLR0911", "PLR0912", "PLR0913", "PLR0915", "PLR2004",
+    "PLW0131",
+    # Tests don't need perf-style refactors.
+    "PERF203", "PERF401",
+    # Test ergonomics: inline imports, short aliases, long fixture
+    # lines, quotes, package layout.
+    "E501", "INP001", "N814", "N817", "PLC0415", "Q003",
+    # Tests inspect internal state.
+    "SLF001",
+    # pytest patterns.
+    "PT017", "RUF043", "SIM105",
+    # Type-checking-only imports stay in scope for test-runtime use.
+    "TC001", "TC002", "TC003",
+]

--- a/nab-index/tests/test_index_client.py
+++ b/nab-index/tests/test_index_client.py
@@ -1,0 +1,18 @@
+"""Tests for nab_index.client helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from nab_index.client import _sdist_member_top_level
+
+
+def test_sdist_member_top_level_normal() -> None:
+    assert _sdist_member_top_level("foo-1.0/PKG-INFO") == (1, "foo-1.0", "PKG-INFO")
+
+
+@pytest.mark.parametrize("name", ["", "./", "/abs", "/"])
+def test_sdist_member_top_level_rejects_empty_or_absolute(name: str) -> None:
+    # A member that strips to nothing, or points at an absolute path, is
+    # reported at depth -1 so callers skip it rather than treat it as a root.
+    assert _sdist_member_top_level(name) == (-1, "", "")

--- a/nab-index/tests/test_index_local.py
+++ b/nab-index/tests/test_index_local.py
@@ -1,0 +1,67 @@
+"""Tests for nab_index.local_index PEP 503 directory scanning."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, TypeVar
+
+from nab_index.local_index import LocalIndexClient, _scan_pep503_directory
+
+if TYPE_CHECKING:
+    from collections.abc import Coroutine
+    from pathlib import Path
+    from typing import Any
+
+_T = TypeVar("_T")
+
+
+def run(coro: Coroutine[Any, Any, _T]) -> _T:
+    return asyncio.run(coro)
+
+
+def _make_index(tmp_path: Path, body: str) -> Path:
+    package_dir = tmp_path / "foo"
+    package_dir.mkdir()
+    (package_dir / "index.html").write_text(body, encoding="utf-8")
+    return package_dir
+
+
+def test_anchor_with_unknown_attribute_is_parsed(tmp_path: Path) -> None:
+    # An attribute the parser does not recognise (here 'rel') is skipped
+    # without disturbing the href it accompanies.
+    body = '<a href="foo-1.0-py3-none-any.whl" rel="nofollow">foo</a>'
+    package_dir = _make_index(tmp_path, body)
+    (package_dir / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+    client = LocalIndexClient(tmp_path.as_uri())
+    result = run(client.get_files("foo"))
+    assert len(result) == 1
+
+
+def test_http_href_without_basename_is_skipped(tmp_path: Path) -> None:
+    # An http href whose path has no final segment yields no filename, so the
+    # link is dropped while a well-formed sibling still lists.
+    body = (
+        '<a href="https://example.com/">nofile</a>'
+        '<a href="foo-1.0-py3-none-any.whl">foo</a>'
+    )
+    package_dir = _make_index(tmp_path, body)
+    (package_dir / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+    client = LocalIndexClient(tmp_path.as_uri())
+    result = run(client.get_files("foo"))
+    assert len(result) == 1
+
+
+def test_scan_directory_without_index_html_returns_empty(tmp_path: Path) -> None:
+    # get_files only calls the scanner once index.html exists; the guard is
+    # exercised directly here.
+    package_dir = tmp_path / "foo"
+    package_dir.mkdir()
+    assert _scan_pep503_directory(package_dir, "foo") == []
+
+
+def test_get_sdist_archive_returns_file_bytes(tmp_path: Path) -> None:
+    sdist = tmp_path / "foo-1.0.tar.gz"
+    sdist.write_bytes(b"SDIST-BYTES")
+    client = LocalIndexClient(tmp_path.as_uri())
+    data = run(client.get_sdist_archive("foo", "1.0", sdist.as_uri()))
+    assert data == b"SDIST-BYTES"

--- a/nab-index/tests/test_index_multi.py
+++ b/nab-index/tests/test_index_multi.py
@@ -1,0 +1,68 @@
+"""Tests for nab_index.multi_index.MultiIndexClient forwarding."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, TypeVar
+
+from nab_index._naming import canonical
+from nab_index.client import WheelFile
+from nab_index.multi_index import MultiIndexClient
+
+if TYPE_CHECKING:
+    from collections.abc import Coroutine
+    from typing import Any
+
+_T = TypeVar("_T")
+
+
+def run(coro: Coroutine[Any, Any, _T]) -> _T:
+    return asyncio.run(coro)
+
+
+def _wheel(name: str, version: str = "1.0") -> WheelFile:
+    return WheelFile(
+        filename=f"{name}-{version}-py3-none-any.whl",
+        url=f"https://example.com/{name}-{version}-py3-none-any.whl",
+        version=version,
+        requires_python=None,
+        has_metadata=False,
+        upload_time=None,
+    )
+
+
+class _RecordingClient:
+    """Client stub that records get_sdist_archive calls."""
+
+    def __init__(self, listing: dict[str, list[WheelFile]], payload: bytes) -> None:
+        self._listing = listing
+        self._payload = payload
+        self.archive_calls: list[tuple[str, str, str]] = []
+
+    async def get_files(self, package: str) -> list[WheelFile]:
+        return list(self._listing.get(canonical(package), []))
+
+    async def get_sdist_archive(
+        self,
+        package: str,
+        version: str,
+        sdist_url: str,
+        sdist_hashes: tuple[tuple[str, str], ...] = (),
+    ) -> bytes:
+        self.archive_calls.append((package, version, sdist_url))
+        return self._payload
+
+
+def test_get_sdist_archive_forwards_to_routed_client() -> None:
+    empty = _RecordingClient({}, b"")
+    holder = _RecordingClient({"foo": [_wheel("foo")]}, b"ARCHIVE")
+    client = MultiIndexClient({"a": empty, "b": holder}, ["a", "b"], {})
+
+    # get_files routes "foo" to the index that lists it; get_sdist_archive
+    # must then reuse that route rather than probing every index again.
+    run(client.get_files("foo"))
+    data = run(client.get_sdist_archive("foo", "1.0", "https://x/s.tar.gz"))
+
+    assert data == b"ARCHIVE"
+    assert holder.archive_calls == [("foo", "1.0", "https://x/s.tar.gz")]
+    assert empty.archive_calls == []

--- a/nab-index/tests/test_index_transport.py
+++ b/nab-index/tests/test_index_transport.py
@@ -1,0 +1,14 @@
+"""Tests for nab_index.urllib3_async_transport pooling."""
+
+from __future__ import annotations
+
+from nab_index.urllib3_async_transport import Urllib3AsyncTransport
+
+
+def test_pool_reused_within_thread() -> None:
+    # The pool is created lazily on first use and cached per worker thread,
+    # so a second call on the same thread returns the same PoolManager.
+    transport = Urllib3AsyncTransport()
+    first = transport._pool()
+    second = transport._pool()
+    assert first is second

--- a/nab-index/tests/test_index_vcs.py
+++ b/nab-index/tests/test_index_vcs.py
@@ -1,0 +1,10 @@
+"""Tests for nab_index.vcs._split_repo_ref."""
+
+from __future__ import annotations
+
+from nab_index.vcs import _split_repo_ref
+
+
+def test_split_repo_ref_bare_local_name_has_no_ref() -> None:
+    # No scheme and no colon: the whole string is the repo, ref is empty.
+    assert _split_repo_ref("myrepo") == ("myrepo", "")

--- a/nab-python/pyproject.toml
+++ b/nab-python/pyproject.toml
@@ -39,3 +39,8 @@ Changelog = "https://github.com/notatallshaw/nab/releases"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+# Benchmarks are development tooling, not part of the shipped package, so the
+# sdist carries only the source and tests.
+[tool.hatch.build.targets.sdist]
+exclude = ["/benchmarks"]

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -662,10 +662,9 @@ class TestRenderers:
 
     def test_render_get_cache_dir_set(self, tmp_path: Path) -> None:
         _project(tmp_path)
-        eff = _resolve(
-            SourceRoots(project_dir=tmp_path), cli={"cache-dir": Path("/c/cli")}
-        )
-        assert render_get(eff, "cache-dir") == "/c/cli\n"
+        cache_dir = Path("/c/cli")
+        eff = _resolve(SourceRoots(project_dir=tmp_path), cli={"cache-dir": cache_dir})
+        assert render_get(eff, "cache-dir") == f"{cache_dir}\n"
 
     def test_render_get_unknown_key(self, tmp_path: Path) -> None:
         _project(tmp_path)

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -7959,12 +7959,14 @@ class TestConsultedMarkers:
 
     def test_a_marker_that_holds_is_recorded_too(self) -> None:
         """A True marker keeps its dep, so it still gated the resolve."""
+        # _PY312 pins python_version to 3.12, so this marker holds on every
+        # host the suite runs on, unlike a platform marker like sys_platform.
         provider = Provider(
-            self._coordinator('bar ; sys_platform != "win32"'), target=_PY312
+            self._coordinator('bar ; python_version == "3.12"'), target=_PY312
         )
         deps = provider.get_dependencies("foo", V("1.0"))
         assert "bar" in deps
-        assert provider.consulted_markers == {Marker('sys_platform != "win32"')}
+        assert provider.consulted_markers == {Marker('python_version == "3.12"')}
 
     def test_an_unmarked_dependency_records_nothing(self) -> None:
         provider = Provider(self._coordinator("bar"), target=_PY312)

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,92 @@
+"""Nox sessions for nab's per-workspace tests and its type-check matrix.
+
+``tests`` runs one workspace's suite and gates each package it owns at 100
+percent. ``fail_under`` and the ``[tool.coverage.paths]`` remaps live in
+``pyproject.toml``; the per-package ``--include`` globs are built here.
+``types`` runs one type-checker over ``nab-resolver/src``. Both take their
+pinned dependencies from ``.github/requirements``.
+
+The Python version comes from whoever launches nox, so CI drives the matrix
+through ``actions/setup-python`` and stays off the per-OS versioned-binary
+lookup. Run a single cell locally, for example::
+
+    nox -s "tests(workspace='python')"
+    nox -s "types(checker='mypy')"
+"""
+
+from __future__ import annotations
+
+import nox
+
+# Stdlib venv keeps the backend explicit; nab never resolves through uv.
+nox.options.default_venv_backend = "venv"
+
+TESTS_LOCK = ".github/requirements/pylock.tests.toml"
+TYPES_LOCK = ".github/requirements/pylock.types.toml"
+
+# workspace -> (editable packages, pytest paths, coverage-gated packages).
+# nab-index rides with the python workspace: nab-python is its only consumer
+# and its tests supply most of nab-index's coverage, so the two are gated here
+# without running nab-python's suite twice.
+WORKSPACES = {
+    "resolver": (
+        ["nab-resolver"],
+        ["nab-resolver/tests"],
+        ["nab_resolver"],
+    ),
+    "python": (
+        ["nab-resolver", "nab-index", "nab-python"],
+        ["nab-python/tests", "nab-index/tests"],
+        ["nab_python", "nab_index"],
+    ),
+    "umbrella": (
+        ["nab-resolver", "nab-index", "nab-python", "."],
+        ["tests"],
+        ["nab"],
+    ),
+}
+
+# checker -> command; pyright reads its targets from [tool.pyright] in
+# pyproject.toml, the rest take nab-resolver/src on the command line.
+TYPE_CHECKERS = {
+    "mypy": ["mypy", "nab-resolver/src"],
+    "pyright": ["pyright"],
+    "ty": ["ty", "check", "nab-resolver/src"],
+    "pyrefly": ["pyrefly", "check", "nab-resolver/src"],
+    "zuban": ["zuban", "check", "nab-resolver/src"],
+}
+
+
+def _install(session: nox.Session, lock: str, editables: list[str]) -> None:
+    """Install a pinned lock, then the given workspace packages editable."""
+    # Installing a PEP 751 lock needs a recent pip.
+    session.install("--upgrade", "pip>=26.1")
+    session.install("-r", lock)
+
+    # --no-deps keeps the run pinned to the locked closure above.
+    editable_args = [arg for package in editables for arg in ("-e", package)]
+    session.install("--no-deps", *editable_args)
+
+
+@nox.session
+@nox.parametrize("workspace", list(WORKSPACES))
+def tests(session: nox.Session, workspace: str) -> None:
+    """Run one workspace's tests and gate each package it owns at 100 percent."""
+    editables, paths, packages = WORKSPACES[workspace]
+    _install(session, TESTS_LOCK, editables)
+
+    session.run("coverage", "erase")
+    session.run("coverage", "run", "-m", "pytest", *paths)
+    session.run("coverage", "combine")
+    for package in packages:
+        session.run("coverage", "report", f"--include=*/{package}/*")
+
+
+@nox.session
+@nox.parametrize("checker", list(TYPE_CHECKERS))
+def types(session: nox.Session, checker: str) -> None:
+    """Type-check nab-resolver/src with one checker."""
+    # Only nab-resolver is checked; the checkers reach sibling packages through
+    # their source-path config, not installs.
+    _install(session, TYPES_LOCK, ["nab-resolver"])
+    session.run(*TYPE_CHECKERS[checker])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,17 @@ nab = "nab.cli:main"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+# The umbrella sdist ships only the CLI package and its own tests. Without this
+# it would pull in the whole monorepo: the sibling workspaces, docs/, .github/,
+# and the release tooling under tasks/.
+[tool.hatch.build.targets.sdist]
+only-include = ["src/nab", "tests", "conftest.py"]
+
+# test_build_dists.py and test_release.py cover the repo-level release tooling
+# in tasks/, not the shipped CLI, so they stay out of the package sdist.
+# (hatchling always ships pyproject.toml, hatch.toml, and .gitignore itself.)
+exclude = ["tests/test_build_dists.py", "tests/test_release.py"]
+
 # Dependency groups feed `nab lock` for CI lockfiles; regenerate via
 # tasks/refresh-locks.sh. Local dev uses hatch envs from hatch.toml.
 [dependency-groups]
@@ -69,6 +80,12 @@ types = [
 ]
 pre-commit = [
     "pre-commit>=4",
+]
+# Nox drives the per-workspace test matrix and the type-check matrix; see
+# noxfile.py. Each session installs its own lock (pylock.tests.toml or
+# pylock.types.toml), so this only bootstraps the runner.
+nox = [
+    "nox>=2025.5.1",
 ]
 # Locked as a single resolution for one interpreter, not against the project's
 # universal matrix; see tasks/refresh-locks.sh.  myst-parser 5.1 is the floor
@@ -131,6 +148,7 @@ addopts = [
 testpaths = [
     "nab-resolver/tests",
     "nab-python/tests",
+    "nab-index/tests",
     "tests",
 ]
 xfail_strict = true
@@ -149,9 +167,14 @@ relative_files = true
 parallel = true
 concurrency = ["thread", "multiprocessing"]
 sigterm = true
+# Per-workspace runs import only one workspace, so coverage would warn about
+# the source packages the run doesn't touch. This applies everywhere, but the
+# full local suite imports all four, where the warning has nothing to flag.
+disable_warnings = ["module-not-imported"]
 source_pkgs = [
     "nab_resolver",
     "nab_python",
+    "nab_index",
     "nab",
 ]
 source = []
@@ -189,6 +212,10 @@ nab_resolver = [
 nab_python = [
     "nab-python/src/nab_python",
     "*/nab_python",
+]
+nab_index = [
+    "nab-index/src/nab_index",
+    "*/nab_index",
 ]
 nab = [
     "src/nab",

--- a/tasks/refresh-locks.sh
+++ b/tasks/refresh-locks.sh
@@ -31,7 +31,7 @@ DOCS_PYTHON="3.13"
 # uv seed the PEP 751 dependency_groups marker from default-groups and cannot
 # select a non-default group at install time, so without this the group's
 # packages carry a marker no install-time flag ever satisfies and are skipped.
-for group in tests types pre-commit crosshair release docs; do
+for group in tests types pre-commit crosshair release docs nox; do
     echo "==> Locking group: ${group}"
     group_args=()
     if [[ "${group}" == "docs" ]]; then

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -375,15 +375,16 @@ class TestConfigErrors:
         self, hermetic_roots: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
         _project(hermetic_roots)
+        cache_dir = Path("/c/cli")
         config_command(
             "get",
             "cache-dir",
             path=hermetic_roots / "pyproject.toml",
             project_resolution="lowest",
-            cache_dir=Path("/c/cli"),
+            cache_dir=cache_dir,
         )
         captured = capsys.readouterr()
-        assert captured.out == "/c/cli\n"
+        assert captured.out == f"{cache_dir}\n"
         # The PROJECT resolution override emits the reproducibility notice.
         # The inspector produces no lock, so it makes no lock claim.
         assert "the lock they produce" not in captured.err


### PR DESCRIPTION
Fixes #362.

Two changes:

- **sdists**: each workspace's sdist now ships only its own code and tests. The umbrella `nab` sdist no longer bundles the sibling packages, `docs/`, `.github/`, or the release tooling under `tasks/`; `nab-python` drops its benchmarks. Done with hatchling `only-include`/`exclude`.
- **coverage + types**: the per-workspace test coverage and the five-checker type matrix run through nox (`noxfile.py`), so each workspace is gated on its own package rather than as one aggregate number. `coverage.py` has no per-package threshold, so nox owns the per-package `coverage report --include` scoping. A new `nab-index` test suite lets `nab_index` join the gate alongside `nab-python`.

Local dev still uses hatch and plain `pytest`; nox is only for the CI matrices (`pip install nox` to run a session locally).
