### PR TITLE
stop retrying unsupported URL schemes on the httpx backend

### DIFF
--- a/nab-index/src/nab_index/httpx_async_transport.py
+++ b/nab-index/src/nab_index/httpx_async_transport.py
@@ -88,8 +88,9 @@ class HttpxAsyncTransport:
         while True:
             try:
                 response = await self._client.get(url, headers=headers)
-            except httpx.TooManyRedirects as exc:
-                # A redirect loop is persistent, so it is raised rather than retried.
+            except (httpx.TooManyRedirects, httpx.UnsupportedProtocol) as exc:
+                # A redirect loop and an unsupported scheme are persistent, so
+                # they are raised rather than retried.
                 msg = f"GET {url} failed: {exc}"
                 raise HttpError(msg) from exc
             except httpx.HTTPError as exc:

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -490,6 +490,41 @@ class TestHttpxAsyncTransport:
         assert route.call_count == MAX_RETRIES + 1
         assert slept == [0.0, 0.5, 1.0]
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "ftp://example.com/x.tar.gz",
+            "gopher://example.com/x",
+            "not-a-url",
+            "://nohost/path",
+        ],
+    )
+    def test_get_does_not_retry_an_unsupported_scheme(
+        self, url: str, slept: list[float], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A URL httpx cannot issue is permanent, so it is raised on the first try."""
+        attempts = 0
+
+        async def go() -> None:
+            transport = HttpxAsyncTransport(http2=False)
+            real_get = transport._client.get
+
+            async def counting_get(*args: object, **kwargs: object) -> object:
+                nonlocal attempts
+                attempts += 1
+                return await real_get(*args, **kwargs)
+
+            monkeypatch.setattr(transport._client, "get", counting_get)
+            try:
+                await transport.get(url)
+            finally:
+                await transport.aclose()
+
+        with pytest.raises(HttpError, match=f"GET {url} failed"):
+            asyncio.run(go())
+        assert attempts == 1
+        assert slept == []
+
     @respx.mock
     def test_get_does_not_retry_a_client_error(self, slept: list[float]) -> None:
         """A 404 is the index's answer, so it is fetched once."""


### PR DESCRIPTION
The httpx backend treated an unsupported or missing URL scheme, such as ftp:// or a URL with no scheme, as a transient network error. It made 4 attempts with 1.5s of backoff before failing, when nothing about the URL will change between tries.

httpx.UnsupportedProtocol is a subclass of httpx.HTTPError, so it fell into the same branch as real connection errors and picked up the retry budget. It now sits alongside TooManyRedirects, which is already raised without retrying, so an unusable URL fails on the first attempt.
