### PR TITLE
re-check the completion marker before wiping a VCS clone dir

### DIFF
--- a/nab-index/src/nab_index/vcs.py
+++ b/nab-index/src/nab_index/vcs.py
@@ -183,8 +183,9 @@ def prepare_clone(
         )
 
     dest.parent.mkdir(parents=True, exist_ok=True)
-    if dest.exists():
-        # Unmarked tree from an interrupted run: wipe and retry.
+    if dest.exists() and not _clone_complete(dest):
+        # A concurrent run may have completed dest since the top check;
+        # only wipe a partial.
         shutil.rmtree(dest)
 
     tmp = Path(tempfile.mkdtemp(dir=dest.parent, prefix=f"{sha}.", suffix=".tmp"))

--- a/nab-python/tests/test_vcs.py
+++ b/nab-python/tests/test_vcs.py
@@ -17,6 +17,7 @@ from nab_index.vcs import (
     _COMPLETE_MARKER,
     VcsCloneError,
     VcsRequest,
+    _clone_complete,
     _resolve_sha,
     _split_repo_ref,
     prepare_clone,
@@ -554,6 +555,47 @@ class TestPrepareClone:
         with pytest.raises(VcsCloneError, match="could not be moved into place"):
             prepare_clone(tmp_path, req, require_pin=True)
         assert [p for p in dest.parent.iterdir() if p != dest] == []
+
+    def test_clone_completing_after_top_check_is_not_wiped(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A clone completed by another run after the top check is reused, not wiped.
+
+        In the window between the top completion check and the pre-clone wipe, a
+        concurrent run renames its finished clone into place. The wipe re-checks
+        the marker so the completed tree survives.
+        """
+        sha = "b" * 40
+        repo_key = "0123456789abcdef"
+        dest = tmp_path / "vcs" / repo_key / sha
+        _mark_complete(dest)
+        payload = dest / "content.txt"
+        payload.write_text("kept")
+        monkeypatch.setattr("nab_index.vcs._repo_key", lambda _url: repo_key)
+
+        checks = {"count": 0}
+
+        def racy_clone_complete(target: Path) -> bool:
+            checks["count"] += 1
+            if checks["count"] == 1:
+                return False
+            return _clone_complete(target)
+
+        monkeypatch.setattr("nab_index.vcs._clone_complete", racy_clone_complete)
+
+        def fake_run(cmd: list[str], **kwargs: object) -> object:
+            cwd = Path(str(kwargs["cwd"]))
+            if cmd[:2] == ["git", "init"]:
+                (cwd / ".git").mkdir(exist_ok=True)
+            return type("P", (), {"returncode": 0})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        req = VcsRequest("git", "https://example/repo.git", sha, "")
+        clone = prepare_clone(tmp_path, req, require_pin=True)
+        assert clone.path == dest
+        assert payload.read_text() == "kept"
 
 
 class TestProviderVcsIntegration:


### PR DESCRIPTION
prepare_clone checks the completion marker at the top and returns the existing clone when it is already there. When it is not, it wipes any leftover dest before starting its own clone. That wipe only tested whether dest existed, so if another run finished the same commit and renamed its marked clone into place in the window between the top check and the wipe, prepare_clone deleted it along with any genuine partial.

Re-check the marker at the wipe point so only an unmarked partial tree is removed. A clone another run completed survives and is reused.
