### PR TITLE
fail cleanly when a file:// index links to a remote artifact

### DIFF
--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
 __all__ = [
     "LocalIndexClient",
     "MalformedLocalListingError",
+    "NonLocalArtifactError",
     "UnsupportedWheelError",
     "parse_file_url",
     "read_wheel_metadata",
@@ -70,6 +71,17 @@ class MalformedLocalListingError(HttpError):
     index error rather than surfacing a raw decode error.  Raising, rather
     than returning an empty listing, keeps a malformed index from reading
     as an absent package.
+    """
+
+
+class NonLocalArtifactError(HttpError):
+    """A ``file://`` index advertised an artifact URL a local client cannot serve.
+
+    A :pep:`503` repository page may link to absolute ``http(s)`` artifact
+    URLs, so the listing is legal, but a filesystem-backed index cannot fetch
+    a remote artifact.  Subclasses :class:`~nab_index.transport.HttpError` so
+    the fetch fails through the same path as a remote index error rather than a
+    raw :class:`ValueError` from :func:`parse_file_url`.
     """
 
 
@@ -97,6 +109,20 @@ def parse_file_url(url: str) -> Path:
         raise ValueError(msg)
 
     return Path(url2pathname(netloc + parsed.path))
+
+
+def _resolve_served_path(url: str) -> Path:
+    """Resolve a served-artifact URL to a local path.
+
+    :func:`parse_file_url` raises :class:`ValueError` for an ``http(s)`` or
+    non-local ``file://`` URL; re-raise it as :class:`NonLocalArtifactError` so
+    the fetch fails through the index-error path.
+    """
+    try:
+        return parse_file_url(url)
+    except ValueError as exc:
+        msg = f"local file:// index cannot serve artifact {url!r}"
+        raise NonLocalArtifactError(msg) from exc
 
 
 _REQUIRES_PYTHON_ATTR = "data-requires-python"
@@ -524,7 +550,7 @@ class LocalIndexClient:
         rather than a raw :class:`UnicodeDecodeError`, matching the
         ``index.html`` reader.
         """
-        path = parse_file_url(metadata_url)
+        path = _resolve_served_path(metadata_url)
         try:
             return path.read_text(encoding="utf-8")
         except UnicodeDecodeError as exc:
@@ -543,7 +569,7 @@ class LocalIndexClient:
         On-disk archives are trusted, so ``sdist_hashes`` matches the remote
         client signature but is not verified.
         """
-        path = parse_file_url(sdist_url)
+        path = _resolve_served_path(sdist_url)
         return _extract_sdist_files(path.read_bytes())
 
     async def get_sdist_archive(
@@ -558,5 +584,5 @@ class LocalIndexClient:
         On-disk archives are trusted, so ``sdist_hashes`` matches the remote
         client signature but is not verified.
         """
-        path = parse_file_url(sdist_url)
+        path = _resolve_served_path(sdist_url)
         return path.read_bytes()

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -877,6 +877,44 @@ class TestMetadataAndSdist:
         assert pyproject is not None
         assert 'name = "foo"' in pyproject
 
+    def test_https_metadata_url_raises_http_error(self, tmp_path: Path) -> None:
+        # An absolute-href record admitted by get_files must fetch through
+        # HttpError, not a raw ValueError, when its sidecar is fetched.
+        package_dir = tmp_path / "foo"
+        package_dir.mkdir()
+        (package_dir / "index.html").write_text(
+            '<a href="https://files.example.com/foo-1.0-py3-none-any.whl"'
+            ' data-core-metadata="true">foo-1.0</a>',
+            encoding="utf-8",
+        )
+        client = LocalIndexClient(tmp_path.as_uri())
+        (record,) = run(client.get_files("foo"))
+        assert isinstance(record, WheelFile)
+        assert record.local_path is None
+        metadata_url = record.metadata_url
+        assert metadata_url == (
+            "https://files.example.com/foo-1.0-py3-none-any.whl.metadata"
+        )
+        with pytest.raises(HttpError):
+            run(client.get_metadata_text("foo", "1.0", metadata_url))
+
+    def test_https_sdist_url_raises_http_error(self, tmp_path: Path) -> None:
+        package_dir = tmp_path / "foo"
+        package_dir.mkdir()
+        (package_dir / "index.html").write_text(
+            '<a href="https://files.example.com/foo-1.0.tar.gz">foo-1.0</a>',
+            encoding="utf-8",
+        )
+        client = LocalIndexClient(tmp_path.as_uri())
+        (record,) = run(client.get_files("foo"))
+        assert isinstance(record, SdistFile)
+        assert record.local_path is None
+        assert record.url == "https://files.example.com/foo-1.0.tar.gz"
+        with pytest.raises(HttpError):
+            run(client.get_sdist_files("foo", "1.0", record.url))
+        with pytest.raises(HttpError):
+            run(client.get_sdist_archive("foo", "1.0", record.url))
+
 
 class TestMakeRecord:
     def test_unrecognised_extension_returns_none(self) -> None:


### PR DESCRIPTION
A PEP 503 index page can link to absolute http(s) artifact URLs even when the index itself is served over file://, and that listing is legal. When a candidate from such a page was selected, fetching its metadata sidecar or sdist passed the http(s) URL to parse_file_url, which raised a bare ValueError and aborted the whole resolve.

The local client now raises NonLocalArtifactError, a subclass of HttpError, for any artifact URL it cannot serve from disk. The fetch fails through the same path as any other index error, so the candidate is rejected and the resolve continues instead of crashing.
