### PR TITLE
Recover wheel metadata via HTTP range read

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -458,7 +458,9 @@ considers and which end up in the lockfile.  The default
 
 `wheel-only` is the equivalent of pip's `--only-binary :all:` and
 `sdist-only` of `--no-binary :all:`, scoped per package or per index
-via an override.
+via an override.  A wheel that ships no PEP 658 sidecar still resolves
+under any wheel-admitting policy: its METADATA is recovered by an HTTP
+range read of the remote wheel rather than the version being skipped.
 
 `sdist-install` is the policy to reach for when an installer needs
 to build the package from source (typically to link against
@@ -469,7 +471,8 @@ lockfile pins only the sdist so `pip install --require-hashes`
 materialises that archive; the resolver, meanwhile, reads
 dependency metadata from whichever source is cheapest at the
 chosen version.  In practice that means the wheel's METADATA via
-PEP 658 when one is published, falling back to the sdist's
+PEP 658 when one is published, or an HTTP range read of the remote
+wheel when no sidecar is published, falling back to the sdist's
 PKG-INFO (with the usual PEP 643 and `pyproject.toml` fallbacks)
 when no wheel exists.  Equivalent in spirit to pip's
 `--no-binary <pkg>` for the install side, without paying the

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -461,6 +461,9 @@ considers and which end up in the lockfile.  The default
 via an override.  A wheel that ships no PEP 658 sidecar still resolves
 under any wheel-admitting policy: its METADATA is recovered by an HTTP
 range read of the remote wheel rather than the version being skipped.
+An index that cannot serve usable ranges has the whole wheel fetched
+instead, so recovery still works there at the cost of a full download
+per sidecar-less wheel the resolver visits.
 
 `sdist-install` is the policy to reach for when an installer needs
 to build the package from source (typically to link against

--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -32,7 +32,8 @@ Each pinned package carries:
 The digests are the ones the index published, so nothing is hashed
 locally to build a lock. A resolve does fetch, but only to read
 metadata, and it takes the cheapest source available: a wheel's
-[PEP 658] metadata sidecar when the index publishes one, otherwise
+[PEP 658] metadata sidecar when the index publishes one, then an HTTP
+range read of the remote wheel when no sidecar is published, otherwise
 the sdist's PKG-INFO (built, if its dependencies are dynamic and the
 [build policy](build-policy.md) allows it). A wheel served from a
 local directory is read straight off disk, with no fetch. VCS and

--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -27,8 +27,15 @@ from .client import (
     _verify_metadata_hash,
     _verify_sdist_hash,
 )
+from .lazy_wheel import (
+    RangeCapabilityMemo,
+    RangeMetadataResult,
+    RangeOutcome,
+    read_wheel_metadata_over_range,
+)
 
 if TYPE_CHECKING:
+    from packaging.utils import NormalizedName
     from typing_extensions import Self
 
     from .transport import AsyncHttpTransport, HttpResponse
@@ -83,12 +90,22 @@ class CachedAsyncSimpleClient:
         index_url: str = DEFAULT_INDEX,
         *,
         offline: bool = False,
+        range_memo: RangeCapabilityMemo | None = None,
     ) -> None:
-        """Create a cached client wrapping ``transport``."""
+        """Create a cached client wrapping ``transport``.
+
+        ``range_memo`` is the per-run range-capability memo shared across the
+        indexes' clients; the coordinator owns the shared instance and injects
+        it. A fresh memo is built when none is passed, so a stand-alone client
+        still learns each host's range behaviour within its own lifetime.
+        """
         self._transport = transport
         self._cache = cache
         self._index_url = index_url.rstrip("/") + "/"
         self._offline = offline
+        self._range_memo = (
+            range_memo if range_memo is not None else RangeCapabilityMemo()
+        )
 
     async def aclose(self) -> None:
         """Close the underlying transport."""
@@ -251,6 +268,39 @@ class CachedAsyncSimpleClient:
             raise MalformedSimpleResponseError(msg) from exc
         self._cache.put_metadata(package, metadata_url, text)
         return text
