### PR TITLE
skip repeated per-file work in the listing base filter

### DIFF
--- a/nab-python/src/nab_python/_iso8601.py
+++ b/nab-python/src/nab_python/_iso8601.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 import re
+import sys
 from datetime import datetime
 
 _FRACTIONAL_SECONDS = re.compile(r"\.(\d+)")
+
+# From 3.11 ``fromisoformat`` reads the ``Z`` suffix and every fraction width
+# PEP 700 permits, so ``_to_isoformat`` is only the 3.10 fallback.
+_NATIVE_ACCEPTS_PEP_700 = sys.version_info >= (3, 11)
 
 
 def parse_iso_datetime(raw: str) -> datetime:
@@ -14,6 +19,12 @@ def parse_iso_datetime(raw: str) -> datetime:
     The offset in ``raw`` is preserved, and the result is naive when there is
     none, so each caller decides what a missing offset means.
     """
+    if _NATIVE_ACCEPTS_PEP_700:
+        try:
+            return datetime.fromisoformat(raw)
+        except ValueError:
+            pass
+
     return datetime.fromisoformat(_to_isoformat(raw))
 
 

--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -514,13 +514,23 @@ def _canonicalize_equal_versions(
     pin is deterministic.
     """
     representative: dict[Version, Version] = {}
+    needs_rebuild = False
     for version, _ in result:
         chosen = representative.get(version)
-        if chosen is None or (len(version.release), str(version)) < (
-            len(chosen.release),
-            str(chosen),
-        ):
+        if chosen is None:
             representative[version] = version
+        elif chosen is not version:
+            # The listing interns its versions, so two distinct objects that
+            # compare equal are two spellings of one release.
+            needs_rebuild = True
+            if (len(version.release), str(version)) < (
+                len(chosen.release),
+                str(chosen),
+            ):
+                representative[version] = version
+
+    if not needs_rebuild:
+        return result
     return [(representative[version], dist) for version, dist in result]
 
 

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -589,6 +589,10 @@ class Provider:
         }
         self._package_overrides = tuple(package_overrides)
         self._index_overrides: Mapping[str, IndexOverride] = index_overrides or {}
+
+        # With no override on either surface, every lookup is the global default.
+        self._has_overrides = bool(self._package_overrides or self._index_overrides)
+
         # True when any override sets a time cutoff or disables one, so the
         # listing filter can skip the per-candidate dispatch otherwise.
         self.overrides_set_time = any(
@@ -857,6 +861,9 @@ class Provider:
         index_name: str | None = None,
     ) -> DistPolicy:
         """Return the dist policy for ``name==version`` served from ``index_name``."""
