### PR TITLE
source `nab cache`'s root from the config ladder

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -213,7 +213,7 @@ See [Configuration](configuration.md) for the source ladder and the
 
 Inspect and clear the on-disk cache. It takes one location selector,
 `--cache-dir PATH`. Without it the root is the one a run in the same
-directory uses: `cache-dir` comes off the same source ladder, so an
+directory uses: `cache-dir` is read off the config source ladder, so a
 `nab.toml` or `NAB_CACHE_DIR` sets it too (see
 [Configuration](configuration.md)). Three actions:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -212,8 +212,10 @@ See [Configuration](configuration.md) for the source ladder and the
 ## `nab cache`
 
 Inspect and clear the on-disk cache. It takes one location selector,
-`--cache-dir PATH`, defaulting to the same root a run uses. Three
-actions:
+`--cache-dir PATH`. Without it the root is the one a run in the same
+directory uses: `cache-dir` comes off the same source ladder, so an
+`nab.toml` or `NAB_CACHE_DIR` sets it too (see
+[Configuration](configuration.md)). Three actions:
 
 * `nab cache dir` prints the resolved cache root to stdout, whether or
   not it exists yet.

--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -1468,6 +1468,7 @@ def discover_layers(
     roots: SourceRoots,
     *,
     rejections: list[RejectedLayer] | None = None,
+    read_pyproject: bool = True,
 ) -> list[Layer]:
     """Read every present TOML source into ordered layers (low -> high).
 
@@ -1476,8 +1477,12 @@ def discover_layers(
     absent.  Hermetic: the caller supplies the roots, so nothing touches
     the real ``~/.config``.  There is no walk-up: the project source is
     the pyproject directory only.
+
+    ``read_pyproject=False`` drops the pyproject layer while keeping the
+    project-dir ``nab.toml``, for a caller reading a USER-scope option
+    the category gate bars pyproject from setting.
     """
-    if roots.project_dir is None:
+    if roots.project_dir is None or not read_pyproject:
         pyproject_path = None
     elif roots.pyproject is not None:
         pyproject_path = roots.pyproject

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -612,6 +612,15 @@ class TestDiscoverAndMissing:
         with pytest.raises(SourceConfigError, match="not a regular file"):
             discover_layers(SourceRoots(project_dir=tmp_path))
 
+    def test_read_pyproject_false_keeps_project_nab_toml(self, tmp_path: Path) -> None:
+        _write(tmp_path / "pyproject.toml", "[project\n")
+        _write(tmp_path / "nab.toml", 'resolution = "lowest"\n')
+        layers = discover_layers(
+            SourceRoots(project_dir=tmp_path), read_pyproject=False
+        )
+        assert [layer.origin.kind for layer in layers] == [SourceKind.PROJECT_TOML]
+        assert layers[0].values["resolution"] is ResolutionStrategy.LOWEST
+
 
 class TestRenderers:
     def test_render_list(self, tmp_path: Path) -> None:

--- a/src/nab/_cache_cmd.py
+++ b/src/nab/_cache_cmd.py
@@ -21,7 +21,6 @@ from nab_index.cache import OnDiskCache, is_recognized_bucket
 from nab_python.config_sources import SourceConfigError
 
 from .cli import (
-    _cli_overrides,
     _default_cache_dir,
     _fail_config,
     app,
@@ -63,18 +62,20 @@ def cache_command(
 def _cache_root(cache_dir: Path | None) -> Path:
     """Resolve the cache root a run in this directory would use.
 
-    ``cache-dir`` is a layered USER-scope option, so a system, user or
-    project ``nab.toml`` and ``NAB_CACHE_DIR`` set it as well as
-    ``--cache-dir``.  Discovery is rooted at the current directory, the
-    same place ``nab lock`` looks for its project sources by default.
+    ``--cache-dir`` is answered without reading any config, so the
+    maintenance verbs still work when a project file is broken.
+    Otherwise ``cache-dir`` comes off the ladder rooted at the current
+    directory, minus the pyproject layer: the key is USER scope, which
+    the category gate bars pyproject from setting.
     """
-    overrides = _cli_overrides(
-        cli_resolution=None, cli_offline=None, cli_cache_dir=cache_dir
-    )
+    if cache_dir is not None:
+        return cache_dir
+
     try:
-        effective = effective_config(Path("pyproject.toml"), cli_overrides=overrides)
+        effective = effective_config(Path("pyproject.toml"), read_pyproject=False)
     except SourceConfigError as exc:
         _fail_config(exc)
+
     configured = effective["cache-dir"].value
     return _default_cache_dir() if configured is None else configured
 

--- a/src/nab/_cache_cmd.py
+++ b/src/nab/_cache_cmd.py
@@ -12,14 +12,22 @@ files.
 from __future__ import annotations
 
 import sys
-from pathlib import Path  # noqa: TC003 - tyro evaluates the flag annotations at runtime
+from pathlib import Path
 from typing import Annotated
 
 import tyro
 
 from nab_index.cache import OnDiskCache, is_recognized_bucket
+from nab_python.config_sources import SourceConfigError
 
-from .cli import _default_cache_dir, app, printer
+from .cli import (
+    _cli_overrides,
+    _default_cache_dir,
+    _fail_config,
+    app,
+    effective_config,
+    printer,
+)
 
 ActionArg = Annotated[str, tyro.conf.Positional]
 
@@ -36,7 +44,7 @@ def cache_command(
     walks the cache read-only and reports corrupt entries. ``nab cache
     clear`` removes every recognized bucket.
     """
-    root = cache_dir if cache_dir is not None else _default_cache_dir()
+    root = _cache_root(cache_dir)
     if action == "dir":
         sys.stdout.write(f"{root}\n")
         return
@@ -50,6 +58,25 @@ def cache_command(
         f"unknown cache action {action!r}; expected one of 'dir', 'verify', 'clear'"
     )
     sys.exit(1)
+
+
+def _cache_root(cache_dir: Path | None) -> Path:
+    """Resolve the cache root a run in this directory would use.
+
+    ``cache-dir`` is a layered USER-scope option, so a system, user or
+    project ``nab.toml`` and ``NAB_CACHE_DIR`` set it as well as
+    ``--cache-dir``.  Discovery is rooted at the current directory, the
+    same place ``nab lock`` looks for its project sources by default.
+    """
+    overrides = _cli_overrides(
+        cli_resolution=None, cli_offline=None, cli_cache_dir=cache_dir
+    )
+    try:
+        effective = effective_config(Path("pyproject.toml"), cli_overrides=overrides)
+    except SourceConfigError as exc:
+        _fail_config(exc)
+    configured = effective["cache-dir"].value
+    return _default_cache_dir() if configured is None else configured
 
 
 def _verify(root: Path) -> None:

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -226,6 +226,7 @@ def effective_config(
     cli_overrides: Mapping[str, object] | None = None,
     collect_rejected: bool = False,
     rejected_out: list[RejectedLayer] | None = None,
+    read_pyproject: bool = True,
 ) -> dict[str, EffectiveValue]:
     """Resolve the full layered config for the pyproject at ``path``.
 
@@ -238,7 +239,9 @@ def effective_config(
     ``rejected_out``, when supplied, is filled with the full rejection
     list so the caller can also surface the orphan rejections (an unknown
     key or ``NAB_*`` var that names no registry option, and so attaches to
-    no key) that ``nab config list`` reports.
+    no key) that ``nab config list`` reports.  ``read_pyproject=False``
+    skips the pyproject layer, for a caller reading a USER-scope key that
+    pyproject may not set.
     """
     roots = _config_search_roots(path)
     rejected: list[RejectedLayer] = []
@@ -247,7 +250,7 @@ def effective_config(
     # durations across the two project files are not read as conflicting
     # values (the resolve path uses its lockfile anchor instead).
     with inspector_anchor():
-        layers = discover_layers(roots, rejections=sink)
+        layers = discover_layers(roots, rejections=sink, read_pyproject=read_pyproject)
         env_layer = read_env_layer(
             os.environ, reserved_env=OUTPUT_ENV_VARS, rejections=sink
         )

--- a/tests/test_cache_cmd.py
+++ b/tests/test_cache_cmd.py
@@ -9,8 +9,31 @@ import pytest
 from nab import cli as nab_cli
 from nab.cli import app
 from nab_index.cache import CachePolicy, OnDiskCache
+from nab_python.config_sources import SourceRoots
 
 _FRESH = CachePolicy(fetched_at=0, max_age=600, etag=None)
+
+
+# Layout of the tmp config tree the autouse fixture points discovery at.
+_USER_TOML = Path("usr") / "nab.toml"
+_PROJECT_TOML = Path("proj") / "nab.toml"
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_config_roots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point config discovery at a tmp tree so the real ~/.config is never read."""
+    roots = SourceRoots(
+        system_toml=tmp_path / "sys" / "nab.toml",
+        user_toml=tmp_path / _USER_TOML,
+        project_dir=tmp_path / _PROJECT_TOML.parent,
+    )
+    monkeypatch.setattr(nab_cli, "_config_search_roots", lambda _: roots)
+    monkeypatch.delenv("NAB_CACHE_DIR", raising=False)
+
+
+def _write_toml(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
 
 
 def _symlink_or_skip(
@@ -76,6 +99,98 @@ class TestCacheDir:
         target = tmp_path / "never-created"
         _run_cache(["dir", "--cache-dir", str(target)])
         assert capsys.readouterr().out == f"{target}\n"
+
+
+class TestLayeredCacheDir:
+    """The default root comes from the same ladder a run resolves it through."""
+
+    def test_user_toml_sets_the_root(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        target = tmp_path / "user-declared"
+        _write_toml(tmp_path / _USER_TOML, f'cache-dir = "{target.as_posix()}"\n')
+        _run_cache(["dir"])
+        assert capsys.readouterr().out == f"{target}\n"
+
+    def test_project_toml_sets_the_root(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        target = tmp_path / "project-declared"
+        _write_toml(tmp_path / _PROJECT_TOML, f'cache-dir = "{target.as_posix()}"\n')
+        _run_cache(["dir"])
+        assert capsys.readouterr().out == f"{target}\n"
+
+    def test_env_var_sets_the_root(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        target = tmp_path / "env-declared"
+        monkeypatch.setenv("NAB_CACHE_DIR", str(target))
+        _run_cache(["dir"])
+        assert capsys.readouterr().out == f"{target}\n"
+
+    def test_env_var_beats_the_user_toml(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        declared = tmp_path / "user-declared"
+        _write_toml(tmp_path / _USER_TOML, f'cache-dir = "{declared.as_posix()}"\n')
+        target = tmp_path / "env-declared"
+        monkeypatch.setenv("NAB_CACHE_DIR", str(target))
+        _run_cache(["dir"])
+        assert capsys.readouterr().out == f"{target}\n"
+
+    def test_flag_beats_the_env_var(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("NAB_CACHE_DIR", str(tmp_path / "env-declared"))
+        target = tmp_path / "flagged"
+        _run_cache(["dir", "--cache-dir", str(target)])
+        assert capsys.readouterr().out == f"{target}\n"
+
+    def test_verify_reads_the_layered_root(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        root = tmp_path / "env-declared"
+        _populate(root)
+        policy_path = root / "simple-v0" / "pypi" / "foo.policy"
+        policy_path.write_bytes(b"not json")
+        monkeypatch.setenv("NAB_CACHE_DIR", str(root))
+        _run_cache(["verify"])
+        assert str(policy_path) in capsys.readouterr().err
+
+    def test_clear_empties_the_layered_root(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        root = tmp_path / "env-declared"
+        _populate(root)
+        monkeypatch.setenv("NAB_CACHE_DIR", str(root))
+        _run_cache(["clear"])
+        assert not (root / "simple-v0").exists()
+        assert not (root / "metadata-v1").exists()
+        assert str(root) in capsys.readouterr().err
+
+    def test_bad_layer_value_exits_one(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _write_toml(tmp_path / _USER_TOML, "cache-dir = 5\n")
+        with pytest.raises(SystemExit) as exc:
+            _run_cache(["dir"])
+        assert exc.value.code == 1
+        assert "config error" in capsys.readouterr().err
 
 
 class TestCacheVerify:

--- a/tests/test_cache_cmd.py
+++ b/tests/test_cache_cmd.py
@@ -14,21 +14,31 @@ from nab_python.config_sources import SourceRoots
 _FRESH = CachePolicy(fetched_at=0, max_age=600, etag=None)
 
 
-# Layout of the tmp config tree the autouse fixture points discovery at.
+# Relative to tmp_path, which the fixture below points discovery at.
 _USER_TOML = Path("usr") / "nab.toml"
 _PROJECT_TOML = Path("proj") / "nab.toml"
 
 
 @pytest.fixture(autouse=True)
-def _hermetic_config_roots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Point config discovery at a tmp tree so the real ~/.config is never read."""
+def config_anchors(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> list[Path]:
+    """Point config discovery at a tmp tree so the real ~/.config is never read.
+
+    The returned list records the anchor each lookup was given.
+    """
     roots = SourceRoots(
         system_toml=tmp_path / "sys" / "nab.toml",
         user_toml=tmp_path / _USER_TOML,
         project_dir=tmp_path / _PROJECT_TOML.parent,
     )
-    monkeypatch.setattr(nab_cli, "_config_search_roots", lambda _: roots)
+    anchors: list[Path] = []
+
+    def _roots(pyproject: Path) -> SourceRoots:
+        anchors.append(pyproject)
+        return roots
+
+    monkeypatch.setattr(nab_cli, "_config_search_roots", _roots)
     monkeypatch.delenv("NAB_CACHE_DIR", raising=False)
+    return anchors
 
 
 def _write_toml(path: Path, body: str) -> None:
@@ -102,9 +112,9 @@ class TestCacheDir:
 
 
 class TestLayeredCacheDir:
-    """The default root comes from the same ladder a run resolves it through."""
+    """Without ``--cache-dir`` the root comes off the config ladder."""
 
-    def test_user_toml_sets_the_root(
+    def test_user_toml_sets_root(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
         target = tmp_path / "user-declared"
@@ -112,7 +122,7 @@ class TestLayeredCacheDir:
         _run_cache(["dir"])
         assert capsys.readouterr().out == f"{target}\n"
 
-    def test_project_toml_sets_the_root(
+    def test_project_toml_sets_root(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
         target = tmp_path / "project-declared"
@@ -120,7 +130,7 @@ class TestLayeredCacheDir:
         _run_cache(["dir"])
         assert capsys.readouterr().out == f"{target}\n"
 
-    def test_env_var_sets_the_root(
+    def test_env_var_sets_root(
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
@@ -131,7 +141,7 @@ class TestLayeredCacheDir:
         _run_cache(["dir"])
         assert capsys.readouterr().out == f"{target}\n"
 
-    def test_env_var_beats_the_user_toml(
+    def test_env_var_beats_user_toml(
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
@@ -144,7 +154,7 @@ class TestLayeredCacheDir:
         _run_cache(["dir"])
         assert capsys.readouterr().out == f"{target}\n"
 
-    def test_flag_beats_the_env_var(
+    def test_flag_beats_env_var(
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
@@ -155,7 +165,7 @@ class TestLayeredCacheDir:
         _run_cache(["dir", "--cache-dir", str(target)])
         assert capsys.readouterr().out == f"{target}\n"
 
-    def test_verify_reads_the_layered_root(
+    def test_verify_reads_layered_root(
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
@@ -169,7 +179,7 @@ class TestLayeredCacheDir:
         _run_cache(["verify"])
         assert str(policy_path) in capsys.readouterr().err
 
-    def test_clear_empties_the_layered_root(
+    def test_clear_empties_layered_root(
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
@@ -191,6 +201,45 @@ class TestLayeredCacheDir:
             _run_cache(["dir"])
         assert exc.value.code == 1
         assert "config error" in capsys.readouterr().err
+
+    def test_discovery_anchored_at_working_dir(
+        self, config_anchors: list[Path], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _run_cache(["dir"])
+        capsys.readouterr()
+        assert config_anchors == [Path("pyproject.toml")]
+
+    def test_flag_wins_over_bad_value(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _write_toml(tmp_path / _PROJECT_TOML, "cache-dir = 5\n")
+        target = tmp_path / "flagged"
+        _run_cache(["dir", "--cache-dir", str(target)])
+        captured = capsys.readouterr()
+        assert captured.out == f"{target}\n"
+        assert captured.err == ""
+
+    def test_flag_wins_over_unparsable_toml(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _write_toml(tmp_path / _PROJECT_TOML, "cache-dir = \n")
+        target = tmp_path / "flagged"
+        _run_cache(["clear", "--cache-dir", str(target)])
+        assert str(target) in capsys.readouterr().err
+
+    def test_pyproject_layer_not_read(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """pyproject cannot carry a USER-scope key, so it is not consulted."""
+        _write_toml(tmp_path / _PROJECT_TOML.parent / "pyproject.toml", "[project\n")
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xc"))
+        _run_cache(["dir"])
+        captured = capsys.readouterr()
+        assert captured.out == f"{tmp_path / 'xc' / 'nab'}\n"
+        assert captured.err == ""
 
 
 class TestCacheVerify:


### PR DESCRIPTION
`nab cache` read its root from the built-in default only, so `NAB_CACHE_DIR` and a `cache-dir` set in a system, user, or project `nab.toml` never reached it. `nab cache dir` printed a root the run never used, `verify` walked the wrong tree, and `clear` reported success on a cache the run never wrote to.

It now resolves `cache-dir` through the same layered config every other surface uses. `--cache-dir` still wins and is answered without reading any config, so the maintenance verbs keep working when a project file is broken. The ladder read skips the pyproject layer, since `cache-dir` is a USER-scope key the category gate bars pyproject from setting.
