### PR TITLE
Fast-fail nab lock --locked on proven mismatches

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -144,6 +144,13 @@ already up to date, writing nothing. It exits non-zero if the lock would
 change or is missing, so CI can assert the lock is current. It covers
 `pylock` output to a file in single-environment mode.
 
+When a mismatch is provable from the inputs alone, a changed direct
+dependency, a narrowed `requires-python`, a changed extra or group, or a
+tightened constraint, `--locked` fails fast with that reason before
+resolving. Otherwise it runs the full re-resolve, and only that comparison
+reports the lock up to date: nab is non-sticky, so a lock can satisfy every
+input yet be stale once a newer admissible version exists.
+
 `--upgrade` re-anchors the `P<n>D` resolve window to the current time
 instead of reusing the timestamp recorded in an existing lockfile, and
 prints a notice naming the cutoff it dropped.

--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -315,6 +315,10 @@ locked packages fails it; volatile provenance metadata is
 ignored. `--locked` applies to a `pylock.toml` file in
 single-environment mode.
 
+Some mismatches are provable from your inputs without resolving, so
+`--locked` can fail fast with the reason before it re-resolves; see the
+[CLI reference](cli.md).
+
 ## `nab download`
 
 `nab download` resolves the project again, then fetches every wheel,

--- a/nab-python/src/nab_python/_lockfile/validate.py
+++ b/nab-python/src/nab_python/_lockfile/validate.py
@@ -133,20 +133,14 @@ def check_direct_requirements(
 ) -> LockDisqualification | None:
     """Check every active direct requirement against the committed lock.
 
-    A requirement is active when its marker holds for ``marker_env``, the
-    single target's marker environment. Each active requirement must have
-    a pin somewhere in the full ``Pylock.packages`` name set, and when the
-    matching pin records a concrete version the requirement's specifier
-    must contain it.
-
-    The check skips, never fires, on anything it cannot prove: a
-    requirement whose marker is false or cannot be evaluated, a direct
-    reference (a URL requirement has no specifier to test), and a pin that
-    records no concrete version or is a URL, VCS or directory pin. Every
-    skip falls through to the full re-resolve.
-
-    Returns the first violation as a :class:`LockDisqualification`, or
-    ``None`` when every active requirement is present and satisfied.
+    A requirement is active when its marker holds for ``marker_env``. Each
+    active requirement must be pinned somewhere in ``committed.packages``, and
+    when the matching pin records a concrete version the specifier must
+    contain it. Anything that cannot be reduced to a name and specifier
+    against a concrete version is skipped: an inactive or indeterminate
+    marker, a URL requirement, a version-less or direct (URL, VCS, directory)
+    pin, and a name carrying more than one versioned pin. Returns the first
+    violation, or ``None``.
     """
     package_names = {package.name for package in committed.packages}
     versioned = _versioned_pins(committed)
@@ -185,14 +179,11 @@ def check_constraints(
 ) -> LockDisqualification | None:
     """Check every active constraint against the committed lock.
 
-    A constraint is active when its marker holds for ``marker_env``. When a
-    constraint names a pin that records a concrete version, that version
-    must satisfy the constraint. A constraint whose marker is false or
-    cannot be evaluated is skipped, and a constraint that matches no
-    versioned pin (an absent package or a version-less pin) is a no-op.
-
-    Returns the first violation as a :class:`LockDisqualification`, or
-    ``None`` when every active constraint is satisfied.
+    A constraint is active when its marker holds for ``marker_env``. When it
+    names a single versioned pin, that version must satisfy the constraint. An
+    inactive or indeterminate marker, and a name with no single versioned pin
+    (absent, version-less, or multiple under a conflict fork), are skipped.
+    Returns the first violation, or ``None``.
     """
     versioned = _versioned_pins(committed)
     for constraint in constraints:
