### PR TITLE
honor <base href> in a local PEP 503 HTML index

### DIFF
--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -28,7 +28,7 @@ from email.parser import BytesParser, Parser
 from html.parser import HTMLParser
 from pathlib import Path
 from typing import TYPE_CHECKING
-from urllib.parse import unquote, urlparse
+from urllib.parse import unquote, urljoin, urlparse
 from urllib.request import url2pathname
 
 from ._naming import canonical as _canonical
@@ -120,44 +120,67 @@ def _html_advertises_metadata(value: str | None) -> bool:
     return bool(sep and algo and digest)
 
 
+def _parse_anchor(
+    attrs: list[tuple[str, str | None]],
+) -> tuple[str, str | None, bool] | None:
+    """Turn an anchor's attributes into ``(href, requires_python, has_metadata)``.
+
+    Returns ``None`` for an anchor with no ``href`` or one carrying
+    ``data-yanked`` (PEP 592), so a yanked link never reaches the listing.
+    The PEP 714 ``data-core-metadata`` attribute (or legacy
+    ``data-dist-info-metadata``) is read so a wheel's advertised sidecar is
+    honoured, matching the PEP 691 JSON behaviour in
+    :func:`nab_index.client._parse_files`.
+    """
+    href: str | None = None
+    requires_python: str | None = None
+    yanked = False
+    core_metadata: str | None = None
+    legacy_metadata: str | None = None
+    for name, value in attrs:
+        if name == "href":
+            href = value
+        elif name == _REQUIRES_PYTHON_ATTR:
+            requires_python = value
+        elif name == _YANKED_ATTR:
+            yanked = True
+        elif name == _CORE_METADATA_ATTR:
+            core_metadata = value
+        elif name == _LEGACY_METADATA_ATTR:
+            legacy_metadata = value
+    if href is None or yanked:
+        return None
+    advertised = core_metadata if core_metadata is not None else legacy_metadata
+    return (href, requires_python, _html_advertises_metadata(advertised))
+
+
 class _Pep503Parser(HTMLParser):
     """Collect ``<a href="..." data-requires-python="...">`` entries.
 
-    Anchors carrying ``data-yanked`` (PEP 592) are dropped at parse
-    time so the listing never surfaces them.  The PEP 714
-    ``data-core-metadata`` attribute (or legacy ``data-dist-info-metadata``)
-    is read so a wheel's advertised sidecar is honoured, matching the PEP
-    691 JSON behaviour in :func:`nab_index.client._parse_files`.
+    The first ``<base href>`` is kept so relative anchors resolve against
+    it rather than the page directory, matching how pip and uv read a
+    Simple-repository page.
     """
 
     def __init__(self) -> None:
         super().__init__()
         self.links: list[tuple[str, str | None, bool]] = []
+        self.base_href: str | None = None
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "base":
+            if self.base_href is None:
+                for name, value in attrs:
+                    if name == "href":
+                        self.base_href = value
+                        break
+            return
+
         if tag != "a":
             return
-        href: str | None = None
-        requires_python: str | None = None
-        yanked = False
-        core_metadata: str | None = None
-        legacy_metadata: str | None = None
-        for name, value in attrs:
-            if name == "href":
-                href = value
-            elif name == _REQUIRES_PYTHON_ATTR:
-                requires_python = value
-            elif name == _YANKED_ATTR:
-                yanked = True
-            elif name == _CORE_METADATA_ATTR:
-                core_metadata = value
-            elif name == _LEGACY_METADATA_ATTR:
-                legacy_metadata = value
-        if href is not None and not yanked:
-            advertised = core_metadata if core_metadata is not None else legacy_metadata
-            self.links.append(
-                (href, requires_python, _html_advertises_metadata(advertised))
-            )
+        link = _parse_anchor(attrs)
+        if link is not None:
+            self.links.append(link)
 
 
 _FLAT_EXTS = re.compile(r"\.(whl|tar\.gz)$", re.IGNORECASE)
