### PR TITLE
Verify published files after publish

### DIFF
--- a/.github/requirements/pylock.release.toml
+++ b/.github/requirements/pylock.release.toml
@@ -1,35 +1,35 @@
 lock-version = "1.0"
 environments = [
-    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
-    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
-    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
-    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
-    "python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
-    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
-    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
-    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
-    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
-    "python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
-    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
-    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
-    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
-    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
-    "python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
-    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
-    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
-    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
-    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\"",
-    "python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\"",
-    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
-    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
-    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
-    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
-    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
-    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
-    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
-    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
-    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\" and python_full_version < \"3.10.2\"",
-    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and os_name == \"nt\" and platform_python_implementation == \"CPython\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Linux\"",
+    "python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Linux\"",
+    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Darwin\"",
+    "python_version == \"3.11\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Darwin\"",
+    "python_version == \"3.11\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and implementation_name == \"cpython\" and os_name == \"nt\" and platform_python_implementation == \"CPython\" and platform_system == \"Windows\"",
+    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Linux\"",
+    "python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Linux\"",
+    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Darwin\"",
+    "python_version == \"3.12\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Darwin\"",
+    "python_version == \"3.12\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and implementation_name == \"cpython\" and os_name == \"nt\" and platform_python_implementation == \"CPython\" and platform_system == \"Windows\"",
+    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Linux\"",
+    "python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Linux\"",
+    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Darwin\"",
+    "python_version == \"3.13\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Darwin\"",
+    "python_version == \"3.13\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and implementation_name == \"cpython\" and os_name == \"nt\" and platform_python_implementation == \"CPython\" and platform_system == \"Windows\"",
+    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Linux\"",
+    "python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Linux\"",
+    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Darwin\"",
+    "python_version == \"3.14\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Darwin\"",
+    "python_version == \"3.14\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and implementation_name == \"cpython\" and os_name == \"nt\" and platform_python_implementation == \"CPython\" and platform_system == \"Windows\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Linux\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Linux\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Linux\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Linux\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Darwin\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Darwin\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Darwin\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and implementation_name == \"cpython\" and os_name == \"posix\" and platform_python_implementation == \"CPython\" and platform_system == \"Darwin\" and python_full_version >= \"3.10.2.dev0\"",
+    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and implementation_name == \"cpython\" and os_name == \"nt\" and platform_python_implementation == \"CPython\" and platform_system == \"Windows\" and python_full_version < \"3.10.2\"",
+    "python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and implementation_name == \"cpython\" and os_name == \"nt\" and platform_python_implementation == \"CPython\" and platform_system == \"Windows\" and python_full_version >= \"3.10.2.dev0\"",
 ]
 requires-python = ">=3.10"
 dependency-groups = [
@@ -39,6 +39,31 @@ default-groups = [
     "release",
 ]
 created-by = "nab"
+
+[[packages]]
+name = "annotated-types"
+version = "0.7.0"
+marker = "\"release\" in dependency_groups"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "annotated_types-0.7.0.tar.gz"
+upload-time = 2024-05-20 21:33:25.928805+00:00
+url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz"
+size = 16081
+
+[packages.sdist.hashes]
+sha256 = "aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"
+
+[[packages.wheels]]
+name = "annotated_types-0.7.0-py3-none-any.whl"
+upload-time = 2024-05-20 21:33:24.100469+00:00
+url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl"
+size = 13643
+
+[packages.wheels.hashes]
+sha256 = "1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"
 
 [[packages]]
 name = "backports-tarfile"
@@ -124,7 +149,7 @@ sha256 = "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a"
 [[packages]]
 name = "cffi"
 version = "2.0.0"
-marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups)"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.9"
 dependencies = [
     { name = "pycparser" },
@@ -139,6 +164,24 @@ size = 523588
 
 [packages.sdist.hashes]
 sha256 = "44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl"
+upload-time = 2025-09-08 23:22:08.010640+00:00
+url = "https://files.pythonhosted.org/packages/93/d7/516d984057745a6cd96575eea814fe1edd6646ee6efd552fb7b0921dec83/cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl"
+size = 184283
+
+[packages.wheels.hashes]
+sha256 = "0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl"
+upload-time = 2025-09-08 23:22:10.637293+00:00
+url = "https://files.pythonhosted.org/packages/9e/84/ad6a0b408daa859246f57c03efd28e5dd1b33c21737c2db84cae8c237aa5/cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl"
+size = 180504
+
+[packages.wheels.hashes]
+sha256 = "f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"
 
 [[packages.wheels]]
 name = "cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
@@ -159,6 +202,33 @@ size = 216475
 sha256 = "fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453"
 
 [[packages.wheels]]
+name = "cffi-2.0.0-cp310-cp310-win_amd64.whl"
+upload-time = 2025-09-08 23:22:24.752920+00:00
+url = "https://files.pythonhosted.org/packages/33/fa/072dd15ae27fbb4e06b437eb6e944e75b068deb09e2a2826039e49ee2045/cffi-2.0.0-cp310-cp310-win_amd64.whl"
+size = 182790
+
+[packages.wheels.hashes]
+sha256 = "b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl"
+upload-time = 2025-09-08 23:22:26.456818+00:00
+url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl"
+size = 184344
+
+[packages.wheels.hashes]
+sha256 = "b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl"
+upload-time = 2025-09-08 23:22:28.197416+00:00
+url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl"
+size = 180560
+
+[packages.wheels.hashes]
+sha256 = "2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c"
+
+[[packages.wheels]]
 name = "cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
 upload-time = 2025-09-08 23:22:31.063786+00:00
 url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
@@ -175,6 +245,33 @@ size = 215574
 
 [packages.wheels.hashes]
 sha256 = "8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp311-cp311-win_amd64.whl"
+upload-time = 2025-09-08 23:22:42.463665+00:00
+url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl"
+size = 182820
+
+[packages.wheels.hashes]
+sha256 = "66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl"
+upload-time = 2025-09-08 23:22:44.795536+00:00
+url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl"
+size = 185271
+
+[packages.wheels.hashes]
+sha256 = "6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl"
+upload-time = 2025-09-08 23:22:45.938542+00:00
+url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl"
+size = 181048
+
+[packages.wheels.hashes]
+sha256 = "8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c"
 
 [[packages.wheels]]
 name = "cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
@@ -195,6 +292,33 @@ size = 219572
 sha256 = "3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba"
 
 [[packages.wheels]]
+name = "cffi-2.0.0-cp312-cp312-win_amd64.whl"
+upload-time = 2025-09-08 23:22:58.351099+00:00
+url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl"
+size = 183557
+
+[packages.wheels.hashes]
+sha256 = "da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl"
+upload-time = 2025-09-08 23:23:00.879077+00:00
+url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl"
+size = 185230
+
+[packages.wheels.hashes]
+sha256 = "00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl"
+upload-time = 2025-09-08 23:23:02.231817+00:00
+url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl"
+size = 181043
+
+[packages.wheels.hashes]
+sha256 = "45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca"
+
+[[packages.wheels]]
 name = "cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
 upload-time = 2025-09-08 23:23:04.792027+00:00
 url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
@@ -213,6 +337,33 @@ size = 219499
 sha256 = "c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26"
 
 [[packages.wheels]]
+name = "cffi-2.0.0-cp313-cp313-win_amd64.whl"
+upload-time = 2025-09-08 23:23:15.535284+00:00
+url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl"
+size = 183402
+
+[packages.wheels.hashes]
+sha256 = "19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl"
+upload-time = 2025-09-08 23:23:18.087995+00:00
+url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl"
+size = 185320
+
+[packages.wheels.hashes]
+sha256 = "fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl"
+upload-time = 2025-09-08 23:23:19.622604+00:00
+url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl"
+size = 181487
+
+[packages.wheels.hashes]
+sha256 = "c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13"
+
+[[packages.wheels]]
 name = "cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
 upload-time = 2025-09-08 23:23:20.853101+00:00
 url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
@@ -229,6 +380,15 @@ size = 219244
 
 [packages.wheels.hashes]
 sha256 = "afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775"
+
+[[packages.wheels]]
+name = "cffi-2.0.0-cp314-cp314-win_amd64.whl"
+upload-time = 2025-09-08 23:23:45.848735+00:00
+url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl"
+size = 185650
+
+[packages.wheels.hashes]
+sha256 = "203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25"
 
 [[packages]]
 name = "charset-normalizer"
@@ -462,9 +622,9 @@ sha256 = "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
 
 [[packages]]
 name = "cryptography"
-version = "48.0.0"
-marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups)"
-requires-python = "!=3.9.0,!=3.9.1,>=3.9"
+version = "46.0.7"
+marker = "\"release\" in dependency_groups"
+requires-python = "!=3.9.0,!=3.9.1,>=3.8"
 dependencies = [
     { name = "cffi" },
     { name = "typing-extensions" },
@@ -472,121 +632,182 @@ dependencies = [
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "cryptography-48.0.0.tar.gz"
-upload-time = 2026-05-04 22:59:38.133475+00:00
-url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz"
-size = 832984
+name = "cryptography-46.0.7.tar.gz"
+upload-time = 2026-04-08 01:57:54.692879+00:00
+url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz"
+size = 750652
 
 [packages.sdist.hashes]
-sha256 = "5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920"
+sha256 = "e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5"
 
 [[packages.wheels]]
-name = "cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
-upload-time = 2026-05-04 22:57:40.373494+00:00
-url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
-size = 4690433
+name = "cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl"
+upload-time = 2026-04-08 01:56:17.157787+00:00
+url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl"
+size = 7179869
 
 [packages.wheels.hashes]
-sha256 = "f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c"
+sha256 = "ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4"
 
 [[packages.wheels]]
-name = "cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
-upload-time = 2026-05-04 22:57:42.935070+00:00
-url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
-size = 4710620
+name = "cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+upload-time = 2026-04-08 01:56:19.360302+00:00
+url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+size = 4275492
 
 [packages.wheels.hashes]
-sha256 = "7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3"
+sha256 = "b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325"
 
 [[packages.wheels]]
-name = "cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-04 22:57:45.294448+00:00
-url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl"
-size = 4696283
+name = "cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+upload-time = 2026-04-08 01:56:21.415813+00:00
+url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+size = 4426670
 
 [packages.wheels.hashes]
-sha256 = "40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5"
+sha256 = "5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308"
 
 [[packages.wheels]]
-name = "cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl"
-upload-time = 2026-05-04 22:57:50.067285+00:00
-url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl"
-size = 4743677
+name = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl"
+upload-time = 2026-04-08 01:56:23.539999+00:00
+url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl"
+size = 4280275
 
 [packages.wheels.hashes]
-sha256 = "a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f"
+sha256 = "73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77"
 
 [[packages.wheels]]
-name = "cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl"
-upload-time = 2026-05-04 22:57:54.603692+00:00
-url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl"
-size = 4695941
+name = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl"
+upload-time = 2026-04-08 01:56:27.309438+00:00
+url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl"
+size = 4459985
 
 [packages.wheels.hashes]
-sha256 = "7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602"
+sha256 = "420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef"
 
 [[packages.wheels]]
-name = "cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl"
-upload-time = 2026-05-04 22:57:59.535546+00:00
-url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl"
-size = 4743326
+name = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl"
+upload-time = 2026-04-08 01:56:30.928964+00:00
+url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl"
+size = 4279805
 
 [packages.wheels.hashes]
-sha256 = "bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5"
+sha256 = "8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83"
 
 [[packages.wheels]]
-name = "cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
-upload-time = 2026-05-04 22:58:46.064772+00:00
-url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
-size = 4683266
+name = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl"
+upload-time = 2026-04-08 01:56:34.306202+00:00
+url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl"
+size = 4459756
 
 [packages.wheels.hashes]
-sha256 = "614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e"
+sha256 = "42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b"
 
 [[packages.wheels]]
-name = "cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
-upload-time = 2026-05-04 22:58:48.220595+00:00
-url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
-size = 4696228
+name = "cryptography-46.0.7-cp311-abi3-win_amd64.whl"
+upload-time = 2026-04-08 01:56:41.893839+00:00
+url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl"
+size = 3488363
 
 [packages.wheels.hashes]
-sha256 = "7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f"
+sha256 = "397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b"
 
 [[packages.wheels]]
-name = "cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl"
-upload-time = 2026-05-04 22:58:50.900159+00:00
-url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl"
-size = 4689097
+name = "cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl"
+upload-time = 2026-04-08 01:57:10.645230+00:00
+url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl"
+size = 7165618
 
 [packages.wheels.hashes]
-sha256 = "2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7"
+sha256 = "462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4"
 
 [[packages.wheels]]
-name = "cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl"
-upload-time = 2026-05-04 22:58:55.611945+00:00
-url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl"
-size = 4730479
+name = "cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+upload-time = 2026-04-08 01:57:12.885492+00:00
+url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+size = 4270628
 
 [packages.wheels.hashes]
-sha256 = "2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c"
+sha256 = "84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7"
 
 [[packages.wheels]]
-name = "cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl"
-upload-time = 2026-05-04 22:59:00.077539+00:00
-url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl"
-size = 4688713
+name = "cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+upload-time = 2026-04-08 01:57:14.923826+00:00
+url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+size = 4415405
 
 [packages.wheels.hashes]
-sha256 = "5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a"
+sha256 = "128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832"
 
 [[packages.wheels]]
-name = "cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl"
-upload-time = 2026-05-04 22:59:05.255870+00:00
-url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl"
-size = 4729947
+name = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl"
+upload-time = 2026-04-08 01:57:16.638217+00:00
+url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl"
+size = 4272715
 
 [packages.wheels.hashes]
-sha256 = "9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239"
+sha256 = "5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163"
+
+[[packages.wheels]]
+name = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl"
+upload-time = 2026-04-08 01:57:21.185336+00:00
+url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl"
+size = 4450634
+
+[packages.wheels.hashes]
+sha256 = "1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067"
+
+[[packages.wheels]]
+name = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl"
+upload-time = 2026-04-08 01:57:24.814145+00:00
+url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl"
+size = 4271955
+
+[packages.wheels.hashes]
+sha256 = "abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba"
+
+[[packages.wheels]]
+name = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl"
+upload-time = 2026-04-08 01:57:29.068363+00:00
+url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl"
+size = 4449961
+
+[packages.wheels.hashes]
+sha256 = "35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0"
+
+[[packages.wheels]]
+name = "cryptography-46.0.7-cp38-abi3-win_amd64.whl"
+upload-time = 2026-04-08 01:57:36.714059+00:00
+url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl"
+size = 3472985
+
+[packages.wheels.hashes]
+sha256 = "506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3"
+
+[[packages]]
+name = "dnspython"
+version = "2.8.0"
+marker = "\"release\" in dependency_groups"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "dnspython-2.8.0.tar.gz"
+upload-time = 2025-09-07 18:58:00.022322+00:00
+url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz"
+size = 368251
+
+[packages.sdist.hashes]
+sha256 = "181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f"
+
+[[packages.wheels]]
+name = "dnspython-2.8.0-py3-none-any.whl"
+upload-time = 2025-09-07 18:57:58.071496+00:00
+url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl"
+size = 331094
+
+[packages.wheels.hashes]
+sha256 = "01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af"
 
 [[packages]]
 name = "docstring-parser"
@@ -636,6 +857,35 @@ size = 633196
 
 [packages.wheels.hashes]
 sha256 = "d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de"
+
+[[packages]]
+name = "email-validator"
+version = "2.3.0"
+marker = "\"release\" in dependency_groups"
+requires-python = ">=3.8"
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "email_validator-2.3.0.tar.gz"
+upload-time = 2025-08-26 13:09:06.831581+00:00
+url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz"
+size = 51238
+
+[packages.sdist.hashes]
+sha256 = "9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426"
+
+[[packages.wheels]]
+name = "email_validator-2.3.0-py3-none-any.whl"
+upload-time = 2025-08-26 13:09:05.858779+00:00
+url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl"
+size = 35604
+
+[packages.wheels.hashes]
+sha256 = "80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4"
 
 [[packages]]
 name = "hatchling"
@@ -749,6 +999,31 @@ size = 27789
 
 [packages.wheels.hashes]
 sha256 = "2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7"
+
+[[packages]]
+name = "importlib-resources"
+version = "5.13.0"
+marker = "(python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"arm64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"darwin\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"win32\" and platform_machine == \"AMD64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups)"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "importlib_resources-5.13.0.tar.gz"
+upload-time = 2023-07-07 16:21:00.171493+00:00
+url = "https://files.pythonhosted.org/packages/a5/f1/8711c49ffd121083007a24c1bff0d324c9ff621d4fdf8b4ffcb8d9e60330/importlib_resources-5.13.0.tar.gz"
+size = 36550
+
+[packages.sdist.hashes]
+sha256 = "82d5c6cca930697dbbd86c93333bb2c2e72861d4789a11c2662b933e5ad2b528"
+
+[[packages.wheels]]
+name = "importlib_resources-5.13.0-py3-none-any.whl"
+upload-time = 2023-07-07 16:20:58.128194+00:00
+url = "https://files.pythonhosted.org/packages/7a/68/bd9dd6bbf06772c7accce77d0354d783333fbe712a60b08fc13540c05422/importlib_resources-5.13.0-py3-none-any.whl"
+size = 32912
+
+[packages.wheels.hashes]
+sha256 = "9f7bd0c97b79972a6cce36a366356d16d5e13b09679c11a58f1014bfdf8e64b2"
 
 [[packages]]
 name = "installer"
@@ -1097,6 +1372,31 @@ size = 57328
 sha256 = "a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189"
 
 [[packages]]
+name = "platformdirs"
+version = "4.9.6"
+marker = "\"release\" in dependency_groups"
+requires-python = ">=3.10"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "platformdirs-4.9.6.tar.gz"
+upload-time = 2026-04-09 00:04:10.812039+00:00
+url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz"
+size = 29400
+
+[packages.sdist.hashes]
+sha256 = "3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a"
+
+[[packages.wheels]]
+name = "platformdirs-4.9.6-py3-none-any.whl"
+upload-time = 2026-04-09 00:04:09.463329+00:00
+url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl"
+size = 21348
+
+[packages.wheels.hashes]
+sha256 = "e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917"
+
+[[packages]]
 name = "pluggy"
 version = "1.6.0"
 marker = "\"release\" in dependency_groups"
@@ -1122,9 +1422,34 @@ size = 20538
 sha256 = "e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
 
 [[packages]]
+name = "pyasn1"
+version = "0.6.3"
+marker = "\"release\" in dependency_groups"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pyasn1-0.6.3.tar.gz"
+upload-time = 2026-03-17 01:06:53.382518+00:00
+url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz"
+size = 148685
+
+[packages.sdist.hashes]
+sha256 = "697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"
+
+[[packages.wheels]]
+name = "pyasn1-0.6.3-py3-none-any.whl"
+upload-time = 2026-03-17 01:06:52.036000+00:00
+url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl"
+size = 83997
+
+[packages.wheels.hashes]
+sha256 = "a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"
+
+[[packages]]
 name = "pycparser"
 version = "3.0"
-marker = "(python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version < \"3.10.2\" and \"release\" in dependency_groups) or (python_version == \"3.10\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and python_full_version >= \"3.10.2.dev0\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.11\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.12\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.13\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"aarch64\" and \"release\" in dependency_groups) or (python_version == \"3.14\" and sys_platform == \"linux\" and platform_machine == \"x86_64\" and \"release\" in dependency_groups)"
+marker = "\"release\" in dependency_groups"
 requires-python = ">=3.10"
 index = "https://pypi.org/simple/"
 
@@ -1145,6 +1470,282 @@ size = 48172
 
 [packages.wheels.hashes]
 sha256 = "b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"
+
+[[packages]]
+name = "pydantic"
+version = "2.13.4"
+marker = "\"release\" in dependency_groups"
+requires-python = ">=3.9"
+dependencies = [
+    { name = "annotated-types" },
+    { name = "email-validator" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pydantic-2.13.4.tar.gz"
+upload-time = 2026-05-06 13:43:05.343572+00:00
+url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz"
+size = 844775
+
+[packages.sdist.hashes]
+sha256 = "c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6"
+
+[[packages.wheels]]
+name = "pydantic-2.13.4-py3-none-any.whl"
+upload-time = 2026-05-06 13:43:02.641507+00:00
+url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl"
+size = 472262
+
+[packages.wheels.hashes]
+sha256 = "45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba"
+
+[[packages]]
+name = "pydantic-core"
+version = "2.46.4"
+marker = "\"release\" in dependency_groups"
+requires-python = ">=3.9"
+dependencies = [
+    { name = "typing-extensions" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pydantic_core-2.46.4.tar.gz"
+upload-time = 2026-05-06 13:37:06.980634+00:00
+url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz"
+size = 471464
+
+[packages.sdist.hashes]
+sha256 = "62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl"
+upload-time = 2026-05-06 13:37:36.537721+00:00
+url = "https://files.pythonhosted.org/packages/e7/08/f1ba952f1c8ae5581c70fa9c6da89f247b83e3dd8c09c035d5d7931fc23d/pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl"
+size = 2113146
+
+[packages.wheels.hashes]
+sha256 = "a396dcc17e5a0b164dbe026896245a4fa9ff402edca1dff0be3d53a517f74de4"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl"
+upload-time = 2026-05-06 13:37:46.365408+00:00
+url = "https://files.pythonhosted.org/packages/56/c6/65f646c7ff09bd257f660434adb45c4dfcbbcebcc030562fecf6f5bf887d/pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl"
+size = 1949769
+
+[packages.wheels.hashes]
+sha256 = "da4b951fe36dc7c3a1ccb4e3cd1747c3542b8c9ceede8fc86cae054e764485f5"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-05-06 13:37:28.611275+00:00
+url = "https://files.pythonhosted.org/packages/64/ba/bfb1d928fd5b49e1258935ff104ae356e9fd89384a55bf9f847e9193ad40/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1974958
+
+[packages.wheels.hashes]
+sha256 = "bb63e0198ca18aad131c089b9204c23079c3afa95487e561f4c522d519e55aba"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-05-06 13:38:46.981295+00:00
+url = "https://files.pythonhosted.org/packages/ba/1e/acc4d70f88a0a277e4a1fa77ebb985ceabaf900430f875bf9338e11c9420/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 2092042
+
+[packages.wheels.hashes]
+sha256 = "395aebd9183f9d112f569aeb5b2214d1a10a33bec8456447f7fbdfa51d38d4cd"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp310-cp310-win_amd64.whl"
+upload-time = 2026-05-06 13:39:59.922640+00:00
+url = "https://files.pythonhosted.org/packages/01/aa/62f082da2c91fac1c234bc9ee0066257ce83f0604abd72e4c9d5991f2d84/pydantic_core-2.46.4-cp310-cp310-win_amd64.whl"
+size = 2074311
+
+[packages.wheels.hashes]
+sha256 = "8358a950c8909158e3df31538a7e4edc2d7265a7c54b47f0864d9e5bae9dcebf"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl"
+upload-time = 2026-05-06 13:40:27.596895+00:00
+url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl"
+size = 2111872
+
+[packages.wheels.hashes]
+sha256 = "0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl"
+upload-time = 2026-05-06 13:39:12.574673+00:00
+url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl"
+size = 1948255
+
+[packages.wheels.hashes]
+sha256 = "e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-05-06 13:38:19.841087+00:00
+url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1972827
+
+[packages.wheels.hashes]
+sha256 = "7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-05-06 13:38:17.762933+00:00
+url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 2089685
+
+[packages.wheels.hashes]
+sha256 = "f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp311-cp311-win_amd64.whl"
+upload-time = 2026-05-06 13:40:35.416873+00:00
+url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl"
+size = 2071114
+
+[packages.wheels.hashes]
+sha256 = "6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl"
+upload-time = 2026-05-06 13:38:57.215819+00:00
+url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl"
+size = 2106158
+
+[packages.wheels.hashes]
+sha256 = "3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl"
+upload-time = 2026-05-06 13:37:02.697872+00:00
+url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl"
+size = 1951724
+
+[packages.wheels.hashes]
+sha256 = "962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-05-06 13:37:09.448733+00:00
+url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1975742
+
+[packages.wheels.hashes]
+sha256 = "8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-05-06 13:39:10.577024+00:00
+url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 2094516
+
+[packages.wheels.hashes]
+sha256 = "926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp312-cp312-win_amd64.whl"
+upload-time = 2026-05-06 13:39:21.153899+00:00
+url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl"
+size = 2072919
+
+[packages.wheels.hashes]
+sha256 = "e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl"
+upload-time = 2026-05-06 13:37:48.029854+00:00
+url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl"
+size = 2106306
+
+[packages.wheels.hashes]
+sha256 = "5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl"
+upload-time = 2026-05-06 13:37:17.012599+00:00
+url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl"
+size = 1951906
+
+[packages.wheels.hashes]
+sha256 = "c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-05-06 13:37:35.113249+00:00
+url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1976802
+
+[packages.wheels.hashes]
+sha256 = "f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-05-06 13:39:18.847733+00:00
+url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 2094467
+
+[packages.wheels.hashes]
+sha256 = "9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp313-cp313-win_amd64.whl"
+upload-time = 2026-05-06 13:38:49.139748+00:00
+url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl"
+size = 2071819
+
+[packages.wheels.hashes]
+sha256 = "6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl"
+upload-time = 2026-05-06 13:38:41.019990+00:00
+url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl"
+size = 2102079
+
+[packages.wheels.hashes]
+sha256 = "428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl"
+upload-time = 2026-05-06 13:36:59.812106+00:00
+url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl"
+size = 1952179
+
+[packages.wheels.hashes]
+sha256 = "23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-05-06 13:37:39.933294+00:00
+url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 1978926
+
+[packages.wheels.hashes]
+sha256 = "ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-05-06 13:39:31.942232+00:00
+url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 2099732
+
+[packages.wheels.hashes]
+sha256 = "7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b"
+
+[[packages.wheels]]
+name = "pydantic_core-2.46.4-cp314-cp314-win_amd64.whl"
+upload-time = 2026-05-06 13:39:40.807145+00:00
+url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl"
+size = 2072238
+
+[packages.wheels.hashes]
+sha256 = "811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac"
 
 [[packages]]
 name = "pygments"
@@ -1170,6 +1771,98 @@ size = 1231151
 
 [packages.wheels.hashes]
 sha256 = "81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"
+
+[[packages]]
+name = "pyjwt"
+version = "2.12.1"
+marker = "\"release\" in dependency_groups"
+requires-python = ">=3.9"
+dependencies = [
+    { name = "typing-extensions" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pyjwt-2.12.1.tar.gz"
+upload-time = 2026-03-13 19:27:37.250291+00:00
+url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz"
+size = 102564
+
+[packages.sdist.hashes]
+sha256 = "c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b"
+
+[[packages.wheels]]
+name = "pyjwt-2.12.1-py3-none-any.whl"
+upload-time = 2026-03-13 19:27:35.677841+00:00
+url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl"
+size = 29726
+
+[packages.wheels.hashes]
+sha256 = "28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c"
+
+[[packages]]
+name = "pyopenssl"
+version = "26.2.0"
+marker = "\"release\" in dependency_groups"
+requires-python = ">=3.8"
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pyopenssl-26.2.0.tar.gz"
+upload-time = 2026-05-04 23:06:09.720714+00:00
+url = "https://files.pythonhosted.org/packages/1a/51/27a5ad5f939d08f690a326ef9582cda7140555180db71695f6fb747d6a36/pyopenssl-26.2.0.tar.gz"
+size = 182195
+
+[packages.sdist.hashes]
+sha256 = "8c6fcecd1183a7fc897548dfe388b0cdb7f37e018200d8409cf33959dbe35387"
+
+[[packages.wheels]]
+name = "pyopenssl-26.2.0-py3-none-any.whl"
+upload-time = 2026-05-04 23:06:08.395604+00:00
+url = "https://files.pythonhosted.org/packages/73/b8/a0e2790ae249d6f38c9f66de7a211621a7ab2650217bcd04e1262f578a56/pyopenssl-26.2.0-py3-none-any.whl"
+size = 55823
+
+[packages.wheels.hashes]
+sha256 = "4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70"
+
+[[packages]]
+name = "pypi-attestations"
+version = "0.0.29"
+marker = "\"release\" in dependency_groups"
+requires-python = ">=3.10"
+dependencies = [
+    { name = "cryptography" },
+    { name = "packaging" },
+    { name = "pyasn1" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "rfc3986" },
+    { name = "sigstore" },
+    { name = "sigstore-models" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "pypi_attestations-0.0.29.tar.gz"
+upload-time = 2025-12-11 13:24:21.425055+00:00
+url = "https://files.pythonhosted.org/packages/8b/a9/20169d7df89a79bfb00045c7d42d81ccc612008474306e1858984990e165/pypi_attestations-0.0.29.tar.gz"
+size = 128954
+
+[packages.sdist.hashes]
+sha256 = "2daf3ec46ff4c7123184ec892852b4d4599b78128f01f742a44406a73200c5df"
+
+[[packages.wheels]]
+name = "pypi_attestations-0.0.29-py3-none-any.whl"
+upload-time = 2025-12-11 13:24:19.943631+00:00
+url = "https://files.pythonhosted.org/packages/c8/4c/a008365b5bdeab52f023945af9aff2baf7f99de5784adca314b55872d6be/pypi_attestations-0.0.29-py3-none-any.whl"
+size = 21922
+
+[packages.wheels.hashes]
+sha256 = "278a28d741b57d62973c00d453ec9b9bb30456464d69296c6780474cd0bf098e"
 
 [[packages]]
 name = "pyproject-hooks"
@@ -1310,6 +2003,70 @@ size = 54481
 sha256 = "cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06"
 
 [[packages]]
+name = "rfc3161-client"
+version = "1.0.6"
+marker = "\"release\" in dependency_groups"
+requires-python = ">=3.9"
+dependencies = [
+    { name = "cryptography" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "rfc3161_client-1.0.6.tar.gz"
+upload-time = 2026-04-08 14:15:05.660949+00:00
+url = "https://files.pythonhosted.org/packages/66/a7/be3b086133a87d595e7b11564931d5e5283edeeabba05dfee636a34b4dab/rfc3161_client-1.0.6.tar.gz"
+size = 106710
+
+[packages.sdist.hashes]
+sha256 = "9969262fe6c08ecce39f9fe3996cf412187793834a022a643803090db5aae6b4"
+
+[[packages.wheels]]
+name = "rfc3161_client-1.0.6-cp39-abi3-macosx_10_12_x86_64.whl"
+upload-time = 2026-04-08 14:14:31.559440+00:00
+url = "https://files.pythonhosted.org/packages/57/b1/262af0901e1507a4e21d268091f1f7b738b44bca424b9bd481981828a7e8/rfc3161_client-1.0.6-cp39-abi3-macosx_10_12_x86_64.whl"
+size = 474975
+
+[packages.wheels.hashes]
+sha256 = "9a98e9c7ff632d9571fcea25fb70bde0e8339b86368aef67a65f6a301f125733"
+
+[[packages.wheels]]
+name = "rfc3161_client-1.0.6-cp39-abi3-macosx_11_0_arm64.whl"
+upload-time = 2026-04-08 14:14:33.556132+00:00
+url = "https://files.pythonhosted.org/packages/8a/b6/da7caa10c2a3e01f244ad116ffe2cc87056fa71a7dd76453faab2fc2c6ad/rfc3161_client-1.0.6-cp39-abi3-macosx_11_0_arm64.whl"
+size = 467442
+
+[packages.wheels.hashes]
+sha256 = "0b3920334f7334ec3bb9c319d53a5d08cd43b6883f75e2669cfd869cd264d53a"
+
+[[packages.wheels]]
+name = "rfc3161_client-1.0.6-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+upload-time = 2026-04-08 14:14:35.062707+00:00
+url = "https://files.pythonhosted.org/packages/64/dd/5c92004ca167ae182f543aedc7a7a8bebeb0668ade7263b82212e4b4c59d/rfc3161_client-1.0.6-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+size = 2435049
+
+[packages.wheels.hashes]
+sha256 = "1671b1be16480ea54c0d36239efd0fb62c13dd572a9865a5e91fea39f1b95303"
+
+[[packages.wheels]]
+name = "rfc3161_client-1.0.6-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+upload-time = 2026-04-08 14:14:40.641320+00:00
+url = "https://files.pythonhosted.org/packages/53/3c/32a0c7de4d63a69eb97e2564e5f1d51879ec93232b0c5ac1ec444843acba/rfc3161_client-1.0.6-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+size = 2177997
+
+[packages.wheels.hashes]
+sha256 = "e3caffaebf43242b000c4a6659d60eaf19c3b161ccbe05b15634a856c9ea7e61"
+
+[[packages.wheels]]
+name = "rfc3161_client-1.0.6-cp39-abi3-win_amd64.whl"
+upload-time = 2026-04-08 14:14:52.364742+00:00
+url = "https://files.pythonhosted.org/packages/26/10/6e54860ae82e4ed5665fd3f1d798a8f68f7bac321431f444640da6f93600/rfc3161_client-1.0.6-cp39-abi3-win_amd64.whl"
+size = 2386738
+
+[packages.wheels.hashes]
+sha256 = "4ef4b096abe7d55b020526e39932c2721939a6c55e9a5cd3b3e77897a0942937"
+
+[[packages]]
 name = "rfc3986"
 version = "2.0.0"
 marker = "\"release\" in dependency_groups"
@@ -1335,10 +2092,35 @@ size = 31326
 sha256 = "50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd"
 
 [[packages]]
-name = "rich"
-version = "15.0.0"
+name = "rfc8785"
+version = "0.1.4"
 marker = "\"release\" in dependency_groups"
-requires-python = ">=3.9.0"
+requires-python = ">=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "rfc8785-0.1.4.tar.gz"
+upload-time = 2024-09-27 16:33:31.206853+00:00
+url = "https://files.pythonhosted.org/packages/ef/2f/fa1d2e740c490191b572d33dbca5daa180cb423c24396b856f5886371d8b/rfc8785-0.1.4.tar.gz"
+size = 14321
+
+[packages.sdist.hashes]
+sha256 = "e545841329fe0eee4f6a3b44e7034343100c12b4ec566dc06ca9735681deb4da"
+
+[[packages.wheels]]
+name = "rfc8785-0.1.4-py3-none-any.whl"
+upload-time = 2024-09-27 16:33:29.683421+00:00
+url = "https://files.pythonhosted.org/packages/4d/78/119878110660b2ad709888c8a1614fce7e2fab39080ab960656dc8605bf6/rfc8785-0.1.4-py3-none-any.whl"
+size = 9240
+
+[packages.wheels.hashes]
+sha256 = "520d690b448ecf0703691c76e1a34a24ddcd4fc5bc41d589cb7c58ec651bcd48"
+
+[[packages]]
+name = "rich"
+version = "14.3.4"
+marker = "\"release\" in dependency_groups"
+requires-python = ">=3.8.0"
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
@@ -1346,22 +2128,22 @@ dependencies = [
 index = "https://pypi.org/simple/"
 
 [packages.sdist]
-name = "rich-15.0.0.tar.gz"
-upload-time = 2026-04-12 08:24:00.750018+00:00
-url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz"
-size = 230680
+name = "rich-14.3.4.tar.gz"
+upload-time = 2026-04-11 02:57:45.419731+00:00
+url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz"
+size = 230524
 
 [packages.sdist.hashes]
-sha256 = "edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36"
+sha256 = "817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9"
 
 [[packages.wheels]]
-name = "rich-15.0.0-py3-none-any.whl"
-upload-time = 2026-04-12 08:24:02.830783+00:00
-url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl"
-size = 310654
+name = "rich-14.3.4-py3-none-any.whl"
+upload-time = 2026-04-11 02:57:47.484524+00:00
+url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl"
+size = 310480
 
 [packages.wheels.hashes]
-sha256 = "33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb"
+sha256 = "07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952"
 
 [[packages]]
 name = "secretstorage"
@@ -1391,6 +2173,130 @@ size = 15554
 
 [packages.wheels.hashes]
 sha256 = "0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137"
+
+[[packages]]
+name = "securesystemslib"
+version = "1.3.1"
+marker = "\"release\" in dependency_groups"
+requires-python = "~=3.8"
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "securesystemslib-1.3.1.tar.gz"
+upload-time = 2025-09-26 13:36:56.790687+00:00
+url = "https://files.pythonhosted.org/packages/c2/dd/d1828dce0db18aa8d34f82aee4dbcf49b0f0303cad123a1c716bb1f3bf83/securesystemslib-1.3.1.tar.gz"
+size = 934782
+
+[packages.sdist.hashes]
+sha256 = "ca915f4b88209bb5450ac05426b859d74b7cd1421cafcf73b8dd3418a0b17486"
+
+[[packages.wheels]]
+name = "securesystemslib-1.3.1-py3-none-any.whl"
+upload-time = 2025-09-26 13:36:54.851211+00:00
+url = "https://files.pythonhosted.org/packages/bd/29/1c560f46b3a95d8c508e1bd8c6d0bbf53c42d412ee7d19ec2a89ceced5b9/securesystemslib-1.3.1-py3-none-any.whl"
+size = 871380
+
+[packages.wheels.hashes]
+sha256 = "2e5414bbdde33155a91805b295cbedc4ae3f12b48dccc63e1089093537f43c81"
+
+[[packages]]
+name = "sigstore"
+version = "4.2.0"
+marker = "\"release\" in dependency_groups"
+requires-python = ">=3.10"
+dependencies = [
+    { name = "cryptography" },
+    { name = "id" },
+    { name = "importlib-resources" },
+    { name = "platformdirs" },
+    { name = "pyasn1" },
+    { name = "pydantic" },
+    { name = "pyjwt" },
+    { name = "pyopenssl" },
+    { name = "requests" },
+    { name = "rfc3161-client" },
+    { name = "rfc8785" },
+    { name = "rich" },
+    { name = "sigstore-models" },
+    { name = "sigstore-rekor-types" },
+    { name = "tuf" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "sigstore-4.2.0.tar.gz"
+upload-time = 2026-01-26 15:01:35.203945+00:00
+url = "https://files.pythonhosted.org/packages/98/c3/84ec81173ade0dba5613feea577308cde4e69045cc804d02953e3a40922c/sigstore-4.2.0.tar.gz"
+size = 88123
+
+[packages.sdist.hashes]
+sha256 = "bdbb49a42fd5f0ea6765919adb42ccee7254c482330764d0842eec4e11ad78d7"
+
+[[packages.wheels]]
+name = "sigstore-4.2.0-py3-none-any.whl"
+upload-time = 2026-01-26 15:01:33.944767+00:00
+url = "https://files.pythonhosted.org/packages/05/ae/d7876024c2c84512e56528bd4de7ea444efed6d2eb74a11957a927f2532e/sigstore-4.2.0-py3-none-any.whl"
+size = 109276
+
+[packages.wheels.hashes]
+sha256 = "ed2e0f50aae85148a8aa4fc0f57c298927fce430ad1f988f38611ce90c85829f"
+
+[[packages]]
+name = "sigstore-models"
+version = "0.0.6"
+marker = "\"release\" in dependency_groups"
+requires-python = ">=3.10"
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "sigstore_models-0.0.6.tar.gz"
+upload-time = 2025-11-26 19:18:12.610187+00:00
+url = "https://files.pythonhosted.org/packages/c6/ed/5c0ff809f90b19f4e971e17c1ed11f4df60082c6010b32a82054087e91e0/sigstore_models-0.0.6.tar.gz"
+size = 7037
+
+[packages.sdist.hashes]
+sha256 = "c766c09470c2a7e8a4a333c893f07e2001c56a3ff1757b1a246119f53169a849"
+
+[[packages.wheels]]
+name = "sigstore_models-0.0.6-py3-none-any.whl"
+upload-time = 2025-11-26 19:18:11.365736+00:00
+url = "https://files.pythonhosted.org/packages/12/dc/7a19864a7bc9f43121ab459e12768ab0080590e3e1b60a29b2f2eb01fb85/sigstore_models-0.0.6-py3-none-any.whl"
+size = 13213
+
+[packages.wheels.hashes]
+sha256 = "5201a68f4d7d0f8bec1e2f4378eb646b084c52609a4e31db8c385095fff68b2e"
+
+[[packages]]
+name = "sigstore-rekor-types"
+version = "0.0.18"
+marker = "\"release\" in dependency_groups"
+requires-python = ">=3.8"
+dependencies = [
+    { name = "pydantic" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "sigstore_rekor_types-0.0.18.tar.gz"
+upload-time = 2024-11-22 13:59:54.009830+00:00
+url = "https://files.pythonhosted.org/packages/b4/54/102e772445c5e849b826fbdcd44eb9ad7b3d10fda17b08964658ec7027dc/sigstore_rekor_types-0.0.18.tar.gz"
+size = 15687
+
+[packages.sdist.hashes]
+sha256 = "19aef25433218ebf9975a1e8b523cc84aaf3cd395ad39a30523b083ea7917ec5"
+
+[[packages.wheels]]
+name = "sigstore_rekor_types-0.0.18-py3-none-any.whl"
+upload-time = 2024-11-22 13:59:52.684229+00:00
+url = "https://files.pythonhosted.org/packages/45/7c/f0b4e19fd424df4cc964f5d454e1d814fd2dc3b386342e6040441024318f/sigstore_rekor_types-0.0.18-py3-none-any.whl"
+size = 20610
+
+[packages.wheels.hashes]
+sha256 = "b62bf38c5b1a62bc0d7fe0ee51a0709e49311d137c7880c329882a8f4b2d1d78"
 
 [[packages]]
 name = "tomli"
@@ -1694,6 +2600,35 @@ size = 18660
 sha256 = "adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"
 
 [[packages]]
+name = "tuf"
+version = "6.0.0"
+marker = "\"release\" in dependency_groups"
+requires-python = ">=3.8"
+dependencies = [
+    { name = "securesystemslib" },
+    { name = "urllib3" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "tuf-6.0.0.tar.gz"
+upload-time = 2025-03-11 10:48:45.489708+00:00
+url = "https://files.pythonhosted.org/packages/25/b5/377a566dfa8286b2ca27ddbc792ab1645de0b6c65dd5bf03027b3bf8cc8f/tuf-6.0.0.tar.gz"
+size = 271268
+
+[packages.sdist.hashes]
+sha256 = "9eed0f7888c5fff45dc62164ff243a05d47fb8a3208035eb268974287e0aee8d"
+
+[[packages.wheels]]
+name = "tuf-6.0.0-py3-none-any.whl"
+upload-time = 2025-03-11 10:48:44.188182+00:00
+url = "https://files.pythonhosted.org/packages/6b/3d/161ab4fec446048707cb13e8ba22220e05a6c4a6587d3631feeb5715037e/tuf-6.0.0-py3-none-any.whl"
+size = 54774
+
+[packages.wheels.hashes]
+sha256 = "458f663a233d95cc76dde0e1a3d01796516a05ce2781fefafebe037f7729601a"
+
+[[packages]]
 name = "twine"
 version = "6.2.0"
 marker = "\"release\" in dependency_groups"
@@ -1779,6 +2714,34 @@ size = 44614
 
 [packages.wheels.hashes]
 sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+
+[[packages]]
+name = "typing-inspection"
+version = "0.4.2"
+marker = "\"release\" in dependency_groups"
+requires-python = ">=3.9"
+dependencies = [
+    { name = "typing-extensions" },
+]
+index = "https://pypi.org/simple/"
+
+[packages.sdist]
+name = "typing_inspection-0.4.2.tar.gz"
+upload-time = 2025-10-01 02:14:41.687923+00:00
+url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz"
+size = 75949
+
+[packages.sdist.hashes]
+sha256 = "ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464"
+
+[[packages.wheels]]
+name = "typing_inspection-0.4.2-py3-none-any.whl"
+upload-time = 2025-10-01 02:14:40.154613+00:00
+url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl"
+size = 14611
+
+[packages.wheels.hashes]
+sha256 = "4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7"
 
 [[packages]]
 name = "tyro"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,3 +99,37 @@ jobs:
           packages-dir: dist/nab
           print-hash: true
           skip-existing: true
+
+  verify:
+    name: Verify published files
+    needs: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Verification reads only public PyPI data; it needs no id-token or write.
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.13"
+
+      # The built artifacts are compared byte-for-byte against what PyPI serves.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: dist
+          path: dist
+
+      - name: Upgrade pip to PEP 751 install support
+        run: python -m pip install --upgrade "pip>=26.1"
+
+      - name: Install release toolchain
+        run: pip install -r .github/requirements/pylock.release.toml
+
+      - name: Verify attestations and published bytes
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: python tasks/verify_published.py "${RELEASE_TAG}" --dist-dir dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ release = [
     "build>=1.2",
     "hatchling>=1.27",
     "twine>=6.1",
+    "pypi-attestations>=0.0.21",
 ]
 # The dists nox session builds every distribution and installs it. It needs
 # build plus the hatchling backend, since it builds without isolation.

--- a/tasks/verify_published.py
+++ b/tasks/verify_published.py
@@ -1,0 +1,298 @@
+"""Verify the files a release just published to PyPI.
+
+Runs after the publish job in the release workflow. For every file the release
+built (an sdist and a wheel for all four workspace packages), it confirms two
+things about what PyPI now serves:
+
+* the PEP 740 attestation verifies against this repository, and
+* the published bytes match the bytes the workflow built, when the built
+  ``dist/`` tree is passed with ``--dist-dir``.
+
+A freshly published file can lag on PyPI's CDN, so a not-yet-available file is
+retried within a time budget shared across the whole run. A real verification
+failure -- a bad signature, the wrong repository, or a digest mismatch -- fails
+at once and is never retried.
+
+Run it against a release tag::
+
+    python tasks/verify_published.py v0.0.11 --dist-dir dist
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import build_dists
+import release
+from packaging.utils import canonicalize_name
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+# The publishing repository the attestations must be signed by.
+REPOSITORY = "https://github.com/notatallshaw/nab"
+
+# PyPI returns 404 for a version whose files have not propagated yet.
+_HTTP_NOT_FOUND = 404
+
+# Build order and package set come from the release build, so the checked files
+# are exactly the set the release publishes.
+PACKAGES = build_dists.PACKAGES
+
+# Total wall-clock a run spends waiting for CDN propagation, shared across every
+# file. A real failure never consumes it; it fails immediately.
+RETRY_BUDGET_SECONDS = 600.0
+
+# Substrings pypi-attestations prints when a file or its provenance has not
+# propagated yet. These are the only attestation failures worth retrying.
+_PENDING_MARKERS = (
+    "Could not find the artifact",
+    "was not found",
+)
+
+
+class VerificationError(Exception):
+    """A file failed verification; the run must not retry it."""
+
+
+class NotYetAvailableError(Exception):
+    """A file has not propagated to PyPI yet; retry within the budget."""
+
+
+def _file_stem(package: str) -> str:
+    """Return the PEP 625 normalized name a package's filenames start with."""
+    return canonicalize_name(package).replace("-", "_")
+
+
+def expected_files(version: str) -> list[tuple[str, str]]:
+    """Return ``(pypi_name, filename)`` for every published sdist and wheel."""
+    files: list[tuple[str, str]] = []
+    for package in PACKAGES:
+        stem = _file_stem(package)
+        files.append((package, f"{stem}-{version}.tar.gz"))
+        files.append((package, f"{stem}-{version}-py3-none-any.whl"))
+    return files
+
+
+def _retry_waits() -> Iterator[float]:
+    """Yield an increasing backoff, capped so no single wait dominates."""
+    wait = 15.0
+    while True:
+        yield wait
+        wait = min(wait * 2.0, 60.0)
+
+
+def _published_sha256(pypi_name: str, version: str, filename: str) -> str:
+    """Return the sha256 PyPI records for a file, or signal it is not up yet."""
+    url = f"https://pypi.org/pypi/{pypi_name}/{version}/json"
+    try:
+        # Host and scheme are fixed above; the request only varies by name.
+        with urllib.request.urlopen(url, timeout=30) as response:  # noqa: S310
+            data = json.load(response)
+    except urllib.error.HTTPError as error:
+        if error.code == _HTTP_NOT_FOUND:
+            msg = f"{pypi_name} {version} is not on PyPI yet (HTTP 404)"
+            raise NotYetAvailableError(msg) from error
+        msg = f"PyPI JSON API failed for {pypi_name} {version}: {error}"
+        raise VerificationError(msg) from error
+    except urllib.error.URLError as error:
+        msg = f"network error reaching {url}: {error.reason}"
+        raise NotYetAvailableError(msg) from error
+    for entry in data.get("urls", []):
+        if entry.get("filename") == filename:
+            digest = entry.get("digests", {}).get("sha256")
+            if not digest:
+                msg = f"{filename}: PyPI lists no sha256 digest"
+                raise VerificationError(msg)
+            return digest
+    msg = f"{filename} is not listed for {pypi_name} {version} yet"
+    raise NotYetAvailableError(msg)
+
+
+def _verify_attestation(filename: str, repository: str) -> None:
+    """Verify a file's PEP 740 attestation, or signal it is not up yet."""
+    command = [
+        sys.executable,
+        "-m",
+        "pypi_attestations",
+        "verify",
+        "pypi",
+        "--repository",
+        repository,
+        f"pypi:{filename}",
+    ]
+    result = subprocess.run(command, check=False, capture_output=True, text=True)
+    if result.returncode == 0:
+        return
+    output = (result.stdout + result.stderr).strip()
+    if any(marker in output for marker in _PENDING_MARKERS):
+        raise NotYetAvailableError(output)
+    msg = f"{filename}: attestation did not verify:\n{output}"
+    raise VerificationError(msg)
+
+
+def _local_sha256(path: Path) -> str:
+    """Return the sha256 of a local file, read in chunks."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _find_local(dist_dir: Path, filename: str) -> Path | None:
+    """Return the built copy of a file under ``dist_dir``, if present."""
+    matches = sorted(dist_dir.rglob(filename))
+    return matches[0] if matches else None
+
+
+def _check_once(
+    pypi_name: str,
+    version: str,
+    filename: str,
+    repository: str,
+    dist_dir: Path | None,
+) -> str:
+    """Run one attempt of every check for a file and return a status detail."""
+    _verify_attestation(filename, repository)
+    if dist_dir is None:
+        return "attestation OK"
+    local = _find_local(dist_dir, filename)
+    if local is None:
+        return "attestation OK; no local copy to compare"
+    published = _published_sha256(pypi_name, version, filename)
+    built = _local_sha256(local)
+    if built != published:
+        msg = (
+            f"{filename}: published bytes differ from built bytes "
+            f"(PyPI sha256 {published}, built {built})"
+        )
+        raise VerificationError(msg)
+    return "attestation OK; published bytes match built bytes"
+
+
+def _check_file(
+    pypi_name: str,
+    version: str,
+    filename: str,
+    repository: str,
+    dist_dir: Path | None,
+    deadline: float,
+) -> str:
+    """Check a file, retrying not-yet-available results until the deadline."""
+    waits = _retry_waits()
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            return _check_once(pypi_name, version, filename, repository, dist_dir)
+        except NotYetAvailableError as pending:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                msg = f"{filename}: still unavailable after the retry budget: {pending}"
+                raise VerificationError(msg) from pending
+            wait = min(next(waits), remaining)
+            print(
+                f"  {filename}: not available yet ({pending}); "
+                f"retrying in {wait:.0f}s [attempt {attempt}]",
+                flush=True,
+            )
+            time.sleep(wait)
+
+
+def _evaluate_file(
+    pypi_name: str,
+    version: str,
+    filename: str,
+    repository: str,
+    dist_dir: Path | None,
+    deadline: float,
+) -> tuple[bool, str]:
+    """Check one file and return ``(passed, detail-or-reason)``."""
+    try:
+        detail = _check_file(
+            pypi_name, version, filename, repository, dist_dir, deadline
+        )
+    except VerificationError as error:
+        return False, str(error)
+    return True, detail
+
+
+def verify_release(
+    version: str,
+    dist_dir: Path | None = None,
+    repository: str = REPOSITORY,
+    deadline: float | None = None,
+) -> None:
+    """Verify every published file for a release, raising on any failure."""
+    if deadline is None:
+        deadline = time.monotonic() + RETRY_BUDGET_SECONDS
+    files = expected_files(version)
+    print(
+        f"Verifying {len(files)} published files for nab {version} "
+        f"against {repository}.",
+        flush=True,
+    )
+    if dist_dir is None:
+        print(
+            "No --dist-dir given; checking attestations only "
+            "(skipping the built-vs-published digest comparison).",
+            flush=True,
+        )
+    failures: list[tuple[str, str]] = []
+    for pypi_name, filename in files:
+        passed, detail = _evaluate_file(
+            pypi_name, version, filename, repository, dist_dir, deadline
+        )
+        if passed:
+            print(f"  ok   {filename}: {detail}", flush=True)
+        else:
+            print(f"  FAIL {filename}", flush=True)
+            failures.append((filename, detail))
+    if failures:
+        print(f"\n{len(failures)} of {len(files)} files failed verification:")
+        for _filename, reason in failures:
+            print(f"  - {reason}")
+        msg = f"{len(failures)} published file(s) failed verification"
+        raise SystemExit(msg)
+    print(f"\nAll {len(files)} published files verified.")
+
+
+def _version_from_tag(tag: str) -> str:
+    """Return the release version named by a ``vX.Y.Z`` tag."""
+    if not tag.startswith("v"):
+        msg = f"release tag {tag!r} must start with 'v'"
+        raise SystemExit(msg)
+    version = tag[1:]
+    if not release.is_release_version(version):
+        msg = f"{tag!r} does not name a release version"
+        raise SystemExit(msg)
+    return version
+
+
+def main() -> None:
+    """Parse arguments and verify the tag's published files."""
+    parser = argparse.ArgumentParser(description="Verify a release's PyPI files.")
+    parser.add_argument("tag", help="release tag, for example v0.0.11")
+    parser.add_argument(
+        "--dist-dir",
+        type=Path,
+        default=None,
+        help="tree of built artifacts to compare against the published files",
+    )
+    args = parser.parse_args()
+    version = _version_from_tag(args.tag)
+    verify_release(version, args.dist_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The release workflow publishes and stops; nothing confirms what PyPI ends up serving. A new `verify` job runs after `publish` and fails the release run unless, for all eight files, the PEP 740 attestation verifies against this repository's identity and the sha256 PyPI serves equals the bytes the workflow built.

`tasks/verify_published.py` drives it and runs locally too (`python tasks/verify_published.py v0.0.11` passes against the live release). Not-yet-propagated files retry against a shared ten-minute budget for CDN lag; genuine verification failures fail immediately. `pypi-attestations` joins the release dependency group; regenerating that lock moved `cryptography` to 46.0.7 and `rich` to 14.3.4, forced by sigstore's upper bounds.
