### PR TITLE
exit cleanly on tie-ranked wheel divergence instead of a traceback

### DIFF
--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -66,6 +66,7 @@ from nab_python.provider import (
     InvalidUploadTimeError,
     MetadataError,
     MissingExtraError,
+    SiblingMetadataDivergenceError,
     SourceNameMismatchError,
     UnsupportedVcsError,
 )
@@ -571,7 +572,12 @@ def _resolve(  # noqa: PLR0913, PLR0912, C901 - one wrapper per resolve_for_targ
     except ResolutionError as e:
         printer().error(f"resolution failed: {e}")
         sys.exit(1)
-    except (UnsupportedVcsError, MissingExtraError, SourceNameMismatchError) as e:
+    except (
+        UnsupportedVcsError,
+        MissingExtraError,
+        SiblingMetadataDivergenceError,
+        SourceNameMismatchError,
+    ) as e:
         printer().error(f"{failure_prefix}: {e}")
         sys.exit(1)
     except InvalidUploadTimeError as e:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,6 +67,7 @@ from nab_python.provider import (
     InvalidUploadTimeError,
     MissingExtraError,
     ResolutionStrategy,
+    SiblingMetadataDivergenceError,
     UnsupportedVcsError,
 )
 from nab_python.requirements_file import InvalidProjectRequirementError
@@ -747,6 +748,33 @@ class TestLockCommandSpecific:
         err = capsys.readouterr().err
         assert "cannot lock" in err
         assert "does not provide extra 'nonexistent'" in err
+        assert "Traceback" not in err
+
+    def test_sibling_metadata_divergence_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A version whose tie-ranked wheels disagree on deps exits 1, not a traceback.
+
+        ``SiblingMetadataDivergenceError`` is not a ``MetadataError``, so the CLI
+        must name it in the exit handlers rather than rely on the ``MetadataError``
+        branch.
+        """
+        pyproject = _make_pyproject(tmp_path)
+        with (
+            patch(
+                "nab.cli.resolve_for_targets",
+                side_effect=SiblingMetadataDivergenceError(
+                    "foo 1.0 has tie-ranked wheels foo-1.0-cp311.cp312-none-any.whl "
+                    "and foo-1.0-cp312.cp313-none-any.whl that declare different "
+                    "dependencies for this target"
+                ),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject)
+        err = capsys.readouterr().err
+        assert "cannot lock" in err
+        assert "tie-ranked wheels" in err
         assert "Traceback" not in err
 
     def test_metadata_hash_mismatch_exits(


### PR DESCRIPTION
A version whose tie-ranked wheels declare different dependencies for a target crashed `nab lock` and `nab download` in universal mode with a raw `SiblingMetadataDivergenceError` traceback. The neighbouring source-name mismatch already exits with a single error line after #540.

`SiblingMetadataDivergenceError` is deliberately not a `MetadataError` (that path skips the version and moves on), so `_resolve` never caught it. Adding it to the same clause as `SourceNameMismatchError` makes the failure print as `cannot lock: ...` or `cannot download: ...` and exit 1.
