### PR TITLE
verify a range-recovered full-body wheel against its published hash

### DIFF
--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -325,6 +325,7 @@ class CachedAsyncSimpleClient:
         version: str,
         wheel_url: str,
         canonical_name: NormalizedName,
+        wheel_hashes: tuple[tuple[str, str], ...] = (),
     ) -> RangeMetadataResult:
         """Recover a sidecar-less wheel's METADATA by HTTP range reads.
 
@@ -336,6 +337,11 @@ class CachedAsyncSimpleClient:
         the shared range-capability memo. Only a successful read is cached; an
         ``UNSUPPORTED`` or ``MISSING`` result writes nothing so the caller can
         step to the sdist rung.
+
+        When ``wheel_hashes`` carries an acceptable published digest, a
+        full-body acquisition is verified against it before its METADATA is
+        read, mirroring the sdist path. A mismatch raises
+        :class:`WheelHashMismatchError` and nothing is cached.
         """
         cached = self._cache.get_metadata(package, wheel_url)
         if cached is not None:
@@ -346,7 +352,11 @@ class CachedAsyncSimpleClient:
             raise OfflineError(msg)
 
         result = await read_wheel_metadata_over_range(
-            self._transport, wheel_url, canonical_name, self._range_memo
+            self._transport,
+            wheel_url,
+            canonical_name,
+            self._range_memo,
+            wheel_hash=_select_artifact_hash(wheel_hashes),
         )
         if result.text is not None:
             self._cache.put_metadata(package, wheel_url, result.text)

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -43,6 +43,7 @@ __all__ = [
     "SdistFile",
     "SdistHashMismatchError",
     "WheelFile",
+    "WheelHashMismatchError",
     "extract_sdist_archive",
 ]
 
@@ -70,6 +71,10 @@ class MetadataHashMismatchError(Exception):
 
 class SdistHashMismatchError(Exception):
     """A fetched sdist archive did not match its published hash."""
+
+
+class WheelHashMismatchError(Exception):
+    """A range-recovered wheel's bytes did not match its published hash."""
 
 
 # Mirrors packaging.utils._build_tag_regex: PEP 427 build numbers start with a digit.

--- a/nab-index/src/nab_index/lazy_wheel.py
+++ b/nab-index/src/nab_index/lazy_wheel.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 import bisect
 import enum
+import hashlib
 import io
 import os
 import re
@@ -29,7 +30,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
-from .client import MalformedSimpleResponseError
+from .client import MalformedSimpleResponseError, WheelHashMismatchError
 from .local_index import UnsupportedWheelError, wheel_metadata_member
 
 if TYPE_CHECKING:
