### PR TITLE
Add unified CLI output policy and progress line

### DIFF
--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -28,7 +28,7 @@ from nab_index.multi_index import IndexConfig, MultiIndexClient
 from ._vendor.packaging.utils import canonicalize_name
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 
     from typing_extensions import Self
 
@@ -557,6 +557,7 @@ class FetchCoordinator:
         cache_backend: CacheBackend | None = None,
         offline: bool = False,
         index_routes: list[IndexRoute] | None = None,
+        on_fetch: Callable[[], None] | None = None,
     ) -> None:
         """Create a coordinator that wraps ``transport``.
 
@@ -604,6 +605,9 @@ class FetchCoordinator:
             self._cache = NullCache()
         self._cache_dir = cache_dir
         self._index_routes = list(index_routes or [])
+        # Progress hook: fired once per successful listing fetch, from the
+        # fetcher thread.  ``None`` when nothing is watching (the common case).
+        self._on_fetch = on_fetch
         self.index = InMemoryIndex()
         self._thread: threading.Thread | None = None
         self._started = False
@@ -1056,6 +1060,9 @@ class FetchCoordinator:
         # filter (mirrors the sdist pyproject store-before-fire ordering).
         self._record_serving_index(client, req.package)
         self.index.store_listing(req.package, files)
+        logger.debug("fetched listing: %s (%d files)", req.package, len(files))
+        if self._on_fetch is not None:
+            self._on_fetch()
 
         # Auto-prefetch metadata for the newest candidates (files are
         # oldest-first). One wheel per version: the first with a sidecar is the
@@ -1103,6 +1110,7 @@ class FetchCoordinator:
             req.package, req.version, req.url, req.metadata_hash
         )
         self.index.store_metadata(req.package, req.version, text, req.url)
+        logger.debug("fetched metadata: %s %s", req.package, req.version)
 
     async def _fetch_sdist(
         self,

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -24,13 +24,14 @@ import logging
 import time
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 from nab_resolver.resolver import (
     Incompatibility,
     IncompatibilityCause,
     ResolutionError,
     Resolver,
+    ResolverObserver,
 )
 
 from ._conflict_kind import dependency_marker_holds, membership_set_in_marker
@@ -92,6 +93,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "InstallContexts",
+    "ProgressSink",
     "ResolveFork",
     "ResolveResult",
     "TargetResult",
@@ -106,6 +108,45 @@ _logger = logging.getLogger(__name__)
 # One environment, as a hashable key: two targets that differ only by
 # their conflict-fork selection share it.
 EnvSignature = tuple[tuple[str, str], ...]
+
+
+class ProgressSink(Protocol):
+    """What the engine reports resolve progress to; the CLI implements it.
+
+    ``on_fetch`` fires once per package listing fetched (from the fetcher
+    thread); ``on_pin`` reports the current count of decided packages (from
+    the resolving thread).  Both are best-effort display hooks.
+    """
+
+    def on_fetch(self) -> None:
+        """Record that one package listing has been fetched."""
+
+    def on_pin(self, decided: int) -> None:
+        """Record the current count of decided (pinned) packages."""
+
+
+class _ResolveObserver(ResolverObserver[str, "Version"]):
+    """Log resolver decisions at DEBUG and drive an optional progress sink.
+
+    A decision level is the count of packages currently decided, so it is the
+    live pinned gauge; a backjump lowers it, keeping the count honest under
+    backtracking.  Logging is unconditional (the log level gates it, so ``-vv``
+    surfaces the pin trace); ``sink`` is present only while a progress line is
+    being rendered.
+    """
+
+    def __init__(self, sink: ProgressSink | None) -> None:
+        self._sink = sink
+
+    def on_decision(self, package: str, version: Version, level: int) -> None:
+        _logger.debug("pinned %s %s", package, version)
+        if self._sink is not None:
+            self._sink.on_pin(level)
+
+    def on_backjump(self, from_level: int, to_level: int) -> None:
+        _logger.debug("backjumped from level %d to %d", from_level, to_level)
+        if self._sink is not None:
+            self._sink.on_pin(to_level)
 
 
 @dataclass(frozen=True, slots=True)
@@ -239,6 +280,7 @@ def resolve_for_targets(  # noqa: PLR0913 - the surface mirrors the CLI; bundlin
     groups: Sequence[str] = (),
     extras: Sequence[str] = (),
     resolution_strategy: ResolutionStrategy | None = None,
+    progress: ProgressSink | None = None,
 ) -> ResolveResult:
     """Resolve the project at ``path`` for every environment it targets.
 
@@ -292,6 +334,7 @@ def resolve_for_targets(  # noqa: PLR0913 - the surface mirrors the CLI; bundlin
         cache_dir=cache_dir,
         offline=offline,
         index_routes=index_routes_from_config(config),
+        on_fetch=progress.on_fetch if progress is not None else None,
     ) as coordinator:
         return resolve_with_coordinator(
             coordinator,
@@ -301,6 +344,7 @@ def resolve_for_targets(  # noqa: PLR0913 - the surface mirrors the CLI; bundlin
             forks=forks,
             base_requirements=base_requirements,
             resolution_strategy=resolution_strategy,
+            progress=progress,
         )
 
 
@@ -316,6 +360,7 @@ def resolve_with_coordinator(  # noqa: PLR0913 - the knobs a caller drives a bar
     resolution_strategy: ResolutionStrategy | None = None,
     align_across_targets: bool = True,
     preferences: Mapping[str, Version] | None = None,
+    progress: ProgressSink | None = None,
 ) -> ResolveResult:
     """Resolve ``targets`` against an already-open coordinator.
 
@@ -349,6 +394,7 @@ def resolve_with_coordinator(  # noqa: PLR0913 - the knobs a caller drives a bar
             if resolution_strategy is not None
             else effective.resolution
         ),
+        progress=progress,
     )
     fork_list = (
         list(forks) if forks is not None else [ResolveFork((), tuple(requirements))]
@@ -527,6 +573,7 @@ class _EngineSettings:
     cache_dir: Path | None
     align: bool
     resolution: ResolutionStrategy
+    progress: ProgressSink | None = None
     # Shared by every target of every pass: the coordinator and the policy
     # config the pre-tag half of the listing filter reads are both fixed here.
     listing_filter_cache: ListingFilterCache = field(default_factory=ListingFilterCache)
@@ -643,10 +690,12 @@ def _resolve_one_target(
         preferences=dict(preferences),
         listing_filter_cache=settings.listing_filter_cache,
     )
+    observer = _ResolveObserver(settings.progress)
     resolver: Resolver[str, Version] = Resolver(
-        provider, range_type=VersionRange, root_version="0"
+        provider, observer=observer, range_type=VersionRange, root_version="0"
     )
 
+    _logger.debug("resolving %s", target.label)
     start = time.monotonic()
     try:
         raw = resolver.resolve(resolver_requirements, constraints=resolver_constraints)
@@ -662,6 +711,14 @@ def _resolve_one_target(
             **_target_stats(resolver, provider),
         )
     elapsed = time.monotonic() - start
+    _logger.info(
+        "resolved %d packages for %s in %.2fs (%d distributions seen, %d fetched)",
+        len(pins),
+        target.label,
+        elapsed,
+        provider.stats.distributions_seen,
+        provider.stats.metadata_fetched,
+    )
     base_roots, selector_roots = _install_context_roots(contexts, environment)
     return TargetResult(
         target=target,

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -438,6 +438,17 @@ class TestFetchCoordinator:
             assert len(listing) >= 2
 
     @respx.mock
+    def test_on_fetch_callback_fires_per_listing(self) -> None:
+        respx.get("https://pypi.org/simple/testpkg/").mock(
+            return_value=httpx.Response(200, json=LISTING_JSON)
+        )
+        calls: list[int] = []
+        with _coord(on_fetch=lambda: calls.append(1)) as coord:
+            event = coord.request_listing("testpkg")
+            event.wait(timeout=5)
+        assert calls == [1]
+
+    @respx.mock
     def test_request_listing_cached(self) -> None:
         with _coord() as coord:
             coord.index.store_listing("cached", ["data"])

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -53,6 +53,7 @@ from nab_python.resolve import (
     _group_requirements_by_group,
     _ProjectTables,
     _raise_for_source_python,
+    _ResolveObserver,
     _walk_no_versions_packages,
     build_lock_input,
     resolve_for_targets,
@@ -3792,3 +3793,53 @@ class TestSidecarFetchFailure:
                 _resolved(pyproject, transport, python_version="3.12.0")
         finally:
             asyncio.run(transport.aclose())
+
+
+class _RecordingSink:
+    """A :class:`~nab_python.resolve.ProgressSink` that records its calls."""
+
+    def __init__(self) -> None:
+        self.fetches = 0
+        self.pins: list[int] = []
+
+    def on_fetch(self) -> None:
+        self.fetches += 1
+
+    def on_pin(self, decided: int) -> None:
+        self.pins.append(decided)
+
+
+class TestProgressReporting:
+    """The progress sink is threaded to the coordinator and the resolver."""
+
+    def test_sink_records_pins_and_reaches_coordinator(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\ndependencies = ["foo"]\n', encoding="utf-8"
+        )
+        coordinator = make_coordinator(
+            listings={"foo": _index_wheels("foo", "1.0")},
+            metadata_by_version={"1.0": _metadata("foo", "1.0")},
+        )
+        sink = _RecordingSink()
+        with patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda _self: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            result = _resolved(
+                pyproject, _FAKE_TRANSPORT, python_version="3.12.0", progress=sink
+            )
+        assert result.success
+        assert sink.pins
+        assert mock_coord_cls.call_args.kwargs["on_fetch"] is not None
+
+    def test_observer_reports_decision_and_backjump_levels(self) -> None:
+        sink = _RecordingSink()
+        observer = _ResolveObserver(sink)
+        observer.on_decision("foo", V("1.0"), 3)
+        observer.on_backjump(3, 1)
+        assert sink.pins == [3, 1]
+
+    def test_observer_without_sink_only_logs(self) -> None:
+        observer = _ResolveObserver(None)
+        observer.on_decision("foo", V("1.0"), 3)
+        observer.on_backjump(3, 1)

--- a/src/nab/_config_cmd.py
+++ b/src/nab/_config_cmd.py
@@ -38,6 +38,7 @@ from .cli import (
     _require_pyproject_file,
     app,
     effective_config,
+    printer,
 )
 
 ActionArg = Annotated[str, tyro.conf.Positional]
@@ -136,14 +137,13 @@ def config_command(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag
         sys.stdout.write(rendered)
         return
 
-    sys.stderr.write(
-        f"Error: unknown config action {action!r};"
-        " expected one of 'list', 'get', 'explain'\n"
+    printer().error(
+        f"unknown config action {action!r}; expected one of 'list', 'get', 'explain'"
     )
     sys.exit(1)
 
 
 def _require_key_arg(key: str, action: str) -> None:
     if not key:
-        sys.stderr.write(f"Error: `nab config {action}` requires a <key>\n")
+        printer().error(f"`nab config {action}` requires a <key>")
         sys.exit(1)

--- a/src/nab/_download.py
+++ b/src/nab/_download.py
@@ -33,6 +33,7 @@ from .cli import (
     ResolutionFlag,
     app,
 )
+from .output import ProgressReporter
 
 
 @app.command
@@ -120,11 +121,12 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
         cache_dir=effective_cache_dir,
         offline=settings.offline,
         transport=transport,
-        failure_prefix="Cannot download",
+        failure_prefix="cannot download",
         python=python,
         groups=selected_groups,
         extras=selected_extras,
         resolution_strategy=settings.resolution,
+        progress=ProgressReporter(_cli.printer()),
     )
     lock_input = _cli.build_lock_input(
         result,
@@ -142,13 +144,13 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
             max_concurrency=settings.max_concurrency,
         )
     except DownloadError as e:
-        sys.stderr.write(f"Download failed: {e}\n")
+        _cli.printer().error(f"download failed: {e}")
         sys.exit(1)
     except OSError as e:
-        sys.stderr.write(f"Error: cannot write to output directory {output}: {e}\n")
+        _cli.printer().error(f"cannot write to output directory {output}: {e}")
         sys.exit(1)
 
-    sys.stderr.write(
+    _cli.printer().done(
         f"Downloaded {len(outcome.written)} files,"
-        f" {len(outcome.skipped)} already present, into {output}\n"
+        f" {len(outcome.skipped)} already present, into {output}"
     )

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -63,6 +63,7 @@ from .cli import (
     ResolutionFlag,
     app,
 )
+from .output import ProgressReporter
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
@@ -75,7 +76,7 @@ def _emit_or_exit(emit: Callable[[], None]) -> None:
     try:
         emit()
     except OSError as e:
-        sys.stderr.write(f"Error: cannot write output: {e}\n")
+        _cli.printer().error(f"cannot write output: {e}")
         sys.exit(1)
 
 
@@ -150,9 +151,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     """
     _validate_pylock_output_name(output=output, format=format)
     if locked and (format != "pylock" or _cli.is_stdout(output)):
-        sys.stderr.write(
-            "Error: --locked is only supported for pylock output to a file.\n"
-        )
+        _cli.printer().error("--locked is only supported for pylock output to a file.")
         sys.exit(1)
     overrides = _cli._cli_overrides(  # noqa: SLF001
         cli_resolution=project_resolution,
@@ -182,7 +181,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
         cli_overrides=project_overrides,
     )
     if locked and config.mode is ResolveMode.UNIVERSAL:
-        sys.stderr.write("Error: --locked is not supported in universal mode.\n")
+        _cli.printer().error("--locked is not supported in universal mode.")
         sys.exit(1)
     _cli._reject_python_override_in_universal(config, python)  # noqa: SLF001
     settings = _cli._layered_run_settings_or_exit(path, overrides)  # noqa: SLF001
@@ -207,9 +206,9 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
     )
 
     if config.mode is ResolveMode.UNIVERSAL:
