### PR TITLE
fix build-remote requires-python gate over-rejecting compatible sdists

### DIFF
--- a/nab-python/src/nab_python/_provider/build_remote.py
+++ b/nab-python/src/nab_python/_provider/build_remote.py
@@ -24,11 +24,11 @@ from nab_index.client import SdistFile, WheelFile, extract_sdist_archive
 
 from .._vendor.packaging.specifiers import SpecifierSet
 from .._vendor.packaging.utils import canonicalize_name
-from .._vendor.packaging.version import Version
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from .._vendor.packaging.version import Version
     from ..metadata import WheelMetadata
     from ..provider import Provider
 
@@ -98,15 +98,19 @@ def build_remote_sdist(
             msg = f"{package}=={version} build-remote backend failed: {exc}"
             raise UnsupportedSdistError(msg) from exc
 
-    target = provider.python_version
+    target = provider.target
     override_rp = provider.effective_requires_python(canonical, version)
     spec = (
         SpecifierSet(override_rp) if override_rp is not None else built.requires_python
     )
-    if spec is not None and target and Version(target) not in spec:
+    if (
+        spec is not None
+        and target is not None
+        and not target.admits_requires_python(spec)
+    ):
         msg = (
             f"{package}=={version} built sdist requires Python {spec} but the"
-            f" resolve targets Python {target}"
+            f" resolve targets Python {target.python_full_version}"
         )
         raise UnsupportedSdistError(msg)
     if canonicalize_name(built.name) != canonical or built.version != version:

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -7940,12 +7940,13 @@ class TestBuildRemoteFailureModes:
         *,
         with_sdist: bool,
         overrides: tuple[PackageOverride, ...] = (),
+        target: ResolveTarget = _PY312,
     ) -> Provider:
         files = [make_sdist("1.0")] if with_sdist else [make_wheel("1.0")]
         coordinator = make_coordinator(files, package="pkg")
         return Provider(
             coordinator,
-            target=_PY312,
+            target=target,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.BUILD_REMOTE,
             package_overrides=overrides,
@@ -8093,8 +8094,9 @@ class TestBuildRemoteFailureModes:
         built: object,
         *,
         overrides: tuple[PackageOverride, ...] = (),
+        target: ResolveTarget = _PY312,
     ) -> Provider:
-        provider = self._provider(with_sdist=True, overrides=overrides)
+        provider = self._provider(with_sdist=True, overrides=overrides, target=target)
         provider.versions_cache["pkg"] = [(V("1.0"), make_sdist("1.0"))]
 
         def _ok_fetch(
@@ -8156,7 +8158,39 @@ class TestBuildRemoteFailureModes:
             provides_extra=[],
         )
         provider = self._build_into(monkeypatch, built)
-        provider.python_version = None
+        provider.target = None
+        result = build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
+        assert result is built
+
+    def test_prerelease_target_admits_matching_requires_python(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        built = WheelMetadata(
+            name="pkg",
+            version=V("1.0"),
+            requires_python=SpecifierSet(">=3.14"),
+            requires_dist=[Requirement("dep-a>=1")],
+            provides_extra=[],
+        )
+        provider = self._build_into(
+            monkeypatch, built, target=ResolveTarget.for_host_python("3.14.0rc1")
+        )
+        result = build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
+        assert result is built
+
+    def test_bare_minor_target_admits_micro_floor_requires_python(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        built = WheelMetadata(
+            name="pkg",
+            version=V("1.0"),
+            requires_python=SpecifierSet(">=3.9.2"),
+            requires_dist=[Requirement("dep-a>=1")],
+            provides_extra=[],
+        )
+        provider = self._build_into(
+            monkeypatch, built, target=ResolveTarget.for_host_python("3.9")
+        )
         result = build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
         assert result is built
 


### PR DESCRIPTION
The BUILD_REMOTE path checks a freshly built sdist's Requires-Python before accepting it, but it parsed the resolve target as a single Version and tested `Version(target) in spec`. That scalar check rejected sdists that build and run fine on the target:

- a prerelease target like 3.14.0rc1 fails `>=3.14`, because the prerelease sorts below 3.14.0
- a bare-minor target like 3.9 fails `>=3.9.2`, because the synthetic 3.9.0 floor sits below 3.9.2 even though the whole 3.9 line covers 3.9.2

Use `target.admits_requires_python(spec)` instead. It admits a minor target when the specifier overlaps the whole minor interval, and a whole target when its release satisfies the spec, which is how the rest of the resolve already treats Requires-Python.
