### PR TITLE
Split synthesized-minor targets on micro boundaries

### DIFF
--- a/docs/explanation/universal.md
+++ b/docs/explanation/universal.md
@@ -26,8 +26,9 @@ alignment.
 
 The lock a matrix produces is the lock a single environment produces,
 with more environments in it: same shape, same
-[environment declaration](../reference/lockfile.md) per tuple, same
-dependency edges.
+[environment declaration](../reference/lockfile.md) mechanism, same
+dependency edges. A tuple whose minor a marker splits contributes one
+declaration per micro slice (see Patch-release markers below).
 
 ## Declaring the matrix
 
@@ -110,9 +111,23 @@ exits 1.
 
 ## Patch-release markers
 
-`python_full_version` defaults to `<minor>.0` per cell. If a
-marker in the dependency graph compares against a patch release,
-declare the real patch you ship on:
+`python_full_version` defaults to `<minor>.0` per cell. When a
+dependency marker compares `python_full_version` against a patch
+release inside a cell's minor (`python_full_version >= "3.11.4"`),
+that minor has a different package set on each side of the boundary,
+so resolving the whole minor at `.0` would declare it by how `.0` read
+the clause and exclude the real interpreters on the other side. nab
+splits the minor at the boundary and resolves one cell per micro slice
+instead: for `>= "3.11.4"`, one cell for `< 3.11.4` and one for
+`>= 3.11.4`, each with its own pins and its own `environments` entry.
+The two entries are disjoint and together cover the whole minor, and
+the gated dep is present only on the slice that reaches it. A marker
+whose boundary lies in a deeper slice (a dep pulled in only above an
+earlier split) is found by re-splitting until no new boundary appears.
+
+Only the ordered comparisons cut a minor (`<`, `<=`, `>`, `>=`). A
+marker naming a single release (`==`, `!=`, `~=`) does not, so declare
+the patch you ship on when one of those gates a dependency:
 
 ```toml
 [tool.nab.matrix.python-patches]
@@ -120,10 +135,9 @@ declare the real patch you ship on:
 "3.12" = "3.12.1"
 ```
 
-Without this, markers like `python_full_version >= "3.11.4"`
-evaluate False on a 3.11 cell, the safe direction (drop the
-gated dep) but a silent failure if your deployed interpreter is
-actually 3.11.4 or later.
+This moves a cell off `.0` onto the micro you name, so such a marker
+evaluates against the interpreter you deploy. A cell a patch names is
+not split: it already sits on a real release.
 
 ## Interpreter implementations
 

--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -145,7 +145,7 @@ absolute, machine-specific path.
 ### The environments the lock is for
 
 A resolve answers for the environments it targeted: the
-[resolve target](configuration.md), or one per tuple of a declared
+[resolve target](configuration.md), or the tuples of a declared
 matrix. Every dependency whose PEP 508 marker was false on a target
 was dropped there, so the pins are not a package set another
 environment can install. The lock says so in the top-level
@@ -184,14 +184,27 @@ so it declares nothing, and a variable no marker's answer turned on
 leaves its axis open.
 
 The lock is then installable on every micro release that reads the
-resolve's markers the way the resolve did, and a marker that
-genuinely splits the micros (`python_full_version >= "3.13.4"`)
-still partitions them. Pinning the value instead would refuse every
-other micro, including every real one when the target names a minor:
-`--python 3.13` synthesizes `3.13.0`, which no released interpreter
-reports. A clause whose complement cannot be stated as a clause (an
-unusual operator such as `~=`, or a PEP 440 prerelease boundary)
-falls back to pinning the exact value.
+resolve's markers the way the resolve did. A clause whose boundary
+lies outside the minor, or on a `.0` prerelease below its floor
+(`<= "3.11.0a6"`), reads the same for every real micro and is declared
+as one clause-complemented row. A clause whose boundary lies inside the
+minor reads differently on each side, so a target whose micro is
+synthesized (a matrix tuple, a declared environment, or a `--python
+<minor>` or platform-less `[tool.nab.environment]` target, which names
+only a minor) is split into micro slices instead, each with its own
+`environments` row and pins: `python_full_version >= "3.13.4"` on a 3.13
+target becomes a `< 3.13.4` row and a `>= 3.13.4` row (see Universal
+mode below).
+
+Pinning the value would refuse every other micro, including every real
+one when the target names a minor: `--python 3.13` synthesizes
+`3.13.0`, which no released interpreter reports, so such a target is
+split rather than pinned. The host target proper, the running
+interpreter nab reads, names a real micro and is not split; its whole
+minor is declared by clause, and so is a target the user pinned to a
+real patch release. A clause whose complement cannot be stated as a
+clause (an unusual operator such as `~=`, or a PEP 440 prerelease
+boundary) falls back to pinning the exact value.
 
 Two variables are never declared: `platform_release` and
 `platform_version` name one machine's kernel build, so a lock
@@ -215,10 +228,14 @@ with PEP 508 markers built from each tuple's `python_version`,
 `sys_platform` and `platform_machine`, plus `implementation_name` on
 the same terms as the `environments` declarations above.
 
-`environments` carries one declaration per tuple, built the same way
-a single-environment lock builds its one: from the markers that
-tuple's resolve consulted. A tuple's `packages.dependencies` edges
-are the union across the tuples an entry covers.
+`environments` carries a declaration per tuple, built the same way a
+single-environment lock builds its one: from the markers that tuple's
+resolve consulted. A tuple whose minor an in-minor `python_full_version`
+boundary splits carries one declaration per micro slice, so a tuple can
+contribute more than one entry (see
+[Universal resolution](../explanation/universal.md)). A tuple's
+`packages.dependencies` edges are the union across the tuples an entry
+covers.
 
 ## Pip-compatible `requirements.txt`
 

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -80,6 +80,8 @@ from .target import (
     ResolveTarget,
     environment_declaration,
     marker_variables,
+    micro_boundary_points,
+    slices_from_points,
 )
 
 if TYPE_CHECKING:
@@ -401,6 +403,158 @@ def resolve_with_coordinator(  # noqa: PLR0913 - the knobs a caller drives a bar
     )
     constraints = [Requirement(text) for text in effective.constraints]
 
