### PR TITLE
Build and install the dists in CI

### DIFF
--- a/.github/requirements/pylock.dists.toml
+++ b/.github/requirements/pylock.dists.toml
@@ -1,0 +1,736 @@
+lock-version = "1.0"
+environments = [
+    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+]
+requires-python = ">=3.10"
+dependency-groups = [
+    "dists",
+]
+default-groups = [
+    "dists",
+]
+created-by = "nab"
+
+[[packages]]
+name = "build"
+version = "1.5.0"
+requires-python = ">=3.10"
+dependencies = [
+    { name = "colorama" },
+    { name = "importlib-metadata" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+    { name = "tomli" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "build-1.5.0.tar.gz"
+upload-time = 2026-04-30 03:18:25.170465+00:00
+url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz"
+size = 89796
+
+[packages.sdist.hashes]
+sha256 = "302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647"
+
+[[packages.wheels]]
+name = "build-1.5.0-py3-none-any.whl"
+upload-time = 2026-04-30 03:18:23.644906+00:00
+url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl"
+size = 26018
+
+[packages.wheels.hashes]
+sha256 = "13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f"
+
+[[packages]]
+name = "colorama"
+version = "0.4.6"
+marker = "(python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version >= \"3.10.2.dev0\") or (python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\") or (python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\")"
+requires-python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "colorama-0.4.6.tar.gz"
+upload-time = 2022-10-25 02:36:22.414799+00:00
+url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz"
+size = 27697
+
+[packages.sdist.hashes]
+sha256 = "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+
+[[packages.wheels]]
+name = "colorama-0.4.6-py2.py3-none-any.whl"
+upload-time = 2022-10-25 02:36:20.889702+00:00
+url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl"
+size = 25335
+
+[packages.wheels.hashes]
+sha256 = "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+
+[[packages]]
+name = "docstring-parser"
+version = "0.18.0"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "docstring_parser-0.18.0.tar.gz"
+upload-time = 2026-04-14 04:09:19.867229+00:00
+url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz"
+size = 29341
+
+[packages.sdist.hashes]
+sha256 = "292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015"
+
+[[packages.wheels]]
+name = "docstring_parser-0.18.0-py3-none-any.whl"
+upload-time = 2026-04-14 04:09:18.638975+00:00
+url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl"
+size = 22484
+
+[packages.wheels.hashes]
+sha256 = "b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b"
+
+[[packages]]
+name = "hatchling"
+version = "1.31.0"
+marker = "\"dists\" in dependency_groups"
+requires-python = ">=3.10"
+dependencies = [
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pluggy" },
+    { name = "tomli" },
+    { name = "trove-classifiers" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "hatchling-1.31.0.tar.gz"
+upload-time = 2026-07-08 01:48:32.237659+00:00
+url = "https://files.pythonhosted.org/packages/25/e2/dfa73fe78f773018dcaebc6d09b819bc10d328ff5a6b4a66efa1e3d71f52/hatchling-1.31.0.tar.gz"
+size = 57208
+
+[packages.sdist.hashes]
+sha256 = "6b48ad4068a482ed7239b3a8215bc55b47aad3345d58dfc94e553c5d2d46211b"
+
+[[packages.wheels]]
+name = "hatchling-1.31.0-py3-none-any.whl"
+upload-time = 2026-07-08 01:48:31.024633+00:00
+url = "https://files.pythonhosted.org/packages/64/e2/2c0af0a52d16be74a4f194564fcdc417521ed863e9b65e4bc9052dacba6f/hatchling-1.31.0-py3-none-any.whl"
+size = 77747
+
+[packages.wheels.hashes]
+sha256 = "aac80bec8b6fe35e8480f1c335be8910fa210a0e6f735a139be205dadcacb544"
+
+[[packages]]
+name = "importlib-metadata"
+version = "9.0.0"
+marker = "(python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\")"
+requires-python = ">=3.10"
+dependencies = [
+    { name = "zipp" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "importlib_metadata-9.0.0.tar.gz"
+upload-time = 2026-03-20 06:42:56.999805+00:00
+url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz"
+size = 56405
+
+[packages.sdist.hashes]
+sha256 = "a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc"
+
+[[packages.wheels]]
+name = "importlib_metadata-9.0.0-py3-none-any.whl"
+upload-time = 2026-03-20 06:42:55.665400+00:00
+url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl"
+size = 27789
+
+[packages.wheels.hashes]
+sha256 = "2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7"
+
+[[packages]]
+name = "installer"
+version = "1.0.1"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "installer-1.0.1.tar.gz"
+upload-time = 2026-05-11 18:13:28.158660+00:00
+url = "https://files.pythonhosted.org/packages/06/fe/b9f481cf0cc867958a21338baa900357b7b7d86cac9b025948049d77923c/installer-1.0.1.tar.gz"
+size = 481132
+
+[packages.sdist.hashes]
+sha256 = "052c7fc3721d54c696e2dea019be67539d7b144e924f559f54beb3121831c364"
+
+[[packages.wheels]]
+name = "installer-1.0.1-py3-none-any.whl"
+upload-time = 2026-05-11 18:13:26.252723+00:00
+url = "https://files.pythonhosted.org/packages/26/48/bedf3ba4163e7db392c9d4cbdfc8217423196c8fccbe5a404a0f094fde63/installer-1.0.1-py3-none-any.whl"
+size = 464455
+
+[packages.wheels.hashes]
+sha256 = "011d045df8b954ced7dde3a7e42ae4418da40ecda7990f2d11d5ed7c146fd98b"
+
+[[packages]]
+name = "packaging"
+version = "26.2"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "packaging-26.2.tar.gz"
+upload-time = 2026-04-24 20:15:23.917886+00:00
+url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz"
+size = 228134
+
+[packages.sdist.hashes]
+sha256 = "ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"
+
+[[packages.wheels]]
+name = "packaging-26.2-py3-none-any.whl"
+upload-time = 2026-04-24 20:15:22.081511+00:00
+url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl"
+size = 100195
+
+[packages.wheels.hashes]
+sha256 = "5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"
+
+[[packages]]
+name = "pathspec"
+version = "1.1.1"
+marker = "\"dists\" in dependency_groups"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pathspec-1.1.1.tar.gz"
+upload-time = 2026-04-27 01:46:08.907631+00:00
+url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz"
+size = 135180
+
+[packages.sdist.hashes]
+sha256 = "17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a"
+
+[[packages.wheels]]
+name = "pathspec-1.1.1-py3-none-any.whl"
+upload-time = 2026-04-27 01:46:07.060850+00:00
+url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl"
+size = 57328
+
+[packages.wheels.hashes]
+sha256 = "a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189"
+
+[[packages]]
+name = "pluggy"
+version = "1.6.0"
+marker = "\"dists\" in dependency_groups"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pluggy-1.6.0.tar.gz"
+upload-time = 2025-05-15 12:30:07.975376+00:00
+url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz"
+size = 69412
+
+[packages.sdist.hashes]
+sha256 = "7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"
+
+[[packages.wheels]]
+name = "pluggy-1.6.0-py3-none-any.whl"
+upload-time = 2025-05-15 12:30:06.134003+00:00
+url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl"
+size = 20538
+
+[packages.wheels.hashes]
+sha256 = "e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
+
+[[packages]]
+name = "pyproject-hooks"
+version = "1.2.0"
+requires-python = ">=3.7"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pyproject_hooks-1.2.0.tar.gz"
+upload-time = 2024-09-29 09:24:13.293934+00:00
+url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz"
+size = 19228
+
+[packages.sdist.hashes]
+sha256 = "1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8"
+
+[[packages.wheels]]
+name = "pyproject_hooks-1.2.0-py3-none-any.whl"
+upload-time = 2024-09-29 09:24:11.978642+00:00
+url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl"
+size = 10216
+
+[packages.wheels.hashes]
+sha256 = "9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913"
+
+[[packages]]
+name = "tomli"
+version = "2.4.1"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "tomli-2.4.1.tar.gz"
+upload-time = 2026-03-25 20:22:03.828102+00:00
+url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz"
+size = 17543
+
+[packages.sdist.hashes]
+sha256 = "7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
+upload-time = 2026-03-25 20:21:10.473841+00:00
+url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl"
+size = 154704
+
+[packages.wheels.hashes]
+sha256 = "f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl"
+upload-time = 2026-03-25 20:21:12.036923+00:00
+url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl"
+size = 149454
+
+[packages.wheels.hashes]
+sha256 = "4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:13.098441+00:00
+url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 237561
+
+[packages.wheels.hashes]
+sha256 = "96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:14.569419+00:00
+url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 243824
+
+[packages.wheels.hashes]
+sha256 = "5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp311-cp311-win_amd64.whl"
+upload-time = 2026-03-25 20:21:18.978514+00:00
+url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl"
+size = 108084
+
+[packages.wheels.hashes]
+sha256 = "5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2026-03-25 20:21:21.626567+00:00
+url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 155924
+
+[packages.wheels.hashes]
+sha256 = "c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl"
+upload-time = 2026-03-25 20:21:23.002533+00:00
+url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl"
+size = 150018
+
+[packages.wheels.hashes]
+sha256 = "7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:24.040813+00:00
+url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 244948
+
+[packages.wheels.hashes]
+sha256 = "ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:25.177901+00:00
+url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 253341
+
+[packages.wheels.hashes]
+sha256 = "136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp312-cp312-win_amd64.whl"
+upload-time = 2026-03-25 20:21:29.386807+00:00
+url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl"
+size = 108847
+
+[packages.wheels.hashes]
+sha256 = "52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2026-03-25 20:21:31.650748+00:00
+url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 155866
+
+[packages.wheels.hashes]
+sha256 = "36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl"
+upload-time = 2026-03-25 20:21:33.028949+00:00
+url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl"
+size = 149887
+
+[packages.wheels.hashes]
+sha256 = "eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:34.510750+00:00
+url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 243704
+
+[packages.wheels.hashes]
+sha256 = "c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:36.012836+00:00
+url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 251628
+
+[packages.wheels.hashes]
+sha256 = "f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp313-cp313-win_amd64.whl"
+upload-time = 2026-03-25 20:21:40.248121+00:00
+url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl"
+size = 108755
+
+[packages.wheels.hashes]
+sha256 = "8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl"
+upload-time = 2026-03-25 20:21:42.230154+00:00
+url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl"
+size = 155726
+
+[packages.wheels.hashes]
+sha256 = "fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl"
+upload-time = 2026-03-25 20:21:43.386384+00:00
+url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl"
+size = 149859
+
+[packages.wheels.hashes]
+sha256 = "a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+upload-time = 2026-03-25 20:21:44.474645+00:00
+url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+size = 244713
+
+[packages.wheels.hashes]
+sha256 = "559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+upload-time = 2026-03-25 20:21:45.620261+00:00
+url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+size = 252084
+
+[packages.wheels.hashes]
+sha256 = "01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-cp314-cp314-win_amd64.whl"
+upload-time = 2026-03-25 20:21:50.506850+00:00
+url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl"
+size = 109082
+
+[packages.wheels.hashes]
+sha256 = "88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7"
+
+[[packages.wheels]]
+name = "tomli-2.4.1-py3-none-any.whl"
+upload-time = 2026-03-25 20:22:03.012768+00:00
+url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl"
+size = 14583
+
+[packages.wheels.hashes]
+sha256 = "0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe"
+
+[[packages]]
+name = "tomli-w"
+version = "1.2.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "tomli_w-1.2.0.tar.gz"
+upload-time = 2025-01-15 12:07:24.262974+00:00
+url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz"
+size = 7184
+
+[packages.sdist.hashes]
+sha256 = "2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021"
+
+[[packages.wheels]]
+name = "tomli_w-1.2.0-py3-none-any.whl"
+upload-time = 2025-01-15 12:07:22.074224+00:00
+url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl"
+size = 6675
+
+[packages.wheels.hashes]
+sha256 = "188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90"
+
+[[packages]]
+name = "trove-classifiers"
+version = "2026.6.1.19"
+marker = "\"dists\" in dependency_groups"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "trove_classifiers-2026.6.1.19.tar.gz"
+upload-time = 2026-06-01 19:41:34.649417+00:00
+url = "https://files.pythonhosted.org/packages/c2/e3/7ca82ee24c82d344584abd5b8637b3bd056f2900226e8d82fc22f1184b92/trove_classifiers-2026.6.1.19.tar.gz"
+size = 17059
+
+[packages.sdist.hashes]
+sha256 = "c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745"
+
+[[packages.wheels]]
+name = "trove_classifiers-2026.6.1.19-py3-none-any.whl"
+upload-time = 2026-06-01 19:41:33.434069+00:00
+url = "https://files.pythonhosted.org/packages/7c/a4/81502f486f01db95bc8320646a8a12511f5e556cb63d5e224d91816605c4/trove_classifiers-2026.6.1.19-py3-none-any.whl"
+size = 14211
+
+[packages.wheels.hashes]
+sha256 = "ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3"
+
+[[packages]]
+name = "truststore"
+version = "0.10.4"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "truststore-0.10.4.tar.gz"
+upload-time = 2025-08-12 18:49:02.730234+00:00
+url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz"
+size = 26169
+
+[packages.sdist.hashes]
+sha256 = "9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301"
+
+[[packages.wheels]]
+name = "truststore-0.10.4-py3-none-any.whl"
+upload-time = 2025-08-12 18:49:01.460601+00:00
+url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl"
+size = 18660
+
+[packages.wheels.hashes]
+sha256 = "adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"
+
+[[packages]]
+name = "typeguard"
+version = "4.5.2"
+requires-python = ">=3.9"
+dependencies = [
+    { name = "typing-extensions" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "typeguard-4.5.2.tar.gz"
+upload-time = 2026-05-14 12:59:40.857502+00:00
+url = "https://files.pythonhosted.org/packages/67/1c/dfba5c4633cafc4c701f237d2ba63b416805047fd6d96aab4cfc40969f98/typeguard-4.5.2.tar.gz"
+size = 80240
+
+[packages.sdist.hashes]
+sha256 = "5a16dcac23502039299c97c8941651bc33d7ea8cc4b2f7d6bbb1b528f6eea423"
+
+[[packages.wheels]]
+name = "typeguard-4.5.2-py3-none-any.whl"
+upload-time = 2026-05-14 12:59:39.473017+00:00
+url = "https://files.pythonhosted.org/packages/5b/29/74eeb4d3f3ae61ca096b018ad486b3b3c74b17bec09ab4edab721cbefec3/typeguard-4.5.2-py3-none-any.whl"
+size = 36748
+
+[packages.wheels.hashes]
+sha256 = "fcf9de18bd945cdb4c7b996e12b4c51ce83f92f191314a6d7cf1739586ec98cf"
+
+[[packages]]
+name = "typing-extensions"
+version = "4.16.0"
+requires-python = ">=3.9"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "typing_extensions-4.16.0.tar.gz"
+upload-time = 2026-07-02 08:40:05.920538+00:00
+url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz"
+size = 113555
+
+[packages.sdist.hashes]
+sha256 = "dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5"
+
+[[packages.wheels]]
+name = "typing_extensions-4.16.0-py3-none-any.whl"
+upload-time = 2026-07-02 08:40:04.659120+00:00
+url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl"
+size = 45571
+
+[packages.wheels.hashes]
+sha256 = "481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8"
+
+[[packages]]
+name = "tyro"
+version = "1.0.15"
+requires-python = ">=3.8"
+dependencies = [
+    { name = "docstring-parser" },
+    { name = "typeguard" },
+    { name = "typing-extensions" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "tyro-1.0.15.tar.gz"
+upload-time = 2026-06-20 08:48:28.364151+00:00
+url = "https://files.pythonhosted.org/packages/12/78/a5749a6c1ee9abc2999e294f339f8f72476d1a60bb95fc0e86156aafed3b/tyro-1.0.15.tar.gz"
+size = 593822
+
+[packages.sdist.hashes]
+sha256 = "3f1d60887723eecb9c489f195d11f079c4a1f33df74b723552ad31ec57c667bb"
+
+[[packages.wheels]]
+name = "tyro-1.0.15-py3-none-any.whl"
+upload-time = 2026-06-20 08:48:27.104712+00:00
+url = "https://files.pythonhosted.org/packages/5d/28/d607636187cf6c18eb72efb5d65c1d1b9e451db03d84676f835dd488fdbd/tyro-1.0.15-py3-none-any.whl"
+size = 215045
+
+[packages.wheels.hashes]
+sha256 = "982da1d566005f1b2a6b56f6be6c6929c96f0e5fab9d61bc6097573ddfaf8d13"
+
+[[packages]]
+name = "urllib3"
+version = "2.7.0"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "urllib3-2.7.0.tar.gz"
+upload-time = 2026-05-07 16:13:18.596909+00:00
+url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz"
+size = 433602
+
+[packages.sdist.hashes]
+sha256 = "231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"
+
+[[packages.wheels]]
+name = "urllib3-2.7.0-py3-none-any.whl"
+upload-time = 2026-05-07 16:13:17.151740+00:00
+url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl"
+size = 131087
+
+[packages.wheels.hashes]
+sha256 = "9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
+
+[[packages]]
+name = "zipp"
+version = "4.1.0"
+marker = "(python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\") or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\")"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "zipp-4.1.0.tar.gz"
+upload-time = 2026-05-18 20:08:57.967214+00:00
+url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz"
+size = 26214
+
+[packages.sdist.hashes]
+sha256 = "4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602"
+
+[[packages.wheels]]
+name = "zipp-4.1.0-py3-none-any.whl"
+upload-time = 2026-05-18 20:08:57.045692+00:00
+url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl"
+size = 10238
+
+[packages.wheels.hashes]
+sha256 = "25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f"
+
+[tool.nab]
+nab-version = "0.0.10.dev0"
+created-at = 2026-07-19 21:06:37.953025+00:00
+command-line = [
+    "nab",
+    "lock",
+    "--groups",
+    "dists",
+    "--project-default-group",
+    "dists",
+    "--no-emit-workspace",
+    "--output",
+    ".github/requirements/pylock.dists.toml",
+]
+input-path = "pyproject.toml"
+mode = "universal"
+python-specifier = ">=3.10,<3.15"
+platforms = [
+    "linux_x86_64",
+    "linux_aarch64",
+    "macos_arm64",
+    "macos_x86_64",
+    "windows_amd64",
+]
+cli-project-overrides = [
+    "--project-default-group=dists",
+]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,6 +120,34 @@ jobs:
       - name: Run CrossHair property tests
         run: python -m pytest -m crosshair
 
+  dists:
+    name: Build and install distributions
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.14"
+          cache: pip
+          cache-dependency-path: |
+            .github/requirements/pylock.nox.toml
+            .github/requirements/pylock.dists.toml
+          allow-prereleases: true
+
+      - name: Upgrade pip to PEP 751 install support
+        run: python -m pip install --upgrade "pip>=26.1"
+
+      - name: Install nox
+        run: pip install -r .github/requirements/pylock.nox.toml
+
+      # Build logic lives in tasks/check_dists.py, driven by the dists session.
+      - name: Build every distribution and install each sdist and wheel
+        run: nox -s dists
+
   pass:
     name: All tests pass
     if: always()
@@ -127,6 +155,7 @@ jobs:
       - test
       - property-tests
       - crosshair-tests
+      - dists
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,8 +3,10 @@
 ``tests`` runs one workspace's suite and gates each package it owns at 100
 percent. ``fail_under`` and the ``[tool.coverage.paths]`` remaps live in
 ``pyproject.toml``; the per-package ``--include`` globs are built here.
-``types`` runs one type-checker over ``nab-resolver/src``. Both take their
-pinned dependencies from ``.github/requirements``.
+``types`` runs one type-checker over ``nab-resolver/src``. ``dists`` builds
+every distribution and installs each sdist and wheel to catch packaging
+regressions that building alone misses. All take their pinned dependencies
+from ``.github/requirements``.
 
 The Python version comes from whoever launches nox, so CI drives the matrix
 through ``actions/setup-python`` and stays off the per-OS versioned-binary
@@ -12,6 +14,7 @@ lookup. Run a single cell locally, for example::
 
     nox -s "tests(workspace='python')"
     nox -s "types(checker='mypy')"
+    nox -s dists
 """
 
 from __future__ import annotations
@@ -23,6 +26,7 @@ nox.options.default_venv_backend = "venv"
 
 TESTS_LOCK = ".github/requirements/pylock.tests.toml"
 TYPES_LOCK = ".github/requirements/pylock.types.toml"
+DISTS_LOCK = ".github/requirements/pylock.dists.toml"
 
 # workspace -> (editable packages, pytest paths, coverage-gated packages).
 # nab-index rides with the python workspace: nab-python is its only consumer
@@ -90,3 +94,13 @@ def types(session: nox.Session, checker: str) -> None:
     # their source-path config, not installs.
     _install(session, TYPES_LOCK, ["nab-resolver"])
     session.run(*TYPE_CHECKERS[checker])
+
+
+@nox.session
+def dists(session: nox.Session) -> None:
+    """Build every distribution and prove each sdist and wheel installs."""
+    # Only the build toolchain lands here; the check builds each package in a
+    # subprocess and installs it into its own throwaway venv.
+    session.install("--upgrade", "pip>=26.1")
+    session.install("-r", DISTS_LOCK)
+    session.run("python", "tasks/check_dists.py")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,12 @@ release = [
     "hatchling>=1.27",
     "twine>=6.1",
 ]
+# The dists nox session builds every distribution and installs it. It needs
+# build plus the hatchling backend, since it builds without isolation.
+dists = [
+    "build>=1.2",
+    "hatchling>=1.27",
+]
 
 # `nab lock` config: universal mode resolves the full matrix in one
 # pass, P7D matches the 7-day Dependabot cooldown.

--- a/tasks/check_dists.py
+++ b/tasks/check_dists.py
@@ -1,0 +1,237 @@
+"""Build the release distributions and prove that they install.
+
+Builds an sdist and a wheel for all four workspace packages, installs every
+sdist and the full wheel set into throwaway venvs, and checks that each
+artifact ships its LICENSE. Building alone does not catch a broken sdist:
+``build`` extracts an sdist with a permissive tar filter, while ``pip install``
+applies the data filter and rejects a link that points outside the archive, so
+an sdist that builds cleanly can still fail for anyone who installs it. A
+symlinked license also drops out of the wheel silently, which the artifact
+checks below catch.
+
+Run through nox::
+
+    nox -s dists
+"""
+
+from __future__ import annotations
+
+import email
+import os
+import subprocess
+import sys
+import tarfile
+import tempfile
+import zipfile
+from pathlib import Path
+
+import build_dists
+
+REPO_ROOT = build_dists.REPO_ROOT
+
+# Build order and package directories come from the release build so the
+# checked artifacts are exactly the set the release publishes.
+PACKAGES = build_dists.PACKAGES
+
+# Every nab-python artifact ships the vendored packaging tree, so its license
+# files have to travel with it. Matched by suffix because the wheel roots the
+# package at nab_python/ while the sdist roots it at <root>/src/nab_python/.
+VENDOR_LICENSES = (
+    "nab_python/_vendor/packaging/LICENSE",
+    "nab_python/_vendor/packaging/LICENSE.APACHE",
+    "nab_python/_vendor/packaging/LICENSE.BSD",
+)
+
+
+def _source_date_epoch() -> str:
+    """Return HEAD's committer timestamp, matching the release build."""
+    result = subprocess.run(
+        ["git", "log", "-1", "--pretty=%ct"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _run(command: list[str]) -> None:
+    """Run a command, streaming its output, and stop the check if it fails."""
+    print("+ " + " ".join(command), flush=True)
+    result = subprocess.run(command, check=False)
+    if result.returncode != 0:
+        msg = f"command failed: {' '.join(command)}"
+        raise SystemExit(msg)
+
+
+def _capture(command: list[str]) -> str:
+    """Run a command, echo its output, and return its stdout."""
+    print("+ " + " ".join(command), flush=True)
+    result = subprocess.run(command, check=False, capture_output=True, text=True)
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    if result.returncode != 0:
+        msg = f"command failed: {' '.join(command)}"
+        raise SystemExit(msg)
+    return result.stdout
+
+
+def _make_venv(path: Path) -> Path:
+    """Create a fresh venv with a current pip and return its interpreter."""
+    _run([sys.executable, "-m", "venv", str(path)])
+    bindir = path / ("Scripts" if os.name == "nt" else "bin")
+    python = bindir / "python"
+    _run([str(python), "-m", "pip", "install", "--upgrade", "pip>=26.1"])
+    return python
+
+
+def _find_links(dist_root: Path) -> list[str]:
+    """Return --find-links args covering every built package directory.
+
+    With these, the nab-* cross-dependencies resolve to the in-tree build
+    rather than an older release on PyPI.
+    """
+    links: list[str] = []
+    for package in PACKAGES:
+        links += ["--find-links", str(dist_root / package)]
+    return links
+
+
+def _only(paths: list[Path], what: str, package: str) -> Path:
+    """Return the sole path, or fail if the build produced anything else."""
+    match paths:
+        case [single]:
+            return single
+    found = [path.name for path in paths]
+    msg = f"expected exactly one {what} for {package}, found {found}"
+    raise SystemExit(msg)
+
+
+def _wheel(dist_root: Path, package: str) -> Path:
+    """Return the built wheel for a package."""
+    return _only(sorted((dist_root / package).glob("*.whl")), "wheel", package)
+
+
+def _sdist(dist_root: Path, package: str) -> Path:
+    """Return the built sdist for a package."""
+    return _only(sorted((dist_root / package).glob("*.tar.gz")), "sdist", package)
+
+
+def _dist_info(names: list[str]) -> str:
+    """Return the .dist-info directory name within a wheel."""
+    for name in names:
+        top = name.split("/", 1)[0]
+        if top.endswith(".dist-info"):
+            return top
+    msg = "wheel has no .dist-info directory"
+    raise SystemExit(msg)
+
+
+def install_each_sdist(dist_root: Path, scratch: Path) -> None:
+    """Install every sdist into its own venv, resolving siblings locally."""
+    links = _find_links(dist_root)
+    for package in PACKAGES:
+        sdist = _sdist(dist_root, package)
+        python = _make_venv(scratch / f"sdist-{package}")
+        _run([str(python), "-m", "pip", "install", *links, str(sdist)])
+
+
+def install_wheels(dist_root: Path, scratch: Path) -> None:
+    """Install all four wheels together, then import and run the CLI."""
+    wheels = [str(_wheel(dist_root, package)) for package in PACKAGES]
+    version = _wheel_version(_wheel(dist_root, "nab"))
+    python = _make_venv(scratch / "wheels")
+    _run([str(python), "-m", "pip", "install", *wheels])
+    _run([str(python), "-c", "import nab, nab_resolver, nab_python, nab_index"])
+    output = _capture([str(python), "-m", "nab", "--version"])
+    expected = f"nab {version}"
+    if expected not in output:
+        msg = f"`nab --version` reported {output.strip()!r}, expected {expected!r}"
+        raise SystemExit(msg)
+
+
+def _wheel_version(wheel: Path) -> str:
+    """Return the Version recorded in a wheel's METADATA."""
+    with zipfile.ZipFile(wheel) as archive:
+        info = _dist_info(archive.namelist())
+        metadata = email.message_from_string(archive.read(f"{info}/METADATA").decode())
+    version = metadata["Version"]
+    if not version:
+        msg = f"{wheel.name}: METADATA has no Version"
+        raise SystemExit(msg)
+    return version
+
+
+def check_wheel_license(wheel: Path) -> None:
+    """Fail unless the wheel carries its LICENSE and records License-File."""
+    with zipfile.ZipFile(wheel) as archive:
+        names = archive.namelist()
+        info = _dist_info(names)
+        member = f"{info}/licenses/LICENSE"
+        if member not in names:
+            msg = f"{wheel.name}: wheel is missing {member}"
+            raise SystemExit(msg)
+        metadata = email.message_from_string(archive.read(f"{info}/METADATA").decode())
+    if not metadata.get_all("License-File"):
+        msg = f"{wheel.name}: METADATA has no License-File header"
+        raise SystemExit(msg)
+
+
+def check_sdist_license(sdist: Path) -> None:
+    """Fail unless the sdist roots a regular-file LICENSE (never a symlink)."""
+    root = sdist.name[: -len(".tar.gz")]
+    member_name = f"{root}/LICENSE"
+    with tarfile.open(sdist) as archive:
+        try:
+            member = archive.getmember(member_name)
+        except KeyError:
+            msg = f"{sdist.name}: sdist is missing {member_name}"
+            raise SystemExit(msg) from None
+        if not member.isreg():
+            msg = (
+                f"{sdist.name}: {member_name} is not a regular file "
+                f"(tar type {member.type!r}); a dangling symlink here fails "
+                f"pip's install-time extraction"
+            )
+            raise SystemExit(msg)
+
+
+def check_vendored_licenses(wheel: Path, sdist: Path) -> None:
+    """Fail unless both nab-python artifacts carry the vendored licenses."""
+    with zipfile.ZipFile(wheel) as archive:
+        wheel_names = archive.namelist()
+    with tarfile.open(sdist) as archive:
+        sdist_names = archive.getnames()
+    for suffix in VENDOR_LICENSES:
+        if not any(name.endswith(suffix) for name in wheel_names):
+            msg = f"{wheel.name}: missing vendored license {suffix}"
+            raise SystemExit(msg)
+        if not any(name.endswith(suffix) for name in sdist_names):
+            msg = f"{sdist.name}: missing vendored license {suffix}"
+            raise SystemExit(msg)
+
+
+def main() -> None:
+    """Build the four distributions, then install and check every artifact."""
+    source_date_epoch = _source_date_epoch()
+    with tempfile.TemporaryDirectory() as tmp:
+        workdir = Path(tmp)
+        dist_root = workdir / "dist"
+        build_dists.build_all(dist_root, source_date_epoch)
+
+        install_each_sdist(dist_root, workdir)
+        install_wheels(dist_root, workdir)
+
+        for package in PACKAGES:
+            check_wheel_license(_wheel(dist_root, package))
+            check_sdist_license(_sdist(dist_root, package))
+        check_vendored_licenses(
+            _wheel(dist_root, "nab-python"),
+            _sdist(dist_root, "nab-python"),
+        )
+
+    print("dists built, installed from sdists and wheels, and license-checked.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/refresh-locks.sh
+++ b/tasks/refresh-locks.sh
@@ -31,7 +31,7 @@ DOCS_PYTHON="3.13"
 # uv seed the PEP 751 dependency_groups marker from default-groups and cannot
 # select a non-default group at install time, so without this the group's
 # packages carry a marker no install-time flag ever satisfies and are skipped.
-for group in tests types pre-commit crosshair release docs nox; do
+for group in tests types pre-commit crosshair release docs nox dists; do
     echo "==> Locking group: ${group}"
     group_args=()
     if [[ "${group}" == "docs" ]]; then


### PR DESCRIPTION
Building the dists never proved they install: `python -m build` extracts sdists with a lax tar filter, so the 0.0.10 sdists' dangling LICENSE symlinks built fine and only failed at `pip install`, and hatchling silently dropped the symlinked license from the wheels.

A new `nox -s dists` session builds all four sdists and wheels the way the release does, pip-installs every sdist into a fresh venv (workspace cross-deps resolve from the local build directory, not PyPI), installs the four wheels together and checks import plus `nab --version`, and asserts each wheel ships `licenses/LICENSE` with a `License-File` header and each sdist a regular LICENSE file. CI runs it as a `dists` job gated in "All tests pass". Session deps come from a new `dists` group with a committed `pylock.dists.toml`, maintained by `refresh-locks.sh`.