@@ -212,17 +203,24 @@ def check_constraints(
 
 
 def _versioned_pins(committed: Pylock) -> dict[str, Version]:
-    """Map canonical name to version for pins that record a concrete version.
+    """Map canonical name to version for names with a single concrete pin.
 
     URL, VCS and directory pins are excluded: they have no index version to
-    compare a specifier against, so a requirement or constraint that matches
-    one is left to the full re-resolve.
+    test a specifier against. A name carrying more than one versioned pin is
+    excluded too: a conflict fork records the same package once per member
+    under a disjoint marker, so no single version stands for the name.
     """
-    return {
-        package.name: package.version
-        for package in committed.packages
-        if package.version is not None and not _is_direct_pin(package)
-    }
+    versions: dict[str, Version] = {}
+    duplicated: set[str] = set()
+    for package in committed.packages:
+        if package.version is None or _is_direct_pin(package):
+            continue
+        if package.name in versions:
+            duplicated.add(package.name)
+        versions[package.name] = package.version
+    for name in duplicated:
+        del versions[name]
+    return versions
 
 
 def _is_direct_pin(package: Package) -> bool:

--- a/nab-python/src/nab_python/_lockfile/validate.py
+++ b/nab-python/src/nab_python/_lockfile/validate.py
@@ -1,0 +1,119 @@
+"""Resolver-free disqualification checks for ``nab lock --locked``.
+
+This module holds the pure, network-free tier that ``nab lock --locked``
+runs before it consumes a fresh resolve. Every function here is a
+disqualifier only: it returns a :class:`LockDisqualification` carrying a
+rendered reason when it can prove that a fresh resolve could not
+reproduce the committed lock, or ``None`` to fall through to the full
+re-resolve.
+
+The tier has no success verdict of its own. There is no "satisfied"
+return value, so no path from this module can report a lock as up to
+date. Only the full re-resolve comparison may do that. nab is
+non-sticky, so a lock can still satisfy every input while a newer
+admissible version makes it stale, and only a fresh resolve can tell the
+two apart.
+
+Family E, the envelope checks, cover the lockfile-level fields the writer
+computes straight from the current inputs rather than from the search:
+``requires-python``, ``extras``, ``dependency-groups`` and
+``default-groups``. When the committed lock carries a different value in
+one of them, the full comparison would also differ, so firing here is
+sound.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .._vendor.packaging.specifiers import SpecifierSet
+from .._vendor.packaging.utils import canonicalize_name
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from .._vendor.packaging.pylock import Pylock
+
+
+@dataclass(frozen=True, slots=True)
+class LockDisqualification:
+    """A proven reason the committed lock is out of date.
+
+    ``reason`` is a plain-language clause naming the disqualifier.
+    """
+
+    reason: str
+
+
+def check_envelope(
+    committed: Pylock,
+    *,
+    requires_python: str | None,
+    extras: tuple[str, ...],
+    dependency_groups: tuple[str, ...],
+    default_groups: tuple[str, ...],
+) -> LockDisqualification | None:
+    """Compare the current envelope against the committed lock.
+
+    ``requires-python`` compares as ``SpecifierSet`` equality and each
+    selection as a set of normalized names, so reformatting or reordering
+    does not fire and an empty selection matches the ``None`` the writer
+    commits. Returns the first difference, or ``None`` when every field agrees.
+    """
+    requires_python_result = _check_requires_python(
+        committed.requires_python, requires_python
+    )
+    if requires_python_result is not None:
+        return requires_python_result
+
+    for kind, committed_names, current_names in (
+        ("extras", committed.extras, extras),
+        ("dependency-groups", committed.dependency_groups, dependency_groups),
+        ("default-groups", committed.default_groups, default_groups),
+    ):
+        result = _check_name_set(kind, committed_names, current_names)
+        if result is not None:
+            return result
+
+    return None
+
+
+def _check_requires_python(
+    committed: SpecifierSet | None,
+    current: str | None,
+) -> LockDisqualification | None:
+    current_set = SpecifierSet(current) if current else None
+    if committed == current_set:
+        return None
+    return LockDisqualification(
+        reason=(
+            f"the lockfile requires-python {_render_specifier(committed)} "
+            f"does not match this run's {_render_specifier(current_set)}"
+        )
+    )
+
+
+def _check_name_set(
+    kind: str,
+    committed: Sequence[str] | None,
+    current: Sequence[str],
+) -> LockDisqualification | None:
+    committed_set = {canonicalize_name(name) for name in committed or ()}
+    current_set = {canonicalize_name(name) for name in current}
+    if committed_set == current_set:
+        return None
+    return LockDisqualification(
+        reason=(
+            f"the lockfile was built with {kind} {_render_name_set(committed_set)} "
+            f"but this run selects {_render_name_set(current_set)}"
+        )
+    )
+
+
+def _render_specifier(spec: SpecifierSet | None) -> str:
+    return "(none)" if spec is None else str(spec)
+
+
+def _render_name_set(names: Iterable[str]) -> str:
+    return "{" + ", ".join(sorted(names)) + "}"

--- a/nab-python/src/nab_python/_lockfile/validate.py
+++ b/nab-python/src/nab_python/_lockfile/validate.py
@@ -1,25 +1,19 @@
 """Resolver-free disqualification checks for ``nab lock --locked``.
 
-This module holds the pure, network-free tier that ``nab lock --locked``
-runs before it consumes a fresh resolve. Every function here is a
-disqualifier only: it returns a :class:`LockDisqualification` carrying a
-rendered reason when it can prove that a fresh resolve could not
-reproduce the committed lock, or ``None`` to fall through to the full
-re-resolve.
+These run before the fresh resolve. Each function is a disqualifier: it
+returns a :class:`LockDisqualification` when it can prove a fresh resolve
+could not reproduce the committed lock, or ``None`` to fall through to the
+full re-resolve. There is no success verdict here; only the full re-resolve
+reports a lock as up to date. nab is non-sticky, so a lock can satisfy every
+input yet be stale once a newer admissible version exists, and only a fresh
+resolve tells the two apart.
 
-The tier has no success verdict of its own. There is no "satisfied"
-return value, so no path from this module can report a lock as up to
-date. Only the full re-resolve comparison may do that. nab is
-non-sticky, so a lock can still satisfy every input while a newer
-admissible version makes it stale, and only a fresh resolve can tell the
-two apart.
-
-Family E, the envelope checks, cover the lockfile-level fields the writer
-computes straight from the current inputs rather than from the search:
-``requires-python``, ``extras``, ``dependency-groups`` and
-``default-groups``. When the committed lock carries a different value in
-one of them, the full comparison would also differ, so firing here is
-sound.
+The envelope checks (:func:`check_envelope`) cover the lockfile fields the
+writer computes straight from the inputs: ``requires-python``, ``extras``,
+``dependency-groups`` and ``default-groups``. The validity checks
+(:func:`check_direct_requirements`, :func:`check_constraints`) cover what
+every successful resolve renders: each active direct requirement is present
+and its specifier met, and each pin satisfies every active constraint.
 """
 
 from __future__ import annotations
@@ -27,13 +21,21 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from .._conflict_kind import dependency_marker_holds
+from .._vendor.packaging.markers import (
+    UndefinedComparison,
+    UndefinedEnvironmentName,
+)
 from .._vendor.packaging.specifiers import SpecifierSet
 from .._vendor.packaging.utils import canonicalize_name
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+    from collections.abc import Iterable, Mapping, Sequence
 
-    from .._vendor.packaging.pylock import Pylock
+    from .._vendor.packaging.markers import Marker
+    from .._vendor.packaging.pylock import Package, Pylock
+    from .._vendor.packaging.requirements import Requirement
+    from .._vendor.packaging.version import Version
 
 
 @dataclass(frozen=True, slots=True)
@@ -44,6 +46,18 @@ class LockDisqualification:
     """
 
     reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class RootRequirement:
+    """One active direct requirement plus the pyproject clause it came from.
+
+    ``source`` is the plain-language origin named in a disqualification
+    reason, for example ``[project].dependencies`` or a selected extra or group.
+    """
+
+    requirement: Requirement
+    source: str
 
 
 def check_envelope(
@@ -109,6 +123,129 @@ def _check_name_set(
             f"but this run selects {_render_name_set(current_set)}"
         )
     )
+
+
+def check_direct_requirements(
+    committed: Pylock,
+    requirements: Iterable[RootRequirement],
+    *,
+    marker_env: Mapping[str, str],
+) -> LockDisqualification | None:
+    """Check every active direct requirement against the committed lock.
+
+    A requirement is active when its marker holds for ``marker_env``, the
+    single target's marker environment. Each active requirement must have
+    a pin somewhere in the full ``Pylock.packages`` name set, and when the
+    matching pin records a concrete version the requirement's specifier
+    must contain it.
+
+    The check skips, never fires, on anything it cannot prove: a
+    requirement whose marker is false or cannot be evaluated, a direct
+    reference (a URL requirement has no specifier to test), and a pin that
+    records no concrete version or is a URL, VCS or directory pin. Every
+    skip falls through to the full re-resolve.
+
+    Returns the first violation as a :class:`LockDisqualification`, or
+    ``None`` when every active requirement is present and satisfied.
+    """
+    package_names = {package.name for package in committed.packages}
+    versioned = _versioned_pins(committed)
+    for root in requirements:
+        req = root.requirement
+        if _marker_skips(req.marker, marker_env):
+            continue
+        name = canonicalize_name(req.name)
+        if name not in package_names:
+            return LockDisqualification(
+                reason=(
+                    f"{root.source} requires {req.name} and its marker applies "
+                    f"here, but the lock has no {req.name} pin"
+                )
+            )
+        if req.url:
+            continue
+        version = versioned.get(name)
+        if version is None:
+            continue
+        if not req.specifier.contains(version, prereleases=True):
+            return LockDisqualification(
+                reason=(
+                    f"{root.source} requires {req.name}{req.specifier} but the "
+                    f"lock pins {req.name} {version}"
+                )
+            )
+    return None
+
+
+def check_constraints(
+    committed: Pylock,
+    constraints: Iterable[Requirement],
+    *,
+    marker_env: Mapping[str, str],
+) -> LockDisqualification | None:
+    """Check every active constraint against the committed lock.
+
+    A constraint is active when its marker holds for ``marker_env``. When a
+    constraint names a pin that records a concrete version, that version
+    must satisfy the constraint. A constraint whose marker is false or
+    cannot be evaluated is skipped, and a constraint that matches no
+    versioned pin (an absent package or a version-less pin) is a no-op.
+
+    Returns the first violation as a :class:`LockDisqualification`, or
+    ``None`` when every active constraint is satisfied.
+    """
+    versioned = _versioned_pins(committed)
+    for constraint in constraints:
+        if _marker_skips(constraint.marker, marker_env):
+            continue
+        version = versioned.get(canonicalize_name(constraint.name))
+        if version is None:
+            continue
+        if not constraint.specifier.contains(version, prereleases=True):
+            return LockDisqualification(
+                reason=(
+                    f"the constraint {constraint.name}{constraint.specifier} is "
+                    f"violated by the pinned {constraint.name} {version}"
+                )
+            )
+    return None
+
+
+def _versioned_pins(committed: Pylock) -> dict[str, Version]:
+    """Map canonical name to version for pins that record a concrete version.
+
+    URL, VCS and directory pins are excluded: they have no index version to
+    compare a specifier against, so a requirement or constraint that matches
+    one is left to the full re-resolve.
+    """
+    return {
+        package.name: package.version
+        for package in committed.packages
+        if package.version is not None and not _is_direct_pin(package)
+    }
+
+
+def _is_direct_pin(package: Package) -> bool:
+    return (
+        package.vcs is not None
+        or package.directory is not None
+        or package.archive is not None
+    )
+
+
+def _marker_skips(marker: Marker | None, marker_env: Mapping[str, str]) -> bool:
+    """Return whether an item is inactive or indeterminate for ``marker_env``.
+
+    A missing marker is active. A false marker is inactive. A marker that
+    cannot be evaluated is indeterminate. Both inactive and indeterminate skip.
+    """
+    if marker is None:
+        return False
+    try:
+        active = dependency_marker_holds(marker, marker_env)
+    except (UndefinedComparison, UndefinedEnvironmentName):
+        return True
+    return not active
 
 
 def _render_specifier(spec: SpecifierSet | None) -> str:

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -35,6 +35,10 @@ from ._lockfile.requirements import (
     write_requirements_with_hashes,
     write_requirements_without_hashes,
 )
+from ._lockfile.validate import (
+    LockDisqualification,
+    check_envelope,
+)
 from ._vendor.packaging.pylock import is_valid_pylock_path
 
 if TYPE_CHECKING:
@@ -55,6 +59,7 @@ __all__ = [
     "DivergentBaseDependencyError",
     "IndexPin",
     "LocalPin",
+    "LockDisqualification",
     "LockInput",
     "MissingHashError",
     "MissingSdistError",
@@ -67,6 +72,7 @@ __all__ = [
     "WheelArtifact",
     "build_pylock",
     "build_target_lock",
+    "check_envelope",
     "is_valid_pylock_path",
     "package_metadata_override_records",
     "read_lockfile_anchor",

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -37,6 +37,9 @@ from ._lockfile.requirements import (
 )
 from ._lockfile.validate import (
     LockDisqualification,
+    RootRequirement,
+    check_constraints,
+    check_direct_requirements,
     check_envelope,
 )
 from ._vendor.packaging.pylock import is_valid_pylock_path
@@ -66,12 +69,15 @@ __all__ = [
     "MissingVcsCommitError",
     "PinShape",
     "Provenance",
+    "RootRequirement",
     "SdistArtifact",
     "TargetLock",
     "VcsPin",
     "WheelArtifact",
     "build_pylock",
     "build_target_lock",
+    "check_constraints",
+    "check_direct_requirements",
     "check_envelope",
     "is_valid_pylock_path",
     "package_metadata_override_records",

--- a/nab-python/tests/test_lockfile_validate.py
+++ b/nab-python/tests/test_lockfile_validate.py
@@ -1,0 +1,211 @@
+"""Unit tests for the resolver-free disqualification checks."""
+
+from __future__ import annotations
+
+from nab_python._vendor.packaging.pylock import Pylock
+from nab_python._vendor.packaging.specifiers import SpecifierSet
+from nab_python._vendor.packaging.utils import canonicalize_name
+from nab_python._vendor.packaging.version import Version
+from nab_python.lockfile import LockDisqualification, check_envelope
+
+
+def make_pylock(
+    *,
+    requires_python: str | None = None,
+    extras: tuple[str, ...] | None = None,
+    dependency_groups: tuple[str, ...] | None = None,
+    default_groups: tuple[str, ...] | None = None,
+) -> Pylock:
+    return Pylock(
+        lock_version=Version("1.0"),
+        requires_python=SpecifierSet(requires_python) if requires_python else None,
+        extras=(
+            tuple(canonicalize_name(e) for e in extras) if extras is not None else None
+        ),
+        dependency_groups=(
+            tuple(canonicalize_name(g) for g in dependency_groups)
+            if dependency_groups is not None
+            else None
+        ),
+        default_groups=(
+            tuple(canonicalize_name(g) for g in default_groups)
+            if default_groups is not None
+            else None
+        ),
+        created_by="nab",
+        packages=(),
+    )
+
+
+def envelope(
+    committed: Pylock,
+    *,
+    requires_python: str | None = None,
+    extras: tuple[str, ...] = (),
+    dependency_groups: tuple[str, ...] = (),
+    default_groups: tuple[str, ...] = (),
+) -> LockDisqualification | None:
+    return check_envelope(
+        committed,
+        requires_python=requires_python,
+        extras=extras,
+        dependency_groups=dependency_groups,
+        default_groups=default_groups,
+    )
+
+
+def test_requires_python_changed_fires() -> None:
+    committed = make_pylock(requires_python=">=3.8")
+    result = envelope(committed, requires_python=">=3.9")
+    assert result is not None
+    assert result.reason == (
+        "the lockfile requires-python >=3.8 does not match this run's >=3.9"
+    )
+
+
+def test_requires_python_reformatted_but_equal_does_not_fire() -> None:
+    committed = make_pylock(requires_python=">=3.8,<4")
+    assert envelope(committed, requires_python="<4,>=3.8") is None
+
+
+def test_requires_python_both_absent_does_not_fire() -> None:
+    committed = make_pylock(requires_python=None)
+    assert envelope(committed, requires_python=None) is None
+
+
+def test_requires_python_empty_string_is_absent() -> None:
+    committed = make_pylock(requires_python=None)
+    assert envelope(committed, requires_python="") is None
+
+
+def test_requires_python_committed_present_current_absent_fires() -> None:
+    committed = make_pylock(requires_python=">=3.8")
+    result = envelope(committed, requires_python=None)
+    assert result is not None
+    assert result.reason == (
+        "the lockfile requires-python >=3.8 does not match this run's (none)"
+    )
+
+
+def test_requires_python_committed_absent_current_present_fires() -> None:
+    committed = make_pylock(requires_python=None)
+    result = envelope(committed, requires_python=">=3.8")
+    assert result is not None
+    assert result.reason == (
+        "the lockfile requires-python (none) does not match this run's >=3.8"
+    )
+
+
+def test_extras_added_fires() -> None:
+    committed = make_pylock(extras=None)
+    result = envelope(committed, extras=("cli",))
+    assert result is not None
+    assert result.reason == (
+        "the lockfile was built with extras {} but this run selects {cli}"
+    )
+
+
+def test_extras_removed_fires() -> None:
+    committed = make_pylock(extras=("cli",))
+    result = envelope(committed, extras=())
+    assert result is not None
+    assert result.reason == (
+        "the lockfile was built with extras {cli} but this run selects {}"
+    )
+
+
+def test_extras_reordered_does_not_fire() -> None:
+    committed = make_pylock(extras=("cli", "test"))
+    assert envelope(committed, extras=("test", "cli")) is None
+
+
+def test_extras_empty_selection_matches_none_committed() -> None:
+    committed = make_pylock(extras=None)
+    assert envelope(committed, extras=()) is None
+
+
+def test_extras_normalized_name_equivalence_does_not_fire() -> None:
+    committed = make_pylock(extras=("fancy-cli",))
+    assert envelope(committed, extras=("Fancy_CLI",)) is None
+
+
+def test_dependency_groups_added_fires() -> None:
+    committed = make_pylock(dependency_groups=None)
+    result = envelope(committed, dependency_groups=("dev",))
+    assert result is not None
+    assert result.reason == (
+        "the lockfile was built with dependency-groups {} but this run selects {dev}"
+    )
+
+
+def test_dependency_groups_removed_fires() -> None:
+    committed = make_pylock(dependency_groups=("dev",))
+    result = envelope(committed, dependency_groups=())
+    assert result is not None
+    assert result.reason == (
+        "the lockfile was built with dependency-groups {dev} but this run selects {}"
+    )
+
+
+def test_dependency_groups_reordered_does_not_fire() -> None:
+    committed = make_pylock(dependency_groups=("dev", "docs"))
+    assert envelope(committed, dependency_groups=("docs", "dev")) is None
+
+
+def test_default_groups_added_fires() -> None:
+    committed = make_pylock(default_groups=None)
+    result = envelope(committed, default_groups=("main",))
+    assert result is not None
+    assert result.reason == (
+        "the lockfile was built with default-groups {} but this run selects {main}"
+    )
+
+
+def test_default_groups_removed_fires() -> None:
+    committed = make_pylock(default_groups=("main",))
+    result = envelope(committed, default_groups=())
+    assert result is not None
+    assert result.reason == (
+        "the lockfile was built with default-groups {main} but this run selects {}"
+    )
+
+
+def test_default_groups_reordered_does_not_fire() -> None:
+    committed = make_pylock(default_groups=("main", "extra"))
+    assert envelope(committed, default_groups=("extra", "main")) is None
+
+
+def test_all_envelope_fields_matching_returns_none() -> None:
+    committed = make_pylock(
+        requires_python=">=3.9",
+        extras=("cli",),
+        dependency_groups=("dev",),
+        default_groups=("main",),
+    )
+    assert (
+        envelope(
+            committed,
+            requires_python=">=3.9",
+            extras=("cli",),
+            dependency_groups=("dev",),
+            default_groups=("main",),
+        )
+        is None
+    )
+
+
+def test_requires_python_checked_before_extras() -> None:
+    committed = make_pylock(requires_python=">=3.8", extras=None)
+    result = envelope(committed, requires_python=">=3.9", extras=("cli",))
+    assert result is not None
+    assert result.reason.startswith("the lockfile requires-python")
+
+
+def test_lock_disqualification_is_frozen() -> None:
+    disq = LockDisqualification(reason="x")
+    try:
+        disq.reason = "y"  # type: ignore[misc]
+    except AttributeError:
+        return
+    msg = "LockDisqualification should be frozen"
+    raise AssertionError(msg)

--- a/nab-python/tests/test_lockfile_validate.py
+++ b/nab-python/tests/test_lockfile_validate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from nab_python._vendor.packaging.markers import Marker
 from nab_python._vendor.packaging.pylock import (
     Package,
     PackageDirectory,
@@ -229,6 +230,14 @@ def index_pin(name: str, version: str) -> Package:
     return Package(name=canonicalize_name(name), version=Version(version))
 
 
+def marked_pin(name: str, version: str, marker: str) -> Package:
+    return Package(
+        name=canonicalize_name(name),
+        version=Version(version),
+        marker=Marker(marker),
+    )
+
+
 def directory_pin(name: str, version: str | None = None) -> Package:
     return Package(
         name=canonicalize_name(name),
@@ -314,6 +323,21 @@ def test_direct_pin_with_version_skips_version_check() -> None:
     committed = pylock_of(directory_pin("foo", "1.0"))
     assert (
         check_direct_requirements(committed, [root("foo>=2.0")], marker_env=LINUX_ENV)
+        is None
+    )
+
+
+def test_direct_duplicate_versioned_pins_skipped() -> None:
+    committed = pylock_of(
+        marked_pin("foo", "1.5", "'old' in extras"),
+        marked_pin("foo", "2.5", "'new' in extras"),
+    )
+    assert (
+        check_direct_requirements(committed, [root("foo<2")], marker_env=LINUX_ENV)
+        is None
+    )
+    assert (
+        check_direct_requirements(committed, [root("foo>=2")], marker_env=LINUX_ENV)
         is None
     )
 
@@ -407,6 +431,17 @@ def test_constraint_absent_package_noop() -> None:
 
 def test_constraint_versionless_pin_skipped() -> None:
     committed = pylock_of(directory_pin("baz"))
+    assert (
+        check_constraints(committed, [Requirement("baz<3")], marker_env=LINUX_ENV)
+        is None
+    )
+
+
+def test_constraint_duplicate_versioned_pins_skipped() -> None:
+    committed = pylock_of(
+        marked_pin("baz", "1.5", "'old' in extras"),
+        marked_pin("baz", "3.1", "'new' in extras"),
+    )
     assert (
         check_constraints(committed, [Requirement("baz<3")], marker_env=LINUX_ENV)
         is None

--- a/nab-python/tests/test_lockfile_validate.py
+++ b/nab-python/tests/test_lockfile_validate.py
@@ -2,11 +2,22 @@
 
 from __future__ import annotations
 
-from nab_python._vendor.packaging.pylock import Pylock
+from nab_python._vendor.packaging.pylock import (
+    Package,
+    PackageDirectory,
+    Pylock,
+)
+from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python._vendor.packaging.version import Version
-from nab_python.lockfile import LockDisqualification, check_envelope
+from nab_python.lockfile import (
+    LockDisqualification,
+    RootRequirement,
+    check_constraints,
+    check_direct_requirements,
+    check_envelope,
+)
 
 
 def make_pylock(
@@ -208,4 +219,205 @@ def test_lock_disqualification_is_frozen() -> None:
     except AttributeError:
         return
     msg = "LockDisqualification should be frozen"
+    raise AssertionError(msg)
+
+
+LINUX_ENV = {"sys_platform": "linux"}
+
+
+def index_pin(name: str, version: str) -> Package:
+    return Package(name=canonicalize_name(name), version=Version(version))
+
+
+def directory_pin(name: str, version: str | None = None) -> Package:
+    return Package(
+        name=canonicalize_name(name),
+        version=Version(version) if version is not None else None,
+        directory=PackageDirectory(path=f"./{name}"),
+    )
+
+
+def pylock_of(*packages: Package) -> Pylock:
+    return Pylock(
+        lock_version=Version("1.0"),
+        created_by="nab",
+        packages=packages,
+    )
+
+
+def root(text: str, source: str = "[project].dependencies") -> RootRequirement:
+    return RootRequirement(requirement=Requirement(text), source=source)
+
+
+def test_direct_present_and_satisfying_returns_none() -> None:
+    committed = pylock_of(index_pin("foo", "2.5"))
+    assert (
+        check_direct_requirements(committed, [root("foo>=2.0")], marker_env=LINUX_ENV)
+        is None
+    )
+
+
+def test_direct_present_and_violating_fires() -> None:
+    committed = pylock_of(index_pin("foo", "1.5"))
+    result = check_direct_requirements(
+        committed, [root("foo>=2.0")], marker_env=LINUX_ENV
+    )
+    assert result is not None
+    assert result.reason == (
+        "[project].dependencies requires foo>=2.0 but the lock pins foo 1.5"
+    )
+
+
+def test_direct_missing_fires() -> None:
+    committed = pylock_of(index_pin("other", "1.0"))
+    result = check_direct_requirements(
+        committed, [root("bar>=1")], marker_env=LINUX_ENV
+    )
+    assert result is not None
+    assert result.reason == (
+        "[project].dependencies requires bar and its marker applies here, "
+        "but the lock has no bar pin"
+    )
+
+
+def test_direct_missing_names_the_source() -> None:
+    committed = pylock_of()
+    result = check_direct_requirements(
+        committed,
+        [root("bar>=1", source="[project.optional-dependencies].cli")],
+        marker_env=LINUX_ENV,
+    )
+    assert result is not None
+    assert result.reason.startswith("[project.optional-dependencies].cli requires bar")
+
+
+def test_direct_marker_true_applies_and_fires() -> None:
+    committed = pylock_of(index_pin("foo", "1.5"))
+    result = check_direct_requirements(
+        committed,
+        [root('foo>=2.0; sys_platform == "linux"')],
+        marker_env=LINUX_ENV,
+    )
+    assert result is not None
+    assert result.reason.startswith("[project].dependencies requires foo>=2.0")
+
+
+def test_direct_versionless_pin_skipped() -> None:
+    committed = pylock_of(directory_pin("foo"))
+    assert (
+        check_direct_requirements(committed, [root("foo>=2.0")], marker_env=LINUX_ENV)
+        is None
+    )
+
+
+def test_direct_pin_with_version_skips_version_check() -> None:
+    committed = pylock_of(directory_pin("foo", "1.0"))
+    assert (
+        check_direct_requirements(committed, [root("foo>=2.0")], marker_env=LINUX_ENV)
+        is None
+    )
+
+
+def test_direct_reference_skipped() -> None:
+    committed = pylock_of(directory_pin("foo", "1.0"))
+    assert (
+        check_direct_requirements(
+            committed,
+            [root("foo @ https://example.com/foo-9.9-py3-none-any.whl")],
+            marker_env=LINUX_ENV,
+        )
+        is None
+    )
+
+
+def test_direct_marker_false_absent_does_not_fire() -> None:
+    committed = pylock_of()
+    assert (
+        check_direct_requirements(
+            committed,
+            [root('bar>=1; sys_platform == "win32"')],
+            marker_env=LINUX_ENV,
+        )
+        is None
+    )
+
+
+def test_direct_indeterminate_form_skipped() -> None:
+    committed = pylock_of()
+    assert (
+        check_direct_requirements(
+            committed,
+            [root('bar>=1; extras == "x"')],
+            marker_env=LINUX_ENV,
+        )
+        is None
+    )
+
+
+def test_direct_no_requirements_returns_none() -> None:
+    assert check_direct_requirements(pylock_of(), [], marker_env=LINUX_ENV) is None
+
+
+def test_constraint_satisfied_returns_none() -> None:
+    committed = pylock_of(index_pin("baz", "2.0"))
+    assert (
+        check_constraints(committed, [Requirement("baz<3")], marker_env=LINUX_ENV)
+        is None
+    )
+
+
+def test_constraint_violated_fires() -> None:
+    committed = pylock_of(index_pin("baz", "3.1"))
+    result = check_constraints(committed, [Requirement("baz<3")], marker_env=LINUX_ENV)
+    assert result is not None
+    assert result.reason == ("the constraint baz<3 is violated by the pinned baz 3.1")
+
+
+def test_constraint_marker_false_skipped() -> None:
+    committed = pylock_of(index_pin("baz", "3.1"))
+    assert (
+        check_constraints(
+            committed,
+            [Requirement('baz<3; sys_platform == "win32"')],
+            marker_env=LINUX_ENV,
+        )
+        is None
+    )
+
+
+def test_constraint_indeterminate_skipped() -> None:
+    committed = pylock_of(index_pin("baz", "3.1"))
+    assert (
+        check_constraints(
+            committed,
+            [Requirement('baz<3; extras == "x"')],
+            marker_env=LINUX_ENV,
+        )
+        is None
+    )
+
+
+def test_constraint_absent_package_noop() -> None:
+    committed = pylock_of(index_pin("other", "1.0"))
+    assert (
+        check_constraints(committed, [Requirement("baz<3")], marker_env=LINUX_ENV)
+        is None
+    )
+
+
+def test_constraint_versionless_pin_skipped() -> None:
+    committed = pylock_of(directory_pin("baz"))
+    assert (
+        check_constraints(committed, [Requirement("baz<3")], marker_env=LINUX_ENV)
+        is None
+    )
+
+
+def test_root_requirement_is_frozen() -> None:
+    rr = root("foo>=1")
+    try:
+        rr.source = "x"  # type: ignore[misc]
+    except AttributeError:
+        return
+    msg = "RootRequirement should be frozen"
     raise AssertionError(msg)

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -236,6 +236,7 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
             python=python,
             extras=selected_extras,
             groups=selected_groups,
+            workspace_to_drop=workspace_to_drop,
         )
 
     transport = _cli._make_transport(settings.http_backend)  # noqa: SLF001
@@ -372,14 +373,13 @@ def _fast_fail_locked(
     python: str | None,
     extras: tuple[str, ...],
     groups: tuple[str, ...],
+    workspace_to_drop: frozenset[str],
 ) -> None:
     """Fast-fail ``nab lock --locked`` before any resolve when a mismatch is proven.
 
-    Reads and parses the committed lock (reporting a missing or malformed
-    lock), then runs the resolver-free envelope and validity checks.  On the
-    first disqualification it prints the reason and exits non-zero; otherwise
-    it returns and the full resolve runs.  The tier is a disqualifier only,
-    so a return never means "up to date": only the full re-resolve says that.
+    Reads and parses the committed lock, then runs the envelope and validity
+    checks.  On the first disqualification it prints the reason and exits
+    non-zero; otherwise it returns and the full resolve runs.
     """
     target = _locked_target_path(output)
     committed = _read_committed_pylock(target)
@@ -392,7 +392,13 @@ def _fast_fail_locked(
     )
     if disqualification is None:
         disqualification = _check_locked_validity(
-            path, config, committed, python=python, extras=extras, groups=groups
+            path,
+            config,
+            committed,
+            python=python,
+            extras=extras,
+            groups=groups,
+            workspace_to_drop=workspace_to_drop,
         )
     if disqualification is None:
         return
@@ -411,15 +417,16 @@ def _check_locked_validity(
     python: str | None,
     extras: tuple[str, ...],
     groups: tuple[str, ...],
+    workspace_to_drop: frozenset[str],
 ) -> LockDisqualification | None:
-    """Run the Family V validity checks against the committed lock.
+    """Run the validity checks against the committed lock.
 
     Returns a disqualification for the first violated direct requirement or
-    constraint, or ``None`` to fall through.  Anything the tier cannot
-    assemble with certainty falls through rather than firing: a target the
-    declaration excludes (so a fresh resolve would fail for its own reason),
-    and a project whose requirements cannot be read (left for the full
-    resolve to report).
+    constraint, or ``None`` to fall through.  A target the declaration excludes
+    or a project whose requirements cannot be read both fall through, left for
+    the full resolve.  A direct requirement naming a ``workspace_to_drop``
+    member is skipped, since ``--no-emit-workspace`` drops it from the lock on
+    both sides.
     """
     try:
         target = plan_targets(with_python_override(config, python))[0]
@@ -434,6 +441,11 @@ def _check_locked_validity(
         LookupError,
     ):
         return None
+    roots = [
+        root
+        for root in roots
+        if canonicalize_name(root.requirement.name) not in workspace_to_drop
+    ]
     direct = check_direct_requirements(committed, roots, marker_env=target.marker_env)
     if direct is not None:
         return direct

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -29,26 +29,42 @@ import tomli_w
 import tyro
 
 from nab._version import __version__
+from nab_python._vendor.packaging.pylock import Pylock, PylockValidationError
+from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python._vendor.packaging.version import Version
 from nab_python.config import (
+    ConfigError,
     NabProjectConfig,
     ResolveMode,
+    plan_targets,
+    with_python_override,
 )
 from nab_python.lockfile import (
     ArchivePin,
     IndexPin,
+    LockDisqualification,
     LockInput,
     Provenance,
+    RootRequirement,
     TargetLock,
+    check_constraints,
+    check_direct_requirements,
+    check_envelope,
     is_valid_pylock_path,
     package_metadata_override_records,
     read_lockfile_anchor,
     read_lockfile_packages,
 )
 from nab_python.requirements_file import (
+    InvalidProjectRequirementError,
+    InvalidProjectTableError,
+    expand_extra_requirements,
+    read_pyproject_dependencies,
     read_pyproject_groups,
+    read_pyproject_name,
     read_pyproject_optional_dependencies,
+    resolve_groups_to_requirements,
 )
 
 from . import cli as _cli
@@ -212,6 +228,16 @@ def lock(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config obje
             " experimental and may change without notice"
         )
 
+    if locked:
+        _fast_fail_locked(
+            path,
+            config=config,
+            output=output,
+            python=python,
+            extras=selected_extras,
+            groups=selected_groups,
+        )
+
     transport = _cli._make_transport(settings.http_backend)  # noqa: SLF001
     result = _cli._resolve(  # noqa: SLF001
         path,
@@ -304,6 +330,153 @@ def _packages_only(text: str) -> str:
     return tomli_w.dumps(data)
 
 
+def _locked_target_path(output: Path | None) -> Path:
+    """Return the file ``--locked`` reads and re-renders against."""
+    return output if output is not None else Path(_cli._DEFAULT_OUTPUT["pylock"])  # noqa: SLF001
+
+
+def _read_committed_pylock(target: Path) -> Pylock:
+    """Read and parse the committed pylock, exiting on a precondition failure.
+
+    A missing lock, a non-TOML file, and a file that parses as TOML but not
+    as a PEP 751 lock each exit non-zero here, before any resolve runs.
+    """
+    if not target.exists():
+        _cli.printer().error(
+            f"--locked: no lockfile at {target} to check; run `nab lock` first."
+        )
+        sys.exit(1)
+    try:
+        data = tomli.loads(target.read_text(encoding="utf-8"))
+    except (UnicodeDecodeError, tomli.TOMLDecodeError) as e:
+        _cli.printer().error(
+            f"--locked: lockfile {target} is not valid TOML: {e};"
+            " re-run `nab lock` to regenerate it."
+        )
+        sys.exit(1)
+    try:
+        return Pylock.from_dict(data)
+    except PylockValidationError as e:
+        _cli.printer().error(
+            f"--locked: lockfile {target} is not a valid PEP 751 lockfile: {e};"
+            " re-run `nab lock` to regenerate it."
+        )
+        sys.exit(1)
+
+
+def _fast_fail_locked(
+    path: Path,
+    *,
+    config: NabProjectConfig,
+    output: Path | None,
+    python: str | None,
+    extras: tuple[str, ...],
+    groups: tuple[str, ...],
+) -> None:
+    """Fast-fail ``nab lock --locked`` before any resolve when a mismatch is proven.
+
+    Reads and parses the committed lock (reporting a missing or malformed
+    lock), then runs the resolver-free envelope and validity checks.  On the
+    first disqualification it prints the reason and exits non-zero; otherwise
+    it returns and the full resolve runs.  The tier is a disqualifier only,
+    so a return never means "up to date": only the full re-resolve says that.
+    """
+    target = _locked_target_path(output)
+    committed = _read_committed_pylock(target)
+    disqualification = check_envelope(
+        committed,
+        requires_python=config.requires_python,
+        extras=extras,
+        dependency_groups=groups,
+        default_groups=config.default_groups,
+    )
+    if disqualification is None:
+        disqualification = _check_locked_validity(
+            path, config, committed, python=python, extras=extras, groups=groups
+        )
+    if disqualification is None:
+        return
+    _cli.printer().error(
+        f"--locked: lockfile {target} is out of date: {disqualification.reason};"
+        " re-run `nab lock` to update it."
+    )
+    sys.exit(1)
+
+
+def _check_locked_validity(
+    path: Path,
+    config: NabProjectConfig,
+    committed: Pylock,
+    *,
+    python: str | None,
+    extras: tuple[str, ...],
+    groups: tuple[str, ...],
+) -> LockDisqualification | None:
+    """Run the Family V validity checks against the committed lock.
+
+    Returns a disqualification for the first violated direct requirement or
+    constraint, or ``None`` to fall through.  Anything the tier cannot
+    assemble with certainty falls through rather than firing: a target the
+    declaration excludes (so a fresh resolve would fail for its own reason),
+    and a project whose requirements cannot be read (left for the full
+    resolve to report).
+    """
+    try:
+        target = plan_targets(with_python_override(config, python))[0]
+    except ConfigError:
+        return None
+    try:
+        roots = _active_root_requirements(path, extras=extras, groups=groups)
+    except (
+        KeyError,
+        InvalidProjectTableError,
+        InvalidProjectRequirementError,
+        LookupError,
+    ):
+        return None
+    direct = check_direct_requirements(committed, roots, marker_env=target.marker_env)
+    if direct is not None:
+        return direct
+    constraints = [Requirement(text) for text in config.constraints]
+    return check_constraints(committed, constraints, marker_env=target.marker_env)
+
+
+def _active_root_requirements(
+    path: Path,
+    *,
+    extras: tuple[str, ...],
+    groups: tuple[str, ...],
+) -> list[RootRequirement]:
+    """Collect this run's active direct requirements with their source clause.
+
+    Covers ``[project].dependencies`` plus the requirements each selected extra
+    and group contributes, each carrying the clause it came from so a
+    disqualification can name it.  Default groups are left to the full resolve.
+    """
+    roots = [
+        RootRequirement(requirement=req, source="[project].dependencies")
+        for req in read_pyproject_dependencies(path)
+    ]
+    if extras:
+        optional = read_pyproject_optional_dependencies(path)
+        project_name = read_pyproject_name(path)
+        for extra in extras:
+            roots.extend(
+                RootRequirement(requirement=req, source=f"the {extra!r} extra")
+                for req in expand_extra_requirements(optional, project_name, [extra])
+            )
+    if groups:
+        table = read_pyproject_groups(path)
+        for group in groups:
+            roots.extend(
+                RootRequirement(
+                    requirement=req, source=f"the {group!r} dependency group"
+                )
+                for req in resolve_groups_to_requirements(table, [group])
+            )
+    return roots
+
+
 def _check_locked(lock_input: LockInput, *, output: Path | None) -> None:
     """Verify the committed pylock matches a fresh resolve, writing nothing.
 
@@ -312,25 +485,13 @@ def _check_locked(lock_input: LockInput, *, output: Path | None) -> None:
     both, so only a real change to the locked packages fails.  The committed
     lock is never read back into the resolve.
     """
-    target = output if output is not None else Path(_cli._DEFAULT_OUTPUT["pylock"])  # noqa: SLF001
-    if not target.exists():
-        _cli.printer().error(
-            f"--locked: no lockfile at {target} to check; run `nab lock` first."
-        )
-        sys.exit(1)
+    target = _locked_target_path(output)
     try:
         new_text = _cli.render_lock(lock_input, lock_dir=target.parent)
     except _cli.MissingHashError as e:
         _cli.printer().error(f"cannot lock: {e}")
         sys.exit(1)
-    try:
-        committed = _packages_only(target.read_text(encoding="utf-8"))
-    except (UnicodeDecodeError, tomli.TOMLDecodeError) as e:
-        _cli.printer().error(
-            f"--locked: lockfile {target} is not valid TOML: {e};"
-            " re-run `nab lock` to regenerate it."
-        )
-        sys.exit(1)
+    committed = _packages_only(target.read_text(encoding="utf-8"))
     if _packages_only(new_text) == committed:
         _cli.printer().done(f"Lockfile {target} is up to date.")
         return

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -326,6 +326,37 @@ def test_requires_python_excludes_host_falls_through(
     mock.assert_called_once()
 
 
+def test_dropped_workspace_member_direct_dep_falls_through(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # --no-emit-workspace drops the member from the lock, so the presence
+    # check must fall through rather than fire on its absence.
+    member = tmp_path / "alpha"
+    member.mkdir()
+    (member / "pyproject.toml").write_text(
+        '[project]\nname = "alpha"\nversion = "0"\n', encoding="utf-8"
+    )
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "ws"\nversion = "0"\ndependencies = ["alpha", "foo"]\n'
+        '[tool.nab.workspace]\nmembers = ["alpha"]\n',
+    )
+    out = tmp_path / "pylock.toml"
+    _write_lock(
+        pyproject,
+        out,
+        _result({"alpha": "0", "foo": "1.0"}),
+        "--no-emit-workspace",
+    )
+    capsys.readouterr()
+
+    mock = _locked_mock(_result({"alpha": "0", "foo": "1.0"}))
+    _run_locked(pyproject, out, mock, "--no-emit-workspace")
+
+    assert "is up to date" in capsys.readouterr().err
+    mock.assert_called_once()
+
+
 # --- precondition cases: no resolve runs ---
 
 

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -1,0 +1,376 @@
+"""Flow tests for the fast-fail tier in ``nab lock --locked``.
+
+Each case drives the real CLI with ``nab.cli.resolve_for_targets`` mocked
+and a committed pylock on disk.  Whether the resolver was called shows
+whether the tier fired: a disqualifier never calls it, a fall-through does.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nab.cli import app
+from nab_python._vendor.packaging.version import Version
+from nab_python.lockfile import (
+    IndexPin,
+    SdistArtifact,
+    TargetLock,
+    WheelArtifact,
+)
+from nab_python.resolve import ResolveResult, TargetResult
+from nab_python.target import ResolveTarget
+
+V = Version
+
+
+def _index_pin(name: str, version: str) -> IndexPin:
+    return IndexPin(
+        name=name,
+        version=version,
+        index="pypi",
+        sdist=SdistArtifact(
+            filename=f"{name}-{version}.tar.gz",
+            url=f"https://example.com/{name}-{version}.tar.gz",
+            hashes=(("sha256", "b" * 64),),
+        ),
+        wheels=(
+            WheelArtifact(
+                filename=f"{name}-{version}-py3-none-any.whl",
+                url=f"https://example.com/{name}-{version}-py3-none-any.whl",
+                hashes=(("sha256", "a" * 64),),
+            ),
+        ),
+    )
+
+
+def _result(pins: dict[str, str]) -> ResolveResult:
+    target = ResolveTarget.for_host()
+    lock = TargetLock(
+        target=target,
+        pins={name: _index_pin(name, version) for name, version in pins.items()},
+    )
+    return ResolveResult(
+        targets=(target,),
+        target_results=[
+            TargetResult(
+                target=target,
+                success=True,
+                pins={name: V(version) for name, version in pins.items()},
+                lock=lock,
+            )
+        ],
+    )
+
+
+def _write_pyproject(tmp_path: Path, body: str) -> Path:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(body, encoding="utf-8")
+    return pyproject
+
+
+def _write_lock(pyproject: Path, out: Path, result: ResolveResult, *extra: str) -> None:
+    with patch("nab.cli.resolve_for_targets", return_value=result):
+        app.cli(args=["lock", str(pyproject), "--output", str(out), *extra], prog="nab")
+
+
+def _locked_mock(result: ResolveResult | None = None) -> MagicMock:
+    return MagicMock(
+        return_value=result if result is not None else _result({"foo": "1.0"})
+    )
+
+
+def _run_locked(pyproject: Path, out: Path, mock: MagicMock, *extra: str) -> None:
+    with patch("nab.cli.resolve_for_targets", mock):
+        app.cli(
+            args=["lock", str(pyproject), "--output", str(out), "--locked", *extra],
+            prog="nab",
+        )
+
+
+# --- fire cases: the resolver is never called ---
+
+
+def test_tightened_direct_specifier_fires_without_resolving(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pyproject = _write_pyproject(tmp_path, '[project]\ndependencies = ["foo"]\n')
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.5"}))
+    capsys.readouterr()
+    before = out.read_bytes()
+    pyproject.write_text('[project]\ndependencies = ["foo>=2.0"]\n', encoding="utf-8")
+
+    mock = _locked_mock()
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock)
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "[project].dependencies requires foo>=2.0 but the lock pins foo 1.5" in err
+    assert "is out of date" in err
+    mock.assert_not_called()
+    assert out.read_bytes() == before
+
+
+def test_tightened_constraint_fires_without_resolving(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pyproject = _write_pyproject(tmp_path, '[project]\ndependencies = ["foo"]\n')
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "3.1"}))
+    capsys.readouterr()
+    pyproject.write_text(
+        '[project]\ndependencies = ["foo"]\n[tool.nab]\nconstraints = ["foo<3"]\n',
+        encoding="utf-8",
+    )
+
+    mock = _locked_mock()
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock)
+
+    assert exc.value.code == 1
+    assert (
+        "the constraint foo<3 is violated by the pinned foo 3.1"
+        in capsys.readouterr().err
+    )
+    mock.assert_not_called()
+
+
+def test_changed_requires_python_fires_without_resolving(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\ndependencies = ["foo"]\n[tool.nab]\nrequires-python = ">=3.8"\n',
+    )
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}))
+    capsys.readouterr()
+    pyproject.write_text(
+        '[project]\ndependencies = ["foo"]\n[tool.nab]\nrequires-python = ">=3.9"\n',
+        encoding="utf-8",
+    )
+
+    mock = _locked_mock()
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock)
+
+    assert exc.value.code == 1
+    assert (
+        "the lockfile requires-python >=3.8 does not match this run's >=3.9"
+        in capsys.readouterr().err
+    )
+    mock.assert_not_called()
+
+
+def test_selected_extra_specifier_fires_without_resolving(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "proj"\ndependencies = ["foo"]\n'
+        "[project.optional-dependencies]\n"
+        'dev = ["bar>=2"]\n',
+    )
+    out = tmp_path / "pylock.toml"
+    _write_lock(
+        pyproject, out, _result({"foo": "1.0", "bar": "1.0"}), "--extras", "dev"
+    )
+    capsys.readouterr()
+
+    mock = _locked_mock()
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock, "--extras", "dev")
+
+    assert exc.value.code == 1
+    assert "the 'dev' extra requires bar>=2 but the lock pins bar 1.0" in (
+        capsys.readouterr().err
+    )
+    mock.assert_not_called()
+
+
+def test_selected_group_specifier_fires_without_resolving(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\ndependencies = ["foo"]\n[dependency-groups]\ntest = ["bar>=2"]\n',
+    )
+    out = tmp_path / "pylock.toml"
+    _write_lock(
+        pyproject, out, _result({"foo": "1.0", "bar": "1.0"}), "--groups", "test"
+    )
+    capsys.readouterr()
+
+    mock = _locked_mock()
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock, "--groups", "test")
+
+    assert exc.value.code == 1
+    assert "the 'test' dependency group requires bar>=2 but the lock pins bar 1.0" in (
+        capsys.readouterr().err
+    )
+    mock.assert_not_called()
+
+
+def test_missing_direct_requirement_fires_without_resolving(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pyproject = _write_pyproject(tmp_path, '[project]\ndependencies = ["foo"]\n')
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}))
+    capsys.readouterr()
+    pyproject.write_text('[project]\ndependencies = ["foo", "bar"]\n', encoding="utf-8")
+
+    mock = _locked_mock()
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock)
+
+    assert exc.value.code == 1
+    assert (
+        "[project].dependencies requires bar and its marker applies here, but the"
+        " lock has no bar pin" in capsys.readouterr().err
+    )
+    mock.assert_not_called()
+
+
+# --- fall-through cases: the resolver is always called ---
+
+
+def test_satisfiable_and_reproducible_falls_through_up_to_date(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pyproject = _write_pyproject(tmp_path, '[project]\ndependencies = ["foo>=1.0"]\n')
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}))
+    capsys.readouterr()
+    before = out.read_bytes()
+
+    mock = _locked_mock(_result({"foo": "1.0"}))
+    _run_locked(pyproject, out, mock)
+
+    assert "is up to date" in capsys.readouterr().err
+    mock.assert_called_once()
+    assert out.read_bytes() == before
+
+
+def test_non_sticky_stale_falls_through_out_of_date(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pyproject = _write_pyproject(tmp_path, '[project]\ndependencies = ["foo>=1.0"]\n')
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}))
+    capsys.readouterr()
+
+    mock = _locked_mock(_result({"foo": "2.0"}))
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock)
+
+    assert exc.value.code == 1
+    assert "out of date" in capsys.readouterr().err
+    mock.assert_called_once()
+
+
+def test_marker_inactive_absent_requirement_falls_through(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\ndependencies = ["foo", "bar; python_version < \\"2.0\\""]\n',
+    )
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}))
+    capsys.readouterr()
+
+    mock = _locked_mock(_result({"foo": "1.0"}))
+    _run_locked(pyproject, out, mock)
+
+    assert "is up to date" in capsys.readouterr().err
+    mock.assert_called_once()
+
+
+def test_unreadable_requirement_falls_through(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pyproject = _write_pyproject(tmp_path, '[project]\ndependencies = ["foo"]\n')
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}))
+    capsys.readouterr()
+    pyproject.write_text('[project]\ndependencies = ["foo (=="]\n', encoding="utf-8")
+
+    mock = _locked_mock(_result({"foo": "1.0"}))
+    _run_locked(pyproject, out, mock)
+
+    mock.assert_called_once()
+
+
+def test_requires_python_excludes_host_falls_through(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # requires-python that excludes the host cannot build a target, so
+    # validity is skipped and the resolve runs.
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\ndependencies = ["foo"]\n[tool.nab]\nrequires-python = ">=99"\n',
+    )
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}))
+    capsys.readouterr()
+
+    mock = _locked_mock(_result({"foo": "1.0"}))
+    _run_locked(pyproject, out, mock)
+
+    mock.assert_called_once()
+
+
+# --- precondition cases: no resolve runs ---
+
+
+def test_missing_lock_precondition(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pyproject = _write_pyproject(tmp_path, '[project]\ndependencies = ["foo"]\n')
+    out = tmp_path / "pylock.toml"
+
+    mock = _locked_mock()
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock)
+
+    assert exc.value.code == 1
+    assert "no lockfile" in capsys.readouterr().err
+    mock.assert_not_called()
+
+
+def test_invalid_toml_precondition(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pyproject = _write_pyproject(tmp_path, '[project]\ndependencies = ["foo"]\n')
+    out = tmp_path / "pylock.toml"
+    out.write_text('lock-version = "1.0"\n<<<<<<< HEAD\n', encoding="utf-8")
+
+    mock = _locked_mock()
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock)
+
+    assert exc.value.code == 1
+    assert "is not valid TOML" in capsys.readouterr().err
+    mock.assert_not_called()
+
+
+def test_non_pep751_precondition(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pyproject = _write_pyproject(tmp_path, '[project]\ndependencies = ["foo"]\n')
+    out = tmp_path / "pylock.toml"
+    out.write_text('title = "not a pylock"\n', encoding="utf-8")
+
+    mock = _locked_mock()
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock)
+
+    assert exc.value.code == 1
+    assert "not a valid PEP 751 lockfile" in capsys.readouterr().err
+    mock.assert_not_called()

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -357,6 +357,63 @@ def test_dropped_workspace_member_direct_dep_falls_through(
     mock.assert_called_once()
 
 
+def _foo_package(version: str, marker: str) -> str:
+    return (
+        "[[packages]]\n"
+        'name = "foo"\n'
+        f'version = "{version}"\n'
+        'index = "pypi"\n'
+        f'marker = "{marker}"\n\n'
+        "[packages.sdist]\n"
+        f'name = "foo-{version}.tar.gz"\n'
+        f'url = "https://example.com/foo-{version}.tar.gz"\n'
+        "[packages.sdist.hashes]\n"
+        f'sha256 = "{"b" * 64}"\n\n'
+        "[[packages.wheels]]\n"
+        f'name = "foo-{version}-py3-none-any.whl"\n'
+        f'url = "https://example.com/foo-{version}-py3-none-any.whl"\n'
+        "[packages.wheels.hashes]\n"
+        f'sha256 = "{"a" * 64}"\n\n'
+    )
+
+
+def test_conflict_fork_duplicate_pins_fall_through(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # The lock holds two foo pins under disjoint conflict-fork markers, so no
+    # single version stands for foo and the tier falls through.
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "proj"\nversion = "0"\ndependencies = []\n'
+        "[project.optional-dependencies]\n"
+        'old = ["foo<2"]\n'
+        'new = ["foo>=2"]\n'
+        "[tool.nab]\n"
+        'conflicts = [[{extra = "old"}, {extra = "new"}]]\n',
+    )
+    out = tmp_path / "pylock.toml"
+    out.write_text(
+        'lock-version = "1.0"\n'
+        "extras = [\n"
+        '    "new",\n'
+        '    "old",\n'
+        "]\n"
+        'created-by = "nab"\n\n'
+        + _foo_package("1.5", "'old' in extras")
+        + _foo_package("2.5", "'new' in extras"),
+        encoding="utf-8",
+    )
+
+    mock = _locked_mock(_result({"foo": "1.5"}))
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock, "--extras", "old", "new")
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "the lock pins foo" not in err
+    mock.assert_called_once()
+
+
 # --- precondition cases: no resolve runs ---
 
 


### PR DESCRIPTION
Add a resolver-free tier to nab lock --locked that checks the committed lock against the current project inputs and reports a precise mismatch before any resolve runs. A changed direct dependency, narrowed requires-python, changed extra or group, or tightened constraint each make the lock impossible to reproduce, so the check exits early with the reason instead of paying for a full re-resolve.