### PR TITLE
Make minor targets pure python_full_version intervals

### DIFF
--- a/docs/explanation/universal.md
+++ b/docs/explanation/universal.md
@@ -16,18 +16,22 @@ they declared.
 
 ## How it works
 
-A matrix is a list of resolve targets, and nab resolves one target at
-a time: the same engine, and the same single-environment resolve, a
-project without a matrix runs once for the host. All cells share one
-fetcher, so each package's metadata is fetched at most once across the
-whole matrix. After each cell resolves, its pins flow forward as
-preferences for the next cell, providing best-effort cross-tuple
-alignment.
+A matrix expands into a list of resolve targets, one target per
+`(python, platform, implementation)` point it names. nab resolves the
+targets one at a time, each on the same engine and the same
+single-environment resolve a project without a matrix runs once for the
+host.
+
+The targets share one fetcher, so each package's metadata is fetched at
+most once across the whole matrix. After a target resolves, its pins
+flow forward as preferences for the next, giving best-effort alignment
+across targets.
 
 The lock a matrix produces is the lock a single environment produces,
-with more environments in it: same shape, same
-[environment declaration](../reference/lockfile.md) per tuple, same
-dependency edges.
+with more environments in it: the same shape, the same
+[environment declarations](../reference/lockfile.md), and the same
+dependency edges. A target whose minor a marker splits contributes
+one declaration per slice (see Patch-release markers below).
 
 ## Declaring the matrix
 
@@ -50,7 +54,7 @@ platforms = ["linux_x86_64", "macos_arm64"]
 python-order = "asc"
 ```
 
-`python` is a PEP 440 specifier expanded into one tuple per
+`python` is a PEP 440 specifier expanded into one target per
 minor version. `platforms` is a list of platform ids
 (`linux_x86_64`, `linux_aarch64`, `linux_i686`, `linux_armv7l`,
 `macos_x86_64`, `macos_arm64`, `windows_amd64`, `windows_arm64`), each
@@ -75,11 +79,11 @@ nab lock pyproject.toml
 ```
 
 Writes a single PEP 751 `pylock.toml` covering the whole matrix.
-Packages whose pinned version differs across tuples appear as
+Packages whose pinned version differs across targets appear as
 multiple `Package` entries with PEP 508 markers; packages that
-agree across every tuple appear once with no marker.
+agree across every target appear once with no marker.
 
-## Inspect the per-tuple pins
+## Inspect the per-target pins
 
 ```bash
 nab lock --format requirements-without-hashes --output - pyproject.toml
@@ -101,18 +105,90 @@ numpy==2.1.3
 ...
 ```
 
-One block per tuple. Pip cannot install a single requirements.txt
-across multiple tuples in hash-checking mode, so the per-tuple
+One block per target. Pip cannot install a single requirements.txt
+across multiple targets in hash-checking mode, so the per-target
 block format is for inspection or for tools that consume one block
-at a time. When a tuple fails resolution, the line reads
+at a time. When a target fails resolution, the line reads
 `# <label>: FAILED` followed by the indented error and the process
 exits 1.
 
 ## Patch-release markers
 
-`python_full_version` defaults to `<minor>.0` per cell. If a
-marker in the dependency graph compares against a patch release,
-declare the real patch you ship on:
+A matrix names Python minors like 3.11, not exact releases, so a 3.11
+target stands for the whole minor: every micro release from 3.11.0
+upward. nab resolves it once, at a representative 3.11.0.
+
+That holds until a dependency's marker turns on a patch release inside
+the minor. If the project asks for
+`some-backport ; python_full_version < "3.11.4"`, then 3.11.3 needs the
+backport and 3.11.5 does not, yet a single resolve at 3.11.0 would
+answer the marker one way for the whole minor. So nab splits the 3.11
+target at 3.11.4 and resolves each side on its own. Each side is a slice
+of the target, with its own pins and its own `environments` row.
+
+Take a project that targets just 3.11 on one platform:
+
+```toml
+[project]
+name = "example-lib"
+version = "0.1.0"
+requires-python = ">=3.11,<3.12"
+dependencies = [
+    'some-backport ; python_full_version < "3.11.4"',
+]
+
+[tool.nab]
+mode = "universal"
+
+[tool.nab.matrix]
+python = ">=3.11,<3.12"
+platforms = ["linux_x86_64"]
+```
+
+The marker cuts the minor at 3.11.4, so the lock declares two
+environments where an unsplit minor would declare one:
+
+```toml
+environments = [
+    'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and python_full_version < "3.11.4"',
+    'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and python_full_version >= "3.11.4.dev0"',
+]
+```
+
+The two rows are identical but for the last clause. `some-backport` is
+pinned only on the lower slice, so it carries that slice's marker and is
+absent from the other:
+
+```toml
+[[packages]]
+name = "some-backport"
+version = "1.2.0"
+marker = 'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and python_full_version < "3.11.4"'
+```
+
+The two slices meet at `3.11.4.dev0`, not at `3.11.4`. The lower slice
+ends at `< "3.11.4"` and the upper starts at `>= "3.11.4.dev0"`. A plain
+`>= "3.11.4"` upper edge would strand the prereleases of 3.11.4, such as
+`3.11.4rc1`: PEP 440 keeps them below `>= "3.11.4"`, and `< "3.11.4"`
+excludes them too, so they would land in neither slice. Snapping the
+edge down to `3.11.4.dev0` puts them on the upper side, so the slices
+meet exactly, with no gap and no overlap, and a user on `3.11.4rc1` gets
+the pins meant for 3.11.4.
+
+A split can pull in a dependency the whole minor did not, and that
+dependency's marker can name a fresh boundary, so nab re-splits a target
+until a pass finds no new one.
+
+Every comparison that names an interval cuts a minor: the ordered
+operators (`<`, `<=`, `>`, `>=`) and the ones naming a region (`==`,
+`!=`, `~=`, `== V.*`). A `python_full_version` marker nab cannot turn
+into an interval is a loud error rather than a silent guess: a
+membership test (`in`, `not in`), a verbatim `===`, a non-version
+comparison, a comparison against another marker variable, or certain
+prerelease literals strictly inside the minor.
+
+To resolve a minor as one real release rather than split it, name the
+patch you deploy on:
 
 ```toml
 [tool.nab.matrix.python-patches]
@@ -120,10 +196,8 @@ declare the real patch you ship on:
 "3.12" = "3.12.1"
 ```
 
-Without this, markers like `python_full_version >= "3.11.4"`
-evaluate False on a 3.11 cell, the safe direction (drop the
-gated dep) but a silent failure if your deployed interpreter is
-actually 3.11.4 or later.
+A minor a patch names is not split: it sits on that single release and
+resolves whole, like the host interpreter.
 
 ## Interpreter implementations
 
@@ -138,8 +212,8 @@ platforms = ["linux_x86_64"]
 implementations = ["cpython", "pypy"]
 ```
 
-Each implementation multiplies the tuple count (pythons x platforms x
-implementations). A PyPy tuple sets `platform_python_implementation =
+Each implementation multiplies the target count (pythons x platforms x
+implementations). A PyPy target sets `platform_python_implementation =
 "PyPy"` / `implementation_name = "pypy"` for marker evaluation and
 accepts `ppXY-pypyXY_pp73` wheel tags instead of `cpXY`. Labels use the
 `pp` interpreter prefix (`pp311-linux_x86_64`).
@@ -147,7 +221,7 @@ accepts `ppXY-pypyXY_pp73` wheel tags instead of `cpXY`. Labels use the
 A CPython-only matrix leaves the axis open: its lockfile markers carry
 `python_version`, `sys_platform` and `platform_machine` only. Any other
 matrix, whether it names two implementations or one non-CPython one,
-puts `implementation_name` on every tuple's marker and on the
+puts `implementation_name` on every target's marker and on the
 `environments` entry it declares. The CPython and PyPy entries for one
 `(python, platform)` point stay mutually exclusive, and a PyPy-only
 lock refuses CPython. PyPy's `implementation_version` is modelled as

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -60,8 +60,9 @@ nab resolves for the interpreter it is running on.  The host is the
 target, like pip: the same lock command on a Python 3.14 machine
 resolves the markers a Python 3.14 install evaluates.
 
