### PR TITLE
don't crash on an unwritable cache root

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -286,6 +286,10 @@ the same refusal ends the run. See [Build policy](build-policy.md).
 others surface a helpful `ImportError` if selected without the
 matching extra.
 
+A cache root nab cannot write to (read-only, out of space, over quota)
+is not fatal. The run warns once and carries on, serving whatever the
+cache already holds but storing nothing new.
+
 ## Global flags
 
 | Flag | Effect |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -286,9 +286,11 @@ the same refusal ends the run. See [Build policy](build-policy.md).
 others surface a helpful `ImportError` if selected without the
 matching extra.
 
-A cache root nab cannot write to (read-only, out of space, over quota)
-is not fatal. The run warns once and carries on, serving whatever the
-cache already holds but storing nothing new.
+A cache root nab cannot write to (read-only, full, over quota) does not
+stop an index fetch. The run warns once and carries on, serving what the
+index cache already holds and storing nothing new. Cloning a VCS
+requirement or unpacking a URL archive still needs a writable cache root
+and fails without one.
 
 ## Global flags
 

--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -180,9 +180,8 @@ def _make_removable(root: Path) -> None:
 class OnDiskCache:
     """File-per-key cache for Simple API and wheel metadata.
 
-    Stores are best-effort: a write the filesystem refuses is dropped, the
-    way an entry that cannot be read is a miss. A root that is read-only,
-    full, or over quota costs a run its cache rather than ending it.
+    Stores are best-effort: a write the filesystem refuses is dropped,
+    just as an entry that cannot be read is a miss.
     """
 
     def __init__(
@@ -206,11 +205,11 @@ class OnDiskCache:
         self._sdist_dir = root / f"sdist-{CACHE_VERSION_SDIST}" / self._index
         self._store_failed = False
 
-    def _store(self, path: Path, data: bytes) -> None:
-        """Write ``data`` to ``path``, dropping the entry if the write fails.
+    def _store(self, path: Path, data: bytes) -> bool:
+        """Write ``data`` to ``path``, returning False if the write failed.
 
-        Only the first failure is reported: the rest of the run meets the
-        same one on every package.
+        Only the first failure warns: a root that refuses one write
+        refuses the rest.
         """
         try:
             _atomic_write(path, data)
@@ -220,6 +219,8 @@ class OnDiskCache:
                 logger.warning(
                     "cannot store cache entries under %s: %s", self._root, exc
                 )
+            return False
+        return True
 
     def _simple_paths(self, package: str) -> tuple[Path, Path]:
         segment = _require_single_segment(package)
@@ -265,10 +266,15 @@ class OnDiskCache:
         return (body, policy)
 
     def put_simple(self, package: str, body: bytes, policy: CachePolicy) -> None:
-        """Write the body and the policy sidecar atomically."""
+        """Write the body and the policy sidecar atomically.
+
+        The sidecar goes out only once the body has landed, so a dropped
+        body write cannot stamp an older body with the new one's ETag and
+        freshness window.
+        """
         body_path, policy_path = self._simple_paths(package)
-        self._store(body_path, body)
-        self._store(policy_path, _encode_policy(policy))
+        if self._store(body_path, body):
+            self._store(policy_path, _encode_policy(policy))
 
     def refresh_simple_policy(self, package: str, policy: CachePolicy) -> None:
         """Replace the policy sidecar without touching the body.

--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -41,6 +41,7 @@ import os
 import shutil
 import stat
 import time
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
@@ -177,7 +178,12 @@ def _make_removable(root: Path) -> None:
 
 
 class OnDiskCache:
-    """File-per-key cache for Simple API and wheel metadata."""
+    """File-per-key cache for Simple API and wheel metadata.
+
+    Stores are best-effort: a write the filesystem refuses is dropped, the
+    way an entry that cannot be read is a miss. A root that is read-only,
+    full, or over quota costs a run its cache rather than ending it.
+    """
 
     def __init__(
         self,
@@ -198,6 +204,22 @@ class OnDiskCache:
         self._neg_dir = root / f"simple-neg-{CACHE_VERSION_SIMPLE_NEG}" / simple_index
         self._metadata_dir = root / f"metadata-{CACHE_VERSION_METADATA}" / self._index
         self._sdist_dir = root / f"sdist-{CACHE_VERSION_SDIST}" / self._index
+        self._store_failed = False
+
+    def _store(self, path: Path, data: bytes) -> None:
+        """Write ``data`` to ``path``, dropping the entry if the write fails.
+
+        Only the first failure is reported: the rest of the run meets the
+        same one on every package.
+        """
+        try:
+            _atomic_write(path, data)
+        except OSError as exc:
+            if not self._store_failed:
+                self._store_failed = True
+                logger.warning(
+                    "cannot store cache entries under %s: %s", self._root, exc
+                )
 
     def _simple_paths(self, package: str) -> tuple[Path, Path]:
         segment = _require_single_segment(package)
@@ -245,8 +267,8 @@ class OnDiskCache:
     def put_simple(self, package: str, body: bytes, policy: CachePolicy) -> None:
         """Write the body and the policy sidecar atomically."""
         body_path, policy_path = self._simple_paths(package)
-        _atomic_write(body_path, body)
-        _atomic_write(policy_path, _encode_policy(policy))
+        self._store(body_path, body)
+        self._store(policy_path, _encode_policy(policy))
 
     def refresh_simple_policy(self, package: str, policy: CachePolicy) -> None:
         """Replace the policy sidecar without touching the body.
@@ -255,7 +277,7 @@ class OnDiskCache:
         valid but the freshness window has slid forward.
         """
         _, policy_path = self._simple_paths(package)
-        _atomic_write(policy_path, _encode_policy(policy))
+        self._store(policy_path, _encode_policy(policy))
 
     def get_metadata(self, package: str, metadata_url: str) -> str | None:
         """Return the cached sidecar text for ``metadata_url``, or ``None``.
@@ -279,7 +301,7 @@ class OnDiskCache:
 
     def put_metadata(self, package: str, metadata_url: str, text: str) -> None:
         """Write the sidecar text served at ``metadata_url``. Immutable."""
-        _atomic_write(self._metadata_path(package, metadata_url), text.encode("utf-8"))
+        self._store(self._metadata_path(package, metadata_url), text.encode("utf-8"))
 
     def get_sdist_files(
         self, package: str, version: str
@@ -313,7 +335,7 @@ class OnDiskCache:
         pyproject_toml: str | None,
     ) -> None:
         """Write the ``(pkg_info, pyproject_toml)`` pair as one record."""
-        _atomic_write(
+        self._store(
             self._sdist_path(package, version),
             json.dumps({"pkg_info": pkg_info, "pyproject": pyproject_toml}).encode(
                 "utf-8"
@@ -337,11 +359,17 @@ class OnDiskCache:
 
     def put_negative(self, package: str, policy: CachePolicy) -> None:
         """Record that ``package`` returned a name-level 404 from this index."""
-        _atomic_write(self._neg_path(package), _encode_policy(policy))
+        self._store(self._neg_path(package), _encode_policy(policy))
 
     def drop_negative(self, package: str) -> None:
-        """Remove any negative entry for ``package``. A miss is not an error."""
-        self._neg_path(package).unlink(missing_ok=True)
+        """Remove any negative entry for ``package``.
+
+        A miss is not an error, and neither is a root that refuses the
+        unlink: there is nothing cached to contradict the fresh listing
+        the caller just fetched.
+        """
+        with suppress(OSError):
+            self._neg_path(package).unlink(missing_ok=True)
 
     def _root_children(self) -> list[Path]:
         try:

--- a/nab-python/tests/test_cache.py
+++ b/nab-python/tests/test_cache.py
@@ -7,12 +7,13 @@ import logging
 import os
 import stat
 import subprocess
+import time
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from nab_index.atomic import atomic_write_text
+from nab_index.atomic import atomic_write, atomic_write_text
 from nab_index.cache import (
     CACHE_VERSION_METADATA,
     CACHE_VERSION_SDIST,
@@ -458,6 +459,33 @@ class TestUnwritableRoot:
             )
         assert caplog.records == []
         assert cache.get_simple("foo") is not None
+
+    def test_dropped_body_write_keeps_the_old_policy(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A body lost to ENOSPC must not be stamped with the new policy.
+
+        The small sidecar can land when the much larger body does not,
+        which would leave the old listing looking fresh under the new
+        body's ETag.
+        """
+        cache = OnDiskCache(tmp_path, "https://pypi.org/simple/")
+        old_policy = CachePolicy(fetched_at=0, max_age=600, etag="E1")
+        cache.put_simple("foo", b"OLD-LISTING", old_policy)
+
+        def fail_body(path: Path, data: bytes) -> None:
+            if path.suffix == ".json":
+                raise OSError(28, "No space left on device")
+            atomic_write(path, data)
+
+        monkeypatch.setattr("nab_index.cache.atomic_write", fail_body)
+        cache.put_simple(
+            "foo",
+            b"NEW-LISTING",
+            CachePolicy(fetched_at=int(time.time()), max_age=600, etag="E2"),
+        )
+
+        assert cache.get_simple("foo") == (b"OLD-LISTING", old_policy)
 
     def test_bad_key_still_raises(self, tmp_path: Path) -> None:
         cache = self._cache(tmp_path)

--- a/nab-python/tests/test_cache.py
+++ b/nab-python/tests/test_cache.py
@@ -394,6 +394,77 @@ class TestOnDiskCache:
         assert list(tmp_path.rglob("*.neg")) == []
 
 
+class TestUnwritableRoot:
+    """A root the process cannot write to degrades to no caching."""
+
+    def _cache(self, tmp_path: Path) -> OnDiskCache:
+        """Return a cache whose root is a regular file, so every store fails."""
+        root = tmp_path / "cache"
+        root.write_bytes(b"not a directory")
+        return OnDiskCache(root, "https://pypi.org/simple/")
+
+    def test_put_simple_does_not_raise(self, tmp_path: Path) -> None:
+        cache = self._cache(tmp_path)
+        cache.put_simple("foo", b"{}", CachePolicy(fetched_at=1, max_age=1, etag=None))
+        assert cache.get_simple("foo") is None
+
+    def test_put_metadata_does_not_raise(self, tmp_path: Path) -> None:
+        cache = self._cache(tmp_path)
+        cache.put_metadata("foo", METADATA_URLS[0], "Name: foo\n")
+        assert cache.get_metadata("foo", METADATA_URLS[0]) is None
+
+    def test_put_sdist_files_does_not_raise(self, tmp_path: Path) -> None:
+        cache = self._cache(tmp_path)
+        cache.put_sdist_files("foo", "1.0", "Name: foo\n", None)
+        assert cache.get_sdist_files("foo", "1.0") is None
+
+    def test_refresh_simple_policy_does_not_raise(self, tmp_path: Path) -> None:
+        cache = self._cache(tmp_path)
+        cache.refresh_simple_policy(
+            "foo", CachePolicy(fetched_at=2, max_age=1, etag=None)
+        )
+        assert cache.get_simple("foo") is None
+
+    def test_permission_denied_does_not_raise(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def denied(_path: Path, _data: bytes) -> None:
+            raise PermissionError(13, "Permission denied")
+
+        monkeypatch.setattr("nab_index.cache.atomic_write", denied)
+        cache = OnDiskCache(tmp_path, "https://pypi.org/simple/")
+        cache.put_metadata("foo", METADATA_URLS[0], "Name: foo\n")
+        assert cache.get_metadata("foo", METADATA_URLS[0]) is None
+
+    def test_warns_once_per_cache(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cache = self._cache(tmp_path)
+        policy = CachePolicy(fetched_at=1, max_age=1, etag=None)
+        with caplog.at_level(logging.WARNING, logger="nab_index.cache"):
+            cache.put_simple("foo", b"{}", policy)
+            cache.put_metadata("foo", METADATA_URLS[0], "Name: foo\n")
+            cache.put_sdist_files("foo", "1.0", "Name: foo\n", None)
+        assert len(caplog.records) == 1
+        assert str(tmp_path / "cache") in caplog.records[0].getMessage()
+
+    def test_writable_root_does_not_warn(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cache = OnDiskCache(tmp_path, "https://pypi.org/simple/")
+        with caplog.at_level(logging.WARNING, logger="nab_index.cache"):
+            cache.put_simple(
+                "foo", b"{}", CachePolicy(fetched_at=1, max_age=1, etag=None)
+            )
+        assert caplog.records == []
+        assert cache.get_simple("foo") is not None
+
+    def test_bad_key_still_raises(self, tmp_path: Path) -> None:
+        cache = self._cache(tmp_path)
+        with pytest.raises(ValueError, match="not a single path segment"):
+            cache.put_metadata("foo/../elsewhere", METADATA_URLS[0], "text")
+
+
 class TestNullCache:
     def test_get_returns_none_and_put_is_noop(self) -> None:
         cache = NullCache()

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -2925,9 +2925,9 @@ class TestGetSdistFiles:
     ) -> None:
         """A crash while writing the entry must not leave a partial cache.
 
-        The first fetch loses its write as the single record is committed;
-        the second must still recover the full PKG-INFO plus pyproject.toml
-        pair.
+        The first fetch's write is dropped as the single record is
+        committed; the second must still recover the full PKG-INFO and
+        pyproject.toml pair.
         """
         cache = _make_cache(tmp_path)
         marker = b"partial-write-marker"

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -1330,6 +1330,24 @@ class TestGetFiles:
         files = asyncio.run(go())
         assert len(files) == 1
 
+    def test_unwritable_cache_root_still_serves_the_listing(
+        self, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "cache"
+        root.write_bytes(b"not a directory")
+        cache = OnDiskCache(root, "https://pypi.org/simple/")
+        transport = _FakeTransport([_FakeResponse(LISTING_BYTES)])
+
+        async def go() -> list:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_files("pkg")
+            finally:
+                await client.aclose()
+
+        files = asyncio.run(go())
+        assert len(files) == 1
+
 
 class TestResponseAge:
     """An Age header counts toward the entry's age (RFC 9111 4.2.3).
@@ -2907,8 +2925,9 @@ class TestGetSdistFiles:
     ) -> None:
         """A crash while writing the entry must not leave a partial cache.
 
-        The first fetch fails as the single record is committed; the second
-        must still recover the full PKG-INFO plus pyproject.toml pair.
+        The first fetch loses its write as the single record is committed;
+        the second must still recover the full PKG-INFO plus pyproject.toml
+        pair.
         """
         cache = _make_cache(tmp_path)
         marker = b"partial-write-marker"
@@ -2941,8 +2960,10 @@ class TestGetSdistFiles:
             finally:
                 await client.aclose()
 
-        with pytest.raises(OSError, match="simulated crash"):
-            asyncio.run(fetch())
+        first_pkg_info, first_pyproject = asyncio.run(fetch())
+        assert first_pkg_info is not None
+        assert first_pyproject is not None
+        assert cache.get_sdist_files("pkg", "1.0") is None
 
         fail["active"] = False
         pkg_info, recovered_pyproject = asyncio.run(fetch())


### PR DESCRIPTION
An unwritable cache root failed the whole run. `nab lock` and `nab download` exited with a raw `OSError` out of the index cache write, even though nothing in the resolve needed the store to succeed. A `~/.cache/nab` owned by root, or one sitting on a read-only container mount, is enough to hit it, as is a disk that fills partway through a resolve.

`OnDiskCache` sent every entry through `atomic_write` with no error handling, so any `OSError` from a store escaped into the fetch path. Stores are best-effort now, the same way an entry that cannot be read is already just a miss: a refused write is dropped and the fetch keeps serving whatever the cache already holds. Each index warns once and carries on.

`put_simple` also writes the policy sidecar only once the body has landed. The small sidecar can succeed where the much larger body hits ENOSPC, which would leave the old listing stamped with the new one's ETag and freshness window.

Cloning a VCS requirement or unpacking a URL archive still needs a writable cache root and fails without one. Noted in the CLI reference.

One call worth a second opinion: `drop_negative` swallows a refused unlink, so an absent-name sentinel that cannot be deleted outlives the successful fetch that should have cleared it and keeps answering "package absent" for the rest of its freshness window, which `assume-fresh-seconds` can widen well past the 600s default.