@@ -442,19 +443,24 @@ async def _acquire(
 
 
 def _absorb_range(
-    response: HttpResponse, sparse: _SparseFile, partial_low: int
+    response: HttpResponse,
+    sparse: _SparseFile,
+    partial_low: int,
+    wheel_hash: tuple[str, str] | None,
 ) -> int | None:
     """Absorb a growth or member range response into ``sparse``.
 
     Returns the low offset at which bytes were populated, or ``None`` when the
-    response yielded no usable bytes.  A volunteered 200 full body populates
-    the whole file from offset 0 and is used rather than discarded.  A range
-    refused mid-read raises :class:`_RangeRefusedError` so the reader can step
-    down to the plain GET.  Any other 4xx/5xx on the wheel URL raises through
-    and fails the resolve, matching the first round trip; a non-identity
-    encoding yields no usable bytes.
+    response yielded no usable bytes.  A volunteered 200 full body is checked
+    against ``wheel_hash`` (raising :class:`WheelHashMismatchError` on a
+    mismatch) and then populates the whole file from offset 0, used rather than
+    discarded.  A range refused mid-read raises :class:`_RangeRefusedError` so
+    the reader can step down to the plain GET.  Any other 4xx/5xx on the wheel
+    URL raises through and fails the resolve, matching the first round trip; a
+    non-identity encoding yields no usable bytes.
     """
     if response.status_code == _HTTP_OK and not _non_identity(response):
+        _verify_full_body(response.content, wheel_hash)
         sparse.add_span(0, response.content)
         return 0
     if response.status_code in _RANGE_REJECT_STATUSES:
@@ -484,7 +490,11 @@ def _try_open(sparse: _SparseFile) -> zipfile.ZipFile | None:
 
 
 async def _open_zip(
-    transport: AsyncHttpTransport, url: str, sparse: _SparseFile, tail_low: int
+    transport: AsyncHttpTransport,
+    url: str,
+    sparse: _SparseFile,
+    tail_low: int,
+    wheel_hash: tuple[str, str] | None,
 ) -> zipfile.ZipFile | None:
     """Open a ZipFile over the sparse buffer, growing the window on demand."""
     total = sparse._length  # noqa: SLF001
@@ -498,7 +508,7 @@ async def _open_zip(
         new_size = min(have * 2, total, _MAX_TAIL)
         new_low = total - new_size
         response = await _range_get(transport, url, f"bytes={new_low}-{tail_low - 1}")
-        low = _absorb_range(response, sparse, new_low)
+        low = _absorb_range(response, sparse, new_low, wheel_hash)
         if low is None:
             return None
         tail_low = low
@@ -526,15 +536,16 @@ async def _read_sparse(
     sparse: _SparseFile,
     tail_low: int,
     canonical_name: NormalizedName,
+    wheel_hash: tuple[str, str] | None,
 ) -> bytes | None:
     """Read the METADATA member out of the sparse buffer, or ``None``.
 
-    Only :class:`_RangeRefusedError` and the transport's errors travel out of
-    the growth and member requests; every way the zip machinery can choke on
-    the fetched bytes reads back as ``None``.
+    Only :class:`_RangeRefusedError`, :class:`WheelHashMismatchError`, and the
+    transport's errors travel out of the growth and member requests; every way
+    the zip machinery can choke on the fetched bytes reads back as ``None``.
     """
     try:
-        zip_file = await _open_zip(transport, url, sparse, tail_low)
+        zip_file = await _open_zip(transport, url, sparse, tail_low, wheel_hash)
         member = (
             None
             if zip_file is None
@@ -547,7 +558,7 @@ async def _read_sparse(
     start, end = _member_span(zip_file, member)
     if not sparse.populated(start, end):
         response = await _range_get(transport, url, f"bytes={start}-{end - 1}")
-        if _absorb_range(response, sparse, start) is None:
+        if _absorb_range(response, sparse, start, wheel_hash) is None:
             return None
     try:
         return zip_file.read(member)
@@ -556,6 +567,23 @@ async def _read_sparse(
         # surface as several exception types; all mean the member is
         # unrecoverable from this artifact, never that the resolver is broken.
         return None
+
+
+def _verify_full_body(body: bytes, wheel_hash: tuple[str, str] | None) -> None:
+    """Raise :class:`WheelHashMismatchError` if a full body fails its published hash.
+
+    ``wheel_hash`` is ``None`` when the listing published no accepted digest, so
+    no check runs. Only a full body can be verified this way; a partial read
+    holds just a slice of the wheel.
+    """
+    if wheel_hash is None:
+        return
+
+    algo, expected = wheel_hash
+    actual = hashlib.new(algo, body).hexdigest()
+    if actual != expected:
+        msg = f"wheel {algo} mismatch: expected {expected}, got {actual}"
+        raise WheelHashMismatchError(msg)
 
 
 def _read_full_body(body: bytes, canonical_name: NormalizedName) -> bytes | None:
@@ -589,15 +617,26 @@ async def read_wheel_metadata_over_range(
     canonical_name: NormalizedName,
     memo: RangeCapabilityMemo,
     *,
+    wheel_hash: tuple[str, str] | None = None,
     tail_size: int = _DEFAULT_TAIL,
 ) -> RangeMetadataResult:
     """Recover a remote wheel's METADATA text by ranged reads of its ZIP.
 
-    Raises :class:`~nab_index.client.MalformedSimpleResponseError` only when
-    the recovered METADATA is not valid UTF-8, and re-raises a transport
-    error when the wheel URL itself cannot be served (a 404, a failing plain
-    GET).  A refused Range mechanism is stepped down, not raised.  Every
-    other failure to obtain metadata returns a result with ``text=None``.
+    ``wheel_hash`` is the wheel's published ``(algorithm, hex_digest)`` from the
+    Simple-API listing, or ``None`` when none was published.  Whenever the whole
+    wheel comes back, whether from a host that ignores or refuses ranges or from
+    a 200 volunteered while a partial read is growing its window, the bytes are
+    checked against ``wheel_hash`` before their METADATA is read, so bytes that
+    disagree with the published digest never drive the resolve.  A partial read
+    that holds only a slice of the wheel is left unverified.
+
+    Raises :class:`~nab_index.client.WheelHashMismatchError` when a full-body
+    wheel fails ``wheel_hash``, and
+    :class:`~nab_index.client.MalformedSimpleResponseError` when the recovered
+    METADATA is not valid UTF-8.  Re-raises a transport error when the wheel URL
+    itself cannot be served (a 404, a failing plain GET).  A refused Range
+    mechanism is stepped down, not raised.  Every other failure to obtain
+    metadata returns a result with ``text=None``.
     """
     netloc = urlsplit(wheel_url).netloc
     owns_probe = False
@@ -621,6 +660,7 @@ async def read_wheel_metadata_over_range(
         return RangeMetadataResult(None, RangeOutcome.UNSUPPORTED)
     if kind is _AcqKind.FULL_BODY:
         assert isinstance(payload, bytes)
+        _verify_full_body(payload, wheel_hash)
         raw = _read_full_body(payload, canonical_name)
         outcome = RangeOutcome.FULL_BODY
     else:
@@ -628,7 +668,7 @@ async def read_wheel_metadata_over_range(
         sparse, tail_low = payload
         try:
             raw = await _read_sparse(
-                transport, wheel_url, sparse, tail_low, canonical_name
+                transport, wheel_url, sparse, tail_low, canonical_name, wheel_hash
             )
             outcome = RangeOutcome.PARTIAL
         except _RangeRefusedError as refusal:
@@ -638,6 +678,7 @@ async def read_wheel_metadata_over_range(
             body = await _full_body_fetch(transport, wheel_url)
             if body is None:
                 return RangeMetadataResult(None, RangeOutcome.MISSING)
+            _verify_full_body(body, wheel_hash)
             if refusal.status != _HTTP_RANGE_NOT_SATISFIABLE:
                 memo.record(netloc, RangeCapability.FULL_BODY_ONLY)
             raw = _read_full_body(body, canonical_name)

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -600,6 +600,7 @@ class LocalIndexClient:
         version: str,  # noqa: ARG002
         wheel_url: str,  # noqa: ARG002
         canonical_name: NormalizedName,  # noqa: ARG002
+        wheel_hashes: tuple[tuple[str, str], ...] = (),  # noqa: ARG002
     ) -> RangeMetadataResult:
         """Return the no-source result.
 

--- a/nab-index/src/nab_index/multi_index.py
+++ b/nab-index/src/nab_index/multi_index.py
@@ -92,6 +92,7 @@ class IndexClient(Protocol):
         version: str,
         wheel_url: str,
         canonical_name: NormalizedName,
+        wheel_hashes: tuple[tuple[str, str], ...] = (),
     ) -> RangeMetadataResult:
         """Recover a sidecar-less wheel's METADATA by HTTP range reads."""
         ...
@@ -267,10 +268,11 @@ class MultiIndexClient:
         version: str,
         wheel_url: str,
         canonical_name: NormalizedName,
+        wheel_hashes: tuple[tuple[str, str], ...] = (),
     ) -> RangeMetadataResult:
         """Forward to the routed client; presupposes ``get_files`` was called."""
         return await self._client_for(package).get_range_metadata(
-            package, version, wheel_url, canonical_name
+            package, version, wheel_url, canonical_name, wheel_hashes
         )
 
     def _client_for(self, package: str) -> IndexClient:

--- a/nab-index/tests/test_lazy_wheel.py
+++ b/nab-index/tests/test_lazy_wheel.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import io
 import zipfile
 from typing import TYPE_CHECKING
@@ -10,7 +11,7 @@ from typing import TYPE_CHECKING
 import pytest
 from packaging.utils import canonicalize_name
 
-from nab_index.client import MalformedSimpleResponseError
+from nab_index.client import MalformedSimpleResponseError, WheelHashMismatchError
 from nab_index.lazy_wheel import (
     RangeCapability,
     RangeCapabilityMemo,
@@ -250,6 +251,28 @@ def test_recovers_metadata_per_mode(
     # Exact counts: creeping per-wheel requests are the amplification failure
     # mode this reader exists to avoid.
     assert len(transport.requests) == expected_requests
+
+
+def test_full_body_matching_published_hash_is_consumed() -> None:
+    wheel = build_wheel()
+    published = ("sha256", hashlib.sha256(wheel).hexdigest())
+    transport = FakeRangeTransport("ignore_range_200", wheel)
+    result = _read(transport, wheel_hash=published)
+    assert result.outcome is RangeOutcome.FULL_BODY
+    assert result.text == _META.decode("utf-8")
+
+
+def test_full_body_failing_published_hash_is_rejected() -> None:
+    # The host ignores Range and returns the whole wheel, but its bytes disagree
+    # with the published digest (mirror skew, a stale hash after a rebuild).
+    served = build_wheel(
+        metadata=b"Metadata-Version: 2.1\nName: widget\nVersion: 1.0\n"
+        b"Requires-Dist: attacker-dep>=9\n\n"
+    )
+    published = ("sha256", hashlib.sha256(build_wheel()).hexdigest())
+    transport = FakeRangeTransport("ignore_range_200", served)
+    with pytest.raises(WheelHashMismatchError):
+        _read(transport, wheel_hash=published)
 
 
 def test_misread_suffix_downgrades_to_absolute() -> None:
@@ -679,6 +702,34 @@ def test_growth_200_full_body_recovers() -> None:
     assert result.text == _META.decode("utf-8")
 
 
+def test_growth_200_full_body_matching_hash_is_consumed() -> None:
+    served = build_wheel(padding=4000)
+    published = ("sha256", hashlib.sha256(served).hexdigest())
+
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return t.partial(max(0, t.total - a), t.total - 1)
+        return t.full()
+
+    result = _run_scripted(script, wheel=served, tail_size=64, wheel_hash=published)
+    assert result.text == _META.decode("utf-8")
+
+
+def test_growth_200_full_body_failing_hash_is_rejected() -> None:
+    # A growth range comes back as the whole wheel but disagrees with the
+    # published digest.
+    served = build_wheel(padding=4000)
+    published = ("sha256", hashlib.sha256(build_wheel()).hexdigest())
+
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return t.partial(max(0, t.total - a), t.total - 1)
+        return t.full()
+
+    with pytest.raises(WheelHashMismatchError):
+        _run_scripted(script, wheel=served, tail_size=64, wheel_hash=published)
+
+
 def test_growth_5xx_raises() -> None:
     def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
         if kind == "suffix":
@@ -745,6 +796,19 @@ def test_member_fetch_200_full_body_recovers() -> None:
 
     result = _run_scripted(script, wheel=build_wheel_member_front())
     assert result.text == _META.decode("utf-8")
+
+
+def test_member_fetch_200_full_body_failing_hash_is_rejected() -> None:
+    served = build_wheel_member_front()
+    published = ("sha256", hashlib.sha256(build_wheel()).hexdigest())
+
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            return t.partial(max(0, t.total - a), t.total - 1)
+        return t.full()
+
+    with pytest.raises(WheelHashMismatchError):
+        _run_scripted(script, wheel=served, wheel_hash=published)
 
 
 def test_member_fetch_gzip_is_missing() -> None:

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -105,7 +105,7 @@ def resolve_metadata(
     # leaves ``metadata_text`` None and the ladder steps to the sdist rung.
     if metadata_text is None and _is_bare_remote_wheel(dist):
         metadata_text, from_sdist = _read_range_metadata(
-            provider, normalized, ver_str, dist.url
+            provider, normalized, ver_str, dist.url, dist.hashes
         )
 
     if metadata_text is not None:
@@ -171,17 +171,24 @@ def _is_bare_remote_wheel(dist: DistFile | None) -> TypeGuard[WheelFile]:
 
 
 def _read_range_metadata(
-    provider: Provider, package: str, version: str, wheel_url: str
+    provider: Provider,
+    package: str,
+    version: str,
+    wheel_url: str,
+    wheel_hashes: tuple[tuple[str, str], ...],
 ) -> tuple[str | None, bool]:
     """Run rung 4 for one bare wheel and return ``(metadata_text, from_sdist)``.
 
     Blocks on the coordinator's range read, re-raises a recorded metadata
-    error (a malformed-UTF-8 blob, an unserveable wheel URL) so the resolve
-    fails, and otherwise records the outcome counter and reads the wheel's
-    slot.  ``from_sdist`` is ``False``: recovered wheel METADATA is
-    authoritative.
+    error (a malformed-UTF-8 blob, an unserveable wheel URL, a full-body wheel
+    failing its published hash) so the resolve fails, and otherwise records the
+    outcome counter and reads the wheel's slot.  ``wheel_hashes`` are the
+    wheel's published digests, verified against a full-body read.  ``from_sdist``
+    is ``False``: recovered wheel METADATA is authoritative.
     """
-    event = provider.coordinator.request_range_metadata(package, version, wheel_url)
+    event = provider.coordinator.request_range_metadata(
+        package, version, wheel_url, wheel_hashes
+    )
     event.wait()
     index = provider.coordinator.index
     integrity_error = index.get_metadata_error(package, version, wheel_url)

--- a/nab-python/src/nab_python/_testing/coordinator_fake.py
+++ b/nab-python/src/nab_python/_testing/coordinator_fake.py
@@ -166,7 +166,12 @@ def _wire_range_side_effects(
     rung.
     """
 
-    def _request_range_metadata(pkg: str, ver: str, url: str) -> threading.Event:
+    def _request_range_metadata(
+        pkg: str,
+        ver: str,
+        url: str,
+        _hashes: tuple[tuple[str, str], ...] = (),
+    ) -> threading.Event:
         if range_error is not None:
             index.store_range_error(pkg, ver, url, range_error)
             return _done_event()

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -107,6 +107,7 @@ class FetchRequest:
     url: str | None = None
     metadata_hash: tuple[str, str] | None = None
     sdist_hashes: tuple[tuple[str, str], ...] = ()
+    wheel_hashes: tuple[tuple[str, str], ...] = ()
 
 
 @dataclass
@@ -835,7 +836,11 @@ class FetchCoordinator:
         return pending.event
 
     def request_range_metadata(
-        self, package: str, version: str, wheel_url: str
+        self,
+        package: str,
+        version: str,
+        wheel_url: str,
+        wheel_hashes: tuple[tuple[str, str], ...] = (),
     ) -> threading.Event:
         """Request a sidecar-less wheel's METADATA over an HTTP range read.
 
@@ -845,7 +850,8 @@ class FetchCoordinator:
         one version (which a matrix picks per target and which can declare
         different dependencies) each get their own read, matching the sidecar
         path.  A warm cache hit is served inside the client, so there is no early
-        cache check here.
+        cache check here.  ``wheel_hashes`` are the wheel's published digests; a
+        full-body read is verified against them before its METADATA is used.
         """
         self._check_alive()
         key = _range_key(package, version, wheel_url)
@@ -857,6 +863,7 @@ class FetchCoordinator:
                     package=package,
                     version=version,
                     url=wheel_url,
+                    wheel_hashes=wheel_hashes,
                 )
             )
         return pending.event
@@ -1282,7 +1289,11 @@ class FetchCoordinator:
         assert req.version is not None
         assert req.url is not None
         result = await client.get_range_metadata(
-            req.package, req.version, req.url, canonicalize_name_boundary(req.package)
+            req.package,
+            req.version,
+            req.url,
+            canonicalize_name_boundary(req.package),
+            req.wheel_hashes,
         )
         self.index.store_range_outcome(
             req.package, req.version, req.url, result.outcome

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -31,6 +31,7 @@ from nab_index.client import (
     SdistFile,
     SdistHashMismatchError,
     WheelFile,
+    WheelHashMismatchError,
     _parse_files,
     _parse_sdist_filename,
     _select_artifact_hash,
@@ -1856,6 +1857,23 @@ class _FullBodyJunkTransport:
         return None
 
 
+class _FullBodyWheelTransport:
+    """Ignore the range and hand back the whole wheel with a 200."""
+
+    def __init__(self, wheel: bytes) -> None:
+        self.wheel = wheel
+        self.calls = 0
+
+    async def get(
+        self, url: str, *, headers: dict[str, str] | None = None
+    ) -> _FakeResponse:
+        self.calls += 1
+        return _FakeResponse(self.wheel, status=200)
+
+    async def aclose(self) -> None:
+        return None
+
+
 class TestGetRangeMetadata:
     _NAME = canonicalize_name("pkg")
 
@@ -1980,6 +1998,46 @@ class TestGetRangeMetadata:
 
         asyncio.run(go())
         assert memo.capability("files.example.com") is RangeCapability.SUFFIX_OK
+
+    def test_full_body_matching_published_hash_is_cached(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        wheel = _build_range_wheel()
+        transport = _FullBodyWheelTransport(wheel)
+        published = (("sha256", hashlib.sha256(wheel).hexdigest()),)
+
+        async def go() -> RangeMetadataResult:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_range_metadata(
+                    "pkg", "1.0", _WHEEL_URL, self._NAME, published
+                )
+            finally:
+                await client.aclose()
+
+        result = asyncio.run(go())
+        assert result.outcome is RangeOutcome.FULL_BODY
+        assert result.text == _RANGE_META.decode()
+        assert cache.get_metadata("pkg", _WHEEL_URL) == _RANGE_META.decode()
+
+    def test_full_body_failing_published_hash_raises_and_skips_cache(
+        self, tmp_path: Path
+    ) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _FullBodyWheelTransport(_build_range_wheel())
+        wrong = (("sha256", "0" * 64),)
+
+        async def go() -> RangeMetadataResult:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_range_metadata(
+                    "pkg", "1.0", _WHEEL_URL, self._NAME, wrong
+                )
+            finally:
+                await client.aclose()
+
+        with pytest.raises(WheelHashMismatchError):
+            asyncio.run(go())
+        assert cache.get_metadata("pkg", _WHEEL_URL) is None
 
 
 def _run_get_files(

--- a/nab-python/tests/test_multi_index.py
+++ b/nab-python/tests/test_multi_index.py
@@ -89,6 +89,7 @@ class FakeClient:
         version: str,
         wheel_url: str,
         canonical_name: str,
+        wheel_hashes: tuple[tuple[str, str], ...] = (),
     ) -> RangeMetadataResult:
         self.range_calls.append((package, version, wheel_url))
         return RangeMetadataResult(f"range:{package}:{version}", RangeOutcome.PARTIAL)

--- a/nab-python/tests/test_range_metadata_integration.py
+++ b/nab-python/tests/test_range_metadata_integration.py
@@ -11,6 +11,7 @@ request at all.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import io
 import json
 import zipfile
@@ -18,6 +19,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from nab_index.client import WheelHashMismatchError
 from nab_index.lazy_wheel import RangeOutcome
 from nab_index.transport import HttpError
 from nab_python._vendor.packaging.requirements import Requirement
@@ -38,28 +40,29 @@ _SIMPLE_URL = "https://pypi.org/simple/widget/"
 _JSON_MEDIA = "application/vnd.pypi.simple.v1+json"
 
 
-def _wheel_bytes() -> bytes:
+def _wheel_bytes(metadata: bytes = _META) -> bytes:
     """A small sidecar-less wheel holding widget's METADATA."""
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
         zf.writestr("widget/__init__.py", b"value = 1\n")
-        zf.writestr("widget-1.0.dist-info/METADATA", _META)
+        zf.writestr("widget-1.0.dist-info/METADATA", metadata)
         zf.writestr("widget-1.0.dist-info/WHEEL", b"Wheel-Version: 1.0\n")
     return buf.getvalue()
 
 
-def _listing_body() -> bytes:
+def _listing_body(hashes: dict[str, str] | None = None) -> bytes:
     """A Simple-API listing whose one wheel publishes no PEP 658 sidecar."""
+    entry: dict[str, object] = {
+        "filename": "widget-1.0-py3-none-any.whl",
+        "url": _WHEEL_URL,
+    }
+    if hashes is not None:
+        entry["hashes"] = hashes
     return json.dumps(
         {
             "meta": {"api-version": "1.0"},
             "name": "widget",
-            "files": [
-                {
-                    "filename": "widget-1.0-py3-none-any.whl",
-                    "url": _WHEEL_URL,
-                }
-            ],
+            "files": [entry],
         }
     ).encode("utf-8")
 
@@ -113,12 +116,18 @@ class FakeRangeTransport:
     """
 
     def __init__(
-        self, wheel: bytes, listing: bytes, *, wheel_status: int | None = None
+        self,
+        wheel: bytes,
+        listing: bytes,
+        *,
+        wheel_status: int | None = None,
+        ignore_range: bool = False,
     ) -> None:
         self.wheel = wheel
         self.total = len(wheel)
         self.listing = listing
         self.wheel_status = wheel_status
+        self.ignore_range = ignore_range
         self.requests: list[tuple[str, str | None]] = []
 
     async def get(
@@ -132,7 +141,7 @@ class FakeRangeTransport:
             return _FakeResponse(200, {"content-type": _JSON_MEDIA}, self.listing)
         if self.wheel_status is not None:
             return _FakeResponse(self.wheel_status, {}, b"")
-        if rng is None:
+        if rng is None or self.ignore_range:
             return _FakeResponse(200, {}, self.wheel)
         return self._range(rng)
 
@@ -198,6 +207,41 @@ def test_resolve_fails_when_wheel_url_unserved(tmp_path: Path) -> None:
     with (
         FetchCoordinator(transport, cache_dir=tmp_path) as coordinator,  # type: ignore[arg-type]
         pytest.raises(HttpError),
+    ):
+        _resolve(coordinator)
+
+
+def test_full_body_wheel_matching_published_hash_resolves(tmp_path: Path) -> None:
+    """A full-body wheel matching its published hash locks over rung 4."""
+    served = _wheel_bytes()
+    published = hashlib.sha256(served).hexdigest()
+    transport = FakeRangeTransport(
+        served, _listing_body({"sha256": published}), ignore_range=True
+    )
+    with FetchCoordinator(transport, cache_dir=tmp_path) as coordinator:  # type: ignore[arg-type]
+        result = _resolve(coordinator)
+        assert result.success
+        assert result.target_results[0].pins == {"widget": Version("1.0")}
+        assert coordinator.index.get_range_outcome("widget", "1.0", _WHEEL_URL) is (
+            RangeOutcome.FULL_BODY
+        )
+
+
+def test_full_body_wheel_failing_published_hash_aborts(tmp_path: Path) -> None:
+    """A full-body wheel whose bytes disagree with the published hash aborts.
+
+    The host ignores Range and returns the whole wheel; its bytes fail the
+    listing's sha256 (mirror skew, a stale hash after a rebuild), so its
+    METADATA never drives the resolve.
+    """
+    served = _wheel_bytes()
+    published = hashlib.sha256(_wheel_bytes(_META + b"skew\n")).hexdigest()
+    transport = FakeRangeTransport(
+        served, _listing_body({"sha256": published}), ignore_range=True
+    )
+    with (
+        FetchCoordinator(transport, cache_dir=tmp_path) as coordinator,  # type: ignore[arg-type]
+        pytest.raises(WheelHashMismatchError),
     ):
         _resolve(coordinator)
 


### PR DESCRIPTION
A remote wheel with no .metadata sidecar is recovered by ranged reads of its ZIP. When the host ignores or refuses HTTP Range the whole wheel comes back instead, and that full body was parsed for METADATA without ever checking it against the wheel's published Simple-API digest. Mirror skew or a stale hash could then drive the dependency graph and the locked pin from bytes that failed their published hash. The sdist rung already verifies before it trusts PKG-INFO.

This threads the wheel's published hashes from the listing down through the range read, and verifies a full-body acquisition against the selected digest before its METADATA is used, raising WheelHashMismatchError on a mismatch. The full body can arrive two ways, from a host that ignores or refuses ranges and from a 200 volunteered while a partial read is still growing its window; both are checked. A partial range read holds only a slice of the wheel, so it stays unverified.
