### PR TITLE
stop one unparseable file URL from failing the whole listing

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -300,14 +300,14 @@ def _parse_files(
 
     PEP 592 ``yanked`` files are dropped unconditionally.
 
-    A single malformed *entry* (non-dict, or missing string ``filename``
-    / ``url``) is skipped so the usable entries in the same listing are
-    kept.  A malformed *body* (not a JSON object, or a ``files`` value
-    that is not a list) is a broken response, not an empty one, so it
-    raises :class:`MalformedSimpleResponseError` rather than returning no
-    files: an empty result means "package absent" to the multi-index router,
-    which would otherwise fall through to a lower-priority index and risk
-    pinning a different version.
+    A single malformed *entry* (non-dict, missing string ``filename`` /
+    ``url``, or a ``url`` that does not parse) is skipped so the usable
+    entries in the same listing are kept.  A malformed *body* (not a JSON
+    object, or a ``files`` value that is not a list) is a broken response,
+    not an empty one, so it raises :class:`MalformedSimpleResponseError`
+    rather than returning no files: an empty result means "package absent"
+    to the multi-index router, which would otherwise fall through to a
+    lower-priority index and risk pinning a different version.
     """
     expected = canonicalize_name(package)
     # PEP 691: relative URLs resolve against the package page, not the index root.
@@ -343,6 +343,25 @@ def _parse_files(
     return files
 
 
+def _resolve_file_url(raw_url: str, base_url: str) -> str | None:
+    """Return the entry's absolute URL, or None when it does not parse.
+
+    PEP 691 allows a relative ``url``, which resolves against the package
+    page.  ``urlsplit`` raises on a netloc it cannot parse, such as an
+    unbalanced bracket in an IPv6 host.
+    """
+    try:
+        if raw_url.startswith(("https://", "http://")):
+            # Split only to reject a host urllib cannot parse; urljoin
+            # would hand back this same string.
+            urlsplit(raw_url)
+            return raw_url
+
+        return urljoin(base_url, raw_url)
+    except ValueError:
+        return None
+
+
 def _parse_file_entry(
     file_info: dict,
     filename: str,
@@ -354,16 +373,13 @@ def _parse_file_entry(
 
     ``filename`` and ``raw_url`` are the entry's already-validated string
     fields.  ``expected`` is the queried package's canonical name; files
-    whose parsed name differs, or whose filename packaging does not
-    recognise, are dropped (see :func:`_parse_files`).
+    whose parsed name differs, whose filename packaging does not
+    recognise, or whose URL does not parse are dropped (see
+    :func:`_parse_files`).
     """
-    # PyPI and most indexes emit absolute file URLs; urljoin then re-parses
-    # both sides only to return the URL unchanged. Skip it for the common
-    # absolute case; relative URLs still resolve against the page below.
-    if raw_url.startswith(("https://", "http://")):
-        file_url = raw_url
-    else:
-        file_url = urljoin(base_url, raw_url)
+    file_url = _resolve_file_url(raw_url, base_url)
+    if file_url is None:
+        return None
 
     hashes = _parse_hashes(file_info.get("hashes"))
     size = _parse_size(file_info.get("size"))

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -1149,6 +1149,10 @@ class FetchCoordinator:
         holds. Any other failure is recorded as an error, because a file the
         listing advertised and the index then failed to serve is not the same as
         a file that does not exist.
+
+        A listing that is already stored keeps it: the fetch succeeded, and the
+        work that raised ran after the waiter woke, so recording an error would
+        make the outcome depend on which thread reads the index first.
         """
         offline = isinstance(exc, OfflineError)
 
@@ -1158,7 +1162,7 @@ class FetchCoordinator:
                 # pending event (see _fetch_listing).
                 self._record_serving_index(client, req.package)
                 self.index.store_listing(req.package, [])
-            else:
+            elif self.index.get_listing(req.package) is None:
                 self.index.store_listing_error(req.package, exc)
             return
 

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -452,6 +452,23 @@ class TestFetchCoordinator:
         assert calls == [1]
 
     @respx.mock
+    def test_listing_survives_a_failure_raised_after_it_is_stored(self) -> None:
+        """A failure raised after the listing is stored records no error."""
+        respx.get("https://pypi.org/simple/testpkg/").mock(
+            return_value=httpx.Response(200, json=LISTING_JSON)
+        )
+
+        def on_fetch() -> None:
+            msg = "progress sink closed"
+            raise RuntimeError(msg)
+
+        with _coord(on_fetch=on_fetch) as coord:
+            assert coord.request_listing("testpkg").wait(timeout=5)
+
+        assert coord.index.get_listing("testpkg") is not None
+        assert coord.index.get_listing_error("testpkg") is None
+
+    @respx.mock
     def test_request_listing_cached(self) -> None:
         with _coord() as coord:
             coord.index.store_listing("cached", ["data"])
@@ -647,6 +664,53 @@ class TestFetchCoordinator:
 
         # The newest PREFETCH_METADATA_COUNT wheels, not all 15.
         assert derived == [f"pkg-{n}.0-py3-none-any.whl" for n in range(6, 16)]
+
+    @respx.mock
+    def test_listing_entry_with_unsplittable_url_is_dropped(self) -> None:
+        """Only the entry whose URL urllib cannot split is dropped."""
+        listing = {
+            "meta": {"api-version": "1.0"},
+            "name": "pkg",
+            "files": [
+                {
+                    "filename": "pkg-1.0-py3-none-any.whl",
+                    "url": "https://[2001:db8::1/pkg-1.0-py3-none-any.whl",
+                    "core-metadata": True,
+                },
+                *(
+                    {
+                        "filename": f"pkg-{n}.0-py3-none-any.whl",
+                        "url": f"https://f.com/pkg-{n}.0-py3-none-any.whl",
+                        "core-metadata": True,
+                    }
+                    for n in (2, 3)
+                ),
+            ],
+        }
+
+        respx.get("https://pypi.org/simple/pkg/").mock(
+            return_value=httpx.Response(200, json=listing)
+        )
+        respx.get(url__regex=r".*\.whl\.metadata$").mock(
+            return_value=httpx.Response(200, text="Metadata-Version: 2.1\n")
+        )
+
+        with _coord() as coord:
+            assert coord.request_listing("pkg").wait(timeout=5)
+
+        # Read after the fetcher thread joins, so the prefetch that follows
+        # store_listing has finished.
+        files = coord.index.get_listing("pkg")
+        assert files is not None
+        assert [f.version for f in files] == ["2.0", "3.0"]
+        assert coord.index.get_listing_error("pkg") is None
+
+        for version in ("2.0", "3.0"):
+            sidecar = f"https://f.com/pkg-{version}-py3-none-any.whl.metadata"
+            _, prefetched = coord.index.get_or_create_pending(
+                f"metadata:pkg:{version}:{sidecar}"
+            )
+            assert prefetched
 
     @respx.mock
     def test_fetch_error_logged_not_raised(self) -> None:

--- a/nab-python/tests/test_simple_client_malformed.py
+++ b/nab-python/tests/test_simple_client_malformed.py
@@ -101,3 +101,26 @@ def test_bad_entry_dropped_good_entry_kept(bad_entry: object) -> None:
     files = _parse_files(data, _INDEX, "foo")
     assert len(files) == 1
     assert files[0].filename == "foo-1.0-py3-none-any.whl"
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "https://[2001:db8::1/foo-2.0-py3-none-any.whl",
+        "http://2001:db8::1]/foo-2.0-py3-none-any.whl",
+        "//[2001:db8::1/foo-2.0-py3-none-any.whl",
+    ],
+)
+def test_entry_with_unsplittable_url_is_skipped(bad_url: str) -> None:
+    entry = {"filename": "foo-2.0-py3-none-any.whl", "url": bad_url}
+    files = _parse_files({"files": [entry, _good_file()]}, _INDEX, "foo")
+    assert [f.filename for f in files] == ["foo-1.0-py3-none-any.whl"]
+
+
+def test_sdist_entry_with_unsplittable_url_is_skipped() -> None:
+    entry = {
+        "filename": "foo-2.0.tar.gz",
+        "url": "https://[2001:db8::1/foo-2.0.tar.gz",
+    }
+    files = _parse_files({"files": [entry, _good_file()]}, _INDEX, "foo")
+    assert [f.filename for f in files] == ["foo-1.0-py3-none-any.whl"]


### PR DESCRIPTION
One listing entry whose URL urllib cannot parse (an unbalanced bracket in an IPv6 host, say) made the package resolve inconsistently: sometimes it resolved from the listing's other entries, sometimes it failed with a listing error.

Absolute URLs skip the urljoin that relative ones go through, so a URL that urlsplit rejects reached the parsed file entries untouched and only raised later, from the sidecar metadata prefetch that runs once the listing is stored. By then the waiting thread was already awake, and the failure handler wrote an error over the stored listing, so which of the two a reader got came down to timing.

`_parse_files` now checks the URL alongside the other malformed-entry checks, so the bad entry is dropped and the rest of the listing is kept. Recording a fetch error also leaves an already-stored listing alone.
