### PR TITLE
read a version's metadata from the wheel the target installs

### DIFF
--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -31,10 +31,13 @@ Each pinned package carries:
 
 The digests are the ones the index published, so nothing is hashed
 locally to build a lock. A resolve does fetch, but only to read
-metadata, and it takes the cheapest source available: a wheel's
-[PEP 658] metadata sidecar when the index publishes one, then an HTTP
-range read of the remote wheel when no sidecar is published, otherwise
-the sdist's PKG-INFO (built, if its dependencies are dynamic and the
+metadata. Sibling wheels of one version can declare different
+dependencies, so where several of them fit the target, the one its
+PEP 425 tags rank most specific is the one read. It takes the
+cheapest source available: the wheel's [PEP 658] metadata sidecar
+when the index publishes one, then an HTTP range read of the remote
+wheel when no sidecar is published, otherwise the sdist's PKG-INFO
+(built, if its dependencies are dynamic and the
 [build policy](build-policy.md) allows it). A wheel served from a
 local directory is read straight off disk, with no fetch. VCS and
 archive sources are cloned or downloaded for the same reason.

--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -16,6 +16,7 @@ from .._iso8601 import parse_iso_datetime
 from .._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from .._vendor.packaging.version import InvalidVersion, Version
 from ..metadata import intern_version as _intern_version
+from .metadata_resolver import pick_dist, pick_dist_for_metadata
 
 if TYPE_CHECKING:
     import threading
@@ -114,38 +115,22 @@ def wheel_by_version(
 ) -> dict[Version, DistFile]:
     """Return the cached ``Version -> DistFile`` mapping for ``normalized``.
 
-    Keeps the cheapest metadata source per version (wheel with PEP 658
-    metadata, then any wheel, then sdist), so a same-version sdist does
-    not displace the wheel.
+    Each version maps to the dist
+    :func:`~nab_python._provider.metadata_resolver.pick_dist` picks, so a
+    prefetch keyed off this mapping warms the metadata the read asks for.
     """
     cached = provider.wheel_by_version_cache.get(normalized)
     if cached is None:
-        cached = {}
+        grouped: dict[Version, list[DistFile]] = {}
         for version, dist in version_list:
-            cached[version] = _prefer_metadata_source(cached.get(version), dist)
+            grouped.setdefault(version, []).append(dist)
+
+        cached = {
+            version: pick_dist(dists, provider.wheel_tags)
+            for version, dists in grouped.items()
+        }
         provider.wheel_by_version_cache[normalized] = cached
     return cached
