### PR TITLE
fix duplicate dist-info left by the build env's second install

### DIFF
--- a/nab-python/src/nab_python/_build/env.py
+++ b/nab-python/src/nab_python/_build/env.py
@@ -29,6 +29,8 @@ import subprocess
 import sys
 import tempfile
 import venv
+from contextlib import suppress
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -43,7 +45,7 @@ from ..download import DownloadError, download_lock
 from ..requirements_file import InvalidProjectRequirementError
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable, Iterable, Mapping
     from typing_extensions import Self
 
     from installer.records import RecordEntry
@@ -55,6 +57,7 @@ __all__ = [
 ]
 
 
+@dataclass
 class _FastSchemeDictionaryDestination(SchemeDictionaryDestination):
     """``SchemeDictionaryDestination`` that skips bytecode-compile work.
 
@@ -64,12 +67,34 @@ class _FastSchemeDictionaryDestination(SchemeDictionaryDestination):
     still hits the filesystem twice per record.  Skipping the early
     work when the levels tuple is empty is safe because the body
     would have been a no-op.
+
+    ``written`` records ``(scheme root, path within it)`` for every
+    file the install writes, so a later install can remove them.
     """
+
+    written: list[tuple[Path, Path]] = field(
+        default_factory=list, init=False, repr=False
+    )
 
     def _compile_bytecode(self, scheme: Scheme, record: RecordEntry) -> None:
         if not self.bytecode_optimization_levels:
             return
         super()._compile_bytecode(scheme, record)
+
+    def finalize_installation(
+        self,
+        scheme: Scheme,
+        record_file_path: str,
+        records: Iterable[tuple[Scheme, RecordEntry]],
+    ) -> None:
+        # ``records`` is consumed once, so materialize it before passing it on.
+        entries = list(records)
+        self.written = [
+            (Path(self.scheme_dict[entry_scheme]), Path(entry.path))
+            for entry_scheme, entry in entries
+        ]
+
+        super().finalize_installation(scheme, record_file_path, entries)
 
 
 logger = logging.getLogger(__name__)
@@ -142,6 +167,7 @@ class NabBuildEnv:
         self._venv_path: Path | None = None
         self._python_executable: Path | None = None
         self._scripts_dir: Path | None = None
+        self._installed_files: list[tuple[Path, Path]] = []
 
     def __enter__(self) -> Self:
         """Build the venv, run the inner resolve, install build requirements."""
@@ -183,12 +209,22 @@ class NabBuildEnv:
     def _install_wheels(
         self, wheel_paths: list[Path], scheme_paths: dict[str, str]
     ) -> None:
-        """Write each wheel into the venv with ``installer``.
+        """Remove what this env installed before, then install ``wheel_paths``.
+
+        Each resolve produces a whole environment, so the previous
+        install comes out rather than being written over: two
+        ``.dist-info`` directories for one distribution leave the
+        version ``importlib.metadata`` reports up to listing order.
+        The removals all run before the first write, since two
+        distributions can ship the same path within a scheme.
 
         A downloaded build dependency can be corrupt or malformed, so
         opening or installing it surfaces as :class:`BuildEnvError`
         rather than a raw zip or installer error.
         """
+        _remove_files(self._installed_files)
+        self._installed_files = []
+
         for wheel_path in wheel_paths:
             logger.debug("installing %s", wheel_path.name)
             try:
@@ -207,6 +243,7 @@ class NabBuildEnv:
                         destination=destination,
                         additional_metadata={"INSTALLER": b"nab\n"},
                     )
+                    self._installed_files.extend(destination.written)
             except Exception as exc:
                 msg = f"could not install build dependency {wheel_path.name}: {exc}"
                 raise BuildEnvError(msg) from exc
@@ -249,8 +286,10 @@ class NabBuildEnv:
 
         Used for ``get_requires_for_build_wheel`` follow-up requests
         (the backend asks for additional deps after the env is
-        already up).  Same code path as the constructor's install,
-        targeting the same venv.
+        already up).  The inner resolve runs over ``requires`` and
+        ``requirements`` together, so its result is the whole build
+        env rather than an addition to it: it can pin a different
+        version of something already installed, or drop it.
         """
         if self._venv_path is None or self._python_executable is None:
             msg = "NabBuildEnv used outside its context-manager scope"
