### PR TITLE
document the output control flags in the CLI reference

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -10,10 +10,14 @@ runtime knobs and can override a project key for one run with a
 
 ```
 nab [--version | -V]
-nab lock     [PATH] [RUNTIME OPTIONS] [--output PATH] [--format pylock|requirements|requirements-without-hashes]
-nab download [PATH] [RUNTIME OPTIONS] [--output DIR] [--max-concurrency N]
-nab config   {list | get <key> | explain <key>} [--path PATH]
+nab [OUTPUT FLAGS] lock     [PATH] [RUNTIME OPTIONS] [--output PATH] [--format pylock|requirements|requirements-without-hashes]
+nab [OUTPUT FLAGS] download [PATH] [RUNTIME OPTIONS] [--output DIR] [--max-concurrency N]
+nab [OUTPUT FLAGS] config   {list | get <key> | explain <key>} [--path PATH]
 ```
+
+`OUTPUT FLAGS` are the global verbosity, colour, and progress knobs listed
+under Output control below. They are read before the subcommand, so they may
+appear anywhere on the line.
 
 `PATH` is positional and defaults to `pyproject.toml` in the
 current directory. Run `nab lock --help` (or `-h`) for the full
@@ -218,11 +222,49 @@ matching extra.
 | `--version`, `-V` | Print `nab <version>` and exit `0`. |
 | `--help`, `-h` | Standard argparse-style help. Per-subcommand help works too: `nab lock --help`. |
 
+The verbosity, colour, and progress flags below are also global.
+
+## Output control
+
+These flags set how much `nab` writes to stderr, whether it colours it,
+and whether it animates a progress line. They are global: `nab` reads them
+before the subcommand, so they work with `lock`, `download`, and `config`.
+stdout carries only the requested output (the lockfile, the requirements
+list, the `config` dump), so it stays pipeable at every verbosity.
+
+| Flag | Effect |
+| ---- | ------ |
+| `-v`, `-vv`, `--verbose` | Raise verbosity. `-v` adds the engine's `INFO` records, `-vv` adds `DEBUG`. `--verbose` counts as one `-v`; repeats add, and `-vvv` saturates at `-vv`. |
+| `-q`, `-qq`, `--quiet` | Lower verbosity. `-q` drops the run summary and notes, keeping warnings and errors; `-qq` keeps only errors. `--quiet` counts as one `-q`. |
+| `--color` | When to colour stderr: `auto` (default), `always`, or `never`. `auto` colours only an stderr terminal and honours `NO_COLOR`, `FORCE_COLOR`, and `TERM=dumb`; `always` and `never` win outright. Colour touches only a message's leading token, so it reads the same stripped. |
+| `--no-color` | Shorthand for `--color never`. |
+| `--no-progress` | Suppress the live progress line (also `NAB_NO_PROGRESS`). |
+
+Verbosity is the count of `-v` minus the count of `-q`. The five levels,
+quietest first, are silent (`-qq`), quiet (`-q`), normal (the default),
+verbose (`-v`), and debug (`-vv`). Errors print at every level; warnings
+print unless `-qq`; the run summary and notes print at normal and above.
+
+While `nab lock` or `nab download` resolves, a live line repaints on
+stderr, counting package listings fetched and packages pinned:
+
+```
+Resolving... 12 fetched, 5 pinned
+```
+
+It shows only at normal verbosity on an stderr terminal; `--no-progress`
+(or `NAB_NO_PROGRESS`) turns it off, and it never writes to stdout.
+
 ## Environment variables
 
 | Variable | Effect |
 | -------- | ------ |
 | `XDG_CACHE_HOME` | If set, `nab`'s default cache root is `$XDG_CACHE_HOME/nab` instead of `~/.cache/nab`. |
+| `NAB_VERBOSITY` | Default verbosity when no `-v` / `-q` flag is given: one of `silent`, `quiet`, `normal`, `verbose`, `debug`. A `-v` / `-q` flag overrides it. An unrecognised value is rejected. |
+| `NAB_NO_PROGRESS` | If set to a non-empty value, suppress the live progress line, like `--no-progress`. |
+| `NO_COLOR` | If set to a non-empty value, disable colour under `--color auto`. |
+| `FORCE_COLOR` | If set to a non-empty value, force colour under `--color auto`. |
+| `TERM` | `dumb` disables colour under `--color auto`. |
 
 ## Exit codes
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import logging
+from pathlib import Path
 
 import pytest
 
@@ -424,3 +425,49 @@ def test_progress_clear_wipes_then_is_noop() -> None:
     err.seek(0)
     reporter.clear()
     assert err.getvalue() == ""
+
+
+_CLI_REFERENCE = Path(__file__).resolve().parents[1] / "docs" / "reference" / "cli.md"
+
+
+def _cli_reference_text() -> str:
+    return _CLI_REFERENCE.read_text(encoding="utf-8")
+
+
+class TestCliReferenceDocumentsOutputPolicy:
+    """The CLI reference must list every output-policy flag and env var the CLI accepts.
+
+    ``parse_output_options`` defines the flags and ``Printer`` reads the env vars.
+    """
+
+    def test_verbosity_flags_documented(self) -> None:
+        text = _cli_reference_text()
+        for flag in ("-v", "-vv", "-q", "-qq", "--verbose", "--quiet"):
+            assert f"`{flag}`" in text, f"CLI reference omits verbosity flag {flag}"
+
+    def test_color_flags_documented(self) -> None:
+        text = _cli_reference_text()
+        assert "`--color`" in text
+        assert "`--no-color`" in text
+        for choice in ColorChoice:
+            assert f"`{choice.value}`" in text, (
+                f"CLI reference omits --color value {choice.value}"
+            )
+
+    def test_progress_documented(self) -> None:
+        text = _cli_reference_text()
+        assert "`--no-progress`" in text
+        assert "Resolving" in text
+
+    def test_output_env_vars_documented(self) -> None:
+        text = _cli_reference_text()
+        for var in ("NAB_VERBOSITY", "NAB_NO_PROGRESS", "NO_COLOR", "FORCE_COLOR"):
+            assert var in text, f"CLI reference omits env var {var}"
+
+    def test_nab_verbosity_values_documented(self) -> None:
+        text = _cli_reference_text()
+        for level in Verbosity:
+            name = level.name.lower()
+            assert f"`{name}`" in text, (
+                f"CLI reference omits NAB_VERBOSITY value {name!r}"
+            )


### PR DESCRIPTION
The CLI reference didn't mention any of the output controls, so `-v`/`-q`, `--color`, `--no-progress`, and the environment variables behind them had no entry even though the CLI accepts them.

This adds an Output control section to `docs/reference/cli.md` covering the verbosity levels, the `-v`/`-vv`/`-q`/`-qq` and `--verbose`/`--quiet` flags, `--color` with its `auto`/`always`/`never` values, `--no-color`, `--no-progress`, and the live progress line. It notes the flags are global and read before the subcommand, and adds `NAB_VERBOSITY`, `NAB_NO_PROGRESS`, `NO_COLOR`, `FORCE_COLOR`, and `TERM` to the environment variables table.

A test walks the `ColorChoice` and `Verbosity` values against the reference text, so the docs fail if a flag or level is added without a matching entry.
