### PR TITLE
don't gunzip artifact bodies before the sha256 check

### DIFF
--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -34,6 +34,7 @@ from .lazy_wheel import (
     RangeOutcome,
     read_wheel_metadata_over_range,
 )
+from .transport import IDENTITY_HEADERS
 
 if TYPE_CHECKING:
     from packaging.utils import NormalizedName
@@ -379,7 +380,7 @@ class CachedAsyncSimpleClient:
             msg = f"No cached sdist PKG-INFO for {package}=={version} (offline mode)"
             raise OfflineError(msg)
 
-        response = await self._transport.get(sdist_url)
+        response = await self._transport.get(sdist_url, headers=IDENTITY_HEADERS)
         response.raise_for_status()
         selected = _select_artifact_hash(sdist_hashes)
         if selected is not None:
@@ -414,7 +415,7 @@ class CachedAsyncSimpleClient:
         if self._offline:
             msg = f"sdist archive fetch unavailable in offline mode ({sdist_url})"
             raise OfflineError(msg)
-        response = await self._transport.get(sdist_url)
+        response = await self._transport.get(sdist_url, headers=IDENTITY_HEADERS)
         response.raise_for_status()
         selected = _select_artifact_hash(sdist_hashes)
         if selected is not None:

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -25,7 +25,7 @@ from packaging.utils import (
 )
 from packaging.version import InvalidVersion, Version
 
-from .transport import HttpError
+from .transport import IDENTITY_HEADERS, HttpError
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -279,7 +279,7 @@ class AsyncSimpleClient:
 
     async def download(self, url: str) -> bytes:
         """Fetch a distribution artefact (wheel or sdist) as raw bytes."""
-        response = await self._transport.get(url)
+        response = await self._transport.get(url, headers=IDENTITY_HEADERS)
         response.raise_for_status()
         return response.content
 

--- a/nab-index/src/nab_index/httpx_async_transport.py
+++ b/nab-index/src/nab_index/httpx_async_transport.py
@@ -11,7 +11,7 @@ import httpx
 import truststore
 
 from .retry import MAX_REDIRECTS, MAX_RETRIES, RETRY_STATUSES, next_delay
