### PR TITLE
Accept any wheel tag unless runs-on is set

### DIFF
--- a/docs/explanation/universal.md
+++ b/docs/explanation/universal.md
@@ -55,8 +55,8 @@ minor version. `platforms` is a list of platform ids
 (`linux_x86_64`, `linux_aarch64`, `linux_i686`, `linux_armv7l`,
 `macos_x86_64`, `macos_arm64`, `windows_amd64`, `windows_arm64`), each
 optionally written as a table to declare its
-wheel-tag knobs (libc family and version, macOS deployment target,
-free-threaded build).  See
+wheel-tag knobs (libc family, the libc and macOS the lock must run
+on, free-threaded build).  See
 [Configuration](../reference/configuration.md).
 
 `python-order` selects the resolution direction:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -87,14 +87,14 @@ bare id at that platform's default tag knobs, or a table declaring them.
 ```toml
 [tool.nab.environment]
 python = "3.13"
-platform = { id = "macos_arm64", macos-min = "14.0" }
+platform = { id = "macos_arm64", runs-on-macos = "14.0" }
 ```
 
 The knobs, their defaults and their rules are the ones the matrix's
-"Platform tag knobs" section below lists.  A bare id keeps the default
-macOS deployment target (12.0 on arm64), so a wheel tagged
-`macosx_14_0_arm64` is not accepted until the target says it runs macOS
-14.
+"Platform tag knobs" section below lists.  A bare id names no system, so
+a wheel of any level is accepted; declare `runs-on-macos` to name a macOS
+the lock must run on: the target then accepts that macOS and every older
+tag and drops a wheel that needs a newer one.
 
 The target declares both halves of the environment: its PEP 508 markers
 gate every dependency, and its PEP 425 wheel tags gate every candidate.
