### PR TITLE
read HTML Simple-API listings instead of failing the lock

### DIFF
--- a/nab-index/src/nab_index/_pep503.py
+++ b/nab-index/src/nab_index/_pep503.py
@@ -1,0 +1,237 @@
+"""PEP 503 HTML project-page reading.
+
+:pep:`691` allows an index to answer a JSON request with the HTML
+serialization, so the ``file://`` index reader and the remote Simple-API
+client both have to read the same anchor-tag shape.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from urllib.parse import unquote, urljoin, urlsplit
+
+__all__ = [
+    "Anchor",
+    "hash_fragment",
+    "json_listing",
+    "metadata_declaration",
+    "read_page",
+]
+
+_REQUIRES_PYTHON_ATTR = "data-requires-python"
+_YANKED_ATTR = "data-yanked"
+_CORE_METADATA_ATTR = "data-core-metadata"
+_LEGACY_METADATA_ATTR = "data-dist-info-metadata"
+_UPLOAD_TIME_ATTR = "data-upload-time"
+_REPOSITORY_VERSION_META = "pypi:repository-version"
+
+
+@dataclass(frozen=True, slots=True)
+class Anchor:
+    """One ``<a>`` link on a project page.
+
+    ``metadata`` is the :pep:`714` ``data-core-metadata`` value, falling back
+    to the legacy ``data-dist-info-metadata`` when only that is set, and
+    ``None`` when the anchor declares neither.
+
+    ``upload_time`` is the ``data-upload-time`` value. No specification
+    covers it (:pep:`700` defines ``upload-time`` for the JSON serialization
+    only), so an index is free to omit it, and PyPI and download.pytorch.org
+    both do. It is read because it is the only upload time an HTML page can
+    carry.
+    """
+
+    href: str
+    requires_python: str | None
+    metadata: str | None
+    yanked: bool
+    upload_time: str | None
+
+
+def _anchor(attrs: list[tuple[str, str | None]]) -> Anchor | None:
+    """Build an :class:`Anchor` from a tag's attributes, or ``None`` if hrefless."""
+    href: str | None = None
+    requires_python: str | None = None
+    yanked = False
+    core_metadata: str | None = None
+    legacy_metadata: str | None = None
+    upload_time: str | None = None
+
+    for name, value in attrs:
+        if name == "href":
+            href = value
+        elif name == _REQUIRES_PYTHON_ATTR:
+            requires_python = value
+        elif name == _YANKED_ATTR:
+            yanked = True
+        elif name == _CORE_METADATA_ATTR:
+            core_metadata = value
+        elif name == _LEGACY_METADATA_ATTR:
+            legacy_metadata = value
+        elif name == _UPLOAD_TIME_ATTR:
+            upload_time = value
+
+    if href is None:
+        return None
+
+    metadata = core_metadata if core_metadata is not None else legacy_metadata
+    return Anchor(href, requires_python, metadata, yanked, upload_time)
+
+
+class _ProjectPageParser(HTMLParser):
+    """Collect a project page's anchors and its first ``<base href>``.
+
+    Also records whether the page declares the :pep:`629` repository version.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.anchors: list[Anchor] = []
+        self.base_href: str | None = None
+        self.declares_repository_version = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "meta":
+            for name, value in attrs:
+                if name == "name" and value == _REPOSITORY_VERSION_META:
+                    self.declares_repository_version = True
+                    break
+            return
+
+        if tag == "base":
+            if self.base_href is None:
+                for name, value in attrs:
+                    if name == "href":
+                        self.base_href = value
+                        break
+            return
+
+        if tag != "a":
+            return
+        anchor = _anchor(attrs)
+        if anchor is not None:
+            self.anchors.append(anchor)
+
+
+def _parse(text: str) -> _ProjectPageParser:
+    """Run the page parser over ``text``."""
+    parser = _ProjectPageParser()
+    parser.feed(text)
+    return parser
+
+
+def read_page(text: str) -> tuple[list[Anchor], str | None]:
+    """Return a project page's anchors and its ``<base href>``, if it has one.
+
+    Relative anchors resolve against the base href rather than the page
+    directory, matching how pip and uv read a Simple-repository page.
+    """
+    parser = _parse(text)
+    return (parser.anchors, parser.base_href)
+
+
+def metadata_declaration(value: str | None) -> bool | dict[str, str] | None:
+    """Translate a metadata-sidecar attribute value into its PEP 691 JSON form.
+
+    :pep:`658`/:pep:`714` set the value to ``true`` (sidecar exists, no
+    published hash) or ``<algo>=<hexdigest>``.  Anything else declares no
+    sidecar and yields ``None``.
+    """
+    if value is None:
+        return None
+    if value == "true":
+        return True
+    algo, sep, digest = value.partition("=")
+    if sep and algo and digest:
+        return {algo: digest}
+    return None
+
+
+def hash_fragment(fragment: str) -> tuple[tuple[str, str], ...]:
+    """Parse one ``algo=digest`` URL fragment into the ``hashes`` tuple shape.
+
+    :pep:`503` carries the artefact's hash in the URL fragment; it is the only
+    place the hash appears when the index has not opted into :pep:`691` JSON.
+    """
+    if not fragment:
+        return ()
+    algo, sep, digest = fragment.partition("=")
+    if not sep or not algo or not digest:
+        return ()
+    return ((algo.lower(), digest.lower()),)
+
+
+def _file_entry(anchor: Anchor, base_url: str) -> dict[str, object] | None:
+    """Render one anchor as a PEP 691 file entry, or ``None`` if it names no file.
+
+    An href with a malformed authority (an unterminated IPv6 bracket) makes
+    both the join and the split raise, so it is dropped like an href that
+    names no file rather than failing the whole listing.
+    """
+    try:
+        url, _, fragment = urljoin(base_url, anchor.href).partition("#")
+        filename = unquote(urlsplit(url).path.rsplit("/", 1)[-1])
+    except ValueError:
+        return None
+    if not filename:
+        return None
+
+    entry: dict[str, object] = {"filename": filename, "url": url}
+    if anchor.requires_python is not None:
+        entry["requires-python"] = anchor.requires_python
+
+    hashes = dict(hash_fragment(fragment))
+    if hashes:
+        entry["hashes"] = hashes
+
+    metadata = metadata_declaration(anchor.metadata)
+    if metadata is not None:
+        entry["core-metadata"] = metadata
+
+    if anchor.upload_time is not None:
+        entry["upload-time"] = anchor.upload_time
+    if anchor.yanked:
+        entry["yanked"] = True
+
+    return entry
+
+
+def json_listing(text: str, page_url: str) -> bytes:
+    """Re-serialize a PEP 503 project page as a PEP 691 JSON listing body.
+
+    Hrefs are resolved here, against the page's ``<base href>`` when it has
+    one and otherwise against ``page_url``, so the cached body stands on its
+    own.
+
+    Raises :class:`ValueError` when the page's ``<base href>`` cannot be
+    parsed. Every relative anchor resolves against it, so the whole page's
+    targets are unknown; the caller maps this to its own malformed-listing
+    error. A single unparseable anchor is dropped instead.
+
+    Also raises :class:`ValueError` for a page carrying neither a link nor
+    the :pep:`629` ``pypi:repository-version`` marker, since nothing in it
+    says it is a project page. An empty listing means "package absent" to
+    the multi-index router (see :func:`nab_index.client._parse_files`), so a
+    site error page served with a 200 would otherwise fall through to a
+    lower-priority index and risk pinning a different version.
+    """
+    parser = _parse(text)
+    anchors, base_href = parser.anchors, parser.base_href
+    if not anchors and not parser.declares_repository_version:
+        msg = (
+            "body has no links and no PEP 629 repository-version marker, "
+            "so it is not a project page"
+        )
+        raise ValueError(msg)
+    base_url = page_url
+    if base_href is not None:
+        try:
+            base_url = urljoin(page_url, base_href)
+        except ValueError as exc:
+            msg = f"unparseable <base href> {base_href!r}: {exc}"
+            raise ValueError(msg) from exc
+    entries = (_file_entry(anchor, base_url) for anchor in anchors)
+    files = [entry for entry in entries if entry is not None]
+    return json.dumps({"files": files}).encode("utf-8")

--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -1,21 +1,25 @@
 """On-disk cache for nab-index.
 