-        sys.stderr.write(
-            "warning: the multi-target ('universal') lockfile format is"
-            " experimental and may change without notice\n"
+        _cli.printer().warning(
+            "the multi-target ('universal') lockfile format is"
+            " experimental and may change without notice"
         )
 
     transport = _cli._make_transport(settings.http_backend)  # noqa: SLF001
@@ -219,11 +218,12 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
         cache_dir=effective_cache_dir,
         offline=settings.offline,
         transport=transport,
-        failure_prefix="Cannot lock",
+        failure_prefix="cannot lock",
         python=python,
         groups=selected_groups,
         extras=selected_extras,
         resolution_strategy=settings.resolution,
+        progress=ProgressReporter(_cli.printer()),
     )
 
     lock_input = _drop_workspace_pins(
@@ -313,30 +313,28 @@ def _check_locked(lock_input: LockInput, *, output: Path | None) -> None:
     """
     target = output if output is not None else Path(_cli._DEFAULT_OUTPUT["pylock"])  # noqa: SLF001
     if not target.exists():
-        sys.stderr.write(
-            f"Error: --locked: no lockfile at {target} to check;"
-            " run `nab lock` first.\n"
+        _cli.printer().error(
+            f"--locked: no lockfile at {target} to check; run `nab lock` first."
         )
         sys.exit(1)
     try:
         new_text = _cli.render_lock(lock_input, lock_dir=target.parent)
     except _cli.MissingHashError as e:
-        sys.stderr.write(f"Cannot lock: {e}\n")
+        _cli.printer().error(f"cannot lock: {e}")
         sys.exit(1)
     try:
         committed = _packages_only(target.read_text(encoding="utf-8"))
     except (UnicodeDecodeError, tomli.TOMLDecodeError) as e:
-        sys.stderr.write(
-            f"Error: --locked: lockfile {target} is not valid TOML: {e};"
-            " re-run `nab lock` to regenerate it.\n"
+        _cli.printer().error(
+            f"--locked: lockfile {target} is not valid TOML: {e};"
+            " re-run `nab lock` to regenerate it."
         )
         sys.exit(1)
     if _packages_only(new_text) == committed:
-        sys.stderr.write(f"Lockfile {target} is up to date.\n")
+        _cli.printer().done(f"Lockfile {target} is up to date.")
         return
-    sys.stderr.write(
-        f"Error: --locked: lockfile {target} is out of date;"
-        " re-run `nab lock` to update it.\n"
+    _cli.printer().error(
+        f"--locked: lockfile {target} is out of date; re-run `nab lock` to update it."
     )
     sys.exit(1)
 
@@ -353,7 +351,7 @@ def _emit_pylock(lock_input: LockInput, *, output: Path | None) -> None:
     # Pass the target so wheel/sdist/directory paths are written relative
     # to the lockfile's own directory, not the cwd.
     _render_lock_or_exit(lock_input, target=target)
-    sys.stderr.write(f"Wrote {target} ({_lock_summary(lock_input, prior)})\n")
+    _cli.printer().done(f"Wrote {target} ({_lock_summary(lock_input, prior)})")
 
 
 def _render_lock_or_exit(lock_input: LockInput, *, target: Path | None) -> str:
@@ -361,10 +359,10 @@ def _render_lock_or_exit(lock_input: LockInput, *, target: Path | None) -> str:
     try:
         return _cli.write_lock(lock_input, output_path=target)
     except _cli.MissingHashError as e:
-        sys.stderr.write(f"Cannot lock: {e}\n")
+        _cli.printer().error(f"cannot lock: {e}")
         sys.exit(1)
     except (_cli.DisjointnessError, _cli.DivergentBaseDependencyError) as e:
-        sys.stderr.write(f"Error: {e}\n")
+        _cli.printer().error(str(e))
         sys.exit(1)
 
 
@@ -486,24 +484,24 @@ def _check_output_template(output: Path, template: str) -> None:
             if name is not None
         ]
     except ValueError as e:
-        sys.stderr.write(f"Error: --output {output} is not a valid template: {e}\n")
+        _cli.printer().error(f"--output {output} is not a valid template: {e}")
         sys.exit(1)
     supported = _and_list(allowed_vars)
     unknown = sorted(f"{{{name}}}" for name, _, _ in fields if name not in allowed)
     if unknown:
-        sys.stderr.write(
-            f"Error: --output {output} has unknown template placeholder(s)"
-            f" {', '.join(unknown)}; only {supported} are supported.\n"
+        _cli.printer().error(
+            f"--output {output} has unknown template placeholder(s)"
+            f" {', '.join(unknown)}; only {supported} are supported."
         )
         sys.exit(1)
     decorated = sorted(
         {f"{{{name}}}" for name, spec, conversion in fields if spec or conversion}
     )
     if decorated:
-        sys.stderr.write(
-            f"Error: --output {output} is not a valid template:"
+        _cli.printer().error(
+            f"--output {output} is not a valid template:"
             f" {', '.join(decorated)} may not carry a format spec or conversion;"
-            f" only bare {supported} are supported.\n"
+            f" only bare {supported} are supported."
         )
         sys.exit(1)
 
@@ -554,7 +552,7 @@ def _emit_requirements(
         _, count = _render_requirements_or_exit(
             lock_input, with_hashes, output_path=target
         )
-        sys.stderr.write(f"Wrote {target} ({count} packages)\n")
+        _cli.printer().done(f"Wrote {target} ({count} packages)")
         return
 
     _check_output_template(target, template)
@@ -583,18 +581,18 @@ def _refuse_untemplated(lock_input: LockInput, output: Path) -> NoReturn:
     count = len(targets)
     varying = _varying_vars(targets)
     if not varying:
-        sys.stderr.write(
-            f"Error: the resolve produced {count} tuples and no --output template"
+        _cli.printer().error(
+            f"the resolve produced {count} tuples and no --output template"
             f" variable tells them apart, so {output} cannot hold them."
-            "  Emit pylock output instead.\n"
+            "  Emit pylock output instead."
         )
         sys.exit(1)
     placeholders = _and_list([f"{{{name}}}" for name in varying])
     example = "constraints" + "".join(f"-{{{name}}}" for name in varying) + ".txt"
-    sys.stderr.write(
-        f"Error: the resolve produced {count} tuples but --output {output} has no"
+    _cli.printer().error(
+        f"the resolve produced {count} tuples but --output {output} has no"
         f" template variable to disambiguate.  Use {placeholders} in the path,"
-        f" e.g.:\n  --output '{example}'\n"
+        f" e.g.:\n  --output '{example}'"
     )
     sys.exit(1)
 
@@ -609,19 +607,19 @@ def _refuse_collision(
         if f"{{{name}}}" not in template
     ]
     head = (
-        f"Error: tuples {first.target.label!r} and {second.target.label!r}"
+        f"tuples {first.target.label!r} and {second.target.label!r}"
         f" both map to {path!r};"
     )
     if not missing:
-        sys.stderr.write(
+        _cli.printer().error(
             f"{head} no --output template variable tells them apart."
-            "  Emit pylock output instead.\n"
+            "  Emit pylock output instead."
         )
         sys.exit(1)
     placeholders = _and_list([f"{{{name}}}" for name in missing])
-    sys.stderr.write(
+    _cli.printer().error(
         f"{head} --output {output} is missing a template variable to"
-        f" disambiguate.  Add {placeholders} to the path.\n"
+        f" disambiguate.  Add {placeholders} to the path."
     )
     sys.exit(1)
 
@@ -682,8 +680,8 @@ def _write_requirements_files(rendered: list[_RenderedFile]) -> None:
 
     for tmp, item in staged:
         tmp.replace(item.path)
-        sys.stderr.write(
-            f"Wrote {item.path} ({item.pin_count} packages, tuple {item.label})\n"
+        _cli.printer().done(
+            f"Wrote {item.path} ({item.pin_count} packages, tuple {item.label})"
         )
 
 
@@ -746,7 +744,7 @@ def _render_requirements_or_exit(
                 lock_input, output_path=output_path
             )
     except _cli.MissingHashError as e:
-        sys.stderr.write(f"Cannot lock: {e}\n")
+        _cli.printer().error(f"cannot lock: {e}")
         sys.exit(1)
     return text, sum(len(lock.pins) for lock in lock_input.targets.values())
 
@@ -764,13 +762,13 @@ def _read_selection_table_or_exit(
         return reader(path)
     except OSError:
         reason = "is a directory" if path.is_dir() else "not found"
-        sys.stderr.write(f"Error: {path} {reason}\n")
+        _cli.printer().error(f"{path} {reason}")
         sys.exit(1)
     except (UnicodeDecodeError, tomli.TOMLDecodeError) as e:
-        sys.stderr.write(f"Error: {path} is not valid TOML: {e}\n")
+        _cli.printer().error(f"{path} is not valid TOML: {e}")
         sys.exit(1)
     except TypeError as e:
-        sys.stderr.write(f"Error in {path}: {e}\n")
+        _cli.printer().error(f"in {path}: {e}")
         sys.exit(1)
 
 
@@ -790,7 +788,7 @@ def resolve_group_selection(
     preferring one over the other.
     """
     if all_groups and groups:
-        sys.stderr.write("Error: --all-groups and --groups are mutually exclusive\n")
+        _cli.printer().error("--all-groups and --groups are mutually exclusive")
         sys.exit(1)
     if not (all_groups or groups):
         return ()
@@ -807,7 +805,7 @@ def resolve_extra_selection(
 ) -> tuple[str, ...]:
     """Return the canonical, deduplicated extras selection for this run."""
     if all_extras and extras:
-        sys.stderr.write("Error: --all-extras and --extras are mutually exclusive\n")
+        _cli.printer().error("--all-extras and --extras are mutually exclusive")
         sys.exit(1)
     if not (all_extras or extras):
         return ()
@@ -910,10 +908,10 @@ def _determine_lock_anchor(
     if upgrade:
         fresh = datetime.now(timezone.utc)
         if prior is not None:
-            sys.stderr.write(
-                "notice: --upgrade re-anchored the resolve window to"
+            _cli.printer().note(
+                "--upgrade re-anchored the resolve window to"
                 f" {fresh.isoformat()}, dropping the cutoff {prior.isoformat()}"
-                " recorded in the existing lockfile.\n"
+                " recorded in the existing lockfile."
             )
         return fresh
     reused = absolute if absolute is not None else prior
@@ -938,9 +936,9 @@ def _validate_pylock_output_name(
         return
     dotted = output.with_name(output.name.replace("-", "."))
     suggestion = dotted.name if is_valid_pylock_path(dotted) else "pylock.toml"
-    sys.stderr.write(
-        f"Error: output file name {output.name!r} must match 'pylock.toml'"
+    _cli.printer().error(
+        f"output file name {output.name!r} must match 'pylock.toml'"
         " or 'pylock.<name>.toml' per PEP 751 (note the dot separator,"
-        f" not a hyphen).  Try {suggestion!r}.\n"
+        f" not a hyphen).  Try {suggestion!r}."
     )
     sys.exit(1)

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -79,6 +79,14 @@ from nab_python.resolve import (
 from nab_python.workspace import WorkspaceDiscoveryError
 from nab_resolver.resolver import ResolutionError
 
+from .output import (
+    OutputOptionError,
+    Printer,
+    ProgressReporter,
+    install_log_handler,
+    parse_output_options,
+)
+
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
@@ -88,6 +96,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "main",
+    "printer",
 ]
 
 
@@ -130,6 +139,18 @@ _SIGINT_EXIT_CODE = 130
 
 app = SubcommandApp()
 
+_printer: Printer | None = None
+
+
+def printer() -> Printer:
+    """Return the run's :class:`~nab.output.Printer`.
+
+    :func:`main` installs the printer resolved from the global output flags.
+    A subcommand called directly (bypassing ``main``, as many tests do) gets a
+    fresh default printer that reads the current process streams.
+    """
+    return _printer if _printer is not None else Printer()
+
 
 def _make_transport(backend: HttpBackend) -> AsyncHttpTransport:
     # httpx is an optional extra; import lazily so a urllib3-only
@@ -140,9 +161,7 @@ def _make_transport(backend: HttpBackend) -> AsyncHttpTransport:
                 HttpxAsyncTransport,
             )
         except ImportError:
-            sys.stderr.write(
-                "Error: httpx is not installed; run `pip install nab[httpx]`\n"
-            )
+            printer().error("httpx is not installed; run `pip install nab[httpx]`")
             sys.exit(1)
         return HttpxAsyncTransport()
 
@@ -388,8 +407,8 @@ def _layered_run_settings_or_exit(
 
 
 def _fail_config(exc: SourceConfigError) -> NoReturn:
-    """Map a layered config error to the shared ``Config error:`` exit."""
-    sys.stderr.write(f"Config error: {exc}\n")
+    """Map a layered config error to the shared ``error: config error:`` exit."""
+    printer().error(f"config error: {exc}")
     sys.exit(1)
 
 
@@ -416,12 +435,12 @@ def _require_pyproject_file(path: Path) -> None:
     """
     if not path.is_file():
         reason = "is a directory" if path.is_dir() else "not found"
-        sys.stderr.write(f"Error: {path} {reason}\n")
+        printer().error(f"{path} {reason}")
         sys.exit(1)
     if _is_pylock(path):
-        sys.stderr.write(
-            f"Error: {path} is a PEP 751 lockfile, not a pyproject.  nab resolves"
-            f" from project inputs, so pass the pyproject.toml instead.\n"
+        printer().error(
+            f"{path} is a PEP 751 lockfile, not a pyproject.  nab resolves"
+            " from project inputs, so pass the pyproject.toml instead."
         )
         sys.exit(1)
 
@@ -443,10 +462,10 @@ def _load_config(
             cli_overrides=cli_overrides,
         )
     except ConfigError as exc:
-        sys.stderr.write(f"Error in [tool.nab]: {exc}\n")
+        printer().error(f"in [tool.nab]: {exc}")
         sys.exit(1)
     except WorkspaceDiscoveryError as exc:
-        sys.stderr.write(f"Workspace discovery error: {exc}\n")
+        printer().error(f"workspace discovery error: {exc}")
         sys.exit(1)
 
 
@@ -464,9 +483,9 @@ def _reject_python_override_in_universal(
     the user did not ask for.
     """
     if python is not None and config.mode is ResolveMode.UNIVERSAL:
-        sys.stderr.write(
-            "Error: --python is not supported in universal mode;"
-            " [tool.nab.matrix].python declares the Python axis.\n"
+        printer().error(
+            "--python is not supported in universal mode;"
+            " [tool.nab.matrix].python declares the Python axis."
         )
         sys.exit(1)
 
@@ -482,11 +501,11 @@ def _python_override_or_exit(
     try:
         return with_python_override(config, python)
     except ConfigError as e:
-        sys.stderr.write(f"Error: {e}\n")
+        printer().error(str(e))
         sys.exit(1)
 
 
-def _resolve(  # noqa: PLR0913, C901 - one wrapper per resolve_for_targets kwarg / exit-mapped error
+def _resolve(  # noqa: PLR0913, PLR0912, C901 - one wrapper per resolve_for_targets kwarg / exit-mapped error
     path: Path,
     *,
     config: NabProjectConfig,
@@ -498,45 +517,55 @@ def _resolve(  # noqa: PLR0913, C901 - one wrapper per resolve_for_targets kwarg
     groups: tuple[str, ...] = (),
     extras: tuple[str, ...] = (),
     resolution_strategy: ResolutionStrategy | None = None,
+    progress: ProgressReporter | None = None,
 ) -> ResolveResult:
     """Run the resolver and translate every failure to an exit.
 
     A returned result is always fully successful: a target that did not
     resolve is reported (one line for a single environment, a per-tuple
     block for a matrix) and the process exits 1.
+
+    ``progress`` renders the live resolve line while ``resolve_for_targets``
+    runs; it is cleared before any summary or error is written, so the two
+    never collide.
     """
     config = _python_override_or_exit(config, python)
     try:
-        result = resolve_for_targets(
-            path,
-            transport,
-            config=config,
-            cache_dir=cache_dir,
-            offline=offline,
-            groups=groups,
-            extras=extras,
-            resolution_strategy=resolution_strategy,
-        )
+        try:
+            result = resolve_for_targets(
+                path,
+                transport,
+                config=config,
+                cache_dir=cache_dir,
+                offline=offline,
+                groups=groups,
+                extras=extras,
+                resolution_strategy=resolution_strategy,
+                progress=progress,
+            )
+        finally:
+            if progress is not None:
+                progress.clear()
     except ResolutionError as e:
-        sys.stderr.write(f"Resolution failed: {e}\n")
+        printer().error(f"resolution failed: {e}")
         sys.exit(1)
     except (UnsupportedVcsError, MissingExtraError) as e:
-        sys.stderr.write(f"{failure_prefix}: {e}\n")
+        printer().error(f"{failure_prefix}: {e}")
         sys.exit(1)
     except InvalidUploadTimeError as e:
-        sys.stderr.write(f"Error: {e}\n")
+        printer().error(str(e))
         sys.exit(1)
     except KeyError:
-        sys.stderr.write(f"Error: {path} has no [project].dependencies\n")
+        printer().error(f"{path} has no [project].dependencies")
         sys.exit(1)
     except InvalidProjectTableError as e:
-        sys.stderr.write(f"Error in {path}: {e}\n")
+        printer().error(f"in {path}: {e}")
         sys.exit(1)
     except InvalidProjectRequirementError as e:
-        sys.stderr.write(f"Error: {e}\n")
+        printer().error(str(e))
         sys.exit(1)
     except LookupError as e:
-        sys.stderr.write(f"Error: {e}\n")
+        printer().error(str(e))
         sys.exit(1)
     except (
         MissingHashError,
@@ -545,16 +574,16 @@ def _resolve(  # noqa: PLR0913, C901 - one wrapper per resolve_for_targets kwarg
         MetadataHashMismatchError,
         SdistHashMismatchError,
     ) as e:
-        sys.stderr.write(f"{failure_prefix}: {e}\n")
+        printer().error(f"{failure_prefix}: {e}")
         sys.exit(1)
     except NotImplementedError as e:
-        sys.stderr.write(f"{failure_prefix}: {e}\n")
+        printer().error(f"{failure_prefix}: {e}")
         sys.exit(1)
     except ConfigError as e:
-        sys.stderr.write(f"Error in [tool.nab]: {e}\n")
+        printer().error(f"in [tool.nab]: {e}")
         sys.exit(1)
     except HttpError as e:
-        sys.stderr.write(f"{failure_prefix}: {e}\n")
+        printer().error(f"{failure_prefix}: {e}")
         sys.exit(1)
 
     if not result.success:
@@ -569,11 +598,13 @@ def _report_failures(result: ResolveResult, *, matrix: bool) -> None:
     A project resolving for one environment has one error, and it is the
     run's error.  A matrix has one per tuple, and the pins that did
     resolve are as informative as the failures, so each tuple gets a
-    labelled block on stdout.
+    labelled block.  Both go to stderr: a failed run exits non-zero, so
+    the report is a diagnostic, not the requested lock, and stdout stays
+    clean for a caller that piped it.
     """
     if not matrix:
         first = next(tr.error for tr in result.every_result if tr.error is not None)
-        sys.stderr.write(f"Resolution failed: {first}\n")
+        printer().error(f"resolution failed: {first}")
         return
 
     blocks: list[str] = []
@@ -594,7 +625,7 @@ def _report_failures(result: ResolveResult, *, matrix: bool) -> None:
         blocks.append(f"# base/{br.target.label}: FAILED")
         blocks.extend(_error_lines(br.error))
 
-    sys.stdout.write("\n".join(blocks) + "\n")
+    sys.stderr.write("\n".join(blocks) + "\n")
 
 
 def _error_lines(error: ResolutionError | None) -> list[str]:
@@ -659,15 +690,30 @@ from . import _lock as _lock_module  # noqa: E402, F401 - side-effect
 
 def main() -> None:
     """Entry point for the nab command."""
-    # Tyro's SubcommandApp does not surface a global ``--version`` flag,
-    # so the check runs before ``app.cli()`` parses the sub-command.
+    global _printer  # noqa: PLW0603 - the run's printer is a module singleton main() sets
+    # Tyro's SubcommandApp does not surface global flags, so ``--version`` and
+    # the output flags (-v/-q, --color, --no-progress) are parsed before
+    # ``app.cli()`` sees the sub-command.
     argv = sys.argv[1:]
     if argv and argv[0] in {"--version", "-V"}:
         sys.stdout.write(f"nab {__version__}\n")
         return
 
     try:
-        app.cli(prog="nab", args=_normalize_layered_bool_flags(argv))
+        options, rest = parse_output_options(argv, os.environ)
+    except OutputOptionError as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        sys.exit(2)
+
+    _printer = Printer(
+        verbosity=options.verbosity, color=options.color, progress=options.progress
+    )
+    install_log_handler(
+        options.verbosity, stream=sys.stderr, color_enabled=_printer.color_enabled
+    )
+
+    try:
+        app.cli(prog="nab", args=_normalize_layered_bool_flags(rest))
     except KeyboardInterrupt:
-        sys.stderr.write("Aborted.\n")
+        _printer.error("interrupted")
         sys.exit(_SIGINT_EXIT_CODE)

--- a/src/nab/output.py
+++ b/src/nab/output.py
@@ -1,0 +1,491 @@
+"""nab's output policy in one place: stream, level, format, and colour.
+
+stdout carries only the requested, machine-readable output (a lockfile, a
+requirements list, a config dump).  stderr carries everything a human reads:
+the run summary, notes, warnings, errors, progress, and logs.  The verbosity
+level and the colour decision are resolved once in :func:`nab.cli.main` and
+shared through a single :class:`Printer`, so no command re-invents the policy.
+
+The design follows uv: a small printer with a level, a data channel that
+survives ``--quiet``, and colour applied only to a message's leading token so
+the body stays legible with colour stripped.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import os
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from typing import IO, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+__all__ = [
+    "ColorChoice",
+    "OutputOptionError",
+    "OutputOptions",
+    "Printer",
+    "ProgressReporter",
+    "Verbosity",
+    "install_log_handler",
+    "logging_level_for",
+    "parse_output_options",
+    "reset_log_handlers",
+    "should_color",
+    "verbosity_from_counts",
+]
+
+
+class Verbosity(enum.IntEnum):
+    """How much nab writes to stderr, from ``-qq`` to ``-vv``.
+
+    The ordering is what the message helpers compare against: a message
+    shows when the active verbosity is at or above its threshold.
+    """
+
+    SILENT = -2
+    QUIET = -1
+    NORMAL = 0
+    VERBOSE = 1
+    DEBUG = 2
+
+
+def verbosity_from_counts(verbose: int, quiet: int) -> Verbosity:
+    """Fold repeated ``-v`` / ``-q`` counts into a clamped :class:`Verbosity`.
+
+    ``verbosity = count(-v) - count(-q)``, clamped to the enum range so
+    ``-vvv`` and ``-qqq`` saturate rather than fall off the scale.
+    """
+    level = max(int(Verbosity.SILENT), min(int(Verbosity.DEBUG), verbose - quiet))
+    return Verbosity(level)
+
+
+class ColorChoice(enum.Enum):
+    """The ``--color`` choice: auto-detect, force on, or force off."""
+
+    AUTO = "auto"
+    ALWAYS = "always"
+    NEVER = "never"
+
+
+def _isatty(stream: IO[str]) -> bool:
+    """Whether ``stream`` is a terminal, tolerant of streams without ``isatty``."""
+    isatty = getattr(stream, "isatty", None)
+    return bool(isatty()) if isatty is not None else False
+
+
+def should_color(choice: ColorChoice, stream: IO[str], env: Mapping[str, str]) -> bool:
+    """Decide whether to colour output on ``stream``.
+
+    ``--color always`` / ``never`` win outright.  Otherwise ``NO_COLOR``
+    (non-empty) disables, ``FORCE_COLOR`` (non-empty) forces, ``TERM=dumb``
+    disables, and the fallback is whether ``stream`` is a terminal.  Reading
+    the standard 16-colour slots this enables lets the user's own terminal
+    theme set the actual contrast.
+    """
+    if choice is ColorChoice.ALWAYS:
+        return True
+    if choice is ColorChoice.NEVER:
+        return False
+    if env.get("NO_COLOR"):
+        return False
+    if env.get("FORCE_COLOR"):
+        return True
+    if env.get("TERM") == "dumb":
+        return False
+    return _isatty(stream)
+
+
+# Standard ANSI SGR codes; the terminal theme remaps these, so we never
+# hardcode 24-bit colours a user's palette cannot override.
+_SGR = {
+    "red": "31",
+    "green": "32",
+    "yellow": "33",
+    "bold": "1",
+    "dim": "2",
+}
+_RESET = "\033[0m"
+
+
+_LOG_LEVELS: dict[Verbosity, int] = {
+    Verbosity.SILENT: logging.ERROR,
+    Verbosity.QUIET: logging.WARNING,
+    Verbosity.NORMAL: logging.WARNING,
+    Verbosity.VERBOSE: logging.INFO,
+    Verbosity.DEBUG: logging.DEBUG,
+}
+
+
+def logging_level_for(verbosity: Verbosity) -> int:
+    """Return the ``logging`` level the engine's records show at.
+
+    Normal and quiet surface engine ``WARNING`` records (the dropped-marker
+    and base-attribution notices); ``-v`` adds ``INFO``, ``-vv`` adds
+    ``DEBUG``, and ``-qq`` keeps only ``ERROR``.
+    """
+    return _LOG_LEVELS[verbosity]
+
+
+class Printer:
+    """The single output seam: stream routing, level gating, and colour.
+
+    ``data`` is the stdout channel and always prints, even under ``--quiet``,
+    because it is the output the user ran the command to get.  ``error`` /
+    ``warning`` / ``note`` / ``done`` write to stderr, gated on the verbosity
+    level, with only the leading token coloured.
+    """
+
+    def __init__(
+        self,
+        *,
+        verbosity: Verbosity = Verbosity.NORMAL,
+        color: ColorChoice = ColorChoice.AUTO,
+        progress: bool = True,
+        stdout: IO[str] | None = None,
+        stderr: IO[str] | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> None:
+        """Build a printer from the resolved run knobs.
+
+        ``stdout`` / ``stderr`` / ``env`` default to the process streams and
+        environment; tests inject their own.  ``progress`` is the
+        ``--no-progress`` switch (with ``NAB_NO_PROGRESS``); animated progress
+        is additionally gated on the normal level and an stderr terminal.
+        """
+        self.verbosity = verbosity
+        self._out = stdout if stdout is not None else sys.stdout
+        self._err = stderr if stderr is not None else sys.stderr
+        environ = env if env is not None else os.environ
+        self.color_enabled = should_color(color, self._err, environ)
+        self.progress_allowed = (
+            progress
+            and not environ.get("NAB_NO_PROGRESS")
+            and verbosity is Verbosity.NORMAL
+            and _isatty(self._err)
+        )
+
+    @property
+    def stderr(self) -> IO[str]:
+        """The stderr stream this printer writes diagnostics and progress to."""
+        return self._err
+
+    def _paint(self, token: str, name: str) -> str:
+        """Wrap ``token`` in the ``name`` SGR code when colour is on."""
+        if not self.color_enabled:
+            return token
+        return f"\033[{_SGR[name]}m{token}{_RESET}"
+
+    def _emit(self, token: str, color: str, message: str, threshold: Verbosity) -> None:
+        """Write ``token message`` to stderr when the level allows it."""
+        if self.verbosity < threshold:
+            return
+        self._err.write(f"{self._paint(token, color)} {message}\n")
+
+    def data(self, text: str) -> None:
+        """Write requested output to stdout verbatim (the pipeable channel)."""
+        self._out.write(text)
+
+    def error(self, message: str) -> None:
+        """Report an error on stderr; shown at every level."""
+        self._emit("error:", "red", message, Verbosity.SILENT)
+
+    def warning(self, message: str) -> None:
+        """Report a warning on stderr; suppressed only by ``-qq``."""
+        self._emit("warning:", "yellow", message, Verbosity.QUIET)
+
+    def note(self, message: str) -> None:
+        """Print a normal-level note on stderr."""
+        self._emit("note:", "bold", message, Verbosity.NORMAL)
+
+    def done(self, message: str) -> None:
+        """Print a normal-level success line, its leading word tinted green.
+
+        The whole line is one message (``Wrote pylock.toml (21 packages)``);
+        only the first word is coloured, so the detail stays default-foreground.
+        """
+        if self.verbosity < Verbosity.NORMAL:
+            return
+        head, sep, tail = message.partition(" ")
+        self._err.write(f"{self._paint(head, 'green')}{sep}{tail}\n")
+
+    def stderr_line(self, message: str) -> None:
+        """Write a raw normal-level line to stderr with no token or colour.
+
+        For multi-line diagnostics a command builds itself (the per-tuple
+        matrix report), where the leading-token shape does not fit.
+        """
+        if self.verbosity >= Verbosity.NORMAL:
+            self._err.write(message)
+
+
+# The engine logs through ``logging.getLogger(__name__)``; these are the
+# top-level names those records live under, so one handler on each captures
+# them all without also grabbing third-party logs (urllib3, httpx).
+_NAB_LOGGERS = ("nab", "nab_python", "nab_index", "nab_resolver")
+
+_LEVEL_TOKENS: dict[int, tuple[str, str]] = {
+    logging.WARNING: ("warning:", "yellow"),
+    logging.ERROR: ("error:", "red"),
+    logging.CRITICAL: ("error:", "red"),
+}
+
+
+class _NabLogHandler(logging.StreamHandler):  # type: ignore[type-arg]
+    """Marker subclass so a re-install can find and drop nab's own handler."""
+
+
+class _LevelFormatter(logging.Formatter):
+    """Format engine log records to match the printer's message shapes.
+
+    At normal verbosity a ``WARNING`` / ``ERROR`` record reads like a printer
+    ``warning:`` / ``error:`` line (coloured token, no level noise on lower
+    records).  Under ``-v`` it switches to the log-file shape,
+    ``LEVEL logger: message``, which is what verbose output is for.
+    """
+
+    def __init__(self, *, verbose: bool, color_enabled: bool) -> None:
+        super().__init__()
+        self._verbose = verbose
+        self._color = color_enabled
+
+    def format(self, record: logging.LogRecord) -> str:
+        message = record.getMessage()
+        if self._verbose:
+            return f"{record.levelname} {record.name}: {message}"
+        token = _LEVEL_TOKENS.get(record.levelno)
+        if token is None:
+            return message
+        name, color = token
+        if self._color:
+            name = f"\033[{_SGR[color]}m{name}{_RESET}"
+        return f"{name} {message}"
+
+
+def _remove_nab_handlers(logger: logging.Logger) -> None:
+    logger.handlers = [h for h in logger.handlers if not isinstance(h, _NabLogHandler)]
+
+
+def install_log_handler(
+    verbosity: Verbosity, *, stream: IO[str], color_enabled: bool
+) -> None:
+    """Route the engine's ``logging`` records to ``stream`` at the run's level.
+
+    One handler is shared across the nab top-level loggers, so engine records
+    follow the same verbosity as the printer instead of Python's uncontrolled
+    ``lastResort`` fallback.  Idempotent: a prior nab handler is dropped first,
+    so calling this again (as the test suite does) does not stack handlers.
+    """
+    level = logging_level_for(verbosity)
+    handler = _NabLogHandler(stream)
+    handler.setLevel(level)
+    handler.setFormatter(
+        _LevelFormatter(
+            verbose=verbosity >= Verbosity.VERBOSE, color_enabled=color_enabled
+        )
+    )
+    for name in _NAB_LOGGERS:
+        logger = logging.getLogger(name)
+        _remove_nab_handlers(logger)
+        logger.addHandler(handler)
+        logger.setLevel(level)
+
+
+def reset_log_handlers() -> None:
+    """Drop nab's log handlers and reset the loggers (test-suite cleanup)."""
+    for name in _NAB_LOGGERS:
+        logger = logging.getLogger(name)
+        _remove_nab_handlers(logger)
+        logger.setLevel(logging.NOTSET)
+
+
+_SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+# Carriage return plus "erase to end of line": repaints the progress line in
+# place and, on its own, wipes it before the run summary.
+_CLEAR_LINE = "\r\033[K"
+_PROGRESS_MIN_INTERVAL = 0.05
+
+
+class ProgressReporter:
+    """The live ``Resolving... N fetched, M pinned`` line on stderr (#35).
+
+    Driven from two threads: the fetcher bumps ``on_fetch`` as listings
+    arrive, the resolver bumps ``on_pin`` as it decides packages.  Rendering
+    is gated on :attr:`Printer.progress_allowed` (normal level, an stderr
+    terminal, progress not switched off), throttled to keep off the hot path,
+    and guarded by a lock since the two callers run on different threads.
+    When it is not allowed every method is a cheap no-op, so a piped, quiet,
+    or verbose run pays nothing and stdout stays clean.
+    """
+
+    def __init__(
+        self,
+        printer: Printer,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        min_interval: float = _PROGRESS_MIN_INTERVAL,
+    ) -> None:
+        """Build a reporter that renders through ``printer``'s stderr."""
+        self._enabled = printer.progress_allowed
+        self._stream = printer.stderr
+        self._color = printer.color_enabled
+        self._clock = clock
+        self._min_interval = min_interval
+        self._lock = threading.Lock()
+        self._fetched = 0
+        self._pinned = 0
+        self._frame = 0
+        self._last = 0.0
+        self._drawn = False
+
+    def on_fetch(self) -> None:
+        """Record one more package listing fetched, then repaint."""
+        if not self._enabled:
+            return
+        with self._lock:
+            self._fetched += 1
+            self._render()
+
+    def on_pin(self, decided: int) -> None:
+        """Record the current count of decided (pinned) packages, then repaint."""
+        if not self._enabled:
+            return
+        with self._lock:
+            self._pinned = decided
+            self._render()
+
+    def _render(self) -> None:
+        """Repaint the line, unless the throttle window has not elapsed."""
+        now = self._clock()
+        if self._drawn and now - self._last < self._min_interval:
+            return
+        self._last = now
+        frame = _SPINNER[self._frame % len(_SPINNER)]
+        self._frame += 1
+        line = f"{frame} Resolving... {self._fetched} fetched, {self._pinned} pinned"
+        if self._color:
+            line = f"\033[2m{line}\033[0m"
+        self._stream.write(_CLEAR_LINE + line)
+        self._stream.flush()
+        self._drawn = True
+
+    def clear(self) -> None:
+        """Wipe the progress line so the next stderr write starts clean."""
+        if not self._enabled:
+            return
+        with self._lock:
+            if self._drawn:
+                self._stream.write(_CLEAR_LINE)
+                self._stream.flush()
+                self._drawn = False
+
+
+class OutputOptionError(ValueError):
+    """A malformed ``--color`` value or ``NAB_VERBOSITY``."""
+
+
+@dataclass(frozen=True, slots=True)
+class OutputOptions:
+    """The output knobs parsed from the global flags, before the subcommand."""
+
+    verbosity: Verbosity
+    color: ColorChoice
+    progress: bool
+
+
+_VERBOSITY_NAMES: dict[str, Verbosity] = {v.name.lower(): v for v in Verbosity}
+
+
+def _verbosity_from_env(env: Mapping[str, str]) -> Verbosity | None:
+    """Read ``NAB_VERBOSITY`` as a level name, or ``None`` when unset."""
+    raw = env.get("NAB_VERBOSITY")
+    if raw is None:
+        return None
+    name = raw.strip().lower()
+    if name not in _VERBOSITY_NAMES:
+        allowed = ", ".join(_VERBOSITY_NAMES)
+        msg = f"NAB_VERBOSITY={raw!r} is not one of {allowed}"
+        raise OutputOptionError(msg)
+    return _VERBOSITY_NAMES[name]
+
+
+def _color_choice(value: str) -> ColorChoice:
+    try:
+        return ColorChoice(value)
+    except ValueError:
+        msg = f"--color {value!r} is not one of auto, always, never"
+        raise OutputOptionError(msg) from None
+
+
+def _repeated_short(arg: str, letter: str) -> bool:
+    """Whether ``arg`` is a short flag of one repeated ``letter`` (``-vv``)."""
+    return (
+        arg.startswith("-")
+        and not arg.startswith("--")
+        and bool(arg[1:])
+        and set(arg[1:]) == {letter}
+    )
+
+
+def parse_output_options(  # noqa: C901, PLR0912 - a small flag scanner; each flag is one branch
+    argv: list[str], env: Mapping[str, str]
+) -> tuple[OutputOptions, list[str]]:
+    """Split the global output flags out of ``argv``, returning the rest.
+
+    Handles repeatable ``-v`` / ``-vv`` / ``-q`` / ``-qq`` (and the long
+    ``--verbose`` / ``--quiet``), ``--color auto|always|never`` (or
+    ``--color=...``), ``--no-color``, and ``--no-progress``.  Flags win over
+    ``NAB_VERBOSITY``; the remaining tokens are handed to the subcommand
+    parser untouched.  Raises :class:`OutputOptionError` on a bad value.
+    """
+    verbose = quiet = 0
+    color_choice: ColorChoice | None = None
+    no_color = False
+    progress = True
+    rest: list[str] = []
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if _repeated_short(arg, "v"):
+            verbose += len(arg) - 1
+        elif _repeated_short(arg, "q"):
+            quiet += len(arg) - 1
+        elif arg == "--verbose":
+            verbose += 1
+        elif arg == "--quiet":
+            quiet += 1
+        elif arg == "--no-color":
+            no_color = True
+        elif arg == "--no-progress":
+            progress = False
+        elif arg == "--color":
+            i += 1
+            if i >= len(argv):
+                msg = "--color needs a value: auto, always, or never"
+                raise OutputOptionError(msg)
+            color_choice = _color_choice(argv[i])
+        elif arg.startswith("--color="):
+            color_choice = _color_choice(arg.split("=", 1)[1])
+        else:
+            rest.append(arg)
+        i += 1
+
+    if verbose or quiet:
+        verbosity = verbosity_from_counts(verbose, quiet)
+    else:
+        from_env = _verbosity_from_env(env)
+        verbosity = from_env if from_env is not None else Verbosity.NORMAL
+
+    if color_choice is not None:
+        color = color_choice
+    elif no_color:
+        color = ColorChoice.NEVER
+    else:
+        color = ColorChoice.AUTO
+
+    return OutputOptions(verbosity=verbosity, color=color, progress=progress), rest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,40 @@
+"""CLI-suite fixtures.
+
+Scoped to the umbrella ``nab`` package's tests so the other workspaces'
+suites (which need not have ``nab`` installed) do not import it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from nab import cli
+from nab.output import reset_log_handlers
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture(autouse=True)
+def _reset_nab_output(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin nab's output state so the CLI suite is deterministic.
+
+    Two hazards this guards against:
+
+    * CI sets ``FORCE_COLOR=1`` so its tool logs are coloured, which would
+      otherwise make nab wrap its message tokens in ANSI and break the plain
+      output the assertions expect.  ``NO_COLOR`` wins over ``FORCE_COLOR`` in
+      :func:`~nab.output.should_color`, so it forces nab's colour off here
+      regardless of the ambient environment; the colour behaviour itself is
+      covered by unit tests that set the choice explicitly.
+    * ``nab.cli.main`` sets a module-level printer (bound to the run's streams)
+      and installs a logging handler on the nab loggers; without the reset a
+      test that runs ``main`` would leak the printer (whose captured stream is
+      closed once the test ends) and the handler into later tests.
+    """
+    monkeypatch.setenv("NO_COLOR", "1")
+    yield
+    cli._printer = None
+    reset_log_handlers()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,6 +36,7 @@ from nab.cli import (
     _default_cache_dir,
     _make_transport,
     _normalize_layered_bool_flags,
+    _resolve,
     app,
     main,
 )
@@ -45,7 +46,7 @@ from nab_index.transport import HttpError
 from nab_index.urllib3_async_transport import Urllib3AsyncTransport
 from nab_python._vendor.packaging.pylock import Pylock
 from nab_python._vendor.packaging.version import Version
-from nab_python.config import ConfigError
+from nab_python.config import ConfigError, read_pyproject_config
 from nab_python.config_sources import SourceRoots
 from nab_python.download import DownloadError
 from nab_python.lockfile import (
@@ -451,7 +452,7 @@ class TestLockCommandSpecific:
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, output=tmp_path / "pylock.toml")
-        assert "Resolution failed: conflict" in capsys.readouterr().err
+        assert "resolution failed: conflict" in capsys.readouterr().err
 
     def test_pylock_to_stdout(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -495,7 +496,7 @@ class TestLockCommandSpecific:
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject)
-        assert "Resolution failed" in capsys.readouterr().err
+        assert "resolution failed" in capsys.readouterr().err
 
     def test_unknown_group_exits_cleanly(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -614,7 +615,7 @@ class TestLockCommandSpecific:
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject)
-        assert "Cannot lock" in capsys.readouterr().err
+        assert "cannot lock" in capsys.readouterr().err
 
     def test_invalid_requirement_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -645,7 +646,7 @@ class TestLockCommandSpecific:
         ):
             lock(pyproject)
         err = capsys.readouterr().err
-        assert "Cannot lock" in err
+        assert "cannot lock" in err
         assert "503" in err
 
     def test_malformed_simple_response_exits(
@@ -684,7 +685,7 @@ class TestLockCommandSpecific:
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject)
-        assert "Cannot lock" in capsys.readouterr().err
+        assert "cannot lock" in capsys.readouterr().err
 
     def test_lookup_error_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -721,7 +722,7 @@ class TestLockCommandSpecific:
         ):
             lock(pyproject)
         err = capsys.readouterr().err
-        assert "Cannot lock" in err
+        assert "cannot lock" in err
         assert "does not provide extra 'nonexistent'" in err
         assert "Traceback" not in err
 
@@ -768,7 +769,7 @@ class TestLockCommandSpecific:
             lock(pyproject, output=tmp_path / "pylock.toml", cache=False)
 
         err = capsys.readouterr().err
-        assert "Cannot lock" in err
+        assert "cannot lock" in err
         assert "sha256 mismatch" in err
         assert "0" * 64 in err
         assert "Traceback" not in err
@@ -790,7 +791,7 @@ class TestLockCommandSpecific:
             lock(pyproject)
 
         err = capsys.readouterr().err
-        assert "Cannot lock" in err
+        assert "cannot lock" in err
         assert "sdist sha256 mismatch" in err
         assert "Traceback" not in err
 
@@ -820,7 +821,7 @@ class TestLockCommandSpecific:
         with pytest.raises(SystemExit, match="1"):
             lock(pyproject, offline=True, output=Path("-"), cache=False)
         err = capsys.readouterr().err
-        assert "Cannot lock" in err
+        assert "cannot lock" in err
         assert "has dynamic metadata" in err
         assert "Traceback" not in err
 
@@ -1001,7 +1002,7 @@ class TestLockCommandSpecific:
         # (the shared [tool.nab] error map) rather than later in the
         # run-settings fold.
         err = capsys.readouterr().err
-        assert "Error in [tool.nab]:" in err
+        assert "in [tool.nab]:" in err
         assert "conflicting values" in err
 
     def test_standalone_nab_toml_malformed_exits(
@@ -1025,7 +1026,7 @@ class TestLockCommandSpecific:
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, output=out)
-        assert "Config error:" in capsys.readouterr().err
+        assert "config error:" in capsys.readouterr().err
 
     def test_standalone_nab_toml_unknown_key_exits(
         self,
@@ -1049,7 +1050,7 @@ class TestLockCommandSpecific:
         ):
             lock(pyproject, output=out)
         err = capsys.readouterr().err
-        assert "Config error:" in err
+        assert "config error:" in err
         assert "typoo" in err
 
 
@@ -1086,7 +1087,7 @@ class TestPythonFlag:
         assert exc.value.code == 1
         err = capsys.readouterr().err
         assert (
-            "Error: --python must be a version like '3.12' or '3.12.4',"
+            "error: --python must be a version like '3.12' or '3.12.4',"
             " got '3.12.x'" in err
         )
         assert "[tool.nab]" not in err
@@ -1100,7 +1101,7 @@ class TestPythonFlag:
             download(pyproject, output=tmp_path / "wheels", python="3.12.x")
         assert exc.value.code == 1
         err = capsys.readouterr().err
-        assert "Error: --python must be a version like" in err
+        assert "error: --python must be a version like" in err
         assert "[tool.nab]" not in err
 
     def test_rejected_in_universal_mode(
@@ -1194,7 +1195,7 @@ class TestLockCommandUniversal:
         ):
             lock(pyproject, output=out)
         err = capsys.readouterr().err
-        assert "Error in [tool.nab]:" in err
+        assert "in [tool.nab]:" in err
         assert "gpuu" in err
 
     def test_not_implemented_vcs_exits(
@@ -1252,7 +1253,7 @@ class TestLockCommandUniversal:
             lock(pyproject, output=Path("-"), groups=("alpha", "beta"), offline=True)
 
         err = capsys.readouterr().err
-        assert "Resolution failed:" in err
+        assert "resolution failed:" in err
         assert "'alpha' and 'beta' conflict on 'idna'" in err
         assert "Traceback" not in err
 
@@ -1385,7 +1386,7 @@ class TestLockCommandUniversal:
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, output=tmp_path / "pylock.toml")
-        assert "Cannot lock" in capsys.readouterr().err
+        assert "cannot lock" in capsys.readouterr().err
 
     def test_pylock_disjointness_error_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -1411,7 +1412,7 @@ class TestLockCommandUniversal:
         ):
             lock(pyproject, output=tmp_path / "pylock.toml")
         err = capsys.readouterr().err
-        assert f"Error: {hint}\n" in err
+        assert f"error: {hint}\n" in err
 
     def test_pylock_divergent_base_dep_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -1436,7 +1437,7 @@ class TestLockCommandUniversal:
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, output=tmp_path / "pylock.toml")
-        assert f"Error: {message}\n" in capsys.readouterr().err
+        assert f"error: {message}\n" in capsys.readouterr().err
 
     def test_universal_lock_collision_without_conflict_shows_hint(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -1479,7 +1480,7 @@ class TestLockCommandUniversal:
                 extras=("cpu", "gpu"),
             )
         err = capsys.readouterr().err
-        assert "Error:" in err
+        assert "error:" in err
         assert "foo" in err
         assert "[tool.nab].conflicts" in err
 
@@ -1497,7 +1498,7 @@ class TestLockCommandUniversal:
         ):
             lock(pyproject, output=tmp_path / "pylock.toml")
         err = capsys.readouterr().err
-        assert "Cannot lock" in err
+        assert "cannot lock" in err
         assert "refusing direct-URL requirement" in err
 
     def test_per_tuple_pins_to_stdout_by_default(
@@ -1579,9 +1580,9 @@ class TestLockCommandUniversal:
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, format="requirements-without-hashes")
-        out = capsys.readouterr().out
-        assert "FAILED" in out
-        assert "#   ResolutionError: conflict" in out
+        err = capsys.readouterr().err
+        assert "FAILED" in err
+        assert "#   ResolutionError: conflict" in err
 
     def test_failed_tuple_multi_line_error(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -1599,10 +1600,10 @@ class TestLockCommandUniversal:
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, format="requirements-without-hashes")
-        out = capsys.readouterr().out
-        assert "#   ResolutionError: first line" in out
-        assert "#   second line" in out
-        assert "#   third line" in out
+        err = capsys.readouterr().err
+        assert "#   ResolutionError: first line" in err
+        assert "#   second line" in err
+        assert "#   third line" in err
 
     def test_failed_tuple_no_error_message(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -1617,7 +1618,7 @@ class TestLockCommandUniversal:
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, format="requirements-without-hashes")
-        assert "FAILED" in capsys.readouterr().out
+        assert "FAILED" in capsys.readouterr().err
 
     def test_missing_dependencies_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -1663,7 +1664,7 @@ class TestLockCommandUniversal:
         ):
             lock(pyproject, format="requirements-without-hashes")
         err = capsys.readouterr().err
-        assert "Cannot lock" in err
+        assert "cannot lock" in err
         assert "503" in err
 
     def test_missing_extra_exits(
@@ -1701,7 +1702,7 @@ class TestLockCommandUniversal:
         ):
             lock(pyproject, format="requirements-without-hashes")
         err = capsys.readouterr().err
-        assert "Cannot lock" in err
+        assert "cannot lock" in err
         assert "malformed Simple-API" in err
 
     def test_requirements_missing_hash_exits(
@@ -1721,7 +1722,7 @@ class TestLockCommandUniversal:
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, format="requirements")
-        assert "Cannot lock" in capsys.readouterr().err
+        assert "cannot lock" in capsys.readouterr().err
 
     def test_print_blocks_includes_succeeded_tuples(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -1747,10 +1748,10 @@ class TestLockCommandUniversal:
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, format="requirements-without-hashes")
-        out = capsys.readouterr().out
-        assert "# py311-linux_x86_64" in out
-        assert "foo==1.0" in out
-        assert "# py311-windows_amd64: FAILED" in out
+        err = capsys.readouterr().err
+        assert "# py311-linux_x86_64" in err
+        assert "foo==1.0" in err
+        assert "# py311-windows_amd64: FAILED" in err
 
     def test_print_blocks_surfaces_base_pass_failure(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -1780,14 +1781,14 @@ class TestLockCommandUniversal:
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, format="requirements-without-hashes")
-        out = capsys.readouterr().out
-        assert "foo==1.0" in out
+        err = capsys.readouterr().err
+        assert "foo==1.0" in err
         # The succeeded base pass contributes no block: only the failed
         # one renders, and the per-tuple labels stay distinct.
-        assert "# base/py311-linux_x86_64: FAILED" not in out
-        assert "# base/py312-linux_x86_64: FAILED" in out
-        assert "#   ResolutionError: base unresolvable" in out
-        assert "#   Diagnostics: missing" in out
+        assert "# base/py311-linux_x86_64: FAILED" not in err
+        assert "# base/py312-linux_x86_64: FAILED" in err
+        assert "#   ResolutionError: base unresolvable" in err
+        assert "#   Diagnostics: missing" in err
 
     def test_template_writes_one_file_per_tuple(self, tmp_path: Path) -> None:
         """``{python_version}`` in --output expands to one file per tuple."""
@@ -2068,7 +2069,7 @@ class TestLockCommandUniversal:
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, format="requirements", output=out)
-        assert "Cannot lock" in capsys.readouterr().err
+        assert "cannot lock" in capsys.readouterr().err
 
     def test_template_missing_hash_writes_no_file(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -2548,7 +2549,7 @@ class TestConfigErrors:
         )
         with pytest.raises(SystemExit, match="1"):
             lock(pyproject)
-        assert "Error in [tool.nab]" in capsys.readouterr().err
+        assert "in [tool.nab]" in capsys.readouterr().err
 
     def test_workspace_discovery_error_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -2566,7 +2567,7 @@ class TestConfigErrors:
         member.write_text('[project]\nname = "alpha"\nversion = "0"\n')
         with pytest.raises(SystemExit, match="1"):
             lock(member)
-        assert "Workspace discovery error" in capsys.readouterr().err
+        assert "workspace discovery error" in capsys.readouterr().err
 
 
 class TestDetermineLockAnchor:
@@ -2954,7 +2955,7 @@ class TestLockedFlag:
                 prog="nab",
             )
         assert exc.value.code == 1
-        assert "Cannot lock" in capsys.readouterr().err
+        assert "cannot lock" in capsys.readouterr().err
         assert out.read_bytes() == before
 
     def test_malformed_committed_lock_exits_one(
@@ -3686,14 +3687,42 @@ class TestMain:
     def test_keyboard_interrupt_aborts_clean(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """Ctrl-C during ``app.cli()`` prints ``Aborted.`` and exits 130."""
+        """Ctrl-C during ``app.cli()`` reports an interrupt and exits 130."""
         monkeypatch.setattr(sys, "argv", ["nab"])
         with patch("nab.cli.app") as mock_app:
             mock_app.cli.side_effect = KeyboardInterrupt
             with pytest.raises(SystemExit) as info:
                 main()
         assert info.value.code == 130
-        assert "Aborted." in capsys.readouterr().err
+        assert "error: interrupted" in capsys.readouterr().err
+
+    def test_bad_color_flag_exits_two(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A malformed --color value is reported and exits 2 before tyro runs."""
+        monkeypatch.setattr(sys, "argv", ["nab", "--color", "rainbow", "lock"])
+        with pytest.raises(SystemExit) as info:
+            main()
+        assert info.value.code == 2
+        assert "error:" in capsys.readouterr().err
+
+    def test_resolve_without_progress_reporter(self, tmp_path: Path) -> None:
+        """_resolve tolerates progress=None (the clear step is skipped)."""
+        pyproject = _make_pyproject(tmp_path)
+        config = read_pyproject_config(pyproject)
+        with patch(
+            "nab.cli.resolve_for_targets",
+            return_value=_stub_resolve_result(pins={}),
+        ):
+            result = _resolve(
+                pyproject,
+                config=config,
+                cache_dir=None,
+                offline=False,
+                transport=MagicMock(),
+                failure_prefix="cannot lock",
+            )
+        assert result.success
 
 
 class TestMakeTransport:
@@ -3806,7 +3835,7 @@ class TestDownloadCommand:
         ):
             download(pyproject)
         err = capsys.readouterr().err
-        assert "Error in [tool.nab]:" in err
+        assert "in [tool.nab]:" in err
         assert "exactly one" in err
 
     @pytest.mark.parametrize("bad", [0, -1])
@@ -3829,7 +3858,7 @@ class TestDownloadCommand:
             pytest.raises(SystemExit, match="1"),
         ):
             download(pyproject)
-        assert "Resolution failed" in capsys.readouterr().err
+        assert "resolution failed" in capsys.readouterr().err
 
     def test_missing_extra_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -3872,7 +3901,7 @@ class TestDownloadCommand:
             pytest.raises(SystemExit, match="1"),
         ):
             download(pyproject)
-        assert "Cannot download" in capsys.readouterr().err
+        assert "cannot download" in capsys.readouterr().err
 
     def test_download_error_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -3884,7 +3913,7 @@ class TestDownloadCommand:
             pytest.raises(SystemExit, match="1"),
         ):
             download(pyproject)
-        assert "Download failed" in capsys.readouterr().err
+        assert "download failed" in capsys.readouterr().err
 
     def test_output_is_existing_file_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -680,7 +680,7 @@ def test_lock_exits_cleanly_on_layered_config_error(
     _write(tmp_path / "usr" / "nab.toml", 'resolution = "lowest"\n')
     with pytest.raises(SystemExit):
         lock(hermetic_roots / "pyproject.toml", output=hermetic_roots / "pylock.toml")
-    assert "Config error" in capsys.readouterr().err
+    assert "config error" in capsys.readouterr().err
 
 
 def test_lock_exits_on_pyproject_user_key_via_fold(
@@ -692,7 +692,7 @@ def test_lock_exits_on_pyproject_user_key_via_fold(
     with pytest.raises(SystemExit):
         lock(hermetic_roots / "pyproject.toml", output=hermetic_roots / "pylock.toml")
     err = capsys.readouterr().err
-    assert "Error in [tool.nab]" in err
+    assert "in [tool.nab]" in err
     assert "user-scope option" in err
 
 
@@ -949,4 +949,4 @@ class TestDownloadLadder:
         _write(hermetic_roots.parent / "usr" / "nab.toml", 'resolution = "lowest"\n')
         with pytest.raises(SystemExit):
             download(hermetic_roots / "pyproject.toml", output=hermetic_roots / "out")
-        assert "Config error" in capsys.readouterr().err
+        assert "config error" in capsys.readouterr().err

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,426 @@
+"""Tests for the nab output seam (streams, levels, format, colour)."""
+
+from __future__ import annotations
+
+import io
+import logging
+
+import pytest
+
+from nab.output import (
+    ColorChoice,
+    OutputOptionError,
+    Printer,
+    ProgressReporter,
+    Verbosity,
+    _isatty,
+    install_log_handler,
+    logging_level_for,
+    parse_output_options,
+    reset_log_handlers,
+    should_color,
+    verbosity_from_counts,
+)
+
+RED = "\033[31m"
+RESET = "\033[0m"
+
+
+class _TTY(io.StringIO):
+    """A StringIO that claims (or denies) being a terminal."""
+
+    def __init__(self, tty: bool) -> None:
+        super().__init__()
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+def _printer(**kwargs: object) -> tuple[Printer, io.StringIO, io.StringIO]:
+    out = io.StringIO()
+    err = io.StringIO()
+    printer = Printer(stdout=out, stderr=err, **kwargs)  # type: ignore[arg-type]
+    return printer, out, err
+
+
+@pytest.mark.parametrize(
+    ("verbose", "quiet", "expected"),
+    [
+        (0, 0, Verbosity.NORMAL),
+        (1, 0, Verbosity.VERBOSE),
+        (2, 0, Verbosity.DEBUG),
+        (5, 0, Verbosity.DEBUG),
+        (0, 1, Verbosity.QUIET),
+        (0, 2, Verbosity.SILENT),
+        (0, 5, Verbosity.SILENT),
+        (1, 1, Verbosity.NORMAL),
+        (2, 1, Verbosity.VERBOSE),
+    ],
+)
+def test_verbosity_from_counts(verbose: int, quiet: int, expected: Verbosity) -> None:
+    assert verbosity_from_counts(verbose, quiet) is expected
+
+
+def test_isatty_present_true() -> None:
+    assert _isatty(_TTY(tty=True)) is True
+
+
+def test_isatty_present_false() -> None:
+    assert _isatty(_TTY(tty=False)) is False
+
+
+def test_isatty_absent() -> None:
+    class NoTty:
+        pass
+
+    assert _isatty(NoTty()) is False  # type: ignore[arg-type]
+
+
+def test_should_color_always_beats_env() -> None:
+    assert should_color(ColorChoice.ALWAYS, _TTY(tty=False), {"NO_COLOR": "1"}) is True
+
+
+def test_should_color_never_beats_tty() -> None:
+    assert should_color(ColorChoice.NEVER, _TTY(tty=True), {}) is False
+
+
+def test_should_color_no_color_disables() -> None:
+    assert should_color(ColorChoice.AUTO, _TTY(tty=True), {"NO_COLOR": "1"}) is False
+
+
+def test_should_color_empty_no_color_is_ignored() -> None:
+    assert should_color(ColorChoice.AUTO, _TTY(tty=True), {"NO_COLOR": ""}) is True
+
+
+def test_should_color_force_color_enables() -> None:
+    assert should_color(ColorChoice.AUTO, _TTY(tty=False), {"FORCE_COLOR": "1"}) is True
+
+
+def test_should_color_term_dumb_disables() -> None:
+    assert should_color(ColorChoice.AUTO, _TTY(tty=True), {"TERM": "dumb"}) is False
+
+
+def test_should_color_auto_follows_tty() -> None:
+    assert should_color(ColorChoice.AUTO, _TTY(tty=True), {}) is True
+    assert should_color(ColorChoice.AUTO, _TTY(tty=False), {}) is False
+
+
+@pytest.mark.parametrize(
+    ("verbosity", "level"),
+    [
+        (Verbosity.SILENT, logging.ERROR),
+        (Verbosity.QUIET, logging.WARNING),
+        (Verbosity.NORMAL, logging.WARNING),
+        (Verbosity.VERBOSE, logging.INFO),
+        (Verbosity.DEBUG, logging.DEBUG),
+    ],
+)
+def test_logging_level_for(verbosity: Verbosity, level: int) -> None:
+    assert logging_level_for(verbosity) == level
+
+
+def test_data_always_prints_even_when_silent() -> None:
+    printer, out, err = _printer(verbosity=Verbosity.SILENT)
+    printer.data("pylock bytes")
+    assert out.getvalue() == "pylock bytes"
+    assert err.getvalue() == ""
+
+
+def test_error_shows_at_silent() -> None:
+    printer, _out, err = _printer(verbosity=Verbosity.SILENT)
+    printer.error("boom")
+    assert err.getvalue() == "error: boom\n"
+
+
+def test_warning_hidden_at_silent_shown_at_quiet() -> None:
+    printer, _out, err = _printer(verbosity=Verbosity.SILENT)
+    printer.warning("careful")
+    assert err.getvalue() == ""
+    printer, _out, err = _printer(verbosity=Verbosity.QUIET)
+    printer.warning("careful")
+    assert err.getvalue() == "warning: careful\n"
+
+
+def test_note_and_done_hidden_at_quiet_shown_at_normal() -> None:
+    printer, _out, err = _printer(verbosity=Verbosity.QUIET)
+    printer.note("heads up")
+    printer.done("Wrote pylock.toml")
+    assert err.getvalue() == ""
+    printer, _out, err = _printer(verbosity=Verbosity.NORMAL)
+    printer.note("heads up")
+    printer.done("Wrote pylock.toml")
+    assert err.getvalue() == "note: heads up\nWrote pylock.toml\n"
+
+
+def test_done_single_word_message() -> None:
+    printer, _out, err = _printer()
+    printer.done("Done")
+    assert err.getvalue() == "Done\n"
+
+
+def test_colour_paints_leading_token_only() -> None:
+    printer, _out, err = _printer(color=ColorChoice.ALWAYS)
+    printer.error("cannot lock")
+    assert err.getvalue() == f"{RED}error:{RESET} cannot lock\n"
+
+
+def test_no_colour_leaves_plain_text() -> None:
+    printer, _out, err = _printer(color=ColorChoice.NEVER)
+    printer.error("cannot lock")
+    assert err.getvalue() == "error: cannot lock\n"
+    assert RED not in err.getvalue()
+
+
+def test_stderr_line_gated_on_normal() -> None:
+    printer, _out, err = _printer(verbosity=Verbosity.QUIET)
+    printer.stderr_line("# tuple block\n")
+    assert err.getvalue() == ""
+    printer, _out, err = _printer(verbosity=Verbosity.NORMAL)
+    printer.stderr_line("# tuple block\n")
+    assert err.getvalue() == "# tuple block\n"
+
+
+def test_progress_allowed_only_at_normal_on_tty() -> None:
+    err = _TTY(tty=True)
+    printer = Printer(stderr=err, verbosity=Verbosity.NORMAL, env={})
+    assert printer.progress_allowed is True
+
+
+def test_progress_blocked_when_not_tty() -> None:
+    printer = Printer(stderr=_TTY(tty=False), verbosity=Verbosity.NORMAL, env={})
+    assert printer.progress_allowed is False
+
+
+def test_progress_blocked_under_verbose() -> None:
+    printer = Printer(stderr=_TTY(tty=True), verbosity=Verbosity.VERBOSE, env={})
+    assert printer.progress_allowed is False
+
+
+def test_progress_blocked_by_flag() -> None:
+    printer = Printer(
+        stderr=_TTY(tty=True), verbosity=Verbosity.NORMAL, progress=False, env={}
+    )
+    assert printer.progress_allowed is False
+
+
+def test_progress_blocked_by_env() -> None:
+    printer = Printer(
+        stderr=_TTY(tty=True),
+        verbosity=Verbosity.NORMAL,
+        env={"NAB_NO_PROGRESS": "1"},
+    )
+    assert printer.progress_allowed is False
+
+
+def test_defaults_use_process_streams() -> None:
+    printer = Printer(env={})
+    assert printer._out is not None
+    assert printer._err is not None
+
+
+def test_parse_counts_and_passthrough() -> None:
+    opts, rest = parse_output_options(["lock", "-vv", "pyproject.toml"], {})
+    assert opts.verbosity is Verbosity.DEBUG
+    assert rest == ["lock", "pyproject.toml"]
+
+
+def test_parse_quiet_counts() -> None:
+    opts, rest = parse_output_options(["-q", "-q", "lock"], {})
+    assert opts.verbosity is Verbosity.SILENT
+    assert rest == ["lock"]
+
+
+def test_parse_long_verbose_quiet() -> None:
+    opts, _rest = parse_output_options(["--verbose", "--quiet", "lock"], {})
+    assert opts.verbosity is Verbosity.NORMAL
+
+
+def test_parse_color_value_form() -> None:
+    opts, rest = parse_output_options(["--color", "always", "lock"], {})
+    assert opts.color is ColorChoice.ALWAYS
+    assert rest == ["lock"]
+
+
+def test_parse_color_equals_form() -> None:
+    opts, _rest = parse_output_options(["--color=never", "lock"], {})
+    assert opts.color is ColorChoice.NEVER
+
+
+def test_parse_no_color() -> None:
+    opts, _rest = parse_output_options(["--no-color", "lock"], {})
+    assert opts.color is ColorChoice.NEVER
+
+
+def test_parse_no_progress() -> None:
+    opts, _rest = parse_output_options(["--no-progress", "lock"], {})
+    assert opts.progress is False
+
+
+def test_parse_default_color_is_auto() -> None:
+    opts, _rest = parse_output_options(["lock"], {})
+    assert opts.color is ColorChoice.AUTO
+
+
+def test_parse_color_missing_value() -> None:
+    with pytest.raises(OutputOptionError, match="needs a value"):
+        parse_output_options(["--color"], {})
+
+
+def test_parse_color_bad_value() -> None:
+    with pytest.raises(OutputOptionError, match="auto, always, never"):
+        parse_output_options(["--color", "rainbow"], {})
+
+
+def test_parse_verbosity_from_env() -> None:
+    opts, _rest = parse_output_options(["lock"], {"NAB_VERBOSITY": "debug"})
+    assert opts.verbosity is Verbosity.DEBUG
+
+
+def test_flags_beat_env_verbosity() -> None:
+    opts, _rest = parse_output_options(["-q", "lock"], {"NAB_VERBOSITY": "debug"})
+    assert opts.verbosity is Verbosity.QUIET
+
+
+def test_parse_bad_env_verbosity() -> None:
+    with pytest.raises(OutputOptionError, match="NAB_VERBOSITY"):
+        parse_output_options(["lock"], {"NAB_VERBOSITY": "loud"})
+
+
+def test_short_dash_v_not_confused_with_capital() -> None:
+    opts, rest = parse_output_options(["-V", "lock"], {})
+    assert opts.verbosity is Verbosity.NORMAL
+    assert rest == ["-V", "lock"]
+
+
+def _emit_record(name: str, level: int, message: str) -> None:
+    logging.getLogger(name).log(level, message)
+
+
+def test_log_handler_normal_prefixes_warning() -> None:
+    stream = io.StringIO()
+    try:
+        install_log_handler(Verbosity.NORMAL, stream=stream, color_enabled=False)
+        _emit_record("nab_python.demo", logging.WARNING, "dropped marker")
+        _emit_record("nab_python.demo", logging.INFO, "hidden at normal")
+    finally:
+        reset_log_handlers()
+    assert stream.getvalue() == "warning: dropped marker\n"
+
+
+def test_log_handler_colours_token() -> None:
+    stream = io.StringIO()
+    try:
+        install_log_handler(Verbosity.NORMAL, stream=stream, color_enabled=True)
+        _emit_record("nab_index.demo", logging.ERROR, "boom")
+    finally:
+        reset_log_handlers()
+    assert stream.getvalue() == f"{RED}error:{RESET} boom\n"
+
+
+def test_log_handler_verbose_shows_info_with_source() -> None:
+    stream = io.StringIO()
+    try:
+        install_log_handler(Verbosity.VERBOSE, stream=stream, color_enabled=False)
+        _emit_record("nab_python.demo", logging.INFO, "fetching")
+    finally:
+        reset_log_handlers()
+    assert stream.getvalue() == "INFO nab_python.demo: fetching\n"
+
+
+def test_log_handler_reinstall_does_not_stack() -> None:
+    stream = io.StringIO()
+    try:
+        install_log_handler(Verbosity.NORMAL, stream=stream, color_enabled=False)
+        install_log_handler(Verbosity.NORMAL, stream=stream, color_enabled=False)
+        _emit_record("nab_resolver.demo", logging.WARNING, "once")
+    finally:
+        reset_log_handlers()
+    assert stream.getvalue() == "warning: once\n"
+
+
+def test_log_handler_untokened_level_is_bare() -> None:
+    stream = io.StringIO()
+    try:
+        install_log_handler(Verbosity.NORMAL, stream=stream, color_enabled=False)
+        _emit_record("nab_python.demo", logging.WARNING + 5, "custom level")
+    finally:
+        reset_log_handlers()
+    assert stream.getvalue() == "custom level\n"
+
+
+def test_reset_log_handlers_detaches() -> None:
+    stream = io.StringIO()
+    install_log_handler(Verbosity.NORMAL, stream=stream, color_enabled=False)
+    reset_log_handlers()
+    _emit_record("nab_python.demo", logging.WARNING, "after reset")
+    assert stream.getvalue() == ""
+
+
+def _enabled_reporter(
+    *,
+    color: ColorChoice = ColorChoice.NEVER,
+    clock: object = None,
+    min_interval: float = 0.05,
+) -> tuple[ProgressReporter, _TTY]:
+    err = _TTY(tty=True)
+    printer = Printer(stderr=err, verbosity=Verbosity.NORMAL, color=color, env={})
+    reporter = ProgressReporter(
+        printer,
+        clock=clock if clock is not None else (lambda: 0.0),  # type: ignore[arg-type]
+        min_interval=min_interval,
+    )
+    return reporter, err
+
+
+def test_progress_disabled_off_tty_is_noop() -> None:
+    err = _TTY(tty=False)
+    printer = Printer(stderr=err, verbosity=Verbosity.NORMAL, env={})
+    reporter = ProgressReporter(printer)
+    reporter.on_fetch()
+    reporter.on_pin(2)
+    reporter.clear()
+    assert err.getvalue() == ""
+
+
+def test_progress_renders_counter_line() -> None:
+    reporter, err = _enabled_reporter()
+    reporter.on_fetch()
+    out = err.getvalue()
+    assert out.startswith("\r\033[K")
+    assert "Resolving... 1 fetched, 0 pinned" in out
+
+
+def test_progress_pin_updates_line() -> None:
+    times = iter([0.0, 10.0])
+    reporter, err = _enabled_reporter(clock=lambda: next(times), min_interval=1.0)
+    reporter.on_fetch()
+    reporter.on_pin(4)
+    assert "1 fetched, 4 pinned" in err.getvalue()
+
+
+def test_progress_throttle_skips_rapid_repaint() -> None:
+    reporter, err = _enabled_reporter(clock=lambda: 5.0, min_interval=1.0)
+    reporter.on_fetch()
+    first = err.getvalue()
+    reporter.on_fetch()
+    assert err.getvalue() == first
+
+
+def test_progress_colour_dims_the_line() -> None:
+    reporter, err = _enabled_reporter(color=ColorChoice.ALWAYS)
+    reporter.on_fetch()
+    assert "\033[2m" in err.getvalue()
+
+
+def test_progress_clear_wipes_then_is_noop() -> None:
+    reporter, err = _enabled_reporter()
+    reporter.on_fetch()
+    err.truncate(0)
+    err.seek(0)
+    reporter.clear()
+    assert err.getvalue() == "\r\033[K"
+    err.truncate(0)
+    err.seek(0)
+    reporter.clear()
+    assert err.getvalue() == ""


### PR DESCRIPTION
Establishes one output policy for the CLI. Fixes #35, fixes #32.

- Verbosity: `-v`/`-vv`/`-q`/`-qq` and `NAB_VERBOSITY`; requested stdout data survives `-q`.
- Streams: stdout carries requested data only; progress, summaries, warnings, errors, and logs go to stderr. The matrix-failure report moves to stderr with them.
- Format: lowercase `error:`/`warning:`/`note:` prefixes; the engine logs flow through one stderr handler whose level follows the flags (`-v` INFO, `-vv` DEBUG).
- Colour: minimal, prefix-only, standard ANSI so the terminal theme sets the shade; honours `--color`, `NO_COLOR`, `FORCE_COLOR`, `TERM`.
- Progress (#35): a live `Resolving... N fetched, M pinned` line on stderr, shown at the default level on a terminal and hidden under verbose.