### PR TITLE
fix `nab cache clear` leaving vcs and archive trees behind

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -217,10 +217,12 @@ actions:
 
 * `nab cache dir` prints the resolved cache root to stdout, whether or
   not it exists yet.
-* `nab cache verify` walks the cache read-only and reports any corrupt
-  entry by path and reason.
-* `nab cache clear` removes every recognized bucket under the root,
-  returning the cache to cold.
+* `nab cache verify` walks the cached index records read-only and
+  reports any corrupt entry by path and reason. Cloned repositories and
+  extracted archives hold upstream files, so they are not parsed.
+* `nab cache clear` removes every bucket under the root, cloned
+  repositories and extracted archives included, returning the cache to
+  cold.
 
 ## Runtime flags
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -220,8 +220,8 @@ actions:
 * `nab cache verify` walks the cached index records read-only and
   reports any corrupt entry by path and reason. Cloned repositories and
   extracted archives hold upstream files, so they are not parsed.
-* `nab cache clear` removes every bucket under the root, cloned
-  repositories and extracted archives included, returning the cache to
+* `nab cache clear` removes every bucket under the root, including the
+  cloned repositories and extracted archives, returning the cache to
   cold.
 
 ## Runtime flags

--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -16,6 +16,12 @@ Layout under ``root``:
 A versioned bucket name (``simple-v0``) gives zero-cost schema
 migration: when the on-disk format changes, bump the suffix and the
 old directory is harmless.
+
+A resolve materialises two more buckets under the same root, holding
+upstream trees rather than nab records:
+
+    vcs/       <- shallow clones, written by :mod:`nab_index.vcs`
+    archive/   <- extracted archive sources, keyed by verified digest
 """
 
 from __future__ import annotations
@@ -38,6 +44,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "ARCHIVE_BUCKET",
+    "VCS_BUCKET",
     "CacheBackend",
     "CachePolicy",
     "NullCache",
@@ -52,9 +60,14 @@ CACHE_VERSION_SIMPLE_NEG = "v0"
 CACHE_VERSION_METADATA = "v1"
 CACHE_VERSION_SDIST = "v1"
 
-# Bucket directories nab owns under a cache root. simple-neg-* is covered
-# by the simple- prefix.
-RECOGNIZED_BUCKET_PREFIXES = ("simple-", "metadata-", "sdist-")
+# Buckets of nab-written records. simple-neg-* is covered by the simple- prefix.
+ENTRY_BUCKET_PREFIXES = ("simple-", "metadata-", "sdist-")
+
+# Buckets holding source trees a resolve materialises: cloned VCS checkouts and
+# extracted archives. nab owns the directories but not the files inside them.
+VCS_BUCKET = "vcs"
+ARCHIVE_BUCKET = "archive"
+SOURCE_BUCKETS = (VCS_BUCKET, ARCHIVE_BUCKET)
 
 DEFAULT_PYPI_URLS = frozenset(
     [
@@ -82,9 +95,14 @@ class CachePolicy:
         return current - self.fetched_at < self.max_age
 
 
+def _is_entry_bucket(name: str) -> bool:
+    """Whether ``name`` is a bucket of records nab writes and parses."""
+    return any(name.startswith(prefix) for prefix in ENTRY_BUCKET_PREFIXES)
+
+
 def is_recognized_bucket(name: str) -> bool:
     """Whether ``name`` is a bucket directory nab owns under a cache root."""
-    return any(name.startswith(prefix) for prefix in RECOGNIZED_BUCKET_PREFIXES)
+    return _is_entry_bucket(name) or name in SOURCE_BUCKETS
 
 
 def _index_dirname(index_url: str) -> str:
@@ -271,25 +289,39 @@ class OnDiskCache:
         """Remove any negative entry for ``package``. A miss is not an error."""
         self._neg_path(package).unlink(missing_ok=True)
 
+    def _root_children(self) -> list[Path]:
+        try:
+            return list(self._root.iterdir())
+        except OSError:
+            return []
+
     def _bucket_dirs(self) -> list[Path]:
         """Return the recognized bucket entries directly under the root.
 
         Symlinks are included so the caller can decide how to handle one
         rather than following it out of the root.
         """
-        try:
-            children = list(self._root.iterdir())
-        except OSError:
-            return []
-        return [child for child in children if is_recognized_bucket(child.name)]
+        return [
+            child for child in self._root_children() if is_recognized_bucket(child.name)
+        ]
+
+    def _entry_bucket_dirs(self) -> list[Path]:
+        """Return the bucket entries holding records nab wrote.
+
+        The source buckets are excluded: they hold upstream files, which
+        have no nab record format to read.
+        """
+        return [
+            child for child in self._root_children() if _is_entry_bucket(child.name)
+        ]
 
     def iter_cache_entries(self) -> Iterator[Path]:
-        """Yield each entry file inside the recognized buckets.
+        """Yield each entry file inside the record buckets.
 
         A symlinked bucket or a symlinked file is skipped, never followed
         out of the tree.
         """
