### PR TITLE
docs: document dependency-groups and per-package lockfile keys

### DIFF
--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -82,9 +82,13 @@ size = 286433
 ### Supported keys
 
 * The top-level keys (`lock-version`, `created-by`,
-  `requires-python`, `environments`, `extras`, `packages`).
-* The `[[packages]]` shape: `name`, `version`, optional `index`,
-  `sdist`, and `wheels`.
+  `requires-python`, `environments`, `extras`,
+  `dependency-groups`, `default-groups`, `packages`), plus a
+  `[tool.nab]` table of informational provenance.
+* The `[[packages]]` shape: `name`, `version`, and optional
+  `marker`, `requires-python`, `dependencies`, one source key
+  (`index`, `directory`, `vcs`, or `archive`), and for an index
+  source `sdist` and `wheels`.
 * `sha256`, `sha384`, and `sha512` digests on every recorded
   artefact. Whatever the index publishes is forwarded; nab
   requires at least one of the three so the lockfile is

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import sys
 from collections.abc import Callable, Mapping, Sequence
 from contextlib import AbstractContextManager
@@ -1732,6 +1733,59 @@ class TestDependencyGroups:
         data = tomllib.loads(text)
         assert data["dependency-groups"] == ["dev-group", "doc-s"]
         assert data["default-groups"] == ["dev-group"]
+
+
+class TestSupportedKeysDocumented:
+    """The lockfile reference lists every key the pylock emitter writes."""
+
+    def _documented_keys(self) -> set[str]:
+        doc = Path(__file__).resolve().parents[2] / "docs" / "reference" / "lockfile.md"
+        text = doc.read_text(encoding="utf-8")
+        start = text.index("### Supported keys")
+        end = text.index("\n### ", start + 1)
+        section = text[start:end]
+        return set(re.findall(r"`([a-z][a-z0-9]*(?:-[a-z0-9]+)*)`", section))
+
+    def test_every_emitted_key_is_documented(self) -> None:
+        target_lock = TargetLock(
+            target=_HOST,
+            pins={
+                "foo": _index_pin("foo", "1.0"),
+                "mytool": _index_pin("mytool", "2.0"),
+                "mylocal": LocalPin(name="mylocal", version="3.0", path="libs/mylocal"),
+                "myvcs": VcsPin(
+                    name="myvcs",
+                    version="4.0",
+                    repo_url="https://github.com/x/y.git",
+                    bare_repo_url="https://github.com/x/y.git",
+                    commit_id="a" * 40,
+                ),
+                "myarchive": ArchivePin(
+                    name="myarchive",
+                    version="5.0",
+                    url="https://ex.com/myarchive-5.0.tar.gz",
+                    hashes=(("sha256", "e" * 64),),
+                ),
+            },
+            dependencies={"mytool": ("foo",)},
+            package_gates={"mytool": (("extra", "cli"),)},
+        )
+        lock_input = LockInput(
+            targets={_HOST.label: target_lock},
+            extras=("cli",),
+            dependency_groups=("dev",),
+            default_groups=("dev",),
+            requires_python=">=3.10",
+            environments=[Marker(_HOST.environment_marker_string)],
+        )
+
+        data = tomllib.loads(write_lock(lock_input))
+        emitted = set(data)
+        for package in data["packages"]:
+            emitted |= set(package)
+
+        undocumented = emitted - self._documented_keys()
+        assert not undocumented, f"undocumented emitted keys: {sorted(undocumented)}"
 
 
 class TestMarkerDisjointness:


### PR DESCRIPTION
The "Supported keys" list in the lockfile reference didn't match what the pylock emitter actually writes. It was missing the top-level `dependency-groups`, `default-groups`, and the `[tool.nab]` provenance table, and the per-package `marker`, `requires-python`, `dependencies`, and the non-index source keys (`directory`, `vcs`, `archive`).

This fills those in so the list covers everything nab emits, and adds a test that writes a lock exercising each source type and fails if the emitter ever produces a key the reference doesn't list.
