### PR TITLE
warn on unrecognized NAB_* env vars instead of crashing

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -834,6 +834,7 @@ by discovery. `nab config` shows the value as written, like
 | `NAB_MAX_CONCURRENCY` | `max-concurrency` | Parallel HTTP fetches for `nab download` (at least `1`). |
 
 A `NAB_*` name that is not one of these (a typo, or `NAB_RESOLUTION`
-for a project-scope option) is an error rather than being silently
-ignored. Run `nab config list` to see every effective value and where
-it came from.
+for a project-scope option) is ignored with a warning naming the
+variable. `NAB_VERBOSITY` and `NAB_NO_PROGRESS` belong to the
+[output layer](cli.md) and pass through silently. Run
+`nab config list` to see every effective value and where it came from.

--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -12,7 +12,7 @@ Everything else is derived by iterating :data:`OPTIONS`:
   table against the registry, raising on any key that names an option
   not allowed in that source kind (the category gate).
 * :func:`read_env_layer` reads ``NAB_*`` for the rows that declare an
-  env var, and rejects a ``NAB_<KEY>`` that names a PROJECT option.
+  env var, and warns on any ``NAB_*`` name it does not recognize.
 * :func:`resolve_config` merges the discovered layers low-to-high and
   attaches ``(scope, origin)`` provenance to each effective value.
 * :func:`render_list` / :func:`render_get` / :func:`render_explain`
@@ -27,6 +27,7 @@ the registry so the one place the CLI surface is not registry-derived
 from __future__ import annotations
 
 import enum
