### PR TITLE
Refuse to emit locks with uncovered targets

### DIFF
--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -159,7 +159,9 @@ was dropped there, so the pins are not a package set another
 environment can install. The lock says so in the top-level
 `environments`, one entry per environment resolved, and a PEP 751
 consumer refuses a lock whose declared environments none of its own
-satisfies.
+satisfies. nab refuses to emit such a lock in the first place: when the
+`environments` declaration would not cover a target the resolve ran for,
+it raises and names the uncovered interpreter.
 
 Each declaration always pins `python_version`, `sys_platform` and
 `platform_machine`, plus `implementation_name` when the target runs

--- a/nab-python/src/nab_python/_lockfile/coverage.py
+++ b/nab-python/src/nab_python/_lockfile/coverage.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from functools import reduce
 from typing import TYPE_CHECKING
 
-from .._vendor.packaging.markersets import MarkerSet
+from .._vendor.packaging.markersets import MarkerSet, variable_names
 from ..target import UNBOUNDABLE_MARKER_VARIABLES, declared_range_marker
 
 if TYPE_CHECKING:
@@ -68,6 +68,7 @@ def validate_marker_coverage(
         (MarkerSet.from_marker(marker) for marker in environments),
         MarkerSet.empty(),
     )
+    covered = _project_implementation_version(covered, environments, targets)
 
     seen: set[str] = set()
     for target in targets:
