### PR TITLE
Simplify per-package lock markers at emission

### DIFF
--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -236,7 +236,8 @@ with PEP 508 markers built from each target's `python_version`,
 `sys_platform` and `platform_machine`, plus `implementation_name` on
 the same terms as the `environments` declarations above. Each such
 marker is emitted in its shortest form equivalent over the lock's
-declared environments.
+declared environments. A marker too large to simplify within budget is
+emitted unsimplified.
 
 `environments` carries a declaration per target, built the same way a
 single-environment lock builds its one: from the markers that target's

--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -234,7 +234,9 @@ whose pinned version is identical across every target appear once with
 no marker; packages that diverge appear as multiple `Package` entries
 with PEP 508 markers built from each target's `python_version`,
 `sys_platform` and `platform_machine`, plus `implementation_name` on
-the same terms as the `environments` declarations above.
+the same terms as the `environments` declarations above. Each such
+marker is emitted in its shortest form equivalent over the lock's
+declared environments.
 
 `environments` carries a declaration per target, built the same way a
 single-environment lock builds its one: from the markers that target's

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 from collections import Counter, defaultdict
+from functools import reduce
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -21,6 +22,7 @@ from nab_index.atomic import atomic_write_text
 
 from .._conflict_kind import MARKER_VARIABLE_FOR_KIND
 from .._vendor.packaging.markers import Marker