-from .transport import ContentDecodingError, HttpError, decode_body
+from .transport import ContentDecodingError, HttpError, accepts_gzip, decode_body
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -24,10 +24,10 @@ __all__ = [
 class _HttpxResponse:
     """Adapter that gives an httpx response the HttpResponse shape.
 
-    The body is fetched undecoded and decoded by the transport (see
-    :func:`~nab_index.transport.decode_body`), so it is carried here
-    rather than read from the httpx response. raise_for_status is
-    translated so callers see one error type.
+    The body is fetched undecoded, and decoded by the transport when the
+    request asked for gzip (see :func:`~nab_index.transport.decode_body`),
+    so it is carried here rather than read from the httpx response.
+    raise_for_status is translated so callers see one error type.
     """
 
     __slots__ = ("_content", "_response")
@@ -87,13 +87,16 @@ class HttpxAsyncTransport:
         httpx has no retry machinery beyond reconnecting, so the shared policy
         runs in this loop rather than in the client. The body is read raw and
         decoded with ``decode_body``, so a truncated gzip stream is retried
-        instead of returned as if complete. Only gzip is advertised, the one
-        coding ``decode_body`` checks.
+        instead of returned as if complete. Only gzip is advertised, and a
+        caller can override that with
+        :data:`~nab_index.transport.IDENTITY_HEADERS` to get the body
+        undecoded.
         """
         request_headers = {"Accept-Encoding": "gzip"}
         if headers is not None:
             request_headers.update(headers)
 
+        decode = accepts_gzip(request_headers)
         failures = 0
 
         while True:
@@ -102,7 +105,11 @@ class HttpxAsyncTransport:
                     "GET", url, headers=request_headers
                 ) as response:
                     raw = b"".join([part async for part in response.aiter_raw()])
-                content = decode_body(raw, response.headers.get("Content-Encoding"))
+                content = (
+                    decode_body(raw, response.headers.get("Content-Encoding"))
+                    if decode
+                    else raw
+                )
             except (httpx.TooManyRedirects, httpx.UnsupportedProtocol) as exc:
                 # A redirect loop and an unsupported scheme are persistent, so
                 # they are raised rather than retried.

--- a/nab-index/src/nab_index/lazy_wheel.py
+++ b/nab-index/src/nab_index/lazy_wheel.py
@@ -31,6 +31,7 @@ from urllib.parse import urlsplit
 
 from .client import MalformedSimpleResponseError
 from .local_index import UnsupportedWheelError, wheel_metadata_member
+from .transport import IDENTITY_HEADERS
 
 if TYPE_CHECKING:
     from packaging.utils import NormalizedName
@@ -288,9 +289,7 @@ async def _range_get(
     transport: AsyncHttpTransport, url: str, range_header: str
 ) -> HttpResponse:
     """GET ``url`` for ``range_header`` bytes, forcing identity encoding."""
-    return await transport.get(
-        url, headers={"Accept-Encoding": "identity", "Range": range_header}
-    )
+    return await transport.get(url, headers={**IDENTITY_HEADERS, "Range": range_header})
 
 
 async def _suffix_attempt(
@@ -389,7 +388,7 @@ async def _full_body_fetch(transport: AsyncHttpTransport, url: str) -> bytes | N
     index cannot serve; a non-identity encoding returns ``None``, no usable
     bytes.
     """
-    response = await transport.get(url, headers={"Accept-Encoding": "identity"})
+    response = await transport.get(url, headers=IDENTITY_HEADERS)
     if response.status_code == _HTTP_OK and not _non_identity(response):
         return response.content
     response.raise_for_status()

--- a/nab-index/src/nab_index/transport.py
+++ b/nab-index/src/nab_index/transport.py
@@ -9,18 +9,23 @@ from __future__ import annotations
 
 import gzip
 import zlib
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Final, Protocol
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
 __all__ = [
+    "IDENTITY_HEADERS",
     "AsyncHttpTransport",
     "ContentDecodingError",
     "HttpError",
     "HttpResponse",
+    "accepts_gzip",
     "decode_body",
 ]
+
+# For a caller that needs the body exactly as stored, undecoded.
+IDENTITY_HEADERS: Final[dict[str, str]] = {"Accept-Encoding": "identity"}
 
 
 class HttpError(Exception):
@@ -33,6 +38,38 @@ class HttpError(Exception):
 
 class ContentDecodingError(Exception):
     """A response body did not decode as its Content-Encoding promised."""
+
+
+def _quality(params: str) -> float:
+    """Return an Accept-Encoding entry's ``q`` value, 1.0 when it carries none.
+
+    A ``q`` that does not parse reads as a refusal.
+    """
+    for param in params.split(";"):
+        key, _, value = param.partition("=")
+        if key.strip().lower() == "q":
+            try:
+                return float(value)
+            except ValueError:
+                return 0.0
+    return 1.0
+
+
+def accepts_gzip(request_headers: Mapping[str, str]) -> bool:
+    """Whether ``request_headers`` asked the server for gzip.
+
+    A static file server derives Content-Encoding from the filename, so it
+    serves a ``.tar.gz`` as its own untouched bytes under
+    ``Content-Encoding: gzip``. Decoding that yields a bare tar, which no
+    published digest covers, so only a coding the request asked for may be
+    undone.
+    """
+    folded = {name.lower(): value for name, value in request_headers.items()}
+    for entry in folded.get("accept-encoding", "").split(","):
+        coding, _, params = entry.partition(";")
+        if coding.strip().lower() == "gzip" and _quality(params) > 0:
+            return True
+    return False
 
 
 def decode_body(body: bytes, content_encoding: str | None) -> bytes:
@@ -104,6 +141,9 @@ class AsyncHttpTransport(Protocol):
         self, url: str, *, headers: dict[str, str] | None = None
     ) -> HttpResponse:
         """Send a GET request and return the response.
+
+        An implementation must not decode a coding ``headers`` did not ask
+        for; see :func:`accepts_gzip`.
 
         Raises :class:`HttpError` on a connection or transport failure.
         """

