### PR TITLE
Set default-groups so pip/uv install the CI locks

### DIFF
--- a/.github/requirements/pylock.crosshair.toml
+++ b/.github/requirements/pylock.crosshair.toml
@@ -1,63 +1,79 @@
 lock-version = "1.0"
 environments = [
-    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
-    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
-    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
-    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
-    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
+    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and implementation_name == \"cpython\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and implementation_name == \"cpython\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and implementation_name == \"cpython\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and implementation_name == \"cpython\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and implementation_name == \"cpython\" and os_name == \"nt\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and implementation_name == \"cpython\" and os_name == \"nt\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
 ]
+requires-python = ">=3.10"
 dependency-groups = [
+    "crosshair",
+]
+default-groups = [
     "crosshair",
 ]
 created-by = "nab"
 
 [[packages]]
 name = "anyio"
-version = "4.13.0"
+version = "4.14.1"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "exceptiongroup" },
+    { name = "idna" },
+    { name = "typing-extensions" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "anyio-4.13.0.tar.gz"
-upload-time = 2026-03-24 12:59:09.671977+00:00
-url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz"
-size = 231622
+name = "anyio-4.14.1.tar.gz"
+upload-time = 2026-06-24 20:56:06.017006+00:00
+url = "https://files.pythonhosted.org/packages/3b/72/5562aabb8dd7181e8e860622a38bea08d17842b99ecd4c91f84ac95251b0/anyio-4.14.1.tar.gz"
+size = 254831
 
 [packages.sdist.hashes]
-sha256 = "334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc"
+sha256 = "8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e"
 
 [[packages.wheels]]
-name = "anyio-4.13.0-py3-none-any.whl"
-upload-time = 2026-03-24 12:59:08.246651+00:00
-url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl"
-size = 114353
+name = "anyio-4.14.1-py3-none-any.whl"
+upload-time = 2026-06-24 20:56:04.413052+00:00
+url = "https://files.pythonhosted.org/packages/b0/7b/90df4a0a816d98d6ea26f559d87836d494a2cf1fcf063be67df50a7bcc30/anyio-4.14.1-py3-none-any.whl"
+size = 124875
 
 [packages.wheels.hashes]
-sha256 = "08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708"
+sha256 = "4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72"
 
 [[packages]]
 name = "attrs"
 version = "26.1.0"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -83,6 +99,13 @@ sha256 = "c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309"
 name = "build"
 version = "1.5.0"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "colorama" },
