### PR TITLE
correct vcs-sources docs: allow policy alone still refuses the URL

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -525,10 +525,14 @@ every `build-policy` level.  Dynamic dependencies require
 
 ## Pinned VCS sources
 
-`[[tool.nab.vcs-sources]]` pins a package to a VCS URL.  Requires
-`vcs.policy = "allow"`; reading static dependencies works at any
-`build-policy`.  Dynamic dependencies on a VCS clone require
-`build-policy = "build-remote"`.
+`[[tool.nab.vcs-sources]]` pins a package to a VCS URL.  Each URL
+passes the same `[tool.nab.vcs]` gate as a direct-URL requirement:
+beyond `vcs.policy = "allow"`, the URL's scheme must be listed in
+`vcs.allowed-schemes` and its repository in `vcs.allowed-repos`, both
+empty by default so each denies every URL until an entry is added, and
+the URL must pin a 40-char commit hash unless `vcs.require-pin = false`.
+Reading static dependencies works at any `build-policy`.  Dynamic
+dependencies on a VCS clone require `build-policy = "build-remote"`.
 
 ```toml
 [[tool.nab.vcs-sources]]

--- a/nab-python/tests/test_provider_declared_target.py
+++ b/nab-python/tests/test_provider_declared_target.py
@@ -31,6 +31,7 @@ from nab_python.provider import (
     DistPolicy,
     ListingFilterCache,
     Provider,
+    UnsupportedVcsError,
     VcsConfig,
     VcsPolicy,
     VcsSource,
@@ -874,6 +875,27 @@ class TestVcsConfigPlumbing:
         )
         assert provider.vcs_source_for("pkg") is source
         assert provider.vcs_config.policy is VcsPolicy.ALLOW
+
+    def test_allow_policy_alone_refuses_vcs_source(self) -> None:
+        """``vcs.policy = "allow"`` with empty allowlists still refuses a source.
+
+        Each declared URL passes through ``admit_vcs_url``, so the empty
+        default ``allowed-schemes`` (deny-all) rejects the source even under
+        ALLOW.
+        """
+        coordinator = _make_coordinator([])
+        source = VcsSource(
+            name="pkg",
+            url=f"git+https://example.com/pkg.git@{_FORTY_SHA}",
+        )
+        with pytest.raises(UnsupportedVcsError, match="vcs.allowed-schemes"):
+            Provider(
+                coordinator,
+                _LINUX_TARGET,
+                vcs_config=VcsConfig(policy=VcsPolicy.ALLOW),
+                vcs_sources=[source],
+                build_policy=BuildPolicy.NEVER,
+            )
 
     def test_vcs_cache_dir_set_on_provider(self, tmp_path: Path) -> None:
         """``vcs_cache_dir`` is stored on the provider for later use.


### PR DESCRIPTION
The config reference's "Pinned VCS sources" section said a vcs-source only needs `vcs.policy = "allow"`. But each declared URL goes through the same `[tool.nab.vcs]` gate as a direct-URL requirement, and `allowed-schemes` and `allowed-repos` both default to empty (deny-all), with a pinned commit required unless `require-pin = false`. So the section's own example URL is refused as written, with nothing in the docs to explain why.

Spell out the full gate in that section, and add a test that a vcs-source is still refused under `vcs.policy = "allow"` with the default empty allowlists.