--- a/nab-index/src/nab_index/urllib3_async_transport.py
+++ b/nab-index/src/nab_index/urllib3_async_transport.py
@@ -19,7 +19,7 @@ import truststore
 import urllib3
 
 from .retry import GET_RETRY, MAX_RETRIES, next_delay
-from .transport import ContentDecodingError, HttpError, decode_body
+from .transport import ContentDecodingError, HttpError, accepts_gzip, decode_body
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -57,9 +57,9 @@ class _SSLContext(truststore.SSLContext):
 class _Urllib3Response:
     """Adapter that gives a urllib3 response the HttpResponse shape.
 
-    The body is fetched undecoded and decoded by the transport (see
-    :func:`~nab_index.transport.decode_body`), so it is carried here
-    rather than read from the urllib3 response.
+    The body is fetched undecoded, and decoded by the transport when the
+    request asked for gzip (see :func:`~nab_index.transport.decode_body`),
+    so it is carried here rather than read from the urllib3 response.
     """
 
     __slots__ = ("_content", "_response")
@@ -140,11 +140,13 @@ class Urllib3AsyncTransport:
     def _request(self, url: str, headers: dict[str, str]) -> _Urllib3Response:
         """Issue the GET on this worker thread, retrying a truncated body.
 
-        The body is fetched raw and decoded with ``decode_body``. urllib3's
-        retries cover connection errors and statuses, not a body that decodes
-        short, so that case is retried here on the same schedule.
+        The body is fetched raw, and decoded with ``decode_body`` when the
+        request asked for gzip. urllib3's retries cover connection errors and
+        statuses, not a body that decodes short, so that case is retried here
+        on the same schedule.
         """
         pool = self._pool()
+        decode = accepts_gzip(headers)
         failures = 0
 
         while True:
@@ -156,6 +158,9 @@ class Urllib3AsyncTransport:
                 retries=GET_RETRY,
                 decode_content=False,
             )