-Stores PEP 691 Simple API responses (raw JSON body plus a sidecar
-cache policy file) and PEP 658 wheel metadata (raw text, treated as
+Stores PEP 691 Simple API responses (JSON body plus a sidecar cache
+policy file) and PEP 658 wheel metadata (raw text, treated as
 immutable). The cache is consulted by :class:`CachedAsyncSimpleClient`
 before any HTTP transport call.
 
 Layout under ``root``:
 
-    simple-v0/<index>/<package>.json       <- raw PyPI JSON body
-    simple-v0/<index>/<package>.policy     <- {fetched_at, max_age, etag}
+    simple-v1/<index>/<package>.json       <- PEP 691 JSON body
+    simple-v1/<index>/<package>.policy     <- {fetched_at, max_age, etag}
     simple-neg-v0/<index>/<package>.neg    <- {fetched_at, max_age, etag}
     metadata-v1/<index>/<package>/<url digest>.metadata
     sdist-v1/<index>/<package>/<version>.json  <- {pkg_info, pyproject}
 
-A versioned bucket name (``simple-v0``) gives zero-cost schema
+A versioned bucket name (``simple-v1``) gives zero-cost schema
 migration: when the on-disk format changes, bump the suffix and the
 old directory is harmless.
+
+When the index serves PEP 503 HTML the stored body is nab's own rendering
+of the page. A 304 revalidation keeps the old body, so changing that
+rendering also needs the suffix bumped to reach warm caches.
 
 A resolve writes two more buckets under the same root, holding upstream
 source trees:
@@ -56,7 +60,7 @@ __all__ = [
 ]
 
 
-CACHE_VERSION_SIMPLE = "v0"
+CACHE_VERSION_SIMPLE = "v1"
 CACHE_VERSION_SIMPLE_NEG = "v0"
 CACHE_VERSION_METADATA = "v1"
 CACHE_VERSION_SDIST = "v1"

--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -18,11 +18,14 @@ from typing import TYPE_CHECKING
 from .cache import CacheBackend, CachePolicy, OfflineError
 from .client import (
     _HTTP_NOT_FOUND,
+    _SIMPLE_ACCEPT,
     DEFAULT_INDEX,
     MalformedSimpleResponseError,
     SdistFile,
     WheelFile,
     _extract_sdist_files,
+    _header,
+    _listing_body,
     _parse_files,
     _select_artifact_hash,
     _verify_metadata_hash,
@@ -49,7 +52,6 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
-_JSON_ACCEPT = "application/vnd.pypi.simple.v1+json"
 _DEFAULT_MAX_AGE = 600
 _HTTP_NOT_MODIFIED = 304
 _MAX_AGE_RE = re.compile(r"max-age\s*=\s*(\d+)")
@@ -62,22 +64,6 @@ def _parse_max_age(cache_control: str | None) -> int:
     if match is None:
         return _DEFAULT_MAX_AGE
     return int(match.group(1))
-
-
-def _header(response: HttpResponse, key: str) -> str | None:
-    """Case-insensitive header lookup.
-
-    The :class:`HttpResponse` Protocol only promises a plain
-    :class:`Mapping`. Both real transports (httpx, urllib3) return
-    case-insensitive header containers, but we don't rely on
-    that here so a plain-dict fake also works.
-    """
-    headers = response.headers
-    target = key.lower()
-    for name, value in headers.items():
-        if name.lower() == target:
-            return value
-    return None
 
 
 class CachedAsyncSimpleClient:
@@ -213,7 +199,7 @@ class CachedAsyncSimpleClient:
         self, package: str, body: bytes, policy: CachePolicy
     ) -> list[WheelFile | SdistFile]:
         url = f"{self._index_url}{package}/"
-        headers = {"Accept": _JSON_ACCEPT}
+        headers = {"Accept": _SIMPLE_ACCEPT}
         if policy.etag is not None:
             headers["If-None-Match"] = policy.etag
         response = await self._transport.get(url, headers=headers)
@@ -236,7 +222,7 @@ class CachedAsyncSimpleClient:
             self._cache.put_negative(package, self._negative_policy(response))
             return []
         raise_unless_ok(response, url)
-        new_body = response.content
+        new_body = _listing_body(response, self._index_url, package)
 
         # Parse before caching so a bad body never poisons the cache.
         files = self._parse_listing(new_body, package)
@@ -251,12 +237,12 @@ class CachedAsyncSimpleClient:
 
     async def _fetch_simple(self, package: str) -> list[WheelFile | SdistFile]:
         url = f"{self._index_url}{package}/"
-        response = await self._transport.get(url, headers={"Accept": _JSON_ACCEPT})
+        response = await self._transport.get(url, headers={"Accept": _SIMPLE_ACCEPT})
         if response.status_code == _HTTP_NOT_FOUND:
             self._cache.put_negative(package, self._negative_policy(response))
             return []
         raise_unless_ok(response, url)
-        body = response.content
+        body = _listing_body(response, self._index_url, package)
 
         # Parse before caching so a bad body never poisons the cache.
         files = self._parse_listing(body, package)

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -1,14 +1,16 @@
 """PyPI Simple API client using PEP 691 JSON and PEP 658/714 metadata.
 
-Fetches package listings and wheel/sdist metadata from PyPI.
-Transport-agnostic: any async HTTP client implementing the
-:class:`AsyncHttpTransport` protocol can be used.
+Fetches package listings and wheel/sdist metadata from PyPI. An index that
+answers with the PEP 503 HTML serialization instead is read through
+:mod:`nab_index._pep503`. Transport-agnostic: any async HTTP client
+implementing the :class:`AsyncHttpTransport` protocol can be used.
 """
 
 from __future__ import annotations
 
 import hashlib
 import io
+import json
 import re
 import sys
 import tarfile
@@ -25,6 +27,7 @@ from packaging.utils import (
 )
 from packaging.version import InvalidVersion, Version
 
+from ._pep503 import json_listing
 from .transport import IDENTITY_HEADERS, HttpError, raise_unless_ok
 
 if TYPE_CHECKING:
@@ -33,7 +36,7 @@ if TYPE_CHECKING:
     from packaging.utils import NormalizedName
     from typing_extensions import Self
 
-    from .transport import AsyncHttpTransport
+    from .transport import AsyncHttpTransport, HttpResponse
 
 __all__ = [
     "DEFAULT_INDEX",
@@ -60,9 +63,10 @@ _SUPPORTS_DATA_FILTER = hasattr(tarfile, "data_filter")
 class MalformedSimpleResponseError(HttpError):
     """The index served a 200 response that is not a usable Simple-API body.
 
-    Covers a listing that is not valid JSON and a PEP 658 metadata sidecar
-    that is not valid UTF-8. Subclasses :class:`HttpError` so a broken body
-    is caught alongside transport and 4xx/5xx failures.
+    Covers a listing that is neither valid JSON nor decodable HTML, and a
+    PEP 658 metadata sidecar that is not valid UTF-8. Subclasses
+    :class:`HttpError` so a broken body is caught alongside transport and
+    4xx/5xx failures.
     """
 
 
@@ -172,10 +176,73 @@ def _parse_sdist_filename(filename: str) -> tuple[NormalizedName, str] | None:
     return (name, str(version))
 
 
-_JSON_ACCEPT = "application/vnd.pypi.simple.v1+json"
+# PEP 691: advertise every serialization we can read, because an index that
+# cannot honour the header may answer with a type we did not ask for.
+_SIMPLE_ACCEPT = (
+    "application/vnd.pypi.simple.v1+json, "
+    "application/vnd.pypi.simple.v1+html;q=0.2, "
+    "text/html;q=0.01"
+)
 _HTTP_NOT_FOUND = 404
 
 DEFAULT_INDEX = "https://pypi.org/simple/"
+
+
+def _header(response: HttpResponse, key: str) -> str | None:
+    """Case-insensitive header lookup.
+
+    The :class:`HttpResponse` Protocol only promises a plain
+    :class:`Mapping`. Both real transports (httpx, urllib3) return
+    case-insensitive header containers, but we don't rely on
+    that here so a plain-dict fake also works.
+    """
+    headers = response.headers
+    target = key.lower()
+    for name, value in headers.items():
+        if name.lower() == target:
+            return value
+    return None
+
+
+def _is_html_listing(content_type: str | None) -> bool:
+    """Return True when a Content-Type names an HTML Simple-API serialization.
+
+    Covers :pep:`503`'s ``text/html`` and :pep:`691`'s
+    ``application/vnd.pypi.simple.vN+html``.
+    """
+    if content_type is None:
+        return False
+    media_type = content_type.partition(";")[0].strip().lower()
+    return media_type == "text/html" or media_type.endswith("+html")
+
+
+def _listing_body(response: HttpResponse, index_url: str, package: str) -> bytes:
+    """Return a listing response's body as PEP 691 JSON bytes.
+
+    The served Content-Type picks the decoder. An HTML page is re-serialized
+    so the parser and the cache only ever see one shape; any other body is
+    passed through untouched.
+    """
+    body = response.content
+    if not _is_html_listing(_header(response, "content-type")):
+        return body
+
+    try:
+        text = body.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        msg = (
+            f"{index_url} served a malformed Simple-API response for "
+            f"{package!r}: HTML body is not valid UTF-8"
+        )
+        raise MalformedSimpleResponseError(msg) from exc
+
+    try:
+        return json_listing(text, f"{index_url}{package}/")
+    except ValueError as exc:
+        msg = (
+            f"{index_url} served a malformed Simple-API response for {package!r}: {exc}"
+        )
+        raise MalformedSimpleResponseError(msg) from exc
 
 
 @dataclass(frozen=True, slots=True)
@@ -271,11 +338,12 @@ class AsyncSimpleClient:
     async def get_files(self, package: str) -> list[WheelFile | SdistFile]:
         """Fetch all distribution files for a package."""
         url = f"{self._index_url}{package}/"
-        response = await self._transport.get(url, headers={"Accept": _JSON_ACCEPT})
+        response = await self._transport.get(url, headers={"Accept": _SIMPLE_ACCEPT})
         if response.status_code == _HTTP_NOT_FOUND:
             return []
         raise_unless_ok(response, url)
-        return _parse_files(response.json(), self._index_url, package)
+        body = _listing_body(response, self._index_url, package)
+        return _parse_files(json.loads(body), self._index_url, package)
 
     async def get_metadata_text(self, metadata_url: str) -> str:
         """Fetch metadata text from a known PEP 658/714 metadata URL."""

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -26,13 +26,13 @@ import sys
 import zipfile
 import zlib
 from email.parser import BytesParser, Parser
-from html.parser import HTMLParser
 from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import unquote, urljoin, urlparse
 from urllib.request import url2pathname
 
 from ._naming import canonical as _canonical
+from ._pep503 import hash_fragment, metadata_declaration, read_page
 from .client import (
     SdistFile,
     WheelFile,
@@ -144,90 +144,6 @@ def _read_served_bytes(path: Path, kind: str) -> bytes:
         raise MalformedLocalListingError(msg) from exc
 
 
-_REQUIRES_PYTHON_ATTR = "data-requires-python"
-_YANKED_ATTR = "data-yanked"
-_CORE_METADATA_ATTR = "data-core-metadata"
-_LEGACY_METADATA_ATTR = "data-dist-info-metadata"
-
-
-def _html_advertises_metadata(value: str | None) -> bool:
-    """Return True when a metadata-sidecar attribute value advertises a sidecar.
-
-    PEP 658/714 set the value to ``true`` (sidecar exists, no hash) or
-    ``<algo>=<hexdigest>``.  Mirrors the JSON path's ``true``/digest
-    semantics in :func:`nab_index.client._has_metadata`.
-    """
-    if value is None:
-        return False
-    if value == "true":
-        return True
-    algo, sep, digest = value.partition("=")
-    return bool(sep and algo and digest)
-
-
-def _parse_anchor(
-    attrs: list[tuple[str, str | None]],
-) -> tuple[str, str | None, bool] | None:
-    """Turn an anchor's attributes into ``(href, requires_python, has_metadata)``.
-
-    Returns ``None`` for an anchor with no ``href`` or one carrying
-    ``data-yanked`` (PEP 592), so a yanked link never reaches the listing.
-    The PEP 714 ``data-core-metadata`` attribute (or legacy
-    ``data-dist-info-metadata``) is read so a wheel's advertised sidecar is
-    honoured, matching the PEP 691 JSON behaviour in
-    :func:`nab_index.client._parse_files`.
-    """
-    href: str | None = None
-    requires_python: str | None = None
-    yanked = False
-    core_metadata: str | None = None
-    legacy_metadata: str | None = None
-    for name, value in attrs:
-        if name == "href":
-            href = value
-        elif name == _REQUIRES_PYTHON_ATTR:
-            requires_python = value
-        elif name == _YANKED_ATTR:
-            yanked = True
-        elif name == _CORE_METADATA_ATTR:
-            core_metadata = value
-        elif name == _LEGACY_METADATA_ATTR:
-            legacy_metadata = value
-    if href is None or yanked:
-        return None
-    advertised = core_metadata if core_metadata is not None else legacy_metadata
-    return (href, requires_python, _html_advertises_metadata(advertised))
-
-
-class _Pep503Parser(HTMLParser):
-    """Collect ``<a href="..." data-requires-python="...">`` entries.
-
-    The first ``<base href>`` is kept so relative anchors resolve against
-    it rather than the page directory, matching how pip and uv read a
-    Simple-repository page.
-    """
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.links: list[tuple[str, str | None, bool]] = []
-        self.base_href: str | None = None
-
-    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        if tag == "base":
-            if self.base_href is None:
-                for name, value in attrs:
-                    if name == "href":
-                        self.base_href = value
-                        break
-            return
-
-        if tag != "a":
-            return
-        link = _parse_anchor(attrs)
-        if link is not None:
-            self.links.append(link)
-
-
 _FLAT_EXTS = re.compile(r"\.(whl|tar\.gz)$", re.IGNORECASE)
 
 
@@ -246,24 +162,27 @@ def _scan_pep503_directory(
         msg = f"{index_html} is not valid UTF-8: {exc}"
         raise MalformedLocalListingError(msg) from exc
 
-    parser = _Pep503Parser()
-    parser.feed(text)
+    anchors, base_href = read_page(text)
     base_url: str | None = None
-    if parser.base_href is not None:
+    if base_href is not None:
         # A base href every relative anchor resolves against, so one that
         # cannot be parsed leaves the whole page's targets unknown. Fail
         # loudly rather than fall back to the package directory, which
         # would resolve each link to a different file than the page names.
         try:
-            base_url = urljoin(index_html.as_uri(), parser.base_href)
+            base_url = urljoin(index_html.as_uri(), base_href)
         except ValueError as exc:
             msg = f"{index_html} has an unparseable <base href>: {exc}"
             raise MalformedLocalListingError(msg) from exc
 
     files: list[WheelFile | SdistFile] = []
-    for href, requires_python, has_metadata in parser.links:
+    for anchor in anchors:
+        # PEP 592: a yanked link never reaches the listing.
+        if anchor.yanked:
+            continue
+
         filename, file_url, local_path, hashes = _resolve_local_link(
-            href, package_dir, base_url
+            anchor.href, package_dir, base_url
         )
         if filename is None:
             continue
@@ -271,10 +190,10 @@ def _scan_pep503_directory(
             filename,
             file_url,
             local_path,
-            requires_python,
+            anchor.requires_python,
             hashes,
             canonical,
-            has_metadata=has_metadata,
+            has_metadata=metadata_declaration(anchor.metadata) is not None,
         )
         if record is not None:
             files.append(record)
@@ -292,18 +211,15 @@ def _resolve_local_link(
     ``None``.  A relative href joins against it; an absolute href ignores
     it per RFC 3986.
 
-    PEP 503 carries the artefact's hash in the URL fragment as
-    ``#<algo>=<hexdigest>``; this is the only place the hash appears
-    when the index has not opted into PEP 691 JSON.  The fragment is
-    parsed here and surfaced as the file record's ``hashes`` tuple so
-    the lockfile writer has something to round-trip.
+    The href's hash fragment is surfaced as the file record's ``hashes``
+    tuple so the lockfile writer has something to round-trip.
 
     ``local_path`` is the artefact's on-disk path when the href names
     a local file, and ``None`` for an ``http``/``https`` href.  It is
     carried so downstream code never has to reverse the ``file:`` URL.
     """
     href_no_frag, _, fragment = href.partition("#")
-    hashes = _parse_pep503_hash_fragment(fragment)
+    hashes = hash_fragment(fragment)
 
     # A malformed authority (an unterminated IPv6 bracket) makes both of
     # these raise, so the drop guard has to start here rather than at the
@@ -332,16 +248,6 @@ def _resolve_local_link(
     except ValueError:
         return (None, href_no_frag, None, hashes)
     return (target.name, target.as_uri(), target, hashes)
-
-
-def _parse_pep503_hash_fragment(fragment: str) -> tuple[tuple[str, str], ...]:
-    """Parse one ``algo=digest`` fragment into the WheelFile.hashes shape."""
-    if not fragment:
-        return ()
-    algo, sep, digest = fragment.partition("=")
-    if not sep or not algo or not digest:
-        return ()
-    return ((algo.lower(), digest.lower()),)
 
 
 def _scan_flat_wheelhouse(

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -1434,9 +1434,15 @@ class TestAsyncSimpleClient:
     """Tests for nab-index's AsyncSimpleClient via a faked transport."""
 
     class _FakeResponse:
-        def __init__(self, body: bytes, status: int = 200) -> None:
+        def __init__(
+            self,
+            body: bytes,
+            status: int = 200,
+            headers: Mapping[str, str] | None = None,
+        ) -> None:
             self._content = body
             self._status = status
+            self._headers = headers or {}
 
         @property
         def status_code(self) -> int:
@@ -1444,7 +1450,7 @@ class TestAsyncSimpleClient:
 
         @property
         def headers(self) -> Mapping[str, str]:
-            return {}
+            return self._headers
 
         @property
         def content(self) -> bytes:
@@ -1463,16 +1469,24 @@ class TestAsyncSimpleClient:
                 raise RuntimeError(msg)
 
     class _FakeTransport:
-        def __init__(self, body: bytes, status: int = 200) -> None:
+        def __init__(
+            self,
+            body: bytes,
+            status: int = 200,
+            headers: Mapping[str, str] | None = None,
+        ) -> None:
             self._body = body
             self._status = status
+            self._headers = headers
             self.calls: list[tuple[str, dict[str, str] | None]] = []
 
         async def get(
             self, url: str, *, headers: dict[str, str] | None = None
         ) -> TestAsyncSimpleClient._FakeResponse:
             self.calls.append((url, headers))
-            return TestAsyncSimpleClient._FakeResponse(self._body, self._status)
+            return TestAsyncSimpleClient._FakeResponse(
+                self._body, self._status, self._headers
+            )
 
         async def aclose(self) -> None:
             return None
@@ -1489,8 +1503,29 @@ class TestAsyncSimpleClient:
         assert len(files) == 1
         assert transport.calls[0][0] == "https://pypi.org/simple/pkg/"
         assert transport.calls[0][1] == {
-            "Accept": "application/vnd.pypi.simple.v1+json"
+            "Accept": (
+                "application/vnd.pypi.simple.v1+json, "
+                "application/vnd.pypi.simple.v1+html;q=0.2, "
+                "text/html;q=0.01"
+            )
         }
+
+    def test_get_files_reads_html_listing(self) -> None:
+        body = (
+            b"<!DOCTYPE html>\n<html>\n  <body>\n"
+            b'    <a href="pkg-1.0-py3-none-any.whl">pkg-1.0-py3-none-any.whl</a>\n'
+            b"  </body>\n</html>\n"
+        )
+        transport = self._FakeTransport(body, headers={"Content-Type": "text/html"})
+
+        async def go() -> list:
+            async with AsyncSimpleClient(transport, "https://pypi.org/simple/") as c:
+                return await c.get_files("pkg")
+
+        files = asyncio.run(go())
+        assert [f.url for f in files] == [
+            "https://pypi.org/simple/pkg/pkg-1.0-py3-none-any.whl"
+        ]
 
     def test_get_files_404_returns_empty(self) -> None:
         transport = self._FakeTransport(b"not found", status=404)

--- a/nab-python/tests/test_cache.py
+++ b/nab-python/tests/test_cache.py
@@ -14,6 +14,7 @@ import pytest
 
 from nab_index.atomic import atomic_write_text
 from nab_index.cache import (
+    CACHE_VERSION_SIMPLE,
     VCS_BUCKET,
     CachePolicy,
     NullCache,
@@ -25,6 +26,9 @@ from nab_index.cache import (
     _index_dirname,
 )
 from nab_index.vcs import VcsRequest, prepare_clone
+
+# Derived so a bucket-version bump does not need every path updated.
+SIMPLE_BUCKET = f"simple-{CACHE_VERSION_SIMPLE}"
 
 # Two wheels of one version, each with its own PEP 658 sidecar.
 METADATA_URLS = (
@@ -207,8 +211,8 @@ class TestOnDiskCache:
             b"{}",
             CachePolicy(fetched_at=1, max_age=1, etag=None),
         )
-        assert (tmp_path / "simple-v0" / "pypi" / "foo.json").exists()
-        assert (tmp_path / "simple-v0" / "pypi" / "foo.policy").exists()
+        assert (tmp_path / SIMPLE_BUCKET / "pypi" / "foo.json").exists()
+        assert (tmp_path / SIMPLE_BUCKET / "pypi" / "foo.policy").exists()
 
     def test_simple_alt_index_uses_hash_dirname(self, tmp_path: Path) -> None:
         cache = OnDiskCache(tmp_path, "https://alt.example/simple/")
@@ -217,7 +221,7 @@ class TestOnDiskCache:
             b"{}",
             CachePolicy(fetched_at=1, max_age=1, etag=None),
         )
-        sub = tmp_path / "simple-v0"
+        sub = tmp_path / SIMPLE_BUCKET
         children = list(sub.iterdir())
         assert len(children) == 1
         assert children[0].name != "pypi"
@@ -537,7 +541,7 @@ class TestReadCacheEntry:
 
     def test_corrupt_policy(self, tmp_path: Path) -> None:
         cache = self._cache(tmp_path)
-        path = tmp_path / "simple-v0" / "pypi" / "foo.policy"
+        path = tmp_path / SIMPLE_BUCKET / "pypi" / "foo.policy"
         path.parent.mkdir(parents=True)
         path.write_bytes(b"not json")
         assert cache.read_cache_entry(path) is not None
@@ -545,7 +549,7 @@ class TestReadCacheEntry:
     def test_valid_policy(self, tmp_path: Path) -> None:
         cache = self._cache(tmp_path)
         cache.put_simple("foo", b"{}", _FRESH)
-        path = tmp_path / "simple-v0" / "pypi" / "foo.policy"
+        path = tmp_path / SIMPLE_BUCKET / "pypi" / "foo.policy"
         assert cache.read_cache_entry(path) is None
 
     def test_corrupt_negative(self, tmp_path: Path) -> None:
@@ -570,7 +574,7 @@ class TestReadCacheEntry:
 
     def test_invalid_simple_json(self, tmp_path: Path) -> None:
         cache = self._cache(tmp_path)
-        path = tmp_path / "simple-v0" / "pypi" / "foo.json"
+        path = tmp_path / SIMPLE_BUCKET / "pypi" / "foo.json"
         path.parent.mkdir(parents=True)
         path.write_bytes(b"{not json")
         assert cache.read_cache_entry(path) == "not valid JSON"
@@ -578,7 +582,7 @@ class TestReadCacheEntry:
     def test_valid_simple_json_is_clean(self, tmp_path: Path) -> None:
         cache = self._cache(tmp_path)
         cache.put_simple("foo", b'{"files": []}', _FRESH)
-        path = tmp_path / "simple-v0" / "pypi" / "foo.json"
+        path = tmp_path / SIMPLE_BUCKET / "pypi" / "foo.json"
         assert cache.read_cache_entry(path) is None
 
     def test_sdist_record_missing_fields(self, tmp_path: Path) -> None:
@@ -597,14 +601,14 @@ class TestReadCacheEntry:
     def test_unknown_suffix_is_clean(self, tmp_path: Path) -> None:
         # A leftover atomic-write temp file is not a nab entry and is ignored.
         cache = self._cache(tmp_path)
-        path = tmp_path / "simple-v0" / "pypi" / "foo.json.abc.tmp"
+        path = tmp_path / SIMPLE_BUCKET / "pypi" / "foo.json.abc.tmp"
         path.parent.mkdir(parents=True)
         path.write_bytes(b"partial")
         assert cache.read_cache_entry(path) is None
 
     def test_unreadable_entry(self, tmp_path: Path) -> None:
         cache = self._cache(tmp_path)
-        path = tmp_path / "simple-v0" / "pypi" / "adir.policy"
+        path = tmp_path / SIMPLE_BUCKET / "pypi" / "adir.policy"
         path.mkdir(parents=True)
         assert cache.read_cache_entry(path) is not None
 
@@ -624,7 +628,7 @@ class TestIterCacheEntries:
         )
         (tmp_path / "sdist-v1-file").write_text("junk")
         _symlink_or_skip(
-            tmp_path / "simple-v0" / "pypi" / "link.json", outside / "x.json"
+            tmp_path / SIMPLE_BUCKET / "pypi" / "link.json", outside / "x.json"
         )
         names = {e.name for e in cache.iter_cache_entries()}
         assert "foo.json" in names
@@ -639,7 +643,7 @@ class TestIterCacheEntries:
         (outside / "leak.json").write_text("{}")
         root = tmp_path / "cache"
         root.mkdir()
-        _symlink_or_skip(root / "simple-v0", outside, target_is_directory=True)
+        _symlink_or_skip(root / SIMPLE_BUCKET, outside, target_is_directory=True)
         cache = OnDiskCache(root, "https://pypi.org/simple")
         assert list(cache.iter_cache_entries()) == []
 
@@ -653,12 +657,12 @@ class TestClearCache:
         cache = _populate(tmp_path)
         removed = cache.clear_cache()
         assert set(removed) == {
-            "simple-v0",
+            SIMPLE_BUCKET,
             "simple-neg-v0",
             "metadata-v1",
             "sdist-v1",
         }
-        assert not (tmp_path / "simple-v0").exists()
+        assert not (tmp_path / SIMPLE_BUCKET).exists()
         assert not (tmp_path / "sdist-v1").exists()
 
     def test_unlinks_symlinked_bucket_without_following(self, tmp_path: Path) -> None:
@@ -667,11 +671,11 @@ class TestClearCache:
         (outside / "keep.txt").write_text("precious")
         root = tmp_path / "cache"
         root.mkdir()
-        _symlink_or_skip(root / "simple-v0", outside, target_is_directory=True)
+        _symlink_or_skip(root / SIMPLE_BUCKET, outside, target_is_directory=True)
         cache = OnDiskCache(root, "https://pypi.org/simple")
-        assert cache.clear_cache() == ["simple-v0"]
+        assert cache.clear_cache() == [SIMPLE_BUCKET]
         assert (outside / "keep.txt").read_text() == "precious"
-        assert not (root / "simple-v0").exists()
+        assert not (root / SIMPLE_BUCKET).exists()
 
     def test_leaves_bucket_named_file(self, tmp_path: Path) -> None:
         root = tmp_path / "cache"

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -1150,8 +1150,8 @@ class TestGetFiles:
 class TestNonJsonListingBody:
     """A 200 response whose body is not JSON must not poison the cache.
 
-    An index that ignores the JSON Accept header can serve PEP 503 HTML
-    (or a proxy/captive-portal page) with status 200.
+    A proxy or captive portal can answer with a page of its own under status
+    200 and no HTML content type, so the body reaches the JSON decoder.
     """
 
     _HTML_BODY = b"<!DOCTYPE html><html><body>links</body></html>"
@@ -1283,6 +1283,248 @@ class TestNonUtf8ListingBody:
         assert cached is not None
         body, _ = cached
         assert body == LISTING_BYTES
+
+
+class TestHtmlListing:
+    """PEP 691: the served Content-Type picks the decoder, not the Accept header.
+
+    An index may answer with a type the client did not ask for;
+    download.pytorch.org answers the JSON request with a PEP 503 page.
+    """
+
+    _INDEX = "https://download.pytorch.org/whl/cpu/"
+    _WHEEL = "torch-2.7.0+cpu-cp312-cp312-manylinux_2_28_x86_64.whl"
+    _DIGEST = "c" * 64
+    _HREF = (
+        "/whl/cpu/torch-2.7.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl"
+        f"#sha256={_DIGEST}"
+    )
+    _UPLOAD_TIME = "2025-04-23T15:03:12Z"
+    _PAGE = (
+        "<!DOCTYPE html>\n"
+        "<html>\n"
+        "  <body>\n"
+        "    <h1>Links for torch</h1>\n"
+        f'    <a href="{_HREF}" data-requires-python="&gt;=3.9" '
+        f'data-upload-time="{_UPLOAD_TIME}">'
+        f"{_WHEEL}</a><br/>\n"
+        "  </body>\n"
+        "</html>\n"
+    ).encode()
+
+    def _fetch(
+        self,
+        cache: OnDiskCache,
+        body: bytes,
+        content_type: str,
+        package: str = "torch",
+    ) -> tuple[list, _FakeTransport]:
+        transport = _FakeTransport(
+            [_FakeResponse(body, headers={"content-type": content_type})]
+        )
+
+        async def go() -> list:
+            client = CachedAsyncSimpleClient(transport, cache, self._INDEX)
+            try:
+                return await client.get_files(package)
+            finally:
+                await client.aclose()
+
+        return (asyncio.run(go()), transport)
+
+    def test_pep503_page_is_read(self, tmp_path: Path) -> None:
+        files, _ = self._fetch(_make_cache(tmp_path), self._PAGE, "text/html")
+        (wheel,) = files
+        assert isinstance(wheel, WheelFile)
+        assert wheel.filename == self._WHEEL
+        assert wheel.version == "2.7.0+cpu"
+        assert wheel.url == (
+            "https://download.pytorch.org/whl/cpu/"
+            "torch-2.7.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl"
+        )
+        assert wheel.requires_python == ">=3.9"
+        assert wheel.hashes == (("sha256", self._DIGEST),)
+        assert wheel.upload_time == self._UPLOAD_TIME
+
+    def test_malformed_ipv6_href_is_dropped(self, tmp_path: Path) -> None:
+        # An unterminated IPv6 bracket makes the href join and split raise;
+        # that anchor is dropped and its good sibling still resolves.
+        page = (
+            b'<a href="http://[bad">bad</a>'
+            b'<a href="torch-2.7.0-py3-none-any.whl">good</a>'
+        )
+        files, _ = self._fetch(_make_cache(tmp_path), page, "text/html")
+        assert [f.filename for f in files] == ["torch-2.7.0-py3-none-any.whl"]
+
+    def test_malformed_base_href_fails_the_listing(self, tmp_path: Path) -> None:
+        # Every relative anchor resolves against <base href>, so one that
+        # cannot be parsed leaves the page's targets unknown.
+        page = (
+            b'<base href="http://[bad"><a href="torch-2.7.0-py3-none-any.whl">good</a>'
+        )
+        with pytest.raises(MalformedSimpleResponseError, match="base href"):
+            self._fetch(_make_cache(tmp_path), page, "text/html")
+
+    def test_page_without_upload_time_leaves_it_unset(self, tmp_path: Path) -> None:
+        page = b'<a href="torch-2.7.0-py3-none-any.whl">a</a>'
+        files, _ = self._fetch(_make_cache(tmp_path), page, "text/html")
+        assert [f.upload_time for f in files] == [None]
+
+    def test_accept_advertises_every_supported_type(self, tmp_path: Path) -> None:
+        _, transport = self._fetch(_make_cache(tmp_path), self._PAGE, "text/html")
+        sent = transport.calls[0][1]
+        assert sent is not None
+        assert sent["Accept"] == (
+            "application/vnd.pypi.simple.v1+json, "
+            "application/vnd.pypi.simple.v1+html;q=0.2, "
+            "text/html;q=0.01"
+        )
+
+    @pytest.mark.parametrize(
+        "content_type",
+        [
+            "text/html",
+            "text/html; charset=UTF-8",
+            "Text/HTML",
+            "application/vnd.pypi.simple.v1+html",
+            "application/vnd.pypi.simple.latest+html",
+        ],
+    )
+    def test_html_content_types_all_decode(
+        self, tmp_path: Path, content_type: str
+    ) -> None:
+        files, _ = self._fetch(_make_cache(tmp_path), self._PAGE, content_type)
+        assert [f.version for f in files] == ["2.7.0+cpu"]
+
+    def test_json_content_type_still_decodes_json(self, tmp_path: Path) -> None:
+        files, _ = self._fetch(
+            _make_cache(tmp_path),
+            LISTING_BYTES,
+            "application/vnd.pypi.simple.v1+json",
+            package="pkg",
+        )
+        assert [f.filename for f in files] == ["pkg-1.0-py3-none-any.whl"]
+
+    def test_cached_page_serves_warm_hit_without_network(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        first, _ = self._fetch(cache, self._PAGE, "text/html")
+        offline = _FakeTransport()
+
+        async def go() -> list:
+            client = CachedAsyncSimpleClient(offline, cache, self._INDEX)
+            try:
+                return await client.get_files("torch")
+            finally:
+                await client.aclose()
+
+        assert asyncio.run(go()) == first
+        assert offline.calls == []
+
+    def test_revalidation_replaces_body_with_new_page(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        self._fetch(cache, self._PAGE, "text/html")
+        cached = cache.get_simple("torch")
+        assert cached is not None
+        cache.put_simple(
+            "torch", cached[0], CachePolicy(fetched_at=0, max_age=1, etag="old")
+        )
+        newer = self._PAGE.replace(b"2.7.0", b"2.8.0")
+        files, transport = self._fetch(cache, newer, "text/html")
+        assert [f.version for f in files] == ["2.8.0+cpu"]
+        assert len(transport.calls) == 1
+
+    def test_yanked_anchor_dropped(self, tmp_path: Path) -> None:
+        page = (
+            b'<a href="torch-2.7.0-py3-none-any.whl" data-yanked="bad build">a</a>'
+            b'<a href="torch-2.8.0-py3-none-any.whl">b</a>'
+        )
+        files, _ = self._fetch(_make_cache(tmp_path), page, "text/html")
+        assert [f.version for f in files] == ["2.8.0"]
+
+    def test_relative_href_resolves_against_page(self, tmp_path: Path) -> None:
+        page = b'<a href="../pkgs/torch-2.7.0-py3-none-any.whl">a</a>'
+        files, _ = self._fetch(_make_cache(tmp_path), page, "text/html")
+        assert [f.url for f in files] == [
+            "https://download.pytorch.org/whl/cpu/pkgs/torch-2.7.0-py3-none-any.whl"
+        ]
+
+    def test_base_href_redirects_relative_anchor(self, tmp_path: Path) -> None:
+        page = (
+            b'<html><head><base href="https://mirror.example/dl/"></head>'
+            b'<body><a href="torch-2.7.0-py3-none-any.whl">a</a></body></html>'
+        )
+        files, _ = self._fetch(_make_cache(tmp_path), page, "text/html")
+        assert [f.url for f in files] == [
+            "https://mirror.example/dl/torch-2.7.0-py3-none-any.whl"
+        ]
+
+    def test_anchor_without_a_filename_skipped(self, tmp_path: Path) -> None:
+        page = b'<a href="../">parent</a><a href="torch-2.7.0-py3-none-any.whl">a</a>'
+        files, _ = self._fetch(_make_cache(tmp_path), page, "text/html")
+        assert [f.version for f in files] == ["2.7.0"]
+
+    def test_core_metadata_hash_carried(self, tmp_path: Path) -> None:
+        page = (
+            b'<a href="torch-2.7.0-py3-none-any.whl" '
+            b'data-core-metadata="sha256=ABCD">a</a>'
+        )
+        files, _ = self._fetch(_make_cache(tmp_path), page, "text/html")
+        (wheel,) = files
+        assert isinstance(wheel, WheelFile)
+        assert wheel.has_metadata
+        assert wheel.metadata_hash == ("sha256", "abcd")
+
+    def test_bare_metadata_attribute_advertises_sidecar_without_hash(
+        self, tmp_path: Path
+    ) -> None:
+        page = (
+            b'<a href="torch-2.7.0-py3-none-any.whl" '
+            b'data-dist-info-metadata="true">a</a>'
+        )
+        files, _ = self._fetch(_make_cache(tmp_path), page, "text/html")
+        (wheel,) = files
+        assert isinstance(wheel, WheelFile)
+        assert wheel.has_metadata
+        assert wheel.metadata_hash is None
+
+    def test_page_without_links_or_marker_is_not_an_empty_listing(
+        self, tmp_path: Path
+    ) -> None:
+        # A 200 site error page would otherwise read as "package absent" and
+        # let the multi-index router fall through to a lower-priority index.
+        page = (
+            b"<html><body><h1>Sorry, that page could not be found.</h1></body></html>"
+        )
+        with pytest.raises(MalformedSimpleResponseError, match="not a project page"):
+            self._fetch(_make_cache(tmp_path), page, "text/html")
+        assert _make_cache(tmp_path).get_simple("torch") is None
+
+    def test_unrelated_meta_tags_do_not_make_it_a_project_page(
+        self, tmp_path: Path
+    ) -> None:
+        page = (
+            b'<html><head><meta charset="utf-8">'
+            b'<meta name="generator" content="mkdocs"></head><body></body></html>'
+        )
+        with pytest.raises(MalformedSimpleResponseError, match="not a project page"):
+            self._fetch(_make_cache(tmp_path), page, "text/html")
+
+    def test_marker_lets_a_project_page_list_no_files(self, tmp_path: Path) -> None:
+        page = (
+            b'<html><head><meta name="pypi:repository-version" content="1.4">'
+            b"</head><body></body></html>"
+        )
+        files, _ = self._fetch(_make_cache(tmp_path), page, "text/html")
+        assert files == []
+
+    def test_non_utf8_page_raises_clean_error(self, tmp_path: Path) -> None:
+        page = '<a href="torch-2.7.0-py3-none-any.whl">café</a>'.encode("latin-1")
+        with pytest.raises(
+            MalformedSimpleResponseError, match="HTML body is not valid UTF-8"
+        ) as caught:
+            self._fetch(_make_cache(tmp_path), page, "text/html")
+        assert isinstance(caught.value, HttpError)
+        assert _make_cache(tmp_path).get_simple("torch") is None
 
 
 class TestGetMetadataText:

--- a/tests/test_cache_cmd.py
+++ b/tests/test_cache_cmd.py
@@ -8,8 +8,11 @@ import pytest
 
 from nab import cli as nab_cli
 from nab.cli import app
-from nab_index.cache import CachePolicy, OnDiskCache
+from nab_index.cache import CACHE_VERSION_SIMPLE, CachePolicy, OnDiskCache
 from nab_python.config_sources import SourceRoots
+
+# Derived so a bucket-version bump does not need every path updated.
+SIMPLE_BUCKET = f"simple-{CACHE_VERSION_SIMPLE}"
 
 _FRESH = CachePolicy(fetched_at=0, max_age=600, etag=None)
 
@@ -173,7 +176,7 @@ class TestLayeredCacheDir:
     ) -> None:
         root = tmp_path / "env-declared"
         _populate(root)
-        policy_path = root / "simple-v0" / "pypi" / "foo.policy"
+        policy_path = root / SIMPLE_BUCKET / "pypi" / "foo.policy"
         policy_path.write_bytes(b"not json")
         monkeypatch.setenv("NAB_CACHE_DIR", str(root))
         _run_cache(["verify"])
@@ -189,7 +192,7 @@ class TestLayeredCacheDir:
         _populate(root)
         monkeypatch.setenv("NAB_CACHE_DIR", str(root))
         _run_cache(["clear"])
-        assert not (root / "simple-v0").exists()
+        assert not (root / SIMPLE_BUCKET).exists()
         assert not (root / "metadata-v1").exists()
         assert str(root) in capsys.readouterr().err
 
@@ -248,7 +251,7 @@ class TestCacheVerify:
     ) -> None:
         root = tmp_path / "cache"
         _populate(root)
-        policy_path = root / "simple-v0" / "pypi" / "foo.policy"
+        policy_path = root / SIMPLE_BUCKET / "pypi" / "foo.policy"
         policy_path.write_bytes(b"not json")
         _run_cache(["verify", "--cache-dir", str(root)])
         err = capsys.readouterr().err
@@ -273,7 +276,7 @@ class TestCacheVerify:
         (outside / "foo.policy").write_bytes(b"not json")
         root = tmp_path / "cache"
         root.mkdir()
-        _symlink_or_skip(root / "simple-v0", outside, target_is_directory=True)
+        _symlink_or_skip(root / SIMPLE_BUCKET, outside, target_is_directory=True)
         _run_cache(["verify", "--cache-dir", str(root)])
         assert capsys.readouterr().err == ""
 
@@ -306,7 +309,7 @@ class TestCacheClear:
         sibling = root / "unrelated.txt"
         sibling.write_text("keep me")
         _run_cache(["clear", "--cache-dir", str(root)])
-        assert not (root / "simple-v0").exists()
+        assert not (root / SIMPLE_BUCKET).exists()
         assert not (root / "simple-neg-v0").exists()
         assert not (root / "metadata-v1").exists()
         assert not (root / "sdist-v1").exists()
@@ -328,11 +331,11 @@ class TestCacheClear:
         (outside / "keep.txt").write_text("precious")
         root = tmp_path / "cache"
         root.mkdir()
-        (root / "simple-v0").mkdir()
+        (root / SIMPLE_BUCKET).mkdir()
         _symlink_or_skip(root / "metadata-v1", outside, target_is_directory=True)
         _run_cache(["clear", "--cache-dir", str(root)])
         assert (outside / "keep.txt").read_text() == "precious"
-        assert not (root / "simple-v0").exists()
+        assert not (root / SIMPLE_BUCKET).exists()
         assert not (root / "metadata-v1").exists()
 
     def test_nonexistent_root_is_noop(
@@ -351,7 +354,7 @@ class TestCacheClear:
         foreign = root / "metadata-notes.txt"
         foreign.write_text("mine")
         _run_cache(["clear", "--cache-dir", str(root)])
-        assert not (root / "simple-v0").exists()
+        assert not (root / SIMPLE_BUCKET).exists()
         assert not (root / "metadata-v1").exists()
         assert foreign.read_text() == "mine"
         assert str(root) in capsys.readouterr().err


### PR DESCRIPTION
Locking against an index that serves PEP 503 HTML fails with "malformed Simple-API response". That includes download.pytorch.org, which the multi-index how-to points people at. The client asked for `application/vnd.pypi.simple.v1+json` and parsed whatever came back as JSON, so an index that cannot honour the Accept header failed the lock.

Accept now lists every serialization the client can read, and the served Content-Type picks the decoder. An HTML page is re-serialized into a PEP 691 body, so the parser and the on-disk cache see one shape. The PEP 503 anchor reading moved out of `local_index.py` into `nab_index._pep503`, shared by the `file://` reader and the remote client.

`data-upload-time` becomes the entry's `upload-time`. It is the only upload time an HTML page carries, and without it `uploaded-prior-to` excludes every file such an index lists. The Simple cache bucket goes to v1 because the stored body is now nab's own rendering of the page, and a 304 against the index's unchanged ETag would otherwise keep an old body forever.
