### PR TITLE
raise BuildBackendError when backend METADATA is not UTF-8

### DIFF
--- a/nab-python/src/nab_python/_build/runner.py
+++ b/nab-python/src/nab_python/_build/runner.py
@@ -214,7 +214,11 @@ def _parse_metadata(metadata_path: Path) -> WheelMetadata:
     if not metadata_path.is_file():
         msg = f"backend produced no METADATA file at {metadata_path}"
         raise BuildBackendError(msg)
-    text = metadata_path.read_text(encoding="utf-8")
+    try:
+        text = metadata_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        msg = f"backend METADATA at {metadata_path} is not valid UTF-8: {exc}"
+        raise BuildBackendError(msg) from exc
     msg_obj = message_from_string(text)
 
     name_raw = msg_obj.get("Name")

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -510,6 +510,18 @@ class TestParseMetadata:
         with pytest.raises(BuildBackendError, match="no METADATA file"):
             _parse_metadata(tmp_path / "DOES-NOT-EXIST")
 
+    def test_non_utf8_metadata_raises_build_backend_error(self, tmp_path: Path) -> None:
+        from nab_python._build.runner import _parse_metadata
+
+        path = tmp_path / "METADATA"
+        path.write_bytes(
+            "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\nAuthor: café\n".encode(
+                "latin-1"
+            )
+        )
+        with pytest.raises(BuildBackendError, match="not valid UTF-8"):
+            _parse_metadata(path)
+
     def test_invalid_version_raises(self, tmp_path: Path) -> None:
         from nab_python._build.runner import _parse_metadata
 


### PR DESCRIPTION
When a build backend produces a METADATA file that isn't valid UTF-8, `_parse_metadata` let the `UnicodeDecodeError` from `read_text` propagate straight out of `run_build_backend`. That breaks the contract that `run_build_backend` raises `BuildBackendError` for any build failure, so a caller catching `BuildBackendError` gets an unexpected exception type instead.

Wrap the decode and re-raise it as `BuildBackendError` naming the METADATA path, matching how the other parse failures in that function are already reported.
