### PR TITLE
fix failure report counting a metadata-blocked version twice

### DIFF
--- a/nab-python/src/nab_python/_provider/lookahead.py
+++ b/nab-python/src/nab_python/_provider/lookahead.py
@@ -51,8 +51,8 @@ def look_ahead_ok(
         try:
             provider.get_dependencies(package, version)
         except MetadataError as exc:
-            provider.pending_metadata_blocks[canonicalize_name(package)].append(
-                (version, str(exc))
+            provider.pending_metadata_blocks[canonicalize_name(package)].setdefault(
+                version, str(exc)
             )
             return False
 
@@ -154,4 +154,4 @@ def flush_pending_blocks(provider: Provider) -> None:
     # Root- and metadata-blocks are diagnostic-only; drop them without
     # emitting clauses.
     provider.pending_root_blocks = defaultdict(list)
-    provider.pending_metadata_blocks = defaultdict(list)
+    provider.pending_metadata_blocks = defaultdict(dict)

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -743,8 +743,9 @@ class Provider:
 
         # Diagnostic-only: metadata-error rejections so the failure message
         # can name the real cause (sdist build needed, malformed PKG-INFO, etc).
-        self.pending_metadata_blocks: defaultdict[str, list[tuple[Version, str]]] = (
-            defaultdict(list)
+        # Keyed by version so a re-checked candidate is counted once.
+        self.pending_metadata_blocks: defaultdict[str, dict[Version, str]] = (
+            defaultdict(dict)
         )
 
         # Last NO_VERSIONS reason per package; consumed by resolve.py to
@@ -1700,7 +1701,7 @@ class Provider:
         meta = self.pending_metadata_blocks.get(normalized)
         if meta:
             count = len(meta)
-            first_msg = meta[0][1]
+            first_msg = next(iter(meta.values()))
             if count == 1:
                 out.append(first_msg)
             else:

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -1349,6 +1349,52 @@ class TestNoVersionsReasons:
         assert "disjoint with current solution range" not in reason
 
 
+class TestMetadataBlockerCount:
+    """The metadata-error line counts versions, not look-ahead rejections."""
+
+    _META = (
+        "Metadata-Version: 2.1\nName: pkg\nVersion: {ver}\nRequires-Python: >=3.13\n\n"
+    )
+
+    def _provider(self, preferred: str | None) -> Provider:
+        versions = ("1.0", "2.0", "3.0")
+        coordinator = make_coordinator(
+            [make_wheel(v) for v in versions],
+            metadata_by_version={v: self._META.format(ver=v) for v in versions},
+            package="pkg",
+        )
+        return Provider(
+            coordinator,
+            target=_PY312,
+            root_requirements={"pkg": VersionRange.full(admit_arbitrary=False)},
+            preferences=None if preferred is None else {"pkg": V(preferred)},
+        )
+
+    def test_counts_each_version_once_without_a_preference(self) -> None:
+        """Three unusable versions read as three."""
+        provider = self._provider(None)
+        assert provider.choose_version("pkg", VersionRange.full()) is None
+        reason = provider.get_no_versions_reason("pkg")
+        assert reason is not None
+        assert "3 versions failed metadata extraction" in reason
+        assert "pkg 3.0 requires Python >=3.13" in reason
+
+    def test_preferred_version_is_not_counted_twice(self) -> None:
+        """A preference re-checked by the full scan must not inflate the count.
+
+        ``_preferred_version`` checks 2.0 first; when its metadata raises, the
+        scan reaches 2.0 again.
+        """
+        provider = self._provider("2.0")
+        assert provider.choose_version("pkg", VersionRange.full()) is None
+        reason = provider.get_no_versions_reason("pkg")
+        assert reason is not None
+        assert "3 versions failed metadata extraction" in reason
+        assert "4 versions" not in reason
+        # The version named is the first failure, here the preferred one.
+        assert "pkg 2.0 requires Python >=3.13" in reason
+
+
 class TestGetDependencies:
     def test_returns_deps_from_metadata(self) -> None:
         """Parse Requires-Dist from fetched metadata."""
@@ -2974,7 +3020,7 @@ class TestLookAheadAbort:
     def test_should_abort_none_when_metadata_block_present(self) -> None:
         provider = self._provider()
         provider.pending_blocks[("foo", "bar", V("1.0"))].append(V("0.9"))
-        provider.pending_metadata_blocks["foo"].append((V("0.8"), "metadata failure"))
+        provider.pending_metadata_blocks["foo"][V("0.8")] = "metadata failure"
         assert provider._should_abort_lookahead("foo") is None
 
     def test_should_abort_ignores_blocks_owned_by_other_packages(self) -> None:
@@ -2986,7 +3032,7 @@ class TestLookAheadAbort:
         provider.pending_range_blocks[
             ("other", "qux", SpecifierSet("<2.0").to_range())
         ].append(V("0.8"))
-        provider.pending_metadata_blocks["other"].append((V("0.5"), "x"))
+        provider.pending_metadata_blocks["other"][V("0.5")] = "x"
         assert provider._should_abort_lookahead("foo") == ("bar", V("1.0"))
 
     def test_discard_drops_only_target_candidate_blocks(self) -> None:


### PR DESCRIPTION
When a resolve fails, the Diagnostics section can name more failed versions than the package has, e.g. "4 versions failed metadata extraction" for a package with three versions.

`pending_metadata_blocks` was a list that took an entry on every look-ahead rejection, and one version can be rejected twice: when another target has already decided a version, `_preferred_version` checks it first and the full scan then reaches it again. It is now keyed by version, so a version checked twice is recorded once.

The wording of the line and the first-failure message it quotes are unchanged.