+from .._vendor.packaging.markersets import IntractableMarkerSet, MarkerSet
 from .._vendor.packaging.pylock import (
     Package,
     PackageArchive,
@@ -54,9 +56,20 @@ if TYPE_CHECKING:
 
 __all__ = [
     "DivergentBaseDependencyError",
+    "UnsoundSimplificationError",
     "build_pylock",
     "write_lock",
 ]
+
+
+class UnsoundSimplificationError(ValueError):
+    """A simplified per-package marker disagrees with the original over the universe.
+
+    Simplification must preserve which environments the marker selects within
+    the lock's declared environments.  Verified on the serialised-and-reparsed
+    bytes at emission, so a mismatch is a bug and emission crashes rather than
+    ship a marker that would install differently.
+    """
 
 
 class DivergentBaseDependencyError(ValueError):
@@ -128,7 +141,8 @@ def build_pylock(lock_input: LockInput, *, lock_dir: Path | None = None) -> Pylo
 
     base = (lock_dir if lock_dir is not None else Path.cwd()).resolve()
     exclusion_groups = conflict_exclusion_groups(lock_input.conflicts)
-    package_records = _build_packages(lock_input, base, exclusion_groups)
+    universe = _emission_universe(lock_input)
+    package_records = _build_packages(lock_input, base, exclusion_groups, universe)
     package_records.sort(key=_package_sort_key)
     validate_marker_disjointness(
         package_records,
@@ -340,10 +354,70 @@ def _sdist_to_package(sdist: SdistArtifact, *, lock_dir: Path) -> PackageSdist:
     )
 
 
+def _emission_universe(lock_input: LockInput) -> MarkerSet:
+    """Return the environment universe simplification must agree over.
+
+    The union of the declared ``environments`` rows, or the full set when none
+    are declared.  PEP 751 step 4 has a conforming installer read a per-package
+    marker only in an environment some row admits, so within-universe
+    equivalence is the sound contract.
+    """
+    if not lock_input.environments:
+        return MarkerSet.full()
+    return reduce(
+        MarkerSet.union,
+        (MarkerSet.from_marker(m) for m in lock_input.environments),
+        MarkerSet.empty(),
+    )
+
+
+def _finalize_marker(
+    raw: Marker | None, within: MarkerSet, name: str = ""
+) -> Marker | None:
+    """Return ``raw`` in its shortest form equivalent over ``within``.
+
+    ``None`` passes through.  The simplified set is serialised, reparsed, and
+    checked equivalent to ``raw`` over ``within`` before return; a mismatch
+    raises :class:`UnsoundSimplificationError`.  A set full over the universe
+    serialises to ``None``.
+
+    A marker whose membership powerset overruns the cell budget cannot be
+    decided, so it ships unsimplified: the raw marker is already correct and
+    gated, and simplification is only a compaction.
+    """
+    if raw is None:
+        return None
+    try:
+        simplified = MarkerSet.from_marker(raw).simplify(within=within)
+        text = simplified.to_marker_string()
+        if text is None:
+            return None
+        rebuilt = Marker(text)
+        _verify_within_universe(raw, rebuilt, within, name)
+    except IntractableMarkerSet:
+        return raw
+    return rebuilt
+
+
+def _verify_within_universe(
+    raw: Marker, rebuilt: Marker, within: MarkerSet, name: str
+) -> None:
+    """Raise if ``rebuilt`` and ``raw`` differ on any environment in ``within``."""
+    raw_set = MarkerSet.from_marker(raw)
+    rebuilt_set = MarkerSet.from_marker(rebuilt)
+    if not (raw_set & within).equivalent(rebuilt_set & within):
+        msg = (
+            f"{name}: simplified marker {str(rebuilt)!r} is not equivalent to"
+            f" {str(raw)!r} over the declared environments"
+        )
+        raise UnsoundSimplificationError(msg)
+
+
 def _build_packages(
     lock_input: LockInput,
     lock_dir: Path,
     exclusion_groups: Sequence[AbstractSet[tuple[str, str]]],
+    universe: MarkerSet,
 ) -> list[Package]:
     """Collapse the per-target pins into Package entries with markers.
 
@@ -358,8 +432,8 @@ def _build_packages(
       unioned across the contributing targets so target-specific
       wheels (e.g. cp310-manylinux vs cp311-macos) survive.
 
-    The emitted marker is the raw OR of the per-target marker
-    expressions; no Boolean minimisation runs.
+    Each emitted marker is finalised to its shortest form equivalent over
+    the declared environments (:func:`_finalize_marker`).
 
     A package a selected extra or group reaches while the project's own
     dependencies do not is gated on that selection, so a default install
@@ -418,6 +492,7 @@ def _build_packages(
                 base_names,
                 selection_markers,
             )
+            marker = _finalize_marker(marker, universe, canonical_name)
             out.append(
                 _pin_to_package(
                     _merge_pins_in_group(pins),

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -391,23 +391,29 @@ def _finalize_marker(
         simplified = MarkerSet.from_marker(raw).simplify(within=within)
         text = simplified.to_marker_string()
         if text is None:
+            _verify_within_universe(raw, MarkerSet.full(), "no marker", within, name)
             return None
         rebuilt = Marker(text)
-        _verify_within_universe(raw, rebuilt, within, name)
+        _verify_within_universe(
+            raw, MarkerSet.from_marker(rebuilt), str(rebuilt), within, name
+        )
     except IntractableMarkerSet:
         return raw
     return rebuilt
 
 
 def _verify_within_universe(
-    raw: Marker, rebuilt: Marker, within: MarkerSet, name: str
+    raw: Marker, emitted: MarkerSet, shown: str, within: MarkerSet, name: str
 ) -> None:
-    """Raise if ``rebuilt`` and ``raw`` differ on any environment in ``within``."""
+    """Raise if ``emitted`` and ``raw`` differ on any environment in ``within``.
+
+    ``emitted`` is what the lock ships: the reparsed marker bytes, or
+    :meth:`MarkerSet.full` when no marker field is emitted.
+    """
     raw_set = MarkerSet.from_marker(raw)
-    rebuilt_set = MarkerSet.from_marker(rebuilt)
-    if not (raw_set & within).equivalent(rebuilt_set & within):
+    if not (raw_set & within).equivalent(emitted & within):
         msg = (
-            f"{name}: simplified marker {str(rebuilt)!r} is not equivalent to"
+            f"{name}: emitted marker {shown!r} is not equivalent to"
             f" {str(raw)!r} over the declared environments"
         )
         raise UnsoundSimplificationError(msg)

--- a/nab-python/src/nab_python/_vendor/packaging/_markersets.py
+++ b/nab-python/src/nab_python/_vendor/packaging/_markersets.py
@@ -1413,8 +1413,13 @@ def _clause_key(clause: frozenset[Atom]) -> tuple:
     return tuple(_atom_key(atom) for atom in sorted(clause, key=_atom_key))
 
 
-def _to_clauses(node: Formula) -> list[frozenset[Atom]]:
-    """Distribute an NNF tree into a disjunction of atom-set clauses (DNF)."""
+def _to_clauses(node: Formula, max_cells: int) -> list[frozenset[Atom]]:
+    """Distribute an NNF tree into a disjunction of atom-set clauses (DNF).
+
+    An AND of ORs expands multiplicatively, so the running clause count is
+    checked against ``max_cells`` and a pathological non-DNF input fails as
+    :class:`IntractableMarkerSet` rather than expanding unbounded.
+    """
     if isinstance(node, BoolConst):
         return [frozenset()] if node.value else []
     if isinstance(node, AtomLeaf):
@@ -1422,13 +1427,16 @@ def _to_clauses(node: Formula) -> list[frozenset[Atom]]:
     if isinstance(node, OrNode):
         clauses: list[frozenset[Atom]] = []
         for child in node.children:
-            clauses.extend(_to_clauses(child))
+            clauses.extend(_to_clauses(child, max_cells))
         return clauses
     and_node = cast("AndNode", node)
     product: list[frozenset[Atom]] = [frozenset()]
     for child in and_node.children:
-        child_clauses = _to_clauses(child)
+        child_clauses = _to_clauses(child, max_cells)
         product = [left | right for left in product for right in child_clauses]
+        if len(product) > max_cells:
+            msg = f"DNF clause count exceeds max_cells={max_cells}"
+            raise IntractableMarkerSet(msg)
     return product
 
 
@@ -1503,7 +1511,7 @@ def simplify_within(node: Formula, universe: Formula, max_cells: int) -> Formula
     context-free factoring. Determinism is fixed by a total atom order.
     """
     nnf = node if isinstance(node, BoolConst) else to_nnf(node)
-    clauses = _dedupe(_to_clauses(nnf))
+    clauses = _dedupe(_to_clauses(nnf, max_cells))
     original = _disjunction(clauses)
     while True:
         before = _canonical(clauses)

--- a/nab-python/src/nab_python/_vendor/packaging/_markersets.py
+++ b/nab-python/src/nab_python/_vendor/packaging/_markersets.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import re
 import sys
 from itertools import pairwise, product
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple, cast
 
 from ._parser import Op, Variable, parse_marker
 from ._tokenizer import ParserSyntaxError
@@ -1390,3 +1390,134 @@ def describe(node: Formula) -> str:
         return serialize(to_nnf(node))
     except UnserializableMarkerSet:
         return "unrepresentable"
+
+
+# ------------------------------------------------------------------- simplify
+
+
+def _atom_key(atom: Atom) -> tuple[str, str, str, bool, bool, str, str, bool]:
+    """A total order over atoms, for a deterministic factored serialisation."""
+    return (
+        atom.origin,
+        atom.op,
+        atom.literal,
+        atom.swapped,
+        atom.positive,
+        atom.kind,
+        atom.variable,
+        atom.derive_mm,
+    )
+
+
+def _clause_key(clause: frozenset[Atom]) -> tuple:
+    return tuple(_atom_key(atom) for atom in sorted(clause, key=_atom_key))
+
+
+def _to_clauses(node: Formula) -> list[frozenset[Atom]]:
+    """Distribute an NNF tree into a disjunction of atom-set clauses (DNF)."""
+    if isinstance(node, BoolConst):
+        return [frozenset()] if node.value else []
+    if isinstance(node, AtomLeaf):
+        return [frozenset((node.atom,))]
+    if isinstance(node, OrNode):
+        clauses: list[frozenset[Atom]] = []
+        for child in node.children:
+            clauses.extend(_to_clauses(child))
+        return clauses
+    and_node = cast("AndNode", node)
+    product: list[frozenset[Atom]] = [frozenset()]
+    for child in and_node.children:
+        child_clauses = _to_clauses(child)
+        product = [left | right for left in product for right in child_clauses]
+    return product
+
+
+def _clause_formula(clause: Iterable[Atom]) -> Formula:
+    return make_and(AtomLeaf(atom) for atom in clause)
+
+
+def _disjunction(clauses: Iterable[frozenset[Atom]]) -> Formula:
+    return make_or(_clause_formula(clause) for clause in clauses)
+
+
+def _equivalent_within(
+    left: Formula, right: Formula, universe: Formula, max_cells: int
+) -> bool:
+    """Whether two trees denote the same set on every point of ``universe``."""
+    return is_empty(
+        make_and((left, universe, make_not(right))), max_cells
+    ) and is_empty(make_and((right, universe, make_not(left))), max_cells)
+
+
+def _dedupe(clauses: list[frozenset[Atom]]) -> list[frozenset[Atom]]:
+    seen: set[frozenset[Atom]] = set()
+    out: list[frozenset[Atom]] = []
+    for clause in clauses:
+        if clause not in seen:
+            seen.add(clause)
+            out.append(clause)
+    return out
+
+
+def _drop_clauses(
+    clauses: list[frozenset[Atom]],
+    original: Formula,
+    universe: Formula,
+    max_cells: int,
+) -> list[frozenset[Atom]]:
+    kept = list(clauses)
+    for clause in sorted(clauses, key=_clause_key):
+        trial = [other for other in kept if other != clause]
+        if _equivalent_within(_disjunction(trial), original, universe, max_cells):
+            kept = trial
+    return kept
+
+
+def _drop_atoms(
+    clauses: list[frozenset[Atom]],
+    original: Formula,
+    universe: Formula,
+    max_cells: int,
+) -> list[frozenset[Atom]]:
+    working = [set(clause) for clause in clauses]
+    for clause in working:
+        for atom in sorted(clause, key=_atom_key):
+            clause.discard(atom)
+            trial = _disjunction(frozenset(current) for current in working)
+            if not _equivalent_within(trial, original, universe, max_cells):
+                clause.add(atom)
+    return [frozenset(clause) for clause in working]
+
+
+def _canonical(clauses: list[frozenset[Atom]]) -> tuple:
+    return tuple(sorted(_clause_key(clause) for clause in clauses))
+
+
+def simplify_within(node: Formula, universe: Formula, max_cells: int) -> Formula:
+    """Return the smallest tree equivalent to ``node`` on every point of ``universe``.
+
+    Greedy: drop each clause, then each atom, whose removal preserves
+    within-universe equivalence, to a fixpoint, then factor the atoms common to
+    every surviving clause into a leading conjunction. Every removal is verified,
+    so the result is sound; on a universe of ``TRUE`` it reduces to a
+    context-free factoring. Determinism is fixed by a total atom order.
+    """
+    nnf = node if isinstance(node, BoolConst) else to_nnf(node)
+    clauses = _dedupe(_to_clauses(nnf))
+    original = _disjunction(clauses)
+    while True:
+        before = _canonical(clauses)
+        clauses = _drop_clauses(clauses, original, universe, max_cells)
+        clauses = _dedupe(_drop_atoms(clauses, original, universe, max_cells))
+        if _canonical(clauses) == before:
+            break
+    if not clauses:
+        return FALSE
+    clauses = sorted(clauses, key=_clause_key)
+    common = frozenset.intersection(*clauses)
+    residual = sorted((clause - common for clause in clauses), key=_clause_key)
+    lead = [AtomLeaf(atom) for atom in sorted(common, key=_atom_key)]
+    inner = make_or(
+        _clause_formula(sorted(clause, key=_atom_key)) for clause in residual
+    )
+    return make_and([*lead, inner])

--- a/nab-python/src/nab_python/_vendor/packaging/markersets.py
+++ b/nab-python/src/nab_python/_vendor/packaging/markersets.py
@@ -286,6 +286,29 @@ class MarkerSet:
         """
         return _markersets.witness(self._tree, _MAX_CELLS)
 
+    # ---- simplification
+
+    @_bounded
+    def simplify(self, *, within: MarkerSet) -> MarkerSet:
+        """Return the smallest set equivalent to this one on every point of ``within``.
+
+        ``within`` is the universe the result must agree with this set over: pass
+        the union of a lock's declared environments for universe-aware
+        simplification, or :meth:`full` for a context-free factoring. The result
+        is a ``MarkerSet``; call :meth:`to_marker_string` for its compact spelling.
+
+        :raises ValueError: if ``within`` is the empty set, which makes every set
+            vacuously equivalent.
+        :raises IntractableMarkerSet: if deciding a removal exceeds the internal
+            cell budget, or the marker nests past the stack.
+        """
+        if within.is_empty():
+            msg = "within must not be the empty set"
+            raise ValueError(msg)
+        return self._wrap(
+            _markersets.simplify_within(self._tree, within._tree, _MAX_CELLS)
+        )
+
     # ---- serialisation
 
     @_bounded

--- a/nab-python/tests/simplify_corpus_fixtures.py
+++ b/nab-python/tests/simplify_corpus_fixtures.py
@@ -1,0 +1,699 @@
+"""Corpus differential harness for MarkerSet.simplify.
+
+Provenance: the FIXTURES below are the 34 per-package markers and their declared
+``environments`` rows from the 11 PEP 751 locks in the phase-0 corpus at
+work/analysis/poetry_uv_gap_survey/stage3/lock-corpus/ (all created-by nab). The
+brute-force oracle vendored here is a copy of the achievable-minimum minimiser
+in stage3/items/M7/analyze_markers.py, an independent second implementation used
+to cross-check soundness and minimality. The documented aggregate tiers
+(9742 total chars, 1188 context-aware at 87.8%, 7332 context-free at 24.7%) come
+from that script's measurement in stage3/items/M7/measurement.md.
+
+The oracle minimises by finding the smallest variable subset that reproduces a
+marker's environment selection over a finite universe, then factors. It is a
+weaker minimiser than the algebra operator (which drops don't-care atoms
+per clause), so it establishes an upper bound on minimal size, not the true
+minimum.
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections.abc import Iterator
+
+from packaging.markers import Marker
+
+TOTAL_CHARS = 9742
+CONTEXT_AWARE_CHARS = 1188
+CONTEXT_AWARE_PCT = 87.8
+CONTEXT_FREE_CHARS = 7332
+CONTEXT_FREE_PCT = 24.7
+
+MARKER_VARS_ORDER = [
+    "python_version",
+    "sys_platform",
+    "platform_machine",
+    "platform_python_implementation",
+    "implementation_name",
+    "platform_system",
+    "os_name",
+]
+
+STRING_SENTINEL = "__other__"
+VERSION_SENTINEL = "3.99"
+
+
+def env_dict_from_marker(marker_str: str) -> dict[str, str]:
+    m = Marker(marker_str)
+    env: dict[str, str] = {}
+
+    def walk(markers: object) -> None:
+        for node in markers:  # type: ignore[attr-defined]
+            if isinstance(node, list):
+                walk(node)
+            elif isinstance(node, tuple):
+                var, op, val = node
+                if str(op) == "==":
+                    env[str(var)] = str(val)
+
+    walk(m._markers)
+    pv = env.get("python_version")
+    if pv and "python_full_version" not in env:
+        env["python_full_version"] = pv + ".0"
+    sysp = env.get("sys_platform")
+    if sysp:
+        env.setdefault("os_name", {"win32": "nt"}.get(sysp, "posix"))
+        env.setdefault(
+            "platform_system",
+            {"linux": "Linux", "darwin": "Darwin", "win32": "Windows"}.get(sysp, sysp),
+        )
+    env.setdefault("platform_python_implementation", "CPython")
+    env.setdefault("implementation_name", "cpython")
+    env.setdefault("extra", "")
+    return env
+
+
+def selects(marker_str: str | None, universe: list[dict[str, str]]) -> frozenset[int]:
+    if marker_str is None:
+        return frozenset(range(len(universe)))
+    m = Marker(marker_str)
+    hits: list[int] = []
+    for i, env in enumerate(universe):
+        try:
+            if m.evaluate(env):
+                hits.append(i)
+        except Exception:  # noqa: BLE001, S110
+            pass
+    return frozenset(hits)
+
+
+def _clause_to_str(clause: frozenset[str]) -> str:
+    return " and ".join(sorted(clause))
+
+
+def _render_factored(clauses: list[frozenset[str]]) -> str:
+    clauses = [c for c in clauses if c]
+    uniq: list[frozenset[str]] = []
+    for c in clauses:
+        if c not in uniq:
+            uniq.append(c)
+    if not uniq:
+        return ""
+    if len(uniq) == 1:
+        return _clause_to_str(uniq[0])
+    common = frozenset.intersection(*uniq)
+    residual = [c - common for c in uniq]
+    residual = [c for c in residual if c]
+    inner = " or ".join(
+        _clause_to_str(c) if len(c) == 1 else f"({_clause_to_str(c)})"
+        for c in sorted(residual, key=lambda s: sorted(s))
+    )
+    if not common:
+        return inner
+    lead = " and ".join(sorted(common))
+    if not residual:
+        return lead
+    return f"{lead} and ({inner})"
+
+
+def achievable_min_marker(
+    selected: frozenset[int],
+    universe: list[dict[str, str]],
+    marker_vars: list[str],
+) -> str:
+    if not selected:
+        return ""
+    if len(selected) == len(universe):
+        return ""
+
+    def proj(idx_set: set[int], keys: tuple[str, ...]) -> set[tuple]:
+        return {tuple(universe[i].get(k) for k in keys) for i in idx_set}
+
+    sel = set(selected)
+    universe_idx = set(range(len(universe)))
+
+    best_keys = marker_vars
+    for r in range(1, len(marker_vars) + 1):
+        found = None
+        for keys in itertools.combinations(marker_vars, r):
+            sel_proj = proj(sel, keys)
+            recon = {
+                i
+                for i in universe_idx
+                if tuple(universe[i].get(k) for k in keys) in sel_proj
+            }
+            if recon == sel:
+                found = list(keys)
+                break
+        if found is not None:
+            best_keys = found
+            break
+
+    tuples = sorted({tuple(universe[i].get(k) for k in best_keys) for i in sel})
+    clauses = []
+    for t in tuples:
+        atoms = frozenset(
+            f'{k} == "{v}"' for k, v in zip(best_keys, t, strict=True) if v is not None
+        )
+        clauses.append(atoms)
+    return _render_factored(clauses)
+
+
+def build_grid_universe(
+    marker_vars: list[str], observed: dict[str, set[str]]
+) -> list[dict[str, str]]:
+    axes = []
+    for v in marker_vars:
+        vals = sorted(observed.get(v, set()))
+        sentinel = VERSION_SENTINEL if "version" in v else STRING_SENTINEL
+        if sentinel not in vals:
+            vals = [*vals, sentinel]
+        axes.append([(v, val) for val in vals])
+    grid = []
+    for combo in itertools.product(*axes):
+        env = dict(combo)
+        pv = env.get("python_version")
+        if pv and "python_full_version" not in env:
+            env["python_full_version"] = pv + ".0"
+        env.setdefault("extra", "")
+        grid.append(env)
+    return grid
+
+
+def marker_vars_of(marker_strings: list[str]) -> list[str]:
+    used: set[str] = set()
+    for mk in marker_strings:
+        for node in _iter_atoms(Marker(mk)._markers):
+            used.add(str(node[0]))
+    return [v for v in MARKER_VARS_ORDER if v in used] or list(used)
+
+
+def observed_values(
+    marker_strings: list[str],
+    universe: list[dict[str, str]],
+    marker_vars: list[str],
+) -> dict[str, set[str]]:
+    observed: dict[str, set[str]] = {v: set() for v in marker_vars}
+    for env in universe:
+        for v in marker_vars:
+            if v in env:
+                observed[v].add(env[v])
+    for mk in marker_strings:
+        for node in _iter_atoms(Marker(mk)._markers):
+            var, op, val = node
+            if str(op) == "==" and str(var) in observed:
+                observed[str(var)].add(str(val))
+    return observed
+
+
+def _iter_atoms(markers: object) -> Iterator[tuple]:
+    for node in markers:  # type: ignore[attr-defined]
+        if isinstance(node, list):
+            yield from _iter_atoms(node)
+        elif isinstance(node, tuple):
+            yield node
+
+
+FIXTURES = [
+    {
+        "lock": "marker-heavy",
+        "package": "pyobjc-core",
+        "marker": 'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64"',
+        "environments": [
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython"',
+            'python_version == "3.11" and sys_platform == "win32" and platform_machine == "AMD64" and platform_python_implementation == "CPython"',
+        ],
+    },
+    {
+        "lock": "marker-heavy",
+        "package": "python-magic",
+        "marker": '(python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64") or (python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64")',
+        "environments": [
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython"',
+            'python_version == "3.11" and sys_platform == "win32" and platform_machine == "AMD64" and platform_python_implementation == "CPython"',
+        ],
+    },
+    {
+        "lock": "marker-heavy",
+        "package": "python-magic-bin",
+        "marker": 'python_version == "3.11" and sys_platform == "win32" and platform_machine == "AMD64"',
+        "environments": [
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython"',
+            'python_version == "3.11" and sys_platform == "win32" and platform_machine == "AMD64" and platform_python_implementation == "CPython"',
+        ],
+    },
+    {
+        "lock": "marker-heavy",
+        "package": "pywin32",
+        "marker": 'python_version == "3.11" and sys_platform == "win32" and platform_machine == "AMD64"',
+        "environments": [
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython"',
+            'python_version == "3.11" and sys_platform == "win32" and platform_machine == "AMD64" and platform_python_implementation == "CPython"',
+        ],
+    },
+    {
+        "lock": "max-25-tuples",
+        "package": "colorama",
+        "marker": '(python_version == "3.10" and sys_platform == "win32" and platform_machine == "AMD64") or (python_version == "3.11" and sys_platform == "win32" and platform_machine == "AMD64") or (python_version == "3.12" and sys_platform == "win32" and platform_machine == "AMD64") or (python_version == "3.13" and sys_platform == "win32" and platform_machine == "AMD64") or (python_version == "3.9" and sys_platform == "win32" and platform_machine == "AMD64")',
+        "environments": [
+            'python_version == "3.9" and sys_platform == "linux" and platform_machine == "x86_64" and platform_system == "Linux"',
+            'python_version == "3.9" and sys_platform == "linux" and platform_machine == "aarch64" and platform_system == "Linux"',
+            'python_version == "3.9" and sys_platform == "darwin" and platform_machine == "arm64" and platform_system == "Darwin"',
+            'python_version == "3.9" and sys_platform == "darwin" and platform_machine == "x86_64" and platform_system == "Darwin"',
+            'python_version == "3.9" and sys_platform == "win32" and platform_machine == "AMD64" and platform_system == "Windows"',
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "aarch64" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64" and platform_system == "Darwin"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "x86_64" and platform_system == "Darwin"',
+            'python_version == "3.10" and sys_platform == "win32" and platform_machine == "AMD64" and platform_system == "Windows"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "aarch64" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "x86_64" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "win32" and platform_machine == "AMD64" and platform_system == "Windows"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "aarch64" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "x86_64" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "win32" and platform_machine == "AMD64" and platform_system == "Windows"',
+            'python_version == "3.13" and sys_platform == "linux" and platform_machine == "x86_64" and platform_system == "Linux"',
+            'python_version == "3.13" and sys_platform == "linux" and platform_machine == "aarch64" and platform_system == "Linux"',
+            'python_version == "3.13" and sys_platform == "darwin" and platform_machine == "arm64" and platform_system == "Darwin"',
+            'python_version == "3.13" and sys_platform == "darwin" and platform_machine == "x86_64" and platform_system == "Darwin"',
+            'python_version == "3.13" and sys_platform == "win32" and platform_machine == "AMD64" and platform_system == "Windows"',
+        ],
+    },
+    {
+        "lock": "max-25-tuples",
+        "package": "importlib-metadata",
+        "marker": '(python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64") or (python_version == "3.10" and sys_platform == "darwin" and platform_machine == "x86_64") or (python_version == "3.10" and sys_platform == "linux" and platform_machine == "aarch64") or (python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.10" and sys_platform == "win32" and platform_machine == "AMD64") or (python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64") or (python_version == "3.11" and sys_platform == "darwin" and platform_machine == "x86_64") or (python_version == "3.11" and sys_platform == "linux" and platform_machine == "aarch64") or (python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.11" and sys_platform == "win32" and platform_machine == "AMD64") or (python_version == "3.9" and sys_platform == "darwin" and platform_machine == "arm64") or (python_version == "3.9" and sys_platform == "darwin" and platform_machine == "x86_64") or (python_version == "3.9" and sys_platform == "linux" and platform_machine == "aarch64") or (python_version == "3.9" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.9" and sys_platform == "win32" and platform_machine == "AMD64")',
+        "environments": [
+            'python_version == "3.9" and sys_platform == "linux" and platform_machine == "x86_64" and platform_system == "Linux"',
+            'python_version == "3.9" and sys_platform == "linux" and platform_machine == "aarch64" and platform_system == "Linux"',
+            'python_version == "3.9" and sys_platform == "darwin" and platform_machine == "arm64" and platform_system == "Darwin"',
+            'python_version == "3.9" and sys_platform == "darwin" and platform_machine == "x86_64" and platform_system == "Darwin"',
+            'python_version == "3.9" and sys_platform == "win32" and platform_machine == "AMD64" and platform_system == "Windows"',
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "aarch64" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64" and platform_system == "Darwin"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "x86_64" and platform_system == "Darwin"',
+            'python_version == "3.10" and sys_platform == "win32" and platform_machine == "AMD64" and platform_system == "Windows"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "aarch64" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "x86_64" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "win32" and platform_machine == "AMD64" and platform_system == "Windows"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "aarch64" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "x86_64" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "win32" and platform_machine == "AMD64" and platform_system == "Windows"',
+            'python_version == "3.13" and sys_platform == "linux" and platform_machine == "x86_64" and platform_system == "Linux"',
+            'python_version == "3.13" and sys_platform == "linux" and platform_machine == "aarch64" and platform_system == "Linux"',
+            'python_version == "3.13" and sys_platform == "darwin" and platform_machine == "arm64" and platform_system == "Darwin"',
+            'python_version == "3.13" and sys_platform == "darwin" and platform_machine == "x86_64" and platform_system == "Darwin"',
+            'python_version == "3.13" and sys_platform == "win32" and platform_machine == "AMD64" and platform_system == "Windows"',
+        ],
+    },
+    {
+        "lock": "max-25-tuples",
+        "package": "zipp",
+        "marker": '(python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64") or (python_version == "3.10" and sys_platform == "darwin" and platform_machine == "x86_64") or (python_version == "3.10" and sys_platform == "linux" and platform_machine == "aarch64") or (python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.10" and sys_platform == "win32" and platform_machine == "AMD64") or (python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64") or (python_version == "3.11" and sys_platform == "darwin" and platform_machine == "x86_64") or (python_version == "3.11" and sys_platform == "linux" and platform_machine == "aarch64") or (python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.11" and sys_platform == "win32" and platform_machine == "AMD64") or (python_version == "3.9" and sys_platform == "darwin" and platform_machine == "arm64") or (python_version == "3.9" and sys_platform == "darwin" and platform_machine == "x86_64") or (python_version == "3.9" and sys_platform == "linux" and platform_machine == "aarch64") or (python_version == "3.9" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.9" and sys_platform == "win32" and platform_machine == "AMD64")',
+        "environments": [
+            'python_version == "3.9" and sys_platform == "linux" and platform_machine == "x86_64" and platform_system == "Linux"',
+            'python_version == "3.9" and sys_platform == "linux" and platform_machine == "aarch64" and platform_system == "Linux"',
+            'python_version == "3.9" and sys_platform == "darwin" and platform_machine == "arm64" and platform_system == "Darwin"',
+            'python_version == "3.9" and sys_platform == "darwin" and platform_machine == "x86_64" and platform_system == "Darwin"',
+            'python_version == "3.9" and sys_platform == "win32" and platform_machine == "AMD64" and platform_system == "Windows"',
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "aarch64" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64" and platform_system == "Darwin"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "x86_64" and platform_system == "Darwin"',
+            'python_version == "3.10" and sys_platform == "win32" and platform_machine == "AMD64" and platform_system == "Windows"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "aarch64" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "x86_64" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "win32" and platform_machine == "AMD64" and platform_system == "Windows"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "aarch64" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "x86_64" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "win32" and platform_machine == "AMD64" and platform_system == "Windows"',
+            'python_version == "3.13" and sys_platform == "linux" and platform_machine == "x86_64" and platform_system == "Linux"',
+            'python_version == "3.13" and sys_platform == "linux" and platform_machine == "aarch64" and platform_system == "Linux"',
+            'python_version == "3.13" and sys_platform == "darwin" and platform_machine == "arm64" and platform_system == "Darwin"',
+            'python_version == "3.13" and sys_platform == "darwin" and platform_machine == "x86_64" and platform_system == "Darwin"',
+            'python_version == "3.13" and sys_platform == "win32" and platform_machine == "AMD64" and platform_system == "Windows"',
+        ],
+    },
+    {
+        "lock": "poetry-numpy-deveps",
+        "package": "exceptiongroup",
+        "marker": 'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64"',
+        "environments": [
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and implementation_name == "cpython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and implementation_name == "cpython" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and implementation_name == "cpython" and platform_system == "Linux"',
+        ],
+    },
+    {
+        "lock": "poetry-numpy-deveps",
+        "package": "tomli",
+        "marker": 'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64"',
+        "environments": [
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and implementation_name == "cpython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and implementation_name == "cpython" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and implementation_name == "cpython" and platform_system == "Linux"',
+        ],
+    },
+    {
+        "lock": "poetry-numpy-deveps",
+        "package": "typing-extensions",
+        "marker": 'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64"',
+        "environments": [
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and implementation_name == "cpython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and implementation_name == "cpython" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and implementation_name == "cpython" and platform_system == "Linux"',
+        ],
+    },
+    {
+        "lock": "scientific-python-multi",
+        "package": "importlib-resources",
+        "marker": '(python_version == "3.9" and sys_platform == "darwin" and platform_machine == "arm64") or (python_version == "3.9" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.9" and sys_platform == "win32" and platform_machine == "AMD64")',
+        "environments": [
+            'python_version == "3.9" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython"',
+            'python_version == "3.9" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython"',
+            'python_version == "3.9" and sys_platform == "win32" and platform_machine == "AMD64" and platform_python_implementation == "CPython"',
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython"',
+            'python_version == "3.10" and sys_platform == "win32" and platform_machine == "AMD64" and platform_python_implementation == "CPython"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython"',
+            'python_version == "3.11" and sys_platform == "win32" and platform_machine == "AMD64" and platform_python_implementation == "CPython"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython"',
+            'python_version == "3.12" and sys_platform == "win32" and platform_machine == "AMD64" and platform_python_implementation == "CPython"',
+        ],
+    },
+    {
+        "lock": "scientific-python-multi",
+        "package": "zipp",
+        "marker": '(python_version == "3.9" and sys_platform == "darwin" and platform_machine == "arm64") or (python_version == "3.9" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.9" and sys_platform == "win32" and platform_machine == "AMD64")',
+        "environments": [
+            'python_version == "3.9" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython"',
+            'python_version == "3.9" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython"',
+            'python_version == "3.9" and sys_platform == "win32" and platform_machine == "AMD64" and platform_python_implementation == "CPython"',
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython"',
+            'python_version == "3.10" and sys_platform == "win32" and platform_machine == "AMD64" and platform_python_implementation == "CPython"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython"',
+            'python_version == "3.11" and sys_platform == "win32" and platform_machine == "AMD64" and platform_python_implementation == "CPython"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython"',
+            'python_version == "3.12" and sys_platform == "win32" and platform_machine == "AMD64" and platform_python_implementation == "CPython"',
+        ],
+    },
+    {
+        "lock": "starlette-fastapi-universal",
+        "package": "exceptiongroup",
+        "marker": '(python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64") or (python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.10" and sys_platform == "win32" and platform_machine == "AMD64")',
+        "environments": [
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.10" and sys_platform == "win32" and platform_machine == "AMD64" and platform_python_implementation == "CPython" and platform_system == "Windows"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "win32" and platform_machine == "AMD64" and platform_python_implementation == "CPython" and platform_system == "Windows"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "win32" and platform_machine == "AMD64" and platform_python_implementation == "CPython" and platform_system == "Windows"',
+        ],
+    },
+    {
+        "lock": "top88-parallel",
+        "package": "colorama",
+        "marker": 'python_version == "3.11" and sys_platform == "win32" and platform_machine == "AMD64"',
+        "environments": [
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "win32" and platform_machine == "AMD64" and platform_python_implementation == "CPython" and platform_system == "Windows"',
+        ],
+    },
+    {
+        "lock": "top88-parallel",
+        "package": "greenlet",
+        "marker": '(python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.11" and sys_platform == "win32" and platform_machine == "AMD64")',
+        "environments": [
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "win32" and platform_machine == "AMD64" and platform_python_implementation == "CPython" and platform_system == "Windows"',
+        ],
+    },
+    {
+        "lock": "top88-pypi-stress",
+        "package": "colorama",
+        "marker": 'python_version == "3.11" and sys_platform == "win32" and platform_machine == "AMD64"',
+        "environments": [
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "win32" and platform_machine == "AMD64" and platform_python_implementation == "CPython" and platform_system == "Windows"',
+        ],
+    },
+    {
+        "lock": "top88-pypi-stress",
+        "package": "greenlet",
+        "marker": '(python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.11" and sys_platform == "win32" and platform_machine == "AMD64")',
+        "environments": [
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "win32" and platform_machine == "AMD64" and platform_python_implementation == "CPython" and platform_system == "Windows"',
+        ],
+    },
+    {
+        "lock": "transformers-cpu-multi-python",
+        "package": "async-timeout",
+        "marker": '(python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64") or (python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64")',
+        "environments": [
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+        ],
+    },
+    {
+        "lock": "transformers-cpu-multi-python",
+        "package": "nvidia-cublas-cu12",
+        "marker": '(python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64")',
+        "environments": [
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+        ],
+    },
+    {
+        "lock": "transformers-cpu-multi-python",
+        "package": "nvidia-cuda-cupti-cu12",
+        "marker": '(python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64")',
+        "environments": [
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+        ],
+    },
+    {
+        "lock": "transformers-cpu-multi-python",
+        "package": "nvidia-cuda-nvrtc-cu12",
+        "marker": '(python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64")',
+        "environments": [
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+        ],
+    },
+    {
+        "lock": "transformers-cpu-multi-python",
+        "package": "nvidia-cuda-runtime-cu12",
+        "marker": '(python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64")',
+        "environments": [
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+        ],
+    },
+    {
+        "lock": "transformers-cpu-multi-python",
+        "package": "nvidia-cudnn-cu12",
+        "marker": '(python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64")',
+        "environments": [
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+        ],
+    },
+    {
+        "lock": "transformers-cpu-multi-python",
+        "package": "nvidia-cufft-cu12",
+        "marker": '(python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64")',
+        "environments": [
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+        ],
+    },
+    {
+        "lock": "transformers-cpu-multi-python",
+        "package": "nvidia-cufile-cu12",
+        "marker": '(python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64")',
+        "environments": [
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+        ],
+    },
+    {
+        "lock": "transformers-cpu-multi-python",
+        "package": "nvidia-curand-cu12",
+        "marker": '(python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64")',
+        "environments": [
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+        ],
+    },
+    {
+        "lock": "transformers-cpu-multi-python",
+        "package": "nvidia-cusolver-cu12",
+        "marker": '(python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64")',
+        "environments": [
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+        ],
+    },
+    {
+        "lock": "transformers-cpu-multi-python",
+        "package": "nvidia-cusparse-cu12",
+        "marker": '(python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64")',
+        "environments": [
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+        ],
+    },
+    {
+        "lock": "transformers-cpu-multi-python",
+        "package": "nvidia-cusparselt-cu12",
+        "marker": '(python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64")',
+        "environments": [
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+        ],
+    },
+    {
+        "lock": "transformers-cpu-multi-python",
+        "package": "nvidia-nccl-cu12",
+        "marker": '(python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64")',
+        "environments": [
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+        ],
+    },
+    {
+        "lock": "transformers-cpu-multi-python",
+        "package": "nvidia-nvjitlink-cu12",
+        "marker": '(python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64")',
+        "environments": [
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+        ],
+    },
+    {
+        "lock": "transformers-cpu-multi-python",
+        "package": "nvidia-nvtx-cu12",
+        "marker": '(python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64")',
+        "environments": [
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+        ],
+    },
+    {
+        "lock": "transformers-cpu-multi-python",
+        "package": "setuptools",
+        "marker": '(python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64") or (python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64")',
+        "environments": [
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+        ],
+    },
+    {
+        "lock": "transformers-cpu-multi-python",
+        "package": "triton",
+        "marker": '(python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64") or (python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64")',
+        "environments": [
+            'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.10" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.11" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+            'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64" and platform_python_implementation == "CPython" and platform_system == "Linux"',
+            'python_version == "3.12" and sys_platform == "darwin" and platform_machine == "arm64" and platform_python_implementation == "CPython" and platform_system == "Darwin"',
+        ],
+    },
+]

--- a/nab-python/tests/simplify_corpus_fixtures.py
+++ b/nab-python/tests/simplify_corpus_fixtures.py
@@ -106,7 +106,7 @@ def _render_factored(clauses: list[frozenset[str]]) -> str:
     residual = [c for c in residual if c]
     inner = " or ".join(
         _clause_to_str(c) if len(c) == 1 else f"({_clause_to_str(c)})"
-        for c in sorted(residual, key=lambda s: sorted(s))
+        for c in sorted(residual, key=sorted)
     )
     if not common:
         return inner

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -5261,10 +5261,34 @@ class TestConflictForkNegatedEmission:
         )
         pylock = Pylock.from_dict(tomllib.loads(text))
 