@@ -362,6 +401,42 @@ class NabBuildEnv:
         # the temp dir, cleaned up with the env.
         all_paths = list(download_result.written) + list(download_result.skipped)
         return [p for p in all_paths if p.suffix == ".whl"]
+
+
+def _remove_files(entries: list[tuple[Path, Path]]) -> None:
+    """Delete installed files and their bytecode, and directories left empty.
+
+    ``entries`` are ``(scheme root, path within it)`` pairs.  The
+    scheme roots stay, as does any directory still holding something
+    the install did not write.
+
+    Cached bytecode goes with its source file: the backend has already
+    run in this venv, so a removed package has usually been imported,
+    and the ``__pycache__`` that import wrote would keep its directory
+    importable as a namespace package.
+    """
+    directories: set[Path] = set()
+    roots: set[Path] = set()
+
+    for root, relative in entries:
+        target = root / relative
+        target.unlink(missing_ok=True)
+
+        if target.suffix == ".py":
+            cache = target.parent / "__pycache__"
+            for compiled in cache.glob(f"{target.stem}.*.pyc"):
+                compiled.unlink()
+            directories.add(cache)
+
+        roots.add(root)
+        directories.update(root / parent for parent in relative.parents)
+
+    # Deepest first, so a parent is tried after the children that emptied it.
+    for directory in sorted(
+        directories - roots, key=lambda path: len(path.parts), reverse=True
+    ):
+        with suppress(OSError):
+            directory.rmdir()
 
 
 def _venv_python(venv_path: Path) -> Path:

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -21,6 +21,7 @@ import subprocess
 import sys
 import tarfile
 import zipfile
+from importlib.util import cache_from_source
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -126,11 +127,13 @@ def _make_installable_wheel(
     name: str,
     version: str,
     data_files: dict[str, bytes] | None = None,
+    package_files: dict[str, bytes] | None = None,
 ) -> None:
     """Write a minimal but installer-valid pure-Python wheel.
 
     ``data_files`` are placed under the PEP 427 ``<dist>.data``
     directory, keyed by their path within it (``headers/foo.h``).
+    ``package_files`` are placed inside the ``<name>/`` package.
     """
     dist = f"{name}-{version}"
     files = {
@@ -143,6 +146,8 @@ def _make_installable_wheel(
             b"Root-Is-Purelib: true\nTag: py3-none-any\n"
         ),
     }