-        for bucket in self._bucket_dirs():
+        for bucket in self._entry_bucket_dirs():
             if bucket.is_symlink() or not bucket.is_dir():
                 continue
             for dirpath, _dirnames, filenames in os.walk(bucket, followlinks=False):
@@ -436,7 +468,7 @@ class CacheBackend(Protocol):
         ...
 
     def iter_cache_entries(self) -> Iterator[Path]:
-        """Yield each entry file inside the recognized buckets."""
+        """Yield each entry file inside the record buckets."""
         ...
 
     def read_cache_entry(self, path: Path) -> str | None:

--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -17,11 +17,11 @@ A versioned bucket name (``simple-v0``) gives zero-cost schema
 migration: when the on-disk format changes, bump the suffix and the
 old directory is harmless.
 
-A resolve materialises two more buckets under the same root, holding
-upstream trees rather than nab records:
+A resolve writes two more buckets under the same root, holding upstream
+source trees:
 
-    vcs/       <- shallow clones, written by :mod:`nab_index.vcs`
-    archive/   <- extracted archive sources, keyed by verified digest
+    vcs/vcs/<repo key>/<commit sha>/   <- shallow clone
+    archive/<archive digest>/          <- extracted archive
 """
 
 from __future__ import annotations
@@ -31,6 +31,7 @@ import json
 import logging
 import os
 import shutil
+import stat
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -63,8 +64,8 @@ CACHE_VERSION_SDIST = "v1"
 # Buckets of nab-written records. simple-neg-* is covered by the simple- prefix.
 ENTRY_BUCKET_PREFIXES = ("simple-", "metadata-", "sdist-")
 
-# Buckets holding source trees a resolve materialises: cloned VCS checkouts and
-# extracted archives. nab owns the directories but not the files inside them.
+# Buckets a resolve fills with upstream source trees. nab owns the directories,
+# not the files inside them.
 VCS_BUCKET = "vcs"
 ARCHIVE_BUCKET = "archive"
 SOURCE_BUCKETS = (VCS_BUCKET, ARCHIVE_BUCKET)
@@ -131,6 +132,30 @@ def _require_single_segment(component: str) -> str:
         msg = f"cache key component is not a single path segment: {component!r}"
         raise ValueError(msg)
     return component
+
+
+def _add_owner_mode(path: Path, bits: int) -> None:
+    """Add ``bits`` to ``path``'s mode, leaving a symlink untouched."""
+    if path.is_symlink():
+        return
+    path.chmod(path.stat().st_mode | bits)
+
+
+def _make_removable(root: Path) -> None:
+    """Give the owner write on ``root`` and everything under it.
+
+    A clone carries read-only packfiles and an extracted archive keeps
+    the mode bits the archive declared, so either can leave a tree
+    ``rmtree`` cannot take apart. Symlinks are skipped so no chmod lands
+    outside the root.
+    """
+    _add_owner_mode(root, stat.S_IRWXU)
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        for name in dirnames:
+            _add_owner_mode(Path(dirpath, name), stat.S_IRWXU)
+        for name in filenames:
+            _add_owner_mode(Path(dirpath, name), stat.S_IWUSR)
 
 
 class OnDiskCache:
@@ -308,8 +333,8 @@ class OnDiskCache:
     def _entry_bucket_dirs(self) -> list[Path]:
         """Return the bucket entries holding records nab wrote.
 
-        The source buckets are excluded: they hold upstream files, which
-        have no nab record format to read.
+        The source buckets are excluded: they hold upstream files, not
+        nab records.
         """
         return [
             child for child in self._root_children() if _is_entry_bucket(child.name)
@@ -387,7 +412,11 @@ class OnDiskCache:
             if bucket.is_symlink():
                 bucket.unlink()
             elif bucket.is_dir():
-                shutil.rmtree(bucket)
+                try:
+                    shutil.rmtree(bucket)
+                except PermissionError:
+                    _make_removable(bucket)
+                    shutil.rmtree(bucket)
             else:
                 continue
             removed.append(bucket.name)

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -26,6 +26,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
 
+from nab_index.cache import ARCHIVE_BUCKET, VCS_BUCKET
 from nab_resolver.resolver import (
     Incompatibility,
     IncompatibilityCause,
@@ -833,9 +834,9 @@ def _resolve_one_target(
         vcs_config=config.vcs,
         local_sources=list(config.local_sources) or None,
         vcs_sources=list(config.vcs_sources) or None,
-        vcs_cache_dir=cache_dir / "vcs" if cache_dir is not None else None,
+        vcs_cache_dir=cache_dir / VCS_BUCKET if cache_dir is not None else None,
         archive_sources=list(config.archive_sources) or None,
-        archive_cache_dir=cache_dir / "archive" if cache_dir is not None else None,
+        archive_cache_dir=cache_dir / ARCHIVE_BUCKET if cache_dir is not None else None,
         build_config=config,
         resolution_strategy=settings.resolution,
         direct_packages=frozenset(

--- a/nab-python/tests/test_cache.py
+++ b/nab-python/tests/test_cache.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -20,6 +21,7 @@ from nab_index.cache import (
     _encode_policy,
     _index_dirname,
 )
+from nab_index.vcs import VcsRequest, prepare_clone
 
 # Two wheels of one version, each with its own PEP 658 sidecar.
 METADATA_URLS = (
@@ -676,6 +678,65 @@ class TestClearCache:
         cache = OnDiskCache(root, "https://pypi.org/simple")
         assert cache.clear_cache() == []
         assert foreign.read_text() == "mine"
+
+
+class TestSourceBuckets:
+    """The clone and archive trees a resolve leaves under the cache root."""
+
+    @staticmethod
+    def _clone_into(cache_root: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        """Return the tree the real clone helper writes under ``cache_root``."""
+
+        def fake_run(cmd: list[str], **kwargs: object) -> object:
+            cwd = Path(str(kwargs["cwd"]))
+            if cmd[:2] == ["git", "init"]:
+                (cwd / ".git").mkdir(exist_ok=True)
+            if cmd[:2] == ["git", "checkout"]:
+                (cwd / "pyproject.toml").write_text("[project]\n")
+            return type("P", (), {"returncode": 0})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        request = VcsRequest("git", "https://example/repo.git", "a" * 40, "")
+        return prepare_clone(cache_root, request, require_pin=True).path
+
+    @staticmethod
+    def _extract_into(cache_root: Path) -> Path:
+        tree = cache_root / ("b" * 64)
+        tree.mkdir(parents=True)
+        (tree / "pyproject.toml").write_text("[project]\n")
+        return tree
+
+    def test_clear_removes_the_clone_tree(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = tmp_path / "cache"
+        cache = _populate(root)
+        clone = self._clone_into(root / "vcs", monkeypatch)
+        assert (clone / "pyproject.toml").is_file()
+        assert "vcs" in cache.clear_cache()
+        assert not clone.exists()
+        assert not (root / "vcs").exists()
+
+    def test_clear_removes_the_archive_tree(self, tmp_path: Path) -> None:
+        root = tmp_path / "cache"
+        cache = _populate(root)
+        tree = self._extract_into(root / "archive")
+        assert "archive" in cache.clear_cache()
+        assert not tree.exists()
+        assert not (root / "archive").exists()
+
+    def test_verify_does_not_parse_source_trees(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = tmp_path / "cache"
+        cache = _populate(root)
+        clone = self._clone_into(root / "vcs", monkeypatch)
+        (clone / "fixture.json").write_text("not json")
+        (self._extract_into(root / "archive") / "data.json").write_text("not json")
+        names = {entry.name for entry in cache.iter_cache_entries()}
+        assert "fixture.json" not in names
+        assert "data.json" not in names
+        assert "foo.json" in names
 
 
 class TestNullCacheEnumeration:

--- a/nab-python/tests/test_cache.py
+++ b/nab-python/tests/test_cache.py
@@ -19,6 +19,7 @@ from nab_index.cache import (
     NullCache,
     OfflineError,
     OnDiskCache,
+    _add_owner_mode,
     _atomic_write,
     _encode_policy,
     _index_dirname,
@@ -760,6 +761,33 @@ class TestSourceBuckets:
         assert "fixture.json" not in names
         assert "data.json" not in names
         assert "foo.json" in names
+
+
+class TestAddOwnerMode:
+    """``_add_owner_mode`` grants the owner bit but never through a symlink."""
+
+    def test_grants_the_bit_on_a_real_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "packfile"
+        target.write_bytes(b"PACK")
+        target.chmod(0o444)
+        _add_owner_mode(target, stat.S_IWUSR)
+        assert target.stat().st_mode & stat.S_IWUSR
+
+    def test_leaves_a_symlink_alone(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A symlink is skipped so no chmod lands outside the cache root.
+
+        ``is_symlink`` is faked rather than making a real link: creating
+        one needs a privilege Windows CI does not have, and the guard
+        must be covered on every platform.
+        """
+        target = tmp_path / "looks-like-a-link"
+        target.write_bytes(b"x")
+        target.chmod(0o444)
+        monkeypatch.setattr(Path, "is_symlink", lambda _self: True)
+        _add_owner_mode(target, stat.S_IWUSR)
+        assert not target.stat().st_mode & stat.S_IWUSR
 
 
 class TestNullCacheEnumeration:

--- a/nab-python/tests/test_cache.py
+++ b/nab-python/tests/test_cache.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import stat
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -13,6 +14,7 @@ import pytest
 
 from nab_index.atomic import atomic_write_text
 from nab_index.cache import (
+    VCS_BUCKET,
     CachePolicy,
     NullCache,
     OfflineError,
@@ -685,7 +687,7 @@ class TestSourceBuckets:
 
     @staticmethod
     def _clone_into(cache_root: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-        """Return the tree the real clone helper writes under ``cache_root``."""
+        """Return the tree ``prepare_clone`` writes under ``cache_root``."""
 
         def fake_run(cmd: list[str], **kwargs: object) -> object:
             cwd = Path(str(kwargs["cwd"]))
@@ -724,6 +726,27 @@ class TestSourceBuckets:
         assert "archive" in cache.clear_cache()
         assert not tree.exists()
         assert not (root / "archive").exists()
+
+    def test_clear_removes_a_read_only_clone(self, tmp_path: Path) -> None:
+        root = tmp_path / "cache"
+        cache = _populate(root)
+        tree = root / VCS_BUCKET / "vcs" / ("0" * 16) / ("a" * 40)
+        tree.mkdir(parents=True)
+        packfile = tree / "pack-0.pack"
+        packfile.write_bytes(b"PACK")
+
+        outside = tmp_path / "outside.txt"
+        outside.write_text("upstream")
+        outside.chmod(0o444)
+        _symlink_or_skip(tree / "link", outside)
+
+        # A read-only file stops rmtree on Windows, a read-only directory on POSIX.
+        packfile.chmod(0o444)
+        tree.chmod(0o500)
+
+        assert VCS_BUCKET in cache.clear_cache()
+        assert not (root / VCS_BUCKET).exists()
+        assert not outside.stat().st_mode & stat.S_IWUSR
 
     def test_verify_does_not_parse_source_trees(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/src/nab/_cache_cmd.py
+++ b/src/nab/_cache_cmd.py
@@ -1,8 +1,9 @@
 """``nab cache`` subcommand: inspect and clear the on-disk cache.
 
 ``dir`` prints the resolved cache root, whether or not it exists.
-``verify`` walks the recognized buckets read-only and reports corrupt
-entries by path and reason. ``clear`` removes the recognized buckets.
+``verify`` walks the record buckets read-only and reports corrupt
+entries by path and reason. ``clear`` removes every bucket nab owns,
+including the cloned and extracted source trees.
 
 ``verify`` and ``clear`` descend only into the buckets nab owns, never
 follow a symlink out of the root, and refuse a root that holds foreign

--- a/tests/test_cache_cmd.py
+++ b/tests/test_cache_cmd.py
@@ -204,6 +204,41 @@ class TestCacheClear:
         assert (root / "metadata-notes.txt").read_text() == "data"
 
 
+class TestCacheSourceTrees:
+    """The vcs and archive trees a resolve writes under the same root."""
+
+    @staticmethod
+    def _populate_source_trees(root: Path) -> None:
+        clone = root / "vcs" / "vcs" / "0123456789abcdef" / ("a" * 40)
+        clone.mkdir(parents=True)
+        (clone / "pyproject.toml").write_text("[project]\n")
+        extracted = root / "archive" / ("b" * 64)
+        extracted.mkdir(parents=True)
+        (extracted / "pyproject.toml").write_text("[project]\n")
+
+    def test_clear_returns_the_cache_to_cold(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        root = tmp_path / "cache"
+        _populate(root)
+        self._populate_source_trees(root)
+        _run_cache(["clear", "--cache-dir", str(root)])
+        assert list(root.iterdir()) == []
+        assert str(root) in capsys.readouterr().err
+
+    def test_verify_and_clear_accept_a_source_only_root(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        root = tmp_path / "cache"
+        self._populate_source_trees(root)
+        _run_cache(["verify", "--cache-dir", str(root)])
+        assert capsys.readouterr().err == ""
+        _run_cache(["clear", "--cache-dir", str(root)])
+        assert list(root.iterdir()) == []
+        _run_cache(["clear", "--cache-dir", str(root)])
+        assert str(root) in capsys.readouterr().err
+
+
 class TestCacheUnknownAction:
     def test_unknown_action_exits_one(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
A resolve writes cloned repositories under `vcs/` and extracted archives under `archive/`, in the same cache root as the index records, but the bucket registry only listed the record buckets. `nab cache clear` walked past both trees, so the cache was not empty afterwards. And once the record buckets were gone, those two leftovers were all that was under the root, so the next `cache clear` or `cache verify` refused it as not a nab cache.

Both buckets are registered now, so clear removes them. Verify still reads only the record buckets: the source trees hold upstream files, not anything nab wrote or can parse.

Removing them also needs a retry. A clone keeps read-only packfiles and an extracted archive keeps whatever mode bits the archive declared, so `rmtree` can fail part way and leave the cache half cleared. On a `PermissionError` the clear adds owner write across the tree and tries again, skipping symlinks so no chmod lands outside the root.