+    return _resolve_with_micro_narrowing(
+        list(targets),
+        fork_list,
+        constraints,
+        settings,
+        preferences,
+        base_requirements,
+    )
+
+
+# The number of split-and-resolve passes the micro-narrowing fixpoint runs
+# before giving up.  Each pass resolves the slices the previous pass revealed,
+# which can expose a boundary reachable only above an earlier split; the set of
+# split points grows every pass, so a real graph converges in a couple.  The
+# cap turns a graph that somehow does not converge into a loud error rather than
+# a hang.
+_MAX_MICRO_SPLIT_PASSES = 10
+
+
+def _resolve_with_micro_narrowing(
+    targets: Sequence[ResolveTarget],
+    fork_list: Sequence[ResolveFork],
+    constraints: Sequence[Requirement],
+    settings: _EngineSettings,
+    preferences: Mapping[str, Version] | None,
+    base_requirements: Sequence[Requirement] | None,
+) -> ResolveResult:
+    """Resolve ``targets``, then split any minor a marker cut and re-resolve.
+
+    A consulted marker can cut a minor's micro line
+    (``python_full_version < "3.10.2"``).  Resolving the minor once at its
+    synthesized ``.0`` declares the whole minor by how ``.0`` read the clause,
+    excluding the real interpreters on the other side.  Resolving one target
+    per micro slice instead lets each slice declare its own environment row and
+    pins.
+
+    The split points come from the markers a resolve consulted, so a boundary
+    reachable only above an earlier split is not visible until that slice has
+    been resolved.  The loop is a fixpoint: it re-splits and re-resolves until a
+    pass reveals no new boundary.  Only a minor that split is re-resolved; every
+    target no marker cut (host targets among them, since they name a real micro)
+    keeps its first-pass result.
+    """
+    result = _resolve_passes(
+        targets, fork_list, constraints, settings, preferences, base_requirements
+    )
+    seed = _threaded_preferences(
+        dict(preferences or {}), result.target_results, align=settings.align
+    )
+    points: list[list[Version]] = [[] for _ in targets]
+    combined = result
+    for _ in range(_MAX_MICRO_SPLIT_PASSES):
+        grown = _grow_micro_points(targets, points, combined)
+        if grown is None:
+            return combined
+        points = grown
+        split_sigs = {
+            env_signature(target)
+            for target, target_points in zip(targets, points, strict=True)
+            if target_points
+        }
+        slices = [
+            sliced
+            for target, target_points in zip(targets, points, strict=True)
+            if target_points
+            for sliced in slices_from_points(target, target_points)
+        ]
+        slice_result = _resolve_passes(
+            slices, fork_list, constraints, settings, seed, base_requirements
+        )
+        combined = _merge_micro_results(targets, result, slice_result, split_sigs)
+    msg = (
+        "environment micro-boundary splitting did not converge in"
+        f" {_MAX_MICRO_SPLIT_PASSES} passes"
+    )
+    raise ResolutionError(msg)
+
+
+def _grow_micro_points(
+    targets: Sequence[ResolveTarget],
+    points: Sequence[Sequence[Version]],
+    result: ResolveResult,
+) -> list[list[Version]] | None:
+    """Return ``points`` grown by the boundaries ``result`` consulted, or None.
+
+    None means no minor gained a split point: the fixpoint has settled.  Each
+    target's boundaries are gathered from every slice it currently has, so a
+    boundary a marker consults only above an earlier split is picked up once
+    that slice has been resolved.
+    """
+    consulted_by_sig: dict[EnvSignature, set[Marker]] = defaultdict(set)
+    for tr in result.every_result:
+        consulted_by_sig[env_signature(tr.target)] |= set(tr.consulted)
+
+    grown: list[list[Version]] = []
+    changed = False
+    for target, target_points in zip(targets, points, strict=True):
+        found = set(target_points)
+        for sliced in slices_from_points(target, target_points):
+            consulted = consulted_by_sig.get(env_signature(sliced), set())
+            found.update(micro_boundary_points(target, consulted))
+        ordered = sorted(found)
+        if ordered != list(target_points):
+            changed = True
+        grown.append(ordered)
+    return grown if changed else None
+
+
+def _merge_micro_results(
+    targets: Sequence[ResolveTarget],
+    result: ResolveResult,
+    slice_result: ResolveResult,
+    split_sigs: set[EnvSignature],
+) -> ResolveResult:
+    """Fold ``slice_result`` back over the first-pass ``result``.
+
+    A target that split is dropped from ``result`` (its ``.0`` entry and its
+    base pass) and its slices are taken from ``slice_result`` instead; every
+    unsplit target keeps its first-pass entry, so it is never resolved again.
+    """
+
+    def kept(results: Sequence[TargetResult]) -> list[TargetResult]:
+        return [tr for tr in results if env_signature(tr.target) not in split_sigs]
+
+    env_base_names = {
+        sig: names
+        for sig, names in result.env_base_names.items()
+        if sig not in split_sigs
+    }
+    env_base_names.update(slice_result.env_base_names)
+    unsplit = tuple(t for t in targets if env_signature(t) not in split_sigs)
+    return ResolveResult(
+        targets=(*unsplit, *slice_result.targets),
+        target_results=kept(result.target_results) + list(slice_result.target_results),
+        base_results=kept(result.base_results) + list(slice_result.base_results),
+        env_base_names=env_base_names,
+    )
+
+
+def _resolve_passes(
+    targets: Sequence[ResolveTarget],
+    fork_list: Sequence[ResolveFork],
+    constraints: Sequence[Requirement],
+    settings: _EngineSettings,
+    preferences: Mapping[str, Version] | None,
+    base_requirements: Sequence[Requirement] | None,
+) -> ResolveResult:
+    """Resolve every fork against every target, plus the base pass.
+
+    The fork loop threads each target's pins forward across the whole run;
+    the base pass, when given, records the no-member pins per environment.
+    """
     accumulated = dict(preferences or {})
     results: list[TargetResult] = []
     for fork in fork_list:

