### PR TITLE
wrap venv-creation and scheme-probe failures as BuildEnvError

### DIFF
--- a/nab-python/src/nab_python/_build/env.py
+++ b/nab-python/src/nab_python/_build/env.py
@@ -94,7 +94,11 @@ _SCHEME_PROBE = (
 
 
 class BuildEnvError(Exception):
-    """The build env could not be set up (resolve, download, or install)."""
+    """The build env could not be set up.
+
+    Covers venv creation, the interpreter scheme probe, and the inner
+    resolve, download, and install of ``[build-system].requires``.
+    """
 
 
 class NabBuildEnv:
@@ -154,13 +158,17 @@ class NabBuildEnv:
         """Lay out the venv, install build requirements, populate paths."""
         self._venv_path = root / "venv"
         wheel_dir = root / "wheels"
-        wheel_dir.mkdir()
 
         logger.debug("creating build venv at %s", self._venv_path)
         builder = venv.EnvBuilder(
             with_pip=False, symlinks=_supports_symlinks(), clear=False
         )
-        builder.create(self._venv_path)
+        try:
+            wheel_dir.mkdir()
+            builder.create(self._venv_path)
+        except OSError as exc:
+            msg = f"could not create build venv at {self._venv_path}: {exc}"
+            raise BuildEnvError(msg) from exc
 
         self._python_executable = _venv_python(self._venv_path)
         self._scripts_dir = self._python_executable.parent
@@ -356,13 +364,22 @@ def _venv_scheme_paths(python_executable: Path) -> dict[str, str]:
     the base interpreter rather than the venv, so the header root comes
     from the venv's own prefix instead.
     """
-    result = subprocess.run(  # noqa: S603 - controlled command, no shell
-        [str(python_executable), "-c", _SCHEME_PROBE],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    probe = json.loads(result.stdout)
+    try:
+        result = subprocess.run(  # noqa: S603 - controlled command, no shell
+            [str(python_executable), "-c", _SCHEME_PROBE],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        msg = f"build venv interpreter probe failed: {exc}"
+        raise BuildEnvError(msg) from exc
+
+    try:
+        probe = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        msg = f"build venv interpreter probe returned non-JSON output: {exc}"
+        raise BuildEnvError(msg) from exc
 
     paths: dict[str, str] = dict(probe["paths"])
     paths["headers"] = str(

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -399,6 +399,32 @@ class TestRunBuildBackend:
         ):
             run_build_backend(tmp_path, config=config)
 
+    def test_venv_creation_oserror_wrapped(
+        self,
+        tmp_path: Path,
+        config: NabProjectConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An OSError building the venv is wrapped as BuildBackendError."""
+        (tmp_path / "pyproject.toml").write_text(
+            '[build-system]\nrequires = ["setuptools"]\n'
+            'build-backend = "setuptools.build_meta"\n',
+            encoding="utf-8",
+        )
+
+        class _Builder:
+            def __init__(self, **_kw: object) -> None:
+                pass
+
+            def create(self, _path: Path) -> None:
+                raise OSError(28, "No space left on device")
+
+        import venv as venv_mod
+
+        monkeypatch.setattr(venv_mod, "EnvBuilder", _Builder)
+        with pytest.raises(BuildBackendError, match="build env setup"):
+            run_build_backend(tmp_path, config=config)
+
 
 class TestShouldSkipPrepare:
     """Unit tests for the hatchling+dynamic-deps detection predicate."""
@@ -1050,6 +1076,29 @@ class TestNabBuildEnvEnterInstall:
             env.__enter__()
         assert env._tmpdir is None  # type: ignore[attr-defined]
 
+    def test_enter_wraps_venv_create_oserror(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An OSError from ``venv.EnvBuilder.create`` is wrapped as
+        BuildEnvError, and the temp directory is still cleaned up.
+        """
+
+        class _Builder:
+            def __init__(self, **_kw: object) -> None:
+                pass
+
+            def create(self, _path: Path) -> None:
+                raise OSError(28, "No space left on device")
+
+        import venv as venv_mod
+
+        monkeypatch.setattr(venv_mod, "EnvBuilder", _Builder)
+        env = NabBuildEnv(requires=[], config=NabProjectConfig())
+        with pytest.raises(BuildEnvError, match="build venv"):
+            env.__enter__()
+        assert env._tmpdir is None  # type: ignore[attr-defined]
+
 
 class TestBuildEnvHeaderScheme:
     """A build requirement whose wheel ships a ``.data/headers/`` payload.
@@ -1130,6 +1179,34 @@ class TestBuildEnvHeaderScheme:
         assert header.read_bytes() == b"#define GREENLET_H\n"
         site = venv_path / "lib" / f"python{py_version}" / "site-packages"
         assert (site / "greenlet" / "__init__.py").is_file()
+
+
+class TestVenvSchemeProbeErrors:
+    """A failed interpreter scheme probe is wrapped as BuildEnvError."""
+
+    def test_probe_called_process_error_wrapped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-zero probe exit is wrapped as BuildEnvError."""
+
+        def _run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            raise subprocess.CalledProcessError(1, cmd)
+
+        monkeypatch.setattr(subprocess, "run", _run)
+        with pytest.raises(BuildEnvError, match="interpreter probe"):
+            _venv_scheme_paths(Path("/nonexistent/venv/bin/python"))
+
+    def test_probe_non_json_output_wrapped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Probe stdout that is not JSON is wrapped as BuildEnvError."""
+
+        def _run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="not json\n", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", _run)
+        with pytest.raises(BuildEnvError, match="interpreter probe"):
+            _venv_scheme_paths(Path("/nonexistent/venv/bin/python"))
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
run_build_backend documents that it raises BuildBackendError on any failure, but two build-env setup paths escaped that contract as raw exceptions. Creating the venv could fail with an OSError (a full disk, for one), and the interpreter scheme-probe subprocess could raise OSError or CalledProcessError. A caller catching BuildBackendError would still see the bare exception.

Both paths now raise BuildEnvError, which run_build_backend already catches and re-raises as BuildBackendError. A non-JSON probe response, which previously surfaced as a raw JSONDecodeError, is wrapped the same way.
