### PR TITLE
remove stale 0.0.0+local default claim from LocalSource docs

### DIFF
--- a/docs/how-to/local-sources.md
+++ b/docs/how-to/local-sources.md
@@ -17,9 +17,11 @@ Relative `path` entries resolve against the directory holding
 `pyproject.toml`, not the process's current working directory.
 Absolute paths are recorded as-is.
 
-The directory is read once.  nab takes the version from
-`[project].version` in the local pyproject.toml; if absent, the
-package is pinned to the synthetic version `0.0.0+local`.
+The directory is read once.  nab reads the version from
+`[project].version` in the local pyproject.toml.  When the pyproject
+declares `dynamic = ["version"]`, nab computes it through the build
+backend instead, the same PEP 517 path used for dynamic dependencies
+below.
 
 The named package becomes the only candidate the resolver will
 consider for that name; the resolver does not fall back to

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -231,9 +231,10 @@ class LocalSource:
     """A source tree on disk used as the only candidate for a package.
 
     ``name`` is the package name; the resolver pins the package to a
-    single synthetic version derived from the directory's
-    ``[project].version`` field (or ``"0.0.0+local"`` if absent).
-    ``path`` is the absolute filesystem path to the source tree.
+    single synthetic version, read from the directory's
+    ``[project].version`` field or computed by the build backend when
+    that field is declared dynamic.  ``path`` is the absolute filesystem
+    path to the source tree.
 
     ``editable`` requests a PEP 660 editable install in the lockfile;
     ``subdirectory`` is a path under ``path`` for monorepo layouts.


### PR DESCRIPTION
The LocalSource docstring and the local-sources how-to both said nab falls back to a synthetic `0.0.0+local` version when `[project].version` is missing. No code produces that value. When the version field is absent and not declared dynamic, static metadata parsing returns None and the source is not admitted, so nothing is ever pinned to a placeholder.

Both now describe what actually happens: the version is read from `[project].version`, or computed through the build backend when that field is declared dynamic.
