### PR TITLE
log wheels omitted from a lock by target tags

### DIFF
--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -9,6 +9,7 @@ be read directly without a second fetch.  This module also owns the
 
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
@@ -43,6 +44,9 @@ if TYPE_CHECKING:
     )
     from ..provider import ArchiveSource, DistPolicy, LocalSource, VcsSource
     from ..target import ResolveTarget
+
+
+logger = logging.getLogger(__name__)
 
 
 __all__ = [
@@ -124,6 +128,10 @@ class LockInputProvider(Protocol):
         self, canonical_name: str, version: Version, /
     ) -> str | None:
         """Return the ``requires-python`` override for ``canonical_name==version``."""
+        ...
+
+    def tag_excluded_wheel_count(self, canonical_name: str, version: Version, /) -> int:
+        """Return how many wheels the tag filter dropped at ``version``."""
         ...
 
 
@@ -288,6 +296,14 @@ def build_target_lock(
     lock_pins: dict[str, PinShape] = {}
     for raw_name, version in pins.items():
         canonical = canonicalize_name(raw_name)
+        pruned = provider.tag_excluded_wheel_count(canonical, version)
+        if pruned:
+            logger.debug(
+                "%s==%s: %d wheel(s) omitted from lock by target tags",
+                canonical,
+                version,
+                pruned,
+            )
         local_source = provider.local_source_for(canonical)
         if local_source is not None:
             lock_pins[canonical] = LocalPin(

--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -424,7 +424,7 @@ def _apply_wheel_tags(
     result: list[tuple[Version, DistFile]] = []
     tag_rejected_versions: set[Version] = set()
     for version, dist in base:
-        if excluded_by_wheel_tags(provider, normalized, dist, tags):
+        if excluded_by_wheel_tags(provider, normalized, version, dist, tags):
             tag_rejected_versions.add(version)
             continue
         result.append((version, dist))
@@ -459,19 +459,28 @@ def _excluded_by_python_or_time(
 
 
 def excluded_by_wheel_tags(
-    provider: Provider, normalized: str, dist: DistFile, tags: TagSet
+    provider: Provider,
+    normalized: str,
+    version: Version,
+    dist: DistFile,
+    tags: TagSet,
 ) -> bool:
     """Return True when ``dist`` is a wheel the target cannot install.
 
     An sdist is never excluded here: it carries no tags, and building it
     produces a wheel for whatever machine runs the build.  Tallied per
-    package so a package left with no candidate can say why.
+    package (so a no-candidate package can say why) and per
+    ``(package, version)``.
     """
     if not isinstance(dist, WheelFile) or tags.accepts(dist.filename):
         return False
     provider.stats.excluded_by_wheel_tags += 1
     provider.tag_excluded_wheels[normalized] = (
         provider.tag_excluded_wheels.get(normalized, 0) + 1
+    )
+    key = (normalized, version)
+    provider.tag_excluded_wheels_by_version[key] = (
+        provider.tag_excluded_wheels_by_version.get(key, 0) + 1
     )
     return True
 

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -641,6 +641,10 @@ class Provider:
         # than blame requires-python or the cutoff.
         self.tag_excluded_wheels: dict[str, int] = {}
 
+        # The same drops keyed by (canonical name, version), for the lock's
+        # per-package omitted count.  Bumped alongside tag_excluded_wheels.
+        self.tag_excluded_wheels_by_version: dict[tuple[str, Version], int] = {}
+
         # Canonical names whose listing lost a file to requires-python,
         # dist-policy, or the upload cutoff before the tag pass ran.  A
         # tag-rejected wheel on some other version must not then claim the
@@ -2083,3 +2087,8 @@ class Provider:
         normalized = canonicalize_name(canonical_name)
         listing = self.versions_cache.get(normalized, [])
         return [dist for v, dist in listing if v == version]
+
+    def tag_excluded_wheel_count(self, canonical_name: str, version: Version) -> int:
+        """Return how many wheels the tag filter dropped at ``version`` (0 if none)."""
+        normalized = canonicalize_name(canonical_name)
+        return self.tag_excluded_wheels_by_version.get((normalized, version), 0)

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import random
 import re
 import sys
 from collections.abc import Callable, Mapping, Sequence
@@ -82,7 +83,12 @@ from nab_python.provider import (
     VcsPolicy,
     VcsSource,
 )
-from nab_python.resolve import ResolveResult, TargetResult, build_lock_input
+from nab_python.resolve import (
+    ResolveResult,
+    TargetResult,
+    build_lock_input,
+    resolve_with_coordinator,
+)
 from nab_python.tags import PlatformSpec
 from nab_python.target import ResolveTarget
 
@@ -4494,3 +4500,201 @@ class TestMembershipGates:
             ' or (python_version == "3.11" and sys_platform == "linux"'
             ' and platform_machine == "x86_64")'
         )
+
+
+# Wheel tags spanning OS and arch, python levels, abi3, a free-threaded
+# build, several manylinux glibc levels, and musllinux.  A pure-python wheel
+# leads so the version survives on every declared target.
+_WHEEL_TAG_CATALOG = (
+    "py3-none-any",
+    "py2.py3-none-any",
+    "cp310-cp310-manylinux_2_17_x86_64",
+    "cp311-cp311-manylinux_2_17_x86_64",
+    "cp311-cp311-manylinux_2_28_x86_64",
+    "cp311-cp311-manylinux_2_34_x86_64",
+    "cp312-cp312-manylinux_2_17_x86_64",
+    "cp311-cp311-musllinux_1_2_x86_64",
+    "cp311-cp311-manylinux_2_17_aarch64",
+    "cp311-abi3-manylinux_2_17_x86_64",
+    "cp39-abi3-manylinux_2_17_x86_64",
+    "cp313-cp313t-manylinux_2_17_x86_64",
+    "cp311-cp311-macosx_11_0_arm64",
+    "cp311-cp311-macosx_14_0_arm64",
+    "cp39-abi3-macosx_11_0_arm64",
+    "cp311-cp311-macosx_10_9_x86_64",
+    "cp311-cp311-win_amd64",
+)
+
+
+def _tag_wheel(tag: str, version: str = "1.0", package: str = "pkg") -> WheelFile:
+    """An index-listing wheel carrying an explicit tag, with a hash for the lock."""
+    filename = f"{package}-{version}-{tag}.whl"
+    return WheelFile(
+        filename=filename,
+        url=f"https://example.com/{filename}",
+        version=version,
+        requires_python=None,
+        has_metadata=True,
+        upload_time=None,
+        hashes=(("sha256", "a" * 64),),
+    )
+
+
+def _tag_sdist(version: str = "1.0", package: str = "pkg") -> SdistFile:
+    filename = f"{package}-{version}.tar.gz"
+    return SdistFile(
+        filename=filename,
+        url=f"https://example.com/{filename}",
+        version=version,
+        requires_python=None,
+        upload_time=None,
+        hashes=(("sha256", "b" * 64),),
+    )
+
+
+_PRUNE_LINUX = ResolveTarget.for_declared(
+    python_version="3.11", spec=PlatformSpec("linux_x86_64")
+)
+_PRUNE_MACOS = ResolveTarget.for_declared(
+    python_version="3.11", spec=PlatformSpec("macos_arm64")
+)
+
+
+def _pkg_entry(pylock: object) -> object:
+    """The single ``pkg`` package entry of a built pylock."""
+    entries = [p for p in pylock.packages if str(p.name) == "pkg"]  # type: ignore[attr-defined]
+    assert len(entries) == 1
+    return entries[0]
+
+
+def _emitted_wheel_names(pkg_entry: object) -> set[str]:
+    return {w.name for w in (pkg_entry.wheels or [])}  # type: ignore[attr-defined]
+
+
+class TestLockWheelPrunePredicate:
+    """The lock keeps a wheel iff a contributing faithful target accepts it."""
+
+    def _resolve_matrix(
+        self, tags: Sequence[str], targets: Sequence[ResolveTarget]
+    ) -> ResolveResult:
+        coordinator = make_coordinator(
+            listings={"pkg": [_tag_wheel(t) for t in tags]}, auto_metadata=True
+        )
+        return resolve_with_coordinator(
+            coordinator,
+            list(targets),
+            [Requirement("pkg")],
+            config=NabProjectConfig(build_policy=BuildPolicy.NEVER),
+        )
+
+    def test_property_union_over_seeded_subsets(self) -> None:
+        """Over seeded random subsets the union is exactly the accepted wheels."""
+        targets = (_PRUNE_LINUX, _PRUNE_MACOS)
+        rng = random.Random(20260722)  # noqa: S311
+        for _ in range(40):
+            present = [t for t in _WHEEL_TAG_CATALOG[1:] if rng.random() < 0.5]
+            # Keep the pure-python wheel so every target holds the version.
+            tags = ["py3-none-any", *present]
+            filenames = [f"pkg-1.0-{t}.whl" for t in tags]
+
+            result = self._resolve_matrix(tags, targets)
+            assert result.success
+
+            accepted_by_some = {
+                fn for fn in filenames if any(t.tags.accepts(fn) for t in targets)
+            }
+            rejected_by_all = {
+                fn
+                for fn in filenames
+                if all(t.tags_faithful and not t.tags.accepts(fn) for t in targets)
+            }
+
+            emitted = _emitted_wheel_names(
+                _pkg_entry(build_pylock(build_lock_input(result)))
+            )
+            assert emitted == accepted_by_some
+            assert emitted.isdisjoint(rejected_by_all)
+
+            # Each target's own pin carries exactly the wheels it accepts.
+            for tr in result.target_results:
+                assert tr.lock is not None
+                pin = tr.lock.pins["pkg"]
+                assert isinstance(pin, IndexPin)
+                pin_names = {w.filename for w in pin.wheels}
+                assert pin_names == {
+                    fn for fn in filenames if tr.target.tags.accepts(fn)
+                }
+
+    def test_union_keeps_both_families_and_drops_windows(self) -> None:
+        """A linux+macos union keeps both platforms and drops the never-declared one."""
+        result = self._resolve_matrix(
+            [
+                "py3-none-any",
+                "cp311-cp311-manylinux_2_17_x86_64",
+                "cp311-cp311-macosx_11_0_arm64",
+                "cp311-cp311-win_amd64",
+            ],
+            (_PRUNE_LINUX, _PRUNE_MACOS),
+        )
+        assert result.success
+        emitted = _emitted_wheel_names(
+            _pkg_entry(build_pylock(build_lock_input(result)))
+        )
+        assert emitted == {
+            "pkg-1.0-py3-none-any.whl",
+            "pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl",
+            "pkg-1.0-cp311-cp311-macosx_11_0_arm64.whl",
+        }
+
+    def test_non_faithful_overlay_keeps_every_wheel(self) -> None:
+        """An overlay moves the markers off the tag axis, so no wheel is pruned."""
+        overlay = _PRUNE_LINUX.with_marker_overrides({"sys_platform": "win32"})
+        assert not overlay.tags_faithful
+        result = self._resolve_matrix(
+            [
+                "cp311-cp311-manylinux_2_17_x86_64",
+                "cp311-cp311-macosx_11_0_arm64",
+                "cp311-cp311-win_amd64",
+            ],
+            (overlay,),
+        )
+        assert result.success
+        lock = result.target_results[0].lock
+        assert lock is not None
+        pin = lock.pins["pkg"]
+        assert isinstance(pin, IndexPin)
+        assert {w.filename for w in pin.wheels} == {
+            "pkg-1.0-cp311-cp311-manylinux_2_17_x86_64.whl",
+            "pkg-1.0-cp311-cp311-macosx_11_0_arm64.whl",
+            "pkg-1.0-cp311-cp311-win_amd64.whl",
+        }
+
+    def test_no_compatible_wheel_and_no_sdist_fails_loudly(self) -> None:
+        """A version pruned to nothing fails via the existing no-candidate error."""
+        result = self._resolve_matrix(["cp311-cp311-win_amd64"], (_PRUNE_LINUX,))
+        assert not result.success
+        error = result.target_results[0].error
+        assert error is not None
+        assert "none of the wheel's tags are compatible" in str(error)
+
+    def test_sdist_survives_when_every_wheel_is_pruned(self) -> None:
+        """The same pruned version keeps its sdist and pins the sdist alone."""
+        coordinator = make_coordinator(
+            listings={"pkg": [_tag_wheel("cp311-cp311-win_amd64"), _tag_sdist()]},
+            auto_metadata=True,
+            sdist_pkg_info="Metadata-Version: 2.4\nName: pkg\nVersion: 1.0\n\n",
+        )
+        result = resolve_with_coordinator(
+            coordinator,
+            [_PRUNE_LINUX],
+            [Requirement("pkg")],
+            config=NabProjectConfig(build_policy=BuildPolicy.NEVER),
+        )
+        assert result.success
+        lock = result.target_results[0].lock
+        assert lock is not None
+        pin = lock.pins["pkg"]
+        assert isinstance(pin, IndexPin)
+        assert pin.wheels == ()
+        assert pin.sdist is not None
+        assert pin.sdist.filename == "pkg-1.0.tar.gz"

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import random
 import re
 import sys
@@ -2443,6 +2444,7 @@ class _FakeProvider:
         extra_deps_map: (
             dict[tuple[str, Version], dict[str, dict[str, object]]] | None
         ) = None,
+        tag_excluded_counts: dict[tuple[str, Version], int] | None = None,
     ) -> None:
         self._listings = listings or {}
         self._local = local_sources or {}
@@ -2454,6 +2456,7 @@ class _FakeProvider:
         self.coordinator = _FakeCoordinator(listing_indexes)
         self.deps_cache = deps_cache or {}
         self.extra_deps_map = extra_deps_map or {}
+        self._tag_excluded_counts = tag_excluded_counts or {}
 
     def local_source_for(self, canonical: str) -> LocalSource | None:
         return self._local.get(canonical)
@@ -2479,6 +2482,9 @@ class _FakeProvider:
 
     def effective_requires_python(self, canonical: str, version: Version) -> str | None:
         return self._requires_python_overrides.get(canonical)
+
+    def tag_excluded_wheel_count(self, canonical: str, version: Version) -> int:
+        return self._tag_excluded_counts.get((canonical, version), 0)
 
 
 def _wheel_file(
@@ -4698,3 +4704,64 @@ class TestLockWheelPrunePredicate:
         assert pin.wheels == ()
         assert pin.sdist is not None
         assert pin.sdist.filename == "pkg-1.0.tar.gz"
+
+
+_BUILDER_LOGGER = "nab_python._lockfile.builder"
+
+
+class TestLockPruneObservability:
+    """The builder reports, per pinned package, how many wheels it omitted."""
+
+    def test_debug_line_only_for_a_pruning_package(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A real resolve logs one line for the pruned package, none for the clean one."""
+        coordinator = make_coordinator(
+            listings={
+                "pruner": [
+                    _tag_wheel("py3-none-any", package="pruner"),
+                    _tag_wheel("cp311-cp311-win_amd64", package="pruner"),
+                ],
+                "clean": [_tag_wheel("py3-none-any", package="clean")],
+            },
+            auto_metadata=True,
+        )
+        with caplog.at_level(logging.DEBUG, logger=_BUILDER_LOGGER):
+            result = resolve_with_coordinator(
+                coordinator,
+                [_PRUNE_LINUX],
+                [Requirement("pruner"), Requirement("clean")],
+                config=NabProjectConfig(build_policy=BuildPolicy.NEVER),
+            )
+        assert result.success
+        messages = [r.getMessage() for r in caplog.records if r.name == _BUILDER_LOGGER]
+        pruner_lines = [m for m in messages if "pruner" in m]
+        assert len(pruner_lines) == 1
+        assert "1" in pruner_lines[0]
+        assert not [m for m in messages if "clean" in m]
+
+    def test_builder_reads_the_provider_count(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The line reflects the provider's ``tag_excluded_wheel_count`` reading."""
+        provider = _FakeProvider(
+            listings={"foo": [(Version("1.0"), _wheel_file())]},
+            tag_excluded_counts={("foo", Version("1.0")): 3},
+        )
+        with caplog.at_level(logging.DEBUG, logger=_BUILDER_LOGGER):
+            build_target_lock(provider, _HOST, {"foo": Version("1.0")})
+        messages = [r.getMessage() for r in caplog.records if r.name == _BUILDER_LOGGER]
+        assert len(messages) == 1
+        assert "foo" in messages[0]
+        assert "3" in messages[0]
+
+    def test_no_line_when_nothing_pruned(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A package with a zero count emits no debug line."""
+        provider = _FakeProvider(
+            listings={"foo": [(Version("1.0"), _wheel_file())]},
+        )
+        with caplog.at_level(logging.DEBUG, logger=_BUILDER_LOGGER):
+            build_target_lock(provider, _HOST, {"foo": Version("1.0")})
+        assert not [r for r in caplog.records if r.name == _BUILDER_LOGGER]

--- a/nab-python/tests/test_provider_declared_target.py
+++ b/nab-python/tests/test_provider_declared_target.py
@@ -685,6 +685,44 @@ class TestWheelTagFiltering:
         assert provider.stats.excluded_versions_no_compatible_wheel == 1
 
 
+class TestPerVersionPruneCounter:
+    """A ``(name, version)``-keyed prune count the lock builder reads."""
+
+    def test_count_matches_the_per_canonical_tally(self) -> None:
+        """The per-version count and the per-canonical count share one event."""
+        wheels = [
+            _platform_wheel("1.0", "cp311-cp311-manylinux_2_17_x86_64"),
+            _platform_wheel("1.0", "cp311-cp311-win_amd64"),
+            _platform_wheel("2.0", "cp311-cp311-win_amd64"),
+        ]
+        provider = Provider(
+            _index_with_files(wheels),
+            _linux_target(PlatformSpec("linux_x86_64")),
+        )
+        provider.filter_distributions("pkg", wheels)
+        assert provider.tag_excluded_wheel_count("pkg", Version("1.0")) == 1
+        assert provider.tag_excluded_wheel_count("pkg", Version("2.0")) == 1
+        assert provider.tag_excluded_wheels["pkg"] == 2
+
+    def test_no_prune_leaves_zero(self) -> None:
+        """A version whose every wheel the target keeps has a zero count."""
+        wheels = [_platform_wheel("1.0", "py3-none-any")]
+        provider = Provider(
+            _index_with_files(wheels),
+            _linux_target(PlatformSpec("linux_x86_64")),
+        )
+        provider.filter_distributions("pkg", wheels)
+        assert provider.tag_excluded_wheel_count("pkg", Version("1.0")) == 0
+
+    def test_unseen_version_is_zero(self) -> None:
+        """A version the funnel never saw has no recorded count."""
+        provider = Provider(
+            _index_with_files([_platform_wheel("1.0", "py3-none-any")]),
+            _linux_target(PlatformSpec("linux_x86_64")),
+        )
+        assert provider.tag_excluded_wheel_count("pkg", Version("9.9")) == 0
+
+
 # Wheel tags spanning OS and arch, python levels, abi3, a free-threaded
 # build, several manylinux glibc levels, and musllinux.
 _TAG_CATALOG = (

--- a/nab-python/tests/test_provider_declared_target.py
+++ b/nab-python/tests/test_provider_declared_target.py
@@ -11,6 +11,7 @@ through a matrix.
 
 from __future__ import annotations
 
+import random
 import threading
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
@@ -682,6 +683,46 @@ class TestWheelTagFiltering:
         result = provider.fetch_versions("pkg")
         assert result == []
         assert provider.stats.excluded_versions_no_compatible_wheel == 1
+
+
+# Wheel tags spanning OS and arch, python levels, abi3, a free-threaded
+# build, several manylinux glibc levels, and musllinux.
+_TAG_CATALOG = (
+    "py3-none-any",
+    "py2.py3-none-any",
+    "cp310-cp310-manylinux_2_17_x86_64",
+    "cp311-cp311-manylinux_2_17_x86_64",
+    "cp311-cp311-manylinux_2_28_x86_64",
+    "cp311-cp311-manylinux_2_34_x86_64",
+    "cp312-cp312-manylinux_2_17_x86_64",
+    "cp311-cp311-musllinux_1_2_x86_64",
+    "cp311-cp311-manylinux_2_17_aarch64",
+    "cp311-abi3-manylinux_2_17_x86_64",
+    "cp39-abi3-manylinux_2_17_x86_64",
+    "cp313-cp313t-manylinux_2_17_x86_64",
+    "cp311-cp311-macosx_11_0_arm64",
+    "cp311-cp311-macosx_14_0_arm64",
+    "cp39-abi3-macosx_11_0_arm64",
+    "cp311-cp311-macosx_10_9_x86_64",
+    "cp311-cp311-win_amd64",
+)
+
+
+class TestWheelTagFilterProperty:
+    """The funnel keeps exactly the wheels a faithful target's TagSet accepts."""
+
+    @pytest.mark.parametrize("platform", ["linux_x86_64", "macos_arm64"])
+    def test_filter_keeps_exactly_the_accepted_wheels(self, platform: str) -> None:
+        target = _linux_target(PlatformSpec(platform))
+        rng = random.Random(20260722)  # noqa: S311
+        for _ in range(60):
+            tags = [t for t in _TAG_CATALOG if rng.random() < 0.5]
+            wheels = [_platform_wheel("1.0", t) for t in tags]
+            provider = Provider(_index_with_files(wheels), target)
+            result = provider.filter_distributions("pkg", wheels)
+            kept = {dist.filename for _, dist in result}
+            expected = {w.filename for w in wheels if target.tags.accepts(w.filename)}
+            assert kept == expected
 
 
 class TestEqualVersionCanonicalization:


### PR DESCRIPTION
The lock already drops any wheel a target's PEP 425 tags reject, but gave no signal that it happened. Add a per-package count of tag-excluded wheels and a debug line naming each pinned package that lost wheels to its target tags.