### PR TITLE
jitter retry backoff so throttled fetches don't retry in lockstep

### DIFF
--- a/nab-index/src/nab_index/retry.py
+++ b/nab-index/src/nab_index/retry.py
@@ -10,6 +10,8 @@ transports take the policy here instead of their library's default.
 
 from __future__ import annotations
 
+import random
+
 import urllib3
 from urllib3.exceptions import InvalidHeader
 
@@ -32,6 +34,10 @@ RETRY_STATUSES = frozenset({429, 500, 502, 503, 504, 520, 527})
 """Statuses that are retried; any other status is served to the caller."""
 
 _BACKOFF_FACTOR = 0.25
+
+# Without a random spread, requests throttled together retry in lockstep and
+# re-trigger the throttle.
+_BACKOFF_JITTER = 0.25
 
 # Unbounded, a "Retry-After: 3600" would park the resolve for an hour.
 _RETRY_AFTER_MAX_SECONDS = 10.0
@@ -66,6 +72,7 @@ GET_RETRY = _BoundedRetry(
     redirect=MAX_REDIRECTS,
     status_forcelist=RETRY_STATUSES,
     backoff_factor=_BACKOFF_FACTOR,
+    backoff_jitter=_BACKOFF_JITTER,
     # Once the budget is spent, hand the response back so the caller sees the
     # status the index served rather than a retry error.
     raise_on_status=False,
@@ -80,4 +87,5 @@ def next_delay(failures: int, retry_after: str | None = None) -> float:
             return seconds
     if failures <= 1:
         return 0.0
-    return _BACKOFF_FACTOR * 2 ** (failures - 1)
+    backoff = _BACKOFF_FACTOR * 2 ** (failures - 1)
+    return backoff + random.random() * _BACKOFF_JITTER  # noqa: S311

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -165,6 +165,14 @@ def thread_slept(monkeypatch: pytest.MonkeyPatch) -> list[float]:
     return delays
 
 
+def _assert_jittered_backoff_schedule(delays: list[float]) -> None:
+    """The full three-retry schedule: immediate, then 0.5 and 1.0 plus jitter."""
+    assert len(delays) == MAX_RETRIES
+    assert delays[0] == 0.0
+    assert 0.5 <= delays[1] < 0.5 + GET_RETRY.backoff_jitter
+    assert 1.0 <= delays[2] < 1.0 + GET_RETRY.backoff_jitter
+
+
 class TestRetryPolicy:
     """The retry policy both transports share."""
 
@@ -203,8 +211,17 @@ class TestRetryPolicy:
         assert GET_RETRY.raise_on_status is False
 
     def test_backoff_grows_between_attempts(self) -> None:
-        """The first retry is immediate, then urllib3's exponential schedule."""
-        assert [next_delay(n) for n in (1, 2, 3)] == [0.0, 0.5, 1.0]
+        """The first retry is immediate, then urllib3's exponential schedule plus jitter."""
+        assert next_delay(1) == 0.0
+        assert 0.5 <= next_delay(2) < 0.5 + GET_RETRY.backoff_jitter
+        assert 1.0 <= next_delay(3) < 1.0 + GET_RETRY.backoff_jitter
+
+    def test_backoff_carries_jitter_to_desynchronize_retries(self) -> None:
+        """Repeated backoff for one failure count spreads across the jitter window."""
+        assert GET_RETRY.backoff_jitter > 0.0
+        delays = {next_delay(2) for _ in range(200)}
+        assert len(delays) > 1
+        assert all(0.5 <= d < 0.5 + GET_RETRY.backoff_jitter for d in delays)
 
     def test_retry_after_overrides_backoff(self) -> None:
         assert next_delay(1, "2") == 2.0
@@ -215,7 +232,7 @@ class TestRetryPolicy:
         assert GET_RETRY.get_retry_after(_urllib3_response(503, "3600")) == 10.0
 
     def test_unparseable_retry_after_falls_back_to_backoff(self) -> None:
-        assert next_delay(2, "soon") == 0.5
+        assert 0.5 <= next_delay(2, "soon") < 0.5 + GET_RETRY.backoff_jitter
         assert GET_RETRY.get_retry_after(_urllib3_response(503, "soon")) is None
 
     def test_absent_retry_after_falls_back_to_backoff(self) -> None:
@@ -558,7 +575,7 @@ class TestHttpxAsyncTransport:
 
         resp = asyncio.run(go())
         assert route.call_count == MAX_RETRIES + 1
-        assert slept == [0.0, 0.5, 1.0]
+        _assert_jittered_backoff_schedule(slept)
         with pytest.raises(HttpError, match="503"):
             resp.raise_for_status()
 
@@ -580,7 +597,7 @@ class TestHttpxAsyncTransport:
         with pytest.raises(HttpError, match="GET https://example.com/pkg failed"):
             asyncio.run(go())
         assert route.call_count == MAX_RETRIES + 1
-        assert slept == [0.0, 0.5, 1.0]
+        _assert_jittered_backoff_schedule(slept)
 
     @pytest.mark.parametrize(
         "url",
@@ -710,7 +727,7 @@ class TestHttpxAsyncTransport:
         with pytest.raises(HttpError, match="GET https://example.com/pkg failed"):
             asyncio.run(go())
         assert route.call_count == MAX_RETRIES + 1
-        assert slept == [0.0, 0.5, 1.0]
+        _assert_jittered_backoff_schedule(slept)
 
     @respx.mock
     def test_get_requests_gzip_without_caller_headers(self) -> None:
@@ -1087,7 +1104,7 @@ class TestUrllib3AsyncTransport:
             with pytest.raises(HttpError, match=f"GET {url} failed"):
                 asyncio.run(go())
             assert len(index.seen) == MAX_RETRIES + 1
-            assert thread_slept == [0.0, 0.5, 1.0]
+            _assert_jittered_backoff_schedule(thread_slept)
 
     def test_response_json(self) -> None:
         fake = MagicMock(spec=urllib3.BaseHTTPResponse)


### PR DESCRIPTION
The retry backoff for index GETs was fully deterministic, so a burst of concurrent fetches that all hit a 429 or 503 at the same moment backed off by the same amount and retried at the same instant, re-triggering the rate limit each round.

This adds jitter to the backoff on both retry paths: `backoff_jitter` on the shared urllib3 Retry, and a matching random spread in `next_delay`, which the httpx transport uses. Each retry now lands at a slightly different time, so a throttled burst spreads out across the backoff window instead of hitting the index together.
