### PR TITLE
fix CLI reference: Ctrl-C prints `error: interrupted`, not `Aborted.`

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -230,6 +230,6 @@ matching extra.
 | ---- | ------- |
 | `0`  | Success. |
 | `1`  | Resolution failed, lockfile cannot be written (missing hash), download failed, missing `[project].dependencies`, invalid `[tool.nab]` configuration, or `--locked` found the lockfile out of date or missing. |
-| `130` | Interrupted with Ctrl-C. `nab` prints `Aborted.` and exits. |
+| `130` | Interrupted with Ctrl-C. `nab` prints `error: interrupted` and exits. |
 
 [PEP 751]: https://peps.python.org/pep-0751/


### PR DESCRIPTION
The exit-code table in the CLI reference says nab prints `Aborted.` when interrupted with Ctrl-C, but it actually prints `error: interrupted`. Update the `130` row to match what the CLI does.