@@ -79,6 +80,35 @@ def validate_marker_coverage(
         witness = residual.witness()
         if witness is not None:
             raise CoverageError(_coverage_message(witness))
+
+
+def _project_implementation_version(
+    covered: MarkerSet,
+    environments: Sequence[Marker],
+    targets: Sequence[ResolveTarget],
+) -> MarkerSet:
+    """Drop ``implementation_version`` from ``covered`` when a row mirrors it.
+
+    On CPython the resolve mirrors each slice's ``python_full_version`` bounds
+    onto ``implementation_version``, and the algebra treats the two as
+    independent.  A cross term (``python_full_version`` from one slice,
+    ``implementation_version`` from another) then survives the plain union and
+    manufactures a false hole on a covering lock, since the reference leaves
+    ``implementation_version`` open.
+
+    With no existential primitive the projection is reproduced by ``restrict``:
+    binding ``implementation_version`` to one representative per slice drops the
+    axis, and the union over the targets' ``python_full_version`` reassembles
+    the minor.  Runs only when a row names ``implementation_version``.
+    """
+    if not any("implementation_version" in variable_names(row) for row in environments):
+        return covered
+    reps = {target.python_full_version for target in targets}
+    return reduce(
+        MarkerSet.union,
+        (covered.restrict({"implementation_version": rep}) for rep in reps),
+        MarkerSet.empty(),
+    )
 
 
 def _coverage_message(witness: dict[str, str | frozenset[str]]) -> str:

--- a/nab-python/src/nab_python/_lockfile/coverage.py
+++ b/nab-python/src/nab_python/_lockfile/coverage.py
@@ -36,6 +36,27 @@ __all__ = [
 ]
 
 
+# Axes a reference leaves open rather than pinning to one value: the shared
+# python-version axis, which a minor interval carries as a range, and
+# implementation_version, which the resolve mirrors onto that range on CPython.
+_OPEN_PYTHON_AXIS = frozenset(
+    {"python_version", "python_full_version", "implementation_version"}
+)
+
+
+def _reference_pins(target: ResolveTarget) -> dict[str, str]:
+    """Return the env axes a reference pins to single equality values.
+
+    Every boundable axis :func:`declared_range_marker` fixes to one value,
+    minus the open python axis.
+    """
+    return {
+        name: value
+        for name, value in target.marker_env.items()
+        if name not in UNBOUNDABLE_MARKER_VARIABLES and name not in _OPEN_PYTHON_AXIS
+    }
+
+
 class CoverageError(ValueError):
     """A resolved target has no covering ``environments`` row.
 
@@ -76,7 +97,12 @@ def validate_marker_coverage(
         if marker in seen:
             continue
         seen.add(marker)
-        residual = MarkerSet.from_marker(marker) & ~covered
+        # Restrict the union to the reference's pinned axes before complementing.
+        # Complementing the whole matrix carries every row's atoms on every axis
+        # at once, overrunning the witness cell budget; restricting first leaves a
+        # single-platform, python-axis-only residual denoting the same set.
+        covered_here = covered.restrict(_reference_pins(target))
+        residual = MarkerSet.from_marker(marker) & ~covered_here
         witness = residual.witness()
         if witness is not None:
             raise CoverageError(_coverage_message(witness))

--- a/nab-python/src/nab_python/_lockfile/coverage.py
+++ b/nab-python/src/nab_python/_lockfile/coverage.py
@@ -1,0 +1,107 @@
+"""Emit-time lock coverage validation for the PEP 751 emitter.
+
+A conformant PEP 751 consumer refuses a lock unless one of its declared
+``environments`` markers matches the installing interpreter.  A
+non-covering lock declares no row for an interpreter its own resolve
+produced pins for, so the installer refuses it there.  This is the
+completeness dual of the disjointness gate: that one forbids two same-name
+entries firing under one context, this one forbids a resolved context with
+no entry.
+
+The universe is not expressible as a single PEP 508 marker, so the check
+runs through the marker algebra.  For each target the resolve ran it asks
+whether the union of the emitted rows admits the whole range the target
+stands for: a minor-interval target stands for its whole minor, a whole
+target for one micro.  A point in that range no row admits is returned as a
+witness, and the gate fires naming the uncovered interpreter.
+"""
+
+from __future__ import annotations
+
+from functools import reduce
+from typing import TYPE_CHECKING
+
+from .._vendor.packaging.markersets import MarkerSet
+from ..target import UNBOUNDABLE_MARKER_VARIABLES, declared_range_marker
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from .._vendor.packaging.markers import Marker
+    from ..target import ResolveTarget
+
+
+__all__ = [
+    "CoverageError",
+]
+
+
+class CoverageError(ValueError):
+    """A resolved target has no covering ``environments`` row.
+
+    The error names one uncovered interpreter as a concrete point so the
+    producer can widen the declaration or drop the target.
+    """
+
+
+def validate_marker_coverage(
+    targets: Sequence[ResolveTarget],
+    *,
+    environments: Sequence[Marker],
+) -> None:
+    """Confirm the emitted rows cover every target the resolve ran.
+
+    For each distinct target reference the validator asks the algebra for a
+    point the union of rows does not admit (``reference & ~covered``); a
+    witness is a real interpreter the declaration would refuse.  References
+    are deduped by marker string, so a split minor's slices and conflict
+    forks sharing an environment are checked once.
+
+    An empty ``environments`` returns early: an omitted field declares
+    support for every environment, so it must not be read as the empty set.
+    """
+    if not environments:
+        return
+
+    covered = reduce(
+        MarkerSet.union,
+        (MarkerSet.from_marker(marker) for marker in environments),
+        MarkerSet.empty(),
+    )
+
+    seen: set[str] = set()
+    for target in targets:
+        marker = declared_range_marker(target)
+        if marker in seen:
+            continue
+        seen.add(marker)
+        residual = MarkerSet.from_marker(marker) & ~covered
+        witness = residual.witness()
+        if witness is not None:
+            raise CoverageError(_coverage_message(witness))
+
+
+def _coverage_message(witness: dict[str, str | frozenset[str]]) -> str:
+    """Render the uncovered interpreter the witness names.
+
+    ``python_full_version`` first, then the other boundable axes the witness
+    pins as a sorted ``name == "value"`` list.  Kernel axes and the
+    ``python_version`` half of the shared python axis are dropped; membership
+    selections never appear on an environment row, so every value is a string.
+    """
+    skip = UNBOUNDABLE_MARKER_VARIABLES | {"python_version"}
+    boundable = {
+        name: value
+        for name, value in witness.items()
+        if isinstance(value, str) and name not in skip
+    }
+    full_version = boundable.pop("python_full_version")
+    axes = ", ".join(
+        f'{name} == "{value}"' for name, value in sorted(boundable.items())
+    )
+    return (
+        "the lock declares no environment covering"
+        f' python_full_version == "{full_version}" ({axes}).'
+        " The resolve produced pins for this interpreter but no environments"
+        " row admits it."
+    )

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -43,6 +43,7 @@ from .._vendor.packaging.utils import canonicalize_name
 from .._vendor.packaging.version import Version
 from ..config import conflict_exclusion_groups, conflict_member_groups
 from .builder import require_artifact_hashes
+from .coverage import validate_marker_coverage
 from .disjointness import validate_marker_disjointness
 
 if TYPE_CHECKING:
@@ -231,6 +232,10 @@ def build_pylock(lock_input: LockInput, *, lock_dir: Path | None = None) -> Pylo
         groups=lock_input.active_groups,
         exclusive_groups=exclusion_groups,
         declared_groups=conflict_member_groups(lock_input.conflicts),
+    )
+    validate_marker_coverage(
+        [lock.target for lock in lock_input.targets.values()],
+        environments=lock_input.environments,
     )
     tool: dict[str, Any] | None = (
         {"nab": lock_input.provenance.to_block()}

--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -55,6 +55,7 @@ __all__ = [
     "apply_python_axis_overlay",
     "check_free_threaded",
     "declared_environment",
+    "declared_range_marker",
     "environment_declaration",
     "host_environment",
     "marker_variables",
@@ -327,6 +328,25 @@ def environment_declaration(target: ResolveTarget, consulted: Iterable[Marker]) 
             clause.replace("python_full_version", "implementation_version")
             for clause in target.micro_clauses
         )
+    return " and ".join(clauses)
+
+
+def declared_range_marker(target: ResolveTarget) -> str:
+    """Render the environment a target resolved for, on its whole declared range.
+
+    Pins every boundable environment axis to the target's value. A minor
+    interval leaves the micro release open, so python_version pins the whole
+    minor; a whole target (host, or a python-patches micro pin) adds the
+    concrete python_full_version it resolved at.
+    """
+    skip = UNBOUNDABLE_MARKER_VARIABLES | set(_BY_CONSTRAINT)
+    clauses = [
+        f'{name} == "{value}"'
+        for name, value in sorted(target.marker_env.items())
+        if name not in skip
+    ]
+    if not target.is_minor_interval:
+        clauses.append(f'python_full_version == "{target.python_full_version}"')
     return " and ".join(clauses)
 
 

--- a/nab-python/tests/property_python/test_coverage_differential.py
+++ b/nab-python/tests/property_python/test_coverage_differential.py
@@ -1,0 +1,257 @@
+"""Differential property tests for :mod:`nab_python._lockfile.coverage`.
+
+`PEP 751`_ consumers refuse a lock unless one of its declared
+``environments`` markers matches the installing interpreter, so a lock
+that declares no row for an interpreter its own resolve produced pins for
+is silently unusable there.  ``validate_marker_coverage`` guards that class
+through the marker algebra: for each target the resolve ran it asks whether
+the union of the emitted rows admits the whole range the target stands for,
+and names an uncovered point when one exists.  These tests drive the real
+emit pipeline and check every witness against direct marker evaluation.
+
+.. _PEP 751: https://peps.python.org/pep-0751/#packages
+"""
+
+from __future__ import annotations
+
+import random
+import re
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_python._lockfile.coverage import CoverageError, validate_marker_coverage
+from nab_python._vendor.packaging.markers import Marker
+from nab_python._vendor.packaging.markersets import IntractableMarkerSet
+from nab_python._vendor.packaging.version import Version
+from nab_python.tags import PlatformSpec
+from nab_python.target import (
+    ResolveTarget,
+    declared_range_marker,
+    environment_declaration,
+    micro_boundary_points,
+    slices_from_points,
+)
+
+from .strategies import PROPERTY_SETTINGS
+
+MINORS = ("3.11", "3.12", "3.13")
+PLATFORMS = ("linux_x86_64", "windows_amd64", "macos_arm64")
+BOUNDARY_MICROS = (1, 2, 3, 5)
+# On CPython implementation_version tracks python_full_version, so a
+# consulted marker on either splits the minor and emits mirror bounds.
+VERSION_VARIABLES = ("python_full_version", "implementation_version")
+
+_WITNESS_CLAUSE = re.compile(r'(\w+) == "([^"]+)"')
+
+points = st.lists(
+    st.tuples(st.sampled_from(MINORS), st.sampled_from(PLATFORMS)),
+    min_size=1,
+    max_size=4,
+    unique=True,
+)
+boundaries = st.lists(
+    st.sampled_from(BOUNDARY_MICROS), min_size=0, max_size=2, unique=True
+)
+version_variables = st.sampled_from(VERSION_VARIABLES)
+
+
+def _emit(
+    matrix_points: list[tuple[str, str]], micros: list[int], variable: str
+) -> tuple[list[ResolveTarget], list[Marker]]:
+    """Run the emit pipeline over a matrix, returning its targets and rows.
+
+    Each ``(minor, platform)`` point becomes a bare-minor target; a
+    consulted ``variable >= "{minor}.{micro}"`` marker per boundary splits
+    it into slices, and every slice declares its own environment row.  With
+    no boundaries the minor stays whole and emits one row.
+    """
+    targets: list[ResolveTarget] = []
+    environments: list[Marker] = []
+    for minor, platform in matrix_points:
+        base = ResolveTarget.for_declared(
+            python_version=minor, spec=PlatformSpec(platform)
+        )
+        consulted = [Marker(f'{variable} >= "{minor}.{micro}"') for micro in micros]
+        slices = slices_from_points(base, micro_boundary_points(base, consulted))
+        for piece in slices:
+            targets.append(piece)
+            environments.append(Marker(environment_declaration(piece, consulted)))
+    return targets, environments
+
+
+def _witness_environment(exc: CoverageError) -> dict[str, str]:
+    """Reconstruct the interpreter the coverage error names.
+
+    The message renders the witness as ``python_full_version`` plus every
+    boundable axis it pins.  Add the derived ``python_version`` and, since
+    the witness names a CPython interpreter where the two are equal,
+    ``implementation_version``, so every emitted row and reference marker
+    evaluates against a complete environment.
+    """
+    pins = dict(_WITNESS_CLAUSE.findall(str(exc)))
+    release = Version(pins["python_full_version"]).release
+    pins["python_version"] = f"{release[0]}.{release[1]}"
+    pins["implementation_version"] = pins["python_full_version"]
+    return pins
+
+
+def _assert_witness_sound(
+    exc: CoverageError,
+    targets: list[ResolveTarget],
+    environments: list[Marker],
+) -> None:
+    """Assert the witness is a real uncovered interpreter by evaluation.
+
+    Some target's reference range admits the witness (it is an environment
+    the resolve ran for) and no emitted row admits it (the declaration
+    would refuse it), decided by evaluating the markers at the point.
+    """
+    env = _witness_environment(exc)
+    references = [Marker(declared_range_marker(target)) for target in targets]
+    assert any(reference.evaluate(env) for reference in references)
+    assert not any(row.evaluate(env) for row in environments)
+
+
+@pytest.mark.property
+class TestCoverageDifferential:
+    """The coverage gate against the real emitter and an evaluation oracle.
+
+    The gate must never fire on what the emitter produces, must fire on a
+    removed region, and every witness it names must be a real interpreter
+    that a target resolved for and no row admits.
+    """
+
+    @given(matrix_points=points, micros=boundaries, variable=version_variables)
+    @PROPERTY_SETTINGS
+    def test_real_emit_pipeline_is_covered(
+        self, matrix_points: list[tuple[str, str]], micros: list[int], variable: str
+    ) -> None:
+        """The gate never fires on rows the real emit pipeline produced.
+
+        An ``IntractableMarkerSet`` on a large matrix is the algebra's
+        bounded-failure escape hatch, a sound non-emit the design allows;
+        only a false ``CoverageError`` is a coverage bug.
+        """
+        targets, environments = _emit(matrix_points, micros, variable)
+        try:
+            validate_marker_coverage(targets, environments=environments)
+        except IntractableMarkerSet:
+            pass
+
+    @given(
+        minor=st.sampled_from(MINORS),
+        platform=st.sampled_from(PLATFORMS),
+        micros=st.lists(
+            st.sampled_from(BOUNDARY_MICROS), min_size=1, max_size=2, unique=True
+        ),
+        variable=version_variables,
+        data=st.data(),
+    )
+    @PROPERTY_SETTINGS
+    def test_dropping_a_slice_row_fires(
+        self,
+        minor: str,
+        platform: str,
+        micros: list[int],
+        variable: str,
+        data: st.DataObject,
+    ) -> None:
+        """Dropping one slice row fires, with the witness inside its region."""
+        targets, environments = _emit([(minor, platform)], micros, variable)
+        assert len(environments) >= 2
+        drop = data.draw(st.integers(min_value=0, max_value=len(environments) - 1))
+        remaining = [row for index, row in enumerate(environments) if index != drop]
+        with pytest.raises(CoverageError) as excinfo:
+            validate_marker_coverage(targets, environments=remaining)
+        env = _witness_environment(excinfo.value)
+        assert environments[drop].evaluate(env)
+        _assert_witness_sound(excinfo.value, targets, remaining)
+
+    @given(
+        matrix_points=points,
+        narrow_micro=st.sampled_from((1, 2, 3)),
+        data=st.data(),
+    )
+    @PROPERTY_SETTINGS
+    def test_narrowing_a_lower_bound_fires(
+        self,
+        matrix_points: list[tuple[str, str]],
+        narrow_micro: int,
+        data: st.DataObject,
+    ) -> None:
+        """Narrowing one row's lower bound fires below the new floor."""
+        targets = [
+            ResolveTarget.for_declared(
+                python_version=minor, spec=PlatformSpec(platform)
+            )
+            for minor, platform in matrix_points
+        ]
+        environments = [
+            Marker(environment_declaration(target, [])) for target in targets
+        ]
+        index = data.draw(st.integers(min_value=0, max_value=len(targets) - 1))
+        minor = matrix_points[index][0]
+        floor = f'python_full_version >= "{minor}.{narrow_micro}"'
+        environments[index] = Marker(f"{environments[index]} and {floor}")
+        with pytest.raises(CoverageError) as excinfo:
+            validate_marker_coverage(targets, environments=environments)
+        witness = Version(_witness_environment(excinfo.value)["python_full_version"])
+        assert witness < Version(f"{minor}.{narrow_micro}")
+        _assert_witness_sound(excinfo.value, targets, environments)
+
+
+def _random_points(rng: random.Random) -> list[tuple[str, str]]:
+    """Draw 1-4 distinct ``(minor, platform)`` points."""
+    grid = [(minor, platform) for minor in MINORS for platform in PLATFORMS]
+    return rng.sample(grid, rng.randint(1, 4))
+
+
+def _random_boundaries(rng: random.Random) -> list[int]:
+    """Draw 0-2 distinct interior micro boundaries."""
+    return rng.sample(BOUNDARY_MICROS, rng.randint(0, 2))
+
+
+class TestCoverageOverRandomEmitShapes:
+    """A bounded, deterministic differential over random emit shapes.
+
+    The hypothesis properties shrink toward small counterexamples; this
+    seeds a fixed pseudo-random stream and drives a larger corpus of whole
+    emit shapes through the gate.  Every shape must be covering as emitted,
+    and dropping any one row must leave a real gap the gate fires on with a
+    sound witness.
+    """
+
+    def test_random_emit_shapes_cover_and_gaps_fire(self) -> None:
+        """Emitted rows cover; a dropped row fires with a sound witness."""
+        rng = random.Random(20260722)  # noqa: S311
+        for _ in range(300):
+            matrix_points = _random_points(rng)
+            variable = rng.choice(VERSION_VARIABLES)
+            targets, environments = _emit(
+                matrix_points, _random_boundaries(rng), variable
+            )
+            try:
+                validate_marker_coverage(targets, environments=environments)
+            except IntractableMarkerSet:
+                continue
+
+            # Dropping the sole row empties ``environments``, which the gate
+            # reads as an omitted field covering everything, so a gap needs a
+            # row left behind.
+            if len(environments) < 2:
+                continue
+            drop = rng.randrange(len(environments))
+            remaining = [row for index, row in enumerate(environments) if index != drop]
+            try:
+                validate_marker_coverage(targets, environments=remaining)
+            except IntractableMarkerSet:
+                continue
+            except CoverageError as exc:
+                env = _witness_environment(exc)
+                assert environments[drop].evaluate(env)
+                _assert_witness_sound(exc, targets, remaining)
+            else:
+                msg = "dropping one row must leave a gap the gate fires on"
+                raise AssertionError(msg)

