### PR TITLE
Add per-index assume-fresh-seconds override

### DIFF
--- a/docs/how-to/multi-index.md
+++ b/docs/how-to/multi-index.md
@@ -75,6 +75,11 @@ it has one, otherwise the first index in declared order that lists it. A
 per-index override therefore governs a package only through that one
 attributing index, not through every index that could also serve it.
 
+A mirror that stamps its listings short-lived makes nab revalidate them
+once per package on every warm run. Set `assume-fresh-seconds` on that
+index to skip those round trips; see the
+[configuration reference](../reference/configuration.md).
+
 ## Policy across both surfaces is an error, not a precedence
 
 The per-package and per-index surfaces are not ranked. If a per-package

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -458,9 +458,9 @@ override does not match a source.
 ### Per-index overrides
 
 `[tool.nab.index.<name>]` is keyed by a declared index name.  Each entry
-sets policy only (`dist-policy`, `build-policy`, `uploaded-prior-to`) and
-applies to every package served from that index.  It carries no routing
-and no version scope.
+sets policy only (`dist-policy`, `build-policy`, `uploaded-prior-to`,
+`assume-fresh-seconds`) and applies to every package served from that
+index.  It carries no routing and no version scope.
 
 ```toml
 # Everything served from PyPI is wheel-only.
@@ -471,7 +471,16 @@ dist-policy = "wheel-only"
 [tool.nab.index.internal]
 build-policy = "build-remote"
 uploaded-prior-to = "2026-05-01T00:00:00Z"
+# Trust this index's package listings as fresh for an hour.
+assume-fresh-seconds = 3600
 ```
+
+`assume-fresh-seconds` treats a cached package listing from this index as
+fresh for at least that many seconds, skipping the revalidation a
+short-lived server `max-age` would otherwise force.  It only extends
+freshness, never shortens it, and reaches only the mutable listing: a
+release published inside the window stays hidden until it lapses.  It
+never affects the metadata and artifacts nab caches by hash.
 
 ### Conflicts across the two surfaces
 

--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -125,6 +125,7 @@ class CachedAsyncSimpleClient:
         offline: bool = False,
         range_memo: RangeCapabilityMemo | None = None,
         serialization: SimpleSerialization = SimpleSerialization.NEGOTIATE,
+        min_fresh_seconds: int | None = None,
     ) -> None:
         """Create a cached client wrapping ``transport``.
 
@@ -135,6 +136,11 @@ class CachedAsyncSimpleClient:
 
         ``serialization`` pins which Simple-API serialization this index is
         asked for and read as.
+
+        ``min_fresh_seconds`` is a read-time freshness floor for this index's
+        Simple listing. A stale positive listing or negative sentinel within
+        the floor is served without revalidation; it only extends freshness and
+        rewrites nothing on disk.
         """
         self._transport = transport
         self._cache = cache
@@ -145,6 +151,7 @@ class CachedAsyncSimpleClient:
         self._range_memo = (
             range_memo if range_memo is not None else RangeCapabilityMemo()
         )
+        self._min_fresh_seconds = min_fresh_seconds
 
     async def aclose(self) -> None:
         """Close the underlying transport."""
@@ -187,18 +194,47 @@ class CachedAsyncSimpleClient:
             if data is not None:
                 if policy.is_fresh() or self._offline:
                     return self._parse_body(data, package)
+                if self._floor_keeps_fresh(policy, package, "listing"):
+                    return self._parse_body(data, package)
                 return await self._revalidate_simple(package, body, policy)
             corrupt_positive = True
 
         if not corrupt_positive:
             negative = self._cache.get_negative(package)
-            if negative is not None and (negative.is_fresh() or self._offline):
+            if negative is not None and (
+                negative.is_fresh()
+                or self._offline
+                or self._floor_keeps_fresh(negative, package, "absent-name sentinel")
+            ):
                 return []
 
         if self._offline:
             msg = f"No cached listing for {package} (offline mode)"
             raise OfflineError(msg)
         return await self._fetch_simple(package)