-`[tool.nab.environment]` retargets it.  The table is one cell of a
-matrix, and every axis it leaves out keeps the host's value:
+`[tool.nab.environment]` retargets it.  The table declares one target's
+axes, the same axes a matrix entry carries; every axis it leaves out
+keeps the host's value:
 
 ```toml
 [tool.nab.environment]
@@ -111,7 +112,7 @@ refuses it elsewhere.  To lock for several machines at once, use
 `mode = "universal"`.
 
 `[tool.nab.environment]` and `[tool.nab.matrix]` cannot both be set: the
-matrix already declares one environment per tuple.
+matrix already declares one environment per target.
 
 ### `[tool.nab.marker-environment]` (deprecated)
 
@@ -561,7 +562,7 @@ over HTTP.
 ## Universal mode
 
 Universal resolution resolves one target per declared
-`(python, platform, implementation)` tuple, on the same engine a
+`(python, platform, implementation)` point, on the same engine a
 single-environment resolve uses, sharing one fetcher so metadata is
 fetched at most once per package.  The multi-target lockfile format it
 produces is experimental and may change without notice.
@@ -580,15 +581,15 @@ python-patches = { "3.11" = "3.11.4" }
 
 The matrix has three axes, and nab resolves the full cross product:
 the example above declares 3 pythons, 2 platforms and 2
-implementations, so it plans 12 tuples.
+implementations, so it plans 12 targets.
 
 | Key | Default | Meaning |
 | --- | --- | --- |
-| `python` | required | A PEP 440 range like `>=3.11,<3.14`, expanded into one tuple per minor |
+| `python` | required | A PEP 440 range like `>=3.11,<3.14`, expanded into one target per minor |
 | `platforms` | required | The platforms to model; a bare id, or a table of the tag knobs below |
 | `implementations` | `["cpython"]` | The interpreter implementations to model: `"cpython"`, `"pypy"` |
-| `python-order` | `"asc"` | Cross-tuple alignment direction |
-| `python-patches` | per-minor `.0` | Overrides the `python_full_version` marker value for a minor |
+| `python-order` | `"asc"` | Cross-target alignment direction |
+| `python-patches` | none | Pins a minor to one patch release, resolved whole instead of split into slices |
 
 `python-order` sets the alignment direction: `asc` mirrors uv's
 `fork-strategy=fewest`, `desc` mirrors `fork-strategy=requires-python`.
@@ -596,7 +597,7 @@ implementations, so it plans 12 tuples.
 ### Interpreter implementations
 
 `implementations` names the interpreters to model, and each entry
-multiplies the tuple count.  An unknown implementation, a duplicate,
+multiplies the target count.  An unknown implementation, a duplicate,
 and an empty list are each a config error.  See
 [Universal resolution](../explanation/universal.md) for how the axis is
 modelled and what it puts on the lockfile markers.
@@ -682,7 +683,7 @@ marker and the lock could not tell their pins apart.  Locking a second
 libc family, or a free-threaded build alongside the GIL one, is a
 second lock run with its own config and output file.
 
-Each tuple impersonates a platform, so universal mode cannot build on
+Each target impersonates a platform, so universal mode cannot build on
 the host: `build-policy` defaults to `never` and cannot be raised.  An
 explicit non-`never` value (global or in any override) is a config
 error.  See [Build policy](build-policy.md).
@@ -702,10 +703,10 @@ error.  See [Build policy](build-policy.md).
   to the host's.  A single version, not a specifier.  `--python X.Y`
   overrides it for one run.
 * `[tool.nab.matrix].python`: a range like `>=3.11,<3.14`, expanded into
-  one tuple per minor version.  Used only by universal mode.  Pair with
+  one target per minor version.  Used only by universal mode.  Pair with
   `[tool.nab.matrix].platforms`, `[tool.nab.matrix].implementations` and
   (optionally) `[tool.nab.matrix].python-patches` to control the resolve
-  and marker shape across all tuples.
+  and marker shape across all targets.
 
 Declaring a `[tool.nab.matrix]` table while `mode` is `specific` is an
 error: the matrix is the list of targets to resolve, so leaving mode

--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -145,7 +145,7 @@ absolute, machine-specific path.
 ### The environments the lock is for
 
 A resolve answers for the environments it targeted: the
-[resolve target](configuration.md), or one per tuple of a declared
+[resolve target](configuration.md), or the targets of a declared
 matrix. Every dependency whose PEP 508 marker was false on a target
 was dropped there, so the pins are not a package set another
 environment can install. The lock says so in the top-level
@@ -163,35 +163,46 @@ A marker nab evaluated is a question whose answer changed the package
 set, so an installer that answers it differently must not use this
 lock.
 
-`python_full_version` is the exception: it is declared by
-constraint, not by value. The pins do not depend on the micro
-release, they depend on how each marker clause reading it answered,
-so that is what the lock declares. A clause that held is declared as
-it stands; one that did not is declared complemented, since PEP 508
-has no `not`:
+`python_full_version` is the exception: it is never declared by
+value. A target that names a minor (a matrix target, a declared
+environment, or a `--python <minor>` target) stands for every micro
+of that minor, so pinning one micro would refuse every other real
+one. Instead the minor covers all its micros, and a consulted
+`python_full_version` marker whose boundary lies inside it splits it
+at that boundary. Each side becomes its own slice with its own
+`environments` row and pins: `pytest ; python_full_version >= "3.13.4"`
+on a 3.13 target cuts the minor into a `< "3.13.4"` slice and a
+`>= "3.13.4.dev0"` slice, and `pytest` joins only the upper one (see
+Universal mode below).
 
-```text
-tomli ; python_full_version <= "3.11.0a6"   read false
-    -> python_full_version > "3.11.0a6"
-```
+The two slice bounds meet at `3.13.4.dev0`: the lower slice ends at
+`< "3.13.4"` and the upper starts at `>= "3.13.4.dev0"`, which together
+cover the minor with no gap and no overlap. The `.dev0` on the lower
+edge is deliberate. A verbatim `< "3.13.4"` / `>= "3.13.4"` pair would
+leave the prereleases of 3.13.4 (`3.13.4rc1`) in neither slice, because
+PEP 440 keeps them out of both; snapping the lower edge to
+`>= "3.13.4.dev0"` puts them on the upper side, so a user on a
+prerelease of 3.13.4 gets the pins intended for 3.13.4.
 
-Only the clauses a marker's answer turned on are declared. A marker
-is an `and`/`or` of clauses, so a clause on the micro release can be
-dead: the other side of an `or` already held, or the other side of an
-`and` already failed. `pytest ; python_full_version >= "3.13.5" or
-sys_platform == "linux"` reads true on Linux whatever the micro is,
-so it declares nothing, and a variable no marker's answer turned on
-leaves its axis open.
+A minor no marker split reverts to a plain `python_version == "3.13"`
+row with no `python_full_version` clause: a marker whose boundary lies
+outside the minor, or a prerelease of the minor's floor
+(`<= "3.11.0a6"`), reads the same for every real micro, so it names no
+in-minor boundary and its dependency is simply kept or dropped for the
+whole minor.
 
-The lock is then installable on every micro release that reads the
-resolve's markers the way the resolve did, and a marker that
-genuinely splits the micros (`python_full_version >= "3.13.4"`)
-still partitions them. Pinning the value instead would refuse every
-other micro, including every real one when the target names a minor:
-`--python 3.13` synthesizes `3.13.0`, which no released interpreter
-reports. A clause whose complement cannot be stated as a clause (an
-unusual operator such as `~=`, or a PEP 440 prerelease boundary)
-falls back to pinning the exact value.
+A whole target is never split: the host interpreter nab reads names a
+real micro, and a `[tool.nab.matrix.python-patches]` pin names one
+concrete deployment micro. Both resolve at that single micro and emit
+the plain `python_version == "X.Y"` row.
+
+A consulted `python_full_version` marker that cannot be tiled into an
+interval is a loud error rather than a pin of the whole minor to one
+answer: a membership (`in` / `not in`), a verbatim `===`, a non-version
+string comparison, a comparison against another variable, or a
+prerelease-version literal strictly inside the minor on an operator that
+fixes the boundary at the literal (`<`, `>=`, `==`, `!=`, `~=`). On `<=`
+or `>` a prerelease literal lands at the next release and tiles cleanly.
 
 Two variables are never declared: `platform_release` and
 `platform_version` name one machine's kernel build, so a lock
@@ -208,17 +219,21 @@ the target's Python. It bounds what the project supports; the
 
 Under `[tool.nab].mode = "universal"`, `nab lock --format pylock`
 writes a single file covering every
-`(python, platform, implementation)` tuple in the matrix. Packages
-whose pinned version is identical across every tuple appear once with
+`(python, platform, implementation)` target in the matrix. Packages
+whose pinned version is identical across every target appear once with
 no marker; packages that diverge appear as multiple `Package` entries
-with PEP 508 markers built from each tuple's `python_version`,
+with PEP 508 markers built from each target's `python_version`,
 `sys_platform` and `platform_machine`, plus `implementation_name` on
 the same terms as the `environments` declarations above.
 
-`environments` carries one declaration per tuple, built the same way
-a single-environment lock builds its one: from the markers that
-tuple's resolve consulted. A tuple's `packages.dependencies` edges
-are the union across the tuples an entry covers.
+`environments` carries a declaration per target, built the same way a
+single-environment lock builds its one: from the markers that target's
+resolve consulted. A target whose minor an in-minor `python_full_version`
+boundary splits carries one declaration per slice, so a target can
+contribute more than one entry (see
+[Universal resolution](../explanation/universal.md)). A target's
+`packages.dependencies` edges are the union across the targets an entry
+covers.
 
 ## Pip-compatible `requirements.txt`
 

--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -560,17 +560,20 @@ def excluded_by_python(
     A per-package ``requires-python`` override substitutes for
     ``dist.requires_python`` and goes through the same cached comparison,
     keyed by the specifier string; the verdict depends only on that string
-    and the fixed ``provider.python_release``.
+    and the fixed ``provider.target``.  A minor-interval target admits the
+    candidate when the specifier overlaps the whole minor; a whole target
+    when its single release satisfies it (see
+    :meth:`~nab_python.target.ResolveTarget.admits_requires_python`).
     """
     override_rp = provider.effective_requires_python(normalized, version)
     effective = override_rp if override_rp is not None else dist.requires_python
-    if not effective or provider.python_release is None:
+    if not effective or provider.target is None:
         return False
     cached = provider.requires_python_cache.get(effective)
     if cached is None:
         try:
             spec = SpecifierSet(effective)
-            cached = provider.python_release not in spec
+            cached = not provider.target.admits_requires_python(spec)
         except InvalidSpecifier:
             # Malformed Requires-Python on the dist: treat as
             # not-excluded, let downstream logic decide.  Our own

--- a/nab-python/src/nab_python/_vendor/packaging/ranges.py
+++ b/nab-python/src/nab_python/_vendor/packaging/ranges.py
@@ -321,6 +321,44 @@ def _partition_indexes(
     return first_inside, first_above
 
 
+def _lattice_release(version: Version, parts: int, *, above: bool) -> Version:
+    """The nearest ``parts``-component release to ``version`` on the lattice.
+
+    Truncates ``version``'s release to ``parts`` components, padding a shorter
+    release with zeros, to land on a lattice point at or below it. With
+    ``above`` the result must be strictly greater than ``version``, so a
+    truncation that lands at or below it is rounded up by one; otherwise a
+    truncation equal to ``version`` is kept and only a strictly smaller one is
+    rounded up.
+    """
+    release = version.release[:parts]
+    padded = (*release, *((0,) * (parts - len(release))))
+    candidate = Version.from_parts(epoch=version.epoch, release=padded)
+    if candidate > version or (not above and candidate == version):
+        return candidate
+    bumped = (*padded[:-1], padded[-1] + 1)
+    return Version.from_parts(epoch=version.epoch, release=bumped)
+
+
+def _release_boundary_point(
+    value: BoundaryVersion | Version | None, parts: int
+) -> Version | None:
+    """The lattice release one interval edge transitions membership at.
+
+    ``None`` for an unbounded (``-inf`` / ``+inf``) edge. A boundary sentinel
+    reports the smallest lattice release strictly above the version it sits
+    over (its final release when that version is a pre-release). A plain
+    version reports its own release projected onto the lattice: the release
+    itself when it is a lattice point, otherwise the smallest lattice release
+    above it.
+    """
+    if value is None:
+        return None
+    if isinstance(value, BoundaryVersion):
+        return _lattice_release(value.version, parts, above=True)
+    return _lattice_release(Version(value.base_version), parts, above=False)
+
+
 # Repr helpers:
 
 
@@ -1256,6 +1294,54 @@ class VersionRange:
             pre_region=self._pre_region,
             prereleases_configured=self._prereleases_configured,
         )
+
+    def release_intervals(
+        self, parts: int
+    ) -> tuple[tuple[Version | None, Version | None], ...]:
+        """The half-open release intervals on which this range is satisfied.
+
+        Projects the range onto the lattice of releases with ``parts`` numeric
+        components and returns the maximal ``[lower, upper)`` intervals it covers,
+        as ``(lower, upper)`` release pairs. ``None`` on a side is unbounded there.
+        Structure finer than the lattice, such as prereleases or posts between two
+        releases, is not represented.
+
+        >>> SpecifierSet(">=3.11.4").to_range().release_intervals(3)
+        ((<Version('3.11.4')>, None),)
+        >>> SpecifierSet("==3.11.4").to_range().release_intervals(3)
+        ((<Version('3.11.4')>, <Version('3.11.5')>),)
+
+        :raises ValueError: if ``parts`` is less than 1.
+        """
+        if parts < 1:
+            raise ValueError(f"parts must be at least 1, got {parts}")
+
+        intervals: list[tuple[Version | None, Version | None]] = []
+        for lower, upper in self._bounds:
+            lower_point = _release_boundary_point(lower.version, parts)
+            upper_point = _release_boundary_point(upper.version, parts)
+            if (
+                lower_point is not None
+                and upper_point is not None
+                and lower_point >= upper_point
+            ):
+                continue
+            if intervals:
+                prev_lower, prev_upper = intervals[-1]
+                if (
+                    prev_upper is not None
+                    and lower_point is not None
+                    and prev_upper >= lower_point
+                ):
+                    merged_upper = (
+                        None
+                        if upper_point is None
+                        else max(prev_upper, upper_point)
+                    )
+                    intervals[-1] = (prev_lower, merged_upper)
+                    continue
+            intervals.append((lower_point, upper_point))
+        return tuple(intervals)
 
     @classmethod
     def _from_specifier_set(cls, specifier_set: SpecifierSet) -> VersionRange:

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -158,9 +158,10 @@ class MatrixConfig:
 class EnvironmentConfig:
     """The single environment ``[tool.nab.environment]`` declares.
 
-    One cell of a matrix: the axes a target is made of.  An unset axis
-    takes the host's value, so an empty table is the host and a table
-    naming only ``python`` is the host machine running another Python.
+    The axes a target is made of, the same ones a matrix entry carries.
+    An unset axis takes the host's value, so an empty table is the host
+    and a table naming only ``python`` is the host machine running
+    another Python.
 
     ``platform`` is the same :class:`~nab_python.tags.PlatformSpec` a
     ``matrix.platforms`` entry parses to, so the wheel-tag knobs (the libc
@@ -1167,18 +1168,22 @@ def _check_requires_python_admits_target(
     does not support would produce a lock the project's own metadata
     rejects, so it fails loud and names the knob that moves the target.
 
-    Which knob that is depends on the target.  A matrix declares the python
-    axis of every target it expands, and both ``--python`` and
-    ``[tool.nab.environment]`` are themselves errors alongside one, so a
-    matrix target is moved by ``matrix.python`` and
-    ``[tool.nab.matrix.python-patches]`` instead.
+    A minor-interval target is admitted when ``requires-python`` overlaps its
+    whole minor, so a micro floor like ``>= "3.11.4"`` admits the 3.11 minor
+    rather than excluding it at the synthetic ``.0`` floor.  Which knob the
+    error names depends on the target.  A matrix declares the python axis of
+    every target it expands, and both ``--python`` and ``[tool.nab.environment]``
+    are themselves errors alongside one, so a matrix target is moved by
+    ``matrix.python`` instead.
     """
     if requires_python is None:
         return
-    # The release, not the marker value: a specifier admits no prerelease
-    # unless it names one, so ">=3.14" has to admit a 3.14 candidate host.
-    # This is the comparison every candidate's Requires-Python takes too.
-    if target.python_release in SpecifierSet(requires_python):
+    # A minor-interval target is admitted when the specifier overlaps the whole
+    # minor; a whole target when its single release satisfies it.  A specifier
+    # admits no prerelease unless it names one, so ">=3.14" has to admit a 3.14
+    # candidate host.  This is the comparison every candidate's Requires-Python
+    # takes too (see ResolveTarget.admits_requires_python).
+    if target.admits_requires_python(SpecifierSet(requires_python)):
         return
     excludes = (
         f"{source} = {requires_python!r} excludes the resolve target"
@@ -1187,10 +1192,8 @@ def _check_requires_python_admits_target(
     if matrix:
         msg = (
             f"{excludes}  [tool.nab.matrix] declares the python axis of every"
-            " target it expands, and a matrix minor resolves at patch 0 unless"
-            " [tool.nab.matrix.python-patches] names a patch: pin"
-            f" {target.python_version} there if only its patch level is excluded,"
-            " narrow matrix.python to drop the version, or widen requires-python."
+            " target it expands: narrow matrix.python to drop the version, or"
+            " widen requires-python."
         )
     else:
         msg = (

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -599,7 +599,6 @@ class Provider:
         # the Python a candidate could be rejecting (see _provider.listing).
         if target is None:
             self.python_version: str | None = None
-            self.python_release: Version | None = None
             self.environment: dict[str, str] = host_environment()
             self.env_with_extra: dict[str, str | frozenset[str]] = {
                 **self.environment,
@@ -607,7 +606,6 @@ class Provider:
             }
         else:
             self.python_version = target.python_full_version
-            self.python_release = target.python_release
             self.environment = dict(target.marker_env)
             self.env_with_extra = target.env_with_membership()
 

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -80,6 +80,8 @@ from .target import (
     ResolveTarget,
     environment_declaration,
     marker_variables,
+    micro_boundary_points,
+    slices_from_points,
 )
 
 if TYPE_CHECKING:
@@ -401,6 +403,158 @@ def resolve_with_coordinator(  # noqa: PLR0913 - the knobs a caller drives a bar
     )
     constraints = [Requirement(text) for text in effective.constraints]
 
+    return _resolve_with_micro_narrowing(
+        list(targets),
+        fork_list,
+        constraints,
+        settings,
+        preferences,
+        base_requirements,
+    )
+
+
+# The number of split-and-resolve passes the micro-narrowing fixpoint runs
+# before giving up.  Each pass resolves the slices the previous pass revealed,
+# which can expose a boundary reachable only above an earlier split; the set of
+# split points grows every pass, so a real graph converges in a couple.  The
+# cap turns a graph that somehow does not converge into a loud error rather than
+# a hang.
+_MAX_MICRO_SPLIT_PASSES = 10
+
+
+def _resolve_with_micro_narrowing(
+    targets: Sequence[ResolveTarget],
+    fork_list: Sequence[ResolveFork],
+    constraints: Sequence[Requirement],
+    settings: _EngineSettings,
+    preferences: Mapping[str, Version] | None,
+    base_requirements: Sequence[Requirement] | None,
+) -> ResolveResult:
+    """Resolve ``targets``, then split any minor a marker cut and re-resolve.
+
+    A consulted marker can cut a minor's micro line
+    (``python_full_version < "3.10.2"``).  Resolving the minor once at its
+    synthesized ``.0`` declares the whole minor by how ``.0`` read the clause,
+    excluding the real interpreters on the other side.  Resolving one target
+    per micro slice instead lets each slice declare its own environment row and
+    pins.
+
+    The split points come from the markers a resolve consulted, so a boundary
+    reachable only above an earlier split is not visible until that slice has
+    been resolved.  The loop is a fixpoint: it re-splits and re-resolves until a
+    pass reveals no new boundary.  Only a minor that split is re-resolved; every
+    target no marker cut (host targets among them, since they name a real micro)
+    keeps its first-pass result.
+    """
+    result = _resolve_passes(
+        targets, fork_list, constraints, settings, preferences, base_requirements
+    )
+    seed = _threaded_preferences(
+        dict(preferences or {}), result.target_results, align=settings.align
+    )
+    points: list[list[Version]] = [[] for _ in targets]
+    combined = result
+    for _ in range(_MAX_MICRO_SPLIT_PASSES):
+        grown = _grow_micro_points(targets, points, combined)
+        if grown is None:
+            return combined
+        points = grown
+        split_sigs = {
+            env_signature(target)
+            for target, target_points in zip(targets, points, strict=True)
+            if target_points
+        }
+        slices = [
+            sliced
+            for target, target_points in zip(targets, points, strict=True)
+            if target_points
+            for sliced in slices_from_points(target, target_points)
+        ]
+        slice_result = _resolve_passes(
+            slices, fork_list, constraints, settings, seed, base_requirements
+        )
+        combined = _merge_micro_results(targets, result, slice_result, split_sigs)
+    msg = (
+        "environment micro-boundary splitting did not converge in"
+        f" {_MAX_MICRO_SPLIT_PASSES} passes"
+    )
+    raise ResolutionError(msg)
+
+
+def _grow_micro_points(
+    targets: Sequence[ResolveTarget],
+    points: Sequence[Sequence[Version]],
+    result: ResolveResult,
+) -> list[list[Version]] | None:
+    """Return ``points`` grown by the boundaries ``result`` consulted, or None.
+
+    None means no minor gained a split point: the fixpoint has settled.  Each
+    target's boundaries are gathered from every slice it currently has, so a
+    boundary a marker consults only above an earlier split is picked up once
+    that slice has been resolved.
+    """
+    consulted_by_sig: dict[EnvSignature, set[Marker]] = defaultdict(set)
+    for tr in result.every_result:
+        consulted_by_sig[env_signature(tr.target)] |= set(tr.consulted)
+
+    grown: list[list[Version]] = []
+    changed = False
+    for target, target_points in zip(targets, points, strict=True):
+        found = set(target_points)
+        for sliced in slices_from_points(target, target_points):
+            consulted = consulted_by_sig.get(env_signature(sliced), set())
+            found.update(micro_boundary_points(target, consulted))
+        ordered = sorted(found)
+        if ordered != list(target_points):
+            changed = True
+        grown.append(ordered)
+    return grown if changed else None
+
+
+def _merge_micro_results(
+    targets: Sequence[ResolveTarget],
+    result: ResolveResult,
+    slice_result: ResolveResult,
+    split_sigs: set[EnvSignature],
+) -> ResolveResult:
+    """Fold ``slice_result`` back over the first-pass ``result``.
+
+    A target that split is dropped from ``result`` (its ``.0`` entry and its
+    base pass) and its slices are taken from ``slice_result`` instead; every
+    unsplit target keeps its first-pass entry, so it is never resolved again.
+    """
+
+    def kept(results: Sequence[TargetResult]) -> list[TargetResult]:
+        return [tr for tr in results if env_signature(tr.target) not in split_sigs]
+
+    env_base_names = {
+        sig: names
+        for sig, names in result.env_base_names.items()
+        if sig not in split_sigs
+    }
+    env_base_names.update(slice_result.env_base_names)
+    unsplit = tuple(t for t in targets if env_signature(t) not in split_sigs)
+    return ResolveResult(
+        targets=(*unsplit, *slice_result.targets),
+        target_results=kept(result.target_results) + list(slice_result.target_results),
+        base_results=kept(result.base_results) + list(slice_result.base_results),
+        env_base_names=env_base_names,
+    )
+
+
+def _resolve_passes(
+    targets: Sequence[ResolveTarget],
+    fork_list: Sequence[ResolveFork],
+    constraints: Sequence[Requirement],
+    settings: _EngineSettings,
+    preferences: Mapping[str, Version] | None,
+    base_requirements: Sequence[Requirement] | None,
+) -> ResolveResult:
+    """Resolve every fork against every target, plus the base pass.
+
+    The fork loop threads each target's pins forward across the whole run;
+    the base pass, when given, records the no-member pins per environment.
+    """
     accumulated = dict(preferences or {})
     results: list[TargetResult] = []
     for fork in fork_list:
@@ -1341,16 +1495,15 @@ def _raise_for_source_python(
     )
     if not managed:
         return
-    python = target.python_release
     for name, version in pins.items():
         normalized = canonicalize_name(name)
         if normalized not in managed:
             continue
         spec = provider.metadata_cache[(normalized, version)].requires_python
-        if spec is not None and python not in spec:
+        if spec is not None and not target.admits_requires_python(spec):
             msg = (
                 f"{normalized} {version} requires Python {spec} but the"
-                f" {target.label} resolve targets Python {python}"
+                f" {target.label} resolve targets Python {target.python_full_version}"
             )
             raise ResolutionError(msg)
 

--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -19,7 +19,6 @@ report metadata for the target or for someone else.
 
 from __future__ import annotations
 
-import itertools
 import re
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
@@ -38,6 +37,7 @@ from .tags import (
 )
 
 if TYPE_CHECKING:
+    from ._vendor.packaging.ranges import VersionRange
     from .tags import TagsSource
 
 
@@ -49,6 +49,7 @@ __all__ = [
     "UNBOUNDABLE_MARKER_VARIABLES",
     "EnvironmentSource",
     "Matrix",
+    "NonIntervalMarkerError",
     "ResolveTarget",
     "apply_python_axis_overlay",
     "check_free_threaded",
@@ -56,7 +57,9 @@ __all__ = [
     "environment_declaration",
     "host_environment",
     "marker_variables",
+    "micro_boundary_points",
     "python_axis_environment",
+    "slices_from_points",
     "unboundable_variables",
 ]
 
@@ -233,26 +236,14 @@ _MARKER_VARIABLE_RE = re.compile(
     r"\b(" + "|".join(sorted(PEP508_MARKER_VARIABLES)) + r")\b"
 )
 
-# The variables a lock declares by constraint rather than by value: see
-# :func:`_version_clauses`.  Both carry a micro release, and on CPython they
-# carry the same one (``implementation_version`` comes from
-# ``sys.implementation.version``), so pinning either collapses the lock to a
-# single patch release.
+# The variables a lock never declares by value: their bounds come only from a
+# slice's ``python_full_version`` clauses (see :func:`slices_from_points`).
+# Both carry a micro release, and on CPython they carry the same one
+# (``implementation_version`` comes from ``sys.implementation.version``), so
+# declaring either by value would pin the lock to a single patch release.  A
+# consulted marker on one splits the minor at its boundary instead, and each
+# slice emits the bounds that fence it off; an unsplit minor emits neither.
 _BY_CONSTRAINT = ("python_full_version", "implementation_version")
-
-# The operator that states the complement of each comparison.  PEP 508 has no
-# ``not``, so a clause the resolve found False is declared by flipping its
-# operator.  ``~=``, ``===`` and the membership operators have no
-# single-clause complement and are deliberately absent; a clause using one is
-# declared by value instead.
-_COMPLEMENT_OPERATOR: dict[str, str] = {
-    "<": ">=",
-    "<=": ">",
-    ">": "<=",
-    ">=": "<",
-    "==": "!=",
-    "!=": "==",
-}
 
 # One ``lhs op rhs`` comparison of a marker, matched against the string form
 # :func:`Marker.__str__` normalises to: an operand is either a quoted literal
@@ -265,13 +256,6 @@ _MARKER_CLAUSE_RE = re.compile(
     r"(?P<op>===|==|!=|<=|>=|~=|<|>|not\s+in|in)\s*"
     rf"(?P<rhs>{_MARKER_OPERAND})"
 )
-
-# How many clauses of one marker the lock can leave open before
-# :func:`_deciding_clauses` stops asking which of its clauses the answer
-# turned on: the question is settled by reading every combination of them, so
-# the cost doubles per clause.  Past this, every clause on the variable is
-# declared.
-_MAX_FREE_CLAUSES = 8
 
 
 def marker_variables(marker_text: str) -> frozenset[str]:
@@ -289,26 +273,28 @@ def marker_variables(marker_text: str) -> frozenset[str]:
 def environment_declaration(target: ResolveTarget, consulted: Iterable[Marker]) -> str:
     """Render the PEP 751 ``environments`` marker for ``target``.
 
-    Declares every variable the ``consulted`` markers named, plus
-    :data:`_ALWAYS_DECLARED` and, when the target names an interpreter
-    other than the sole default (see
-    :attr:`ResolveTarget.declares_implementation`),
-    ``implementation_name``.  A resolve drops every dependency whose
-    marker is False under the target, so an installer that consults the
-    same variable and gets a different answer would be missing the deps
-    that environment needs: the declaration refuses it instead.
+    Declares :data:`_ALWAYS_DECLARED`, ``implementation_name`` when the
+    target names a non-default interpreter (see
+    :attr:`ResolveTarget.declares_implementation`), and every variable the
+    ``consulted`` markers named.  The resolve dropped every dependency whose
+    marker was False here, so a lock that let an installer answer one of
+    those variables differently would miss deps; the declaration refuses it.
 
-    Most variables are declared by value: a marker on ``platform_system``
-    pins the OS.  The variables in :data:`_BY_CONSTRAINT` are declared by
-    constraint (see :func:`_version_clauses`), because a lock that pinned
-    the micro release would refuse the very interpreters it resolved for.
-    The variables :func:`unboundable_variables` names for the target are
-    dropped: the kernel axes always, and ``implementation_version`` on a
-    non-CPython target, whose value is the target's Python level rather than
-    the interpreter's own release.  Dropping it leaves the lock open on that
-    axis, so a dependency the resolve gated on ``implementation_version``
-    under PyPy may still be missed at install; the resolve's own use of the
-    synthetic value stays a known limitation (a real axis is needed).
+    Most variables are declared by value (a ``platform_system`` marker pins
+    the OS).  The :data:`_BY_CONSTRAINT` variables (``python_full_version``,
+    and ``implementation_version`` on CPython) are not, since pinning the
+    micro release would refuse the interpreters the resolve ran for.  A minor
+    target is a micro interval: a consulted marker that splits it (see
+    :func:`micro_boundary_points`) leaves each slice its
+    :attr:`~ResolveTarget.micro_clauses` bounds and the row emits those,
+    while an unsplit minor emits none and stays a plain ``python_version``
+    row.  On CPython ``implementation_version`` tracks ``python_full_version``,
+    so a marker consulting it gets the same bounds mirrored onto its name.
+
+    The variables :func:`unboundable_variables` names are dropped: the kernel
+    axes always, and ``implementation_version`` on a non-CPython target (its
+    value there is the Python level, not the interpreter's release), so a dep
+    gated on that axis may be missed at install.
     """
     texts = sorted({str(marker) for marker in consulted})
     variables: set[str] = set()
@@ -318,206 +304,23 @@ def environment_declaration(target: ResolveTarget, consulted: Iterable[Marker]) 
     always = list(_ALWAYS_DECLARED)
     if target.declares_implementation:
         always.append("implementation_name")
-    names = [
-        *always,
-        *sorted(variables - set(always) - unboundable_variables(target)),
-    ]
-    declaring = _Declaring(
-        marker_env=target.marker_env,
-        environment=target.env_with_membership(),
-        pinned=frozenset(name for name in names if name not in _BY_CONSTRAINT),
-    )
+    by_value = variables - set(always) - unboundable_variables(target)
+    names = [*always, *sorted(by_value - set(_BY_CONSTRAINT))]
 
-    clauses: list[str] = []
-    for name in names:
-        if name in _BY_CONSTRAINT:
-            clauses.extend(_version_clauses(declaring, texts, name))
-        else:
-            clauses.append(f'{name} == "{target.marker_env[name]}"')
+    clauses = [f'{name} == "{target.marker_env[name]}"' for name in names]
+
+    # A micro-slice target (see :func:`slices_from_points`) carries the
+    # python_full_version bounds of its slice explicitly, so the environment
+    # row covers exactly that slice.  On CPython implementation_version equals
+    # python_full_version, so a marker that consulted it gets the same bounds
+    # mirrored onto its own name.
+    clauses.extend(target.micro_clauses)
+    if "implementation_version" in variables and target.implementation == "cpython":
+        clauses.extend(
+            clause.replace("python_full_version", "implementation_version")
+            for clause in target.micro_clauses
+        )
     return " and ".join(clauses)
-
-
-@dataclass(frozen=True, slots=True)
-class _Declaring:
-    """What deciding a clause of a consulted marker needs.
-
-    ``environment`` is the target's marker env seeded with the empty
-    membership sets the resolve evaluated its dependency markers under, so a
-    marker reads here exactly as it read there.  ``pinned`` is the set of
-    variables the declaration states by value: a clause on one of those
-    answers the same in every environment the lock admits, so it can be held
-    at the answer it gave.  Every other clause (``extra``, a kernel axis, the
-    other by-constraint variable) is one the lock leaves open, so it has to
-    be tried both ways.
-    """
-
-    marker_env: Mapping[str, str]
-    environment: Mapping[str, str | frozenset[str]]
-    pinned: frozenset[str]
-
-    def constant(self, *, value: bool) -> str:
-        """Render a clause that reads ``value`` under :attr:`environment`.
-
-        ``python_version`` is always declared by value, so a clause on it
-        reads the same in every environment the lock admits; here it is only
-        a carrier for a truth value substituted into a marker.
-        """
-        operator = "==" if value else "!="
-        return f'python_version {operator} "{self.marker_env["python_version"]}"'
-
-
-def _version_clauses(
-    declaring: _Declaring, texts: Sequence[str], variable: str
-) -> list[str]:
-    """Declare how the resolve read ``variable``, not its value.
-
-    Pinning the target's own ``python_full_version`` would refuse every
-    other micro release, including every real one when the target names a
-    minor (``--python 3.13`` synthesizes ``3.13.0``, which no released
-    interpreter reports).  The pins do not depend on the micro; they depend
-    on how the markers reading it answered.  So that is what the lock
-    declares: a clause the marker's answer turned on is declared as it
-    stands when it held, and complemented when it did not
-    (``python_full_version <= "3.11.0a6"`` read False becomes
-    ``python_full_version > "3.11.0a6"``).  A clause the answer did not turn
-    on (see :func:`_deciding_clauses`) is not declared at all, and a
-    variable no marker's answer turned on leaves its axis open.  Every
-    environment the result admits answers the resolve's markers the way the
-    resolve did, and a marker that genuinely splits the micros (``>=
-    "3.13.4"``) still partitions them.
-
-    Each clause is decided by asking packaging: it is rebuilt as a marker of
-    its own and evaluated against the target through the public
-    ``Marker.evaluate``, so no marker semantics are re-derived here.
-
-    A clause whose outcome nab cannot state as a clause falls back to
-    declaring the target's exact value, which is sound if narrow: an unusual
-    operator (``~=``, ``===``, a membership test), a comparison against
-    another variable rather than a literal, or a PEP 440 boundary where the
-    flipped operator is not the complement: ``< "3.10.2"`` excludes the
-    prereleases of 3.10.2 and so does ``>= "3.10.2"``, so on a ``3.10.2rc1``
-    target neither side holds.
-    """
-    exact = f'{variable} == "{declaring.marker_env[variable]}"'
-    declared: set[str] = set()
-    for text in texts:
-        for lhs, op, rhs in _deciding_clauses(declaring, text, variable):
-            declaration = _declared_clause(lhs, op, rhs, declaring, variable)
-            if declaration is None:
-                return [exact]
-            declared.add(declaration)
-
-    return sorted(declared)
-
-
-def _deciding_clauses(
-    declaring: _Declaring, text: str, variable: str
-) -> list[tuple[str, str, str]]:
-    """Return the clauses of ``text`` on ``variable`` that decide its answer.
-
-    A marker is an ``and``/``or`` of clauses, so a clause on ``variable``
-    can be dead: the other side of an ``or`` already held
-    (``python_full_version >= "3.13.5" or sys_platform == "linux"`` on
-    Linux), or the other side of an ``and`` already failed.  Declaring a
-    dead clause would refuse a micro release that reads every consulted
-    marker exactly as the resolve did, which is the environment the lock
-    was resolved for.
-
-    A clause is dropped only when the marker answers the same however that
-    clause reads, whatever the clauses the lock leaves open read.  Both are
-    settled by substituting truth values into the marker text and asking
-    packaging for the answer: a marker has no ``not``, so its answer rises
-    with its clauses, and testing the two extremes of a set of clauses
-    settles every reading in between.
-
-    Dropping is decided for the set as a whole, so clauses that only matter
-    together cannot all go: ``>= "3.13.4" and >= "3.14"`` (both read False)
-    drops the first, keeps the second, and the declaration still refuses
-    3.14.
-
-    The analysis is exponential in the number of clauses the lock leaves
-    open, so past :data:`_MAX_FREE_CLAUSES` every clause on ``variable`` is
-    declared, which is the narrow but sound answer.
-    """
-    atoms = list(_MARKER_CLAUSE_RE.finditer(text))
-    candidates = [
-        index for index, atom in enumerate(atoms) if variable in _clause_variables(atom)
-    ]
-    if not candidates:
-        return []
-
-    free = [
-        index
-        for index, atom in enumerate(atoms)
-        if index not in candidates and not _clause_variables(atom) <= declaring.pinned
-    ]
-    if len(free) <= _MAX_FREE_CLAUSES:
-        released: set[int] = set()
-        for index in candidates:
-            trial = released | {index}
-            if _answer_ignores(declaring, text, atoms, free, trial):
-                released = trial
-        candidates = [index for index in candidates if index not in released]
-
-    return [_clause_parts(atoms[index]) for index in candidates]
-
-
-def _answer_ignores(
-    declaring: _Declaring,
-    text: str,
-    atoms: Sequence[re.Match[str]],
-    free: Sequence[int],
-    released: set[int],
-) -> bool:
-    """Whether ``text`` answers the same however the ``released`` clauses read.
-
-    Every combination of the ``free`` clauses is tried, since the lock does
-    not pin them and the installer's environment (or its choice of extras)
-    settles them.  Under each, the released clauses are read all False and
-    all True; a marker's answer rises with its clauses, so agreeing at those
-    two extremes means agreeing at every reading between them, the target's
-    own included.  Clauses that are neither free nor released keep the text
-    they had, and so keep the answer they gave the resolve.
-    """
-    for combination in itertools.product((False, True), repeat=len(free)):
-        fixed = dict(zip(free, combination, strict=True))
-        low = _substituted(
-            declaring, text, atoms, {**fixed, **dict.fromkeys(released, False)}
-        )
-        high = _substituted(
-            declaring, text, atoms, {**fixed, **dict.fromkeys(released, True)}
-        )
-        if Marker(low).evaluate(declaring.environment) != Marker(high).evaluate(
-            declaring.environment
-        ):
-            return False
-    return True
-
-
-def _substituted(
-    declaring: _Declaring,
-    text: str,
-    atoms: Sequence[re.Match[str]],
-    readings: Mapping[int, bool],
-) -> str:
-    """Return ``text`` with each clause in ``readings`` forced to its reading."""
-    pieces: list[str] = []
-    end = 0
-    for index, atom in enumerate(atoms):
-        if index not in readings:
-            continue
-        pieces.append(text[end : atom.start()])
-        pieces.append(declaring.constant(value=readings[index]))
-        end = atom.end()
-    pieces.append(text[end:])
-    return "".join(pieces)
-
-
-def _clause_variables(atom: re.Match[str]) -> frozenset[str]:
-    """Return the environment variables one ``lhs op rhs`` clause reads."""
-    return frozenset(
-        operand for operand in atom.group("lhs", "rhs") if not operand.startswith('"')
-    )
 
 
 def _clause_parts(atom: re.Match[str]) -> tuple[str, str, str]:
@@ -526,35 +329,244 @@ def _clause_parts(atom: re.Match[str]) -> tuple[str, str, str]:
     return lhs, " ".join(op.split()), rhs
 
 
-def _declared_clause(
-    lhs: str, op: str, rhs: str, declaring: _Declaring, variable: str
-) -> str | None:
-    """Return the clause declaring how ``lhs op rhs`` read, or None.
+# The operators nab cannot tile into a micro interval: a membership or verbatim
+# ``===`` test on python_full_version is not uniform across a slice.  A
+# consulted marker using one on a minor interval is a loud crash.
+_NON_INTERVAL_OPERATORS = frozenset({"===", "in", "not in"})
 
-    The clause is one comparison of a marker the resolve evaluated, with
-    ``variable`` on one side; packaging decides which way it read.
-    None means nab cannot state that outcome as a clause of its own, and the
-    caller declares the exact value instead.
+# The operators whose boundary lands at the literal.  A prerelease literal there
+# carves a slice whose release-floor representative sits outside it, so a
+# prerelease literal on one of these, strictly inside the minor, is not
+# renderable and crashes.  ``<=``/``>`` land after the literal at a real
+# release, so a prerelease there maps cleanly to that release.
+_AT_LITERAL_OPERATORS = frozenset({"<", ">=", "==", "!=", "~="})
 
-    A clause that held is declared as it stands, whatever its operator: an
-    environment satisfying it reads it the way the resolve did, and no
-    complement is needed.  Only a clause that read False needs one, so only
-    an operator PEP 508 cannot complement (``~=``, ``===``, a membership
-    test) sends the caller to the exact value.
+# PEP 508 lets either operand be the variable, and packaging preserves the
+# written order, so ``python_full_version < "3.10.2"`` and its literal-first
+# equivalent ``"3.10.2" > python_full_version`` both reach the scanner.  When
+# the literal is on the left, an ordered or symmetric operator is mirrored back
+# to the variable-on-left form; ``~=``/``===`` and the membership operators are
+# absent because they cannot be mirrored, so a literal-first one of those is not
+# tileable.
+_MIRRORED_OPERATOR: dict[str, str] = {
+    "<": ">",
+    ">": "<",
+    "<=": ">=",
+    ">=": "<=",
+    "==": "==",
+    "!=": "!=",
+}
+
+
+class NonIntervalMarkerError(ValueError):
+    """A consulted version marker cannot tile a minor interval.
+
+    A minor target stands for every micro of its minor, and each consulted
+    ``python_full_version`` (or, on CPython, ``implementation_version``)
+    comparison has to partition that interval so every real interpreter reads
+    it the same way its slice does.  A membership (``in``/``not in``), a
+    verbatim ``===``, a non-version string comparison, a comparison against
+    another variable, or a prerelease-version literal that would carve a slice
+    off a real micro cannot be tiled, so the resolve stops loudly rather than
+    pin the whole minor to one synthetic answer.
     """
-    literal = rhs if lhs == variable else lhs
-    if not literal.startswith('"'):
-        # A comparison against another variable states nothing about this one.
+
+
+def _non_interval(
+    parts: tuple[str, str, str], target: ResolveTarget
+) -> NonIntervalMarkerError:
+    """Build the crash for a clause that cannot tile ``target``'s minor."""
+    lhs, op, rhs = parts
+    return NonIntervalMarkerError(
+        f"consulted marker clause {lhs} {op} {rhs} cannot tile the"
+        f" {target.label} minor interval: a python_full_version membership,"
+        " verbatim ===, non-version, variable, or prerelease comparison names"
+        " no micro boundary the lock can render"
+    )
+
+
+def slices_from_points(
+    target: ResolveTarget, points: Sequence[Version]
+) -> list[ResolveTarget]:
+    """Partition ``target``'s minor into one slice per micro interval.
+
+    ``points`` are the in-minor releases the micro line is cut at (see
+    :func:`micro_boundary_points`), sorted ascending.  They partition
+    ``[{minor}.0, inf)`` into intervals; each interval becomes ``target``
+    moved onto its lower-bound release, carrying the python_full_version
+    bounds that fence it off (see :meth:`ResolveTarget.with_micro_slice`).
+    Every marker answers unambiguously at an interval's lower bound, so that
+    release is where the slice resolves.  Each slice declares its own
+    environment row and pins, so a marker that genuinely splits the micros is
+    honoured per slice rather than lifted onto the whole minor.
+
+    Returns ``[target]`` unchanged when ``points`` is empty: nothing cut the
+    minor, so the whole minor resolves at once.
+    """
+    if not points:
+        return [target]
+    floor = Version(f"{target.python_version}.0")
+    reps = [floor, *points]
+    lowers: list[Version | None] = [None, *points]
+    uppers: list[Version | None] = [*points, None]
+
+    slices: list[ResolveTarget] = []
+    for rep, low, high in zip(reps, lowers, uppers, strict=True):
+        clauses: list[str] = []
+        if low is not None:
+            clauses.append(f'python_full_version >= "{_dev0(low)}"')
+        if high is not None:
+            clauses.append(f'python_full_version < "{high}"')
+        slices.append(target.with_micro_slice(str(rep), tuple(clauses)))
+    return slices
+
+
+def _dev0(version: Version) -> str:
+    """Return the ``.dev0`` boundary form of a release ``version``.
+
+    The canonical disjoint and exhaustive split pair at a boundary ``X`` is
+    ``< "X"`` on the lower side and ``>= "X.dev0"`` on the upper: a verbatim
+    ``< "X"`` / ``>= "X"`` pair leaves a gap at prereleases of ``X`` (packaging
+    carries a ``< X`` upper as ``X.dev0``), so the ``>=`` lower edge is snapped
+    to ``X.dev0`` to meet the adjacent ``< "X"`` exactly.  The suffix is a
+    syntactic form on a packaging-parsed version, validated by re-parsing.
+    """
+    return str(Version(f"{version}.dev0"))
+
+
+def _scanned_version_variables(target: ResolveTarget) -> frozenset[str]:
+    """Return the version variables whose comparisons split ``target``.
+
+    Always ``python_full_version``.  On CPython ``implementation_version``
+    tracks it, so a comparison on it mints the same boundary; on other
+    implementations its value is synthetic (:func:`unboundable_variables`), so
+    it is never split and its markers stay a known limitation.
+    """
+    if target.implementation == "cpython":
+        return frozenset({"python_full_version", "implementation_version"})
+    return frozenset({"python_full_version"})
+
+
+def micro_boundary_points(
+    target: ResolveTarget, consulted: Iterable[Marker]
+) -> list[Version]:
+    """Return the in-minor releases ``consulted`` cuts ``target``'s minor at.
+
+    A minor target stands for every micro of its minor (its
+    ``python_full_version`` is the synthesized ``{minor}.0`` floor).  A
+    consulted marker comparing ``python_full_version`` against a literal inside
+    the minor (``python_full_version < "3.10.2"``) needs different package sets
+    on each side, so the release it flips at is a point the micro line is split
+    on (see :func:`slices_from_points`).  On CPython ``implementation_version``
+    tracks ``python_full_version``, so a comparison on it mints the same
+    boundary.
+
+    The per-operator boundary comes from the edges of the range's
+    :meth:`~packaging.ranges.VersionRange.release_intervals`:
+    ``<``/``>=`` at the literal, ``<=``/``>`` at the release just after it, and
+    ``==``/``!=``/``~=``/``== V.*`` at each edge of the region they name.  A
+    boundary outside the minor or at its floor cuts nothing.
+
+    An operator that cannot tile the interval raises
+    :class:`NonIntervalMarkerError` (see there); with the whole-minor pin gone,
+    an untileable marker stops the resolve loudly.  A whole target (a host, or
+    a python-patches pin) is not an interval and is never cut.
+    """
+    if not target.is_minor_interval:
+        return []
+    minor_release = Version(target.python_version).release[:_PYTHON_VERSION_PARTS]
+    floor = Version(f"{target.python_version}.0")
+    scanned = _scanned_version_variables(target)
+
+    points: set[Version] = set()
+    for marker in consulted:
+        for atom in _MARKER_CLAUSE_RE.finditer(str(marker)):
+            points.update(
+                _clause_boundary_points(
+                    _clause_parts(atom), scanned, minor_release, floor, target
+                )
+            )
+    return sorted(points)
+
+
+def _clause_boundary_points(
+    parts: tuple[str, str, str],
+    scanned: frozenset[str],
+    minor_release: tuple[int, ...],
+    floor: Version,
+    target: ResolveTarget,
+) -> set[Version]:
+    """Return the in-minor release boundaries one clause cuts the minor at.
+
+    Empty when the clause names no scanned version variable, or its boundaries
+    fall outside the minor or at its floor.  Raises
+    :class:`NonIntervalMarkerError` when the clause names a scanned variable
+    but cannot tile the interval.
+    """
+    parsed = _clause_interval_literal(parts, scanned, target)
+    if parsed is None:
+        return set()
+    op, raw, version = parsed
+
+    if version.is_prerelease and op in _AT_LITERAL_OPERATORS:
+        # The boundary lands at the prerelease itself; only a strictly interior
+        # one carves a slice whose release floor sits outside it.  A prerelease
+        # of the minor's floor, or one outside the minor, is uniform under the
+        # rides-with-X convention and splits nothing.
+        if _in_minor(Version(version.base_version), minor_release, floor):
+            raise _non_interval(parts, target)
+        return set()
+
+    intervals = (
+        SpecifierSet(f"{op}{raw}")
+        .to_range()
+        .release_intervals(_PYTHON_FULL_VERSION_PARTS)
+    )
+    return {
+        edge
+        for lower, upper in intervals
+        for edge in (lower, upper)
+        if edge is not None and _in_minor(edge, minor_release, floor)
+    }
+
+
+def _in_minor(point: Version, minor_release: tuple[int, ...], floor: Version) -> bool:
+    """Whether ``point`` is an interior micro of the minor above its floor."""
+    return point.release[:_PYTHON_VERSION_PARTS] == minor_release and point > floor
+
+
+def _clause_interval_literal(
+    parts: tuple[str, str, str], scanned: frozenset[str], target: ResolveTarget
+) -> tuple[str, str, Version] | None:
+    """Return ``(op, literal, version)`` for a version-boundary clause.
+
+    ``None`` when the clause names no scanned version variable.  Raises
+    :class:`NonIntervalMarkerError` when it names one but cannot tile an
+    interval.  A literal-first clause has an ordered or symmetric operator
+    mirrored back to variable-on-left form; ``~=``/``===`` and the membership
+    operators cannot be mirrored, so a literal-first one of those is untileable.
+    """
+    lhs, op, rhs = parts
+    if lhs in scanned:
+        literal = rhs
+    elif rhs in scanned:
+        literal = lhs
+        mirrored = _MIRRORED_OPERATOR.get(op)
+        if mirrored is None:
+            raise _non_interval(parts, target)
+        op = mirrored
+    else:
         return None
-    clause = f"{lhs} {op} {rhs}"
-    if Marker(clause).evaluate(declaring.environment):
-        return clause
-    if op not in _COMPLEMENT_OPERATOR:
-        return None
-    complement = f"{lhs} {_COMPLEMENT_OPERATOR[op]} {rhs}"
-    if not Marker(complement).evaluate(declaring.environment):
-        return None
-    return complement
+
+    if op in _NON_INTERVAL_OPERATORS or not literal.startswith('"'):
+        raise _non_interval(parts, target)
+    raw = literal.strip('"')
+    base = raw.removesuffix(".*")
+    try:
+        version = Version(base)
+    except InvalidVersion:
+        raise _non_interval(parts, target) from None
+    return op, raw, version
 
 
 def host_environment(
@@ -665,6 +677,12 @@ class ResolveTarget:
     platform_spec: PlatformSpec | None = field(default=None, compare=False)
     multi_implementation: bool = field(default=False, compare=False)
     tags_faithful: bool = field(default=True, compare=False)
+    # The python_full_version clauses bounding this target's micro slice, set
+    # by :func:`slices_from_points` when a consulted marker splits the minor.
+    # Empty for an ordinary target.  Appended to
+    # :attr:`environment_marker_string` so the per-package pins of one slice
+    # do not leak onto another slice of the same python/platform.
+    micro_clauses: tuple[str, ...] = field(default=(), compare=False)
 
     def __post_init__(self) -> None:
         """Reject a python the resolve cannot compare Requires-Python against.
@@ -703,6 +721,46 @@ class ResolveTarget:
         candidate for.  pip compares ``sys.version_info``, and so does this.
         """
         return Version(Version(self.python_full_version).base_version)
+
+    @property
+    def is_minor_interval(self) -> bool:
+        """Whether this target is a bare minor resolved as a micro interval.
+
+        A host reports a real interpreter and a python-patches pin names a
+        concrete micro; both are whole and resolve at one point.  A bare minor
+        synthesizes ``{minor}.0`` and stands for every real micro of the minor,
+        so the micro line can be split on it and Requires-Python is answered
+        against the whole minor, not the synthetic floor.  A slice off that
+        minor carries ``micro_clauses`` and still stands for every interpreter
+        its bounds admit, so it too is an interval answering Requires-Python at
+        the same whole minor.
+        """
+        if self.host_faithful:
+            return False
+        if self.micro_clauses:
+            return True
+        return self.python_full_version == f"{self.python_version}.0"
+
+    @property
+    def minor_range(self) -> VersionRange:
+        """The ``[X.Y.0, X.(Y+1).0)`` range this target's minor covers."""
+        release = Version(self.python_version).release
+        major, minor = release[0], release[1]
+        return SpecifierSet(f">={major}.{minor}.0,<{major}.{minor + 1}.0").to_range()
+
+    def admits_requires_python(self, spec: SpecifierSet) -> bool:
+        """Whether a candidate's ``Requires-Python`` admits this target.
+
+        A whole target (host or a concrete micro) is admitted when its single
+        release satisfies ``spec``.  A minor interval is admitted when ``spec``
+        overlaps the whole minor, so a micro floor like ``>= "3.13.2"`` admits
+        the 3.13 minor instead of excluding it at the synthetic ``.0`` floor.
+        The test is range overlap, not a scalar ``in``: ``>= "3.13.2"`` would
+        exclude both ``3.13`` and ``3.13.0``.
+        """
+        if self.is_minor_interval:
+            return not spec.to_range().intersection(self.minor_range).is_empty
+        return self.python_release in spec
 
     @property
     def implementation(self) -> str:
@@ -765,6 +823,8 @@ class ResolveTarget:
         )
         if self.declares_implementation:
             marker += f' and implementation_name == "{self.implementation}"'
+        for clause in self.micro_clauses:
+            marker += f" and {clause}"
         return marker
 
     @property
@@ -840,6 +900,30 @@ class ResolveTarget:
             selection=selection,
         )
 
+    def with_micro_slice(
+        self, python_full_version: str, clauses: tuple[str, ...]
+    ) -> ResolveTarget:
+        """Return this target moved onto one micro slice of its minor.
+
+        ``python_full_version`` is the representative release the slice
+        resolves at (its lower bound), and ``clauses`` are the
+        python_full_version bounds that fence the slice off from the others,
+        appended to :attr:`environment_marker_string`.  The label gains a
+        ``-pfXYZ`` suffix so each slice pins under its own key.  The python
+        axis is re-derived, so ``python_version`` stays the minor and only
+        the micro (and, on CPython, ``implementation_version``) moves; the
+        wheel tags do not move with the micro, so they stay faithful.
+        """
+        env = dict(self.marker_env)
+        apply_python_axis_overlay(env, {"python_full_version": python_full_version})
+        compact = python_full_version.replace(".", "")
+        return replace(
+            self,
+            label=f"{self.label}-pf{compact}",
+            marker_env=env,
+            micro_clauses=clauses,
+        )
+
     @classmethod
     def for_host(
         cls,
@@ -897,9 +981,11 @@ class ResolveTarget:
     ) -> ResolveTarget:
         """Return a target declared as (python, platform, implementation).
 
-        ``python_full_version`` overrides the default ``{minor}.0``
-        patch release, which makes a marker like ``python_full_version >=
-        "3.11.4"`` evaluate against the user's actual deployment.
+        A bare minor resolves as a micro interval: its ``python_full_version``
+        floor is ``{minor}.0`` and a consulted ``python_full_version`` marker
+        splits it at the boundary it names.  Passing ``python_full_version``
+        pins the target to one concrete deployment micro and resolves it whole,
+        the manual single-point alternative to splitting.
         """
         return cls(
             label=_python_label(python_version, implementation) + f"-{spec.label}",
@@ -968,12 +1054,10 @@ class Matrix:
     propagates, so older Pythons diverge only when the new version is
     incompatible).
 
-    ``python_patches``: optional ``{minor: full_version}`` mapping that
-    sets the per-target ``python_full_version`` marker.  Defaults to
-    ``{minor}.0`` per target, which makes a marker like
-    ``python_full_version >= "3.11.4"`` evaluate False on a 3.11 target.
-    Users with deployments on later patch releases should declare them
-    here so marker evaluation matches reality.  Example:
+    ``python_patches``: optional ``{minor: full_version}`` mapping that pins a
+    matrix minor to one concrete deployment micro and resolves it whole,
+    instead of as a micro interval split at each consulted boundary.  Use it to
+    resolve a minor as the single patch release you deploy.  Example:
     ``python_patches={"3.11": "3.11.4", "3.12": "3.12.1"}``.
 
     ``implementations``: the interpreter implementations to model

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -900,15 +900,13 @@ class TestRequiresPython:
     def test_matrix_target_message_names_the_matrix_knobs(self, tmp_path: Path) -> None:
         """A matrix target is moved by the matrix, not by --python.
 
-        A minor expands at patch 0 unless ``python-patches`` names a patch,
-        so a micro-level floor excludes the target the matrix plans.  Both
-        knobs the host wording names are hard errors under a matrix, so the
-        message may not name either.
+        Both knobs the host wording names are hard errors under a matrix, so
+        the message may not name either; it names ``matrix.python`` instead.
         """
         path = write(
             tmp_path,
-            '[tool.nab]\nmode = "universal"\nrequires-python = ">=3.11.4"\n'
-            '[tool.nab.matrix]\npython = ">=3.11,<3.12"\n'
+            '[tool.nab]\nmode = "universal"\nrequires-python = ">=3.12"\n'
+            '[tool.nab.matrix]\npython = ">=3.11,<3.13"\n'
             'platforms = ["linux_x86_64"]\n',
         )
         config = read_pyproject_config(path)
@@ -916,12 +914,29 @@ class TestRequiresPython:
             plan_targets(config)
         message = str(exc.value)
         assert "excludes the resolve target Python 3.11.0" in message
-        assert "[tool.nab.matrix.python-patches]" in message
+        assert "matrix.python" in message
+        assert "python-patches" not in message
         assert "--python" not in message
         assert "[tool.nab.environment]" not in message
 
-    def test_python_patches_admits_the_matrix_target(self, tmp_path: Path) -> None:
-        """The knob the matrix message names has to clear the error."""
+    def test_a_micro_floor_admits_the_whole_matrix_minor(self, tmp_path: Path) -> None:
+        """A micro Requires-Python floor admits the language minor it names.
+
+        ``>= "3.11.4"`` overlaps the whole 3.11 minor, so the 3.11 target the
+        matrix expands is admitted rather than excluded at its synthetic ``.0``
+        floor.  The scalar probe the old code used was a no-op trap.
+        """
+        path = write(
+            tmp_path,
+            '[tool.nab]\nmode = "universal"\nrequires-python = ">=3.11.4"\n'
+            '[tool.nab.matrix]\npython = ">=3.11,<3.12"\n'
+            'platforms = ["linux_x86_64"]\n',
+        )
+        (target,) = plan_targets(read_pyproject_config(path))
+        assert target.python_version == "3.11"
+
+    def test_python_patches_pins_the_matrix_target(self, tmp_path: Path) -> None:
+        """python-patches pins the minor to one concrete deployment micro."""
         path = write(
             tmp_path,
             '[tool.nab]\nmode = "universal"\nrequires-python = ">=3.11.4"\n'

--- a/nab-python/tests/test_provider_declared_target.py
+++ b/nab-python/tests/test_provider_declared_target.py
@@ -767,7 +767,13 @@ class TestUnsetKnobAcceptsAnyLevel:
 
 
 class TestRequiresPythonPatch:
-    """Requires-Python is evaluated against the tuple's full patch version."""
+    """A whole target evaluates Requires-Python at its full patch version.
+
+    A python-patches tuple names one concrete micro and is admitted when that
+    micro satisfies the specifier.  A bare minor is an interval and is admitted
+    when the specifier overlaps the whole minor, so a micro floor keeps the
+    dist rather than excluding it at the synthetic ``.0`` floor.
+    """
 
     def test_dist_kept_when_patch_satisfies_requires_python(self) -> None:
         """python_full_version 3.13.4 keeps a dist that requires >=3.13.1."""
@@ -782,10 +788,33 @@ class TestRequiresPythonPatch:
         result = provider.fetch_versions("pkg")
         assert [v for v, _ in result] == [Version("1.0")]
 
-    def test_dist_excluded_when_patch_below_requires_python(self) -> None:
-        """A tuple targeting 3.13.0 excludes a >=3.13.1 dist."""
+    def test_whole_target_excludes_a_dist_its_patch_fails(self) -> None:
+        """A 3.13.1 python-patches tuple excludes a >=3.13.5 dist."""
+        provider = Provider(
+            _make_coordinator([_make_wheel("1.0", requires_python=">=3.13.5")]),
+            ResolveTarget.for_declared(
+                python_version="3.13",
+                spec=PlatformSpec("linux_x86_64"),
+                python_full_version="3.13.1",
+            ),
+        )
+        assert provider.fetch_versions("pkg") == []
+
+    def test_minor_interval_keeps_a_dist_its_floor_would_fail(self) -> None:
+        """A bare 3.13 minor keeps a >=3.13.1 dist: the range overlaps 3.13."""
         provider = Provider(
             _make_coordinator([_make_wheel("1.0", requires_python=">=3.13.1")]),
+            ResolveTarget.for_declared(
+                python_version="3.13", spec=PlatformSpec("linux_x86_64")
+            ),
+        )
+        result = provider.fetch_versions("pkg")
+        assert [v for v, _ in result] == [Version("1.0")]
+
+    def test_minor_interval_excludes_a_disjoint_dist(self) -> None:
+        """A bare 3.13 minor still excludes a >=3.14 dist: no overlap."""
+        provider = Provider(
+            _make_coordinator([_make_wheel("1.0", requires_python=">=3.14")]),
             ResolveTarget.for_declared(
                 python_version="3.13", spec=PlatformSpec("linux_x86_64")
             ),

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -3511,14 +3511,13 @@ class TestLockDeclaresItsEnvironment:
         assert "bar" not in _locked(lock_input)
         assert "implementation_version" not in caplog.text
 
-    def test_a_full_version_marker_declares_how_it_read_not_the_micro(
+    def test_a_uniform_full_version_marker_leaves_a_plain_row(
         self, tmp_path: Path
     ) -> None:
-        """``--python 3.12`` invents the micro 3.12.0; no interpreter reports it.
-
-        Pinning it would refuse every real 3.12, so the lock declares what
-        the resolve actually depends on: the marker read false, and it
-        reads false on every 3.12.
+        """A ``3.12`` minor is a micro interval, but ``<= "3.11.0a6"`` reads the
+        same (false) on every real 3.12, so it names no in-minor boundary.  The
+        minor is not split, ``tomli`` is dropped, and the row is the plain minor
+        with no ``python_full_version`` clause.
         """
         lock_input = self._resolve(
             tmp_path,
@@ -3528,27 +3527,59 @@ class TestLockDeclaresItsEnvironment:
             ),
         )
         (environment,) = lock_input.environments
-        assert 'python_full_version > "3.11.0a6"' in str(environment)
-        assert "python_full_version ==" not in str(environment)
+        assert "python_full_version" not in str(environment)
+        assert str(environment) == (
+            'python_version == "3.12" and sys_platform == "linux"'
+            ' and platform_machine == "x86_64"'
+        )
         assert "tomli" not in _locked(lock_input)
         assert Marker(str(environment)).evaluate(_PY312_ENV)
 
-    def test_a_marker_that_splits_the_micros_refuses_the_other_side(
+    def test_a_marker_that_splits_the_micros_resolves_each_side(
         self, tmp_path: Path
     ) -> None:
-        """Here the micro really does change the pins, so the lock says so."""
-        lock_input = self._resolve(
-            tmp_path,
-            self._PYPROJECT,
-            self._coordinator('Requires-Dist: bar ; python_full_version >= "3.12.4"\n'),
+        """A micro that changes the pins splits the minor into two slices.
+
+        ``foo`` needs ``bar`` only on 3.12.4 and up, so the minor cannot be
+        declared by how ``3.12.0`` read the clause: that would exclude every
+        real 3.12.  The engine resolves one slice per side of the boundary, each
+        with its own environment row and pins, and ``bar`` joins only the upper
+        slice.
+        """
+        coordinator = make_coordinator(
+            listings={
+                "foo": _index_wheels("foo", "1.0"),
+                "bar": _index_wheels("bar", "2.0"),
+            },
+            metadata_by_version={
+                "1.0": (
+                    "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n"
+                    'Requires-Dist: bar ; python_full_version >= "3.12.4"\n'
+                ),
+                "2.0": "Metadata-Version: 2.1\nName: bar\nVersion: 2.0\n",
+            },
         )
-        (environment,) = lock_input.environments
-        assert 'python_full_version < "3.12.4"' in str(environment)
-        assert "bar" not in _locked(lock_input)
-        assert Marker(str(environment)).evaluate(_PY312_ENV)
-        assert not Marker(str(environment)).evaluate(
-            {**_PY312_ENV, "python_full_version": "3.12.5"}
-        )
+        lock_input = self._resolve(tmp_path, self._PYPROJECT, coordinator)
+
+        below = lock_input.targets["py312-linux_x86_64-pf3120"]
+        above = lock_input.targets["py312-linux_x86_64-pf3124"]
+        assert set(below.pins) == {"foo"}
+        assert set(above.pins) == {"foo", "bar"}
+
+        rows = {
+            "below" if 'python_full_version < "3.12.4"' in str(m) else "above": str(m)
+            for m in lock_input.environments
+        }
+        assert set(rows) == {"below", "above"}
+        assert 'python_full_version >= "3.12.4.dev0"' in rows["above"]
+
+        # The two rows are disjoint and together cover the whole minor.
+        low = {**_PY312_ENV, "python_full_version": "3.12.1"}
+        high = {**_PY312_ENV, "python_full_version": "3.12.5"}
+        assert Marker(rows["below"]).evaluate(low)
+        assert not Marker(rows["below"]).evaluate(high)
+        assert Marker(rows["above"]).evaluate(high)
+        assert not Marker(rows["above"]).evaluate(low)
 
 
 class TestExtraAndGroupMembershipMarkers:

--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -1820,3 +1820,264 @@ class TestSharedListingFilter:
 
         assert result.success
         assert [tr.distributions_seen for tr in result.target_results] == [2, 2]
+
+
+class TestMicroBoundaryNarrowing:
+    """A minor a consulted marker cuts is resolved once per micro slice.
+
+    A declared target names a minor and synthesizes ``{minor}.0``.  When a
+    marker's python_full_version boundary lies inside that minor, resolving
+    the whole minor at ``.0`` would declare it by how ``.0`` read the clause,
+    excluding the real interpreters on the other side.  The engine splits the
+    minor and resolves each slice instead.
+    """
+
+    @staticmethod
+    def _coordinator(metadata: dict[str, str]) -> MagicMock:
+        listings = {
+            name: [_make_wheel(version, package=name)]
+            for name, version in (("foo", "1.0"), ("mid", "2.0"), ("top", "3.0"))
+        }
+        return make_coordinator(listings=listings, metadata_by_version=metadata)
+
+    @staticmethod
+    def _meta(name: str, version: str, *requires: str) -> str:
+        head = f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n"
+        return head + "".join(f"Requires-Dist: {req}\n" for req in requires)
+
+    @staticmethod
+    def _pins_by_label(result: ResolveResult) -> dict[str, set[str]]:
+        return {tr.target.label: set(tr.pins) for tr in result.target_results}
+
+    def test_only_split_targets_are_re_resolved(self) -> None:
+        """An unsplit minor keeps its first-pass result; only the split one
+        is resolved again, so the whole matrix is not re-run."""
+        coordinator = self._coordinator(
+            {
+                "1.0": self._meta(
+                    "foo", "1.0", 'mid ; python_full_version >= "3.10.4"'
+                ),
+                "2.0": self._meta("mid", "2.0"),
+            }
+        )
+        targets = Matrix(
+            python=">=3.10,<3.13", platforms=(PlatformSpec("linux_x86_64"),)
+        ).expand()
+
+        with patch.object(
+            resolve_mod,
+            "_resolve_one_target",
+            wraps=resolve_mod._resolve_one_target,
+        ) as spy:
+            result = resolve_with_coordinator(
+                coordinator, targets, _reqs("foo"), config=_no_build()
+            )
+
+        assert result.success
+        labels = [call.args[0].label for call in spy.call_args_list]
+        # 3.11 and 3.12 have no in-minor boundary, so each resolves once.
+        assert labels.count("py311-linux_x86_64") == 1
+        assert labels.count("py312-linux_x86_64") == 1
+        # Three minors resolved once each, plus 3.10's two slices: no full re-run.
+        assert len(labels) == 5
+
+    def test_a_host_target_is_not_split(self) -> None:
+        """A host target names a real micro, so no ``.0`` is synthesized and a
+        full-version marker never splits it."""
+        coordinator = self._coordinator(
+            {
+                "1.0": self._meta(
+                    "foo", "1.0", 'mid ; python_full_version >= "3.10.4"'
+                ),
+                "2.0": self._meta("mid", "2.0"),
+            }
+        )
+
+        with patch.object(
+            resolve_mod,
+            "_resolve_one_target",
+            wraps=resolve_mod._resolve_one_target,
+        ) as spy:
+            result = resolve_with_coordinator(
+                coordinator,
+                [ResolveTarget.for_host()],
+                _reqs("foo"),
+                config=_no_build(),
+            )
+
+        assert result.success
+        assert len(result.target_results) == 1
+        assert spy.call_count == 1
+
+    @staticmethod
+    def _linux_host_env() -> dict[str, str]:
+        return {
+            "implementation_name": "cpython",
+            "os_name": "posix",
+            "platform_machine": "x86_64",
+            "platform_python_implementation": "CPython",
+            "platform_release": "6.8.0",
+            "platform_system": "Linux",
+            "python_full_version": "3.13.2",
+            "python_version": "3.13",
+            "sys_platform": "linux",
+        }
+
+    def test_a_bare_minor_python_target_splits_and_covers_the_minor(self) -> None:
+        """``--python 3.11`` (and a platform-less ``[tool.nab.environment]``)
+        synthesizes ``3.11.0`` yet carries no ``platform_spec``.  A dep gated
+        below a patch still splits it, so the lock covers every real 3.11
+        instead of a row an installer rejects on 3.11.9.
+        """
+        coordinator = self._coordinator(
+            {
+                "1.0": self._meta("foo", "1.0", 'mid ; python_full_version < "3.11.4"'),
+                "2.0": self._meta("mid", "2.0"),
+            }
+        )
+        target = ResolveTarget.for_host_python("3.11", env_source=self._linux_host_env)
+
+        result = resolve_with_coordinator(
+            coordinator, [target], _reqs("foo"), config=_no_build()
+        )
+
+        assert result.success
+        assert self._pins_by_label(result) == {
+            "py311-host-pf3110": {"foo", "mid"},
+            "py311-host-pf3114": {"foo"},
+        }
+        rows = build_lock_input(result, config=_no_build()).environments
+        assert len(rows) == 2
+        real_3119 = {
+            "python_version": "3.11",
+            "python_full_version": "3.11.9",
+            "sys_platform": "linux",
+            "platform_machine": "x86_64",
+            "implementation_name": "cpython",
+        }
+        assert any(row.evaluate(real_3119) for row in rows)
+
+    def _fixpoint_coordinator(self) -> MagicMock:
+        return self._coordinator(
+            {
+                "1.0": self._meta(
+                    "foo", "1.0", 'mid ; python_full_version >= "3.10.2"'
+                ),
+                "2.0": self._meta(
+                    "mid", "2.0", 'top ; python_full_version >= "3.10.5"'
+                ),
+                "3.0": self._meta("top", "3.0"),
+            }
+        )
+
+    def test_a_boundary_reachable_only_above_a_split_is_found(self) -> None:
+        """``top``'s 3.10.5 boundary is consulted only once ``mid`` is present,
+        which needs 3.10.2 first.  The fixpoint re-splits until it settles."""
+        targets = Matrix(
+            python="==3.10", platforms=(PlatformSpec("linux_x86_64"),)
+        ).expand()
+
+        result = resolve_with_coordinator(
+            self._fixpoint_coordinator(), targets, _reqs("foo"), config=_no_build()
+        )
+
+        assert result.success
+        assert self._pins_by_label(result) == {
+            "py310-linux_x86_64-pf3100": {"foo"},
+            "py310-linux_x86_64-pf3102": {"foo", "mid"},
+            "py310-linux_x86_64-pf3105": {"foo", "mid", "top"},
+        }
+
+    def test_a_split_that_does_not_converge_raises(self) -> None:
+        """The pass cap turns a graph that never settles into a loud error
+        rather than a hang."""
+        targets = Matrix(
+            python="==3.10", platforms=(PlatformSpec("linux_x86_64"),)
+        ).expand()
+
+        with (
+            patch.object(resolve_mod, "_MAX_MICRO_SPLIT_PASSES", 1),
+            pytest.raises(ResolutionError, match="did not converge"),
+        ):
+            resolve_with_coordinator(
+                self._fixpoint_coordinator(),
+                targets,
+                _reqs("foo"),
+                config=_no_build(),
+            )
+
+    def test_divergent_slice_pins_validate_as_disjoint(self) -> None:
+        """Two slices pinning one package at different versions carry disjoint
+        micro markers, so the emitted lock passes disjointness validation."""
+        coordinator = make_coordinator(
+            listings={
+                "bar": [
+                    _make_wheel("1.0", package="bar"),
+                    _make_wheel("2.0", package="bar"),
+                ]
+            },
+            auto_metadata=True,
+        )
+        targets = Matrix(
+            python="==3.10", platforms=(PlatformSpec("linux_x86_64"),)
+        ).expand()
+
+        result = resolve_with_coordinator(
+            coordinator,
+            targets,
+            _reqs(
+                'bar==1.0 ; python_full_version < "3.10.4"',
+                'bar==2.0 ; python_full_version >= "3.10.4"',
+            ),
+            config=_no_build(),
+        )
+
+        assert result.success
+        versions = {
+            tr.target.label: str(tr.pins["bar"]) for tr in result.target_results
+        }
+        assert versions == {
+            "py310-linux_x86_64-pf3100": "1.0",
+            "py310-linux_x86_64-pf3104": "2.0",
+        }
+
+        pylock = build_pylock(build_lock_input(result, config=_no_build()))
+        pylock.validate()
+        bars = [pkg for pkg in pylock.packages if str(pkg.name) == "bar"]
+        assert len(bars) == 2
+
+    def test_a_literal_on_the_left_marker_splits_and_covers_the_minor(self) -> None:
+        """A dep gated by a literal-first marker (``"3.10.4" > pfv``) splits
+        the minor the same as ``pfv < "3.10.4"`` would, so the two rows cover
+        every real 3.10 with no interpreter left between them.
+        """
+        coordinator = self._coordinator(
+            {
+                "1.0": self._meta("foo", "1.0", 'mid ; "3.10.4" > python_full_version'),
+                "2.0": self._meta("mid", "2.0"),
+            }
+        )
+        targets = Matrix(
+            python="==3.10", platforms=(PlatformSpec("linux_x86_64"),)
+        ).expand()
+
+        result = resolve_with_coordinator(
+            coordinator, targets, _reqs("foo"), config=_no_build()
+        )
+
+        assert result.success
+        assert self._pins_by_label(result) == {
+            "py310-linux_x86_64-pf3100": {"foo", "mid"},
+            "py310-linux_x86_64-pf3104": {"foo"},
+        }
+        rows = build_lock_input(result, config=_no_build()).environments
+        assert len(rows) == 2
+        for micro in ("3.10.0", "3.10.3", "3.10.4", "3.10.19"):
+            env = {
+                "python_version": "3.10",
+                "python_full_version": micro,
+                "sys_platform": "linux",
+                "platform_machine": "x86_64",
+                "implementation_name": "cpython",
+            }
+            assert sum(row.evaluate(env) for row in rows) == 1

--- a/nab-python/tests/test_target.py
+++ b/nab-python/tests/test_target.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import pytest
 
 from nab_python._vendor.packaging.markers import Marker
+from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.tags import Tag
 from nab_python._vendor.packaging.version import InvalidVersion, Version
@@ -20,13 +21,16 @@ from nab_python.target import (
     PLATFORM_MARKERS,
     UNBOUNDABLE_MARKER_VARIABLES,
     Matrix,
+    NonIntervalMarkerError,
     ResolveTarget,
     apply_python_axis_overlay,
     declared_environment,
     environment_declaration,
     host_environment,
     marker_variables,
+    micro_boundary_points,
     python_axis_environment,
+    slices_from_points,
     unboundable_variables,
 )
 
@@ -258,6 +262,70 @@ class TestForDeclared:
         tag_strs = {str(t) for t in target.tags.ordered}
         assert "cp311-cp311-musllinux_1_2_x86_64" in tag_strs
         assert not any("manylinux" in t for t in tag_strs)
+
+
+class TestAdmitsRequiresPython:
+    """A minor interval admits a candidate whose Requires-Python overlaps it.
+
+    Range overlap, not a scalar probe: truncating the compared scalar to
+    major.minor is a no-op, since ``3.13`` and ``3.13.0`` are both excluded by
+    ``>= "3.13.2"``.  The interval minor honours a micro floor at the language
+    minor it names; a whole target keeps the scalar test.
+    """
+
+    @staticmethod
+    def _minor_target() -> ResolveTarget:
+        return ResolveTarget.for_declared(
+            python_version="3.13", spec=PlatformSpec("linux_x86_64")
+        )
+
+    def test_a_micro_floor_admits_the_whole_minor(self) -> None:
+        target = self._minor_target()
+        assert target.is_minor_interval
+        assert target.admits_requires_python(SpecifierSet(">=3.13.2"))
+
+    def test_the_scalar_probe_is_a_no_op_trap(self) -> None:
+        target = self._minor_target()
+        assert target.python_release not in SpecifierSet(">=3.13.2")
+        assert Version("3.13") not in SpecifierSet(">=3.13.2")
+
+    def test_a_disjoint_floor_still_excludes(self) -> None:
+        target = self._minor_target()
+        assert not target.admits_requires_python(SpecifierSet(">=3.14"))
+        assert not target.admits_requires_python(SpecifierSet("<3.13"))
+
+    def test_a_whole_host_target_uses_the_scalar_test(self) -> None:
+        target = ResolveTarget.for_host(env_source=_host_env, tags_source=_host_tags)
+        assert not target.is_minor_interval
+        assert target.admits_requires_python(SpecifierSet(">=3.13.2"))
+        assert not target.admits_requires_python(SpecifierSet(">=3.13.3"))
+
+    def test_a_python_patches_micro_is_whole(self) -> None:
+        target = ResolveTarget.for_declared(
+            python_version="3.13",
+            spec=PlatformSpec("linux_x86_64"),
+            python_full_version="3.13.4",
+        )
+        assert not target.is_minor_interval
+        assert target.admits_requires_python(SpecifierSet(">=3.13.2"))
+        assert not target.admits_requires_python(SpecifierSet(">=3.13.5"))
+
+    def test_every_slice_of_a_split_minor_agrees(self) -> None:
+        """A slice off a bare minor is an interval on every side of the split.
+
+        A split moves the upper slice onto a real micro representative, but the
+        row still stands for every interpreter above the boundary, so the whole
+        minor is the admission granularity.  Answering the upper slice at its
+        representative reverts to the synthetic-floor bug: a candidate whose
+        Requires-Python only its interpreters satisfy would be dropped on the
+        slice that can install it.
+        """
+        floor, upper = slices_from_points(self._minor_target(), [Version("3.13.4")])
+        assert floor.is_minor_interval
+        assert upper.is_minor_interval
+        spec = SpecifierSet(">=3.13.6")
+        assert floor.admits_requires_python(spec)
+        assert upper.admits_requires_python(spec)
 
 
 class TestLabels:
@@ -769,141 +837,83 @@ class TestEnvironmentDeclaration:
         assert Marker(declaration).evaluate(real_pypy)
 
 
-class TestFullVersionDeclaration:
-    """``python_full_version`` is declared by constraint, not by value: the
-    resolve depends on how its clauses read the micro release, not on the
-    micro release itself, so a lock built on 3.13.2 must install on 3.13.9.
+class TestVersionEmission:
+    """``python_full_version`` is never declared by value.  A minor target is a
+    micro interval and a consulted marker splits it at its boundary, so each
+    slice carries its own ``python_full_version`` bounds; a whole target and an
+    unsplit minor emit no ``python_full_version`` clause at all.
     """
 
-    def _target(self, full_version: str) -> ResolveTarget:
+    def _minor(self) -> ResolveTarget:
+        return ResolveTarget.for_declared(
+            python_version="3.12", spec=PlatformSpec("linux_x86_64")
+        )
+
+    def _host(self, full_version: str = "3.13.2") -> ResolveTarget:
         def env_source() -> dict[str, str]:
             return {**_HOST_ENV, "python_full_version": full_version}
 
         return ResolveTarget.for_host(env_source=env_source, tags_source=_host_tags)
 
-    def test_a_clause_that_read_false_is_declared_complemented(self) -> None:
-        """coverage's ``tomli ; python_full_version <= "3.11.0a6"`` is the case."""
-        declaration = environment_declaration(
-            self._target("3.13.2"), [Marker('python_full_version <= "3.11.0a6"')]
-        )
-        assert 'python_full_version > "3.11.0a6"' in declaration
-        assert "python_full_version ==" not in declaration
-        assert Marker(declaration).evaluate(
-            {**_HOST_ENV, "python_full_version": "3.13.9"}
+    def test_an_unsplit_minor_emits_a_plain_row(self) -> None:
+        """A minor no marker split reverts to a plain ``python_version`` row."""
+        declaration = environment_declaration(self._minor(), ())
+        assert declaration == (
+            'python_version == "3.12" and sys_platform == "linux"'
+            ' and platform_machine == "x86_64"'
         )
 
-    def test_a_clause_that_read_true_is_declared_as_it_stands(self) -> None:
+    def test_a_uniform_marker_leaves_the_minor_plain(self) -> None:
+        """A consulted marker whose boundary falls outside the minor is uniform,
+        so it splits nothing and the row carries no python_full_version."""
         declaration = environment_declaration(
-            self._target("3.13.5"), [Marker('python_full_version >= "3.13.4"')]
+            self._minor(), [Marker('python_full_version <= "3.11.0a6"')]
         )
-        assert declaration.endswith('and python_full_version >= "3.13.4"')
+        assert "python_full_version" not in declaration
 
-    def test_a_clause_that_splits_the_micros_still_splits_them(self) -> None:
-        """The dep this marker gates is in the pins; a 3.13.2 install is not."""
+    def test_a_whole_target_emits_no_full_version_clause(self) -> None:
+        """A host names a real micro and is whole, so a consulted marker on the
+        micro is not lifted onto the row: the row is its plain minor."""
         declaration = environment_declaration(
-            self._target("3.13.5"), [Marker('python_full_version >= "3.13.4"')]
+            self._host(), [Marker('python_full_version >= "3.13.4"')]
         )
-        assert Marker(declaration).evaluate(
-            {**_HOST_ENV, "python_full_version": "3.13.5"}
-        )
-        assert not Marker(declaration).evaluate(
-            {**_HOST_ENV, "python_full_version": "3.13.2"}
-        )
-
-    def test_the_complement_of_a_split_refuses_the_other_side(self) -> None:
-        declaration = environment_declaration(
-            self._target("3.13.2"), [Marker('python_full_version >= "3.13.4"')]
-        )
-        assert 'python_full_version < "3.13.4"' in declaration
-        assert not Marker(declaration).evaluate(
-            {**_HOST_ENV, "python_full_version": "3.13.5"}
-        )
-
-    def test_every_full_version_clause_is_declared(self) -> None:
-        """nab's own docs graph reads the axis twice, and both readings hold."""
-        declaration = environment_declaration(
-            self._target("3.13.2"),
-            [
-                Marker('python_full_version <= "3.11.0a6"'),
-                Marker('python_full_version < "3.10.2" and os_name == "posix"'),
-            ],
-        )
+        assert "python_full_version" not in declaration
         assert declaration == (
             'python_version == "3.13" and sys_platform == "linux"'
-            ' and platform_machine == "x86_64" and os_name == "posix"'
-            ' and python_full_version > "3.11.0a6"'
-            ' and python_full_version >= "3.10.2"'
+            ' and platform_machine == "x86_64"'
         )
 
-    def test_implementation_version_is_declared_by_constraint(self) -> None:
-        """It is the micro release under another name, so pinning it is the same bug.
+    def test_a_split_slice_emits_dev0_lower_and_release_upper(self) -> None:
+        """The above slice's lower bound is snapped to ``.dev0``; the below
+        slice's upper bound stays release form."""
+        below, above = slices_from_points(self._minor(), [Version("3.12.4")])
+        consulted = [Marker('python_full_version >= "3.12.4"')]
+        assert 'python_full_version < "3.12.4"' in environment_declaration(
+            below, consulted
+        )
+        assert 'python_full_version >= "3.12.4.dev0"' in environment_declaration(
+            above, consulted
+        )
 
-        On CPython ``implementation_version`` reports
-        ``sys.implementation.version``, which is the same release
-        ``python_full_version`` reports, so declaring its value would refuse
-        every interpreter but the one micro the target names.
-        """
+    def test_implementation_version_mirrors_the_slice_bounds(self) -> None:
+        """On CPython ``implementation_version`` tracks ``python_full_version``,
+        so a marker that consulted it gets the slice's bounds mirrored onto its
+        own name alongside the ``python_full_version`` ones."""
+        _below, above = slices_from_points(self._minor(), [Version("3.12.4")])
         declaration = environment_declaration(
-            self._target("3.13.2"),
-            [Marker('implementation_version >= "3.0"')],
+            above, [Marker('implementation_version >= "3.12.4"')]
         )
-        assert 'implementation_version >= "3.0"' in declaration
-        assert 'implementation_version == "3.13.2"' not in declaration
-        assert Marker(declaration).evaluate(
-            {
-                **_HOST_ENV,
-                "python_full_version": "3.13.9",
-                "implementation_version": "3.13.9",
-            }
-        )
+        assert 'python_full_version >= "3.12.4.dev0"' in declaration
+        assert 'implementation_version >= "3.12.4.dev0"' in declaration
 
-    def test_a_clause_that_held_is_declared_whatever_its_operator(self) -> None:
-        """A clause that held needs no complement, so ``~=`` declares itself.
-
-        Pinning the exact value instead would refuse every other micro of the
-        line the resolve was valid for.
-        """
+    def test_implementation_version_is_not_mirrored_when_not_consulted(self) -> None:
+        """No marker consulted ``implementation_version``, so only the
+        ``python_full_version`` bound is emitted."""
+        _below, above = slices_from_points(self._minor(), [Version("3.12.4")])
         declaration = environment_declaration(
-            self._target("3.13.2"), [Marker('python_full_version ~= "3.13.0"')]
+            above, [Marker('python_full_version >= "3.12.4"')]
         )
-        assert declaration.endswith('and python_full_version ~= "3.13.0"')
-        assert Marker(declaration).evaluate(
-            {**_HOST_ENV, "python_version": "3.13", "python_full_version": "3.13.9"}
-        )
-
-    def test_an_operator_with_no_complement_pins_the_value(self) -> None:
-        """``~=`` read False has no single-clause negation; the value is sound."""
-        declaration = environment_declaration(
-            self._target("3.13.2"), [Marker('python_full_version ~= "3.14.0"')]
-        )
-        assert declaration.endswith('and python_full_version == "3.13.2"')
-
-    def test_a_literal_on_the_left_is_declared_in_place(self) -> None:
-        """PEP 508 allows either operand order; the complement keeps it."""
-        declaration = environment_declaration(
-            self._target("3.13.2"), [Marker('"3.10.2" > python_full_version')]
-        )
-        assert declaration.endswith('and "3.10.2" <= python_full_version')
-        assert Marker(declaration).evaluate(
-            {**_HOST_ENV, "python_full_version": "3.13.9"}
-        )
-
-    def test_a_comparison_against_another_variable_pins_the_value(self) -> None:
-        declaration = environment_declaration(
-            self._target("3.13.2"), [Marker("python_full_version == python_version")]
-        )
-        assert declaration.endswith('and python_full_version == "3.13.2"')
-
-    def test_a_prerelease_boundary_pins_the_value(self) -> None:
-        """PEP 440 keeps 3.13.0rc1 out of both ``< 3.13.0`` and ``>= 3.13.0``.
-
-        Flipping the operator is not the complement there, so the target
-        would not satisfy its own declaration; pin the value instead.
-        """
-        declaration = environment_declaration(
-            self._target("3.13.0rc1"), [Marker('python_full_version < "3.13.0"')]
-        )
-        assert declaration.endswith('and python_full_version == "3.13.0rc1"')
+        assert "implementation_version" not in declaration
 
 
 class TestUnboundableVariables:
@@ -931,100 +941,404 @@ class TestUnboundableVariables:
         )
 
 
-class TestDecidingClauses:
-    """A clause is declared only when the marker's answer turned on it.
-
-    A marker is an ``and``/``or`` of clauses, so a clause on the micro
-    release can be dead: the other side of an ``or`` already held, or the
-    other side of an ``and`` already failed.  Declaring it anyway would
-    refuse a micro release that reads every marker exactly as the resolve
-    did, which is the environment the lock was built for.
+class TestMicroBoundarySplitting:
+    """A declared target names a minor and synthesizes its ``.0`` micro.  A
+    consulted marker with an in-minor python_full_version boundary cuts the
+    micro line, and the minor is resolved once per slice.
     """
 
-    def _target(self, full_version: str = "3.13.2") -> ResolveTarget:
-        def env_source() -> dict[str, str]:
-            return {**_HOST_ENV, "python_full_version": full_version}
-
-        return ResolveTarget.for_host(env_source=env_source, tags_source=_host_tags)
+    def _target(
+        self, python_version: str = "3.12", full_version: str | None = None
+    ) -> ResolveTarget:
+        return ResolveTarget.for_declared(
+            python_version=python_version,
+            spec=PlatformSpec("linux_x86_64"),
+            python_full_version=full_version,
+        )
 
     def _probe(self, full_version: str) -> dict[str, str]:
-        return {**_HOST_ENV, "python_full_version": full_version}
+        return {
+            "python_version": "3.12",
+            "python_full_version": full_version,
+            "sys_platform": "linux",
+            "platform_machine": "x86_64",
+            "implementation_name": "cpython",
+        }
 
     @pytest.mark.parametrize(
-        "text",
+        ("marker", "points"),
         [
-            'python_full_version >= "3.13.5" or sys_platform == "linux"',
-            'python_full_version < "3.13.5" or sys_platform == "linux"',
-            'python_full_version < "3.13.5" and sys_platform == "win32"',
-            'os_name == "python_full_version"',
+            ('python_full_version < "3.12.4"', ["3.12.4"]),
+            ('python_full_version >= "3.12.4"', ["3.12.4"]),
+            ('python_full_version <= "3.12.4"', ["3.12.5"]),
+            ('python_full_version > "3.12.4"', ["3.12.5"]),
+            ('python_full_version == "3.12.4"', ["3.12.4", "3.12.5"]),
+            ('python_full_version != "3.12.4"', ["3.12.4", "3.12.5"]),
+            ('python_full_version ~= "3.12.4"', ["3.12.4"]),
+            ('python_full_version == "3.12.*"', []),
+            ('python_full_version == "3.12.4.*"', ["3.12.4", "3.12.5"]),
         ],
     )
-    def test_a_dead_clause_leaves_the_micro_open(self, text: str) -> None:
-        """Every one of these reads the same on 3.13.2 and on 3.13.9."""
-        marker = Marker(text)
-        target = self._target()
-        probe = self._probe("3.13.9")
-        assert marker.evaluate(probe) == marker.evaluate(target.marker_env)
-
-        declaration = environment_declaration(target, [marker])
-        assert "python_full_version" not in declaration
-        assert Marker(declaration).evaluate(probe)
-
-    def test_a_live_clause_still_splits_the_micros(self) -> None:
-        """The ``and`` holds here, so the dep this gates is in the pins."""
-        target = self._target()
-        declaration = environment_declaration(
-            target, [Marker('python_full_version < "3.13.5" and sys_platform=="linux"')]
-        )
-        assert 'python_full_version < "3.13.5"' in declaration
-        assert not Marker(declaration).evaluate(self._probe("3.13.9"))
-
-    def test_a_clause_under_an_extra_is_live(self) -> None:
-        """The resolve read this marker under the extra too, where it splits.
-
-        ``extra`` is not an environment axis a lock declares, so the
-        installer picks it: the clause has to hold for every choice.
+    def test_each_operator_maps_to_its_boundaries(
+        self, marker: str, points: list[str]
+    ) -> None:
+        """``<``/``>=`` cut at the literal, ``<=``/``>`` at the release after
+        it, and ``==``/``!=``/``~=``/``== V.*`` at each edge of the region they
+        name.  A boundary outside the minor or at its floor cuts nothing, so
+        ``~= "3.12.4"`` cuts only its lower edge and ``== "3.12.*"`` cuts
+        nothing.  Every boundary comes from an edge of the range's
+        ``release_intervals``.
         """
-        target = self._target()
-        declaration = environment_declaration(
-            target, [Marker('python_full_version < "3.13.5" and extra == "test"')]
-        )
-        assert 'python_full_version < "3.13.5"' in declaration
-        assert not Marker(declaration).evaluate(self._probe("3.13.9"))
+        found = micro_boundary_points(self._target(), [Marker(marker)])
+        assert [str(point) for point in found] == points
 
-    def test_clauses_that_only_matter_together_still_split_the_micros(self) -> None:
-        """Neither clause alone moves the marker; both flipping does.
-
-        Dropping is decided for the set as a whole, so one of the pair
-        survives and the declaration still refuses 3.14.
+    @pytest.mark.parametrize(
+        ("marker", "points"),
+        [
+            ('"3.12.4" > python_full_version', ["3.12.4"]),
+            ('"3.12.4" <= python_full_version', ["3.12.4"]),
+            ('"3.12.4" >= python_full_version', ["3.12.5"]),
+            ('"3.12.4" < python_full_version', ["3.12.5"]),
+            ('"3.12.4" == python_full_version', ["3.12.4", "3.12.5"]),
+            ('"3.12.4" != python_full_version', ["3.12.4", "3.12.5"]),
+        ],
+    )
+    def test_a_literal_on_the_left_mirrors_the_operator(
+        self, marker: str, points: list[str]
+    ) -> None:
+        """PEP 508 allows the literal first, and packaging keeps that order.
+        An ordered or symmetric operator is mirrored back to variable-on-left
+        form, so each literal-first clause cuts at the same release as its
+        variable-first equivalent: ``"3.12.4" > python_full_version`` reads
+        like ``< "3.12.4"``.
         """
-        target = self._target()
-        declaration = environment_declaration(
-            target,
+        found = micro_boundary_points(self._target(), [Marker(marker)])
+        assert [str(point) for point in found] == points
+
+    @pytest.mark.parametrize(
+        ("marker", "points"),
+        [
+            ('python_full_version < "3.12.0"', []),
+            ('python_full_version >= "3.12.0"', []),
+            ('python_full_version <= "3.12.0"', ["3.12.1"]),
+            ('python_full_version > "3.12.0"', ["3.12.1"]),
+            ('python_full_version < "3.12"', []),
+            ('python_full_version >= "3.12"', []),
+            ('python_full_version <= "3.12"', ["3.12.1"]),
+            ('python_full_version > "3.12"', ["3.12.1"]),
+        ],
+    )
+    def test_a_boundary_at_the_floor_splits_only_after_the_literal(
+        self, marker: str, points: list[str]
+    ) -> None:
+        """``.0`` is the minor's floor. ``<``/``>=`` flip there and cut
+        nothing, but ``<=``/``>`` flip at ``.1``, so they still split. The
+        two-component literal ``3.12`` equals ``3.12.0`` and behaves the same.
+        """
+        found = micro_boundary_points(self._target(), [Marker(marker)])
+        assert [str(point) for point in found] == points
+
+    def test_an_after_literal_prerelease_below_the_floor_does_not_split(
+        self,
+    ) -> None:
+        """``<= "3.11.0a6"`` flips at ``3.11.0``, the minor's floor, so the
+        whole real minor reads it False. Bumping to ``3.11.1`` would split it
+        spuriously; the flip is the boundary's own final release, not the next
+        micro."""
+        target = self._target(python_version="3.11")
+        markers = [
+            Marker('python_full_version <= "3.11.0a6"'),
+            Marker('python_full_version > "3.11.0a6"'),
+        ]
+        assert micro_boundary_points(target, markers) == []
+
+    def test_an_after_literal_prerelease_above_the_floor_splits_at_its_final(
+        self,
+    ) -> None:
+        """``<= "3.12.2a1"`` flips at ``3.12.2``, its own final release, so a
+        real 3.12.1 and 3.12.2 land on opposite slices."""
+        found = micro_boundary_points(
+            self._target(), [Marker('python_full_version <= "3.12.2a1"')]
+        )
+        assert [str(point) for point in found] == ["3.12.2"]
+
+    def test_an_after_literal_post_release_splits_at_the_next_micro(self) -> None:
+        """A post release sorts above its final, so ``<= "3.11.0.post1"`` still
+        flips at the next micro, ``3.11.1``."""
+        found = micro_boundary_points(
+            self._target(python_version="3.11"),
+            [Marker('python_full_version <= "3.11.0.post1"')],
+        )
+        assert [str(point) for point in found] == ["3.11.1"]
+
+    def test_a_boundary_outside_the_minor_does_not_split(self) -> None:
+        """An earlier or later minor is the whole-minor declaration's business."""
+        markers = [
+            Marker('python_full_version < "3.11.5"'),
+            Marker('python_full_version >= "3.13.0"'),
+        ]
+        assert micro_boundary_points(self._target(), markers) == []
+
+    def test_a_prerelease_literal_below_the_floor_does_not_split(self) -> None:
+        """``>= "3.12.0a1"`` names a prerelease of the floor, so it is uniform
+        across the real minor under the rides-with-X convention and crashes
+        nothing: its release form ``3.12.0`` is not above the floor."""
+        assert (
+            micro_boundary_points(
+                self._target(), [Marker('python_full_version >= "3.12.0a1"')]
+            )
+            == []
+        )
+
+    def test_a_prerelease_literal_outside_the_minor_does_not_split(self) -> None:
+        """A prerelease of another minor is uniform here, so no crash."""
+        assert (
+            micro_boundary_points(
+                self._target(), [Marker('python_full_version < "3.13.4rc1"')]
+            )
+            == []
+        )
+
+    @pytest.mark.parametrize(
+        "marker",
+        [
+            "python_full_version < python_version",
+            "python_full_version >= implementation_version",
+            'python_full_version < "3.12.x"',
+            'python_full_version == "wat"',
+            'python_full_version === "3.12.4"',
+            'python_full_version in "3.12.4"',
+            'python_full_version not in "3.12.4"',
+            'python_full_version < "3.12.4rc1"',
+            'python_full_version == "3.12.4rc1"',
+            'python_full_version ~= "3.12.4b1"',
+            '"3.12.4" ~= python_full_version',
+            '"3.12.4rc1" == python_full_version',
+        ],
+    )
+    def test_an_untileable_marker_crashes(self, marker: str) -> None:
+        """A membership, verbatim ===, non-version, variable, or interior
+        prerelease comparison on a minor interval is a loud crash: the
+        whole-minor pin that once absorbed it is gone."""
+        with pytest.raises(NonIntervalMarkerError):
+            micro_boundary_points(self._target(), [Marker(marker)])
+
+    def test_a_non_version_clause_is_ignored(self) -> None:
+        """Only the python_full_version clause of a marker is a boundary."""
+        found = micro_boundary_points(
+            self._target(),
+            [Marker('python_full_version < "3.12.4" and os_name == "posix"')],
+        )
+        assert [str(point) for point in found] == ["3.12.4"]
+
+    def test_many_boundaries_in_one_minor_all_split(self) -> None:
+        found = micro_boundary_points(
+            self._target(),
             [
-                Marker(
-                    'python_full_version >= "3.13.4" and python_full_version >= "3.14"'
-                )
+                Marker('python_full_version < "3.12.2"'),
+                Marker('python_full_version >= "3.12.6"'),
+                Marker('python_full_version <= "3.12.8"'),
             ],
         )
-        assert not Marker(declaration).evaluate(self._probe("3.14.1"))
-        assert Marker(declaration).evaluate(self._probe("3.13.9"))
+        assert [str(point) for point in found] == ["3.12.2", "3.12.6", "3.12.9"]
 
-    def test_a_marker_of_many_free_clauses_declares_every_clause(self) -> None:
-        """The analysis is exponential in the clauses a lock cannot pin.
-
-        Past the cap every clause on the variable is declared, which is
-        narrow but sound.
-        """
-        extras = " or ".join(f'extra == "e{index}"' for index in range(9))
-        target = self._target()
-        declaration = environment_declaration(
-            target,
-            [
-                Marker(
-                    f'(python_full_version < "3.13.5" and sys_platform == "win32")'
-                    f" or {extras}"
-                )
-            ],
+    def test_a_host_target_is_never_split(self) -> None:
+        """A host target names a real micro, so nothing is synthesized to cut."""
+        host = ResolveTarget.for_host(env_source=_host_env, tags_source=_host_tags)
+        assert (
+            micro_boundary_points(host, [Marker('python_full_version < "3.13.4"')])
+            == []
         )
-        assert 'python_full_version < "3.13.5"' in declaration
+
+    def test_a_user_pinned_micro_is_never_split(self) -> None:
+        """A declared target moved past ``.0`` names a real deployment micro."""
+        assert (
+            micro_boundary_points(
+                self._target(full_version="3.12.4"),
+                [Marker('python_full_version < "3.12.6"')],
+            )
+            == []
+        )
+
+    def test_a_bare_minor_python_target_is_split(self) -> None:
+        """``--python 3.11`` (and a platform-less ``[tool.nab.environment]``)
+        synthesizes ``3.11.0`` like a matrix tuple, so an in-minor boundary
+        cuts it even though it carries no ``platform_spec``."""
+        target = ResolveTarget.for_host_python(
+            "3.11", env_source=_host_env, tags_source=_host_tags
+        )
+        assert target.platform_spec is None
+        found = micro_boundary_points(
+            target, [Marker('python_full_version < "3.11.4"')]
+        )
+        assert [str(point) for point in found] == ["3.11.4"]
+
+    def test_a_host_target_at_a_zero_micro_is_never_split(self) -> None:
+        """A host reporting ``3.13.0`` names a real interpreter, so it stays
+        whole even though its micro equals the minor's floor."""
+        host = ResolveTarget.for_host(
+            env_source=lambda: {**_host_env(), "python_full_version": "3.13.0"},
+            tags_source=_host_tags,
+        )
+        assert (
+            micro_boundary_points(host, [Marker('python_full_version < "3.13.4"')])
+            == []
+        )
+
+    def test_no_points_leaves_the_target_whole(self) -> None:
+        target = self._target()
+        assert slices_from_points(target, []) == [target]
+
+    def test_one_point_makes_two_slices(self) -> None:
+        below, above = slices_from_points(self._target(), [Version("3.12.4")])
+        assert below.label == "py312-linux_x86_64-pf3120"
+        assert below.python_full_version == "3.12.0"
+        assert below.micro_clauses == ('python_full_version < "3.12.4"',)
+        assert above.label == "py312-linux_x86_64-pf3124"
+        assert above.python_full_version == "3.12.4"
+        assert above.micro_clauses == ('python_full_version >= "3.12.4.dev0"',)
+
+    def test_a_middle_slice_carries_both_bounds(self) -> None:
+        points = [Version("3.12.4"), Version("3.12.8")]
+        _low, mid, _high = slices_from_points(self._target(), points)
+        assert mid.python_full_version == "3.12.4"
+        assert mid.micro_clauses == (
+            'python_full_version >= "3.12.4.dev0"',
+            'python_full_version < "3.12.8"',
+        )
+
+    def test_slice_rows_are_disjoint_and_cover_the_minor(self) -> None:
+        below, above = slices_from_points(self._target(), [Version("3.12.4")])
+        consulted = [Marker('python_full_version >= "3.12.4"')]
+        below_row = environment_declaration(below, consulted)
+        above_row = environment_declaration(above, consulted)
+        assert 'python_full_version < "3.12.4"' in below_row
+        assert 'python_full_version >= "3.12.4.dev0"' in above_row
+        assert Marker(below_row).evaluate(self._probe("3.12.1"))
+        assert not Marker(below_row).evaluate(self._probe("3.12.5"))
+        assert Marker(above_row).evaluate(self._probe("3.12.5"))
+        assert not Marker(above_row).evaluate(self._probe("3.12.1"))
+
+    def test_a_slice_emits_its_own_bounds_not_the_consulted_clause(self) -> None:
+        """The row carries the slice's own ``python_full_version`` bounds, not
+        the consulted clause: a ``<=`` boundary flips one release past the
+        literal, so the slice's upper bound ``< "3.12.5"`` is what fences it,
+        and the raw ``<= "3.12.4"`` clause is not lifted onto the row."""
+        below, _above = slices_from_points(self._target(), [Version("3.12.5")])
+        row = environment_declaration(
+            below, [Marker('python_full_version <= "3.12.4"')]
+        )
+        assert 'python_full_version < "3.12.5"' in row
+        assert 'python_full_version <= "3.12.4"' not in row
+
+    def test_a_slice_marker_string_carries_its_micro_bounds(self) -> None:
+        below, above = slices_from_points(self._target(), [Version("3.12.4")])
+        assert below.environment_marker_string.endswith(
+            'and python_full_version < "3.12.4"'
+        )
+        assert 'python_full_version >= "3.12.4.dev0"' in above.environment_marker_string
+
+
+class TestReleaseIntervals:
+    """The public ``VersionRange.release_intervals`` contract nab drives.
+
+    ``micro_boundary_points`` reads the edges of these intervals and filters
+    them to the target's minor; here they are exercised on the range directly,
+    so the per-operator lattice mapping is pinned without the minor filter.
+    """
+
+    @staticmethod
+    def _intervals(spec: str, parts: int = 3) -> list[tuple[str | None, str | None]]:
+        return [
+            (
+                None if lower is None else str(lower),
+                None if upper is None else str(upper),
+            )
+            for lower, upper in SpecifierSet(spec).to_range().release_intervals(parts)
+        ]
+
+    @pytest.mark.parametrize(
+        ("spec", "intervals"),
+        [
+            ("<3.10.2", [(None, "3.10.2")]),
+            ("<=3.10.2", [(None, "3.10.3")]),
+            (">3.10.2", [("3.10.3", None)]),
+            (">=3.10.2", [("3.10.2", None)]),
+            ("==3.10.2", [("3.10.2", "3.10.3")]),
+            ("!=3.10.2", [(None, "3.10.2"), ("3.10.3", None)]),
+            ("~=3.10.2", [("3.10.2", "3.11.0")]),
+            ("==3.10.*", [("3.10.0", "3.11.0")]),
+            ("!=3.10.*", [(None, "3.10.0"), ("3.11.0", None)]),
+            ("==3.10.4.*", [("3.10.4", "3.10.5")]),
+            (">3.10.2,<3.10.4", [("3.10.3", "3.10.4")]),
+        ],
+    )
+    def test_each_operator_maps_to_lattice_intervals(
+        self, spec: str, intervals: list[tuple[str | None, str | None]]
+    ) -> None:
+        """``<``/``>=`` open at the literal, ``<=``/``>`` at the release just
+        above it, and ``==``/``!=``/``~=``/``== V.*`` bracket the region they
+        name.  Each interval is a half-open ``[lower, upper)`` release pair, so
+        the excluded upper edge is the release just past the region; ``None`` on
+        a side is unbounded there."""
+        assert self._intervals(spec) == intervals
+
+    def test_a_dev0_snap_edge_reports_its_final_release(self) -> None:
+        """``< X`` is carried as ``X.dev0``; the upper edge is the final release
+        ``X``, not the dev snap, and ``X`` sits outside the half-open interval."""
+        assert self._intervals("<3.11.4") == [(None, "3.11.4")]
+
+    def test_an_upper_over_a_prerelease_reports_its_final_release(self) -> None:
+        """``<= "3.11.4rc1"`` sits just above the prerelease, whose smallest
+        lattice release above is its own final ``3.11.4``, the interval's
+        excluded upper edge."""
+        assert self._intervals("<=3.11.4rc1") == [(None, "3.11.4")]
+
+    def test_an_unbounded_side_is_none(self) -> None:
+        """An ``-inf`` / ``+inf`` edge names no release, so ``>=`` reports a
+        single interval open on the right and ``<`` one open on the left."""
+        assert self._intervals(">=3.11.4") == [("3.11.4", None)]
+        assert self._intervals("<3.11.4") == [(None, "3.11.4")]
+
+    def test_a_dev0_snapped_lower_bound_reports_its_release(self) -> None:
+        """``>= X.dev0`` carries the prerelease as its lower edge; the interval
+        starts at the final release ``X``, which the range includes."""
+        assert self._intervals(">=3.11.4.dev0") == [("3.11.4", None)]
+
+    def test_an_exclusion_yields_two_intervals(self) -> None:
+        """``!=`` cuts the line in two, so the range covers two disjoint
+        half-open intervals, one on each side of the excluded release."""
+        assert self._intervals("!=3.11.4") == [(None, "3.11.4"), ("3.11.5", None)]
+
+    def test_a_sub_lattice_literal_starts_at_the_release_above_it(self) -> None:
+        """A literal finer than the lattice (``2.3.0.1`` on the three-part
+        lattice) is not a lattice point, so the interval opens at the smallest
+        lattice release above it, which the ``>=`` range includes."""
+        assert self._intervals(">=2.3.0.1") == [("2.3.1", None)]
+
+    def test_adjacent_intervals_merge_at_a_shared_edge(self) -> None:
+        """Two ranges whose projected intervals meet at one release fold into a
+        single interval spanning both."""
+        lower = SpecifierSet(">=3.10.1,<3.10.3").to_range()
+        upper = SpecifierSet("==3.10.3").to_range()
+        merged = (lower | upper).release_intervals(3)
+        assert [(str(lo), str(hi)) for lo, hi in merged] == [("3.10.1", "3.10.4")]
+
+    def test_a_sub_lattice_interval_collapses_at_a_coarse_parts(self) -> None:
+        """Coarsening the lattice folds both edges of a narrow interval onto one
+        release, leaving an empty half-open span that is dropped."""
+        assert SpecifierSet("~=3.10.2").to_range().release_intervals(2) == ()
+        assert self._intervals(">=3.11.4,<3.11.9", 2) == []
+
+    def test_an_empty_range_covers_no_interval(self) -> None:
+        """The empty range has no finite edge and covers nothing."""
+        assert VersionRange.empty().release_intervals(3) == ()
+
+    def test_a_full_range_is_one_unbounded_interval(self) -> None:
+        """The full range covers one interval unbounded on both sides."""
+        assert VersionRange.full().release_intervals(3) == ((None, None),)
+
+    @pytest.mark.parametrize("parts", [0, -1])
+    def test_parts_below_one_is_rejected(self, parts: int) -> None:
+        with pytest.raises(ValueError, match="parts must be at least 1"):
+            SpecifierSet(">=3.11.4").to_range().release_intervals(parts)

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -1,8 +1,8 @@
 diff --git a/nab-python/src/nab_python/_vendor/packaging/ranges.py b/nab-python/src/nab_python/_vendor/packaging/ranges.py
-index 8dd5e66..0d33d1c 100644
+index 8dd5e66..512cc2f 100644
 --- a/nab-python/src/nab_python/_vendor/packaging/ranges.py
 +++ b/nab-python/src/nab_python/_vendor/packaging/ranges.py
-@@ -280,6 +280,47 @@ def _struct_admits(
+@@ -280,6 +280,85 @@ def _struct_admits(
      return matches_bounds_only(bounds, parsed)
  
  
@@ -47,10 +47,48 @@ index 8dd5e66..0d33d1c 100644
 +    return first_inside, first_above
 +
 +
++def _lattice_release(version: Version, parts: int, *, above: bool) -> Version:
++    """The nearest ``parts``-component release to ``version`` on the lattice.
++
++    Truncates ``version``'s release to ``parts`` components, padding a shorter
++    release with zeros, to land on a lattice point at or below it. With
++    ``above`` the result must be strictly greater than ``version``, so a
++    truncation that lands at or below it is rounded up by one; otherwise a
++    truncation equal to ``version`` is kept and only a strictly smaller one is
++    rounded up.
++    """
++    release = version.release[:parts]
++    padded = (*release, *((0,) * (parts - len(release))))
++    candidate = Version.from_parts(epoch=version.epoch, release=padded)
++    if candidate > version or (not above and candidate == version):
++        return candidate
++    bumped = (*padded[:-1], padded[-1] + 1)
++    return Version.from_parts(epoch=version.epoch, release=bumped)
++
++
++def _release_boundary_point(
++    value: BoundaryVersion | Version | None, parts: int
++) -> Version | None:
++    """The lattice release one interval edge transitions membership at.
++
++    ``None`` for an unbounded (``-inf`` / ``+inf``) edge. A boundary sentinel
++    reports the smallest lattice release strictly above the version it sits
++    over (its final release when that version is a pre-release). A plain
++    version reports its own release projected onto the lattice: the release
++    itself when it is a lattice point, otherwise the smallest lattice release
++    above it.
++    """
++    if value is None:
++        return None
++    if isinstance(value, BoundaryVersion):
++        return _lattice_release(value.version, parts, above=True)
++    return _lattice_release(Version(value.base_version), parts, above=False)
++
++
  # Repr helpers:
  
  
-@@ -316,7 +357,8 @@ class VersionRange:
+@@ -316,7 +395,8 @@ class VersionRange:
      :class:`~packaging.specifiers.SpecifierSet`.
  
      Construct via :meth:`~packaging.specifiers.SpecifierSet.to_range`, or with
@@ -60,7 +98,7 @@ index 8dd5e66..0d33d1c 100644
      Compose with :meth:`intersection`, :meth:`union`, :meth:`complement`, and
      :meth:`difference` (or the ``&`` / ``|`` / ``~`` / ``-`` operators). Test
      membership with ``in`` or :meth:`contains`, filter an iterable with
-@@ -407,7 +449,8 @@ class VersionRange:
+@@ -407,7 +487,8 @@ class VersionRange:
          raise TypeError(
              "cannot create 'VersionRange' instances directly; use "
              "SpecifierSet.to_range(), VersionRange.full(), "
@@ -70,7 +108,7 @@ index 8dd5e66..0d33d1c 100644
          )
  
      @classmethod
-@@ -599,6 +642,73 @@ class VersionRange:
+@@ -599,6 +680,73 @@ class VersionRange:
              prereleases_configured=prereleases,
          )
  
@@ -144,7 +182,7 @@ index 8dd5e66..0d33d1c 100644
      def intersection(self, other: VersionRange) -> VersionRange:
          """Range containing exactly the versions in both self and other.
  
-@@ -1078,6 +1188,75 @@ class VersionRange:
+@@ -1078,6 +1226,123 @@ class VersionRange:
          if not found_final:
              yield from all_nonfinal
  
@@ -216,6 +254,54 @@ index 8dd5e66..0d33d1c 100644
 +            pre_region=self._pre_region,
 +            prereleases_configured=self._prereleases_configured,
 +        )
++
++    def release_intervals(
++        self, parts: int
++    ) -> tuple[tuple[Version | None, Version | None], ...]:
++        """The half-open release intervals on which this range is satisfied.
++
++        Projects the range onto the lattice of releases with ``parts`` numeric
++        components and returns the maximal ``[lower, upper)`` intervals it covers,
++        as ``(lower, upper)`` release pairs. ``None`` on a side is unbounded there.
++        Structure finer than the lattice, such as prereleases or posts between two
++        releases, is not represented.
++
++        >>> SpecifierSet(">=3.11.4").to_range().release_intervals(3)
++        ((<Version('3.11.4')>, None),)
++        >>> SpecifierSet("==3.11.4").to_range().release_intervals(3)
++        ((<Version('3.11.4')>, <Version('3.11.5')>),)
++
++        :raises ValueError: if ``parts`` is less than 1.
++        """
++        if parts < 1:
++            raise ValueError(f"parts must be at least 1, got {parts}")
++
++        intervals: list[tuple[Version | None, Version | None]] = []
++        for lower, upper in self._bounds:
++            lower_point = _release_boundary_point(lower.version, parts)
++            upper_point = _release_boundary_point(upper.version, parts)
++            if (
++                lower_point is not None
++                and upper_point is not None
++                and lower_point >= upper_point
++            ):
++                continue
++            if intervals:
++                prev_lower, prev_upper = intervals[-1]
++                if (
++                    prev_upper is not None
++                    and lower_point is not None
++                    and prev_upper >= lower_point
++                ):
++                    merged_upper = (
++                        None
++                        if upper_point is None
++                        else max(prev_upper, upper_point)
++                    )
++                    intervals[-1] = (prev_lower, merged_upper)
++                    continue
++            intervals.append((lower_point, upper_point))
++        return tuple(intervals)
 +
      @classmethod
      def _from_specifier_set(cls, specifier_set: SpecifierSet) -> VersionRange:


### PR DESCRIPTION
A lock target that names only a Python minor (a matrix tuple, a declared environment, or `--python <minor>`) synthesized `{minor}.0` and answered every consulted `python_full_version` marker at that one micro, so the emitted `environments` rows could exclude the real interpreters the lock was resolved for: a consulted `python_full_version < "3.10.2"` read at `3.10.0` pinned the whole minor to that answer and shut out 3.10.19.

Now a minor target is a pure interval over `python_full_version`, split at every consulted boundary, with no synthesized `.0` answering markers. Each split pair emits `< "X"` on the lower side and `>= "X.dev0"` on the upper, so a prerelease interpreter of X lands in exactly one row. A minor that consults no `python_full_version` marker emits a plain `python_version == "X.Y"` row.

A `python_full_version` marker shape that cannot be an interval (`in`, `not in`, `===`, a string comparison, or a prerelease literal) on a minor target fails loudly instead of feeding the same leak. The clause-lifting fallback that produced the leaking pins is removed. The split boundaries come from a new public `VersionRange.release_intervals()` on the vendored packaging.

`Requires-Python` is compared at the language minor by range overlap at every site (index candidates, the config guard, and source pins), so a micro floor like `>= "3.11.4"` admits the whole 3.11 minor rather than excluding it at `.0`. `python-patches` pins a minor to one release, resolved whole. The committed locks are untouched here; #491 regenerates them with this engine.

One behaviour change to note: a split boundary and its lock rows put prereleases of X on the upper side, so a resolve on a prerelease of X gets the pins intended for X.