-        torch_versions = {
-            str(p.version) for p in pylock.packages if str(p.name) == "torch"
+        torch_markers = {
+            str(p.version): str(p.marker)
+            for p in pylock.packages
+            if str(p.name) == "torch"
         }
-        assert torch_versions == {"2.5.0", "2.6.0"}
+        assert set(torch_markers) == {"2.5.0", "2.6.0"}
+
+        # simplify overruns the cell budget on this fork, so the emitter
+        # passes the raw marker through unchanged: base env, the fork's three
+        # drawn members, then the 12 negated co-members by set in declaration
+        # order.
+        base = (
+            'python_version == "3.12" and sys_platform == "linux"'
+            ' and platform_machine == "x86_64"'
+        )
+
+        def raw_marker(drawn: tuple[str, str, str]) -> str:
+            positives = " and ".join(f'"{name}" in extras' for name in drawn)
+            negatives = " and ".join(
+                f'"{name}" not in extras'
+                for members in sets
+                for name in members
+                if name not in drawn
+            )
+            return f"{base} and {positives} and {negatives}"
+
+        assert torch_markers["2.5.0"] == raw_marker(("a0", "b0", "c0"))
+        assert torch_markers["2.6.0"] == raw_marker(("a1", "b1", "c1"))
 
 
 class TestMarkerCoverage:

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -677,7 +677,10 @@ class TestPerTargetMarkerSimplification:
         )
         data = tomllib.loads(text)
         assert len(data["packages"]) == 1