+
+            if not decode:
+                return _Urllib3Response(response, response.data)
 
             try:
                 content = decode_body(
@@ -176,7 +181,9 @@ class Urllib3AsyncTransport:
         """Send a GET request, off-loaded to a worker thread.
 
         Requests gzip; without it urllib3's stdlib base sends
-        ``Accept-Encoding: identity``, which disables compression.
+        ``Accept-Encoding: identity``, which disables compression. A caller
+        can override that with :data:`~nab_index.transport.IDENTITY_HEADERS`
+        to get the body undecoded.
         """
         request_headers = {"Accept-Encoding": "gzip"}
         if headers is not None:

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -27,6 +27,7 @@ from nab_index.client import SdistFile, WheelFile
 from nab_index.lazy_wheel import RangeCapabilityMemo, RangeOutcome
 from nab_index.local_index import LocalIndexClient, parse_file_url
 from nab_index.multi_index import IndexConfig, MultiIndexClient
+from nab_index.transport import IDENTITY_HEADERS
 
 from ._vendor.packaging.utils import canonicalize_name
 
@@ -1342,7 +1343,7 @@ class FetchCoordinator:
             if self._offline:
                 msg = f"archive fetch unavailable in offline mode ({req.url})"
                 raise OfflineError(msg)
-            response = await self._transport.get(req.url)
+            response = await self._transport.get(req.url, headers=IDENTITY_HEADERS)
             response.raise_for_status()
             data = response.content
 

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import gzip
+import hashlib
 import io
 import json
 import ssl
 import tarfile
 import threading
-from collections.abc import Iterator, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
@@ -21,6 +22,8 @@ import respx
 import truststore
 import urllib3
 
+from nab_index.cache import NullCache
+from nab_index.cached_client import CachedAsyncSimpleClient
 from nab_index.client import AsyncSimpleClient, _extract_sdist_files
 from nab_index.httpx_async_transport import HttpxAsyncTransport, _HttpxResponse
 from nab_index.retry import (
@@ -30,7 +33,13 @@ from nab_index.retry import (
     RETRY_STATUSES,
     next_delay,
 )
-from nab_index.transport import ContentDecodingError, HttpError, decode_body
+from nab_index.transport import (
+    AsyncHttpTransport,
+    ContentDecodingError,
+    HttpError,
+    accepts_gzip,
+    decode_body,
+)
 from nab_index.urllib3_async_transport import (
     Urllib3AsyncTransport,
     _SSLContext,
@@ -129,6 +138,50 @@ def _gzip_stub_index(bodies: list[bytes]) -> Iterator[_GzipStubIndex]:
     server = _GzipStubIndex(("127.0.0.1", 0), _GzipStubIndexHandler)
     server.bodies = list(bodies)
     server.seen = []
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+class _ArtifactStubIndex(ThreadingHTTPServer):
+    """Loopback index that labels a body from its filename.
+
+    ``mimetypes.guess_type("demo-1.0.tar.gz")`` reports a gzip encoding, so a
+    static file server sends the archive's own bytes under
+    ``Content-Encoding: gzip`` whatever the request asked for.
+    """
+
+    body: bytes
+    accept_encoding: list[str | None]
+
+
+class _ArtifactStubIndexHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        assert isinstance(self.server, _ArtifactStubIndex)
+        self.server.accept_encoding.append(self.headers.get("Accept-Encoding"))
+        body = self.server.body
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/x-tar")
+        self.send_header("Content-Encoding", "gzip")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        """Drop the handler's stderr access log."""
+
+
+@contextmanager
+def _artifact_stub_index(body: bytes) -> Iterator[_ArtifactStubIndex]:
+    server = _ArtifactStubIndex(("127.0.0.1", 0), _ArtifactStubIndexHandler)
+    server.body = body
+    server.accept_encoding = []
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
@@ -268,6 +321,42 @@ class TestDecodeBody:
     def test_corrupt_gzip_raises(self) -> None:
         with pytest.raises(ContentDecodingError, match="truncated or corrupt"):
             decode_body(b"not gzip at all", "gzip")
+
+
+class TestAcceptsGzip:
+    """The Accept-Encoding parsing that decides whether a body is decoded."""
+
+    def test_requested_gzip(self) -> None:
+        assert accepts_gzip({"Accept-Encoding": "gzip"})
+
+    def test_requested_identity(self) -> None:
+        assert not accepts_gzip({"Accept-Encoding": "identity"})
+
+    def test_value_is_case_insensitive(self) -> None:
+        assert accepts_gzip({"Accept-Encoding": "GZip"})
+
+    def test_name_is_case_insensitive(self) -> None:
+        assert accepts_gzip({"accept-encoding": "gzip"})
+        assert not accepts_gzip({"ACCEPT-ENCODING": "identity"})
+
+    def test_caller_override_replaces_the_transport_default(self) -> None:
+        """A transport merges the caller's headers over its own ``Accept-Encoding``."""
+        assert not accepts_gzip(
+            {"Accept-Encoding": "gzip", "accept-encoding": "identity"}
+        )
+
+    def test_zero_quality_is_a_refusal(self) -> None:
+        """``q=0`` says the coding is not acceptable."""
+        assert not accepts_gzip({"Accept-Encoding": "identity, gzip;q=0"})
+
+    def test_quality_above_zero_is_a_request(self) -> None:
+        assert accepts_gzip({"Accept-Encoding": "gzip; q=0.5, identity"})
+
+    def test_unparseable_quality_is_a_refusal(self) -> None:
+        assert not accepts_gzip({"Accept-Encoding": "gzip;q=high"})
+
+    def test_absent_header(self) -> None:
+        assert not accepts_gzip({"Accept": "application/json"})
 
 
 class TestFetchCoordinatorTransport:
@@ -1263,6 +1352,97 @@ def _build_tarball(members: list[tuple[str, bytes | None]]) -> bytes:
                 info.size = len(data)
                 tar.addfile(info, io.BytesIO(data))
     return buf.getvalue()
+
+
+SDIST_BODY = _build_tarball(
+    [
+        ("demo-1.0/PKG-INFO", b"Metadata-Version: 2.2\nName: demo\nVersion: 1.0\n"),
+        ("demo-1.0/pyproject.toml", b"[project]\nname = 'demo'\n"),
+    ]
+)
+SDIST_SHA256 = hashlib.sha256(SDIST_BODY).hexdigest()
+
+TRANSPORTS = [
+    pytest.param(Urllib3AsyncTransport, id="urllib3"),
+    pytest.param(lambda: HttpxAsyncTransport(http2=False), id="httpx"),
+]
+
+
+class TestArtifactContentEncoding:
+    """An artifact body is hashed as served, so it is never content-decoded."""
+
+    @pytest.mark.parametrize("make_transport", TRANSPORTS)
+    def test_download_returns_the_served_bytes(
+        self, make_transport: Callable[[], AsyncHttpTransport]
+    ) -> None:
+        with _artifact_stub_index(SDIST_BODY) as server:
+            url = f"http://127.0.0.1:{server.server_port}/demo-1.0.tar.gz"
+
+            async def go() -> bytes:
+                async with AsyncSimpleClient(make_transport()) as client:
+                    return await client.download(url)
+
+            data = asyncio.run(go())
+
+        assert data == SDIST_BODY
+        assert hashlib.sha256(data).hexdigest() == SDIST_SHA256
+        assert server.accept_encoding == ["identity"]
+
+    @pytest.mark.parametrize("make_transport", TRANSPORTS)
+    def test_sdist_files_clear_the_published_hash(
+        self, make_transport: Callable[[], AsyncHttpTransport]
+    ) -> None:
+        with _artifact_stub_index(SDIST_BODY) as server:
+            url = f"http://127.0.0.1:{server.server_port}/demo-1.0.tar.gz"
+
+            async def go() -> tuple[str | None, str | None]:
+                async with CachedAsyncSimpleClient(
+                    make_transport(), NullCache()
+                ) as client:
+                    return await client.get_sdist_files(
+                        "demo", "1.0", url, (("sha256", SDIST_SHA256),)
+                    )
+
+            pkg_info, pyproject = asyncio.run(go())
+
+        assert pkg_info is not None
+        assert "Name: demo" in pkg_info
+        assert pyproject == "[project]\nname = 'demo'\n"
+        assert server.accept_encoding == ["identity"]
+
+    @pytest.mark.parametrize("make_transport", TRANSPORTS)
+    def test_sdist_archive_clears_the_published_hash(
+        self, make_transport: Callable[[], AsyncHttpTransport]
+    ) -> None:
+        with _artifact_stub_index(SDIST_BODY) as server:
+            url = f"http://127.0.0.1:{server.server_port}/demo-1.0.tar.gz"
+
+            async def go() -> bytes:
+                async with CachedAsyncSimpleClient(
+                    make_transport(), NullCache()
+                ) as client:
+                    return await client.get_sdist_archive(
+                        "demo", "1.0", url, (("sha256", SDIST_SHA256),)
+                    )
+
+            assert asyncio.run(go()) == SDIST_BODY
+
+        assert server.accept_encoding == ["identity"]
+
+    @pytest.mark.parametrize("make_transport", TRANSPORTS)
+    def test_direct_archive_keeps_the_served_bytes(
+        self, make_transport: Callable[[], AsyncHttpTransport]
+    ) -> None:
+        """The ``archive-sources`` path, whose caller checks the declared hash."""
+        with (
+            _artifact_stub_index(SDIST_BODY) as server,
+            FetchCoordinator(transport=make_transport()) as coord,
+        ):
+            url = f"http://127.0.0.1:{server.server_port}/demo-1.0.tar.gz"
+            coord.request_direct_archive("demo", SDIST_SHA256, url).wait(timeout=10)
+            assert coord.index.get_sdist_archive("demo", SDIST_SHA256) == SDIST_BODY
+
+        assert server.accept_encoding == ["identity"]
 
 
 class TestExtractSdistFiles:


### PR DESCRIPTION
An index that derives `Content-Encoding` from the filename serves a `.tar.gz` under `Content-Encoding: gzip`, where the body is the stored file itself. nab decoded the body before checking the published hash, so it hashed a bare tar. An intact sdist then failed with a sha256 mismatch and the lock aborted.

Artifact fetches now send `Accept-Encoding: identity`, and both async transports only decode a coding the request asked for.