+    for module, data in (package_files or {}).items():
+        files[f"{name}/{module}"] = data
     for data_path, data in (data_files or {}).items():
         files[f"{dist}.data/{data_path}"] = data
     record = "".join(
@@ -1434,6 +1439,125 @@ class TestBuildEnvHeaderScheme:
         assert header.read_bytes() == b"#define GREENLET_H\n"
         site = venv_path / "lib" / f"python{py_version}" / "site-packages"
         assert (site / "greenlet" / "__init__.py").is_file()
+
+
+class TestBuildEnvFollowUpInstall:
+    """A follow-up ``install`` leaves the venv holding what its resolve pinned.
+
+    The second resolve covers the whole build env, so it can pin a
+    different version of a package the first phase installed, or stop
+    needing it at all.
+    """
+
+    def _env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> tuple[NabBuildEnv, dict[str, str], Path]:
+        from nab_python._build import env as env_mod
+
+        env = NabBuildEnv(requires=["probefoo"], config=NabProjectConfig())
+        venv_path = tmp_path / "venv"
+        venv_path.mkdir()
+        (tmp_path / "wheels").mkdir()
+        env._venv_path = venv_path  # type: ignore[attr-defined]
+        env._python_executable = venv_path / "bin" / "python"  # type: ignore[attr-defined]
+        site = venv_path / "site-packages"
+        scheme = {
+            "purelib": str(site),
+            "platlib": str(site),
+            "scripts": str(venv_path / "bin"),
+            "data": str(venv_path),
+            "headers": str(venv_path / "include"),
+        }
+        monkeypatch.setattr(env_mod, "_venv_scheme_paths", lambda _python: scheme)
+        return env, scheme, site
+
+    def test_lower_pin_replaces_the_installed_version(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        env, scheme, site = self._env(tmp_path, monkeypatch)
+
+        first = tmp_path / "probefoo-2.0-py3-none-any.whl"
+        _make_installable_wheel(
+            first, "probefoo", "2.0", package_files={"only_in_v2.py": b"VALUE = 2\n"}
+        )
+        env._install_wheels([first], scheme)
+        assert (site / "probefoo" / "only_in_v2.py").is_file()
+
+        second = tmp_path / "probefoo-1.0-py3-none-any.whl"
+        _make_installable_wheel(second, "probefoo", "1.0")
+        monkeypatch.setattr(env, "_resolve_and_download", lambda *_a, **_k: [second])
+
+        env.install(["probefoo<2"])
+
+        assert sorted(p.name for p in site.iterdir()) == [
+            "probefoo",
+            "probefoo-1.0.dist-info",
+        ]
+        assert sorted(p.name for p in (site / "probefoo").iterdir()) == ["__init__.py"]
+
+    def test_package_dropped_by_the_new_resolve_is_removed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        env, scheme, site = self._env(tmp_path, monkeypatch)
+
+        kept = tmp_path / "probefoo-1.0-py3-none-any.whl"
+        _make_installable_wheel(kept, "probefoo", "1.0")
+        dropped = tmp_path / "probebar-1.0-py3-none-any.whl"
+        _make_installable_wheel(dropped, "probebar", "1.0")
+        env._install_wheels([kept, dropped], scheme)
+        assert (site / "probebar" / "__init__.py").is_file()
+
+        monkeypatch.setattr(env, "_resolve_and_download", lambda *_a, **_k: [kept])
+
+        env.install(["probefoo<2"])
+
+        assert sorted(p.name for p in site.iterdir()) == [
+            "probefoo",
+            "probefoo-1.0.dist-info",
+        ]
+
+    def test_dropped_package_does_not_take_a_shared_data_file_with_it(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two distributions can ship the same path within a scheme."""
+        env, scheme, _site = self._env(tmp_path, monkeypatch)
+        shared = "data/share/probe.txt"
+
+        dropped = tmp_path / "probeold-1.0-py3-none-any.whl"
+        _make_installable_wheel(
+            dropped, "probeold", "1.0", data_files={shared: b"old\n"}
+        )
+        env._install_wheels([dropped], scheme)
+
+        added = tmp_path / "probenew-1.0-py3-none-any.whl"
+        _make_installable_wheel(added, "probenew", "1.0", data_files={shared: b"new\n"})
+        monkeypatch.setattr(env, "_resolve_and_download", lambda *_a, **_k: [added])
+
+        env.install(["probenew"])
+
+        assert (Path(scheme["data"]) / "share" / "probe.txt").read_bytes() == b"new\n"
+
+    def test_bytecode_of_a_dropped_package_goes_with_it(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A leftover ``__pycache__`` would keep the package importable."""
+        env, scheme, site = self._env(tmp_path, monkeypatch)
+
+        kept = tmp_path / "probefoo-1.0-py3-none-any.whl"
+        _make_installable_wheel(kept, "probefoo", "1.0")
+        dropped = tmp_path / "probebar-1.0-py3-none-any.whl"
+        _make_installable_wheel(dropped, "probebar", "1.0")
+        env._install_wheels([kept, dropped], scheme)
+
+        compiled = Path(cache_from_source(str(site / "probebar" / "__init__.py")))
+        compiled.parent.mkdir()
+        compiled.write_bytes(b"")
+
+        monkeypatch.setattr(env, "_resolve_and_download", lambda *_a, **_k: [kept])
+
+        env.install(["probefoo<2"])
+
+        assert not (site / "probebar").exists()
 
 
 class TestVenvSchemeProbeErrors:


### PR DESCRIPTION
`install()` handles the extra requirements a backend asks for from `get_requires_for_build_wheel`. It re-resolves `[build-system].requires` together with those requirements, so the result describes the whole build env rather than an addition to it, and it can pin a lower version of something the first phase already installed. `installer` writes the new wheel over the old one and leaves the old files in place, so site-packages ends up with two `.dist-info` directories for one distribution and `importlib.metadata` reports whichever comes first in the directory listing. A backend that asks for a version below what is already installed can go on seeing the version it just ruled out.

The env now records the files each install writes and removes them before the next install writes anything, bytecode included, so a package the new resolve dropped does not stay importable as a namespace package. Removal runs ahead of the first write because two distributions can ship the same path within a scheme.
