### PR TITLE
assert default Printer streams are sys.stdout/sys.stderr

### DIFF
--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import logging
+import sys
 from pathlib import Path
 
 import pytest
@@ -216,8 +217,8 @@ def test_progress_blocked_by_env() -> None:
 
 def test_defaults_use_process_streams() -> None:
     printer = Printer(env={})
-    assert printer._out is not None
-    assert printer._err is not None
+    assert printer._out is sys.stdout
+    assert printer._err is sys.stderr
 
 
 def test_parse_counts_and_passthrough() -> None:


### PR DESCRIPTION
test_defaults_use_process_streams only checked that a default Printer's _out and _err were not None. That still passes if the defaults stop being the process streams, so the test can't catch a regression in what Printer() falls back to. Assert the streams are sys.stdout and sys.stderr instead.