@@ -180,9 +203,16 @@ def _scan_pep503_directory(
 
     parser = _Pep503Parser()
     parser.feed(text)
+    if parser.base_href is not None:
+        base_url: str | None = urljoin(index_html.as_uri(), parser.base_href)
+    else:
+        base_url = None
+
     files: list[WheelFile | SdistFile] = []
     for href, requires_python, has_metadata in parser.links:
-        filename, file_url, local_path, hashes = _resolve_local_link(href, package_dir)
+        filename, file_url, local_path, hashes = _resolve_local_link(
+            href, package_dir, base_url
+        )
         if filename is None:
             continue
         record = _make_record(
@@ -202,8 +232,13 @@ def _scan_pep503_directory(
 def _resolve_local_link(
     href: str,
     package_dir: Path,
+    base_url: str | None,
 ) -> tuple[str | None, str, Path | None, tuple[tuple[str, str], ...]]:
     """Resolve an anchor href to ``(filename, url, local_path, hashes)``.
+
+    ``base_url`` is the page's ``<base href>`` when it carries one, else
+    ``None``.  A relative href joins against it; an absolute href ignores
+    it per RFC 3986.
 
     PEP 503 carries the artefact's hash in the URL fragment as
     ``#<algo>=<hexdigest>``; this is the only place the hash appears
@@ -217,6 +252,8 @@ def _resolve_local_link(
     """
     href_no_frag, _, fragment = href.partition("#")
     hashes = _parse_pep503_hash_fragment(fragment)
+    if base_url is not None:
+        href_no_frag = urljoin(base_url, href_no_frag)
     parsed = urlparse(href_no_frag)
 
     if parsed.scheme in {"http", "https"}:
@@ -226,7 +263,7 @@ def _resolve_local_link(
         path = parse_file_url(href_no_frag)
         return (path.name, href_no_frag, path, hashes)
 
-    # A relative href resolves against the package page wherever it points;
+    # Without a base href a relative link resolves against the package page;
     # the standard mirror layout links to a shared ../../packages/ tree, so the
     # target legitimately sits outside the package directory.
     target = (package_dir.resolve() / unquote(href_no_frag)).resolve()

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -531,6 +531,83 @@ class TestPep503Directory:
         assert len(result) == 1
         assert result[0].local_path == wheel_path.resolve()
 
+    def test_base_href_redirects_relative_anchor(self, tmp_path: Path) -> None:
+        # An absolute <base href> moves the resolution base off the page
+        # directory; the relative anchor must land on the real wheel there.
+        packages = tmp_path / "packages"
+        packages.mkdir()
+        wheel_path = packages / "foo-1.0-py3-none-any.whl"
+        wheel_path.write_bytes(b"")
+        package_dir = tmp_path / "foo"
+        package_dir.mkdir()
+        body = (
+            f'<base href="{packages.as_uri()}/">'
+            '<a href="foo-1.0-py3-none-any.whl">foo</a>'
+        )
+        (package_dir / "index.html").write_text(body, encoding="utf-8")
+        client = LocalIndexClient(tmp_path.as_uri())
+        result = run(client.get_files("foo"))
+        assert len(result) == 1
+        assert result[0].local_path == wheel_path
+        assert parse_file_url(result[0].url) == wheel_path
+
+    def test_base_href_relative_resolves_against_page(self, tmp_path: Path) -> None:
+        # A relative <base href> resolves against the index page URL, so a
+        # sibling directory is reachable from the listing.
+        packages = tmp_path / "packages"
+        packages.mkdir()
+        wheel_path = packages / "foo-1.0-py3-none-any.whl"
+        wheel_path.write_bytes(b"")
+        package_dir = tmp_path / "foo"
+        package_dir.mkdir()
+        body = '<base href="../packages/"><a href="foo-1.0-py3-none-any.whl">foo</a>'
+        (package_dir / "index.html").write_text(body, encoding="utf-8")
+        client = LocalIndexClient(tmp_path.as_uri())
+        result = run(client.get_files("foo"))
+        assert len(result) == 1
+        assert result[0].local_path == wheel_path
+
+    def test_first_base_href_wins(self, tmp_path: Path) -> None:
+        packages = tmp_path / "packages"
+        packages.mkdir()
+        wheel_path = packages / "foo-1.0-py3-none-any.whl"
+        wheel_path.write_bytes(b"")
+        package_dir = tmp_path / "foo"
+        package_dir.mkdir()
+        body = (
+            f'<base href="{packages.as_uri()}/">'
+            f'<base href="{tmp_path.as_uri()}/other/">'
+            '<a href="foo-1.0-py3-none-any.whl">foo</a>'
+        )
+        (package_dir / "index.html").write_text(body, encoding="utf-8")
+        client = LocalIndexClient(tmp_path.as_uri())
+        result = run(client.get_files("foo"))
+        assert len(result) == 1
+        assert result[0].local_path == wheel_path
+
+    def test_base_without_href_ignored(self, tmp_path: Path) -> None:
+        body = '<base target="_blank"><a href="foo-1.0-py3-none-any.whl">foo</a>'
+        package_dir = self._make_index(tmp_path, body)
+        (package_dir / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        result = run(client.get_files("foo"))
+        assert len(result) == 1
+        assert (
+            result[0].local_path == package_dir.resolve() / "foo-1.0-py3-none-any.whl"
+        )
+
+    def test_base_href_ignored_by_absolute_anchor(self, tmp_path: Path) -> None:
+        body = (
+            f'<base href="{tmp_path.as_uri()}/packages/">'
+            '<a href="https://example.com/foo/foo-1.0-py3-none-any.whl">foo</a>'
+        )
+        self._make_index(tmp_path, body)
+        client = LocalIndexClient(tmp_path.as_uri())
+        result = run(client.get_files("foo"))
+        assert len(result) == 1
+        assert result[0].url == "https://example.com/foo/foo-1.0-py3-none-any.whl"
+        assert result[0].local_path is None
+
     def test_https_href_pass_through(self, tmp_path: Path) -> None:
         body = '<a href="https://example.com/foo/foo-1.0-py3-none-any.whl">foo</a>'
         self._make_index(tmp_path, body)


### PR DESCRIPTION
A local PEP 503 index page can set a `<base href>` to point its relative links at a shared packages directory. nab ignored the element and resolved every relative anchor against the package page directory instead, so it could resolve to the wrong path or miss the artifact. pip and uv both read `<base href>`, so the same index resolved differently under nab.

This reads the first `<base href>` on the page and joins each relative href against it before resolving. An absolute href still ignores the base, per RFC 3986.
