### PR TITLE
Enforce METADATA Requires-Python for index candidates

### DIFF
--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -728,6 +728,9 @@ def await_metadata_batch(
     submitted: list[tuple[Version, str, str, threading.Event]],
 ) -> None:
     """Wait for all submitted metadata to arrive, then parse into cache."""
+    # Imported lazily: provider.py imports this module.
+    from ..provider import IncompatiblePythonError
+
     for version, ver_str, metadata_url, event in submitted:
         cache_key = (package, version)
         if cache_key in provider.deps_cache:
@@ -756,8 +759,14 @@ def await_metadata_batch(
             continue
         try:
             provider.parse_and_cache_metadata(cache_key, text)
-        except (ValueError, InvalidVersion, InvalidSpecifier):
-            # Malformed metadata: same reason, refuse via get_dependencies
+        except (
+            ValueError,
+            InvalidVersion,
+            InvalidSpecifier,
+            IncompatiblePythonError,
+        ):
+            # Malformed metadata or a Python-incompatible METADATA
+            # Requires-Python: same reason, refuse via get_dependencies
             # (_invalid_metadata) instead of caching empty deps.
             continue
 

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -458,7 +458,42 @@ def parse_and_cache_metadata(
     ):
         metadata = resolve_dynamic_sdist(provider, cache_key, metadata)
 
+    _reject_incompatible_python(provider, cache_key, metadata)
     cache_deps_from_metadata(provider, cache_key, metadata)
+
+
+def _reject_incompatible_python(
+    provider: Provider, cache_key: tuple[str, Version], metadata: WheelMetadata
+) -> None:
+    """Reject an index candidate whose METADATA Requires-Python excludes the target.
+
+    The listing gate (:func:`nab_python._provider.listing.excluded_by_python`)
+    reads the optional Simple-API ``requires-python`` hint, so a version whose
+    listing omits it reaches here unfiltered.  The wheel's own METADATA (or the
+    sdist's PKG-INFO) carries the authoritative field; a per-package override
+    still replaces it, matching the listing gate.  Raised before the deps are
+    cached so no partial state survives the rejection.
+    """
+    # Late import: ``provider`` imports this module at module load.
+    from ..provider import IncompatiblePythonError
+
+    target = provider.target
+    if target is None:
+        return
+    package, version = cache_key
+    override_rp = provider.effective_requires_python(package, version)
+    spec = (
+        SpecifierSet(override_rp)
+        if override_rp is not None
+        else metadata.requires_python
+    )
+    if spec is None or target.admits_requires_python(spec):
+        return
+    msg = (
+        f"{package} {version} requires Python {spec} but the"
+        f" {target.label} resolve targets Python {target.python_full_version}"
+    )
+    raise IncompatiblePythonError(msg)
 
 
 def cache_deps_from_metadata(

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -480,6 +480,7 @@ def _reject_incompatible_python(
     target = provider.target
     if target is None:
         return
+
     package, version = cache_key
     override_rp = provider.effective_requires_python(package, version)
     spec = (
@@ -489,6 +490,7 @@ def _reject_incompatible_python(
     )
     if spec is None or target.admits_requires_python(spec):
         return
+
     msg = (
         f"{package} {version} requires Python {spec} but the"
         f" {target.label} resolve targets Python {target.python_full_version}"

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -61,6 +61,7 @@ __all__ = [
     "DistFile",
     "DistPolicy",
     "ExtrasMode",
+    "IncompatiblePythonError",
     "InvalidUploadTimeError",
     "ListingFilterCache",
     "LocalSource",
@@ -290,6 +291,17 @@ class UnsupportedSdistError(MetadataError):
     under :attr:`BuildPolicy.BUILD_REMOTE`.  Caught by
     :meth:`Provider._look_ahead_ok` so the resolver skips the
     version instead of failing.
+    """
+
+
+class IncompatiblePythonError(MetadataError):
+    """An index candidate's METADATA Requires-Python excludes the resolve target.
+
+    The Simple-API ``requires-python`` hint is optional, so the listing gate
+    admits a version whose listing omits it.  Once the wheel METADATA (or sdist
+    PKG-INFO) is fetched, its authoritative ``Requires-Python`` is checked and
+    an incompatible candidate is rejected.  Caught by
+    :meth:`Provider._look_ahead_ok` so the resolver skips the version.
     """
 
 
@@ -1881,7 +1893,25 @@ class Provider:
             return self.deps_cache[cache_key]
 
         metadata_text, from_sdist = self._resolve_metadata(versions, package, version)
+        self._parse_and_cache_metadata_guarded(
+            cache_key, metadata_text, from_sdist=from_sdist
+        )
 
+        self.stats.metadata_fetched += 1
+        self.prefetch_new_deps(self.deps_cache[cache_key])
+
+        return self.deps_cache[cache_key]
+
+    def _parse_and_cache_metadata_guarded(
+        self, cache_key: tuple[str, Version], metadata_text: str, *, from_sdist: bool
+    ) -> None:
+        """Parse fetched metadata, routing each failure to its own cache.
+
+        A disallowed build, a Python-incompatible candidate, and an unparseable
+        payload each record their own failure kind so a re-query is answered
+        from cache. Hard errors propagate unrecorded.
+        """
+        package, version = cache_key
         from .config import OverrideConflictError  # noqa: PLC0415 (config import cycle)
 
         try:
@@ -1890,6 +1920,9 @@ class Provider:
             )
         except UnsupportedSdistError:
             self._unsupported_sdists.add(cache_key)
+            raise
+        except IncompatiblePythonError as exc:
+            self._invalid_metadata[cache_key] = str(exc)
             raise
         except (
             SdistHashMismatchError,
@@ -1915,11 +1948,6 @@ class Provider:
             msg = f"Invalid metadata for {package}=={version}: {exc}"
             self._invalid_metadata[cache_key] = msg
             raise MetadataError(msg) from exc
-
-        self.stats.metadata_fetched += 1
-        self.prefetch_new_deps(self.deps_cache[cache_key])
-
-        return self.deps_cache[cache_key]
 
     def prefetch_new_deps(self, deps: dict[str, VersionRange]) -> None:
         """See :func:`nab_python._provider.listing.prefetch_new_deps`."""

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -1484,9 +1484,9 @@ def _raise_for_source_python(
 ) -> None:
     """Reject a local, VCS, or archive pin whose Requires-Python excludes ``target``.
 
-    Index candidates are filtered by Requires-Python while listing; local,
-    VCS, and archive sources skip that filter, so a source that rejects the
-    resolve target could otherwise reach the lock.
+    Index candidates are filtered by Requires-Python while listing and again
+    from their fetched metadata; local, VCS, and archive sources skip both, so
+    a source that rejects the resolve target could otherwise reach the lock.
     """
     managed = (
         provider.local_sources.keys()

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -49,6 +49,7 @@ from nab_python.provider import (
     BuildPolicy,
     DistPolicy,
     ExtrasMode,
+    IncompatiblePythonError,
     InvalidUploadTimeError,
     LocalSource,
     MetadataError,
@@ -3901,6 +3902,70 @@ class TestRequiresPythonListingGate:
             package_overrides=(pkg_override("foo", requires_python=">=3.11"),),
         )
         assert len(provider.fetch_versions("foo")) == 1
+
+
+class TestRequiresPythonMetadataGate:
+    """The wheel METADATA Requires-Python gates a candidate the listing admits.
+
+    The Simple-API requires-python hint is optional, so a listing that omits
+    it admits the version; the fetched METADATA carries the authoritative
+    field, and ``get_dependencies`` rejects a candidate it marks incompatible.
+    """
+
+    @staticmethod
+    def _coordinator(requires_python: str | None) -> MagicMock:
+        body = f"Requires-Python: {requires_python}\n" if requires_python else ""
+        return make_coordinator(
+            [make_wheel("1.0", requires_python=None)],
+            package="foo",
+            metadata_text=f"Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n{body}\n",
+        )
+
+    def test_excludes_when_listing_omits_hint(self) -> None:
+        provider = Provider(
+            self._coordinator(">=3.12"),
+            target=ResolveTarget.for_host_python("3.8.0"),
+        )
+        with pytest.raises(IncompatiblePythonError, match="requires Python >=3.12"):
+            provider.get_dependencies("foo", V("1.0"))
+
+    def test_admits_when_metadata_python_is_compatible(self) -> None:
+        provider = Provider(
+            self._coordinator(">=3.8"),
+            target=ResolveTarget.for_host_python("3.8.0"),
+        )
+        assert provider.get_dependencies("foo", V("1.0")) == {}
+
+    def test_admits_when_metadata_omits_requires_python(self) -> None:
+        provider = Provider(
+            self._coordinator(None),
+            target=ResolveTarget.for_host_python("3.8.0"),
+        )
+        assert provider.get_dependencies("foo", V("1.0")) == {}
+
+    def test_no_target_skips_metadata_gate(self) -> None:
+        provider = Provider(self._coordinator(">=3.99"), target=None)
+        assert provider.get_dependencies("foo", V("1.0")) == {}
+
+    def test_override_replaces_incompatible_metadata_python(self) -> None:
+        provider = Provider(
+            self._coordinator(">=3.12"),
+            target=ResolveTarget.for_host_python("3.8.0"),
+            package_overrides=(pkg_override("foo", requires_python=">=3.8"),),
+        )
+        assert provider.get_dependencies("foo", V("1.0")) == {}
+
+    def test_rejection_caches_invalid_and_leaves_no_deps(self) -> None:
+        provider = Provider(
+            self._coordinator(">=3.12"),
+            target=ResolveTarget.for_host_python("3.8.0"),
+        )
+        with pytest.raises(IncompatiblePythonError):
+            provider.get_dependencies("foo", V("1.0"))
+        assert ("foo", V("1.0")) not in provider.deps_cache
+        assert provider.has_invalid_metadata("foo", V("1.0"))
+        with pytest.raises(MetadataError, match="requires Python >=3.12"):
+            provider.get_dependencies("foo", V("1.0"))
 
 
 class TestSkipFetch:

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -3967,6 +3967,35 @@ class TestRequiresPythonMetadataGate:
         with pytest.raises(MetadataError, match="requires Python >=3.12"):
             provider.get_dependencies("foo", V("1.0"))
 
+    def test_prefetch_batch_skips_incompatible_non_first_version(self) -> None:
+        # The prefetch batch parses a non-first candidate's METADATA directly,
+        # so an incompatible Requires-Python there must skip that version, not
+        # abort the scan. 3.0 and 2.0 exclude the 3.8 target; the scan leaves
+        # them un-cached and falls through to 1.0.
+        def _meta(version: str, requires_python: str) -> str:
+            return (
+                f"Metadata-Version: 2.1\nName: foo\nVersion: {version}\n"
+                f"Requires-Python: {requires_python}\n\n"
+            )
+
+        coordinator = make_coordinator(
+            [make_wheel("3.0"), make_wheel("2.0"), make_wheel("1.0")],
+            metadata_by_version={
+                "3.0": _meta("3.0", ">=3.99"),
+                "2.0": _meta("2.0", ">=3.99"),
+                "1.0": _meta("1.0", ">=3.8"),
+            },
+            package="foo",
+        )
+        provider = Provider(
+            coordinator,
+            target=ResolveTarget.for_host_python("3.8.0"),
+            root_requirements={"foo": VersionRange.full()},
+        )
+        assert provider.choose_version("foo", VersionRange.full()) == V("1.0")
+        assert ("foo", V("2.0")) not in provider.deps_cache
+        assert provider.has_invalid_metadata("foo", V("2.0"))
+
 
 class TestSkipFetch:
     """A complete ``dependencies`` override skips the metadata fetch/build."""

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -3209,6 +3209,46 @@ class TestLocalVcsRequiresPython:
             result = _resolved(root, _FAKE_TRANSPORT)
         assert _pins(result)["foo"] == V("1.0")
 
+    def test_resolve_index_metadata_requires_python_rejects_omitted_listing(
+        self, tmp_path: Path
+    ) -> None:
+        """The wheel METADATA gates an index candidate the listing does not.
+
+        The Simple-API requires-python hint is optional; when the listing omits
+        it the wheel's METADATA carries the authoritative Requires-Python, and a
+        candidate it marks incompatible with the target is rejected rather than
+        written to the lock.
+        """
+        wheel = WheelFile(
+            filename="foo-1.0-py3-none-any.whl",
+            url="https://example.com/foo-1.0-py3-none-any.whl",
+            version="1.0",
+            requires_python=None,
+            has_metadata=True,
+            upload_time=None,
+        )
+        root = tmp_path / "pyproject.toml"
+        root.write_text(
+            '[project]\nname = "proj"\ndependencies = ["foo"]\n',
+            encoding="utf-8",
+        )
+        fake = make_coordinator(
+            [wheel],
+            package="foo",
+            metadata_text=(
+                "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n"
+                "Requires-Python: >=3.12\n\n"
+            ),
+        )
+        with (
+            patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls,
+            patch("nab_python.resolve.build_target_lock"),
+        ):
+            mock_coord_cls.return_value.__enter__ = lambda _self: fake
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            with pytest.raises(ResolutionError, match="requires Python"):
+                _resolved(root, _FAKE_TRANSPORT, python_version="3.8.0")
+
 
 def _metadata(name: str, version: str, *requires: str) -> str:
     """METADATA text for ``name`` ``version`` with one Requires-Dist per entry."""


### PR DESCRIPTION
The Simple-API requires-python hint is optional. nab only checked that listing hint, so when a listing omitted it a wheel whose own METADATA declared an incompatible Requires-Python was admitted and could reach the lock.

After the metadata is fetched, its authoritative Requires-Python (from the wheel METADATA, or an sdist's PKG-INFO) is now checked against the resolve target, and the candidate is skipped when the target is excluded. A per-package requires-python override still takes precedence over the metadata value, the same as the listing gate. The check also runs on the prefetch batch path, so an incompatible non-first version is skipped rather than aborting the scan.