--- a/nab-python/tests/property_python/test_coverage_differential.py
+++ b/nab-python/tests/property_python/test_coverage_differential.py
@@ -202,6 +202,77 @@ class TestCoverageDifferential:
         _assert_witness_sound(excinfo.value, targets, environments)
 
 
+# The nab CI-lock matrix that overran the witness cell budget: 5 minors x 5
+# platforms, 3.10 split at micro 2, giving 30 targets and 30 rows.
+BLOWUP_MINORS = ("3.10", "3.11", "3.12", "3.13", "3.14")
+BLOWUP_PLATFORMS = (
+    "linux_x86_64",
+    "linux_aarch64",
+    "macos_arm64",
+    "macos_x86_64",
+    "windows_amd64",
+)
+
+
+def _blowup_matrix() -> tuple[list[ResolveTarget], list[Marker]]:
+    """Build the 30-target / 30-row CI-lock fixture that overran the budget.
+
+    Every minor stays whole (one row) except 3.10, which a consulted
+    ``python_full_version >= "3.10.2"`` splits into two micro slices.
+    """
+    targets: list[ResolveTarget] = []
+    environments: list[Marker] = []
+    for minor in BLOWUP_MINORS:
+        consulted = (
+            [Marker('python_full_version >= "3.10.2"')] if minor == "3.10" else []
+        )
+        for platform in BLOWUP_PLATFORMS:
+            base = ResolveTarget.for_declared(
+                python_version=minor, spec=PlatformSpec(platform)
+            )
+            slices = slices_from_points(base, micro_boundary_points(base, consulted))
+            for piece in slices:
+                targets.append(piece)
+                environments.append(Marker(environment_declaration(piece, consulted)))
+    return targets, environments
+
+
+class TestCoverageGateBlowupRegression:
+    """The CI-lock fixture that crashed the gate with ``IntractableMarkerSet``.
+
+    Complementing the 30-row union carried every axis every row named at once,
+    overrunning the witness cell budget. The fix restricts the union to each
+    reference's pinned axes first.
+    """
+
+    def test_full_ci_lock_matrix_is_decidable(self) -> None:
+        """The covering 30x30 matrix validates without raising."""
+        targets, environments = _blowup_matrix()
+        assert len(targets) == 30
+        assert len(environments) == 30
+        validate_marker_coverage(targets, environments=environments)
+
+    def test_dropping_a_matrix_row_fires_with_exact_witness(self) -> None:
+        """Dropping 3.12 / linux_x86_64 fires naming that exact interpreter."""
+        targets, environments = _blowup_matrix()
+        drop = next(
+            index
+            for index, target in enumerate(targets)
+            if target.python_version == "3.12"
+            and target.marker_env["sys_platform"] == "linux"
+            and target.marker_env["platform_machine"] == "x86_64"
+        )
+        remaining = [row for index, row in enumerate(environments) if index != drop]
+        assert len(remaining) == len(environments) - 1
+        with pytest.raises(CoverageError) as excinfo:
+            validate_marker_coverage(targets, environments=remaining)
+        message = str(excinfo.value)
+        assert 'python_full_version == "3.12"' in message
+        assert 'sys_platform == "linux"' in message
+        assert 'platform_machine == "x86_64"' in message
+        _assert_witness_sound(excinfo.value, targets, remaining)
+
+
 def _random_points(rng: random.Random) -> list[tuple[str, str]]:
     """Draw 1-4 distinct ``(minor, platform)`` points."""
     grid = [(minor, platform) for minor in MINORS for platform in PLATFORMS]

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -23,6 +23,10 @@ else:
 from nab_index.client import SdistFile, WheelFile
 from nab_index.multi_index import IndexConfig
 from nab_python._lockfile.builder import _common_requires_python