-
-
-def _prefer_metadata_source(current: DistFile | None, candidate: DistFile) -> DistFile:
-    """Return the cheaper metadata source of ``current`` and ``candidate``.
-
-    Same ranking as
-    :func:`nab_python._provider.metadata_resolver.pick_dist_for_metadata`:
-    a wheel with a PEP 658 ``metadata_url``, then any wheel, then an sdist.
-    """
-    if current is None:
-        return candidate
-    return (
-        current if _metadata_rank(current) <= _metadata_rank(candidate) else candidate
-    )
-
-
-def _metadata_rank(dist: DistFile) -> int:
-    """Rank a dist by metadata-fetch cost (lower is cheaper)."""
-    if isinstance(dist, WheelFile):
-        return 0 if dist.has_metadata else 1
-    return 2
 
 
 def speculative_prefetch(
@@ -227,9 +212,13 @@ def prefetch_transitive_best(
     best = provider.pick_best_candidate(normalized, versions)
     if best is None:
         return
-    version, dist = best
+    version, _ = best
     if _has_complete_override(provider, normalized, version):
         return
+
+    # Prefetch the artifact the read picks, not the listing's first at that version.
+    dist = pick_dist_for_metadata(versions, version, provider.wheel_tags)
+
     cache_key = (normalized, version)
     if (
         cache_key not in provider.deps_cache
@@ -626,17 +615,6 @@ def excluded_by_time(
     return excluded
 
 
-def _first_wheel_per_version(
-    versions_list: list[tuple[Version, DistFile]],
-) -> dict[Version, WheelFile]:
-    """First wheel-with-PEP-658-metadata per unique version, in list order."""
-    out: dict[Version, WheelFile] = {}
-    for version, dist in versions_list:
-        if isinstance(dist, WheelFile) and dist.has_metadata:
-            out.setdefault(version, dist)
-    return out
-
-
 def prefetch_walk_ahead(
     provider: Provider,
     normalized: str,
@@ -648,16 +626,15 @@ def prefetch_walk_ahead(
     window.  Front-loading the rest of the walk lets ``_try_abort_skip``
     and any restart hit cache instead of one RTT per visit.
 
-    Walks ``versions_cache[normalized]`` directly so same-version
-    (wheel, sdist) pairs do not lose the wheel the way they would
-    via ``wheel_by_version_cache``.  Skips already-cached versions,
-    sdist-only versions, and versions whose metadata the coordinator
-    already holds.  Fire-and-forget.
+    Takes each version's artifact from :func:`wheel_by_version`, so the
+    sidecar it warms is the one the read asks for.  Skips already-cached
+    versions, versions whose artifact publishes no sidecar, and versions
+    whose metadata the coordinator already holds.  Fire-and-forget.
     """
     versions_list = provider.versions_cache.get(normalized)
     if not versions_list:
         return
-    wheel_for_v = _first_wheel_per_version(versions_list)
+    picked = wheel_by_version(provider, normalized, versions_list)
     coordinator_index = provider.coordinator.index
     items: list[tuple[str, str, str, tuple[str, str] | None]] = []
     seen_versions: set[Version] = set()
@@ -667,17 +644,16 @@ def prefetch_walk_ahead(
         seen_versions.add(version)
         if len(seen_versions) > deep_count:
             break
-        wheel = wheel_for_v.get(version)
-        if wheel is None or (normalized, version) in provider.deps_cache:
+        if (normalized, version) in provider.deps_cache:
+            continue
+        dist = picked[version]
+        if not isinstance(dist, WheelFile) or (url := dist.metadata_url) is None:
             continue
         if _has_complete_override(provider, normalized, version):
             continue
-        # ``_first_wheel_per_version`` keeps only wheels with a sidecar.
-        metadata_url = wheel.metadata_url
-        assert metadata_url is not None
-        if coordinator_index.has_metadata(normalized, wheel.version, metadata_url):
+        if coordinator_index.has_metadata(normalized, dist.version, url):
             continue
-        items.append((normalized, wheel.version, metadata_url, wheel.metadata_hash))
+        items.append((normalized, dist.version, url, dist.metadata_hash))
     if items:
         provider.coordinator.request_metadata_batch(items)
 

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from .._vendor.packaging.requirements import Requirement
     from .._vendor.packaging.version import Version
     from ..provider import DistFile, Provider
+    from ..tags import TagSet
 
 
 def resolve_metadata(
@@ -69,7 +70,7 @@ def resolve_metadata(
     # sidecar wheel keys on its sidecar URL; a bare remote wheel (rung 4) keys
     # on its own wheel URL, so its range-recovered text stays independent of a
     # sibling wheel's.
-    dist = pick_dist_for_metadata(versions, version)
+    dist = pick_dist_for_metadata(versions, version, provider.wheel_tags)
     if _is_bare_remote_wheel(dist):
         metadata_url = dist.url
     elif isinstance(dist, WheelFile):
@@ -206,37 +207,47 @@ def _record_range_outcome(
 
 
 def pick_dist_for_metadata(
-    versions: Sequence[tuple[Version, DistFile]], version: Version
+    versions: Sequence[tuple[Version, DistFile]],
+    version: Version,
+    tags: TagSet | None,
 ) -> DistFile | None:
-    """Pick the cheapest dist source for ``version``'s metadata.
+    """Pick the dist whose metadata answers for ``version``. See :func:`pick_dist`."""
+    dists = [d for v, d in versions if v == version]
+    return pick_dist(dists, tags) if dists else None
 
-    Preference order at the same version:
 
-    1. A wheel with a PEP 658 ``metadata_url`` (smallest fetch).
-    2. Any wheel (range-fetch / stream still beats an sdist build).
-    3. The sdist (PKG-INFO; may require a build if Dynamic).
+def pick_dist(dists: Sequence[DistFile], tags: TagSet | None) -> DistFile:
+    """Pick the dist of one version whose metadata answers for the target.
 
-    The picker is policy-agnostic and applies whatever ``versions``
-    holds.  :attr:`~nab_python.provider.DistPolicy.SDIST_INSTALL` works
-    by keeping both kinds of dists in the listing so this preference
-    order naturally chooses the wheel when one exists, falling back
-    to the sdist when only the sdist is published.
+    ``dists`` are the artifacts of a single version, and must be non-empty.
+
+    Sibling wheels of one version can declare different dependencies, so
+    the wheel the ``tags`` rank most specific wins: :pep:`425` is what an
+    installer picks by, so that wheel's METADATA is the one the pin has to
+    satisfy.  ``tags`` is ``None`` when there is no tag axis to rank by,
+    either because nothing said which machine the resolve is for or because
+    a marker overlay moved the target off its tags.
+
+    Without tags, and between wheels the tags rank equally, the cheapest
+    metadata source wins: a wheel with a :pep:`658` ``metadata_url``, then
+    any wheel.  Only a version publishing no wheel is read from its sdist,
+    which lets :attr:`~nab_python.provider.DistPolicy.SDIST_INSTALL` keep
+    wheels in the listing purely as a metadata source.
     """
-    wheel_with_meta: DistFile | None = None
-    wheel_without_meta: DistFile | None = None
-    sdist: DistFile | None = None
-    for v, d in versions:
-        if v != version:
-            continue
-        if isinstance(d, WheelFile):
-            if d.has_metadata:
-                if wheel_with_meta is None:
-                    wheel_with_meta = d
-            elif wheel_without_meta is None:
-                wheel_without_meta = d
-        elif sdist is None:
-            sdist = d
-    return wheel_with_meta or wheel_without_meta or sdist
+    if len(dists) == 1:
+        return dists[0]
+
+    wheels = [d for d in dists if isinstance(d, WheelFile)]
+    if not wheels:
+        return dists[0]
+
+    # Sidecars first: ``pick`` keeps input order among wheels it ranks equally.
+    installed = (
+        tags.pick(sorted(wheels, key=lambda w: not w.has_metadata))
+        if tags is not None
+        else None
+    )
+    return installed or next((w for w in wheels if w.has_metadata), wheels[0])
 
 
 def _sdist_deps_need_dynamic(

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -98,6 +98,19 @@ def make_wheel(
     )
 
 
+def make_tagged_wheel(tag: str, *, has_metadata: bool = True) -> WheelFile:
+    """Build a 1.0 WheelFile carrying an explicit PEP 425 tag."""
+    filename = f"pkg-1.0-{tag}.whl"
+    return WheelFile(
+        filename=filename,
+        url=f"https://example.com/{filename}",
+        version="1.0",
+        requires_python=None,
+        has_metadata=has_metadata,
+        upload_time=None,
+    )
+
+
 def make_sdist(
     version: str = "1.0",
     requires_python: str | None = None,
@@ -6188,8 +6201,13 @@ class TestPrefetchWalkAhead:
         assert "1.0" in versions
 
     def test_picks_wheel_when_both_present(self) -> None:
-        """A version with both a wheel and a sdist still prefetches the wheel."""
+        """A version with both a wheel and a sdist still prefetches the wheel.
+
+        2.0 is the newest, so the listing prefetch takes it and 1.0 is the
+        version left for the walk-ahead batch.
+        """
         wheels: list[WheelFile | SdistFile] = [
+            make_wheel("2.0"),
             make_sdist("1.0"),
             make_wheel("1.0"),
         ]
@@ -6817,7 +6835,7 @@ class TestPickDistForMetadata:
         sdist = make_sdist("1.0")
         wheel = make_wheel("1.0")
         versions = [(V("1.0"), sdist), (V("1.0"), wheel)]
-        assert pick_dist_for_metadata(versions, V("1.0")) is wheel
+        assert pick_dist_for_metadata(versions, V("1.0"), None) is wheel
 
     def test_prefers_any_wheel_over_sdist_when_no_pep658(self) -> None:
         """Without PEP 658, a plain wheel still wins over an sdist.
@@ -6832,26 +6850,60 @@ class TestPickDistForMetadata:
         sdist = make_sdist("1.0")
         wheel_no_meta = make_wheel("1.0", has_metadata=False)
         versions = [(V("1.0"), sdist), (V("1.0"), wheel_no_meta)]
-        assert pick_dist_for_metadata(versions, V("1.0")) is wheel_no_meta
+        assert pick_dist_for_metadata(versions, V("1.0"), None) is wheel_no_meta
 
     def test_falls_back_to_sdist_when_no_wheel_at_version(self) -> None:
         """When no wheel exists at the version, the sdist is returned."""
         sdist = make_sdist("1.0")
         versions = [(V("1.0"), sdist)]
-        assert pick_dist_for_metadata(versions, V("1.0")) is sdist
+        assert pick_dist_for_metadata(versions, V("1.0"), None) is sdist
 
     def test_returns_none_for_unknown_version(self) -> None:
         """No matching version yields ``None``."""
         versions = [(V("2.0"), make_wheel("2.0"))]
-        assert pick_dist_for_metadata(versions, V("1.0")) is None
+        assert pick_dist_for_metadata(versions, V("1.0"), None) is None
+
+    def test_prefers_the_wheel_the_tags_rank_most_specific(self) -> None:
+        """The tags rank the siblings; listing order does not.
+
+        An abi3 wheel published beside a full-ABI one is a routine
+        layout, and the target installs the full-ABI one.
+        """
+        tags = ResolveTarget.for_declared(
+            python_version="3.12", spec=PlatformSpec("linux_x86_64")
+        ).tags
+        abi3 = make_tagged_wheel("cp312-abi3-manylinux_2_17_x86_64")
+        full_abi = make_tagged_wheel("cp312-cp312-manylinux_2_17_x86_64")
+        versions = [(V("1.0"), abi3), (V("1.0"), full_abi)]
+        assert pick_dist_for_metadata(versions, V("1.0"), tags) is full_abi
+
+    def test_prefers_a_wheel_over_an_sdist_under_a_tag_set(self) -> None:
+        """The tag pick runs over the wheels; an sdist stays the last resort."""
+        tags = ResolveTarget.for_declared(
+            python_version="3.12", spec=PlatformSpec("linux_x86_64")
+        ).tags
+        sdist = make_sdist("1.0")
+        wheel = make_wheel("1.0")
+        versions = [(V("1.0"), sdist), (V("1.0"), wheel)]
+        assert pick_dist_for_metadata(versions, V("1.0"), tags) is wheel
+
+    def test_breaks_a_tag_tie_with_the_cheaper_metadata_source(self) -> None:
+        """Two wheels the tags rank equally fall back to the cheaper source."""
+        tags = ResolveTarget.for_declared(
+            python_version="3.12", spec=PlatformSpec("linux_x86_64")
+        ).tags
+        no_sidecar = make_tagged_wheel("py2.py3-none-any", has_metadata=False)
+        sidecar = make_tagged_wheel("py3-none-any")
+        versions = [(V("1.0"), no_sidecar), (V("1.0"), sidecar)]
+        assert pick_dist_for_metadata(versions, V("1.0"), tags) is sidecar
 
     def test_first_match_wins_for_each_dist_kind(self) -> None:
         """Repeated entries at the same version do not displace the first.
 
-        The picker keeps the *first* candidate in each preference tier
-        (wheel-with-meta, wheel-without-meta, sdist) it sees, so a
-        later candidate of the same kind never silently overrides an
-        earlier one.  Covers the ``is None`` guards on each tier.
+        With nothing to rank the wheels by, the picker keeps the *first*
+        candidate in each preference tier (wheel-with-meta,
+        wheel-without-meta, sdist) it sees, so a later candidate of the
+        same kind never silently overrides an earlier one.
         """
         first_meta = make_wheel("1.0")
         second_meta = WheelFile(
@@ -6887,7 +6939,7 @@ class TestPickDistForMetadata:
             (V("1.0"), first_meta),
             (V("1.0"), second_meta),
         ]
-        assert pick_dist_for_metadata(versions, V("1.0")) is first_meta
+        assert pick_dist_for_metadata(versions, V("1.0"), None) is first_meta
         # Strip PEP 658 wheels: the plain wheel still wins, first one
         # encountered wins within the tier.
         versions_no_meta = [
@@ -6896,13 +6948,15 @@ class TestPickDistForMetadata:
             (V("1.0"), first_plain),
             (V("1.0"), second_plain),
         ]
-        assert pick_dist_for_metadata(versions_no_meta, V("1.0")) is first_plain
+        assert pick_dist_for_metadata(versions_no_meta, V("1.0"), None) is first_plain
         # And with sdists only, first sdist wins.
         versions_sdist_only = [
             (V("1.0"), first_sdist),
             (V("1.0"), second_sdist),
         ]
-        assert pick_dist_for_metadata(versions_sdist_only, V("1.0")) is first_sdist
+        assert (
+            pick_dist_for_metadata(versions_sdist_only, V("1.0"), None) is first_sdist
+        )
 
 
 class TestBuildPolicyDefaults:

--- a/nab-python/tests/test_provider_declared_target.py
+++ b/nab-python/tests/test_provider_declared_target.py
@@ -30,6 +30,7 @@ from nab_python.provider import (
     BuildPolicy,
     DistPolicy,
     ListingFilterCache,
+    MetadataError,
     Provider,
     VcsConfig,
     VcsPolicy,
@@ -1133,3 +1134,142 @@ class TestSiblingWheelDependencies:
         )
         assert set(macos.get_dependencies("pkg", Version("1.0"))) == {"sdistdep"}
         assert set(windows.get_dependencies("pkg", Version("1.0"))) == {"windep"}
+
+
+_PURE_WHEEL = _platform_wheel("1.0", "py3-none-any")
+
+_PURE_WHEEL_METADATA = (
+    "Metadata-Version: 2.4\nName: pkg\nVersion: 1.0\nRequires-Dist: puredep\n\n"
+)
+
+_LINUX_WHEEL_EXTRA_METADATA = (
+    "Metadata-Version: 2.4\nName: pkg\nVersion: 1.0\n"
+    'Provides-Extra: speed\nRequires-Dist: fastdep; extra == "speed"\n\n'
+)
+
+
+def _both_installable(
+    files: Sequence[WheelFile | SdistFile],
+    *,
+    linux_metadata: str = _LINUX_WHEEL_METADATA,
+) -> Provider:
+    """A linux provider over a version published as a pure and a linux wheel."""
+    coordinator = make_coordinator(
+        files,
+        package="pkg",
+        metadata_by_url={
+            _sidecar(_PURE_WHEEL): _PURE_WHEEL_METADATA,
+            _sidecar(_LINUX_WHEEL): linux_metadata,
+        },
+    )
+    return Provider(coordinator, _LINUX_TARGET)
+
+
+class TestTwoInstallableSiblingWheels:
+    """One target installing two of a version's wheels reads the specific one.
+
+    The target installs the manylinux wheel, so its ``Requires-Dist`` is the
+    one the pin has to satisfy; the pure-Python wheel beside it is there for
+    targets with no compiled build.
+    """
+
+    def test_the_pure_wheel_listed_first_does_not_supply_the_deps(self) -> None:
+        provider = _both_installable([_PURE_WHEEL, _LINUX_WHEEL])
+        assert set(provider.get_dependencies("pkg", Version("1.0"))) == {"linuxdep"}
+
+    def test_the_listing_order_does_not_change_the_deps(self) -> None:
+        provider = _both_installable([_LINUX_WHEEL, _PURE_WHEEL])
+        assert set(provider.get_dependencies("pkg", Version("1.0"))) == {"linuxdep"}
+
+    def test_the_batch_prefetch_caches_the_same_wheels_deps(self) -> None:
+        """The batch prefetch fills ``deps_cache`` from the same wheel.
+
+        Caching the pure wheel's deps for the version would leave
+        ``get_dependencies`` answering from that cache.
+        """
+        provider = _both_installable([_PURE_WHEEL, _LINUX_WHEEL])
+        version_list = provider.fetch_versions("pkg")
+        mapping = provider._wheel_by_version("pkg", version_list)
+
+        submitted = provider._prefetch_batch("pkg", [Version("1.0")], mapping)
+        provider._await_metadata_batch("pkg", submitted)
+
+        assert set(provider.deps_cache[("pkg", Version("1.0"))]) == {"linuxdep"}
+
+    def test_an_extra_only_the_installed_wheel_declares_is_provided(self) -> None:
+        """Sibling wheels can differ in ``Provides-Extra`` too."""
+        provider = _both_installable(
+            [_PURE_WHEEL, _LINUX_WHEEL], linux_metadata=_LINUX_WHEEL_EXTRA_METADATA
+        )
+        assert set(provider.get_dependencies("pkg[speed]", Version("1.0"))) == {
+            "fastdep",
+            "pkg",
+        }
+
+    def test_the_listing_prefetch_warms_the_wheel_the_read_uses(self) -> None:
+        """The speculative prefetch fetches the sidecar the read then uses.
+
+        A prefetch keyed on the pure wheel would cost a round trip nothing
+        reads and still leave the read blocking on a fetch.
+        """
+        provider = _both_installable([_PURE_WHEEL, _LINUX_WHEEL])
+        provider.fetch_versions("pkg")
+
+        requested = provider.coordinator.request_metadata
+        assert [call.args[2] for call in requested.call_args_list] == [
+            _sidecar(_LINUX_WHEEL)
+        ]
+
+        assert set(provider.get_dependencies("pkg", Version("1.0"))) == {"linuxdep"}
+        assert requested.call_count == 1
+
+    def test_the_walk_ahead_prefetch_warms_the_same_wheels_sidecar(self) -> None:
+        """The deep prefetch keys on the same pick as the read.
+
+        2.0 publishes only a pure wheel and the listing prefetch already
+        warmed it, so 1.0 is the version the walk-ahead batch carries.
+        """
+        pure_two = _platform_wheel("2.0", "py3-none-any")
+        coordinator = make_coordinator(
+            [pure_two, _PURE_WHEEL, _LINUX_WHEEL],
+            package="pkg",
+            metadata_by_url={
+                _sidecar(pure_two): (
+                    "Metadata-Version: 2.4\nName: pkg\nVersion: 2.0\n\n"
+                ),
+                _sidecar(_PURE_WHEEL): _PURE_WHEEL_METADATA,
+                _sidecar(_LINUX_WHEEL): _LINUX_WHEEL_METADATA,
+            },
+        )
+        provider = Provider(coordinator, _LINUX_TARGET)
+        provider.fetch_versions("pkg")
+        coordinator.reset_mock()
+
+        provider.prefetch_walk_ahead("pkg")
+
+        items = coordinator.request_metadata_batch.call_args[0][0]
+        assert [url for _pkg, _ver, url, _hash in items] == [_sidecar(_LINUX_WHEEL)]
+
+    def test_a_cheaper_sibling_does_not_answer_for_the_installed_wheel(self) -> None:
+        """Metadata-fetch cost never overrides the PEP 425 pick.
+
+        The installed wheel publishes no sidecar and the version ships no
+        sdist, so nab has nothing it can read; the pure wheel's sidecar is
+        not a stand-in for it.
+        """
+        linux_no_sidecar = WheelFile(
+            filename=_LINUX_WHEEL.filename,
+            url=_LINUX_WHEEL.url,
+            version="1.0",
+            requires_python=None,
+            has_metadata=False,
+            upload_time=None,
+        )
+        coordinator = make_coordinator(
+            [_PURE_WHEEL, linux_no_sidecar],
+            package="pkg",
+            metadata_by_url={_sidecar(_PURE_WHEEL): _PURE_WHEEL_METADATA},
+        )
+        provider = Provider(coordinator, _LINUX_TARGET)
+        with pytest.raises(MetadataError, match="No metadata for pkg==1.0"):
+            provider.get_dependencies("pkg", Version("1.0"))


### PR DESCRIPTION
A version can publish several wheels that one target could install, and they don't have to declare the same dependencies: an abi3 wheel beside a full-ABI one, or a pure-Python wheel beside a manylinux one. nab read the metadata of whichever of them came first in the index listing, so a resolve could pin the dependencies, or the extras, of a wheel the target would never install.

A version's wheels are now ranked by the target's PEP 425 tags, the way an installer picks. The cheapest metadata source (a PEP 658 sidecar, then any wheel, then the sdist) is only a tie-break: it applies to wheels the tags rank equally, and when there are no tags to rank by. The speculative and walk-ahead prefetches key off the same pick, so they warm the sidecar for the wheel that will actually be read.
