### PR TITLE
raise HttpError on non-UTF-8 local PEP 658 metadata sidecar

### DIFF
--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -63,13 +63,13 @@ class UnsupportedWheelError(Exception):
 
 
 class MalformedLocalListingError(HttpError):
-    """A local ``file://`` index's ``index.html`` is not a usable listing.
+    """A local ``file://`` index's ``index.html`` or metadata sidecar is unreadable.
 
     Subclasses :class:`~nab_index.transport.HttpError` so a broken local
-    listing fails through the same path as a remote index error rather
-    than surfacing a raw decode error.  Raising, rather than returning an
-    empty listing, keeps a malformed index from reading as an absent
-    package.
+    listing or PEP 658 sidecar fails through the same path as a remote
+    index error rather than surfacing a raw decode error.  Raising, rather
+    than returning an empty listing, keeps a malformed index from reading
+    as an absent package.
     """
 
 
@@ -518,10 +518,18 @@ class LocalIndexClient:
         """Return PEP 658 metadata text for a wheel sitting on disk.
 
         The on-disk sidecar is trusted, so ``metadata_hash`` is accepted
-        only to match the remote client signature and is not verified.
+        only to match the remote client signature and is not verified.  A
+        sidecar that is not valid UTF-8 raises
+        :class:`MalformedLocalListingError` (an :class:`HttpError` subclass)
+        rather than a raw :class:`UnicodeDecodeError`, matching the
+        ``index.html`` reader.
         """
         path = parse_file_url(metadata_url)
-        return path.read_text(encoding="utf-8")
+        try:
+            return path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as exc:
+            msg = f"{path} is not valid UTF-8: {exc}"
+            raise MalformedLocalListingError(msg) from exc
 
     async def get_sdist_files(
         self,

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -844,6 +844,17 @@ class TestMetadataAndSdist:
         text = run(client.get_metadata_text("foo", "1.0", meta_path.as_uri()))
         assert text.startswith("Name: foo")
 
+    def test_non_utf8_metadata_sidecar_raises_http_error(self, tmp_path: Path) -> None:
+        # A non-UTF-8 sidecar must fail through HttpError like the
+        # index.html reader, not a raw UnicodeDecodeError.
+        meta_path = tmp_path / "foo-1.0.metadata"
+        meta_path.write_bytes(b"Author: J\xe9an\n")
+        client = LocalIndexClient(tmp_path.as_uri())
+        with pytest.raises(MalformedLocalListingError) as caught:
+            run(client.get_metadata_text("foo", "1.0", meta_path.as_uri()))
+        assert isinstance(caught.value, HttpError)
+        assert "not valid UTF-8" in str(caught.value)
+
     def test_get_sdist_files(self, tmp_path: Path) -> None:
         sdist_path = tmp_path / "foo-1.0.tar.gz"
         buf = io.BytesIO()


### PR DESCRIPTION
A local file:// PEP 658 metadata sidecar that isn't valid UTF-8 crashed nab lock and download with a raw UnicodeDecodeError. LocalIndexClient.get_metadata_text read the sidecar with read_text(encoding="utf-8") and let the decode error escape, even though the index.html reader on the same client already turns a bad body into MalformedLocalListingError.

Wrap the read and raise MalformedLocalListingError (an HttpError subclass) naming the path, so a broken local sidecar fails the same way as the other index errors instead of surfacing as a bare decode error. This is the local twin of the remote fix in #485.