+        if not self._has_overrides:
+            return self._dist_policy
+
         result = self._effective_field(
             canonical_name,
             version,
@@ -884,6 +891,9 @@ class Provider:
         field.  A per-package (range-matching) and a per-index override
         that both set the field are a conflict.
         """
+        if not self._has_overrides:
+            return self.uploaded_prior_to
+
         result = self._effective_field(
             canonical_name,
             version,
@@ -949,6 +959,9 @@ class Provider:
         range-matching override sets (which may be ``""``, meaning "no Python
         requirement"), else ``None`` when nothing overrides it.
         """
+        if not self._package_overrides:
+            return None
+
         override = self._matching_package_override(
             canonical_name,
             version,

--- a/nab-python/tests/test_iso8601.py
+++ b/nab-python/tests/test_iso8601.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
+from nab_python import _iso8601
 from nab_python._iso8601 import _to_isoformat, parse_iso_datetime
 
 # PEP 700 serves upload-time as an ISO 8601 UTC timestamp, so an index may use
@@ -71,3 +72,43 @@ def test_offset_fraction_is_widened_too() -> None:
 def test_non_datetime_raises_value_error() -> None:
     with pytest.raises(ValueError, match="not-a-date"):
         parse_iso_datetime("not-a-date")
+
+
+# Shapes an index could serve, plus the malformed ones the parser has to refuse.
+PARSE_INPUTS = [
+    *[raw for raw, _ in PEP_700_WIDTHS],
+    "2024-01-15T12:30:45.1234567Z",
+    "2024-01-15T12:30:45.123456789Z",
+    "2024-01-15T12:30:45,123Z",
+    "2024-01-15T12:30:45",
+    "2024-01-15T12:30:45.5+05:30",
+    "2024-01-15T12:30:45.5+05:30:00.5",
+    "2024-01-15T12:30:45-00:00",
+    "20240115T123045Z",
+    "2024-01-15",
+    "2024-01-15T12:30:45.",
+    "2024-01-15T25:00:00Z",
+    "not-a-date",
+    "",
+]
+
+
+def _parse_or_error(raw: str) -> object:
+    try:
+        return parse_iso_datetime(raw)
+    except ValueError:
+        return ValueError
+
+
+@pytest.mark.parametrize("raw", PARSE_INPUTS)
+def test_native_path_agrees_with_compatibility_path(
+    raw: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Handing ``raw`` straight to ``fromisoformat`` must not change the verdict."""
+    monkeypatch.setattr(_iso8601, "_NATIVE_ACCEPTS_PEP_700", False)
+    compatibility = _parse_or_error(raw)
+
+    monkeypatch.setattr(_iso8601, "_NATIVE_ACCEPTS_PEP_700", True)
+    native = _parse_or_error(raw)
+
+    assert native == compatibility

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -25,6 +25,7 @@ from nab_index.client import (
 from nab_index.lazy_wheel import RangeMetadataResult, RangeOutcome
 from nab_index.local_index import LocalIndexClient
 from nab_python._provider import build_remote, metadata_resolver
+from nab_python._provider import listing as listing_mod
 from nab_python._provider.metadata_resolver import (
     add_classified_dep,
     cache_deps_from_metadata,
@@ -850,6 +851,27 @@ class TestEqualVersionDifferentStrings:
         assert v_forward is not None
         assert v_backward is not None
         assert str(v_forward) == str(v_backward)
+
+
+class TestCanonicalizeEqualVersions:
+    """Only a listing that holds an equal group is rebuilt."""
+
+    def test_distinct_versions_keep_the_same_list(self) -> None:
+        pairs = [(V("2.0"), make_wheel("2.0")), (V("1.0"), make_sdist("1.0"))]
+        assert listing_mod._canonicalize_equal_versions(pairs) is pairs
+
+    def test_one_version_across_two_artifacts_keeps_the_same_list(self) -> None:
+        """The listing interns its versions, so a repeat is the same object."""
+        version = V("1.0")
+        pairs = [(version, make_wheel("1.0")), (version, make_sdist("1.0"))]
+        assert listing_mod._canonicalize_equal_versions(pairs) is pairs
+
+    @pytest.mark.parametrize("first", ["1.0", "1.0.0"])
+    def test_equal_group_collapses_to_the_shortest_string(self, first: str) -> None:
+        second = "1.0.0" if first == "1.0" else "1.0"
+        pairs = [(V(first), make_wheel(first)), (V(second), make_sdist(second))]
+        result = listing_mod._canonicalize_equal_versions(pairs)
+        assert [str(version) for version, _ in result] == ["1.0", "1.0"]
 
 
 class TestPrereleaseAdmission:


### PR DESCRIPTION
The base listing filter runs once per file in every listing, so anything it repeats is multiplied by the size of the index page. Three parts of it were redoing work that cannot change from one artifact to the next, which shows up most on a warm resolve, where every fetch is a cache hit.

- `parse_iso_datetime` always ran the pre-3.11 rewrite (an f-string splice and a regex sub with a Python callback) before calling `fromisoformat`. From 3.11 `fromisoformat` reads the `Z` suffix and every fraction width PEP 700 permits, so hand it the raw string and keep the rewrite as the 3.10 fallback.
- `effective_dist_policy`, `effective_uploaded_prior_to`, and `effective_requires_python` built a closure and walked the override arbitration only to return the global default when nothing is configured. They now check for a configured override first.
- `_canonicalize_equal_versions` stringified both sides of a comparison between one interned `Version` and itself, and rebuilt the list even when nothing collapsed. It now compares identity first, and returns the input list when no equal group needs canonicalizing.

The filter returns the same list it did before.
