### PR TITLE
fix stale `Error in [tool.nab]:` prefix in the conflicts doc

### DIFF
--- a/docs/explanation/conflicts.md
+++ b/docs/explanation/conflicts.md
@@ -97,9 +97,7 @@ is refused before any network work:
 
 ```console
 $ nab lock --extras all
-Error in [tool.nab]: extra 'cpu', extra 'gpu' cannot be selected
-together: declared mutually exclusive (at-most-one) in
-[tool.nab].conflicts
+error: in [tool.nab]: extra 'cpu', extra 'gpu' cannot be selected together: declared mutually exclusive (at-most-one) in [tool.nab].conflicts
 ```
 
 This happens when an umbrella extra self-references both members

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -100,7 +100,7 @@ A template that maps two tuples onto one path is rejected, naming the
 variable that would separate them.
 
 Exits non-zero on resolution failure; the message starts with
-`Resolution failed:` followed by a derivation tree, and any
+`error: resolution failed:` followed by a derivation tree, and any
 captured diagnostics are appended under a `Diagnostics:` section.
 
 Universal mode (`[tool.nab].mode = "universal"`) is supported for

--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -1161,7 +1161,7 @@ def reject_user_keys_in_pyproject(raw: Mapping[str, Any]) -> None:
     does not own are left for the pyproject parser to handle.
 
     The message carries no ``[tool.nab]:`` prefix: the only caller is the
-    pyproject parser, whose ``Error in [tool.nab]:`` wrapper already
+    pyproject parser, whose ``error: in [tool.nab]:`` wrapper already
     supplies it, so prefixing here would double it.
     """
     for key in raw:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -222,7 +222,7 @@ class TestTopLevelKeys:
     def test_invalid_toml_rejected(self, tmp_path: Path) -> None:
         # A TOML syntax error (here a duplicated table) is reported as a
         # ConfigError, not a raw TOMLDecodeError, so the CLI renders it
-        # under "Error in [tool.nab]" like every other config problem.
+        # under "error: in [tool.nab]" like every other config problem.
         path = write(
             tmp_path,
             '[tool.nab.packages.foo]\nindex = "a"\n'

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -391,7 +391,7 @@ def _layered_run_settings_or_exit(
     """Fold the layered run settings, exiting on a category error.
 
     Wraps :func:`_layered_run_settings` with the single
-    ``SourceConfigError`` -> ``Config error: ...`` -> ``exit(1)`` mapping
+    ``SourceConfigError`` -> ``error: config error: ...`` -> ``exit(1)`` mapping
     shared by ``nab lock`` and ``nab download``.  On success it also emits
     the reproducibility notice when a PROJECT option was set on the CLI,
     so a result-shaping override is never silent.  ``produces_lock`` picks

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2681,6 +2681,44 @@ class TestConfigErrors:
         assert "workspace discovery error" in capsys.readouterr().err
 
 
+_CONFLICTS_DOC = (
+    Path(__file__).resolve().parents[1] / "docs" / "explanation" / "conflicts.md"
+)
+
+
+def _console_block(text: str) -> list[str]:
+    lines = text.splitlines()
+    start = lines.index("```console")
+    return lines[start + 1 : lines.index("```", start + 1)]
+
+
+class TestConflictsDocTranscript:
+    """The conflicts page quotes the refusal line the CLI prints."""
+
+    _UMBRELLA = (
+        '[project]\nname = "proj"\nversion = "0.1.0"\ndependencies = []\n'
+        "[project.optional-dependencies]\n"
+        "cpu = []\n"
+        "gpu = []\n"
+        'all = ["proj[cpu]", "proj[gpu]"]\n'
+        "[tool.nab]\n"
+        'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+    )
+
+    def test_umbrella_refusal_matches_documented_transcript(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An umbrella extra reaching both members prints the page's line."""
+        pyproject = _make_pyproject(tmp_path, self._UMBRELLA)
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, cache_dir=tmp_path / "cache", extras=("all",))
+        printed = capsys.readouterr().err.strip()
+
+        block = _console_block(_CONFLICTS_DOC.read_text(encoding="utf-8"))
+        assert block[0] == "$ nab lock --extras all"
+        assert printed in block[1:]
+
+
 class TestDetermineLockAnchor:
     """``_determine_lock_anchor`` chooses between fresh and reused anchors."""
 


### PR DESCRIPTION
The console transcript on the conflicts page still quotes `Error in [tool.nab]: ...`, wrapped over three lines. nab prints `error: in [tool.nab]: ...` on one line since the unified CLI output policy landed, so the example does not match what a reader gets. The CLI reference has the same problem with `Resolution failed:`, and two docstrings quote the old wrappers.

Replaces the transcript with the line the CLI prints, and adds a test that triggers the umbrella-extra refusal and checks its output against that console block.
