### PR TITLE
docs: note global output flags also apply to nab cache

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -253,9 +253,10 @@ The verbosity, colour, and progress flags below are also global.
 
 These flags set how much `nab` writes to stderr, whether it colours it,
 and whether it animates a progress line. They are global: `nab` reads them
-before the subcommand, so they work with `lock`, `download`, and `config`.
-stdout carries only the requested output (the lockfile, the requirements
-list, the `config` dump), so it stays pipeable at every verbosity.
+before the subcommand, so they work with `lock`, `download`, `config`, and
+`cache`. stdout carries only the requested output (the lockfile, the
+requirements list, the `config` dump), so it stays pipeable at every
+verbosity.
 
 | Flag | Effect |
 | ---- | ------ |

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -430,9 +430,16 @@ def test_progress_clear_wipes_then_is_noop() -> None:
 
 _CLI_REFERENCE = Path(__file__).resolve().parents[1] / "docs" / "reference" / "cli.md"
 
+_SUBCOMMANDS = ("lock", "download", "config", "cache")
+
 
 def _cli_reference_text() -> str:
     return _CLI_REFERENCE.read_text(encoding="utf-8")
+
+
+def _section_body(text: str, heading: str) -> str:
+    after = text.partition(f"\n{heading}\n")[2]
+    return after.partition("\n## ")[0]
 
 
 class TestCliReferenceDocumentsOutputPolicy:
@@ -471,4 +478,25 @@ class TestCliReferenceDocumentsOutputPolicy:
             name = level.name.lower()
             assert f"`{name}`" in text, (
                 f"CLI reference omits NAB_VERBOSITY value {name!r}"
+            )
+
+    def test_output_control_scope_covers_every_subcommand(self) -> None:
+        """The scope paragraph must name every subcommand the flags reach.
+
+        ``main`` extracts a global ``-q`` before dispatching to any
+        subcommand, so the doc's enumeration must include ``cache``.
+        """
+        for sub in _SUBCOMMANDS:
+            _opts, rest = parse_output_options(["-q", sub], {})
+            assert rest == [sub], f"global -q not extracted before {sub!r}"
+
+        text = _cli_reference_text()
+        scope = next(
+            para
+            for para in _section_body(text, "## Output control").split("\n\n")
+            if "before the subcommand" in para
+        )
+        for sub in _SUBCOMMANDS:
+            assert f"`{sub}`" in scope, (
+                f"Output control scope omits the {sub!r} subcommand"
             )


### PR DESCRIPTION
The Output control section said the verbosity, colour, and progress flags work with `lock`, `download`, and `config`, but left `cache` out. That contradicts the same page's synopsis, which already lists `nab [OUTPUT FLAGS] cache`, and `cli.py::main`, which parses those flags before dispatching to any subcommand.

Add `cache` to the enumeration, plus a test that checks the global `-q` is extracted ahead of every subcommand and that the scope paragraph names each one.