+
+    async def get_range_metadata(
+        self,
+        package: str,
+        version: str,
+        wheel_url: str,
+        canonical_name: NormalizedName,
+    ) -> RangeMetadataResult:
+        """Recover a sidecar-less wheel's METADATA by HTTP range reads.
+
+        The recovered text is cached under the same immutable ``metadata-v1``
+        store the PEP 658 sidecar uses, keyed by the wheel URL. A cache hit is
+        returned without any transport call, so a warm or previously-warmed
+        offline resolve never re-ranges. A cold miss in offline mode raises
+        :class:`OfflineError`; otherwise the reader drives the transport with
+        the shared range-capability memo. Only a successful read is cached; an
+        ``UNSUPPORTED`` or ``MISSING`` result writes nothing so the caller can
+        step to the sdist rung.
+        """
+        cached = self._cache.get_metadata(package, wheel_url)
+        if cached is not None:
+            return RangeMetadataResult(cached, RangeOutcome.PARTIAL)
+
+        if self._offline:
+            msg = f"No cached range metadata for {package}=={version} (offline mode)"
+            raise OfflineError(msg)
+
+        result = await read_wheel_metadata_over_range(
+            self._transport, wheel_url, canonical_name, self._range_memo
+        )
+        if result.text is not None:
+            self._cache.put_metadata(package, wheel_url, result.text)
+        return result
 
     async def get_sdist_files(
         self,

--- a/nab-index/src/nab_index/lazy_wheel.py
+++ b/nab-index/src/nab_index/lazy_wheel.py
@@ -7,10 +7,13 @@ capability once per run through a shared :class:`RangeCapabilityMemo`, and
 navigates the ZIP with the standard library's :class:`zipfile.ZipFile` over a
 sparse buffer so no EOCD scan, deflate, or CRC logic is hand-rolled.
 
-The one exception raised outward is
-:class:`~nab_index.client.MalformedSimpleResponseError`, and only for METADATA
-bytes that are not valid UTF-8. Every other failure to obtain metadata returns
-a result whose ``text`` is ``None``.
+Two kinds of exception travel outward: a
+:class:`~nab_index.client.MalformedSimpleResponseError` for METADATA bytes
+that are not valid UTF-8, and the transport's error when the wheel URL itself
+cannot be served (a 404 on the file, a failing plain GET).  A server that
+merely refuses the Range mechanism is stepped down instead, from a suffix
+range to absolute ranges to a plain full-body GET.  Every other failure to
+obtain metadata returns a result whose ``text`` is ``None``.
 """
 
 from __future__ import annotations
@@ -22,7 +25,6 @@ import io
 import os
 import re
 import zipfile
-import zlib
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
@@ -51,8 +53,12 @@ _MAX_TAIL = 1024 * 1024
 
 _HTTP_OK = 200
 _HTTP_PARTIAL = 206
-# The suffix form is unusable on these; downgrade to absolute ranges.
-_SUFFIX_REJECT_STATUSES = frozenset({400, 416, 501})
+_HTTP_RANGE_NOT_SATISFIABLE = 416
+# Statuses a server uses to refuse the Range mechanism itself (416 for an
+# unsatisfiable range, 501 for an unimplemented one, 400 from strict parsers,
+# 403 from request filters).  None of them proves the file is unserveable, so
+# a refusal steps down to the next request shape rather than failing the read.
+_RANGE_REJECT_STATUSES = frozenset({400, 403, _HTTP_RANGE_NOT_SATISFIABLE, 501})
 
 _CONTENT_RANGE_RE = re.compile(r"bytes\s+(\d+)-(\d+)/(\d+)")
 
@@ -75,7 +81,17 @@ class RangeMetadataResult:
 
 
 class RangeCapability(enum.Enum):
-    """A netloc's learned range behaviour, monotonic toward more restrictive."""
+    """The request shape to lead with on a netloc, monotonic toward more restrictive.
+
+    ``SUFFIX_OK`` is optimistic: a host that volunteers a 200 full body for a
+    suffix range stays ``SUFFIX_OK``, since leading with the suffix form again
+    costs the same single request while a proxy that only ignores ranges while
+    filling its cache gets to serve cheap partial reads again.
+    ``FULL_BODY_ONLY`` is for hosts that refused or ignored ranges once the
+    suffix form was already unusable; their wheels are fetched whole.  A 416
+    never latches it: an unsatisfiable range speaks for the one file, not the
+    netloc.
+    """
 
     UNKNOWN = "unknown"
     SUFFIX_OK = "suffix-ok"
@@ -91,6 +107,10 @@ class RangeCapabilityMemo:
     needs no lock. Discovery of an ``UNKNOWN`` host is kept to one probe
     under a burst by an :class:`asyncio.Event` per netloc: the first task
     probes while later tasks await the event, then read the settled state.
+    The owner releases the probe as soon as the capability settles, so
+    waiters overlap with its remaining growth and member reads.  An owner
+    whose acquisition fails settles nothing; its released waiters then probe
+    for themselves.
     """
 
     def __init__(self) -> None:
@@ -235,6 +255,18 @@ _UNSUPPORTED_NONE: tuple[RangeCapability, _AcqKind, object] = (
 )
 
 
+class _RangeRefusedError(Exception):
+    """A growth or member range was refused after the tail had been honoured."""
+
+    def __init__(self, status: int) -> None:
+        super().__init__(f"range refused with HTTP {status}")
+        self.status = status
+
+
+class _UnreadableWheelError(Exception):
+    """The zip machinery cannot read the fetched bytes as an archive at all."""
+
+
 def _non_identity(response: HttpResponse) -> bool:
     """Return whether the response carries a non-identity Content-Encoding."""
     encoding = response.headers.get("content-encoding")
@@ -263,7 +295,12 @@ async def _range_get(
 async def _suffix_attempt(
     transport: AsyncHttpTransport, url: str, tail_size: int
 ) -> _SuffixOutcome:
-    """Try a suffix range, classifying the server's answer."""
+    """Try a suffix range, classifying the server's answer.
+
+    A 206 whose Content-Range is absent, unparseable, or of unknown length
+    (``bytes a-b/*``) gives no offset to anchor the returned bytes, so it
+    steps down to absolute ranges rather than guessing what the body is.
+    """
     response = await _range_get(transport, url, f"bytes=-{tail_size}")
     status = response.status_code
     if status == _HTTP_OK and not _non_identity(response):
@@ -272,12 +309,12 @@ async def _suffix_attempt(
         body = response.content
         parsed = _parse_content_range(response.headers.get("content-range"))
         if parsed is None:
-            return _SuffixOutcome("full", body=body)
+            return _SuffixOutcome("downgrade")
         start, end, total = parsed
         if end == total - 1 and end - start + 1 == len(body):
             return _SuffixOutcome("suffix", total=total, low=start, body=body)
         return _SuffixOutcome("downgrade")
-    if status not in _SUFFIX_REJECT_STATUSES and status not in (
+    if status not in _RANGE_REJECT_STATUSES and status not in (
         _HTTP_OK,
         _HTTP_PARTIAL,
     ):
@@ -288,17 +325,26 @@ async def _suffix_attempt(
 async def _absolute_attempt(
     transport: AsyncHttpTransport, url: str, tail_size: int
 ) -> tuple[RangeCapability, _AcqKind, object]:
-    """Learn the length with ``bytes=0-0``, then read the tail absolutely."""
+    """Learn the length with ``bytes=0-0``, then read the tail absolutely.
+
+    A refused probe steps down to the plain GET: the refusal is aimed at the
+    Range header, not the file, so only the plain GET's answer is
+    authoritative for whether the wheel can be served at all.
+    """
     probe = await _range_get(transport, url, "bytes=0-0")
+    if probe.status_code in _RANGE_REJECT_STATUSES:
+        return await _fallback_full_body(transport, url, probe.status_code)
     if _non_identity(probe):
         return _UNSUPPORTED_NONE
     if probe.status_code == _HTTP_OK:
         return (RangeCapability.FULL_BODY_ONLY, _AcqKind.FULL_BODY, probe.content)
     if probe.status_code != _HTTP_PARTIAL:
         probe.raise_for_status()
-        return _UNSUPPORTED_NONE  # pragma: no cover
+        return _UNSUPPORTED_NONE
     parsed = _parse_content_range(probe.headers.get("content-range"))
-    if parsed is None:
+    if parsed is None or parsed[2] == 0:
+        # A zero total has no tail to ask for, and would put the malformed
+        # range "bytes=0--1" on the wire.
         return _UNSUPPORTED_NONE
     return await _absolute_tail(transport, url, parsed[2], tail_size)
 
@@ -306,38 +352,60 @@ async def _absolute_attempt(
 async def _absolute_tail(
     transport: AsyncHttpTransport, url: str, total: int, tail_size: int
 ) -> tuple[RangeCapability, _AcqKind, object]:
-    """Read the tail window with an absolute range once the length is known."""
+    """Read the tail window with an absolute range once the length is known.
+
+    A tail refused after an honoured probe still steps down to the plain GET,
+    since a shrunk file or a flaky proxy can 416 a range the probe implied.
+    """
     low = max(0, total - tail_size)
     tail = await _range_get(transport, url, f"bytes={low}-{total - 1}")
+    if tail.status_code in _RANGE_REJECT_STATUSES:
+        return await _fallback_full_body(transport, url, tail.status_code)
     if _non_identity(tail):
         return _UNSUPPORTED_NONE
     if tail.status_code == _HTTP_OK:
         return (RangeCapability.FULL_BODY_ONLY, _AcqKind.FULL_BODY, tail.content)
     if tail.status_code != _HTTP_PARTIAL:
         tail.raise_for_status()
-        return _UNSUPPORTED_NONE  # pragma: no cover
+        return _UNSUPPORTED_NONE
     sparse = _SparseFile(total)
     sparse.add_span(low, tail.content)
     return (RangeCapability.ABSOLUTE_ONLY, _AcqKind.SPARSE, (sparse, low))
 
 
-async def _full_body_fetch(
-    transport: AsyncHttpTransport, url: str
-) -> tuple[RangeCapability, _AcqKind, object]:
-    """Fetch the whole wheel from a host known to ignore ranges.
+async def _full_body_fetch(transport: AsyncHttpTransport, url: str) -> bytes | None:
+    """Fetch the whole wheel with a plain GET, leaving the Range mechanism out.
 
-    A range-ignoring host answered an earlier probe with the full body, so it
-    is memoed ``FULL_BODY_ONLY``.  Later wheels on that host skip the wasted
-    range probe and fetch the body directly with a plain GET, so every
-    sidecar-less wheel there recovers its METADATA rather than only the first.
-    A 4xx/5xx (the file went missing) raises through and drops the candidate; a
-    non-identity encoding yields no usable bytes.
+    Reached for a netloc memoed ``FULL_BODY_ONLY`` and as the last step down
+    after a refused range: the file may still be served without the Range
+    header, and this GET is the authoritative check.  A 4xx/5xx here raises
+    through and fails the resolve, since the listing advertised a file the
+    index cannot serve; a non-identity encoding returns ``None``, no usable
+    bytes.
     """
     response = await transport.get(url, headers={"Accept-Encoding": "identity"})
     if response.status_code == _HTTP_OK and not _non_identity(response):
-        return (RangeCapability.FULL_BODY_ONLY, _AcqKind.FULL_BODY, response.content)
+        return response.content
     response.raise_for_status()
-    return _UNSUPPORTED_NONE
+    return None
+
+
+async def _fallback_full_body(
+    transport: AsyncHttpTransport, url: str, status: int
+) -> tuple[RangeCapability, _AcqKind, object]:
+    """Step a refused range down to the plain GET, choosing what it teaches.
+
+    A refusal aimed at the Range mechanism latches the netloc
+    ``FULL_BODY_ONLY``, so later wheels on the host skip the refused probes.
+    A 416 speaks for the one file (empty, or shrunk since the listing), so it
+    teaches the memo nothing and later wheels probe ranges again.
+    """
+    body = await _full_body_fetch(transport, url)
+    if body is None:
+        return _UNSUPPORTED_NONE
+    if status == _HTTP_RANGE_NOT_SATISFIABLE:
+        return (RangeCapability.UNKNOWN, _AcqKind.FULL_BODY, body)
+    return (RangeCapability.FULL_BODY_ONLY, _AcqKind.FULL_BODY, body)
 
 
 async def _acquire(
@@ -350,7 +418,10 @@ async def _acquire(
     if capability is RangeCapability.UNSUPPORTED:
         return _UNSUPPORTED_NONE
     if capability is RangeCapability.FULL_BODY_ONLY:
-        return await _full_body_fetch(transport, url)
+        body = await _full_body_fetch(transport, url)
+        if body is None:
+            return _UNSUPPORTED_NONE
+        return (RangeCapability.FULL_BODY_ONLY, _AcqKind.FULL_BODY, body)
     if capability in (RangeCapability.UNKNOWN, RangeCapability.SUFFIX_OK):
         suffix = await _suffix_attempt(transport, url, tail_size)
         if suffix.kind == "suffix":
@@ -358,7 +429,8 @@ async def _acquire(
             sparse.add_span(suffix.low, suffix.body)
             return (RangeCapability.SUFFIX_OK, _AcqKind.SPARSE, (sparse, suffix.low))
         if suffix.kind == "full":
-            return (RangeCapability.FULL_BODY_ONLY, _AcqKind.FULL_BODY, suffix.body)
+            # Not latched to FULL_BODY_ONLY: see RangeCapability.
+            return (RangeCapability.SUFFIX_OK, _AcqKind.FULL_BODY, suffix.body)
     return await _absolute_attempt(transport, url, tail_size)
 
 
@@ -368,14 +440,18 @@ def _absorb_range(
     """Absorb a growth or member range response into ``sparse``.
 
     Returns the low offset at which bytes were populated, or ``None`` when the
-    response yielded no usable bytes.  A volunteered 200 full body populates the
-    whole file from offset 0 and is used rather than discarded.  A 4xx/5xx on
-    the wheel URL raises through so the candidate drops, matching the first
-    round trip; a non-identity encoding yields no usable bytes.
+    response yielded no usable bytes.  A volunteered 200 full body populates
+    the whole file from offset 0 and is used rather than discarded.  A range
+    refused mid-read raises :class:`_RangeRefusedError` so the reader can step
+    down to the plain GET.  Any other 4xx/5xx on the wheel URL raises through
+    and fails the resolve, matching the first round trip; a non-identity
+    encoding yields no usable bytes.
     """
     if response.status_code == _HTTP_OK and not _non_identity(response):
         sparse.add_span(0, response.content)
         return 0
+    if response.status_code in _RANGE_REJECT_STATUSES:
+        raise _RangeRefusedError(response.status_code)
     if response.status_code != _HTTP_PARTIAL or _non_identity(response):
         response.raise_for_status()
         return None
@@ -384,11 +460,20 @@ def _absorb_range(
 
 
 def _try_open(sparse: _SparseFile) -> zipfile.ZipFile | None:
-    """Open a ZipFile over the current spans, or ``None`` if more bytes are needed."""
+    """Open a ZipFile over the current spans, or ``None`` if more bytes are needed.
+
+    A window with a gap always reads as a truncated directory, which is
+    :class:`zipfile.BadZipFile`, the grow signal.  Anything else the zip
+    machinery raises comes from the archive's own bytes (an undecodable
+    member name, offsets outside the file), so it marks the wheel unreadable
+    rather than the window short.
+    """
     try:
         return zipfile.ZipFile(sparse)
     except zipfile.BadZipFile:
         return None
+    except Exception as exc:
+        raise _UnreadableWheelError from exc
 
 
 async def _open_zip(
@@ -435,15 +520,22 @@ async def _read_sparse(
     tail_low: int,
     canonical_name: NormalizedName,
 ) -> bytes | None:
-    """Read the METADATA member out of the sparse buffer, or ``None``."""
-    zip_file = await _open_zip(transport, url, sparse, tail_low)
-    if zip_file is None:
-        return None
+    """Read the METADATA member out of the sparse buffer, or ``None``.
+
+    Only :class:`_RangeRefusedError` and the transport's errors travel out of
+    the growth and member requests; every way the zip machinery can choke on
+    the fetched bytes reads back as ``None``.
+    """
     try:
-        member = wheel_metadata_member(zip_file.namelist(), canonical_name)
-    except UnsupportedWheelError:
+        zip_file = await _open_zip(transport, url, sparse, tail_low)
+        member = (
+            None
+            if zip_file is None
+            else wheel_metadata_member(zip_file.namelist(), canonical_name)
+        )
+    except (_UnreadableWheelError, UnsupportedWheelError):
         return None
-    if member is None:
+    if zip_file is None or member is None:
         return None
     start, end = _member_span(zip_file, member)
     if not sparse.populated(start, end):
@@ -452,7 +544,10 @@ async def _read_sparse(
             return None
     try:
         return zip_file.read(member)
-    except (zipfile.BadZipFile, zlib.error, OSError):
+    except Exception:  # noqa: BLE001 - untrusted archive bytes
+        # Encrypted members, unknown compression methods, and corrupt streams
+        # surface as several exception types; all mean the member is
+        # unrecoverable from this artifact, never that the resolver is broken.
         return None
 
 
@@ -464,7 +559,11 @@ def _read_full_body(body: bytes, canonical_name: NormalizedName) -> bytes | None
         if member is None:
             return None
         return zip_file.read(member)
-    except (zipfile.BadZipFile, zlib.error, OSError, UnsupportedWheelError):
+    except Exception:  # noqa: BLE001 - untrusted archive bytes
+        # The zip machinery raises several exception types over bytes that are
+        # not a readable wheel (including the resolver's own
+        # UnsupportedWheelError); all of them mean this artifact has no
+        # recoverable METADATA.
         return None
 
 
@@ -489,8 +588,9 @@ async def read_wheel_metadata_over_range(
 
     Raises :class:`~nab_index.client.MalformedSimpleResponseError` only when
     the recovered METADATA is not valid UTF-8, and re-raises a transport
-    error for a 4xx/5xx on the wheel URL. Every other failure to obtain
-    metadata returns a result with ``text=None``.
+    error when the wheel URL itself cannot be served (a 404, a failing plain
+    GET).  A refused Range mechanism is stepped down, not raised.  Every
+    other failure to obtain metadata returns a result with ``text=None``.
     """
     netloc = urlsplit(wheel_url).netloc
     owns_probe = False
@@ -501,23 +601,40 @@ async def read_wheel_metadata_over_range(
         new_capability, kind, payload = await _acquire(
             transport, wheel_url, capability, tail_size
         )
-        memo.record(netloc, new_capability)
-        if kind is _AcqKind.NONE:
-            return RangeMetadataResult(None, RangeOutcome.UNSUPPORTED)
-        if kind is _AcqKind.FULL_BODY:
-            assert isinstance(payload, bytes)
-            raw = _read_full_body(payload, canonical_name)
-            outcome = RangeOutcome.FULL_BODY
-        else:
-            assert isinstance(payload, tuple)
-            sparse, tail_low = payload
+        if new_capability is not RangeCapability.UNKNOWN:
+            # A 416-driven fallback returns UNKNOWN: it taught nothing about
+            # the netloc and must not erase a learned capability.
+            memo.record(netloc, new_capability)
+    finally:
+        # Settled (or failed): waiters re-read the memo, so the growth and
+        # member reads below need not keep them parked.
+        if owns_probe:
+            memo.finish_probe(netloc)
+    if kind is _AcqKind.NONE:
+        return RangeMetadataResult(None, RangeOutcome.UNSUPPORTED)
+    if kind is _AcqKind.FULL_BODY:
+        assert isinstance(payload, bytes)
+        raw = _read_full_body(payload, canonical_name)
+        outcome = RangeOutcome.FULL_BODY
+    else:
+        assert isinstance(payload, tuple)
+        sparse, tail_low = payload
+        try:
             raw = await _read_sparse(
                 transport, wheel_url, sparse, tail_low, canonical_name
             )
             outcome = RangeOutcome.PARTIAL
-        if raw is None:
-            return RangeMetadataResult(None, RangeOutcome.MISSING)
-        return RangeMetadataResult(_decode(raw), outcome)
-    finally:
-        if owns_probe:
-            memo.finish_probe(netloc)
+        except _RangeRefusedError as refusal:
+            # A growth or member range refused after an honoured tail: step
+            # down to the plain GET like the acquisition path, teaching the
+            # memo only when the refusal was aimed at the mechanism.
+            body = await _full_body_fetch(transport, wheel_url)
+            if body is None:
+                return RangeMetadataResult(None, RangeOutcome.MISSING)
+            if refusal.status != _HTTP_RANGE_NOT_SATISFIABLE:
+                memo.record(netloc, RangeCapability.FULL_BODY_ONLY)
+            raw = _read_full_body(body, canonical_name)
+            outcome = RangeOutcome.FULL_BODY
+    if raw is None:
+        return RangeMetadataResult(None, RangeOutcome.MISSING)
+    return RangeMetadataResult(_decode(raw), outcome)

--- a/nab-index/src/nab_index/lazy_wheel.py
+++ b/nab-index/src/nab_index/lazy_wheel.py
@@ -1,0 +1,481 @@
+"""HTTP range-request reader for a remote wheel's core metadata.
+
+Recovers a wheel's ``METADATA`` by ranged reads of the remote ZIP when the
+index publishes no PEP 658 sidecar. The reader drives an
+:class:`~nab_index.transport.AsyncHttpTransport`, learns each host's range
+capability once per run through a shared :class:`RangeCapabilityMemo`, and
+navigates the ZIP with the standard library's :class:`zipfile.ZipFile` over a
+sparse buffer so no EOCD scan, deflate, or CRC logic is hand-rolled.
+
+The one exception raised outward is
+:class:`~nab_index.client.MalformedSimpleResponseError`, and only for METADATA
+bytes that are not valid UTF-8. Every other failure to obtain metadata returns
+a result whose ``text`` is ``None``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import bisect
+import enum
+import io
+import os
+import re
+import zipfile
+import zlib
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
+
+from .client import MalformedSimpleResponseError
+from .local_index import UnsupportedWheelError, wheel_metadata_member
+
+if TYPE_CHECKING:
+    from packaging.utils import NormalizedName
+
+    from .transport import AsyncHttpTransport, HttpResponse
+
+__all__ = [
+    "RangeCapability",
+    "RangeCapabilityMemo",
+    "RangeMetadataResult",
+    "RangeOutcome",
+    "read_wheel_metadata_over_range",
+]
+
+# Initial suffix window. pip and poetry read about 10 KiB; the growth loop
+# makes correctness independent of the exact value.
+_DEFAULT_TAIL = 10240
+# Hard ceiling on the window the growth loop will fetch before giving up.
+_MAX_TAIL = 1024 * 1024
+
+_HTTP_OK = 200
+_HTTP_PARTIAL = 206
+# The suffix form is unusable on these; downgrade to absolute ranges.
+_SUFFIX_REJECT_STATUSES = frozenset({400, 416, 501})
+
+_CONTENT_RANGE_RE = re.compile(r"bytes\s+(\d+)-(\d+)/(\d+)")
+
+
+class RangeOutcome(enum.Enum):
+    """How rung 4 obtained (or failed to obtain) a wheel's METADATA."""
+
+    PARTIAL = "partial"
+    FULL_BODY = "full-body"
+    UNSUPPORTED = "unsupported"
+    MISSING = "missing"
+
+
+@dataclass(frozen=True, slots=True)
+class RangeMetadataResult:
+    """The recovered METADATA text and the outcome that produced it."""
+
+    text: str | None
+    outcome: RangeOutcome
+
+
+class RangeCapability(enum.Enum):
+    """A netloc's learned range behaviour, monotonic toward more restrictive."""
+
+    UNKNOWN = "unknown"
+    SUFFIX_OK = "suffix-ok"
+    ABSOLUTE_ONLY = "absolute-only"
+    UNSUPPORTED = "unsupported"
+
+
+class RangeCapabilityMemo:
+    """Per-netloc range capability, single-flight per host within one run.
+
+    Touched only on the fetcher event loop's single thread, so its state
+    needs no lock. Discovery of an ``UNKNOWN`` host is kept to one probe
+    under a burst by an :class:`asyncio.Event` per netloc: the first task
+    probes while later tasks await the event, then read the settled state.
+    """
+
+    def __init__(self) -> None:
+        """Start with every netloc ``UNKNOWN`` and no probe in flight."""
+        self._states: dict[str, RangeCapability] = {}
+        self._inflight: dict[str, asyncio.Event] = {}
+
+    def capability(self, netloc: str) -> RangeCapability:
+        """Return the learned capability for ``netloc``."""
+        return self._states.get(netloc, RangeCapability.UNKNOWN)
+
+    def record(self, netloc: str, capability: RangeCapability) -> None:
+        """Store the capability discovered for ``netloc``."""
+        self._states[netloc] = capability
+
+    async def await_probe(self, netloc: str) -> bool:
+        """Coordinate single-flight discovery for ``netloc``.
+
+        Returns ``True`` when the caller owns the probe and must discover
+        the capability. Returns ``False`` when another task is already
+        probing; the caller awaits it and then re-reads
+        :meth:`capability`.
+        """
+        event = self._inflight.get(netloc)
+        if event is not None:
+            await event.wait()
+            return False
+        self._inflight[netloc] = asyncio.Event()
+        return True
+
+    def finish_probe(self, netloc: str) -> None:
+        """Wake tasks waiting on ``netloc``'s probe and clear it."""
+        self._inflight.pop(netloc).set()
+
+
+class _SparseFile:
+    """A read-only file-like over sparse byte spans of a remote file.
+
+    Implements the subset :class:`zipfile.ZipFile` drives: ``read``,
+    ``seek``, ``tell``, ``seekable``. Populated spans are kept sorted and
+    non-overlapping; a read across an unpopulated gap returns only the bytes
+    up to the gap (zero bytes when the start is unpopulated), which makes
+    ZipFile raise :class:`zipfile.BadZipFile`, the signal to fetch more or
+    give up.
+    """
+
+    def __init__(self, length: int) -> None:
+        """Create a file of ``length`` bytes with no spans populated."""
+        self._length = length
+        self._pos = 0
+        self._starts: list[int] = []
+        self._spans: list[bytes] = []
+
+    def add_span(self, start: int, data: bytes) -> None:
+        """Populate ``[start, start + len(data))`` with ``data``."""
+        if not data:
+            return
+        index = bisect.bisect_left(self._starts, start)
+        if index < len(self._starts) and self._starts[index] == start:
+            return
+        self._starts.insert(index, start)
+        self._spans.insert(index, data)
+
+    def populated(self, start: int, end: int) -> bool:
+        """Return whether ``[start, end)`` is fully populated."""
+        saved = self._pos
+        self._pos = start
+        data = self.read(end - start)
+        self._pos = saved
+        return len(data) == end - start
+
+    def seekable(self) -> bool:
+        """Report the file as seekable."""
+        return True
+
+    def seek(self, offset: int, whence: int = os.SEEK_SET) -> int:
+        """Move the read position and return it."""
+        if whence == os.SEEK_SET:
+            self._pos = offset
+        elif whence == os.SEEK_CUR:
+            self._pos += offset
+        elif whence == os.SEEK_END:
+            self._pos = self._length + offset
+        else:
+            msg = f"unsupported whence: {whence}"
+            raise ValueError(msg)
+        return self._pos
+
+    def tell(self) -> int:
+        """Return the current read position."""
+        return self._pos
+
+    def read(self, size: int = -1) -> bytes:
+        """Return up to ``size`` bytes from the current position.
+
+        Reads across contiguous spans and stops at the first gap, so a
+        short return is the caller's cue that more bytes are needed.
+        """
+        remaining = self._length - self._pos if size is None or size < 0 else size
+        result = bytearray()
+        pos = self._pos
+        while remaining > 0:
+            index = bisect.bisect_right(self._starts, pos) - 1
+            if index < 0:
+                break
+            start = self._starts[index]
+            data = self._spans[index]
+            if pos >= start + len(data):
+                break
+            offset = pos - start
+            take = min(len(data) - offset, remaining)
+            result += data[offset : offset + take]
+            pos += take
+            remaining -= take
+        self._pos = pos
+        return bytes(result)
+
+
+@dataclass(frozen=True, slots=True)
+class _SuffixOutcome:
+    """The result of one suffix-range attempt."""
+
+    kind: str  # "suffix", "full", or "downgrade"
+    total: int = 0
+    low: int = 0
+    body: bytes = b""
+
+
+class _AcqKind(enum.Enum):
+    """Which shape of bytes an acquisition handed back."""
+
+    SPARSE = "sparse"
+    FULL_BODY = "full-body"
+    NONE = "none"
+
+
+# A netloc that cannot serve usable ranges and volunteered no full body.
+_UNSUPPORTED_NONE: tuple[RangeCapability, _AcqKind, object] = (
+    RangeCapability.UNSUPPORTED,
+    _AcqKind.NONE,
+    None,
+)
+
+
+def _non_identity(response: HttpResponse) -> bool:
+    """Return whether the response carries a non-identity Content-Encoding."""
+    encoding = response.headers.get("content-encoding")
+    return encoding is not None and encoding.lower() != "identity"
+
+
+def _parse_content_range(value: str | None) -> tuple[int, int, int] | None:
+    """Parse ``bytes start-end/total`` into a tuple, or ``None``."""
+    if value is None:
+        return None
+    match = _CONTENT_RANGE_RE.match(value.strip())
+    if match is None:
+        return None
+    return (int(match[1]), int(match[2]), int(match[3]))
+
+
+async def _range_get(
+    transport: AsyncHttpTransport, url: str, range_header: str
+) -> HttpResponse:
+    """GET ``url`` for ``range_header`` bytes, forcing identity encoding."""
+    return await transport.get(
+        url, headers={"Accept-Encoding": "identity", "Range": range_header}
+    )
+
+
+async def _suffix_attempt(
+    transport: AsyncHttpTransport, url: str, tail_size: int
+) -> _SuffixOutcome:
+    """Try a suffix range, classifying the server's answer."""
+    response = await _range_get(transport, url, f"bytes=-{tail_size}")
+    status = response.status_code
+    if status == _HTTP_OK and not _non_identity(response):
+        return _SuffixOutcome("full", body=response.content)
+    if status == _HTTP_PARTIAL and not _non_identity(response):
+        body = response.content
+        parsed = _parse_content_range(response.headers.get("content-range"))
+        if parsed is None:
+            return _SuffixOutcome("full", body=body)
+        start, end, total = parsed
+        if end == total - 1 and end - start + 1 == len(body):
+            return _SuffixOutcome("suffix", total=total, low=start, body=body)
+        return _SuffixOutcome("downgrade")
+    if status not in _SUFFIX_REJECT_STATUSES and status not in (
+        _HTTP_OK,
+        _HTTP_PARTIAL,
+    ):
+        response.raise_for_status()
+    return _SuffixOutcome("downgrade")
+
+
+async def _absolute_attempt(
+    transport: AsyncHttpTransport, url: str, tail_size: int
+) -> tuple[RangeCapability, _AcqKind, object]:
+    """Learn the length with ``bytes=0-0``, then read the tail absolutely."""
+    probe = await _range_get(transport, url, "bytes=0-0")
+    if _non_identity(probe):
+        return _UNSUPPORTED_NONE
+    if probe.status_code == _HTTP_OK:
+        return (RangeCapability.UNSUPPORTED, _AcqKind.FULL_BODY, probe.content)
+    if probe.status_code != _HTTP_PARTIAL:
+        probe.raise_for_status()
+        return _UNSUPPORTED_NONE  # pragma: no cover
+    parsed = _parse_content_range(probe.headers.get("content-range"))
+    if parsed is None:
+        return _UNSUPPORTED_NONE
+    return await _absolute_tail(transport, url, parsed[2], tail_size)
+
+
+async def _absolute_tail(
+    transport: AsyncHttpTransport, url: str, total: int, tail_size: int
+) -> tuple[RangeCapability, _AcqKind, object]:
+    """Read the tail window with an absolute range once the length is known."""
+    low = max(0, total - tail_size)
+    tail = await _range_get(transport, url, f"bytes={low}-{total - 1}")
+    if _non_identity(tail):
+        return _UNSUPPORTED_NONE
+    if tail.status_code == _HTTP_OK:
+        return (RangeCapability.UNSUPPORTED, _AcqKind.FULL_BODY, tail.content)
+    if tail.status_code != _HTTP_PARTIAL:
+        tail.raise_for_status()
+        return _UNSUPPORTED_NONE  # pragma: no cover
+    sparse = _SparseFile(total)
+    sparse.add_span(low, tail.content)
+    return (RangeCapability.ABSOLUTE_ONLY, _AcqKind.SPARSE, (sparse, low))
+
+
+async def _acquire(
+    transport: AsyncHttpTransport,
+    url: str,
+    capability: RangeCapability,
+    tail_size: int,
+) -> tuple[RangeCapability, _AcqKind, object]:
+    """Fetch bytes per the netloc's known capability, learning it if unknown."""
+    if capability is RangeCapability.UNSUPPORTED:
+        return _UNSUPPORTED_NONE
+    if capability in (RangeCapability.UNKNOWN, RangeCapability.SUFFIX_OK):
+        suffix = await _suffix_attempt(transport, url, tail_size)
+        if suffix.kind == "suffix":
+            sparse = _SparseFile(suffix.total)
+            sparse.add_span(suffix.low, suffix.body)
+            return (RangeCapability.SUFFIX_OK, _AcqKind.SPARSE, (sparse, suffix.low))
+        if suffix.kind == "full":
+            return (RangeCapability.UNSUPPORTED, _AcqKind.FULL_BODY, suffix.body)
+    return await _absolute_attempt(transport, url, tail_size)
+
+
+def _try_open(sparse: _SparseFile) -> zipfile.ZipFile | None:
+    """Open a ZipFile over the current spans, or ``None`` if more bytes are needed."""
+    try:
+        return zipfile.ZipFile(sparse)
+    except zipfile.BadZipFile:
+        return None
+
+
+async def _open_zip(
+    transport: AsyncHttpTransport, url: str, sparse: _SparseFile, tail_low: int
+) -> zipfile.ZipFile | None:
+    """Open a ZipFile over the sparse buffer, growing the window on demand."""
+    total = sparse._length  # noqa: SLF001
+    while True:
+        opened = _try_open(sparse)
+        if opened is not None:
+            return opened
+        have = total - tail_low
+        if have >= total or have >= _MAX_TAIL:
+            return None
+        new_size = min(have * 2, total, _MAX_TAIL)
+        new_low = total - new_size
+        response = await _range_get(transport, url, f"bytes={new_low}-{tail_low - 1}")
+        if response.status_code != _HTTP_PARTIAL or _non_identity(response):
+            return None
+        sparse.add_span(new_low, response.content)
+        tail_low = new_low
+
+
+def _member_span(zip_file: zipfile.ZipFile, member: str) -> tuple[int, int]:
+    """Return the ``[header_offset, next)`` byte span of ``member``.
+
+    ``next`` is the smallest other entry offset greater than this one, or
+    the central-directory start when this entry is the last by offset. This
+    avoids parsing the local file header, whose extra-field length can
+    differ from the central directory's.
+    """
+    start = zip_file.getinfo(member).header_offset
+    laters = [
+        info.header_offset for info in zip_file.infolist() if info.header_offset > start
+    ]
+    end = min(laters) if laters else zip_file.start_dir
+    return (start, end)
+
+
+async def _read_sparse(
+    transport: AsyncHttpTransport,
+    url: str,
+    sparse: _SparseFile,
+    tail_low: int,
+    canonical_name: NormalizedName,
+) -> bytes | None:
+    """Read the METADATA member out of the sparse buffer, or ``None``."""
+    zip_file = await _open_zip(transport, url, sparse, tail_low)
+    if zip_file is None:
+        return None
+    try:
+        member = wheel_metadata_member(zip_file.namelist(), canonical_name)
+    except UnsupportedWheelError:
+        return None
+    if member is None:
+        return None
+    start, end = _member_span(zip_file, member)
+    if not sparse.populated(start, end):
+        response = await _range_get(transport, url, f"bytes={start}-{end - 1}")
+        if response.status_code != _HTTP_PARTIAL or _non_identity(response):
+            return None
+        sparse.add_span(start, response.content)
+    try:
+        return zip_file.read(member)
+    except (zipfile.BadZipFile, zlib.error, OSError):
+        return None
+
+
+def _read_full_body(body: bytes, canonical_name: NormalizedName) -> bytes | None:
+    """Read the METADATA member out of a complete in-memory wheel, or ``None``."""
+    try:
+        zip_file = zipfile.ZipFile(io.BytesIO(body))
+        member = wheel_metadata_member(zip_file.namelist(), canonical_name)
+        if member is None:
+            return None
+        return zip_file.read(member)
+    except (zipfile.BadZipFile, zlib.error, OSError, UnsupportedWheelError):
+        return None
+
+
+def _decode(raw: bytes) -> str:
+    """Decode METADATA bytes as UTF-8, raising on invalid input."""
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        msg = f"range-read METADATA is not valid UTF-8: {exc}"
+        raise MalformedSimpleResponseError(msg) from exc
+
+
+async def read_wheel_metadata_over_range(
+    transport: AsyncHttpTransport,
+    wheel_url: str,
+    canonical_name: NormalizedName,
+    memo: RangeCapabilityMemo,
+    *,
+    tail_size: int = _DEFAULT_TAIL,
+) -> RangeMetadataResult:
+    """Recover a remote wheel's METADATA text by ranged reads of its ZIP.
+
+    Raises :class:`~nab_index.client.MalformedSimpleResponseError` only when
+    the recovered METADATA is not valid UTF-8, and re-raises a transport
+    error for a 4xx/5xx on the wheel URL. Every other failure to obtain
+    metadata returns a result with ``text=None``.
+    """
+    netloc = urlsplit(wheel_url).netloc
+    owns_probe = False
+    if memo.capability(netloc) is RangeCapability.UNKNOWN:
+        owns_probe = await memo.await_probe(netloc)
+    try:
+        capability = memo.capability(netloc)
+        new_capability, kind, payload = await _acquire(
+            transport, wheel_url, capability, tail_size
+        )
+        memo.record(netloc, new_capability)
+        if kind is _AcqKind.NONE:
+            return RangeMetadataResult(None, RangeOutcome.UNSUPPORTED)
+        if kind is _AcqKind.FULL_BODY:
+            assert isinstance(payload, bytes)
+            raw = _read_full_body(payload, canonical_name)
+            outcome = RangeOutcome.FULL_BODY
+        else:
+            assert isinstance(payload, tuple)
+            sparse, tail_low = payload
+            raw = await _read_sparse(
+                transport, wheel_url, sparse, tail_low, canonical_name
+            )
+            outcome = RangeOutcome.PARTIAL
+        if raw is None:
+            return RangeMetadataResult(None, RangeOutcome.MISSING)
+        return RangeMetadataResult(_decode(raw), outcome)
+    finally:
+        if owns_probe:
+            memo.finish_probe(netloc)

--- a/nab-index/src/nab_index/lazy_wheel.py
+++ b/nab-index/src/nab_index/lazy_wheel.py
@@ -80,6 +80,7 @@ class RangeCapability(enum.Enum):
     UNKNOWN = "unknown"
     SUFFIX_OK = "suffix-ok"
     ABSOLUTE_ONLY = "absolute-only"
+    FULL_BODY_ONLY = "full-body-only"
     UNSUPPORTED = "unsupported"
 
 
@@ -292,7 +293,7 @@ async def _absolute_attempt(
     if _non_identity(probe):
         return _UNSUPPORTED_NONE
     if probe.status_code == _HTTP_OK:
-        return (RangeCapability.UNSUPPORTED, _AcqKind.FULL_BODY, probe.content)
+        return (RangeCapability.FULL_BODY_ONLY, _AcqKind.FULL_BODY, probe.content)
     if probe.status_code != _HTTP_PARTIAL:
         probe.raise_for_status()
         return _UNSUPPORTED_NONE  # pragma: no cover
@@ -311,13 +312,32 @@ async def _absolute_tail(
     if _non_identity(tail):
         return _UNSUPPORTED_NONE
     if tail.status_code == _HTTP_OK:
-        return (RangeCapability.UNSUPPORTED, _AcqKind.FULL_BODY, tail.content)
+        return (RangeCapability.FULL_BODY_ONLY, _AcqKind.FULL_BODY, tail.content)
     if tail.status_code != _HTTP_PARTIAL:
         tail.raise_for_status()
         return _UNSUPPORTED_NONE  # pragma: no cover
     sparse = _SparseFile(total)
     sparse.add_span(low, tail.content)
     return (RangeCapability.ABSOLUTE_ONLY, _AcqKind.SPARSE, (sparse, low))
+
+
+async def _full_body_fetch(
+    transport: AsyncHttpTransport, url: str
+) -> tuple[RangeCapability, _AcqKind, object]:
+    """Fetch the whole wheel from a host known to ignore ranges.
+
+    A range-ignoring host answered an earlier probe with the full body, so it
+    is memoed ``FULL_BODY_ONLY``.  Later wheels on that host skip the wasted
+    range probe and fetch the body directly with a plain GET, so every
+    sidecar-less wheel there recovers its METADATA rather than only the first.
+    A 4xx/5xx (the file went missing) raises through and drops the candidate; a
+    non-identity encoding yields no usable bytes.
+    """
+    response = await transport.get(url, headers={"Accept-Encoding": "identity"})
+    if response.status_code == _HTTP_OK and not _non_identity(response):
+        return (RangeCapability.FULL_BODY_ONLY, _AcqKind.FULL_BODY, response.content)
+    response.raise_for_status()
+    return _UNSUPPORTED_NONE
 
 
 async def _acquire(
@@ -329,6 +349,8 @@ async def _acquire(
     """Fetch bytes per the netloc's known capability, learning it if unknown."""
     if capability is RangeCapability.UNSUPPORTED:
         return _UNSUPPORTED_NONE
+    if capability is RangeCapability.FULL_BODY_ONLY:
+        return await _full_body_fetch(transport, url)
     if capability in (RangeCapability.UNKNOWN, RangeCapability.SUFFIX_OK):
         suffix = await _suffix_attempt(transport, url, tail_size)
         if suffix.kind == "suffix":
@@ -336,8 +358,29 @@ async def _acquire(
             sparse.add_span(suffix.low, suffix.body)
             return (RangeCapability.SUFFIX_OK, _AcqKind.SPARSE, (sparse, suffix.low))
         if suffix.kind == "full":
-            return (RangeCapability.UNSUPPORTED, _AcqKind.FULL_BODY, suffix.body)
+            return (RangeCapability.FULL_BODY_ONLY, _AcqKind.FULL_BODY, suffix.body)
     return await _absolute_attempt(transport, url, tail_size)
+
+
+def _absorb_range(
+    response: HttpResponse, sparse: _SparseFile, partial_low: int
+) -> int | None:
+    """Absorb a growth or member range response into ``sparse``.
+
+    Returns the low offset at which bytes were populated, or ``None`` when the
+    response yielded no usable bytes.  A volunteered 200 full body populates the
+    whole file from offset 0 and is used rather than discarded.  A 4xx/5xx on
+    the wheel URL raises through so the candidate drops, matching the first
+    round trip; a non-identity encoding yields no usable bytes.
+    """
+    if response.status_code == _HTTP_OK and not _non_identity(response):
+        sparse.add_span(0, response.content)
+        return 0
+    if response.status_code != _HTTP_PARTIAL or _non_identity(response):
+        response.raise_for_status()
+        return None
+    sparse.add_span(partial_low, response.content)
+    return partial_low
 
 
 def _try_open(sparse: _SparseFile) -> zipfile.ZipFile | None:
@@ -363,10 +406,10 @@ async def _open_zip(
         new_size = min(have * 2, total, _MAX_TAIL)
         new_low = total - new_size
         response = await _range_get(transport, url, f"bytes={new_low}-{tail_low - 1}")
-        if response.status_code != _HTTP_PARTIAL or _non_identity(response):
+        low = _absorb_range(response, sparse, new_low)
+        if low is None:
             return None
-        sparse.add_span(new_low, response.content)
-        tail_low = new_low
+        tail_low = low
 
 
 def _member_span(zip_file: zipfile.ZipFile, member: str) -> tuple[int, int]:
@@ -405,9 +448,8 @@ async def _read_sparse(
     start, end = _member_span(zip_file, member)
     if not sparse.populated(start, end):
         response = await _range_get(transport, url, f"bytes={start}-{end - 1}")
-        if response.status_code != _HTTP_PARTIAL or _non_identity(response):
+        if _absorb_range(response, sparse, start) is None:
             return None
-        sparse.add_span(start, response.content)
     try:
         return zip_file.read(member)
     except (zipfile.BadZipFile, zlib.error, OSError):

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -42,7 +42,10 @@ from .client import (
 from .transport import HttpError
 
 if TYPE_CHECKING:
+    from packaging.utils import NormalizedName
     from typing_extensions import Self
+
+    from .lazy_wheel import RangeMetadataResult
 
 __all__ = [
     "LocalIndexClient",
@@ -564,3 +567,21 @@ class LocalIndexClient:
         """
         path = parse_file_url(sdist_url)
         return path.read_bytes()
+
+    async def get_range_metadata(
+        self,
+        package: str,  # noqa: ARG002 - matches CachedAsyncSimpleClient signature
+        version: str,  # noqa: ARG002
+        wheel_url: str,  # noqa: ARG002
+        canonical_name: NormalizedName,  # noqa: ARG002
+    ) -> RangeMetadataResult:
+        """Return the no-source result.
+
+        A local wheel is read through the resolver's ``local_path`` branch, not
+        over HTTP, so there is no range read to perform here.
+        """
+        # Imported inside the method to break the lazy_wheel <-> local_index
+        # import cycle: lazy_wheel imports this module's shared member selector.
+        from .lazy_wheel import RangeMetadataResult, RangeOutcome  # noqa: PLC0415
+
+        return RangeMetadataResult(None, RangeOutcome.UNSUPPORTED)

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -50,6 +50,7 @@ __all__ = [
     "UnsupportedWheelError",
     "parse_file_url",
     "read_wheel_metadata",
+    "wheel_metadata_member",
 ]
 
 
@@ -343,7 +344,7 @@ def _read_wheel_requires_python(wheel_path: Path, expected: str) -> str | None:
     """Return ``Requires-Python`` from a wheel's METADATA, or ``None``."""
     try:
         with zipfile.ZipFile(wheel_path) as archive:
-            member = _wheel_metadata_member(archive.namelist(), expected)
+            member = wheel_metadata_member(archive.namelist(), expected)
             if member is None:
                 return None
             raw = archive.read(member)
@@ -423,7 +424,7 @@ def read_wheel_metadata(wheel_path: Path) -> str | None:
         return None
     try:
         with zipfile.ZipFile(wheel_path) as zf:
-            member = _wheel_metadata_member(zf.namelist(), parsed[0])
+            member = wheel_metadata_member(zf.namelist(), parsed[0])
             if member is None:
                 return None
             return zf.read(member).decode("utf-8")
@@ -431,11 +432,14 @@ def read_wheel_metadata(wheel_path: Path) -> str | None:
         return None
 
 
-def _wheel_metadata_member(names: list[str], expected: str) -> str | None:
+def wheel_metadata_member(names: list[str], expected: str) -> str | None:
     """Return ``expected``'s own top-level ``*.dist-info/METADATA`` member.
 
-    ``expected`` is the wheel's canonical name from its filename.  Returns
-    ``None`` when no top-level ``.dist-info`` holds a METADATA file.  Raises
+    ``expected`` is the wheel's canonical name.  Both the local wheel reader
+    and the HTTP range reader select the METADATA member through this one
+    helper, so the two paths agree on what counts as a wheel's own metadata.
+    Returns ``None`` when no top-level ``.dist-info`` holds a METADATA file.
+    Raises
     :class:`UnsupportedWheelError` when the wheel carries several top-level
     ``.dist-info`` directories, or a single one whose name does not
     canonicalise to ``expected``.

--- a/nab-index/src/nab_index/multi_index.py
+++ b/nab-index/src/nab_index/multi_index.py
@@ -30,9 +30,11 @@ from .cache import OfflineError
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
+    from packaging.utils import NormalizedName
     from typing_extensions import Self
 
     from .client import SdistFile, WheelFile
+    from .lazy_wheel import RangeMetadataResult
 
 __all__ = [
     "IndexClient",
@@ -82,6 +84,16 @@ class IndexClient(Protocol):
         sdist_hashes: tuple[tuple[str, str], ...] = (),
     ) -> bytes:
         """Return the raw sdist archive bytes."""
+        ...
+
+    async def get_range_metadata(
+        self,
+        package: str,
+        version: str,
+        wheel_url: str,
+        canonical_name: NormalizedName,
+    ) -> RangeMetadataResult:
+        """Recover a sidecar-less wheel's METADATA by HTTP range reads."""
         ...
 
     async def aclose(self) -> None:
@@ -247,6 +259,18 @@ class MultiIndexClient:
         """Forward to the routed client; presupposes ``get_files`` was called."""
         return await self._client_for(package).get_sdist_archive(
             package, version, sdist_url, sdist_hashes
+        )
+
+    async def get_range_metadata(
+        self,
+        package: str,
+        version: str,
+        wheel_url: str,
+        canonical_name: NormalizedName,
+    ) -> RangeMetadataResult:
+        """Forward to the routed client; presupposes ``get_files`` was called."""
+        return await self._client_for(package).get_range_metadata(
+            package, version, wheel_url, canonical_name
         )
 
     def _client_for(self, package: str) -> IndexClient:

--- a/nab-index/tests/test_index_local.py
+++ b/nab-index/tests/test_index_local.py
@@ -65,3 +65,18 @@ def test_get_sdist_archive_returns_file_bytes(tmp_path: Path) -> None:
     client = LocalIndexClient(tmp_path.as_uri())
     data = run(client.get_sdist_archive("foo", "1.0", sdist.as_uri()))
     assert data == b"SDIST-BYTES"
+
+
+def test_get_range_metadata_returns_no_source_result(tmp_path: Path) -> None:
+    from packaging.utils import canonicalize_name
+
+    from nab_index.lazy_wheel import RangeOutcome
+
+    client = LocalIndexClient(tmp_path.as_uri())
+    result = run(
+        client.get_range_metadata(
+            "foo", "1.0", "https://x/foo-1.0-py3-none-any.whl", canonicalize_name("foo")
+        )
+    )
+    assert result.text is None
+    assert result.outcome is RangeOutcome.UNSUPPORTED

--- a/nab-index/tests/test_lazy_wheel.py
+++ b/nab-index/tests/test_lazy_wheel.py
@@ -189,6 +189,15 @@ class FakeRangeTransport:
             if kind == "suffix":
                 return _FakeResponse(416, {}, b"")
             return self._full()
+        if self.mode.startswith("reject_"):
+            return _FakeResponse(int(self.mode.removeprefix("reject_")), {}, b"")
+        if self.mode == "miss_200_then_206":
+            ranged = sum(1 for rng, _ in self.requests if rng is not None)
+            if ranged == 1:
+                return self._full()
+            if kind == "suffix":
+                return self._partial(max(0, self.total - a), self.total - 1)
+            return self._partial(a, b)
         if self.mode == "gzip_range":
             if kind == "suffix":
                 return self._partial(max(0, self.total - a), self.total - 1, gzip=True)
@@ -217,21 +226,30 @@ def _read(transport: object, url: str = _URL, **kwargs: object) -> RangeMetadata
 
 
 @pytest.mark.parametrize(
-    ("mode", "outcome"),
+    ("mode", "outcome", "expected_requests"),
     [
-        ("well_behaved", RangeOutcome.PARTIAL),
-        ("suffix_501", RangeOutcome.PARTIAL),
-        ("ignore_range_200", RangeOutcome.FULL_BODY),
-        ("no_ranges", RangeOutcome.FULL_BODY),
+        ("well_behaved", RangeOutcome.PARTIAL, 1),
+        ("suffix_501", RangeOutcome.PARTIAL, 3),
+        ("ignore_range_200", RangeOutcome.FULL_BODY, 1),
+        ("no_ranges", RangeOutcome.FULL_BODY, 2),
+        ("reject_400", RangeOutcome.FULL_BODY, 3),
+        ("reject_403", RangeOutcome.FULL_BODY, 3),
+        ("reject_416", RangeOutcome.FULL_BODY, 3),
+        ("reject_501", RangeOutcome.FULL_BODY, 3),
     ],
 )
-def test_recovers_metadata_per_mode(mode: str, outcome: RangeOutcome) -> None:
+def test_recovers_metadata_per_mode(
+    mode: str, outcome: RangeOutcome, expected_requests: int
+) -> None:
     wheel = build_wheel()
     transport = FakeRangeTransport(mode, wheel)
     result = _read(transport)
     assert result.outcome is outcome
     assert result.text == _META.decode("utf-8")
     assert all(enc == "identity" for _, enc in transport.requests)
+    # Exact counts: creeping per-wheel requests are the amplification failure
+    # mode this reader exists to avoid.
+    assert len(transport.requests) == expected_requests
 
 
 def test_misread_suffix_downgrades_to_absolute() -> None:
@@ -247,6 +265,42 @@ def test_gzip_range_is_unsupported() -> None:
     result = _read(transport)
     assert result.outcome is RangeOutcome.UNSUPPORTED
     assert result.text is None
+
+
+def test_range_rejecting_host_memoizes_full_body() -> None:
+    async def run() -> tuple[RangeMetadataResult, int]:
+        memo = RangeCapabilityMemo()
+        transport = FakeRangeTransport("reject_403", build_wheel())
+        await read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
+        capability = memo.capability("files.example.org")
+        assert capability is RangeCapability.FULL_BODY_ONLY
+        before = len(transport.requests)
+        result = await read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
+        return result, len(transport.requests) - before
+
+    result, second_requests = asyncio.run(run())
+    assert result.outcome is RangeOutcome.FULL_BODY
+    assert result.text == _META.decode("utf-8")
+    # The refused probes are not repeated: later wheels go straight to the GET.
+    assert second_requests == 1
+
+
+def test_cdn_miss_200_then_206_returns_to_ranges() -> None:
+    async def run() -> tuple[RangeMetadataResult, RangeMetadataResult, int]:
+        memo = RangeCapabilityMemo()
+        transport = FakeRangeTransport("miss_200_then_206", build_wheel_member_front())
+        first = await read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
+        assert first.text == _META.decode("utf-8")
+        assert memo.capability("files.example.org") is RangeCapability.SUFFIX_OK
+        after_first = len(transport.requests)
+        second = await read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
+        return first, second, len(transport.requests) - after_first
+
+    first, second, second_requests = asyncio.run(run())
+    assert first.outcome is RangeOutcome.FULL_BODY
+    assert second.outcome is RangeOutcome.PARTIAL
+    assert second.text == _META.decode("utf-8")
+    assert second_requests == 2
 
 
 @pytest.mark.parametrize("mode", ["error_404", "error_500"])
@@ -385,7 +439,10 @@ class _ScriptedTransport:
 
 
 def _run_scripted(
-    script: object, wheel: bytes | None = None, **kwargs: object
+    script: object,
+    wheel: bytes | None = None,
+    memo: RangeCapabilityMemo | None = None,
+    **kwargs: object,
 ) -> RangeMetadataResult:
     transport = _ScriptedTransport(
         wheel if wheel is not None else build_wheel(), script
@@ -395,7 +452,7 @@ def _run_scripted(
             transport,  # type: ignore[arg-type]
             _URL,
             _NAME,
-            RangeCapabilityMemo(),
+            memo if memo is not None else RangeCapabilityMemo(),
             **kwargs,  # type: ignore[arg-type]
         )
     )
@@ -412,12 +469,33 @@ def test_suffix_200_gzip_downgrades_to_absolute() -> None:
     assert result.text == _META.decode("utf-8")
 
 
-def test_suffix_206_without_content_range_is_full_body() -> None:
+def test_suffix_206_without_content_range_downgrades() -> None:
     def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
-        return _FakeResponse(206, {}, t.wheel)
+        if kind == "suffix":
+            return _FakeResponse(206, {}, t.wheel)
+        return t.partial(a, b)
 
     result = _run_scripted(script)
-    assert result.outcome is RangeOutcome.FULL_BODY
+    assert result.outcome is RangeOutcome.PARTIAL
+    assert result.text == _META.decode("utf-8")
+
+
+def test_suffix_206_star_total_downgrades() -> None:
+    """An honoured suffix with ``bytes a-b/*`` is unanchored, not a full body.
+
+    The tail slice mistaken for a whole wheel used to leak a ValueError out
+    of the zip machinery once METADATA sat in front of the window.
+    """
+
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            start = max(0, t.total - a)
+            headers = {"content-range": f"bytes {start}-{t.total - 1}/*"}
+            return _FakeResponse(206, headers, t.wheel[start:])
+        return t.partial(a, b)
+
+    result = _run_scripted(script, wheel=build_wheel_member_front())
+    assert result.outcome is RangeOutcome.PARTIAL
     assert result.text == _META.decode("utf-8")
 
 
@@ -461,6 +539,70 @@ def test_absolute_probe_error_raises() -> None:
         _run_scripted(script)
 
 
+def test_range_rejected_plain_get_error_raises() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "full":
+            return _FakeResponse(404, {}, b"")
+        return _FakeResponse(416, {}, b"")
+
+    with pytest.raises(HttpError):
+        _run_scripted(script)
+
+
+def test_range_rejected_gzip_plain_get_is_unsupported() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "full":
+            return t.full(gzip=True)
+        return _FakeResponse(416, {}, b"")
+
+    result = _run_scripted(script)
+    assert result.outcome is RangeOutcome.UNSUPPORTED
+    assert result.text is None
+
+
+def test_absolute_probe_weird_success_is_unsupported() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return _FakeResponse(501, {}, b"")
+        return _FakeResponse(204, {}, b"")
+
+    result = _run_scripted(script)
+    assert result.outcome is RangeOutcome.UNSUPPORTED
+
+
+@pytest.mark.parametrize("status", [400, 403, 416, 501])
+def test_absolute_tail_rejected_recovers_full_body(status: int) -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return _FakeResponse(501, {}, b"")
+        if kind == "full":
+            return t.full()
+        if a == 0 and b == 0:
+            return t.partial(0, 0)
+        return _FakeResponse(status, {}, b"")
+
+    memo = RangeCapabilityMemo()
+    result = _run_scripted(script, memo=memo)
+    assert result.outcome is RangeOutcome.FULL_BODY
+    assert result.text == _META.decode("utf-8")
+    expected = (
+        RangeCapability.UNKNOWN if status == 416 else RangeCapability.FULL_BODY_ONLY
+    )
+    assert memo.capability("files.example.org") is expected
+
+
+def test_absolute_tail_weird_success_is_unsupported() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return _FakeResponse(501, {}, b"")
+        if a == 0 and b == 0:
+            return t.partial(0, 0)
+        return _FakeResponse(204, {}, b"")
+
+    result = _run_scripted(script)
+    assert result.outcome is RangeOutcome.UNSUPPORTED
+
+
 def test_absolute_tail_200_full_body() -> None:
     def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
         if kind == "suffix":
@@ -469,8 +611,10 @@ def test_absolute_tail_200_full_body() -> None:
             return t.partial(0, 0)
         return t.full()
 
-    result = _run_scripted(script)
+    memo = RangeCapabilityMemo()
+    result = _run_scripted(script, memo=memo)
     assert result.outcome is RangeOutcome.FULL_BODY
+    assert memo.capability("files.example.org") is RangeCapability.FULL_BODY_ONLY
 
 
 def test_absolute_tail_200_gzip_is_unsupported() -> None:
@@ -539,6 +683,27 @@ def test_growth_gzip_full_body_is_missing() -> None:
     assert result.outcome is RangeOutcome.MISSING
 
 
+@pytest.mark.parametrize("status", [403, 416])
+def test_growth_rejection_recovers_full_body(status: int) -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return t.partial(max(0, t.total - a), t.total - 1)
+        if kind == "full":
+            return t.full()
+        return _FakeResponse(status, {}, b"")
+
+    memo = RangeCapabilityMemo()
+    result = _run_scripted(
+        script, wheel=build_wheel(padding=4000), memo=memo, tail_size=64
+    )
+    assert result.outcome is RangeOutcome.FULL_BODY
+    assert result.text == _META.decode("utf-8")
+    expected = (
+        RangeCapability.SUFFIX_OK if status == 416 else RangeCapability.FULL_BODY_ONLY
+    )
+    assert memo.capability("files.example.org") is expected
+
+
 def test_member_fetch_success() -> None:
     transport = FakeRangeTransport("well_behaved", build_wheel_member_front())
     result = _read(transport)
@@ -576,6 +741,60 @@ def test_member_fetch_gzip_is_missing() -> None:
     assert result.outcome is RangeOutcome.MISSING
 
 
+@pytest.mark.parametrize("status", [400, 501])
+def test_member_fetch_rejection_recovers_full_body(status: int) -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return t.partial(max(0, t.total - a), t.total - 1)
+        if kind == "full":
+            return t.full()
+        return _FakeResponse(status, {}, b"")
+
+    memo = RangeCapabilityMemo()
+    result = _run_scripted(script, wheel=build_wheel_member_front(), memo=memo)
+    assert result.outcome is RangeOutcome.FULL_BODY
+    assert result.text == _META.decode("utf-8")
+    assert memo.capability("files.example.org") is RangeCapability.FULL_BODY_ONLY
+
+
+def test_member_fetch_rejected_plain_get_error_raises() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return t.partial(max(0, t.total - a), t.total - 1)
+        if kind == "full":
+            return _FakeResponse(404, {}, b"")
+        return _FakeResponse(416, {}, b"")
+
+    with pytest.raises(HttpError):
+        _run_scripted(script, wheel=build_wheel_member_front())
+
+
+def test_member_fetch_rejected_gzip_plain_get_is_missing() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return t.partial(max(0, t.total - a), t.total - 1)
+        if kind == "full":
+            return t.full(gzip=True)
+        return _FakeResponse(416, {}, b"")
+
+    result = _run_scripted(script, wheel=build_wheel_member_front())
+    assert result.outcome is RangeOutcome.MISSING
+    assert result.text is None
+
+
+@pytest.mark.parametrize(
+    "build", [build_wheel_member_front, lambda: build_wheel(padding=4000)]
+)
+def test_mid_read_404_raises(build: object) -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return t.partial(max(0, t.total - a), t.total - 1)
+        return _FakeResponse(404, {}, b"")
+
+    with pytest.raises(HttpError):
+        _run_scripted(script, wheel=build(), tail_size=64)  # type: ignore[operator]
+
+
 def test_member_last_uses_directory_upper_bound() -> None:
     big_meta = (
         b"Metadata-Version: 2.1\nName: widget\nVersion: 1.0\n\n"
@@ -595,13 +814,26 @@ def test_member_last_uses_directory_upper_bound() -> None:
     )
 
 
-def test_suffix_206_unparseable_content_range_is_full_body() -> None:
+def test_suffix_206_unparseable_content_range_downgrades() -> None:
     def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
-        return _FakeResponse(206, {"content-range": "bogus"}, t.wheel)
+        if kind == "suffix":
+            return _FakeResponse(206, {"content-range": "bogus"}, t.wheel)
+        return t.partial(a, b)
 
     result = _run_scripted(script)
-    assert result.outcome is RangeOutcome.FULL_BODY
+    assert result.outcome is RangeOutcome.PARTIAL
     assert result.text == _META.decode("utf-8")
+
+
+def test_absolute_probe_zero_total_is_unsupported() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return _FakeResponse(501, {}, b"")
+        return _FakeResponse(206, {"content-range": "bytes 0-0/0"}, b"")
+
+    result = _run_scripted(script)
+    assert result.outcome is RangeOutcome.UNSUPPORTED
+    assert result.text is None
 
 
 def test_memo_suffix_ok_no_reprobe() -> None:
@@ -630,21 +862,25 @@ def test_memo_absolute_only_skips_reprobe() -> None:
     assert negatives == 1
 
 
-def test_memo_full_body_only_refetches() -> None:
-    async def run() -> RangeMetadataResult:
+def test_memo_range_ignoring_host_stays_suffix_ok() -> None:
+    async def run() -> tuple[RangeMetadataResult, int]:
         memo = RangeCapabilityMemo()
         transport = FakeRangeTransport("ignore_range_200", build_wheel())
         first = await read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
         assert first.text == _META.decode("utf-8")
-        assert memo.capability("files.example.org") is RangeCapability.FULL_BODY_ONLY
-        # A second sidecar-less wheel on the same range-ignoring host still
-        # recovers its METADATA from a full-body GET, so resolvability does not
-        # depend on which wheel is fetched first.
-        return await read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
+        # A volunteered 200 answers the suffix request with the whole body, so
+        # leading with the suffix form again costs the same single request on a
+        # host that keeps ignoring ranges, while a proxy that only ignored them
+        # on a cache miss gets to serve cheap partial reads again.
+        assert memo.capability("files.example.org") is RangeCapability.SUFFIX_OK
+        before = len(transport.requests)
+        second = await read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
+        return second, len(transport.requests) - before
 
-    result = asyncio.run(run())
+    result, second_requests = asyncio.run(run())
     assert result.text == _META.decode("utf-8")
     assert result.outcome is RangeOutcome.FULL_BODY
+    assert second_requests == 1
 
 
 def test_memo_gzip_stays_unsupported() -> None:
@@ -700,6 +936,221 @@ def test_memo_concurrent_single_flight() -> None:
         return transport.negative_requests
 
     assert asyncio.run(run()) == 1
+
+
+def test_memo_ignored_absolute_latches_full_body() -> None:
+    async def run() -> tuple[RangeMetadataResult, int]:
+        memo = RangeCapabilityMemo()
+        transport = FakeRangeTransport("no_ranges", build_wheel())
+        await read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
+        capability = memo.capability("files.example.org")
+        assert capability is RangeCapability.FULL_BODY_ONLY
+        before = len(transport.requests)
+        result = await read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
+        return result, len(transport.requests) - before
+
+    result, second_requests = asyncio.run(run())
+    assert result.outcome is RangeOutcome.FULL_BODY
+    assert result.text == _META.decode("utf-8")
+    assert second_requests == 1
+
+
+def test_reject_416_does_not_latch_netloc() -> None:
+    async def run() -> tuple[RangeMetadataResult, int]:
+        memo = RangeCapabilityMemo()
+        transport = FakeRangeTransport("reject_416", build_wheel())
+        first = await read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
+        assert first.outcome is RangeOutcome.FULL_BODY
+        # A 416 speaks for the one file, so the host is probed afresh.
+        assert memo.capability("files.example.org") is RangeCapability.UNKNOWN
+        before = len(transport.requests)
+        second = await read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
+        return second, len(transport.requests) - before
+
+    result, second_requests = asyncio.run(run())
+    assert result.outcome is RangeOutcome.FULL_BODY
+    assert result.text == _META.decode("utf-8")
+    assert second_requests == 3
+
+
+def test_reject_statuses_disjoint_from_transport_retries() -> None:
+    """A refused range must come back on the first answer, never retried."""
+    from nab_index.lazy_wheel import _RANGE_REJECT_STATUSES
+    from nab_index.retry import RETRY_STATUSES
+
+    assert _RANGE_REJECT_STATUSES.isdisjoint(RETRY_STATUSES)
+
+
+def _patch_member(
+    wheel: bytes, member: str, *, flag_or: int | None = None, method: int | None = None
+) -> bytes:
+    """Rewrite one member's local and central headers in place."""
+    import struct
+
+    data = bytearray(wheel)
+    with zipfile.ZipFile(io.BytesIO(wheel)) as zf:
+        local_off = zf.getinfo(member).header_offset
+    name_bytes = member.encode()
+    if flag_or is not None:
+        flags = struct.unpack_from("<H", data, local_off + 6)[0] | flag_or
+        struct.pack_into("<H", data, local_off + 6, flags)
+    if method is not None:
+        struct.pack_into("<H", data, local_off + 8, method)
+    pos = 0
+    while (pos := data.find(b"PK\x01\x02", pos)) != -1:
+        name_len = struct.unpack_from("<H", data, pos + 28)[0]
+        if bytes(data[pos + 46 : pos + 46 + name_len]) == name_bytes:
+            if flag_or is not None:
+                flags = struct.unpack_from("<H", data, pos + 8)[0] | flag_or
+                struct.pack_into("<H", data, pos + 8, flags)
+            if method is not None:
+                struct.pack_into("<H", data, pos + 10, method)
+        pos += 4
+    return bytes(data)
+
+
+def _wheel_bad_utf8_name() -> bytes:
+    """A wheel whose UTF-8-flagged member name does not decode."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_STORED) as zf:
+        zf.writestr("widget-1.0.dist-info/METADATA", _META)
+        zf.writestr("widget/pÄd.py", b"x")
+    needle = "widget/pÄd.py".encode()
+    wheel = buf.getvalue()
+    assert wheel.count(needle) == 2
+    return wheel.replace(needle, b"widget/p\xff\xffd.py")
+
+
+def _wheel_encrypted_metadata() -> bytes:
+    return _patch_member(
+        build_wheel(compression=zipfile.ZIP_STORED),
+        "widget-1.0.dist-info/METADATA",
+        flag_or=0x1,
+    )
+
+
+def _wheel_method_99() -> bytes:
+    return _patch_member(
+        build_wheel(compression=zipfile.ZIP_STORED),
+        "widget-1.0.dist-info/METADATA",
+        method=99,
+    )
+
+
+@pytest.mark.parametrize("mode", ["well_behaved", "ignore_range_200"])
+@pytest.mark.parametrize(
+    "shape", [_wheel_bad_utf8_name, _wheel_encrypted_metadata, _wheel_method_99]
+)
+def test_unreadable_wheel_is_missing(mode: str, shape: object) -> None:
+    """Zip shapes the machinery cannot read step the ladder on, never raise."""
+    transport = FakeRangeTransport(mode, shape())  # type: ignore[operator]
+    result = _read(transport)
+    assert result.outcome is RangeOutcome.MISSING
+    assert result.text is None
+
+
+def test_probe_releases_when_owner_acquisition_fails() -> None:
+    """A failed owner still releases parked waiters, who probe for themselves."""
+    wheel = build_wheel()
+    url_b = "https://files.example.org/packages/other/widget-1.0-py3-none-any.whl"
+
+    async def run() -> RangeMetadataResult:
+        memo = RangeCapabilityMemo()
+        total = len(wheel)
+        owner_started = asyncio.Event()
+        release_owner = asyncio.Event()
+
+        class GatedTransport:
+            async def get(
+                self, url: str, *, headers: dict[str, str] | None = None
+            ) -> _FakeResponse:
+                kind, a, b = _parse_range((headers or {})["Range"])
+                if url == _URL:
+                    owner_started.set()
+                    await release_owner.wait()
+                    return _FakeResponse(404, {}, b"")
+                if kind == "suffix":
+                    start, end = max(0, total - a), total - 1
+                else:
+                    start, end = a, min(b, total - 1)
+                headers_out = {"content-range": f"bytes {start}-{end}/{total}"}
+                return _FakeResponse(206, headers_out, wheel[start : end + 1])
+
+            async def aclose(self) -> None:
+                return None
+
+        transport = GatedTransport()
+        owner = asyncio.create_task(
+            read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
+        )
+        await owner_started.wait()
+        waiter = asyncio.create_task(
+            read_wheel_metadata_over_range(transport, url_b, _NAME, memo)  # type: ignore[arg-type]
+        )
+        await asyncio.sleep(0)
+        release_owner.set()
+        with pytest.raises(HttpError):
+            await owner
+        return await waiter
+
+    waiter_result = asyncio.run(asyncio.wait_for(run(), timeout=5))
+    assert waiter_result.text == _META.decode("utf-8")
+
+
+def test_probe_releases_once_capability_settles() -> None:
+    """A waiter proceeds as soon as the owner's capability is settled.
+
+    The owner's member read is gated on the waiter finishing first, so the
+    test deadlocks (and times out) if the probe were held for the owner's
+    whole read rather than released after acquisition.
+    """
+    wheel = build_wheel_member_front()
+    url_b = "https://files.example.org/packages/other/widget-1.0-py3-none-any.whl"
+
+    async def run() -> tuple[RangeMetadataResult, RangeMetadataResult]:
+        memo = RangeCapabilityMemo()
+        total = len(wheel)
+        owner_suffix_started = asyncio.Event()
+        release_owner_suffix = asyncio.Event()
+        waiter_done = asyncio.Event()
+
+        class GatedTransport:
+            async def get(
+                self, url: str, *, headers: dict[str, str] | None = None
+            ) -> _FakeResponse:
+                kind, a, b = _parse_range((headers or {})["Range"])
+                if kind == "suffix":
+                    if url == _URL:
+                        owner_suffix_started.set()
+                        await release_owner_suffix.wait()
+                    start, end = max(0, total - a), total - 1
+                else:
+                    if url == _URL:
+                        await waiter_done.wait()
+                    start, end = a, min(b, total - 1)
+                headers_out = {"content-range": f"bytes {start}-{end}/{total}"}
+                return _FakeResponse(206, headers_out, wheel[start : end + 1])
+
+            async def aclose(self) -> None:
+                return None
+
+        transport = GatedTransport()
+        owner = asyncio.create_task(
+            read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
+        )
+        await owner_suffix_started.wait()
+        waiter = asyncio.create_task(
+            read_wheel_metadata_over_range(transport, url_b, _NAME, memo)  # type: ignore[arg-type]
+        )
+        await asyncio.sleep(0)
+        release_owner_suffix.set()
+        waiter_result = await waiter
+        waiter_done.set()
+        return await owner, waiter_result
+
+    owner_result, waiter_result = asyncio.run(asyncio.wait_for(run(), timeout=5))
+    assert owner_result.text == _META.decode("utf-8")
+    assert waiter_result.text == _META.decode("utf-8")
 
 
 def test_sparse_file_seek_and_read() -> None:

--- a/nab-index/tests/test_lazy_wheel.py
+++ b/nab-index/tests/test_lazy_wheel.py
@@ -71,6 +71,21 @@ def build_wheel_member_front(padding: int = 20000) -> bytes:
     return buf.getvalue()
 
 
+def build_wheel_member_last(metadata: bytes) -> bytes:
+    """Build a wheel whose METADATA is the last member by offset.
+
+    A stored blob and WHEEL precede METADATA, so METADATA has the largest
+    header offset and _member_span bounds it with the central-directory start
+    rather than a following entry.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_STORED) as zf:
+        zf.writestr("widget/_pad.bin", b"\x00" * 20000)
+        zf.writestr("widget-1.0.dist-info/WHEEL", b"Wheel-Version: 1.0\n")
+        zf.writestr("widget-1.0.dist-info/METADATA", metadata)
+    return buf.getvalue()
+
+
 def _parse_range(value: str) -> tuple[str, int, int]:
     body = value.removeprefix("bytes=")
     if body.startswith("-"):
@@ -559,6 +574,25 @@ def test_member_fetch_gzip_is_missing() -> None:
 
     result = _run_scripted(script, wheel=build_wheel_member_front())
     assert result.outcome is RangeOutcome.MISSING
+
+
+def test_member_last_uses_directory_upper_bound() -> None:
+    big_meta = (
+        b"Metadata-Version: 2.1\nName: widget\nVersion: 1.0\n\n"
+        + b"filler line\n" * 400
+    )
+    wheel = build_wheel_member_last(big_meta)
+    with zipfile.ZipFile(io.BytesIO(wheel)) as zf:
+        meta_offset = zf.getinfo("widget-1.0.dist-info/METADATA").header_offset
+        directory_start = zf.start_dir
+    transport = FakeRangeTransport("well_behaved", wheel)
+    result = _read(transport, tail_size=64)
+    assert result.outcome is RangeOutcome.PARTIAL
+    assert result.text == big_meta.decode("utf-8")
+    assert any(
+        rng == f"bytes={meta_offset}-{directory_start - 1}"
+        for rng, _ in transport.requests
+    )
 
 
 def test_suffix_206_unparseable_content_range_is_full_body() -> None:

--- a/nab-index/tests/test_lazy_wheel.py
+++ b/nab-index/tests/test_lazy_wheel.py
@@ -1,0 +1,623 @@
+"""Tests for nab_index.lazy_wheel, the HTTP range metadata reader."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import zipfile
+from typing import TYPE_CHECKING
+
+import pytest
+from packaging.utils import canonicalize_name
+
+from nab_index.client import MalformedSimpleResponseError
+from nab_index.lazy_wheel import (
+    RangeCapability,
+    RangeCapabilityMemo,
+    RangeMetadataResult,
+    RangeOutcome,
+    _SparseFile,
+    read_wheel_metadata_over_range,
+)
+from nab_index.transport import HttpError
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+_META = b"Metadata-Version: 2.1\nName: widget\nVersion: 1.0\n\nBody text.\n"
+_URL = "https://files.example.org/packages/widget-1.0-py3-none-any.whl"
+
+
+def build_wheel(
+    *,
+    dist_info_dirs: tuple[str, ...] = ("widget-1.0.dist-info",),
+    metadata: bytes | None = _META,
+    compression: int = zipfile.ZIP_DEFLATED,
+    padding: int = 0,
+    force_zip64: bool = False,
+) -> bytes:
+    """Build a wheel zip in memory with controllable layout."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression) as zf:
+        if padding:
+            zf.writestr("widget/_pad.bin", b"\x00" * padding)
+        zf.writestr("widget/__init__.py", b"value = 1\n")
+        for info in dist_info_dirs:
+            if metadata is not None:
+                if force_zip64:
+                    with zf.open(
+                        zipfile.ZipInfo(f"{info}/METADATA"),
+                        mode="w",
+                        force_zip64=True,
+                    ) as handle:
+                        handle.write(metadata)
+                else:
+                    zf.writestr(f"{info}/METADATA", metadata)
+            zf.writestr(f"{info}/WHEEL", b"Wheel-Version: 1.0\n")
+    return buf.getvalue()
+
+
+def build_wheel_member_front(padding: int = 20000) -> bytes:
+    """Build a wheel whose METADATA sits at offset 0 and a big stored blob after.
+
+    With a default tail the central directory is inside the window but the
+    front-loaded METADATA member is not, forcing a member-range fetch.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_STORED) as zf:
+        zf.writestr("widget-1.0.dist-info/METADATA", _META)
+        zf.writestr("widget-1.0.dist-info/WHEEL", b"Wheel-Version: 1.0\n")
+        zf.writestr("widget/_pad.bin", b"\x00" * padding)
+    return buf.getvalue()
+
+
+def _parse_range(value: str) -> tuple[str, int, int]:
+    body = value.removeprefix("bytes=")
+    if body.startswith("-"):
+        return ("suffix", int(body[1:]), 0)
+    start, _, end = body.partition("-")
+    return ("absolute", int(start), int(end))
+
+
+class _FakeResponse:
+    def __init__(self, status: int, headers: dict[str, str], content: bytes) -> None:
+        self._status = status
+        self._headers = headers
+        self._content = content
+
+    @property
+    def status_code(self) -> int:
+        return self._status
+
+    @property
+    def headers(self) -> Mapping[str, str]:
+        return self._headers
+
+    @property
+    def content(self) -> bytes:
+        return self._content
+
+    @property
+    def text(self) -> str:
+        return self._content.decode("utf-8")
+
+    def json(self) -> object:
+        import json
+
+        return json.loads(self._content)
+
+    def raise_for_status(self) -> None:
+        if self._status >= 400:
+            msg = f"HTTP {self._status}"
+            raise HttpError(msg)
+
+
+class FakeRangeTransport:
+    """Serve wheel bytes over ranges per a named server-quirk mode."""
+
+    def __init__(self, mode: str, wheel_bytes: bytes) -> None:
+        self.mode = mode
+        self.wheel = wheel_bytes
+        self.total = len(wheel_bytes)
+        self.requests: list[tuple[str | None, str | None]] = []
+
+    async def get(
+        self, url: str, *, headers: dict[str, str] | None = None
+    ) -> _FakeResponse:
+        await asyncio.sleep(0)
+        headers = headers or {}
+        rng = headers.get("Range")
+        enc = headers.get("Accept-Encoding")
+        self.requests.append((rng, enc))
+        assert rng is not None
+        return self._respond(rng)
+
+    async def aclose(self) -> None:
+        return None
+
+    @property
+    def negative_requests(self) -> int:
+        return sum(1 for rng, _ in self.requests if rng and "=-" in rng)
+
+    def _partial(self, start: int, end: int, *, gzip: bool = False) -> _FakeResponse:
+        end = min(end, self.total - 1)
+        data = self.wheel[start : end + 1]
+        headers = {"content-range": f"bytes {start}-{end}/{self.total}"}
+        if gzip:
+            headers["content-encoding"] = "gzip"
+        return _FakeResponse(206, headers, data)
+
+    def _full(self, *, gzip: bool = False) -> _FakeResponse:
+        headers = {"content-encoding": "gzip"} if gzip else {}
+        return _FakeResponse(200, headers, self.wheel)
+
+    def _respond(self, rng: str) -> _FakeResponse:
+        kind, a, b = _parse_range(rng)
+        if self.mode == "well_behaved":
+            if kind == "suffix":
+                return self._partial(max(0, self.total - a), self.total - 1)
+            return self._partial(a, b)
+        if self.mode == "suffix_501":
+            if kind == "suffix":
+                return _FakeResponse(501, {}, b"")
+            return self._partial(a, b)
+        if self.mode == "ignore_range_200":
+            return self._full()
+        if self.mode == "misread_suffix":
+            if kind == "suffix":
+                data = self.wheel[:a]
+                headers = {"content-range": f"bytes 0-{len(data) - 1}/{self.total}"}
+                return _FakeResponse(206, headers, data)
+            return self._partial(a, b)
+        if self.mode == "no_ranges":
+            if kind == "suffix":
+                return _FakeResponse(416, {}, b"")
+            return self._full()
+        if self.mode == "gzip_range":
+            if kind == "suffix":
+                return self._partial(max(0, self.total - a), self.total - 1, gzip=True)
+            return self._partial(a, b, gzip=True)
+        if self.mode == "error_404":
+            return _FakeResponse(404, {}, b"")
+        if self.mode == "error_500":
+            return _FakeResponse(500, {}, b"")
+        msg = f"unknown mode {self.mode}"
+        raise AssertionError(msg)
+
+
+_NAME = canonicalize_name("widget")
+
+
+def _read(transport: object, url: str = _URL, **kwargs: object) -> RangeMetadataResult:
+    return asyncio.run(
+        read_wheel_metadata_over_range(
+            transport,  # type: ignore[arg-type]
+            url,
+            _NAME,
+            RangeCapabilityMemo(),
+            **kwargs,  # type: ignore[arg-type]
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("mode", "outcome"),
+    [
+        ("well_behaved", RangeOutcome.PARTIAL),
+        ("suffix_501", RangeOutcome.PARTIAL),
+        ("ignore_range_200", RangeOutcome.FULL_BODY),
+        ("no_ranges", RangeOutcome.FULL_BODY),
+    ],
+)
+def test_recovers_metadata_per_mode(mode: str, outcome: RangeOutcome) -> None:
+    wheel = build_wheel()
+    transport = FakeRangeTransport(mode, wheel)
+    result = _read(transport)
+    assert result.outcome is outcome
+    assert result.text == _META.decode("utf-8")
+    assert all(enc == "identity" for _, enc in transport.requests)
+
+
+def test_misread_suffix_downgrades_to_absolute() -> None:
+    wheel = build_wheel_member_front()
+    transport = FakeRangeTransport("misread_suffix", wheel)
+    result = _read(transport, tail_size=64)
+    assert result.outcome is RangeOutcome.PARTIAL
+    assert result.text == _META.decode("utf-8")
+
+
+def test_gzip_range_is_unsupported() -> None:
+    transport = FakeRangeTransport("gzip_range", build_wheel())
+    result = _read(transport)
+    assert result.outcome is RangeOutcome.UNSUPPORTED
+    assert result.text is None
+
+
+@pytest.mark.parametrize("mode", ["error_404", "error_500"])
+def test_wheel_url_error_raises(mode: str) -> None:
+    transport = FakeRangeTransport(mode, build_wheel())
+    with pytest.raises(HttpError):
+        _read(transport)
+
+
+def test_growth_loop_when_directory_beyond_tail() -> None:
+    wheel = build_wheel(padding=4000)
+    transport = FakeRangeTransport("well_behaved", wheel)
+    result = _read(transport, tail_size=64)
+    assert result.outcome is RangeOutcome.PARTIAL
+    assert result.text == _META.decode("utf-8")
+
+
+def test_growth_cap_returns_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    import nab_index.lazy_wheel as lw
+
+    monkeypatch.setattr(lw, "_MAX_TAIL", 48)
+    wheel = build_wheel(padding=4000)
+    transport = FakeRangeTransport("well_behaved", wheel)
+    result = _read(transport, tail_size=16)
+    assert result.outcome is RangeOutcome.MISSING
+    assert result.text is None
+
+
+@pytest.mark.parametrize("compression", [zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED])
+def test_compression_methods(compression: int) -> None:
+    wheel = build_wheel(compression=compression)
+    transport = FakeRangeTransport("well_behaved", wheel)
+    result = _read(transport)
+    assert result.text == _META.decode("utf-8")
+
+
+def test_zip64_member() -> None:
+    wheel = build_wheel(force_zip64=True)
+    transport = FakeRangeTransport("well_behaved", wheel)
+    result = _read(transport)
+    assert result.text == _META.decode("utf-8")
+
+
+@pytest.mark.parametrize("mode", ["well_behaved", "ignore_range_200"])
+def test_no_dist_info_is_missing(mode: str) -> None:
+    wheel = build_wheel(dist_info_dirs=())
+    transport = FakeRangeTransport(mode, wheel)
+    result = _read(transport)
+    assert result.outcome is RangeOutcome.MISSING
+    assert result.text is None
+
+
+def test_dist_info_without_metadata_is_missing() -> None:
+    wheel = build_wheel(metadata=None)
+    transport = FakeRangeTransport("well_behaved", wheel)
+    result = _read(transport)
+    assert result.outcome is RangeOutcome.MISSING
+
+
+def test_multiple_dist_info_is_missing() -> None:
+    wheel = build_wheel(
+        dist_info_dirs=("widget-1.0.dist-info", "widget-1.0.data.dist-info")
+    )
+    transport = FakeRangeTransport("well_behaved", wheel)
+    result = _read(transport)
+    assert result.outcome is RangeOutcome.MISSING
+
+
+def test_foreign_dist_info_is_missing() -> None:
+    wheel = build_wheel(dist_info_dirs=("gadget-2.0.dist-info",))
+    transport = FakeRangeTransport("well_behaved", wheel)
+    result = _read(transport)
+    assert result.outcome is RangeOutcome.MISSING
+
+
+@pytest.mark.parametrize("mode", ["well_behaved", "ignore_range_200"])
+def test_non_utf8_metadata_raises(mode: str) -> None:
+    wheel = build_wheel(metadata=b"\xff\xfe not utf-8")
+    transport = FakeRangeTransport(mode, wheel)
+    with pytest.raises(MalformedSimpleResponseError):
+        _read(transport)
+
+
+def test_corrupt_member_is_missing() -> None:
+    wheel = bytearray(build_wheel(compression=zipfile.ZIP_STORED))
+    marker = _META[:8]
+    idx = wheel.find(marker)
+    assert idx != -1
+    wheel[idx] ^= 0xFF
+    transport = FakeRangeTransport("well_behaved", bytes(wheel))
+    result = _read(transport)
+    assert result.outcome is RangeOutcome.MISSING
+
+
+def test_full_body_not_a_zip_is_missing() -> None:
+    transport = FakeRangeTransport("ignore_range_200", b"this is not a zip file")
+    result = _read(transport)
+    assert result.outcome is RangeOutcome.MISSING
+
+
+class _ScriptedTransport:
+    """Serve responses from per-request-shape callables."""
+
+    def __init__(self, wheel: bytes, script: object) -> None:
+        self.wheel = wheel
+        self.total = len(wheel)
+        self.script = script
+        self.requests: list[str] = []
+
+    async def get(
+        self, url: str, *, headers: dict[str, str] | None = None
+    ) -> _FakeResponse:
+        await asyncio.sleep(0)
+        headers = headers or {}
+        rng = headers["Range"]
+        self.requests.append(rng)
+        kind, a, b = _parse_range(rng)
+        return self.script(self, kind, a, b)  # type: ignore[operator]
+
+    async def aclose(self) -> None:
+        return None
+
+    def partial(self, start: int, end: int, *, gzip: bool = False) -> _FakeResponse:
+        end = min(end, self.total - 1)
+        headers = {"content-range": f"bytes {start}-{end}/{self.total}"}
+        if gzip:
+            headers["content-encoding"] = "gzip"
+        return _FakeResponse(206, headers, self.wheel[start : end + 1])
+
+    def full(self, *, gzip: bool = False) -> _FakeResponse:
+        headers = {"content-encoding": "gzip"} if gzip else {}
+        return _FakeResponse(200, headers, self.wheel)
+
+
+def _run_scripted(
+    script: object, wheel: bytes | None = None, **kwargs: object
+) -> RangeMetadataResult:
+    transport = _ScriptedTransport(
+        wheel if wheel is not None else build_wheel(), script
+    )
+    return asyncio.run(
+        read_wheel_metadata_over_range(
+            transport,  # type: ignore[arg-type]
+            _URL,
+            _NAME,
+            RangeCapabilityMemo(),
+            **kwargs,  # type: ignore[arg-type]
+        )
+    )
+
+
+def test_suffix_200_gzip_downgrades_to_absolute() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return t.full(gzip=True)
+        return t.partial(a, b)
+
+    result = _run_scripted(script)
+    assert result.outcome is RangeOutcome.PARTIAL
+    assert result.text == _META.decode("utf-8")
+
+
+def test_suffix_206_without_content_range_is_full_body() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        return _FakeResponse(206, {}, t.wheel)
+
+    result = _run_scripted(script)
+    assert result.outcome is RangeOutcome.FULL_BODY
+    assert result.text == _META.decode("utf-8")
+
+
+def test_absolute_probe_200_full_body() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return _FakeResponse(501, {}, b"")
+        return t.full()
+
+    result = _run_scripted(script)
+    assert result.outcome is RangeOutcome.FULL_BODY
+
+
+def test_absolute_probe_200_gzip_is_unsupported() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return _FakeResponse(501, {}, b"")
+        return t.full(gzip=True)
+
+    result = _run_scripted(script)
+    assert result.outcome is RangeOutcome.UNSUPPORTED
+
+
+def test_absolute_probe_206_no_content_range_is_unsupported() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return _FakeResponse(501, {}, b"")
+        return _FakeResponse(206, {}, b"\x00")
+
+    result = _run_scripted(script)
+    assert result.outcome is RangeOutcome.UNSUPPORTED
+
+
+def test_absolute_probe_error_raises() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return _FakeResponse(501, {}, b"")
+        return _FakeResponse(404, {}, b"")
+
+    with pytest.raises(HttpError):
+        _run_scripted(script)
+
+
+def test_absolute_tail_200_full_body() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return _FakeResponse(501, {}, b"")
+        if a == 0 and b == 0:
+            return t.partial(0, 0)
+        return t.full()
+
+    result = _run_scripted(script)
+    assert result.outcome is RangeOutcome.FULL_BODY
+
+
+def test_absolute_tail_200_gzip_is_unsupported() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return _FakeResponse(501, {}, b"")
+        if a == 0 and b == 0:
+            return t.partial(0, 0)
+        return t.full(gzip=True)
+
+    result = _run_scripted(script)
+    assert result.outcome is RangeOutcome.UNSUPPORTED
+
+
+def test_absolute_tail_206_gzip_is_unsupported() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return _FakeResponse(501, {}, b"")
+        if a == 0 and b == 0:
+            return t.partial(0, 0)
+        return t.partial(a, b, gzip=True)
+
+    result = _run_scripted(script)
+    assert result.outcome is RangeOutcome.UNSUPPORTED
+
+
+def test_absolute_tail_error_raises() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return _FakeResponse(501, {}, b"")
+        if a == 0 and b == 0:
+            return t.partial(0, 0)
+        return _FakeResponse(500, {}, b"")
+
+    with pytest.raises(HttpError):
+        _run_scripted(script)
+
+
+def test_growth_non_206_is_missing() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return t.partial(max(0, t.total - a), t.total - 1)
+        return t.full()
+
+    result = _run_scripted(script, wheel=build_wheel(padding=4000), tail_size=64)
+    assert result.outcome is RangeOutcome.MISSING
+
+
+def test_member_fetch_success() -> None:
+    transport = FakeRangeTransport("well_behaved", build_wheel_member_front())
+    result = _read(transport)
+    assert result.outcome is RangeOutcome.PARTIAL
+    assert result.text == _META.decode("utf-8")
+
+
+def test_member_fetch_non_206_is_missing() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return t.partial(max(0, t.total - a), t.total - 1)
+        return _FakeResponse(500, {}, b"")
+
+    result = _run_scripted(script, wheel=build_wheel_member_front())
+    assert result.outcome is RangeOutcome.MISSING
+
+
+def test_suffix_206_unparseable_content_range_is_full_body() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        return _FakeResponse(206, {"content-range": "bogus"}, t.wheel)
+
+    result = _run_scripted(script)
+    assert result.outcome is RangeOutcome.FULL_BODY
+    assert result.text == _META.decode("utf-8")
+
+
+def test_memo_suffix_ok_no_reprobe() -> None:
+    async def run() -> RangeCapability:
+        memo = RangeCapabilityMemo()
+        transport = FakeRangeTransport("well_behaved", build_wheel())
+        await read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
+        assert memo.capability("files.example.org") is RangeCapability.SUFFIX_OK
+        await read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
+        return memo.capability("files.example.org")
+
+    assert asyncio.run(run()) is RangeCapability.SUFFIX_OK
+
+
+def test_memo_absolute_only_skips_reprobe() -> None:
+    async def run() -> tuple[RangeCapability, int]:
+        memo = RangeCapabilityMemo()
+        transport = FakeRangeTransport("suffix_501", build_wheel())
+        await read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
+        assert memo.capability("files.example.org") is RangeCapability.ABSOLUTE_ONLY
+        await read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
+        return memo.capability("files.example.org"), transport.negative_requests
+
+    capability, negatives = asyncio.run(run())
+    assert capability is RangeCapability.ABSOLUTE_ONLY
+    assert negatives == 1
+
+
+def test_memo_unsupported_skips_all_requests() -> None:
+    async def run() -> int:
+        memo = RangeCapabilityMemo()
+        transport = FakeRangeTransport("ignore_range_200", build_wheel())
+        await read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
+        assert memo.capability("files.example.org") is RangeCapability.UNSUPPORTED
+        first = len(transport.requests)
+        result = await read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
+        assert result.outcome is RangeOutcome.UNSUPPORTED
+        return len(transport.requests) - first
+
+    assert asyncio.run(run()) == 0
+
+
+def test_memo_concurrent_single_flight() -> None:
+    async def run() -> int:
+        memo = RangeCapabilityMemo()
+        transport = FakeRangeTransport("suffix_501", build_wheel())
+        await asyncio.gather(
+            read_wheel_metadata_over_range(transport, _URL, _NAME, memo),  # type: ignore[arg-type]
+            read_wheel_metadata_over_range(transport, _URL, _NAME, memo),  # type: ignore[arg-type]
+        )
+        return transport.negative_requests
+
+    assert asyncio.run(run()) == 1
+
+
+def test_sparse_file_seek_and_read() -> None:
+    sf = _SparseFile(100)
+    sf.add_span(10, b"abcdef")
+    assert sf.seekable() is True
+    sf.seek(10)
+    assert sf.tell() == 10
+    assert sf.read(3) == b"abc"
+    sf.seek(1, 1)
+    assert sf.read(2) == b"ef"
+    sf.seek(-90, 2)
+    assert sf.read(4) == b"abcd"
+    assert sf.read() == b"ef"
+
+
+def test_sparse_file_gap_returns_partial() -> None:
+    sf = _SparseFile(100)
+    sf.add_span(10, b"abc")
+    sf.seek(0)
+    assert sf.read(20) == b""
+    sf.seek(10)
+    assert sf.read(20) == b"abc"
+
+
+def test_sparse_file_invalid_whence() -> None:
+    sf = _SparseFile(100)
+    with pytest.raises(ValueError, match="whence"):
+        sf.seek(0, 5)
+
+
+def test_sparse_file_add_empty_span_ignored() -> None:
+    sf = _SparseFile(100)
+    sf.add_span(10, b"")
+    sf.seek(10)
+    assert sf.read(4) == b""
+
+
+def test_sparse_file_duplicate_span_ignored() -> None:
+    sf = _SparseFile(100)
+    sf.add_span(10, b"abc")
+    sf.add_span(10, b"abc")
+    sf.seek(10)
+    assert sf.read(3) == b"abc"

--- a/nab-index/tests/test_lazy_wheel.py
+++ b/nab-index/tests/test_lazy_wheel.py
@@ -129,7 +129,8 @@ class FakeRangeTransport:
         rng = headers.get("Range")
         enc = headers.get("Accept-Encoding")
         self.requests.append((rng, enc))
-        assert rng is not None
+        if rng is None:
+            return self._full()
         return self._respond(rng)
 
     async def aclose(self) -> None:
@@ -345,7 +346,10 @@ class _ScriptedTransport:
     ) -> _FakeResponse:
         await asyncio.sleep(0)
         headers = headers or {}
-        rng = headers["Range"]
+        rng = headers.get("Range")
+        if rng is None:
+            self.requests.append("full")
+            return self.script(self, "full", 0, 0)  # type: ignore[operator]
         self.requests.append(rng)
         kind, a, b = _parse_range(rng)
         return self.script(self, kind, a, b)  # type: ignore[operator]
@@ -490,11 +494,31 @@ def test_absolute_tail_error_raises() -> None:
         _run_scripted(script)
 
 
-def test_growth_non_206_is_missing() -> None:
+def test_growth_200_full_body_recovers() -> None:
     def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
         if kind == "suffix":
             return t.partial(max(0, t.total - a), t.total - 1)
         return t.full()
+
+    result = _run_scripted(script, wheel=build_wheel(padding=4000), tail_size=64)
+    assert result.text == _META.decode("utf-8")
+
+
+def test_growth_5xx_raises() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return t.partial(max(0, t.total - a), t.total - 1)
+        return _FakeResponse(500, {}, b"")
+
+    with pytest.raises(HttpError):
+        _run_scripted(script, wheel=build_wheel(padding=4000), tail_size=64)
+
+
+def test_growth_gzip_full_body_is_missing() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return t.partial(max(0, t.total - a), t.total - 1)
+        return t.full(gzip=True)
 
     result = _run_scripted(script, wheel=build_wheel(padding=4000), tail_size=64)
     assert result.outcome is RangeOutcome.MISSING
@@ -507,11 +531,31 @@ def test_member_fetch_success() -> None:
     assert result.text == _META.decode("utf-8")
 
 
-def test_member_fetch_non_206_is_missing() -> None:
+def test_member_fetch_5xx_raises() -> None:
     def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
         if kind == "suffix":
             return t.partial(max(0, t.total - a), t.total - 1)
         return _FakeResponse(500, {}, b"")
+
+    with pytest.raises(HttpError):
+        _run_scripted(script, wheel=build_wheel_member_front())
+
+
+def test_member_fetch_200_full_body_recovers() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return t.partial(max(0, t.total - a), t.total - 1)
+        return t.full()
+
+    result = _run_scripted(script, wheel=build_wheel_member_front())
+    assert result.text == _META.decode("utf-8")
+
+
+def test_member_fetch_gzip_is_missing() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return t.partial(max(0, t.total - a), t.total - 1)
+        return t.partial(a, b, gzip=True)
 
     result = _run_scripted(script, wheel=build_wheel_member_front())
     assert result.outcome is RangeOutcome.MISSING
@@ -552,18 +596,63 @@ def test_memo_absolute_only_skips_reprobe() -> None:
     assert negatives == 1
 
 
-def test_memo_unsupported_skips_all_requests() -> None:
-    async def run() -> int:
+def test_memo_full_body_only_refetches() -> None:
+    async def run() -> RangeMetadataResult:
         memo = RangeCapabilityMemo()
         transport = FakeRangeTransport("ignore_range_200", build_wheel())
-        await read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
-        assert memo.capability("files.example.org") is RangeCapability.UNSUPPORTED
-        first = len(transport.requests)
+        first = await read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
+        assert first.text == _META.decode("utf-8")
+        assert memo.capability("files.example.org") is RangeCapability.FULL_BODY_ONLY
+        # A second sidecar-less wheel on the same range-ignoring host still
+        # recovers its METADATA from a full-body GET, so resolvability does not
+        # depend on which wheel is fetched first.
+        return await read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
+
+    result = asyncio.run(run())
+    assert result.text == _META.decode("utf-8")
+    assert result.outcome is RangeOutcome.FULL_BODY
+
+
+def test_memo_gzip_stays_unsupported() -> None:
+    async def run() -> int:
+        memo = RangeCapabilityMemo()
+        transport = FakeRangeTransport("gzip_range", build_wheel())
         result = await read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
         assert result.outcome is RangeOutcome.UNSUPPORTED
+        assert memo.capability("files.example.org") is RangeCapability.UNSUPPORTED
+        first = len(transport.requests)
+        again = await read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
+        assert again.outcome is RangeOutcome.UNSUPPORTED
         return len(transport.requests) - first
 
     assert asyncio.run(run()) == 0
+
+
+def _read_full_body_only(script: object) -> RangeMetadataResult:
+    """Read against a host already memoed ``FULL_BODY_ONLY`` (a plain GET)."""
+    memo = RangeCapabilityMemo()
+    memo.record("files.example.org", RangeCapability.FULL_BODY_ONLY)
+    transport = _ScriptedTransport(build_wheel(), script)
+    return asyncio.run(
+        read_wheel_metadata_over_range(transport, _URL, _NAME, memo)  # type: ignore[arg-type]
+    )
+
+
+def test_full_body_only_gzip_is_unsupported() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        return t.full(gzip=True)
+
+    result = _read_full_body_only(script)
+    assert result.text is None
+    assert result.outcome is RangeOutcome.UNSUPPORTED
+
+
+def test_full_body_only_error_raises() -> None:
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        return _FakeResponse(500, {}, b"")
+
+    with pytest.raises(HttpError):
+        _read_full_body_only(script)
 
 
 def test_memo_concurrent_single_flight() -> None:

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -8,9 +8,11 @@ each ``Requires-Dist`` entry into base deps vs per-extra deps.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeGuard
+from urllib.parse import urlsplit
 
 from nab_index.client import SdistFile, WheelFile
+from nab_index.lazy_wheel import RangeOutcome
 from nab_index.local_index import UnsupportedWheelError, read_wheel_metadata
 
 from .._conflict_kind import EMPTY_MEMBERSHIP_SETS
@@ -75,28 +77,19 @@ def resolve_metadata(
         msg = f"Version {version} of {package} not found in listing"
         raise MetadataError(msg)
 
-    from_sdist = False
-    if isinstance(dist, WheelFile) and (url := dist.metadata_url) is not None:
-        event = provider.coordinator.request_metadata(
-            normalized, ver_str, url, dist.metadata_hash
+    metadata_text, from_sdist = _read_direct_wheel_metadata(
+        provider, dist, normalized, ver_str
+    )
+
+    # Rung 4: a sidecar-less remote wheel recovers its METADATA over ranged
+    # HTTP reads.  Fires only for a bare http/https wheel (no PEP 658 URL, no
+    # local path); a malformed-UTF-8 blob or a transport failure fetching the
+    # advertised wheel is re-raised so the candidate drops, while a plain miss
+    # leaves ``metadata_text`` None and the ladder steps to the sdist rung.
+    if metadata_text is None and _is_bare_remote_wheel(dist):
+        metadata_text, from_sdist = _read_range_metadata(
+            provider, normalized, ver_str, dist.url
         )
-        event.wait()
-        integrity_error = index.get_metadata_error(
-            normalized, ver_str, dist.metadata_url
-        )
-        if integrity_error is not None:
-            raise integrity_error
-        metadata_text, from_sdist = index.get_metadata_with_origin(
-            normalized, ver_str, dist.metadata_url
-        )
-    elif isinstance(dist, WheelFile) and dist.local_path is not None:
-        try:
-            metadata_text = read_wheel_metadata(dist.local_path)
-        except UnsupportedWheelError:
-            # A contradictory .dist-info is unusable, like an unreadable wheel.
-            metadata_text = None
-    else:
-        metadata_text = None
 
     if metadata_text is not None:
         return (metadata_text, from_sdist)
@@ -114,6 +107,90 @@ def resolve_metadata(
         f"no PEP 658 metadata and no sdist available"
     )
     raise MetadataError(msg)
+
+
+def _read_direct_wheel_metadata(
+    provider: Provider, dist: DistFile | None, package: str, version: str
+) -> tuple[str | None, bool]:
+    """Rungs 2 and 3: a PEP 658 sidecar read, then a local wheel read.
+
+    Returns ``(metadata_text, from_sdist)``; ``from_sdist`` is always ``False``
+    since both sources are wheel METADATA.  A recorded sidecar integrity error
+    is re-raised so the candidate drops; a contradictory local ``.dist-info``
+    reads back as ``None`` and the ladder steps on.
+    """
+    index = provider.coordinator.index
+    if isinstance(dist, WheelFile) and (url := dist.metadata_url) is not None:
+        event = provider.coordinator.request_metadata(
+            package, version, url, dist.metadata_hash
+        )
+        event.wait()
+        integrity_error = index.get_metadata_error(package, version, url)
+        if integrity_error is not None:
+            raise integrity_error
+        return index.get_metadata_with_origin(package, version, url)
+    if isinstance(dist, WheelFile) and dist.local_path is not None:
+        try:
+            return read_wheel_metadata(dist.local_path), False
+        except UnsupportedWheelError:
+            # A contradictory .dist-info is unusable, like an unreadable wheel.
+            return None, False
+    return None, False
+
+
+def _is_bare_remote_wheel(dist: DistFile | None) -> TypeGuard[WheelFile]:
+    """Whether ``dist`` is a sidecar-less remote wheel eligible for rung 4.
+
+    A bare wheel has no PEP 658 sidecar (``metadata_url`` is ``None``) and no
+    local path, and is served over ``http``/``https`` so its bytes can be read
+    with ranged requests.
+    """
+    return (
+        isinstance(dist, WheelFile)
+        and dist.metadata_url is None
+        and dist.local_path is None
+        and urlsplit(dist.url).scheme in ("http", "https")
+    )
+
+
+def _read_range_metadata(
+    provider: Provider, package: str, version: str, wheel_url: str
+) -> tuple[str | None, bool]:
+    """Run rung 4 for one bare wheel and return ``(metadata_text, from_sdist)``.
+
+    Blocks on the coordinator's range read, re-raises a recorded metadata error
+    (a malformed-UTF-8 blob or a transport failure) so the candidate drops, and
+    otherwise records the outcome counter and returns the version-level slot.
+    ``from_sdist`` is ``False``: recovered wheel METADATA is authoritative.
+    """
+    event = provider.coordinator.request_range_metadata(package, version, wheel_url)
+    event.wait()
+    index = provider.coordinator.index
+    integrity_error = index.get_metadata_error(package, version)
+    if integrity_error is not None:
+        raise integrity_error
+    _record_range_outcome(provider, package, version)
+    return index.get_metadata_with_origin(package, version)
+
+
+def _record_range_outcome(provider: Provider, package: str, version: str) -> None:
+    """Bump the :class:`ProviderStats` counter for a range read's outcome.
+
+    The mechanical outcome is discovered in nab-index and recorded on the
+    index; the provider owns tier accounting.  A read that recorded no outcome
+    (a refused or offline-missed request) leaves every counter untouched.
+    """
+    outcome = provider.coordinator.index.get_range_outcome(package, version)
+    if outcome is None:
+        return
+    if outcome is RangeOutcome.PARTIAL:
+        provider.stats.wheel_metadata_range_fetched += 1
+    elif outcome is RangeOutcome.FULL_BODY:
+        provider.stats.wheel_metadata_range_full_body += 1
+    elif outcome is RangeOutcome.UNSUPPORTED:
+        provider.stats.wheel_metadata_range_unsupported += 1
+    else:
+        provider.stats.wheel_metadata_range_missing += 1
 
 
 def pick_dist_for_metadata(

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -65,9 +65,17 @@ def resolve_metadata(
 
     # Sibling wheels of one version can declare different dependencies, so the
     # read is keyed by the artifact this target would install.  ``versions`` is
-    # the target's own tag-filtered listing, so the pick is per-target.
+    # the target's own tag-filtered listing, so the pick is per-target.  A
+    # sidecar wheel keys on its sidecar URL; a bare remote wheel (rung 4) keys
+    # on its own wheel URL, so its range-recovered text stays independent of a
+    # sibling wheel's.
     dist = pick_dist_for_metadata(versions, version)
-    metadata_url = dist.metadata_url if isinstance(dist, WheelFile) else None
+    if _is_bare_remote_wheel(dist):
+        metadata_url = dist.url
+    elif isinstance(dist, WheelFile):
+        metadata_url = dist.metadata_url
+    else:
+        metadata_url = None
 
     text, from_sdist = index.get_metadata_with_origin(normalized, ver_str, metadata_url)
     if text is not None:
@@ -166,11 +174,11 @@ def _read_range_metadata(
     event = provider.coordinator.request_range_metadata(package, version, wheel_url)
     event.wait()
     index = provider.coordinator.index
-    integrity_error = index.get_metadata_error(package, version)
+    integrity_error = index.get_metadata_error(package, version, wheel_url)
     if integrity_error is not None:
         raise integrity_error
     _record_range_outcome(provider, package, version)
-    return index.get_metadata_with_origin(package, version)
+    return index.get_metadata_with_origin(package, version, wheel_url)
 
 
 def _record_range_outcome(provider: Provider, package: str, version: str) -> None:

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -91,8 +91,9 @@ def resolve_metadata(
 
     # Rung 4: a sidecar-less remote wheel recovers its METADATA over ranged
     # HTTP reads.  Fires only for a bare http/https wheel (no PEP 658 URL, no
-    # local path); a malformed-UTF-8 blob or a transport failure fetching the
-    # advertised wheel is re-raised so the candidate drops, while a plain miss
+    # local path); a malformed-UTF-8 blob or an advertised wheel the index
+    # cannot serve is re-raised and fails the resolve, like an unserveable
+    # sidecar, while a plain miss (including a host without usable ranges)
     # leaves ``metadata_text`` None and the ladder steps to the sdist rung.
     if metadata_text is None and _is_bare_remote_wheel(dist):
         metadata_text, from_sdist = _read_range_metadata(
@@ -124,7 +125,7 @@ def _read_direct_wheel_metadata(
 
     Returns ``(metadata_text, from_sdist)``; ``from_sdist`` is always ``False``
     since both sources are wheel METADATA.  A recorded sidecar integrity error
-    is re-raised so the candidate drops; a contradictory local ``.dist-info``
+    is re-raised and fails the resolve; a contradictory local ``.dist-info``
     reads back as ``None`` and the ladder steps on.
     """
     index = provider.coordinator.index
@@ -166,10 +167,11 @@ def _read_range_metadata(
 ) -> tuple[str | None, bool]:
     """Run rung 4 for one bare wheel and return ``(metadata_text, from_sdist)``.
 
-    Blocks on the coordinator's range read, re-raises a recorded metadata error
-    (a malformed-UTF-8 blob or a transport failure) so the candidate drops, and
-    otherwise records the outcome counter and returns the version-level slot.
-    ``from_sdist`` is ``False``: recovered wheel METADATA is authoritative.
+    Blocks on the coordinator's range read, re-raises a recorded metadata
+    error (a malformed-UTF-8 blob, an unserveable wheel URL) so the resolve
+    fails, and otherwise records the outcome counter and reads the wheel's
+    slot.  ``from_sdist`` is ``False``: recovered wheel METADATA is
+    authoritative.
     """
     event = provider.coordinator.request_range_metadata(package, version, wheel_url)
     event.wait()
@@ -177,18 +179,20 @@ def _read_range_metadata(
     integrity_error = index.get_metadata_error(package, version, wheel_url)
     if integrity_error is not None:
         raise integrity_error
-    _record_range_outcome(provider, package, version)
+    _record_range_outcome(provider, package, version, wheel_url)
     return index.get_metadata_with_origin(package, version, wheel_url)
 
 
-def _record_range_outcome(provider: Provider, package: str, version: str) -> None:
+def _record_range_outcome(
+    provider: Provider, package: str, version: str, wheel_url: str
+) -> None:
     """Bump the :class:`ProviderStats` counter for a range read's outcome.
 
     The mechanical outcome is discovered in nab-index and recorded on the
     index; the provider owns tier accounting.  A read that recorded no outcome
     (a refused or offline-missed request) leaves every counter untouched.
     """
-    outcome = provider.coordinator.index.get_range_outcome(package, version)
+    outcome = provider.coordinator.index.get_range_outcome(package, version, wheel_url)
     if outcome is None:
         return
     if outcome is RangeOutcome.PARTIAL:

--- a/nab-python/src/nab_python/_testing/coordinator_fake.py
+++ b/nab-python/src/nab_python/_testing/coordinator_fake.py
@@ -157,12 +157,13 @@ def _wire_range_side_effects(
 
     Mirrors the coordinator's ``_fetch_range_metadata`` handler: a recorded
     ``range_error`` lands a per-wheel metadata error (the malformed-UTF-8
-    or transport drop), otherwise the read stores the recovered METADATA or
-    marks the read absent.  ``range_by_url`` selects a result per wheel URL,
-    which is how sibling sidecar-less wheels of one version are given different
-    dependencies; ``range_result`` is the single-result shortcut.  With none set
-    the request is a no-op that still returns a done event, so a rung-4 read
-    finds nothing and the ladder steps to the sdist rung.
+    blob, the unserveable wheel URL), otherwise the read stores the recovered
+    METADATA or marks the read absent.  ``range_by_url`` selects a result per
+    wheel URL, which is how sibling sidecar-less wheels of one version are
+    given different dependencies; ``range_result`` is the single-result
+    shortcut.  With none set the request is a no-op that still returns a done
+    event, so a rung-4 read finds nothing and the ladder steps to the sdist
+    rung.
     """
 
     def _request_range_metadata(pkg: str, ver: str, url: str) -> threading.Event:
@@ -171,7 +172,7 @@ def _wire_range_side_effects(
             return _done_event()
         result = range_by_url.get(url) if range_by_url is not None else range_result
         if result is not None:
-            index.store_range_outcome(pkg, ver, result.outcome)
+            index.store_range_outcome(pkg, ver, url, result.outcome)
             if result.text is None:
                 index.store_range_absent(pkg, ver, url)
             else:

--- a/nab-python/src/nab_python/_testing/coordinator_fake.py
+++ b/nab-python/src/nab_python/_testing/coordinator_fake.py
@@ -151,26 +151,31 @@ def _wire_range_side_effects(
     *,
     range_result: RangeMetadataResult | None,
     range_error: BaseException | None,
+    range_by_url: Mapping[str, RangeMetadataResult] | None,
 ) -> None:
     """Attach the ``request_range_metadata`` side effect.
 
     Mirrors the coordinator's ``_fetch_range_metadata`` handler: a recorded
-    ``range_error`` lands a version-level metadata error (the malformed-UTF-8
-    or transport drop), otherwise ``range_result`` records its outcome and
-    either stores the recovered METADATA or marks the read absent.  With
-    neither set the request is a no-op that still returns a done event, so a
-    rung-4 read finds nothing and the ladder steps to the sdist rung.
+    ``range_error`` lands a per-wheel metadata error (the malformed-UTF-8
+    or transport drop), otherwise the read stores the recovered METADATA or
+    marks the read absent.  ``range_by_url`` selects a result per wheel URL,
+    which is how sibling sidecar-less wheels of one version are given different
+    dependencies; ``range_result`` is the single-result shortcut.  With none set
+    the request is a no-op that still returns a done event, so a rung-4 read
+    finds nothing and the ladder steps to the sdist rung.
     """
 
-    def _request_range_metadata(pkg: str, ver: str, _url: str) -> threading.Event:
+    def _request_range_metadata(pkg: str, ver: str, url: str) -> threading.Event:
         if range_error is not None:
-            index.store_range_error(pkg, ver, range_error)
-        elif range_result is not None:
-            index.store_range_outcome(pkg, ver, range_result.outcome)
-            if range_result.text is None:
-                index.store_range_absent(pkg, ver)
+            index.store_range_error(pkg, ver, url, range_error)
+            return _done_event()
+        result = range_by_url.get(url) if range_by_url is not None else range_result
+        if result is not None:
+            index.store_range_outcome(pkg, ver, result.outcome)
+            if result.text is None:
+                index.store_range_absent(pkg, ver, url)
             else:
-                index.store_range_metadata(pkg, ver, range_result.text)
+                index.store_range_metadata(pkg, ver, url, result.text)
         return _done_event()
 
     coordinator.request_range_metadata.side_effect = _request_range_metadata
@@ -189,6 +194,7 @@ def make_coordinator(  # noqa: PLR0913 - one keyword per index slot a test pre-l
     sdist_pyproject_toml: str | None = None,
     range_result: RangeMetadataResult | None = None,
     range_error: BaseException | None = None,
+    range_by_url: Mapping[str, RangeMetadataResult] | None = None,
 ) -> MagicMock:
     """Build a mock :class:`FetchCoordinator` backed by an :class:`InMemoryIndex`.
 
@@ -213,10 +219,12 @@ def make_coordinator(  # noqa: PLR0913 - one keyword per index slot a test pre-l
       version are given different dependencies.
     * ``request_sdist`` writes ``sdist_pkg_info`` and, if not ``None``,
       ``sdist_pyproject_toml``.
-    * ``request_range_metadata`` records ``range_result`` (its outcome plus
-      the recovered METADATA, or an absent read when its text is ``None``),
-      or lands ``range_error`` as a version-level metadata error.  With
-      neither it is a no-op, so rung 4 finds nothing.
+    * ``request_range_metadata`` records the recovered METADATA (or an absent
+      read when its text is ``None``), or lands ``range_error`` as a per-wheel
+      metadata error.  ``range_by_url`` picks a result per wheel URL, so sibling
+      sidecar-less wheels of one version get different dependencies;
+      ``range_result`` is the single-result shortcut.  With none it is a no-op,
+      so rung 4 finds nothing.
 
     Call sites that need request side effects beyond what this helper
     wires up (for example ``request_sdist_archive``) can reassign
@@ -250,5 +258,6 @@ def make_coordinator(  # noqa: PLR0913 - one keyword per index slot a test pre-l
         index,
         range_result=range_result,
         range_error=range_error,
+        range_by_url=range_by_url,
     )
     return coordinator

--- a/nab-python/src/nab_python/_testing/coordinator_fake.py
+++ b/nab-python/src/nab_python/_testing/coordinator_fake.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
 
     from nab_index.client import SdistFile, WheelFile
+    from nab_index.lazy_wheel import RangeMetadataResult
 
 
 _MINIMAL_METADATA = "Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n\n"
@@ -144,6 +145,37 @@ def _wire_sdist_side_effects(
     coordinator.request_sdist.side_effect = _request_sdist
 
 
+def _wire_range_side_effects(
+    coordinator: MagicMock,
+    index: InMemoryIndex,
+    *,
+    range_result: RangeMetadataResult | None,
+    range_error: BaseException | None,
+) -> None:
+    """Attach the ``request_range_metadata`` side effect.
+
+    Mirrors the coordinator's ``_fetch_range_metadata`` handler: a recorded
+    ``range_error`` lands a version-level metadata error (the malformed-UTF-8
+    or transport drop), otherwise ``range_result`` records its outcome and
+    either stores the recovered METADATA or marks the read absent.  With
+    neither set the request is a no-op that still returns a done event, so a
+    rung-4 read finds nothing and the ladder steps to the sdist rung.
+    """
+
+    def _request_range_metadata(pkg: str, ver: str, _url: str) -> threading.Event:
+        if range_error is not None:
+            index.store_range_error(pkg, ver, range_error)
+        elif range_result is not None:
+            index.store_range_outcome(pkg, ver, range_result.outcome)
+            if range_result.text is None:
+                index.store_range_absent(pkg, ver)
+            else:
+                index.store_range_metadata(pkg, ver, range_result.text)
+        return _done_event()
+
+    coordinator.request_range_metadata.side_effect = _request_range_metadata
+
+
 def make_coordinator(  # noqa: PLR0913 - one keyword per index slot a test pre-loads
     wheels: Sequence[WheelFile | SdistFile] | None = None,
     *,
@@ -155,6 +187,8 @@ def make_coordinator(  # noqa: PLR0913 - one keyword per index slot a test pre-l
     auto_metadata: bool = False,
     sdist_pkg_info: str | None = None,
     sdist_pyproject_toml: str | None = None,
+    range_result: RangeMetadataResult | None = None,
+    range_error: BaseException | None = None,
 ) -> MagicMock:
     """Build a mock :class:`FetchCoordinator` backed by an :class:`InMemoryIndex`.
 
@@ -179,6 +213,10 @@ def make_coordinator(  # noqa: PLR0913 - one keyword per index slot a test pre-l
       version are given different dependencies.
     * ``request_sdist`` writes ``sdist_pkg_info`` and, if not ``None``,
       ``sdist_pyproject_toml``.
+    * ``request_range_metadata`` records ``range_result`` (its outcome plus
+      the recovered METADATA, or an absent read when its text is ``None``),
+      or lands ``range_error`` as a version-level metadata error.  With
+      neither it is a no-op, so rung 4 finds nothing.
 
     Call sites that need request side effects beyond what this helper
     wires up (for example ``request_sdist_archive``) can reassign
@@ -206,5 +244,11 @@ def make_coordinator(  # noqa: PLR0913 - one keyword per index slot a test pre-l
         index,
         sdist_pkg_info=sdist_pkg_info,
         sdist_pyproject_toml=sdist_pyproject_toml,
+    )
+    _wire_range_side_effects(
+        coordinator,
+        index,
+        range_result=range_result,
+        range_error=range_error,
     )
     return coordinator

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -160,9 +160,11 @@ class InMemoryIndex:
         self._sdist_pyproject: dict[tuple[str, str], str | None] = {}
         self._sdist_archives: dict[tuple[str, str], bytes | None] = {}
         self._sdist_archive_errors: dict[tuple[str, str], BaseException] = {}
-        # The mechanical outcome of a rung-4 range read, per version, for the
-        # provider's tier accounting.  Discovered in nab-index, recorded here.
-        self._range_outcomes: dict[tuple[str, str], RangeOutcome] = {}
+        # The mechanical outcome of a rung-4 range read, per wheel URL, for
+        # the provider's tier accounting.  Discovered in nab-index, recorded
+        # here; keyed like the read itself so sibling wheels of one version
+        # do not overwrite each other's outcome.
+        self._range_outcomes: dict[tuple[str, str, str], RangeOutcome] = {}
         self._pending: dict[str, _Pending] = {}
 
         # Parsed metadata is a pure function of the underlying text, so it
@@ -469,12 +471,11 @@ class InMemoryIndex:
         """Record a failed range read as a per-wheel error and unblock rung 4.
 
         Distinct from :meth:`store_range_absent`: a malformed-UTF-8 METADATA
-        blob or a transport failure fetching the advertised wheel must drop the
-        candidate, not fall through to the sdist.  The error lands in the
-        ``(package, version, wheel_url)`` slot the provider reads for that wheel,
-        so a per-artifact failure drops only that wheel and not an
-        independently-resolvable sibling, mirroring the sidecar's per-URL error.
-        The ``range:`` pending fires so the waiter unblocks.
+        blob, or a wheel URL the index advertised and then could not serve,
+        fails the resolve rather than falling through to the sdist, mirroring
+        :meth:`store_metadata_error` for an advertised sidecar.  The error
+        lands in the ``(package, version, wheel_url)`` slot the provider reads
+        for that wheel.  The ``range:`` pending fires so the waiter unblocks.
         """
         key = _range_key(package, version, wheel_url)
         with self._lock:
@@ -484,16 +485,18 @@ class InMemoryIndex:
             pending.event.set()
 
     def store_range_outcome(
-        self, package: str, version: str, outcome: RangeOutcome
+        self, package: str, version: str, wheel_url: str, outcome: RangeOutcome
     ) -> None:
         """Record the mechanical outcome of a range read for tier accounting."""
         with self._lock:
-            self._range_outcomes[(package, version)] = outcome
+            self._range_outcomes[(package, version, wheel_url)] = outcome
 
-    def get_range_outcome(self, package: str, version: str) -> RangeOutcome | None:
+    def get_range_outcome(
+        self, package: str, version: str, wheel_url: str
+    ) -> RangeOutcome | None:
         """Return the recorded range-read outcome, or ``None`` if none ran."""
         with self._lock:
-            return self._range_outcomes.get((package, version))
+            return self._range_outcomes.get((package, version, wheel_url))
 
     def store_sdist_pyproject(self, package: str, version: str, data: str) -> None:
         """Store sdist-derived pyproject.toml text for static-metadata fallback.
@@ -1184,8 +1187,8 @@ class FetchCoordinator:
                 # A cold offline miss is a rung miss: fall through to the sdist.
                 self.index.store_range_absent(req.package, req.version, req.url)
             else:
-                # A malformed blob or a transport failure on the advertised
-                # wheel drops the candidate; record the per-wheel error.
+                # A malformed blob or an unserveable advertised wheel fails
+                # the resolve; record the per-wheel error.
                 self.index.store_range_error(req.package, req.version, req.url, exc)
         elif req.kind is FetchKind.SDIST:
             if offline:
@@ -1268,18 +1271,20 @@ class FetchCoordinator:
     ) -> None:
         """Recover a sidecar-less wheel's METADATA over an HTTP range read.
 
-        A read that returns text stores it in the version-level slot; a read
+        A read that returns text stores it in the wheel's own slot; a read
         that returns none (ranges unsupported, no METADATA member) records the
         outcome and fires the waiter with no slot, so the provider steps to the
-        sdist rung.  A malformed blob or transport failure raises out of the
-        client and is caught by :meth:`_handle` as a fetch failure.
+        sdist rung.  A malformed blob or an unserveable wheel URL raises out of
+        the client and is caught by :meth:`_handle` as a fetch failure.
         """
         assert req.version is not None
         assert req.url is not None
         result = await client.get_range_metadata(
             req.package, req.version, req.url, canonicalize_name_boundary(req.package)
         )
-        self.index.store_range_outcome(req.package, req.version, result.outcome)
+        self.index.store_range_outcome(
+            req.package, req.version, req.url, result.outcome
+        )
         if result.text is None:
             self.index.store_range_absent(req.package, req.version, req.url)
         else:

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -19,9 +19,12 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit
 
+from packaging.utils import canonicalize_name as canonicalize_name_boundary
+
 from nab_index.cache import CacheBackend, NullCache, OfflineError, OnDiskCache
 from nab_index.cached_client import CachedAsyncSimpleClient
 from nab_index.client import SdistFile, WheelFile
+from nab_index.lazy_wheel import RangeCapabilityMemo, RangeOutcome
 from nab_index.local_index import LocalIndexClient, parse_file_url
 from nab_index.multi_index import IndexConfig, MultiIndexClient
 
@@ -63,6 +66,7 @@ class FetchKind(enum.Enum):
 
     LISTING = "listing"
     METADATA = "metadata"
+    RANGE_METADATA = "range-metadata"
     SDIST = "sdist"
     SDIST_ARCHIVE = "sdist-archive"
     DIRECT_ARCHIVE = "direct-archive"
@@ -146,6 +150,9 @@ class InMemoryIndex:
         self._sdist_pyproject: dict[tuple[str, str], str | None] = {}
         self._sdist_archives: dict[tuple[str, str], bytes | None] = {}
         self._sdist_archive_errors: dict[tuple[str, str], BaseException] = {}
+        # The mechanical outcome of a rung-4 range read, per version, for the
+        # provider's tier accounting.  Discovered in nab-index, recorded here.
+        self._range_outcomes: dict[tuple[str, str], RangeOutcome] = {}
         self._pending: dict[str, _Pending] = {}
 
         # Parsed metadata is a pure function of the underlying text, so it
@@ -409,6 +416,67 @@ class InMemoryIndex:
         with self._lock:
             return (package, version) in self._metadata_from_sdist
 
+    def store_range_metadata(self, package: str, version: str, data: str) -> None:
+        """Store range-recovered wheel METADATA in the version-level slot.
+
+        The text is authoritative wheel METADATA, so it lands in the
+        ``(package, version, None)`` slot with ``from_sdist=False`` and stays
+        off the :pep:`643` dynamic-deps gate.  Firing the ``range:`` pending
+        releases the provider thread blocked on rung 4.
+        """
+        key = f"range:{package}:{version}"
+        with self._lock:
+            self._write_metadata_slot((package, version, None), data, from_sdist=False)
+            pending = self._pending.get(key)
+        if pending is not None:
+            pending.result = data
+            pending.event.set()
+
+    def store_range_absent(self, package: str, version: str) -> None:
+        """Release a rung-4 waiter without writing a metadata slot.
+
+        A range read that yielded no METADATA (ranges unsupported, no matching
+        dist-info, an offline cold miss, a dead fetcher loop) is a rung miss,
+        not an error: the pending fires so the provider reads ``None`` and steps
+        to the sdist rung, which can still write the version-level slot.
+        """
+        key = f"range:{package}:{version}"
+        with self._lock:
+            pending = self._pending.get(key)
+        if pending is not None:
+            pending.event.set()
+
+    def store_range_error(
+        self, package: str, version: str, error: BaseException
+    ) -> None:
+        """Record a failed range read as a version-level error and unblock rung 4.
+
+        Distinct from :meth:`store_range_absent`: a malformed-UTF-8 METADATA
+        blob or a transport failure fetching the advertised wheel must drop the
+        candidate, not fall through to the sdist.  The error lands in the
+        version-level slot the provider reads with ``metadata_url=None`` and the
+        ``range:`` pending fires so the waiter unblocks, mirroring
+        :meth:`store_sdist_metadata_error`.
+        """
+        key = f"range:{package}:{version}"
+        with self._lock:
+            self._metadata_errors[(package, version, None)] = error
+            pending = self._pending.get(key)
+        if pending is not None:
+            pending.event.set()
+
+    def store_range_outcome(
+        self, package: str, version: str, outcome: RangeOutcome
+    ) -> None:
+        """Record the mechanical outcome of a range read for tier accounting."""
+        with self._lock:
+            self._range_outcomes[(package, version)] = outcome
+
+    def get_range_outcome(self, package: str, version: str) -> RangeOutcome | None:
+        """Return the recorded range-read outcome, or ``None`` if none ran."""
+        with self._lock:
+            return self._range_outcomes.get((package, version))
+
     def store_sdist_pyproject(self, package: str, version: str, data: str) -> None:
         """Store sdist-derived pyproject.toml text for static-metadata fallback.
 
@@ -609,6 +677,10 @@ class FetchCoordinator:
         # fetcher thread.  ``None`` when nothing is watching (the common case).
         self._on_fetch = on_fetch
         self.index = InMemoryIndex()
+        # Shared per-run range-capability memo.  Rebuilt fresh on the fetcher
+        # loop in _async_fetcher so each run starts with empty per-netloc state;
+        # built here too so the attribute is always a real memo for typing.
+        self._range_memo = RangeCapabilityMemo()
         self._thread: threading.Thread | None = None
         self._started = False
         self._crashed = False
@@ -686,6 +758,10 @@ class FetchCoordinator:
                 self.index.store_metadata_error(
                     req.package, req.version, error, req.url
                 )
+            elif req.kind is FetchKind.RANGE_METADATA:
+                # A dead loop is a rung miss: unblock the waiter and let it fall
+                # through to the sdist rung, not a candidate-dropping error.
+                self.index.store_range_absent(req.package, req.version)
             elif req.kind is FetchKind.SDIST:
                 self.index.store_sdist_metadata_error(req.package, req.version, error)
             else:
@@ -732,6 +808,30 @@ class FetchCoordinator:
                     version=version,
                     url=url,
                     metadata_hash=metadata_hash,
+                )
+            )
+        return pending.event
+
+    def request_range_metadata(
+        self, package: str, version: str, wheel_url: str
+    ) -> threading.Event:
+        """Request a sidecar-less wheel's METADATA over an HTTP range read.
+
+        This is rung 4: the picker returns one bare wheel per version, so the
+        ``range:`` pending key is per ``(package, version)`` and two provider
+        threads asking for that version enqueue a single read.  A warm cache hit
+        is served inside the client, so there is no early cache check here.
+        """
+        self._check_alive()
+        key = f"range:{package}:{version}"
+        pending, existed = self.index.get_or_create_pending(key)
+        if not existed:
+            self._submit(
+                FetchRequest(
+                    kind=FetchKind.RANGE_METADATA,
+                    package=package,
+                    version=version,
+                    url=wheel_url,
                 )
             )
         return pending.event
@@ -913,10 +1013,14 @@ class FetchCoordinator:
             backend,
             url,
             offline=self._offline,
+            range_memo=self._range_memo,
         )
 
     async def _async_fetcher(self) -> None:
         self._loop = asyncio.get_running_loop()
+        # Fresh per-run memo, owned on this single loop thread, injected into
+        # every client _build_client constructs below.
+        self._range_memo = RangeCapabilityMemo()
         queue: asyncio.Queue[_QueueItem] = asyncio.Queue()
         self._async_q = queue
         self._queue_ready.set()
@@ -991,6 +1095,8 @@ class FetchCoordinator:
                     await self._fetch_sdist(client, req)
                 elif req.kind is FetchKind.SDIST_ARCHIVE:
                     await self._fetch_sdist_archive(client, req)
+                elif req.kind is FetchKind.RANGE_METADATA:
+                    await self._fetch_range_metadata(client, req)
                 else:
                     await self._fetch_direct_archive(req)
             except OfflineError as exc:
@@ -1032,12 +1138,32 @@ class FetchCoordinator:
             return
 
         assert req.version is not None
+        self._record_versioned_failure(req, exc, offline=offline)
 
+    def _record_versioned_failure(
+        self, req: FetchRequest, exc: Exception, *, offline: bool
+    ) -> None:
+        """Record the failure of a version-scoped fetch, unblocking its waiter.
+
+        Offline is the one deliberate degradation: the artifact is recorded
+        absent so the resolver works with what the cache holds.  Any other
+        failure is recorded as an error, because a file the listing advertised
+        and the index then failed to serve is not one that does not exist.
+        """
+        assert req.version is not None
         if req.kind is FetchKind.METADATA:
             if offline:
                 self.index.store_metadata(req.package, req.version, None, req.url)
             else:
                 self.index.store_metadata_error(req.package, req.version, exc, req.url)
+        elif req.kind is FetchKind.RANGE_METADATA:
+            if offline:
+                # A cold offline miss is a rung miss: fall through to the sdist.
+                self.index.store_range_absent(req.package, req.version)
+            else:
+                # A malformed blob or a transport failure on the advertised
+                # wheel drops the candidate; record the version-level error.
+                self.index.store_range_error(req.package, req.version, exc)
         elif req.kind is FetchKind.SDIST:
             if offline:
                 self.index.store_sdist_metadata(req.package, req.version, None)
@@ -1111,6 +1237,36 @@ class FetchCoordinator:
         )
         self.index.store_metadata(req.package, req.version, text, req.url)
         logger.debug("fetched metadata: %s %s", req.package, req.version)
+
+    async def _fetch_range_metadata(
+        self,
+        client: CachedAsyncSimpleClient | LocalIndexClient | MultiIndexClient,
+        req: FetchRequest,
+    ) -> None:
+        """Recover a sidecar-less wheel's METADATA over an HTTP range read.
+
+        A read that returns text stores it in the version-level slot; a read
+        that returns none (ranges unsupported, no METADATA member) records the
+        outcome and fires the waiter with no slot, so the provider steps to the
+        sdist rung.  A malformed blob or transport failure raises out of the
+        client and is caught by :meth:`_handle` as a fetch failure.
+        """
+        assert req.version is not None
+        assert req.url is not None
+        result = await client.get_range_metadata(
+            req.package, req.version, req.url, canonicalize_name_boundary(req.package)
+        )
+        self.index.store_range_outcome(req.package, req.version, result.outcome)
+        if result.text is None:
+            self.index.store_range_absent(req.package, req.version)
+        else:
+            self.index.store_range_metadata(req.package, req.version, result.text)
+        logger.debug(
+            "range metadata: %s %s (%s)",
+            req.package,
+            req.version,
+            result.outcome.value,
+        )
 
     async def _fetch_sdist(
         self,

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -124,6 +124,16 @@ def _metadata_key(package: str, version: str, metadata_url: str | None) -> str:
     return f"metadata:{package}:{version}:{metadata_url}"
 
 
+def _range_key(package: str, version: str, wheel_url: str) -> str:
+    """Return the pending key for one range read.
+
+    The wheel URL is in the key so sibling sidecar-less wheels of a version do
+    not share a request: sibling wheels can declare different dependencies, so a
+    waiter is released by the wheel it asked for, matching the sidecar path.
+    """
+    return f"range:{package}:{version}:{wheel_url}"
+
+
 class InMemoryIndex:
     """Thread-safe storage for fetched package data.
 
@@ -416,23 +426,30 @@ class InMemoryIndex:
         with self._lock:
             return (package, version) in self._metadata_from_sdist
 
-    def store_range_metadata(self, package: str, version: str, data: str) -> None:
-        """Store range-recovered wheel METADATA in the version-level slot.
+    def store_range_metadata(
+        self, package: str, version: str, wheel_url: str, data: str
+    ) -> None:
+        """Store range-recovered wheel METADATA in the wheel's own slot.
 
         The text is authoritative wheel METADATA, so it lands in the
-        ``(package, version, None)`` slot with ``from_sdist=False`` and stays
-        off the :pep:`643` dynamic-deps gate.  Firing the ``range:`` pending
-        releases the provider thread blocked on rung 4.
+        ``(package, version, wheel_url)`` slot with ``from_sdist=False`` and
+        stays off the :pep:`643` dynamic-deps gate.  Keying by the wheel URL,
+        like the sidecar path, keeps sibling sidecar-less wheels of one version
+        independent: a matrix target that picks one wheel never reads another
+        wheel's dependencies.  Firing the ``range:`` pending releases the
+        provider thread blocked on rung 4.
         """
-        key = f"range:{package}:{version}"
+        key = _range_key(package, version, wheel_url)
         with self._lock:
-            self._write_metadata_slot((package, version, None), data, from_sdist=False)
+            self._write_metadata_slot(
+                (package, version, wheel_url), data, from_sdist=False
+            )
             pending = self._pending.get(key)
         if pending is not None:
             pending.result = data
             pending.event.set()
 
-    def store_range_absent(self, package: str, version: str) -> None:
+    def store_range_absent(self, package: str, version: str, wheel_url: str) -> None:
         """Release a rung-4 waiter without writing a metadata slot.
 
         A range read that yielded no METADATA (ranges unsupported, no matching
@@ -440,27 +457,28 @@ class InMemoryIndex:
         not an error: the pending fires so the provider reads ``None`` and steps
         to the sdist rung, which can still write the version-level slot.
         """
-        key = f"range:{package}:{version}"
+        key = _range_key(package, version, wheel_url)
         with self._lock:
             pending = self._pending.get(key)
         if pending is not None:
             pending.event.set()
 
     def store_range_error(
-        self, package: str, version: str, error: BaseException
+        self, package: str, version: str, wheel_url: str, error: BaseException
     ) -> None:
-        """Record a failed range read as a version-level error and unblock rung 4.
+        """Record a failed range read as a per-wheel error and unblock rung 4.
 
         Distinct from :meth:`store_range_absent`: a malformed-UTF-8 METADATA
         blob or a transport failure fetching the advertised wheel must drop the
         candidate, not fall through to the sdist.  The error lands in the
-        version-level slot the provider reads with ``metadata_url=None`` and the
-        ``range:`` pending fires so the waiter unblocks, mirroring
-        :meth:`store_sdist_metadata_error`.
+        ``(package, version, wheel_url)`` slot the provider reads for that wheel,
+        so a per-artifact failure drops only that wheel and not an
+        independently-resolvable sibling, mirroring the sidecar's per-URL error.
+        The ``range:`` pending fires so the waiter unblocks.
         """
-        key = f"range:{package}:{version}"
+        key = _range_key(package, version, wheel_url)
         with self._lock:
-            self._metadata_errors[(package, version, None)] = error
+            self._metadata_errors[(package, version, wheel_url)] = error
             pending = self._pending.get(key)
         if pending is not None:
             pending.event.set()
@@ -761,7 +779,8 @@ class FetchCoordinator:
             elif req.kind is FetchKind.RANGE_METADATA:
                 # A dead loop is a rung miss: unblock the waiter and let it fall
                 # through to the sdist rung, not a candidate-dropping error.
-                self.index.store_range_absent(req.package, req.version)
+                assert req.url is not None
+                self.index.store_range_absent(req.package, req.version, req.url)
             elif req.kind is FetchKind.SDIST:
                 self.index.store_sdist_metadata_error(req.package, req.version, error)
             else:
@@ -817,13 +836,16 @@ class FetchCoordinator:
     ) -> threading.Event:
         """Request a sidecar-less wheel's METADATA over an HTTP range read.
 
-        This is rung 4: the picker returns one bare wheel per version, so the
-        ``range:`` pending key is per ``(package, version)`` and two provider
-        threads asking for that version enqueue a single read.  A warm cache hit
-        is served inside the client, so there is no early cache check here.
+        This is rung 4: the ``range:`` pending key is per
+        ``(package, version, wheel_url)``, so two provider threads asking for the
+        same wheel enqueue a single read, while sibling sidecar-less wheels of
+        one version (which a matrix picks per target and which can declare
+        different dependencies) each get their own read, matching the sidecar
+        path.  A warm cache hit is served inside the client, so there is no early
+        cache check here.
         """
         self._check_alive()
-        key = f"range:{package}:{version}"
+        key = _range_key(package, version, wheel_url)
         pending, existed = self.index.get_or_create_pending(key)
         if not existed:
             self._submit(
@@ -1157,13 +1179,14 @@ class FetchCoordinator:
             else:
                 self.index.store_metadata_error(req.package, req.version, exc, req.url)
         elif req.kind is FetchKind.RANGE_METADATA:
+            assert req.url is not None
             if offline:
                 # A cold offline miss is a rung miss: fall through to the sdist.
-                self.index.store_range_absent(req.package, req.version)
+                self.index.store_range_absent(req.package, req.version, req.url)
             else:
                 # A malformed blob or a transport failure on the advertised
-                # wheel drops the candidate; record the version-level error.
-                self.index.store_range_error(req.package, req.version, exc)
+                # wheel drops the candidate; record the per-wheel error.
+                self.index.store_range_error(req.package, req.version, req.url, exc)
         elif req.kind is FetchKind.SDIST:
             if offline:
                 self.index.store_sdist_metadata(req.package, req.version, None)
@@ -1258,9 +1281,11 @@ class FetchCoordinator:
         )
         self.index.store_range_outcome(req.package, req.version, result.outcome)
         if result.text is None:
-            self.index.store_range_absent(req.package, req.version)
+            self.index.store_range_absent(req.package, req.version, req.url)
         else:
-            self.index.store_range_metadata(req.package, req.version, result.text)
+            self.index.store_range_metadata(
+                req.package, req.version, req.url, result.text
+            )
         logger.debug(
             "range metadata: %s %s (%s)",
             req.package,

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -147,7 +147,8 @@ class DistPolicy(enum.Enum):
     """How to admit wheels and sdists during resolution."""
 
     WHEEL_ONLY = "wheel-only"
-    """Ignore sdists entirely. Only use wheels with PEP 658 metadata."""
+    """Ignore sdists entirely. Use wheels, reading PEP 658 metadata when
+    published or an HTTP range read of the wheel otherwise."""
 
     PREFER_WHEEL = "prefer-wheel"
     """Try wheels first, fall back to sdists for versions without wheels."""
@@ -336,6 +337,10 @@ class ProviderStats:
     listings_fetched: int = 0
     metadata_fetched: int = 0
     sdist_pkg_info_fetched: int = 0
+    wheel_metadata_range_fetched: int = 0
+    wheel_metadata_range_full_body: int = 0
+    wheel_metadata_range_unsupported: int = 0
+    wheel_metadata_range_missing: int = 0
     distributions_seen: int = 0
     wheels_seen: int = 0
     sdists_seen: int = 0

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -7,12 +7,14 @@ import hashlib
 import io
 import json
 import tarfile
+import zipfile
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 from urllib.parse import urljoin, urlsplit
 
 import pytest
+from packaging.utils import canonicalize_name
 
 import nab_index.cache as cache_mod
 from nab_index.cache import CachePolicy, OfflineError, OnDiskCache
@@ -31,6 +33,7 @@ from nab_index.client import (
     _parse_sdist_filename,
     _select_artifact_hash,
 )
+from nab_index.lazy_wheel import RangeMetadataResult, RangeOutcome
 from nab_index.transport import HttpError
 from nab_python.metadata import parse_metadata
 
@@ -1788,3 +1791,189 @@ class TestContextManager:
 
         asyncio.run(go())
         assert closes == [True]
+
+
+_RANGE_META = b"Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n\nbody\n"
+_WHEEL_URL = "https://files.example.com/pkg-1.0-py3-none-any.whl"
+
+
+def _build_range_wheel() -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("pkg/__init__.py", b"value = 1\n")
+        zf.writestr("pkg-1.0.dist-info/METADATA", _RANGE_META)
+        zf.writestr("pkg-1.0.dist-info/WHEEL", b"Wheel-Version: 1.0\n")
+    return buf.getvalue()
+
+
+class _WellBehavedRangeTransport:
+    """Serve a wheel over well-behaved 206 range responses, counting calls."""
+
+    def __init__(self, wheel: bytes) -> None:
+        self.wheel = wheel
+        self.total = len(wheel)
+        self.calls = 0
+
+    async def get(
+        self, url: str, *, headers: dict[str, str] | None = None
+    ) -> _FakeResponse:
+        self.calls += 1
+        headers = headers or {}
+        body = headers["Range"].removeprefix("bytes=")
+        if body.startswith("-"):
+            start = max(0, self.total - int(body[1:]))
+            end = self.total - 1
+        else:
+            lo, _, hi = body.partition("-")
+            start, end = int(lo), min(int(hi), self.total - 1)
+        data = self.wheel[start : end + 1]
+        return _FakeResponse(
+            data,
+            status=206,
+            headers={"content-range": f"bytes {start}-{end}/{self.total}"},
+        )
+
+    async def aclose(self) -> None:
+        return None
+
+
+class _FullBodyJunkTransport:
+    """Ignore the range and hand back a 200 body that is not a zip."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def get(
+        self, url: str, *, headers: dict[str, str] | None = None
+    ) -> _FakeResponse:
+        self.calls += 1
+        return _FakeResponse(b"not a zip file", status=200)
+
+    async def aclose(self) -> None:
+        return None
+
+
+class TestGetRangeMetadata:
+    _NAME = canonicalize_name("pkg")
+
+    def test_cache_hit_returns_without_transport_and_works_offline(
+        self, tmp_path: Path
+    ) -> None:
+        cache = _make_cache(tmp_path)
+        cache.put_metadata("pkg", _WHEEL_URL, _RANGE_META.decode())
+        transport = _FakeTransport()  # raises on any request
+
+        async def go() -> RangeMetadataResult:
+            client = CachedAsyncSimpleClient(transport, cache, offline=True)
+            try:
+                return await client.get_range_metadata(
+                    "pkg", "1.0", _WHEEL_URL, self._NAME
+                )
+            finally:
+                await client.aclose()
+
+        result = asyncio.run(go())
+        assert result.text == _RANGE_META.decode()
+        assert result.outcome is RangeOutcome.PARTIAL
+        assert transport.calls == []
+
+    def test_cold_offline_raises(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport()
+
+        async def go() -> RangeMetadataResult:
+            client = CachedAsyncSimpleClient(transport, cache, offline=True)
+            try:
+                return await client.get_range_metadata(
+                    "pkg", "1.0", _WHEEL_URL, self._NAME
+                )
+            finally:
+                await client.aclose()
+
+        with pytest.raises(OfflineError, match="pkg==1.0"):
+            asyncio.run(go())
+
+    def test_recovery_writes_metadata_v1_store(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _WellBehavedRangeTransport(_build_range_wheel())
+
+        async def go() -> RangeMetadataResult:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_range_metadata(
+                    "pkg", "1.0", _WHEEL_URL, self._NAME
+                )
+            finally:
+                await client.aclose()
+
+        result = asyncio.run(go())
+        assert result.text == _RANGE_META.decode()
+        assert result.outcome is RangeOutcome.PARTIAL
+        assert transport.calls > 0
+        # Recovered METADATA lands in the metadata-v1 store keyed by wheel URL.
+        assert cache.get_metadata("pkg", _WHEEL_URL) == _RANGE_META.decode()
+
+    def test_warm_range_cache_returns_without_transport(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _WellBehavedRangeTransport(_build_range_wheel())
+
+        async def warm() -> None:
+            client = CachedAsyncSimpleClient(transport, cache)
+            await client.get_range_metadata("pkg", "1.0", _WHEEL_URL, self._NAME)
+            await client.aclose()
+
+        asyncio.run(warm())
+        first = transport.calls
+
+        offline = _FakeTransport()
+
+        async def again() -> RangeMetadataResult:
+            client = CachedAsyncSimpleClient(offline, cache, offline=True)
+            try:
+                return await client.get_range_metadata(
+                    "pkg", "1.0", _WHEEL_URL, self._NAME
+                )
+            finally:
+                await client.aclose()
+
+        result = asyncio.run(again())
+        assert result.text == _RANGE_META.decode()
+        assert transport.calls == first
+        assert offline.calls == []
+
+    def test_unreadable_wheel_returns_none_and_skips_cache(
+        self, tmp_path: Path
+    ) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _FullBodyJunkTransport()
+
+        async def go() -> RangeMetadataResult:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_range_metadata(
+                    "pkg", "1.0", _WHEEL_URL, self._NAME
+                )
+            finally:
+                await client.aclose()
+
+        result = asyncio.run(go())
+        assert result.text is None
+        assert result.outcome is RangeOutcome.MISSING
+        assert cache.get_metadata("pkg", _WHEEL_URL) is None
+
+    def test_injected_memo_is_used(self, tmp_path: Path) -> None:
+        from nab_index.lazy_wheel import RangeCapability, RangeCapabilityMemo
+
+        cache = _make_cache(tmp_path)
+        memo = RangeCapabilityMemo()
+        transport = _WellBehavedRangeTransport(_build_range_wheel())
+
+        async def go() -> None:
+            client = CachedAsyncSimpleClient(transport, cache, range_memo=memo)
+            try:
+                await client.get_range_metadata("pkg", "1.0", _WHEEL_URL, self._NAME)
+            finally:
+                await client.aclose()
+
+        asyncio.run(go())
+        assert memo.capability("files.example.com") is RangeCapability.SUFFIX_OK

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -2192,9 +2192,13 @@ class TestRangeMetadataIndex:
 
     def test_range_outcome_roundtrip(self) -> None:
         idx = InMemoryIndex()
-        assert idx.get_range_outcome("widget", "1.0") is None
-        idx.store_range_outcome("widget", "1.0", RangeOutcome.PARTIAL)
-        assert idx.get_range_outcome("widget", "1.0") is RangeOutcome.PARTIAL
+        assert idx.get_range_outcome("widget", "1.0", _RANGE_URL_A) is None
+        idx.store_range_outcome("widget", "1.0", _RANGE_URL_A, RangeOutcome.PARTIAL)
+        assert (
+            idx.get_range_outcome("widget", "1.0", _RANGE_URL_A) is RangeOutcome.PARTIAL
+        )
+        # Keyed like the read itself: a sibling wheel's slot stays empty.
+        assert idx.get_range_outcome("widget", "1.0", _RANGE_URL_B) is None
 
 
 def _crashed_range_coord() -> FetchCoordinator:
@@ -2266,7 +2270,7 @@ class TestRangeMetadataCoordinator:
                 == _RANGE_META.decode()
             )
             assert not coord.index.metadata_from_sdist("widget", "1.0")
-            assert coord.index.get_range_outcome("widget", "1.0") in (
+            assert coord.index.get_range_outcome("widget", "1.0", _RANGE_URL) in (
                 RangeOutcome.PARTIAL,
                 RangeOutcome.FULL_BODY,
             )
@@ -2281,7 +2285,8 @@ class TestRangeMetadataCoordinator:
             assert coord.index.get_metadata("widget", "1.0", _RANGE_URL) is None
             assert coord.index.get_metadata_error("widget", "1.0", _RANGE_URL) is None
             assert (
-                coord.index.get_range_outcome("widget", "1.0") is RangeOutcome.MISSING
+                coord.index.get_range_outcome("widget", "1.0", _RANGE_URL)
+                is RangeOutcome.MISSING
             )
 
     def test_handler_stores_absent_on_unsupported(self) -> None:
@@ -2291,7 +2296,7 @@ class TestRangeMetadataCoordinator:
             assert event.wait(timeout=5)
             assert coord.index.get_metadata("widget", "1.0", _RANGE_URL) is None
             assert (
-                coord.index.get_range_outcome("widget", "1.0")
+                coord.index.get_range_outcome("widget", "1.0", _RANGE_URL)
                 is RangeOutcome.UNSUPPORTED
             )
 

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -11,6 +11,7 @@ import tarfile
 import tempfile
 import threading
 import time
+import zipfile
 from collections.abc import Callable, Sequence
 from pathlib import Path
 
@@ -21,12 +22,14 @@ import respx
 from nab_index.cache import NullCache
 from nab_index.cached_client import CachedAsyncSimpleClient
 from nab_index.client import (
+    MalformedSimpleResponseError,
     MetadataHashMismatchError,
     SdistFile,
     SdistHashMismatchError,
     WheelFile,
 )
 from nab_index.httpx_async_transport import HttpxAsyncTransport
+from nab_index.lazy_wheel import RangeOutcome
 from nab_index.local_index import LocalIndexClient
 from nab_index.multi_index import IndexConfig, MultiIndexClient
 from nab_index.transport import HttpError
@@ -2015,3 +2018,264 @@ class TestSiblingWheelMetadata:
 
         assert linux.call_count == 1
         assert win.call_count == 1
+
+
+_RANGE_META = b"Metadata-Version: 2.1\nName: widget\nVersion: 1.0\n\nBody.\n"
+_RANGE_URL = "https://files.example.org/packages/widget-1.0-py3-none-any.whl"
+
+
+def _build_range_wheel(
+    *,
+    dist_info: str | None = "widget-1.0.dist-info",
+    metadata: bytes | None = _RANGE_META,
+) -> bytes:
+    """Build a small wheel zip in memory for range-reader round trips."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("widget/__init__.py", b"value = 1\n")
+        if dist_info is not None:
+            if metadata is not None:
+                zf.writestr(f"{dist_info}/METADATA", metadata)
+            zf.writestr(f"{dist_info}/WHEEL", b"Wheel-Version: 1.0\n")
+    return buf.getvalue()
+
+
+def _parse_range(value: str) -> tuple[str, int, int]:
+    body = value.removeprefix("bytes=")
+    if body.startswith("-"):
+        return ("suffix", int(body[1:]), 0)
+    start, _, end = body.partition("-")
+    return ("absolute", int(start), int(end))
+
+
+class _FakeRangeResponse:
+    def __init__(self, status: int, headers: dict[str, str], content: bytes) -> None:
+        self._status = status
+        self._headers = headers
+        self._content = content
+
+    @property
+    def status_code(self) -> int:
+        return self._status
+
+    @property
+    def headers(self) -> dict[str, str]:
+        return self._headers
+
+    @property
+    def content(self) -> bytes:
+        return self._content
+
+    @property
+    def text(self) -> str:
+        return self._content.decode("utf-8")
+
+    def json(self) -> object:
+        return json.loads(self._content)
+
+    def raise_for_status(self) -> None:
+        if self._status >= 400:
+            msg = f"HTTP {self._status}"
+            raise HttpError(msg)
+
+
+class FakeRangeTransport:
+    """Serve wheel bytes over ranges per a named server-quirk mode."""
+
+    def __init__(self, mode: str, wheel_bytes: bytes) -> None:
+        self.mode = mode
+        self.wheel = wheel_bytes
+        self.total = len(wheel_bytes)
+        self.requests: list[str] = []
+
+    async def get(
+        self, url: str, *, headers: dict[str, str] | None = None
+    ) -> _FakeRangeResponse:
+        await asyncio.sleep(0)
+        headers = headers or {}
+        rng = headers["Range"]
+        self.requests.append(rng)
+        return self._respond(rng)
+
+    async def aclose(self) -> None:
+        return None
+
+    def _partial(
+        self, start: int, end: int, *, gzip: bool = False
+    ) -> _FakeRangeResponse:
+        end = min(end, self.total - 1)
+        data = self.wheel[start : end + 1]
+        headers = {"content-range": f"bytes {start}-{end}/{self.total}"}
+        if gzip:
+            headers["content-encoding"] = "gzip"
+        return _FakeRangeResponse(206, headers, data)
+
+    def _respond(self, rng: str) -> _FakeRangeResponse:
+        kind, a, b = _parse_range(rng)
+        if self.mode == "well_behaved":
+            if kind == "suffix":
+                return self._partial(max(0, self.total - a), self.total - 1)
+            return self._partial(a, b)
+        if self.mode == "gzip_range":
+            if kind == "suffix":
+                return self._partial(max(0, self.total - a), self.total - 1, gzip=True)
+            return self._partial(a, b, gzip=True)
+        if self.mode == "error_500":
+            return _FakeRangeResponse(500, {}, b"")
+        msg = f"unknown mode {self.mode}"
+        raise AssertionError(msg)
+
+
+class TestRangeMetadataIndex:
+    def test_store_range_metadata_fires_pending(self) -> None:
+        idx = InMemoryIndex()
+        pending, _ = idx.get_or_create_pending("range:widget:1.0")
+        idx.store_range_metadata("widget", "1.0", "META")
+        assert pending.event.is_set()
+        assert idx.get_metadata("widget", "1.0") == "META"
+        assert not idx.metadata_from_sdist("widget", "1.0")
+
+    def test_store_range_metadata_without_pending(self) -> None:
+        idx = InMemoryIndex()
+        idx.store_range_metadata("widget", "1.0", "META")
+        assert idx.get_metadata("widget", "1.0") == "META"
+
+    def test_store_range_absent_fires_pending_without_slot(self) -> None:
+        idx = InMemoryIndex()
+        pending, _ = idx.get_or_create_pending("range:widget:1.0")
+        idx.store_range_absent("widget", "1.0")
+        assert pending.event.is_set()
+        assert idx.get_metadata("widget", "1.0") is None
+
+    def test_store_range_absent_without_pending(self) -> None:
+        idx = InMemoryIndex()
+        idx.store_range_absent("widget", "1.0")
+        assert idx.get_metadata("widget", "1.0") is None
+
+    def test_store_range_error_fires_pending_and_records(self) -> None:
+        idx = InMemoryIndex()
+        pending, _ = idx.get_or_create_pending("range:widget:1.0")
+        error = MalformedSimpleResponseError("bad")
+        idx.store_range_error("widget", "1.0", error)
+        assert pending.event.is_set()
+        assert idx.get_metadata_error("widget", "1.0") is error
+        assert idx.get_metadata("widget", "1.0") is None
+
+    def test_store_range_error_without_pending(self) -> None:
+        idx = InMemoryIndex()
+        error = HttpError("boom")
+        idx.store_range_error("widget", "1.0", error)
+        assert idx.get_metadata_error("widget", "1.0") is error
+
+    def test_range_outcome_roundtrip(self) -> None:
+        idx = InMemoryIndex()
+        assert idx.get_range_outcome("widget", "1.0") is None
+        idx.store_range_outcome("widget", "1.0", RangeOutcome.PARTIAL)
+        assert idx.get_range_outcome("widget", "1.0") is RangeOutcome.PARTIAL
+
+
+def _crashed_range_coord() -> FetchCoordinator:
+    """Return a crashed coordinator caught before _crashed is visible."""
+    coord = _coord(index_routes=[IndexRoute(name="foo", index="missing")])
+    coord.start()
+    assert coord._thread is not None
+    coord._thread.join(timeout=5)
+    coord._crashed = False
+    return coord
+
+
+class TestRangeMetadataCoordinator:
+    def test_single_flight_one_enqueue(self) -> None:
+        transport = FakeRangeTransport("well_behaved", _build_range_wheel())
+        with FetchCoordinator(transport=transport) as coord:  # type: ignore[arg-type]
+            submitted: list[FetchRequest] = []
+            orig = coord._submit
+
+            def spy(item: object) -> None:
+                if (
+                    isinstance(item, FetchRequest)
+                    and item.kind is FetchKind.RANGE_METADATA
+                ):
+                    submitted.append(item)
+                orig(item)  # type: ignore[arg-type]
+
+            coord._submit = spy  # type: ignore[method-assign, assignment]
+            e1 = coord.request_range_metadata("widget", "1.0", _RANGE_URL)
+            e2 = coord.request_range_metadata("widget", "1.0", _RANGE_URL)
+            assert e1 is e2
+            assert e1.wait(timeout=5)
+            assert len(submitted) == 1
+            assert coord.index.get_metadata("widget", "1.0") == _RANGE_META.decode()
+
+    def test_handler_stores_text(self) -> None:
+        transport = FakeRangeTransport("well_behaved", _build_range_wheel())
+        with FetchCoordinator(transport=transport) as coord:  # type: ignore[arg-type]
+            event = coord.request_range_metadata("widget", "1.0", _RANGE_URL)
+            assert event.wait(timeout=5)
+            assert coord.index.get_metadata("widget", "1.0") == _RANGE_META.decode()
+            assert not coord.index.metadata_from_sdist("widget", "1.0")
+            assert coord.index.get_range_outcome("widget", "1.0") in (
+                RangeOutcome.PARTIAL,
+                RangeOutcome.FULL_BODY,
+            )
+
+    def test_handler_stores_absent_on_missing(self) -> None:
+        transport = FakeRangeTransport(
+            "well_behaved", _build_range_wheel(dist_info=None)
+        )
+        with FetchCoordinator(transport=transport) as coord:  # type: ignore[arg-type]
+            event = coord.request_range_metadata("widget", "1.0", _RANGE_URL)
+            assert event.wait(timeout=5)
+            assert coord.index.get_metadata("widget", "1.0") is None
+            assert coord.index.get_metadata_error("widget", "1.0") is None
+            assert (
+                coord.index.get_range_outcome("widget", "1.0") is RangeOutcome.MISSING
+            )
+
+    def test_handler_stores_absent_on_unsupported(self) -> None:
+        transport = FakeRangeTransport("gzip_range", _build_range_wheel())
+        with FetchCoordinator(transport=transport) as coord:  # type: ignore[arg-type]
+            event = coord.request_range_metadata("widget", "1.0", _RANGE_URL)
+            assert event.wait(timeout=5)
+            assert coord.index.get_metadata("widget", "1.0") is None
+            assert (
+                coord.index.get_range_outcome("widget", "1.0")
+                is RangeOutcome.UNSUPPORTED
+            )
+
+    def test_handler_stores_error_on_bad_utf8(self) -> None:
+        transport = FakeRangeTransport(
+            "well_behaved", _build_range_wheel(metadata=b"\xff\xfe not utf-8")
+        )
+        with FetchCoordinator(transport=transport) as coord:  # type: ignore[arg-type]
+            event = coord.request_range_metadata("widget", "1.0", _RANGE_URL)
+            assert event.wait(timeout=5)
+            assert coord.index.get_metadata("widget", "1.0") is None
+            error = coord.index.get_metadata_error("widget", "1.0")
+            assert isinstance(error, MalformedSimpleResponseError)
+
+    def test_handler_stores_error_on_transport_failure(self) -> None:
+        transport = FakeRangeTransport("error_500", _build_range_wheel())
+        with FetchCoordinator(transport=transport) as coord:  # type: ignore[arg-type]
+            event = coord.request_range_metadata("widget", "1.0", _RANGE_URL)
+            assert event.wait(timeout=5)
+            assert coord.index.get_metadata("widget", "1.0") is None
+            error = coord.index.get_metadata_error("widget", "1.0")
+            assert isinstance(error, HttpError)
+
+    def test_offline_cold_stores_absent(self) -> None:
+        transport = FakeRangeTransport("well_behaved", _build_range_wheel())
+        with FetchCoordinator(transport=transport, offline=True) as coord:  # type: ignore[arg-type]
+            event = coord.request_range_metadata("widget", "1.0", _RANGE_URL)
+            assert event.wait(timeout=5)
+            assert coord.index.get_metadata("widget", "1.0") is None
+            assert coord.index.get_metadata_error("widget", "1.0") is None
+            assert transport.requests == []
+        assert not coord._crashed
+
+    def test_refused_request_releases_waiter(self) -> None:
+        coord = _crashed_range_coord()
+        event = coord.request_range_metadata("widget", "1.0", _RANGE_URL)
+        assert event.is_set()
+        assert coord.index.get_metadata("widget", "1.0") is None
+        assert coord.index.get_metadata_error("widget", "1.0") is None

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -2126,46 +2126,69 @@ class FakeRangeTransport:
         raise AssertionError(msg)
 
 
+_RANGE_URL_A = "https://files.example.org/packages/widget-1.0-cp312-linux.whl"
+_RANGE_URL_B = "https://files.example.org/packages/widget-1.0-cp312-macos.whl"
+
+
 class TestRangeMetadataIndex:
     def test_store_range_metadata_fires_pending(self) -> None:
         idx = InMemoryIndex()
-        pending, _ = idx.get_or_create_pending("range:widget:1.0")
-        idx.store_range_metadata("widget", "1.0", "META")
+        key = f"range:widget:1.0:{_RANGE_URL_A}"
+        pending, _ = idx.get_or_create_pending(key)
+        idx.store_range_metadata("widget", "1.0", _RANGE_URL_A, "META")
         assert pending.event.is_set()
-        assert idx.get_metadata("widget", "1.0") == "META"
+        assert idx.get_metadata("widget", "1.0", _RANGE_URL_A) == "META"
         assert not idx.metadata_from_sdist("widget", "1.0")
 
     def test_store_range_metadata_without_pending(self) -> None:
         idx = InMemoryIndex()
-        idx.store_range_metadata("widget", "1.0", "META")
-        assert idx.get_metadata("widget", "1.0") == "META"
+        idx.store_range_metadata("widget", "1.0", _RANGE_URL_A, "META")
+        assert idx.get_metadata("widget", "1.0", _RANGE_URL_A) == "META"
+
+    def test_sibling_wheels_keep_independent_range_slots(self) -> None:
+        idx = InMemoryIndex()
+        idx.store_range_metadata("widget", "1.0", _RANGE_URL_A, "META_A")
+        idx.store_range_metadata("widget", "1.0", _RANGE_URL_B, "META_B")
+        assert idx.get_metadata("widget", "1.0", _RANGE_URL_A) == "META_A"
+        assert idx.get_metadata("widget", "1.0", _RANGE_URL_B) == "META_B"
 
     def test_store_range_absent_fires_pending_without_slot(self) -> None:
         idx = InMemoryIndex()
-        pending, _ = idx.get_or_create_pending("range:widget:1.0")
-        idx.store_range_absent("widget", "1.0")
+        key = f"range:widget:1.0:{_RANGE_URL_A}"
+        pending, _ = idx.get_or_create_pending(key)
+        idx.store_range_absent("widget", "1.0", _RANGE_URL_A)
         assert pending.event.is_set()
-        assert idx.get_metadata("widget", "1.0") is None
+        assert idx.get_metadata("widget", "1.0", _RANGE_URL_A) is None
 
     def test_store_range_absent_without_pending(self) -> None:
         idx = InMemoryIndex()
-        idx.store_range_absent("widget", "1.0")
-        assert idx.get_metadata("widget", "1.0") is None
+        idx.store_range_absent("widget", "1.0", _RANGE_URL_A)
+        assert idx.get_metadata("widget", "1.0", _RANGE_URL_A) is None
 
     def test_store_range_error_fires_pending_and_records(self) -> None:
         idx = InMemoryIndex()
-        pending, _ = idx.get_or_create_pending("range:widget:1.0")
+        key = f"range:widget:1.0:{_RANGE_URL_A}"
+        pending, _ = idx.get_or_create_pending(key)
         error = MalformedSimpleResponseError("bad")
-        idx.store_range_error("widget", "1.0", error)
+        idx.store_range_error("widget", "1.0", _RANGE_URL_A, error)
         assert pending.event.is_set()
-        assert idx.get_metadata_error("widget", "1.0") is error
-        assert idx.get_metadata("widget", "1.0") is None
+        assert idx.get_metadata_error("widget", "1.0", _RANGE_URL_A) is error
+        assert idx.get_metadata("widget", "1.0", _RANGE_URL_A) is None
 
     def test_store_range_error_without_pending(self) -> None:
         idx = InMemoryIndex()
         error = HttpError("boom")
-        idx.store_range_error("widget", "1.0", error)
-        assert idx.get_metadata_error("widget", "1.0") is error
+        idx.store_range_error("widget", "1.0", _RANGE_URL_A, error)
+        assert idx.get_metadata_error("widget", "1.0", _RANGE_URL_A) is error
+
+    def test_sibling_range_error_spares_the_other_wheel(self) -> None:
+        idx = InMemoryIndex()
+        error = HttpError("boom")
+        idx.store_range_error("widget", "1.0", _RANGE_URL_A, error)
+        idx.store_range_metadata("widget", "1.0", _RANGE_URL_B, "META_B")
+        assert idx.get_metadata_error("widget", "1.0", _RANGE_URL_A) is error
+        assert idx.get_metadata_error("widget", "1.0", _RANGE_URL_B) is None
+        assert idx.get_metadata("widget", "1.0", _RANGE_URL_B) == "META_B"
 
     def test_range_outcome_roundtrip(self) -> None:
         idx = InMemoryIndex()
@@ -2205,14 +2228,43 @@ class TestRangeMetadataCoordinator:
             assert e1 is e2
             assert e1.wait(timeout=5)
             assert len(submitted) == 1
-            assert coord.index.get_metadata("widget", "1.0") == _RANGE_META.decode()
+            assert (
+                coord.index.get_metadata("widget", "1.0", _RANGE_URL)
+                == _RANGE_META.decode()
+            )
+
+    def test_distinct_wheel_urls_enqueue_separately(self) -> None:
+        transport = FakeRangeTransport("well_behaved", _build_range_wheel())
+        other_url = _RANGE_URL.replace("py3-none-any", "cp312-cp312-macosx")
+        with FetchCoordinator(transport=transport) as coord:  # type: ignore[arg-type]
+            submitted: list[FetchRequest] = []
+            orig = coord._submit
+
+            def spy(item: object) -> None:
+                if (
+                    isinstance(item, FetchRequest)
+                    and item.kind is FetchKind.RANGE_METADATA
+                ):
+                    submitted.append(item)
+                orig(item)  # type: ignore[arg-type]
+
+            coord._submit = spy  # type: ignore[method-assign, assignment]
+            e1 = coord.request_range_metadata("widget", "1.0", _RANGE_URL)
+            e2 = coord.request_range_metadata("widget", "1.0", other_url)
+            assert e1 is not e2
+            assert e1.wait(timeout=5)
+            assert e2.wait(timeout=5)
+            assert len(submitted) == 2
 
     def test_handler_stores_text(self) -> None:
         transport = FakeRangeTransport("well_behaved", _build_range_wheel())
         with FetchCoordinator(transport=transport) as coord:  # type: ignore[arg-type]
             event = coord.request_range_metadata("widget", "1.0", _RANGE_URL)
             assert event.wait(timeout=5)
-            assert coord.index.get_metadata("widget", "1.0") == _RANGE_META.decode()
+            assert (
+                coord.index.get_metadata("widget", "1.0", _RANGE_URL)
+                == _RANGE_META.decode()
+            )
             assert not coord.index.metadata_from_sdist("widget", "1.0")
             assert coord.index.get_range_outcome("widget", "1.0") in (
                 RangeOutcome.PARTIAL,
@@ -2226,8 +2278,8 @@ class TestRangeMetadataCoordinator:
         with FetchCoordinator(transport=transport) as coord:  # type: ignore[arg-type]
             event = coord.request_range_metadata("widget", "1.0", _RANGE_URL)
             assert event.wait(timeout=5)
-            assert coord.index.get_metadata("widget", "1.0") is None
-            assert coord.index.get_metadata_error("widget", "1.0") is None
+            assert coord.index.get_metadata("widget", "1.0", _RANGE_URL) is None
+            assert coord.index.get_metadata_error("widget", "1.0", _RANGE_URL) is None
             assert (
                 coord.index.get_range_outcome("widget", "1.0") is RangeOutcome.MISSING
             )
@@ -2237,7 +2289,7 @@ class TestRangeMetadataCoordinator:
         with FetchCoordinator(transport=transport) as coord:  # type: ignore[arg-type]
             event = coord.request_range_metadata("widget", "1.0", _RANGE_URL)
             assert event.wait(timeout=5)
-            assert coord.index.get_metadata("widget", "1.0") is None
+            assert coord.index.get_metadata("widget", "1.0", _RANGE_URL) is None
             assert (
                 coord.index.get_range_outcome("widget", "1.0")
                 is RangeOutcome.UNSUPPORTED
@@ -2250,8 +2302,8 @@ class TestRangeMetadataCoordinator:
         with FetchCoordinator(transport=transport) as coord:  # type: ignore[arg-type]
             event = coord.request_range_metadata("widget", "1.0", _RANGE_URL)
             assert event.wait(timeout=5)
-            assert coord.index.get_metadata("widget", "1.0") is None
-            error = coord.index.get_metadata_error("widget", "1.0")
+            assert coord.index.get_metadata("widget", "1.0", _RANGE_URL) is None
+            error = coord.index.get_metadata_error("widget", "1.0", _RANGE_URL)
             assert isinstance(error, MalformedSimpleResponseError)
 
     def test_handler_stores_error_on_transport_failure(self) -> None:
@@ -2259,8 +2311,8 @@ class TestRangeMetadataCoordinator:
         with FetchCoordinator(transport=transport) as coord:  # type: ignore[arg-type]
             event = coord.request_range_metadata("widget", "1.0", _RANGE_URL)
             assert event.wait(timeout=5)
-            assert coord.index.get_metadata("widget", "1.0") is None
-            error = coord.index.get_metadata_error("widget", "1.0")
+            assert coord.index.get_metadata("widget", "1.0", _RANGE_URL) is None
+            error = coord.index.get_metadata_error("widget", "1.0", _RANGE_URL)
             assert isinstance(error, HttpError)
 
     def test_offline_cold_stores_absent(self) -> None:
@@ -2268,8 +2320,8 @@ class TestRangeMetadataCoordinator:
         with FetchCoordinator(transport=transport, offline=True) as coord:  # type: ignore[arg-type]
             event = coord.request_range_metadata("widget", "1.0", _RANGE_URL)
             assert event.wait(timeout=5)
-            assert coord.index.get_metadata("widget", "1.0") is None
-            assert coord.index.get_metadata_error("widget", "1.0") is None
+            assert coord.index.get_metadata("widget", "1.0", _RANGE_URL) is None
+            assert coord.index.get_metadata_error("widget", "1.0", _RANGE_URL) is None
             assert transport.requests == []
         assert not coord._crashed
 
@@ -2277,5 +2329,5 @@ class TestRangeMetadataCoordinator:
         coord = _crashed_range_coord()
         event = coord.request_range_metadata("widget", "1.0", _RANGE_URL)
         assert event.is_set()
-        assert coord.index.get_metadata("widget", "1.0") is None
-        assert coord.index.get_metadata_error("widget", "1.0") is None
+        assert coord.index.get_metadata("widget", "1.0", _RANGE_URL) is None
+        assert coord.index.get_metadata_error("widget", "1.0", _RANGE_URL) is None

--- a/nab-python/tests/test_multi_index.py
+++ b/nab-python/tests/test_multi_index.py
@@ -6,11 +6,13 @@ import asyncio
 from typing import TYPE_CHECKING, TypeVar
 
 import pytest
+from packaging.utils import canonicalize_name
 
 from nab_index._naming import canonical as _normalise_name
 from nab_index.cache import OfflineError, OnDiskCache
 from nab_index.cached_client import CachedAsyncSimpleClient
 from nab_index.client import SdistFile, WheelFile
+from nab_index.lazy_wheel import RangeMetadataResult, RangeOutcome
 from nab_index.local_index import LocalIndexClient
 from nab_index.multi_index import IndexConfig, MultiIndexClient
 
@@ -45,6 +47,7 @@ class FakeClient:
         self.get_files_calls: list[str] = []
         self.metadata_calls: list[tuple[str, str, str]] = []
         self.sdist_calls: list[tuple[str, str, str]] = []
+        self.range_calls: list[tuple[str, str, str]] = []
         self.closed = False
 
     async def get_files(self, package: str) -> list[WheelFile | SdistFile]:
@@ -79,6 +82,16 @@ class FakeClient:
         sdist_hashes: tuple[tuple[str, str], ...] = (),
     ) -> bytes:
         return b""
+
+    async def get_range_metadata(
+        self,
+        package: str,
+        version: str,
+        wheel_url: str,
+        canonical_name: str,
+    ) -> RangeMetadataResult:
+        self.range_calls.append((package, version, wheel_url))
+        return RangeMetadataResult(f"range:{package}:{version}", RangeOutcome.PARTIAL)
 
     async def aclose(self) -> None:
         self.closed = True
@@ -297,6 +310,45 @@ class TestMetadataRouting:
         )
         run(client.get_metadata_text("foo", "1.0", "https://x/m.metadata"))
         assert first.metadata_calls == [("foo", "1.0", "https://x/m.metadata")]
+
+    def test_range_metadata_goes_to_routed_client(self) -> None:
+        first = FakeClient({})
+        second = FakeClient({"foo": [_wheel("foo")]})
+        client = MultiIndexClient(
+            {"a": first, "b": second},
+            ["a", "b"],
+            {},
+        )
+        run(client.get_files("foo"))
+        result = run(
+            client.get_range_metadata(
+                "foo",
+                "1.0",
+                "https://x/foo-1.0-py3-none-any.whl",
+                canonicalize_name("foo"),
+            )
+        )
+        assert result.text == "range:foo:1.0"
+        assert result.outcome is RangeOutcome.PARTIAL
+        assert second.range_calls == [
+            ("foo", "1.0", "https://x/foo-1.0-py3-none-any.whl")
+        ]
+        assert first.range_calls == []
+
+    def test_range_metadata_without_prior_get_files_uses_first(self) -> None:
+        first = FakeClient({})
+        second = FakeClient({})
+        client = MultiIndexClient(
+            {"a": first, "b": second},
+            ["a", "b"],
+            {},
+        )
+        run(
+            client.get_range_metadata(
+                "foo", "1.0", "https://x/foo.whl", canonicalize_name("foo")
+            )
+        )
+        assert first.range_calls == [("foo", "1.0", "https://x/foo.whl")]
 
 
 class TestAClose:

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -1775,6 +1775,58 @@ class TestRangeMetadataRung:
         assert provider.stats.wheel_metadata_range_unsupported == 0
         assert provider.stats.wheel_metadata_range_missing == 0
 
+    def test_sibling_bare_wheels_isolated_across_targets(self) -> None:
+        """Two sibling sidecar-less wheels of one version keep separate deps.
+
+        In a matrix resolve two targets share one coordinator and pick different
+        bare wheels of the same ``(package, version)`` from their own
+        tag-filtered listings.  Each must read the deps of the wheel it picked,
+        not whichever sibling ranged first.
+        """
+        url_a = "https://example.com/foo-1.0-cp312-manylinux.whl"
+        url_b = "https://example.com/foo-1.0-cp312-macosx.whl"
+        wheel_a = WheelFile(
+            filename="foo-1.0-cp312-manylinux.whl",
+            url=url_a,
+            version="1.0",
+            requires_python=None,
+            has_metadata=False,
+            upload_time=None,
+        )
+        wheel_b = WheelFile(
+            filename="foo-1.0-cp312-macosx.whl",
+            url=url_b,
+            version="1.0",
+            requires_python=None,
+            has_metadata=False,
+            upload_time=None,
+        )
+        meta_a = (
+            "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\nRequires-Dist: linux-dep\n"
+        )
+        meta_b = (
+            "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\nRequires-Dist: macos-dep\n"
+        )
+        coordinator = make_coordinator(
+            [wheel_a, wheel_b],
+            package="foo",
+            range_by_url={
+                url_a: RangeMetadataResult(meta_a, RangeOutcome.PARTIAL),
+                url_b: RangeMetadataResult(meta_b, RangeOutcome.PARTIAL),
+            },
+        )
+        provider = Provider(coordinator, target=_PY312)
+        text_a, from_a = metadata_resolver.resolve_metadata(
+            provider, [(V("1.0"), wheel_a)], "foo", V("1.0")
+        )
+        text_b, from_b = metadata_resolver.resolve_metadata(
+            provider, [(V("1.0"), wheel_b)], "foo", V("1.0")
+        )
+        assert text_a == meta_a
+        assert text_b == meta_b
+        assert not from_a
+        assert not from_b
+
     def test_wheel_only_bare_wheel_resolves_over_range(self) -> None:
         """Under WHEEL_ONLY a sidecar-less wheel now resolves instead of skipping."""
         coordinator = make_coordinator(

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -1708,8 +1708,8 @@ class TestRangeMetadataRung:
         assert provider.stats.wheel_metadata_range_missing == 1
         assert provider.stats.sdist_pkg_info_fetched == 1
 
-    def test_range_utf8_error_drops_candidate(self) -> None:
-        """Malformed-UTF-8 METADATA from a range read drops the candidate."""
+    def test_range_utf8_error_fails_resolve(self) -> None:
+        """Malformed-UTF-8 METADATA from a range read fails the resolve."""
         coordinator = make_coordinator(
             [make_wheel("1.0", has_metadata=False), make_sdist("1.0")],
             package="foo",

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -15,12 +15,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from nab_index.client import (
+    MalformedSimpleResponseError,
     MetadataHashMismatchError,
     SdistFile,
     SdistHashMismatchError,
     WheelFile,
     _parse_files,
 )
+from nab_index.lazy_wheel import RangeMetadataResult, RangeOutcome
 from nab_index.local_index import LocalIndexClient
 from nab_python._provider import build_remote, metadata_resolver
 from nab_python._provider.metadata_resolver import (
@@ -1665,6 +1667,127 @@ class TestGetDependencies:
         assert "custom-build" in deps["bar"]
         assert V("1.0") not in deps["bar"]
         assert "baz" in deps
+
+
+_RANGE_METADATA = (
+    "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\nRequires-Dist: bar>=2\n"
+)
+
+
+class TestRangeMetadataRung:
+    """Rung 4: a sidecar-less remote wheel recovers METADATA over an HTTP range."""
+
+    def test_bare_remote_wheel_resolves_via_range(self) -> None:
+        """A bare remote wheel with no sidecar resolves from a range read."""
+        coordinator = make_coordinator(
+            [make_wheel("1.0", has_metadata=False)],
+            package="foo",
+            range_result=RangeMetadataResult(_RANGE_METADATA, RangeOutcome.PARTIAL),
+        )
+        provider = Provider(coordinator, target=_PY312)
+        deps = provider.get_dependencies("foo", V("1.0"))
+        assert "bar" in deps
+        assert V("2.0") in deps["bar"]
+        assert V("1.0") not in deps["bar"]
+        assert provider.stats.wheel_metadata_range_fetched == 1
+
+    def test_range_miss_falls_to_sdist(self) -> None:
+        """A range read that yields no METADATA steps to the sdist rung."""
+        coordinator = make_coordinator(
+            [make_wheel("1.0", has_metadata=False), make_sdist("1.0")],
+            package="foo",
+            range_result=RangeMetadataResult(None, RangeOutcome.MISSING),
+            sdist_pkg_info=(
+                "Metadata-Version: 2.2\nName: foo\nVersion: 1.0\n"
+                "Requires-Dist: baz>=3\n"
+            ),
+        )
+        provider = Provider(coordinator, target=_PY312)
+        deps = provider.get_dependencies("foo", V("1.0"))
+        assert "baz" in deps
+        assert provider.stats.wheel_metadata_range_missing == 1
+        assert provider.stats.sdist_pkg_info_fetched == 1
+
+    def test_range_utf8_error_drops_candidate(self) -> None:
+        """Malformed-UTF-8 METADATA from a range read drops the candidate."""
+        coordinator = make_coordinator(
+            [make_wheel("1.0", has_metadata=False), make_sdist("1.0")],
+            package="foo",
+            range_error=MalformedSimpleResponseError("bad utf-8"),
+            sdist_pkg_info=(
+                "Metadata-Version: 2.2\nName: foo\nVersion: 1.0\n"
+                "Requires-Dist: baz>=3\n"
+            ),
+        )
+        provider = Provider(coordinator, target=_PY312)
+        with pytest.raises(MalformedSimpleResponseError):
+            provider.get_dependencies("foo", V("1.0"))
+
+    @pytest.mark.parametrize(
+        ("outcome", "text", "stat_name"),
+        [
+            (RangeOutcome.PARTIAL, _RANGE_METADATA, "wheel_metadata_range_fetched"),
+            (RangeOutcome.FULL_BODY, _RANGE_METADATA, "wheel_metadata_range_full_body"),
+            (RangeOutcome.UNSUPPORTED, None, "wheel_metadata_range_unsupported"),
+            (RangeOutcome.MISSING, None, "wheel_metadata_range_missing"),
+        ],
+    )
+    def test_each_outcome_increments_its_counter(
+        self, outcome: RangeOutcome, text: str | None, stat_name: str
+    ) -> None:
+        """Each range outcome bumps exactly its own ProviderStats counter."""
+        coordinator = make_coordinator(
+            [make_wheel("1.0", has_metadata=False), make_sdist("1.0")],
+            package="foo",
+            range_result=RangeMetadataResult(text, outcome),
+            sdist_pkg_info=(
+                "Metadata-Version: 2.2\nName: foo\nVersion: 1.0\n"
+                "Requires-Dist: baz>=3\n"
+            ),
+        )
+        provider = Provider(coordinator, target=_PY312)
+        provider.get_dependencies("foo", V("1.0"))
+        counters = {
+            "wheel_metadata_range_fetched",
+            "wheel_metadata_range_full_body",
+            "wheel_metadata_range_unsupported",
+            "wheel_metadata_range_missing",
+        }
+        assert getattr(provider.stats, stat_name) == 1
+        for other in counters - {stat_name}:
+            assert getattr(provider.stats, other) == 0
+
+    def test_no_outcome_recorded_leaves_counters_zero(self) -> None:
+        """A refused or offline-missed range read records no outcome counter."""
+        coordinator = make_coordinator(
+            [make_wheel("1.0", has_metadata=False), make_sdist("1.0")],
+            package="foo",
+            sdist_pkg_info=(
+                "Metadata-Version: 2.2\nName: foo\nVersion: 1.0\n"
+                "Requires-Dist: baz>=3\n"
+            ),
+        )
+        provider = Provider(coordinator, target=_PY312)
+        deps = provider.get_dependencies("foo", V("1.0"))
+        assert "baz" in deps
+        assert provider.stats.wheel_metadata_range_fetched == 0
+        assert provider.stats.wheel_metadata_range_full_body == 0
+        assert provider.stats.wheel_metadata_range_unsupported == 0
+        assert provider.stats.wheel_metadata_range_missing == 0
+
+    def test_wheel_only_bare_wheel_resolves_over_range(self) -> None:
+        """Under WHEEL_ONLY a sidecar-less wheel now resolves instead of skipping."""
+        coordinator = make_coordinator(
+            [make_wheel("1.0", has_metadata=False)],
+            package="foo",
+            range_result=RangeMetadataResult(_RANGE_METADATA, RangeOutcome.PARTIAL),
+        )
+        provider = Provider(
+            coordinator, target=_PY312, dist_policy=DistPolicy.WHEEL_ONLY
+        )
+        deps = provider.get_dependencies("foo", V("1.0"))
+        assert "bar" in deps
+        assert provider.stats.wheel_metadata_range_fetched == 1
 
 
 class TestTransitiveDirectUrlDep:

--- a/nab-python/tests/test_range_metadata_integration.py
+++ b/nab-python/tests/test_range_metadata_integration.py
@@ -16,7 +16,10 @@ import json
 import zipfile
 from typing import TYPE_CHECKING
 
+import pytest
+
 from nab_index.lazy_wheel import RangeOutcome
+from nab_index.transport import HttpError
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.version import Version
 from nab_python.config import NabProjectConfig
@@ -95,21 +98,27 @@ class _FakeResponse:
         return json.loads(self._content)
 
     def raise_for_status(self) -> None:
-        return None
+        if self._status >= 400:
+            msg = f"HTTP {self._status}"
+            raise HttpError(msg)
 
 
 class FakeRangeTransport:
     """Serve a Simple listing on a plain GET and wheel bytes over ranges.
 
-    A request carrying a ``Range`` header is a wheel range read; every other
-    GET is the listing fetch. Both are counted so a test can assert a warm
-    offline replay touched the network zero times.
+    A request for the wheel URL is a wheel read; every other GET is the
+    listing fetch. Both are counted so a test can assert a warm offline
+    replay touched the network zero times. ``wheel_status`` makes every
+    wheel request answer that status instead, for failure-path tests.
     """
 
-    def __init__(self, wheel: bytes, listing: bytes) -> None:
+    def __init__(
+        self, wheel: bytes, listing: bytes, *, wheel_status: int | None = None
+    ) -> None:
         self.wheel = wheel
         self.total = len(wheel)
         self.listing = listing
+        self.wheel_status = wheel_status
         self.requests: list[tuple[str, str | None]] = []
 
     async def get(
@@ -119,8 +128,12 @@ class FakeRangeTransport:
         headers = headers or {}
         rng = headers.get("Range")
         self.requests.append((url, rng))
-        if rng is None:
+        if url != _WHEEL_URL:
             return _FakeResponse(200, {"content-type": _JSON_MEDIA}, self.listing)
+        if self.wheel_status is not None:
+            return _FakeResponse(self.wheel_status, {}, b"")
+        if rng is None:
+            return _FakeResponse(200, {}, self.wheel)
         return self._range(rng)
 
     async def aclose(self) -> None:
@@ -168,14 +181,25 @@ def test_cold_resolve_recovers_metadata_over_range(tmp_path: Path) -> None:
         result = _resolve(coordinator)
         assert result.success
         assert result.target_results[0].pins == {"widget": Version("1.0")}
-        assert coordinator.index.get_range_outcome("widget", "1.0") is (
+        assert coordinator.index.get_range_outcome("widget", "1.0", _WHEEL_URL) is (
             RangeOutcome.PARTIAL
         )
 
-    # The listing was fetched once and the wheel was ranged for its METADATA.
+    # The listing was fetched once, and the small wheel's whole METADATA came
+    # back in the single suffix read: any extra request here is a regression
+    # toward the request amplification pip's fast-deps suffers.
     assert transport.listing_requests == [_SIMPLE_URL]
-    assert all(url == _WHEEL_URL for url in transport.range_requests)
-    assert transport.range_requests
+    assert transport.range_requests == [_WHEEL_URL]
+
+
+def test_resolve_fails_when_wheel_url_unserved(tmp_path: Path) -> None:
+    """An advertised wheel the index cannot serve fails the resolve loudly."""
+    transport = FakeRangeTransport(_wheel_bytes(), _listing_body(), wheel_status=404)
+    with (
+        FetchCoordinator(transport, cache_dir=tmp_path) as coordinator,  # type: ignore[arg-type]
+        pytest.raises(HttpError),
+    ):
+        _resolve(coordinator)
 
 
 def test_warm_offline_replay_serves_cache_without_ranging(tmp_path: Path) -> None:
@@ -192,7 +216,7 @@ def test_warm_offline_replay_serves_cache_without_ranging(tmp_path: Path) -> Non
         result = _resolve(coordinator)
         assert result.success
         assert result.target_results[0].pins == {"widget": Version("1.0")}
-        assert coordinator.index.get_range_outcome("widget", "1.0") is (
+        assert coordinator.index.get_range_outcome("widget", "1.0", _WHEEL_URL) is (
             RangeOutcome.PARTIAL
         )
 

--- a/nab-python/tests/test_range_metadata_integration.py
+++ b/nab-python/tests/test_range_metadata_integration.py
@@ -1,0 +1,200 @@
+"""End-to-end integration for the HTTP range-metadata fallback (rung 4).
+
+One flow proves the seams between coordinator, client, reader, provider, and
+cache: a full resolve through a real :class:`FetchCoordinator` and a
+:class:`FakeRangeTransport` locks a package whose only artifact is a
+sidecar-less wheel, recovering its METADATA over ranged reads. A warmed-cache
+offline replay then serves the recovered METADATA from the cache with no range
+request at all.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import zipfile
+from typing import TYPE_CHECKING
+
+from nab_index.lazy_wheel import RangeOutcome
+from nab_python._vendor.packaging.requirements import Requirement
+from nab_python._vendor.packaging.version import Version
+from nab_python.config import NabProjectConfig
+from nab_python.fetch import FetchCoordinator
+from nab_python.provider import BuildPolicy
+from nab_python.resolve import ResolveResult, resolve_with_coordinator
+from nab_python.tags import PlatformSpec
+from nab_python.target import ResolveTarget
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_META = b"Metadata-Version: 2.1\nName: widget\nVersion: 1.0\n\nBody text.\n"
+_WHEEL_URL = "https://files.example.org/packages/widget-1.0-py3-none-any.whl"
+_SIMPLE_URL = "https://pypi.org/simple/widget/"
+_JSON_MEDIA = "application/vnd.pypi.simple.v1+json"
+
+
+def _wheel_bytes() -> bytes:
+    """A small sidecar-less wheel holding widget's METADATA."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("widget/__init__.py", b"value = 1\n")
+        zf.writestr("widget-1.0.dist-info/METADATA", _META)
+        zf.writestr("widget-1.0.dist-info/WHEEL", b"Wheel-Version: 1.0\n")
+    return buf.getvalue()
+
+
+def _listing_body() -> bytes:
+    """A Simple-API listing whose one wheel publishes no PEP 658 sidecar."""
+    return json.dumps(
+        {
+            "meta": {"api-version": "1.0"},
+            "name": "widget",
+            "files": [
+                {
+                    "filename": "widget-1.0-py3-none-any.whl",
+                    "url": _WHEEL_URL,
+                }
+            ],
+        }
+    ).encode("utf-8")
+
+
+def _parse_range(value: str) -> tuple[str, int, int]:
+    body = value.removeprefix("bytes=")
+    if body.startswith("-"):
+        return ("suffix", int(body[1:]), 0)
+    start, _, end = body.partition("-")
+    return ("absolute", int(start), int(end))
+
+
+class _FakeResponse:
+    def __init__(self, status: int, headers: dict[str, str], content: bytes) -> None:
+        self._status = status
+        self._headers = headers
+        self._content = content
+
+    @property
+    def status_code(self) -> int:
+        return self._status
+
+    @property
+    def headers(self) -> dict[str, str]:
+        return self._headers
+
+    @property
+    def content(self) -> bytes:
+        return self._content
+
+    @property
+    def text(self) -> str:
+        return self._content.decode("utf-8")
+
+    def json(self) -> object:
+        return json.loads(self._content)
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class FakeRangeTransport:
+    """Serve a Simple listing on a plain GET and wheel bytes over ranges.
+
+    A request carrying a ``Range`` header is a wheel range read; every other
+    GET is the listing fetch. Both are counted so a test can assert a warm
+    offline replay touched the network zero times.
+    """
+
+    def __init__(self, wheel: bytes, listing: bytes) -> None:
+        self.wheel = wheel
+        self.total = len(wheel)
+        self.listing = listing
+        self.requests: list[tuple[str, str | None]] = []
+
+    async def get(
+        self, url: str, *, headers: dict[str, str] | None = None
+    ) -> _FakeResponse:
+        await asyncio.sleep(0)
+        headers = headers or {}
+        rng = headers.get("Range")
+        self.requests.append((url, rng))
+        if rng is None:
+            return _FakeResponse(200, {"content-type": _JSON_MEDIA}, self.listing)
+        return self._range(rng)
+
+    async def aclose(self) -> None:
+        return None
+
+    @property
+    def range_requests(self) -> list[str]:
+        return [url for url, rng in self.requests if rng is not None]
+
+    @property
+    def listing_requests(self) -> list[str]:
+        return [url for url, rng in self.requests if rng is None]
+
+    def _range(self, value: str) -> _FakeResponse:
+        kind, a, b = _parse_range(value)
+        if kind == "suffix":
+            start, end = max(0, self.total - a), self.total - 1
+        else:
+            start, end = a, min(b, self.total - 1)
+        headers = {"content-range": f"bytes {start}-{end}/{self.total}"}
+        return _FakeResponse(206, headers, self.wheel[start : end + 1])
+
+
+_TARGET = ResolveTarget.for_declared(
+    python_version="3.11", spec=PlatformSpec("linux_x86_64")
+)
+_NO_BUILD = NabProjectConfig(build_policy=BuildPolicy.NEVER)
+
+
+def _resolve(coordinator: FetchCoordinator) -> ResolveResult:
+    result = resolve_with_coordinator(
+        coordinator,
+        [_TARGET],
+        [Requirement("widget")],
+        config=_NO_BUILD,
+    )
+    result.raise_for_failure()
+    return result
+
+
+def test_cold_resolve_recovers_metadata_over_range(tmp_path: Path) -> None:
+    """A sidecar-less wheel locks by recovering METADATA over ranged reads."""
+    transport = FakeRangeTransport(_wheel_bytes(), _listing_body())
+    with FetchCoordinator(transport, cache_dir=tmp_path) as coordinator:  # type: ignore[arg-type]
+        result = _resolve(coordinator)
+        assert result.success
+        assert result.target_results[0].pins == {"widget": Version("1.0")}
+        assert coordinator.index.get_range_outcome("widget", "1.0") is (
+            RangeOutcome.PARTIAL
+        )
+
+    # The listing was fetched once and the wheel was ranged for its METADATA.
+    assert transport.listing_requests == [_SIMPLE_URL]
+    assert all(url == _WHEEL_URL for url in transport.range_requests)
+    assert transport.range_requests
+
+
+def test_warm_offline_replay_serves_cache_without_ranging(tmp_path: Path) -> None:
+    """A warmed cache serves the recovered METADATA offline with no range read."""
+    warm = FakeRangeTransport(_wheel_bytes(), _listing_body())
+    with FetchCoordinator(warm, cache_dir=tmp_path) as coordinator:  # type: ignore[arg-type]
+        _resolve(coordinator)
+    assert warm.range_requests
+
+    offline = FakeRangeTransport(_wheel_bytes(), _listing_body())
+    with FetchCoordinator(  # type: ignore[arg-type]
+        offline, cache_dir=tmp_path, offline=True
+    ) as coordinator:
+        result = _resolve(coordinator)
+        assert result.success
+        assert result.target_results[0].pins == {"widget": Version("1.0")}
+        assert coordinator.index.get_range_outcome("widget", "1.0") is (
+            RangeOutcome.PARTIAL
+        )
+
+    # Offline over a warm cache: neither the listing nor the wheel was fetched.
+    assert offline.requests == []


### PR DESCRIPTION
Recover a wheel's METADATA with an HTTP range read of the remote wheel when it ships no PEP 658 sidecar, instead of skipping the version. This lets wheel-only and sdist-install policies resolve packages whose indexes publish no metadata sidecar.