### PR TITLE
build a build requirement when the depth allows it

### DIFF
--- a/docs/reference/build-policy.md
+++ b/docs/reference/build-policy.md
@@ -119,6 +119,49 @@ know the package's dependencies, a `dependencies` metadata override
 (see the [configuration reference](configuration.md)) resolves it under
 `never` without building at all.
 
+## Building a build requirement
+
+A backend runs in a venv holding its project's `[build-system].requires`,
+and a venv takes wheels.  When the version a requirement resolves to
+publishes none this host can install, satisfying it means building that
+first.  `build-requires-depth` counts the build environments nab may
+open beneath the first one:
+
+```toml
+[tool.nab]
+build-requires-depth = 0   # the default
+```
+
+`0` refuses, naming the requirement and the chain of builds that
+reached it.  `1` builds it from its sdist, and its own build
+requirements must then be wheels.  `n` allows `n` levels.
+
+The resolve is never narrowed to wheels; that would settle on an older
+backend than `[build-system].requires` asked for without saying so.  The
+requirement resolves as written and the refusal names the version it
+landed on.
+
+A build already in the chain cannot be re-entered:
+
+```text
+cyclic build requirement: a 1.0 -> b 2.0 -> a 1.0
+```
+
+Two versions of one package in a chain are not a cycle; that terminates.
+
+A build environment reads its build requirements' metadata statically,
+so a per-package or per-index `build-policy` override may forbid a
+build there but never permit one.  To keep a build requirement from
+being built, pin it to wheels:
+
+```toml
+[tool.nab.packages.meson]
+dist-policy = "wheel-only"
+```
+
+The setting is inert where builds cannot run: under
+`build-policy = "never"`, and for any target that declares a platform.
+
 ## Overrides
 
 A per-package override replaces the global build policy for its selected

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -51,6 +51,10 @@ dist-policy = "wheel-or-sdist"
 
 # PEP 517 build policy.
 build-policy = "build-local"    # "never" | "build-local" | "build-remote"