+import logging
 import types
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -53,6 +54,8 @@ from .provider import (
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+
+_logger = logging.getLogger(__name__)
 
 __all__ = [
     "OPTIONS",
@@ -1348,21 +1351,24 @@ def _read_raw_table(path: Path, kind: SourceKind) -> Mapping[str, Any]:
 def read_env_layer(
     environ: Mapping[str, str],
     *,
+    reserved_env: Iterable[str] = (),
     rejections: list[RejectedLayer] | None = None,
 ) -> Layer:
     """Read ``NAB_*`` for every registry row that declares an env var.
 
     PROJECT options never declare an env var, so the env layer carries
     USER options only.  A ``NAB_<KEY>`` naming a PROJECT option (e.g.
-    ``NAB_RESOLUTION``) is a hard error caught by
-    :func:`_reject_renamed_env`; any other unknown ``NAB_*`` name (e.g. a
-    typo) is rejected by :func:`_reject_unknown_env`.  When ``rejections``
-    is supplied (``nab config explain --include-rejected``) those env
-    casualties are recorded there and skipped instead of raised, mirroring
-    the TOML loader.
+    ``NAB_RESOLUTION``) draws a warning from :func:`_warn_renamed_env`;
+    any other unknown ``NAB_*`` name (e.g. a typo) one from
+    :func:`_warn_unknown_env`.  Neither is applied, and neither is fatal.
+    ``reserved_env`` names the ``NAB_*`` vars other layers own (nab's
+    output layer consumes ``NAB_VERBOSITY`` and ``NAB_NO_PROGRESS``), so
+    the guard skips them silently.  When ``rejections`` is supplied
+    (``nab config explain --include-rejected``) those env casualties are
+    recorded there instead of warned, mirroring the TOML loader.
     """
-    _reject_renamed_env(environ, rejections=rejections)
-    _reject_unknown_env(environ, rejections=rejections)
+    _warn_renamed_env(environ, rejections=rejections)
+    _warn_unknown_env(environ, reserved_env=reserved_env, rejections=rejections)
     values: dict[str, Any] = {}
     for spec in OPTIONS:
         if spec.env_var is None:
@@ -1374,34 +1380,43 @@ def read_env_layer(
     return Layer(Origin(SourceKind.ENV, "env"), values)
 
 
-def _reject_unknown_env(
+def _warn_unknown_env(
     environ: Mapping[str, str],
     *,
+    reserved_env: Iterable[str] = (),
     rejections: list[RejectedLayer] | None = None,
 ) -> None:
-    """Reject any ``NAB_*`` var that is neither a known nor renamed name.
+    """Warn about any ``NAB_*`` var that is neither a known nor renamed name.
 
-    The env half of the category gate: a typo'd or made-up
-    ``NAB_<KEY>`` (e.g. ``NAB_OFLINE``) must crash naming the variable
-    rather than being silently dropped.  Renamed PROJECT names are left
-    for :func:`_reject_renamed_env`, which gives the more specific
-    not-env-settable message.  When ``rejections`` is supplied the var is
-    recorded there and skipped instead of raised.
+    The env half of the category gate: a typo'd or made-up ``NAB_<KEY>``
+    (e.g. ``NAB_OFLINE``) is ignored with a warning naming the variable,
+    never applied and never fatal.  Renamed PROJECT names are left for
+    :func:`_warn_renamed_env`, which gives the more specific
+    not-env-settable message.  ``reserved_env`` names ``NAB_*`` vars owned
+    by other layers (the output layer's ``NAB_VERBOSITY`` and
+    ``NAB_NO_PROGRESS``); those are skipped silently.  When ``rejections``
+    is supplied the var is recorded there instead of warned.
     """
     known = {spec.env_var for spec in OPTIONS if spec.env_var is not None}
     renamed = set(_renamed_env_names())
+    reserved = set(reserved_env)
     for name in environ:
-        if not name.startswith("NAB_") or name in known or name in renamed:
+        if (
+            not name.startswith("NAB_")
+            or name in known
+            or name in renamed
+            or name in reserved
+        ):
             continue
         valid = sorted(known)
         msg = (
-            f"{name} is not a valid nab setting; the known NAB_* variables"
-            f" are {valid!r}."
+            f"{name} is not a recognized nab setting and was ignored; the"
+            f" known NAB_* variables are {valid!r}."
         )
         if rejections is not None:
             rejections.append(RejectedLayer(Origin(SourceKind.ENV, name), name, msg))
             continue
-        raise SourceConfigError(msg)
+        _logger.warning("%s", msg)
 
 
 def _renamed_env_names() -> dict[str, OptionSpec]:
@@ -1414,16 +1429,17 @@ def _renamed_env_names() -> dict[str, OptionSpec]:
     return names
 
 
-def _reject_renamed_env(
+def _warn_renamed_env(
     environ: Mapping[str, str],
     *,
     rejections: list[RejectedLayer] | None = None,
 ) -> None:
-    """Reject a ``NAB_<KEY>`` that names a PROJECT (non-env-settable) option.
+    """Warn about a ``NAB_<KEY>`` naming a PROJECT (non-env-settable) option.
 
-    When ``rejections`` is supplied the var is recorded there under the
-    spec's key (so ``explain <key> --include-rejected`` lists it) and
-    skipped instead of raised.
+    The variable is ignored, never applied and never fatal.  When
+    ``rejections`` is supplied the var is recorded there under the spec's
+    key (so ``explain <key> --include-rejected`` lists it) instead of
+    warned.
     """
     for env_name, spec in _renamed_env_names().items():
         if env_name in environ:
@@ -1435,7 +1451,7 @@ def _reject_renamed_env(
                 else f", or override per-run with {spec.cli_flag}"
             )
             msg = (
-                f"{env_name} is not a valid nab setting: {spec.key!r} is a"
+                f"{env_name} was ignored: {spec.key!r} is a"
                 f" {spec.scope.value}-scope option and is not env-settable."
                 f"  Set it in pyproject [tool.nab].{spec.key} or a project-dir"
                 f" nab.toml{override}."
@@ -1445,7 +1461,7 @@ def _reject_renamed_env(
                     RejectedLayer(Origin(SourceKind.ENV, env_name), spec.key, msg)
                 )
                 continue
-            raise SourceConfigError(msg)
+            _logger.warning("%s", msg)
 
 
 def discover_layers(

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -11,6 +11,7 @@ renderers.  Search roots are injected so nothing reads the real
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -149,13 +150,18 @@ class TestResolutionLadder:
         with pytest.raises(SourceConfigError, match="cannot be set in a system"):
             _resolve(roots)
 
-    def test_nab_resolution_env_errors(self, tmp_path: Path) -> None:
+    def test_nab_resolution_env_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
         _project(tmp_path)
-        with pytest.raises(SourceConfigError, match="NAB_RESOLUTION is not a valid"):
-            _resolve(
+        with caplog.at_level(logging.WARNING, logger="nab_python"):
+            eff = _resolve(
                 SourceRoots(project_dir=tmp_path),
                 environ={"NAB_RESOLUTION": "lowest"},
             )
+        assert eff["resolution"].value is ResolutionStrategy.HIGHEST
+        assert "NAB_RESOLUTION" in caplog.text
+        assert "not env-settable" in caplog.text
 
     def test_bad_resolution_value_errors(self, tmp_path: Path) -> None:
         _project(tmp_path, 'resolution = "sideways"\n')
@@ -225,14 +231,19 @@ class TestOfflineLadder:
                 environ={"NAB_OFFLINE": "maybe"},
             )
 
-    def test_unknown_nab_env_var_errors(self, tmp_path: Path) -> None:
-        # A typo'd NAB_* var (e.g. NAB_OFLINE) must crash, not be dropped.
+    def test_unknown_nab_env_var_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # A typo'd NAB_* var (e.g. NAB_OFLINE) warns and is ignored.
         _project(tmp_path)
-        with pytest.raises(SourceConfigError, match="NAB_OFLINE is not a valid"):
-            _resolve(
+        with caplog.at_level(logging.WARNING, logger="nab_python"):
+            eff = _resolve(
                 SourceRoots(project_dir=tmp_path),
                 environ={"NAB_OFLINE": "true"},
             )
+        assert eff["offline"].value is False
+        assert "NAB_OFLINE" in caplog.text
+        assert "ignored" in caplog.text
 
     def test_offline_in_pyproject_errors(self, tmp_path: Path) -> None:
         _project(tmp_path, "offline = true\n")
@@ -919,12 +930,16 @@ class TestScalarProjectOptions:
         with pytest.raises(SourceConfigError, match="project-scope option"):
             _resolve(roots)
 
-    def test_nab_mode_env_errors(self, tmp_path: Path) -> None:
+    def test_nab_mode_env_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
         _project(tmp_path)
-        with pytest.raises(SourceConfigError, match="not env-settable"):
+        with caplog.at_level(logging.WARNING, logger="nab_python"):
             _resolve(
                 SourceRoots(project_dir=tmp_path), environ={"NAB_MODE": "universal"}
             )
+        assert "NAB_MODE" in caplog.text
+        assert "not env-settable" in caplog.text
 
     def test_mode_bad_value_keeps_existing_message(self, tmp_path: Path) -> None:
         _project(tmp_path, 'mode = "sideways"\n')
@@ -1132,13 +1147,17 @@ class TestTableProjectOptions:
         with pytest.raises(SourceConfigError, match="project-scope option"):
             _resolve(roots)
 
-    def test_nab_marker_environment_env_errors(self, tmp_path: Path) -> None:
+    def test_nab_marker_environment_env_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
         _project(tmp_path)
-        with pytest.raises(SourceConfigError, match="not env-settable"):
+        with caplog.at_level(logging.WARNING, logger="nab_python"):
             _resolve(
                 SourceRoots(project_dir=tmp_path),
                 environ={"NAB_MARKER_ENVIRONMENT": "x"},
             )
+        assert "NAB_MARKER_ENVIRONMENT" in caplog.text
+        assert "not env-settable" in caplog.text
 
     def test_marker_environment_bad_value_keeps_message(self, tmp_path: Path) -> None:
         _project(
@@ -1239,10 +1258,14 @@ class TestTableProjectOptions:
         with pytest.raises(SourceConfigError, match="project-scope option"):
             _resolve(roots)
 
-    def test_nab_vcs_env_errors(self, tmp_path: Path) -> None:
+    def test_nab_vcs_env_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
         _project(tmp_path)
-        with pytest.raises(SourceConfigError, match="not env-settable"):
+        with caplog.at_level(logging.WARNING, logger="nab_python"):
             _resolve(SourceRoots(project_dir=tmp_path), environ={"NAB_VCS": "x"})
+        assert "NAB_VCS" in caplog.text
+        assert "not env-settable" in caplog.text
 
     def test_vcs_bad_value_keeps_message(self, tmp_path: Path) -> None:
         _project(tmp_path, '[tool.nab.vcs]\npolicy = "sometimes"\n')
@@ -1304,10 +1327,14 @@ class TestTableProjectOptions:
         with pytest.raises(SourceConfigError, match="project-scope option"):
             _resolve(roots)
 
-    def test_nab_workspace_env_errors(self, tmp_path: Path) -> None:
+    def test_nab_workspace_env_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
         _project(tmp_path)
-        with pytest.raises(SourceConfigError, match="not env-settable"):
+        with caplog.at_level(logging.WARNING, logger="nab_python"):
             _resolve(SourceRoots(project_dir=tmp_path), environ={"NAB_WORKSPACE": "x"})
+        assert "NAB_WORKSPACE" in caplog.text
+        assert "not env-settable" in caplog.text
 
     def test_workspace_bad_value_keeps_message(self, tmp_path: Path) -> None:
         _project(tmp_path, '[tool.nab.workspace]\nmember = ["pkgs/a"]\n')
@@ -1397,12 +1424,16 @@ class TestArrayProjectOptions:
         with pytest.raises(SourceConfigError, match="project-scope option"):
             _resolve(roots)
 
-    def test_nab_constraints_env_errors(self, tmp_path: Path) -> None:
+    def test_nab_constraints_env_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
         _project(tmp_path)
-        with pytest.raises(SourceConfigError, match="not env-settable"):
+        with caplog.at_level(logging.WARNING, logger="nab_python"):
             _resolve(
                 SourceRoots(project_dir=tmp_path), environ={"NAB_CONSTRAINTS": "x"}
             )
+        assert "NAB_CONSTRAINTS" in caplog.text
+        assert "not env-settable" in caplog.text
 
     def test_constraints_bad_pep508_keeps_message(self, tmp_path: Path) -> None:
         _project(tmp_path, 'constraints = ["not a valid !! req"]\n')
@@ -1458,13 +1489,17 @@ class TestArrayProjectOptions:
         with pytest.raises(SourceConfigError, match="project-scope option"):
             _resolve(roots)
 
-    def test_nab_default_groups_env_errors(self, tmp_path: Path) -> None:
+    def test_nab_default_groups_env_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
         _project(tmp_path)
-        with pytest.raises(SourceConfigError, match="not env-settable"):
+        with caplog.at_level(logging.WARNING, logger="nab_python"):
             _resolve(
                 SourceRoots(project_dir=tmp_path),
                 environ={"NAB_DEFAULT_GROUPS": "x"},
             )
+        assert "NAB_DEFAULT_GROUPS" in caplog.text
+        assert "not env-settable" in caplog.text
 
     def test_default_groups_non_string_item_keeps_message(self, tmp_path: Path) -> None:
         _project(tmp_path, "default-groups = [1]\n")
@@ -1593,10 +1628,14 @@ class TestArrayOfTablesSources:
         with pytest.raises(SourceConfigError, match="project-scope option"):
             _resolve(roots)
 
-    def test_nab_indexes_env_errors(self, tmp_path: Path) -> None:
+    def test_nab_indexes_env_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
         _project(tmp_path)
-        with pytest.raises(SourceConfigError, match="not env-settable"):
+        with caplog.at_level(logging.WARNING, logger="nab_python"):
             _resolve(SourceRoots(project_dir=tmp_path), environ={"NAB_INDEXES": "x"})
+        assert "NAB_INDEXES" in caplog.text
+        assert "not env-settable" in caplog.text
 
     def test_indexes_bad_shape_keeps_message(self, tmp_path: Path) -> None:
         _project(tmp_path, 'indexes = "pypi"\n')
@@ -1687,13 +1726,17 @@ class TestArrayOfTablesSources:
         with pytest.raises(SourceConfigError, match="project-scope option"):
             _resolve(roots)
 
-    def test_nab_local_sources_env_errors(self, tmp_path: Path) -> None:
+    def test_nab_local_sources_env_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
         _project(tmp_path)
-        with pytest.raises(SourceConfigError, match="not env-settable"):
+        with caplog.at_level(logging.WARNING, logger="nab_python"):
             _resolve(
                 SourceRoots(project_dir=tmp_path),
                 environ={"NAB_LOCAL_SOURCES": "x"},
             )
+        assert "NAB_LOCAL_SOURCES" in caplog.text
+        assert "not env-settable" in caplog.text
 
     def test_local_sources_bad_shape_keeps_message(self, tmp_path: Path) -> None:
         _project(tmp_path, 'local-sources = "pkg"\n')
@@ -1753,13 +1796,17 @@ class TestArrayOfTablesSources:
         with pytest.raises(SourceConfigError, match="project-scope option"):
             _resolve(roots)
 
-    def test_nab_vcs_sources_env_errors(self, tmp_path: Path) -> None:
+    def test_nab_vcs_sources_env_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
         _project(tmp_path)
-        with pytest.raises(SourceConfigError, match="not env-settable"):
+        with caplog.at_level(logging.WARNING, logger="nab_python"):
             _resolve(
                 SourceRoots(project_dir=tmp_path),
                 environ={"NAB_VCS_SOURCES": "x"},
             )
+        assert "NAB_VCS_SOURCES" in caplog.text
+        assert "not env-settable" in caplog.text
 
     def test_vcs_sources_bad_shape_keeps_message(self, tmp_path: Path) -> None:
         _project(tmp_path, 'vcs-sources = "pkg"\n')
@@ -1852,10 +1899,14 @@ class TestOverrideTables:
         with pytest.raises(SourceConfigError, match="project-scope option"):
             _resolve(roots)
 
-    def test_nab_packages_env_errors(self, tmp_path: Path) -> None:
+    def test_nab_packages_env_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
         _project(tmp_path)
-        with pytest.raises(SourceConfigError, match="not env-settable"):
+        with caplog.at_level(logging.WARNING, logger="nab_python"):
             _resolve(SourceRoots(project_dir=tmp_path), environ={"NAB_PACKAGES": "x"})
+        assert "NAB_PACKAGES" in caplog.text
+        assert "not env-settable" in caplog.text
 
     def test_packages_bad_shape_keeps_message(self, tmp_path: Path) -> None:
         _project(tmp_path, '[[tool.nab.packages]]\nmatch = ["foo"]\n')
@@ -1958,13 +2009,17 @@ class TestOverrideTables:
         with pytest.raises(SourceConfigError, match="project-scope option"):
             _resolve(roots)
 
-    def test_nab_package_rules_env_errors(self, tmp_path: Path) -> None:
+    def test_nab_package_rules_env_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
         _project(tmp_path)
-        with pytest.raises(SourceConfigError, match="not env-settable"):
+        with caplog.at_level(logging.WARNING, logger="nab_python"):
             _resolve(
                 SourceRoots(project_dir=tmp_path),
                 environ={"NAB_PACKAGE_RULES": "x"},
             )
+        assert "NAB_PACKAGE_RULES" in caplog.text
+        assert "not env-settable" in caplog.text
 
     def test_package_rules_bad_shape_keeps_message(self, tmp_path: Path) -> None:
         _project(tmp_path, 'package-rules = ["x"]\n')
@@ -2013,10 +2068,14 @@ class TestOverrideTables:
         with pytest.raises(SourceConfigError, match="project-scope option"):
             _resolve(roots)
 
-    def test_nab_index_env_errors(self, tmp_path: Path) -> None:
+    def test_nab_index_env_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
         _project(tmp_path)
-        with pytest.raises(SourceConfigError, match="not env-settable"):
+        with caplog.at_level(logging.WARNING, logger="nab_python"):
             _resolve(SourceRoots(project_dir=tmp_path), environ={"NAB_INDEX": "x"})
+        assert "NAB_INDEX" in caplog.text
+        assert "not env-settable" in caplog.text
 
     def test_index_bad_shape_keeps_message(self, tmp_path: Path) -> None:
         _project(tmp_path, 'index = "pypi"\n')
@@ -2202,10 +2261,14 @@ class TestCrossFieldProjectOptions:
         with pytest.raises(SourceConfigError, match="project-scope option"):
             _resolve(roots)
 
-    def test_nab_conflicts_env_errors(self, tmp_path: Path) -> None:
+    def test_nab_conflicts_env_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
         _project(tmp_path)
-        with pytest.raises(SourceConfigError, match="not env-settable"):
+        with caplog.at_level(logging.WARNING, logger="nab_python"):
             _resolve(SourceRoots(project_dir=tmp_path), environ={"NAB_CONFLICTS": "x"})
+        assert "NAB_CONFLICTS" in caplog.text
+        assert "not env-settable" in caplog.text
 
     def test_conflicts_bad_shape_keeps_message(self, tmp_path: Path) -> None:
         _project(tmp_path, 'conflicts = "cpu"\n')
@@ -2292,10 +2355,14 @@ class TestCrossFieldProjectOptions:
         with pytest.raises(SourceConfigError, match="project-scope option"):
             _resolve(roots)
 
-    def test_nab_matrix_env_errors(self, tmp_path: Path) -> None:
+    def test_nab_matrix_env_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
         _project(tmp_path)
-        with pytest.raises(SourceConfigError, match="not env-settable"):
+        with caplog.at_level(logging.WARNING, logger="nab_python"):
             _resolve(SourceRoots(project_dir=tmp_path), environ={"NAB_MATRIX": "x"})
+        assert "NAB_MATRIX" in caplog.text
+        assert "not env-settable" in caplog.text
 
     def test_matrix_bad_shape_keeps_message(self, tmp_path: Path) -> None:
         _project(tmp_path, "matrix = 3\n")

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -80,6 +80,7 @@ from nab_python.workspace import WorkspaceDiscoveryError
 from nab_resolver.resolver import ResolutionError
 
 from .output import (
+    OUTPUT_ENV_VARS,
     OutputOptionError,
     Printer,
     ProgressReporter,
@@ -246,7 +247,9 @@ def effective_config(
     # values (the resolve path uses its lockfile anchor instead).
     with inspector_anchor():
         layers = discover_layers(roots, rejections=sink)
-        env_layer = read_env_layer(os.environ, rejections=sink)
+        env_layer = read_env_layer(
+            os.environ, reserved_env=OUTPUT_ENV_VARS, rejections=sink
+        )
         cli_layer = build_cli_layer(cli_overrides or {})
         if rejected_out is not None:
             rejected_out.extend(rejected)

--- a/src/nab/output.py
+++ b/src/nab/output.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
 
 __all__ = [
+    "OUTPUT_ENV_VARS",
     "ColorChoice",
     "OutputOptionError",
     "OutputOptions",
@@ -39,6 +40,11 @@ __all__ = [
     "should_color",
     "verbosity_from_counts",
 ]
+
+NAB_VERBOSITY_ENV = "NAB_VERBOSITY"
+NAB_NO_PROGRESS_ENV = "NAB_NO_PROGRESS"
+OUTPUT_ENV_VARS: frozenset[str] = frozenset({NAB_VERBOSITY_ENV, NAB_NO_PROGRESS_ENV})
+"""The ``NAB_*`` environment variables the output layer owns."""
 
 
 class Verbosity(enum.IntEnum):
@@ -165,7 +171,7 @@ class Printer:
         self.color_enabled = should_color(color, self._err, environ)
         self.progress_allowed = (
             progress
-            and not environ.get("NAB_NO_PROGRESS")
+            and not environ.get(NAB_NO_PROGRESS_ENV)
             and verbosity is Verbosity.NORMAL
             and _isatty(self._err)
         )
@@ -403,13 +409,13 @@ _VERBOSITY_NAMES: dict[str, Verbosity] = {v.name.lower(): v for v in Verbosity}
 
 def _verbosity_from_env(env: Mapping[str, str]) -> Verbosity | None:
     """Read ``NAB_VERBOSITY`` as a level name, or ``None`` when unset."""
-    raw = env.get("NAB_VERBOSITY")
+    raw = env.get(NAB_VERBOSITY_ENV)
     if raw is None:
         return None
     name = raw.strip().lower()
     if name not in _VERBOSITY_NAMES:
         allowed = ", ".join(_VERBOSITY_NAMES)
-        msg = f"NAB_VERBOSITY={raw!r} is not one of {allowed}"
+        msg = f"{NAB_VERBOSITY_ENV}={raw!r} is not one of {allowed}"
         raise OutputOptionError(msg)
     return _VERBOSITY_NAMES[name]
 

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import inspect
 import io
+import logging
 from collections.abc import Mapping
 from contextlib import redirect_stderr, redirect_stdout, suppress
 from datetime import datetime, timezone
@@ -145,6 +146,41 @@ class TestConfigList:
         assert "lowest" in out
         assert "offline" in out
         assert "cache-dir" in out
+
+    @pytest.mark.parametrize(
+        ("var", "value"),
+        [("NAB_VERBOSITY", "verbose"), ("NAB_NO_PROGRESS", "1")],
+    )
+    def test_output_env_vars_do_not_trip_config_layer(
+        self,
+        hermetic_roots: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        var: str,
+        value: str,
+    ) -> None:
+        # NAB_VERBOSITY / NAB_NO_PROGRESS belong to the output layer, so the
+        # config env-layer must not reject them as unknown NAB_* settings.
+        _project(hermetic_roots)
+        monkeypatch.setenv(var, value)
+        out = _run_config(["list", "--path", str(hermetic_roots / "pyproject.toml")])
+        assert "offline" in out
+
+    def test_unknown_env_var_warns_and_runs(
+        self,
+        hermetic_roots: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # An unrecognized NAB_* var warns and is ignored; the run completes.
+        _project(hermetic_roots)
+        monkeypatch.setenv("NAB_OFLINE", "1")
+        with caplog.at_level(logging.WARNING, logger="nab_python"):
+            out = _run_config(
+                ["list", "--path", str(hermetic_roots / "pyproject.toml")]
+            )
+        assert "offline" in out
+        assert "NAB_OFLINE" in caplog.text
+        assert "ignored" in caplog.text
 
 
 class TestConfigGet:


### PR DESCRIPTION
An unrecognized NAB_* variable (a typo, or a documented output-layer var like NAB_VERBOSITY) crashed every nab run before it did any work.

The config env guard now warns and ignores unrecognized NAB_* names instead of raising, keeping the more specific not-env-settable message for project-scope options. NAB_VERBOSITY and NAB_NO_PROGRESS belong to the output layer and pass through silently. A recognized variable with a bad value still errors.