--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -56,7 +56,9 @@ __all__ = [
     "environment_declaration",
     "host_environment",
     "marker_variables",
+    "micro_boundary_points",
     "python_axis_environment",
+    "slices_from_points",
     "unboundable_variables",
 ]
 
@@ -334,6 +336,14 @@ def environment_declaration(target: ResolveTarget, consulted: Iterable[Marker]) 
             clauses.extend(_version_clauses(declaring, texts, name))
         else:
             clauses.append(f'{name} == "{target.marker_env[name]}"')
+
+    # A micro-slice target (see :func:`slices_from_points`) carries the
+    # python_full_version bounds of its slice explicitly, so the environment
+    # row covers exactly that slice even if the consulted markers did not pin
+    # both ends.  Deduped against what _version_clauses derived.
+    for clause in target.micro_clauses:
+        if clause not in clauses:
+            clauses.append(clause)
     return " and ".join(clauses)
 
 
@@ -557,6 +567,164 @@ def _declared_clause(
     return complement
 
 
+# The comparison operators whose truth, over the releases of one minor,
+# flips exactly at the literal (``<``/``>=``) or just past it, at the smallest
+# real micro above it (``<=``/``>``).  A clause using one of these against an
+# in-minor literal is a boundary the micro line has to be split on.
+_SPLIT_AT_LITERAL = frozenset({"<", ">="})
+_SPLIT_AFTER_LITERAL = frozenset({"<=", ">"})
+
+# PEP 508 lets either operand be the variable, and packaging preserves the
+# written order, so ``python_full_version < "3.10.2"`` and its literal-first
+# equivalent ``"3.10.2" > python_full_version`` both reach the split path.
+# When the literal is on the left, the operator's meaning is mirrored, so it
+# is flipped back to the variable-on-left form before the flip release is read.
+_MIRRORED_OPERATOR: dict[str, str] = {"<": ">", ">": "<", "<=": ">=", ">=": "<="}
+
+
+def slices_from_points(
+    target: ResolveTarget, points: Sequence[Version]
+) -> list[ResolveTarget]:
+    """Partition ``target``'s minor into one slice per micro interval.
+
+    ``points`` are the in-minor releases the micro line is cut at (see
+    :func:`micro_boundary_points`), sorted ascending.  They partition
+    ``[{minor}.0, inf)`` into intervals; each interval becomes ``target``
+    moved onto its lower-bound release, carrying the python_full_version
+    bounds that fence it off (see :meth:`ResolveTarget.with_micro_slice`).
+    Every marker answers unambiguously at an interval's lower bound, so that
+    release is where the slice resolves.  Each slice declares its own
+    environment row and pins, so a marker that genuinely splits the micros is
+    honoured per slice rather than lifted onto the whole minor.
+
+    Returns ``[target]`` unchanged when ``points`` is empty: nothing cut the
+    minor, so the whole minor resolves at once.
+    """
+    if not points:
+        return [target]
+    floor = Version(f"{target.python_version}.0")
+    reps = [floor, *points]
+    lowers: list[Version | None] = [None, *points]
+    uppers: list[Version | None] = [*points, None]
+
+    slices: list[ResolveTarget] = []
+    for rep, low, high in zip(reps, lowers, uppers, strict=True):
+        clauses: list[str] = []
+        if low is not None:
+            clauses.append(f'python_full_version >= "{low}"')
+        if high is not None:
+            clauses.append(f'python_full_version < "{high}"')
+        slices.append(target.with_micro_slice(str(rep), tuple(clauses)))
+    return slices
+
+
+def micro_boundary_points(
+    target: ResolveTarget, consulted: Iterable[Marker]
+) -> list[Version]:
+    """Return the in-minor releases ``consulted`` cuts ``target``'s minor at.
+
+    A declared target names a minor and synthesizes ``{minor}.0`` for its
+    ``python_full_version``.  When a consulted marker compares
+    ``python_full_version`` against a literal inside that minor
+    (``python_full_version < "3.10.2"``), the minor was resolved at ``.0``,
+    where that clause reads one way, but a real interpreter on the other side
+    of the literal (every real 3.10 is 3.10.2 or newer) reads it the other way
+    and needs a different package set.  The release the clause flips at is a
+    point the micro line has to be split on (see :func:`slices_from_points`).
+
+    Only the ordered operators cut a line: ``<``/``>=`` flip at the literal,
+    ``<=``/``>`` at the release just after it.  ``==``/``!=``/``~=``/``===``
+    and membership tests name a single release or a set with no single flip,
+    and are left to the whole-minor declaration.
+
+    A host-faithful target is the running interpreter, so its micro is the
+    real one it reports and nothing is cut, even on the rare host that reports
+    ``{minor}.0``.  Every other target synthesizes ``{minor}.0``: a matrix
+    tuple, a platform ``[tool.nab.environment]``, and equally a ``--python
+    <minor>`` or platform-less ``[tool.nab.environment]`` target, which shares
+    the host's platform but names only a minor.  All of those are cut the same
+    way.  A target a user pinned to a real patch release
+    (``python_full_version`` past ``.0``) names a real deployment micro and is
+    left alone.
+    """
+    if target.host_faithful:
+        return []
+    minor = target.python_version
+    floor_str = f"{minor}.0"
+    if target.python_full_version != floor_str:
+        return []
+    minor_release = Version(floor_str).release[:_PYTHON_VERSION_PARTS]
+    floor = Version(floor_str)
+
+    points: set[Version] = set()
+    for marker in consulted:
+        for atom in _MARKER_CLAUSE_RE.finditer(str(marker)):
+            point = _clause_split_point(_clause_parts(atom), minor_release, floor)
+            if point is not None:
+                points.add(point)
+    return sorted(points)
+
+
+def _clause_split_point(
+    parts: tuple[str, str, str],
+    minor_release: tuple[int, ...],
+    floor: Version,
+) -> Version | None:
+    """Return the release ``lhs op rhs`` splits ``floor``'s minor at, or None.
+
+    None when the clause is not an ordered comparison of
+    ``python_full_version`` against an in-minor literal whose flip release is
+    above ``floor``.  The flip is what matters, not the literal: ``<``/``>=``
+    flip at the literal, so a literal equal to ``floor`` cuts nothing, but
+    ``<=``/``>`` flip one release past it, so ``> "3.10.0"`` still cuts the
+    line at ``3.10.1``.  A literal-first clause (``"3.10.2" > python_full_version``)
+    has the operator mirrored back to variable-on-left form first, so it reads
+    the same flip as its ``python_full_version < "3.10.2"`` equivalent.
+    """
+    lhs, op, rhs = parts
+    if "python_full_version" not in (lhs, rhs):
+        return None
+    if lhs == "python_full_version":
+        literal = rhs
+    else:
+        literal = lhs
+        op = _MIRRORED_OPERATOR.get(op, op)
+    if not literal.startswith('"'):
+        return None
+    try:
+        boundary = Version(literal.strip('"'))
+    except InvalidVersion:
+        return None
+    if boundary.release[:_PYTHON_VERSION_PARTS] != minor_release:
+        return None
+    point = _split_point(op, boundary)
+    if point is None or point <= floor:
+        return None
+    return point
+
+
+def _split_point(op: str, boundary: Version) -> Version | None:
+    """Return the release the micro line splits at for ``op boundary``.
+
+    ``<``/``>=`` flip exactly at the boundary.  ``<=``/``>`` flip at the
+    smallest real micro strictly above it: the boundary's own final release
+    when the boundary is a prerelease or dev release of it (``<= "3.11.0a6"``
+    flips at ``3.11.0``, not ``3.11.1``, so it does not narrow a whole 3.11),
+    and the next micro otherwise (``<= "3.11.0"`` flips at ``3.11.1``).  Any
+    other operator returns ``None`` (not split here).
+    """
+    if op in _SPLIT_AT_LITERAL:
+        return boundary
+    if op in _SPLIT_AFTER_LITERAL:
+        release = boundary.release
+        micro = release[2] if len(release) >= _PYTHON_FULL_VERSION_PARTS else 0
+        final = Version(f"{release[0]}.{release[1]}.{micro}")
+        if final > boundary:
+            return final
+        return Version(f"{release[0]}.{release[1]}.{micro + 1}")
+    return None
+
+
 def host_environment(
     env_source: EnvironmentSource = default_environment,
 ) -> dict[str, str]:
@@ -665,6 +833,12 @@ class ResolveTarget:
     platform_spec: PlatformSpec | None = field(default=None, compare=False)
     multi_implementation: bool = field(default=False, compare=False)
     tags_faithful: bool = field(default=True, compare=False)
+    # The python_full_version clauses bounding this target's micro slice, set
+    # by :func:`slices_from_points` when a consulted marker splits the minor.
+    # Empty for an ordinary target.  Appended to
+    # :attr:`environment_marker_string` so the per-package pins of one slice
+    # do not leak onto another slice of the same python/platform.
+    micro_clauses: tuple[str, ...] = field(default=(), compare=False)
 
     def __post_init__(self) -> None:
         """Reject a python the resolve cannot compare Requires-Python against.
@@ -765,6 +939,8 @@ class ResolveTarget:
         )
         if self.declares_implementation:
             marker += f' and implementation_name == "{self.implementation}"'
+        for clause in self.micro_clauses:
+            marker += f" and {clause}"
         return marker
 
     @property
@@ -838,6 +1014,30 @@ class ResolveTarget:
             self,
             label=base + _selection_suffix(selection),
             selection=selection,
+        )
+
+    def with_micro_slice(
+        self, python_full_version: str, clauses: tuple[str, ...]
+    ) -> ResolveTarget:
+        """Return this target moved onto one micro slice of its minor.
+
+        ``python_full_version`` is the representative release the slice
+        resolves at (its lower bound), and ``clauses`` are the
+        python_full_version bounds that fence the slice off from the others,
+        appended to :attr:`environment_marker_string`.  The label gains a
+        ``-pfXYZ`` suffix so each slice pins under its own key.  The python
+        axis is re-derived, so ``python_version`` stays the minor and only
+        the micro (and, on CPython, ``implementation_version``) moves; the
+        wheel tags do not move with the micro, so they stay faithful.
+        """
+        env = dict(self.marker_env)
+        apply_python_axis_overlay(env, {"python_full_version": python_full_version})
+        compact = python_full_version.replace(".", "")
+        return replace(
+            self,
+            label=f"{self.label}-pf{compact}",
+            marker_env=env,
+            micro_clauses=clauses,
         )
 
     @classmethod

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -3533,22 +3533,51 @@ class TestLockDeclaresItsEnvironment:
         assert "tomli" not in _locked(lock_input)
         assert Marker(str(environment)).evaluate(_PY312_ENV)
 
-    def test_a_marker_that_splits_the_micros_refuses_the_other_side(
+    def test_a_marker_that_splits_the_micros_resolves_each_side(
         self, tmp_path: Path
     ) -> None:
-        """Here the micro really does change the pins, so the lock says so."""
-        lock_input = self._resolve(
-            tmp_path,
-            self._PYPROJECT,
-            self._coordinator('Requires-Dist: bar ; python_full_version >= "3.12.4"\n'),
+        """A micro that changes the pins splits the minor into two slices.
+
+        ``foo`` needs ``bar`` only on 3.12.4 and up, so the minor cannot be
+        declared by how ``3.12.0`` read the clause: that would exclude every
+        real 3.12.  The engine resolves one slice per side of the boundary, each
+        with its own environment row and pins, and ``bar`` joins only the upper
+        slice.
+        """
+        coordinator = make_coordinator(
+            listings={
+                "foo": _index_wheels("foo", "1.0"),
+                "bar": _index_wheels("bar", "2.0"),
+            },
+            metadata_by_version={
+                "1.0": (
+                    "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n"
+                    'Requires-Dist: bar ; python_full_version >= "3.12.4"\n'
+                ),
+                "2.0": "Metadata-Version: 2.1\nName: bar\nVersion: 2.0\n",
+            },
         )
-        (environment,) = lock_input.environments
-        assert 'python_full_version < "3.12.4"' in str(environment)
-        assert "bar" not in _locked(lock_input)
-        assert Marker(str(environment)).evaluate(_PY312_ENV)
-        assert not Marker(str(environment)).evaluate(
-            {**_PY312_ENV, "python_full_version": "3.12.5"}
-        )
+        lock_input = self._resolve(tmp_path, self._PYPROJECT, coordinator)
+
+        below = lock_input.targets["py312-linux_x86_64-pf3120"]
+        above = lock_input.targets["py312-linux_x86_64-pf3124"]
+        assert set(below.pins) == {"foo"}
+        assert set(above.pins) == {"foo", "bar"}
+
+        rows = {
+            "below" if 'python_full_version < "3.12.4"' in str(m) else "above": str(m)
+            for m in lock_input.environments
+        }
+        assert set(rows) == {"below", "above"}
+        assert 'python_full_version >= "3.12.4"' in rows["above"]
+
+        # The two rows are disjoint and together cover the whole minor.
+        low = {**_PY312_ENV, "python_full_version": "3.12.1"}
+        high = {**_PY312_ENV, "python_full_version": "3.12.5"}
+        assert Marker(rows["below"]).evaluate(low)
+        assert not Marker(rows["below"]).evaluate(high)
+        assert Marker(rows["above"]).evaluate(high)
+        assert not Marker(rows["above"]).evaluate(low)
 
 
 class TestExtraAndGroupMembershipMarkers:

--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -1820,3 +1820,264 @@ class TestSharedListingFilter:
 
         assert result.success
         assert [tr.distributions_seen for tr in result.target_results] == [2, 2]
+
+
+class TestMicroBoundaryNarrowing:
+    """A minor a consulted marker cuts is resolved once per micro slice.
+
+    A declared target names a minor and synthesizes ``{minor}.0``.  When a
+    marker's python_full_version boundary lies inside that minor, resolving
+    the whole minor at ``.0`` would declare it by how ``.0`` read the clause,
+    excluding the real interpreters on the other side.  The engine splits the
+    minor and resolves each slice instead.
+    """
+
+    @staticmethod
+    def _coordinator(metadata: dict[str, str]) -> MagicMock:
+        listings = {
+            name: [_make_wheel(version, package=name)]
+            for name, version in (("foo", "1.0"), ("mid", "2.0"), ("top", "3.0"))
+        }
+        return make_coordinator(listings=listings, metadata_by_version=metadata)
+
+    @staticmethod
+    def _meta(name: str, version: str, *requires: str) -> str:
+        head = f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n"
+        return head + "".join(f"Requires-Dist: {req}\n" for req in requires)
+
+    @staticmethod
+    def _pins_by_label(result: ResolveResult) -> dict[str, set[str]]:
+        return {tr.target.label: set(tr.pins) for tr in result.target_results}
+
+    def test_only_split_targets_are_re_resolved(self) -> None:
+        """An unsplit minor keeps its first-pass result; only the split one
+        is resolved again, so the whole matrix is not re-run."""
+        coordinator = self._coordinator(
+            {
+                "1.0": self._meta(
+                    "foo", "1.0", 'mid ; python_full_version >= "3.10.4"'
+                ),
+                "2.0": self._meta("mid", "2.0"),
+            }
+        )
+        targets = Matrix(
+            python=">=3.10,<3.13", platforms=(PlatformSpec("linux_x86_64"),)
+        ).expand()
+
+        with patch.object(
+            resolve_mod,
+            "_resolve_one_target",
+            wraps=resolve_mod._resolve_one_target,
+        ) as spy:
+            result = resolve_with_coordinator(
+                coordinator, targets, _reqs("foo"), config=_no_build()
+            )
+
+        assert result.success
+        labels = [call.args[0].label for call in spy.call_args_list]
+        # 3.11 and 3.12 have no in-minor boundary, so each resolves once.
+        assert labels.count("py311-linux_x86_64") == 1
+        assert labels.count("py312-linux_x86_64") == 1
+        # Three minors resolved once each, plus 3.10's two slices: no full re-run.
+        assert len(labels) == 5
+
+    def test_a_host_target_is_not_split(self) -> None:
+        """A host target names a real micro, so no ``.0`` is synthesized and a
+        full-version marker never splits it."""
+        coordinator = self._coordinator(
+            {
+                "1.0": self._meta(
+                    "foo", "1.0", 'mid ; python_full_version >= "3.10.4"'
+                ),
+                "2.0": self._meta("mid", "2.0"),
+            }
+        )
+
+        with patch.object(
+            resolve_mod,
+            "_resolve_one_target",
+            wraps=resolve_mod._resolve_one_target,
+        ) as spy:
+            result = resolve_with_coordinator(
+                coordinator,
+                [ResolveTarget.for_host()],
+                _reqs("foo"),
+                config=_no_build(),
+            )
+
+        assert result.success
+        assert len(result.target_results) == 1
+        assert spy.call_count == 1
+
+    @staticmethod
+    def _linux_host_env() -> dict[str, str]:
+        return {
+            "implementation_name": "cpython",
+            "os_name": "posix",
+            "platform_machine": "x86_64",
+            "platform_python_implementation": "CPython",
+            "platform_release": "6.8.0",
+            "platform_system": "Linux",
+            "python_full_version": "3.13.2",
+            "python_version": "3.13",
+            "sys_platform": "linux",
+        }
+
+    def test_a_bare_minor_python_target_splits_and_covers_the_minor(self) -> None:
+        """``--python 3.11`` (and a platform-less ``[tool.nab.environment]``)
+        synthesizes ``3.11.0`` yet carries no ``platform_spec``.  A dep gated
+        below a patch still splits it, so the lock covers every real 3.11
+        instead of a row an installer rejects on 3.11.9.
+        """
+        coordinator = self._coordinator(
+            {
+                "1.0": self._meta("foo", "1.0", 'mid ; python_full_version < "3.11.4"'),
+                "2.0": self._meta("mid", "2.0"),
+            }
+        )
+        target = ResolveTarget.for_host_python("3.11", env_source=self._linux_host_env)
+
+        result = resolve_with_coordinator(
+            coordinator, [target], _reqs("foo"), config=_no_build()
+        )
+
+        assert result.success
+        assert self._pins_by_label(result) == {
+            "py311-host-pf3110": {"foo", "mid"},
+            "py311-host-pf3114": {"foo"},
+        }
+        rows = build_lock_input(result, config=_no_build()).environments
+        assert len(rows) == 2
+        real_3119 = {
+            "python_version": "3.11",
+            "python_full_version": "3.11.9",
+            "sys_platform": "linux",
+            "platform_machine": "x86_64",
+            "implementation_name": "cpython",
+        }
+        assert any(row.evaluate(real_3119) for row in rows)
+
+    def _fixpoint_coordinator(self) -> MagicMock:
+        return self._coordinator(
+            {
+                "1.0": self._meta(
+                    "foo", "1.0", 'mid ; python_full_version >= "3.10.2"'
+                ),
+                "2.0": self._meta(
+                    "mid", "2.0", 'top ; python_full_version >= "3.10.5"'
+                ),
+                "3.0": self._meta("top", "3.0"),
+            }
+        )
+
+    def test_a_boundary_reachable_only_above_a_split_is_found(self) -> None:
+        """``top``'s 3.10.5 boundary is consulted only once ``mid`` is present,
+        which needs 3.10.2 first.  The fixpoint re-splits until it settles."""
+        targets = Matrix(
+            python="==3.10", platforms=(PlatformSpec("linux_x86_64"),)
+        ).expand()
+
+        result = resolve_with_coordinator(
+            self._fixpoint_coordinator(), targets, _reqs("foo"), config=_no_build()
+        )
+
+        assert result.success
+        assert self._pins_by_label(result) == {
+            "py310-linux_x86_64-pf3100": {"foo"},
+            "py310-linux_x86_64-pf3102": {"foo", "mid"},
+            "py310-linux_x86_64-pf3105": {"foo", "mid", "top"},
+        }
+
+    def test_a_split_that_does_not_converge_raises(self) -> None:
+        """The pass cap turns a graph that never settles into a loud error
+        rather than a hang."""
+        targets = Matrix(
+            python="==3.10", platforms=(PlatformSpec("linux_x86_64"),)
+        ).expand()
+
+        with (
+            patch.object(resolve_mod, "_MAX_MICRO_SPLIT_PASSES", 1),
+            pytest.raises(ResolutionError, match="did not converge"),
+        ):
+            resolve_with_coordinator(
+                self._fixpoint_coordinator(),
+                targets,
+                _reqs("foo"),
+                config=_no_build(),
+            )
+
+    def test_divergent_slice_pins_validate_as_disjoint(self) -> None:
+        """Two slices pinning one package at different versions carry disjoint
+        micro markers, so the emitted lock passes disjointness validation."""
+        coordinator = make_coordinator(
+            listings={
+                "bar": [
+                    _make_wheel("1.0", package="bar"),
+                    _make_wheel("2.0", package="bar"),
+                ]
+            },
+            auto_metadata=True,
+        )
+        targets = Matrix(
+            python="==3.10", platforms=(PlatformSpec("linux_x86_64"),)
+        ).expand()
+
+        result = resolve_with_coordinator(
+            coordinator,
+            targets,
+            _reqs(
+                'bar==1.0 ; python_full_version < "3.10.4"',
+                'bar==2.0 ; python_full_version >= "3.10.4"',
+            ),
+            config=_no_build(),
+        )
+
+        assert result.success
+        versions = {
+            tr.target.label: str(tr.pins["bar"]) for tr in result.target_results
+        }
+        assert versions == {
+            "py310-linux_x86_64-pf3100": "1.0",
+            "py310-linux_x86_64-pf3104": "2.0",
+        }
+
+        pylock = build_pylock(build_lock_input(result, config=_no_build()))
+        pylock.validate()
+        bars = [pkg for pkg in pylock.packages if str(pkg.name) == "bar"]
+        assert len(bars) == 2
+
+    def test_a_literal_on_the_left_marker_splits_and_covers_the_minor(self) -> None:
+        """A dep gated by a literal-first marker (``"3.10.4" > pfv``) splits
+        the minor the same as ``pfv < "3.10.4"`` would, so the two rows cover
+        every real 3.10 with no interpreter left between them.
+        """
+        coordinator = self._coordinator(
+            {
+                "1.0": self._meta("foo", "1.0", 'mid ; "3.10.4" > python_full_version'),
+                "2.0": self._meta("mid", "2.0"),
+            }
+        )
+        targets = Matrix(
+            python="==3.10", platforms=(PlatformSpec("linux_x86_64"),)
+        ).expand()
+
+        result = resolve_with_coordinator(
+            coordinator, targets, _reqs("foo"), config=_no_build()
+        )
+
+        assert result.success
+        assert self._pins_by_label(result) == {
+            "py310-linux_x86_64-pf3100": {"foo", "mid"},
+            "py310-linux_x86_64-pf3104": {"foo"},
+        }
+        rows = build_lock_input(result, config=_no_build()).environments
+        assert len(rows) == 2
+        for micro in ("3.10.0", "3.10.3", "3.10.4", "3.10.19"):
+            env = {
+                "python_version": "3.10",
+                "python_full_version": micro,
+                "sys_platform": "linux",
+                "platform_machine": "x86_64",
+                "implementation_name": "cpython",
+            }
+            assert sum(row.evaluate(env) for row in rows) == 1

--- a/nab-python/tests/test_target.py
+++ b/nab-python/tests/test_target.py
@@ -26,7 +26,9 @@ from nab_python.target import (
     environment_declaration,
     host_environment,
     marker_variables,
+    micro_boundary_points,
     python_axis_environment,
+    slices_from_points,
     unboundable_variables,
 )
 
@@ -1028,3 +1030,263 @@ class TestDecidingClauses:
             ],
         )
         assert 'python_full_version < "3.13.5"' in declaration
+
+
+class TestMicroBoundarySplitting:
+    """A declared target names a minor and synthesizes its ``.0`` micro.  A
+    consulted marker with an in-minor python_full_version boundary cuts the
+    micro line, and the minor is resolved once per slice.
+    """
+
+    def _target(
+        self, python_version: str = "3.12", full_version: str | None = None
+    ) -> ResolveTarget:
+        return ResolveTarget.for_declared(
+            python_version=python_version,
+            spec=PlatformSpec("linux_x86_64"),
+            python_full_version=full_version,
+        )
+
+    def _probe(self, full_version: str) -> dict[str, str]:
+        return {
+            "python_version": "3.12",
+            "python_full_version": full_version,
+            "sys_platform": "linux",
+            "platform_machine": "x86_64",
+            "implementation_name": "cpython",
+        }
+
+    @pytest.mark.parametrize(
+        ("marker", "points"),
+        [
+            ('python_full_version < "3.12.4"', ["3.12.4"]),
+            ('python_full_version >= "3.12.4"', ["3.12.4"]),
+            ('python_full_version <= "3.12.4"', ["3.12.5"]),
+            ('python_full_version > "3.12.4"', ["3.12.5"]),
+            ('python_full_version == "3.12.4"', []),
+            ('python_full_version != "3.12.4"', []),
+            ('python_full_version ~= "3.12.4"', []),
+        ],
+    )
+    def test_each_operator_maps_to_its_flip_release(
+        self, marker: str, points: list[str]
+    ) -> None:
+        found = micro_boundary_points(self._target(), [Marker(marker)])
+        assert [str(point) for point in found] == points
+
+    @pytest.mark.parametrize(
+        ("marker", "points"),
+        [
+            ('"3.12.4" > python_full_version', ["3.12.4"]),
+            ('"3.12.4" <= python_full_version', ["3.12.4"]),
+            ('"3.12.4" >= python_full_version', ["3.12.5"]),
+            ('"3.12.4" < python_full_version', ["3.12.5"]),
+            ('"3.12.4" == python_full_version', []),
+            ('"3.12.4" != python_full_version', []),
+            ('"3.12.4" ~= python_full_version', []),
+        ],
+    )
+    def test_a_literal_on_the_left_mirrors_the_operator(
+        self, marker: str, points: list[str]
+    ) -> None:
+        """PEP 508 allows the literal first, and packaging keeps that order.
+        The operator's meaning is mirrored there, so each literal-first clause
+        cuts at the same release as its variable-first equivalent:
+        ``"3.12.4" > python_full_version`` reads like ``< "3.12.4"``.
+        """
+        found = micro_boundary_points(self._target(), [Marker(marker)])
+        assert [str(point) for point in found] == points
+
+    @pytest.mark.parametrize(
+        ("marker", "points"),
+        [
+            ('python_full_version < "3.12.0"', []),
+            ('python_full_version >= "3.12.0"', []),
+            ('python_full_version <= "3.12.0"', ["3.12.1"]),
+            ('python_full_version > "3.12.0"', ["3.12.1"]),
+            ('python_full_version < "3.12"', []),
+            ('python_full_version >= "3.12"', []),
+            ('python_full_version <= "3.12"', ["3.12.1"]),
+            ('python_full_version > "3.12"', ["3.12.1"]),
+        ],
+    )
+    def test_a_boundary_at_the_floor_splits_only_after_the_literal(
+        self, marker: str, points: list[str]
+    ) -> None:
+        """``.0`` is the minor's floor. ``<``/``>=`` flip there and cut
+        nothing, but ``<=``/``>`` flip at ``.1``, so they still split. The
+        two-component literal ``3.12`` equals ``3.12.0`` and behaves the same.
+        """
+        found = micro_boundary_points(self._target(), [Marker(marker)])
+        assert [str(point) for point in found] == points
+
+    def test_an_after_literal_prerelease_below_the_floor_does_not_split(
+        self,
+    ) -> None:
+        """``<= "3.11.0a6"`` flips at ``3.11.0``, the minor's floor, so the
+        whole real minor reads it False. Bumping to ``3.11.1`` would split it
+        spuriously; the flip is the boundary's own final release, not the next
+        micro."""
+        target = self._target(python_version="3.11")
+        markers = [
+            Marker('python_full_version <= "3.11.0a6"'),
+            Marker('python_full_version > "3.11.0a6"'),
+        ]
+        assert micro_boundary_points(target, markers) == []
+
+    def test_an_after_literal_prerelease_above_the_floor_splits_at_its_final(
+        self,
+    ) -> None:
+        """``<= "3.12.2a1"`` flips at ``3.12.2``, its own final release, so a
+        real 3.12.1 and 3.12.2 land on opposite slices."""
+        found = micro_boundary_points(
+            self._target(), [Marker('python_full_version <= "3.12.2a1"')]
+        )
+        assert [str(point) for point in found] == ["3.12.2"]
+
+    def test_an_after_literal_post_release_splits_at_the_next_micro(self) -> None:
+        """A post release sorts above its final, so ``<= "3.11.0.post1"`` still
+        flips at the next micro, ``3.11.1``."""
+        found = micro_boundary_points(
+            self._target(python_version="3.11"),
+            [Marker('python_full_version <= "3.11.0.post1"')],
+        )
+        assert [str(point) for point in found] == ["3.11.1"]
+
+    def test_a_boundary_outside_the_minor_does_not_split(self) -> None:
+        """An earlier or later minor is the whole-minor declaration's business."""
+        markers = [
+            Marker('python_full_version < "3.11.5"'),
+            Marker('python_full_version >= "3.13.0"'),
+        ]
+        assert micro_boundary_points(self._target(), markers) == []
+
+    def test_a_comparison_against_another_variable_does_not_split(self) -> None:
+        assert (
+            micro_boundary_points(
+                self._target(), [Marker("python_full_version < python_version")]
+            )
+            == []
+        )
+
+    def test_an_unparseable_version_literal_does_not_split(self) -> None:
+        """A literal that is not a PEP 440 version names no release to cut at."""
+        assert (
+            micro_boundary_points(
+                self._target(), [Marker('python_full_version < "3.12.x"')]
+            )
+            == []
+        )
+
+    def test_a_non_version_clause_is_ignored(self) -> None:
+        """Only the python_full_version clause of a marker is a boundary."""
+        found = micro_boundary_points(
+            self._target(),
+            [Marker('python_full_version < "3.12.4" and os_name == "posix"')],
+        )
+        assert [str(point) for point in found] == ["3.12.4"]
+
+    def test_many_boundaries_in_one_minor_all_split(self) -> None:
+        found = micro_boundary_points(
+            self._target(),
+            [
+                Marker('python_full_version < "3.12.2"'),
+                Marker('python_full_version >= "3.12.6"'),
+                Marker('python_full_version <= "3.12.8"'),
+            ],
+        )
+        assert [str(point) for point in found] == ["3.12.2", "3.12.6", "3.12.9"]
+
+    def test_a_host_target_is_never_split(self) -> None:
+        """A host target names a real micro, so nothing is synthesized to cut."""
+        host = ResolveTarget.for_host(env_source=_host_env, tags_source=_host_tags)
+        assert (
+            micro_boundary_points(host, [Marker('python_full_version < "3.13.4"')])
+            == []
+        )
+
+    def test_a_user_pinned_micro_is_never_split(self) -> None:
+        """A declared target moved past ``.0`` names a real deployment micro."""
+        assert (
+            micro_boundary_points(
+                self._target(full_version="3.12.4"),
+                [Marker('python_full_version < "3.12.6"')],
+            )
+            == []
+        )
+
+    def test_a_bare_minor_python_target_is_split(self) -> None:
+        """``--python 3.11`` (and a platform-less ``[tool.nab.environment]``)
+        synthesizes ``3.11.0`` like a matrix tuple, so an in-minor boundary
+        cuts it even though it carries no ``platform_spec``."""
+        target = ResolveTarget.for_host_python(
+            "3.11", env_source=_host_env, tags_source=_host_tags
+        )
+        assert target.platform_spec is None
+        found = micro_boundary_points(
+            target, [Marker('python_full_version < "3.11.4"')]
+        )
+        assert [str(point) for point in found] == ["3.11.4"]
+
+    def test_a_host_target_at_a_zero_micro_is_never_split(self) -> None:
+        """A host reporting ``3.13.0`` names a real interpreter, so it stays
+        whole even though its micro equals the minor's floor."""
+        host = ResolveTarget.for_host(
+            env_source=lambda: {**_host_env(), "python_full_version": "3.13.0"},
+            tags_source=_host_tags,
+        )
+        assert (
+            micro_boundary_points(host, [Marker('python_full_version < "3.13.4"')])
+            == []
+        )
+
+    def test_no_points_leaves_the_target_whole(self) -> None:
+        target = self._target()
+        assert slices_from_points(target, []) == [target]
+
+    def test_one_point_makes_two_slices(self) -> None:
+        below, above = slices_from_points(self._target(), [Version("3.12.4")])
+        assert below.label == "py312-linux_x86_64-pf3120"
+        assert below.python_full_version == "3.12.0"
+        assert below.micro_clauses == ('python_full_version < "3.12.4"',)
+        assert above.label == "py312-linux_x86_64-pf3124"
+        assert above.python_full_version == "3.12.4"
+        assert above.micro_clauses == ('python_full_version >= "3.12.4"',)
+
+    def test_a_middle_slice_carries_both_bounds(self) -> None:
+        points = [Version("3.12.4"), Version("3.12.8")]
+        _low, mid, _high = slices_from_points(self._target(), points)
+        assert mid.python_full_version == "3.12.4"
+        assert mid.micro_clauses == (
+            'python_full_version >= "3.12.4"',
+            'python_full_version < "3.12.8"',
+        )
+
+    def test_slice_rows_are_disjoint_and_cover_the_minor(self) -> None:
+        below, above = slices_from_points(self._target(), [Version("3.12.4")])
+        consulted = [Marker('python_full_version >= "3.12.4"')]
+        below_row = environment_declaration(below, consulted)
+        above_row = environment_declaration(above, consulted)
+        assert 'python_full_version < "3.12.4"' in below_row
+        assert 'python_full_version >= "3.12.4"' in above_row
+        assert Marker(below_row).evaluate(self._probe("3.12.1"))
+        assert not Marker(below_row).evaluate(self._probe("3.12.5"))
+        assert Marker(above_row).evaluate(self._probe("3.12.5"))
+        assert not Marker(above_row).evaluate(self._probe("3.12.1"))
+
+    def test_a_slice_appends_a_bound_the_clauses_did_not_derive(self) -> None:
+        """A ``<=`` boundary flips one release past the literal, so the slice's
+        own upper bound is not the clause the resolve read, and it is added."""
+        below, _above = slices_from_points(self._target(), [Version("3.12.5")])
+        row = environment_declaration(
+            below, [Marker('python_full_version <= "3.12.4"')]
+        )
+        assert 'python_full_version <= "3.12.4"' in row
+        assert 'python_full_version < "3.12.5"' in row
+
+    def test_a_slice_marker_string_carries_its_micro_bounds(self) -> None:
+        below, above = slices_from_points(self._target(), [Version("3.12.4")])
+        assert below.environment_marker_string.endswith(
+            'and python_full_version < "3.12.4"'
+        )
+        assert 'python_full_version >= "3.12.4"' in above.environment_marker_string


### PR DESCRIPTION
A lock target that names only a Python minor (a matrix tuple, a declared environment, or a `--python <minor>` target) synthesizes `{minor}.0` and resolves the whole minor there. When a consulted marker compared `python_full_version` against a patch release inside that minor (`python_full_version >= "3.10.4"`), the minor's PEP 751 `environments` row was declared by how `.0` read the clause, excluding every real interpreter past the boundary, 3.10.19 among them.

Now such a minor is split at each in-minor boundary, and each micro slice resolves on its own with its own `environments` row and pins. The gated dependency joins only the slice that reaches it, and the slices are disjoint and together cover the minor. Boundaries come from the markers a resolve consulted, so one reachable only above an earlier split is found by re-resolving to a fixpoint; only the minors that split are re-resolved. A host target names the real micro the interpreter reports, so it stays whole.

Only the ordered comparisons (`<`, `<=`, `>`, `>=`) cut a minor; `==`, `!=`, and `~=` name a single release, so the `python-patches` escape hatch still covers those.

The test for the old refuse-the-other-side behaviour is rewritten to assert the two slices and their pins.

Stacked on #490.