+
+# Build environments nab may open beneath the first one, to build a
+# build requirement with no installable wheel.  A non-negative integer.
+build-requires-depth = 0
 ```
 
 The global `dist-policy` may instead be a table that folds in the

--- a/nab-python/src/nab_python/_build/env.py
+++ b/nab-python/src/nab_python/_build/env.py
@@ -32,31 +32,39 @@ import venv
 from contextlib import suppress
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 import tomli_w
 from installer import install as installer_install
 from installer.destinations import SchemeDictionaryDestination
 from installer.sources import WheelFile
+
+from nab_index.client import extract_sdist_archive
 from nab_index.urllib3_async_transport import Urllib3AsyncTransport
 
 from .._vcs_admission import UnsupportedVcsError
+from .._vendor.packaging.utils import canonicalize_name
 from ..config import NabProjectConfig
 from ..download import DownloadError, download_lock
 from ..lockfile import IndexPin
-from ..provider import MissingExtraError
+from ..provider import BuildPolicy, DistPolicy, MissingExtraError
 from ..requirements_file import InvalidProjectRequirementError
+from .errors import BuildBackendError
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Mapping
-    from typing_extensions import Self
 
     from installer.records import RecordEntry
     from installer.utils import Scheme
+    from typing_extensions import Self
+
     from nab_index.transport import AsyncHttpTransport
 
-    from ..lockfile import LockInput, PinShape
+    from ..config import IndexOverride, PackageOverride
+    from ..lockfile import LockInput, PinShape, SdistArtifact, TargetLock
     from ..tags import TagSet
+
+    _OverrideT = TypeVar("_OverrideT", PackageOverride, IndexOverride)
 
 __all__ = [
     "NabBuildEnv",
@@ -132,6 +140,30 @@ class BuildEnvError(Exception):
     """
 
 
+BuildChain = tuple[str, ...]
+"""The builds already in progress beneath the first one, outermost first.
+
+Each entry is a ``chain_label`` for a build requirement nab is building so
+that some other build can run.  The chain is empty for the build a resolve
+asks for directly, and gains an entry every time a build requirement has to
+be built to populate an env.  Its length is how deep the recursion has gone,
+and a repeated entry is a cycle.
+"""
+
+
+def chain_label(name: str, version: str) -> str:
+    """Return the chain entry for one build, canonical so two spellings match."""
+    return f"{canonicalize_name(name)} {version}"
+
+
+@dataclass(frozen=True, slots=True)
+class _PendingBuild:
+    """A build requirement this env has to build before it can install it."""
+
+    label: str
+    sdist: SdistArtifact
+
+
 class NabBuildEnv:
     """An isolated PEP 518 build environment driven by nab.
 
@@ -152,6 +184,12 @@ class NabBuildEnv:
     requirement would have to come off the network.  An empty
     ``requires`` needs nothing fetched and is still served.
 
+    ``chain`` is the :data:`BuildChain` of builds this env is already
+    nested inside.  It is empty for the build a resolve asked for, and
+    every build requirement this env has to build itself passes on a
+    longer one, which is what bounds the recursion against
+    ``[tool.nab].build-requires-depth`` and detects a cycle.
+
     The venv is created from the host interpreter and the PEP 517
     hooks run in it, so the build requirements resolve for the host
     and not for any ``--python`` retarget: a wheel for another
@@ -168,12 +206,14 @@ class NabBuildEnv:
         config: NabProjectConfig,
         offline: bool = False,
         transport_factory: Callable[[], AsyncHttpTransport] = Urllib3AsyncTransport,
+        chain: BuildChain = (),
     ) -> None:
         """Capture inputs; the venv and inner resolve happen in __enter__."""
         self._requires = list(requires)
         self._config = config
         self._offline = offline
         self._transport_factory = transport_factory
+        self._chain = tuple(chain)
 
         self._tmpdir: tempfile.TemporaryDirectory[str] | None = None
         self._venv_path: Path | None = None
@@ -329,6 +369,18 @@ class NabBuildEnv:
         :func:`nab_python.download.download_lock` end-to-end.  No
         local sources / workspace / marker overlay; build deps
         come from the configured indexes only.
+
+        It admits wheels and sdists, like any resolve, so the version
+        it settles on is the one the requirement asked for rather than
+        the newest that happens to publish a wheel.  Whether a version
+        without an installable wheel can be used is
+        :meth:`_plan_install`'s decision, taken once the resolve has
+        named it.
+
+        It reads metadata statically: its build policy is ``never`` and
+        no inherited override may raise it.  A backend invocation to
+        learn a build requirement's dependencies would be a second
+        recursion, one the depth budget does not count.
         """
         # Late import: avoids a cycle through ``resolve.py`` which
         # itself imports ``pypi.py`` which imports ``build_backend``
@@ -351,9 +403,17 @@ class NabBuildEnv:
 
         inner_config = NabProjectConfig(
             indexes=self._config.indexes,
-            package_overrides=self._config.package_overrides,
-            index_overrides=self._config.index_overrides,
+            package_overrides=tuple(
+                _without_build_permission(override)
+                for override in self._config.package_overrides
+            ),
+            index_overrides={
+                name: _without_build_permission(override)
+                for name, override in self._config.index_overrides.items()
+            },
             uploaded_prior_to=self._config.uploaded_prior_to,
+            dist_policy=DistPolicy.WHEEL_OR_SDIST,
+            build_policy=BuildPolicy.NEVER,
         )
         # download_lock closes its transport, and ``install`` may call
         # this again for ``get_requires_for_build_wheel`` follow-ups;
@@ -381,28 +441,9 @@ class NabBuildEnv:
             msg = f"build env resolve failed: {exc}"
             raise BuildEnvError(msg) from exc
 
-        lock_input = _one_wheel_per_pin(build_lock_input(result, config=inner_config))
-
-        # Reject sdist-only pins early: build deps that ship only an
-        # sdist trigger a recursive backend invocation that this
-        # builder does not handle.  Most build tools (hatchling,
-        # setuptools, flit, pdm-backend) publish wheels.
-        pins = {
-            name: pin
-            for lock in lock_input.targets.values()
-            for name, pin in lock.pins.items()
-        }
-        sdist_only: list[str] = []
-        for canonical, pin in pins.items():
-            if isinstance(pin, IndexPin) and not pin.wheels:
-                sdist_only.append(f"{canonical}=={pin.version}")
-        if sdist_only:
-            msg = (
-                "build env requires sdist-only packages which nab cannot"
-                " install without recursing through the build path: "
-                + ", ".join(sdist_only)
-            )
-            raise BuildEnvError(msg)
+        lock_input, to_build = self._plan_install(
+            build_lock_input(result, config=inner_config)
+        )
 
         try:
             download_result = download_lock(lock_input, transport, wheel_dir)
@@ -413,59 +454,152 @@ class NabBuildEnv:
             msg = f"build env download failed: {exc}"
             raise BuildEnvError(msg) from exc
 
-        # Both wheels and sdists are downloaded; only wheels feed
-        # ``installer.install``.  The sdists are inert clutter under
-        # the temp dir, cleaned up with the env.
         all_paths = list(download_result.written) + list(download_result.skipped)
-        return [p for p in all_paths if p.suffix == ".whl"]
-
-
-def _one_wheel_per_pin(lock_input: LockInput) -> LockInput:
-    """Narrow every index pin to the one wheel its target installs.
-
-    A lock records every wheel of the pinned version the target
-    accepts, so a pin can carry several: the tiered manylinux
-    aliases, or a ``py3-none-any`` beside a platform wheel.  The
-    inner resolve plans the host alone, so the target's tags are
-    those of the interpreter the backend runs under.
-
-    Narrowing is for the download and the install; a written lock
-    keeps every wheel, so one lock stays portable across targets.
-    """
-    targets = {
-        label: replace(
-            lock,
-            pins={
-                name: _picked_wheel_pin(pin, lock.target.tags)
-                for name, pin in lock.pins.items()
-            },
+        wheels = [p for p in all_paths if p.suffix == ".whl"]
+        wheels.extend(
+            self._build_requirement(pending, wheel_dir) for pending in to_build
         )
-        for label, lock in lock_input.targets.items()
-    }
+        return wheels
 
-    return replace(lock_input, targets=targets)
+    @property
+    def _build_budget(self) -> int:
+        """How many more build envs may be opened beneath this one."""
+        return self._config.build_requires_depth - len(self._chain)
+
+    def _plan_install(
+        self, lock_input: LockInput
+    ) -> tuple[LockInput, list[_PendingBuild]]:
+        """Decide how each pin reaches the env, and narrow it to that artifact.
+
+        A pin with a wheel the host accepts is narrowed to that one
+        wheel: a lock records every wheel of the pinned version the
+        target admits, which can be several (the tiered manylinux
+        aliases, or a ``py3-none-any`` beside a platform wheel), and
+        the env installs one.  Narrowing is for the download and the
+        install; a written lock keeps every wheel, so one lock stays
+        portable across targets.
+
+        A pin with no such wheel has to be built, and comes back in the
+        second element with its wheels dropped so only its sdist is
+        fetched.  Refusing that build is this method's other job: it
+        raises rather than leaving a requirement quietly uninstalled,
+        because the backend would then fail on an import error that
+        names nothing useful.
+        """
+        planned: dict[str, TargetLock] = {}
+        to_build: list[_PendingBuild] = []
+        for label, lock in lock_input.targets.items():
+            pins: dict[str, PinShape] = {}
+            for name, pin in lock.pins.items():
+                pins[name] = self._planned_pin(pin, lock.target.tags, to_build)
+            planned[label] = replace(lock, pins=pins)
+
+        return replace(lock_input, targets=planned), to_build
+
+    def _planned_pin(
+        self, pin: PinShape, tags: TagSet, to_build: list[_PendingBuild]
+    ) -> PinShape:
+        """Return ``pin`` narrowed to the artifact the env will install.
+
+        Appends to ``to_build`` when the answer is the sdist, so the
+        caller knows which pins still owe it a build.
+
+        The wheel is chosen by the target's tags rather than by the
+        provider's ``pick_dist``.  That one answers whose METADATA the
+        pin has to satisfy, so between wheels the tags rank equally it
+        takes the one carrying a :pep:`658` sidecar, and it may answer
+        with an sdist or with a wheel this host cannot install.  An
+        install has none of those outs: it must be the wheel
+        :pep:`425` ranks highest.
+        """
+        if not isinstance(pin, IndexPin):
+            return pin
+
+        preferred = tags.pick(pin.wheels) if pin.wheels else None
+        if preferred is not None:
+            # The sdist goes with the wheels the narrowing drops: nothing
+            # installs it, and a bad one would fail the download and take
+            # the build with it.
+            return replace(pin, wheels=(preferred,), sdist=None)
+
+        label = chain_label(pin.name, pin.version)
+        chain = self._chain
+        if pin.sdist is None:
+            msg = (
+                f"{label} publishes no wheel this build host can install,"
+                f" and no sdist to build{_chain_suffix(chain)}"
+            )
+            raise BuildEnvError(msg)
+        # A cycle before a depth: raising the depth to walk into a loop is
+        # the one piece of advice that cannot help.
+        if label in chain:
+            msg = f"cyclic build requirement: {' -> '.join([*chain, label])}"
+            raise BuildEnvError(msg)
+        if self._build_budget <= 0:
+            msg = (
+                f"{label} publishes no wheel this build host can install, so"
+                " satisfying it means building it; [tool.nab].build-requires-depth"
+                f" is {self._config.build_requires_depth}{_chain_suffix(chain)}"
+            )
+            raise BuildEnvError(msg)
+
+        to_build.append(_PendingBuild(label=label, sdist=pin.sdist))
+        return replace(pin, wheels=())
+
+    def _build_requirement(self, pending: _PendingBuild, wheel_dir: Path) -> Path:
+        """Build the downloaded sdist of ``pending`` and return the wheel's path.
+
+        The wheel lands beside the downloaded artifacts, which live as
+        long as the env does.
+        """
+        # Late import: ``runner`` imports this module at module load.
+        from .runner import build_wheel_for_install
+
+        label = pending.label
+        archive = wheel_dir / pending.sdist.filename
+        logger.info("building %s to populate a build env", label)
+
+        try:
+            data = archive.read_bytes()
+        except OSError as exc:
+            msg = f"build requirement {label} could not be read at {archive}: {exc}"
+            raise BuildEnvError(msg) from exc
+
+        with tempfile.TemporaryDirectory(prefix="nab-build-req-") as td:
+            try:
+                source_dir = extract_sdist_archive(data, Path(td))
+            except ValueError as exc:
+                msg = f"build requirement {label} could not be extracted: {exc}"
+                raise BuildEnvError(msg) from exc
+            try:
+                return build_wheel_for_install(
+                    source_dir,
+                    output_dir=wheel_dir,
+                    config=self._config,
+                    offline=self._offline,
+                    chain=(*self._chain, label),
+                )
+            except BuildBackendError as exc:
+                msg = f"build requirement {label} could not be built: {exc}"
+                raise BuildEnvError(msg) from exc
 
 
-def _picked_wheel_pin(pin: PinShape, tags: TagSet) -> PinShape:
-    """Return ``pin`` narrowed to the one wheel ``tags`` prefers.
+def _chain_suffix(chain: BuildChain) -> str:
+    """Render ``chain`` for an error message, or nothing when it is empty."""
+    return f" (chain: {' -> '.join(chain)})" if chain else ""
 
-    Deliberately not the provider's ``pick_dist``.  That one answers
-    whose METADATA the pin has to satisfy, so between wheels the tags
-    rank equally it takes the one carrying a :pep:`658` sidecar, and
-    it may answer with an sdist or with a wheel this host cannot
-    install.  An install has none of those outs: it must be a wheel,
-    it must be the wheel :pep:`425` ranks highest, and nothing
-    compatible is an error.
+
+def _without_build_permission(override: _OverrideT) -> _OverrideT:
+    """Return ``override`` with any build permission it grants removed.
+
+    An override reaches the build env's own resolve, where the build
+    policy is ``never``.  Letting one raise it there would start a
+    backend invocation nothing counts against the depth budget, so a
+    permission is dropped and only a refusal survives.
     """
-    if not isinstance(pin, IndexPin) or not pin.wheels:
-        return pin
-
-    preferred = tags.pick(pin.wheels)
-    if preferred is None:
-        msg = f"no wheel of {pin.name}=={pin.version} matches the build host's tags"
-        raise BuildEnvError(msg)
-
-    return replace(pin, wheels=(preferred,))
+    if override.build_policy in (None, BuildPolicy.NEVER):
+        return override
+    return replace(override, build_policy=None)
 
 
 def _remove_files(entries: list[tuple[Path, Path]]) -> None:

--- a/nab-python/src/nab_python/_build/runner.py
+++ b/nab-python/src/nab_python/_build/runner.py
@@ -29,6 +29,7 @@ import os
 import tempfile
 import zipfile
 import zlib
+from contextlib import contextmanager
 from email import message_from_string
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -46,14 +47,17 @@ from .._vendor.packaging.utils import canonicalize_name, parse_wheel_filename
 from .._vendor.packaging.version import Version
 from ..metadata import WheelMetadata, validate_specifier_versions
 from ..paths import PathState, path_state
-from .env import BuildEnvError, NabBuildEnv
+from .env import BuildChain, BuildEnvError, NabBuildEnv
 from .errors import BuildBackendError
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from ..config import NabProjectConfig
 
 __all__ = [
     "BuildBackendError",
+    "build_wheel_for_install",
     "run_build_backend",
 ]
 
@@ -69,6 +73,7 @@ def run_build_backend(
     *,
     config: NabProjectConfig,
     offline: bool = False,
+    chain: BuildChain = (),
 ) -> WheelMetadata:
     """Extract wheel metadata for ``source_dir`` via the build backend.
 
@@ -76,75 +81,100 @@ def run_build_backend(
     the ``METADATA`` file the backend produces.  Raises
     :class:`BuildBackendError` on any failure: backend import
     error, a rejected ``backend-path``, hook crash, malformed
-    METADATA, an unreadable built wheel, sdist-only build deps, or
-    build requirements ``offline`` bars from being fetched.
+    METADATA, an unreadable built wheel, a build requirement that
+    cannot be installed or built, or build requirements ``offline``
+    bars from being fetched.
 
     The build runs in an isolated venv driven by
     :class:`NabBuildEnv`; nothing in the user's main environment is
     perturbed.  The build env owns its own HTTP transport (see
     :class:`NabBuildEnv` for why) so callers do not pass one in.
+
+    ``chain`` names the builds this one is nested inside; see
+    :data:`~nab_python._build.env.BuildChain`.
     """
-    pyproject = source_dir / "pyproject.toml"
-    state = path_state(pyproject)
+    data = _read_pyproject(source_dir)
 
-    if state.should_read:
+    with (
+        _prepared_project(
+            source_dir, data, config=config, offline=offline, chain=chain
+        ) as (project, backend),
+        tempfile.TemporaryDirectory(prefix="nab-build-meta-") as out_str,
+    ):
+        metadata_dir = _extract_metadata_dir(
+            project,
+            Path(out_str),
+            backend=backend,
+            skip_prepare=_should_skip_prepare(backend, data),
+        )
+        return _parse_metadata(metadata_dir / "METADATA")
+
+
+def build_wheel_for_install(
+    source_dir: Path,
+    *,
+    output_dir: Path,
+    config: NabProjectConfig,
+    offline: bool = False,
+    chain: BuildChain = (),
+) -> Path:
+    """Build ``source_dir`` into a wheel under ``output_dir`` and return its path.
+
+    The metadata path only ever needs a backend's answer, so it can
+    stop at ``prepare_metadata_for_build_wheel``.  This one is for a
+    build requirement that has to be installed, which takes a real
+    wheel and therefore the full ``build_wheel`` hook.
+
+    Raises :class:`BuildBackendError` on any failure, like
+    :func:`run_build_backend`.
+    """
+    data = _read_pyproject(source_dir)
+
+    with _prepared_project(
+        source_dir, data, config=config, offline=offline, chain=chain
+    ) as (project, backend):
         try:
-            data = tomli.loads(pyproject.read_text(encoding="utf-8"))
-        except (OSError, UnicodeDecodeError, tomli.TOMLDecodeError) as exc:
-            msg = f"could not read pyproject.toml at {source_dir}: {exc}"
+            return Path(project.build("wheel", str(output_dir)))
+        # PEP 517's path-returning hooks must return a basename string, so a
+        # non-string reaches os.path.join as-is.
+        except TypeError as exc:
+            msg = (
+                f"build backend {backend!r} returned a non-string path"
+                f" from build_wheel: {exc}"
+            )
             raise BuildBackendError(msg) from exc
-    elif state is not PathState.ABSENT:
-        # The file is there, so the tree is not the legacy setup.py case.
-        msg = f"{pyproject} exists but is not a regular file"
-        raise BuildBackendError(msg)
-    elif path_state(source_dir / "setup.py").should_read:
-        # PEP 517 fallback for legacy setup.py projects: treat the
-        # missing ``[build-system]`` as the documented default
-        # (setuptools.build_meta:__legacy__).
-        data = {}
-    else:
-        msg = f"no pyproject.toml or setup.py at {source_dir}"
-        raise BuildBackendError(msg)
 
+
+@contextmanager
+def _prepared_project(
+    source_dir: Path,
+    data: dict,
+    *,
+    config: NabProjectConfig,
+    offline: bool,
+    chain: BuildChain,
+) -> Iterator[tuple[build.ProjectBuilder, str]]:
+    """Yield a builder for ``source_dir`` in an env holding its build requirements.
+
+    Yields the backend name beside the builder because every failure
+    message names it.  Failures from setting the env up and from the
+    caller's own block both come out as :class:`BuildBackendError`,
+    which is the contract both entry points advertise.
+    """
     backend, requires, backend_path = _read_build_system(data)
     _validate_backend_path(source_dir, backend_path)
 
-    skip_prepare = _should_skip_prepare(backend, data)
-
     try:
         with NabBuildEnv(
-            requires=list(requires), config=config, offline=offline
+            requires=list(requires), config=config, offline=offline, chain=chain
         ) as env:
             project = build.ProjectBuilder.from_isolated_env(
                 env,
                 source_dir=str(source_dir),
                 runner=pyproject_hooks.quiet_subprocess_runner,
             )
-
-            # build returns the hook's result as a set, so sort for a stable
-            # order. key=str keeps a non-string item from raising here.
-            extra = sorted(project.get_requires_for_build("wheel"), key=str)
-            if extra:
-                # PEP 517 requires the hook to return a list of strings.
-                non_str = [item for item in extra if not isinstance(item, str)]
-                if non_str:
-                    msg = (
-                        f"build backend {backend!r} returned a non-string build"
-                        f" requirement from get_requires_for_build_wheel: {non_str!r}"
-                    )
-                    raise BuildBackendError(msg)
-
-                logger.debug("build backend asked for extras: %s", extra)
-                env.install(extra)
-
-            with tempfile.TemporaryDirectory(prefix="nab-build-meta-") as out_str:
-                metadata_dir = _extract_metadata_dir(
-                    project,
-                    Path(out_str),
-                    backend=backend,
-                    skip_prepare=skip_prepare,
-                )
-                return _parse_metadata(metadata_dir / "METADATA")
+            _install_extra_requires(project, env, backend=backend)
+            yield project, backend
     except (
         build.BuildException,
         build.BuildBackendException,
@@ -155,6 +185,54 @@ def run_build_backend(
     except (BuildEnvError, ResolutionError) as exc:
         msg = f"build env setup for {backend!r} failed: {exc}"
         raise BuildBackendError(msg) from exc
+
+
+def _install_extra_requires(
+    project: build.ProjectBuilder, env: NabBuildEnv, *, backend: str
+) -> None:
+    """Install whatever ``get_requires_for_build_wheel`` asks for on top."""
+    # build returns the hook's result as a set, so sort for a stable
+    # order. key=str keeps a non-string item from raising here.
+    extra = sorted(project.get_requires_for_build("wheel"), key=str)
+    if not extra:
+        return
+
+    # PEP 517 requires the hook to return a list of strings.
+    non_str = [item for item in extra if not isinstance(item, str)]
+    if non_str:
+        msg = (
+            f"build backend {backend!r} returned a non-string build"
+            f" requirement from get_requires_for_build_wheel: {non_str!r}"
+        )
+        raise BuildBackendError(msg)
+
+    logger.debug("build backend asked for extras: %s", extra)
+    env.install(extra)
+
+
+def _read_pyproject(source_dir: Path) -> dict:
+    """Return the parsed ``pyproject.toml``, or ``{}`` for a legacy setup.py tree."""
+    pyproject = source_dir / "pyproject.toml"
+    state = path_state(pyproject)
+
+    if state.should_read:
+        try:
+            return tomli.loads(pyproject.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, tomli.TOMLDecodeError) as exc:
+            msg = f"could not read pyproject.toml at {source_dir}: {exc}"
+            raise BuildBackendError(msg) from exc
+    if state is not PathState.ABSENT:
+        # The file is there, so the tree is not the legacy setup.py case.
+        msg = f"{pyproject} exists but is not a regular file"
+        raise BuildBackendError(msg)
+    if path_state(source_dir / "setup.py").should_read:
+        # PEP 517 fallback for legacy setup.py projects: treat the
+        # missing ``[build-system]`` as the documented default
+        # (setuptools.build_meta:__legacy__).
+        return {}
+
+    msg = f"no pyproject.toml or setup.py at {source_dir}"
+    raise BuildBackendError(msg)
 
 
 def _read_build_system(

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -441,6 +441,9 @@ class NabProjectConfig:
     uploaded_prior_to: datetime | None = None
     dist_policy: DistPolicy = DistPolicy.WHEEL_OR_SDIST
     build_policy: BuildPolicy = BuildPolicy.BUILD_LOCAL
+    # How many build environments may be opened beneath the first one, to
+    # build a build requirement that publishes no wheel this host installs.
+    build_requires_depth: int = 0
     trust_unverified_sdist_deps: bool = False
     # The declared resolve environment from ``[tool.nab.environment]``, or
     # ``None`` for the host.  Mutually exclusive with ``matrix``.
@@ -771,6 +774,7 @@ def _config_from_effective(
         uploaded_prior_to=effective["uploaded-prior-to"].value,
         dist_policy=dist_policy,
         build_policy=build_policy,
+        build_requires_depth=effective["build-requires-depth"].value,
         trust_unverified_sdist_deps=trust_unverified,
         environment=environment,
         indexes=indexes,

--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -413,6 +413,17 @@ def _parse_dist_policy(value: Any, where: str) -> tuple[DistPolicy, bool]:
     return _delegate(lambda: _impl(value))
 
 
+def _parse_build_requires_depth(value: Any, where: str) -> int:
+    # bool is an int subclass, so reject it rather than read True as 1.
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        msg = (
+            f"{where} must be a non-negative integer number of nested build"
+            f" environments, got {value!r}"
+        )
+        raise SourceConfigError(msg)
+    return value
+
+
 def _parse_build_policy(value: Any, where: str) -> BuildPolicy:
     # The plain scalar last-wins value only.  The host-build gate that forces
     # never for a declared target is a post-merge transform applied over the
@@ -884,6 +895,17 @@ OPTIONS: tuple[OptionSpec, ...] = (
         cli_param="project_build_policy",
         parse=_parse_build_policy,
         render=lambda v: v.value,
+    ),
+    OptionSpec(
+        key="build-requires-depth",
+        scope=Scope.PROJECT,
+        type_label="int",
+        default=0,
+        env_var=None,
+        cli_flag=None,
+        cli_param=None,
+        parse=_parse_build_requires_depth,
+        render=str,
     ),
     OptionSpec(
         key="environment",

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -41,33 +41,55 @@ from nab_python._build.env import (
     BuildEnvError,
     NabBuildEnv,
     _FastSchemeDictionaryDestination,
-    _picked_wheel_pin,
+    _PendingBuild,
     _venv_scheme_paths,
 )
 from nab_python._build.runner import (
     BuildBackendError,
     _build_wheel_and_extract,
     _validate_backend_path,
+    build_wheel_for_install,
     run_build_backend,
 )
 from nab_python._provider.metadata_resolver import pick_dist
+from nab_python._testing.overrides import pkg_override
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python._vendor.packaging.version import Version
-from nab_python.config import NabProjectConfig
+from nab_python.config import IndexOverride, NabProjectConfig
 from nab_python.download import DownloadError, DownloadResult, iter_artifacts
 from nab_python.lockfile import (
     IndexPin,
+    LocalPin,
     LockInput,
     SdistArtifact,
     TargetLock,
     WheelArtifact,
 )
-from nab_python.provider import MissingExtraError
+from nab_python.provider import BuildPolicy, DistPolicy, MissingExtraError
 from nab_python.resolve import ResolveResult, TargetResult
 from nab_python.tags import PlatformSpec, TagSet
 from nab_python.target import ResolveTarget
 from nab_resolver.resolver import ResolutionError
+
+
+def _unpack_fixture_sdist(data: bytes, target_dir: Path) -> Path:
+    """Stand in for ``extract_sdist_archive`` on any supported Python.
+
+    The real one refuses to run without the tar data filter (:pep:`706`),
+    which 3.10 and 3.11 before their .12 and .4 releases lack, and every
+    archive here is one a fixture just wrote.  Returns the lone top-level
+    directory, which is the source root the real one would return.
+    """
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
+        if hasattr(tarfile, "data_filter"):
+            tar.extractall(target_dir, filter="data")
+        else:
+            tar.extractall(target_dir)  # noqa: S202
+
+    entries = list(target_dir.iterdir())
+    return entries[0] if len(entries) == 1 and entries[0].is_dir() else target_dir
+
 
 # A minimal, in-tree PEP 517 backend.  Implements
 # ``prepare_metadata_for_build_wheel`` only, enough to exercise
@@ -145,6 +167,53 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
 '''
 
 
+# The backend shipped inside a buildable sdist fixture.  Writes a real,
+# installer-valid wheel, since the point is that the build env installs it.
+_SDIST_BACKEND_SRC = '''\
+"""In-tree PEP 517 backend for a nab_python._build sdist fixture."""
+import base64
+import hashlib
+import os
+import zipfile
+
+NAME = "{name}"
+VERSION = "{version}"
+
+
+def get_requires_for_build_wheel(config_settings=None):
+    return []
+
+
+def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+    escaped = NAME.replace("-", "_")
+    distinfo = escaped + "-" + VERSION + ".dist-info"
+    members = {{
+        escaped + "/__init__.py": b"",
+        distinfo + "/METADATA": (
+            "Metadata-Version: 2.1\\nName: " + NAME + "\\nVersion: " + VERSION + "\\n"
+        ).encode(),
+        distinfo + "/WHEEL": (
+            b"Wheel-Version: 1.0\\nGenerator: nab-test\\n"
+            b"Root-Is-Purelib: true\\nTag: py3-none-any\\n"
+        ),
+    }}
+    records = []
+    for member, data in members.items():
+        digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=")
+        records.append(
+            member + ",sha256=" + digest.decode() + "," + str(len(data))
+        )
+    records.append(distinfo + "/RECORD,,")
+
+    wheel_name = escaped + "-" + VERSION + "-py3-none-any.whl"
+    with zipfile.ZipFile(os.path.join(wheel_directory, wheel_name), "w") as zf:
+        for member, data in members.items():
+            zf.writestr(member, data)
+        zf.writestr(distinfo + "/RECORD", "\\n".join(records) + "\\n")
+    return wheel_name
+'''
+
+
 def _wheel_record_hash(data: bytes) -> str:
     digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=")
     return "sha256=" + digest.decode()
@@ -197,20 +266,69 @@ def _make_pep643_sdist(path: Path, name: str, version: str) -> None:
         tf.addfile(info, io.BytesIO(pkg_info))
 
 
-def _make_local_index(root: Path, name: str, version: str) -> None:
-    """Create a PEP 503 ``file://`` index serving ``name`` as a wheel + sdist."""
+def _make_buildable_sdist(
+    path: Path, name: str, version: str, requires: tuple[str, ...] = ()
+) -> None:
+    """Write an sdist that builds into an installable wheel.
+
+    Static PKG-INFO so the inner resolve can read it without a build,
+    and an in-tree backend reached through ``backend-path`` so the
+    build needs nothing from an index beyond ``requires``.  Passing a
+    non-empty ``requires`` is how a fixture reaches a second level of
+    nesting.
+    """
+    escaped = name.replace("-", "_")
+    root = f"{name}-{version}"
+    requires_block = ", ".join(f'"{req}"' for req in requires)
+    members = {
+        "PKG-INFO": f"Metadata-Version: 2.2\nName: {name}\nVersion: {version}\n",
+        "pyproject.toml": (
+            "[build-system]\n"
+            f"requires = [{requires_block}]\n"
+            f'build-backend = "{escaped}_backend"\n'
+            'backend-path = ["."]\n'
+        ),
+        f"{escaped}_backend.py": _SDIST_BACKEND_SRC.format(name=name, version=version),
+    }
+    with tarfile.open(path, "w:gz") as tf:
+        for member, text in members.items():
+            data = text.encode()
+            info = tarfile.TarInfo(f"{root}/{member}")
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+
+
+def _make_local_index(
+    root: Path,
+    name: str,
+    version: str,
+    *,
+    sdist_only: bool = False,
+    requires: tuple[str, ...] = (),
+) -> None:
+    """Create a PEP 503 ``file://`` index serving ``name``.
+
+    Serves a wheel beside the sdist by default.  ``sdist_only`` serves
+    an sdist alone, and that sdist is one a build can turn into a
+    wheel, declaring ``requires`` as its own build requirements.
+    """
     pkg_dir = root / name
     pkg_dir.mkdir(parents=True)
-    wheel = pkg_dir / f"{name}-{version}-py3-none-any.whl"
     sdist = pkg_dir / f"{name}-{version}.tar.gz"
-    _make_installable_wheel(wheel, name, version)
-    _make_pep643_sdist(sdist, name, version)
+    files = [sdist]
+    if sdist_only:
+        _make_buildable_sdist(sdist, name, version, requires)
+    else:
+        wheel = pkg_dir / f"{name}-{version}-py3-none-any.whl"
+        _make_installable_wheel(wheel, name, version)
+        _make_pep643_sdist(sdist, name, version)
+        files.append(wheel)
 
     def _digest(p: Path) -> str:
         return hashlib.sha256(p.read_bytes()).hexdigest()
 
     links = "".join(
-        f'<a href="{p.name}#sha256={_digest(p)}">{p.name}</a>\n' for p in (wheel, sdist)
+        f'<a href="{p.name}#sha256={_digest(p)}">{p.name}</a>\n' for p in files
     )
     (pkg_dir / "index.html").write_text(
         f"<!DOCTYPE html><html><body>{links}</body></html>", encoding="utf-8"
@@ -1454,9 +1572,7 @@ class TestNabBuildEnvOutsideContext:
 
 
 class TestNabBuildEnvInstall:
-    """The ``install`` shortcut: empty list, the inner re-resolve path,
-    and the sdist-only rejection.
-    """
+    """The ``install`` shortcut: empty list and the inner re-resolve path."""
 
     def test_install_empty_returns_immediately(
         self,
@@ -1519,29 +1635,18 @@ class TestNabBuildEnvInstall:
 
 
 class TestResolveAndDownload:
-    """``_resolve_and_download`` rejects sdist-only pins so the build
-    env never ends up with a dep that needs another build to install.
-    """
+    """What the inner build-requires resolve is allowed to see and do."""
 
-    def test_sdist_only_pin_raises(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        from nab_python._vendor.packaging.version import Version
-        from nab_python.lockfile import IndexPin, TargetLock
+    @staticmethod
+    def _capture_inner_config(
+        env: NabBuildEnv, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> NabProjectConfig:
+        """Run the inner resolve against stubs and return the config it got."""
         from nab_python.resolve import ResolveResult, TargetResult
-        from nab_python.target import ResolveTarget
 
-        env = NabBuildEnv(requires=["foo"], config=NabProjectConfig())
         env._tmpdir = MagicMock()  # type: ignore[attr-defined]
         env._venv_path = tmp_path / "venv"  # type: ignore[attr-defined]
         env._python_executable = tmp_path / "venv" / "bin" / "python"  # type: ignore[attr-defined]
-        sdist_pin = IndexPin(
-            name="foo",
-            version="1.0",
-            index="pypi",
-            wheels=(),
-            sdist=None,
-        )
         target = ResolveTarget.for_host()
         fake_result = ResolveResult(
             targets=(target,),
@@ -1549,16 +1654,79 @@ class TestResolveAndDownload:
                 TargetResult(
                     target=target,
                     success=True,
-                    pins={"foo": Version("1.0")},
-                    lock=TargetLock(target=target, pins={"foo": sdist_pin}),
+                    pins={},
+                    lock=TargetLock(target=target, pins={}),
                 )
             ],
         )
-        with patch("nab_python.resolve.resolve_for_targets", return_value=fake_result):
-            wheel_dir = tmp_path / "wheels"
-            wheel_dir.mkdir()
-            with pytest.raises(BuildEnvError, match="sdist-only"):
-                env._resolve_and_download(wheel_dir)
+        captured: dict[str, object] = {}
+
+        def fake_resolve(
+            _path: Path, _transport: object, **kwargs: object
+        ) -> ResolveResult:
+            captured.update(kwargs)
+            return fake_result
+
+        monkeypatch.setattr("nab_python.resolve.resolve_for_targets", fake_resolve)
+        monkeypatch.setattr(
+            "nab_python._build.env.download_lock",
+            lambda *_a, **_k: MagicMock(written=[], skipped=[]),
+        )
+        wheel_dir = tmp_path / "wheels"
+        wheel_dir.mkdir()
+
+        env._resolve_and_download(wheel_dir)
+        inner = captured["config"]
+        assert isinstance(inner, NabProjectConfig)
+        return inner
+
+    def test_inner_resolve_admits_both_artifact_kinds(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Candidacy is not narrowed to wheels.
+
+        Hiding the wheel-less versions from the resolver would settle
+        on an older build backend than the requirement asked for and
+        say nothing about it; whether the one it settles on can be
+        installed is decided after the resolve, by ``_plan_install``.
+        """
+        env = NabBuildEnv(requires=["foo"], config=NabProjectConfig())
+
+        inner = self._capture_inner_config(env, tmp_path, monkeypatch)
+
+        assert inner.dist_policy is DistPolicy.WHEEL_OR_SDIST
+
+    def test_inner_resolve_reads_metadata_statically(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The build env's own resolve never invokes a backend.
+
+        A build the depth budget does not count is one it cannot bound,
+        so an inherited override may keep its refusal and loses its
+        permission.
+        """
+        env = NabBuildEnv(
+            requires=["foo"],
+            config=NabProjectConfig(
+                build_policy=BuildPolicy.BUILD_REMOTE,
+                package_overrides=(
+                    pkg_override("foo", build_policy=BuildPolicy.BUILD_REMOTE),
+                    pkg_override("bar", build_policy=BuildPolicy.NEVER),
+                ),
+                index_overrides={
+                    "pypi": IndexOverride(build_policy=BuildPolicy.BUILD_REMOTE)
+                },
+            ),
+        )
+
+        inner = self._capture_inner_config(env, tmp_path, monkeypatch)
+
+        assert inner.build_policy is BuildPolicy.NEVER
+        assert [o.build_policy for o in inner.package_overrides] == [
+            None,
+            BuildPolicy.NEVER,
+        ]
+        assert inner.index_overrides["pypi"].build_policy is None
 
     def test_inner_resolve_runs_for_the_host(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1965,11 +2133,13 @@ class TestResolveAndDownloadSiblingWheels:
         assert requested == [self.MANYLINUX1]
         assert [p.name for p in wheels] == [self.MANYLINUX1]
 
-    def test_sdist_is_kept(
+    def test_sdist_goes_with_the_narrowed_wheels(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Narrowing the wheels leaves the sdist, so the pin does not
-        then read as sdist-only.
+        """The sdist of a pin installed from a wheel is not even fetched.
+
+        Nothing installs it, and a corrupt one would fail the download
+        and take a build with it that the wheel alone would satisfy.
         """
         requested, wheels = self._run(
             tmp_path,
@@ -1977,7 +2147,7 @@ class TestResolveAndDownloadSiblingWheels:
             [self.MANYLINUX2014, self.MANYLINUX1],
             with_sdist=True,
         )
-        assert requested == [self.SDIST, self.MANYLINUX2014]
+        assert requested == [self.MANYLINUX2014]
         assert [p.name for p in wheels] == [self.MANYLINUX2014]
 
     @pytest.mark.parametrize(
@@ -1996,10 +2166,9 @@ class TestResolveAndDownloadSiblingWheels:
         The provider's tag filter drops those wheels before a pin is
         built, so this holds a cross-module invariant rather than a
         case a real resolve reaches; hence the hand-built lock input.
+        With no sdist there is not even a build to refuse.
         """
-        with pytest.raises(
-            BuildEnvError, match="no wheel of demo==1.0 matches the build host's tags"
-        ):
+        with pytest.raises(BuildEnvError, match="no sdist to build"):
             self._run(tmp_path, monkeypatch, filenames)
 
 
@@ -2126,6 +2295,25 @@ class TestInstallPickIsNotTheMetadataPick:
             ),
         )
 
+    @staticmethod
+    def _env(depth: int = 0) -> NabBuildEnv:
+        return NabBuildEnv(
+            requires=[], config=NabProjectConfig(build_requires_depth=depth)
+        )
+
+    @classmethod
+    def _sdist_pin(cls) -> IndexPin:
+        return IndexPin(
+            name="demo",
+            version="1.0",
+            index="https://pypi.org/simple/",
+            sdist=SdistArtifact(
+                filename=cls.SDIST,
+                url=f"https://pypi.example/{cls.SDIST}",
+                hashes=(("sha256", "1" * 64),),
+            ),
+        )
+
     def test_tag_tie_goes_to_the_sidecar_only_for_metadata(self) -> None:
         """A tie breaks on the sidecar for metadata and on order for install.
 
@@ -2140,13 +2328,18 @@ class TestInstallPickIsNotTheMetadataPick:
         assert tags.wheel_rank(self.TIE_PLAIN) == tags.wheel_rank(self.TIE_SIDECAR)
         assert pick_dist(listed, tags).filename == self.TIE_SIDECAR
 
-        pin = _picked_wheel_pin(self._pin([self.TIE_PLAIN, self.TIE_SIDECAR]), tags)
+        pin = self._env()._planned_pin(
+            self._pin([self.TIE_PLAIN, self.TIE_SIDECAR]), tags, []
+        )
         assert isinstance(pin, IndexPin)
         assert [w.filename for w in pin.wheels] == [self.TIE_PLAIN]
 
     def test_metadata_may_come_from_a_wheel_the_host_cannot_install(self) -> None:
         """Two off-target wheels, since ``pick_dist`` falls back only
         when the tags rank nothing at all.
+
+        The install side has no such fallback, and with no sdist to
+        build there is nothing left to try.
         """
         tags = self._tags()
         listed = [
@@ -2157,32 +2350,302 @@ class TestInstallPickIsNotTheMetadataPick:
         assert picked.filename == self.WINDOWS
         assert not tags.accepts(picked.filename)
 
-        with pytest.raises(BuildEnvError, match="matches the build host's tags"):
-            _picked_wheel_pin(self._pin([self.WINDOWS, self.MACOS]), tags)
+        with pytest.raises(BuildEnvError, match="no sdist to build"):
+            self._env()._planned_pin(self._pin([self.WINDOWS, self.MACOS]), tags, [])
 
     def test_metadata_may_come_from_an_sdist(self) -> None:
         """A version publishing no wheel is read from its sdist.
 
         Two sdists, because ``pick_dist`` hands back a lone dist
-        without ranking anything.  The install side has no such
-        fallback: the pin comes back untouched, and the sdist-only
-        check rejects it.
+        without ranking anything.  Installing that version means
+        building the sdist, which the default depth refuses.
         """
         tags = self._tags()
         listed = [self._listed_sdist(self.SDIST), self._listed_sdist(self.SDIST_ZIP)]
         assert pick_dist(listed, tags) is listed[0]
 
-        pin = IndexPin(
-            name="demo",
-            version="1.0",
-            index="https://pypi.org/simple/",
-            sdist=SdistArtifact(
-                filename=self.SDIST,
-                url=f"https://pypi.example/{self.SDIST}",
-                hashes=(("sha256", "1" * 64),),
-            ),
+        with pytest.raises(BuildEnvError, match="build-requires-depth is 0"):
+            self._env()._planned_pin(self._sdist_pin(), tags, [])
+
+    def test_sdist_pin_is_queued_for_a_build_when_the_depth_allows(self) -> None:
+        """With budget the sdist stays, the wheels go, and a build is queued."""
+        to_build: list[_PendingBuild] = []
+        planned = self._env(depth=1)._planned_pin(
+            self._sdist_pin(), self._tags(), to_build
         )
-        assert _picked_wheel_pin(pin, tags) is pin
+
+        assert isinstance(planned, IndexPin)
+        assert planned.wheels == ()
+        assert planned.sdist is not None
+        assert [pending.label for pending in to_build] == ["demo 1.0"]
+
+    @pytest.mark.parametrize("depth", [1, 3], ids=["budget-spent", "budget-left"])
+    def test_a_pin_already_on_the_chain_is_a_cycle(self, depth: int) -> None:
+        """A build requirement that needs itself built is reported as a cycle.
+
+        At depth 1 the chain has also spent the budget, and the cycle
+        is still what the message says: raising the depth to walk into
+        a loop is the one piece of advice that cannot help.
+        """
+        env = NabBuildEnv(
+            requires=[],
+            config=NabProjectConfig(build_requires_depth=depth),
+            chain=("demo 1.0",),
+        )
+
+        with pytest.raises(BuildEnvError, match="cyclic build requirement: demo 1.0"):
+            env._planned_pin(self._sdist_pin(), self._tags(), [])
+
+    def test_a_pin_that_is_not_from_an_index_passes_through(self) -> None:
+        """A local pin carries no artifacts to choose between."""
+        pin = LocalPin(name="demo", version="1.0", path="/src/demo")
+
+        assert self._env()._planned_pin(pin, self._tags(), []) is pin
+
+    def test_a_refusal_names_the_builds_that_led_to_it(self) -> None:
+        """Nested refusals are unreadable without the path that reached them."""
+        env = NabBuildEnv(
+            requires=[], config=NabProjectConfig(), chain=("meson 1.4.2", "ninja 1.11")
+        )
+
+        with pytest.raises(BuildEnvError, match=r"chain: meson 1\.4\.2 -> ninja 1\.11"):
+            env._planned_pin(self._sdist_pin(), self._tags(), [])
+
+
+class TestBuildRequirementNeedingItsOwnBuild:
+    """A build requirement published as an sdist alone.
+
+    The env installs wheels, so satisfying one of these means building
+    it, which is what ``[tool.nab].build-requires-depth`` governs.  The
+    index is a local ``file://`` tree and the download step is stubbed
+    to copy from it, so the whole flow runs without network.
+    """
+
+    NAME = "buildstub"
+    VERSION = "1.0"
+
+    def _config(self, tmp_path: Path, depth: int) -> NabProjectConfig:
+        index_dir = tmp_path / "index"
+        _make_local_index(index_dir, self.NAME, self.VERSION, sdist_only=True)
+        return NabProjectConfig(
+            indexes=(IndexConfig("local", index_dir.as_uri()),),
+            build_requires_depth=depth,
+        )
+
+    @staticmethod
+    def _stub_download(monkeypatch: pytest.MonkeyPatch, index_dir: Path) -> None:
+        """Copy from the local index in place of the HTTP download.
+
+        ``download_lock`` speaks HTTP, so it cannot fetch the ``file://``
+        index these tests serve.  Extraction is swapped at the same time
+        for a fixture unpacker that does not need the tar data filter.
+        """
+
+        def fake_download_lock(
+            lock_input: LockInput, _transport: object, wheel_dir: Path, *_a: object
+        ) -> DownloadResult:
+            written = []
+            for lock in lock_input.targets.values():
+                for name, pin in lock.pins.items():
+                    assert isinstance(pin, IndexPin)
+                    assert pin.sdist is not None
+                    dest = wheel_dir / pin.sdist.filename
+                    dest.write_bytes(
+                        (index_dir / name / pin.sdist.filename).read_bytes()
+                    )
+                    written.append(dest)
+            return DownloadResult(written=tuple(written), skipped=())
+
+        monkeypatch.setattr("nab_python._build.env.download_lock", fake_download_lock)
+        monkeypatch.setattr(
+            "nab_python._build.env.extract_sdist_archive", _unpack_fixture_sdist
+        )
+
+    def test_built_and_installed_when_the_depth_allows(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """At depth 1 the sdist is built and the wheel lands in the venv."""
+        config = self._config(tmp_path, depth=1)
+        self._stub_download(monkeypatch, tmp_path / "index")
+
+        with NabBuildEnv(requires=[self.NAME], config=config) as env:
+            installed = [str(root / rel) for root, rel in env._installed_files]
+
+        assert any(self.NAME in path for path in installed)
+
+    def test_refused_at_the_default_depth(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """At depth 0 the sdist is not a candidate, and the error says why."""
+        config = self._config(tmp_path, depth=0)
+        self._stub_download(monkeypatch, tmp_path / "index")
+
+        env = NabBuildEnv(requires=[self.NAME], config=config)
+        with pytest.raises(BuildEnvError, match="build-requires-depth is"):
+            env.__enter__()
+
+    def test_the_nested_env_carries_the_chain(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The env a nested build opens knows what it is nested inside."""
+        config = self._config(tmp_path, depth=1)
+        self._stub_download(monkeypatch, tmp_path / "index")
+        chains: list[tuple[str, ...]] = []
+        original = NabBuildEnv.__init__
+
+        def record(self: NabBuildEnv, *args: object, **kwargs: object) -> None:
+            original(self, *args, **kwargs)  # type: ignore[arg-type]
+            chains.append(self._chain)
+
+        monkeypatch.setattr(NabBuildEnv, "__init__", record)
+
+        with NabBuildEnv(requires=[self.NAME], config=config):
+            pass
+
+        assert chains == [(), (f"{self.NAME} {self.VERSION}",)]
+
+
+class TestBuildRequirementTwoLevelsDown:
+    """A build requirement whose own build requirement needs building.
+
+    ``buildstub`` publishes an sdist alone and build-requires
+    ``deepstub``, which publishes an sdist alone too.  Satisfying the
+    first is one nested env, satisfying the second is a second one, so
+    the pair pins that the budget is spent as the chain grows rather
+    than reread at every level.
+    """
+
+    OUTER = "buildstub"
+    INNER = "deepstub"
+    VERSION = "1.0"
+
+    def _config(self, tmp_path: Path, depth: int) -> NabProjectConfig:
+        index_dir = tmp_path / "index"
+        _make_local_index(
+            index_dir, self.OUTER, self.VERSION, sdist_only=True, requires=(self.INNER,)
+        )
+        _make_local_index(index_dir, self.INNER, self.VERSION, sdist_only=True)
+        return NabProjectConfig(
+            indexes=(IndexConfig("local", index_dir.as_uri()),),
+            build_requires_depth=depth,
+        )
+
+    def test_refused_one_level_short(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Depth 1 pays for the outer build and has nothing left for the inner."""
+        config = self._config(tmp_path, depth=1)
+        TestBuildRequirementNeedingItsOwnBuild._stub_download(
+            monkeypatch, tmp_path / "index"
+        )
+
+        env = NabBuildEnv(requires=[self.OUTER], config=config)
+        with pytest.raises(BuildEnvError) as excinfo:
+            env.__enter__()
+
+        message = str(excinfo.value)
+        assert self.INNER in message
+        assert f"chain: {self.OUTER} {self.VERSION}" in message
+
+    def test_built_when_the_depth_reaches(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Depth 2 pays for both, and the outer wheel lands in the venv."""
+        config = self._config(tmp_path, depth=2)
+        TestBuildRequirementNeedingItsOwnBuild._stub_download(
+            monkeypatch, tmp_path / "index"
+        )
+
+        with NabBuildEnv(requires=[self.OUTER], config=config) as env:
+            installed = [str(root / rel) for root, rel in env._installed_files]
+
+        assert any(self.OUTER in path for path in installed)
+
+
+class TestBuildRequirementBuildFailures:
+    """``_build_requirement`` wraps every way the nested build can fail.
+
+    Each surfaces as ``BuildEnvError`` naming the requirement, so the
+    outer resolve skips the sdist it was building rather than aborting
+    on a raw archive or backend error.
+    """
+
+    PENDING = _PendingBuild(
+        label="demo 1.0",
+        sdist=SdistArtifact(
+            filename="demo-1.0.tar.gz",
+            url="https://pypi.example/demo-1.0.tar.gz",
+            hashes=(("sha256", "1" * 64),),
+        ),
+    )
+
+    @staticmethod
+    def _env() -> NabBuildEnv:
+        return NabBuildEnv(requires=[], config=NabProjectConfig(build_requires_depth=1))
+
+    def test_missing_archive(self, tmp_path: Path) -> None:
+        """The download step promised a file that is not there."""
+        with pytest.raises(BuildEnvError, match="could not be read"):
+            self._env()._build_requirement(self.PENDING, tmp_path)
+
+    def test_unextractable_archive(self, tmp_path: Path) -> None:
+        """A downloaded sdist that is not an archive at all."""
+        (tmp_path / self.PENDING.sdist.filename).write_bytes(b"not a tarball")
+
+        with pytest.raises(BuildEnvError, match="could not be extracted"):
+            self._env()._build_requirement(self.PENDING, tmp_path)
+
+    def test_backend_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The sdist extracts but names a backend that cannot be imported."""
+        archive = tmp_path / self.PENDING.sdist.filename
+        members = {
+            "PKG-INFO": "Metadata-Version: 2.2\nName: demo\nVersion: 1.0\n",
+            "pyproject.toml": (
+                "[build-system]\nrequires = []\n"
+                'build-backend = "demo_missing_backend"\nbackend-path = ["."]\n'
+            ),
+        }
+        with tarfile.open(archive, "w:gz") as tf:
+            for member, text in members.items():
+                data = text.encode()
+                info = tarfile.TarInfo(f"demo-1.0/{member}")
+                info.size = len(data)
+                tf.addfile(info, io.BytesIO(data))
+        monkeypatch.setattr(
+            "nab_python._build.env.extract_sdist_archive", _unpack_fixture_sdist
+        )
+
+        with pytest.raises(BuildEnvError, match="could not be built"):
+            self._env()._build_requirement(self.PENDING, tmp_path)
+
+    def test_non_string_wheel_path(self, tmp_path: Path) -> None:
+        """A backend returning something other than a wheel's basename.
+
+        ``build`` joins the hook's result onto the output directory
+        without checking it, so the ``TypeError`` is nab's to report.
+        """
+        source_dir = tmp_path / "src"
+        source_dir.mkdir()
+        (source_dir / "nab_test_backend.py").write_text(
+            "def get_requires_for_build_wheel(config_settings=None):\n"
+            "    return []\n\n"
+            "def build_wheel(wheel_directory, config_settings=None,"
+            " metadata_directory=None):\n"
+            "    return 42\n",
+            encoding="utf-8",
+        )
+        (source_dir / "pyproject.toml").write_text(
+            "[build-system]\nrequires = []\n"
+            'build-backend = "nab_test_backend"\nbackend-path = ["."]\n',
+            encoding="utf-8",
+        )
+
+        with pytest.raises(BuildBackendError, match="non-string path"):
+            build_wheel_for_install(
+                source_dir, output_dir=tmp_path / "out", config=NabProjectConfig()
+            )
 
 
 class TestNabBuildEnvLifecycle:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -1368,6 +1368,17 @@ class TestPolicies:
         with pytest.raises(ConfigError, match="dist-policy must be a string"):
             read_pyproject_config(path)
 
+    @pytest.mark.parametrize("value", ["-1", "true", '"1"'])
+    def test_invalid_build_requires_depth(self, tmp_path: Path, value: str) -> None:
+        """A count of nested builds: not negative, not a bool, not a string."""
+        path = write(tmp_path, f"[tool.nab]\nbuild-requires-depth = {value}\n")
+        with pytest.raises(ConfigError, match="must be a non-negative integer"):
+            read_pyproject_config(path)
+
+    def test_build_requires_depth_reaches_the_config(self, tmp_path: Path) -> None:
+        path = write(tmp_path, "[tool.nab]\nbuild-requires-depth = 2\n")
+        assert read_pyproject_config(path).build_requires_depth == 2
+
 
 _UNIVERSAL_MATRIX = (
     '[tool.nab.matrix]\npython = ">=3.11,<3.12"\nplatforms = ["linux_x86_64"]\n'

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -893,6 +893,7 @@ class TestParserFoldHelpers:
                 "uploaded-prior-to",
                 "dist-policy",
                 "build-policy",
+                "build-requires-depth",
                 "environment",
                 "marker-environment",
                 "vcs",


### PR DESCRIPTION
The isolated build env installs wheels, so a build requirement whose resolved version publishes none this host can install had no way in. meson 1.4.2 is the last release of the 1.4 series and ships an sdist alone; numpy publishes nothing installable on s390x or on an interpreter too new to have wheels. pip and uv build those from source.

Adds `[tool.nab].build-requires-depth`, the build environments nab may open beneath the first one, default 0: allowing a build does not allow building what that build needs. Refusals name the requirement and the chain that reached it, and a build already in the chain cannot be re-entered.

The build-requires resolve admits sdists again rather than quietly settling on an older backend, and it reads metadata statically, so an inherited `build-policy` override may forbid a build there but no longer grant one.
