### PR TITLE
raise BuildBackendError when the built wheel is unreadable

### DIFF
--- a/nab-python/src/nab_python/_build/runner.py
+++ b/nab-python/src/nab_python/_build/runner.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import logging
 import tempfile
+import zipfile
 from email import message_from_string
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -68,7 +69,8 @@ def run_build_backend(
     Returns a :class:`~nab_python.metadata.WheelMetadata` parsed from
     the ``METADATA`` file the backend produces.  Raises
     :class:`BuildBackendError` on any failure: backend import
-    error, hook crash, malformed METADATA, or sdist-only build deps.
+    error, hook crash, malformed METADATA, an unreadable built
+    wheel, or sdist-only build deps.
 
     The build runs in an isolated venv driven by
     :class:`NabBuildEnv`; nothing in the user's main environment is
@@ -110,10 +112,17 @@ def run_build_backend(
 
             with tempfile.TemporaryDirectory(prefix="nab-build-meta-") as out_str:
                 output_dir = Path(out_str)
-                if skip_prepare:
-                    metadata_dir = _build_wheel_and_extract(project, output_dir)
-                else:
-                    metadata_dir = Path(project.metadata_path(output_dir))
+                try:
+                    if skip_prepare:
+                        metadata_dir = _build_wheel_and_extract(project, output_dir)
+                    else:
+                        metadata_dir = Path(project.metadata_path(output_dir))
+                # build raises a bare ValueError for a wheel whose name will not parse
+                except (zipfile.BadZipFile, ValueError, OSError) as exc:
+                    msg = (
+                        f"build backend {backend!r} produced an unreadable wheel: {exc}"
+                    )
+                    raise BuildBackendError(msg) from exc
                 return _parse_metadata(metadata_dir / "METADATA")
     except (
         build.BuildException,
@@ -184,10 +193,6 @@ def _build_wheel_and_extract(
     """
     wheel = project.build("wheel", str(output_directory))
     wheel_path = Path(wheel)
-    # zipfile is only needed for the build path; deferred to keep
-    # import-time work minimal.
-    import zipfile
-
     with zipfile.ZipFile(wheel_path) as zf:
         dist_info_members = [
             n

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -24,6 +24,7 @@ import zipfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import build
 import pytest
 from installer.utils import SCHEME_NAMES, Scheme
 
@@ -621,6 +622,105 @@ class TestBuildWheelExtraction:
 
         with pytest.raises(BuildBackendError, match="no .dist-info"):
             _build_wheel_and_extract(_Builder(), tmp_path)  # type: ignore[arg-type]
+
+
+class TestRunBuildBackendCorruptBuiltWheel:
+    """A ``build_wheel`` hook that succeeds but emits an unreadable wheel must
+    normalize to ``BuildBackendError``, not leak the ``zipfile.BadZipFile`` from
+    reading the wheel back nor the bare ``ValueError`` ``build`` raises for an
+    unparseable wheel name. The read-back sits outside the hook-error wrapper on
+    both the ``build.metadata_path`` fallback and the runner's own skip path.
+    """
+
+    def _pyproject(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            "[build-system]\n"
+            "requires = []\n"
+            'build-backend = "nab_test_backend"\n'
+            'backend-path = ["."]\n',
+            encoding="utf-8",
+        )
+
+    def _mock_env(self) -> MagicMock:
+        env = MagicMock()
+        env.__enter__ = MagicMock(return_value=env)
+        env.__exit__ = MagicMock(return_value=None)
+        return env
+
+    def _corrupt_building_project(self, wheel_name: str) -> MagicMock:
+        """A project whose ``build_wheel`` writes non-zip bytes and returns
+        ``wheel_name``. ``prepare`` returns None so ``metadata_path`` runs
+        ``build``'s real build_wheel fallback, whose read-back hits the real
+        ``parse_wheel_filename`` and ``zipfile.ZipFile``.
+        """
+        project = MagicMock()
+        project.get_requires_for_build.return_value = []
+        project.prepare.return_value = None
+
+        def fake_build(_dist: str, outdir: str, *_a: object, **_k: object) -> str:
+            path = Path(outdir) / wheel_name
+            path.write_bytes(b"not a zip")
+            return str(path)
+
+        project.build.side_effect = fake_build
+        project.metadata_path.side_effect = lambda outdir: (
+            build.ProjectBuilder.metadata_path(project, outdir)
+        )
+        return project
+
+    def _run(
+        self, tmp_path: Path, config: NabProjectConfig, project: MagicMock
+    ) -> None:
+        with (
+            patch(
+                "nab_python._build.runner.NabBuildEnv",
+                return_value=self._mock_env(),
+            ),
+            patch(
+                "nab_python._build.runner.build.ProjectBuilder.from_isolated_env",
+                return_value=project,
+            ),
+            pytest.raises(BuildBackendError, match="unreadable wheel"),
+        ):
+            run_build_backend(tmp_path, config=config)
+
+    def test_default_path_corrupt_wheel_wrapped(
+        self, tmp_path: Path, config: NabProjectConfig
+    ) -> None:
+        """The backend has no prepare hook, so ``build.metadata_path`` builds a
+        wheel and reads it with ``zipfile.ZipFile`` after the hook wrapper; a
+        corrupt wheel raises ``BadZipFile`` there, which the runner normalizes.
+        """
+        self._pyproject(tmp_path)
+        self._run(
+            tmp_path, config, self._corrupt_building_project("foo-1.0-py3-none-any.whl")
+        )
+
+    def test_invalid_wheel_name_wrapped(
+        self, tmp_path: Path, config: NabProjectConfig
+    ) -> None:
+        """``build.metadata_path`` raises a bare ``ValueError('Invalid wheel')``
+        when the built wheel's name does not parse; the runner normalizes it.
+        """
+        self._pyproject(tmp_path)
+        self._run(tmp_path, config, self._corrupt_building_project("garbage.whl"))
+
+    def test_skip_prepare_corrupt_wheel_wrapped(
+        self,
+        tmp_path: Path,
+        config: NabProjectConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """On the skip-prepare path the runner's own ``_build_wheel_and_extract``
+        reads the built wheel; a corrupt wheel there normalizes as well.
+        """
+        from nab_python._build import runner as runner_mod
+
+        self._pyproject(tmp_path)
+        monkeypatch.setattr(runner_mod, "_should_skip_prepare", lambda *_a: True)
+        self._run(
+            tmp_path, config, self._corrupt_building_project("foo-1.0-py3-none-any.whl")
+        )
 
 
 class TestRunBuildBackendDefaults:


### PR DESCRIPTION
When a build backend's build_wheel hook succeeds but writes a wheel that is not a valid zip, run_build_backend read the wheel back and let the raw zipfile.BadZipFile escape. A wheel whose filename does not parse leaked a bare ValueError in the same way. Both broke the documented promise that this function raises BuildBackendError on any failure, so callers catching BuildBackendError missed these cases.

The read-back happens on two paths: build's metadata_path fallback when the backend has no prepare_metadata hook, and the runner's own _build_wheel_and_extract on the skip-prepare path. Both now sit inside a wrapper that turns BadZipFile, ValueError, and OSError from reading the built wheel into BuildBackendError.
