### PR TITLE
stop a build-dep download failure from crashing the whole resolve

### DIFF
--- a/nab-python/src/nab_python/_build/env.py
+++ b/nab-python/src/nab_python/_build/env.py
@@ -39,7 +39,7 @@ from nab_index.urllib3_async_transport import Urllib3AsyncTransport
 
 from .._vcs_admission import UnsupportedVcsError
 from ..config import NabProjectConfig
-from ..download import download_lock
+from ..download import DownloadError, download_lock
 from ..requirements_file import InvalidProjectRequirementError
 
 if TYPE_CHECKING:
@@ -348,7 +348,15 @@ class NabBuildEnv:
             )
             raise BuildEnvError(msg)
 
-        download_result = download_lock(lock_input, transport, wheel_dir)
+        try:
+            download_result = download_lock(lock_input, transport, wheel_dir)
+        except DownloadError as exc:
+            # A build dependency failed its HTTP fetch or hash check. Wrap it so
+            # the outer resolve skips this sdist rather than aborting on the raw
+            # download error.
+            msg = f"build env download failed: {exc}"
+            raise BuildEnvError(msg) from exc
+
         # Both wheels and sdists are downloaded; only wheels feed
         # ``installer.install``.  The sdists are inert clutter under
         # the temp dir, cleaned up with the env.

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -37,7 +37,7 @@ from nab_python._build.env import (
 )
 from nab_python._build.runner import BuildBackendError, run_build_backend
 from nab_python.config import NabProjectConfig
-from nab_python.download import DownloadResult
+from nab_python.download import DownloadError, DownloadResult
 from nab_python.lockfile import LockInput
 from nab_resolver.resolver import ResolutionError
 
@@ -1039,6 +1039,47 @@ class TestResolveAndDownload:
         wheel_dir = tmp_path / "wheels"
         wheel_dir.mkdir()
         with pytest.raises(BuildEnvError, match="build env resolve"):
+            env._resolve_and_download(wheel_dir)
+
+    def test_download_error_wrapped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A DownloadError fetching a build-dep wheel is wrapped as
+        BuildEnvError, so the outer resolve skips the unbuildable sdist
+        instead of aborting on the raw DownloadError.
+        """
+        from nab_python.lockfile import TargetLock
+        from nab_python.resolve import ResolveResult, TargetResult
+        from nab_python.target import ResolveTarget
+
+        env = NabBuildEnv(requires=["foo"], config=NabProjectConfig())
+        env._tmpdir = MagicMock()  # type: ignore[attr-defined]
+        env._venv_path = tmp_path / "venv"  # type: ignore[attr-defined]
+        env._python_executable = tmp_path / "venv" / "bin" / "python"  # type: ignore[attr-defined]
+        target = ResolveTarget.for_host()
+        fake_result = ResolveResult(
+            targets=(target,),
+            target_results=[
+                TargetResult(
+                    target=target,
+                    success=True,
+                    pins={},
+                    lock=TargetLock(target=target, pins={}),
+                )
+            ],
+        )
+        monkeypatch.setattr(
+            "nab_python.resolve.resolve_for_targets", lambda *_a, **_k: fake_result
+        )
+
+        def _boom(*_a: object, **_k: object) -> DownloadResult:
+            msg = "foo==1.0: failed to fetch foo-1.0-py3-none-any.whl: GET x 404"
+            raise DownloadError(msg)
+
+        monkeypatch.setattr("nab_python._build.env.download_lock", _boom)
+        wheel_dir = tmp_path / "wheels"
+        wheel_dir.mkdir()
+        with pytest.raises(BuildEnvError, match="build env download"):
             env._resolve_and_download(wheel_dir)
 
 


### PR DESCRIPTION
When nab sets up the build environment for a local, VCS, or archive source and one of that source's build dependencies fails to download (a 404, a dropped connection, or a hash mismatch), the raw DownloadError propagated out and aborted the entire resolve with an uncaught traceback.

The other failures in the same build-env setup path, an unresolvable build requirement or an unsupported VCS pin, are already wrapped as BuildEnvError, which the outer resolve treats as an unbuildable sdist and skips. The download step slipped through. This wraps DownloadError the same way, so a build dependency that cannot be fetched drops the sdist candidate instead of killing the run.