@@ -611,8 +611,8 @@ platform's defaults, or a table declaring the wheel-tag knobs:
 python = ">=3.11,<3.14"
 platforms = [
     "windows_amd64",
-    { id = "linux_x86_64", libc = "musl", libc-version = "1.2" },
-    { id = "macos_arm64", macos-min = "14.0" },
+    { id = "linux_x86_64", libc = "musl", runs-on-libc = "1.2" },
+    { id = "macos_arm64", runs-on-macos = "14.0" },
     { id = "linux_aarch64", platform-release = "5.15.0" },
 ]
 ```
@@ -621,30 +621,42 @@ platforms = [
 | --- | --- | --- |
 | `id` | required | `linux_x86_64`, `linux_aarch64`, `linux_i686`, `linux_armv7l`, `macos_arm64`, `macos_x86_64`, `windows_amd64`, or `windows_arm64` |
 | `libc` | `"glibc"` | The Linux C library: `"glibc"` or `"musl"` |
-| `libc-version` | glibc `2.28` (armv7l `2.31`), musl `1.2` | The libc version the target runs |
-| `macos-min` | arm64 `12.0`, x86_64 `10.13` | The macOS deployment target |
+| `runs-on-libc` | unset (accept any level) | The glibc/musl the lock must run on; wheels needing newer are dropped |
+| `runs-on-macos` | unset (accept any level) | The macOS the lock must run on; wheels needing newer are dropped |
 | `platform-release` | `""` | The `platform_release` marker value |
 | `platform-version` | `""` | The `platform_version` marker value |
 | `free-threaded` | `false` | Target the free-threaded (`cp3XXt`) CPython build |
 
 A machine links one C library, so a target accepts one family's wheels:
 a `glibc` target takes manylinux wheels and never musllinux ones, and a
-`musl` target the reverse.  `libc-version` is the version the target
-guarantees, and a wheel built against an older libc runs on a newer one,
-so the target accepts every version at or below it.  A higher value
-therefore accepts more wheels, not fewer.  The glibc default is 2.28,
-the `manylinux_2_28` build image; a target that runs a newer glibc
-should say so, because a wheel built above 2.28 is otherwise rejected.
-Its major has to match the family (glibc `2.x`, musl `1.x`): those are
-the only majors either has shipped, so no wheel targets another.
+`musl` target the reverse.  Left unset, `runs-on-libc` names no system:
+the target accepts a wheel of any manylinux/musllinux level and whether
+it runs is left to install time, the way uv resolves.  Set it to name the
+glibc or musl the lock must run on.  Its major has to match the family
+(glibc `2.x`, musl `1.x`): those are the only majors either has shipped,
+so no wheel targets another.
 
-`macos-min` reads the same way, as the newest macOS a wheel may target.
-Below the oldest macOS the architecture ever ran (10.4 on x86_64, 11.0
-on Apple Silicon) there is no machine to model and no tag to name, so
-that is a config error.
+`runs-on-libc = "2.28"` means the lock must run on glibc 2.28.  A wheel is
+lockable only if it runs on every target machine, so:
 
-A knob belongs to its platform.  `libc` and `libc-version` are Linux
-knobs and `macos-min` is a macOS one, so declaring one on a platform
+- `manylinux_2_17` and `manylinux_2_28` wheels run there and are accepted.
+- a `manylinux_2_34` wheel cannot run there and is dropped: it needs a
+  newer glibc.
+
+Older wheels are never excluded; the knob only rules out wheels that need
+something newer than the declared system, so a higher `runs-on-libc`
+accepts more wheels, not fewer.  Newer systems are always fine: a lock
+that runs on glibc 2.28 runs on anything newer (the same holds for macOS).
+
+`runs-on-macos` reads the same way: `runs-on-macos = "14.0"` means the
+lock must run on macOS 14.0, so a `macosx_10_9` or `macosx_14_0` wheel is
+accepted and a `macosx_15_0` wheel is dropped.  It borrows Apple's
+`MACOSX_DEPLOYMENT_TARGET`, a machine minimum.  Below the oldest macOS the
+architecture ever ran (10.4 on x86_64, 11.0 on Apple Silicon) there is
+no machine to model and no tag to name, so that is a config error.
+
+A knob belongs to its platform.  `libc` and `runs-on-libc` are Linux
+knobs and `runs-on-macos` is a macOS one, so declaring one on a platform
 that cannot read it is a config error.  It would select no wheel, and it
 would still name the machine the lock was resolved for.
 

--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -434,18 +434,10 @@ def _apply_wheel_tags(
 
     result: list[tuple[Version, DistFile]] = []
     tag_rejected_versions: set[Version] = set()
-    kept_wheel_versions: set[Version] = set()
-    ceiling_drops: dict[Version, tuple[WheelFile, tuple[str, tuple[int, int]]]] = {}
     for version, dist in base:
         if excluded_by_wheel_tags(provider, normalized, dist, tags):
             tag_rejected_versions.add(version)
-            if version not in ceiling_drops and isinstance(dist, WheelFile):
-                admitting = provider.ceiling_would_admit(dist.filename)
-                if admitting is not None:
-                    ceiling_drops[version] = (dist, admitting)
             continue
-        if isinstance(dist, WheelFile):
-            kept_wheel_versions.add(version)
         result.append((version, dist))
 
     if tag_rejected_versions:
@@ -455,12 +447,6 @@ def _apply_wheel_tags(
         provider.stats.excluded_versions_no_compatible_wheel += len(
             tag_rejected_versions - kept
         )
-
-    # Warn only where an unset default ceiling took a version's last wheel: a
-    # release that also ships an in-ceiling wheel keeps it and stays silent.
-    for version, (wheel, (knob, raise_to)) in ceiling_drops.items():
-        if version not in kept_wheel_versions:
-            provider.warn_ceiling_drop(normalized, version, wheel, knob, raise_to)
 
     return result
 

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -164,8 +164,8 @@ class EnvironmentConfig:
 
     ``platform`` is the same :class:`~nab_python.tags.PlatformSpec` a
     ``matrix.platforms`` entry parses to, so the wheel-tag knobs (the libc
-    family and version, the macOS deployment target, the kernel marker
-    values, the free-threaded build) are declarable here too.
+    family, the libc and macOS the lock must run on, the kernel
+    marker values, the free-threaded build) are declarable here too.
     """
 
     python: str | None = None
@@ -2853,8 +2853,8 @@ _PLATFORM_TABLE_KEYS = frozenset(
     {
         "id",
         "libc",
-        "libc-version",
-        "macos-min",
+        "runs-on-libc",
+        "runs-on-macos",
         "platform-release",
         "platform-version",
         "free-threaded",
@@ -2863,8 +2863,8 @@ _PLATFORM_TABLE_KEYS = frozenset(
 # The platform kind that reads each knob key; any other kind rejects it.
 _PLATFORM_KNOB_OWNER: Mapping[str, frozenset[str]] = MappingProxyType(
     {
-        "linux": frozenset({"libc", "libc-version"}),
-        "macos": frozenset({"macos-min"}),
+        "linux": frozenset({"libc", "runs-on-libc"}),
+        "macos": frozenset({"runs-on-macos"}),
     }
 )
 
@@ -2873,9 +2873,9 @@ def _parse_matrix_platforms(value: object) -> tuple[PlatformSpec, ...]:
     """Parse ``matrix.platforms``: bare ids, tables, or a mix of both.
 
     A bare id takes the platform's default tag knobs; the table form declares
-    them (libc family and version, macOS deployment target, kernel marker
-    values, free-threaded build).  Both become a :class:`PlatformSpec`, so
-    everything downstream reads one shape.
+    them (libc family, the libc and macOS the lock must run on, kernel
+    marker values, free-threaded build).  Both become a :class:`PlatformSpec`,
+    so everything downstream reads one shape.
     """
     if not isinstance(value, list):
         msg = f"matrix.platforms must be a list, got {type(value).__name__}"
@@ -2922,10 +2922,12 @@ def _parse_platform_table(where: str, value: dict[str, Any]) -> PlatformSpec:
         where,
         platform_id=platform_id,
         libc=_parse_libc(f"{where}.libc", value.get("libc")),
-        libc_version=_parse_major_minor(
-            f"{where}.libc-version", value.get("libc-version")
+        runs_on_libc=_parse_major_minor(
+            f"{where}.runs-on-libc", value.get("runs-on-libc")
         ),
-        macos_min=_parse_major_minor(f"{where}.macos-min", value.get("macos-min")),
+        runs_on_macos=_parse_major_minor(
+            f"{where}.runs-on-macos", value.get("runs-on-macos")
+        ),
         platform_release=_parse_string_value(
             f"{where}.platform-release", value.get("platform-release", "")
         ),

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -37,7 +37,6 @@ from ._vcs_admission import (
 from ._vendor.packaging.ranges import VersionRange
 from ._vendor.packaging.utils import canonicalize_name
 from .metadata import WheelMetadata
-from .tags import default_ceiling_admitting
 from .target import host_environment
 
 if TYPE_CHECKING:
@@ -632,10 +631,6 @@ class Provider:
         # whole package failed on wheel tags alone.
         self.base_filtered_packages: set[str] = set()
 
-        # (package, version) pairs already warned about losing their last wheel
-        # to an unset default tag ceiling, so the warning fires once per drop.
-        self._warned_ceiling_versions: set[tuple[str, Version]] = set()
-
         self.root_requirements = root_requirements or {}
         self.versions_cache: dict[str, list[tuple[Version, DistFile]]] = {}
         self.deps_cache: dict[tuple[str, Version], dict[str, VersionRange]] = {}
@@ -1173,50 +1168,6 @@ class Provider:
     ) -> list[tuple[Version, DistFile]]:
         """See :func:`nab_python._provider.listing.filter_distributions`."""
         return _listing.filter_distributions(self, normalized, files)
-
-    def ceiling_would_admit(
-        self, wheel_filename: str
-    ) -> tuple[str, tuple[int, int]] | None:
-        """Return the unset default ceiling that alone drops ``wheel_filename``.
-
-        Delegates to :func:`nab_python.tags.default_ceiling_admitting` for a
-        declared target; a host target names no platform_spec and never has a
-        raisable ceiling, so it returns ``None``.
-        """
-        if self.target is None or self.target.platform_spec is None:
-            return None
-        return default_ceiling_admitting(
-            self.target.platform_spec,
-            python_version=self.target.python_version,
-            implementation=self.target.implementation,
-            wheel_filename=wheel_filename,
-        )
-
-    def warn_ceiling_drop(
-        self,
-        normalized: str,
-        version: Version,
-        wheel: WheelFile,
-        knob: str,
-        raise_to: tuple[int, int],
-    ) -> None:
-        """Warn once that an unset default ceiling dropped a version's last wheel."""
-        key = (normalized, version)
-        if key in self._warned_ceiling_versions:
-            return
-        self._warned_ceiling_versions.add(key)
-        logger.warning(
-            "%s %s: wheel %s is above the default %s ceiling and was"
-            " dropped, leaving the version with no installable wheel;"
-            " set %s to %s.%s to keep it",
-            normalized,
-            version,
-            wheel.filename,
-            knob,
-            knob,
-            raise_to[0],
-            raise_to[1],
-        )
 
     def pick_best_candidate(
         self,

--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Callable, Iterable
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from functools import cache, cached_property, lru_cache
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Literal
@@ -47,7 +47,6 @@ __all__ = [
     "PlatformSpec",
     "TagSet",
     "TagsSource",
-    "default_ceiling_admitting",
     "platform_kind",
     "supports_free_threading",
     "wheel_tag_set",
@@ -79,37 +78,16 @@ _MAX_WHEEL_TAGS = 4096
 _WHEEL_PARTS_WITH_BUILD = 6
 _BUILD_TAG_RE = re.compile(r"(\d{1,9})(\D.*)?$", re.ASCII)
 
-# A libc version is a floor on the machine and a ceiling on the tag: the
-# target accepts every manylinux/musllinux tag at or below it, so a target
-# that runs a newer libc has to say so to reach the wheels built above the
-# default.  glibc 2.28 is the manylinux_2_28 build image; musl 1.2 is the
-# Alpine 3.13 baseline musllinux wheels target.
+# runs-on-libc (or runs-on-macos) names a system the lock must run on.  A
+# wheel is a member iff it runs there: the target accepts every
+# manylinux/musllinux (or macosx) tag at or below the named level and drops a
+# wheel that needs something newer.  Unset, the knob names no system and a
+# wheel of any level is accepted, deferring compatibility to install time, the
+# way uv resolves.
 DEFAULT_LIBC: Libc = "glibc"
-_DEFAULT_LIBC_VERSION: Mapping[Libc, tuple[int, int]] = MappingProxyType(
-    {"glibc": (2, 28), "musl": (1, 2)}
-)
-# A glibc default the arch raises above the family's.  armv7l's current PyPI
-# wheels are built at manylinux_2_31 (Debian bullseye / Raspberry Pi OS is glibc
-# 2.31), and a 2.28 floor would reject every one of them.  The floor stays a
-# ceiling on the tag, so this only holds where armv7l machines run 2.31 or newer;
-# an older one has to declare its libc-version.  musl armv7l keeps the 1.2 default.
-_ARCH_DEFAULT_GLIBC: Mapping[str, tuple[int, int]] = MappingProxyType(
-    {"armv7l": (2, 31)}
-)
 # The only major each family has shipped.  Tags expand within the declared
 # major, so a foreign major names platform tags no wheel is built for.
 LIBC_MAJOR: Mapping[Libc, int] = MappingProxyType({"glibc": 2, "musl": 1})
-
-# The macOS version is the deployment target of the machine, which
-# ``mac_platforms`` reads as a ceiling: the target accepts a wheel built for
-# its own version and older, never newer.  The defaults are deliberately
-# conservative, because the two ways to be wrong are not symmetric: too low
-# only misses the newest wheels and falls back to an older version or an
-# sdist, while too high writes a wheel into the lock that an older machine
-# cannot install.
-_DEFAULT_MACOS_MIN: Mapping[str, tuple[int, int]] = MappingProxyType(
-    {"arm64": (12, 0), "x86_64": (10, 13)}
-)
 
 # The oldest macOS each arch can name a wheel tag for.  ``mac_platforms``
 # yields no x86_64 binary format below 10.4, and Apple Silicon shipped at
@@ -129,16 +107,28 @@ _LEGACY_MANYLINUX: dict[tuple[int, int], str] = {
 
 # A tag list runs one entry per version below the declared one, so a typo
 # like "2.99999999" would build tags until it ran out of memory.  No libc or
-# macOS release is anywhere near this cap.
+# macOS release is anywhere near this max.
 _MAX_VERSION_PART = 99
 
-# Lowest glibc 2.x minor a manylinux wheel may target, by arch.  manylinux1
+# The no-limit sentinel an unset knob stands in for.  A tag generator reads a
+# version as a max and yields it and every older one, so the sentinel admits
+# every real tag.  macOS enumerates on the major for 11+, so the sentinel major
+# is 11 or newer; the minor is 0, which is all mac_platforms emits above 11.
+_MACOS_NO_LIMIT = (_MAX_VERSION_PART, 0)
+
+
+def _libc_no_limit(libc: Libc) -> tuple[int, int]:
+    """Return a libc family's no-limit sentinel: its major at the max minor."""
+    return (LIBC_MAJOR[libc], _MAX_VERSION_PART)
+
+
+# Glibc 2.x minor floor a manylinux wheel may target, by arch.  manylinux1
 # (PEP 513) and manylinux2010 (PEP 571) cover only x86_64/i686; manylinux2014
 # (PEP 599, glibc 2.17) was the first to add other arches, so every other arch
 # stops at glibc 2.17.
 _X86_MANYLINUX_ARCHS = frozenset({"x86_64", "i686"})
-_X86_MIN_GLIBC2_MINOR = 5
-_OTHER_MIN_GLIBC2_MINOR = 17
+_X86_GLIBC2_MINOR_FLOOR = 5
+_OTHER_GLIBC2_MINOR_FLOOR = 17
 
 
 @dataclass(frozen=True)
@@ -147,9 +137,12 @@ class PlatformSpec:
 
     ``libc`` names the C library the Linux target runs; a machine links one,
     so the target emits that family's wheel tags and never the other's.
-    ``libc_version`` is the version the target guarantees, and a wheel built
-    against an older libc runs on a newer one, so every version at or below
-    it is accepted.  Unset, it takes the family default.
+    ``runs_on_libc`` names a glibc or musl the lock must run on: a wheel built
+    against it or an older libc runs there and is accepted, and one built
+    against a newer libc is dropped.  Unset, the knob names no system and a
+    wheel of any level is accepted, deferring compatibility to install time.
+    ``runs_on_macos`` reads the same way for macOS: a macOS the lock must run
+    on.
 
     ``platform_release`` and ``platform_version`` set the corresponding PEP 508
     marker values.  Left empty, a kernel-conditioned marker
@@ -162,8 +155,8 @@ class PlatformSpec:
 
     platform_id: str
     libc: Libc = DEFAULT_LIBC
-    libc_version: tuple[int, int] | None = None  # unset: the family default
-    macos_min: tuple[int, int] | None = None  # unset: the arch default
+    runs_on_libc: tuple[int, int] | None = None  # unset: accept any level
+    runs_on_macos: tuple[int, int] | None = None  # unset: accept any level
     platform_release: str = ""
     platform_version: str = ""
     free_threaded: bool = False
@@ -185,59 +178,51 @@ class PlatformSpec:
             return
 
         if kind == "linux":
-            self._check_libc_version()
-        elif self.libc != DEFAULT_LIBC or self.libc_version is not None:
-            msg = f"libc is a Linux knob, and {self.platform_id} is not Linux"
+            self._check_runs_on_libc()
+        elif self.libc != DEFAULT_LIBC or self.runs_on_libc is not None:
+            msg = (
+                "libc and runs-on-libc are Linux knobs, and"
+                f" {self.platform_id} is not Linux"
+            )
             raise ValueError(msg)
 
         if kind == "macos":
-            self._check_macos_min()
-        elif self.macos_min is not None:
-            msg = f"macos-min is a macOS knob, and {self.platform_id} is not macOS"
+            self._check_runs_on_macos()
+        elif self.runs_on_macos is not None:
+            msg = f"runs-on-macos is a macOS knob, and {self.platform_id} is not macOS"
             raise ValueError(msg)
 
-    def _check_libc_version(self) -> None:
+    def _check_runs_on_libc(self) -> None:
         """Reject a libc version outside its family's only major."""
-        if self.libc_version is None:
+        if self.runs_on_libc is None:
             return
         major = LIBC_MAJOR[self.libc]
-        if self.libc_version[0] != major:
+        if self.runs_on_libc[0] != major:
             msg = (
-                f"{self.libc} has only a {major}.x series, so libc-version"
-                f" {_version_tag(self.libc_version)} names platform tags"
+                f"{self.libc} has only a {major}.x series, so runs-on-libc"
+                f" {_version_tag(self.runs_on_libc)} names platform tags"
                 f" nothing is built for"
             )
             raise ValueError(msg)
-        _check_version_cap("libc-version", self.libc_version)
+        _check_version_max("runs-on-libc", self.runs_on_libc)
 
-    def _check_macos_min(self) -> None:
+    def _check_runs_on_macos(self) -> None:
         """Reject a macOS version below the oldest this arch can name a tag for."""
-        if self.macos_min is None:
+        if self.runs_on_macos is None:
             return
         floor = _MACOS_TAG_FLOOR[self.arch]
-        if self.macos_min < floor:
+        if self.runs_on_macos < floor:
             msg = (
-                f"macos-min {_version_tag(self.macos_min)} is below"
+                f"runs-on-macos {_version_tag(self.runs_on_macos)} is below"
                 f" {_version_tag(floor)}, the oldest macOS {self.arch} runs"
             )
             raise ValueError(msg)
-        _check_version_cap("macos-min", self.macos_min)
+        _check_version_max("runs-on-macos", self.runs_on_macos)
 
     @property
     def arch(self) -> str:
         """The architecture suffix used in platform tags."""
         return _PLATFORM_ARCH[self.platform_id]
-
-    @property
-    def effective_libc_version(self) -> tuple[int, int]:
-        """The declared libc version, or the arch/family default."""
-        if self.libc_version is not None:
-            return self.libc_version
-        if self.libc == "glibc":
-            arch_default = _ARCH_DEFAULT_GLIBC.get(self.arch)
-            if arch_default is not None:
-                return arch_default
-        return _DEFAULT_LIBC_VERSION[self.libc]
 
     @property
     def label(self) -> str:
@@ -253,11 +238,11 @@ class PlatformSpec:
 
         # The family shows even without a version, so a musl target never
         # renders the label of a glibc one.
-        if self.libc != DEFAULT_LIBC or self.libc_version is not None:
-            parts.append(f"-{self.libc}{_version_tag(self.libc_version)}")
+        if self.libc != DEFAULT_LIBC or self.runs_on_libc is not None:
+            parts.append(f"-{self.libc}{_version_tag(self.runs_on_libc)}")
 
         fields = (
-            ("macos", _version_tag(self.macos_min)),
+            ("macos", _version_tag(self.runs_on_macos)),
             ("rel", _escape_label_value(self.platform_release)),
             ("ver", _escape_label_value(self.platform_version)),
         )
@@ -291,7 +276,7 @@ _PLATFORM_KIND: dict[str, str] = {
 }
 
 
-def _check_version_cap(key: str, version: tuple[int, int]) -> None:
+def _check_version_max(key: str, version: tuple[int, int]) -> None:
     """Reject a version so high the tag list it names would exhaust memory."""
     if max(version) > _MAX_VERSION_PART:
         msg = (
@@ -304,87 +289,6 @@ def _check_version_cap(key: str, version: tuple[int, int]) -> None:
 def platform_kind(platform_id: str) -> str | None:
     """Return a platform id's kind, or ``None`` if nab does not know the id."""
     return _PLATFORM_KIND.get(platform_id)
-
-
-# The libc/OS version a versioned platform tag carries, which the target reads
-# as a ceiling.  Used to pull the ``(major, minor)`` back out of a wheel's tag
-# when deciding whether raising an unset default ceiling would admit it.
-_MACOS_PLATFORM_RE = re.compile(r"^macosx_(\d+)_(\d+)_")
-_MANYLINUX_PLATFORM_RE = re.compile(r"^manylinux_(\d+)_(\d+)_")
-_MUSLLINUX_PLATFORM_RE = re.compile(r"^musllinux_(\d+)_(\d+)_")
-
-
-def _platform_versions(
-    wheel_filename: str, pattern: re.Pattern[str]
-) -> list[tuple[int, int]]:
-    """Return the ``(major, minor)`` pairs ``pattern`` matches in a wheel's tags."""
-    wheel_tags = wheel_tag_set(wheel_filename)
-    if wheel_tags is None:
-        return []
-    out: list[tuple[int, int]] = []
-    for tag in wheel_tags:
-        match = pattern.match(tag.platform)
-        if match is not None:
-            out.append((int(match.group(1)), int(match.group(2))))
-    return out
-
-
-def default_ceiling_admitting(
-    spec: PlatformSpec,
-    *,
-    python_version: str,
-    implementation: str,
-    wheel_filename: str,
-) -> tuple[str, tuple[int, int]] | None:
-    """Return the unset default ceiling that alone keeps a wheel out, or ``None``.
-
-    A macOS or Linux target reads its OS/libc version as a ceiling on the
-    wheels it accepts.  When that version is a default the caller never set,
-    an incompatible wheel might be one the target would install if the
-    ceiling were raised.  This returns ``(knob, raise_to)`` naming the knob
-    (``macos-min`` or ``libc-version``) and the lowest version it would need
-    to be raised to, but only when raising it is enough: the result is
-    confirmed by rebuilding the target's tags at ``raise_to`` and rechecking
-    acceptance, so an arch, Python, ABI, or libc-family mismatch (which no
-    ceiling change fixes) yields ``None``.  A ceiling the caller set, and any
-    non-macOS/Linux target, also yield ``None``.
-    """
-    kind = platform_kind(spec.platform_id)
-    if kind == "macos" and spec.macos_min is None:
-        knob = "macos-min"
-        current = _DEFAULT_MACOS_MIN[spec.arch]
-        candidates = _platform_versions(wheel_filename, _MACOS_PLATFORM_RE)
-        field = "macos_min"
-    elif kind == "linux" and spec.libc_version is None:
-        knob = "libc-version"
-        current = _DEFAULT_LIBC_VERSION[spec.libc]
-        pattern = (
-            _MUSLLINUX_PLATFORM_RE if spec.libc == "musl" else _MANYLINUX_PLATFORM_RE
-        )
-        candidates = _platform_versions(wheel_filename, pattern)
-        field = "libc_version"
-    else:
-        return None
-
-    higher = [version for version in candidates if version > current]
-    if not higher:
-        return None
-    raise_to = min(higher)
-
-    try:
-        raised = TagSet.for_spec(
-            python_version=python_version,
-            spec=replace(spec, **{field: raise_to}),
-            implementation=implementation,
-        )
-    except ValueError:
-        # A tag naming a version past the knob's cap (or below its floor) is
-        # not a ceiling nab can raise to, so it is not the sole cause.
-        return None
-
-    if raised.accepts(wheel_filename):
-        return knob, raise_to
-    return None
 
 
 def _version_tag(version: tuple[int, int] | None) -> str:
@@ -420,13 +324,13 @@ def _manylinux_platform_tags(arch: str, glibc_version: tuple[int, int]) -> list[
     The target stops at the arch's oldest tag: 2.5 for x86, 2.17 otherwise.
     """
     major, minor = glibc_version
-    min_minor = (
-        _X86_MIN_GLIBC2_MINOR
+    floor_minor = (
+        _X86_GLIBC2_MINOR_FLOOR
         if arch in _X86_MANYLINUX_ARCHS
-        else _OTHER_MIN_GLIBC2_MINOR
+        else _OTHER_GLIBC2_MINOR_FLOOR
     )
     out: list[str] = []
-    for m in range(minor, min_minor - 1, -1):
+    for m in range(minor, floor_minor - 1, -1):
         out.append(f"manylinux_{major}_{m}_{arch}")
         legacy = _LEGACY_MANYLINUX.get((major, m))
         if legacy is not None:
@@ -470,14 +374,22 @@ def _platform_tags_for_spec(spec: PlatformSpec) -> list[str]:
     arch = spec.arch
 
     if kind == "linux":
-        return _linux_platform_tags(
-            arch, libc=spec.libc, libc_version=spec.effective_libc_version
+        # Unset runs-on-libc names no system: enumerate to the max so a wheel
+        # of any manylinux/musllinux level is a set member.
+        libc_version = (
+            spec.runs_on_libc
+            if spec.runs_on_libc is not None
+            else _libc_no_limit(spec.libc)
         )
+        return _linux_platform_tags(arch, libc=spec.libc, libc_version=libc_version)
 
     if kind == "macos":
-        macos_min = spec.macos_min or _DEFAULT_MACOS_MIN[arch]
-        # mac_platforms treats the declared OS as a max and yields older too.
-        return list(ptags.mac_platforms(version=macos_min, arch=arch))
+        # Unset runs-on-macos names no system; the sentinel accepts every macosx
+        # tag.  mac_platforms treats the version as a max and yields older.
+        macos_version = (
+            spec.runs_on_macos if spec.runs_on_macos is not None else _MACOS_NO_LIMIT
+        )
+        return list(ptags.mac_platforms(version=macos_version, arch=arch))
 
     if kind == "windows":
         return [f"win_{arch}"]

--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -789,8 +789,8 @@ class ResolveTarget:
         The python axis is re-derived when the overlay moves it, so
         ``python_version`` and ``python_full_version`` never describe two
         different interpreters.  The tag set does not move with it: an
-        overlay names no libc floor or macOS deployment target, so it
-        cannot rebuild the wheel-tag axis.  The result is no longer
+        overlay names no runs-on libc or macOS, so it cannot rebuild the
+        wheel-tag axis.  The result is no longer
         host-faithful; a build backend run under it reports the host's
         metadata, not the impersonated target's.
 

--- a/nab-python/tests/property_python/test_matrix_labels.py
+++ b/nab-python/tests/property_python/test_matrix_labels.py
@@ -59,7 +59,7 @@ def _libc_knobs(platform_id: str) -> st.SearchStrategy[dict[str, object]]:
         lambda libc: st.fixed_dictionaries(
             {
                 "libc": st.just(libc),
-                "libc_version": st.none()
+                "runs_on_libc": st.none()
                 | st.tuples(st.just(LIBC_MAJOR[libc]), st.integers(0, 20)),
             }
         )
@@ -73,7 +73,7 @@ def _macos_knobs(platform_id: str) -> st.SearchStrategy[dict[str, object]]:
     floor = _MACOS_TAG_FLOOR[_PLATFORM_ARCH[platform_id]]
     return st.fixed_dictionaries(
         {
-            "macos_min": st.none()
+            "runs_on_macos": st.none()
             | st.tuples(st.integers(10, 15), st.integers(0, 3)).filter(
                 lambda version: version >= floor
             )

--- a/nab-python/tests/property_python/test_tags_differential.py
+++ b/nab-python/tests/property_python/test_tags_differential.py
@@ -63,14 +63,14 @@ linux_specs = st.one_of(
         PlatformSpec,
         platform_id=st.sampled_from(LINUX_IDS),
         libc=st.just("glibc"),
-        libc_version=st.tuples(st.just(2), st.integers(0, 35)),
+        runs_on_libc=st.tuples(st.just(2), st.integers(0, 35)),
         free_threaded=st.booleans(),
     ),
     st.builds(
         PlatformSpec,
         platform_id=st.sampled_from(LINUX_IDS),
         libc=st.just("musl"),
-        libc_version=st.tuples(st.just(1), st.integers(0, 4)),
+        runs_on_libc=st.tuples(st.just(1), st.integers(0, 4)),
         free_threaded=st.booleans(),
     ),
 )
@@ -78,7 +78,7 @@ macos_specs = st.sampled_from(MACOS_IDS).flatmap(
     lambda platform_id: st.builds(
         PlatformSpec,
         platform_id=st.just(platform_id),
-        macos_min=st.none()
+        runs_on_macos=st.none()
         | st.tuples(st.integers(10, 15), st.integers(0, 15)).filter(
             lambda v: v >= _MACOS_TAG_FLOOR[_PLATFORM_ARCH[platform_id]]
         ),

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -1390,18 +1390,18 @@ class TestEnvironment:
         assert target.marker_env["platform_machine"] == "i686"
         assert target.tags.accepts("somepkg-1.0-cp312-cp312-manylinux2014_i686.whl")
 
-    def test_linux_armv7l_table_with_libc_version_override(
+    def test_linux_armv7l_table_with_runs_on_libc_override(
         self, tmp_path: Path
     ) -> None:
         path = write(
             tmp_path,
             '[tool.nab.environment]\npython = "3.12"\n'
-            'platform = { id = "linux_armv7l", libc-version = "2.34" }\n'
+            'platform = { id = "linux_armv7l", runs-on-libc = "2.34" }\n'
             '[tool.nab]\nbuild-policy = "never"\n',
         )
         config = read_pyproject_config(path)
         assert config.environment == EnvironmentConfig(
-            python="3.12", platform=PlatformSpec("linux_armv7l", libc_version=(2, 34))
+            python="3.12", platform=PlatformSpec("linux_armv7l", runs_on_libc=(2, 34))
         )
         (target,) = plan_targets(config)
         assert target.marker_env["platform_machine"] == "armv7l"
@@ -1426,17 +1426,19 @@ class TestEnvironment:
             tmp_path,
             "[tool.nab.environment]\n"
             'python = "3.12"\n'
-            'platform = { id = "macos_arm64", macos-min = "14.0" }\n'
+            'platform = { id = "macos_arm64", runs-on-macos = "14.0" }\n'
             '[tool.nab]\nbuild-policy = "never"\n',
         )
         config = read_pyproject_config(path)
         assert config.environment == EnvironmentConfig(
-            python="3.12", platform=PlatformSpec("macos_arm64", macos_min=(14, 0))
+            python="3.12", platform=PlatformSpec("macos_arm64", runs_on_macos=(14, 0))
         )
         (target,) = plan_targets(config)
         wheel = "somepkg-1.0-cp312-cp312-macosx_14_0_arm64.whl"
         assert target.tags.accepts(wheel)
-        assert "platform=macos_arm64[macos-min=14.0]" in _inspect(path, "environment")
+        assert "platform=macos_arm64[runs-on-macos=14.0]" in _inspect(
+            path, "environment"
+        )
 
     def test_the_inspector_renders_a_knobless_table(self, tmp_path: Path) -> None:
         path = write(
@@ -1446,8 +1448,8 @@ class TestEnvironment:
         )
         assert "platform=linux_x86_64" in _inspect(path, "environment")
 
-    def test_bare_platform_id_keeps_the_default_knobs(self, tmp_path: Path) -> None:
-        """Without macos-min the deployment target is the arch default (12.0)."""
+    def test_bare_platform_id_accepts_any_level(self, tmp_path: Path) -> None:
+        """Without runs-on-macos any level is accepted, so a newer wheel passes."""
         path = write(
             tmp_path,
             "[tool.nab.environment]\n"
@@ -1457,23 +1459,23 @@ class TestEnvironment:
         )
         (target,) = plan_targets(read_pyproject_config(path))
         wheel = "somepkg-1.0-cp312-cp312-macosx_14_0_arm64.whl"
-        assert not target.tags.accepts(wheel)
+        assert target.tags.accepts(wheel)
 
     def test_platform_table_rejects_a_foreign_knob(self, tmp_path: Path) -> None:
         path = write(
             tmp_path,
             "[tool.nab.environment]\n"
-            'platform = { id = "linux_x86_64", macos-min = "14.0" }\n',
+            'platform = { id = "linux_x86_64", runs-on-macos = "14.0" }\n',
         )
         with pytest.raises(
             ConfigError,
-            match=r"environment.platform declares \['macos-min'\]",
+            match=r"environment.platform declares \['runs-on-macos'\]",
         ):
             read_pyproject_config(path)
 
     def test_platform_table_needs_an_id(self, tmp_path: Path) -> None:
         path = write(
-            tmp_path, '[tool.nab.environment]\nplatform = { macos-min = "14.0" }\n'
+            tmp_path, '[tool.nab.environment]\nplatform = { runs-on-macos = "14.0" }\n'
         )
         with pytest.raises(
             ConfigError, match="environment.platform missing required key 'id'"
@@ -3446,14 +3448,14 @@ class TestMatrix:
             tmp_path,
             self._platforms_body(
                 '["macos_arm64", { id = "linux_x86_64", libc = "musl",'
-                ' libc-version = "1.2" }]'
+                ' runs-on-libc = "1.2" }]'
             ),
         )
         matrix = read_pyproject_config(path).matrix
         assert matrix is not None
         assert matrix.platforms == (
             PlatformSpec("macos_arm64"),
-            PlatformSpec("linux_x86_64", libc="musl", libc_version=(1, 2)),
+            PlatformSpec("linux_x86_64", libc="musl", runs_on_libc=(1, 2)),
         )
 
     def test_windows_arm64_and_linux_i686_are_known_ids(self, tmp_path: Path) -> None:
@@ -3482,10 +3484,13 @@ class TestMatrix:
         [
             ('{ id = "windows_amd64", libc = "musl" }', "only a linux platform"),
             ('{ id = "windows_amd64", libc = "glibc" }', "only a linux platform"),
-            ('{ id = "macos_arm64", libc-version = "2.28" }', "only a linux platform"),
-            ('{ id = "linux_x86_64", macos-min = "14.0" }', "only a macos platform"),
-            ('{ id = "macos_arm64", macos-min = "10.15" }', "below 11.0"),
-            ('{ id = "macos_x86_64", macos-min = "10.3" }', "below 10.4"),
+            ('{ id = "macos_arm64", runs-on-libc = "2.28" }', "only a linux platform"),
+            (
+                '{ id = "linux_x86_64", runs-on-macos = "14.0" }',
+                "only a macos platform",
+            ),
+            ('{ id = "macos_arm64", runs-on-macos = "10.15" }', "below 11.0"),
+            ('{ id = "macos_x86_64", runs-on-macos = "10.3" }', "below 10.4"),
         ],
     )
     def test_platform_table_rejects_a_knob_the_platform_cannot_use(
@@ -3501,7 +3506,7 @@ class TestMatrix:
         path = write(
             tmp_path,
             self._platforms_body(
-                '[{ id = "macos_arm64", macos-min = "14.0",'
+                '[{ id = "macos_arm64", runs-on-macos = "14.0",'
                 ' platform-release = "23.1.0", platform-version = "Darwin 23" }]'
             ),
         )
@@ -3510,7 +3515,7 @@ class TestMatrix:
         assert matrix.platforms == (
             PlatformSpec(
                 "macos_arm64",
-                macos_min=(14, 0),
+                runs_on_macos=(14, 0),
                 platform_release="23.1.0",
                 platform_version="Darwin 23",
             ),
@@ -3574,29 +3579,29 @@ class TestMatrix:
             read_pyproject_config(path)
 
     @pytest.mark.parametrize("value", ["2", "2.28.1", "1!2.28", "2.28rc1", "garbage"])
-    def test_platform_table_bad_libc_version(self, tmp_path: Path, value: str) -> None:
+    def test_platform_table_bad_runs_on_libc(self, tmp_path: Path, value: str) -> None:
         path = write(
             tmp_path,
             self._platforms_body(
-                f'[{{ id = "linux_x86_64", libc-version = "{value}" }}]'
+                f'[{{ id = "linux_x86_64", runs-on-libc = "{value}" }}]'
             ),
         )
-        with pytest.raises(ConfigError, match="libc-version must be"):
+        with pytest.raises(ConfigError, match="runs-on-libc must be"):
             read_pyproject_config(path)
 
-    def test_platform_table_libc_version_must_be_a_string(self, tmp_path: Path) -> None:
+    def test_platform_table_runs_on_libc_must_be_a_string(self, tmp_path: Path) -> None:
         path = write(
             tmp_path,
-            self._platforms_body('[{ id = "linux_x86_64", libc-version = 2.28 }]'),
+            self._platforms_body('[{ id = "linux_x86_64", runs-on-libc = 2.28 }]'),
         )
-        with pytest.raises(ConfigError, match="libc-version must be a string"):
+        with pytest.raises(ConfigError, match="runs-on-libc must be a string"):
             read_pyproject_config(path)
 
     def test_platform_table_glibc_version_major_must_be_2(self, tmp_path: Path) -> None:
         """A glibc major other than 2 tags a platform no wheel is built for."""
         path = write(
             tmp_path,
-            self._platforms_body('[{ id = "linux_x86_64", libc-version = "3.0" }]'),
+            self._platforms_body('[{ id = "linux_x86_64", runs-on-libc = "3.0" }]'),
         )
         with pytest.raises(ConfigError, match=r"glibc has only a 2.x series"):
             read_pyproject_config(path)
@@ -3606,7 +3611,7 @@ class TestMatrix:
         path = write(
             tmp_path,
             self._platforms_body(
-                '[{ id = "linux_x86_64", libc = "musl", libc-version = "2.0" }]'
+                '[{ id = "linux_x86_64", libc = "musl", runs-on-libc = "2.0" }]'
             ),
         )
         with pytest.raises(ConfigError, match=r"musl has only a 1.x series"):

--- a/nab-python/tests/test_matrix.py
+++ b/nab-python/tests/test_matrix.py
@@ -306,7 +306,7 @@ class TestTargetLabels:
             python="==3.11",
             platforms=(
                 PlatformSpec("linux_x86_64"),
-                PlatformSpec("linux_x86_64", libc_version=(2, 34)),
+                PlatformSpec("linux_x86_64", runs_on_libc=(2, 34)),
                 PlatformSpec("linux_x86_64", libc="musl"),
             ),
         )

--- a/nab-python/tests/test_provider_declared_target.py
+++ b/nab-python/tests/test_provider_declared_target.py
@@ -11,7 +11,6 @@ through a matrix.
 
 from __future__ import annotations
 
-import logging
 import threading
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
@@ -594,28 +593,28 @@ class TestWheelTagFiltering:
         assert [v for v, _ in result] == [Version("1.0")]
         assert provider.stats.excluded_by_wheel_tags == 0
 
-    def test_higher_glibc_wheel_dropped_below_floor(self) -> None:
-        """A manylinux 2.34 wheel is incompatible with a 2.17 floor."""
+    def test_higher_glibc_wheel_dropped_when_it_needs_newer(self) -> None:
+        """A manylinux 2.34 wheel needs newer glibc than a 2.17 runs-on system."""
         wheels = [
             _platform_wheel("1.0", "cp311-cp311-manylinux_2_34_x86_64"),
         ]
         provider = Provider(
             _index_with_files(wheels),
-            _linux_target(PlatformSpec("linux_x86_64", libc_version=(2, 17))),
+            _linux_target(PlatformSpec("linux_x86_64", runs_on_libc=(2, 17))),
             build_policy=BuildPolicy.NEVER,
         )
         result = provider.filter_distributions("pkg", wheels)
         assert result == []
         assert provider.stats.excluded_by_wheel_tags == 1
 
-    def test_higher_glibc_wheel_admitted_when_floor_raised(self) -> None:
-        """The same wheel passes if the user declares a 2.34 floor."""
+    def test_higher_glibc_wheel_admitted_when_runs_on_has_it(self) -> None:
+        """The same wheel passes once runs-on-libc names glibc 2.34 to run on."""
         wheels = [
             _platform_wheel("1.0", "cp311-cp311-manylinux_2_34_x86_64"),
         ]
         provider = Provider(
             _index_with_files(wheels),
-            _linux_target(PlatformSpec("linux_x86_64", libc_version=(2, 34))),
+            _linux_target(PlatformSpec("linux_x86_64", runs_on_libc=(2, 34))),
         )
         result = provider.filter_distributions("pkg", wheels)
         assert [v for v, _ in result] == [Version("1.0")]
@@ -739,133 +738,32 @@ class TestEqualVersionCanonicalization:
         assert windows.stats.excluded_versions_no_compatible_wheel == 1
 
 
-class TestDefaultCeilingWarning:
-    """A version losing its last wheel to an unset default ceiling is announced."""
+class TestUnsetKnobAcceptsAnyLevel:
+    """An unset knob names no system, so a wheel of any level survives."""
 
-    @staticmethod
-    def _macos_provider(
-        files: Sequence[WheelFile | SdistFile], spec: PlatformSpec
-    ) -> Provider:
-        return Provider(
+    def test_default_macos_keeps_a_newer_wheel(self) -> None:
+        """A macosx_14_0 wheel on a default macos_arm64 target is kept."""
+        files = [_platform_wheel("2.0", "cp311-cp311-macosx_14_0_arm64")]
+        provider = Provider(
             _index_with_files(files),
-            ResolveTarget.for_declared(python_version="3.11", spec=spec),
+            ResolveTarget.for_declared(
+                python_version="3.11", spec=PlatformSpec("macos_arm64")
+            ),
             build_policy=BuildPolicy.NEVER,
         )
-
-    def test_default_macos_ceiling_drop_warns(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """A version whose only wheel needs a newer macOS is named in a warning."""
-        files = [_platform_wheel("2.0", "cp311-cp311-macosx_14_0_arm64")]
-        provider = self._macos_provider(files, PlatformSpec("macos_arm64"))
-        with caplog.at_level(logging.WARNING, logger="nab_python.provider"):
-            provider.filter_distributions("pkg", files)
-        assert len(caplog.records) == 1
-        message = caplog.records[0].getMessage()
-        assert "pkg" in message
-        assert "2.0" in message
-        assert "pkg-2.0-cp311-cp311-macosx_14_0_arm64.whl" in message
-        assert "macos-min" in message
-        assert "14.0" in message
-
-    def test_explicit_macos_min_does_not_warn(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """A user-set ceiling is the user's own choice, so no warning fires."""
-        files = [_platform_wheel("2.0", "cp311-cp311-macosx_14_0_arm64")]
-        provider = self._macos_provider(
-            files, PlatformSpec("macos_arm64", macos_min=(12, 0))
-        )
-        with caplog.at_level(logging.WARNING, logger="nab_python.provider"):
-            provider.filter_distributions("pkg", files)
-        assert caplog.records == []
-
-    def test_in_ceiling_wheel_kept_does_not_warn(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """A release that also ships an installable wheel stays silent."""
-        files = [
-            _platform_wheel("2.0", "cp311-cp311-macosx_14_0_arm64"),
-            _platform_wheel("2.0", "cp311-cp311-macosx_12_0_arm64"),
-        ]
-        provider = self._macos_provider(files, PlatformSpec("macos_arm64"))
-        with caplog.at_level(logging.WARNING, logger="nab_python.provider"):
-            result = provider.filter_distributions("pkg", files)
+        result = provider.filter_distributions("pkg", files)
         assert Version("2.0") in {v for v, _ in result}
-        assert caplog.records == []
 
-    def test_default_linux_ceiling_drop_warns(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """A manylinux wheel above the default glibc names the libc knob."""
+    def test_default_linux_keeps_a_newer_wheel(self) -> None:
+        """A manylinux_2_34 wheel on a default linux target is kept."""
         files = [_platform_wheel("2.0", "cp311-cp311-manylinux_2_34_x86_64")]
         provider = Provider(
             _index_with_files(files),
             _linux_target(PlatformSpec("linux_x86_64")),
             build_policy=BuildPolicy.NEVER,
         )
-        with caplog.at_level(logging.WARNING, logger="nab_python.provider"):
-            provider.filter_distributions("pkg", files)
-        assert len(caplog.records) == 1
-        message = caplog.records[0].getMessage()
-        assert "libc-version" in message
-        assert "2.34" in message
-
-    def test_ordinary_platform_mismatch_does_not_warn(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """A win wheel on a linux target is a mismatch no ceiling change fixes."""
-        files = [_platform_wheel("2.0", "cp311-cp311-win_amd64")]
-        provider = Provider(
-            _index_with_files(files),
-            _linux_target(PlatformSpec("linux_x86_64")),
-            build_policy=BuildPolicy.NEVER,
-        )
-        with caplog.at_level(logging.WARNING, logger="nab_python.provider"):
-            provider.filter_distributions("pkg", files)
-        assert caplog.records == []
-
-    def test_arch_mismatch_does_not_warn(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """A macOS x86_64 wheel on an arm64 target is an arch mismatch, not a ceiling."""
-        files = [_platform_wheel("2.0", "cp311-cp311-macosx_14_0_x86_64")]
-        provider = self._macos_provider(files, PlatformSpec("macos_arm64"))
-        with caplog.at_level(logging.WARNING, logger="nab_python.provider"):
-            provider.filter_distributions("pkg", files)
-        assert caplog.records == []
-
-    def test_warns_once_per_version(self, caplog: pytest.LogCaptureFixture) -> None:
-        """A second filter pass over the same drop does not warn again."""
-        files = [_platform_wheel("2.0", "cp311-cp311-macosx_14_0_arm64")]
-        provider = self._macos_provider(files, PlatformSpec("macos_arm64"))
-        with caplog.at_level(logging.WARNING, logger="nab_python.provider"):
-            provider.filter_distributions("pkg", files)
-            provider.filter_distributions("pkg", files)
-        assert len(caplog.records) == 1
-
-    def test_two_dropped_wheels_warn_once(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """A version with two above-ceiling wheels is recorded once, warned once."""
-        files = [
-            _platform_wheel("2.0", "cp311-cp311-macosx_14_0_arm64"),
-            _platform_wheel("2.0", "cp311-cp311-macosx_15_0_arm64"),
-        ]
-        provider = self._macos_provider(files, PlatformSpec("macos_arm64"))
-        with caplog.at_level(logging.WARNING, logger="nab_python.provider"):
-            provider.filter_distributions("pkg", files)
-        assert len(caplog.records) == 1
-
-    def test_host_target_never_warns(self) -> None:
-        """A host provider has no platform_spec, so the ceiling check is skipped."""
-        provider = Provider(_index_with_files([]), ResolveTarget.for_host())
-        assert provider.ceiling_would_admit("pkg-2.0-py3-none-any.whl") is None
-
-    def test_no_target_has_no_ceiling(self) -> None:
-        """With no target there is nothing to raise, so the check is skipped."""
-        provider = Provider(_index_with_files([]))
-        assert provider.ceiling_would_admit("pkg-2.0-py3-none-any.whl") is None
+        result = provider.filter_distributions("pkg", files)
+        assert Version("2.0") in {v for v, _ in result}
 
 
 class TestRequiresPythonPatch:

--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -1424,8 +1424,8 @@ class TestBuildLockInput:
         older, newer = Matrix(
             python="==3.11",
             platforms=(
-                PlatformSpec("linux_x86_64", libc_version=(2, 17)),
-                PlatformSpec("linux_x86_64", libc_version=(2, 34)),
+                PlatformSpec("linux_x86_64", runs_on_libc=(2, 17)),
+                PlatformSpec("linux_x86_64", runs_on_libc=(2, 34)),
             ),
         ).expand()
         results = [

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -3,8 +3,9 @@
 Pins:
 
 - the knobs a platform can carry, and the ones it refuses
-- one libc family per target, at or below its version (PEP 600 / PEP 656)
-- the macOS deployment target as a ceiling, and its floor per arch
+- one libc family per target, at or below a set version (PEP 600 / PEP 656)
+- an unset runs-on-libc/runs-on-macos accepts any level; a set one drops wheels
+  needing newer, per floor
 - the free-threaded ``cpXYt`` ABI, and ``abi3t`` in place of ``abi3``
 - ``py3-none-any`` fallback ordering
 - compressed-tag-set wheels (``cp310.cp311``)
@@ -27,7 +28,6 @@ from nab_python.tags import (
     _ordered_tags_for_spec,
     _parse_tag_str,
     _platform_tags_for_spec,
-    default_ceiling_admitting,
     wheel_tag_set,
 )
 from nab_python.target import PLATFORM_MARKERS
@@ -94,30 +94,30 @@ class TestPlatformSpecKnobsBelongToTheirPlatform:
     )
     def test_libc_outside_linux_raises(self, platform_id: str) -> None:
         """Only a Linux target links a C library."""
-        with pytest.raises(ValueError, match="libc is a Linux knob"):
+        with pytest.raises(ValueError, match="libc and runs-on-libc are Linux knobs"):
             PlatformSpec(platform_id, libc="musl")
 
     @pytest.mark.parametrize("platform_id", ["macos_arm64", "windows_amd64"])
-    def test_libc_version_outside_linux_raises(self, platform_id: str) -> None:
+    def test_runs_on_libc_outside_linux_raises(self, platform_id: str) -> None:
         """A libc version is as Linux-only as the family it versions."""
-        with pytest.raises(ValueError, match="libc is a Linux knob"):
-            PlatformSpec(platform_id, libc_version=(2, 28))
+        with pytest.raises(ValueError, match="libc and runs-on-libc are Linux knobs"):
+            PlatformSpec(platform_id, runs_on_libc=(2, 28))
 
     @pytest.mark.parametrize("platform_id", ["linux_x86_64", "windows_amd64"])
-    def test_macos_min_outside_macos_raises(self, platform_id: str) -> None:
-        """A deployment target means nothing off macOS."""
-        with pytest.raises(ValueError, match="macos-min is a macOS knob"):
-            PlatformSpec(platform_id, macos_min=(14, 0))
+    def test_runs_on_macos_outside_macos_raises(self, platform_id: str) -> None:
+        """The macOS a lock runs on means nothing off macOS."""
+        with pytest.raises(ValueError, match="runs-on-macos is a macOS knob"):
+            PlatformSpec(platform_id, runs_on_macos=(14, 0))
 
     @pytest.mark.parametrize(
-        ("platform_id", "macos_min", "floor"),
+        ("platform_id", "runs_on_macos", "floor"),
         [
             ("macos_x86_64", (10, 3), "10.4"),
             ("macos_arm64", (10, 15), "11.0"),
         ],
     )
-    def test_macos_min_below_the_arch_floor_raises(
-        self, platform_id: str, macos_min: tuple[int, int], floor: str
+    def test_runs_on_macos_below_the_arch_floor_raises(
+        self, platform_id: str, runs_on_macos: tuple[int, int], floor: str
     ) -> None:
         """No wheel tag names a macOS older than the arch itself.
 
@@ -127,13 +127,16 @@ class TestPlatformSpecKnobsBelongToTheirPlatform:
         host nab happens to be running on.
         """
         with pytest.raises(ValueError, match=f"below {floor}"):
-            PlatformSpec(platform_id, macos_min=macos_min)
+            PlatformSpec(platform_id, runs_on_macos=runs_on_macos)
 
     @pytest.mark.parametrize(
         ("kwargs", "message"),
         [
-            ({"platform_id": "linux_x86_64", "libc_version": (2, 500)}, "libc-version"),
-            ({"platform_id": "macos_arm64", "macos_min": (500, 0)}, "macos-min"),
+            ({"platform_id": "linux_x86_64", "runs_on_libc": (2, 500)}, "runs-on-libc"),
+            (
+                {"platform_id": "macos_arm64", "runs_on_macos": (500, 0)},
+                "runs-on-macos",
+            ),
         ],
     )
     def test_a_version_above_every_release_raises(
@@ -155,21 +158,17 @@ class TestPlatformSpecKnobsBelongToTheirPlatform:
 class TestPlatformSpec:
     """``PlatformSpec`` exposes per-platform tag knobs."""
 
-    def test_default_libc_is_glibc_2_28(self) -> None:
-        """An undeclared Linux target is glibc 2.28."""
+    def test_undeclared_linux_target_is_glibc_accepting_any_level(self) -> None:
+        """An undeclared Linux target is glibc with no runs-on-libc, so any level."""
         spec = PlatformSpec("linux_x86_64")
         assert spec.libc == "glibc"
-        assert spec.effective_libc_version == (2, 28)
+        assert spec.runs_on_libc is None
 
-    def test_musl_libc_version_defaults_per_family(self) -> None:
-        """A musl target with no version takes musl's default, not glibc's."""
+    def test_musl_target_carries_no_default_version(self) -> None:
+        """A musl target with no runs-on-libc accepts any level too."""
         spec = PlatformSpec("linux_x86_64", libc="musl")
-        assert spec.effective_libc_version == (1, 2)
-
-    def test_declared_libc_version_wins(self) -> None:
-        """An explicit ``libc_version`` overrides the family default."""
-        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
-        assert spec.effective_libc_version == (2, 17)
+        assert spec.libc == "musl"
+        assert spec.runs_on_libc is None
 
     def test_label_of_default_spec_is_the_id(self) -> None:
         """A spec left at the platform defaults renders as its id."""
@@ -187,8 +186,8 @@ class TestPlatformSpec:
         that dropped the family could collapse two targets with disjoint
         wheel sets onto one key.
         """
-        glibc = PlatformSpec("linux_x86_64", libc_version=(2, 17))
-        musl = PlatformSpec("linux_x86_64", libc="musl", libc_version=(1, 1))
+        glibc = PlatformSpec("linux_x86_64", runs_on_libc=(2, 17))
+        musl = PlatformSpec("linux_x86_64", libc="musl", runs_on_libc=(1, 1))
         assert glibc.label == "linux_x86_64-glibc2.17"
         assert musl.label == "linux_x86_64-musl1.1"
 
@@ -214,30 +213,14 @@ class TestPlatformSpec:
         """``linux_armv7l`` carries the ``armv7l`` arch."""
         assert PlatformSpec("linux_armv7l").arch == "armv7l"
 
-    def test_armv7l_default_glibc_is_2_31(self) -> None:
-        """An undeclared armv7l target floors at glibc 2.31, not 2.28.
+    def test_armv7l_target_carries_no_default_version(self) -> None:
+        """An undeclared armv7l target sets no runs-on-libc, so it accepts any level.
 
-        Current armv7l wheels on PyPI (cryptography 46+) are built at
-        manylinux_2_31; a 2.28 floor would reject every one of them.
+        Its manylinux_2_31 wheels, and any newer, are all admitted.
         """
         spec = PlatformSpec("linux_armv7l")
         assert spec.libc == "glibc"
-        assert spec.effective_libc_version == (2, 31)
-
-    def test_armv7l_musl_keeps_the_family_default(self) -> None:
-        """The armv7l glibc floor does not move its musl default."""
-        spec = PlatformSpec("linux_armv7l", libc="musl")
-        assert spec.effective_libc_version == (1, 2)
-
-    def test_armv7l_declared_libc_version_wins(self) -> None:
-        """An explicit ``libc_version`` still overrides the armv7l default."""
-        spec = PlatformSpec("linux_armv7l", libc_version=(2, 17))
-        assert spec.effective_libc_version == (2, 17)
-
-    def test_other_arches_keep_glibc_2_28_default(self) -> None:
-        """The armv7l floor is a pure addition; every other arch stays 2.28."""
-        for platform_id in ("linux_x86_64", "linux_aarch64", "linux_i686"):
-            assert PlatformSpec(platform_id).effective_libc_version == (2, 28)
+        assert spec.runs_on_libc is None
 
     def test_label_distinguishes_space_from_underscore(self) -> None:
         """Whitespace and ``_`` in ``platform_release`` encode differently.
@@ -479,11 +462,11 @@ class TestLinuxArmv7l:
         wheel = _wheel("foo-1.0-cp312-cp312-manylinux_2_31_armv7l.whl")
         assert _compatible(wheel, python_version="3.12", spec=spec)
 
-    def test_rejects_a_manylinux_2_34_armv7l_wheel(self) -> None:
-        """A wheel above the default floor needs an explicit libc-version."""
+    def test_accepts_a_manylinux_2_34_armv7l_wheel(self) -> None:
+        """With no runs-on-libc, an above-2.31 armv7l wheel is installable."""
         spec = PlatformSpec("linux_armv7l")
         wheel = _wheel("foo-1.0-cp312-cp312-manylinux_2_34_armv7l.whl")
-        assert not _compatible(wheel, python_version="3.12", spec=spec)
+        assert _compatible(wheel, python_version="3.12", spec=spec)
 
 
 class TestTagsForTarget:
@@ -501,34 +484,35 @@ class TestTagsForTarget:
         members = TagSet.for_spec(python_version="3.15", spec=spec).members
         assert any(t.abi == "cp315t" for t in members)
 
-    def test_linux_includes_manylinux_at_or_below_libc_version(self) -> None:
+    def test_linux_includes_manylinux_at_or_below_runs_on_libc(self) -> None:
         """A glibc 2.17 target admits manylinux_2_17 and below."""
-        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
+        spec = PlatformSpec("linux_x86_64", runs_on_libc=(2, 17))
         tag_strs = {
             str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
         }
         assert "cp311-cp311-manylinux_2_17_x86_64" in tag_strs
         assert "cp311-cp311-manylinux_2_5_x86_64" in tag_strs
 
-    def test_linux_excludes_manylinux_above_libc_version(self) -> None:
+    def test_linux_excludes_manylinux_above_runs_on_libc(self) -> None:
         """manylinux_2_28 needs glibc 2.28; a 2.17 target cannot run it."""
-        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
+        spec = PlatformSpec("linux_x86_64", runs_on_libc=(2, 17))
         tag_strs = {
             str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
         }
         assert "cp311-cp311-manylinux_2_28_x86_64" not in tag_strs
 
-    def test_default_linux_admits_manylinux_2_28(self) -> None:
-        """The default glibc version admits manylinux_2_28."""
+    def test_default_linux_admits_any_manylinux(self) -> None:
+        """With no runs-on-libc, an undeclared target admits old and new glibc."""
         spec = PlatformSpec("linux_x86_64")
         tag_strs = {
             str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
         }
         assert "cp311-cp311-manylinux_2_28_x86_64" in tag_strs
+        assert "cp311-cp311-manylinux_2_39_x86_64" in tag_strs
 
     def test_linux_includes_legacy_aliases(self) -> None:
         """manylinux1, manylinux2010, manylinux2014 aliases are included."""
-        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
+        spec = PlatformSpec("linux_x86_64", runs_on_libc=(2, 17))
         tag_strs = {
             str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
         }
@@ -536,9 +520,9 @@ class TestTagsForTarget:
         assert "cp311-cp311-manylinux2010_x86_64" in tag_strs
         assert "cp311-cp311-manylinux2014_x86_64" in tag_strs
 
-    def test_linux_excludes_aliases_above_libc_version(self) -> None:
+    def test_linux_excludes_aliases_above_runs_on_libc(self) -> None:
         """manylinux2014 means glibc 2.17; a 2.12 target excludes it."""
-        spec = PlatformSpec("linux_x86_64", libc_version=(2, 12))
+        spec = PlatformSpec("linux_x86_64", runs_on_libc=(2, 12))
         tag_strs = {
             str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
         }
@@ -547,7 +531,7 @@ class TestTagsForTarget:
 
     def test_aarch64_manylinux_stops_at_2_17(self) -> None:
         """aarch64 does not descend below glibc 2.17 (PEP 599)."""
-        spec = PlatformSpec("linux_aarch64", libc_version=(2, 17))
+        spec = PlatformSpec("linux_aarch64", runs_on_libc=(2, 17))
         tag_strs = {
             str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
         }
@@ -567,7 +551,7 @@ class TestTagsForTarget:
 
     def test_x86_64_keeps_legacy_alias_range(self) -> None:
         """x86_64 still descends to manylinux1 (glibc 2.5)."""
-        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
+        spec = PlatformSpec("linux_x86_64", runs_on_libc=(2, 17))
         tag_strs = {
             str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
         }
@@ -576,40 +560,41 @@ class TestTagsForTarget:
 
     def test_musl_includes_musllinux_at_or_below_version(self) -> None:
         """A musl 1.2 target admits musllinux_1_2 and below."""
-        spec = PlatformSpec("linux_x86_64", libc="musl", libc_version=(1, 2))
+        spec = PlatformSpec("linux_x86_64", libc="musl", runs_on_libc=(1, 2))
         tag_strs = {
             str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
         }
         assert "cp311-cp311-musllinux_1_2_x86_64" in tag_strs
         assert "cp311-cp311-musllinux_1_0_x86_64" in tag_strs
 
-    def test_macos_arm64_default_accepts_modern_wheels(self) -> None:
-        """The default ``macos_arm64`` admits ``macosx_11_0`` and ``macosx_12_0``."""
+    def test_macos_arm64_default_accepts_any_wheel(self) -> None:
+        """An undeclared ``macos_arm64`` sets no runs-on-macos: old and new admit."""
         spec = PlatformSpec("macos_arm64")
         tag_strs = {
             str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
         }
-        # mac_platforms yields versions <= the declared one
         assert "cp311-cp311-macosx_11_0_arm64" in tag_strs
         assert "cp311-cp311-macosx_12_0_arm64" in tag_strs
-        # Still a ceiling: a newer-than-default macOS wheel is excluded.
-        assert "cp311-cp311-macosx_13_0_arm64" not in tag_strs
+        assert "cp311-cp311-macosx_13_0_arm64" in tag_strs
+        assert "cp311-cp311-macosx_26_0_arm64" in tag_strs
 
-    def test_macos_x86_64_uses_default_min(self) -> None:
-        """``macos_x86_64`` defaults to macOS 10.13 (x86_64-era)."""
+    def test_macos_x86_64_default_accepts_any_wheel(self) -> None:
+        """An undeclared ``macos_x86_64`` admits both x86_64-era and newer wheels."""
         spec = PlatformSpec("macos_x86_64")
         tag_strs = {
             str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
         }
         assert "cp311-cp311-macosx_10_13_x86_64" in tag_strs
+        assert "cp311-cp311-macosx_15_0_x86_64" in tag_strs
 
-    def test_macos_explicit_min(self) -> None:
-        """An explicit ``macos_min`` overrides the default."""
-        spec = PlatformSpec("macos_arm64", macos_min=(14, 0))
+    def test_macos_explicit_runs_on_drops_newer_wheels(self) -> None:
+        """A set ``runs_on_macos`` admits its version and older, and drops newer."""
+        spec = PlatformSpec("macos_arm64", runs_on_macos=(14, 0))
         tag_strs = {
             str(t) for t in TagSet.for_spec(python_version="3.11", spec=spec).members
         }
         assert "cp311-cp311-macosx_14_0_arm64" in tag_strs
+        assert "cp311-cp311-macosx_15_0_arm64" not in tag_strs
 
     def test_windows_amd64(self) -> None:
         """Windows amd64 generates ``win_amd64`` tags."""
@@ -662,15 +647,15 @@ class TestWheelCompatibility:
         assert all(result is first for result in repeats)
         assert parse.call_count == 1
 
-    def test_accepts_manylinux_at_libc_version(self) -> None:
+    def test_accepts_manylinux_at_runs_on_libc(self) -> None:
         """A manylinux_2_17 wheel matches a glibc 2.17 target."""
-        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
+        spec = PlatformSpec("linux_x86_64", runs_on_libc=(2, 17))
         wheel = _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl")
         assert _compatible(wheel, python_version="3.11", spec=spec)
 
-    def test_rejects_manylinux_above_libc_version(self) -> None:
+    def test_rejects_manylinux_above_runs_on_libc(self) -> None:
         """A manylinux_2_28 wheel does not match a glibc 2.17 target."""
-        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
+        spec = PlatformSpec("linux_x86_64", runs_on_libc=(2, 17))
         wheel = _wheel("pkg-1.0-cp311-cp311-manylinux_2_28_x86_64.whl")
         assert not _compatible(wheel, python_version="3.11", spec=spec)
 
@@ -858,7 +843,7 @@ class TestSelectWheel:
         compatible.  manylinux_2_17 is the more-specific tag (PEP 600
         recommends preferring it) and should be selected.
         """
-        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
+        spec = PlatformSpec("linux_x86_64", runs_on_libc=(2, 17))
         wheels = [
             _wheel("pkg-1.0-cp311-cp311-manylinux_2_5_x86_64.whl"),
             _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl"),
@@ -875,7 +860,7 @@ class TestSelectWheel:
         its equivalent manylinux_X_Y tag, so manylinux2014 outranks
         manylinux_2_5.
         """
-        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
+        spec = PlatformSpec("linux_x86_64", runs_on_libc=(2, 17))
         wheels = [
             _wheel("pkg-1.0-cp311-cp311-manylinux_2_5_x86_64.whl"),
             _wheel("pkg-1.0-cp311-cp311-manylinux2014_x86_64.whl"),
@@ -891,7 +876,7 @@ class TestSelectWheel:
         and manylinux_2_5 second, the loop must keep the first as
         best and not replace it.
         """
-        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
+        spec = PlatformSpec("linux_x86_64", runs_on_libc=(2, 17))
         wheels = [
             _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl"),
             _wheel("pkg-1.0-cp311-cp311-manylinux_2_5_x86_64.whl"),
@@ -902,7 +887,7 @@ class TestSelectWheel:
 
     def test_higher_build_tag_wins_at_same_rank(self) -> None:
         """Among same-tag wheels, the higher PEP 427 build tag wins."""
-        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
+        spec = PlatformSpec("linux_x86_64", runs_on_libc=(2, 17))
         build1 = _wheel("pkg-1.0-1-cp311-cp311-manylinux_2_17_x86_64.whl")
         build5 = _wheel("pkg-1.0-5-cp311-cp311-manylinux_2_17_x86_64.whl")
         chosen = TagSet.for_spec(python_version="3.11", spec=spec).pick(
@@ -912,7 +897,7 @@ class TestSelectWheel:
 
     def test_build_tag_selection_is_order_independent(self) -> None:
         """The same wheel is chosen regardless of index file order."""
-        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
+        spec = PlatformSpec("linux_x86_64", runs_on_libc=(2, 17))
         build1 = _wheel("pkg-1.0-1-cp311-cp311-manylinux_2_17_x86_64.whl")
         build5 = _wheel("pkg-1.0-5-cp311-cp311-manylinux_2_17_x86_64.whl")
         forward = TagSet.for_spec(python_version="3.11", spec=spec).pick(
@@ -926,7 +911,7 @@ class TestSelectWheel:
 
     def test_build_tagged_wheel_beats_untagged_at_same_rank(self) -> None:
         """An absent build tag sorts lowest, so a tagged wheel wins."""
-        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
+        spec = PlatformSpec("linux_x86_64", runs_on_libc=(2, 17))
         untagged = _wheel("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl")
         build3 = _wheel("pkg-1.0-3-cp311-cp311-manylinux_2_17_x86_64.whl")
         chosen = TagSet.for_spec(python_version="3.11", spec=spec).pick(
@@ -946,7 +931,7 @@ class TestSelectWheel:
 
     def test_malformed_build_tag_treated_as_absent(self) -> None:
         """A build segment without a leading digit sorts lowest."""
-        spec = PlatformSpec("linux_x86_64", libc_version=(2, 17))
+        spec = PlatformSpec("linux_x86_64", runs_on_libc=(2, 17))
         malformed = _wheel("pkg-1.0-x-cp311-cp311-manylinux_2_17_x86_64.whl")
         build5 = _wheel("pkg-1.0-5-cp311-cp311-manylinux_2_17_x86_64.whl")
         chosen = TagSet.for_spec(python_version="3.11", spec=spec).pick(
@@ -1172,12 +1157,13 @@ class TestLinuxPlatformOrderMatchesSysTags:
     def test_plain_linux_tag_comes_first(self) -> None:
         platforms = _platform_tags_for_spec(PlatformSpec("linux_x86_64"))
         assert platforms[0] == "linux_x86_64"
-        assert platforms[1] == "manylinux_2_28_x86_64"
+        # No runs-on-libc enumerates from the max down, so the top is manylinux_2_99.
+        assert platforms[1] == "manylinux_2_99_x86_64"
 
     def test_musl_target_ranks_the_plain_tag_first_too(self) -> None:
         platforms = _platform_tags_for_spec(PlatformSpec("linux_x86_64", libc="musl"))
         assert platforms[0] == "linux_x86_64"
-        assert platforms[1] == "musllinux_1_2_x86_64"
+        assert platforms[1] == "musllinux_1_99_x86_64"
 
     def test_plain_linux_wheel_wins_over_manylinux(self) -> None:
         """The install pick follows the ranking, as pip's does."""
@@ -1205,67 +1191,3 @@ class TestLinuxPlatformOrderMatchesSysTags:
         many = Tag("cp311", "cp311", "manylinux_2_28_x86_64")
         assert host.rank[plain] < host.rank[many]
         assert declared.rank[plain] < declared.rank[many]
-
-
-class TestDefaultCeilingAdmitting:
-    """``default_ceiling_admitting`` names an unset default ceiling, or nothing."""
-
-    def test_musl_default_ceiling_named(self) -> None:
-        """A musllinux wheel above the 1.2 default names the raise-to version."""
-        got = default_ceiling_admitting(
-            PlatformSpec("linux_x86_64", libc="musl"),
-            python_version="3.11",
-            implementation="cpython",
-            wheel_filename="pkg-2.0-cp311-cp311-musllinux_1_3_x86_64.whl",
-        )
-        assert got == ("libc-version", (1, 3))
-
-    def test_python_mismatch_is_not_a_ceiling(self) -> None:
-        """A cp312 wheel on a 3.11 target is not admitted by any ceiling change."""
-        got = default_ceiling_admitting(
-            PlatformSpec("macos_arm64"),
-            python_version="3.11",
-            implementation="cpython",
-            wheel_filename="pkg-2.0-cp312-cp312-macosx_14_0_arm64.whl",
-        )
-        assert got is None
-
-    def test_windows_target_has_no_ceiling(self) -> None:
-        """Windows names no versioned platform tag, so there is no ceiling."""
-        got = default_ceiling_admitting(
-            PlatformSpec("windows_amd64"),
-            python_version="3.11",
-            implementation="cpython",
-            wheel_filename="pkg-2.0-cp311-cp311-manylinux_2_34_x86_64.whl",
-        )
-        assert got is None
-
-    def test_non_wheel_filename_has_no_ceiling(self) -> None:
-        """A filename that is not a parseable wheel yields no candidate versions."""
-        got = default_ceiling_admitting(
-            PlatformSpec("macos_arm64"),
-            python_version="3.11",
-            implementation="cpython",
-            wheel_filename="pkg-2.0.tar.gz",
-        )
-        assert got is None
-
-    def test_below_ceiling_tag_is_not_a_ceiling(self) -> None:
-        """A manylinux 2.17 wheel is at or below the default, so nothing is raised."""
-        got = default_ceiling_admitting(
-            PlatformSpec("linux_x86_64"),
-            python_version="3.11",
-            implementation="cpython",
-            wheel_filename="pkg-2.0-cp311-cp311-manylinux_2_17_x86_64.whl",
-        )
-        assert got is None
-
-    def test_version_past_the_cap_is_not_raisable(self) -> None:
-        """A tag naming a version past the knob cap is not a ceiling nab can raise to."""
-        got = default_ceiling_admitting(
-            PlatformSpec("macos_arm64"),
-            python_version="3.11",
-            implementation="cpython",
-            wheel_filename="pkg-2.0-cp311-cp311-macosx_100_0_arm64.whl",
-        )
-        assert got is None


### PR DESCRIPTION
nab now accepts wheel tags of any libc or macOS level unless you declare a system the lock must run on.

Before, an unset knob held the accepted tags to a conservative default (glibc 2.28, macOS arm64 12.0 / x86_64 10.13), so nab dropped any wheel that needed a newer system than that. When a package's only wheel for a platform needs newer (for example z3-solver ships only a `manylinux_2_38` aarch64 wheel), the universal resolve failed at lock time.

Now an unset knob names no system: nab accepts a wheel of any glibc, musl, or macOS level and defers compatibility to install time, the way pip and uv do. Set `runs-on-libc` / `runs-on-macos` per platform to name a system the lock must run on, and nab drops any wheel that cannot run there, validated exactly as before. A higher value accepts more wheels, not fewer.

The change is mostly deletion: the built-in default path and its `_DEFAULT_LIBC_VERSION` / `_ARCH_DEFAULT_GLIBC` / `_DEFAULT_MACOS_MIN` constants are gone. An unset knob becomes a no-limit sentinel only inside tag generation, so it never reaches the spec or its validation.