+    { name = "importlib-metadata" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+    { name = "tomli" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -106,7 +129,13 @@ sha256 = "13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f"
 [[packages]]
 name = "cattrs"
 version = "26.1.0"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "attrs" },
+    { name = "exceptiongroup" },
+    { name = "typing-extensions" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -129,32 +158,33 @@ sha256 = "d1e0804c42639494d469d08d4f26d6b9de9b8ab26b446db7b5f8c2e97f7c3096"
 
 [[packages]]
 name = "certifi"
-version = "2026.4.22"
+version = "2026.6.17"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.7"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "certifi-2026.4.22.tar.gz"
-upload-time = 2026-04-22 11:26:11.191984+00:00
-url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz"
-size = 137077
+name = "certifi-2026.6.17.tar.gz"
+upload-time = 2026-06-17 10:31:07.894439+00:00
+url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz"
+size = 134594
 
 [packages.sdist.hashes]
-sha256 = "8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580"
+sha256 = "024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432"
 
 [[packages.wheels]]
-name = "certifi-2026.4.22-py3-none-any.whl"
-upload-time = 2026-04-22 11:26:09.372209+00:00
-url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl"
-size = 135707
+name = "certifi-2026.6.17-py3-none-any.whl"
+upload-time = 2026-06-17 10:31:06.348672+00:00
+url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl"
+size = 133289
 
 [packages.wheels.hashes]
-sha256 = "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a"
+sha256 = "2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"
 
 [[packages]]
 name = "colorama"
 version = "0.4.6"
-marker = "(python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version >= \"3.10.2.dev0\") or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
 requires-python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 index = "https://pypi.org/simple/"
 
@@ -178,618 +208,503 @@ sha256 = "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
 
 [[packages]]
 name = "coverage"
-version = "7.14.0"
+version = "7.15.0"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "coverage-7.14.0.tar.gz"
-upload-time = 2026-05-10 18:02:31.397557+00:00
-url = "https://files.pythonhosted.org/packages/23/7f/d0720730a397a999ffc0fd3f5bebef347338e3a47b727da66fbb228e2ff2/coverage-7.14.0.tar.gz"
-size = 919489
+name = "coverage-7.15.0.tar.gz"
+upload-time = 2026-07-02 13:10:50.535990+00:00
+url = "https://files.pythonhosted.org/packages/cc/8b/adeb62ea8951f13c4c7fef2e7a85e1a06b499c8d8237ea589d496029e53f/coverage-7.15.0.tar.gz"
+size = 925362
 
 [packages.sdist.hashes]
-sha256 = "057a6af2f160a85384cde4ab36f0d2777bae1057bae255f95413cdd382aa5c74"
+sha256 = "9ac3fe7a1435986463eaa8ee253ae2f2a268709ba4ae5c7dd1f52a05391ad78f"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-05-10 17:59:29.479819+00:00
-url = "https://files.pythonhosted.org/packages/b5/d9/92600e89486fd074c50f0117422b2c9592c3e144e2f25bd5ac0bc62bc7a0/coverage-7.14.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 248762
+name = "coverage-7.15.0-cp310-cp310-macosx_10_9_x86_64.whl"
+upload-time = 2026-07-02 13:08:19.252129+00:00
+url = "https://files.pythonhosted.org/packages/2a/97/c52dc440c390b6cfa87be9432b141a956e2d56d9b9f5fc8bd71c5f471722/coverage-7.15.0-cp310-cp310-macosx_10_9_x86_64.whl"
+size = 220539
 
 [packages.wheels.hashes]
-sha256 = "3fd43f0616e765ab78d069cf8358def7363957a45cee446d65c502dcfeea7893"
+sha256 = "50913d4bf5ddafa6ca3693da5e4dd833dd1b772e0283c99ca7f7d287db67331a"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 17:59:43.471850+00:00
-url = "https://files.pythonhosted.org/packages/70/db/cef0228de493f2c740c760a9057a61d00c6849480073b70a75b87c7d4bab/coverage-7.14.0-cp310-cp310-musllinux_1_2_x86_64.whl"
-size = 247544
+name = "coverage-7.15.0-cp310-cp310-macosx_11_0_arm64.whl"
+upload-time = 2026-07-02 13:08:21.013798+00:00
+url = "https://files.pythonhosted.org/packages/3f/26/602de8c2aec7e2e3e99ebfb8e04ba65598f746275396eea5f6794ff4673f/coverage-7.15.0-cp310-cp310-macosx_11_0_arm64.whl"
+size = 221058
 
 [packages.wheels.hashes]
-sha256 = "d128b1bba9361fbaaf6a19e179e6cfd6a9103ce0c0555876f72780acc93efd85"
+sha256 = "359e141ccd33893ce3f1ad5525f8b96083003677c82182e5907d62d4ea5799fc"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-py3-none-any.whl"
-upload-time = 2026-05-10 18:02:29.538126+00:00
-url = "https://files.pythonhosted.org/packages/61/e8/cb8e80d6f9f55b99588625062822bf946cf03ed06315df4bd8397f5632a1/coverage-7.14.0-py3-none-any.whl"
-size = 211764
+name = "coverage-7.15.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-07-02 13:08:23.803003+00:00
+url = "https://files.pythonhosted.org/packages/d3/b7/b6ffb9e042aa48dc4144a8a65529affaec8dca0685309353614a2a7386ad/coverage-7.15.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 249626
 
 [packages.wheels.hashes]
-sha256 = "8de5b61163aee3d05c8a2beab6f47913df7981dad1baf82c414d99158c286ab1"
+sha256 = "be616bf61346883b2cfdc5178669647e03531d81ab761a7e378558b7e8bcb628"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 17:59:31.330855+00:00
-url = "https://files.pythonhosted.org/packages/0d/e1/9ea1eb9c311da7f15853559dc1d9d82bef88ecd3e59fbeb51f16bc2ffa91/coverage-7.14.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 250625
+name = "coverage-7.15.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-07-02 13:08:25.397353+00:00
+url = "https://files.pythonhosted.org/packages/9c/06/243ff05b652333d8e3d060c11223efc2723b19cacf6605e433fa686ab5d4/coverage-7.15.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 251493
 
 [packages.wheels.hashes]
-sha256 = "731e535b1498b27d13594a0527a79b0510867b0ad891532be41cb883f2128e20"
+sha256 = "cc7bafc3fe1059463a8fdd97ca79972d6e2bf819d775c7d54991b5b1971201d6"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 17:59:36.232646+00:00
-url = "https://files.pythonhosted.org/packages/f0/e2/0b7898cda21041cc67546e19b80ba66cbbb47cbece52a76a5904de6a3aaf/coverage-7.14.0-cp310-cp310-musllinux_1_2_aarch64.whl"
-size = 248666
+name = "coverage-7.15.0-cp310-cp310-win_amd64.whl"
+upload-time = 2026-07-02 13:08:37.885862+00:00
+url = "https://files.pythonhosted.org/packages/ef/94/a09d8ee618956f626741b0734854bac4425a00e10c0565f5abca64e7e751/coverage-7.15.0-cp310-cp310-win_amd64.whl"
+size = 223214
 
 [packages.wheels.hashes]
-sha256 = "0a951308cde22cf77f953955a754d04dccb57fe3bb8e345d685778ed9fc1632a"
+sha256 = "b3b3e22030f3f6f5e01a5ce69936552a5c0f6992b7698777377b99041961031f"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-macosx_11_0_arm64.whl"
-upload-time = 2026-05-10 17:59:26.095633+00:00
-url = "https://files.pythonhosted.org/packages/24/34/898546aefbd28f0af131201d0dc852c9e976f817bd7d5bfb8dc4e02863bb/coverage-7.14.0-cp310-cp310-macosx_11_0_arm64.whl"
-size = 220192
+name = "coverage-7.15.0-cp311-cp311-macosx_10_9_x86_64.whl"
+upload-time = 2026-07-02 13:08:39.205994+00:00
+url = "https://files.pythonhosted.org/packages/ae/23/82e910835ef4b8391047025e1d53aa48d66029f444eb8b25373c849bf503/coverage-7.15.0-cp311-cp311-macosx_10_9_x86_64.whl"
+size = 220662
 
 [packages.wheels.hashes]
-sha256 = "7c843572c605ab51cfdb5c6b5f2586e2a8467c0d28eca4bdef4ec70c5fecbd82"
+sha256 = "003fff99412ea848c0aaebcc78ed2b6ce7d8a1227ed17e68470672770b78a02a"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-macosx_10_9_x86_64.whl"
-upload-time = 2026-05-10 17:59:23.106199+00:00
-url = "https://files.pythonhosted.org/packages/59/9d/7c83ef51c3eb495f10010094e661833588b7709946da634c8b66520b97c7/coverage-7.14.0-cp310-cp310-macosx_10_9_x86_64.whl"
-size = 219668
+name = "coverage-7.15.0-cp311-cp311-macosx_11_0_arm64.whl"
+upload-time = 2026-07-02 13:08:40.471642+00:00
+url = "https://files.pythonhosted.org/packages/6d/0d/c7b213dde2f1579de5231062b386d8413f79c11667eb58c39319b25991da/coverage-7.15.0-cp311-cp311-macosx_11_0_arm64.whl"
+size = 221168
 
 [packages.wheels.hashes]
-sha256 = "84c32d90bf4537f0e7b4dec9aaa9a938fb8205136b9d2ecf4d7629d5262dc075"
+sha256 = "5cbd804bf2784ce7b45114516050f346ecd50f960c4bb630a7ee9e1d78fa2118"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-win_amd64.whl"
-upload-time = 2026-05-10 17:59:46.779937+00:00
-url = "https://files.pythonhosted.org/packages/85/c0/30c454c7d3cf47b2805d4e06f12443f5eece8a5d030d3b0350e7b74ecb49/coverage-7.14.0-cp310-cp310-win_amd64.whl"
-size = 223215
+name = "coverage-7.15.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-07-02 13:08:43.387758+00:00
+url = "https://files.pythonhosted.org/packages/cc/e0/86787c56b9df17afd370d5e293515dd4d9a107a561d13054873eefad8ecc/coverage-7.15.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 253497
 
 [packages.wheels.hashes]
-sha256 = "b34ece8065914f938ed7f2c5872bb865336977a52919149846eac3744327267a"
+sha256 = "f50e40081494c1dc4239ebb202014cbcc3306ea96fb6302a34c8cc0967fc5ae8"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-05-10 17:59:53.244429+00:00
-url = "https://files.pythonhosted.org/packages/fd/35/202235eb5c3c14c212462cd91d61b7386bf8fc44bc7a77f4742d2a69174b/coverage-7.14.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 252633
+name = "coverage-7.15.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-07-02 13:08:44.897095+00:00
+url = "https://files.pythonhosted.org/packages/3f/02/181bc917359299c07dead6270f94e411151c8b60cec905c33499da69afe6/coverage-7.15.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 255607
 
 [packages.wheels.hashes]
-sha256 = "9336e23e8bb3a3925398261385e2a1533957d3e760e91070dcb0e98bfa514eed"
+sha256 = "daf96f37f5fc3a7b6c6da862eb4aee61c426bd63da236ed4a73ef0e503b4bca5"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 18:00:06.858179+00:00
-url = "https://files.pythonhosted.org/packages/35/60/a4257538ce2f6b978aeb51870d6c4208c510928a03db7e0339bb625dccb7/coverage-7.14.0-cp311-cp311-musllinux_1_2_x86_64.whl"
-size = 251125
+name = "coverage-7.15.0-cp311-cp311-win_amd64.whl"
+upload-time = 2026-07-02 13:08:58.594661+00:00
+url = "https://files.pythonhosted.org/packages/2a/ee/cd4847ebc9be6a9c0123d763645a6f1f3be6b8c58c962706368b79cbac07/coverage-7.15.0-cp311-cp311-win_amd64.whl"
+size = 223225
 
 [packages.wheels.hashes]
-sha256 = "bcb2e855b87321259a037429288ae85216d191c74de3e79bf57cd2bc0761992c"
+sha256 = "821e92b3631d762a339695824cadbbc73020354eba2a23a551a99ad34938fbe6"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 17:59:55.021505+00:00
-url = "https://files.pythonhosted.org/packages/bb/80/5f596e8995785124ee191c42535664c5e62c65995b66f4ca21e28ae04c81/coverage-7.14.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 254743
+name = "coverage-7.15.0-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2026-07-02 13:09:02.084473+00:00
+url = "https://files.pythonhosted.org/packages/2a/74/fd4c0901137c4f8d81a76ada99e43c65163b4c94a02ece107a4ec0c6b615/coverage-7.15.0-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 220838
 
 [packages.wheels.hashes]
-sha256 = "9cd1169b2230f9cbe9c638ba38022ed7a2b1e641cc07f7cea0365e4be2a74980"
+sha256 = "b75ee5e8cb7575636ac598719b4307ac529ec8fcd79608a35c3cd4d4dada812d"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 17:59:59.688294+00:00
-url = "https://files.pythonhosted.org/packages/3d/1c/b94f9f5f36396021ee2f62c5834b12e6a3d31f0bed5d6fc6d1c3caec087c/coverage-7.14.0-cp311-cp311-musllinux_1_2_aarch64.whl"
-size = 252433
+name = "coverage-7.15.0-cp312-cp312-macosx_11_0_arm64.whl"
+upload-time = 2026-07-02 13:09:03.617945+00:00
+url = "https://files.pythonhosted.org/packages/0f/2e/2347583467bd7f0402635101a916961915cc68fce652cd0db5f173ea04fc/coverage-7.15.0-cp312-cp312-macosx_11_0_arm64.whl"
+size = 221197
 
 [packages.wheels.hashes]
-sha256 = "5904abf7e18cddc463219b17552229650c6b79e061d31a1059283051169cf7d5"
+sha256 = "ffb31267816b93b075302248cc1737506081b4f163df4401e9df1a6424aafabe"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-macosx_11_0_arm64.whl"
-upload-time = 2026-05-10 17:59:49.683626+00:00
-url = "https://files.pythonhosted.org/packages/7f/8d/46692d24b3f395d4cbf17bfcc57136b4f2f9c0c0df864b0bddfc1d71a014/coverage-7.14.0-cp311-cp311-macosx_11_0_arm64.whl"
-size = 220299
+name = "coverage-7.15.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-07-02 13:09:06.559353+00:00
+url = "https://files.pythonhosted.org/packages/fb/02/6a95a5cd83b74839017ef9cf48d2d8c9ae60af919e17a3f336e6f9f1b7bd/coverage-7.15.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 255441
 
 [packages.wheels.hashes]
-sha256 = "a1816c505187592dcd1c5a5f226601a549f70365fbd00930ac88b0c225b76bb4"
+sha256 = "20d9ccc4ebd0edc434d86dfd2a1dd2a8efa6b6b3073d0485a394fee86459ebb4"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-macosx_10_9_x86_64.whl"
-upload-time = 2026-05-10 17:59:48.198844+00:00
-url = "https://files.pythonhosted.org/packages/fc/e4/649c8d4f7f1709b6dbfc474358aa1bba02f67bcd52e2fec291a5014006cd/coverage-7.14.0-cp311-cp311-macosx_10_9_x86_64.whl"
-size = 219795
+name = "coverage-7.15.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-07-02 13:09:08.197998+00:00
+url = "https://files.pythonhosted.org/packages/67/f2/406f6c57d600f68185942422c4c00f1a3255d60aee6e5fd961425cd9987e/coverage-7.15.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 256556
 
 [packages.wheels.hashes]
-sha256 = "6a78e2a9d9c5e3b8d4ab9b9d28c985ea66fced0a7d7c2aec1f216e03a2011480"
+sha256 = "20c8a976c365c8cb12f0cbd099508772ea41fb5fa80657a8506df0e11bd278c5"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-win_amd64.whl"
-upload-time = 2026-05-10 18:00:10.746583+00:00
-url = "https://files.pythonhosted.org/packages/f0/f0/a71ddbd874431e7a7cd96071f0c331cfbbad07704833c765d24ffbab8a67/coverage-7.14.0-cp311-cp311-win_amd64.whl"
-size = 223241
+name = "coverage-7.15.0-cp312-cp312-win_amd64.whl"
+upload-time = 2026-07-02 13:09:22.315686+00:00
+url = "https://files.pythonhosted.org/packages/a9/69/e34c481915fecb499b3146975061dac528752e37706edc1804f32c822469/coverage-7.15.0-cp312-cp312-win_amd64.whl"
+size = 223429
 
 [packages.wheels.hashes]
-sha256 = "bfb0ed8ec5d25e93face268115d7964db9df8b9aae8edcde9ec6b16c726a7cc1"
+sha256 = "52f9a4d2c4c56c8848bc2f524916698354b0211488b38c49ad9ae54f6cafbff6"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-05-10 18:00:18.829529+00:00
-url = "https://files.pythonhosted.org/packages/69/ff/6699e7b71e60d3049eb2bdcbc95ee3f35707b2b0e48f32e9e63d3ce30c08/coverage-7.14.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 254576
+name = "coverage-7.15.0-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2026-07-02 13:09:25.371203+00:00
+url = "https://files.pythonhosted.org/packages/76/04/145a3748098bcc86b631a85408d2c3dc5c104e0bd86d605468239b25b6c4/coverage-7.15.0-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 220863
 
 [packages.wheels.hashes]
-sha256 = "ca3d9cf2c32b521bd9518385608787fa86f38daf993695307531822c3430ed67"
+sha256 = "5be4caf3b28836f078abe700f8944dac4a65d78f16d6c600c89cb624e5535782"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 18:00:32.211009+00:00
-url = "https://files.pythonhosted.org/packages/18/9d/50f05a72dff8487464fdd4178dda5daed642a060e60afb644e3d45123559/coverage-7.14.0-cp312-cp312-musllinux_1_2_x86_64.whl"
-size = 253197
+name = "coverage-7.15.0-cp313-cp313-macosx_11_0_arm64.whl"
+upload-time = 2026-07-02 13:09:26.897907+00:00
+url = "https://files.pythonhosted.org/packages/a4/5c/4ed55708fed2c64b63c9bc5715daef670872202101938869b7fe5d5fbb8f/coverage-7.15.0-cp313-cp313-macosx_11_0_arm64.whl"
+size = 221230
 
 [packages.wheels.hashes]
-sha256 = "fcaba850dd317c65423a9d63d88f9573c53b00354d6dd95724576cc98a131595"
+sha256 = "dd58ad1404704303ca8d4f4b8a1095e7cbc7040ef17a66df1e6619aa10176430"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 18:00:20.648358+00:00
-url = "https://files.pythonhosted.org/packages/22/ec/c936d495fcd67f48f03a9c4ad3297ff80d1f222a5df3980f15b34c186c21/coverage-7.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 255690
+name = "coverage-7.15.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-07-02 13:09:30.177817+00:00
+url = "https://files.pythonhosted.org/packages/a1/fa/b70062750686bd7da454da27927622f48bbac6990ac7a4c4a4653e7b0036/coverage-7.15.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 254823
 
 [packages.wheels.hashes]
-sha256 = "92af52828e7f29d827346b0294e5a0853fa206db77db0395b282918d41e28db9"
+sha256 = "27f31ecb458da3f859aab3f15ada871eb7a7768807d88df4a9f186bb17737970"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 18:00:25.588879+00:00
-url = "https://files.pythonhosted.org/packages/f1/7f/9e65495298c3ea414742998539c37d048b5e81cc818fb1828cc6b51d10bf/coverage-7.14.0-cp312-cp312-musllinux_1_2_aarch64.whl"
-size = 253608
+name = "coverage-7.15.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-07-02 13:09:31.979017+00:00
+url = "https://files.pythonhosted.org/packages/a9/09/dad6a75a2e561b9dc5086a8c5257a7591d584246f67e23e70d2995b89ab6/coverage-7.15.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 256059
 
 [packages.wheels.hashes]
-sha256 = "8231ade007f37959fbf58acc677f26b922c02eda6f0428ea307da0fd39681bf3"
+sha256 = "13fb759be317fdc62e0f56bffdf61cfcb45c7761ad6b71e3e583e71a67ae753c"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-macosx_11_0_arm64.whl"
-upload-time = 2026-05-10 18:00:15.264075+00:00
-url = "https://files.pythonhosted.org/packages/34/23/35c7aea1274aef7525bdd2dc92f710bdde6d11652239d71d1ec450067939/coverage-7.14.0-cp312-cp312-macosx_11_0_arm64.whl"
-size = 220329
+name = "coverage-7.15.0-cp313-cp313-win_amd64.whl"
+upload-time = 2026-07-02 13:09:47.687150+00:00
+url = "https://files.pythonhosted.org/packages/a0/10/0355894d34e231f2c5449e71287e81a50793a325df2e2b027b7bcd9dfd19/coverage-7.15.0-cp313-cp313-win_amd64.whl"
+size = 223444
 
 [packages.wheels.hashes]
-sha256 = "829994cfe1aeb773ca27bf246d4badc1e764893e3bfb98fff820fcecd1ca4662"
+sha256 = "2c57a275078ee3fa185f83e400f765bc764a549de66d99b47881645cbd4ea629"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-macosx_10_13_x86_64.whl"
-upload-time = 2026-05-10 18:00:13.756391+00:00
-url = "https://files.pythonhosted.org/packages/09/1e/2f996b2c8415cbb6f54b0f5ec1ee850c96d7911961afb4fc05f4a89d8c58/coverage-7.14.0-cp312-cp312-macosx_10_13_x86_64.whl"
-size = 219967
+name = "coverage-7.15.0-cp314-cp314-macosx_10_15_x86_64.whl"
+upload-time = 2026-07-02 13:09:51.339901+00:00
+url = "https://files.pythonhosted.org/packages/4f/9c/1e3ca54f72a3185ece06c58d871099898c48f0ed6430d17b6ab75f0d180a/coverage-7.15.0-cp314-cp314-macosx_10_15_x86_64.whl"
+size = 220906
 
 [packages.wheels.hashes]
-sha256 = "7ffd19fc8aed057fd686a17a4935eef5f9859d69208f96310e893e64b9b6ccf5"
+sha256 = "41cb79af843222e11da87127ad0ecbfa878abadd0f770a4a99391a27d3887324"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-win_amd64.whl"
-upload-time = 2026-05-10 18:00:35.172847+00:00
-url = "https://files.pythonhosted.org/packages/85/19/93853133df2cb371083285ef6a93982a0173e7a233b0f61373ba9fd30eb2/coverage-7.14.0-cp312-cp312-win_amd64.whl"
-size = 223324
+name = "coverage-7.15.0-cp314-cp314-macosx_11_0_arm64.whl"
+upload-time = 2026-07-02 13:09:53.138119+00:00
+url = "https://files.pythonhosted.org/packages/09/37/f718613d83b274880382f6b67e78f3802549ae39b0b3e65ae5b5974df56e/coverage-7.15.0-cp314-cp314-macosx_11_0_arm64.whl"
+size = 221239
 
 [packages.wheels.hashes]
-sha256 = "70390b0da32cb90b501953716302906e8bcce087cb283e70d8c97729f22e92b2"
+sha256 = "7d2008989ef8fe54188d3f3bfa2e3099b025af11e90a6a1b9e7dc433d04263d8"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-05-10 18:00:44.079319+00:00
-url = "https://files.pythonhosted.org/packages/6f/5f/b5370068b2f57787454592ed7dcd1002f0f1703b7db1fa30f6a325a4ca6e/coverage-7.14.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 253961
+name = "coverage-7.15.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-07-02 13:09:56.678658+00:00
+url = "https://files.pythonhosted.org/packages/dd/1e/bec5e32aa508615d9d7a2790effb25fb4dc28606e995816afe400b25ece3/coverage-7.15.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 254789
 
 [packages.wheels.hashes]
-sha256 = "9d1aa57a1dc8e05bdc42e81c5d671d849577aeedf279f4c449d6d286f9ed88ca"
+sha256 = "65a6b6164ee5c39e2f3803f314292d6c61a607ba7fee253d1e03c42dc3903502"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 18:00:57.967216+00:00
-url = "https://files.pythonhosted.org/packages/37/53/20c5009477660f084e6ed60bc02a91894b8e234e617e86ecfd9aaf78e27b/coverage-7.14.0-cp313-cp313-musllinux_1_2_x86_64.whl"
-size = 252885
+name = "coverage-7.15.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-07-02 13:09:58.343385+00:00
+url = "https://files.pythonhosted.org/packages/17/29/0e865435b4354e4a7c03b1b7920046d31d0a273d55decefea27e011cb9bf/coverage-7.15.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 256135
 
 [packages.wheels.hashes]
-sha256 = "7b79d646cf46d5cf9a9f40281d4441df5849e445726e369006d2b117710b33fe"
+sha256 = "75128817f95a5c45bb01d65fd2d8b9cb54bbe03d81608fb70e3e14b437ad56c2"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 18:00:45.623804+00:00
-url = "https://files.pythonhosted.org/packages/29/1e/51adf17738976e8f2b85ddef7b7aa12a0838b056c92f175941d8862767c1/coverage-7.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 255193
+name = "coverage-7.15.0-cp314-cp314-win_amd64.whl"
+upload-time = 2026-07-02 13:10:15.906838+00:00
+url = "https://files.pythonhosted.org/packages/ae/3e/c8c3b75d8dbe0e35f7b0cc3ff5e949fc59500f70b21d0398813f66740664/coverage-7.15.0-cp314-cp314-win_amd64.whl"
+size = 223597
 
 [packages.wheels.hashes]
-sha256 = "90c1a51bcfddf645b3bb7ec333d9e94393a8e94f55642380fa8a9a5a9e636cb7"
+sha256 = "3bb3040e9f4bbe26fcb0cd7cc85ac63e630d3f3a9c74f027abf4caa27e706663"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 18:00:51.252258+00:00
-url = "https://files.pythonhosted.org/packages/34/46/746704f95980ba220214e1a41e18cec5aea80a898eaa53c51bf2d645ff36/coverage-7.14.0-cp313-cp313-musllinux_1_2_aarch64.whl"
-size = 253325
+name = "coverage-7.15.0-py3-none-any.whl"
+upload-time = 2026-07-02 13:10:48.641518+00:00
+url = "https://files.pythonhosted.org/packages/52/30/21b2ad45959cd50e909e02ebac1e30b4ceb7162e91c11d4c570223a458b7/coverage-7.15.0-py3-none-any.whl"
+size = 212632
 
 [packages.wheels.hashes]
-sha256 = "1b23b0c6f0b1db6ad769b7050c8b641c0bf215ded26c1816955b17b7f26edfa9"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-macosx_11_0_arm64.whl"
-upload-time = 2026-05-10 18:00:40.864715+00:00
-url = "https://files.pythonhosted.org/packages/b3/af/e567cbad5ba69c013a50146dfa886dc7193361fda77521f51274ff620e1b/coverage-7.14.0-cp313-cp313-macosx_11_0_arm64.whl"
-size = 220365
-
-[packages.wheels.hashes]
-sha256 = "23b81107f46d3f21d0cbce30664fcec0f5d9f585638a67081750f99738f6bf66"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-macosx_10_13_x86_64.whl"
-upload-time = 2026-05-10 18:00:38.887090+00:00
-url = "https://files.pythonhosted.org/packages/6b/76/b7c66ee3c66e1b0f9d894c8125983aa0c03fb2336f2fd16559f9c966157f/coverage-7.14.0-cp313-cp313-macosx_10_13_x86_64.whl"
-size = 219990
-
-[packages.wheels.hashes]
-sha256 = "f2bbb8254370eb4c628ff3d6fa8a7f74ddc40565394d4f7ab791d1fe568e37ef"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-win_amd64.whl"
-upload-time = 2026-05-10 18:01:01.531432+00:00
-url = "https://files.pythonhosted.org/packages/8f/b8/9228523e80321c2cb4880d1f589bc0171f2f71432c35118ad04dc01decce/coverage-7.14.0-cp313-cp313-win_amd64.whl"
-size = 223344
-
-[packages.wheels.hashes]
-sha256 = "0773d8329cf32b6fd222e4b52622c61fe8d503eb966cfc8d3c3c10c96266d50e"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-05-10 18:01:38.985686+00:00
-url = "https://files.pythonhosted.org/packages/d7/51/ec641c26e6dca1b25a7d2035ba6ecb7c884ef1a100a9e42fbe4ce4405139/coverage-7.14.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 253924
-
-[packages.wheels.hashes]
-sha256 = "5ebb8f4614a3787d567e610bbfdf96a4798dd69a1afb1bd8ad228d4111fe6ff3"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp314-cp314-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 18:01:54.506054+00:00
-url = "https://files.pythonhosted.org/packages/a4/66/2881853e0363a5e0a724d1103e53650795367471b6afb234f8b49e713bc6/coverage-7.14.0-cp314-cp314-musllinux_1_2_x86_64.whl"
-size = 252716
-
-[packages.wheels.hashes]
-sha256 = "65c86fb646d2bd2972e96bd1a8b45817ed907cee68655d6295fe7ec031d04cca"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 18:01:40.957470+00:00
-url = "https://files.pythonhosted.org/packages/33/c4/59c3de0bd1b538824173fd518fed51c1ce740ca5ed68e74545983f4053a9/coverage-7.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 255269
-
-[packages.wheels.hashes]
-sha256 = "6b9bf47223dd8db3d4c4b2e443b02bace480d428f0822c3f991600448a176c97"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp314-cp314-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 18:01:46.175307+00:00
-url = "https://files.pythonhosted.org/packages/ee/df/6770eaa576e604575e9a78055313250faef5faa84bd6f71a39fece519c43/coverage-7.14.0-cp314-cp314-musllinux_1_2_aarch64.whl"
-size = 253280
-
-[packages.wheels.hashes]
-sha256 = "15228a6800ce7bdf1b74800595e56db7138cecb338fdbf044806e10dcf182dfe"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp314-cp314-macosx_11_0_arm64.whl"
-upload-time = 2026-05-10 18:01:34.705980+00:00
-url = "https://files.pythonhosted.org/packages/f3/9b/4165a1d56ddc302a0e2d518fd9d412a4fd0b57562618c78c5f21c57194f5/coverage-7.14.0-cp314-cp314-macosx_11_0_arm64.whl"
-size = 220368
-
-[packages.wheels.hashes]
-sha256 = "ba3b8390db29296dbbf49e91b6fe08f990743a90c8f447ba4c2ffc29670dfa63"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp314-cp314-win_amd64.whl"
-upload-time = 2026-05-10 18:01:58.497925+00:00
-url = "https://files.pythonhosted.org/packages/f9/58/6e1b8f52fdc3184b47dc5037f5070d83a3d11042db1594b02d2a44d786c8/coverage-7.14.0-cp314-cp314-win_amd64.whl"
-size = 223600
-
-[packages.wheels.hashes]
-sha256 = "45e0f79d8351fa76e256716df91eab12890d32678b9590df7ae1042e4bd4cf5d"
+sha256 = "56da6a4cbe8f7e9e80bd072ca9cefe67d7106a440a7ec06519ec6507ac94ad19"
 
 [[packages]]
 name = "crosshair-tool"
-version = "0.0.104"
+version = "0.0.108"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.8"
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "packaging" },
+    { name = "pygls" },
+    { name = "typeshed-client" },
+    { name = "typing-extensions" },
+    { name = "typing-inspect" },
+    { name = "z3-solver" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "crosshair_tool-0.0.104.tar.gz"
-upload-time = 2026-04-26 11:39:24.845771+00:00
-url = "https://files.pythonhosted.org/packages/60/c7/ac2e7a78fa58d08b66919de9c9e13d45974976407e53ef8bfc64d62d11d5/crosshair_tool-0.0.104.tar.gz"
-size = 487964
+name = "crosshair_tool-0.0.108.tar.gz"
+upload-time = 2026-07-10 08:48:10.910820+00:00
+url = "https://files.pythonhosted.org/packages/ce/6c/b97dac06f6db50b5ca7c5b3cb06ca55c3cccca471bfa56874f5c3cf44da4/crosshair_tool-0.0.108.tar.gz"
+size = 591472
 
 [packages.sdist.hashes]
-sha256 = "c92cc8554ec1f35e079c041025cf0534d8ce83f6a8aedb7dec68d60c6d6989c2"
+sha256 = "ef5d8b2efda155145186f9dca79a0b45877a4abc4bbb57e900ded8b679e23086"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-04-26 11:38:14.767081+00:00
-url = "https://files.pythonhosted.org/packages/ad/4e/75630ada8e56f666b6b496910c61d40b5070dd07f41f99a940a8f8e3b168/crosshair_tool-0.0.104-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 568122
+name = "crosshair_tool-0.0.108-cp310-cp310-macosx_10_9_universal2.whl"
+upload-time = 2026-07-10 08:47:08.806888+00:00
+url = "https://files.pythonhosted.org/packages/21/78/5a77266abfbc13942735a15c988674f24096b325afba07e3ff10f8cb0c3d/crosshair_tool-0.0.108-cp310-cp310-macosx_10_9_universal2.whl"
+size = 676408
 
 [packages.wheels.hashes]
-sha256 = "ab958b0d5f5af991039452ef91f0392eb179a292f63d6f7900dcb938e58468a6"
+sha256 = "0a3ab38e17490b99ef4cf17cca887890c6d48041f454732c656f11dcbffba99e"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp310-cp310-musllinux_1_2_x86_64.whl"
-upload-time = 2026-04-26 11:38:15.965412+00:00
-url = "https://files.pythonhosted.org/packages/e3/0c/238d7b758f4b9ea8e1024f53a7d1d81f8f3b439fb2235f49afcc0574413f/crosshair_tool-0.0.104-cp310-cp310-musllinux_1_2_x86_64.whl"
-size = 568102
+name = "crosshair_tool-0.0.108-cp310-cp310-macosx_10_9_x86_64.whl"
+upload-time = 2026-07-10 08:47:10.302769+00:00
+url = "https://files.pythonhosted.org/packages/f9/81/7a5f5ea9651d2c2f6f248b78be1ee9a0c61222327921ffc62a1e3f184223/crosshair_tool-0.0.108-cp310-cp310-macosx_10_9_x86_64.whl"
+size = 665185
 
 [packages.wheels.hashes]
-sha256 = "cae55bc97afc15ff96f02e609f677ca4903e62814a9e621216d182e64aad2bf1"
+sha256 = "d7b9b0f28fa621e1b1b6e2c797f8babf54fc87a0c7eb53696a79b6fe0978af1c"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp310-cp310-macosx_10_9_universal2.whl"
-upload-time = 2026-04-26 11:38:10.064742+00:00
-url = "https://files.pythonhosted.org/packages/7e/03/77c8e47a2e8b3622dbb96634f84b3366fbada89c23d2268fae464258eed4/crosshair_tool-0.0.104-cp310-cp310-macosx_10_9_universal2.whl"
-size = 552469
+name = "crosshair_tool-0.0.108-cp310-cp310-macosx_11_0_arm64.whl"
+upload-time = 2026-07-10 08:47:11.443067+00:00
+url = "https://files.pythonhosted.org/packages/70/34/5f2b26ec54bc39a4cdb4ac8ef1bf724fda8d4d52bb673af9224f96fa403c/crosshair_tool-0.0.108-cp310-cp310-macosx_11_0_arm64.whl"
+size = 665898
 
 [packages.wheels.hashes]
-sha256 = "9c4e54f8def1f450b111819f7ccef3df2a9605d1fa500729e279da236f8e0629"
+sha256 = "c6f007a367f2bbeabe82ea5871b33453ad0fb9b68f63a86b6171258f42284e09"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp310-cp310-macosx_11_0_arm64.whl"
-upload-time = 2026-04-26 11:38:12.824077+00:00
-url = "https://files.pythonhosted.org/packages/8a/a5/e6c70570260317a4557d520ed73ad65774568bbeb234a48535798d38e181/crosshair_tool-0.0.104-cp310-cp310-macosx_11_0_arm64.whl"
-size = 545244
+name = "crosshair_tool-0.0.108-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-07-10 08:47:12.703429+00:00
+url = "https://files.pythonhosted.org/packages/cc/61/f7c98f3334c3f278ce0e91b8f2d3ab1431b1800f58c5dade4569d0431d6d/crosshair_tool-0.0.108-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 708509
 
 [packages.wheels.hashes]
-sha256 = "dd90d1b5b7ee769cd3c2cbdd5c3e30072bca4500663696a95ecf3698bbb0aee0"
+sha256 = "c7c268f7dba813b32d4d41537f3901c4fc5cbc942cc89d48d938277b433181c0"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp310-cp310-macosx_10_9_x86_64.whl"
-upload-time = 2026-04-26 11:38:11.683527+00:00
-url = "https://files.pythonhosted.org/packages/2c/3d/4f251fa77d0ef501496e6ca3c74b0a93db3b17b2161a83d865c5c70521d5/crosshair_tool-0.0.104-cp310-cp310-macosx_10_9_x86_64.whl"
-size = 544488
+name = "crosshair_tool-0.0.108-cp310-cp310-win_amd64.whl"
+upload-time = 2026-07-10 08:47:16.449655+00:00
+url = "https://files.pythonhosted.org/packages/05/7f/b1309d13726a4b92f5451f9ce13ba16e8cc9f768197a9456152fa37bc65c/crosshair_tool-0.0.108-cp310-cp310-win_amd64.whl"
+size = 664726
 
 [packages.wheels.hashes]
-sha256 = "6cab5eb7c36cb7582252942a620be4a49207fc09838e31fc6cafc7360c8478b8"
+sha256 = "a54f2585df0ef8518b279a1454ec114504d05ace059561ed37a4cdea3b2d4d5d"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp310-cp310-win_amd64.whl"
-upload-time = 2026-04-26 11:38:19.285117+00:00
-url = "https://files.pythonhosted.org/packages/09/57/1db86d10eed372c869032c5e40474a6b408e2be0fbc74c6166318bfb8165/crosshair_tool-0.0.104-cp310-cp310-win_amd64.whl"
-size = 548616
+name = "crosshair_tool-0.0.108-cp311-cp311-macosx_10_9_universal2.whl"
+upload-time = 2026-07-10 08:47:17.504618+00:00
+url = "https://files.pythonhosted.org/packages/43/1d/762f2bce4176a47503df1813f966ec960f8ee6cbabfabc95c28762679b1d/crosshair_tool-0.0.108-cp311-cp311-macosx_10_9_universal2.whl"
+size = 676345
 
 [packages.wheels.hashes]
-sha256 = "b8842abff5fd9f214ec0218b1f797c8a00fa42d8af7b06c8acb7f63f9201cf21"
+sha256 = "7bbb620392d19fa4fa1fc9f0056769c8ebfe35f944e21b7e5f945a035d0c2c9b"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-04-26 11:38:25.757902+00:00
-url = "https://files.pythonhosted.org/packages/cd/b2/0f49cb9c9c09770973247c7c8026dc242d455edcf7747f90c5d80d248098/crosshair_tool-0.0.104-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 568540
+name = "crosshair_tool-0.0.108-cp311-cp311-macosx_10_9_x86_64.whl"
+upload-time = 2026-07-10 08:47:18.831181+00:00
+url = "https://files.pythonhosted.org/packages/0b/e8/b6068c90e3f43020c697f1af3be794a367c1fe3949cdd25fa8b99bf01309/crosshair_tool-0.0.108-cp311-cp311-macosx_10_9_x86_64.whl"
+size = 665153
 
 [packages.wheels.hashes]
-sha256 = "482b097763d415dd6cf9a3f32cebe43ed1da7a2a5711fd9d7cd250f09ca723c0"
+sha256 = "47660d12b2050303bc026330620e90048455b8414ca3c775ef74acb35ffaec7c"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp311-cp311-musllinux_1_2_x86_64.whl"
-upload-time = 2026-04-26 11:38:27.408094+00:00
-url = "https://files.pythonhosted.org/packages/31/b1/0744c244177fb41f19584dcfb9927aa10e68198d0e459f5145bf935da5fe/crosshair_tool-0.0.104-cp311-cp311-musllinux_1_2_x86_64.whl"
-size = 568537
+name = "crosshair_tool-0.0.108-cp311-cp311-macosx_11_0_arm64.whl"
+upload-time = 2026-07-10 08:47:19.890469+00:00
+url = "https://files.pythonhosted.org/packages/fb/c3/004144fded85daaf306d7bde21dc3ec6b2dd7769fb786e22ccbf8667f955/crosshair_tool-0.0.108-cp311-cp311-macosx_11_0_arm64.whl"
+size = 665876
 
 [packages.wheels.hashes]
-sha256 = "746547a6524f58e9ae37ea33a9d324009e9e5b89f9da5f70076637ac44ca8f41"
+sha256 = "c3bda1f4d16f0049725def3dde089b48c0b99a73078bd7c8191dabe12500bdc3"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp311-cp311-macosx_10_9_universal2.whl"
-upload-time = 2026-04-26 11:38:21.060689+00:00
-url = "https://files.pythonhosted.org/packages/d3/8b/e8571130e46c11893e83ef4987ed24fd3e0c874eeda69b28073503252560/crosshair_tool-0.0.104-cp311-cp311-macosx_10_9_universal2.whl"
-size = 552570
+name = "crosshair_tool-0.0.108-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-07-10 08:47:21.187141+00:00
+url = "https://files.pythonhosted.org/packages/5b/4d/815a24d9e4b92673ffe11512fd60b77dccc834071c687f50648334be6f29/crosshair_tool-0.0.108-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 706441
 
 [packages.wheels.hashes]
-sha256 = "0fee67cef8472719f8cd4b38ff3d353ad50d1a318c1abf442e038de478fdcc1a"
+sha256 = "6050a410da2602eedcf8e83a79908015e7c85c99cb557f80ceafbf5c62a63beb"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp311-cp311-macosx_11_0_arm64.whl"
-upload-time = 2026-04-26 11:38:24.556834+00:00
-url = "https://files.pythonhosted.org/packages/99/fa/6bf6c9850518835f5ee403dbea9f110ffd630c08d04c9cfe95dc495221c6/crosshair_tool-0.0.104-cp311-cp311-macosx_11_0_arm64.whl"
-size = 545289
+name = "crosshair_tool-0.0.108-cp311-cp311-win_amd64.whl"
+upload-time = 2026-07-10 08:47:24.996148+00:00
+url = "https://files.pythonhosted.org/packages/54/b2/1746b283b46d8f4b589459824c5645f4ff045f550d741e237b78d664a263/crosshair_tool-0.0.108-cp311-cp311-win_amd64.whl"
+size = 664662
 
 [packages.wheels.hashes]
-sha256 = "044a030de364a8418e71ac21eb878c3a782d439e85c79481fed4e6a64399f0a7"
+sha256 = "50536e4534f5227dbfe98d6582c6fd8a14a760ad50432306934546d2b6226459"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp311-cp311-macosx_10_9_x86_64.whl"
-upload-time = 2026-04-26 11:38:22.837326+00:00
-url = "https://files.pythonhosted.org/packages/f4/36/2e4d178c03944daf3da205120a2a668865891a4d4e45cc3808ec107eece2/crosshair_tool-0.0.104-cp311-cp311-macosx_10_9_x86_64.whl"
-size = 544540
+name = "crosshair_tool-0.0.108-cp312-cp312-macosx_10_13_universal2.whl"
+upload-time = 2026-07-10 08:47:26.522229+00:00
+url = "https://files.pythonhosted.org/packages/58/59/d35f2ddbdb5b779bbaff94ef7a3df0f11bfd422561610c3de4831cabdbba/crosshair_tool-0.0.108-cp312-cp312-macosx_10_13_universal2.whl"
+size = 680989
 
 [packages.wheels.hashes]
-sha256 = "58a813295b3fce061ac74f6e42dd40c745bc21ccf0af48b2f7a1e0b97e96d040"
+sha256 = "ccd3a09f9b06e8b1572f80e24f5afcbd9b3f0ac8ff8dccace1cb7cb52bd32d33"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp311-cp311-win_amd64.whl"
-upload-time = 2026-04-26 11:38:30.420511+00:00
-url = "https://files.pythonhosted.org/packages/3b/32/a13631ce4d43057c305904611e69d2d800c159bdad9aba6df7cad46f6644/crosshair_tool-0.0.104-cp311-cp311-win_amd64.whl"
-size = 548644
+name = "crosshair_tool-0.0.108-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2026-07-10 08:47:28.211480+00:00
+url = "https://files.pythonhosted.org/packages/12/8e/14bc41258d8aef257bc64ea52b3603c4d33f920a821d71eb1642825d7cab/crosshair_tool-0.0.108-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 667579
 
 [packages.wheels.hashes]
-sha256 = "aa5b5892646d5a95191ea7182dbdf60561165ec75ebef5f24fad5bea9cd9dcff"
+sha256 = "7973a20d9573e5a7946aa3fd49b238e31c518b88540b2f8b67c3aba6486218f0"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-04-26 11:38:36.529600+00:00
-url = "https://files.pythonhosted.org/packages/ef/33/286fa2180a7d328c3d8f047e40527b348f4d62debbdfa729cb112bf223f3/crosshair_tool-0.0.104-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 578527
+name = "crosshair_tool-0.0.108-cp312-cp312-macosx_11_0_arm64.whl"
+upload-time = 2026-07-10 08:47:29.425590+00:00
+url = "https://files.pythonhosted.org/packages/2a/04/36457ed9759df2d67b8e5e1e1fa248b86d0c789475a5d41ab3d4426f44e8/crosshair_tool-0.0.108-cp312-cp312-macosx_11_0_arm64.whl"
+size = 668028
 
 [packages.wheels.hashes]
-sha256 = "bb3f5c4f4c39b78c68f0d52889cf127da18994f5177faae90c7aedb79dbe4df5"
+sha256 = "ece0813571ccb444fc0490beffe5bfed507ba4632ff899364379e1b2d6d8c317"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp312-cp312-musllinux_1_2_x86_64.whl"
-upload-time = 2026-04-26 11:38:38.040720+00:00
-url = "https://files.pythonhosted.org/packages/fc/a8/c8d0ed5a6b1e5889811c360b0e89028ef5d9d43caad62282b82b159fa444/crosshair_tool-0.0.104-cp312-cp312-musllinux_1_2_x86_64.whl"
-size = 577584
+name = "crosshair_tool-0.0.108-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-07-10 08:47:30.910852+00:00
+url = "https://files.pythonhosted.org/packages/fa/8e/8c0e63f7608e3d69759119d8a9eb6f33e804046f0cc81063c3ad256346f9/crosshair_tool-0.0.108-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 715647
 
 [packages.wheels.hashes]
-sha256 = "6c2f33631751443c64f35d95daf44bcc262841acc22f24d0f1daa5edf49ced28"
+sha256 = "3e8a4a2cce69550e05ab7aee07b6d4aaf3d128a92c54d447f85d7a1ab6346212"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp312-cp312-macosx_10_13_universal2.whl"
-upload-time = 2026-04-26 11:38:32.069823+00:00
-url = "https://files.pythonhosted.org/packages/f3/23/ec19144d79d09afef4042e5b8e464ddf8587941547a0b9abf2f42cd2a16a/crosshair_tool-0.0.104-cp312-cp312-macosx_10_13_universal2.whl"
-size = 556457
+name = "crosshair_tool-0.0.108-cp312-cp312-win_amd64.whl"
+upload-time = 2026-07-10 08:47:34.515085+00:00
+url = "https://files.pythonhosted.org/packages/f4/4f/2ebc480814158c69678c3fa24300c390d5dc96657e0e790d206343d20ffb/crosshair_tool-0.0.108-cp312-cp312-win_amd64.whl"
+size = 666608
 
 [packages.wheels.hashes]
-sha256 = "aa131e3e486cd5b158399e939bd6e1231c26980a8006fa3162fa859bf34aecc0"
+sha256 = "1c9295975886bf987663df6141a3c5a85074fa5d7280daa19c3044fe5b0c0032"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp312-cp312-macosx_11_0_arm64.whl"
-upload-time = 2026-04-26 11:38:34.775093+00:00
-url = "https://files.pythonhosted.org/packages/c1/48/8351d3c3ad9a172d4ddf98a63c466b78537aa0ae69e561a4d8e672a3f9be/crosshair_tool-0.0.104-cp312-cp312-macosx_11_0_arm64.whl"
-size = 547571
+name = "crosshair_tool-0.0.108-cp313-cp313-macosx_10_13_universal2.whl"
+upload-time = 2026-07-10 08:47:35.604204+00:00
+url = "https://files.pythonhosted.org/packages/51/67/4a32161a22013f71e5c5b85aa578b4a630a34dadfefac7d274d49b13e82e/crosshair_tool-0.0.108-cp313-cp313-macosx_10_13_universal2.whl"
+size = 688606
 
 [packages.wheels.hashes]
-sha256 = "15003ef84efed7d17de342792dc304661c6c9a093b7c5bcbaaf327a4252a3747"
+sha256 = "4ac85767d80fbe387f8f61c77826601b322c55a813cc567d6c34f66c02e94c11"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp312-cp312-macosx_10_13_x86_64.whl"
-upload-time = 2026-04-26 11:38:33.485445+00:00
-url = "https://files.pythonhosted.org/packages/68/aa/db67175ab75791384c4e0c55c359520611a73dcb927647d282b16c875cf1/crosshair_tool-0.0.104-cp312-cp312-macosx_10_13_x86_64.whl"
-size = 546979
+name = "crosshair_tool-0.0.108-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2026-07-10 08:47:36.761382+00:00
+url = "https://files.pythonhosted.org/packages/e7/e8/67fbc1bd2d0b0ffb4a148ca343cf118ba5e879be40f82ae15249003de49f/crosshair_tool-0.0.108-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 671327
 
 [packages.wheels.hashes]
-sha256 = "cceb359a046e94ac50d123cdb6b6e120c26ed0029e75230bae2210c21ca33434"
+sha256 = "450de74804eb4608c97e85825e09eb28b0af93479d914b63f824befc3bec2ffd"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp312-cp312-win_amd64.whl"
-upload-time = 2026-04-26 11:38:40.688601+00:00
-url = "https://files.pythonhosted.org/packages/f4/60/c6bf30b1c65950afd622f2aa77f66a8a87c2934295ec9c3c0cbba158470c/crosshair_tool-0.0.104-cp312-cp312-win_amd64.whl"
-size = 550451
+name = "crosshair_tool-0.0.108-cp313-cp313-macosx_11_0_arm64.whl"
+upload-time = 2026-07-10 08:47:37.857392+00:00
+url = "https://files.pythonhosted.org/packages/21/6d/fab23022515382217c0d3c3b88b2a4dd7485a4ecc9a6a96c549c7026d134/crosshair_tool-0.0.108-cp313-cp313-macosx_11_0_arm64.whl"
+size = 671923
 
 [packages.wheels.hashes]
-sha256 = "294e70a2c35b655d1214b99443e853844fa63fbf9d2d8ab658b842fb1575021d"
+sha256 = "af99c75ded24de91cfe2f147e1797de59b0890bbcc813360da6fff0f3fae8c28"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-04-26 11:38:47.195747+00:00
-url = "https://files.pythonhosted.org/packages/05/ea/3a2db77a94941df6e0c0dbd312b5289bf55df0ba6f5ae52227304a0318bd/crosshair_tool-0.0.104-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 585256
+name = "crosshair_tool-0.0.108-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-07-10 08:47:39.139135+00:00
+url = "https://files.pythonhosted.org/packages/9d/5c/25d0bb25492e7bbbea1d7a23d8144b843bdff90a234009db85221461b02f/crosshair_tool-0.0.108-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 722114
 
 [packages.wheels.hashes]
-sha256 = "c1c1cfe3fbb3054f1031ac3b2ca2cb268b6330efd4737e50a3b5d81e748002e4"
+sha256 = "5458fd1079bc0f61dff7f4ebb74c75c188c29468674b69c17214df94b2110120"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp313-cp313-musllinux_1_2_x86_64.whl"
-upload-time = 2026-04-26 11:38:49.011091+00:00
-url = "https://files.pythonhosted.org/packages/c9/14/d1c6f7540fe474eacf8da1a8e0be3ffba03ed5b98de30a229dc16c2d1be2/crosshair_tool-0.0.104-cp313-cp313-musllinux_1_2_x86_64.whl"
-size = 584271
+name = "crosshair_tool-0.0.108-cp313-cp313-win_amd64.whl"
+upload-time = 2026-07-10 08:47:42.718981+00:00
+url = "https://files.pythonhosted.org/packages/e0/d4/fde88f71a48f318f6d131c282753c51f40b78436de94842a0c690e1ea509/crosshair_tool-0.0.108-cp313-cp313-win_amd64.whl"
+size = 666605
 
 [packages.wheels.hashes]
-sha256 = "299cd2748313d2adab0aa22c890212efacd20560e071c3c9890e42648e728a3b"
+sha256 = "9f2749037b3ba07e1f6f5d7c8840dfdd72e729efde6588633dbb43fa255c101c"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp313-cp313-macosx_10_13_universal2.whl"
-upload-time = 2026-04-26 11:38:42.160349+00:00
-url = "https://files.pythonhosted.org/packages/af/52/66a5f834bd0c98558092f625cca1e06f22d2157e10a3ea68f664e5688710/crosshair_tool-0.0.104-cp313-cp313-macosx_10_13_universal2.whl"
-size = 565185
+name = "crosshair_tool-0.0.108-cp314-cp314-macosx_10_13_universal2.whl"
+upload-time = 2026-07-10 08:47:44.199213+00:00
+url = "https://files.pythonhosted.org/packages/18/8e/a4eb3c36411092122ba3c8fa6f4a193f38d0e157bff096eab45c78636550/crosshair_tool-0.0.108-cp314-cp314-macosx_10_13_universal2.whl"
+size = 686394
 
 [packages.wheels.hashes]
-sha256 = "946ab8b537ff35cde1c1e47582242f84cfbaec7a304438411b2cf399d32cfdd7"
+sha256 = "b95d3a179db84ecfa7b5f1e0b52db890507b716e9ad01b1de17aa0e03b028765"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp313-cp313-macosx_11_0_arm64.whl"
-upload-time = 2026-04-26 11:38:45.481606+00:00
-url = "https://files.pythonhosted.org/packages/b9/79/c09da37ce2f39fb24957ffd6b9afc8afa1797d797af8055cf01945b4802c/crosshair_tool-0.0.104-cp313-cp313-macosx_11_0_arm64.whl"
-size = 551440
+name = "crosshair_tool-0.0.108-cp314-cp314-macosx_10_13_x86_64.whl"
+upload-time = 2026-07-10 08:47:45.496974+00:00
+url = "https://files.pythonhosted.org/packages/de/ce/facb11aa1cc7218c87939b65f426772a4aeeac3e90b25d4f124bc6eb540f/crosshair_tool-0.0.108-cp314-cp314-macosx_10_13_x86_64.whl"
+size = 670236
 
 [packages.wheels.hashes]
-sha256 = "82fb84d44d7fde08dba2e77771ec9adead0b4e6953694f49e745531c75f75779"
+sha256 = "b1f197f5e2c4a886b54438f5b668fc3a77aa17b6ae20fe835bbc07673a58001f"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp313-cp313-macosx_10_13_x86_64.whl"
-upload-time = 2026-04-26 11:38:43.672933+00:00
-url = "https://files.pythonhosted.org/packages/f9/08/db7ac3f0876937e3fb05d19343b757571a8d3095e6e4daab023b5307f5a2/crosshair_tool-0.0.104-cp313-cp313-macosx_10_13_x86_64.whl"
-size = 550775
+name = "crosshair_tool-0.0.108-cp314-cp314-macosx_11_0_arm64.whl"
+upload-time = 2026-07-10 08:47:46.607522+00:00
+url = "https://files.pythonhosted.org/packages/a3/24/2be298c3a8b45d627d05b18787eabfbdd81ffc5f197695095b348917078e/crosshair_tool-0.0.108-cp314-cp314-macosx_11_0_arm64.whl"
+size = 670850
 
 [packages.wheels.hashes]
-sha256 = "8ce233e4568b67bcf812413a7ffa20b807fd776551036aa98b3484bc26fa1914"
+sha256 = "f646ab3934381181b6ff810f0ddb7fa2b44603fc1c58aa3772f097deb62aa654"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp313-cp313-win_amd64.whl"
-upload-time = 2026-04-26 11:38:52.428834+00:00
-url = "https://files.pythonhosted.org/packages/5a/9b/427700c38d9912993fc414c504c735a61e3c40f476fd3b3a3659e55276d0/crosshair_tool-0.0.104-cp313-cp313-win_amd64.whl"
-size = 550474
+name = "crosshair_tool-0.0.108-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-07-10 08:47:47.868731+00:00
+url = "https://files.pythonhosted.org/packages/20/ec/dd866f521730850a34ed899f7ebaeb247245b063e6f6d3536cfb0ee8d700/crosshair_tool-0.0.108-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 760746
 
 [packages.wheels.hashes]
-sha256 = "beecba3d1d306cc3a1ab551fe22777cd0c162e97d61b81fa01a57eaa3b00fa21"
+sha256 = "3946eb508175618928a74f95eb00d9827e5da92fc1271b4b5ca56f65af512abb"
 
 [[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-04-26 11:38:57.834245+00:00
-url = "https://files.pythonhosted.org/packages/97/54/b4b9143d36634f281b0122e01a7b57902813b1ab7daf3ce7da69cae3a131/crosshair_tool-0.0.104-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 621829
+name = "crosshair_tool-0.0.108-cp314-cp314-win_amd64.whl"
+upload-time = 2026-07-10 08:47:51.719548+00:00
+url = "https://files.pythonhosted.org/packages/1b/1a/a95714de87cff9f5e30c98d1d1049a1876a40e48983c0b5b1252fb338939/crosshair_tool-0.0.108-cp314-cp314-win_amd64.whl"
+size = 665470
 
 [packages.wheels.hashes]
-sha256 = "26e8ec24a65e4a0d0af48c1c2fa6aa35fe0ed9dba6a9a631b733306eb28627dc"
-
-[[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp314-cp314-musllinux_1_2_x86_64.whl"
-upload-time = 2026-04-26 11:38:59.327237+00:00
-url = "https://files.pythonhosted.org/packages/81/ec/cb3b1c419ec9353485a7df7f074def4af91e4b921011e916142a6b44683c/crosshair_tool-0.0.104-cp314-cp314-musllinux_1_2_x86_64.whl"
-size = 619940
-
-[packages.wheels.hashes]
-sha256 = "22aaa4f318a0b316c0b54dd9a0ebcd90bac17a4fc4a8f92159f9cb2d12510ba8"
-
-[[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp314-cp314-macosx_10_13_universal2.whl"
-upload-time = 2026-04-26 11:38:53.760757+00:00
-url = "https://files.pythonhosted.org/packages/f4/83/e851837d69ea3ebce1bd1c6d755e976aab03086de69070f1dd06ca183367/crosshair_tool-0.0.104-cp314-cp314-macosx_10_13_universal2.whl"
-size = 562899
-
-[packages.wheels.hashes]
-sha256 = "1cb7d856355954c371361cfe6f1e3de2aa4e3ec9c9e00c71bebd6344f72a5a53"
-
-[[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp314-cp314-macosx_11_0_arm64.whl"
-upload-time = 2026-04-26 11:38:56.513055+00:00
-url = "https://files.pythonhosted.org/packages/fb/84/d3b9868079d6e2970ec230954694d084aa76024c37223f2a83456286335b/crosshair_tool-0.0.104-cp314-cp314-macosx_11_0_arm64.whl"
-size = 550295
-
-[packages.wheels.hashes]
-sha256 = "efe35ed148effc6bd8cc3d997a87d85edc4419af3fa0fa96486d7b1284d36c17"
-
-[[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp314-cp314-macosx_10_13_x86_64.whl"
-upload-time = 2026-04-26 11:38:55.054959+00:00
-url = "https://files.pythonhosted.org/packages/ae/ca/d705535707dd4cadd0870540762d34ca3d287c8386b8a6678b761998ba03/crosshair_tool-0.0.104-cp314-cp314-macosx_10_13_x86_64.whl"
-size = 549622
-
-[packages.wheels.hashes]
-sha256 = "93651387e63549a2c7578f81bc93aae1a237582da45a96b52f91143009fb16fb"
-
-[[packages.wheels]]
-name = "crosshair_tool-0.0.104-cp314-cp314-win_amd64.whl"
-upload-time = 2026-04-26 11:39:02.291093+00:00
-url = "https://files.pythonhosted.org/packages/50/19/85fd7ea65d07368e3e7ec364b169d163e3bfdaac35fd11d779ffab523b38/crosshair_tool-0.0.104-cp314-cp314-win_amd64.whl"
-size = 549178
-
-[packages.wheels.hashes]
-sha256 = "d086515a49c881a2f234e75d62bfe59b9b19d954054be3ed18ea6150913db026"
+sha256 = "b1b338182953362526bce43ed036e9a609c2e7900cb773a4945ee95e346f7aef"
 
 [[packages]]
 name = "docstring-parser"
@@ -818,8 +733,11 @@ sha256 = "b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b"
 [[packages]]
 name = "exceptiongroup"
 version = "1.3.1"
-marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version < \"3.10.2\" and \"crosshair\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version >= \"3.10.2.dev0\" and \"crosshair\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\" and \"crosshair\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"crosshair\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\" and \"crosshair\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version >= \"3.10.2.dev0\" and \"crosshair\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\" and \"crosshair\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"crosshair\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\" and \"crosshair\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version >= \"3.10.2.dev0\" and \"crosshair\" in dependency_groups)"
 requires-python = ">=3.7"
+dependencies = [
+    { name = "typing-extensions" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -843,6 +761,7 @@ sha256 = "a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598"
 [[packages]]
 name = "h11"
 version = "0.16.0"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.8"
 index = "https://pypi.org/simple/"
 
@@ -867,7 +786,12 @@ sha256 = "63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"
 [[packages]]
 name = "h2"
 version = "4.3.0"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.9"
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -890,32 +814,38 @@ sha256 = "c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd"
 
 [[packages]]
 name = "hpack"
-version = "4.1.0"
-requires-python = ">=3.9"
+version = "4.2.0"
+marker = "\"crosshair\" in dependency_groups"
+requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "hpack-4.1.0.tar.gz"
-upload-time = 2025-01-22 21:44:58.347520+00:00
-url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz"
-size = 51276
+name = "hpack-4.2.0.tar.gz"
+upload-time = 2026-06-23 18:34:46.667449+00:00
+url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz"
+size = 51300
 
 [packages.sdist.hashes]
-sha256 = "ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca"
+sha256 = "0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0"
 
 [[packages.wheels]]
-name = "hpack-4.1.0-py3-none-any.whl"
-upload-time = 2025-01-22 21:44:56.920811+00:00
-url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl"
-size = 34357
+name = "hpack-4.2.0-py3-none-any.whl"
+upload-time = 2026-06-23 18:34:45.472685+00:00
+url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl"
+size = 34246
 
 [packages.wheels.hashes]
-sha256 = "157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496"
+sha256 = "858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986"
 
 [[packages]]
 name = "httpcore"
 version = "1.0.9"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.8"
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -939,7 +869,15 @@ sha256 = "2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"
 [[packages]]
 name = "httpx"
 version = "0.28.1"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.8"
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "h2" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -963,6 +901,7 @@ sha256 = "d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"
 [[packages]]
 name = "hyperframe"
 version = "6.1.0"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -986,32 +925,303 @@ sha256 = "b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5"
 
 [[packages]]
 name = "hypothesis"
-version = "6.152.7"
+version = "6.156.6"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "exceptiongroup" },
+    { name = "sortedcontainers" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "hypothesis-6.152.7.tar.gz"
-upload-time = 2026-05-13 04:19:34.124471+00:00
-url = "https://files.pythonhosted.org/packages/91/dd/19d273652eb20dac15f32bbc484f2f6d51ccd8fe51fdb27da3f85f9017e8/hypothesis-6.152.7.tar.gz"
-size = 468147
+name = "hypothesis-6.156.6.tar.gz"
+upload-time = 2026-07-10 20:56:49.960567+00:00
+url = "https://files.pythonhosted.org/packages/20/83/8dbe89bdb8c6f25a7a52e7898af6d82fe35dfef08e5c702f6e33231ce6c6/hypothesis-6.156.6.tar.gz"
+size = 476304
 
 [packages.sdist.hashes]
-sha256 = "741dedcede2ae0f32c32929a5992804b61f2b0400403b6a51a881a2b58482782"
+sha256 = "96de02faefa3ce079873541da96f42595583bb001e8e4219294ed7d4501cc4cc"
 
 [[packages.wheels]]
-name = "hypothesis-6.152.7-py3-none-any.whl"
-upload-time = 2026-05-13 04:19:30.635768+00:00
-url = "https://files.pythonhosted.org/packages/0a/1e/8222edaee03c37350eaa726213614e343a62f1e56396dd000ad9277bfa3d/hypothesis-6.152.7-py3-none-any.whl"
-size = 533802
+name = "hypothesis-6.156.6-cp310-abi3-macosx_10_12_x86_64.whl"
+upload-time = 2026-07-10 20:56:16.311529+00:00
+url = "https://files.pythonhosted.org/packages/1a/dc/0c2a851f06c91d5ac9ef0f3b9615efc1ed650411d2eee23b6334f491c85e/hypothesis-6.156.6-cp310-abi3-macosx_10_12_x86_64.whl"
+size = 747998
 
 [packages.wheels.hashes]
-sha256 = "c0b17dd428fcb6e962f60315f6f4a77816c72fbb281ce9ba73699dabead5ec82"
+sha256 = "caf6a93d011c10972da111c38ceb34ced20feaa8581e2b350c0655b022e27875"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp310-abi3-macosx_11_0_arm64.whl"
+upload-time = 2026-07-10 20:55:36.825547+00:00
+url = "https://files.pythonhosted.org/packages/8e/f8/59203ca978ab51595d12d6bc7e7a63300d7373431ab42ca3f1742e45db68/hypothesis-6.156.6-cp310-abi3-macosx_11_0_arm64.whl"
+size = 743073
+
+[packages.wheels.hashes]
+sha256 = "07f2bc9df1aeba80e12029c1618e2ee54abc440068c305d7075ffd6b85251843"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-07-10 20:55:49.470201+00:00
+url = "https://files.pythonhosted.org/packages/68/d8/86a0023740434098d1b187a62bd5f99b198f098fb43e7fc58342283a8270/hypothesis-6.156.6-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1070169
+
+[packages.wheels.hashes]
+sha256 = "7baca17f4803ad4aa151732326f3990baf54c3127df44aa872ac5bdf8a98a9a6"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-07-10 20:55:53.502287+00:00
+url = "https://files.pythonhosted.org/packages/9b/82/673453915fd0c67673f35a4876ba88f48c621335f293f3537d77b27d4286/hypothesis-6.156.6-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 1121760
+
+[packages.wheels.hashes]
+sha256 = "8083806645f84243aade727f4978185caaa0b7190af4318673999ee15fdbf424"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp310-abi3-win_amd64.whl"
+upload-time = 2026-07-10 20:55:30.634731+00:00
+url = "https://files.pythonhosted.org/packages/d6/89/2008d287289841a936456cb13443ca89d88da6e4527d611d482e9544164d/hypothesis-6.156.6-cp310-abi3-win_amd64.whl"
+size = 640382
+
+[packages.wheels.hashes]
+sha256 = "32710718c22fe8c5571464e898bb87d282837b02617d6ad68130abf7cb4843cb"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp310-cp310-macosx_10_12_x86_64.whl"
+upload-time = 2026-07-10 20:55:35.708080+00:00
+url = "https://files.pythonhosted.org/packages/0b/dc/b502504a972af7368b62e712268d310ffbc81d0ebfb31d5a9c60332a5063/hypothesis-6.156.6-cp310-cp310-macosx_10_12_x86_64.whl"
+size = 749319
+
+[packages.wheels.hashes]
+sha256 = "afec0631a7a557acb50f665108b5d1d1123c21bc702d156a740db1cc33be4a7d"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp310-cp310-macosx_11_0_arm64.whl"
+upload-time = 2026-07-10 20:55:31.983920+00:00
+url = "https://files.pythonhosted.org/packages/8f/fe/a4867bc2b8b81d9b1648992fb7e4a732b3db480ff2d02df2c7b59189c812/hypothesis-6.156.6-cp310-cp310-macosx_11_0_arm64.whl"
+size = 743969
+
+[packages.wheels.hashes]
+sha256 = "583a658162ee7e1a82155e3f146932a3a2269030294f3c83f5cf52fcaa0562c3"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-07-10 20:55:44.277491+00:00
+url = "https://files.pythonhosted.org/packages/2e/22/6ece4337e01c634594bb177009c049aa3133c151d9e397edccb6c3938567/hypothesis-6.156.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1070874
+
+[packages.wheels.hashes]
+sha256 = "f9600277defbfa769d8a6af264cbdff16294682c210c2d058ef39348fec16c0c"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-07-10 20:56:20.721347+00:00
+url = "https://files.pythonhosted.org/packages/05/00/5820a3b1fe264b23770f77dbb3ac0f6fdadd21b640624791a05950f934da/hypothesis-6.156.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 1122191
+
+[packages.wheels.hashes]
+sha256 = "c7c3f067166bfc28b67f0042fc5fdcc87b3b58664da0c2f563fe544448b7ab3b"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp310-cp310-win_amd64.whl"
+upload-time = 2026-07-10 20:56:26.939622+00:00
+url = "https://files.pythonhosted.org/packages/96/4e/bfe57f182f51784549210903241057ae94784858117b965613089f5f89ad/hypothesis-6.156.6-cp310-cp310-win_amd64.whl"
+size = 640384
+
+[packages.wheels.hashes]
+sha256 = "02accb187617ebaebb120da931f799a3cb0df7c38706f97f9d022441d4faf533"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp311-cp311-macosx_10_12_x86_64.whl"
+upload-time = 2026-07-10 20:56:48.220633+00:00
+url = "https://files.pythonhosted.org/packages/13/64/e4a0796190d8089e85f06731e21fdddd7e8edd3a4e562101527a048e21c4/hypothesis-6.156.6-cp311-cp311-macosx_10_12_x86_64.whl"
+size = 748988
+
+[packages.wheels.hashes]
+sha256 = "5baec7943a14d106e982121dd4f74cfc5ef45e37c17f94fe49338d3d1377f38c"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp311-cp311-macosx_11_0_arm64.whl"
+upload-time = 2026-07-10 20:56:09.113141+00:00
+url = "https://files.pythonhosted.org/packages/9a/a2/4a789b286cd2cced31992e1f683036b51dd6909b934ea007ffb43aa3a32f/hypothesis-6.156.6-cp311-cp311-macosx_11_0_arm64.whl"
+size = 743754
+
+[packages.wheels.hashes]
+sha256 = "b5f519905ddeb10e23b8ba2c254541a5b1a8f146fe0551be94d972f4a77226f4"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-07-10 20:56:28.738149+00:00
+url = "https://files.pythonhosted.org/packages/d2/f7/3dd36c1c03d24ae3ffc3c5b0eca8cc4ae90c07abc320f76509eceb37019a/hypothesis-6.156.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1070732
+
+[packages.wheels.hashes]
+sha256 = "4c108655960b58ded3ca71b2dc5c69fb2ba7e9c723aeb6106facec3892d09087"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-07-10 20:56:07.676236+00:00
+url = "https://files.pythonhosted.org/packages/57/51/befc4b816b471078034a875eb1ef69e0411ab84bcce582b4be173258785a/hypothesis-6.156.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 1121988
+
+[packages.wheels.hashes]
+sha256 = "7c8d37bebb6924729bc0bbf5852689df568842948abe4d93dd0ad3377adf76fa"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp311-cp311-win_amd64.whl"
+upload-time = 2026-07-10 20:56:10.396173+00:00
+url = "https://files.pythonhosted.org/packages/13/03/7106a110df29eb631d66776e8aa8128f82f04a9dd2b6b22b612e6025e3a2/hypothesis-6.156.6-cp311-cp311-win_amd64.whl"
+size = 640222
+
+[packages.wheels.hashes]
+sha256 = "84dc89caaf741a02f904ca7bd02b1af99650c75552868162290208aeecb70858"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp312-cp312-macosx_10_12_x86_64.whl"
+upload-time = 2026-07-10 20:56:38.036137+00:00
+url = "https://files.pythonhosted.org/packages/8c/45/9f009005b9c796f4a40424484ac7e70847bc088456fd940a937f96bb4b6d/hypothesis-6.156.6-cp312-cp312-macosx_10_12_x86_64.whl"
+size = 748844
+
+[packages.wheels.hashes]
+sha256 = "a2a728b514fceb81e3f0464508911d5220fd74dadc3270f859427a686b60c4cf"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp312-cp312-macosx_11_0_arm64.whl"
+upload-time = 2026-07-10 20:55:27.539490+00:00
+url = "https://files.pythonhosted.org/packages/02/2f/4d852bb8a9c73a68b18eca9b5b085285282122166e158f4d2a477639bfee/hypothesis-6.156.6-cp312-cp312-macosx_11_0_arm64.whl"
+size = 741936
+
+[packages.wheels.hashes]
+sha256 = "7489b9a8f9df8227edd6c7cd8b9ccfab2483bab24da6a474c175973ca2294f58"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-07-10 20:56:43.017461+00:00
+url = "https://files.pythonhosted.org/packages/74/89/b9968070ae042f9bf3149bb6ba6399d5f28f452e0fb7f638cafc69ff0b9a/hypothesis-6.156.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1069749
+
+[packages.wheels.hashes]
+sha256 = "42760873d6db1069d6edbaa355a61b9078a9950259efcfc72fc695741d7db7cd"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-07-10 20:56:25.424325+00:00
+url = "https://files.pythonhosted.org/packages/00/a9/753806f5292b40aeab1d269e408e3a7e85be3c0d88828fb78ab4a34d6626/hypothesis-6.156.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 1120983
+
+[packages.wheels.hashes]
+sha256 = "b4e66aaa7385538a5d617174d47c198ee807f06de99e282a67c6cb724c69340d"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp312-cp312-win_amd64.whl"
+upload-time = 2026-07-10 20:55:39.056924+00:00
+url = "https://files.pythonhosted.org/packages/5a/b3/c347ad913e1c5f2988956fe17826c0400b4ce470b973e6c248e97b6a0acf/hypothesis-6.156.6-cp312-cp312-win_amd64.whl"
+size = 637679
+
+[packages.wheels.hashes]
+sha256 = "c3363d3fb8015594636689572510bb6090602d8e8e838a5693c2d52d3b5b09d8"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp313-cp313-macosx_10_12_x86_64.whl"
+upload-time = 2026-07-10 20:56:46.118514+00:00
+url = "https://files.pythonhosted.org/packages/70/5d/9583fe153573523dac27226c89e041a86ad4aeeae08c868160cbb93d39d2/hypothesis-6.156.6-cp313-cp313-macosx_10_12_x86_64.whl"
+size = 749264
+
+[packages.wheels.hashes]
+sha256 = "59a8def90d9a5a9b67e1ac529e903a2363ceb6cf873c209da6b4284c5daab671"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp313-cp313-macosx_11_0_arm64.whl"
+upload-time = 2026-07-10 20:56:41.412199+00:00
+url = "https://files.pythonhosted.org/packages/86/35/e4113d06769b544f0fb77ffea9195b598b4c56a298905c21fd47c4eed388/hypothesis-6.156.6-cp313-cp313-macosx_11_0_arm64.whl"
+size = 742095
+
+[packages.wheels.hashes]
+sha256 = "c574c3224563d730848bc5d1ef1683c4f83993400c0167899fe328f4bfcd4725"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-07-10 20:56:04.845191+00:00
+url = "https://files.pythonhosted.org/packages/d8/5c/a47666ede10384e8978722cade7ab96a42df71d2ab577317092d0fed7c8a/hypothesis-6.156.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1069917
+
+[packages.wheels.hashes]
+sha256 = "01bb8270c46b3ef53b0c2d23ff613ea506d609d06f936d823ea57c58b66b05f7"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-07-10 20:55:52.008669+00:00
+url = "https://files.pythonhosted.org/packages/79/93/75f6057dadd9dc0134f37c08d5d14d04d3cd7374debbcb0cc4569c6712f1/hypothesis-6.156.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 1121204
+
+[packages.wheels.hashes]
+sha256 = "d4ea6559c13606e13b645927f2e0906e52b5ac5d99b40d3abaaeb2e8c7ceeb75"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp313-cp313-win_amd64.whl"
+upload-time = 2026-07-10 20:56:33.350630+00:00
+url = "https://files.pythonhosted.org/packages/cf/8d/794fb26e1fd3ff004978f8f18b7aa7e1c2270ba72e1f977b987a812064f8/hypothesis-6.156.6-cp313-cp313-win_amd64.whl"
+size = 637954
+
+[packages.wheels.hashes]
+sha256 = "f0d73edab7b8a0051b3634f2d04d62b7e7282f8f274963b11188ee4957d672ef"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp314-cp314-macosx_10_12_x86_64.whl"
+upload-time = 2026-07-10 20:55:46.902698+00:00
+url = "https://files.pythonhosted.org/packages/a5/be/5b4b27984cb43c60e95f570b069660335dad34cb67f7d226017c5d35d31e/hypothesis-6.156.6-cp314-cp314-macosx_10_12_x86_64.whl"
+size = 749312
+
+[packages.wheels.hashes]
+sha256 = "34a70a7b8226e34d658072d8fb81d03f97f0a75ceb536329a321b94ce2232fd6"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp314-cp314-macosx_11_0_arm64.whl"
+upload-time = 2026-07-10 20:56:30.254485+00:00
+url = "https://files.pythonhosted.org/packages/31/11/709cceffc28666c9d4cb75ffc6df5ce30db8c7dd5cc2c8b38a2fd837427f/hypothesis-6.156.6-cp314-cp314-macosx_11_0_arm64.whl"
+size = 742332
+
+[packages.wheels.hashes]
+sha256 = "f1969646beead7d8cf6a2537d2765af89d73056e2cb218e7fae92b83802250a3"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-07-10 20:55:48.244573+00:00
+url = "https://files.pythonhosted.org/packages/84/52/cfc79b13d8dd3cd6de6b9df921c557efe8528a9c90a3a7cd93b37188d57e/hypothesis-6.156.6-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1070109
+
+[packages.wheels.hashes]
+sha256 = "cbc2ec7b7d905e6b6ec1635f6340bfa52aaab718101c59f052bc012a6b486cd8"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-07-10 20:56:39.665955+00:00
+url = "https://files.pythonhosted.org/packages/ca/ac/1da4def1f006b5ad01187ff96379e24c37439d659ec10c3e944c03436c0f/hypothesis-6.156.6-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 1121528
+
+[packages.wheels.hashes]
+sha256 = "9367ae25dfa6dc1af37904785e43c4f8fe1c4118cafdc2f06514154fbdd90992"
+
+[[packages.wheels]]
+name = "hypothesis-6.156.6-cp314-cp314-win_amd64.whl"
+upload-time = 2026-07-10 20:56:34.970283+00:00
+url = "https://files.pythonhosted.org/packages/8c/75/2c8a0411bbe76429f3ae738ef9a00107201bf6146d9534350014ce369d98/hypothesis-6.156.6-cp314-cp314-win_amd64.whl"
+size = 637774
+
+[packages.wheels.hashes]
+sha256 = "f9631cd604ae6032c3edf99160dc1b9e33873f2e52762246b24f07fb758652ae"
 
 [[packages]]
 name = "hypothesis-crosshair"
 version = "0.0.28"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.9"
+dependencies = [
+    { name = "crosshair-tool" },
+    { name = "hypothesis" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1034,32 +1244,37 @@ sha256 = "fa7651a4f74d219db84743370ddc206fcfed612d80a49d58988baf75f497f018"
 
 [[packages]]
 name = "idna"
-version = "3.15"
-requires-python = ">=3.8"
+version = "3.18"
+marker = "\"crosshair\" in dependency_groups"
+requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "idna-3.15.tar.gz"
-upload-time = 2026-05-12 22:45:57.011321+00:00
-url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz"
-size = 199245
+name = "idna-3.18.tar.gz"
+upload-time = 2026-06-02 14:34:07.794523+00:00
+url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz"
+size = 196711
 
 [packages.sdist.hashes]
-sha256 = "ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc"
+sha256 = "ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"
 
 [[packages.wheels]]
-name = "idna-3.15-py3-none-any.whl"
-upload-time = 2026-05-12 22:45:55.733813+00:00
-url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl"
-size = 72340
+name = "idna-3.18-py3-none-any.whl"
+upload-time = 2026-06-02 14:34:06.319954+00:00
+url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl"
+size = 65455
 
 [packages.wheels.hashes]
-sha256 = "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"
+sha256 = "7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"
 
 [[packages]]
 name = "importlib-metadata"
 version = "9.0.0"
+marker = "(python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version >= \"3.10.2.dev0\" and \"crosshair\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"crosshair\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version >= \"3.10.2.dev0\" and \"crosshair\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"crosshair\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version >= \"3.10.2.dev0\" and \"crosshair\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and \"crosshair\" in dependency_groups)"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "zipp" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1083,6 +1298,7 @@ sha256 = "2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7"
 [[packages]]
 name = "importlib-resources"
 version = "7.1.0"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
@@ -1107,6 +1323,7 @@ sha256 = "1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1"
 [[packages]]
 name = "iniconfig"
 version = "2.3.0"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
@@ -1155,7 +1372,12 @@ sha256 = "011d045df8b954ced7dde3a7e42ae4418da40ecda7990f2d11d5ed7c146fd98b"
 [[packages]]
 name = "lsprotocol"
 version = "2025.0.0"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.8"
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1179,6 +1401,7 @@ sha256 = "f9d78f25221f2a60eaa4a96d3b4ffae011b107537facee61d3da3313880995c7"
 [[packages]]
 name = "mypy-extensions"
 version = "1.1.0"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.8"
 index = "https://pypi.org/simple/"
 
@@ -1227,6 +1450,7 @@ sha256 = "5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"
 [[packages]]
 name = "pluggy"
 version = "1.6.0"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -1251,7 +1475,13 @@ sha256 = "e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
 [[packages]]
 name = "pygls"
 version = "2.1.1"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.9"
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+    { name = "lsprotocol" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1275,6 +1505,7 @@ sha256 = "510a6dea2476177230c7d851125e5948efdf3fdb9ebfd8543fc434972f8faed4"
 [[packages]]
 name = "pygments"
 version = "2.20.0"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -1322,32 +1553,46 @@ sha256 = "9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913"
 
 [[packages]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "colorama" },
+    { name = "exceptiongroup" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "pytest-9.0.3.tar.gz"
-upload-time = 2026-04-07 17:16:18.027317+00:00
-url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz"
-size = 1572165
+name = "pytest-9.1.1.tar.gz"
+upload-time = 2026-06-19 10:58:32.857420+00:00
+url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz"
+size = 1636369
 
 [packages.sdist.hashes]
-sha256 = "b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"
+sha256 = "1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313"
 
 [[packages.wheels]]
-name = "pytest-9.0.3-py3-none-any.whl"
-upload-time = 2026-04-07 17:16:16.130051+00:00
-url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl"
-size = 375249
+name = "pytest-9.1.1-py3-none-any.whl"
+upload-time = 2026-06-19 10:58:31.347074+00:00
+url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl"
+size = 386536
 
 [packages.wheels.hashes]
-sha256 = "2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"
+sha256 = "37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"
 
 [[packages]]
 name = "pytest-timeout"
 version = "2.4.0"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.7"
+dependencies = [
+    { name = "pytest" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1371,7 +1616,11 @@ sha256 = "c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2"
 [[packages]]
 name = "respx"
 version = "0.23.1"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.8"
+dependencies = [
+    { name = "httpx" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1395,6 +1644,7 @@ sha256 = "b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a"
 [[packages]]
 name = "sortedcontainers"
 version = "2.4.0"
+marker = "\"crosshair\" in dependency_groups"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1431,49 +1681,13 @@ size = 17543
 sha256 = "7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-py3-none-any.whl"
-upload-time = 2026-03-25 20:22:03.012768+00:00
-url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl"
-size = 14583
+name = "tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
+upload-time = 2026-03-25 20:21:10.473841+00:00
+url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
+size = 154704
 
 [packages.wheels.hashes]
-sha256 = "0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-03-25 20:21:14.569419+00:00
-url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 243824
-
-[packages.wheels.hashes]
-sha256 = "5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl"
-upload-time = 2026-03-25 20:21:17.001171+00:00
-url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl"
-size = 247859
-
-[packages.wheels.hashes]
-sha256 = "ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-03-25 20:21:13.098441+00:00
-url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 237561
-
-[packages.wheels.hashes]
-sha256 = "96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl"
-upload-time = 2026-03-25 20:21:15.712337+00:00
-url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl"
-size = 242227
-
-[packages.wheels.hashes]
-sha256 = "47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c"
+sha256 = "f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl"
@@ -1485,13 +1699,22 @@ size = 149454
 sha256 = "4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
-upload-time = 2026-03-25 20:21:10.473841+00:00
-url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
-size = 154704
+name = "tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:13.098441+00:00
+url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 237561
 
 [packages.wheels.hashes]
-sha256 = "f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30"
+sha256 = "96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:14.569419+00:00
+url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 243824
+
+[packages.wheels.hashes]
+sha256 = "5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp311-cp311-win_amd64.whl"
@@ -1503,40 +1726,13 @@ size = 108084
 sha256 = "5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-03-25 20:21:25.177901+00:00
-url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 253341
+name = "tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2026-03-25 20:21:21.626567+00:00
+url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 155924
 
 [packages.wheels.hashes]
-sha256 = "136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl"
-upload-time = 2026-03-25 20:21:27.460413+00:00
-url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl"
-size = 253290
-
-[packages.wheels.hashes]
-sha256 = "5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-03-25 20:21:24.040813+00:00
-url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 244948
-
-[packages.wheels.hashes]
-sha256 = "ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl"
-upload-time = 2026-03-25 20:21:26.364996+00:00
-url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl"
-size = 248159
-
-[packages.wheels.hashes]
-sha256 = "5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585"
+sha256 = "c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl"
@@ -1548,13 +1744,22 @@ size = 150018
 sha256 = "7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
-upload-time = 2026-03-25 20:21:21.626567+00:00
-url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
-size = 155924
+name = "tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:24.040813+00:00
+url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 244948
 
 [packages.wheels.hashes]
-sha256 = "c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a"
+sha256 = "ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:25.177901+00:00
+url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 253341
+
+[packages.wheels.hashes]
+sha256 = "136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp312-cp312-win_amd64.whl"
@@ -1566,40 +1771,13 @@ size = 108847
 sha256 = "52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-03-25 20:21:36.012836+00:00
-url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 251628
+name = "tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2026-03-25 20:21:31.650748+00:00
+url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 155866
 
 [packages.wheels.hashes]
-sha256 = "f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl"
-upload-time = 2026-03-25 20:21:38.298846+00:00
-url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl"
-size = 251674
-
-[packages.wheels.hashes]
-sha256 = "51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-03-25 20:21:34.510750+00:00
-url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 243704
-
-[packages.wheels.hashes]
-sha256 = "c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl"
-upload-time = 2026-03-25 20:21:37.136802+00:00
-url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl"
-size = 247180
-
-[packages.wheels.hashes]
-sha256 = "d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d"
+sha256 = "36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl"
@@ -1611,13 +1789,22 @@ size = 149887
 sha256 = "eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
-upload-time = 2026-03-25 20:21:31.650748+00:00
-url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
-size = 155866
+name = "tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:34.510750+00:00
+url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 243704
 
 [packages.wheels.hashes]
-sha256 = "36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54"
+sha256 = "c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:36.012836+00:00
+url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 251628
+
+[packages.wheels.hashes]
+sha256 = "f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp313-cp313-win_amd64.whl"
@@ -1629,40 +1816,13 @@ size = 108755
 sha256 = "8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-03-25 20:21:45.620261+00:00
-url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 252084
+name = "tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl"
+upload-time = 2026-03-25 20:21:42.230154+00:00
+url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl"
+size = 155726
 
 [packages.wheels.hashes]
-sha256 = "01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl"
-upload-time = 2026-03-25 20:21:48.467732+00:00
-url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl"
-size = 256223
-
-[packages.wheels.hashes]
-sha256 = "ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-03-25 20:21:44.474645+00:00
-url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 244713
-
-[packages.wheels.hashes]
-sha256 = "559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl"
-upload-time = 2026-03-25 20:21:46.937942+00:00
-url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl"
-size = 247973
-
-[packages.wheels.hashes]
-sha256 = "7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15"
+sha256 = "fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl"
@@ -1674,6 +1834,24 @@ size = 149859
 sha256 = "a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac"
 
 [[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:44.474645+00:00
+url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 244713
+
+[packages.wheels.hashes]
+sha256 = "559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:45.620261+00:00
+url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 252084
+
+[packages.wheels.hashes]
+sha256 = "01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853"
+
+[[packages.wheels]]
 name = "tomli-2.4.1-cp314-cp314-win_amd64.whl"
 upload-time = 2026-03-25 20:21:50.506850+00:00
 url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl"
@@ -1681,6 +1859,15 @@ size = 109082
 
 [packages.wheels.hashes]
 sha256 = "88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-py3-none-any.whl"
+upload-time = 2026-03-25 20:22:03.012768+00:00
+url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl"
+size = 14583
+
+[packages.wheels.hashes]
+sha256 = "0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe"
 
 [[packages]]
 name = "tomli-w"
@@ -1709,6 +1896,7 @@ sha256 = "188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90"
 [[packages]]
 name = "tomlkit"
 version = "0.15.0"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -1758,6 +1946,9 @@ sha256 = "adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"
 name = "typeguard"
 version = "4.5.2"
 requires-python = ">=3.9"
+dependencies = [
+    { name = "typing-extensions" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1780,55 +1971,65 @@ sha256 = "fcf9de18bd945cdb4c7b996e12b4c51ce83f92f191314a6d7cf1739586ec98cf"
 
 [[packages]]
 name = "typeshed-client"
-version = "2.11.0"
+version = "2.12.0"
+marker = "\"crosshair\" in dependency_groups"
 requires-python = ">=3.9"
+dependencies = [
+    { name = "importlib-resources" },
+    { name = "typing-extensions" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "typeshed_client-2.11.0.tar.gz"
-upload-time = 2026-05-01 14:51:52.380574+00:00
-url = "https://files.pythonhosted.org/packages/85/7d/62fbae352d5fb7ce5ef4d9ca73bf7a9b02b790d2524ab6ef1e0e799a5d1b/typeshed_client-2.11.0.tar.gz"
-size = 522774
+name = "typeshed_client-2.12.0.tar.gz"
+upload-time = 2026-06-02 04:00:51.510275+00:00
+url = "https://files.pythonhosted.org/packages/54/5d/97d6fa8c204b0d42be931e7a568b306cda43f93ff45f8b47537ee61390de/typeshed_client-2.12.0.tar.gz"
+size = 529457
 
 [packages.sdist.hashes]
-sha256 = "0b8f2ab88f611f5e97b70d2a8123942d3d7d5c74cee8ae694db83422f32f9481"
+sha256 = "54dcfa25fcff82cedcb1b51c03c1b3c51a614097aab8fe49e4316aff6f79d9c7"
 
 [[packages.wheels]]
-name = "typeshed_client-2.11.0-py3-none-any.whl"
-upload-time = 2026-05-01 14:51:51.005104+00:00
-url = "https://files.pythonhosted.org/packages/4f/22/fa16b462157bd869dfad528f5637506b9430ca63d48fb536ecf4cc78481a/typeshed_client-2.11.0-py3-none-any.whl"
-size = 787609
+name = "typeshed_client-2.12.0-py3-none-any.whl"
+upload-time = 2026-06-02 04:00:49.643760+00:00
+url = "https://files.pythonhosted.org/packages/85/98/3aef1587ec9b3a5cd062b8d8910545a0ee3715c31fd65b1f2386b27b94af/typeshed_client-2.12.0-py3-none-any.whl"
+size = 796929
 
 [packages.wheels.hashes]
-sha256 = "5745e0990b80b29a286b22d68f81779c5c7adf1cac8969eeafba44b73b486c36"
+sha256 = "da3ef54a0e60c0f45f59006b73a3cb20b1acbf7a784e982476d8193e8828ddf5"
 
 [[packages]]
 name = "typing-extensions"
-version = "4.15.0"
+version = "4.16.0"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "typing_extensions-4.15.0.tar.gz"
-upload-time = 2025-08-25 13:49:26.313895+00:00
-url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz"
-size = 109391
+name = "typing_extensions-4.16.0.tar.gz"
+upload-time = 2026-07-02 08:40:05.920538+00:00
+url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz"
+size = 113555
 
 [packages.sdist.hashes]
-sha256 = "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"
+sha256 = "dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5"
 
 [[packages.wheels]]
-name = "typing_extensions-4.15.0-py3-none-any.whl"
-upload-time = 2025-08-25 13:49:24.860024+00:00
-url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl"
-size = 44614
+name = "typing_extensions-4.16.0-py3-none-any.whl"
+upload-time = 2026-07-02 08:40:04.659120+00:00
+url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl"
+size = 45571
 
 [packages.wheels.hashes]
-sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+sha256 = "481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8"
 
 [[packages]]
 name = "typing-inspect"
 version = "0.9.0"
+marker = "\"crosshair\" in dependency_groups"
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1851,27 +2052,32 @@ sha256 = "9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f"
 
 [[packages]]
 name = "tyro"
-version = "1.0.13"
+version = "1.0.15"
 requires-python = ">=3.8"
+dependencies = [
+    { name = "docstring-parser" },
+    { name = "typeguard" },
+    { name = "typing-extensions" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "tyro-1.0.13.tar.gz"
-upload-time = 2026-04-14 18:21:52.888049+00:00
-url = "https://files.pythonhosted.org/packages/24/d6/7126f9e7de139632134d59b5d1972e93c610ee2cb13829e8f4f48f6613cb/tyro-1.0.13.tar.gz"
-size = 489479
+name = "tyro-1.0.15.tar.gz"
+upload-time = 2026-06-20 08:48:28.364151+00:00
+url = "https://files.pythonhosted.org/packages/12/78/a5749a6c1ee9abc2999e294f339f8f72476d1a60bb95fc0e86156aafed3b/tyro-1.0.15.tar.gz"
+size = 593822
 
 [packages.sdist.hashes]
-sha256 = "731a90c9836b77fffe7c3fa0477ef2d3b6fa91252ddc0bb4d32dadd4fcc143d4"
+sha256 = "3f1d60887723eecb9c489f195d11f079c4a1f33df74b723552ad31ec57c667bb"
 
 [[packages.wheels]]
-name = "tyro-1.0.13-py3-none-any.whl"
-upload-time = 2026-04-14 18:21:54.328769+00:00
-url = "https://files.pythonhosted.org/packages/93/4f/c43a0a8f0c66fd40a1d6cc47332a5a1d1043e9b331f7070ea701b91a7598/tyro-1.0.13-py3-none-any.whl"
-size = 185221
+name = "tyro-1.0.15-py3-none-any.whl"
+upload-time = 2026-06-20 08:48:27.104712+00:00
+url = "https://files.pythonhosted.org/packages/5d/28/d607636187cf6c18eb72efb5d65c1d1b9e451db03d84676f835dd488fdbd/tyro-1.0.15-py3-none-any.whl"
+size = 215045
 
 [packages.wheels.hashes]
-sha256 = "a0bdb8462c551dd84fc00a76916ce4d37e879c84eefaf34e2165312407cc6c09"
+sha256 = "982da1d566005f1b2a6b56f6be6c6929c96f0e5fab9d61bc6097573ddfaf8d13"
 
 [[packages]]
 name = "urllib3"
@@ -1899,67 +2105,98 @@ sha256 = "9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
 
 [[packages]]
 name = "z3-solver"
-version = "4.15.4.0"
+version = "4.16.0.0"
+marker = "\"crosshair\" in dependency_groups"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "z3_solver-4.15.4.0.tar.gz"
-upload-time = 2025-10-29 18:12:03.062278+00:00
-url = "https://files.pythonhosted.org/packages/8a/8e/0c8f17309549d2e5cde9a3ccefa6365437f1e7bafe71878eaf9478e47b18/z3_solver-4.15.4.0.tar.gz"
-size = 5018600
+name = "z3_solver-4.16.0.0.tar.gz"
+upload-time = 2026-02-19 04:14:08.818060+00:00
+url = "https://files.pythonhosted.org/packages/93/3b/2b714c40ef2ecf6d8aa080056b9c24a77fe4ca2c83abd83e9c93d34212ac/z3_solver-4.16.0.0.tar.gz"
+size = 5098891
 
 [packages.sdist.hashes]
-sha256 = "928c29b58c4eb62106da51c1914f6a4a55d0441f8f48a81b9da07950434a8946"
+sha256 = "263d9ad668966e832c2b246ba0389298a599637793da2dc01cc5e4ef4b0b6c78"
 
 [[packages.wheels]]
-name = "z3_solver-4.15.4.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-upload-time = 2025-10-29 18:11:53.032680+00:00
-url = "https://files.pythonhosted.org/packages/21/c9/bb51a96af0091324c81b803f16c49f719f9f6ea0b0bb52200f5c97ec4892/z3_solver-4.15.4.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-size = 29268352
+name = "z3_solver-4.16.0.0-py3-none-macosx_15_0_arm64.whl"
+upload-time = 2026-02-19 04:13:44.303318+00:00
+url = "https://files.pythonhosted.org/packages/2d/5d/9b277a80333db6b85fedd0f5082e311efcbaec47f2c44c57d38953c2d4d9/z3_solver-4.16.0.0-py3-none-macosx_15_0_arm64.whl"
+size = 36963251
 
 [packages.wheels.hashes]
-sha256 = "7e103a6f203f505b8b8b8e5c931cc407c95b61556512d4921c1ddc0b3f41b08e"
+sha256 = "cc52843cfdd3d3f2cd24bedc62e71c18af8c8b7b23fb05e639ab60b01b5f8f2f"
 
 [[packages.wheels]]
-name = "z3_solver-4.15.4.0-py3-none-win_amd64.whl"
-upload-time = 2025-10-29 18:12:01.140381+00:00
-url = "https://files.pythonhosted.org/packages/03/d6/a0b135e4419df475177ae78fc93c422430b0fd8875649486f9a5989772e6/z3_solver-4.15.4.0-py3-none-win_amd64.whl"
-size = 16259597
+name = "z3_solver-4.16.0.0-py3-none-macosx_15_0_x86_64.whl"
+upload-time = 2026-02-19 04:13:48.154355+00:00
+url = "https://files.pythonhosted.org/packages/1c/c4/fc99aa544930fb7bfcd88947c2788f318acaf1b9704a7a914445e204436a/z3_solver-4.16.0.0-py3-none-macosx_15_0_x86_64.whl"
+size = 47523873
 
 [packages.wheels.hashes]
-sha256 = "00e35b02632ed085ea8199fb230f6015e6fc40554a6680c097bd5f060e827431"
+sha256 = "e292df40951523e4ecfbc8dee549d93dee00a3fe4ee4833270d19876b713e210"
+
+[[packages.wheels]]
+name = "z3_solver-4.16.0.0-py3-none-manylinux_2_27_x86_64.whl"
+upload-time = 2026-02-19 04:13:52.283754+00:00
+url = "https://files.pythonhosted.org/packages/f6/e6/98741b086b6e01630a55db1fbda596949f738204aac14ef35e64a9526ccb/z3_solver-4.16.0.0-py3-none-manylinux_2_27_x86_64.whl"
+size = 31741807
+
+[packages.wheels.hashes]
+sha256 = "afae2551f795670f0522cfce82132d129c408a2694adff71eb01ba0f2ece44f9"
+
+[[packages.wheels]]
+name = "z3_solver-4.16.0.0-py3-none-manylinux_2_38_aarch64.whl"
+upload-time = 2026-02-19 04:13:55.787944+00:00
+url = "https://files.pythonhosted.org/packages/e7/2e/295d467c7c796c01337bff790dbedc28cf279f9d365ed64aa9f8ca6b2ba1/z3_solver-4.16.0.0-py3-none-manylinux_2_38_aarch64.whl"
+size = 27326531
+
+[packages.wheels.hashes]
+sha256 = "358648c3b5ef82b9ec9a25711cf4fc498c7881f03a9f4a2ea6ffa9304ca65d94"
+
+[[packages.wheels]]
+name = "z3_solver-4.16.0.0-py3-none-win_amd64.whl"
+upload-time = 2026-02-19 04:14:03.232577+00:00
+url = "https://files.pythonhosted.org/packages/86/20/cef4f4d70845df24572d005d19995f92b7f527eb2ffb63a3f5f938a0de2e/z3_solver-4.16.0.0-py3-none-win_amd64.whl"
+size = 16419861
+
+[packages.wheels.hashes]
+sha256 = "eb5df383cb6a3d6b7767dbdca348ac71f6f41e82f76c9ac42002a1f55e35f462"
 
 [[packages]]
 name = "zipp"
-version = "3.23.1"
-requires-python = ">=3.9"
+version = "4.1.0"
+marker = "(python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version >= \"3.10.2.dev0\" and \"crosshair\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"crosshair\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version >= \"3.10.2.dev0\" and \"crosshair\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"crosshair\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version >= \"3.10.2.dev0\" and \"crosshair\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"crosshair\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and \"crosshair\" in dependency_groups)"
+requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "zipp-3.23.1.tar.gz"
-upload-time = 2026-04-13 23:21:46.600996+00:00
-url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz"
-size = 25965
+name = "zipp-4.1.0.tar.gz"
+upload-time = 2026-05-18 20:08:57.967214+00:00
+url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz"
+size = 26214
 
 [packages.sdist.hashes]
-sha256 = "32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110"
+sha256 = "4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602"
 
 [[packages.wheels]]
-name = "zipp-3.23.1-py3-none-any.whl"
-upload-time = 2026-04-13 23:21:45.386171+00:00
-url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl"
-size = 10378
+name = "zipp-4.1.0-py3-none-any.whl"
+upload-time = 2026-05-18 20:08:57.045692+00:00
+url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl"
+size = 10238
 
 [packages.wheels.hashes]
-sha256 = "0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc"
+sha256 = "25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f"
 
 [tool.nab]
-nab-version = "0.0.2"
-created-at = 2026-05-24 15:38:04.658978+00:00
+nab-version = "0.0.10.dev0"
+created-at = 2026-07-18 23:27:26.043178+00:00
 command-line = [
-    "/home/damian/opensource/remote/projects/resolver/nab/src/nab/__main__.py",
+    "nab",
     "lock",
     "--groups",
+    "crosshair",
+    "--project-default-group",
     "crosshair",
     "--no-emit-workspace",
     "--output",
@@ -1974,4 +2211,7 @@ platforms = [
     "macos_arm64",
     "macos_x86_64",
     "windows_amd64",
+]
+cli-project-overrides = [
+    "--project-default-group=crosshair",
 ]

--- a/.github/requirements/pylock.docs.toml
+++ b/.github/requirements/pylock.docs.toml
@@ -1,9 +1,12 @@
 lock-version = "1.0"
 environments = [
-    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2\"",
+    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
 ]
 requires-python = ">=3.10"
 dependency-groups = [
+    "docs",
+]
+default-groups = [
     "docs",
 ]
 created-by = "nab"
@@ -11,6 +14,7 @@ created-by = "nab"
 [[packages]]
 name = "accessible-pygments"
 version = "0.0.5"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.9"
 dependencies = [
     { name = "pygments" },
@@ -38,6 +42,7 @@ sha256 = "88ae3211e68a1d0b011504b2ffc1691feafce124b845bd072ab6f9f66f34d4b7"
 [[packages]]
 name = "alabaster"
 version = "1.0.0"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
@@ -62,6 +67,7 @@ sha256 = "fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b"
 [[packages]]
 name = "babel"
 version = "2.18.0"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.8"
 index = "https://pypi.org/simple/"
 
@@ -86,6 +92,7 @@ sha256 = "e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35"
 [[packages]]
 name = "beautifulsoup4"
 version = "4.15.0"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.7.0"
 dependencies = [
     { name = "soupsieve" },
@@ -142,6 +149,7 @@ sha256 = "13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f"
 [[packages]]
 name = "certifi"
 version = "2026.6.17"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.7"
 index = "https://pypi.org/simple/"
 
@@ -166,6 +174,7 @@ sha256 = "2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"
 [[packages]]
 name = "charset-normalizer"
 version = "3.4.7"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.7"
 index = "https://pypi.org/simple/"
 
@@ -223,6 +232,7 @@ sha256 = "b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b"
 [[packages]]
 name = "docutils"
 version = "0.22.4"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -247,6 +257,7 @@ sha256 = "d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de"
 [[packages]]
 name = "furo"
 version = "2025.12.19"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.8"
 dependencies = [
     { name = "accessible-pygments" },
@@ -278,6 +289,7 @@ sha256 = "bb0ead5309f9500130665a26bee87693c41ce4dbdff864dbfb6b0dae4673d24f"
 [[packages]]
 name = "idna"
 version = "3.18"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -302,6 +314,7 @@ sha256 = "7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"
 [[packages]]
 name = "imagesize"
 version = "2.0.0"
+marker = "\"docs\" in dependency_groups"
 requires-python = "<3.15,>=3.10"
 index = "https://pypi.org/simple/"
 
@@ -350,6 +363,7 @@ sha256 = "011d045df8b954ced7dde3a7e42ae4418da40ecda7990f2d11d5ed7c146fd98b"
 [[packages]]
 name = "jinja2"
 version = "3.1.6"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.7"
 dependencies = [
     { name = "markupsafe" },
@@ -377,6 +391,7 @@ sha256 = "85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"
 [[packages]]
 name = "linkify-it-py"
 version = "2.1.0"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.10"
 dependencies = [
     { name = "uc-micro-py" },
@@ -404,6 +419,7 @@ sha256 = "0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e"
 [[packages]]
 name = "markdown-it-py"
 version = "4.2.0"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.10"
 dependencies = [
     { name = "mdurl" },
@@ -431,6 +447,7 @@ sha256 = "9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a"
 [[packages]]
 name = "markupsafe"
 version = "3.0.3"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -455,6 +472,7 @@ sha256 = "ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676"
 [[packages]]
 name = "mdit-py-plugins"
 version = "0.6.1"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.10"
 dependencies = [
     { name = "markdown-it-py" },
@@ -482,6 +500,7 @@ sha256 = "214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d"
 [[packages]]
 name = "mdurl"
 version = "0.1.2"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.7"
 index = "https://pypi.org/simple/"
 
@@ -506,6 +525,7 @@ sha256 = "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"
 [[packages]]
 name = "myst-parser"
 version = "5.1.0"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.11"
 dependencies = [
     { name = "docutils" },
@@ -562,6 +582,7 @@ sha256 = "5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"
 [[packages]]
 name = "pygments"
 version = "2.20.0"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -610,6 +631,7 @@ sha256 = "9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913"
 [[packages]]
 name = "pyyaml"
 version = "6.0.3"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.8"
 index = "https://pypi.org/simple/"
 
@@ -634,6 +656,7 @@ sha256 = "0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6"
 [[packages]]
 name = "requests"
 version = "2.34.2"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.10"
 dependencies = [
     { name = "certifi" },
@@ -664,6 +687,7 @@ sha256 = "2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"
 [[packages]]
 name = "roman-numerals"
 version = "4.1.0"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
@@ -688,6 +712,7 @@ sha256 = "647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7"
 [[packages]]
 name = "snowballstemmer"
 version = "3.1.1"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.3"
 index = "https://pypi.org/simple/"
 
@@ -712,6 +737,7 @@ sha256 = "7e207fa178741da09cdee59d3ecec3827ad5f92b1fc5c9ff3755b639f71f5752"
 [[packages]]
 name = "soupsieve"
 version = "2.8.4"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -736,6 +762,7 @@ sha256 = "e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65"
 [[packages]]
 name = "sphinx"
 version = "9.1.0"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.12"
 dependencies = [
     { name = "alabaster" },
@@ -778,6 +805,7 @@ sha256 = "c84fdd4e782504495fe4f2c0b3413d6c2bf388589bb352d439b2a3bb99991978"
 [[packages]]
 name = "sphinx-basic-ng"
 version = "1.0.0b2"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.7"
 dependencies = [
     { name = "sphinx" },
@@ -805,6 +833,7 @@ sha256 = "eb09aedbabfb650607e9b4b68c9d240b90b1e1be221d6ad71d61c52e29f7932b"
 [[packages]]
 name = "sphinx-copybutton"
 version = "0.5.2"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.7"
 dependencies = [
     { name = "sphinx" },
@@ -832,6 +861,7 @@ sha256 = "fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e"
 [[packages]]
 name = "sphinx-design"
 version = "0.7.0"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.11"
 dependencies = [
     { name = "sphinx" },
@@ -859,6 +889,7 @@ sha256 = "f82bf179951d58f55dca78ab3706aeafa496b741a91b1911d371441127d64282"
 [[packages]]
 name = "sphinxcontrib-applehelp"
 version = "2.0.0"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -883,6 +914,7 @@ sha256 = "4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5"
 [[packages]]
 name = "sphinxcontrib-devhelp"
 version = "2.0.0"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -907,6 +939,7 @@ sha256 = "aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2"
 [[packages]]
 name = "sphinxcontrib-htmlhelp"
 version = "2.1.0"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -931,6 +964,7 @@ sha256 = "166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8"
 [[packages]]
 name = "sphinxcontrib-jsmath"
 version = "1.0.1"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.5"
 index = "https://pypi.org/simple/"
 
@@ -955,6 +989,7 @@ sha256 = "2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178"
 [[packages]]
 name = "sphinxcontrib-qthelp"
 version = "2.0.0"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -979,6 +1014,7 @@ sha256 = "b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb"
 [[packages]]
 name = "sphinxcontrib-serializinghtml"
 version = "2.0.0"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -1164,6 +1200,7 @@ sha256 = "982da1d566005f1b2a6b56f6be6c6929c96f0e5fab9d61bc6097573ddfaf8d13"
 [[packages]]
 name = "uc-micro-py"
 version = "2.0.0"
+marker = "\"docs\" in dependency_groups"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
@@ -1210,12 +1247,14 @@ size = 131087
 sha256 = "9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
 
 [tool.nab]
-nab-version = "0.0.9.dev0"
+nab-version = "0.0.10.dev0"
 created-at = 2026-07-12 21:09:20.266433+00:00
 command-line = [
-    "/home/damian/opensource/remote/projects/resolver/worktrees/docs-rtd/src/nab/__main__.py",
+    "nab",
     "lock",
     "--groups",
+    "docs",
+    "--project-default-group",
     "docs",
     "--no-emit-workspace",
     "--output",
@@ -1230,4 +1269,5 @@ mode = "specific"
 python-specifier = ">=3.10"
 cli-project-overrides = [
     "--project-mode=specific",
+    "--project-default-group=docs",
 ]

--- a/.github/requirements/pylock.pre-commit.toml
+++ b/.github/requirements/pylock.pre-commit.toml
@@ -1,32 +1,41 @@
 lock-version = "1.0"
 environments = [
-    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
-    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
-    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
-    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
-    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
+    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
 ]
+requires-python = ">=3.10"
 dependency-groups = [
+    "pre-commit",
+]
+default-groups = [
     "pre-commit",
 ]
 created-by = "nab"
@@ -35,6 +44,13 @@ created-by = "nab"
 name = "build"
 version = "1.5.0"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "colorama" },
+    { name = "importlib-metadata" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+    { name = "tomli" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -58,6 +74,7 @@ sha256 = "13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f"
 [[packages]]
 name = "cfgv"
 version = "3.5.0"
+marker = "\"pre-commit\" in dependency_groups"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
@@ -82,7 +99,7 @@ sha256 = "a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0"
 [[packages]]
 name = "colorama"
 version = "0.4.6"
-marker = "(python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version >= \"3.10.2.dev0\") or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
 requires-python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 index = "https://pypi.org/simple/"
 
@@ -107,6 +124,7 @@ sha256 = "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
 [[packages]]
 name = "distlib"
 version = "0.4.0"
+marker = "\"pre-commit\" in dependency_groups"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -154,6 +172,7 @@ sha256 = "b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b"
 [[packages]]
 name = "filelock"
 version = "3.29.0"
+marker = "\"pre-commit\" in dependency_groups"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
@@ -178,6 +197,7 @@ sha256 = "96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258"
 [[packages]]
 name = "identify"
 version = "2.6.19"
+marker = "\"pre-commit\" in dependency_groups"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
@@ -202,8 +222,11 @@ sha256 = "20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a"
 [[packages]]
 name = "importlib-metadata"
 version = "9.0.0"
-marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\")"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "zipp" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -251,6 +274,7 @@ sha256 = "011d045df8b954ced7dde3a7e42ae4418da40ecda7990f2d11d5ed7c146fd98b"
 [[packages]]
 name = "nodeenv"
 version = "1.10.0"
+marker = "\"pre-commit\" in dependency_groups"
 requires-python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 index = "https://pypi.org/simple/"
 
@@ -299,6 +323,7 @@ sha256 = "5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"
 [[packages]]
 name = "platformdirs"
 version = "4.9.6"
+marker = "\"pre-commit\" in dependency_groups"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
@@ -323,7 +348,15 @@ sha256 = "e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917"
 [[packages]]
 name = "pre-commit"
 version = "4.6.0"
+marker = "\"pre-commit\" in dependency_groups"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -371,7 +404,12 @@ sha256 = "9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913"
 [[packages]]
 name = "python-discovery"
 version = "1.3.1"
+marker = "\"pre-commit\" in dependency_groups"
 requires-python = ">=3.8"
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -395,6 +433,7 @@ sha256 = "ed188687ebb3b82c01a17cd5ac62fc94d9f6487a7f1a0f9dfe89753fec91039c"
 [[packages]]
 name = "pyyaml"
 version = "6.0.3"
+marker = "\"pre-commit\" in dependency_groups"
 requires-python = ">=3.8"
 index = "https://pypi.org/simple/"
 
@@ -408,40 +447,13 @@ size = 130960
 sha256 = "d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"
 
 [[packages.wheels]]
-name = "pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2025-09-25 21:31:51.828716+00:00
-url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 770293
+name = "pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl"
+upload-time = 2025-09-25 21:31:46.040932+00:00
+url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl"
+size = 184227
 
 [packages.wheels.hashes]
-sha256 = "9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b"
-
-[[packages.wheels]]
-name = "pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl"
-upload-time = 2025-09-25 21:31:54.807344+00:00
-url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl"
-size = 758828
-
-[packages.wheels.hashes]
-sha256 = "5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69"
-
-[[packages.wheels]]
-name = "pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2025-09-25 21:31:49.210067+00:00
-url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 740646
-
-[packages.wheels.hashes]
-sha256 = "b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8"
-
-[[packages.wheels]]
-name = "pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl"
-upload-time = 2025-09-25 21:31:53.282215+00:00
-url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl"
-size = 732872
-
-[packages.wheels.hashes]
-sha256 = "418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0"
+sha256 = "214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b"
 
 [[packages.wheels]]
 name = "pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl"
@@ -453,13 +465,22 @@ size = 174019
 sha256 = "02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956"
 
 [[packages.wheels]]
-name = "pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl"
-upload-time = 2025-09-25 21:31:46.040932+00:00
-url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl"
-size = 184227
+name = "pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2025-09-25 21:31:49.210067+00:00
+url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 740646
 
 [packages.wheels.hashes]
-sha256 = "214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b"
+sha256 = "b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2025-09-25 21:31:51.828716+00:00
+url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 770293
+
+[packages.wheels.hashes]
+sha256 = "9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b"
 
 [[packages.wheels]]
 name = "pyyaml-6.0.3-cp310-cp310-win_amd64.whl"
@@ -471,40 +492,13 @@ size = 158561
 sha256 = "bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c"
 
 [[packages.wheels]]
-name = "pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2025-09-25 21:32:04.553491+00:00
-url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 806638
+name = "pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl"
+upload-time = 2025-09-25 21:31:58.655967+00:00
+url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl"
+size = 185826
 
 [packages.wheels.hashes]
-sha256 = "b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d"
-
-[[packages.wheels]]
-name = "pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl"
-upload-time = 2025-09-25 21:32:07.367150+00:00
-url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl"
-size = 794986
-
-[packages.wheels.hashes]
-sha256 = "37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4"
-
-[[packages.wheels]]
-name = "pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2025-09-25 21:32:01.310546+00:00
-url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 775556
-
-[packages.wheels.hashes]
-sha256 = "10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c"
-
-[[packages.wheels]]
-name = "pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl"
-upload-time = 2025-09-25 21:32:06.152188+00:00
-url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl"
-size = 767463
-
-[packages.wheels.hashes]
-sha256 = "1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a"
+sha256 = "44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e"
 
 [[packages.wheels]]
 name = "pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl"
@@ -516,13 +510,22 @@ size = 175577
 sha256 = "652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824"
 
 [[packages.wheels]]
-name = "pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl"
-upload-time = 2025-09-25 21:31:58.655967+00:00
-url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl"
-size = 185826
+name = "pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2025-09-25 21:32:01.310546+00:00
+url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 775556
 
 [packages.wheels.hashes]
-sha256 = "44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e"
+sha256 = "10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2025-09-25 21:32:04.553491+00:00
+url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 806638
+
+[packages.wheels.hashes]
+sha256 = "b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d"
 
 [[packages.wheels]]
 name = "pyyaml-6.0.3-cp311-cp311-win_amd64.whl"
@@ -534,40 +537,13 @@ size = 158763
 sha256 = "9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf"
 
 [[packages.wheels]]
-name = "pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2025-09-25 21:32:16.431392+00:00
-url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 807870
+name = "pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2025-09-25 21:32:11.445337+00:00
+url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 182063
 
 [packages.wheels.hashes]
-sha256 = "ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc"
-
-[[packages.wheels]]
-name = "pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl"
-upload-time = 2025-09-25 21:32:18.834540+00:00
-url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl"
-size = 790181
-
-[packages.wheels.hashes]
-sha256 = "41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea"
-
-[[packages.wheels]]
-name = "pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2025-09-25 21:32:13.652062+00:00
-url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 775116
-
-[packages.wheels.hashes]
-sha256 = "9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28"
-
-[[packages.wheels]]
-name = "pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl"
-upload-time = 2025-09-25 21:32:17.560500+00:00
-url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl"
-size = 761089
-
-[packages.wheels.hashes]
-sha256 = "8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e"
+sha256 = "7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196"
 
 [[packages.wheels]]
 name = "pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl"
@@ -579,13 +555,22 @@ size = 173973
 sha256 = "fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0"
 
 [[packages.wheels]]
-name = "pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl"
-upload-time = 2025-09-25 21:32:11.445337+00:00
-url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl"
-size = 182063
+name = "pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2025-09-25 21:32:13.652062+00:00
+url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 775116
 
 [packages.wheels.hashes]
-sha256 = "7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196"
+sha256 = "9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2025-09-25 21:32:16.431392+00:00
+url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 807870
+
+[packages.wheels.hashes]
+sha256 = "ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc"
 
 [[packages.wheels]]
 name = "pyyaml-6.0.3-cp312-cp312-win_amd64.whl"
@@ -597,40 +582,13 @@ size = 154003
 sha256 = "5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b"
 
 [[packages.wheels]]
-name = "pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2025-09-25 21:32:28.878522+00:00
-url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 801626
+name = "pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2025-09-25 21:32:23.673728+00:00
+url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 181669
 
 [packages.wheels.hashes]
-sha256 = "0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6"
-
-[[packages.wheels]]
-name = "pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl"
-upload-time = 2025-09-25 21:32:31.353769+00:00
-url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl"
-size = 794115
-
-[packages.wheels.hashes]
-sha256 = "eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be"
-
-[[packages.wheels]]
-name = "pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2025-09-25 21:32:26.575286+00:00
-url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 767081
-
-[packages.wheels.hashes]
-sha256 = "ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c"
-
-[[packages.wheels]]
-name = "pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl"
-upload-time = 2025-09-25 21:32:30.178904+00:00
-url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl"
-size = 753613
-
-[packages.wheels.hashes]
-sha256 = "f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6"
+sha256 = "8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8"
 
 [[packages.wheels]]
 name = "pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl"
@@ -642,13 +600,22 @@ size = 173252
 sha256 = "2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1"
 
 [[packages.wheels]]
-name = "pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl"
-upload-time = 2025-09-25 21:32:23.673728+00:00
-url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl"
-size = 181669
+name = "pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2025-09-25 21:32:26.575286+00:00
+url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 767081
 
 [packages.wheels.hashes]
-sha256 = "8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8"
+sha256 = "ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2025-09-25 21:32:28.878522+00:00
+url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 801626
+
+[packages.wheels.hashes]
+sha256 = "0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6"
 
 [[packages.wheels]]
 name = "pyyaml-6.0.3-cp313-cp313-win_amd64.whl"
@@ -660,40 +627,13 @@ size = 154090
 sha256 = "79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c"
 
 [[packages.wheels]]
-name = "pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2025-09-25 21:32:40.865549+00:00
-url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 794175
+name = "pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl"
+upload-time = 2025-09-25 21:32:35.712547+00:00
+url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl"
+size = 181814
 
 [packages.wheels.hashes]
-sha256 = "c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5"
-
-[[packages.wheels]]
-name = "pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl"
-upload-time = 2025-09-25 21:32:43.362137+00:00
-url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl"
-size = 789194
-
-[packages.wheels.hashes]
-sha256 = "5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35"
-
-[[packages.wheels]]
-name = "pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2025-09-25 21:32:37.966620+00:00
-url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 766454
-
-[packages.wheels.hashes]
-sha256 = "501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7"
-
-[[packages.wheels]]
-name = "pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl"
-upload-time = 2025-09-25 21:32:42.084806+00:00
-url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl"
-size = 755228
-
-[packages.wheels.hashes]
-sha256 = "7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764"
+sha256 = "8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac"
 
 [[packages.wheels]]
 name = "pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl"
@@ -705,13 +645,22 @@ size = 173809
 sha256 = "34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310"
 
 [[packages.wheels]]
-name = "pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl"
-upload-time = 2025-09-25 21:32:35.712547+00:00
-url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl"
-size = 181814
+name = "pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2025-09-25 21:32:37.966620+00:00
+url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 766454
 
 [packages.wheels.hashes]
-sha256 = "8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac"
+sha256 = "501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7"
+
+[[packages.wheels]]
+name = "pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2025-09-25 21:32:40.865549+00:00
+url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 794175
+
+[packages.wheels.hashes]
+sha256 = "c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5"
 
 [[packages.wheels]]
 name = "pyyaml-6.0.3-cp314-cp314-win_amd64.whl"
@@ -738,49 +687,13 @@ size = 17543
 sha256 = "7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-py3-none-any.whl"
-upload-time = 2026-03-25 20:22:03.012768+00:00
-url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl"
-size = 14583
+name = "tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
+upload-time = 2026-03-25 20:21:10.473841+00:00
+url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
+size = 154704
 
 [packages.wheels.hashes]
-sha256 = "0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-03-25 20:21:14.569419+00:00
-url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 243824
-
-[packages.wheels.hashes]
-sha256 = "5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl"
-upload-time = 2026-03-25 20:21:17.001171+00:00
-url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl"
-size = 247859
-
-[packages.wheels.hashes]
-sha256 = "ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-03-25 20:21:13.098441+00:00
-url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 237561
-
-[packages.wheels.hashes]
-sha256 = "96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl"
-upload-time = 2026-03-25 20:21:15.712337+00:00
-url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl"
-size = 242227
-
-[packages.wheels.hashes]
-sha256 = "47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c"
+sha256 = "f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl"
@@ -792,13 +705,22 @@ size = 149454
 sha256 = "4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
-upload-time = 2026-03-25 20:21:10.473841+00:00
-url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
-size = 154704
+name = "tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:13.098441+00:00
+url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 237561
 
 [packages.wheels.hashes]
-sha256 = "f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30"
+sha256 = "96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:14.569419+00:00
+url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 243824
+
+[packages.wheels.hashes]
+sha256 = "5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp311-cp311-win_amd64.whl"
@@ -810,40 +732,13 @@ size = 108084
 sha256 = "5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-03-25 20:21:25.177901+00:00
-url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 253341
+name = "tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2026-03-25 20:21:21.626567+00:00
+url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 155924
 
 [packages.wheels.hashes]
-sha256 = "136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl"
-upload-time = 2026-03-25 20:21:27.460413+00:00
-url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl"
-size = 253290
-
-[packages.wheels.hashes]
-sha256 = "5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-03-25 20:21:24.040813+00:00
-url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 244948
-
-[packages.wheels.hashes]
-sha256 = "ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl"
-upload-time = 2026-03-25 20:21:26.364996+00:00
-url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl"
-size = 248159
-
-[packages.wheels.hashes]
-sha256 = "5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585"
+sha256 = "c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl"
@@ -855,13 +750,22 @@ size = 150018
 sha256 = "7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
-upload-time = 2026-03-25 20:21:21.626567+00:00
-url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
-size = 155924
+name = "tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:24.040813+00:00
+url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 244948
 
 [packages.wheels.hashes]
-sha256 = "c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a"
+sha256 = "ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:25.177901+00:00
+url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 253341
+
+[packages.wheels.hashes]
+sha256 = "136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp312-cp312-win_amd64.whl"
@@ -873,40 +777,13 @@ size = 108847
 sha256 = "52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-03-25 20:21:36.012836+00:00
-url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 251628
+name = "tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2026-03-25 20:21:31.650748+00:00
+url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 155866
 
 [packages.wheels.hashes]
-sha256 = "f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl"
-upload-time = 2026-03-25 20:21:38.298846+00:00
-url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl"
-size = 251674
-
-[packages.wheels.hashes]
-sha256 = "51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-03-25 20:21:34.510750+00:00
-url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 243704
-
-[packages.wheels.hashes]
-sha256 = "c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl"
-upload-time = 2026-03-25 20:21:37.136802+00:00
-url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl"
-size = 247180
-
-[packages.wheels.hashes]
-sha256 = "d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d"
+sha256 = "36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl"
@@ -918,13 +795,22 @@ size = 149887
 sha256 = "eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
-upload-time = 2026-03-25 20:21:31.650748+00:00
-url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
-size = 155866
+name = "tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:34.510750+00:00
+url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 243704
 
 [packages.wheels.hashes]
-sha256 = "36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54"
+sha256 = "c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:36.012836+00:00
+url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 251628
+
+[packages.wheels.hashes]
+sha256 = "f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp313-cp313-win_amd64.whl"
@@ -936,40 +822,13 @@ size = 108755
 sha256 = "8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-03-25 20:21:45.620261+00:00
-url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 252084
+name = "tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl"
+upload-time = 2026-03-25 20:21:42.230154+00:00
+url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl"
+size = 155726
 
 [packages.wheels.hashes]
-sha256 = "01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl"
-upload-time = 2026-03-25 20:21:48.467732+00:00
-url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl"
-size = 256223
-
-[packages.wheels.hashes]
-sha256 = "ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-03-25 20:21:44.474645+00:00
-url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 244713
-
-[packages.wheels.hashes]
-sha256 = "559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl"
-upload-time = 2026-03-25 20:21:46.937942+00:00
-url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl"
-size = 247973
-
-[packages.wheels.hashes]
-sha256 = "7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15"
+sha256 = "fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl"
@@ -981,6 +840,24 @@ size = 149859
 sha256 = "a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac"
 
 [[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:44.474645+00:00
+url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 244713
+
+[packages.wheels.hashes]
+sha256 = "559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:45.620261+00:00
+url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 252084
+
+[packages.wheels.hashes]
+sha256 = "01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853"
+
+[[packages.wheels]]
 name = "tomli-2.4.1-cp314-cp314-win_amd64.whl"
 upload-time = 2026-03-25 20:21:50.506850+00:00
 url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl"
@@ -988,6 +865,15 @@ size = 109082
 
 [packages.wheels.hashes]
 sha256 = "88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-py3-none-any.whl"
+upload-time = 2026-03-25 20:22:03.012768+00:00
+url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl"
+size = 14583
+
+[packages.wheels.hashes]
+sha256 = "0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe"
 
 [[packages]]
 name = "tomli-w"
@@ -1041,6 +927,9 @@ sha256 = "adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"
 name = "typeguard"
 version = "4.5.1"
 requires-python = ">=3.9"
+dependencies = [
+    { name = "typing-extensions" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1089,6 +978,11 @@ sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
 name = "tyro"
 version = "1.0.13"
 requires-python = ">=3.8"
+dependencies = [
+    { name = "docstring-parser" },
+    { name = "typeguard" },
+    { name = "typing-extensions" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1136,7 +1030,15 @@ sha256 = "9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
 [[packages]]
 name = "virtualenv"
 version = "21.3.2"
+marker = "\"pre-commit\" in dependency_groups"
 requires-python = ">=3.8"
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+    { name = "typing-extensions" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1160,7 +1062,7 @@ sha256 = "c58ea748fa50bb2a4367da5ba3d30b02458ed40b4ea888faad94021f3309f764"
 [[packages]]
 name = "zipp"
 version = "3.23.1"
-marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\")"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -1183,12 +1085,14 @@ size = 10378
 sha256 = "0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc"
 
 [tool.nab]
-nab-version = "0.0.2"
+nab-version = "0.0.10.dev0"
 created-at = 2026-05-20 04:01:43.488182+00:00
 command-line = [
-    "/home/damian/opensource/remote/projects/resolver/nab/src/nab/__main__.py",
+    "nab",
     "lock",
     "--groups",
+    "pre-commit",
+    "--project-default-group",
     "pre-commit",
     "--no-emit-workspace",
     "--output",
@@ -1203,4 +1107,7 @@ platforms = [
     "macos_arm64",
     "macos_x86_64",
     "windows_amd64",
+]
+cli-project-overrides = [
+    "--project-default-group=pre-commit",
 ]

--- a/.github/requirements/pylock.release.toml
+++ b/.github/requirements/pylock.release.toml
@@ -1,32 +1,41 @@
 lock-version = "1.0"
 environments = [
-    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
-    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
-    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
-    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
-    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
+    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
 ]
+requires-python = ">=3.10"
 dependency-groups = [
+    "release",
+]
+default-groups = [
     "release",
 ]
 created-by = "nab"
@@ -34,7 +43,7 @@ created-by = "nab"
 [[packages]]
 name = "backports-tarfile"
 version = "1.2.0"
-marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and \"release\" in dependency_groups)"
 requires-python = ">=3.8"
 index = "https://pypi.org/simple/"
 
@@ -60,6 +69,13 @@ sha256 = "77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34"
 name = "build"
 version = "1.5.0"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "colorama" },
+    { name = "importlib-metadata" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+    { name = "tomli" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -83,6 +99,7 @@ sha256 = "13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f"
 [[packages]]
 name = "certifi"
 version = "2026.4.22"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.7"
 index = "https://pypi.org/simple/"
 
@@ -107,8 +124,11 @@ sha256 = "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a"
 [[packages]]
 name = "cffi"
 version = "2.0.0"
-marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups)"
 requires-python = ">=3.9"
+dependencies = [
+    { name = "pycparser" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -121,24 +141,6 @@ size = 523588
 sha256 = "44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"
 
 [[packages.wheels]]
-name = "cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
-upload-time = 2025-09-08 23:22:17.427460+00:00
-url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
-size = 216475
-
-[packages.wheels.hashes]
-sha256 = "fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453"
-
-[[packages.wheels]]
-name = "cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl"
-upload-time = 2025-09-08 23:22:22.143512+00:00
-url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl"
-size = 218036
-
-[packages.wheels.hashes]
-sha256 = "8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb"
-
-[[packages.wheels]]
 name = "cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
 upload-time = 2025-09-08 23:22:13.455255+00:00
 url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
@@ -148,31 +150,13 @@ size = 216402
 sha256 = "3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb"
 
 [[packages.wheels]]
-name = "cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl"
-upload-time = 2025-09-08 23:22:19.069108+00:00
-url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl"
-size = 218829
+name = "cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+upload-time = 2025-09-08 23:22:17.427460+00:00
+url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+size = 216475
 
 [packages.wheels.hashes]
-sha256 = "cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495"
-
-[[packages.wheels]]
-name = "cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
-upload-time = 2025-09-08 23:22:35.443762+00:00
-url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
-size = 215574
-
-[packages.wheels.hashes]
-sha256 = "8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26"
-
-[[packages.wheels]]
-name = "cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl"
-upload-time = 2025-09-08 23:22:39.776413+00:00
-url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl"
-size = 217078
-
-[packages.wheels.hashes]
-sha256 = "5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743"
+sha256 = "fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453"
 
 [[packages.wheels]]
 name = "cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
@@ -184,31 +168,13 @@ size = 216476
 sha256 = "730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93"
 
 [[packages.wheels]]
-name = "cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl"
-upload-time = 2025-09-08 23:22:36.805953+00:00
-url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl"
-size = 218971
+name = "cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+upload-time = 2025-09-08 23:22:35.443762+00:00
+url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+size = 215574
 
 [packages.wheels.hashes]
-sha256 = "a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9"
-
-[[packages.wheels]]
-name = "cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
-upload-time = 2025-09-08 23:22:52.902102+00:00
-url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
-size = 219572
-
-[packages.wheels.hashes]
-sha256 = "3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba"
-
-[[packages.wheels]]
-name = "cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl"
-upload-time = 2025-09-08 23:22:55.867772+00:00
-url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl"
-size = 221361
-
-[packages.wheels.hashes]
-sha256 = "2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187"
+sha256 = "8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26"
 
 [[packages.wheels]]
 name = "cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
@@ -220,31 +186,13 @@ size = 220097
 sha256 = "b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062"
 
 [[packages.wheels]]
-name = "cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl"
-upload-time = 2025-09-08 23:22:54.518730+00:00
-url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl"
-size = 222963
+name = "cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+upload-time = 2025-09-08 23:22:52.902102+00:00
+url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+size = 219572
 
 [packages.wheels.hashes]
-sha256 = "3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94"
-
-[[packages.wheels]]
-name = "cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
-upload-time = 2025-09-08 23:23:09.648916+00:00
-url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
-size = 219499
-
-[packages.wheels.hashes]
-sha256 = "c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26"
-
-[[packages.wheels]]
-name = "cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl"
-upload-time = 2025-09-08 23:23:12.420731+00:00
-url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl"
-size = 221302
-
-[packages.wheels.hashes]
-sha256 = "6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b"
+sha256 = "3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba"
 
 [[packages.wheels]]
 name = "cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
@@ -256,31 +204,13 @@ size = 220101
 sha256 = "d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b"
 
 [[packages.wheels]]
-name = "cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl"
-upload-time = 2025-09-08 23:23:10.928601+00:00
-url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl"
-size = 222928
+name = "cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+upload-time = 2025-09-08 23:23:09.648916+00:00
+url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+size = 219499
 
 [packages.wheels.hashes]
-sha256 = "d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c"
-
-[[packages.wheels]]
-name = "cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
-upload-time = 2025-09-08 23:23:24.541361+00:00
-url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
-size = 219244
-
-[packages.wheels.hashes]
-sha256 = "afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775"
-
-[[packages.wheels]]
-name = "cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl"
-upload-time = 2025-09-08 23:23:27.873096+00:00
-url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl"
-size = 220926
-
-[packages.wheels.hashes]
-sha256 = "38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1"
+sha256 = "c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26"
 
 [[packages.wheels]]
 name = "cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
@@ -292,17 +222,18 @@ size = 220049
 sha256 = "24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b"
 
 [[packages.wheels]]
-name = "cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl"
-upload-time = 2025-09-08 23:23:26.143606+00:00
-url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl"
-size = 222828
+name = "cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+upload-time = 2025-09-08 23:23:24.541361+00:00
+url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+size = 219244
 
 [packages.wheels.hashes]
-sha256 = "737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205"
+sha256 = "afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775"
 
 [[packages]]
 name = "charset-normalizer"
 version = "3.4.7"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.7"
 index = "https://pypi.org/simple/"
 
@@ -316,31 +247,13 @@ size = 144271
 sha256 = "ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-04-02 09:25:46.580440+00:00
-url = "https://files.pythonhosted.org/packages/20/e7/bed0024a0f4ab0c8a9c64d4445f39b30c99bd1acd228291959e3de664247/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 216930
+name = "charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl"
+upload-time = 2026-04-02 09:25:40.673194+00:00
+url = "https://files.pythonhosted.org/packages/26/08/0f303cb0b529e456bb116f2d50565a482694fbb94340bf56d44677e7ed03/charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl"
+size = 315182
 
 [packages.wheels.hashes]
-sha256 = "cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393"
-
-[[packages.wheels]]
-name = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl"
-upload-time = 2026-04-02 09:25:57.074827+00:00
-url = "https://files.pythonhosted.org/packages/1d/98/3a45bf8247889cf28262ebd3d0872edff11565b2a1e3064ccb132db3fbb0/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl"
-size = 218884
-
-[packages.wheels.hashes]
-sha256 = "94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a"
-
-[[packages.wheels]]
-name = "charset_normalizer-3.4.7-py3-none-any.whl"
-upload-time = 2026-04-02 09:28:37.794693+00:00
-url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl"
-size = 61958
-
-[packages.wheels.hashes]
-sha256 = "3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d"
+sha256 = "cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d"
 
 [[packages.wheels]]
 name = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
@@ -352,22 +265,13 @@ size = 209329
 sha256 = "e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl"
-upload-time = 2026-04-02 09:25:50.671425+00:00
-url = "https://files.pythonhosted.org/packages/71/94/8c61d8da9f062fdf457c80acfa25060ec22bf1d34bbeaca4350f13bcfd07/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl"
-size = 212785
+name = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-04-02 09:25:46.580440+00:00
+url = "https://files.pythonhosted.org/packages/20/e7/bed0024a0f4ab0c8a9c64d4445f39b30c99bd1acd228291959e3de664247/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 216930
 
 [packages.wheels.hashes]
-sha256 = "b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34"
-
-[[packages.wheels]]
-name = "charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl"
-upload-time = 2026-04-02 09:25:40.673194+00:00
-url = "https://files.pythonhosted.org/packages/26/08/0f303cb0b529e456bb116f2d50565a482694fbb94340bf56d44677e7ed03/charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl"
-size = 315182
-
-[packages.wheels.hashes]
-sha256 = "cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d"
+sha256 = "cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393"
 
 [[packages.wheels]]
 name = "charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl"
@@ -379,22 +283,13 @@ size = 159174
 sha256 = "6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-04-02 09:26:08.347975+00:00
-url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 214061
+name = "charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl"
+upload-time = 2026-04-02 09:26:02.191455+00:00
+url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl"
+size = 309705
 
 [packages.wheels.hashes]
-sha256 = "2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df"
-
-[[packages.wheels]]
-name = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl"
-upload-time = 2026-04-02 09:26:18.981084+00:00
-url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl"
-size = 216277
-
-[packages.wheels.hashes]
-sha256 = "ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d"
+sha256 = "7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7"
 
 [[packages.wheels]]
 name = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
@@ -406,22 +301,13 @@ size = 206419
 sha256 = "202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl"
-upload-time = 2026-04-02 09:26:12.142221+00:00
-url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl"
-size = 209841
+name = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-04-02 09:26:08.347975+00:00
+url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 214061
 
 [packages.wheels.hashes]
-sha256 = "e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e"
-
-[[packages.wheels]]
-name = "charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl"
-upload-time = 2026-04-02 09:26:02.191455+00:00
-url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl"
-size = 309705
-
-[packages.wheels.hashes]
-sha256 = "7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7"
+sha256 = "2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df"
 
 [[packages.wheels]]
 name = "charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl"
@@ -433,22 +319,13 @@ size = 159281
 sha256 = "8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-04-02 09:26:29.239485+00:00
-url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 216589
+name = "charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl"
+upload-time = 2026-04-02 09:26:24.331339+00:00
+url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl"
+size = 311328
 
 [packages.wheels.hashes]
-sha256 = "5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116"
-
-[[packages.wheels]]
-name = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl"
-upload-time = 2026-04-02 09:26:40.170193+00:00
-url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl"
-size = 218468
-
-[packages.wheels.hashes]
-sha256 = "bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49"
+sha256 = "eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46"
 
 [[packages.wheels]]
 name = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
@@ -460,22 +337,13 @@ size = 208061
 sha256 = "6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl"
-upload-time = 2026-04-02 09:26:33.282753+00:00
-url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl"
-size = 211229
+name = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-04-02 09:26:29.239485+00:00
+url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 216589
 
 [packages.wheels.hashes]
-sha256 = "708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15"
-
-[[packages.wheels]]
-name = "charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl"
-upload-time = 2026-04-02 09:26:24.331339+00:00
-url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl"
-size = 311328
-
-[packages.wheels.hashes]
-sha256 = "eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46"
+sha256 = "5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116"
 
 [[packages.wheels]]
 name = "charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl"
@@ -487,22 +355,13 @@ size = 159330
 sha256 = "5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-04-02 09:26:50.915844+00:00
-url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 215595
+name = "charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl"
+upload-time = 2026-04-02 09:26:45.198440+00:00
+url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl"
+size = 309627
 
 [packages.wheels.hashes]
-sha256 = "e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd"
-
-[[packages.wheels]]
-name = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl"
-upload-time = 2026-04-02 09:27:02.021863+00:00
-url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl"
-size = 217723
-
-[packages.wheels.hashes]
-sha256 = "64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a"
+sha256 = "f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063"
 
 [[packages.wheels]]
 name = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
@@ -514,22 +373,13 @@ size = 207008
 sha256 = "0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl"
-upload-time = 2026-04-02 09:26:54.975572+00:00
-url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl"
-size = 210036
+name = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-04-02 09:26:50.915844+00:00
+url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 215595
 
 [packages.wheels.hashes]
-sha256 = "7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8"
-
-[[packages.wheels]]
-name = "charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl"
-upload-time = 2026-04-02 09:26:45.198440+00:00
-url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl"
-size = 309627
-
-[packages.wheels.hashes]
-sha256 = "f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063"
+sha256 = "e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd"
 
 [[packages.wheels]]
 name = "charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl"
@@ -541,22 +391,13 @@ size = 158819
 sha256 = "3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-04-02 09:27:12.446519+00:00
-url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 215882
+name = "charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl"
+upload-time = 2026-04-02 09:27:07.194784+00:00
+url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl"
+size = 309234
 
 [packages.wheels.hashes]
-sha256 = "bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e"
-
-[[packages.wheels]]
-name = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl"
-upload-time = 2026-04-02 09:27:23.486452+00:00
-url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl"
-size = 217869
-
-[packages.wheels.hashes]
-sha256 = "7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72"
+sha256 = "c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0"
 
 [[packages.wheels]]
 name = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
@@ -568,22 +409,13 @@ size = 208042
 sha256 = "1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a"
 
 [[packages.wheels]]
-name = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl"
-upload-time = 2026-04-02 09:27:16.834768+00:00
-url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl"
-size = 211276
+name = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-04-02 09:27:12.446519+00:00
+url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 215882
 
 [packages.wheels.hashes]
-sha256 = "e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b"
-
-[[packages.wheels]]
-name = "charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl"
-upload-time = 2026-04-02 09:27:07.194784+00:00
-url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl"
-size = 309234
-
-[packages.wheels.hashes]
-sha256 = "c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0"
+sha256 = "bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e"
 
 [[packages.wheels]]
 name = "charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl"
@@ -594,10 +426,19 @@ size = 159634
 [packages.wheels.hashes]
 sha256 = "92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f"
 
+[[packages.wheels]]
+name = "charset_normalizer-3.4.7-py3-none-any.whl"
+upload-time = 2026-04-02 09:28:37.794693+00:00
+url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl"
+size = 61958
+
+[packages.wheels.hashes]
+sha256 = "3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d"
+
 [[packages]]
 name = "colorama"
 version = "0.4.6"
-marker = "(python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version >= \"3.10.2.dev0\") or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
 requires-python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 index = "https://pypi.org/simple/"
 
@@ -622,8 +463,12 @@ sha256 = "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
 [[packages]]
 name = "cryptography"
 version = "48.0.0"
-marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups)"
 requires-python = "!=3.9.0,!=3.9.1,>=3.9"
+dependencies = [
+    { name = "cffi" },
+    { name = "typing-extensions" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -636,40 +481,13 @@ size = 832984
 sha256 = "5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920"
 
 [[packages.wheels]]
-name = "cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
-upload-time = 2026-05-04 22:58:48.220595+00:00
-url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
-size = 4696228
+name = "cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+upload-time = 2026-05-04 22:57:40.373494+00:00
+url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+size = 4690433
 
 [packages.wheels.hashes]
-sha256 = "7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f"
-
-[[packages.wheels]]
-name = "cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-04 22:59:09.851839+00:00
-url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl"
-size = 4960575
-
-[packages.wheels.hashes]
-sha256 = "a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4"
-
-[[packages.wheels]]
-name = "cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
-upload-time = 2026-05-04 22:58:46.064772+00:00
-url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
-size = 4683266
-
-[packages.wheels.hashes]
-sha256 = "614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e"
-
-[[packages.wheels]]
-name = "cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-04 22:59:07.802300+00:00
-url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl"
-size = 4822059
-
-[packages.wheels.hashes]
-sha256 = "1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c"
+sha256 = "f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c"
 
 [[packages.wheels]]
 name = "cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
@@ -681,31 +499,94 @@ size = 4710620
 sha256 = "7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3"
 
 [[packages.wheels]]
-name = "cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-04 22:58:03.968945+00:00
-url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl"
-size = 4972574
+name = "cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-04 22:57:45.294448+00:00
+url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl"
+size = 4696283
 
 [packages.wheels.hashes]
-sha256 = "9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74"
+sha256 = "40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5"
 
 [[packages.wheels]]
-name = "cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
-upload-time = 2026-05-04 22:57:40.373494+00:00
-url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
-size = 4690433
+name = "cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl"
+upload-time = 2026-05-04 22:57:50.067285+00:00
+url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl"
+size = 4743677
 
 [packages.wheels.hashes]
-sha256 = "f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c"
+sha256 = "a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f"
 
 [[packages.wheels]]
-name = "cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-04 22:58:01.996904+00:00
-url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl"
-size = 4826672
+name = "cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl"
+upload-time = 2026-05-04 22:57:54.603692+00:00
+url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl"
+size = 4695941
 
 [packages.wheels.hashes]
-sha256 = "59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321"
+sha256 = "7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602"
+
+[[packages.wheels]]
+name = "cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl"
+upload-time = 2026-05-04 22:57:59.535546+00:00
+url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl"
+size = 4743326
+
+[packages.wheels.hashes]
+sha256 = "bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5"
+
+[[packages.wheels]]
+name = "cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+upload-time = 2026-05-04 22:58:46.064772+00:00
+url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+size = 4683266
+
+[packages.wheels.hashes]
+sha256 = "614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e"
+
+[[packages.wheels]]
+name = "cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+upload-time = 2026-05-04 22:58:48.220595+00:00
+url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+size = 4696228
+
+[packages.wheels.hashes]
+sha256 = "7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f"
+
+[[packages.wheels]]
+name = "cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-04 22:58:50.900159+00:00
+url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl"
+size = 4689097
+
+[packages.wheels.hashes]
+sha256 = "2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7"
+
+[[packages.wheels]]
+name = "cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl"
+upload-time = 2026-05-04 22:58:55.611945+00:00
+url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl"
+size = 4730479
+
+[packages.wheels.hashes]
+sha256 = "2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c"
+
+[[packages.wheels]]
+name = "cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl"
+upload-time = 2026-05-04 22:59:00.077539+00:00
+url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl"
+size = 4688713
+
+[packages.wheels.hashes]
+sha256 = "5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a"
+
+[[packages.wheels]]
+name = "cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl"
+upload-time = 2026-05-04 22:59:05.255870+00:00
+url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl"
+size = 4729947
+
+[packages.wheels.hashes]
+sha256 = "9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239"
 
 [[packages]]
 name = "docstring-parser"
@@ -734,6 +615,7 @@ sha256 = "b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b"
 [[packages]]
 name = "docutils"
 version = "0.22.4"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -758,7 +640,15 @@ sha256 = "d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de"
 [[packages]]
 name = "hatchling"
 version = "1.29.0"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pluggy" },
+    { name = "tomli" },
+    { name = "trove-classifiers" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -782,7 +672,11 @@ sha256 = "50af9343281f34785fab12da82e445ed987a6efb34fd8c2fc0f6e6630dbcc1b0"
 [[packages]]
 name = "id"
 version = "1.6.1"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.9"
+dependencies = [
+    { name = "urllib3" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -806,6 +700,7 @@ sha256 = "f5ec41ed2629a508f5d0988eda142e190c9c6da971100612c4de9ad9f9b237ca"
 [[packages]]
 name = "idna"
 version = "3.15"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.8"
 index = "https://pypi.org/simple/"
 
@@ -830,8 +725,11 @@ sha256 = "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"
 [[packages]]
 name = "importlib-metadata"
 version = "9.0.0"
-marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and \"release\" in dependency_groups)"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "zipp" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -879,7 +777,11 @@ sha256 = "011d045df8b954ced7dde3a7e42ae4418da40ecda7990f2d11d5ed7c146fd98b"
 [[packages]]
 name = "jaraco-classes"
 version = "3.4.0"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.8"
+dependencies = [
+    { name = "more-itertools" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -903,7 +805,11 @@ sha256 = "f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790"
 [[packages]]
 name = "jaraco-context"
 version = "6.1.2"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "backports-tarfile" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -927,7 +833,11 @@ sha256 = "bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535"
 [[packages]]
 name = "jaraco-functools"
 version = "4.5.0"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "more-itertools" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -951,7 +861,7 @@ sha256 = "79ce39246eddbde4b3a03b77ea5f0f7878dc669b166a66cf3fa8e266aa3fa2f4"
 [[packages]]
 name = "jeepney"
 version = "0.9.0"
-marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups)"
 requires-python = ">=3.7"
 index = "https://pypi.org/simple/"
 
@@ -976,7 +886,17 @@ sha256 = "97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683"
 [[packages]]
 name = "keyring"
 version = "25.7.0"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.9"
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney" },
+    { name = "pywin32-ctypes" },
+    { name = "secretstorage" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1000,7 +920,11 @@ sha256 = "be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f"
 [[packages]]
 name = "markdown-it-py"
 version = "4.2.0"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "mdurl" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1024,6 +948,7 @@ sha256 = "9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a"
 [[packages]]
 name = "mdurl"
 version = "0.1.2"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.7"
 index = "https://pypi.org/simple/"
 
@@ -1048,6 +973,7 @@ sha256 = "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"
 [[packages]]
 name = "more-itertools"
 version = "11.0.2"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
@@ -1072,6 +998,7 @@ sha256 = "6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4"
 [[packages]]
 name = "nh3"
 version = "0.3.5"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.8"
 index = "https://pypi.org/simple/"
 
@@ -1085,22 +1012,13 @@ size = 20743
 sha256 = "45855e14ff056064fec77133bfcf7cd691838168e5e17bbef075394954dc9dc8"
 
 [[packages.wheels]]
-name = "nh3-0.3.5-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-upload-time = 2026-04-25 10:44:01.743347+00:00
-url = "https://files.pythonhosted.org/packages/1b/0e/bf298920729f216adcb002acf7ea01b90842603d2e4e2ce9b900d9ee8fab/nh3-0.3.5-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-size = 806976
+name = "nh3-0.3.5-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"
+upload-time = 2026-04-25 10:43:53.556226+00:00
+url = "https://files.pythonhosted.org/packages/85/30/d162e99746a2fb1d98bb0ef23af3e201b156cf09f7de867c7390c8fe1c06/nh3-0.3.5-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"
+size = 1442393
 
 [packages.wheels.hashes]
-sha256 = "fe3a787dc76b50de6bee54ef242f26c41dfe47654428e3e94f0fae5bb6dd2cc1"
-
-[[packages.wheels]]
-name = "nh3-0.3.5-cp38-abi3-musllinux_1_2_x86_64.whl"
-upload-time = 2026-04-25 10:44:10.775616+00:00
-url = "https://files.pythonhosted.org/packages/ce/cb/7a39e72e668c8445bdd95e494b3e21cfdddc68329be8ea3522c8befb46c4/nh3-0.3.5-cp38-abi3-musllinux_1_2_x86_64.whl"
-size = 1040938
-
-[packages.wheels.hashes]
-sha256 = "e49c9b564e6bcb03ecd2f057213df9a0de15a95812ac9db9600b590db23d3ae9"
+sha256 = "3bb854485c9b33e5bb143ff3e49e577073bc6bc320f0ff8fc316dd89c0d3c101"
 
 [[packages.wheels]]
 name = "nh3-0.3.5-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
@@ -1112,22 +1030,13 @@ size = 837722
 sha256 = "50d401ab2d8e86d59e2126e3ab2a2f45840c405842b626d9a51624b3a33b6878"
 
 [[packages.wheels]]
-name = "nh3-0.3.5-cp38-abi3-musllinux_1_2_aarch64.whl"
-upload-time = 2026-04-25 10:44:06.180431+00:00
-url = "https://files.pythonhosted.org/packages/58/36/734d353dfaf292fed574b8b3092f0ef79dc6404f3879f7faaa61a4701fad/nh3-0.3.5-cp38-abi3-musllinux_1_2_aarch64.whl"
-size = 1018600
+name = "nh3-0.3.5-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-04-25 10:44:01.743347+00:00
+url = "https://files.pythonhosted.org/packages/1b/0e/bf298920729f216adcb002acf7ea01b90842603d2e4e2ce9b900d9ee8fab/nh3-0.3.5-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 806976
 
 [packages.wheels.hashes]
-sha256 = "eeedc90ed8c42c327e8e10e621ccfa314fc6cce35d5929f4297ff1cdb89667c4"
-
-[[packages.wheels]]
-name = "nh3-0.3.5-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"
-upload-time = 2026-04-25 10:43:53.556226+00:00
-url = "https://files.pythonhosted.org/packages/85/30/d162e99746a2fb1d98bb0ef23af3e201b156cf09f7de867c7390c8fe1c06/nh3-0.3.5-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"
-size = 1442393
-
-[packages.wheels.hashes]
-sha256 = "3bb854485c9b33e5bb143ff3e49e577073bc6bc320f0ff8fc316dd89c0d3c101"
+sha256 = "fe3a787dc76b50de6bee54ef242f26c41dfe47654428e3e94f0fae5bb6dd2cc1"
 
 [[packages.wheels]]
 name = "nh3-0.3.5-cp38-abi3-win_amd64.whl"
@@ -1165,6 +1074,7 @@ sha256 = "5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"
 [[packages]]
 name = "pathspec"
 version = "1.1.1"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -1189,6 +1099,7 @@ sha256 = "a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189"
 [[packages]]
 name = "pluggy"
 version = "1.6.0"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -1213,7 +1124,7 @@ sha256 = "e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
 [[packages]]
 name = "pycparser"
 version = "3.0"
-marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups)"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
@@ -1238,6 +1149,7 @@ sha256 = "b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"
 [[packages]]
 name = "pygments"
 version = "2.20.0"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -1286,7 +1198,7 @@ sha256 = "9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913"
 [[packages]]
 name = "pywin32-ctypes"
 version = "0.2.3"
-marker = "(python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and \"release\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and \"release\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and \"release\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and \"release\" in dependency_groups)"
 requires-python = ">=3.6"
 index = "https://pypi.org/simple/"
 
@@ -1311,7 +1223,13 @@ sha256 = "8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8"
 [[packages]]
 name = "readme-renderer"
 version = "44.0"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.9"
+dependencies = [
+    { name = "docutils" },
+    { name = "nh3" },
+    { name = "pygments" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1335,7 +1253,14 @@ sha256 = "2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151"
 [[packages]]
 name = "requests"
 version = "2.34.2"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1359,7 +1284,11 @@ sha256 = "2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"
 [[packages]]
 name = "requests-toolbelt"
 version = "1.0.0"
+marker = "\"release\" in dependency_groups"
 requires-python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+dependencies = [
+    { name = "requests" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1383,6 +1312,7 @@ sha256 = "cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06"
 [[packages]]
 name = "rfc3986"
 version = "2.0.0"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.7"
 index = "https://pypi.org/simple/"
 
@@ -1407,7 +1337,12 @@ sha256 = "50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd"
 [[packages]]
 name = "rich"
 version = "15.0.0"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.9.0"
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1431,8 +1366,12 @@ sha256 = "33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb"
 [[packages]]
 name = "secretstorage"
 version = "3.5.0"
-marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups)"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1469,49 +1408,13 @@ size = 17543
 sha256 = "7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-py3-none-any.whl"
-upload-time = 2026-03-25 20:22:03.012768+00:00
-url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl"
-size = 14583
+name = "tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
+upload-time = 2026-03-25 20:21:10.473841+00:00
+url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
+size = 154704
 
 [packages.wheels.hashes]
-sha256 = "0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-03-25 20:21:14.569419+00:00
-url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 243824
-
-[packages.wheels.hashes]
-sha256 = "5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl"
-upload-time = 2026-03-25 20:21:17.001171+00:00
-url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl"
-size = 247859
-
-[packages.wheels.hashes]
-sha256 = "ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-03-25 20:21:13.098441+00:00
-url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 237561
-
-[packages.wheels.hashes]
-sha256 = "96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl"
-upload-time = 2026-03-25 20:21:15.712337+00:00
-url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl"
-size = 242227
-
-[packages.wheels.hashes]
-sha256 = "47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c"
+sha256 = "f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl"
@@ -1523,13 +1426,22 @@ size = 149454
 sha256 = "4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
-upload-time = 2026-03-25 20:21:10.473841+00:00
-url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
-size = 154704
+name = "tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:13.098441+00:00
+url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 237561
 
 [packages.wheels.hashes]
-sha256 = "f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30"
+sha256 = "96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:14.569419+00:00
+url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 243824
+
+[packages.wheels.hashes]
+sha256 = "5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp311-cp311-win_amd64.whl"
@@ -1541,40 +1453,13 @@ size = 108084
 sha256 = "5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-03-25 20:21:25.177901+00:00
-url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 253341
+name = "tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2026-03-25 20:21:21.626567+00:00
+url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 155924
 
 [packages.wheels.hashes]
-sha256 = "136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl"
-upload-time = 2026-03-25 20:21:27.460413+00:00
-url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl"
-size = 253290
-
-[packages.wheels.hashes]
-sha256 = "5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-03-25 20:21:24.040813+00:00
-url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 244948
-
-[packages.wheels.hashes]
-sha256 = "ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl"
-upload-time = 2026-03-25 20:21:26.364996+00:00
-url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl"
-size = 248159
-
-[packages.wheels.hashes]
-sha256 = "5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585"
+sha256 = "c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl"
@@ -1586,13 +1471,22 @@ size = 150018
 sha256 = "7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
-upload-time = 2026-03-25 20:21:21.626567+00:00
-url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
-size = 155924
+name = "tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:24.040813+00:00
+url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 244948
 
 [packages.wheels.hashes]
-sha256 = "c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a"
+sha256 = "ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:25.177901+00:00
+url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 253341
+
+[packages.wheels.hashes]
+sha256 = "136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp312-cp312-win_amd64.whl"
@@ -1604,40 +1498,13 @@ size = 108847
 sha256 = "52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-03-25 20:21:36.012836+00:00
-url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 251628
+name = "tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2026-03-25 20:21:31.650748+00:00
+url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 155866
 
 [packages.wheels.hashes]
-sha256 = "f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl"
-upload-time = 2026-03-25 20:21:38.298846+00:00
-url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl"
-size = 251674
-
-[packages.wheels.hashes]
-sha256 = "51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-03-25 20:21:34.510750+00:00
-url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 243704
-
-[packages.wheels.hashes]
-sha256 = "c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl"
-upload-time = 2026-03-25 20:21:37.136802+00:00
-url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl"
-size = 247180
-
-[packages.wheels.hashes]
-sha256 = "d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d"
+sha256 = "36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl"
@@ -1649,13 +1516,22 @@ size = 149887
 sha256 = "eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
-upload-time = 2026-03-25 20:21:31.650748+00:00
-url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
-size = 155866
+name = "tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:34.510750+00:00
+url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 243704
 
 [packages.wheels.hashes]
-sha256 = "36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54"
+sha256 = "c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:36.012836+00:00
+url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 251628
+
+[packages.wheels.hashes]
+sha256 = "f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp313-cp313-win_amd64.whl"
@@ -1667,40 +1543,13 @@ size = 108755
 sha256 = "8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-03-25 20:21:45.620261+00:00
-url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 252084
+name = "tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl"
+upload-time = 2026-03-25 20:21:42.230154+00:00
+url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl"
+size = 155726
 
 [packages.wheels.hashes]
-sha256 = "01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl"
-upload-time = 2026-03-25 20:21:48.467732+00:00
-url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl"
-size = 256223
-
-[packages.wheels.hashes]
-sha256 = "ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-03-25 20:21:44.474645+00:00
-url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 244713
-
-[packages.wheels.hashes]
-sha256 = "559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl"
-upload-time = 2026-03-25 20:21:46.937942+00:00
-url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl"
-size = 247973
-
-[packages.wheels.hashes]
-sha256 = "7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15"
+sha256 = "fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl"
@@ -1712,6 +1561,24 @@ size = 149859
 sha256 = "a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac"
 
 [[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:44.474645+00:00
+url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 244713
+
+[packages.wheels.hashes]
+sha256 = "559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:45.620261+00:00
+url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 252084
+
+[packages.wheels.hashes]
+sha256 = "01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853"
+
+[[packages.wheels]]
 name = "tomli-2.4.1-cp314-cp314-win_amd64.whl"
 upload-time = 2026-03-25 20:21:50.506850+00:00
 url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl"
@@ -1719,6 +1586,15 @@ size = 109082
 
 [packages.wheels.hashes]
 sha256 = "88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-py3-none-any.whl"
+upload-time = 2026-03-25 20:22:03.012768+00:00
+url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl"
+size = 14583
+
+[packages.wheels.hashes]
+sha256 = "0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe"
 
 [[packages]]
 name = "tomli-w"
@@ -1747,6 +1623,7 @@ sha256 = "188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90"
 [[packages]]
 name = "tomlkit"
 version = "0.15.0"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -1771,6 +1648,7 @@ sha256 = "4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738"
 [[packages]]
 name = "trove-classifiers"
 version = "2026.5.7.17"
+marker = "\"release\" in dependency_groups"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1818,7 +1696,19 @@ sha256 = "adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"
 [[packages]]
 name = "twine"
 version = "6.2.0"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.9"
+dependencies = [
+    { name = "id" },
+    { name = "keyring" },
+    { name = "packaging" },
+    { name = "readme-renderer" },
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+    { name = "rfc3986" },
+    { name = "rich" },
+    { name = "urllib3" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1843,6 +1733,9 @@ sha256 = "418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8"
 name = "typeguard"
 version = "4.5.2"
 requires-python = ">=3.9"
+dependencies = [
+    { name = "typing-extensions" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1891,6 +1784,11 @@ sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
 name = "tyro"
 version = "1.0.13"
 requires-python = ">=3.8"
+dependencies = [
+    { name = "docstring-parser" },
+    { name = "typeguard" },
+    { name = "typing-extensions" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1938,7 +1836,7 @@ sha256 = "9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
 [[packages]]
 name = "zipp"
 version = "3.23.1"
-marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and \"release\" in dependency_groups)"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -1961,12 +1859,14 @@ size = 10378
 sha256 = "0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc"
 
 [tool.nab]
-nab-version = "0.0.2"
+nab-version = "0.0.10.dev0"
 created-at = 2026-05-25 02:58:47.561385+00:00
 command-line = [
-    "/home/damian/opensource/remote/projects/resolver/nab/src/nab/__main__.py",
+    "nab",
     "lock",
     "--groups",
+    "release",
+    "--project-default-group",
     "release",
     "--no-emit-workspace",
     "--output",
@@ -1981,4 +1881,7 @@ platforms = [
     "macos_arm64",
     "macos_x86_64",
     "windows_amd64",
+]
+cli-project-overrides = [
+    "--project-default-group=release",
 ]

--- a/.github/requirements/pylock.tests.toml
+++ b/.github/requirements/pylock.tests.toml
@@ -1,32 +1,41 @@
 lock-version = "1.0"
 environments = [
-    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
-    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
-    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
-    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
-    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
+    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
 ]
+requires-python = ">=3.10"
 dependency-groups = [
+    "tests",
+]
+default-groups = [
     "tests",
 ]
 created-by = "nab"
@@ -34,7 +43,13 @@ created-by = "nab"
 [[packages]]
 name = "anyio"
 version = "4.13.0"
+marker = "\"tests\" in dependency_groups"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "exceptiongroup" },
+    { name = "idna" },
+    { name = "typing-extensions" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -59,6 +74,13 @@ sha256 = "08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708"
 name = "build"
 version = "1.5.0"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "colorama" },
+    { name = "importlib-metadata" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+    { name = "tomli" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -82,6 +104,7 @@ sha256 = "13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f"
 [[packages]]
 name = "certifi"
 version = "2026.4.22"
+marker = "\"tests\" in dependency_groups"
 requires-python = ">=3.7"
 index = "https://pypi.org/simple/"
 
@@ -106,7 +129,7 @@ sha256 = "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a"
 [[packages]]
 name = "colorama"
 version = "0.4.6"
-marker = "(python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version >= \"3.10.2.dev0\") or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
 requires-python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 index = "https://pypi.org/simple/"
 
@@ -131,6 +154,7 @@ sha256 = "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
 [[packages]]
 name = "coverage"
 version = "7.14.0"
+marker = "\"tests\" in dependency_groups"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
@@ -144,49 +168,13 @@ size = 919489
 sha256 = "057a6af2f160a85384cde4ab36f0d2777bae1057bae255f95413cdd382aa5c74"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-05-10 17:59:29.479819+00:00
-url = "https://files.pythonhosted.org/packages/b5/d9/92600e89486fd074c50f0117422b2c9592c3e144e2f25bd5ac0bc62bc7a0/coverage-7.14.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 248762
+name = "coverage-7.14.0-cp310-cp310-macosx_10_9_x86_64.whl"
+upload-time = 2026-05-10 17:59:23.106199+00:00
+url = "https://files.pythonhosted.org/packages/59/9d/7c83ef51c3eb495f10010094e661833588b7709946da634c8b66520b97c7/coverage-7.14.0-cp310-cp310-macosx_10_9_x86_64.whl"
+size = 219668
 
 [packages.wheels.hashes]
-sha256 = "3fd43f0616e765ab78d069cf8358def7363957a45cee446d65c502dcfeea7893"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 17:59:43.471850+00:00
-url = "https://files.pythonhosted.org/packages/70/db/cef0228de493f2c740c760a9057a61d00c6849480073b70a75b87c7d4bab/coverage-7.14.0-cp310-cp310-musllinux_1_2_x86_64.whl"
-size = 247544
-
-[packages.wheels.hashes]
-sha256 = "d128b1bba9361fbaaf6a19e179e6cfd6a9103ce0c0555876f72780acc93efd85"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-py3-none-any.whl"
-upload-time = 2026-05-10 18:02:29.538126+00:00
-url = "https://files.pythonhosted.org/packages/61/e8/cb8e80d6f9f55b99588625062822bf946cf03ed06315df4bd8397f5632a1/coverage-7.14.0-py3-none-any.whl"
-size = 211764
-
-[packages.wheels.hashes]
-sha256 = "8de5b61163aee3d05c8a2beab6f47913df7981dad1baf82c414d99158c286ab1"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 17:59:31.330855+00:00
-url = "https://files.pythonhosted.org/packages/0d/e1/9ea1eb9c311da7f15853559dc1d9d82bef88ecd3e59fbeb51f16bc2ffa91/coverage-7.14.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 250625
-
-[packages.wheels.hashes]
-sha256 = "731e535b1498b27d13594a0527a79b0510867b0ad891532be41cb883f2128e20"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 17:59:36.232646+00:00
-url = "https://files.pythonhosted.org/packages/f0/e2/0b7898cda21041cc67546e19b80ba66cbbb47cbece52a76a5904de6a3aaf/coverage-7.14.0-cp310-cp310-musllinux_1_2_aarch64.whl"
-size = 248666
-
-[packages.wheels.hashes]
-sha256 = "0a951308cde22cf77f953955a754d04dccb57fe3bb8e345d685778ed9fc1632a"
+sha256 = "84c32d90bf4537f0e7b4dec9aaa9a938fb8205136b9d2ecf4d7629d5262dc075"
 
 [[packages.wheels]]
 name = "coverage-7.14.0-cp310-cp310-macosx_11_0_arm64.whl"
@@ -198,13 +186,22 @@ size = 220192
 sha256 = "7c843572c605ab51cfdb5c6b5f2586e2a8467c0d28eca4bdef4ec70c5fecbd82"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-macosx_10_9_x86_64.whl"
-upload-time = 2026-05-10 17:59:23.106199+00:00
-url = "https://files.pythonhosted.org/packages/59/9d/7c83ef51c3eb495f10010094e661833588b7709946da634c8b66520b97c7/coverage-7.14.0-cp310-cp310-macosx_10_9_x86_64.whl"
-size = 219668
+name = "coverage-7.14.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-05-10 17:59:29.479819+00:00
+url = "https://files.pythonhosted.org/packages/b5/d9/92600e89486fd074c50f0117422b2c9592c3e144e2f25bd5ac0bc62bc7a0/coverage-7.14.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 248762
 
 [packages.wheels.hashes]
-sha256 = "84c32d90bf4537f0e7b4dec9aaa9a938fb8205136b9d2ecf4d7629d5262dc075"
+sha256 = "3fd43f0616e765ab78d069cf8358def7363957a45cee446d65c502dcfeea7893"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-10 17:59:31.330855+00:00
+url = "https://files.pythonhosted.org/packages/0d/e1/9ea1eb9c311da7f15853559dc1d9d82bef88ecd3e59fbeb51f16bc2ffa91/coverage-7.14.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 250625
+
+[packages.wheels.hashes]
+sha256 = "731e535b1498b27d13594a0527a79b0510867b0ad891532be41cb883f2128e20"
 
 [[packages.wheels]]
 name = "coverage-7.14.0-cp310-cp310-win_amd64.whl"
@@ -216,40 +213,13 @@ size = 223215
 sha256 = "b34ece8065914f938ed7f2c5872bb865336977a52919149846eac3744327267a"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-05-10 17:59:53.244429+00:00
-url = "https://files.pythonhosted.org/packages/fd/35/202235eb5c3c14c212462cd91d61b7386bf8fc44bc7a77f4742d2a69174b/coverage-7.14.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 252633
+name = "coverage-7.14.0-cp311-cp311-macosx_10_9_x86_64.whl"
+upload-time = 2026-05-10 17:59:48.198844+00:00
+url = "https://files.pythonhosted.org/packages/fc/e4/649c8d4f7f1709b6dbfc474358aa1bba02f67bcd52e2fec291a5014006cd/coverage-7.14.0-cp311-cp311-macosx_10_9_x86_64.whl"
+size = 219795
 
 [packages.wheels.hashes]
-sha256 = "9336e23e8bb3a3925398261385e2a1533957d3e760e91070dcb0e98bfa514eed"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 18:00:06.858179+00:00
-url = "https://files.pythonhosted.org/packages/35/60/a4257538ce2f6b978aeb51870d6c4208c510928a03db7e0339bb625dccb7/coverage-7.14.0-cp311-cp311-musllinux_1_2_x86_64.whl"
-size = 251125
-
-[packages.wheels.hashes]
-sha256 = "bcb2e855b87321259a037429288ae85216d191c74de3e79bf57cd2bc0761992c"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 17:59:55.021505+00:00
-url = "https://files.pythonhosted.org/packages/bb/80/5f596e8995785124ee191c42535664c5e62c65995b66f4ca21e28ae04c81/coverage-7.14.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 254743
-
-[packages.wheels.hashes]
-sha256 = "9cd1169b2230f9cbe9c638ba38022ed7a2b1e641cc07f7cea0365e4be2a74980"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 17:59:59.688294+00:00
-url = "https://files.pythonhosted.org/packages/3d/1c/b94f9f5f36396021ee2f62c5834b12e6a3d31f0bed5d6fc6d1c3caec087c/coverage-7.14.0-cp311-cp311-musllinux_1_2_aarch64.whl"
-size = 252433
-
-[packages.wheels.hashes]
-sha256 = "5904abf7e18cddc463219b17552229650c6b79e061d31a1059283051169cf7d5"
+sha256 = "6a78e2a9d9c5e3b8d4ab9b9d28c985ea66fced0a7d7c2aec1f216e03a2011480"
 
 [[packages.wheels]]
 name = "coverage-7.14.0-cp311-cp311-macosx_11_0_arm64.whl"
@@ -261,13 +231,22 @@ size = 220299
 sha256 = "a1816c505187592dcd1c5a5f226601a549f70365fbd00930ac88b0c225b76bb4"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-macosx_10_9_x86_64.whl"
-upload-time = 2026-05-10 17:59:48.198844+00:00
-url = "https://files.pythonhosted.org/packages/fc/e4/649c8d4f7f1709b6dbfc474358aa1bba02f67bcd52e2fec291a5014006cd/coverage-7.14.0-cp311-cp311-macosx_10_9_x86_64.whl"
-size = 219795
+name = "coverage-7.14.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-05-10 17:59:53.244429+00:00
+url = "https://files.pythonhosted.org/packages/fd/35/202235eb5c3c14c212462cd91d61b7386bf8fc44bc7a77f4742d2a69174b/coverage-7.14.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 252633
 
 [packages.wheels.hashes]
-sha256 = "6a78e2a9d9c5e3b8d4ab9b9d28c985ea66fced0a7d7c2aec1f216e03a2011480"
+sha256 = "9336e23e8bb3a3925398261385e2a1533957d3e760e91070dcb0e98bfa514eed"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-10 17:59:55.021505+00:00
+url = "https://files.pythonhosted.org/packages/bb/80/5f596e8995785124ee191c42535664c5e62c65995b66f4ca21e28ae04c81/coverage-7.14.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 254743
+
+[packages.wheels.hashes]
+sha256 = "9cd1169b2230f9cbe9c638ba38022ed7a2b1e641cc07f7cea0365e4be2a74980"
 
 [[packages.wheels]]
 name = "coverage-7.14.0-cp311-cp311-win_amd64.whl"
@@ -279,40 +258,13 @@ size = 223241
 sha256 = "bfb0ed8ec5d25e93face268115d7964db9df8b9aae8edcde9ec6b16c726a7cc1"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-05-10 18:00:18.829529+00:00
-url = "https://files.pythonhosted.org/packages/69/ff/6699e7b71e60d3049eb2bdcbc95ee3f35707b2b0e48f32e9e63d3ce30c08/coverage-7.14.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 254576
+name = "coverage-7.14.0-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2026-05-10 18:00:13.756391+00:00
+url = "https://files.pythonhosted.org/packages/09/1e/2f996b2c8415cbb6f54b0f5ec1ee850c96d7911961afb4fc05f4a89d8c58/coverage-7.14.0-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 219967
 
 [packages.wheels.hashes]
-sha256 = "ca3d9cf2c32b521bd9518385608787fa86f38daf993695307531822c3430ed67"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 18:00:32.211009+00:00
-url = "https://files.pythonhosted.org/packages/18/9d/50f05a72dff8487464fdd4178dda5daed642a060e60afb644e3d45123559/coverage-7.14.0-cp312-cp312-musllinux_1_2_x86_64.whl"
-size = 253197
-
-[packages.wheels.hashes]
-sha256 = "fcaba850dd317c65423a9d63d88f9573c53b00354d6dd95724576cc98a131595"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 18:00:20.648358+00:00
-url = "https://files.pythonhosted.org/packages/22/ec/c936d495fcd67f48f03a9c4ad3297ff80d1f222a5df3980f15b34c186c21/coverage-7.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 255690
-
-[packages.wheels.hashes]
-sha256 = "92af52828e7f29d827346b0294e5a0853fa206db77db0395b282918d41e28db9"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 18:00:25.588879+00:00
-url = "https://files.pythonhosted.org/packages/f1/7f/9e65495298c3ea414742998539c37d048b5e81cc818fb1828cc6b51d10bf/coverage-7.14.0-cp312-cp312-musllinux_1_2_aarch64.whl"
-size = 253608
-
-[packages.wheels.hashes]
-sha256 = "8231ade007f37959fbf58acc677f26b922c02eda6f0428ea307da0fd39681bf3"
+sha256 = "7ffd19fc8aed057fd686a17a4935eef5f9859d69208f96310e893e64b9b6ccf5"
 
 [[packages.wheels]]
 name = "coverage-7.14.0-cp312-cp312-macosx_11_0_arm64.whl"
@@ -324,13 +276,22 @@ size = 220329
 sha256 = "829994cfe1aeb773ca27bf246d4badc1e764893e3bfb98fff820fcecd1ca4662"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-macosx_10_13_x86_64.whl"
-upload-time = 2026-05-10 18:00:13.756391+00:00
-url = "https://files.pythonhosted.org/packages/09/1e/2f996b2c8415cbb6f54b0f5ec1ee850c96d7911961afb4fc05f4a89d8c58/coverage-7.14.0-cp312-cp312-macosx_10_13_x86_64.whl"
-size = 219967
+name = "coverage-7.14.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-05-10 18:00:18.829529+00:00
+url = "https://files.pythonhosted.org/packages/69/ff/6699e7b71e60d3049eb2bdcbc95ee3f35707b2b0e48f32e9e63d3ce30c08/coverage-7.14.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 254576
 
 [packages.wheels.hashes]
-sha256 = "7ffd19fc8aed057fd686a17a4935eef5f9859d69208f96310e893e64b9b6ccf5"
+sha256 = "ca3d9cf2c32b521bd9518385608787fa86f38daf993695307531822c3430ed67"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-10 18:00:20.648358+00:00
+url = "https://files.pythonhosted.org/packages/22/ec/c936d495fcd67f48f03a9c4ad3297ff80d1f222a5df3980f15b34c186c21/coverage-7.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 255690
+
+[packages.wheels.hashes]
+sha256 = "92af52828e7f29d827346b0294e5a0853fa206db77db0395b282918d41e28db9"
 
 [[packages.wheels]]
 name = "coverage-7.14.0-cp312-cp312-win_amd64.whl"
@@ -342,40 +303,13 @@ size = 223324
 sha256 = "70390b0da32cb90b501953716302906e8bcce087cb283e70d8c97729f22e92b2"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-05-10 18:00:44.079319+00:00
-url = "https://files.pythonhosted.org/packages/6f/5f/b5370068b2f57787454592ed7dcd1002f0f1703b7db1fa30f6a325a4ca6e/coverage-7.14.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 253961
+name = "coverage-7.14.0-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2026-05-10 18:00:38.887090+00:00
+url = "https://files.pythonhosted.org/packages/6b/76/b7c66ee3c66e1b0f9d894c8125983aa0c03fb2336f2fd16559f9c966157f/coverage-7.14.0-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 219990
 
 [packages.wheels.hashes]
-sha256 = "9d1aa57a1dc8e05bdc42e81c5d671d849577aeedf279f4c449d6d286f9ed88ca"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 18:00:57.967216+00:00
-url = "https://files.pythonhosted.org/packages/37/53/20c5009477660f084e6ed60bc02a91894b8e234e617e86ecfd9aaf78e27b/coverage-7.14.0-cp313-cp313-musllinux_1_2_x86_64.whl"
-size = 252885
-
-[packages.wheels.hashes]
-sha256 = "7b79d646cf46d5cf9a9f40281d4441df5849e445726e369006d2b117710b33fe"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 18:00:45.623804+00:00
-url = "https://files.pythonhosted.org/packages/29/1e/51adf17738976e8f2b85ddef7b7aa12a0838b056c92f175941d8862767c1/coverage-7.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 255193
-
-[packages.wheels.hashes]
-sha256 = "90c1a51bcfddf645b3bb7ec333d9e94393a8e94f55642380fa8a9a5a9e636cb7"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 18:00:51.252258+00:00
-url = "https://files.pythonhosted.org/packages/34/46/746704f95980ba220214e1a41e18cec5aea80a898eaa53c51bf2d645ff36/coverage-7.14.0-cp313-cp313-musllinux_1_2_aarch64.whl"
-size = 253325
-
-[packages.wheels.hashes]
-sha256 = "1b23b0c6f0b1db6ad769b7050c8b641c0bf215ded26c1816955b17b7f26edfa9"
+sha256 = "f2bbb8254370eb4c628ff3d6fa8a7f74ddc40565394d4f7ab791d1fe568e37ef"
 
 [[packages.wheels]]
 name = "coverage-7.14.0-cp313-cp313-macosx_11_0_arm64.whl"
@@ -387,13 +321,22 @@ size = 220365
 sha256 = "23b81107f46d3f21d0cbce30664fcec0f5d9f585638a67081750f99738f6bf66"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-macosx_10_13_x86_64.whl"
-upload-time = 2026-05-10 18:00:38.887090+00:00
-url = "https://files.pythonhosted.org/packages/6b/76/b7c66ee3c66e1b0f9d894c8125983aa0c03fb2336f2fd16559f9c966157f/coverage-7.14.0-cp313-cp313-macosx_10_13_x86_64.whl"
-size = 219990
+name = "coverage-7.14.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-05-10 18:00:44.079319+00:00
+url = "https://files.pythonhosted.org/packages/6f/5f/b5370068b2f57787454592ed7dcd1002f0f1703b7db1fa30f6a325a4ca6e/coverage-7.14.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 253961
 
 [packages.wheels.hashes]
-sha256 = "f2bbb8254370eb4c628ff3d6fa8a7f74ddc40565394d4f7ab791d1fe568e37ef"
+sha256 = "9d1aa57a1dc8e05bdc42e81c5d671d849577aeedf279f4c449d6d286f9ed88ca"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-10 18:00:45.623804+00:00
+url = "https://files.pythonhosted.org/packages/29/1e/51adf17738976e8f2b85ddef7b7aa12a0838b056c92f175941d8862767c1/coverage-7.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 255193
+
+[packages.wheels.hashes]
+sha256 = "90c1a51bcfddf645b3bb7ec333d9e94393a8e94f55642380fa8a9a5a9e636cb7"
 
 [[packages.wheels]]
 name = "coverage-7.14.0-cp313-cp313-win_amd64.whl"
@@ -405,40 +348,13 @@ size = 223344
 sha256 = "0773d8329cf32b6fd222e4b52622c61fe8d503eb966cfc8d3c3c10c96266d50e"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-05-10 18:01:38.985686+00:00
-url = "https://files.pythonhosted.org/packages/d7/51/ec641c26e6dca1b25a7d2035ba6ecb7c884ef1a100a9e42fbe4ce4405139/coverage-7.14.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 253924
+name = "coverage-7.14.0-cp314-cp314-macosx_10_15_x86_64.whl"
+upload-time = 2026-05-10 18:01:33.057085+00:00
+url = "https://files.pythonhosted.org/packages/1c/18/b9a6586d73992807c26f9a5f274131be3d76b56b18a82b9392e2a25d2e45/coverage-7.14.0-cp314-cp314-macosx_10_15_x86_64.whl"
+size = 220036
 
 [packages.wheels.hashes]
-sha256 = "5ebb8f4614a3787d567e610bbfdf96a4798dd69a1afb1bd8ad228d4111fe6ff3"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp314-cp314-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 18:01:54.506054+00:00
-url = "https://files.pythonhosted.org/packages/a4/66/2881853e0363a5e0a724d1103e53650795367471b6afb234f8b49e713bc6/coverage-7.14.0-cp314-cp314-musllinux_1_2_x86_64.whl"
-size = 252716
-
-[packages.wheels.hashes]
-sha256 = "65c86fb646d2bd2972e96bd1a8b45817ed907cee68655d6295fe7ec031d04cca"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 18:01:40.957470+00:00
-url = "https://files.pythonhosted.org/packages/33/c4/59c3de0bd1b538824173fd518fed51c1ce740ca5ed68e74545983f4053a9/coverage-7.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 255269
-
-[packages.wheels.hashes]
-sha256 = "6b9bf47223dd8db3d4c4b2e443b02bace480d428f0822c3f991600448a176c97"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp314-cp314-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 18:01:46.175307+00:00
-url = "https://files.pythonhosted.org/packages/ee/df/6770eaa576e604575e9a78055313250faef5faa84bd6f71a39fece519c43/coverage-7.14.0-cp314-cp314-musllinux_1_2_aarch64.whl"
-size = 253280
-
-[packages.wheels.hashes]
-sha256 = "15228a6800ce7bdf1b74800595e56db7138cecb338fdbf044806e10dcf182dfe"
+sha256 = "9aed9fa983514ca032790f3fe0d1c0e42ca7e16b42432af1706b50a9a46bef5d"
 
 [[packages.wheels]]
 name = "coverage-7.14.0-cp314-cp314-macosx_11_0_arm64.whl"
@@ -450,6 +366,24 @@ size = 220368
 sha256 = "ba3b8390db29296dbbf49e91b6fe08f990743a90c8f447ba4c2ffc29670dfa63"
 
 [[packages.wheels]]
+name = "coverage-7.14.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-05-10 18:01:38.985686+00:00
+url = "https://files.pythonhosted.org/packages/d7/51/ec641c26e6dca1b25a7d2035ba6ecb7c884ef1a100a9e42fbe4ce4405139/coverage-7.14.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 253924
+
+[packages.wheels.hashes]
+sha256 = "5ebb8f4614a3787d567e610bbfdf96a4798dd69a1afb1bd8ad228d4111fe6ff3"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-10 18:01:40.957470+00:00
+url = "https://files.pythonhosted.org/packages/33/c4/59c3de0bd1b538824173fd518fed51c1ce740ca5ed68e74545983f4053a9/coverage-7.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 255269
+
+[packages.wheels.hashes]
+sha256 = "6b9bf47223dd8db3d4c4b2e443b02bace480d428f0822c3f991600448a176c97"
+
+[[packages.wheels]]
 name = "coverage-7.14.0-cp314-cp314-win_amd64.whl"
 upload-time = 2026-05-10 18:01:58.497925+00:00
 url = "https://files.pythonhosted.org/packages/f9/58/6e1b8f52fdc3184b47dc5037f5070d83a3d11042db1594b02d2a44d786c8/coverage-7.14.0-cp314-cp314-win_amd64.whl"
@@ -457,6 +391,15 @@ size = 223600
 
 [packages.wheels.hashes]
 sha256 = "45e0f79d8351fa76e256716df91eab12890d32678b9590df7ae1042e4bd4cf5d"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-py3-none-any.whl"
+upload-time = 2026-05-10 18:02:29.538126+00:00
+url = "https://files.pythonhosted.org/packages/61/e8/cb8e80d6f9f55b99588625062822bf946cf03ed06315df4bd8397f5632a1/coverage-7.14.0-py3-none-any.whl"
+size = 211764
+
+[packages.wheels.hashes]
+sha256 = "8de5b61163aee3d05c8a2beab6f47913df7981dad1baf82c414d99158c286ab1"
 
 [[packages]]
 name = "docstring-parser"
@@ -485,8 +428,11 @@ sha256 = "b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b"
 [[packages]]
 name = "exceptiongroup"
 version = "1.3.1"
-marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version < \"3.10.2\" and \"tests\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version >= \"3.10.2.dev0\" and \"tests\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\" and \"tests\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"tests\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\" and \"tests\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version >= \"3.10.2.dev0\" and \"tests\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\" and \"tests\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"tests\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\" and \"tests\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version >= \"3.10.2.dev0\" and \"tests\" in dependency_groups)"
 requires-python = ">=3.7"
+dependencies = [
+    { name = "typing-extensions" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -510,6 +456,7 @@ sha256 = "a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598"
 [[packages]]
 name = "h11"
 version = "0.16.0"
+marker = "\"tests\" in dependency_groups"
 requires-python = ">=3.8"
 index = "https://pypi.org/simple/"
 
@@ -534,7 +481,12 @@ sha256 = "63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"
 [[packages]]
 name = "h2"
 version = "4.3.0"
+marker = "\"tests\" in dependency_groups"
 requires-python = ">=3.9"
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -558,6 +510,7 @@ sha256 = "c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd"
 [[packages]]
 name = "hpack"
 version = "4.1.0"
+marker = "\"tests\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -582,7 +535,12 @@ sha256 = "157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496"
 [[packages]]
 name = "httpcore"
 version = "1.0.9"
+marker = "\"tests\" in dependency_groups"
 requires-python = ">=3.8"
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -606,7 +564,15 @@ sha256 = "2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"
 [[packages]]
 name = "httpx"
 version = "0.28.1"
+marker = "\"tests\" in dependency_groups"
 requires-python = ">=3.8"
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "h2" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -630,6 +596,7 @@ sha256 = "d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"
 [[packages]]
 name = "hyperframe"
 version = "6.1.0"
+marker = "\"tests\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -654,7 +621,12 @@ sha256 = "b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5"
 [[packages]]
 name = "hypothesis"
 version = "6.152.6"
+marker = "\"tests\" in dependency_groups"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "exceptiongroup" },
+    { name = "sortedcontainers" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -678,6 +650,7 @@ sha256 = "b20ffc532e5f2901229348d10ed7cb37fd9723ebf4799df663d2dce1cdce4e32"
 [[packages]]
 name = "idna"
 version = "3.15"
+marker = "\"tests\" in dependency_groups"
 requires-python = ">=3.8"
 index = "https://pypi.org/simple/"
 
@@ -702,8 +675,11 @@ sha256 = "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"
 [[packages]]
 name = "importlib-metadata"
 version = "9.0.0"
-marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\")"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "zipp" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -727,6 +703,7 @@ sha256 = "2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7"
 [[packages]]
 name = "iniconfig"
 version = "2.3.0"
+marker = "\"tests\" in dependency_groups"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
@@ -799,6 +776,7 @@ sha256 = "5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"
 [[packages]]
 name = "pluggy"
 version = "1.6.0"
+marker = "\"tests\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -823,6 +801,7 @@ sha256 = "e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
 [[packages]]
 name = "pygments"
 version = "2.20.0"
+marker = "\"tests\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -871,7 +850,17 @@ sha256 = "9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913"
 [[packages]]
 name = "pytest"
 version = "9.0.3"
+marker = "\"tests\" in dependency_groups"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "colorama" },
+    { name = "exceptiongroup" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -895,7 +884,11 @@ sha256 = "2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"
 [[packages]]
 name = "pytest-timeout"
 version = "2.4.0"
+marker = "\"tests\" in dependency_groups"
 requires-python = ">=3.7"
+dependencies = [
+    { name = "pytest" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -919,7 +912,11 @@ sha256 = "c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2"
 [[packages]]
 name = "respx"
 version = "0.23.1"
+marker = "\"tests\" in dependency_groups"
 requires-python = ">=3.8"
+dependencies = [
+    { name = "httpx" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -943,6 +940,7 @@ sha256 = "b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a"
 [[packages]]
 name = "sortedcontainers"
 version = "2.4.0"
+marker = "\"tests\" in dependency_groups"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -979,49 +977,13 @@ size = 17543
 sha256 = "7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-py3-none-any.whl"
-upload-time = 2026-03-25 20:22:03.012768+00:00
-url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl"
-size = 14583
+name = "tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
+upload-time = 2026-03-25 20:21:10.473841+00:00
+url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
+size = 154704
 
 [packages.wheels.hashes]
-sha256 = "0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-03-25 20:21:14.569419+00:00
-url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 243824
-
-[packages.wheels.hashes]
-sha256 = "5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl"
-upload-time = 2026-03-25 20:21:17.001171+00:00
-url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl"
-size = 247859
-
-[packages.wheels.hashes]
-sha256 = "ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-03-25 20:21:13.098441+00:00
-url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 237561
-
-[packages.wheels.hashes]
-sha256 = "96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl"
-upload-time = 2026-03-25 20:21:15.712337+00:00
-url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl"
-size = 242227
-
-[packages.wheels.hashes]
-sha256 = "47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c"
+sha256 = "f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl"
@@ -1033,13 +995,22 @@ size = 149454
 sha256 = "4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
-upload-time = 2026-03-25 20:21:10.473841+00:00
-url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
-size = 154704
+name = "tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:13.098441+00:00
+url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 237561
 
 [packages.wheels.hashes]
-sha256 = "f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30"
+sha256 = "96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:14.569419+00:00
+url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 243824
+
+[packages.wheels.hashes]
+sha256 = "5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp311-cp311-win_amd64.whl"
@@ -1051,40 +1022,13 @@ size = 108084
 sha256 = "5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-03-25 20:21:25.177901+00:00
-url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 253341
+name = "tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2026-03-25 20:21:21.626567+00:00
+url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 155924
 
 [packages.wheels.hashes]
-sha256 = "136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl"
-upload-time = 2026-03-25 20:21:27.460413+00:00
-url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl"
-size = 253290
-
-[packages.wheels.hashes]
-sha256 = "5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-03-25 20:21:24.040813+00:00
-url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 244948
-
-[packages.wheels.hashes]
-sha256 = "ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl"
-upload-time = 2026-03-25 20:21:26.364996+00:00
-url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl"
-size = 248159
-
-[packages.wheels.hashes]
-sha256 = "5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585"
+sha256 = "c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl"
@@ -1096,13 +1040,22 @@ size = 150018
 sha256 = "7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
-upload-time = 2026-03-25 20:21:21.626567+00:00
-url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
-size = 155924
+name = "tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:24.040813+00:00
+url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 244948
 
 [packages.wheels.hashes]
-sha256 = "c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a"
+sha256 = "ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:25.177901+00:00
+url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 253341
+
+[packages.wheels.hashes]
+sha256 = "136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp312-cp312-win_amd64.whl"
@@ -1114,40 +1067,13 @@ size = 108847
 sha256 = "52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-03-25 20:21:36.012836+00:00
-url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 251628
+name = "tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2026-03-25 20:21:31.650748+00:00
+url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 155866
 
 [packages.wheels.hashes]
-sha256 = "f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl"
-upload-time = 2026-03-25 20:21:38.298846+00:00
-url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl"
-size = 251674
-
-[packages.wheels.hashes]
-sha256 = "51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-03-25 20:21:34.510750+00:00
-url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 243704
-
-[packages.wheels.hashes]
-sha256 = "c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl"
-upload-time = 2026-03-25 20:21:37.136802+00:00
-url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl"
-size = 247180
-
-[packages.wheels.hashes]
-sha256 = "d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d"
+sha256 = "36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl"
@@ -1159,13 +1085,22 @@ size = 149887
 sha256 = "eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
-upload-time = 2026-03-25 20:21:31.650748+00:00
-url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
-size = 155866
+name = "tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:34.510750+00:00
+url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 243704
 
 [packages.wheels.hashes]
-sha256 = "36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54"
+sha256 = "c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:36.012836+00:00
+url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 251628
+
+[packages.wheels.hashes]
+sha256 = "f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp313-cp313-win_amd64.whl"
@@ -1177,40 +1112,13 @@ size = 108755
 sha256 = "8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-03-25 20:21:45.620261+00:00
-url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 252084
+name = "tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl"
+upload-time = 2026-03-25 20:21:42.230154+00:00
+url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl"
+size = 155726
 
 [packages.wheels.hashes]
-sha256 = "01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl"
-upload-time = 2026-03-25 20:21:48.467732+00:00
-url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl"
-size = 256223
-
-[packages.wheels.hashes]
-sha256 = "ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-03-25 20:21:44.474645+00:00
-url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 244713
-
-[packages.wheels.hashes]
-sha256 = "559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl"
-upload-time = 2026-03-25 20:21:46.937942+00:00
-url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl"
-size = 247973
-
-[packages.wheels.hashes]
-sha256 = "7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15"
+sha256 = "fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl"
@@ -1222,6 +1130,24 @@ size = 149859
 sha256 = "a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac"
 
 [[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:44.474645+00:00
+url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 244713
+
+[packages.wheels.hashes]
+sha256 = "559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:45.620261+00:00
+url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 252084
+
+[packages.wheels.hashes]
+sha256 = "01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853"
+
+[[packages.wheels]]
 name = "tomli-2.4.1-cp314-cp314-win_amd64.whl"
 upload-time = 2026-03-25 20:21:50.506850+00:00
 url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl"
@@ -1229,6 +1155,15 @@ size = 109082
 
 [packages.wheels.hashes]
 sha256 = "88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-py3-none-any.whl"
+upload-time = 2026-03-25 20:22:03.012768+00:00
+url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl"
+size = 14583
+
+[packages.wheels.hashes]
+sha256 = "0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe"
 
 [[packages]]
 name = "tomli-w"
@@ -1257,6 +1192,7 @@ sha256 = "188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90"
 [[packages]]
 name = "tomlkit"
 version = "0.15.0"
+marker = "\"tests\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -1306,6 +1242,9 @@ sha256 = "adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"
 name = "typeguard"
 version = "4.5.1"
 requires-python = ">=3.9"
+dependencies = [
+    { name = "typing-extensions" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1354,6 +1293,11 @@ sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
 name = "tyro"
 version = "1.0.13"
 requires-python = ">=3.8"
+dependencies = [
+    { name = "docstring-parser" },
+    { name = "typeguard" },
+    { name = "typing-extensions" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1401,7 +1345,7 @@ sha256 = "9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
 [[packages]]
 name = "zipp"
 version = "3.23.1"
-marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\")"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -1424,12 +1368,14 @@ size = 10378
 sha256 = "0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc"
 
 [tool.nab]
-nab-version = "0.0.2"
+nab-version = "0.0.10.dev0"
 created-at = 2026-05-20 04:01:36.148929+00:00
 command-line = [
-    "/home/damian/opensource/remote/projects/resolver/nab/src/nab/__main__.py",
+    "nab",
     "lock",
     "--groups",
+    "tests",
+    "--project-default-group",
     "tests",
     "--no-emit-workspace",
     "--output",
@@ -1444,4 +1390,7 @@ platforms = [
     "macos_arm64",
     "macos_x86_64",
     "windows_amd64",
+]
+cli-project-overrides = [
+    "--project-default-group=tests",
 ]

--- a/.github/requirements/pylock.types.toml
+++ b/.github/requirements/pylock.types.toml
@@ -1,32 +1,41 @@
 lock-version = "1.0"
 environments = [
-    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
-    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
-    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
-    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
-    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\"",
-    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"arm64\"",
-    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\"",
-    "python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\"",
+    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
 ]
+requires-python = ">=3.10"
 dependency-groups = [
+    "types",
+]
+default-groups = [
     "types",
 ]
 created-by = "nab"
@@ -34,7 +43,13 @@ created-by = "nab"
 [[packages]]
 name = "anyio"
 version = "4.13.0"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "exceptiongroup" },
+    { name = "idna" },
+    { name = "typing-extensions" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -58,6 +73,7 @@ sha256 = "08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708"
 [[packages]]
 name = "ast-serialize"
 version = "0.3.0"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.7"
 index = "https://pypi.org/simple/"
 
@@ -71,40 +87,13 @@ size = 60689
 sha256 = "1bc3ca09a63a021376527c4e938deedd11d11d675ce850e6f9c7487f5889992b"
 
 [[packages.wheels]]
-name = "ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-upload-time = 2026-04-30 23:24:33.088363+00:00
-url = "https://files.pythonhosted.org/packages/25/13/44aa28d97f10e25247e8576b5f6b2795d4fa1a80acc88acc942c508d06f7/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-size = 1266458
+name = "ast_serialize-0.3.0-cp39-abi3-macosx_10_12_x86_64.whl"
+upload-time = 2026-04-30 23:24:22.486917+00:00
+url = "https://files.pythonhosted.org/packages/bc/93/72abad83966ed6235647c9f956417dc1e17e997696388521910e3d1fa3f4/ast_serialize-0.3.0-cp39-abi3-macosx_10_12_x86_64.whl"
+size = 1190024
 
 [packages.wheels.hashes]
-sha256 = "c1c9e763d70293d65ce1e1ea8c943140c68d0953f0268c7ee0998f2e07f77dd0"
-
-[[packages.wheels]]
-name = "ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_x86_64.whl"
-upload-time = 2026-04-30 23:24:41.305157+00:00
-url = "https://files.pythonhosted.org/packages/56/ec/d75fc2b788d319f1fad77c14156896f31afdfc68af85b505e5bdebcb9592/ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_x86_64.whl"
-size = 1460917
-
-[packages.wheels.hashes]
-sha256 = "11eae0cf1b7b3e0678133cc2daa974ea972caf02eb4b3aa062af6fa9acd52c57"
-
-[[packages.wheels]]
-name = "ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-upload-time = 2026-04-30 23:24:25.987108+00:00
-url = "https://files.pythonhosted.org/packages/56/51/cf1ec1ff3e616373d0dcbd5fad502e0029dc541f13ab642259762a7d127f/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-size = 1241351
-
-[packages.wheels.hashes]
-sha256 = "3d841424f41b886e98044abc80769c14a956e6e5ccd5fb5b0d9f5ead72be18a4"
-
-[[packages.wheels]]
-name = "ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_aarch64.whl"
-upload-time = 2026-04-30 23:24:36.562452+00:00
-url = "https://files.pythonhosted.org/packages/13/03/f8312d6b57f5471a9dc7946f22b8798a1fc296d38c25766223aacadec42c/ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_aarch64.whl"
-size = 1416724
-
-[packages.wheels.hashes]
-sha256 = "5283cdcc0c64c3d8b9b688dc6aaa012d9c0cf1380a7f774a6bae6a1c01b3205a"
+sha256 = "2ec2fafa5e4313cc8feed96e436ebe19ac7bc6fa41fbc2827e826c48b9e4c3a9"
 
 [[packages.wheels]]
 name = "ast_serialize-0.3.0-cp39-abi3-macosx_11_0_arm64.whl"
@@ -116,13 +105,22 @@ size = 1178633
 sha256 = "ef6d3c08b7b4cd29b48410338e134764a00e76d25841eb02c1084e868c888ecc"
 
 [[packages.wheels]]
-name = "ast_serialize-0.3.0-cp39-abi3-macosx_10_12_x86_64.whl"
-upload-time = 2026-04-30 23:24:22.486917+00:00
-url = "https://files.pythonhosted.org/packages/bc/93/72abad83966ed6235647c9f956417dc1e17e997696388521910e3d1fa3f4/ast_serialize-0.3.0-cp39-abi3-macosx_10_12_x86_64.whl"
-size = 1190024
+name = "ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-04-30 23:24:25.987108+00:00
+url = "https://files.pythonhosted.org/packages/56/51/cf1ec1ff3e616373d0dcbd5fad502e0029dc541f13ab642259762a7d127f/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1241351
 
 [packages.wheels.hashes]
-sha256 = "2ec2fafa5e4313cc8feed96e436ebe19ac7bc6fa41fbc2827e826c48b9e4c3a9"
+sha256 = "3d841424f41b886e98044abc80769c14a956e6e5ccd5fb5b0d9f5ead72be18a4"
+
+[[packages.wheels]]
+name = "ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-04-30 23:24:33.088363+00:00
+url = "https://files.pythonhosted.org/packages/25/13/44aa28d97f10e25247e8576b5f6b2795d4fa1a80acc88acc942c508d06f7/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 1266458
+
+[packages.wheels.hashes]
+sha256 = "c1c9e763d70293d65ce1e1ea8c943140c68d0953f0268c7ee0998f2e07f77dd0"
 
 [[packages.wheels]]
 name = "ast_serialize-0.3.0-cp39-abi3-win_amd64.whl"
@@ -137,6 +135,13 @@ sha256 = "a2cd125adccf7969470621905d302750cd25951f22ea430d9a25b7be031e5549"
 name = "build"
 version = "1.5.0"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "colorama" },
+    { name = "importlib-metadata" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+    { name = "tomli" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -160,6 +165,7 @@ sha256 = "13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f"
 [[packages]]
 name = "certifi"
 version = "2026.4.22"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.7"
 index = "https://pypi.org/simple/"
 
@@ -184,7 +190,7 @@ sha256 = "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a"
 [[packages]]
 name = "colorama"
 version = "0.4.6"
-marker = "(python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version >= \"3.10.2.dev0\") or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
 requires-python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 index = "https://pypi.org/simple/"
 
@@ -209,6 +215,7 @@ sha256 = "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
 [[packages]]
 name = "coverage"
 version = "7.14.0"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
@@ -222,49 +229,13 @@ size = 919489
 sha256 = "057a6af2f160a85384cde4ab36f0d2777bae1057bae255f95413cdd382aa5c74"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-05-10 17:59:29.479819+00:00
-url = "https://files.pythonhosted.org/packages/b5/d9/92600e89486fd074c50f0117422b2c9592c3e144e2f25bd5ac0bc62bc7a0/coverage-7.14.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 248762
+name = "coverage-7.14.0-cp310-cp310-macosx_10_9_x86_64.whl"
+upload-time = 2026-05-10 17:59:23.106199+00:00
+url = "https://files.pythonhosted.org/packages/59/9d/7c83ef51c3eb495f10010094e661833588b7709946da634c8b66520b97c7/coverage-7.14.0-cp310-cp310-macosx_10_9_x86_64.whl"
+size = 219668
 
 [packages.wheels.hashes]
-sha256 = "3fd43f0616e765ab78d069cf8358def7363957a45cee446d65c502dcfeea7893"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 17:59:43.471850+00:00
-url = "https://files.pythonhosted.org/packages/70/db/cef0228de493f2c740c760a9057a61d00c6849480073b70a75b87c7d4bab/coverage-7.14.0-cp310-cp310-musllinux_1_2_x86_64.whl"
-size = 247544
-
-[packages.wheels.hashes]
-sha256 = "d128b1bba9361fbaaf6a19e179e6cfd6a9103ce0c0555876f72780acc93efd85"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-py3-none-any.whl"
-upload-time = 2026-05-10 18:02:29.538126+00:00
-url = "https://files.pythonhosted.org/packages/61/e8/cb8e80d6f9f55b99588625062822bf946cf03ed06315df4bd8397f5632a1/coverage-7.14.0-py3-none-any.whl"
-size = 211764
-
-[packages.wheels.hashes]
-sha256 = "8de5b61163aee3d05c8a2beab6f47913df7981dad1baf82c414d99158c286ab1"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 17:59:31.330855+00:00
-url = "https://files.pythonhosted.org/packages/0d/e1/9ea1eb9c311da7f15853559dc1d9d82bef88ecd3e59fbeb51f16bc2ffa91/coverage-7.14.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 250625
-
-[packages.wheels.hashes]
-sha256 = "731e535b1498b27d13594a0527a79b0510867b0ad891532be41cb883f2128e20"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 17:59:36.232646+00:00
-url = "https://files.pythonhosted.org/packages/f0/e2/0b7898cda21041cc67546e19b80ba66cbbb47cbece52a76a5904de6a3aaf/coverage-7.14.0-cp310-cp310-musllinux_1_2_aarch64.whl"
-size = 248666
-
-[packages.wheels.hashes]
-sha256 = "0a951308cde22cf77f953955a754d04dccb57fe3bb8e345d685778ed9fc1632a"
+sha256 = "84c32d90bf4537f0e7b4dec9aaa9a938fb8205136b9d2ecf4d7629d5262dc075"
 
 [[packages.wheels]]
 name = "coverage-7.14.0-cp310-cp310-macosx_11_0_arm64.whl"
@@ -276,13 +247,22 @@ size = 220192
 sha256 = "7c843572c605ab51cfdb5c6b5f2586e2a8467c0d28eca4bdef4ec70c5fecbd82"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp310-cp310-macosx_10_9_x86_64.whl"
-upload-time = 2026-05-10 17:59:23.106199+00:00
-url = "https://files.pythonhosted.org/packages/59/9d/7c83ef51c3eb495f10010094e661833588b7709946da634c8b66520b97c7/coverage-7.14.0-cp310-cp310-macosx_10_9_x86_64.whl"
-size = 219668
+name = "coverage-7.14.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-05-10 17:59:29.479819+00:00
+url = "https://files.pythonhosted.org/packages/b5/d9/92600e89486fd074c50f0117422b2c9592c3e144e2f25bd5ac0bc62bc7a0/coverage-7.14.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 248762
 
 [packages.wheels.hashes]
-sha256 = "84c32d90bf4537f0e7b4dec9aaa9a938fb8205136b9d2ecf4d7629d5262dc075"
+sha256 = "3fd43f0616e765ab78d069cf8358def7363957a45cee446d65c502dcfeea7893"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-10 17:59:31.330855+00:00
+url = "https://files.pythonhosted.org/packages/0d/e1/9ea1eb9c311da7f15853559dc1d9d82bef88ecd3e59fbeb51f16bc2ffa91/coverage-7.14.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 250625
+
+[packages.wheels.hashes]
+sha256 = "731e535b1498b27d13594a0527a79b0510867b0ad891532be41cb883f2128e20"
 
 [[packages.wheels]]
 name = "coverage-7.14.0-cp310-cp310-win_amd64.whl"
@@ -294,40 +274,13 @@ size = 223215
 sha256 = "b34ece8065914f938ed7f2c5872bb865336977a52919149846eac3744327267a"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-05-10 17:59:53.244429+00:00
-url = "https://files.pythonhosted.org/packages/fd/35/202235eb5c3c14c212462cd91d61b7386bf8fc44bc7a77f4742d2a69174b/coverage-7.14.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 252633
+name = "coverage-7.14.0-cp311-cp311-macosx_10_9_x86_64.whl"
+upload-time = 2026-05-10 17:59:48.198844+00:00
+url = "https://files.pythonhosted.org/packages/fc/e4/649c8d4f7f1709b6dbfc474358aa1bba02f67bcd52e2fec291a5014006cd/coverage-7.14.0-cp311-cp311-macosx_10_9_x86_64.whl"
+size = 219795
 
 [packages.wheels.hashes]
-sha256 = "9336e23e8bb3a3925398261385e2a1533957d3e760e91070dcb0e98bfa514eed"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 18:00:06.858179+00:00
-url = "https://files.pythonhosted.org/packages/35/60/a4257538ce2f6b978aeb51870d6c4208c510928a03db7e0339bb625dccb7/coverage-7.14.0-cp311-cp311-musllinux_1_2_x86_64.whl"
-size = 251125
-
-[packages.wheels.hashes]
-sha256 = "bcb2e855b87321259a037429288ae85216d191c74de3e79bf57cd2bc0761992c"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 17:59:55.021505+00:00
-url = "https://files.pythonhosted.org/packages/bb/80/5f596e8995785124ee191c42535664c5e62c65995b66f4ca21e28ae04c81/coverage-7.14.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 254743
-
-[packages.wheels.hashes]
-sha256 = "9cd1169b2230f9cbe9c638ba38022ed7a2b1e641cc07f7cea0365e4be2a74980"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 17:59:59.688294+00:00
-url = "https://files.pythonhosted.org/packages/3d/1c/b94f9f5f36396021ee2f62c5834b12e6a3d31f0bed5d6fc6d1c3caec087c/coverage-7.14.0-cp311-cp311-musllinux_1_2_aarch64.whl"
-size = 252433
-
-[packages.wheels.hashes]
-sha256 = "5904abf7e18cddc463219b17552229650c6b79e061d31a1059283051169cf7d5"
+sha256 = "6a78e2a9d9c5e3b8d4ab9b9d28c985ea66fced0a7d7c2aec1f216e03a2011480"
 
 [[packages.wheels]]
 name = "coverage-7.14.0-cp311-cp311-macosx_11_0_arm64.whl"
@@ -339,13 +292,22 @@ size = 220299
 sha256 = "a1816c505187592dcd1c5a5f226601a549f70365fbd00930ac88b0c225b76bb4"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp311-cp311-macosx_10_9_x86_64.whl"
-upload-time = 2026-05-10 17:59:48.198844+00:00
-url = "https://files.pythonhosted.org/packages/fc/e4/649c8d4f7f1709b6dbfc474358aa1bba02f67bcd52e2fec291a5014006cd/coverage-7.14.0-cp311-cp311-macosx_10_9_x86_64.whl"
-size = 219795
+name = "coverage-7.14.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-05-10 17:59:53.244429+00:00
+url = "https://files.pythonhosted.org/packages/fd/35/202235eb5c3c14c212462cd91d61b7386bf8fc44bc7a77f4742d2a69174b/coverage-7.14.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 252633
 
 [packages.wheels.hashes]
-sha256 = "6a78e2a9d9c5e3b8d4ab9b9d28c985ea66fced0a7d7c2aec1f216e03a2011480"
+sha256 = "9336e23e8bb3a3925398261385e2a1533957d3e760e91070dcb0e98bfa514eed"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-10 17:59:55.021505+00:00
+url = "https://files.pythonhosted.org/packages/bb/80/5f596e8995785124ee191c42535664c5e62c65995b66f4ca21e28ae04c81/coverage-7.14.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 254743
+
+[packages.wheels.hashes]
+sha256 = "9cd1169b2230f9cbe9c638ba38022ed7a2b1e641cc07f7cea0365e4be2a74980"
 
 [[packages.wheels]]
 name = "coverage-7.14.0-cp311-cp311-win_amd64.whl"
@@ -357,40 +319,13 @@ size = 223241
 sha256 = "bfb0ed8ec5d25e93face268115d7964db9df8b9aae8edcde9ec6b16c726a7cc1"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-05-10 18:00:18.829529+00:00
-url = "https://files.pythonhosted.org/packages/69/ff/6699e7b71e60d3049eb2bdcbc95ee3f35707b2b0e48f32e9e63d3ce30c08/coverage-7.14.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 254576
+name = "coverage-7.14.0-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2026-05-10 18:00:13.756391+00:00
+url = "https://files.pythonhosted.org/packages/09/1e/2f996b2c8415cbb6f54b0f5ec1ee850c96d7911961afb4fc05f4a89d8c58/coverage-7.14.0-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 219967
 
 [packages.wheels.hashes]
-sha256 = "ca3d9cf2c32b521bd9518385608787fa86f38daf993695307531822c3430ed67"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 18:00:32.211009+00:00
-url = "https://files.pythonhosted.org/packages/18/9d/50f05a72dff8487464fdd4178dda5daed642a060e60afb644e3d45123559/coverage-7.14.0-cp312-cp312-musllinux_1_2_x86_64.whl"
-size = 253197
-
-[packages.wheels.hashes]
-sha256 = "fcaba850dd317c65423a9d63d88f9573c53b00354d6dd95724576cc98a131595"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 18:00:20.648358+00:00
-url = "https://files.pythonhosted.org/packages/22/ec/c936d495fcd67f48f03a9c4ad3297ff80d1f222a5df3980f15b34c186c21/coverage-7.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 255690
-
-[packages.wheels.hashes]
-sha256 = "92af52828e7f29d827346b0294e5a0853fa206db77db0395b282918d41e28db9"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 18:00:25.588879+00:00
-url = "https://files.pythonhosted.org/packages/f1/7f/9e65495298c3ea414742998539c37d048b5e81cc818fb1828cc6b51d10bf/coverage-7.14.0-cp312-cp312-musllinux_1_2_aarch64.whl"
-size = 253608
-
-[packages.wheels.hashes]
-sha256 = "8231ade007f37959fbf58acc677f26b922c02eda6f0428ea307da0fd39681bf3"
+sha256 = "7ffd19fc8aed057fd686a17a4935eef5f9859d69208f96310e893e64b9b6ccf5"
 
 [[packages.wheels]]
 name = "coverage-7.14.0-cp312-cp312-macosx_11_0_arm64.whl"
@@ -402,13 +337,22 @@ size = 220329
 sha256 = "829994cfe1aeb773ca27bf246d4badc1e764893e3bfb98fff820fcecd1ca4662"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp312-cp312-macosx_10_13_x86_64.whl"
-upload-time = 2026-05-10 18:00:13.756391+00:00
-url = "https://files.pythonhosted.org/packages/09/1e/2f996b2c8415cbb6f54b0f5ec1ee850c96d7911961afb4fc05f4a89d8c58/coverage-7.14.0-cp312-cp312-macosx_10_13_x86_64.whl"
-size = 219967
+name = "coverage-7.14.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-05-10 18:00:18.829529+00:00
+url = "https://files.pythonhosted.org/packages/69/ff/6699e7b71e60d3049eb2bdcbc95ee3f35707b2b0e48f32e9e63d3ce30c08/coverage-7.14.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 254576
 
 [packages.wheels.hashes]
-sha256 = "7ffd19fc8aed057fd686a17a4935eef5f9859d69208f96310e893e64b9b6ccf5"
+sha256 = "ca3d9cf2c32b521bd9518385608787fa86f38daf993695307531822c3430ed67"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-10 18:00:20.648358+00:00
+url = "https://files.pythonhosted.org/packages/22/ec/c936d495fcd67f48f03a9c4ad3297ff80d1f222a5df3980f15b34c186c21/coverage-7.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 255690
+
+[packages.wheels.hashes]
+sha256 = "92af52828e7f29d827346b0294e5a0853fa206db77db0395b282918d41e28db9"
 
 [[packages.wheels]]
 name = "coverage-7.14.0-cp312-cp312-win_amd64.whl"
@@ -420,40 +364,13 @@ size = 223324
 sha256 = "70390b0da32cb90b501953716302906e8bcce087cb283e70d8c97729f22e92b2"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-05-10 18:00:44.079319+00:00
-url = "https://files.pythonhosted.org/packages/6f/5f/b5370068b2f57787454592ed7dcd1002f0f1703b7db1fa30f6a325a4ca6e/coverage-7.14.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 253961
+name = "coverage-7.14.0-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2026-05-10 18:00:38.887090+00:00
+url = "https://files.pythonhosted.org/packages/6b/76/b7c66ee3c66e1b0f9d894c8125983aa0c03fb2336f2fd16559f9c966157f/coverage-7.14.0-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 219990
 
 [packages.wheels.hashes]
-sha256 = "9d1aa57a1dc8e05bdc42e81c5d671d849577aeedf279f4c449d6d286f9ed88ca"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 18:00:57.967216+00:00
-url = "https://files.pythonhosted.org/packages/37/53/20c5009477660f084e6ed60bc02a91894b8e234e617e86ecfd9aaf78e27b/coverage-7.14.0-cp313-cp313-musllinux_1_2_x86_64.whl"
-size = 252885
-
-[packages.wheels.hashes]
-sha256 = "7b79d646cf46d5cf9a9f40281d4441df5849e445726e369006d2b117710b33fe"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 18:00:45.623804+00:00
-url = "https://files.pythonhosted.org/packages/29/1e/51adf17738976e8f2b85ddef7b7aa12a0838b056c92f175941d8862767c1/coverage-7.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 255193
-
-[packages.wheels.hashes]
-sha256 = "90c1a51bcfddf645b3bb7ec333d9e94393a8e94f55642380fa8a9a5a9e636cb7"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 18:00:51.252258+00:00
-url = "https://files.pythonhosted.org/packages/34/46/746704f95980ba220214e1a41e18cec5aea80a898eaa53c51bf2d645ff36/coverage-7.14.0-cp313-cp313-musllinux_1_2_aarch64.whl"
-size = 253325
-
-[packages.wheels.hashes]
-sha256 = "1b23b0c6f0b1db6ad769b7050c8b641c0bf215ded26c1816955b17b7f26edfa9"
+sha256 = "f2bbb8254370eb4c628ff3d6fa8a7f74ddc40565394d4f7ab791d1fe568e37ef"
 
 [[packages.wheels]]
 name = "coverage-7.14.0-cp313-cp313-macosx_11_0_arm64.whl"
@@ -465,13 +382,22 @@ size = 220365
 sha256 = "23b81107f46d3f21d0cbce30664fcec0f5d9f585638a67081750f99738f6bf66"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp313-cp313-macosx_10_13_x86_64.whl"
-upload-time = 2026-05-10 18:00:38.887090+00:00
-url = "https://files.pythonhosted.org/packages/6b/76/b7c66ee3c66e1b0f9d894c8125983aa0c03fb2336f2fd16559f9c966157f/coverage-7.14.0-cp313-cp313-macosx_10_13_x86_64.whl"
-size = 219990
+name = "coverage-7.14.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-05-10 18:00:44.079319+00:00
+url = "https://files.pythonhosted.org/packages/6f/5f/b5370068b2f57787454592ed7dcd1002f0f1703b7db1fa30f6a325a4ca6e/coverage-7.14.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 253961
 
 [packages.wheels.hashes]
-sha256 = "f2bbb8254370eb4c628ff3d6fa8a7f74ddc40565394d4f7ab791d1fe568e37ef"
+sha256 = "9d1aa57a1dc8e05bdc42e81c5d671d849577aeedf279f4c449d6d286f9ed88ca"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-10 18:00:45.623804+00:00
+url = "https://files.pythonhosted.org/packages/29/1e/51adf17738976e8f2b85ddef7b7aa12a0838b056c92f175941d8862767c1/coverage-7.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 255193
+
+[packages.wheels.hashes]
+sha256 = "90c1a51bcfddf645b3bb7ec333d9e94393a8e94f55642380fa8a9a5a9e636cb7"
 
 [[packages.wheels]]
 name = "coverage-7.14.0-cp313-cp313-win_amd64.whl"
@@ -483,40 +409,13 @@ size = 223344
 sha256 = "0773d8329cf32b6fd222e4b52622c61fe8d503eb966cfc8d3c3c10c96266d50e"
 
 [[packages.wheels]]
-name = "coverage-7.14.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-upload-time = 2026-05-10 18:01:38.985686+00:00
-url = "https://files.pythonhosted.org/packages/d7/51/ec641c26e6dca1b25a7d2035ba6ecb7c884ef1a100a9e42fbe4ce4405139/coverage-7.14.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-size = 253924
+name = "coverage-7.14.0-cp314-cp314-macosx_10_15_x86_64.whl"
+upload-time = 2026-05-10 18:01:33.057085+00:00
+url = "https://files.pythonhosted.org/packages/1c/18/b9a6586d73992807c26f9a5f274131be3d76b56b18a82b9392e2a25d2e45/coverage-7.14.0-cp314-cp314-macosx_10_15_x86_64.whl"
+size = 220036
 
 [packages.wheels.hashes]
-sha256 = "5ebb8f4614a3787d567e610bbfdf96a4798dd69a1afb1bd8ad228d4111fe6ff3"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp314-cp314-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 18:01:54.506054+00:00
-url = "https://files.pythonhosted.org/packages/a4/66/2881853e0363a5e0a724d1103e53650795367471b6afb234f8b49e713bc6/coverage-7.14.0-cp314-cp314-musllinux_1_2_x86_64.whl"
-size = 252716
-
-[packages.wheels.hashes]
-sha256 = "65c86fb646d2bd2972e96bd1a8b45817ed907cee68655d6295fe7ec031d04cca"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 18:01:40.957470+00:00
-url = "https://files.pythonhosted.org/packages/33/c4/59c3de0bd1b538824173fd518fed51c1ce740ca5ed68e74545983f4053a9/coverage-7.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 255269
-
-[packages.wheels.hashes]
-sha256 = "6b9bf47223dd8db3d4c4b2e443b02bace480d428f0822c3f991600448a176c97"
-
-[[packages.wheels]]
-name = "coverage-7.14.0-cp314-cp314-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 18:01:46.175307+00:00
-url = "https://files.pythonhosted.org/packages/ee/df/6770eaa576e604575e9a78055313250faef5faa84bd6f71a39fece519c43/coverage-7.14.0-cp314-cp314-musllinux_1_2_aarch64.whl"
-size = 253280
-
-[packages.wheels.hashes]
-sha256 = "15228a6800ce7bdf1b74800595e56db7138cecb338fdbf044806e10dcf182dfe"
+sha256 = "9aed9fa983514ca032790f3fe0d1c0e42ca7e16b42432af1706b50a9a46bef5d"
 
 [[packages.wheels]]
 name = "coverage-7.14.0-cp314-cp314-macosx_11_0_arm64.whl"
@@ -528,6 +427,24 @@ size = 220368
 sha256 = "ba3b8390db29296dbbf49e91b6fe08f990743a90c8f447ba4c2ffc29670dfa63"
 
 [[packages.wheels]]
+name = "coverage-7.14.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+upload-time = 2026-05-10 18:01:38.985686+00:00
+url = "https://files.pythonhosted.org/packages/d7/51/ec641c26e6dca1b25a7d2035ba6ecb7c884ef1a100a9e42fbe4ce4405139/coverage-7.14.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+size = 253924
+
+[packages.wheels.hashes]
+sha256 = "5ebb8f4614a3787d567e610bbfdf96a4798dd69a1afb1bd8ad228d4111fe6ff3"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-10 18:01:40.957470+00:00
+url = "https://files.pythonhosted.org/packages/33/c4/59c3de0bd1b538824173fd518fed51c1ce740ca5ed68e74545983f4053a9/coverage-7.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 255269
+
+[packages.wheels.hashes]
+sha256 = "6b9bf47223dd8db3d4c4b2e443b02bace480d428f0822c3f991600448a176c97"
+
+[[packages.wheels]]
 name = "coverage-7.14.0-cp314-cp314-win_amd64.whl"
 upload-time = 2026-05-10 18:01:58.497925+00:00
 url = "https://files.pythonhosted.org/packages/f9/58/6e1b8f52fdc3184b47dc5037f5070d83a3d11042db1594b02d2a44d786c8/coverage-7.14.0-cp314-cp314-win_amd64.whl"
@@ -535,6 +452,15 @@ size = 223600
 
 [packages.wheels.hashes]
 sha256 = "45e0f79d8351fa76e256716df91eab12890d32678b9590df7ae1042e4bd4cf5d"
+
+[[packages.wheels]]
+name = "coverage-7.14.0-py3-none-any.whl"
+upload-time = 2026-05-10 18:02:29.538126+00:00
+url = "https://files.pythonhosted.org/packages/61/e8/cb8e80d6f9f55b99588625062822bf946cf03ed06315df4bd8397f5632a1/coverage-7.14.0-py3-none-any.whl"
+size = 211764
+
+[packages.wheels.hashes]
+sha256 = "8de5b61163aee3d05c8a2beab6f47913df7981dad1baf82c414d99158c286ab1"
 
 [[packages]]
 name = "docstring-parser"
@@ -563,8 +489,11 @@ sha256 = "b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b"
 [[packages]]
 name = "exceptiongroup"
 version = "1.3.1"
-marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version < \"3.10.2\" and \"types\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version >= \"3.10.2.dev0\" and \"types\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\" and \"types\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"types\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\" and \"types\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version >= \"3.10.2.dev0\" and \"types\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\" and \"types\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"types\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\" and \"types\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version >= \"3.10.2.dev0\" and \"types\" in dependency_groups)"
 requires-python = ">=3.7"
+dependencies = [
+    { name = "typing-extensions" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -588,6 +517,7 @@ sha256 = "a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598"
 [[packages]]
 name = "h11"
 version = "0.16.0"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.8"
 index = "https://pypi.org/simple/"
 
@@ -612,7 +542,12 @@ sha256 = "63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"
 [[packages]]
 name = "h2"
 version = "4.3.0"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.9"
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -636,6 +571,7 @@ sha256 = "c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd"
 [[packages]]
 name = "hpack"
 version = "4.1.0"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -660,7 +596,12 @@ sha256 = "157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496"
 [[packages]]
 name = "httpcore"
 version = "1.0.9"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.8"
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -684,7 +625,15 @@ sha256 = "2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"
 [[packages]]
 name = "httpx"
 version = "0.28.1"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.8"
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "h2" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -708,6 +657,7 @@ sha256 = "d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"
 [[packages]]
 name = "hyperframe"
 version = "6.1.0"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -732,7 +682,12 @@ sha256 = "b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5"
 [[packages]]
 name = "hypothesis"
 version = "6.152.6"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "exceptiongroup" },
+    { name = "sortedcontainers" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -756,6 +711,7 @@ sha256 = "b20ffc532e5f2901229348d10ed7cb37fd9723ebf4799df663d2dce1cdce4e32"
 [[packages]]
 name = "idna"
 version = "3.15"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.8"
 index = "https://pypi.org/simple/"
 
@@ -780,8 +736,11 @@ sha256 = "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"
 [[packages]]
 name = "importlib-metadata"
 version = "9.0.0"
-marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\")"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "zipp" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -805,6 +764,7 @@ sha256 = "2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7"
 [[packages]]
 name = "iniconfig"
 version = "2.3.0"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
@@ -853,6 +813,7 @@ sha256 = "011d045df8b954ced7dde3a7e42ae4418da40ecda7990f2d11d5ed7c146fd98b"
 [[packages]]
 name = "librt"
 version = "0.11.0"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -866,40 +827,13 @@ size = 200139
 sha256 = "075dc3ef4458a278e0195cbf6ac9d38808d9b906c5a6c7f7f79c3888276a3fb1"
 
 [[packages.wheels]]
-name = "librt-0.11.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-05-10 18:15:22.616956+00:00
-url = "https://files.pythonhosted.org/packages/6f/50/5ec949d7f9ce1a07af903aa3e13abb98b717923bdead6e719b2f824ccc07/librt-0.11.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 496918
+name = "librt-0.11.0-cp310-cp310-macosx_10_9_x86_64.whl"
+upload-time = 2026-05-10 18:15:16.129809+00:00
+url = "https://files.pythonhosted.org/packages/83/10/37fd9e9ba96cb0bd742dfb20fc3d082e54bdbec759d7300df927f360ef07/librt-0.11.0-cp310-cp310-macosx_10_9_x86_64.whl"
+size = 141706
 
 [packages.wheels.hashes]
-sha256 = "88145c15c67731d54283d135b03244028c750cc9edc334a96a4f5950ebdb2884"
-
-[[packages.wheels]]
-name = "librt-0.11.0-cp310-cp310-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 18:15:30.928624+00:00
-url = "https://files.pythonhosted.org/packages/cd/43/acdd5ce317cb46e8253ca9bfbdb8b12e68a24d745949336a7f3d5fb79ba0/librt-0.11.0-cp310-cp310-musllinux_1_2_x86_64.whl"
-size = 538878
-
-[packages.wheels.hashes]
-sha256 = "f37aa505b3cf60701562eddb32df74b12a9e380c207fd8b06dd157a943ac7ea0"
-
-[[packages.wheels]]
-name = "librt-0.11.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 18:15:19.569517+00:00
-url = "https://files.pythonhosted.org/packages/ca/85/ed26dd2f6bc9a0baf48306433e579e8d354d70b2bcb78134ed950a5d0e1e/librt-0.11.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 476555
-
-[packages.wheels.hashes]
-sha256 = "dc329359321b67d24efdf4bc69012b0597001649544db662c001db5a0184794c"
-
-[[packages.wheels]]
-name = "librt-0.11.0-cp310-cp310-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 18:15:26.226120+00:00
-url = "https://files.pythonhosted.org/packages/13/1f/da3112f7569eda3b49f9a2629bae1fe059812b6085df16c885f6454dff49/librt-0.11.0-cp310-cp310-musllinux_1_2_aarch64.whl"
-size = 511287
-
-[packages.wheels.hashes]
-sha256 = "d00f3ac06a2a8b246327f11e186a53a100a4d5c7ed52346367e5ec751d51586c"
+sha256 = "6e94ebfcfa2d5e9926d6c3b9aa4617ffc42a845b4321fb84021b872358c82a0f"
 
 [[packages.wheels]]
 name = "librt-0.11.0-cp310-cp310-macosx_11_0_arm64.whl"
@@ -911,13 +845,22 @@ size = 142605
 sha256 = "ae627397a2f351560440d872d6f7c8dbb4072e57868e7b2fc5b8b430fe489d45"
 
 [[packages.wheels]]
-name = "librt-0.11.0-cp310-cp310-macosx_10_9_x86_64.whl"
-upload-time = 2026-05-10 18:15:16.129809+00:00
-url = "https://files.pythonhosted.org/packages/83/10/37fd9e9ba96cb0bd742dfb20fc3d082e54bdbec759d7300df927f360ef07/librt-0.11.0-cp310-cp310-macosx_10_9_x86_64.whl"
-size = 141706
+name = "librt-0.11.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-10 18:15:19.569517+00:00
+url = "https://files.pythonhosted.org/packages/ca/85/ed26dd2f6bc9a0baf48306433e579e8d354d70b2bcb78134ed950a5d0e1e/librt-0.11.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 476555
 
 [packages.wheels.hashes]
-sha256 = "6e94ebfcfa2d5e9926d6c3b9aa4617ffc42a845b4321fb84021b872358c82a0f"
+sha256 = "dc329359321b67d24efdf4bc69012b0597001649544db662c001db5a0184794c"
+
+[[packages.wheels]]
+name = "librt-0.11.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-05-10 18:15:22.616956+00:00
+url = "https://files.pythonhosted.org/packages/6f/50/5ec949d7f9ce1a07af903aa3e13abb98b717923bdead6e719b2f824ccc07/librt-0.11.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 496918
+
+[packages.wheels.hashes]
+sha256 = "88145c15c67731d54283d135b03244028c750cc9edc334a96a4f5950ebdb2884"
 
 [[packages.wheels]]
 name = "librt-0.11.0-cp310-cp310-win_amd64.whl"
@@ -929,40 +872,13 @@ size = 117918
 sha256 = "dec7db73758c2b54953fd8b7fe348c45188fe26b39ee18446196edd08453a5d4"
 
 [[packages.wheels]]
-name = "librt-0.11.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-05-10 18:15:40.634911+00:00
-url = "https://files.pythonhosted.org/packages/6b/6f/59c74b560ca8853834d5501d589c8a2519f4184f273a085ffd0f37a1cc47/librt-0.11.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 497083
+name = "librt-0.11.0-cp311-cp311-macosx_10_9_x86_64.whl"
+upload-time = 2026-05-10 18:15:34.795575+00:00
+url = "https://files.pythonhosted.org/packages/fe/87/2bf31fe17587b29e3f93ec31421e2b1e1c3e349b8bf6c7c313dbad1d5340/librt-0.11.0-cp311-cp311-macosx_10_9_x86_64.whl"
+size = 141092
 
 [packages.wheels.hashes]
-sha256 = "993f028be9e96a08d31df3479ac80d99be374d17f3b78e4796b3fd3c913d4e89"
-
-[[packages.wheels]]
-name = "librt-0.11.0-cp311-cp311-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 18:15:47.629491+00:00
-url = "https://files.pythonhosted.org/packages/9d/fb/541cdad5b1ab1300398c74c4c9a497b88e5074c21b1244c8f49731d3a284/librt-0.11.0-cp311-cp311-musllinux_1_2_x86_64.whl"
-size = 537585
-
-[packages.wheels.hashes]
-sha256 = "22bdf239b219d3993761a148ffa134b19e52e9989c84f845d5d7b71d70a17412"
-
-[[packages.wheels]]
-name = "librt-0.11.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 18:15:37.560100+00:00
-url = "https://files.pythonhosted.org/packages/06/20/662a03d254e5b000d838e8b345d83303ddb768c080fd488e40634c0fa66b/librt-0.11.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 475022
-
-[packages.wheels.hashes]
-sha256 = "f230cb1cbc9faaa616f9a678f530ebcf186e414b6bcbd88b960e4ba1b92428d5"
-
-[[packages.wheels]]
-name = "librt-0.11.0-cp311-cp311-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 18:15:43.206681+00:00
-url = "https://files.pythonhosted.org/packages/d6/31/9143803d7da6856a69153785768c4936864430eec0fd9461c3ea527d9922/librt-0.11.0-cp311-cp311-musllinux_1_2_aarch64.whl"
-size = 508442
-
-[packages.wheels.hashes]
-sha256 = "0827efe7854718f04aaddf6496e96960a956e676fe1d0f04eb41511fd8ad06d5"
+sha256 = "93d95bd45b7d58343d8b90d904450a545144eec19a002511163426f8ab1fae29"
 
 [[packages.wheels]]
 name = "librt-0.11.0-cp311-cp311-macosx_11_0_arm64.whl"
@@ -974,13 +890,22 @@ size = 142035
 sha256 = "4ee278c769a713638cdacd4c0436d72156e75df3ebc0166ab2b9dc43acc386c9"
 
 [[packages.wheels]]
-name = "librt-0.11.0-cp311-cp311-macosx_10_9_x86_64.whl"
-upload-time = 2026-05-10 18:15:34.795575+00:00
-url = "https://files.pythonhosted.org/packages/fe/87/2bf31fe17587b29e3f93ec31421e2b1e1c3e349b8bf6c7c313dbad1d5340/librt-0.11.0-cp311-cp311-macosx_10_9_x86_64.whl"
-size = 141092
+name = "librt-0.11.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-10 18:15:37.560100+00:00
+url = "https://files.pythonhosted.org/packages/06/20/662a03d254e5b000d838e8b345d83303ddb768c080fd488e40634c0fa66b/librt-0.11.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 475022
 
 [packages.wheels.hashes]
-sha256 = "93d95bd45b7d58343d8b90d904450a545144eec19a002511163426f8ab1fae29"
+sha256 = "f230cb1cbc9faaa616f9a678f530ebcf186e414b6bcbd88b960e4ba1b92428d5"
+
+[[packages.wheels]]
+name = "librt-0.11.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-05-10 18:15:40.634911+00:00
+url = "https://files.pythonhosted.org/packages/6b/6f/59c74b560ca8853834d5501d589c8a2519f4184f273a085ffd0f37a1cc47/librt-0.11.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 497083
+
+[packages.wheels.hashes]
+sha256 = "993f028be9e96a08d31df3479ac80d99be374d17f3b78e4796b3fd3c913d4e89"
 
 [[packages.wheels]]
 name = "librt-0.11.0-cp311-cp311-win_amd64.whl"
@@ -992,40 +917,13 @@ size = 118628
 sha256 = "902e546ff044f579ff1c953ff5fce97b636fe9e3943996b2177710c6ef076f73"
 
 [[packages.wheels]]
-name = "librt-0.11.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-05-10 18:15:58.805765+00:00
-url = "https://files.pythonhosted.org/packages/b0/da/5d1876984b3746c85dbd219dbfcb73c85f54ee263fd32e5b2a632ec14571/librt-0.11.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 513082
+name = "librt-0.11.0-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2026-05-10 18:15:53.227779+00:00
+url = "https://files.pythonhosted.org/packages/8b/d0/07c77e067f0838949b43bd89232c29d72efebb9d2801a9750184eb706b71/librt-0.11.0-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 144147
 
 [packages.wheels.hashes]
-sha256 = "d5b0eea49f5562861ee8d757a32ef7d559c1d35be2aaaa1ec28941d74c9ffc8a"
-
-[[packages.wheels]]
-name = "librt-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 18:16:06.839646+00:00
-url = "https://files.pythonhosted.org/packages/9e/58/9384b2f4eb1ed1d273d40948a7c5c4b2360213b402ef3be4641c06299f9c/librt-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl"
-size = 553608
-
-[packages.wheels.hashes]
-sha256 = "070aa8c26c0a74774317a72df8851facc7f0f012a5b406557ac56992d92e1ec8"
-
-[[packages.wheels]]
-name = "librt-0.11.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 18:15:56.117344+00:00
-url = "https://files.pythonhosted.org/packages/ff/1e/f8bad050810d9171f34a1648ed910e56814c2ba61639f2bd53c6377ae24b/librt-0.11.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 485538
-
-[packages.wheels.hashes]
-sha256 = "137e79445c896a0ea7b265f52d23954e05b64222ee1af69e2cb34219067cbb67"
-
-[[packages.wheels]]
-name = "librt-0.11.0-cp312-cp312-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 18:16:01.708912+00:00
-url = "https://files.pythonhosted.org/packages/07/10/f1f23a7c595ee90ece4d35c851e5d104b1311a887ed1b4ac4c35bbd13da8/librt-0.11.0-cp312-cp312-musllinux_1_2_aarch64.whl"
-size = 522268
-
-[packages.wheels.hashes]
-sha256 = "bc3ce6b33c5828d9e80592011a5c584cb2ce86edbc4088405f70da47dc1d1b3b"
+sha256 = "b87504f1690a23b9a2cca841191a04f83895d4fc2dd04df91d82b1a04ca2ad46"
 
 [[packages.wheels]]
 name = "librt-0.11.0-cp312-cp312-macosx_11_0_arm64.whl"
@@ -1037,13 +935,22 @@ size = 143614
 sha256 = "40071fc5fe0ce8daa6de616702314a01e1250711682b0523d6ab8d4525910cb3"
 
 [[packages.wheels]]
-name = "librt-0.11.0-cp312-cp312-macosx_10_13_x86_64.whl"
-upload-time = 2026-05-10 18:15:53.227779+00:00
-url = "https://files.pythonhosted.org/packages/8b/d0/07c77e067f0838949b43bd89232c29d72efebb9d2801a9750184eb706b71/librt-0.11.0-cp312-cp312-macosx_10_13_x86_64.whl"
-size = 144147
+name = "librt-0.11.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-10 18:15:56.117344+00:00
+url = "https://files.pythonhosted.org/packages/ff/1e/f8bad050810d9171f34a1648ed910e56814c2ba61639f2bd53c6377ae24b/librt-0.11.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 485538
 
 [packages.wheels.hashes]
-sha256 = "b87504f1690a23b9a2cca841191a04f83895d4fc2dd04df91d82b1a04ca2ad46"
+sha256 = "137e79445c896a0ea7b265f52d23954e05b64222ee1af69e2cb34219067cbb67"
+
+[[packages.wheels]]
+name = "librt-0.11.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-05-10 18:15:58.805765+00:00
+url = "https://files.pythonhosted.org/packages/b0/da/5d1876984b3746c85dbd219dbfcb73c85f54ee263fd32e5b2a632ec14571/librt-0.11.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 513082
+
+[packages.wheels.hashes]
+sha256 = "d5b0eea49f5562861ee8d757a32ef7d559c1d35be2aaaa1ec28941d74c9ffc8a"
 
 [[packages.wheels]]
 name = "librt-0.11.0-cp312-cp312-win_amd64.whl"
@@ -1055,40 +962,13 @@ size = 119831
 sha256 = "75672f0bc524ede266287d532d7923dbce94c7514ad07627bac3d0c6d92cc4d9"
 
 [[packages.wheels]]
-name = "librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-05-10 18:16:17.647725+00:00
-url = "https://files.pythonhosted.org/packages/a6/6d/d8ee9c114bebf2c50e29ec2aa940826fccb62a645c3e4c18760987d0e16d/librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 513010
+name = "librt-0.11.0-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2026-05-10 18:16:11.771773+00:00
+url = "https://files.pythonhosted.org/packages/82/61/e59168d4d0bf2bf90f4f0caf7a001bfc60254c3af4586013b04dc3ef517b/librt-0.11.0-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 144119
 
 [packages.wheels.hashes]
-sha256 = "7c39513d8b7477a2e1ed8c43fc21c524e8d5a0f8d4e8b7b074dbdbe7820a08e2"
-
-[[packages.wheels]]
-name = "librt-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 18:16:25.025105+00:00
-url = "https://files.pythonhosted.org/packages/ae/66/6e6323787d592b55204a42595ff1102da5115601b53a7e9ddebc889a6da5/librt-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl"
-size = 553920
-
-[packages.wheels.hashes]
-sha256 = "970b09f7044ea2b64c9da42fd3d335666518cfd1c6e8a182c95da73d0214b41e"
-
-[[packages.wheels]]
-name = "librt-0.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 18:16:14.729440+00:00
-url = "https://files.pythonhosted.org/packages/b8/a9/dc744f5c2b4978d48db970be29f22716d3413d28b14ad99740817315cf2c/librt-0.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 485395
-
-[packages.wheels.hashes]
-sha256 = "621db29691044bdeda22e789e482e1b0f3a985d90e3426c9c6d17606416205ea"
-
-[[packages.wheels]]
-name = "librt-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 18:16:20.642469+00:00
-url = "https://files.pythonhosted.org/packages/4a/50/356187247d09013490481033183b3532b58acf8028bcb34b2b56a375c9b2/librt-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl"
-size = 522595
-
-[packages.wheels.hashes]
-sha256 = "557183ddc36babe46b27dd60facbd5adb4492181a5be887587d57cda6e092f21"
+sha256 = "78dc31f7fdfe9c9d0eb0e8f42d139db230e826415bbcabd9f0e9faaaee909894"
 
 [[packages.wheels]]
 name = "librt-0.11.0-cp313-cp313-macosx_11_0_arm64.whl"
@@ -1100,13 +980,22 @@ size = 143565
 sha256 = "fa475675db22290c3158e1d42326d0f5a65f04f44a0e68c3630a25b53560fb9c"
 
 [[packages.wheels]]
-name = "librt-0.11.0-cp313-cp313-macosx_10_13_x86_64.whl"
-upload-time = 2026-05-10 18:16:11.771773+00:00
-url = "https://files.pythonhosted.org/packages/82/61/e59168d4d0bf2bf90f4f0caf7a001bfc60254c3af4586013b04dc3ef517b/librt-0.11.0-cp313-cp313-macosx_10_13_x86_64.whl"
-size = 144119
+name = "librt-0.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-10 18:16:14.729440+00:00
+url = "https://files.pythonhosted.org/packages/b8/a9/dc744f5c2b4978d48db970be29f22716d3413d28b14ad99740817315cf2c/librt-0.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 485395
 
 [packages.wheels.hashes]
-sha256 = "78dc31f7fdfe9c9d0eb0e8f42d139db230e826415bbcabd9f0e9faaaee909894"
+sha256 = "621db29691044bdeda22e789e482e1b0f3a985d90e3426c9c6d17606416205ea"
+
+[[packages.wheels]]
+name = "librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-05-10 18:16:17.647725+00:00
+url = "https://files.pythonhosted.org/packages/a6/6d/d8ee9c114bebf2c50e29ec2aa940826fccb62a645c3e4c18760987d0e16d/librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 513010
+
+[packages.wheels.hashes]
+sha256 = "7c39513d8b7477a2e1ed8c43fc21c524e8d5a0f8d4e8b7b074dbdbe7820a08e2"
 
 [[packages.wheels]]
 name = "librt-0.11.0-cp313-cp313-win_amd64.whl"
@@ -1118,40 +1007,13 @@ size = 119812
 sha256 = "8ca8aa88751a775870b764e93bad5135385f563cb8dcee399abf034ea4d3cb47"
 
 [[packages.wheels]]
-name = "librt-0.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-05-10 18:16:36.705186+00:00
-url = "https://files.pythonhosted.org/packages/0a/7e/f5d92af8486b8272c23b3e686b46ff72d89c8169585eb61eef01a2ac7147/librt-0.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 505174
+name = "librt-0.11.0-cp314-cp314-macosx_10_13_x86_64.whl"
+upload-time = 2026-05-10 18:16:30.674049+00:00
+url = "https://files.pythonhosted.org/packages/29/eb/dbce197da4e227779e56b5735f2decc3eb36e55a1cdbf1bd65d6639d76c1/librt-0.11.0-cp314-cp314-macosx_10_13_x86_64.whl"
+size = 143345
 
 [packages.wheels.hashes]
-sha256 = "05fb8fb2ab90e21c8d12ea240d744ad514da9baf381ebfa70d91d20d21713175"
-
-[[packages.wheels]]
-name = "librt-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 18:16:44.408171+00:00
-url = "https://files.pythonhosted.org/packages/a5/ec/ae5525eb16edc827a044e7bb8777a455ff95d4bca9379e7e6bddd7383647/librt-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl"
-size = 546261
-
-[packages.wheels.hashes]
-sha256 = "de3bf945454d032f9e390b85c4072e0a0570bf825421c8be0e71209fa65e1abe"
-
-[[packages.wheels]]
-name = "librt-0.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-10 18:16:33.493034+00:00
-url = "https://files.pythonhosted.org/packages/f1/3f/f77d6122d21ac7bf6ae8a7dfced1bd2a7ac545d3273ebdcaf8042f6d619f/librt-0.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 477024
-
-[packages.wheels.hashes]
-sha256 = "7da327dacd7be8f8ec36547373550744a3cc0e536d54665cd83f8bcd961200e8"
-
-[[packages.wheels]]
-name = "librt-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 18:16:39.848807+00:00
-url = "https://files.pythonhosted.org/packages/18/06/094820f91558b66e29943c0ec41c9914f460f48dd51fc503c3101e10842d/librt-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl"
-size = 513921
-
-[packages.wheels.hashes]
-sha256 = "32bcc918c0148eb7e3d57385125bac7e5f9e4359d05f07448b09f6f778c2f31c"
+sha256 = "4a017a95e5837dc15a8c5661d60e05daa96b90908b1aa6b7acdf443cd25c8ebd"
 
 [[packages.wheels]]
 name = "librt-0.11.0-cp314-cp314-macosx_11_0_arm64.whl"
@@ -1163,13 +1025,22 @@ size = 143131
 sha256 = "b1ecbd9819deccc39b7542bf4d2a740d8a620694d39989e58661d3763458f8d4"
 
 [[packages.wheels]]
-name = "librt-0.11.0-cp314-cp314-macosx_10_13_x86_64.whl"
-upload-time = 2026-05-10 18:16:30.674049+00:00
-url = "https://files.pythonhosted.org/packages/29/eb/dbce197da4e227779e56b5735f2decc3eb36e55a1cdbf1bd65d6639d76c1/librt-0.11.0-cp314-cp314-macosx_10_13_x86_64.whl"
-size = 143345
+name = "librt-0.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-10 18:16:33.493034+00:00
+url = "https://files.pythonhosted.org/packages/f1/3f/f77d6122d21ac7bf6ae8a7dfced1bd2a7ac545d3273ebdcaf8042f6d619f/librt-0.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 477024
 
 [packages.wheels.hashes]
-sha256 = "4a017a95e5837dc15a8c5661d60e05daa96b90908b1aa6b7acdf443cd25c8ebd"
+sha256 = "7da327dacd7be8f8ec36547373550744a3cc0e536d54665cd83f8bcd961200e8"
+
+[[packages.wheels]]
+name = "librt-0.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-05-10 18:16:36.705186+00:00
+url = "https://files.pythonhosted.org/packages/0a/7e/f5d92af8486b8272c23b3e686b46ff72d89c8169585eb61eef01a2ac7147/librt-0.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 505174
+
+[packages.wheels.hashes]
+sha256 = "05fb8fb2ab90e21c8d12ea240d744ad514da9baf381ebfa70d91d20d21713175"
 
 [[packages.wheels]]
 name = "librt-0.11.0-cp314-cp314-win_amd64.whl"
@@ -1183,7 +1054,16 @@ sha256 = "ab73e8db5e3f564d812c1f5c3a175930a5f9bc96ccb5e3b22a34d7858b401cf7"
 [[packages]]
 name = "mypy"
 version = "2.1.0"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "tomli" },
+    { name = "typing-extensions" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1196,40 +1076,13 @@ size = 3898359
 sha256 = "81e76ad12c2d804512e9b13240d1588316531bfba07558286078bfbce9613633"
 
 [[packages.wheels]]
-name = "mypy-2.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-05-11 18:31:57.678621+00:00
-url = "https://files.pythonhosted.org/packages/41/5a/93093f0b29a9e982deafde698f740a2eb2e05886e79ccf0594c7fd5413a3/mypy-2.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 14953128
+name = "mypy-2.1.0-cp310-cp310-macosx_10_9_x86_64.whl"
+upload-time = 2026-05-11 18:36:23.605877+00:00
+url = "https://files.pythonhosted.org/packages/a4/71/d351dca3e9b30da2328ee9d445c88b8388072808ebfbc49eb69d30b67749/mypy-2.1.0-cp310-cp310-macosx_10_9_x86_64.whl"
+size = 14778792
 
 [packages.wheels.hashes]
-sha256 = "47cebf61abde7c088a4e27718a8b13a81655686b2e9c251f5c0915a802248166"
-
-[[packages.wheels]]
-name = "mypy-2.1.0-cp310-cp310-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-11 18:33:00.101521+00:00
-url = "https://files.pythonhosted.org/packages/7f/2f/a196f5331d96170ad3d28f144d2aba690d4b2911381f68d51e489c7ab82a/mypy-2.1.0-cp310-cp310-musllinux_1_2_x86_64.whl"
-size = 15249378
-
-[packages.wheels.hashes]
-sha256 = "d57a90ae5e872138a425ec328edbc9b235d1934c4377881a33ec05b341acc9a8"
-
-[[packages.wheels]]
-name = "mypy-2.1.0-py3-none-any.whl"
-upload-time = 2026-05-11 18:31:29.246181+00:00
-url = "https://files.pythonhosted.org/packages/0d/2a/13ca1f292f6db1b98ff495ef3467736b331621c5917cad984b7043e7348d/mypy-2.1.0-py3-none-any.whl"
-size = 2693302
-
-[packages.wheels.hashes]
-sha256 = "a663814603a5c563fb87a4f96fb473eeb30d1f5a4885afcf44f9db000a366289"
-
-[[packages.wheels]]
-name = "mypy-2.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-11 18:35:09.292836+00:00
-url = "https://files.pythonhosted.org/packages/65/01/455c31b170e9468265074840bf18863a8482a24103fdaabe4e199392aa5f/mypy-2.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 14074199
-
-[packages.wheels.hashes]
-sha256 = "c209a90853081ff01d01ee895cafe10f7db1474e0d95beaeef0f6c1db9119bbd"
+sha256 = "11a6beb180257a805961aea9ec591bbd0bd17f1e18d35b8456d57aee5bedfedc"
 
 [[packages.wheels]]
 name = "mypy-2.1.0-cp310-cp310-macosx_11_0_arm64.whl"
@@ -1241,13 +1094,22 @@ size = 13645739
 sha256 = "8ef78c1d306bbf9a8a12f526c44902c9c28dffd6c52c52bf6a72641ce18d3849"
 
 [[packages.wheels]]
-name = "mypy-2.1.0-cp310-cp310-macosx_10_9_x86_64.whl"
-upload-time = 2026-05-11 18:36:23.605877+00:00
-url = "https://files.pythonhosted.org/packages/a4/71/d351dca3e9b30da2328ee9d445c88b8388072808ebfbc49eb69d30b67749/mypy-2.1.0-cp310-cp310-macosx_10_9_x86_64.whl"
-size = 14778792
+name = "mypy-2.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-11 18:35:09.292836+00:00
+url = "https://files.pythonhosted.org/packages/65/01/455c31b170e9468265074840bf18863a8482a24103fdaabe4e199392aa5f/mypy-2.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 14074199
 
 [packages.wheels.hashes]
-sha256 = "11a6beb180257a805961aea9ec591bbd0bd17f1e18d35b8456d57aee5bedfedc"
+sha256 = "c209a90853081ff01d01ee895cafe10f7db1474e0d95beaeef0f6c1db9119bbd"
+
+[[packages.wheels]]
+name = "mypy-2.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-05-11 18:31:57.678621+00:00
+url = "https://files.pythonhosted.org/packages/41/5a/93093f0b29a9e982deafde698f740a2eb2e05886e79ccf0594c7fd5413a3/mypy-2.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 14953128
+
+[packages.wheels.hashes]
+sha256 = "47cebf61abde7c088a4e27718a8b13a81655686b2e9c251f5c0915a802248166"
 
 [[packages.wheels]]
 name = "mypy-2.1.0-cp310-cp310-win_amd64.whl"
@@ -1259,31 +1121,13 @@ size = 11060994
 sha256 = "aea7f7a8a55b459c34275fc468ada6ca7c173a5e43a68f5dbe588a563d8a06b8"
 
 [[packages.wheels]]
-name = "mypy-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-05-11 18:34:49.765909+00:00
-url = "https://files.pythonhosted.org/packages/d4/fa/285946c33bce716e082c11dfeee9ee196eaf1f5042efb3581a31f9f205e4/mypy-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 14864618
+name = "mypy-2.1.0-cp311-cp311-macosx_10_9_x86_64.whl"
+upload-time = 2026-05-11 18:33:27.973580+00:00
+url = "https://files.pythonhosted.org/packages/0a/a1/639f3024794a2a15899cb90707fe02e044c4412794c39c5769fd3df2e2ef/mypy-2.1.0-cp311-cp311-macosx_10_9_x86_64.whl"
+size = 14691685
 
 [packages.wheels.hashes]
-sha256 = "e0210d626fc8b31ccc90233754c7bc90e1f43205e85d96387f7db1285b55c398"
-
-[[packages.wheels]]
-name = "mypy-2.1.0-cp311-cp311-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-11 18:34:05.855229+00:00
-url = "https://files.pythonhosted.org/packages/2b/83/82397f48af6c27e295d57979ded8490c9829040152cf7571b2f026aeb9a0/mypy-2.1.0-cp311-cp311-musllinux_1_2_x86_64.whl"
-size = 15102063
-
-[packages.wheels.hashes]
-sha256 = "3712c20deed54e814eaaa825603bada8ea1c390670a397c95b98405347acc563"
-
-[[packages.wheels]]
-name = "mypy-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-11 18:32:39.256847+00:00
-url = "https://files.pythonhosted.org/packages/81/dc/7c42cc9c6cb01e8eb09961f1f738741d3e9c7e9d5c5b30ec69222625cd5f/mypy-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 13994376
-
-[packages.wheels.hashes]
-sha256 = "7406f4d048e71e576f5356d317e5b0a9e666dfd966bd99f9d14ca06e1a341538"
+sha256 = "a683016b16fe2f572dc04c72be7ee0504ac1605a265d0200f5cea695fb788f41"
 
 [[packages.wheels]]
 name = "mypy-2.1.0-cp311-cp311-macosx_11_0_arm64.whl"
@@ -1295,13 +1139,22 @@ size = 13555165
 sha256 = "1a293c534adb55271fef24a26da04b855540a8c13cc07bc5917b9fd2c394f2ca"
 
 [[packages.wheels]]
-name = "mypy-2.1.0-cp311-cp311-macosx_10_9_x86_64.whl"
-upload-time = 2026-05-11 18:33:27.973580+00:00
-url = "https://files.pythonhosted.org/packages/0a/a1/639f3024794a2a15899cb90707fe02e044c4412794c39c5769fd3df2e2ef/mypy-2.1.0-cp311-cp311-macosx_10_9_x86_64.whl"
-size = 14691685
+name = "mypy-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-11 18:32:39.256847+00:00
+url = "https://files.pythonhosted.org/packages/81/dc/7c42cc9c6cb01e8eb09961f1f738741d3e9c7e9d5c5b30ec69222625cd5f/mypy-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 13994376
 
 [packages.wheels.hashes]
-sha256 = "a683016b16fe2f572dc04c72be7ee0504ac1605a265d0200f5cea695fb788f41"
+sha256 = "7406f4d048e71e576f5356d317e5b0a9e666dfd966bd99f9d14ca06e1a341538"
+
+[[packages.wheels]]
+name = "mypy-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-05-11 18:34:49.765909+00:00
+url = "https://files.pythonhosted.org/packages/d4/fa/285946c33bce716e082c11dfeee9ee196eaf1f5042efb3581a31f9f205e4/mypy-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 14864618
+
+[packages.wheels.hashes]
+sha256 = "e0210d626fc8b31ccc90233754c7bc90e1f43205e85d96387f7db1285b55c398"
 
 [[packages.wheels]]
 name = "mypy-2.1.0-cp311-cp311-win_amd64.whl"
@@ -1313,31 +1166,13 @@ size = 11060564
 sha256 = "fcaa0e479066e31f7cceb6a3bea39cb22b2ff51a6b2f24f193d19179ba17c389"
 
 [[packages.wheels]]
-name = "mypy-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-05-11 18:37:06.898372+00:00
-url = "https://files.pythonhosted.org/packages/a0/32/615eb5911859e43d054941b0d0a7d06cfa2870eba86529cf385b052b111c/mypy-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 15061630
+name = "mypy-2.1.0-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2026-05-11 18:37:31.784994+00:00
+url = "https://files.pythonhosted.org/packages/95/b1/55861beb5c339b44f9a2ba92df9e2cb1eeb4ae1eee674cdf7772c797778b/mypy-2.1.0-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 14874381
 
 [packages.wheels.hashes]
-sha256 = "bf03e12003084a67395184d3eb8cbd6a489dc3655b5664b28c210a9e2403ab0b"
-
-[[packages.wheels]]
-name = "mypy-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-11 18:31:18.070625+00:00
-url = "https://files.pythonhosted.org/packages/d4/03/4eafbfff8bfab1b87082741eae6e6a624028c984e6708b73bce2a8570c9d/mypy-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl"
-size = 15288831
-
-[packages.wheels.hashes]
-sha256 = "20509760fd791c51579d573153407d226385ec1f8bcce55d730b354f3336bc22"
-
-[[packages.wheels]]
-name = "mypy-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-11 18:31:48.151751+00:00
-url = "https://files.pythonhosted.org/packages/b6/f3/8ae2037967e2126689a0c11d99e2b707134a565191e92c60ca2572aec60a/mypy-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 14045750
-
-[packages.wheels.hashes]
-sha256 = "d8161b6ff4392410023224f0969d17db93e1e154bc3e4ba62598e720723ae211"
+sha256 = "244358bf1c0da7722230bce60683d52e8e9fd030554926f15b747a84efb5b3af"
 
 [[packages.wheels]]
 name = "mypy-2.1.0-cp312-cp312-macosx_11_0_arm64.whl"
@@ -1349,13 +1184,22 @@ size = 13665501
 sha256 = "4ec7c57657493c7a75534df2751c8ae2cda383c16ecc55d2106c54476b1b16f6"
 
 [[packages.wheels]]
-name = "mypy-2.1.0-cp312-cp312-macosx_10_13_x86_64.whl"
-upload-time = 2026-05-11 18:37:31.784994+00:00
-url = "https://files.pythonhosted.org/packages/95/b1/55861beb5c339b44f9a2ba92df9e2cb1eeb4ae1eee674cdf7772c797778b/mypy-2.1.0-cp312-cp312-macosx_10_13_x86_64.whl"
-size = 14874381
+name = "mypy-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-11 18:31:48.151751+00:00
+url = "https://files.pythonhosted.org/packages/b6/f3/8ae2037967e2126689a0c11d99e2b707134a565191e92c60ca2572aec60a/mypy-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 14045750
 
 [packages.wheels.hashes]
-sha256 = "244358bf1c0da7722230bce60683d52e8e9fd030554926f15b747a84efb5b3af"
+sha256 = "d8161b6ff4392410023224f0969d17db93e1e154bc3e4ba62598e720723ae211"
+
+[[packages.wheels]]
+name = "mypy-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-05-11 18:37:06.898372+00:00
+url = "https://files.pythonhosted.org/packages/a0/32/615eb5911859e43d054941b0d0a7d06cfa2870eba86529cf385b052b111c/mypy-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 15061630
+
+[packages.wheels.hashes]
+sha256 = "bf03e12003084a67395184d3eb8cbd6a489dc3655b5664b28c210a9e2403ab0b"
 
 [[packages.wheels]]
 name = "mypy-2.1.0-cp312-cp312-win_amd64.whl"
@@ -1367,31 +1211,13 @@ size = 11135228
 sha256 = "6753d0c1fdd6b1a23b9e4f283ce80b2153b724adcb2653b20b85a8a28ac6436b"
 
 [[packages.wheels]]
-name = "mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-05-11 18:33:10.281425+00:00
-url = "https://files.pythonhosted.org/packages/94/21/f54be870d6dd53a82c674407e0f8eed7174b05ec78d42e5abd7b42e84fd5/mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 15039200
+name = "mypy-2.1.0-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2026-05-11 18:31:38.929343+00:00
+url = "https://files.pythonhosted.org/packages/6e/dd/c7191469c777f07689c032a8f7326e393ea34c92d6d76eb7ce5ba57ea66d/mypy-2.1.0-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 14852174
 
 [packages.wheels.hashes]
-sha256 = "e195b817c13f02352a9c124301f9f30f078405444679b6753c1b96b6eed37285"
-
-[[packages.wheels]]
-name = "mypy-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-11 18:32:07.205797+00:00
-url = "https://files.pythonhosted.org/packages/17/99/bf21748626a40ce59fd29a39386ab46afec88b7bd2f0fa6c3a97c995523f/mypy-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl"
-size = 15272690
-
-[packages.wheels.hashes]
-sha256 = "5431d42af987ebd92ba2f71d45c85ed41d8e6ca9f5fd209a69f68f707d2469e5"
-
-[[packages.wheels]]
-name = "mypy-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-11 18:35:55.742069+00:00
-url = "https://files.pythonhosted.org/packages/3a/8e/f371a824b1f1fa8ea6e3dbb8703d232977d572be2329554a3bc4d960302f/mypy-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 14033929
-
-[packages.wheels.hashes]
-sha256 = "5fdf2941a07434af755837d9880f7d7d25f1dacb1af9dcd4b9b66f2220a3024e"
+sha256 = "35aac3bb114e03888f535d5eb51b8bafbb3266586b599da1940f9b1be3ec5bd5"
 
 [[packages.wheels]]
 name = "mypy-2.1.0-cp313-cp313-macosx_11_0_arm64.whl"
@@ -1403,13 +1229,22 @@ size = 13651542
 sha256 = "8de55a8c861f2a49331f807be98d90caeceeef520bde13d43a160207f8af613e"
 
 [[packages.wheels]]
-name = "mypy-2.1.0-cp313-cp313-macosx_10_13_x86_64.whl"
-upload-time = 2026-05-11 18:31:38.929343+00:00
-url = "https://files.pythonhosted.org/packages/6e/dd/c7191469c777f07689c032a8f7326e393ea34c92d6d76eb7ce5ba57ea66d/mypy-2.1.0-cp313-cp313-macosx_10_13_x86_64.whl"
-size = 14852174
+name = "mypy-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-11 18:35:55.742069+00:00
+url = "https://files.pythonhosted.org/packages/3a/8e/f371a824b1f1fa8ea6e3dbb8703d232977d572be2329554a3bc4d960302f/mypy-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 14033929
 
 [packages.wheels.hashes]
-sha256 = "35aac3bb114e03888f535d5eb51b8bafbb3266586b599da1940f9b1be3ec5bd5"
+sha256 = "5fdf2941a07434af755837d9880f7d7d25f1dacb1af9dcd4b9b66f2220a3024e"
+
+[[packages.wheels]]
+name = "mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-05-11 18:33:10.281425+00:00
+url = "https://files.pythonhosted.org/packages/94/21/f54be870d6dd53a82c674407e0f8eed7174b05ec78d42e5abd7b42e84fd5/mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 15039200
+
+[packages.wheels.hashes]
+sha256 = "e195b817c13f02352a9c124301f9f30f078405444679b6753c1b96b6eed37285"
 
 [[packages.wheels]]
 name = "mypy-2.1.0-cp313-cp313-win_amd64.whl"
@@ -1421,31 +1256,13 @@ size = 11147435
 sha256 = "767fe8c66dc3e01e19e1737d4c38ebefead16125e1b8e58ad421903b376f5c65"
 
 [[packages.wheels]]
-name = "mypy-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-05-11 18:34:59.618382+00:00
-url = "https://files.pythonhosted.org/packages/51/4d/b6d34db183133b83761b9199a82d31557cdbb70a380d8c3b3438e11882a3/mypy-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 15020937
+name = "mypy-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl"
+upload-time = 2026-05-11 18:35:45.984591+00:00
+url = "https://files.pythonhosted.org/packages/b0/ca/b279a672e874aedd5498ae25f722dacc8aa86bbffb939b3f97cbb1cf6686/mypy-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl"
+size = 14848422
 
 [packages.wheels.hashes]
-sha256 = "c90345fc182dc363b891350457ec69c35140858538f38b4540845afcc32b1aef"
-
-[[packages.wheels]]
-name = "mypy-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-11 18:36:41.081858+00:00
-url = "https://files.pythonhosted.org/packages/ff/d7/f08360c691d758acb02f45022c34d98b92892f4ea756644e1000d4b9f3d8/mypy-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl"
-size = 15253371
-
-[packages.wheels.hashes]
-sha256 = "b84802e7b5a6daf1f5e15bc9fcd7ddae77be13981ffab037f1c67bb84d67d135"
-
-[[packages.wheels]]
-name = "mypy-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-11 18:35:18.361618+00:00
-url = "https://files.pythonhosted.org/packages/84/7f/8107ea87a44fd1f1b59882442f033c9c3488c127201b1d1d15f1cbd6022e/mypy-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 14055743
-
-[packages.wheels.hashes]
-sha256 = "761be68e023ef5d94678772396a8af1220030f80837a3afd8d0aef3b419666f4"
+sha256 = "7354c5a7f69d9345c3d6e69921d57088eea3ddeeb6b20d34c1b3855b02c36ec2"
 
 [[packages.wheels]]
 name = "mypy-2.1.0-cp314-cp314-macosx_11_0_arm64.whl"
@@ -1457,6 +1274,24 @@ size = 13677374
 sha256 = "49890d4f76ac9e06ec117f9e09f3174da70a620a0c300953d8595c926e80947f"
 
 [[packages.wheels]]
+name = "mypy-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-05-11 18:35:18.361618+00:00
+url = "https://files.pythonhosted.org/packages/84/7f/8107ea87a44fd1f1b59882442f033c9c3488c127201b1d1d15f1cbd6022e/mypy-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 14055743
+
+[packages.wheels.hashes]
+sha256 = "761be68e023ef5d94678772396a8af1220030f80837a3afd8d0aef3b419666f4"
+
+[[packages.wheels]]
+name = "mypy-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-05-11 18:34:59.618382+00:00
+url = "https://files.pythonhosted.org/packages/51/4d/b6d34db183133b83761b9199a82d31557cdbb70a380d8c3b3438e11882a3/mypy-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 15020937
+
+[packages.wheels.hashes]
+sha256 = "c90345fc182dc363b891350457ec69c35140858538f38b4540845afcc32b1aef"
+
+[[packages.wheels]]
 name = "mypy-2.1.0-cp314-cp314-win_amd64.whl"
 upload-time = 2026-05-11 18:34:13.526563+00:00
 url = "https://files.pythonhosted.org/packages/67/1b/09460a13719530a19bce27bd3bc8449e83569dd2ba7faf51c9c3c30c0b61/mypy-2.1.0-cp314-cp314-win_amd64.whl"
@@ -1465,9 +1300,19 @@ size = 11326429
 [packages.wheels.hashes]
 sha256 = "022c771234936ceac541ebaf836fe9e2abeb3f5e09aff21588fe543ff006fe21"
 
+[[packages.wheels]]
+name = "mypy-2.1.0-py3-none-any.whl"
+upload-time = 2026-05-11 18:31:29.246181+00:00
+url = "https://files.pythonhosted.org/packages/0d/2a/13ca1f292f6db1b98ff495ef3467736b331621c5917cad984b7043e7348d/mypy-2.1.0-py3-none-any.whl"
+size = 2693302
+
+[packages.wheels.hashes]
+sha256 = "a663814603a5c563fb87a4f96fb473eeb30d1f5a4885afcf44f9db000a366289"
+
 [[packages]]
 name = "mypy-extensions"
 version = "1.1.0"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.8"
 index = "https://pypi.org/simple/"
 
@@ -1492,6 +1337,7 @@ sha256 = "1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"
 [[packages]]
 name = "nodeenv"
 version = "1.10.0"
+marker = "\"types\" in dependency_groups"
 requires-python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 index = "https://pypi.org/simple/"
 
@@ -1540,6 +1386,7 @@ sha256 = "5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"
 [[packages]]
 name = "pathspec"
 version = "1.1.1"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -1564,6 +1411,7 @@ sha256 = "a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189"
 [[packages]]
 name = "pluggy"
 version = "1.6.0"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -1588,6 +1436,7 @@ sha256 = "e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
 [[packages]]
 name = "pygments"
 version = "2.20.0"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -1636,6 +1485,7 @@ sha256 = "9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913"
 [[packages]]
 name = "pyrefly"
 version = "1.0.0"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.8"
 index = "https://pypi.org/simple/"
 
@@ -1649,22 +1499,13 @@ size = 5677995
 sha256 = "5c2b810ffcebd84be71de5df1223651edee951653a66935c6f091e957c452455"
 
 [[packages.wheels]]
-name = "pyrefly-1.0.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-upload-time = 2026-05-12 20:12:35.302254+00:00
-url = "https://files.pythonhosted.org/packages/61/16/cfa2d61a4aa1e1f7bca48bb37acd01c6a09db4864b16a54f9587092765ff/pyrefly-1.0.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-size = 13470398
+name = "pyrefly-1.0.0-py3-none-macosx_10_12_x86_64.whl"
+upload-time = 2026-05-12 20:12:20.711992+00:00
+url = "https://files.pythonhosted.org/packages/f4/c6/90788819bac9c61dd7bacba53b79f3c12d47ccbe5e51b3d6d89f2387e1d2/pyrefly-1.0.0-py3-none-macosx_10_12_x86_64.whl"
+size = 13122950
 
 [packages.wheels.hashes]
-sha256 = "1382d5b1fcdb49a4de9f34d112d2bddf290a78ff93ee8149492ad5f1077ddffc"
-
-[[packages.wheels]]
-name = "pyrefly-1.0.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-upload-time = 2026-05-12 20:12:25.951311+00:00
-url = "https://files.pythonhosted.org/packages/cd/ab/74d1e11e737e99b1c003ecc5d7d2e846c4ea1f328966bfdbbd0ac63fad0a/pyrefly-1.0.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-size = 12995507
-
-[packages.wheels.hashes]
-sha256 = "da331ca515ed1c08791da2b5f664cf9c1294c48fd802133262e7d5d51e0f4416"
+sha256 = "e355a0908555348ed4b9585ef25c76ff566673e345c866c325f1633f44d890b6"
 
 [[packages.wheels]]
 name = "pyrefly-1.0.0-py3-none-macosx_11_0_arm64.whl"
@@ -1676,13 +1517,22 @@ size = 12599494
 sha256 = "a7038efc3a40f8294edee339895633cf22db268c0d434cdbcbefc34f78a9ecc3"
 
 [[packages.wheels]]
-name = "pyrefly-1.0.0-py3-none-macosx_10_12_x86_64.whl"
-upload-time = 2026-05-12 20:12:20.711992+00:00
-url = "https://files.pythonhosted.org/packages/f4/c6/90788819bac9c61dd7bacba53b79f3c12d47ccbe5e51b3d6d89f2387e1d2/pyrefly-1.0.0-py3-none-macosx_10_12_x86_64.whl"
-size = 13122950
+name = "pyrefly-1.0.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-05-12 20:12:25.951311+00:00
+url = "https://files.pythonhosted.org/packages/cd/ab/74d1e11e737e99b1c003ecc5d7d2e846c4ea1f328966bfdbbd0ac63fad0a/pyrefly-1.0.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 12995507
 
 [packages.wheels.hashes]
-sha256 = "e355a0908555348ed4b9585ef25c76ff566673e345c866c325f1633f44d890b6"
+sha256 = "da331ca515ed1c08791da2b5f664cf9c1294c48fd802133262e7d5d51e0f4416"
+
+[[packages.wheels]]
+name = "pyrefly-1.0.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-05-12 20:12:35.302254+00:00
+url = "https://files.pythonhosted.org/packages/61/16/cfa2d61a4aa1e1f7bca48bb37acd01c6a09db4864b16a54f9587092765ff/pyrefly-1.0.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 13470398
+
+[packages.wheels.hashes]
+sha256 = "1382d5b1fcdb49a4de9f34d112d2bddf290a78ff93ee8149492ad5f1077ddffc"
 
 [[packages.wheels]]
 name = "pyrefly-1.0.0-py3-none-win_amd64.whl"
@@ -1696,7 +1546,12 @@ sha256 = "c8abcb0f2082e83c890375128f9cff4aa4d3f210b85eea7b3046c1ae764e77f5"
 [[packages]]
 name = "pyright"
 version = "1.1.409"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.7"
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1720,7 +1575,17 @@ sha256 = "aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3"
 [[packages]]
 name = "pytest"
 version = "9.0.3"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.10"
+dependencies = [
+    { name = "colorama" },
+    { name = "exceptiongroup" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1744,7 +1609,11 @@ sha256 = "2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"
 [[packages]]
 name = "pytest-timeout"
 version = "2.4.0"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.7"
+dependencies = [
+    { name = "pytest" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1768,7 +1637,11 @@ sha256 = "c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2"
 [[packages]]
 name = "respx"
 version = "0.23.1"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.8"
+dependencies = [
+    { name = "httpx" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1792,6 +1665,7 @@ sha256 = "b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a"
 [[packages]]
 name = "sortedcontainers"
 version = "2.4.0"
+marker = "\"types\" in dependency_groups"
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -1828,49 +1702,13 @@ size = 17543
 sha256 = "7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-py3-none-any.whl"
-upload-time = 2026-03-25 20:22:03.012768+00:00
-url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl"
-size = 14583
+name = "tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
+upload-time = 2026-03-25 20:21:10.473841+00:00
+url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
+size = 154704
 
 [packages.wheels.hashes]
-sha256 = "0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-03-25 20:21:14.569419+00:00
-url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 243824
-
-[packages.wheels.hashes]
-sha256 = "5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl"
-upload-time = 2026-03-25 20:21:17.001171+00:00
-url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl"
-size = 247859
-
-[packages.wheels.hashes]
-sha256 = "ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-03-25 20:21:13.098441+00:00
-url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 237561
-
-[packages.wheels.hashes]
-sha256 = "96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl"
-upload-time = 2026-03-25 20:21:15.712337+00:00
-url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl"
-size = 242227
-
-[packages.wheels.hashes]
-sha256 = "47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c"
+sha256 = "f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl"
@@ -1882,13 +1720,22 @@ size = 149454
 sha256 = "4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
-upload-time = 2026-03-25 20:21:10.473841+00:00
-url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
-size = 154704
+name = "tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:13.098441+00:00
+url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 237561
 
 [packages.wheels.hashes]
-sha256 = "f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30"
+sha256 = "96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:14.569419+00:00
+url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 243824
+
+[packages.wheels.hashes]
+sha256 = "5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp311-cp311-win_amd64.whl"
@@ -1900,40 +1747,13 @@ size = 108084
 sha256 = "5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-03-25 20:21:25.177901+00:00
-url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 253341
+name = "tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2026-03-25 20:21:21.626567+00:00
+url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 155924
 
 [packages.wheels.hashes]
-sha256 = "136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl"
-upload-time = 2026-03-25 20:21:27.460413+00:00
-url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl"
-size = 253290
-
-[packages.wheels.hashes]
-sha256 = "5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-03-25 20:21:24.040813+00:00
-url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 244948
-
-[packages.wheels.hashes]
-sha256 = "ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl"
-upload-time = 2026-03-25 20:21:26.364996+00:00
-url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl"
-size = 248159
-
-[packages.wheels.hashes]
-sha256 = "5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585"
+sha256 = "c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl"
@@ -1945,13 +1765,22 @@ size = 150018
 sha256 = "7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
-upload-time = 2026-03-25 20:21:21.626567+00:00
-url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
-size = 155924
+name = "tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:24.040813+00:00
+url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 244948
 
 [packages.wheels.hashes]
-sha256 = "c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a"
+sha256 = "ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:25.177901+00:00
+url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 253341
+
+[packages.wheels.hashes]
+sha256 = "136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp312-cp312-win_amd64.whl"
@@ -1963,40 +1792,13 @@ size = 108847
 sha256 = "52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-03-25 20:21:36.012836+00:00
-url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 251628
+name = "tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2026-03-25 20:21:31.650748+00:00
+url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 155866
 
 [packages.wheels.hashes]
-sha256 = "f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl"
-upload-time = 2026-03-25 20:21:38.298846+00:00
-url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl"
-size = 251674
-
-[packages.wheels.hashes]
-sha256 = "51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-03-25 20:21:34.510750+00:00
-url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 243704
-
-[packages.wheels.hashes]
-sha256 = "c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl"
-upload-time = 2026-03-25 20:21:37.136802+00:00
-url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl"
-size = 247180
-
-[packages.wheels.hashes]
-sha256 = "d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d"
+sha256 = "36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl"
@@ -2008,13 +1810,22 @@ size = 149887
 sha256 = "eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
-upload-time = 2026-03-25 20:21:31.650748+00:00
-url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
-size = 155866
+name = "tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:34.510750+00:00
+url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 243704
 
 [packages.wheels.hashes]
-sha256 = "36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54"
+sha256 = "c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:36.012836+00:00
+url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 251628
+
+[packages.wheels.hashes]
+sha256 = "f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp313-cp313-win_amd64.whl"
@@ -2026,40 +1837,13 @@ size = 108755
 sha256 = "8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36"
 
 [[packages.wheels]]
-name = "tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-upload-time = 2026-03-25 20:21:45.620261+00:00
-url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
-size = 252084
+name = "tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl"
+upload-time = 2026-03-25 20:21:42.230154+00:00
+url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl"
+size = 155726
 
 [packages.wheels.hashes]
-sha256 = "01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl"
-upload-time = 2026-03-25 20:21:48.467732+00:00
-url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl"
-size = 256223
-
-[packages.wheels.hashes]
-sha256 = "ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-upload-time = 2026-03-25 20:21:44.474645+00:00
-url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-size = 244713
-
-[packages.wheels.hashes]
-sha256 = "559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662"
-
-[[packages.wheels]]
-name = "tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl"
-upload-time = 2026-03-25 20:21:46.937942+00:00
-url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl"
-size = 247973
-
-[packages.wheels.hashes]
-sha256 = "7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15"
+sha256 = "fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf"
 
 [[packages.wheels]]
 name = "tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl"
@@ -2071,6 +1855,24 @@ size = 149859
 sha256 = "a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac"
 
 [[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:44.474645+00:00
+url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 244713
+
+[packages.wheels.hashes]
+sha256 = "559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:45.620261+00:00
+url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 252084
+
+[packages.wheels.hashes]
+sha256 = "01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853"
+
+[[packages.wheels]]
 name = "tomli-2.4.1-cp314-cp314-win_amd64.whl"
 upload-time = 2026-03-25 20:21:50.506850+00:00
 url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl"
@@ -2078,6 +1880,15 @@ size = 109082
 
 [packages.wheels.hashes]
 sha256 = "88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-py3-none-any.whl"
+upload-time = 2026-03-25 20:22:03.012768+00:00
+url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl"
+size = 14583
+
+[packages.wheels.hashes]
+sha256 = "0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe"
 
 [[packages]]
 name = "tomli-w"
@@ -2106,6 +1917,7 @@ sha256 = "188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90"
 [[packages]]
 name = "tomlkit"
 version = "0.15.0"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -2154,6 +1966,7 @@ sha256 = "adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"
 [[packages]]
 name = "ty"
 version = "0.0.35"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.8"
 index = "https://pypi.org/simple/"
 
@@ -2167,40 +1980,13 @@ size = 5629237
 sha256 = "8375c240ab38138a19db07996c9808fb7a92047c1492e1ce587c2ef5112ad3a9"
 
 [[packages.wheels]]
-name = "ty-0.0.35-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-upload-time = 2026-05-10 18:25:05.172859+00:00
-url = "https://files.pythonhosted.org/packages/18/a1/a977c0e07e9f88db9c67f90c6342a4dc4422c8091fa07bf26521870687c5/ty-0.0.35-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-size = 11560482
+name = "ty-0.0.35-py3-none-macosx_10_12_x86_64.whl"
+upload-time = 2026-05-10 18:24:58.246979+00:00
+url = "https://files.pythonhosted.org/packages/62/df/7e5b6f83d85b4d2e5b72b5dceb388f440acc10679417bd46f829b9200fab/ty-0.0.35-py3-none-macosx_10_12_x86_64.whl"
+size = 10948304
 
 [packages.wheels.hashes]
-sha256 = "eb44bb742d52c309dcaa6598bcf4d82eb4bf1241b9e4940461e522e30093fe8b"
-
-[[packages.wheels]]
-name = "ty-0.0.35-py3-none-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-10 18:24:56.223225+00:00
-url = "https://files.pythonhosted.org/packages/4d/b1/a845d2066ed521c477450f436d4bd353d107e7c02dd6536a485944aaf892/ty-0.0.35-py3-none-musllinux_1_2_x86_64.whl"
-size = 11671005
-
-[packages.wheels.hashes]
-sha256 = "1ad0a2f0530d0933dcc99ad36ac556c63e384ea72ab9a18d23ad2e2c9fd61c73"
-
-[[packages.wheels]]
-name = "ty-0.0.35-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-upload-time = 2026-05-10 18:24:47.401353+00:00
-url = "https://files.pythonhosted.org/packages/b6/23/fda6fae8a81ce0cb5f24cdfe63260e110c7af8844e31fa07d1e6e8ef0232/ty-0.0.35-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-size = 10932614
-
-[packages.wheels.hashes]
-sha256 = "e7afbcfc61904b7e82e7fe1a1db832a40d8f01e69dee1775f6594e552980536c"
-
-[[packages.wheels]]
-name = "ty-0.0.35-py3-none-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-10 18:25:02.941240+00:00
-url = "https://files.pythonhosted.org/packages/3c/cb/e92e4317388b6d1fd821a46941b448a8a1ff0bf13e22147c5167d8fa1b00/ty-0.0.35-py3-none-musllinux_1_2_aarch64.whl"
-size = 10900815
-
-[packages.wheels.hashes]
-sha256 = "88e2ac497decc0940ef1a07571dee8a746112a93a09cdc7f8bca0099752e2e05"
+sha256 = "709dbb7af4fcadb1196863c00b8791bbbbcc9dacbe15a0ff17f0af82b35d415b"
 
 [[packages.wheels]]
 name = "ty-0.0.35-py3-none-macosx_11_0_arm64.whl"
@@ -2212,13 +1998,22 @@ size = 10407413
 sha256 = "2cb0877419ab0c8708b6925cb0c2800b263842bd3c425113f200538772f3a0cc"
 
 [[packages.wheels]]
-name = "ty-0.0.35-py3-none-macosx_10_12_x86_64.whl"
-upload-time = 2026-05-10 18:24:58.246979+00:00
-url = "https://files.pythonhosted.org/packages/62/df/7e5b6f83d85b4d2e5b72b5dceb388f440acc10679417bd46f829b9200fab/ty-0.0.35-py3-none-macosx_10_12_x86_64.whl"
-size = 10948304
+name = "ty-0.0.35-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-05-10 18:24:47.401353+00:00
+url = "https://files.pythonhosted.org/packages/b6/23/fda6fae8a81ce0cb5f24cdfe63260e110c7af8844e31fa07d1e6e8ef0232/ty-0.0.35-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 10932614
 
 [packages.wheels.hashes]
-sha256 = "709dbb7af4fcadb1196863c00b8791bbbbcc9dacbe15a0ff17f0af82b35d415b"
+sha256 = "e7afbcfc61904b7e82e7fe1a1db832a40d8f01e69dee1775f6594e552980536c"
+
+[[packages.wheels]]
+name = "ty-0.0.35-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-05-10 18:25:05.172859+00:00
+url = "https://files.pythonhosted.org/packages/18/a1/a977c0e07e9f88db9c67f90c6342a4dc4422c8091fa07bf26521870687c5/ty-0.0.35-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 11560482
+
+[packages.wheels.hashes]
+sha256 = "eb44bb742d52c309dcaa6598bcf4d82eb4bf1241b9e4940461e522e30093fe8b"
 
 [[packages.wheels]]
 name = "ty-0.0.35-py3-none-win_amd64.whl"
@@ -2233,6 +2028,9 @@ sha256 = "6a0a6d259f6f2f8f2f954c6f013d4e0b5eba68af6b353bf19a47d59ec254a3d5"
 name = "typeguard"
 version = "4.5.1"
 requires-python = ">=3.9"
+dependencies = [
+    { name = "typing-extensions" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -2281,6 +2079,11 @@ sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
 name = "tyro"
 version = "1.0.13"
 requires-python = ">=3.8"
+dependencies = [
+    { name = "docstring-parser" },
+    { name = "typeguard" },
+    { name = "typing-extensions" },
+]
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
@@ -2328,7 +2131,7 @@ sha256 = "9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
 [[packages]]
 name = "zipp"
 version = "3.23.1"
-marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+marker = "(python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\")"
 requires-python = ">=3.9"
 index = "https://pypi.org/simple/"
 
@@ -2353,53 +2156,9 @@ sha256 = "0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc"
 [[packages]]
 name = "zuban"
 version = "0.7.2"
+marker = "\"types\" in dependency_groups"
 requires-python = ">=3.7"
 index = "https://pypi.org/simple/"
-
-[[packages.wheels]]
-name = "zuban-0.7.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-upload-time = 2026-05-03 15:36:21.162991+00:00
-url = "https://files.pythonhosted.org/packages/81/19/a65982d180bdb2b8f2aa4be99e14d09a95b34f217eda76bf2b2951025f81/zuban-0.7.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-size = 30458158
-
-[packages.wheels.hashes]
-sha256 = "ada57d1e876c903bf202bd3188904229b774abc7db227ccfa20e9938f418c5c1"
-
-[[packages.wheels]]
-name = "zuban-0.7.2-py3-none-musllinux_1_2_x86_64.whl"
-upload-time = 2026-05-03 15:36:36.812024+00:00
-url = "https://files.pythonhosted.org/packages/54/63/4a054802ca0d97e550b718349ddc0cacdb7813997f26e90cd12dedd073fb/zuban-0.7.2-py3-none-musllinux_1_2_x86_64.whl"
-size = 28668800
-
-[packages.wheels.hashes]
-sha256 = "61d91b7a1b1da72e2cfa42a3c2fe7258b5bde9603ca5f76675aca79989515ea2"
-
-[[packages.wheels]]
-name = "zuban-0.7.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-upload-time = 2026-05-03 15:36:10.448802+00:00
-url = "https://files.pythonhosted.org/packages/98/8e/2cf71f02be4de5398787b551fe8dc3056f99109196a7a0c9c30fef034baf/zuban-0.7.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-size = 28055795
-
-[packages.wheels.hashes]
-sha256 = "d2c5e6015e4a8b27d7fb0cf38629449b8bc0599aa144d8ee4bec0fc79e065b66"
-
-[[packages.wheels]]
-name = "zuban-0.7.2-py3-none-musllinux_1_2_aarch64.whl"
-upload-time = 2026-05-03 15:36:25.044389+00:00
-url = "https://files.pythonhosted.org/packages/de/ce/0c73285da471d8c529ac263f3e65855d917a0fcef1f996611551d49f52c9/zuban-0.7.2-py3-none-musllinux_1_2_aarch64.whl"
-size = 28195120
-
-[packages.wheels.hashes]
-sha256 = "b736e8945efa84cd225c304f38fd5b366b566518b4d43d12c256d192ba36fa15"
-
-[[packages.wheels]]
-name = "zuban-0.7.2-py3-none-macosx_11_0_arm64.whl"
-upload-time = 2026-05-03 15:36:06.699040+00:00
-url = "https://files.pythonhosted.org/packages/0e/dd/bc94b699e9ddc857143806b8aa24d064f50dd5e89c9de0013c90d5bdcbea/zuban-0.7.2-py3-none-macosx_11_0_arm64.whl"
-size = 11095967
-
-[packages.wheels.hashes]
-sha256 = "a3cf4c85c993f375d411a589195983818cd675f7c396835e2141b5b2b7c2fb74"
 
 [[packages.wheels]]
 name = "zuban-0.7.2-py3-none-macosx_10_12_x86_64.whl"
@@ -2411,6 +2170,33 @@ size = 11374640
 sha256 = "82e9ad81c84cb39c7082d6f8ff39fe7a3e67a1765b63ae215dcf469745c67c63"
 
 [[packages.wheels]]
+name = "zuban-0.7.2-py3-none-macosx_11_0_arm64.whl"
+upload-time = 2026-05-03 15:36:06.699040+00:00
+url = "https://files.pythonhosted.org/packages/0e/dd/bc94b699e9ddc857143806b8aa24d064f50dd5e89c9de0013c90d5bdcbea/zuban-0.7.2-py3-none-macosx_11_0_arm64.whl"
+size = 11095967
+
+[packages.wheels.hashes]
+sha256 = "a3cf4c85c993f375d411a589195983818cd675f7c396835e2141b5b2b7c2fb74"
+
+[[packages.wheels]]
+name = "zuban-0.7.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-05-03 15:36:10.448802+00:00
+url = "https://files.pythonhosted.org/packages/98/8e/2cf71f02be4de5398787b551fe8dc3056f99109196a7a0c9c30fef034baf/zuban-0.7.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 28055795
+
+[packages.wheels.hashes]
+sha256 = "d2c5e6015e4a8b27d7fb0cf38629449b8bc0599aa144d8ee4bec0fc79e065b66"
+
+[[packages.wheels]]
+name = "zuban-0.7.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-05-03 15:36:21.162991+00:00
+url = "https://files.pythonhosted.org/packages/81/19/a65982d180bdb2b8f2aa4be99e14d09a95b34f217eda76bf2b2951025f81/zuban-0.7.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 30458158
+
+[packages.wheels.hashes]
+sha256 = "ada57d1e876c903bf202bd3188904229b774abc7db227ccfa20e9938f418c5c1"
+
+[[packages.wheels]]
 name = "zuban-0.7.2-py3-none-win_amd64.whl"
 upload-time = 2026-05-03 15:36:42.509724+00:00
 url = "https://files.pythonhosted.org/packages/dc/20/6b030577b144f47ecd543a333b7611039acb0faf43c829521dfc1d4fdd31/zuban-0.7.2-py3-none-win_amd64.whl"
@@ -2420,12 +2206,14 @@ size = 10701959
 sha256 = "72ce37001958ca923dd8be4317e11ea7d9b65b74b6a8c3bcd759c7078678e1e0"
 
 [tool.nab]
-nab-version = "0.0.2"
+nab-version = "0.0.10.dev0"
 created-at = 2026-05-20 04:01:38.745248+00:00
 command-line = [
-    "/home/damian/opensource/remote/projects/resolver/nab/src/nab/__main__.py",
+    "nab",
     "lock",
     "--groups",
+    "types",
+    "--project-default-group",
     "types",
     "--no-emit-workspace",
     "--output",
@@ -2440,4 +2228,7 @@ platforms = [
     "macos_arm64",
     "macos_x86_64",
     "windows_amd64",
+]
+cli-project-overrides = [
+    "--project-default-group=types",
 ]

--- a/tasks/refresh-locks.sh
+++ b/tasks/refresh-locks.sh
@@ -27,6 +27,10 @@ EXTRA_ARGS=("$@")
 # comes from whoever runs this, which is Linux, as both builders are.
 DOCS_PYTHON="3.13"
 
+# Each lock covers a single group, so that group is also its default: pip and
+# uv seed the PEP 751 dependency_groups marker from default-groups and cannot
+# select a non-default group at install time, so without this the group's
+# packages carry a marker no install-time flag ever satisfies and are skipped.
 for group in tests types pre-commit crosshair release docs; do
     echo "==> Locking group: ${group}"
     group_args=()
@@ -35,6 +39,7 @@ for group in tests types pre-commit crosshair release docs; do
     fi
     "${NAB[@]}" lock \
         --groups "${group}" \
+        --project-default-group "${group}" \
         --no-emit-workspace \
         --output ".github/requirements/pylock.${group}.toml" \
         "${group_args[@]}" \


### PR DESCRIPTION
`nab lock --groups X` marks the group's packages with a PEP 751 `"X" in dependency_groups` marker and sets top-level `dependency-groups`, but never set `default-groups`. Per PEP 751 an installer seeds the `dependency_groups` marker set from `default-groups`, and neither pip 26.1 nor uv can select a non-default group from a pylock at install time, so `pip install -r pylock.X.toml` evaluated the marker false and skipped every group package (nox, pytest, the type-checkers, and so on). The committed locks worked only because they predate this emitter behaviour.

`tasks/refresh-locks.sh` now passes `--project-default-group "${group}"` alongside `--groups "${group}"`, so each single-group lock declares its group as a default group and installs by default. All six locks are regenerated. Five keep their pinned versions; `crosshair` is refreshed because its old `crosshair-tool` predates wheels for the full Python matrix.

Stacked on #490 (the ceiling change), which is what lets `crosshair` resolve at all.
