### PR TITLE
report the blocking dependency when a constraint clips all versions

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -1289,6 +1289,13 @@ class Provider:
         their pre-probe values.  A failed-resolve attribution probe therefore
         cannot alter a later decision.
 
+        The one exception is ``package``'s own no-versions reason.  When the
+        un-narrowed range yields no version because a transitive conflict
+        rejected every candidate, this probe is the only pass that names the
+        blocker, so its reason is kept rather than rolled back to the generic
+        no-match the constraint-narrowed pass recorded.  The reason map only
+        labels a ``NO_VERSIONS`` clause, so keeping it cannot alter a decision.
+
         The probe also suppresses both look-ahead shortcuts, which could
         otherwise report a version the decided blocker rejects: it hides the
         abort markers (so neither a fresh abort nor a recorded skip fires) and
@@ -1327,7 +1334,12 @@ class Provider:
             self.consume_force_backtrack_targets()
             self._lookahead_aborted = saved_aborted
             self._force_backtrack_counts = saved_counts
+
+            # Restore the snapshot but keep the probe's own blocker reason.
+            probed_reason = self._no_versions_reasons.get(package)
             self._no_versions_reasons = saved_reasons
+            if probed_reason is not None:
+                self._no_versions_reasons[package] = probed_reason
 
     def _try_abort_skip(self, normalized: str, first: Version) -> Version | None:
         """Return the first candidate when a prior abort is still valid.

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -2824,6 +2824,53 @@ class TestAugmentResolutionError:
         assert "bar" in diagnostics
         assert "foo: no version matches the requirement" not in diagnostics
 
+    def test_constraint_does_not_hide_the_transitive_blocker(
+        self, tmp_path: Path
+    ) -> None:
+        """A user constraint keeps the blocker reason, not a bare no-match.
+
+        ``foo<2.0`` clips away foo's only versions, which each need
+        ``lib==5.0`` and so conflict with ``app``'s ``lib==9.0``.  The
+        constraint-attribution probe recomputes the blocker reason, so it
+        must survive: the failure names the ``lib`` conflict rather than
+        reporting "no version matches the requirement", which would point
+        the user at a missing release that does not exist.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\ndependencies = ["foo", "app"]\n'
+            '[tool.nab]\nconstraints = ["foo<2.0"]\n',
+            encoding="utf-8",
+        )
+
+        coordinator = make_coordinator(
+            listings={
+                "foo": _index_wheels("foo", "3.0", "4.0"),
+                "app": _index_wheels("app", "1.0"),
+                "lib": _index_wheels("lib", "5.0", "9.0"),
+            },
+            metadata_by_version={
+                "3.0": _metadata("foo", "3.0", "lib==5.0"),
+                "4.0": _metadata("foo", "4.0", "lib==5.0"),
+                "1.0": _metadata("app", "1.0", "lib==9.0"),
+                "5.0": _metadata("lib", "5.0"),
+                "9.0": _metadata("lib", "9.0"),
+            },
+        )
+
+        with patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda _self: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            with pytest.raises(ResolutionError) as info:
+                _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
+
+        diagnostics = str(info.value).split("Diagnostics:")[1]
+        assert (
+            "foo: every version in range was rejected: requires lib != 9.0"
+            in diagnostics
+        )
+        assert "foo: no version matches the requirement" not in diagnostics
+
 
 def _tuple_for_python(python_version: str) -> ResolveTarget:
     """Build a linux_x86_64 target for ``python_version``.


### PR DESCRIPTION
When a user constraint clips away every version of a package, and those clipped versions would each have failed on a transitive conflict anyway, the failure reported "foo: no version matches the requirement" instead of naming the dependency that actually blocked it. That points the user at a missing release when the real problem is the conflict.

The constraint-attribution probe runs choose_version over the un-narrowed range, so it is the only pass that reaches those versions and computes the real blocker reason. But has_satisfying_version rolled the whole no-versions reason map back in its finally, throwing that reason away, so the diagnostic fell back to the generic no-match line the narrowed pass had recorded.

Keep the probed package's own reason across the rollback. Everything else in the snapshot is still restored, and the reason only labels a NO_VERSIONS clause, so keeping it cannot change a decision.