+from nab_python._lockfile.coverage import (
+    CoverageError,
+    validate_marker_coverage,
+)
 from nab_python._lockfile.disjointness import (
     validate_marker_disjointness,
 )
@@ -94,7 +98,12 @@ from nab_python.resolve import (
     resolve_with_coordinator,
 )
 from nab_python.tags import PlatformSpec
-from nab_python.target import ResolveTarget
+from nab_python.target import (
+    ResolveTarget,
+    environment_declaration,
+    micro_boundary_points,
+    slices_from_points,
+)
 
 
 def _target(
@@ -5820,3 +5829,121 @@ class TestConflictSetDeclaredMemberWithNoFork:
         if b is not None:
             expected.add(f"idna {self._B[b]}")
         assert self._select(self._lock(), groups) == expected
+
+
+class TestMarkerCoverage:
+    def _minor(
+        self, python_version: str = "3.13", platform: str = "linux_x86_64"
+    ) -> ResolveTarget:
+        """A bare-minor target resolved as a micro interval."""
+        return ResolveTarget.for_declared(
+            python_version=python_version, spec=PlatformSpec(platform)
+        )
+
+    def _row(self, target: ResolveTarget, consulted: Sequence[str] = ()) -> Marker:
+        """The environments row the emitter renders for ``target``."""
+        markers = [Marker(text) for text in consulted]
+        return Marker(environment_declaration(target, markers))
+
+    def _split(
+        self, target: ResolveTarget, consulted: str
+    ) -> tuple[list[ResolveTarget], list[Marker]]:
+        """Split ``target``'s minor at ``consulted`` into slices and their rows."""
+        markers = [Marker(consulted)]
+        points = micro_boundary_points(target, markers)
+        slices = slices_from_points(target, points)
+        rows = [Marker(environment_declaration(s, markers)) for s in slices]
+        return slices, rows
+
+    def _full_version(self, exc: CoverageError) -> Version:
+        """The python_full_version the witness message names."""
+        match = re.search(r'python_full_version == "([^"]+)"', str(exc))
+        assert match is not None
+        return Version(match.group(1))
+
+    def test_covering_unsplit_minor_passes(self) -> None:
+        target = self._minor("3.13")
+        validate_marker_coverage([target], environments=[self._row(target)])
+
+    def test_covering_split_minor_dedups_shared_reference(self) -> None:
+        target = self._minor("3.13")
+        slices, rows = self._split(target, 'python_full_version >= "3.13.2"')
+        assert len(slices) == 2
+        validate_marker_coverage(slices, environments=rows)
+
+    def test_empty_environments_returns_early(self) -> None:
+        validate_marker_coverage([self._minor("3.13")], environments=[])
+
+    def test_prerelease_floor_slice_passes(self) -> None:
+        target = self._minor("3.13")
+        slices, rows = self._split(target, 'python_full_version >= "3.13.5"')
+        validate_marker_coverage(slices, environments=rows)
+
+    def test_two_platform_lock_passes(self) -> None:
+        linux = self._minor("3.11", "linux_x86_64")
+        windows = self._minor("3.11", "windows_amd64")
+        validate_marker_coverage(
+            [linux, windows],
+            environments=[self._row(linux), self._row(windows)],
+        )
+
+    def test_whole_target_under_minor_row_passes(self) -> None:
+        whole = ResolveTarget.for_declared(
+            python_version="3.11",
+            spec=PlatformSpec("linux_x86_64"),
+            python_full_version="3.11.4",
+        )
+        validate_marker_coverage([whole], environments=[self._row(whole)])
+
+    def test_conflict_forks_covered_by_shared_row_pass(self) -> None:
+        base = self._minor("3.11")
+        cpu = base.with_selection((("extra", "cpu"),))
+        gpu = base.with_selection((("extra", "gpu"),))
+        validate_marker_coverage([cpu, gpu], environments=[self._row(base)])
+
+    def test_micro_narrowing_reconstruction_fires(self) -> None:
+        target = self._minor("3.13")
+        row = Marker(
+            'python_version == "3.13" and sys_platform == "linux"'
+            ' and platform_machine == "x86_64"'
+            ' and python_full_version >= "3.13.2"'
+        )
+        with pytest.raises(CoverageError) as excinfo:
+            validate_marker_coverage([target], environments=[row])
+        found = self._full_version(excinfo.value)
+        assert found.release[:2] == (3, 13)
+        assert found < Version("3.13.2")
+
+    def test_interior_slice_gap_fires(self) -> None:
+        target = self._minor("3.13")
+        rows = [
+            Marker(
+                'python_version == "3.13" and sys_platform == "linux"'
+                ' and platform_machine == "x86_64"'
+                ' and python_full_version < "3.13.2"'
+            ),
+            Marker(
+                'python_version == "3.13" and sys_platform == "linux"'
+                ' and platform_machine == "x86_64"'
+                ' and python_full_version >= "3.13.5"'
+            ),
+        ]
+        with pytest.raises(CoverageError) as excinfo:
+            validate_marker_coverage([target], environments=rows)
+        found = self._full_version(excinfo.value)
+        assert Version("3.13.2") <= found < Version("3.13.5")
+
+    def test_dropped_target_row_fires(self) -> None:
+        linux = self._minor("3.13", "linux_x86_64")
+        windows = self._minor("3.11", "windows_amd64")
+        with pytest.raises(CoverageError, match="win32"):
+            validate_marker_coverage([linux, windows], environments=[self._row(linux)])
+
+    def test_intractable_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def boom(self: MarkerSet) -> None:
+            raise IntractableMarkerSet("patched")
+
+        monkeypatch.setattr(MarkerSet, "witness", boom)
+        target = self._minor("3.13")
+        with pytest.raises(IntractableMarkerSet, match="patched"):
+            validate_marker_coverage([target], environments=[self._row(target)])

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -5965,3 +5965,32 @@ class TestMarkerCoverage:
         target = self._minor("3.13")
         with pytest.raises(IntractableMarkerSet, match="patched"):
             validate_marker_coverage([target], environments=[self._row(target)])
+
+    def test_build_pylock_non_covering_raises(self) -> None:
+        target = self._minor("3.13")
+        lock_input = LockInput(
+            targets={
+                target.label: TargetLock(target=target, pins={"foo": _index_pin()})
+            },
+            environments=[
+                Marker(
+                    'python_version == "3.13" and sys_platform == "linux"'
+                    ' and platform_machine == "x86_64"'
+                    ' and python_full_version >= "3.13.2"'
+                )
+            ],
+        )
+        with pytest.raises(CoverageError) as excinfo:
+            build_pylock(lock_input)
+        assert self._full_version(excinfo.value) < Version("3.13.2")
+
+    def test_build_pylock_covering_emits_cleanly(self) -> None:
+        target = self._minor("3.11")
+        lock_input = LockInput(
+            targets={
+                target.label: TargetLock(target=target, pins={"foo": _index_pin()})
+            },
+            environments=[self._row(target)],
+        )
+        pylock = build_pylock(lock_input)
+        assert pylock.environments is not None

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -5901,6 +5901,24 @@ class TestMarkerCoverage:
         gpu = base.with_selection((("extra", "gpu"),))
         validate_marker_coverage([cpu, gpu], environments=[self._row(base)])
 
+    def test_cpython_iv_mirror_split_minor_passes(self) -> None:
+        target = self._minor("3.13")
+        slices, rows = self._split(target, 'implementation_version >= "3.13.2"')
+        assert len(slices) == 2
+        assert any("implementation_version" in str(row) for row in rows)
+        validate_marker_coverage(slices, environments=rows)
+
+    def test_cpython_iv_mirror_genuine_gap_fires(self) -> None:
+        target = self._minor("3.13")
+        slices = slices_from_points(target, [Version("3.13.2"), Version("3.13.5")])
+        consulted = [Marker('implementation_version >= "3.13.0"')]
+        rows = [Marker(environment_declaration(s, consulted)) for s in slices]
+        del rows[1]
+        with pytest.raises(CoverageError) as excinfo:
+            validate_marker_coverage(slices, environments=rows)
+        found = self._full_version(excinfo.value)
+        assert Version("3.13.2") <= found < Version("3.13.5")
+
     def test_micro_narrowing_reconstruction_fires(self) -> None:
         target = self._minor("3.13")
         row = Marker(

--- a/nab-python/tests/test_pylock.py
+++ b/nab-python/tests/test_pylock.py
@@ -22,6 +22,7 @@ else:
     import tomli as tomllib  # type: ignore[no-redef]
 
 from nab_python._lockfile import pylock
+from nab_python._lockfile.coverage import CoverageError
 from nab_python._lockfile.disjointness import validate_marker_disjointness
 from nab_python._lockfile.pylock import (
     UnsoundSimplificationError,
@@ -283,6 +284,18 @@ class TestFinalizeMarker:
         assert str(result) == str(raw)
 
 
+@pytest.fixture
+def ungated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stand the coverage gate down for a hand-built declaration.
+
+    ``build_pylock`` refuses a lock whose ``environments`` leave a resolved
+    target uncovered, so a non-covering shape never reaches the simplification
+    layer through the public entry point.  The tests that ask what that layer
+    does with one drive it with the gate stood down.
+    """
+    monkeypatch.setattr(pylock, "validate_marker_coverage", lambda *_, **__: None)
+
+
 def _non_covering_lock() -> LockInput:
     """A lock whose declared rows cover the linux targets only.
 
@@ -306,13 +319,19 @@ class TestNonCoveringEnvironments:
     is nothing shorter to emit.
     """
 
+    @pytest.mark.usefixtures("ungated")
     def test_uncovered_package_ships_raw_marker(self) -> None:
         emitted = _emitted(_non_covering_lock())["pywin32"]["marker"]
         expected = " or ".join(f"({t.environment_marker_string})" for t in _WIN)
         assert emitted == str(Marker(expected))
 
+    @pytest.mark.usefixtures("ungated")
     def test_covered_packages_still_finalise(self) -> None:
         assert "marker" not in _emitted(_non_covering_lock())["bar"]
+
+    def test_the_coverage_gate_refuses_the_shape(self) -> None:
+        with pytest.raises(CoverageError, match="win32"):
+            render_lock(_non_covering_lock())
 
     def test_direct_empty_within_universe_ships_raw(self) -> None:
         raw = Marker('sys_platform == "aix"')
@@ -357,10 +376,16 @@ class TestEmissionUniverse:
         universe = _emission_universe(self._with_environments(rows))
         assert universe.equivalent(MarkerSet.from_marker('sys_platform == "linux"'))
 
+    @pytest.mark.usefixtures("ungated")
     def test_uninhabited_lock_still_emits(self) -> None:
         rows = [Marker('sys_platform == "linux" and sys_platform == "win32"')]
         data = tomllib.loads(render_lock(self._with_environments(rows)))
         assert [p["name"] for p in data["packages"]] == ["foo"]
+
+    def test_uninhabited_rows_do_not_get_past_the_coverage_gate(self) -> None:
+        rows = [Marker('sys_platform == "linux" and sys_platform == "win32"')]
+        with pytest.raises(CoverageError):
+            render_lock(self._with_environments(rows))
 
     def test_undecidable_row_counts_as_inhabited(self) -> None:
         wide = Marker(" and ".join(f'"e{i}" in extras' for i in range(20)))

--- a/nab-python/tests/test_target.py
+++ b/nab-python/tests/test_target.py
@@ -28,6 +28,7 @@ from nab_python.target import (
     ResolveTarget,
     apply_python_axis_overlay,
     declared_environment,
+    declared_range_marker,
     environment_declaration,
     host_environment,
     marker_variables,
@@ -1055,6 +1056,74 @@ class TestEnvironmentDeclarationDocumented:
 
         missing = carried - self._documented_names()
         assert not missing, f"undocumented clause variables: {sorted(missing)}"
+
+
+class TestDeclaredRangeMarker:
+    """The environment a target stands for on its whole declared range."""
+
+    def test_a_minor_interval_leaves_the_micro_open(self) -> None:
+        target = ResolveTarget.for_declared(
+            python_version="3.13", spec=PlatformSpec("linux_x86_64")
+        )
+        assert target.is_minor_interval
+        assert declared_range_marker(target) == (
+            'implementation_name == "cpython" and os_name == "posix"'
+            ' and platform_machine == "x86_64"'
+            ' and platform_python_implementation == "CPython"'
+            ' and platform_system == "Linux" and python_version == "3.13"'
+            ' and sys_platform == "linux"'
+        )
+
+    def test_a_host_target_pins_the_full_version(self) -> None:
+        target = ResolveTarget.for_host(env_source=_host_env, tags_source=_host_tags)
+        assert not target.is_minor_interval
+        assert declared_range_marker(target) == (
+            'implementation_name == "cpython" and os_name == "posix"'
+            ' and platform_machine == "x86_64"'
+            ' and platform_python_implementation == "CPython"'
+            ' and platform_system == "Linux" and python_version == "3.13"'
+            ' and sys_platform == "linux"'
+            ' and python_full_version == "3.13.2"'
+        )
+
+    def test_a_python_patches_micro_pins_the_full_version(self) -> None:
+        target = ResolveTarget.for_declared(
+            python_version="3.13",
+            spec=PlatformSpec("linux_x86_64"),
+            python_full_version="3.13.4",
+        )
+        assert not target.is_minor_interval
+        assert declared_range_marker(target).endswith(
+            'and python_full_version == "3.13.4"'
+        )
+
+    def test_the_kernel_and_by_constraint_axes_are_never_pinned(self) -> None:
+        target = ResolveTarget.for_host(env_source=_host_env, tags_source=_host_tags)
+        marker = declared_range_marker(target)
+        assert "platform_release" not in marker
+        assert "platform_version" not in marker
+        assert "implementation_version" not in marker
+
+    def test_a_non_cpython_target_pins_its_implementation(self) -> None:
+        target = ResolveTarget.for_declared(
+            python_version="3.11",
+            spec=PlatformSpec("linux_x86_64"),
+            implementation="pypy",
+        )
+        assert target.is_minor_interval
+        assert declared_range_marker(target) == (
+            'implementation_name == "pypy" and os_name == "posix"'
+            ' and platform_machine == "x86_64"'
+            ' and platform_python_implementation == "PyPy"'
+            ' and platform_system == "Linux" and python_version == "3.11"'
+            ' and sys_platform == "linux"'
+        )
+
+    def test_the_marker_evaluates_true_on_the_target_environment(self) -> None:
+        target = ResolveTarget.for_declared(
+            python_version="3.13", spec=PlatformSpec("linux_x86_64")
+        )
+        assert Marker(declared_range_marker(target)).evaluate(target.marker_env)
 
 
 class TestMicroBoundarySplitting:


### PR DESCRIPTION
nab could emit a PEP 751 lock whose `environments` declaration did not cover an interpreter its own resolve pinned for, which a conformant consumer then refuses to install. Add an emit-time gate that checks the declared rows cover every resolved target and raises naming the uncovered interpreter, the completeness dual of the existing disjointness check.