### PR TITLE
report an invalid --project-* value against the flag, not [tool.nab]

### DIFF
--- a/src/nab/_download.py
+++ b/src/nab/_download.py
@@ -102,10 +102,12 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
         cli_constraint=project_constraint,
         cli_default_group=project_default_group,
     )
+    project_overrides = _cli.project_config_overrides(overrides)
+    _cli._project_cli_overrides_or_exit(project_overrides)  # noqa: SLF001
     config = _cli._load_config(  # noqa: SLF001
         path,
         discover_workspace=workspace_discovery,
-        cli_overrides=_cli.project_config_overrides(overrides),
+        cli_overrides=project_overrides,
     )
     settings = _cli._layered_run_settings_or_exit(  # noqa: SLF001
         path, overrides, produces_lock=False

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -167,6 +167,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
         cli_default_group=project_default_group,
     )
     project_overrides = _cli.project_config_overrides(overrides)
+    _cli._project_cli_overrides_or_exit(project_overrides)  # noqa: SLF001
     anchor = _determine_lock_anchor(
         path,
         output=output,

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -445,6 +445,24 @@ def _require_pyproject_file(path: Path) -> None:
         sys.exit(1)
 
 
+def _project_cli_overrides_or_exit(project_overrides: Mapping[str, object]) -> None:
+    """Exit 1 when a ``--project-*`` override has a bad value, naming the flag.
+
+    These overrides otherwise reach validation only through the
+    ``[tool.nab]`` parse in :func:`_load_config`, which stamps every error
+    ``in [tool.nab]:`` and points at a table the project may not have.
+    Parsing them here surfaces the error against the flag instead.
+    """
+    for spec in OPTIONS:
+        if spec.key not in project_overrides:
+            continue
+        try:
+            build_cli_layer({spec.key: project_overrides[spec.key]})
+        except SourceConfigError as exc:
+            printer().error(f"{spec.cli_flag}: {exc}")
+            sys.exit(1)
+
+
 def _load_config(
     path: Path,
     *,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1142,6 +1142,93 @@ class TestPythonFlag:
         assert "--python is not supported in universal mode" in capsys.readouterr().err
 
 
+class TestProjectFlagErrors:
+    """A bad ``--project-*`` value reads as a flag error, not a table one.
+
+    These overrides fold through the same ``[tool.nab]`` parse the file
+    uses, so the error must name the flag rather than the ``[tool.nab]``
+    table, which the project may not even have.
+    """
+
+    def test_requires_python_bad_value_names_the_flag(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with pytest.raises(SystemExit) as exc:
+            lock(pyproject, output=out, project_requires_python="@@@")
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert (
+            "error: --project-requires-python: requires-python must be a"
+            " PEP 440 specifier, got '@@@'" in err
+        )
+        assert "[tool.nab]" not in err
+        assert not out.exists()
+
+    def test_uploaded_prior_to_bad_value_names_the_flag(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with pytest.raises(SystemExit) as exc:
+            lock(pyproject, output=out, project_uploaded_prior_to="not-a-date")
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "--project-uploaded-prior-to: uploaded-prior-to must be an" in err
+        assert "[tool.nab]" not in err
+        assert not out.exists()
+
+    def test_constraint_bad_value_names_the_flag(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with pytest.raises(SystemExit) as exc:
+            lock(pyproject, output=out, project_constraint=("this is not pep508 !!!",))
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "--project-constraint: constraints[0] is not a valid requirement" in err
+        assert "[tool.nab]" not in err
+        assert not out.exists()
+
+    def test_download_requires_python_bad_value_names_the_flag(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        with pytest.raises(SystemExit) as exc:
+            download(
+                pyproject, output=tmp_path / "wheels", project_requires_python="@@@"
+            )
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "error: --project-requires-python: requires-python must be a" in err
+        assert "[tool.nab]" not in err
+
+    def test_valid_override_threads_through(self, tmp_path: Path) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with patch(
+            "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
+        ) as mock_resolve:
+            lock(pyproject, output=out, project_requires_python="==3.11")
+        assert mock_resolve.call_args.kwargs["config"].requires_python == "==3.11"
+
+    def test_bad_file_value_still_reads_as_a_table_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\ndependencies = ["foo"]\n[tool.nab]\nrequires-python = "@@@"\n',
+        )
+        out = tmp_path / "pylock.toml"
+        with pytest.raises(SystemExit) as exc:
+            lock(pyproject, output=out)
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "in [tool.nab]: requires-python must be a PEP 440 specifier" in err
+
+
 class TestLockCommandUniversal:
     """Tests for `nab lock` in universal mode."""
 


### PR DESCRIPTION
A bad value on --project-requires-python, --project-uploaded-prior-to, or --project-constraint was reported as "in [tool.nab]: ...", blaming a pyproject table the value never came from and that the project may not even have.

These flags fold into the same [tool.nab] parse the config file uses, so their validation errors picked up the table's prefix. The fix validates each --project-* override on its own before that parse and reports a bad value against the flag that carried it, for both `nab lock` and `nab download`.

This is the same misdirection #471 fixed for the other flags, which left the --project-* family untouched.
