### PR TITLE
assert the wheel is prefetched in the root-batch sdist-skip test

### DIFF
--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -6293,11 +6293,7 @@ class TestSpeculativePrefetchSkipsNonWheelDists:
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
         provider.fetch_versions("foo")
-        # Batch should only contain the wheel v1.0, not the sdist v2.0.
-        if coordinator.request_metadata_batch.called:
-            items = coordinator.request_metadata_batch.call_args[0][0]
-            for _, ver, _, _ in items:
-                assert ver != "2.0"
+        assert _prefetched_batch_versions(coordinator) == ["1.0"]
 
 
 class TestChooseVersionBatchLoop:


### PR DESCRIPTION
test_skips_sdists_in_root_batch was supposed to check that the root prefetch batches the wheel and skips the sdist, but the assertion did neither. It was wrapped in `if request_metadata_batch.called` and only checked `ver != "2.0"`, so it passed even if the prefetch stopped firing at all, and it never confirmed the wheel was prefetched.

Replace it with an exact check that the single batch prefetches ["1.0"], reusing the existing _prefetched_batch_versions helper.