-        assert data["packages"][0]["marker"] == str(Marker(py310.marker_string))
+        assert data["packages"][0]["marker"] == (
+            'platform_machine == "x86_64" and python_version == "3.10"'
+            ' and sys_platform == "linux"'
+        )
 
     def test_package_in_two_of_four_targets_gets_or_marker(self) -> None:
         # ``foo`` resolves on py3.10 and py3.11 only with the same pin.
@@ -737,7 +740,10 @@ class TestPerTargetMarkerSimplification:
         assert len(data["packages"]) == 2
         v1_marker = next(p["marker"] for p in data["packages"] if p["version"] == "1.0")
         v2_marker = next(p["marker"] for p in data["packages"] if p["version"] == "2.0")
-        assert v1_marker == str(Marker(py310.marker_string))
+        assert v1_marker == (
+            'platform_machine == "x86_64" and python_version == "3.10"'
+            ' and sys_platform == "linux"'
+        )
         assert 'python_version == "3.11"' in v2_marker
         assert 'python_version == "3.12"' in v2_marker
         assert 'python_version == "3.13"' not in v2_marker
@@ -4549,7 +4555,7 @@ class TestMembershipGates:
         )
         pylock = build_pylock(_lock_from(lock))
         (package,) = pylock.packages
-        assert str(package.marker) == ('"cli" in extras or "dev" in dependency_groups')
+        assert str(package.marker) == ('"dev" in dependency_groups or "cli" in extras')
 
     def test_extras_proxy_gates_only_what_the_extra_adds(self) -> None:
         """The project requires ``foo``; the extra requires ``foo[fancy]``.
@@ -4708,10 +4714,9 @@ class TestMembershipGates:
         }
         assert markers["core"] is None
         assert markers["mytool"] == (
-            '(python_version == "3.10" and sys_platform == "linux"'
-            ' and platform_machine == "x86_64" and "cli" in extras)'
-            ' or (python_version == "3.11" and sys_platform == "linux"'
-            ' and platform_machine == "x86_64")'
+            'platform_machine == "x86_64" and sys_platform == "linux"'
+            ' and (("cli" in extras and python_version == "3.10")'
+            ' or python_version == "3.11")'
         )
 
 

--- a/nab-python/tests/test_markersets.py
+++ b/nab-python/tests/test_markersets.py
@@ -1,0 +1,228 @@
+"""Unit suite for MarkerSet.simplify and the corpus differential harness.
+
+The direct-call cases pin byte-exact ``to_marker_string`` output and
+within-universe equivalence for the operator's two tiers; the harness runs the
+operator over the phase-0 lock corpus and cross-checks soundness and minimality
+against an independent brute-force oracle.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+from nab_python._vendor.packaging.markersets import MarkerSet
+
+_spec = importlib.util.spec_from_file_location(
+    "simplify_corpus_fixtures",
+    Path(__file__).with_name("simplify_corpus_fixtures.py"),
+)
+assert _spec is not None
+assert _spec.loader is not None
+corpus = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(corpus)
+
+
+def ms(text: str) -> MarkerSet:
+    return MarkerSet.from_marker(text)
+
+
+def union(*texts: str) -> MarkerSet:
+    result = MarkerSet.empty()
+    for text in texts:
+        result = result | ms(text)
+    return result
+
+
+SPAN = (
+    '(python_version == "3.10" and sys_platform == "linux") '
+    'or (python_version == "3.11" and sys_platform == "linux") '
+    'or (python_version == "3.12" and sys_platform == "linux")'
+)
+PY_ROWS = (
+    'python_version == "3.10"',
+    'python_version == "3.11"',
+    'python_version == "3.12"',
+)
+
+
+def test_context_free_factoring_keeps_python_axis() -> None:
+    result = ms(SPAN).simplify(within=MarkerSet.full())
+    assert result.to_marker_string() == (
+        'sys_platform == "linux" and (python_version == "3.10" '
+        'or python_version == "3.11" or python_version == "3.12")'
+    )
+    assert result.equivalent(ms(SPAN))
+
+
+def test_universe_aware_drop_and_dedupe_collapses() -> None:
+    within = union(*PY_ROWS)
+    result = ms(SPAN).simplify(within=within)
+    assert result.to_marker_string() == 'sys_platform == "linux"'
+    assert (result & within).equivalent(ms(SPAN) & within)
+
+
+def test_universe_aware_diverges_outside_universe() -> None:
+    result = ms(SPAN).simplify(within=union(*PY_ROWS))
+    outside = {
+        "python_version": "3.13",
+        "python_full_version": "3.13.0",
+        "sys_platform": "linux",
+    }
+    assert result.evaluate(outside) is True
+    assert ms(SPAN).evaluate(outside) is False
+
+
+def test_partial_span_keeps_win32_branch() -> None:
+    marker = SPAN + ' or (python_version == "3.10" and sys_platform == "win32")'
+    result = ms(marker).simplify(within=union(*PY_ROWS))
+    assert result.to_marker_string() == (
+        '(python_version == "3.10" and sys_platform == "win32") '
+        'or sys_platform == "linux"'
+    )
+
+
+def test_single_minor_tautology_drops() -> None:
+    marker = 'python_version == "3.11" and sys_platform == "linux"'
+    result = ms(marker).simplify(within=union('python_version == "3.11"'))
+    assert result.to_marker_string() == 'sys_platform == "linux"'
+
+
+def test_membership_atoms_survive_while_python_drops() -> None:
+    marker = 'python_version == "3.11" and "cpu" in extras and "gpu" not in extras'
+    result = ms(marker).simplify(within=union('python_version == "3.11"'))
+    assert result.to_marker_string() == ('"cpu" in extras and "gpu" not in extras')
+
+
+def test_dev0_split_boundary_bounds_drop() -> None:
+    minor = 'python_full_version >= "3.11.dev0" and python_full_version < "3.12"'
+    marker = minor + ' and sys_platform == "linux"'
+    result = ms(marker).simplify(within=union(minor))
+    assert result.to_marker_string() == 'sys_platform == "linux"'
+
+
+def test_full_set_serialises_to_none() -> None:
+    result = MarkerSet.full().simplify(within=MarkerSet.full())
+    assert result.to_marker_string() is None
+
+
+def test_empty_self_stays_empty() -> None:
+    result = MarkerSet.empty().simplify(within=MarkerSet.full())
+    assert result.is_empty() is True
+
+
+def test_empty_within_universe_collapses_to_empty() -> None:
+    result = ms('sys_platform == "win32"').simplify(
+        within=union('sys_platform == "linux"')
+    )
+    assert result.is_empty() is True
+
+
+def test_idempotence() -> None:
+    once = ms(SPAN).simplify(within=MarkerSet.full())
+    text = once.to_marker_string()
+    assert text is not None
+    twice = ms(text).simplify(within=MarkerSet.full())
+    assert twice.to_marker_string() == text
+
+
+def test_determinism_under_shuffled_input() -> None:
+    shuffled = (
+        '(sys_platform == "linux" and python_version == "3.12") '
+        'or (sys_platform == "linux" and python_version == "3.10") '
+        'or (python_version == "3.11" and sys_platform == "linux")'
+    )
+    assert (
+        ms(shuffled).simplify(within=MarkerSet.full()).to_marker_string()
+        == ms(SPAN).simplify(within=MarkerSet.full()).to_marker_string()
+    )
+
+
+def test_within_empty_raises() -> None:
+    with pytest.raises(ValueError, match="empty set"):
+        ms(SPAN).simplify(within=MarkerSet.empty())
+
+
+def test_within_full_equals_context_free() -> None:
+    via_full = ms(SPAN).simplify(within=MarkerSet.full())
+    assert via_full.to_marker_string() == (
+        'sys_platform == "linux" and (python_version == "3.10" '
+        'or python_version == "3.11" or python_version == "3.12")'
+    )
+
+
+def _grouped_fixtures() -> dict[tuple[str, tuple[str, ...]], list[dict]]:
+    groups: dict[tuple[str, tuple[str, ...]], list[dict]] = defaultdict(list)
+    for fixture in corpus.FIXTURES:
+        key = (fixture["lock"], tuple(fixture["environments"]))
+        groups[key].append(fixture)
+    return groups
+
+
+def test_corpus_operator_sound_minimal_and_reproduces_tiers() -> None:
+    total = context_aware = context_free = 0
+    for (_lock, environments), items in _grouped_fixtures().items():
+        within = union(*environments)
+        universe = [corpus.env_dict_from_marker(e) for e in environments]
+        marker_strings = [item["marker"] for item in items]
+        marker_vars = corpus.marker_vars_of(marker_strings)
+        observed = corpus.observed_values(marker_strings, universe, marker_vars)
+        grid = corpus.build_grid_universe(marker_vars, observed)
+
+        for item in items:
+            marker = item["marker"]
+            total += len(marker)
+            ca_text = ms(marker).simplify(within=within).to_marker_string()
+            cf_text = ms(marker).simplify(within=MarkerSet.full()).to_marker_string()
+            context_aware += len(ca_text or "")
+            context_free += len(cf_text or "")
+
+            original_selection = corpus.selects(marker, universe)
+            assert corpus.selects(ca_text, universe) == original_selection
+            assert corpus.selects(cf_text, universe) == original_selection
+
+            ca_oracle = corpus.achievable_min_marker(
+                original_selection, universe, marker_vars
+            )
+            cf_oracle = corpus.achievable_min_marker(
+                corpus.selects(marker, grid), grid, marker_vars
+            )
+            assert len(ca_text or "") <= len(ca_oracle)
+            assert len(cf_text or "") <= len(cf_oracle)
+
+    assert total == corpus.TOTAL_CHARS
+    context_aware_pct = round(100 * (total - context_aware) / total, 1)
+    context_free_pct = round(100 * (total - context_free) / total, 1)
+    assert context_aware_pct >= corpus.CONTEXT_AWARE_PCT
+    assert context_aware == 1010
+    assert context_free == corpus.CONTEXT_FREE_CHARS
+    assert context_free_pct == corpus.CONTEXT_FREE_PCT
+
+
+def test_corpus_oracle_reproduces_documented_tiers() -> None:
+    total = context_aware = context_free = 0
+    for (_lock, environments), items in _grouped_fixtures().items():
+        universe = [corpus.env_dict_from_marker(e) for e in environments]
+        marker_strings = [item["marker"] for item in items]
+        marker_vars = corpus.marker_vars_of(marker_strings)
+        observed = corpus.observed_values(marker_strings, universe, marker_vars)
+        grid = corpus.build_grid_universe(marker_vars, observed)
+        for item in items:
+            marker = item["marker"]
+            total += len(marker)
+            context_aware += len(
+                corpus.achievable_min_marker(
+                    corpus.selects(marker, universe), universe, marker_vars
+                )
+            )
+            context_free += len(
+                corpus.achievable_min_marker(
+                    corpus.selects(marker, grid), grid, marker_vars
+                )
+            )
+    assert total == corpus.TOTAL_CHARS
+    assert context_aware == corpus.CONTEXT_AWARE_CHARS
+    assert context_free == corpus.CONTEXT_FREE_CHARS

