### PR TITLE
Error when tie-ranked wheels disagree on deps

### DIFF
--- a/docs/explanation/universal.md
+++ b/docs/explanation/universal.md
@@ -33,6 +33,20 @@ with more environments in it: the same shape, the same
 dependency edges. A target whose minor a marker splits contributes
 one declaration per slice (see Patch-release markers below).
 
+## Where a version's metadata comes from
+
+nab reads a version's dependency metadata from the one wheel its
+target's tags rank most preferred (most specific tag, then highest
+build tag) and treats it as authoritative for that version on that
+target. Per-target tag filtering already keeps cross-platform wheels
+apart, so this is exact wherever the installer's own rules can rank a
+version's wheels.
+
+When a version's wheels tie for a target and the siblings already
+fetched declare different dependencies, nab reports an error rather
+than pick one by guessing. It compares only the siblings in hand, so
+it does not promise to catch every such case.
+
 ## Declaring the matrix
 
 ```toml

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -39,8 +39,15 @@ if TYPE_CHECKING:
     from .._vendor.packaging.markers import Marker
     from .._vendor.packaging.requirements import Requirement
     from .._vendor.packaging.version import Version
+    from ..fetch import InMemoryIndex
     from ..provider import DistFile, Provider
     from ..tags import TagSet
+
+TargetDepSignature = tuple[
+    dict[str, VersionRange],
+    dict[str, dict[str, VersionRange]],
+    dict[str | None, set[tuple[str, frozenset[str], str]]],
+]
 
 
 def resolve_metadata(
@@ -598,6 +605,53 @@ def _reject_incompatible_python(
     raise IncompatiblePythonError(msg)
 
 
+def effective_metadata(
+    provider: Provider,
+    cache_key: tuple[str, Version],
+    metadata: WheelMetadata,
+) -> WheelMetadata:
+    """Apply the per-package metadata override, or return ``metadata`` as is.
+
+    A fresh record rather than a mutation: the raw parse is shared across
+    tuples via ``store_parsed_metadata``, so mutating would leak one tuple's
+    override into another.  A replaced dep list strips extra-gated lines, so an
+    unset provides-extra declares none rather than keep now-incoherent extras.
+    """
+    package, version = cache_key
+    override_deps, override_rp, override_pe = provider.effective_metadata_override(
+        package, version
+    )
+    if override_deps is None and override_rp is None and override_pe is None:
+        return metadata
+
+    requires_python = (
+        SpecifierSet(override_rp)
+        if override_rp is not None
+        else metadata.requires_python
+    )
+    requires_dist = (
+        list(override_deps)
+        if override_deps is not None
+        else list(metadata.requires_dist)
+    )
+    if override_pe is not None:
+        provides_extra = list(override_pe)
+    elif override_deps is not None:
+        provides_extra = []
+    else:
+        provides_extra = list(metadata.provides_extra)
+
+    return WheelMetadata(
+        name=metadata.name,
+        version=metadata.version,
+        requires_python=requires_python,
+        requires_dist=requires_dist,
+        provides_extra=provides_extra,
+        metadata_version=metadata.metadata_version,
+        dynamic=metadata.dynamic,
+    )
+
+
 def cache_deps_from_metadata(
     provider: Provider,
     cache_key: tuple[str, Version],
@@ -616,48 +670,11 @@ def cache_deps_from_metadata(
     # Late import: ``provider`` imports this module at module load.
     from ..provider import _normalize_extra
 
-    package, version = cache_key
-    override_deps, override_rp, override_pe = provider.effective_metadata_override(
-        package, version
-    )
-    if override_deps is not None or override_rp is not None or override_pe is not None:
-        # Build a fresh record rather than mutate the input: the raw parse is
-        # shared across tuples via ``store_parsed_metadata``, so mutating it
-        # would leak one tuple's override into another.  Each field falls back
-        # to the parsed value when the override leaves it unset.
-        requires_python = (
-            SpecifierSet(override_rp)
-            if override_rp is not None
-            else metadata.requires_python
-        )
-        requires_dist = (
-            list(override_deps)
-            if override_deps is not None
-            else list(metadata.requires_dist)
-        )
-
-        # An explicit provides-extra wins; else keep the parsed extras, unless
-        # the dep list was replaced, which strips their extra-gated lines and
-        # leaves them incoherent, so declare none.
-        if override_pe is not None:
-            provides_extra = list(override_pe)
-        elif override_deps is not None:
-            provides_extra = []
-        else:
-            provides_extra = list(metadata.provides_extra)
-
-        metadata = WheelMetadata(
-            name=metadata.name,
-            version=metadata.version,
-            requires_python=requires_python,
-            requires_dist=requires_dist,
-            provides_extra=provides_extra,
-            metadata_version=metadata.metadata_version,
-            dynamic=metadata.dynamic,
-        )
+    metadata = effective_metadata(provider, cache_key, metadata)
 
     # Split the (possibly overridden) requirements into base deps and
     # per-extra deps, deferring any direct-URL deps that aren't yet active.
+    package = cache_key[0]
     provider.metadata_cache[cache_key] = metadata
     provided_extras = {_normalize_extra(e) for e in metadata.provides_extra}
     base_deps: dict[str, VersionRange] = {}
@@ -704,6 +721,259 @@ def refuse_url_dep(provider: Provider, req: Requirement, url: str) -> None:
         f" implemented: {req.name} @ {url}"
     )
     raise NotImplementedError(msg)
+
+
+def _classify_requirement_uncached(
+    provider: Provider,
+    req: Requirement,
+    provided_extras: set[str],
+) -> set[str] | None:
+    """Classify like :func:`classify_requirement`, recording nothing.
+
+    These markers come from wheels :func:`target_dep_signature` parses but
+    never keeps in ``metadata_cache``.  The id-keyed marker caches would be
+    unsound here: a collected marker's ``id`` can alias a later live marker.
+    ``consulted_markers`` would leak a never-installed sibling's clauses into
+    the lock's ``environments``.  So each marker is evaluated directly.
+    """
+    marker = req.marker
+    if marker is None:
+        return set()
+    if marker.evaluate({**provider.environment, **EMPTY_MEMBERSHIP_SETS}):
+        return set()
+    if "extra" not in str(marker):
+        return None
+    env = dict(provider.env_with_extra)
+    matched: set[str] = set()
+    for extra_name in provided_extras:
+        env["extra"] = extra_name
+        if marker.evaluate(env):
+            matched.add(extra_name)
+    return matched or None
+
+
+def target_dep_signature(
+    provider: Provider,
+    metadata: WheelMetadata,
+) -> TargetDepSignature:
+    """Project ``metadata`` to a target-effective dependency signature.
+
+    Returns ``(base_deps, extra_deps_map, url_buckets)``, compared with ``!=``
+    to tell two wheels of one version apart by the dependencies they impose on
+    this target rather than by raw text.  Each requirement is classified the way
+    the resolver classifies deps, so a marker both wheels evaluate the same
+    folds away, and ranges go through :func:`add_classified_dep`, so ordering,
+    whitespace, and specifier spelling normalize equal.  It records nothing into
+    the marker caches or ``consulted_markers``: see
+    :func:`_classify_requirement_uncached`.
+
+    The per-package override is applied first, so a ``provides-extra`` override
+    is compared in the same view the resolver pins from.  A complete
+    ``dependencies`` override takes the skip-fetch path in
+    :meth:`nab_python.provider.Provider.get_dependencies` and never reaches
+    here.  ``Requires-Python`` is left out: it gates admission, not the
+    dependency edges a lock records.
+
+    Unlike :func:`cache_deps_from_metadata` this never raises: a direct-URL dep
+    is bucketed instead of routed through :func:`refuse_url_dep`, since the pick
+    already refused its own URL deps, so a sibling's URL dep is a divergence to
+    report.
+    """
+    # Late import: ``provider`` imports this module at module load.
+    from ..provider import _normalize_extra
+
+    cache_key = (canonicalize_name(metadata.name), metadata.version)
+    metadata = effective_metadata(provider, cache_key, metadata)
+    provided_extras = {_normalize_extra(e) for e in metadata.provides_extra}
+    base_deps: dict[str, VersionRange] = {}
+    extra_deps_map: dict[str, dict[str, VersionRange]] = {
+        e: {} for e in provided_extras
+    }
+    url_buckets: dict[str | None, set[tuple[str, frozenset[str], str]]] = {}
+    for req in metadata.requires_dist:
+        req_extras = _classify_requirement_uncached(provider, req, provided_extras)
+        if req_extras is None:
+            continue
+        if req.url is not None:
+            entry = (canonicalize_name(req.name), frozenset(req.extras), req.url)
+            for key in req_extras or {None}:
+                url_buckets.setdefault(key, set()).add(entry)
+            continue
+        add_classified_dep(req, req_extras, base_deps, extra_deps_map)
+    return (base_deps, extra_deps_map, url_buckets)
+
+
+def check_sibling_metadata_divergence(
+    provider: Provider,
+    versions: Sequence[tuple[Version, DistFile]],
+    package: str,
+    version: Version,
+) -> None:
+    """Crash when a resident tie sibling's target deps diverge from the pick's.
+
+    nab reads one version's dependencies from the wheel the target's tags rank
+    most preferred and treats it as authoritative.  Two wheels the target's own
+    rules cannot rank against each other (a tie) can still declare different
+    target-effective dependencies, so pinning from one silently disagrees with
+    an install of the other.
+
+    Only siblings already resident in the shared index are compared; this never
+    fetches.  On the first tie sibling whose projection differs from the pick's,
+    a :class:`~nab_python.provider.SiblingMetadataDivergenceError` is raised.  It
+    is deliberately not a :class:`~nab_python.provider.MetadataError`, which
+    :meth:`~nab_python.provider.Provider._look_ahead_ok` would turn into a
+    dropped candidate: dropping would silently remove a version an installer can
+    legitimately install.
+    """
+    # Late import: ``provider`` imports this module at module load.
+    from ..provider import SiblingMetadataDivergenceError
+
+    tags = provider.wheel_tags
+    pick = pick_dist_for_metadata(versions, version, tags)
+    if not isinstance(pick, WheelFile):
+        return
+
+    _, _, normalized = provider.split_and_normalize(package)
+    ver_str = str(version)
+    index = provider.coordinator.index
+
+    pick_text = _resident_wheel_text(index, normalized, ver_str, pick)
+    if pick_text is None:
+        return
+
+    wheels = [d for v, d in versions if v == version and isinstance(d, WheelFile)]
+    if len(wheels) <= 1:
+        return
+
+    pick_key = None if tags is None else tags.wheel_rank(pick.filename)
+    pick_sig: TargetDepSignature | None = None
+    for sibling in wheels:
+        if sibling is pick or not _wheels_tie(tags, pick_key, sibling.filename):
+            continue
+        sibling_metadata = _tie_sibling_metadata(
+            provider, index, normalized, version, sibling
+        )
+        if sibling_metadata is None:
+            continue
+        if pick_sig is None:
+            pick_sig = target_dep_signature(provider, parse_metadata(pick_text))
+        sibling_sig = target_dep_signature(provider, sibling_metadata)
+        if sibling_sig == pick_sig:
+            continue
+        labels = _divergent_dep_labels(pick_sig, sibling_sig)
+        msg = (
+            f"{package} {version} has tie-ranked wheels {pick.filename} and"
+            f" {sibling.filename} that declare different dependencies for this"
+            f" target ({', '.join(labels)}). Pin the dependencies with a"
+            f" per-package dependencies override to resolve this version."
+        )
+        raise SiblingMetadataDivergenceError(msg)
+
+
+def _tie_sibling_metadata(
+    provider: Provider,
+    index: InMemoryIndex,
+    package: str,
+    version: Version,
+    sibling: WheelFile,
+) -> WheelMetadata | None:
+    """Parse a resident tie sibling's own METADATA, or None to skip it.
+
+    Skipped when the text is not resident, does not parse, or its effective
+    Requires-Python excludes the target.  Tags rank by :pep:`425` and say
+    nothing about the Python floor, so a tie sibling can still declare a
+    Requires-Python an installer would reject for this target; comparing it
+    would false-crash a version an installer resolves fine.  A per-package
+    override wins over the parsed floor.
+    """
+    text = _resident_wheel_text(index, package, str(version), sibling)
+    if text is None:
+        return None
+    try:
+        metadata = parse_metadata(text)
+    except ValueError:
+        return None
+    target = provider.target
+    override_rp = provider.effective_requires_python(package, version)
+    spec = (
+        SpecifierSet(override_rp)
+        if override_rp is not None
+        else metadata.requires_python
+    )
+    if (
+        target is not None
+        and spec is not None
+        and not target.admits_requires_python(spec)
+    ):
+        return None
+    return metadata
+
+
+def _resident_wheel_text(
+    index: InMemoryIndex, package: str, version: str, wheel: WheelFile
+) -> str | None:
+    """Return a wheel's own resident METADATA text, or None if not in hand.
+
+    Reads only the slot the wheel's text would occupy: a bare remote wheel's
+    own URL (rung 4), else its sidecar URL.  A local wheel keeps no text in the
+    index and reads back None.  Sdist-origin text never stands in for a wheel.
+    """
+    if _is_bare_remote_wheel(wheel):
+        url = wheel.url
+    elif wheel.metadata_url is not None:
+        url = wheel.metadata_url
+    else:
+        return None
+    text, from_sdist = index.get_metadata_with_origin(package, version, url)
+    return None if from_sdist else text
+
+
+def _wheels_tie(
+    tags: TagSet | None,
+    pick_key: tuple[int, tuple[int, str]] | None,
+    sibling_filename: str,
+) -> bool:
+    """Whether a sibling wheel ties the pick under the target's install rules.
+
+    With no tag axis every resident sibling wheel is a real ambiguity, so any
+    sibling ties.  Otherwise a sibling ties only when its
+    :meth:`~nab_python.tags.TagSet.wheel_rank` key equals the pick's and is not
+    None; a sibling the pick ranks strictly below is never installed and is
+    exempt.
+    """
+    if tags is None:
+        return True
+    sibling_key = tags.wheel_rank(sibling_filename)
+    return sibling_key is not None and sibling_key == pick_key
+
+
+def _divergent_dep_labels(
+    pick_sig: TargetDepSignature, sibling_sig: TargetDepSignature
+) -> list[str]:
+    """Return sorted labels for the signature entries that differ."""
+    pick_flat = _flatten_signature(pick_sig)
+    sibling_flat = _flatten_signature(sibling_sig)
+    return sorted(
+        label
+        for label in pick_flat.keys() | sibling_flat.keys()
+        if pick_flat.get(label) != sibling_flat.get(label)
+    )
+
+
+def _flatten_signature(signature: TargetDepSignature) -> dict[str, object]:
+    """Flatten a target-dep signature to labelled values for a diff.
+
+    Base deps, per-extra dep maps, and URL buckets each become one entry.
+    """
+    base_deps, extra_deps_map, url_buckets = signature
+    flat: dict[str, object] = {}
+    for name, rng in base_deps.items():
+        flat[f"base:{name}"] = rng
+    for extra, deps in extra_deps_map.items():
+        flat[f"extra:{extra}"] = deps
+    for key, entries in url_buckets.items():
+        flat[f"url:{key}"] = entries
+    return flat
 
 
 def add_classified_dep(

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -70,6 +70,7 @@ __all__ = [
     "Provider",
     "ProviderStats",
     "ResolutionStrategy",
+    "SiblingMetadataDivergenceError",
     "SourceNameMismatchError",
     "UnsupportedSdistError",
     "UnsupportedVcsError",
@@ -310,6 +311,18 @@ class IncompatiblePythonError(MetadataError):
 # and would silently reject the version; a naive upload-time is a hard error.
 class InvalidUploadTimeError(Exception):
     """Raised when an index upload-time is not the timezone-aware UTC PEP 700 needs."""
+
+
+# Deliberately not a MetadataError: _look_ahead_ok catches those and skips the
+# version, but tie-ranked wheels that disagree on a target's dependencies are an
+# ambiguity nab cannot resolve, so it must abort rather than drop the version.
+class SiblingMetadataDivergenceError(Exception):
+    """Raised when a version's tie-ranked wheels declare different target deps.
+
+    nab reads one wheel's dependencies per version and treats it as
+    authoritative, so a tie whose wheels declare different dependencies is an
+    ambiguity: pinning from one silently disagrees with an install of the other.
+    """
 
 
 # Deliberately not a MetadataError: _look_ahead_ok catches those and skips the
@@ -1309,9 +1322,10 @@ class Provider:
 
         The un-narrowed range spans versions the constraint clipped away, so
         look-ahead can reach one whose metadata raises a hard error the narrowed
-        resolve never touched.  The probe catches those and returns ``False``
-        rather than letting them abort the resolve; the ``finally`` restores the
-        snapshot either way.
+        resolve never touched (a failed integrity check, or a tie-ranked-wheel
+        divergence).  The probe catches those and returns ``False`` rather than
+        aborting; the crash still fires when the version is pinned for real.  The
+        ``finally`` restores the snapshot either way.
         """
         # Late import: config imports provider at module load.
         from .config import OverrideConflictError  # noqa: PLC0415
@@ -1330,6 +1344,7 @@ class Provider:
             UnsupportedVcsError,
             InvalidUploadTimeError,
             OverrideConflictError,
+            SiblingMetadataDivergenceError,
             NotImplementedError,
         ):
             return False
@@ -1913,6 +1928,7 @@ class Provider:
         self._parse_and_cache_metadata_guarded(
             cache_key, metadata_text, from_sdist=from_sdist
         )
+        self._check_sibling_metadata_divergence(versions, package, version)
 
         self.stats.metadata_fetched += 1
         self.prefetch_new_deps(self.deps_cache[cache_key])
@@ -1978,6 +1994,20 @@ class Provider:
     ) -> tuple[str, bool]:
         """See :func:`nab_python._provider.metadata_resolver.resolve_metadata`."""
         return _metadata_resolver.resolve_metadata(self, versions, package, version)
+
+    def _check_sibling_metadata_divergence(
+        self,
+        versions: list[tuple[Version, DistFile]],
+        package: str,
+        version: Version,
+    ) -> None:
+        """Check the version's tie-ranked wheels for divergent target deps.
+
+        See :func:`._provider.metadata_resolver.check_sibling_metadata_divergence`.
+        """
+        _metadata_resolver.check_sibling_metadata_divergence(
+            self, versions, package, version
+        )
 
     def parse_and_cache_metadata(
         self,

--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -535,6 +535,26 @@ class TagSet:
         wheel_tags = wheel_tag_set(wheel_filename)
         return wheel_tags is not None and not wheel_tags.isdisjoint(self.members)
 
+    def wheel_rank(self, wheel_filename: str) -> tuple[int, tuple[int, str]] | None:
+        """Return the target's install-preference key for a wheel, or None.
+
+        The key is ``(min_rank_index, build_key)``: the index of the most
+        specific tag the target accepts (lowest wins), then the PEP 427
+        build key (an absent tag sorts lowest).  None means the target
+        accepts no tag the wheel carries, or the filename is not a wheel.
+
+        Two wheels the target's own rules cannot order return an equal,
+        non-None key, so an equal, non-None pair is exactly a tie.
+        """
+        wheel_tags = wheel_tag_set(wheel_filename)
+        if not wheel_tags:
+            return None
+        rank = self.rank
+        rank_index = min((rank[t] for t in wheel_tags if t in rank), default=None)
+        if rank_index is None:
+            return None
+        return (rank_index, _build_tag_sort_key(wheel_filename))
+
     def pick(self, wheels: Iterable[WheelFile]) -> WheelFile | None:
         """Pick the most-specific compatible wheel for the target, or None.
 
@@ -544,24 +564,21 @@ class TagSet:
         with the highest PEP 427 build tag wins (an absent tag sorts
         lowest); exact ties keep input order.
         """
-        rank = self.rank
-        best: tuple[int, tuple[int, str], WheelFile] | None = None
+        best_key: tuple[int, tuple[int, str]] | None = None
+        best_wheel: WheelFile | None = None
         for wheel in wheels:
-            wheel_tags = wheel_tag_set(wheel.filename)
-            if not wheel_tags:
+            key = self.wheel_rank(wheel.filename)
+            if key is None:
                 continue
-            # Lowest rank index wins (most-specific tag).
-            wheel_rank = min((rank[t] for t in wheel_tags if t in rank), default=None)
-            if wheel_rank is None:
-                continue
-            build_key = _build_tag_sort_key(wheel.filename)
+            rank_index, build_key = key
             if (
-                best is None
-                or wheel_rank < best[0]
-                or (wheel_rank == best[0] and build_key > best[1])
+                best_key is None
+                or rank_index < best_key[0]
+                or (rank_index == best_key[0] and build_key > best_key[1])
             ):
-                best = (wheel_rank, build_key, wheel)
-        return best[2] if best is not None else None
+                best_key = key
+                best_wheel = wheel
+        return best_wheel
 
     @classmethod
     def for_spec(

--- a/nab-python/tests/test_constraint_probe_hard_error.py
+++ b/nab-python/tests/test_constraint_probe_hard_error.py
@@ -35,6 +35,22 @@ def _wheel(name: str, version: str) -> WheelFile:
     )
 
 
+def _tie_wheel(tag: str) -> WheelFile:
+    filename = f"pkg-1.0-{tag}.whl"
+    return WheelFile(
+        filename=filename,
+        url=f"https://example.com/{filename}",
+        version="1.0",
+        requires_python=None,
+        has_metadata=True,
+        upload_time=None,
+    )
+
+
+def _tie_meta(requires_dist: str) -> str:
+    return f"Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\nRequires-Dist: {requires_dist}\n\n"
+
+
 class TestConstraintProbeContainsHardError:
     def test_excluded_version_hard_error_does_not_abort_resolve(self) -> None:
         """A broken sidecar on a constraint-excluded version stays out of play.
@@ -84,3 +100,28 @@ class TestConstraintProbeContainsHardError:
 
         assert found is False
         assert provider._lookahead_aborted == sentinel
+
+    def test_tie_divergence_on_probed_version_returns_false(self) -> None:
+        """A tie divergence reached only by the probe returns False, not crash.
+
+        The probe re-runs ``choose_version`` to attribute an already-failing
+        resolve.  A version whose tie-ranked wheels declare divergent deps is a
+        hard error like a failed integrity check, so it must stay out of play
+        rather than abort the resolve.  The genuine crash still fires when the
+        version is actually pinned outside a probe.
+        """
+        wheel_a = _tie_wheel("py2.py3-none-any")
+        wheel_b = _tie_wheel("py3-none-any")
+        coordinator = make_coordinator([wheel_a, wheel_b], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _tie_meta("alpha>=1"), wheel_a.metadata_url
+        )
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _tie_meta("beta>=1"), wheel_b.metadata_url
+        )
+        root_reqs = {"pkg": VersionRange.full(admit_arbitrary=False)}
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
+
+        found = provider.has_satisfying_version("pkg", VersionRange.full())
+
+        assert found is False

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -30,6 +30,7 @@ from nab_python._provider.metadata_resolver import (
     cache_deps_from_metadata,
     classify_requirement,
     pick_dist_for_metadata,
+    target_dep_signature,
 )
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._testing.overrides import pkg_override
@@ -58,6 +59,7 @@ from nab_python.provider import (
     MissingExtraError,
     Provider,
     ResolutionStrategy,
+    SiblingMetadataDivergenceError,
     SourceNameMismatchError,
     UnsupportedSdistError,
     UnsupportedVcsError,
@@ -65,7 +67,11 @@ from nab_python.provider import (
     VcsPolicy,
     VcsSource,
 )
-from nab_python.resolve import _build_resolver_inputs, _raise_for_source_python
+from nab_python.resolve import (
+    _build_resolver_inputs,
+    _raise_for_source_python,
+    resolve_with_coordinator,
+)
 from nab_python.tags import PlatformSpec
 from nab_python.target import ResolveTarget
 from nab_resolver.resolver import ResolutionError, Resolver
@@ -77,6 +83,11 @@ V = Version
 # CPython 3.12.0.  Shared because it is frozen and building one walks the
 # host's whole tag set.
 _PY312 = ResolveTarget.for_host_python("3.12.0")
+
+# A declared linux/3.11 target: host-independent tags for the tie tests.
+_LINUX311 = ResolveTarget.for_declared(
+    python_version="3.11", spec=PlatformSpec("linux_x86_64")
+)
 
 
 def make_wheel(
@@ -2074,6 +2085,155 @@ class TestAddClassifiedDep:
         extra_map: dict[str, dict[str, VersionRange]] = {"g": {}}
         add_classified_dep(req, {"g"}, {}, extra_map)
         assert list(extra_map["g"]) == ["bar", "bar[x]", "bar[y]", "bar[z]"]
+
+
+class TestTargetDepSignature:
+    """``target_dep_signature`` projects metadata to a comparable signature."""
+
+    def _provider(self) -> Provider:
+        coordinator = make_coordinator([make_wheel("1.0")], package="pkg")
+        return Provider(coordinator, target=_PY312)
+
+    @staticmethod
+    def _md(
+        requires_dist: list[str],
+        *,
+        provides_extra: tuple[str, ...] = (),
+        requires_python: str | None = None,
+    ) -> WheelMetadata:
+        return WheelMetadata(
+            name="pkg",
+            version=V("1.0"),
+            requires_python=(
+                SpecifierSet(requires_python) if requires_python is not None else None
+            ),
+            requires_dist=[Requirement(r) for r in requires_dist],
+            provides_extra=list(provides_extra),
+        )
+
+    def test_permuted_lines_equal(self) -> None:
+        """Line order does not change the signature."""
+        provider = self._provider()
+        a = self._md(["foo>=1", "bar<2"])
+        b = self._md(["bar<2", "foo>=1"])
+        assert target_dep_signature(provider, a) == target_dep_signature(provider, b)
+
+    def test_specifier_spelling_equal(self) -> None:
+        """Whitespace and specifier spelling normalize equal."""
+        provider = self._provider()
+        a = self._md(["foo>=1,<2"])
+        b = self._md(["foo >= 1, < 2"])
+        assert target_dep_signature(provider, a) == target_dep_signature(provider, b)
+
+    def test_target_equal_marker_equal(self) -> None:
+        """Markers that evaluate the same for the target project equal."""
+        provider = self._provider()
+        a = self._md(['foo; python_version >= "3.0"'])
+        b = self._md(['foo; python_version >= "3.5"'])
+        assert target_dep_signature(provider, a) == target_dep_signature(provider, b)
+
+    def test_genuine_dep_difference_unequal(self) -> None:
+        """A real base-dep range difference is unequal."""
+        provider = self._provider()
+        a = self._md(["foo>=1"])
+        b = self._md(["foo>=2"])
+        assert target_dep_signature(provider, a) != target_dep_signature(provider, b)
+
+    def test_extra_only_difference_unequal(self) -> None:
+        """A difference confined to an extra-gated dep is unequal."""
+        provider = self._provider()
+        a = self._md(['foo; extra == "e"'], provides_extra=("e",))
+        b = self._md(['foo>=2; extra == "e"'], provides_extra=("e",))
+        assert target_dep_signature(provider, a) != target_dep_signature(provider, b)
+
+    def test_url_dep_only_difference_unequal(self) -> None:
+        """A difference confined to a URL dep is unequal."""
+        provider = self._provider()
+        a = self._md(["foo @ https://example.com/a.whl"])
+        b = self._md(["foo @ https://example.com/b.whl"])
+        assert target_dep_signature(provider, a) != target_dep_signature(provider, b)
+
+    def test_requires_python_difference_folds(self) -> None:
+        """A Requires-Python difference alone does not change the signature.
+
+        Requires-Python gates admission, not the dependency edges a lock
+        records, so two wheels with the same deps but different Python floors
+        project equal.
+        """
+        provider = self._provider()
+        a = self._md(["foo"], requires_python=">=3.8")
+        b = self._md(["foo"], requires_python=">=3.9")
+        assert target_dep_signature(provider, a) == target_dep_signature(provider, b)
+
+    def test_marker_dropped_dep_absent(self) -> None:
+        """A dep whose marker fails for the target is not projected."""
+        provider = self._provider()
+        base_deps = target_dep_signature(
+            provider, self._md(['foo; python_version < "3.0"'])
+        )[0]
+        assert base_deps == {}
+
+    def test_duplicate_name_intersected(self) -> None:
+        """A name on two base lines folds to the range intersection."""
+        provider = self._provider()
+        base_deps = target_dep_signature(provider, self._md(["foo>=1", "foo<5"]))[0]
+        assert V("3") in base_deps["foo"]
+        assert V("6") not in base_deps["foo"]
+
+    def test_extra_gated_url_dep_bucketed_by_extra(self) -> None:
+        """An extra-gated URL dep buckets under its extra name."""
+        provider = self._provider()
+        url_buckets = target_dep_signature(
+            provider,
+            self._md(
+                ['foo @ https://example.com/a.whl ; extra == "e"'],
+                provides_extra=("e",),
+            ),
+        )[2]
+        assert "e" in url_buckets
+
+    def test_base_url_dep_bucketed(self) -> None:
+        """A base URL dep buckets under the base key, not an extra."""
+        provider = self._provider()
+        url_buckets = target_dep_signature(
+            provider, self._md(["foo @ https://example.com/a.whl"])
+        )[2]
+        assert list(url_buckets) == [None]
+
+    def test_per_extra_dep_projected(self) -> None:
+        """An extra-gated non-URL dep lands in the per-extra map."""
+        provider = self._provider()
+        extra_map = target_dep_signature(
+            provider, self._md(['foo>=2; extra == "e"'], provides_extra=("e",))
+        )[1]
+        assert V("3") in extra_map["e"]["foo"]
+        assert V("1") not in extra_map["e"]["foo"]
+
+    def test_extra_marker_matches_only_named_extra(self) -> None:
+        """An extra-gated dep lands only under the extras its marker matches."""
+        provider = self._provider()
+        extra_map = target_dep_signature(
+            provider, self._md(['foo; extra == "e"'], provides_extra=("e", "f"))
+        )[1]
+        assert "foo" in extra_map["e"]
+        assert extra_map["f"] == {}
+
+    def test_provides_extra_override_applied(self) -> None:
+        """A provides-extra override reshapes the projection before comparison.
+
+        Two wheels declaring different raw extras project apart on their raw
+        extras, but a provides-extra override normalizes both to the same
+        declared set, so the overridden view they resolve from agrees.
+        """
+        coordinator = make_coordinator([make_wheel("1.0")], package="pkg")
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            package_overrides=(pkg_override("pkg", provides_extra=("e",)),),
+        )
+        a = self._md(['foo; extra == "e"'], provides_extra=("e",))
+        b = self._md(['foo; extra == "e"'], provides_extra=("e", "f"))
+        assert target_dep_signature(provider, a) == target_dep_signature(provider, b)
 
 
 class TestLocalSources:
@@ -8363,3 +8523,521 @@ class TestPrereleaseHostTarget:
         )
         assert provider.python_version == "3.15.0rc1"
         assert [v for v, _ in provider.fetch_versions("foo")] == [V("1.0")]
+
+
+def _sib_wheel(
+    tag: str, *, has_metadata: bool = True, local_path: Path | None = None
+) -> WheelFile:
+    """A pkg 1.0 wheel carrying an explicit tag, one url per filename."""
+    filename = f"pkg-1.0-{tag}.whl"
+    return WheelFile(
+        filename=filename,
+        url=f"https://example.com/{filename}",
+        version="1.0",
+        requires_python=None,
+        has_metadata=has_metadata,
+        upload_time=None,
+        local_path=local_path,
+    )
+
+
+def _sib_meta(*requires_dist: str, provides_extra: tuple[str, ...] = ()) -> str:
+    """A METADATA blob for pkg 1.0 with the given Requires-Dist lines."""
+    head = "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n"
+    extras = "".join(f"Provides-Extra: {name}\n" for name in provides_extra)
+    body = "".join(f"Requires-Dist: {line}\n" for line in requires_dist)
+    return f"{head}{extras}{body}\n"
+
+
+class TestSiblingMetadataDivergence:
+    """A version whose tie-ranked wheels declare different target deps crashes.
+
+    nab reads one wheel's deps per version and treats it as authoritative.
+    Two wheels an installer's own rules cannot rank against each other can
+    still declare different dependencies, so pinning from one silently
+    disagrees with an install of the other.  The check compares only siblings
+    already resident in the shared index and never fetches.
+    """
+
+    _V = V("1.0")
+
+    def test_divergent_tie_siblings_crash(self) -> None:
+        """Two resident tie siblings with different deps crash naming both."""
+        wheel_a = _sib_wheel("py2.py3-none-any")
+        wheel_b = _sib_wheel("py3-none-any")
+        coordinator = make_coordinator([wheel_a, wheel_b], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("common>=1", "alpha>=1"), wheel_a.metadata_url
+        )
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("common>=1", "beta>=1"), wheel_b.metadata_url
+        )
+        provider = Provider(coordinator, target=_LINUX311)
+        with pytest.raises(SiblingMetadataDivergenceError) as exc:
+            provider.get_dependencies("pkg", self._V)
+        message = str(exc.value)
+        assert "pkg-1.0-py2.py3-none-any.whl" in message
+        assert "pkg-1.0-py3-none-any.whl" in message
+        assert "alpha" in message
+        assert "beta" in message
+        # A hard crash, not an invalid-metadata candidate drop.
+        assert ("pkg", self._V) not in provider._invalid_metadata
+
+    def test_check_issues_no_fetch(self) -> None:
+        """The check reads stored text only; it never requests a fetch."""
+        wheel_a = _sib_wheel("py2.py3-none-any")
+        wheel_b = _sib_wheel("py3-none-any")
+        coordinator = make_coordinator([wheel_a, wheel_b], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("alpha>=1"), wheel_a.metadata_url
+        )
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("beta>=1"), wheel_b.metadata_url
+        )
+        provider = Provider(coordinator, target=_LINUX311)
+        with pytest.raises(SiblingMetadataDivergenceError):
+            metadata_resolver.check_sibling_metadata_divergence(
+                provider,
+                [(self._V, wheel_a), (self._V, wheel_b)],
+                "pkg",
+                self._V,
+            )
+        coordinator.request_metadata.assert_not_called()
+        coordinator.request_range_metadata.assert_not_called()
+
+    def test_agreeing_tie_siblings_no_crash(self) -> None:
+        """Reordered, whitespace-different siblings project equal, so no crash.
+
+        Three tie wheels (no tag axis) exercise the pick-signature reuse across
+        more than one resident sibling.
+        """
+        wheel_a = _sib_wheel("py3-none-any")
+        wheel_b = _sib_wheel("py2.py3-none-any")
+        wheel_c = _sib_wheel("cp311-cp311-manylinux_2_17_x86_64")
+        coordinator = make_coordinator([wheel_a, wheel_b, wheel_c], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("common>=1", "alpha>=1"), wheel_a.metadata_url
+        )
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("alpha>=1", "common>=1"), wheel_b.metadata_url
+        )
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("common >= 1", "alpha >= 1"), wheel_c.metadata_url
+        )
+        provider = Provider(coordinator, target=None)
+        deps = provider.get_dependencies("pkg", self._V)
+        assert "alpha" in deps
+        assert "common" in deps
+
+    def test_benign_marker_variation_no_crash(self) -> None:
+        """Markers that both evaluate the same for the target do not diverge."""
+        wheel_a = _sib_wheel("py2.py3-none-any")
+        wheel_b = _sib_wheel("py3-none-any")
+        coordinator = make_coordinator([wheel_a, wheel_b], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg",
+            "1.0",
+            _sib_meta('alpha; python_version >= "3"'),
+            wheel_a.metadata_url,
+        )
+        coordinator.index.store_metadata(
+            "pkg",
+            "1.0",
+            _sib_meta('alpha; python_version >= "2"'),
+            wheel_b.metadata_url,
+        )
+        provider = Provider(coordinator, target=_LINUX311)
+        deps = provider.get_dependencies("pkg", self._V)
+        assert "alpha" in deps
+
+    def test_non_tie_multiwheel_no_crash(self) -> None:
+        """A specific wheel outranks the generic sibling, so divergence is fine."""
+        specific = _sib_wheel("cp311-cp311-manylinux_2_17_x86_64")
+        generic = _sib_wheel("py3-none-any")
+        coordinator = make_coordinator([specific, generic], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("mldep>=1"), specific.metadata_url
+        )
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("gendep>=1"), generic.metadata_url
+        )
+        provider = Provider(coordinator, target=_LINUX311)
+        deps = provider.get_dependencies("pkg", self._V)
+        assert "mldep" in deps
+        assert "gendep" not in deps
+
+    def test_one_wheel_version_returns_early(self) -> None:
+        """A version with a single wheel never reaches the sibling compare."""
+        wheel = _sib_wheel("py3-none-any")
+        coordinator = make_coordinator([wheel], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("alpha>=1"), wheel.metadata_url
+        )
+        provider = Provider(coordinator, target=_LINUX311)
+        deps = provider.get_dependencies("pkg", self._V)
+        assert "alpha" in deps
+
+    def test_sdist_pick_returns_early(self) -> None:
+        """An sdist pick is not a wheel, so the check returns without reading."""
+        provider = Provider(make_coordinator(package="pkg"), target=_LINUX311)
+        metadata_resolver.check_sibling_metadata_divergence(
+            provider, [(self._V, make_sdist("1.0"))], "pkg", self._V
+        )
+
+    def test_local_wheel_pick_returns_early(self) -> None:
+        """A local wheel keeps no index text, so the pick reads as not resident."""
+        local = _sib_wheel(
+            "py3-none-any", has_metadata=False, local_path=Path("/w/pkg.whl")
+        )
+        provider = Provider(make_coordinator([local], package="pkg"), target=_LINUX311)
+        metadata_resolver.check_sibling_metadata_divergence(
+            provider, [(self._V, local)], "pkg", self._V
+        )
+
+    def test_no_tag_axis_divergent_siblings_crash(self) -> None:
+        """With no tag axis every resident sibling wheel is a real ambiguity."""
+        wheel_a = _sib_wheel("cp311-cp311-manylinux_2_17_x86_64")
+        wheel_b = _sib_wheel("cp311-cp311-macosx_11_0_arm64")
+        coordinator = make_coordinator([wheel_a, wheel_b], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("alpha>=1"), wheel_a.metadata_url
+        )
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("beta>=1"), wheel_b.metadata_url
+        )
+        provider = Provider(coordinator, target=None)
+        with pytest.raises(SiblingMetadataDivergenceError) as exc:
+            provider.get_dependencies("pkg", self._V)
+        message = str(exc.value)
+        assert "alpha" in message
+        assert "beta" in message
+
+    def test_absent_sibling_text_skipped(self) -> None:
+        """A tie sibling with no resident text is skipped, not fetched."""
+        wheel_a = _sib_wheel("py2.py3-none-any")
+        wheel_b = _sib_wheel("py3-none-any")
+        coordinator = make_coordinator([wheel_a, wheel_b], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("alpha>=1"), wheel_a.metadata_url
+        )
+        provider = Provider(coordinator, target=_LINUX311)
+        metadata_resolver.check_sibling_metadata_divergence(
+            provider, [(self._V, wheel_a), (self._V, wheel_b)], "pkg", self._V
+        )
+
+    def test_sibling_sdist_origin_skipped(self) -> None:
+        """Sdist PKG-INFO never stands in for a tie sibling wheel's own text."""
+        wheel_a = _sib_wheel("py2.py3-none-any")
+        wheel_b = _sib_wheel("py3-none-any")
+        coordinator = make_coordinator([wheel_a, wheel_b], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("alpha>=1"), wheel_a.metadata_url
+        )
+        coordinator.index.store_metadata("pkg", "1.0", None, wheel_b.metadata_url)
+        coordinator.index.store_sdist_metadata("pkg", "1.0", _sib_meta("sdistdep>=1"))
+        provider = Provider(coordinator, target=_LINUX311)
+        metadata_resolver.check_sibling_metadata_divergence(
+            provider, [(self._V, wheel_a), (self._V, wheel_b)], "pkg", self._V
+        )
+
+    def test_incompatible_tag_sibling_skipped(self) -> None:
+        """A sibling the target cannot install has no rank, so it never ties."""
+        pick = _sib_wheel("py3-none-any")
+        incompatible = _sib_wheel("cp311-cp311-win_amd64")
+        coordinator = make_coordinator([pick, incompatible], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("alpha>=1"), pick.metadata_url
+        )
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("beta>=1"), incompatible.metadata_url
+        )
+        provider = Provider(coordinator, target=_LINUX311)
+        metadata_resolver.check_sibling_metadata_divergence(
+            provider, [(self._V, pick), (self._V, incompatible)], "pkg", self._V
+        )
+
+    def test_python_incompatible_sibling_skipped(self) -> None:
+        """A sibling the target's Python excludes never ties, so no false crash.
+
+        Two pure-python wheels tie on tags, but the py3 sibling's own METADATA
+        Requires-Python excludes the 3.9 target, so an installer would reject
+        it.  Comparing it would crash on a version an installer resolves fine.
+        """
+        target = ResolveTarget.for_declared(
+            python_version="3.9", spec=PlatformSpec("linux_x86_64")
+        )
+        pick = _sib_wheel("py2.py3-none-any")
+        incompatible = _sib_wheel("py3-none-any")
+        coordinator = make_coordinator([pick, incompatible], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg",
+            "1.0",
+            "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n"
+            "Requires-Python: >=3.8\nRequires-Dist: alpha>=1\n\n",
+            pick.metadata_url,
+        )
+        coordinator.index.store_metadata(
+            "pkg",
+            "1.0",
+            "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n"
+            "Requires-Python: >=3.11\nRequires-Dist: alpha>=1\n"
+            "Requires-Dist: beta>=1\n\n",
+            incompatible.metadata_url,
+        )
+        provider = Provider(coordinator, target=target)
+        deps = provider.get_dependencies("pkg", self._V)
+        assert "alpha" in deps
+        assert "beta" not in deps
+
+    def test_agreeing_siblings_record_no_markers(self) -> None:
+        """Projecting tie siblings touches no provider marker state."""
+        wheel_a = _sib_wheel("py2.py3-none-any")
+        wheel_b = _sib_wheel("py3-none-any")
+        coordinator = make_coordinator([wheel_a, wheel_b], package="pkg")
+        md = _sib_meta(
+            'alpha; python_version >= "3"',
+            'gamma; extra == "x"',
+            provides_extra=("x",),
+        )
+        coordinator.index.store_metadata("pkg", "1.0", md, wheel_a.metadata_url)
+        coordinator.index.store_metadata("pkg", "1.0", md, wheel_b.metadata_url)
+        provider = Provider(coordinator, target=_LINUX311)
+        metadata_resolver.check_sibling_metadata_divergence(
+            provider, [(self._V, wheel_a), (self._V, wheel_b)], "pkg", self._V
+        )
+        assert provider.consulted_markers == set()
+        assert provider.marker_base_cache == {}
+        assert provider.marker_text_cache == {}
+        assert provider.marker_extra_cache == {}
+
+    def test_sidecar_vs_range_recovered_sibling_crash(self) -> None:
+        """A sidecar pick and a bare rung-4 sibling are compared as equals."""
+        sidecar = _sib_wheel("py2.py3-none-any")
+        bare = _sib_wheel("py3-none-any", has_metadata=False)
+        coordinator = make_coordinator([sidecar, bare], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("alpha>=1"), sidecar.metadata_url
+        )
+        coordinator.index.store_metadata("pkg", "1.0", _sib_meta("beta>=1"), bare.url)
+        provider = Provider(coordinator, target=_LINUX311)
+        with pytest.raises(SiblingMetadataDivergenceError) as exc:
+            metadata_resolver.check_sibling_metadata_divergence(
+                provider, [(self._V, sidecar), (self._V, bare)], "pkg", self._V
+            )
+        message = str(exc.value)
+        assert "alpha" in message
+        assert "beta" in message
+
+    def test_extra_dep_divergence_crash(self) -> None:
+        """Divergence confined to an extra's deps still crashes."""
+        wheel_a = _sib_wheel("py2.py3-none-any")
+        wheel_b = _sib_wheel("py3-none-any")
+        coordinator = make_coordinator([wheel_a, wheel_b], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg",
+            "1.0",
+            _sib_meta('alpha; extra == "x"', provides_extra=("x",)),
+            wheel_a.metadata_url,
+        )
+        coordinator.index.store_metadata(
+            "pkg",
+            "1.0",
+            _sib_meta('beta; extra == "x"', provides_extra=("x",)),
+            wheel_b.metadata_url,
+        )
+        provider = Provider(coordinator, target=_LINUX311)
+        with pytest.raises(SiblingMetadataDivergenceError) as exc:
+            metadata_resolver.check_sibling_metadata_divergence(
+                provider, [(self._V, wheel_a), (self._V, wheel_b)], "pkg", self._V
+            )
+        assert "extra:x" in str(exc.value)
+
+    def test_url_dep_divergence_crash(self) -> None:
+        """A sibling's direct-URL dep is a divergence, bucketed not refused."""
+        wheel_a = _sib_wheel("py2.py3-none-any")
+        wheel_b = _sib_wheel("py3-none-any")
+        coordinator = make_coordinator([wheel_a, wheel_b], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("dep>=1"), wheel_a.metadata_url
+        )
+        coordinator.index.store_metadata(
+            "pkg",
+            "1.0",
+            _sib_meta("dep @ https://example.com/dep-1.0-py3-none-any.whl"),
+            wheel_b.metadata_url,
+        )
+        provider = Provider(coordinator, target=_LINUX311)
+        with pytest.raises(SiblingMetadataDivergenceError) as exc:
+            metadata_resolver.check_sibling_metadata_divergence(
+                provider, [(self._V, wheel_a), (self._V, wheel_b)], "pkg", self._V
+            )
+        assert "dep" in str(exc.value)
+
+    def test_requires_python_floor_variation_no_crash(self) -> None:
+        """Siblings differing only on the Python floor do not diverge.
+
+        A universal py2.py3 wheel and a py3 wheel routinely ship different
+        Requires-Python floors while imposing the same dependencies.  Both
+        install identically on the target, so the version stays resolvable.
+        """
+        wheel_a = _sib_wheel("py2.py3-none-any")
+        wheel_b = _sib_wheel("py3-none-any")
+        coordinator = make_coordinator([wheel_a, wheel_b], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg",
+            "1.0",
+            "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n"
+            "Requires-Python: >=2.7\nRequires-Dist: common>=1\n\n",
+            wheel_a.metadata_url,
+        )
+        coordinator.index.store_metadata(
+            "pkg",
+            "1.0",
+            "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n"
+            "Requires-Python: >=3.6\nRequires-Dist: common>=1\n\n",
+            wheel_b.metadata_url,
+        )
+        provider = Provider(coordinator, target=_LINUX311)
+        deps = provider.get_dependencies("pkg", self._V)
+        assert "common" in deps
+
+    def test_unparseable_sibling_skipped(self) -> None:
+        """A tie sibling whose own METADATA does not parse is dropped, not raised.
+
+        A malformed sibling is an invalid candidate, so it is skipped like any
+        other; it must not escape as an uncaught parse error, nor stand in as a
+        divergence.
+        """
+        wheel_a = _sib_wheel("py2.py3-none-any")
+        wheel_b = _sib_wheel("py3-none-any")
+        coordinator = make_coordinator([wheel_a, wheel_b], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("alpha>=1"), wheel_a.metadata_url
+        )
+        coordinator.index.store_metadata(
+            "pkg", "1.0", "Metadata-Version: 2.1\nName: pkg\n\n", wheel_b.metadata_url
+        )
+        provider = Provider(coordinator, target=_LINUX311)
+        deps = provider.get_dependencies("pkg", self._V)
+        assert "alpha" in deps
+
+    def test_provides_extra_override_folds_divergence(self) -> None:
+        """A provides-extra override is applied to both siblings before compare.
+
+        Two tie wheels share a base dep but declare different Provides-Extra.
+        Raw, the extra maps differ and the version crashes; an override that
+        normalizes both to the same declared extras reconciles them, matching
+        the overridden view the resolver actually pins from.
+        """
+        wheel_a = _sib_wheel("py2.py3-none-any")
+        wheel_b = _sib_wheel("py3-none-any")
+        coordinator = make_coordinator([wheel_a, wheel_b], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg",
+            "1.0",
+            _sib_meta("alpha>=1", provides_extra=("x",)),
+            wheel_a.metadata_url,
+        )
+        coordinator.index.store_metadata(
+            "pkg",
+            "1.0",
+            _sib_meta("alpha>=1", provides_extra=("y",)),
+            wheel_b.metadata_url,
+        )
+        provider = Provider(
+            coordinator,
+            target=_LINUX311,
+            package_overrides=(pkg_override("pkg", provides_extra=()),),
+        )
+        deps = provider.get_dependencies("pkg", self._V)
+        assert "alpha" in deps
+
+    def test_requires_python_override_admits_sibling(self) -> None:
+        """The sibling admission check uses the effective Requires-Python.
+
+        A sibling whose parsed Requires-Python excludes the target would be
+        skipped, missing its divergence; a Requires-Python override that admits
+        the target puts it back in play, so the divergence crashes.
+        """
+        target = ResolveTarget.for_declared(
+            python_version="3.9", spec=PlatformSpec("linux_x86_64")
+        )
+        pick = _sib_wheel("py2.py3-none-any")
+        sibling = _sib_wheel("py3-none-any")
+        coordinator = make_coordinator([pick, sibling], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg",
+            "1.0",
+            "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n"
+            "Requires-Python: >=3.8\nRequires-Dist: alpha>=1\n\n",
+            pick.metadata_url,
+        )
+        coordinator.index.store_metadata(
+            "pkg",
+            "1.0",
+            "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n"
+            "Requires-Python: >=3.11\nRequires-Dist: alpha>=1\n"
+            "Requires-Dist: beta>=1\n\n",
+            sibling.metadata_url,
+        )
+        provider = Provider(
+            coordinator,
+            target=target,
+            package_overrides=(pkg_override("pkg", requires_python=">=3.8"),),
+        )
+        with pytest.raises(SiblingMetadataDivergenceError) as exc:
+            provider.get_dependencies("pkg", self._V)
+        assert "beta" in str(exc.value)
+
+    def test_resolve_aborts_on_lone_divergent_version(self) -> None:
+        """A full resolve over a diverging version aborts, never silently fails.
+
+        The divergence must not read as a MetadataError candidate drop: that
+        would turn the version into a soft "no versions available" rejection
+        rather than the loud crash the ambiguity demands.
+        """
+        wheel_a = _sib_wheel("py2.py3-none-any")
+        wheel_b = _sib_wheel("py3-none-any")
+        coordinator = make_coordinator([wheel_a, wheel_b], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("alpha>=1"), wheel_a.metadata_url
+        )
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("beta>=1"), wheel_b.metadata_url
+        )
+        with pytest.raises(SiblingMetadataDivergenceError):
+            resolve_with_coordinator(
+                coordinator,
+                [_LINUX311],
+                [Requirement("pkg")],
+                config=NabProjectConfig(build_policy=BuildPolicy.NEVER),
+            )
+
+    def test_resolve_aborts_not_downgrades_past_divergent(self) -> None:
+        """A diverging version aborts rather than silently pinning a clean one."""
+        wheel_a = _sib_wheel("py2.py3-none-any")
+        wheel_b = _sib_wheel("py3-none-any")
+        clean = WheelFile(
+            filename="pkg-0.9-py3-none-any.whl",
+            url="https://example.com/pkg-0.9-py3-none-any.whl",
+            version="0.9",
+            requires_python=None,
+            has_metadata=True,
+            upload_time=None,
+            local_path=None,
+        )
+        coordinator = make_coordinator([wheel_a, wheel_b, clean], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("alpha>=1"), wheel_a.metadata_url
+        )
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("beta>=1"), wheel_b.metadata_url
+        )
+        coordinator.index.store_metadata("pkg", "0.9", _sib_meta(), clean.metadata_url)
+        with pytest.raises(SiblingMetadataDivergenceError):
+            resolve_with_coordinator(
+                coordinator,
+                [_LINUX311],
+                [Requirement("pkg")],
+                config=NabProjectConfig(build_policy=BuildPolicy.NEVER),
+            )

--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -805,6 +805,77 @@ class TestLowestDirectAcrossTargets:
         }
 
 
+class TestMatrixPerTargetWheelDivergence:
+    """A version whose wheels differ per platform resolves per target.
+
+    Each target's tag-filtered listing holds only its own wheel, so the
+    sibling divergence check never fires across the matrix boundary and every
+    target reads the dependencies of the wheel it installs.
+    """
+
+    def _coordinator(self) -> MagicMock:
+        linux_wheel = WheelFile(
+            filename="pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl",
+            url="https://example.com/pkg-1.0-linux.whl",
+            version="1.0",
+            requires_python=None,
+            has_metadata=True,
+            upload_time=None,
+        )
+        win_wheel = WheelFile(
+            filename="pkg-1.0-cp311-cp311-win_amd64.whl",
+            url="https://example.com/pkg-1.0-win.whl",
+            version="1.0",
+            requires_python=None,
+            has_metadata=True,
+            upload_time=None,
+        )
+        coordinator = make_coordinator(
+            listings={
+                "pkg": [linux_wheel, win_wheel],
+                "linuxdep": [_make_wheel("1.0", package="linuxdep")],
+                "windep": [_make_wheel("1.0", package="windep")],
+            },
+            auto_metadata=True,
+        )
+        coordinator.index.store_metadata(
+            "pkg",
+            "1.0",
+            "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\nRequires-Dist: linuxdep\n\n",
+            linux_wheel.metadata_url,
+        )
+        coordinator.index.store_metadata(
+            "pkg",
+            "1.0",
+            "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\nRequires-Dist: windep\n\n",
+            win_wheel.metadata_url,
+        )
+        return coordinator
+
+    def test_each_target_reads_its_own_wheel(self) -> None:
+        targets = Matrix(
+            python="==3.11",
+            platforms=(PlatformSpec("linux_x86_64"), PlatformSpec("windows_amd64")),
+        ).expand()
+        result = resolve_with_coordinator(
+            self._coordinator(), targets, _reqs("pkg"), config=_no_build()
+        )
+        assert result.success
+        pins = {
+            tr.target.platform_spec.platform_id: tr.pins
+            for tr in result.target_results
+            if tr.target.platform_spec is not None
+        }
+        assert pins["linux_x86_64"] == {
+            "pkg": Version("1.0"),
+            "linuxdep": Version("1.0"),
+        }
+        assert pins["windows_amd64"] == {
+            "pkg": Version("1.0"),
+            "windep": Version("1.0"),
+        }
+
+
 _FORTY_SHA = "0123456789abcdef0123456789abcdef01234567"
 
 

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -940,6 +940,52 @@ class TestSelectWheel:
         assert chosen is build5
 
 
+class TestWheelRank:
+    """wheel_rank exposes pick's ordering as a comparable key.
+
+    Two wheels the target's own rules cannot order return an equal,
+    non-None key; a more-specific wheel returns a strictly lower key; a
+    rejected or non-wheel filename returns None.
+    """
+
+    def test_tie_wheels_share_rank(self) -> None:
+        """py2.py3-none-any and py3-none-any tie for a py3 target."""
+        tags = TagSet.for_spec(python_version="3.11", spec=PlatformSpec("linux_x86_64"))
+        both = tags.wheel_rank("pkg-1.0-py2.py3-none-any.whl")
+        py3 = tags.wheel_rank("pkg-1.0-py3-none-any.whl")
+        assert both is not None
+        assert both == py3
+
+    def test_specific_outranks_generic(self) -> None:
+        """A manylinux wheel ranks strictly below the py3-none-any fallback."""
+        tags = TagSet.for_spec(python_version="3.11", spec=PlatformSpec("linux_x86_64"))
+        specific = tags.wheel_rank("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl")
+        generic = tags.wheel_rank("pkg-1.0-py3-none-any.whl")
+        assert specific is not None
+        assert generic is not None
+        assert specific < generic
+
+    def test_rejected_wheel_has_no_rank(self) -> None:
+        """A wheel the target cannot install ranks None."""
+        tags = TagSet.for_spec(python_version="3.11", spec=PlatformSpec("linux_x86_64"))
+        assert tags.wheel_rank("pkg-1.0-cp311-cp311-win_amd64.whl") is None
+
+    def test_non_wheel_has_no_rank(self) -> None:
+        """An unparseable filename ranks None."""
+        tags = TagSet.for_spec(python_version="3.11", spec=PlatformSpec("linux_x86_64"))
+        assert tags.wheel_rank("garbage.whl") is None
+
+    def test_rank_carries_build_key(self) -> None:
+        """Same-tag wheels order by build key, higher build sorting later."""
+        tags = TagSet.for_spec(python_version="3.11", spec=PlatformSpec("linux_x86_64"))
+        untagged = tags.wheel_rank("pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl")
+        build5 = tags.wheel_rank("pkg-1.0-5-cp311-cp311-manylinux_2_17_x86_64.whl")
+        assert untagged is not None
+        assert build5 is not None
+        assert untagged[0] == build5[0]
+        assert untagged[1] < build5[1]
+
+
 class TestUnknownPlatformKindGuard:
     """A platform kind with no tag rule raises rather than tagging as Windows."""
 


### PR DESCRIPTION
nab reads a version's dependency metadata from the single wheel its target ranks most preferred. When two or more wheels tie for that target and the siblings already fetched declare different dependencies, the pick was arbitrary and nab could silently use the wrong metadata. This adds a tie-gated check that compares the resident siblings and aborts rather than guessing which wheel is authoritative.