+
+    def _floor_keeps_fresh(self, policy: CachePolicy, package: str, kind: str) -> bool:
+        """Whether the read-time freshness floor still covers a stale entry.
+
+        Consulted only after the stored policy has said stale and offline is
+        false.
+        """
+        if self._min_fresh_seconds is None:
+            return False
+        age = int(time.time()) - policy.fetched_at
+        if age >= self._min_fresh_seconds:
+            return False
+        logger.debug(
+            "assume-fresh-seconds=%d: %s for %r from %s kept fresh at age %ds "
+            "(server max-age %ds); skipping revalidation",
+            self._min_fresh_seconds,
+            kind,
+            package,
+            self._index_url,
+            age,
+            policy.max_age,
+        )
+        return True
 
     def _negative_policy(self, response: HttpResponse) -> CachePolicy:
         """Freshness policy for a name-level 404, clamped to the 600s cap."""

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -104,6 +104,7 @@ __all__ = [
     "conflict_forks",
     "conflict_member_groups",
     "enforce_build_policy_for_targets",
+    "index_cache_floors_from_config",
     "index_routes_from_config",
     "matrix_from_config",
     "plan_targets",
@@ -338,10 +339,11 @@ class IndexOverride:
 
     Keyed by a declared index name.  The body sets any combination of
     ``dist_policy`` (with ``dist_trust_unverified_deps``),
-    ``build_policy``, and the ``uploaded_prior_to`` cutoff (or
-    ``uploaded_prior_to_disabled`` for the ``false`` form).  It applies
-    to every package served from that index; it carries no routing and
-    no version scope.
+    ``build_policy``, the ``uploaded_prior_to`` cutoff (or
+    ``uploaded_prior_to_disabled`` for the ``false`` form), and
+    ``assume_fresh_seconds``, a read-time freshness floor on the index's
+    Simple listing.  It applies to every package served from that index;
+    it carries no routing and no version scope.
     """
 
     dist_policy: DistPolicy | None = None
@@ -349,6 +351,7 @@ class IndexOverride:
     build_policy: BuildPolicy | None = None
     uploaded_prior_to: datetime | None = None
     uploaded_prior_to_disabled: bool = False
+    assume_fresh_seconds: int | None = None
 
 
 # Two active selections engage the set's exclusivity, forcing a fork.
@@ -1316,6 +1319,15 @@ def index_routes_from_config(config: NabProjectConfig) -> list[IndexRoute]:
     ]
 
 
+def index_cache_floors_from_config(config: NabProjectConfig) -> dict[str, int]:
+    """Project per-index cache-freshness floors, keyed by index name."""
+    return {
+        name: override.assume_fresh_seconds
+        for name, override in config.index_overrides.items()
+        if override.assume_fresh_seconds is not None
+    }
+
+
 def _parse_uploaded_prior_to(value: object, *, anchor: datetime) -> datetime:
     """Parse ``uploaded-prior-to`` (ISO datetime, TOML datetime, or ``P<n>D``).
 
@@ -1810,7 +1822,9 @@ _PACKAGE_OVERRIDE_BODY_KEYS = frozenset(
 )
 # A [[tool.nab.package-rules]] entry carries a ``match`` selector plus body keys.
 _PACKAGE_RULE_KEYS = frozenset({"match"}) | _PACKAGE_OVERRIDE_BODY_KEYS
-_INDEX_OVERRIDE_KEYS = frozenset({"dist-policy", "build-policy", "uploaded-prior-to"})
+_INDEX_OVERRIDE_KEYS = frozenset(
+    {"dist-policy", "build-policy", "uploaded-prior-to", "assume-fresh-seconds"}
+)
 # Override-body keys not supported yet; rejected so nothing inert ships.
 # ``metadata`` is the nested-table form the flat body keys replace.
 _OVERRIDE_DEFERRED_KEYS = frozenset(
@@ -2160,12 +2174,16 @@ def _parse_index_override_body(
         anchor=anchor,
         present="uploaded-prior-to" in body,
     )
+    assume_fresh_seconds = _parse_index_assume_fresh(
+        body.get("assume-fresh-seconds"), where
+    )
     has_body = (
         dist_policy is not None
         or dist_trust is not None
         or build_policy is not None
         or uploaded_prior_to is not None
         or uploaded_disabled
+        or assume_fresh_seconds is not None
     )
     if not has_body:
         msg = (
@@ -2179,6 +2197,7 @@ def _parse_index_override_body(
         build_policy=build_policy,
         uploaded_prior_to=uploaded_prior_to,
         uploaded_prior_to_disabled=uploaded_disabled,
+        assume_fresh_seconds=assume_fresh_seconds,
     )
 
 
@@ -2262,6 +2281,19 @@ def _parse_override_uploaded_prior_to(
         msg = f"{where}.uploaded-prior-to: {exc}"
         raise ConfigError(msg) from exc
     return (cutoff, False)
+
+
+def _parse_index_assume_fresh(value: object, where: str) -> int | None:
+    """Parse ``assume-fresh-seconds``: a positive integer number of seconds."""
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        msg = (
+            f"{where}.assume-fresh-seconds must be a positive integer number of"
+            f" seconds, got {value!r}"
+        )
+        raise ConfigError(msg)
+    return value
 
 
 def _parse_override_requires_python(value: object, where: str) -> str | None:

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -33,7 +33,7 @@ from nab_index.transport import IDENTITY_HEADERS, raise_unless_ok
 from ._vendor.packaging.utils import canonicalize_name
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable, Mapping, Sequence
 
     from typing_extensions import Self
 
@@ -701,7 +701,7 @@ class FetchCoordinator:
 
     PREFETCH_METADATA_COUNT = 10
 
-    def __init__(
+    def __init__(  # noqa: PLR0913 - the per-index knobs a coordinator wires up
         self,
         transport: AsyncHttpTransport,
         *,
@@ -711,6 +711,7 @@ class FetchCoordinator:
         cache_backend: CacheBackend | None = None,
         offline: bool = False,
         index_routes: list[IndexRoute] | None = None,
+        index_cache_floors: Mapping[str, int] | None = None,
         on_fetch: Callable[[], None] | None = None,
     ) -> None:
         """Create a coordinator that wraps ``transport``.
@@ -724,6 +725,11 @@ class FetchCoordinator:
         ``index_routes`` adds per-package routing rules; an entry's
         ``index`` field names one of the configured indexes and pins that
         package's listing fetch to it.
+
+        ``index_cache_floors`` maps an index name to a read-time
+        freshness floor in seconds, passed to that index's cached client
+        as ``min_fresh_seconds``.  Indexes absent from the map, and the
+        ``file://`` local client, get no floor.
 
         ``cache_backend`` wins over ``cache_dir`` if both are given;
         otherwise ``cache_dir`` enables a per-index :class:`OnDiskCache`
@@ -769,6 +775,7 @@ class FetchCoordinator:
             self._cache = NullCache()
         self._cache_dir = cache_dir
         self._index_routes = list(index_routes or [])
+        self._index_cache_floors = dict(index_cache_floors or {})
         # Progress hook: fired once per successful listing fetch, from the
         # fetcher thread.  ``None`` when nothing is watching (the common case).
         self._on_fetch = on_fetch
@@ -1117,6 +1124,8 @@ class FetchCoordinator:
         :class:`LocalIndexClient` (no caching; the filesystem is the
         cache).  Everything else goes to :class:`CachedAsyncSimpleClient`
         with a per-URL :class:`OnDiskCache` when ``cache_dir`` is set.
+        Any freshness floor registered for ``cfg.name`` is passed as
+        ``min_fresh_seconds``.
         """
         if is_file_url(cfg.url):
             return LocalIndexClient(cfg.url)
@@ -1135,6 +1144,7 @@ class FetchCoordinator:
             offline=self._offline,
             range_memo=self._range_memo,
             serialization=cfg.serialization,
+            min_fresh_seconds=self._index_cache_floors.get(cfg.name),
         )
 
     async def _async_fetcher(self) -> None:

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -52,6 +52,7 @@ from .config import (
     ConflictSet,
     NabProjectConfig,
     conflict_forks,
+    index_cache_floors_from_config,
     index_routes_from_config,
     plan_targets,
     read_pyproject_config,
@@ -342,6 +343,7 @@ def resolve_for_targets(  # noqa: PLR0913 - the surface mirrors the CLI; bundlin
         cache_dir=cache_dir,
         offline=offline,
         index_routes=index_routes_from_config(config),
+        index_cache_floors=index_cache_floors_from_config(config),
         on_fetch=progress.on_fetch if progress is not None else None,
     ) as coordinator:
         return resolve_with_coordinator(

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -3365,3 +3365,253 @@ class TestModuleDocstring:
         cache_type = annotations["cache"].split(".")[-1]
         assert transport_type in referenced
         assert cache_type in referenced
+
+
+def _run_get_files_floor(
+    transport: object,
+    cache: object,
+    package: str,
+    *,
+    min_fresh_seconds: int | None = None,
+    offline: bool = False,
+) -> list:
+    async def go() -> list:
+        client = CachedAsyncSimpleClient(
+            transport,  # type: ignore[arg-type]
+            cache,  # type: ignore[arg-type]
+            offline=offline,
+            min_fresh_seconds=min_fresh_seconds,
+        )
+        try:
+            return await client.get_files(package)
+        finally:
+            await client.aclose()
+
+    return asyncio.run(go())
+
+
+def _debug_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [
+        r
+        for r in caplog.records
+        if r.levelno == logging.DEBUG and r.name == "nab_index.cached_client"
+    ]
+
+
+class TestAssumeFreshFloor:
+    """Read-time freshness floor: extend, never shorten, and never rewrite disk."""
+
+    def test_stale_positive_within_floor_serves_cached_no_transport(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.setattr(time, "time", lambda: 1000.0)
+        cache = _make_cache(tmp_path)
+        cache.put_simple(
+            "pkg", LISTING_BYTES, CachePolicy(fetched_at=500, max_age=1, etag="e")
+        )
+        transport = _FakeTransport()  # raises on any call
+
+        with caplog.at_level(logging.DEBUG, logger="nab_index.cached_client"):
+            files = _run_get_files_floor(
+                transport, cache, "pkg", min_fresh_seconds=3600
+            )
+
+        assert len(files) == 1
+        assert transport.calls == []
+        records = _debug_records(caplog)
+        assert len(records) == 1
+        assert "listing" in records[0].getMessage()
+
+    def test_stale_positive_past_floor_revalidates(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(time, "time", lambda: 200.0)
+        cache = _make_cache(tmp_path)
+        cache.put_simple(
+            "pkg", LISTING_BYTES, CachePolicy(fetched_at=0, max_age=1, etag="old")
+        )
+        transport = _FakeTransport(
+            [_FakeResponse(b"", status=304, headers={"etag": "old"})]
+        )
+
+        files = _run_get_files_floor(transport, cache, "pkg", min_fresh_seconds=100)
+        assert len(files) == 1
+        assert len(transport.calls) == 1
+
+    def test_no_floor_revalidates_and_no_debug_line(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cache = _make_cache(tmp_path)
+        cache.put_simple(
+            "pkg", LISTING_BYTES, CachePolicy(fetched_at=0, max_age=1, etag="old")
+        )
+        transport = _FakeTransport(
+            [_FakeResponse(b"", status=304, headers={"etag": "old"})]
+        )
+
+        with caplog.at_level(logging.DEBUG, logger="nab_index.cached_client"):
+            files = _run_get_files_floor(
+                transport, cache, "pkg", min_fresh_seconds=None
+            )
+        assert len(files) == 1
+        assert len(transport.calls) == 1
+        assert _debug_records(caplog) == []
+
+    def test_stale_sentinel_within_floor_answers_empty_no_transport(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.setattr(time, "time", lambda: 1000.0)
+        cache = _make_cache(tmp_path)
+        cache.put_negative("absent", CachePolicy(fetched_at=500, max_age=1, etag=None))
+        transport = _FakeTransport()
+
+        with caplog.at_level(logging.DEBUG, logger="nab_index.cached_client"):
+            result = _run_get_files_floor(
+                transport, cache, "absent", min_fresh_seconds=3600
+            )
+
+        assert result == []
+        assert transport.calls == []
+        records = _debug_records(caplog)
+        assert len(records) == 1
+        assert "absent-name sentinel" in records[0].getMessage()
+
+    def test_stale_sentinel_past_floor_reprobes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(time, "time", lambda: 1000.0)
+        cache = _make_cache(tmp_path)
+        cache.put_negative("absent", CachePolicy(fetched_at=0, max_age=1, etag=None))
+        transport = _FakeTransport([_FakeResponse(b"gone", status=404)])
+
+        result = _run_get_files_floor(transport, cache, "absent", min_fresh_seconds=100)
+        assert result == []
+        assert len(transport.calls) == 1
+
+    def test_floor_smaller_than_stored_window_is_noop(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.setattr(time, "time", lambda: 1300.0)
+        cache = _make_cache(tmp_path)
+        cache.put_simple(
+            "pkg", LISTING_BYTES, CachePolicy(fetched_at=1000, max_age=600, etag="e")
+        )
+        transport = _FakeTransport()  # raises on any call
+
+        with caplog.at_level(logging.DEBUG, logger="nab_index.cached_client"):
+            files = _run_get_files_floor(transport, cache, "pkg", min_fresh_seconds=100)
+
+        assert len(files) == 1
+        assert transport.calls == []
+        assert _debug_records(caplog) == []
+
+    def test_offline_with_floor_serves_cached_no_helper_no_debug(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cache = _make_cache(tmp_path)
+        cache.put_simple(
+            "pkg", LISTING_BYTES, CachePolicy(fetched_at=0, max_age=1, etag="old")
+        )
+        transport = _FakeTransport()  # raises on any call
+
+        with caplog.at_level(logging.DEBUG, logger="nab_index.cached_client"):
+            files = _run_get_files_floor(
+                transport, cache, "pkg", min_fresh_seconds=3600, offline=True
+            )
+
+        assert len(files) == 1
+        assert transport.calls == []
+        assert _debug_records(caplog) == []
+
+    def test_stored_policy_unchanged_after_floor_suppressed_read(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(time, "time", lambda: 1000.0)
+        cache = _make_cache(tmp_path)
+        stored = CachePolicy(fetched_at=500, max_age=1, etag="e")
+        cache.put_simple("pkg", LISTING_BYTES, stored)
+        transport = _FakeTransport()
+
+        _run_get_files_floor(transport, cache, "pkg", min_fresh_seconds=3600)
+
+        cached = cache.get_simple("pkg")
+        assert cached is not None
+        body, policy = cached
+        assert body == LISTING_BYTES
+        assert policy == stored
+
+    def test_stored_sentinel_unchanged_after_floor_suppressed_read(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(time, "time", lambda: 1000.0)
+        cache = _make_cache(tmp_path)
+        stored = CachePolicy(fetched_at=500, max_age=1, etag=None)
+        cache.put_negative("absent", stored)
+        transport = _FakeTransport()
+
+        _run_get_files_floor(transport, cache, "absent", min_fresh_seconds=3600)
+
+        assert cache.get_negative("absent") == stored
+
+    def test_immutable_metadata_text_warm_hit_with_floor(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        cache.put_metadata("pkg", "https://x/pkg.metadata", "stored")
+        transport = _FakeTransport()
+
+        async def go() -> str:
+            client = CachedAsyncSimpleClient(transport, cache, min_fresh_seconds=3600)
+            try:
+                return await client.get_metadata_text(
+                    "pkg", "1.0", "https://x/pkg.metadata"
+                )
+            finally:
+                await client.aclose()
+
+        assert asyncio.run(go()) == "stored"
+        assert transport.calls == []
+
+    def test_immutable_range_metadata_warm_hit_with_floor(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        cache.put_metadata("pkg", _WHEEL_URL, _RANGE_META.decode())
+        transport = _FakeTransport()
+
+        async def go() -> RangeMetadataResult:
+            client = CachedAsyncSimpleClient(transport, cache, min_fresh_seconds=3600)
+            try:
+                return await client.get_range_metadata(
+                    "pkg", "1.0", _WHEEL_URL, canonicalize_name("pkg")
+                )
+            finally:
+                await client.aclose()
+
+        result = asyncio.run(go())
+        assert result.text == _RANGE_META.decode()
+        assert transport.calls == []
+
+    def test_immutable_sdist_files_warm_hit_with_floor(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        cache.put_sdist_files("pkg", "1.0", "Name: cached\n", None)
+        transport = _FakeTransport()
+
+        async def go() -> tuple[str | None, str | None]:
+            client = CachedAsyncSimpleClient(transport, cache, min_fresh_seconds=3600)
+            try:
+                return await client.get_sdist_files(
+                    "pkg", "1.0", "https://x/pkg.tar.gz"
+                )
+            finally:
+                await client.aclose()
+
+        pkg_info, pyproject = asyncio.run(go())
+        assert pkg_info == "Name: cached\n"
+        assert pyproject is None
+        assert transport.calls == []

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -30,6 +30,7 @@ from nab_python.config import (
     _check_requires_python_admits_target,
     conflict_exclusion_groups,
     conflict_forks,
+    index_cache_floors_from_config,
     index_routes_from_config,
     plan_targets,
     read_pyproject_config,
@@ -3485,6 +3486,102 @@ class TestIndexOverrides:
         with pytest.raises(ConfigError, match="are not supported") as excinfo:
             read_pyproject_config(path, discover_workspace=False)
         assert "flat body keys" not in str(excinfo.value)
+
+    def test_assume_fresh_seconds(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            self._two_indexes()
+            + "[tool.nab.index.internal]\nassume-fresh-seconds = 3600\n",
+        )
+        override = read_pyproject_config(
+            path, discover_workspace=False
+        ).index_overrides["internal"]
+        assert override.assume_fresh_seconds == 3600
+
+    def test_assume_fresh_seconds_zero_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            self._two_indexes()
+            + "[tool.nab.index.internal]\nassume-fresh-seconds = 0\n",
+        )
+        with pytest.raises(ConfigError, match=r"index\.internal\.assume-fresh-seconds"):
+            read_pyproject_config(path, discover_workspace=False)
+
+    def test_assume_fresh_seconds_negative_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            self._two_indexes()
+            + "[tool.nab.index.internal]\nassume-fresh-seconds = -5\n",
+        )
+        with pytest.raises(ConfigError, match=r"index\.internal\.assume-fresh-seconds"):
+            read_pyproject_config(path, discover_workspace=False)
+
+    def test_assume_fresh_seconds_string_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            self._two_indexes()
+            + '[tool.nab.index.internal]\nassume-fresh-seconds = "soon"\n',
+        )
+        with pytest.raises(ConfigError, match=r"index\.internal\.assume-fresh-seconds"):
+            read_pyproject_config(path, discover_workspace=False)
+
+    def test_assume_fresh_seconds_float_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            self._two_indexes()
+            + "[tool.nab.index.internal]\nassume-fresh-seconds = 3.5\n",
+        )
+        with pytest.raises(ConfigError, match=r"index\.internal\.assume-fresh-seconds"):
+            read_pyproject_config(path, discover_workspace=False)
+
+    def test_assume_fresh_seconds_boolean_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            self._two_indexes()
+            + "[tool.nab.index.internal]\nassume-fresh-seconds = true\n",
+        )
+        with pytest.raises(ConfigError, match=r"index\.internal\.assume-fresh-seconds"):
+            read_pyproject_config(path, discover_workspace=False)
+
+    def test_assume_fresh_seconds_rejected_on_package_surface(
+        self, tmp_path: Path
+    ) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab.packages.numpy]\nassume-fresh-seconds = 60\n",
+        )
+        with pytest.raises(ConfigError, match="unknown override key"):
+            read_pyproject_config(path, discover_workspace=False)
+
+
+class TestIndexCacheFloorsProjection:
+    def _two_indexes(self) -> str:
+        return (
+            "[[tool.nab.indexes]]\n"
+            'name = "pypi"\n'
+            'url = "https://pypi.org/simple/"\n'
+            "[[tool.nab.indexes]]\n"
+            'name = "internal"\n'
+            'url = "https://pkgs.example.com/simple/"\n'
+        )
+
+    def test_projects_only_setters(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            self._two_indexes()
+            + "[tool.nab.index.internal]\nassume-fresh-seconds = 120\n"
+            + '[tool.nab.index.pypi]\ndist-policy = "wheel-only"\n',
+        )
+        config = read_pyproject_config(path, discover_workspace=False)
+        assert index_cache_floors_from_config(config) == {"internal": 120}
+
+    def test_empty_when_none_set(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            self._two_indexes() + '[tool.nab.index.pypi]\ndist-policy = "wheel-only"\n',
+        )
+        config = read_pyproject_config(path, discover_workspace=False)
+        assert index_cache_floors_from_config(config) == {}
 
 
 class TestMatrixReferenceDocs:

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -2228,6 +2228,20 @@ class TestOverrideTables:
         eff = _resolve(SourceRoots(project_dir=tmp_path))
         assert set(eff["index"].value) == {"pypi", "internal"}
 
+    def test_index_assume_fresh_seconds_merges(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            "[tool.nab.index.pypi]\nassume-fresh-seconds = 3600\n",
+        )
+        _write(
+            tmp_path / "nab.toml",
+            "[index.internal]\nassume-fresh-seconds = 30\n",
+        )
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        overrides = eff["index"].value
+        assert overrides["pypi"].assume_fresh_seconds == 3600
+        assert overrides["internal"].assume_fresh_seconds == 30
+
     def test_index_identical_duration_across_files_ok(self, tmp_path: Path) -> None:
         # An identical relative P<n>D in an index override body across both
         # project files must not read as conflicting: the inspector pins one

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -2322,6 +2322,93 @@ class TestMultiIndexCoordinator:
         finally:
             coord.shutdown()
 
+    def test_cache_floor_single_index(self, tmp_path: Path) -> None:
+        """A floor keyed by the single index sets the client's window."""
+        coord = FetchCoordinator(
+            transport=HttpxAsyncTransport(),
+            cache_dir=tmp_path,
+            indexes=[IndexConfig("custom", "https://custom.example/")],
+            index_cache_floors={"custom": 42},
+        )
+        try:
+            client = coord._build_client()
+            assert isinstance(client, CachedAsyncSimpleClient)
+            assert client._min_fresh_seconds == 42
+        finally:
+            coord.shutdown()
+
+    def test_cache_floor_single_index_absent(self, tmp_path: Path) -> None:
+        """A floor keyed by another index leaves this client's window None."""
+        coord = FetchCoordinator(
+            transport=HttpxAsyncTransport(),
+            cache_dir=tmp_path,
+            indexes=[IndexConfig("custom", "https://custom.example/")],
+            index_cache_floors={"other": 42},
+        )
+        try:
+            client = coord._build_client()
+            assert isinstance(client, CachedAsyncSimpleClient)
+            assert client._min_fresh_seconds is None
+        finally:
+            coord.shutdown()
+
+    def test_cache_floor_multi_index(self, tmp_path: Path) -> None:
+        """Each index's client gets its own floor by name; absent means None."""
+        coord = FetchCoordinator(
+            transport=HttpxAsyncTransport(),
+            cache_dir=tmp_path,
+            indexes=[
+                IndexConfig("pypi", "https://pypi.org/simple/"),
+                IndexConfig("torch-cpu", "https://torch.example/cpu/"),
+            ],
+            index_cache_floors={"pypi": 99},
+        )
+        try:
+            client = coord._build_client()
+            assert isinstance(client, MultiIndexClient)
+            pypi = client._clients["pypi"]
+            torch = client._clients["torch-cpu"]
+            assert isinstance(pypi, CachedAsyncSimpleClient)
+            assert isinstance(torch, CachedAsyncSimpleClient)
+            assert pypi._min_fresh_seconds == 99
+            assert torch._min_fresh_seconds is None
+        finally:
+            coord.shutdown()
+
+    def test_cache_floor_default_none(self, tmp_path: Path) -> None:
+        """Without index_cache_floors the client's window is None."""
+        coord = FetchCoordinator(
+            transport=HttpxAsyncTransport(),
+            cache_dir=tmp_path,
+            indexes=[IndexConfig("custom", "https://custom.example/")],
+        )
+        try:
+            client = coord._build_client()
+            assert isinstance(client, CachedAsyncSimpleClient)
+            assert client._min_fresh_seconds is None
+        finally:
+            coord.shutdown()
+
+    def test_cache_floor_local_index_inert(self, tmp_path: Path) -> None:
+        """A floor on a file:// index builds a LocalIndexClient unaffected."""
+        wheelhouse = tmp_path / "wheelhouse"
+        wheelhouse.mkdir()
+        (wheelhouse / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+        coord = FetchCoordinator(
+            transport=HttpxAsyncTransport(),
+            indexes=[
+                IndexConfig("pypi", "https://pypi.org/simple/"),
+                IndexConfig("local", wheelhouse.as_uri()),
+            ],
+            index_cache_floors={"local": 3600},
+        )
+        try:
+            client = coord._build_client()
+            assert isinstance(client, MultiIndexClient)
+            assert isinstance(client._clients["local"], LocalIndexClient)
+        finally:
+            coord.shutdown()
+
 
 _SIBLING_LINUX = "foo-1.0-cp311-cp311-manylinux_2_17_x86_64.whl"
 _SIBLING_WIN = "foo-1.0-cp311-cp311-win_amd64.whl"


### PR DESCRIPTION
A per-index `assume-fresh-seconds` sets a read-time floor on how long nab treats that index's cached package listings as fresh. It lets you skip the per-package revalidation a mirror with a short server max-age otherwise forces on every warm run. The floor only extends freshness and reaches only the mutable listing, never the hash-addressed metadata and artifacts.