--- a/nab-python/tests/test_markersets.py
+++ b/nab-python/tests/test_markersets.py
@@ -10,11 +10,12 @@ from __future__ import annotations
 
 import importlib.util
 from collections import defaultdict
+from functools import reduce
 from pathlib import Path
 
 import pytest
 
-from nab_python._vendor.packaging.markersets import MarkerSet
+from nab_python._vendor.packaging.markersets import IntractableMarkerSet, MarkerSet
 
 _spec = importlib.util.spec_from_file_location(
     "simplify_corpus_fixtures",
@@ -144,6 +145,13 @@ def test_determinism_under_shuffled_input() -> None:
 def test_within_empty_raises() -> None:
     with pytest.raises(ValueError, match="empty set"):
         ms(SPAN).simplify(within=MarkerSet.empty())
+
+
+def test_non_dnf_product_overrun_raises() -> None:
+    terms = [ms(f'extra == "a{i}"') | ms(f'extra == "b{i}"') for i in range(25)]
+    conjunction = reduce(MarkerSet.intersection, terms)
+    with pytest.raises(IntractableMarkerSet):
+        conjunction.simplify(within=MarkerSet.full())
 
 
 def test_within_full_equals_context_free() -> None:

--- a/nab-python/tests/test_pylock.py
+++ b/nab-python/tests/test_pylock.py
@@ -27,7 +27,7 @@ from nab_python._lockfile.pylock import (
     render_lock,
 )
 from nab_python._vendor.packaging.markers import Marker
-from nab_python._vendor.packaging.markersets import MarkerSet
+from nab_python._vendor.packaging.markersets import IntractableMarkerSet, MarkerSet
 from nab_python._vendor.packaging.pylock import Package, PackageWheel
 from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python._vendor.packaging.version import Version
@@ -256,6 +256,17 @@ class TestFailClosed:
         with pytest.raises(UnsoundSimplificationError, match="foo"):
             build_pylock(_span_lock())
 
+    def test_collapse_to_full_off_universe_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def collapse(self: MarkerSet, *, within: MarkerSet) -> MarkerSet:
+            return MarkerSet.full()
+
+        monkeypatch.setattr(MarkerSet, "simplify", collapse)
+        raw = Marker('sys_platform == "linux"')
+        with pytest.raises(UnsoundSimplificationError, match="foo"):
+            _finalize_marker(raw, _union(_ENVS), "foo")
+
 
 class TestFinalizeMarker:
     def test_none_marker_passes_through(self) -> None:
@@ -264,6 +275,18 @@ class TestFinalizeMarker:
     def test_full_over_universe_emits_none(self) -> None:
         tautology = Marker('python_version == "3.11" or python_version != "3.11"')
         assert _finalize_marker(tautology, MarkerSet.full()) is None
+
+    def test_intractable_emits_raw_byte_identical(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def intractable(self: MarkerSet, *, within: MarkerSet) -> MarkerSet:
+            raise IntractableMarkerSet("over budget")
+
+        monkeypatch.setattr(MarkerSet, "simplify", intractable)
+        raw = Marker('sys_platform == "linux" and "gpu" not in extras')
+        result = _finalize_marker(raw, _union(_ENVS), "torch")
+        assert result is not None
+        assert str(result) == str(raw)
 
 
 class TestDeterminism:

--- a/nab-python/tests/test_pylock.py
+++ b/nab-python/tests/test_pylock.py
@@ -1,0 +1,273 @@
+"""Emission-time per-package marker simplification.
+
+Covers the ``build_pylock`` wiring that finalises each per-package marker
+to its shortest within-universe form before the disjointness and coverage
+gates, plus the fail-closed verify on the emitted bytes.
+"""
+
+from __future__ import annotations
+
+import sys
+from functools import reduce
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+from nab_python._lockfile.coverage import CoverageError
+from nab_python._lockfile.disjointness import validate_marker_disjointness
+from nab_python._lockfile.pylock import (
+    UnsoundSimplificationError,
+    _finalize_marker,
+    build_pylock,
+    render_lock,
+)
+from nab_python._vendor.packaging.markers import Marker
+from nab_python._vendor.packaging.markersets import MarkerSet
+from nab_python._vendor.packaging.pylock import Package, PackageWheel
+from nab_python._vendor.packaging.utils import canonicalize_name
+from nab_python._vendor.packaging.version import Version
+from nab_python.lockfile import (
+    DisjointnessError,
+    IndexPin,
+    LockInput,
+    SdistArtifact,
+    TargetLock,
+    WheelArtifact,
+)
+from nab_python.tags import PlatformSpec
+from nab_python.target import ResolveTarget, environment_declaration
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+
+def _target(python_version: str, platform: str = "linux_x86_64") -> ResolveTarget:
+    return ResolveTarget.for_declared(
+        python_version=python_version, spec=PlatformSpec(platform)
+    )
+
+
+def _index_pin(name: str = "foo", version: str = "1.0") -> IndexPin:
+    return IndexPin(
+        name=name,
+        version=version,
+        index="pypi",
+        sdist=SdistArtifact(
+            filename=f"{name}-{version}.tar.gz",
+            url=f"https://example.com/{name}-{version}.tar.gz",
+            hashes=(("sha256", "b" * 64),),
+            size=2048,
+        ),
+        wheels=(
+            WheelArtifact(
+                filename=f"{name}-{version}-py3-none-any.whl",
+                url=f"https://example.com/{name}-{version}-py3-none-any.whl",
+                hashes=(("sha256", "a" * 64),),
+                size=1024,
+            ),
+        ),
+        requires_python=">=3.10",
+    )
+
+
+def _row(target: ResolveTarget) -> Marker:
+    return Marker(environment_declaration(target, []))
+
+
+def _union(markers: Sequence[Marker]) -> MarkerSet:
+    return reduce(
+        MarkerSet.union,
+        (MarkerSet.from_marker(m) for m in markers),
+        MarkerSet.empty(),
+    )
+
+
+# foo resolves on linux 3.10/3.11/3.12; bar everywhere. The declared
+# environments span linux and windows across those three minors, so
+# foo's verbose per-minor OR is within-universe equivalent to a bare
+# ``sys_platform == "linux"``.
+_LINUX = [_target(v) for v in ("3.10", "3.11", "3.12")]
+_WIN = [_target(v, "windows_amd64") for v in ("3.10", "3.11", "3.12")]
+_ENVS = [_row(t) for t in (*_LINUX, *_WIN)]
+
+
+def _span_lock(order: Sequence[ResolveTarget] | None = None) -> LockInput:
+    targets: dict[str, TargetLock] = {}
+    for t in order if order is not None else (*_LINUX, *_WIN):
+        pins: dict[str, IndexPin] = {"bar": _index_pin("bar")}
+        if t in _LINUX:
+            pins["foo"] = _index_pin("foo")
+        targets[t.label] = TargetLock(target=t, pins=pins)
+    return LockInput(targets=targets, environments=list(_ENVS))
+
+
+def _emitted(lock_input: LockInput) -> dict[str, dict[str, Any]]:
+    data = tomllib.loads(render_lock(lock_input))
+    return {p["name"]: p for p in data["packages"]}
+
+
+def _marker_of(lock_input: LockInput, name: str) -> str | None:
+    return _emitted(lock_input)[name].get("marker")
+
+
+class TestEmittedMarker:
+    def test_verbose_tuple_emits_simplified(self) -> None:
+        assert _marker_of(_span_lock(), "foo") == 'sys_platform == "linux"'
+
+    def test_unconditional_package_emits_no_marker(self) -> None:
+        assert "marker" not in _emitted(_span_lock())["bar"]
+
+    def test_gate_only_marker_survives_unchanged(self) -> None:
+        host = _target("3.11")
+        lock_input = LockInput(
+            targets={
+                host.label: TargetLock(
+                    target=host,
+                    pins={"mytool": _index_pin("mytool")},
+                    package_gates={"mytool": (("extra", "cli"),)},
+                )
+            },
+            environments=[_row(host)],
+            extras=("cli",),
+        )
+        assert _marker_of(lock_input, "mytool") == '"cli" in extras'
+
+    def test_context_free_tier_keeps_python_axis(self) -> None:
+        lin4 = [_target(v) for v in ("3.10", "3.11", "3.12", "3.13")]
+        targets: dict[str, TargetLock] = {}
+        for i, t in enumerate(lin4):
+            pins: dict[str, IndexPin] = {"bar": _index_pin("bar")}
+            if i < 3:
+                pins["foo"] = _index_pin("foo")
+            targets[t.label] = TargetLock(target=t, pins=pins)
+        lock_input = LockInput(targets=targets, environments=[])
+        assert _marker_of(lock_input, "foo") == (
+            'platform_machine == "x86_64" and sys_platform == "linux"'
+            ' and (python_version == "3.10" or python_version == "3.11"'
+            ' or python_version == "3.12")'
+        )
+
+
+class TestGatesRunOnSimplified:
+    def test_gates_pass_on_simplified_output(self) -> None:
+        emitted = _emitted(_span_lock())
+        assert emitted["foo"].get("marker") == 'sys_platform == "linux"'
+
+    def test_environments_rows_unchanged(self) -> None:
+        data = tomllib.loads(render_lock(_span_lock()))
+        assert data["environments"] == [str(m) for m in _ENVS]
+
+    def test_non_covering_lock_still_fails(self) -> None:
+        target = _target("3.13")
+        lock_input = LockInput(
+            targets={
+                target.label: TargetLock(target=target, pins={"foo": _index_pin()})
+            },
+            environments=[
+                Marker(
+                    'python_version == "3.13" and sys_platform == "linux"'
+                    ' and platform_machine == "x86_64"'
+                    ' and python_full_version >= "3.13.2"'
+                )
+            ],
+        )
+        with pytest.raises(CoverageError):
+            build_pylock(lock_input)
+
+
+class TestDisjointnessVerdictInvariance:
+    def _pkg(self, version: str, marker: str) -> Package:
+        return Package(
+            name=canonicalize_name("foo"),
+            version=Version(version),
+            marker=Marker(marker),
+            wheels=(
+                PackageWheel(
+                    name=f"foo-{version}-py3-none-any.whl",
+                    url=f"https://x/foo-{version}-py3-none-any.whl",
+                    hashes={"sha256": "a" * 64},
+                ),
+            ),
+        )
+
+    def _envs(self) -> Mapping[str, Mapping[str, str]]:
+        return {t.label: t.marker_env for t in (*_LINUX, *_WIN)}
+
+    def _passes(self, markers: Sequence[str]) -> bool:
+        packages = [self._pkg(str(i), m) for i, m in enumerate(markers)]
+        try:
+            validate_marker_disjointness(
+                packages, environments=self._envs(), extras=(), groups=()
+            )
+        except DisjointnessError:
+            return False
+        return True
+
+    def _simplify(self, marker: str) -> str:
+        text = (
+            MarkerSet.from_marker(marker)
+            .simplify(within=_union(_ENVS))
+            .to_marker_string()
+        )
+        assert text is not None
+        return text
+
+    def test_disjoint_pair_stays_disjoint(self) -> None:
+        linux = " or ".join(f"({t.environment_marker_string})" for t in _LINUX)
+        windows = " or ".join(f"({t.environment_marker_string})" for t in _WIN)
+        assert self._passes([linux, windows]) is True
+        assert self._passes([self._simplify(linux), self._simplify(windows)]) is True
+
+    def test_colliding_pair_still_collides(self) -> None:
+        linux = " or ".join(f"({t.environment_marker_string})" for t in _LINUX)
+        assert self._passes([linux, linux]) is False
+        simplified = self._simplify(linux)
+        assert self._passes([simplified, simplified]) is False
+
+
+class TestOutOfUniverseDivergence:
+    def test_simplified_marker_diverges_outside_universe(self) -> None:
+        raw = " or ".join(f"({t.environment_marker_string})" for t in _LINUX)
+        emitted = _marker_of(_span_lock(), "foo")
+        assert emitted == 'sys_platform == "linux"'
+        outside = {
+            "python_version": "3.13",
+            "python_full_version": "3.13.0",
+            "sys_platform": "linux",
+            "platform_machine": "x86_64",
+        }
+        assert MarkerSet.from_marker(emitted).evaluate(outside) is True
+        assert MarkerSet.from_marker(raw).evaluate(outside) is False
+
+
+class TestFailClosed:
+    def test_injected_bug_raises_and_emits_nothing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def diverge(self: MarkerSet, *, within: MarkerSet) -> MarkerSet:
+            return MarkerSet.from_marker('sys_platform == "win32"')
+
+        monkeypatch.setattr(MarkerSet, "simplify", diverge)
+        with pytest.raises(UnsoundSimplificationError, match="foo"):
+            build_pylock(_span_lock())
+
+
+class TestFinalizeMarker:
+    def test_none_marker_passes_through(self) -> None:
+        assert _finalize_marker(None, MarkerSet.full()) is None
+
+    def test_full_over_universe_emits_none(self) -> None:
+        tautology = Marker('python_version == "3.11" or python_version != "3.11"')
+        assert _finalize_marker(tautology, MarkerSet.full()) is None
+
+
+class TestDeterminism:
+    def test_shuffled_target_order_is_byte_identical(self) -> None:
+        forward = render_lock(_span_lock((*_LINUX, *_WIN)))
+        reversed_order = render_lock(_span_lock((*reversed(_WIN), *reversed(_LINUX))))
+        assert forward == reversed_order

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -1,9 +1,9 @@
 diff --git a/nab-python/src/nab_python/_vendor/packaging/_markersets.py b/nab-python/src/nab_python/_vendor/packaging/_markersets.py
 new file mode 100644
-index 0000000..28c8b18
+index 0000000..7b75bc8
 --- /dev/null
 +++ b/nab-python/src/nab_python/_vendor/packaging/_markersets.py
-@@ -0,0 +1,1392 @@
+@@ -0,0 +1,1531 @@
 +"""Marker algebra engine: reason about PEP 508 markers as sets of environments.
 +
 +The private engine behind :class:`~packaging.markersets.MarkerSet`. Parses a
@@ -23,7 +23,7 @@ index 0000000..28c8b18
 +import re
 +import sys
 +from itertools import pairwise, product
-+from typing import TYPE_CHECKING, NamedTuple
++from typing import TYPE_CHECKING, NamedTuple, cast
 +
 +from ._parser import Op, Variable, parse_marker
 +from ._tokenizer import ParserSyntaxError
@@ -1396,6 +1396,145 @@ index 0000000..28c8b18
 +        return serialize(to_nnf(node))
 +    except UnserializableMarkerSet:
 +        return "unrepresentable"
++
++
++# ------------------------------------------------------------------- simplify
++
++
++def _atom_key(atom: Atom) -> tuple[str, str, str, bool, bool, str, str, bool]:
++    """A total order over atoms, for a deterministic factored serialisation."""
++    return (
++        atom.origin,
++        atom.op,
++        atom.literal,
++        atom.swapped,
++        atom.positive,
++        atom.kind,
++        atom.variable,
++        atom.derive_mm,
++    )
++
++
++def _clause_key(clause: frozenset[Atom]) -> tuple:
++    return tuple(_atom_key(atom) for atom in sorted(clause, key=_atom_key))
++
++
++def _to_clauses(node: Formula, max_cells: int) -> list[frozenset[Atom]]:
++    """Distribute an NNF tree into a disjunction of atom-set clauses (DNF).
++
++    An AND of ORs expands multiplicatively, so the running clause count is
++    checked against ``max_cells`` and a pathological non-DNF input fails as
++    :class:`IntractableMarkerSet` rather than expanding unbounded.
++    """
++    if isinstance(node, BoolConst):
++        return [frozenset()] if node.value else []
++    if isinstance(node, AtomLeaf):
++        return [frozenset((node.atom,))]
++    if isinstance(node, OrNode):
++        clauses: list[frozenset[Atom]] = []
++        for child in node.children:
++            clauses.extend(_to_clauses(child, max_cells))
++        return clauses
++    and_node = cast("AndNode", node)
++    product: list[frozenset[Atom]] = [frozenset()]
++    for child in and_node.children:
++        child_clauses = _to_clauses(child, max_cells)
++        product = [left | right for left in product for right in child_clauses]
++        if len(product) > max_cells:
++            msg = f"DNF clause count exceeds max_cells={max_cells}"
++            raise IntractableMarkerSet(msg)
++    return product
++
++
++def _clause_formula(clause: Iterable[Atom]) -> Formula:
++    return make_and(AtomLeaf(atom) for atom in clause)
++
++
++def _disjunction(clauses: Iterable[frozenset[Atom]]) -> Formula:
++    return make_or(_clause_formula(clause) for clause in clauses)
++
++
++def _equivalent_within(
++    left: Formula, right: Formula, universe: Formula, max_cells: int
++) -> bool:
++    """Whether two trees denote the same set on every point of ``universe``."""
++    return is_empty(
++        make_and((left, universe, make_not(right))), max_cells
++    ) and is_empty(make_and((right, universe, make_not(left))), max_cells)
++
++
++def _dedupe(clauses: list[frozenset[Atom]]) -> list[frozenset[Atom]]:
++    seen: set[frozenset[Atom]] = set()
++    out: list[frozenset[Atom]] = []
++    for clause in clauses:
++        if clause not in seen:
++            seen.add(clause)
++            out.append(clause)
++    return out
++
++
++def _drop_clauses(
++    clauses: list[frozenset[Atom]],
++    original: Formula,
++    universe: Formula,
++    max_cells: int,
++) -> list[frozenset[Atom]]:
++    kept = list(clauses)
++    for clause in sorted(clauses, key=_clause_key):
++        trial = [other for other in kept if other != clause]
++        if _equivalent_within(_disjunction(trial), original, universe, max_cells):
++            kept = trial
++    return kept
++
++
++def _drop_atoms(
++    clauses: list[frozenset[Atom]],
++    original: Formula,
++    universe: Formula,
++    max_cells: int,
++) -> list[frozenset[Atom]]:
++    working = [set(clause) for clause in clauses]
++    for clause in working:
++        for atom in sorted(clause, key=_atom_key):
++            clause.discard(atom)
++            trial = _disjunction(frozenset(current) for current in working)
++            if not _equivalent_within(trial, original, universe, max_cells):
++                clause.add(atom)
++    return [frozenset(clause) for clause in working]
++
++
++def _canonical(clauses: list[frozenset[Atom]]) -> tuple:
++    return tuple(sorted(_clause_key(clause) for clause in clauses))
++
++
++def simplify_within(node: Formula, universe: Formula, max_cells: int) -> Formula:
++    """Return the smallest tree equivalent to ``node`` on every point of ``universe``.
++
++    Greedy: drop each clause, then each atom, whose removal preserves
++    within-universe equivalence, to a fixpoint, then factor the atoms common to
++    every surviving clause into a leading conjunction. Every removal is verified,
++    so the result is sound; on a universe of ``TRUE`` it reduces to a
++    context-free factoring. Determinism is fixed by a total atom order.
++    """
++    nnf = node if isinstance(node, BoolConst) else to_nnf(node)
++    clauses = _dedupe(_to_clauses(nnf, max_cells))
++    original = _disjunction(clauses)
++    while True:
++        before = _canonical(clauses)
++        clauses = _drop_clauses(clauses, original, universe, max_cells)
++        clauses = _dedupe(_drop_atoms(clauses, original, universe, max_cells))
++        if _canonical(clauses) == before:
++            break
++    if not clauses:
++        return FALSE
++    clauses = sorted(clauses, key=_clause_key)
++    common = frozenset.intersection(*clauses)
++    residual = sorted((clause - common for clause in clauses), key=_clause_key)
++    lead = [AtomLeaf(atom) for atom in sorted(common, key=_atom_key)]
++    inner = make_or(
++        _clause_formula(sorted(clause, key=_atom_key)) for clause in residual
++    )
++    return make_and([*lead, inner])
 diff --git a/nab-python/src/nab_python/_vendor/packaging/markers.py b/nab-python/src/nab_python/_vendor/packaging/markers.py
 index c78fd5d..0d7ee1d 100644
 --- a/nab-python/src/nab_python/_vendor/packaging/markers.py
@@ -1424,10 +1563,10 @@ index c78fd5d..0d7ee1d 100644
      """
 diff --git a/nab-python/src/nab_python/_vendor/packaging/markersets.py b/nab-python/src/nab_python/_vendor/packaging/markersets.py
 new file mode 100644
-index 0000000..13b4574
+index 0000000..63b2994
 --- /dev/null
 +++ b/nab-python/src/nab_python/_vendor/packaging/markersets.py
-@@ -0,0 +1,316 @@
+@@ -0,0 +1,339 @@
 +"""The public :class:`MarkerSet`: a marker's denotation as a set of environments.
 +
 +A :class:`MarkerSet` is the denotation of a PEP 508 marker as a set of
@@ -1715,6 +1854,29 @@ index 0000000..13b4574
 +        axis, so those constraints can sit on different variables.
 +        """
 +        return _markersets.witness(self._tree, _MAX_CELLS)
++
++    # ---- simplification
++
++    @_bounded
++    def simplify(self, *, within: MarkerSet) -> MarkerSet:
++        """Return the smallest set equivalent to this one on every point of ``within``.
++
++        ``within`` is the universe the result must agree with this set over: pass
++        the union of a lock's declared environments for universe-aware
++        simplification, or :meth:`full` for a context-free factoring. The result
++        is a ``MarkerSet``; call :meth:`to_marker_string` for its compact spelling.
++
++        :raises ValueError: if ``within`` is the empty set, which makes every set
++            vacuously equivalent.
++        :raises IntractableMarkerSet: if deciding a removal exceeds the internal
++            cell budget, or the marker nests past the stack.
++        """
++        if within.is_empty():
++            msg = "within must not be the empty set"
++            raise ValueError(msg)
++        return self._wrap(
++            _markersets.simplify_within(self._tree, within._tree, _MAX_CELLS)
++        )
 +
 +    # ---- serialisation
 +


### PR DESCRIPTION
Per-package markers were emitted as the raw OR of each target's marker expression, which left long redundant clauses in the lock. Add a universe-aware MarkerSet.simplify and apply it at emission so each marker ships in its shortest form equivalent over the lock's declared environments. A marker too large to decide within the cell budget is emitted unsimplified, and any mismatch between the simplified and original marker fails the emission.