### PR TITLE
Serve large warm listing hits synchronously

### DIFF
--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -279,6 +279,18 @@ class OnDiskCache:
         except OSError:
             return None
 
+    def get_simple_parsed_size(self, package: str) -> int | None:
+        """Return the on-disk size of the parsed-listing blob in bytes, or ``None``.
+
+        A single ``stat`` on the same path :meth:`get_simple_parsed` reads, so a
+        caller can size the blob before deciding whether to read and decode it.
+        An absent blob is a silent miss.
+        """
+        try:
+            return self._parsed_path(package).stat().st_size
+        except OSError:
+            return None
+
     def put_simple_parsed(self, package: str, blob: bytes) -> None:
         """Write the opaque parsed-listing blob for ``package`` atomically."""
         _atomic_write(self._parsed_path(package), blob)
@@ -549,6 +561,10 @@ class CacheBackend(Protocol):
         """Return the opaque parsed-listing blob for ``package``, or ``None``."""
         ...
 
+    def get_simple_parsed_size(self, package: str) -> int | None:
+        """Return the parsed-listing blob's on-disk size in bytes, or ``None``."""
+        ...
+
     def put_simple_parsed(self, package: str, blob: bytes) -> None:
         """Store the opaque parsed-listing blob for ``package``."""
         ...
@@ -631,6 +647,9 @@ class NullCache:
         """Return ``None`` (always a miss)."""
 
     def get_simple_parsed(self, package: str) -> bytes | None:
+        """Return ``None`` (always a miss)."""
+
+    def get_simple_parsed_size(self, package: str) -> int | None:
         """Return ``None`` (always a miss)."""
 
     def put_simple_parsed(self, package: str, blob: bytes) -> None:

--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
 __all__ = [
     "CachedAsyncSimpleClient",
     "ParsedCacheStats",
+    "read_fresh_parsed_listing",
 ]
 
 logger = logging.getLogger(__name__)
@@ -110,6 +111,36 @@ def _header(response: HttpResponse, key: str) -> str | None:
         if name.lower() == target:
             return value
     return None
+
+
+def read_fresh_parsed_listing(
+    cache: CacheBackend, package: str, *, offline: bool
+) -> list[WheelFile | SdistFile] | None:
+    """Read a clean fresh (or offline) parsed listing for ``package``, or ``None``.
+
+    The synchronous, write-free subset of :meth:`CachedAsyncSimpleClient.get_files`'
+    fresh-hit branch: it consults the same ``get_simple_policy``, the same
+    ``policy.is_fresh() or offline`` freshness expression, the same
+    ``get_simple_parsed`` blob, and the same :func:`parsed_listing.decode`, so on a
+    hit it returns the identical records ``get_files`` would. It declines to
+    ``None`` on every other reason (no policy, stale-online, no blob, a
+    non-binding digest, or a corrupt blob) and, unlike ``get_files``, never reads
+    the raw body, revalidates, rebuilds, writes, or logs: a decline routes the
+    caller to the unchanged async path, which owns every write and self-heal.
+
+    Total by construction (never raises): each cache read swallows ``OSError`` to
+    ``None``, ``is_fresh`` is pure arithmetic, and ``decode`` returns ``None`` on
+    any marshal/shape/build/digest failure.
+    """
+    policy = cache.get_simple_policy(package)
+    if policy is None:
+        return None
+    if not (policy.is_fresh() or offline):
+        return None
+    blob = cache.get_simple_parsed(package)
+    if blob is None:
+        return None
+    return _decode_parsed(blob, policy)
 
 
 class CachedAsyncSimpleClient:

--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -116,21 +116,15 @@ def _header(response: HttpResponse, key: str) -> str | None:
 def read_fresh_parsed_listing(
     cache: CacheBackend, package: str, *, offline: bool
 ) -> list[WheelFile | SdistFile] | None:
-    """Read a clean fresh (or offline) parsed listing for ``package``, or ``None``.
+    """Read a fresh (or offline) parsed listing for ``package``, or ``None``.
 
-    The synchronous, write-free subset of :meth:`CachedAsyncSimpleClient.get_files`'
-    fresh-hit branch: it consults the same ``get_simple_policy``, the same
-    ``policy.is_fresh() or offline`` freshness expression, the same
-    ``get_simple_parsed`` blob, and the same :func:`parsed_listing.decode`, so on a
-    hit it returns the identical records ``get_files`` would. It declines to
-    ``None`` on every other reason (no policy, stale-online, no blob, a
-    non-binding digest, or a corrupt blob) and, unlike ``get_files``, never reads
-    the raw body, revalidates, rebuilds, writes, or logs: a decline routes the
-    caller to the unchanged async path, which owns every write and self-heal.
-
-    Total by construction (never raises): each cache read swallows ``OSError`` to
-    ``None``, ``is_fresh`` is pure arithmetic, and ``decode`` returns ``None`` on
-    any marshal/shape/build/digest failure.
+    The write-free subset of :meth:`CachedAsyncSimpleClient.get_files`' fresh-hit
+    branch: same policy, same ``is_fresh() or offline`` test, same blob, same
+    :func:`parsed_listing.decode`, so on a hit it returns the records
+    ``get_files`` would. Every other case (no policy, stale-online, no blob, a
+    non-binding digest, a corrupt blob) declines to ``None`` and, unlike
+    ``get_files``, never reads the raw body, revalidates, rebuilds, writes, or
+    logs. It never raises, so a caller's pending is never stranded.
     """
     policy = cache.get_simple_policy(package)
     if policy is None:

--- a/nab-index/tests/test_index_parsed_cache.py
+++ b/nab-index/tests/test_index_parsed_cache.py
@@ -236,6 +236,9 @@ class TestNullCacheParsed:
     def test_get_simple_parsed(self) -> None:
         assert NullCache().get_simple_parsed("foo") is None
 
+    def test_get_simple_parsed_size(self) -> None:
+        assert NullCache().get_simple_parsed_size("foo") is None
+
     def test_put_simple_parsed_noop(self) -> None:
         assert NullCache().put_simple_parsed("foo", b"blob") is None
 

--- a/nab-index/tests/test_read_fresh_parsed_listing.py
+++ b/nab-index/tests/test_read_fresh_parsed_listing.py
@@ -107,6 +107,18 @@ def _warm_bound(
     return files, digest
 
 
+class TestParsedBlobSize:
+    def test_size_matches_written_blob(self, tmp_path: Path) -> None:
+        cache = _cache(tmp_path)
+        _warm_bound(cache)
+        blob = cache.get_simple_parsed("pkg")
+        assert blob is not None
+        assert cache.get_simple_parsed_size("pkg") == len(blob)
+
+    def test_size_none_when_absent(self, tmp_path: Path) -> None:
+        assert _cache(tmp_path).get_simple_parsed_size("pkg") is None
+
+
 class TestReadFreshParsedListing:
     def test_fresh_hit_returns_records(self, tmp_path: Path) -> None:
         cache = _cache(tmp_path)

--- a/nab-index/tests/test_read_fresh_parsed_listing.py
+++ b/nab-index/tests/test_read_fresh_parsed_listing.py
@@ -1,0 +1,230 @@
+"""Tests for the module-level ``read_fresh_parsed_listing`` read helper.
+
+The helper is the synchronous, write-free subset of ``get_files``' fresh-hit
+branch used by the warm-sync listing path: it serves records only on a clean
+fresh (or offline) parsed-blob hit and declines to ``None`` on every other
+reason, never writing, revalidating, or rebuilding. These tests pin its
+serve/decline taxonomy and, on a shared warmed fixture, pin the served records
+to ``get_files`` so a future edit to either cannot drift them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Coroutine, Mapping
+from pathlib import Path
+from typing import Any, TypeVar
+
+import pytest
+
+from nab_index.cache import CachePolicy, OnDiskCache
+from nab_index.cached_client import (
+    CachedAsyncSimpleClient,
+    read_fresh_parsed_listing,
+)
+from nab_index.client import _parse_files
+from nab_index.parsed_listing import encode
+
+_T = TypeVar("_T")
+
+_INDEX = "https://pypi.org/simple"
+_INDEX_NORM = "https://pypi.org/simple/"
+
+_LISTING = {
+    "meta": {"api-version": "1.0"},
+    "name": "pkg",
+    "files": [
+        {
+            "filename": "pkg-1.0-py3-none-any.whl",
+            "url": "https://files.example.com/pkg-1.0-py3-none-any.whl",
+            "requires-python": ">=3.8",
+            "core-metadata": {"sha256": "abc"},
+            "hashes": {"sha256": "deadbeef"},
+        },
+        {
+            "filename": "pkg-1.0.tar.gz",
+            "url": "https://files.example.com/pkg-1.0.tar.gz",
+            "hashes": {"sha256": "cafef00d"},
+        },
+    ],
+}
+_LISTING_BYTES = json.dumps(_LISTING).encode()
+_PARSED = _parse_files(json.loads(_LISTING_BYTES), _INDEX_NORM, "pkg")
+_JSON_PATH_PARTS = ("simple-v0", "pypi", "pkg.json")
+
+
+def _run(coro: Coroutine[Any, Any, _T]) -> _T:
+    return asyncio.run(coro)
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        body: bytes,
+        status: int = 200,
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
+        self.content = body
+        self.status_code = status
+        self.headers = headers or {}
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _FakeTransport:
+    def __init__(self, responses: list[_FakeResponse]) -> None:
+        self._responses = responses
+        self.calls: list[tuple[str, dict[str, str] | None]] = []
+
+    async def get(
+        self, url: str, *, headers: dict[str, str] | None = None
+    ) -> _FakeResponse:
+        self.calls.append((url, headers))
+        return self._responses.pop(0)
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _cache(root: Path) -> OnDiskCache:
+    return OnDiskCache(root, _INDEX)
+
+
+def _warm_bound(
+    cache: OnDiskCache, *, fresh: bool = True, body: bytes = _LISTING_BYTES
+) -> tuple[list, str]:
+    """Warm a package's body, policy, and a parsed blob bound to that body."""
+    policy = CachePolicy(
+        fetched_at=2_000_000_000 if fresh else 0,
+        max_age=99999 if fresh else 0,
+        etag="e",
+    )
+    digest = cache.put_simple("pkg", body, policy)
+    files = _parse_files(json.loads(body), _INDEX_NORM, "pkg")
+    cache.put_simple_parsed("pkg", encode(files, digest))
+    return files, digest
+
+
+class TestReadFreshParsedListing:
+    def test_fresh_hit_returns_records(self, tmp_path: Path) -> None:
+        cache = _cache(tmp_path)
+        files, _ = _warm_bound(cache)
+        assert read_fresh_parsed_listing(cache, "pkg", offline=False) == files
+
+    def test_fresh_offline_returns_records(self, tmp_path: Path) -> None:
+        cache = _cache(tmp_path)
+        files, _ = _warm_bound(cache)
+        assert read_fresh_parsed_listing(cache, "pkg", offline=True) == files
+
+    def test_stale_offline_returns_records(self, tmp_path: Path) -> None:
+        cache = _cache(tmp_path)
+        files, _ = _warm_bound(cache, fresh=False)
+        assert read_fresh_parsed_listing(cache, "pkg", offline=True) == files
+
+    def test_absent_policy_returns_none(self, tmp_path: Path) -> None:
+        assert read_fresh_parsed_listing(_cache(tmp_path), "pkg", offline=False) is None
+
+    def test_stale_online_returns_none(self, tmp_path: Path) -> None:
+        cache = _cache(tmp_path)
+        _warm_bound(cache, fresh=False)
+        assert read_fresh_parsed_listing(cache, "pkg", offline=False) is None
+
+    def test_absent_blob_returns_none(self, tmp_path: Path) -> None:
+        cache = _cache(tmp_path)
+        cache.put_simple(
+            "pkg",
+            _LISTING_BYTES,
+            CachePolicy(fetched_at=2_000_000_000, max_age=99999, etag=None),
+        )
+        assert cache.get_simple_parsed("pkg") is None
+        assert read_fresh_parsed_listing(cache, "pkg", offline=False) is None
+
+    def test_digest_mismatch_returns_none(self, tmp_path: Path) -> None:
+        cache = _cache(tmp_path)
+        files, _ = _warm_bound(cache)
+        cache.put_simple_parsed("pkg", encode(files, "f" * 64))
+        assert read_fresh_parsed_listing(cache, "pkg", offline=False) is None
+
+    @pytest.mark.parametrize("blob", [b"\xff\xfe not marshal", b"", b"\x00\x01\x02"])
+    def test_corrupt_blob_returns_none(self, tmp_path: Path, blob: bytes) -> None:
+        cache = _cache(tmp_path)
+        _warm_bound(cache)
+        cache.put_simple_parsed("pkg", blob)
+        assert read_fresh_parsed_listing(cache, "pkg", offline=False) is None
+
+    def test_hit_does_not_write(self, tmp_path: Path) -> None:
+        cache = _cache(tmp_path)
+        _warm_bound(cache)
+        before = cache.get_simple_parsed("pkg")
+        read_fresh_parsed_listing(cache, "pkg", offline=False)
+        assert cache.get_simple_parsed("pkg") == before
+
+    def test_decline_does_not_write(self, tmp_path: Path) -> None:
+        cache = _cache(tmp_path)
+        files, _ = _warm_bound(cache)
+        mismatched = encode(files, "f" * 64)
+        cache.put_simple_parsed("pkg", mismatched)
+        read_fresh_parsed_listing(cache, "pkg", offline=False)
+        # No rebuild: the mismatched blob is left exactly as it was.
+        assert cache.get_simple_parsed("pkg") == mismatched
+
+
+class TestIdenticalByConstruction:
+    def test_hit_records_equal_get_files(self, tmp_path: Path) -> None:
+        cache = _cache(tmp_path)
+        files, _ = _warm_bound(cache)
+        # Serve get_files from the blob alone: drop the raw body first.
+        tmp_path.joinpath(*_JSON_PATH_PARTS).unlink()
+        client = CachedAsyncSimpleClient(_FakeTransport([]), cache, _INDEX)
+
+        served = _run(client.get_files("pkg"))
+        helper = read_fresh_parsed_listing(cache, "pkg", offline=False)
+
+        assert helper == served == files
+
+    def test_absent_blob_declines_while_get_files_rebuilds(
+        self, tmp_path: Path
+    ) -> None:
+        cache = _cache(tmp_path)
+        cache.put_simple(
+            "pkg",
+            _LISTING_BYTES,
+            CachePolicy(fetched_at=2_000_000_000, max_age=99999, etag=None),
+        )
+        assert read_fresh_parsed_listing(cache, "pkg", offline=False) is None
+        client = CachedAsyncSimpleClient(_FakeTransport([]), cache, _INDEX)
+        assert _run(client.get_files("pkg")) == _PARSED
+
+    def test_digest_mismatch_declines_while_get_files_rebuilds(
+        self, tmp_path: Path
+    ) -> None:
+        cache = _cache(tmp_path)
+        files, _ = _warm_bound(cache)
+        cache.put_simple_parsed("pkg", encode(files, "f" * 64))
+        assert read_fresh_parsed_listing(cache, "pkg", offline=False) is None
+        client = CachedAsyncSimpleClient(_FakeTransport([]), cache, _INDEX)
+        assert _run(client.get_files("pkg")) == files
+
+    def test_corrupt_blob_declines_while_get_files_rebuilds(
+        self, tmp_path: Path
+    ) -> None:
+        cache = _cache(tmp_path)
+        files, _ = _warm_bound(cache)
+        cache.put_simple_parsed("pkg", b"not marshal")
+        assert read_fresh_parsed_listing(cache, "pkg", offline=False) is None
+        client = CachedAsyncSimpleClient(_FakeTransport([]), cache, _INDEX)
+        assert _run(client.get_files("pkg")) == files
+
+    def test_stale_online_declines_while_get_files_revalidates(
+        self, tmp_path: Path
+    ) -> None:
+        cache = _cache(tmp_path)
+        files, _ = _warm_bound(cache, fresh=False)
+        assert read_fresh_parsed_listing(cache, "pkg", offline=False) is None
+        transport = _FakeTransport(
+            [_FakeResponse(b"", status=304, headers={"etag": "e"})]
+        )
+        client = CachedAsyncSimpleClient(transport, cache, _INDEX)
+        assert _run(client.get_files("pkg")) == files

--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -791,9 +791,11 @@ def prefetch_new_deps(provider: Provider, deps: Mapping[str, VersionRange]) -> N
         ):
             continue
         if normalized not in provider.versions_cache:
-            # Listing not cached: request it. When it arrives,
-            # prioritize() will notice and fire metadata prefetch.
-            provider.coordinator.request_listing(normalized)
+            # Listing not cached: request it speculatively. When it arrives,
+            # prioritize() will notice and fire metadata prefetch. Speculative
+            # so its read work overlaps resolver CPU on the fetcher thread
+            # rather than serializing onto the main thread (S-CRIT).
+            provider.coordinator.request_listing(normalized, speculative=True)
         else:
             # Listing cached: fire speculative metadata prefetch.
             speculative_prefetch(

--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -791,10 +791,9 @@ def prefetch_new_deps(provider: Provider, deps: Mapping[str, VersionRange]) -> N
         ):
             continue
         if normalized not in provider.versions_cache:
-            # Listing not cached: request it speculatively. When it arrives,
-            # prioritize() will notice and fire metadata prefetch. Speculative
-            # so its read work overlaps resolver CPU on the fetcher thread
-            # rather than serializing onto the main thread (S-CRIT).
+            # Listing not cached: request it speculatively so its read work
+            # overlaps resolver CPU on the fetcher thread. When it arrives,
+            # prioritize() notices and fires metadata prefetch.
             provider.coordinator.request_listing(normalized, speculative=True)
         else:
             # Listing cached: fire speculative metadata prefetch.

--- a/nab-python/src/nab_python/_testing/coordinator_fake.py
+++ b/nab-python/src/nab_python/_testing/coordinator_fake.py
@@ -87,7 +87,11 @@ def _wire_metadata_side_effects(
 ) -> None:
     """Attach ``request_listing``/``request_metadata``/batch side effects."""
 
-    def _request_listing(_pkg: str) -> threading.Event:
+    def _request_listing(
+        _pkg: str,
+        *,
+        speculative: bool = False,  # noqa: ARG001 (mirrors the real keyword)
+    ) -> threading.Event:
         return _done_event()
 
     def _fetch_metadata(pkg: str, ver: str, url: str) -> None:

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -1245,10 +1245,18 @@ class FetchCoordinator:
         logger.debug("fetched listing: %s (%d files)", req.package, len(files))
         if self._on_fetch is not None:
             self._on_fetch()
+        self._prefetch_metadata_after_listing(req.package, files)
 
-        # Auto-prefetch metadata for the newest candidates (files are
-        # oldest-first). One wheel per version: the first with a sidecar is the
-        # one the provider picks for that version's metadata.
+    def _prefetch_metadata_after_listing(
+        self, package: str, files: Sequence[WheelFile | SdistFile]
+    ) -> None:
+        """Enqueue metadata for the newest candidates of a stored listing.
+
+        Files are oldest-first. One wheel per version: the first with a sidecar
+        is the one the provider picks for that version's metadata. Fire-and-
+        forget through ``request_metadata`` so the reads warm concurrently with
+        resolver CPU.
+        """
         first_wheel: dict[str, WheelFile] = {}
         for f in files:
             if isinstance(f, WheelFile) and f.has_metadata:
@@ -1258,7 +1266,7 @@ class FetchCoordinator:
         for w in newest:
             url = w.metadata_url
             assert url is not None
-            self.request_metadata(req.package, w.version, url, w.metadata_hash)
+            self.request_metadata(package, w.version, url, w.metadata_hash)
 
     def _record_serving_index(
         self,

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -59,6 +59,12 @@ DEFAULT_INDEX_URL = "https://pypi.org/simple/"
 # its queue and exit on :meth:`FetchCoordinator.shutdown`.
 _COORDINATOR_JOIN_TIMEOUT_SECONDS = 10
 
+# A warm listing whose parsed blob is smaller than this is declined to the
+# async path instead of served inline: serving a small blob inline exposes
+# main-thread selection work with no round trip to offset it, while a large
+# blob's materialize dominates that overhead.
+_WARM_SYNC_MIN_BLOB_BYTES = 64 * 1024
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -120,12 +126,9 @@ class FetchRequest:
 class WarmSyncStats:
     """Counters for the synchronous warm-hit listing path.
 
-    Complementary to ``ParsedCacheStats``: a sync hit bypasses ``get_files``, so
-    it bumps ``listing_hits`` and no parsed counter; a decline runs the async
-    ``get_files`` and bumps the parsed counters as usual. The decline
-    sub-counters (their sum is ``listing_declines``) attribute each decline to a
-    reason for A/B diagnosis. Written only from the main resolver thread, so the
-    reads and writes need no lock.
+    A sync hit bumps ``listing_hits``; a decline bumps ``listing_declines`` and
+    one reason sub-counter, then runs the async path. Written only from the main
+    resolver thread, so the counters need no lock.
     """
 
     listing_hits: int = 0
@@ -134,6 +137,7 @@ class WarmSyncStats:
     declined_no_policy: int = 0
     declined_stale_online: int = 0
     declined_no_blob: int = 0
+    declined_small_blob: int = 0
 
 
 @dataclass
@@ -721,11 +725,10 @@ class FetchCoordinator:
             self._cache = NullCache()
         self._cache_dir = cache_dir
         self._index_routes = list(index_routes or [])
-        # The synchronous warm-hit listing path serves exactly one shape: a
-        # single non-file index over an OnDiskCache, unrouted, so the serving
-        # index is always ``self.indexes[0].name`` and the probe reads
-        # ``self._cache`` (the same backend the fetcher's client reads).
-        # Everything else declines to the untouched async path.
+        # The sync warm-hit path serves one shape only: a single non-file index
+        # over an OnDiskCache, unrouted, so the serving index is always
+        # indexes[0] and the probe reads the same backend the fetcher's client
+        # reads. Everything else declines to the async path.
         self._sync_listing_enabled = (
             len(self.indexes) == 1
             and not self._index_routes
@@ -744,8 +747,8 @@ class FetchCoordinator:
         # index client the same way; rebuilt on the fetcher loop so each run
         # starts at zero.
         self._parsed_cache_stats = ParsedCacheStats()
-        # Warm-hit listing counters, reset on each start() (main thread only).
         self._warm_sync_stats = WarmSyncStats()
+        self._warm_sync_min_blob_bytes = _WARM_SYNC_MIN_BLOB_BYTES
         self._thread: threading.Thread | None = None
         self._started = False
         self._crashed = False
@@ -774,12 +777,7 @@ class FetchCoordinator:
 
     @property
     def warm_sync_stats(self) -> WarmSyncStats:
-        """Synchronous warm-hit listing counters for this run.
-
-        Reset at the start of each run (main thread), so the counts reflect the
-        most recent run. A warm resolve should show ``listing_hits`` dominate and
-        no LISTING request submitted; a cold run shows all declines.
-        """
+        """Synchronous warm-hit listing counters, reset at each ``start()``."""
         return self._warm_sync_stats
 
     def start(self) -> None:
@@ -830,7 +828,6 @@ class FetchCoordinator:
     def _post_to_loop(self, callback: Callable[..., object], *args: object) -> bool:
         """Hand ``callback`` to the fetcher loop from any thread.
 
-        Shares ``_submit``'s guard so one place knows how to reach the loop.
         Returns ``False`` when there is no live loop (never started, or closed
         between the read and the post) so the caller can run the work inline.
         """
@@ -879,12 +876,9 @@ class FetchCoordinator:
     def _try_listing_sync(self, package: str) -> list[WheelFile | SdistFile] | None:
         """Read a fresh parsed listing on the caller's thread, or ``None``.
 
-        Total by construction (``read_fresh_parsed_listing`` never raises), which
-        the single-flight claim relies on: the caller has already created the
-        pending, so a raise would strand it. Declines bump a reason sub-counter
-        for A/B diagnosis; on a decline the policy is re-read (a cheap sidecar
-        read) to attribute the reason rather than threading it out of the pure
-        helper.
+        ``read_fresh_parsed_listing`` never raises, so the caller's pending is
+        never stranded. On a decline the policy is re-read to attribute a reason
+        counter rather than threading it out of the pure helper.
         """
         stats = self._warm_sync_stats
         if not self._sync_listing_enabled:
@@ -902,21 +896,34 @@ class FetchCoordinator:
             stats.declined_no_blob += 1
         return None
 
+    def _overlap_gate_admits(self, package: str) -> bool:
+        """Whether a warm listing may be served inline, or must go async.
+
+        A parsed blob below ``_WARM_SYNC_MIN_BLOB_BYTES`` declines to the async
+        path. A blob whose size cannot be stat'd, or a run where the sync path is
+        disabled, is admitted and left to ``_try_listing_sync`` to classify.
+        """
+        if not self._sync_listing_enabled:
+            return True
+        size = self._cache.get_simple_parsed_size(package)
+        if size is None:
+            return True
+        return size >= self._warm_sync_min_blob_bytes
+
     def request_listing(
         self, package: str, *, speculative: bool = False
     ) -> threading.Event:
         """Request a listing fetch; return an event set when the result lands.
 
-        Claim the single-flight pending first: an existing pending means another
-        party owns fulfillment, so join its event and never probe. Only the
-        pending's creator probes the warm cache on this thread; a fresh parsed
-        hit is served inline (no round trip), and every other outcome declines to
-        the unchanged async fetch, which owns every cache write and self-heal.
+        The single-flight pending is claimed first: an existing pending means
+        another party owns fulfillment, so its event is joined and the cache is
+        never probed. Only the pending's creator probes; a fresh parsed hit is
+        served inline, and every other outcome declines to the async fetch, which
+        owns every cache write and self-heal.
 
-        ``speculative`` callers (the fire-and-forget prefetch cascade) skip the
-        sync probe and dispatch async, so their read+parse work overlaps
-        resolver CPU on the fetcher thread instead of serializing onto the main
-        thread; only blocking critical-path callers serve inline (S-CRIT).
+        ``speculative`` callers skip the sync probe and dispatch async, so their
+        read work overlaps resolver CPU on the fetcher thread; only blocking
+        critical-path callers serve inline.
         """
         self._check_alive()
         if self.index.get_listing(package) is not None:
@@ -928,20 +935,20 @@ class FetchCoordinator:
         if existed:
             return pending.event
         if not speculative:
-            records = self._try_listing_sync(package)
-            if records is not None:
-                # Serve inline on the caller thread: the serving index then
-                # store_listing, which fires the pending with no round trip.
-                # The progress tick and the newest-N prefetch walk run on the
-                # fetcher loop, exactly where async _fetch_listing runs them, so
-                # the caller thread does no selection work beyond the read and
-                # the materialize.
-                self.index.store_listing_index(package, self.indexes[0].name)
-                self.index.store_listing(package, records)
-                self._warm_sync_stats.listing_hits += 1
-                if not self._post_to_loop(self._run_listing_tail, package, records):
-                    self._run_listing_tail(package, records)
-                return pending.event
+            if self._overlap_gate_admits(package):
+                records = self._try_listing_sync(package)
+                if records is not None:
+                    # Store the serving index before store_listing fires the
+                    # pending, matching the async path's ordering. The tail runs
+                    # on the fetcher loop, or inline when the loop is gone.
+                    self.index.store_listing_index(package, self.indexes[0].name)
+                    self.index.store_listing(package, records)
+                    self._warm_sync_stats.listing_hits += 1
+                    if not self._post_to_loop(self._run_listing_tail, package, records):
+                        self._run_listing_tail(package, records)
+                    return pending.event
+            else:
+                self._warm_sync_stats.declined_small_blob += 1
             self._warm_sync_stats.listing_declines += 1
         self._submit(FetchRequest(kind=FetchKind.LISTING, package=package))
         return pending.event
@@ -1376,9 +1383,7 @@ class FetchCoordinator:
         """Enqueue metadata for the newest candidates of a stored listing.
 
         Files are oldest-first. One wheel per version: the first with a sidecar
-        is the one the provider picks for that version's metadata. Fire-and-
-        forget through ``request_metadata`` so the reads warm concurrently with
-        resolver CPU.
+        is the one the provider picks for that version's metadata.
         """
         first_wheel: dict[str, WheelFile] = {}
         for f in files:
@@ -1396,10 +1401,9 @@ class FetchCoordinator:
     ) -> None:
         """Run the post-listing tail on the fetcher loop: tick then prefetch.
 
-        Mirrors the tail of the async ``_fetch_listing``. A failure is logged at
-        WARNING and swallowed rather than turned into a listing error: the
-        listing pending has already fired on the caller thread, so the served
-        listing must not be overwritten.
+        Mirrors the tail of the async ``_fetch_listing``. A failure is swallowed
+        rather than turned into a listing error: the pending has already fired,
+        so the served listing must not be overwritten.
         """
         try:
             if self._on_fetch is not None:

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -885,7 +885,9 @@ class FetchCoordinator:
             stats.declined_no_blob += 1
         return None
 
-    def request_listing(self, package: str) -> threading.Event:
+    def request_listing(
+        self, package: str, *, speculative: bool = False
+    ) -> threading.Event:
         """Request a listing fetch; return an event set when the result lands.
 
         Claim the single-flight pending first: an existing pending means another
@@ -893,6 +895,11 @@ class FetchCoordinator:
         pending's creator probes the warm cache on this thread; a fresh parsed
         hit is served inline (no round trip), and every other outcome declines to
         the unchanged async fetch, which owns every cache write and self-heal.
+
+        ``speculative`` callers (the fire-and-forget prefetch cascade) skip the
+        sync probe and dispatch async, so their read+parse work overlaps
+        resolver CPU on the fetcher thread instead of serializing onto the main
+        thread; only blocking critical-path callers serve inline (S-CRIT).
         """
         self._check_alive()
         if self.index.get_listing(package) is not None:
@@ -903,20 +910,21 @@ class FetchCoordinator:
         pending, existed = self.index.get_or_create_pending(key)
         if existed:
             return pending.event
-        records = self._try_listing_sync(package)
-        if records is not None:
-            # Reproduce every observable effect of a successful async
-            # _fetch_listing: serving index before store_listing (which fires
-            # the pending), the progress tick, and the prefetch batch. Only the
-            # round trip is removed.
-            self.index.store_listing_index(package, self.indexes[0].name)
-            self.index.store_listing(package, records)
-            if self._on_fetch is not None:
-                self._on_fetch()
-            self._prefetch_metadata_after_listing(package, records)
-            self._warm_sync_stats.listing_hits += 1
-            return pending.event
-        self._warm_sync_stats.listing_declines += 1
+        if not speculative:
+            records = self._try_listing_sync(package)
+            if records is not None:
+                # Reproduce every observable effect of a successful async
+                # _fetch_listing: serving index before store_listing (which
+                # fires the pending), the progress tick, and the prefetch batch.
+                # Only the round trip is removed.
+                self.index.store_listing_index(package, self.indexes[0].name)
+                self.index.store_listing(package, records)
+                if self._on_fetch is not None:
+                    self._on_fetch()
+                self._prefetch_metadata_after_listing(package, records)
+                self._warm_sync_stats.listing_hits += 1
+                return pending.event
+            self._warm_sync_stats.listing_declines += 1
         self._submit(FetchRequest(kind=FetchKind.LISTING, package=package))
         return pending.event
 

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -827,6 +827,23 @@ class FetchCoordinator:
             # call_soon_threadsafe raises RuntimeError once the loop is closed.
             self._refuse(item)
 
+    def _post_to_loop(self, callback: Callable[..., object], *args: object) -> bool:
+        """Hand ``callback`` to the fetcher loop from any thread.
+
+        Shares ``_submit``'s guard so one place knows how to reach the loop.
+        Returns ``False`` when there is no live loop (never started, or closed
+        between the read and the post) so the caller can run the work inline.
+        """
+        loop = self._loop
+        if loop is None:
+            return False
+        try:
+            loop.call_soon_threadsafe(callback, *args)
+        except RuntimeError:
+            # call_soon_threadsafe raises RuntimeError once the loop is closed.
+            return False
+        return True
+
     def _refuse(self, item: _QueueItem) -> None:
         """Record a failure for each request in ``item``, unblocking waiters."""
         # None is the shutdown sentinel; it has no waiters.
@@ -913,16 +930,17 @@ class FetchCoordinator:
         if not speculative:
             records = self._try_listing_sync(package)
             if records is not None:
-                # Reproduce every observable effect of a successful async
-                # _fetch_listing: serving index before store_listing (which
-                # fires the pending), the progress tick, and the prefetch batch.
-                # Only the round trip is removed.
+                # Serve inline on the caller thread: the serving index then
+                # store_listing, which fires the pending with no round trip.
+                # The progress tick and the newest-N prefetch walk run on the
+                # fetcher loop, exactly where async _fetch_listing runs them, so
+                # the caller thread does no selection work beyond the read and
+                # the materialize.
                 self.index.store_listing_index(package, self.indexes[0].name)
                 self.index.store_listing(package, records)
-                if self._on_fetch is not None:
-                    self._on_fetch()
-                self._prefetch_metadata_after_listing(package, records)
                 self._warm_sync_stats.listing_hits += 1
+                if not self._post_to_loop(self._run_listing_tail, package, records):
+                    self._run_listing_tail(package, records)
                 return pending.event
             self._warm_sync_stats.listing_declines += 1
         self._submit(FetchRequest(kind=FetchKind.LISTING, package=package))
@@ -1372,6 +1390,23 @@ class FetchCoordinator:
             url = w.metadata_url
             assert url is not None
             self.request_metadata(package, w.version, url, w.metadata_hash)
+
+    def _run_listing_tail(
+        self, package: str, records: Sequence[WheelFile | SdistFile]
+    ) -> None:
+        """Run the post-listing tail on the fetcher loop: tick then prefetch.
+
+        Mirrors the tail of the async ``_fetch_listing``. A failure is logged at
+        WARNING and swallowed rather than turned into a listing error: the
+        listing pending has already fired on the caller thread, so the served
+        listing must not be overwritten.
+        """
+        try:
+            if self._on_fetch is not None:
+                self._on_fetch()
+            self._prefetch_metadata_after_listing(package, records)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("listing prefetch tail failed: %s: %s", package, exc)
 
     def _record_serving_index(
         self,

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -22,7 +22,11 @@ from urllib.parse import urlsplit
 from packaging.utils import canonicalize_name as canonicalize_name_boundary
 
 from nab_index.cache import CacheBackend, NullCache, OfflineError, OnDiskCache
-from nab_index.cached_client import CachedAsyncSimpleClient, ParsedCacheStats
+from nab_index.cached_client import (
+    CachedAsyncSimpleClient,
+    ParsedCacheStats,
+    read_fresh_parsed_listing,
+)
 from nab_index.client import SdistFile, WheelFile
 from nab_index.lazy_wheel import RangeCapabilityMemo, RangeOutcome
 from nab_index.local_index import LocalIndexClient, parse_file_url
@@ -44,6 +48,7 @@ __all__ = [
     "FetchRequest",
     "InMemoryIndex",
     "IndexRoute",
+    "WarmSyncStats",
 ]
 
 
@@ -109,6 +114,26 @@ class FetchRequest:
     metadata_hash: tuple[str, str] | None = None
     sdist_hashes: tuple[tuple[str, str], ...] = ()
     wheel_hashes: tuple[tuple[str, str], ...] = ()
+
+
+@dataclass
+class WarmSyncStats:
+    """Counters for the synchronous warm-hit listing path.
+
+    Complementary to ``ParsedCacheStats``: a sync hit bypasses ``get_files``, so
+    it bumps ``listing_hits`` and no parsed counter; a decline runs the async
+    ``get_files`` and bumps the parsed counters as usual. The decline
+    sub-counters (their sum is ``listing_declines``) attribute each decline to a
+    reason for A/B diagnosis. Written only from the main resolver thread, so the
+    reads and writes need no lock.
+    """
+
+    listing_hits: int = 0
+    listing_declines: int = 0
+    declined_ineligible: int = 0
+    declined_no_policy: int = 0
+    declined_stale_online: int = 0
+    declined_no_blob: int = 0
 
 
 @dataclass
@@ -696,6 +721,17 @@ class FetchCoordinator:
             self._cache = NullCache()
         self._cache_dir = cache_dir
         self._index_routes = list(index_routes or [])
+        # The synchronous warm-hit listing path serves exactly one shape: a
+        # single non-file index over an OnDiskCache, unrouted, so the serving
+        # index is always ``self.indexes[0].name`` and the probe reads
+        # ``self._cache`` (the same backend the fetcher's client reads).
+        # Everything else declines to the untouched async path.
+        self._sync_listing_enabled = (
+            len(self.indexes) == 1
+            and not self._index_routes
+            and not self.indexes[0].url.startswith("file://")
+            and isinstance(self._cache, OnDiskCache)
+        )
         # Progress hook: fired once per successful listing fetch, from the
         # fetcher thread.  ``None`` when nothing is watching (the common case).
         self._on_fetch = on_fetch
@@ -708,6 +744,8 @@ class FetchCoordinator:
         # index client the same way; rebuilt on the fetcher loop so each run
         # starts at zero.
         self._parsed_cache_stats = ParsedCacheStats()
+        # Warm-hit listing counters, reset on each start() (main thread only).
+        self._warm_sync_stats = WarmSyncStats()
         self._thread: threading.Thread | None = None
         self._started = False
         self._crashed = False
@@ -734,11 +772,22 @@ class FetchCoordinator:
         """
         return self._parsed_cache_stats
 
+    @property
+    def warm_sync_stats(self) -> WarmSyncStats:
+        """Synchronous warm-hit listing counters for this run.
+
+        Reset at the start of each run (main thread), so the counts reflect the
+        most recent run. A warm resolve should show ``listing_hits`` dominate and
+        no LISTING request submitted; a cold run shows all declines.
+        """
+        return self._warm_sync_stats
+
     def start(self) -> None:
         """Start the fetcher thread (idempotent)."""
         if self._started:
             return
         self._started = True
+        self._warm_sync_stats = WarmSyncStats()
         self._thread = threading.Thread(
             target=self._run_loop,
             daemon=True,
@@ -810,8 +859,41 @@ class FetchCoordinator:
             msg = "Fetcher thread crashed, see log for details"
             raise RuntimeError(msg)
 
+    def _try_listing_sync(self, package: str) -> list[WheelFile | SdistFile] | None:
+        """Read a fresh parsed listing on the caller's thread, or ``None``.
+
+        Total by construction (``read_fresh_parsed_listing`` never raises), which
+        the single-flight claim relies on: the caller has already created the
+        pending, so a raise would strand it. Declines bump a reason sub-counter
+        for A/B diagnosis; on a decline the policy is re-read (a cheap sidecar
+        read) to attribute the reason rather than threading it out of the pure
+        helper.
+        """
+        stats = self._warm_sync_stats
+        if not self._sync_listing_enabled:
+            stats.declined_ineligible += 1
+            return None
+        records = read_fresh_parsed_listing(self._cache, package, offline=self._offline)
+        if records is not None:
+            return records
+        policy = self._cache.get_simple_policy(package)
+        if policy is None:
+            stats.declined_no_policy += 1
+        elif not (policy.is_fresh() or self._offline):
+            stats.declined_stale_online += 1
+        else:
+            stats.declined_no_blob += 1
+        return None
+
     def request_listing(self, package: str) -> threading.Event:
-        """Request a listing fetch; return an event set when the result lands."""
+        """Request a listing fetch; return an event set when the result lands.
+
+        Claim the single-flight pending first: an existing pending means another
+        party owns fulfillment, so join its event and never probe. Only the
+        pending's creator probes the warm cache on this thread; a fresh parsed
+        hit is served inline (no round trip), and every other outcome declines to
+        the unchanged async fetch, which owns every cache write and self-heal.
+        """
         self._check_alive()
         if self.index.get_listing(package) is not None:
             done = threading.Event()
@@ -819,8 +901,23 @@ class FetchCoordinator:
             return done
         key = f"listing:{package}"
         pending, existed = self.index.get_or_create_pending(key)
-        if not existed:
-            self._submit(FetchRequest(kind=FetchKind.LISTING, package=package))
+        if existed:
+            return pending.event
+        records = self._try_listing_sync(package)
+        if records is not None:
+            # Reproduce every observable effect of a successful async
+            # _fetch_listing: serving index before store_listing (which fires
+            # the pending), the progress tick, and the prefetch batch. Only the
+            # round trip is removed.
+            self.index.store_listing_index(package, self.indexes[0].name)
+            self.index.store_listing(package, records)
+            if self._on_fetch is not None:
+                self._on_fetch()
+            self._prefetch_metadata_after_listing(package, records)
+            self._warm_sync_stats.listing_hits += 1
+            return pending.event
+        self._warm_sync_stats.listing_declines += 1
+        self._submit(FetchRequest(kind=FetchKind.LISTING, package=package))
         return pending.event
 
     def request_metadata(

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -35,6 +35,7 @@ from nab_index.multi_index import IndexConfig, MultiIndexClient
 from nab_index.parsed_listing import encode as encode_parsed
 from nab_index.transport import HttpError, HttpResponse
 from nab_python.fetch import (
+    _WARM_SYNC_MIN_BLOB_BYTES,
     FetchCoordinator,
     FetchKind,
     FetchRequest,
@@ -52,8 +53,15 @@ def no_retries(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _coord(**kwargs: object) -> FetchCoordinator:
-    """Build a FetchCoordinator wired to httpx so respx can mock it."""
-    return FetchCoordinator(transport=HttpxAsyncTransport(), **kwargs)  # type: ignore[arg-type]
+    """Build a FetchCoordinator wired to httpx so respx can mock it.
+
+    The overlap gate defaults off (threshold 0) so the serve-mechanism tests
+    exercise the sync path independent of the blob-size gate, which has its own
+    dedicated tests.
+    """
+    coord = FetchCoordinator(transport=HttpxAsyncTransport(), **kwargs)  # type: ignore[arg-type]
+    coord._warm_sync_min_blob_bytes = 0
+    return coord
 
 
 def _make_wheel(name: str = "foo", version: str = "1.0") -> WheelFile:
@@ -2741,6 +2749,7 @@ class TestWarmSyncListingPath:
             transport=_RaiseOnGetTransport(),  # type: ignore[arg-type]
             cache_dir=tmp_path,
         )
+        coord._warm_sync_min_blob_bytes = 0
         with coord:
             coord._prefetch_metadata_after_listing = (  # type: ignore[method-assign]
                 lambda package, records: None
@@ -2821,6 +2830,78 @@ class TestWarmSyncListingPath:
 
             assert coord.index.get_listing("testpkg") is not None
             assert len(_listing_submits(calls)) == 1
+            assert coord.warm_sync_stats.declined_no_blob == 1
+            assert coord.warm_sync_stats.listing_declines == 1
+
+    def test_gate_default_threshold(self, tmp_path: Path) -> None:
+        """A fresh coordinator carries the module default blob-size threshold."""
+        coord = FetchCoordinator(
+            transport=HttpxAsyncTransport(),  # type: ignore[arg-type]
+            cache_dir=tmp_path,
+        )
+        try:
+            assert coord._warm_sync_min_blob_bytes == _WARM_SYNC_MIN_BLOB_BYTES
+        finally:
+            coord.shutdown()
+
+    def test_gate_admits_when_sync_disabled(self) -> None:
+        """The gate admits (defers to the eligibility gate) when sync is off."""
+        coord = _coord()
+        try:
+            assert coord._sync_listing_enabled is False
+            assert coord._overlap_gate_admits("pkg") is True
+        finally:
+            coord.shutdown()
+
+    @respx.mock
+    def test_gate_declines_small_blob_to_async(self, tmp_path: Path) -> None:
+        """A parsed blob below the threshold declines to the async path."""
+        cache = OnDiskCache(tmp_path, _PYPI)
+        _warm_parsed(cache, "pkg", [_sync_sdist("1.0")])
+
+        with _coord(cache_dir=tmp_path) as coord:
+            coord._warm_sync_min_blob_bytes = 10**9
+            calls = _spy_submit(coord)
+            coord.request_listing("pkg").wait(timeout=5)
+
+            assert coord.index.get_listing("pkg") is not None
+            assert len(_listing_submits(calls)) == 1
+            assert coord.warm_sync_stats.listing_hits == 0
+            assert coord.warm_sync_stats.declined_small_blob == 1
+            assert coord.warm_sync_stats.listing_declines == 1
+
+    @respx.mock
+    def test_gate_admits_blob_at_threshold(self, tmp_path: Path) -> None:
+        """A parsed blob at or above the threshold serves inline."""
+        cache = OnDiskCache(tmp_path, _PYPI)
+        files: list[WheelFile | SdistFile] = [_sync_sdist("1.0")]
+        _warm_parsed(cache, "pkg", files)
+        size = cache.get_simple_parsed_size("pkg")
+        assert size is not None
+
+        with _coord(cache_dir=tmp_path) as coord:
+            coord._warm_sync_min_blob_bytes = size
+            calls = _spy_submit(coord)
+            event = coord.request_listing("pkg")
+
+            assert event.is_set()
+            assert coord.index.get_listing("pkg") == files
+            assert _listing_submits(calls) == []
+            assert coord.warm_sync_stats.listing_hits == 1
+            assert coord.warm_sync_stats.declined_small_blob == 0
+
+    @respx.mock
+    def test_gate_admits_when_blob_size_unknown(self, tmp_path: Path) -> None:
+        """A missing blob has no size, so the gate admits and _try declines."""
+        cache = OnDiskCache(tmp_path, _PYPI)
+        _warm_parsed(cache, "pkg", [_sync_sdist("1.0")], blob=False)
+        assert cache.get_simple_parsed_size("pkg") is None
+
+        with _coord(cache_dir=tmp_path) as coord:
+            coord._warm_sync_min_blob_bytes = 10**9
+            coord.request_listing("pkg").wait(timeout=5)
+
+            assert coord.warm_sync_stats.declined_small_blob == 0
             assert coord.warm_sync_stats.declined_no_blob == 1
             assert coord.warm_sync_stats.listing_declines == 1
 
@@ -2979,12 +3060,18 @@ class TestWarmSyncListingPath:
         def writer() -> None:
             toggle = False
             while not stop.is_set():
-                if toggle:
-                    _warm_parsed(cache, "pkg", files_b)
-                    _warm_parsed(cache, "pkg", files_a, blob=False)
-                else:
-                    _warm_parsed(cache, "pkg", files_a)
-                    _warm_parsed(cache, "pkg", files_b, blob=False)
+                try:
+                    if toggle:
+                        _warm_parsed(cache, "pkg", files_b)
+                        _warm_parsed(cache, "pkg", files_a, blob=False)
+                    else:
+                        _warm_parsed(cache, "pkg", files_a)
+                        _warm_parsed(cache, "pkg", files_b, blob=False)
+                except PermissionError:
+                    # Windows refuses os.replace onto a file the reader has open;
+                    # retry. Production single-flight keeps a sync read and a
+                    # fetcher write off the same file, so this race is harness-only.
+                    continue
                 toggle = not toggle
 
         def reader() -> None:

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -2906,6 +2906,49 @@ class TestWarmSyncListingPath:
         finally:
             coord.shutdown()
 
+    @respx.mock
+    def test_speculative_skips_probe_and_routes_async(self, tmp_path: Path) -> None:
+        """A speculative call skips the sync probe and dispatches async.
+
+        S-CRIT keeps speculative listing reads on the fetcher thread so their
+        read+parse work overlaps resolver CPU; only blocking critical-path
+        callers serve the warm cache inline.
+        """
+        cache = OnDiskCache(tmp_path, _PYPI)
+        _warm_parsed(cache, "pkg", [_sync_sdist("1.0")])
+
+        with _coord(cache_dir=tmp_path) as coord:
+            probed: list[str] = []
+            coord._try_listing_sync = probed.append  # type: ignore[method-assign]
+            calls = _spy_submit(coord)
+
+            coord.request_listing("pkg", speculative=True).wait(timeout=5)
+
+            assert probed == []
+            assert len(_listing_submits(calls)) == 1
+            assert coord.warm_sync_stats.listing_hits == 0
+            assert coord.warm_sync_stats.listing_declines == 0
+
+    @respx.mock
+    def test_default_call_serves_synchronously(self, tmp_path: Path) -> None:
+        """The default (critical-path) call still serves the warm cache inline."""
+        cache = OnDiskCache(tmp_path, _PYPI)
+        files: list[WheelFile | SdistFile] = [_sync_sdist("1.0")]
+        _warm_parsed(cache, "pkg", files)
+
+        with _coord(cache_dir=tmp_path) as coord:
+            coord._prefetch_metadata_after_listing = (  # type: ignore[method-assign]
+                lambda package, records: None
+            )
+            calls = _spy_submit(coord)
+
+            event = coord.request_listing("pkg")
+
+            assert event.is_set()
+            assert coord.index.get_listing("pkg") == files
+            assert _listing_submits(calls) == []
+            assert coord.warm_sync_stats.listing_hits == 1
+
     def test_skew_reader_never_serves_torn_pair(self, tmp_path: Path) -> None:
         """Interleaved writer/reader: every non-None probe is a bound pair."""
         cache = OnDiskCache(tmp_path, _PYPI)

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -665,6 +665,63 @@ class TestFetchCoordinator:
         # The newest PREFETCH_METADATA_COUNT wheels, not all 15.
         assert derived == [f"pkg-{n}.0-py3-none-any.whl" for n in range(6, 16)]
 
+    def test_prefetch_after_listing_enqueues_newest_batch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The extracted tail picks the newest N, one wheel per version."""
+
+        def _wheel(version: str, *, has_meta: bool = True) -> WheelFile:
+            return WheelFile(
+                filename=f"pkg-{version}-py3-none-any.whl",
+                url=f"https://f.com/pkg-{version}-py3-none-any.whl",
+                version=version,
+                requires_python=None,
+                has_metadata=has_meta,
+                upload_time=None,
+                metadata_hash=("sha256", f"h{version}") if has_meta else None,
+            )
+
+        # Oldest-first, more versions than PREFETCH_METADATA_COUNT, plus a
+        # second wheel for one version (first-with-sidecar wins), a
+        # sidecar-less wheel, and an sdist that the tail must skip.
+        files: list[WheelFile | SdistFile] = []
+        for n in range(1, 16):
+            files.append(_wheel(f"{n}.0"))
+        files.append(_wheel("15.0"))  # duplicate version, must not re-enqueue
+        files.append(_wheel("16.0", has_meta=False))  # no sidecar, skipped
+        files.append(
+            SdistFile(
+                filename="pkg-17.0.tar.gz",
+                url="https://f.com/pkg-17.0.tar.gz",
+                version="17.0",
+                requires_python=None,
+                upload_time=None,
+            )
+        )
+
+        calls: list[tuple[object, ...]] = []
+
+        def _spy(*args: object, **kwargs: object) -> threading.Event:
+            calls.append(args)
+            done = threading.Event()
+            done.set()
+            return done
+
+        coord = _coord()
+        monkeypatch.setattr(coord, "request_metadata", _spy)
+        coord._prefetch_metadata_after_listing("pkg", files)
+
+        expected = [
+            (
+                "pkg",
+                f"{n}.0",
+                f"https://f.com/pkg-{n}.0-py3-none-any.whl.metadata",
+                ("sha256", f"h{n}.0"),
+            )
+            for n in range(6, 16)
+        ]
+        assert calls == expected
+
     @respx.mock
     def test_listing_entry_with_unsplittable_url_is_dropped(self) -> None:
         """Only the entry whose URL urllib cannot split is dropped."""

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -2576,6 +2576,19 @@ def _sync_sdist(version: str = "1.0", name: str = "pkg") -> SdistFile:
     )
 
 
+def _sync_wheel(version: str = "1.0", name: str = "pkg") -> WheelFile:
+    """A minimal sidecar-bearing WheelFile for warm-hit prefetch round trips."""
+    return WheelFile(
+        filename=f"{name}-{version}-py3-none-any.whl",
+        url=f"https://f.example/{name}-{version}-py3-none-any.whl",
+        version=version,
+        requires_python=None,
+        has_metadata=True,
+        upload_time=None,
+        metadata_hash=None,
+    )
+
+
 def _warm_parsed(
     cache: OnDiskCache,
     package: str,
@@ -2698,10 +2711,11 @@ class TestWarmSyncListingPath:
             assert event.is_set()
             assert coord.index.get_listing("pkg") == files
             assert coord.index.get_listing_index("pkg") == "pypi"
-            assert prefetched == [("pkg", files)]
             assert _listing_submits(calls) == []
             assert coord.warm_sync_stats.listing_hits == 1
             assert coord.warm_sync_stats.listing_declines == 0
+            coord.shutdown()
+            assert prefetched == [("pkg", files)]
 
     @respx.mock
     def test_warm_hit_fires_progress_hook(self, tmp_path: Path) -> None:
@@ -2712,6 +2726,7 @@ class TestWarmSyncListingPath:
         ticks: list[int] = []
         with _coord(cache_dir=tmp_path, on_fetch=lambda: ticks.append(1)) as coord:
             coord.request_listing("pkg")
+            coord.shutdown()
             assert ticks == [1]
             assert coord.warm_sync_stats.listing_hits == 1
 
@@ -2994,3 +3009,163 @@ class TestWarmSyncListingPath:
         finally:
             stop.set()
             coord.shutdown()
+
+
+class TestWarmSyncTailOffload:
+    """The post-listing tail runs on the fetcher loop, not the caller thread."""
+
+    @respx.mock
+    def test_sync_hit_runs_tail_off_the_caller_thread(self, tmp_path: Path) -> None:
+        """The newest-N selection walk executes on the fetcher thread only."""
+        cache = OnDiskCache(tmp_path, _PYPI)
+        files: list[WheelFile | SdistFile] = [_sync_wheel("1.0"), _sync_wheel("2.0")]
+        _warm_parsed(cache, "pkg", files)
+
+        with _coord(cache_dir=tmp_path) as coord:
+            fetcher_ident = coord._thread.ident
+            caller_ident = threading.get_ident()
+
+            tail_idents: list[int | None] = []
+            done = threading.Event()
+            original = coord._prefetch_metadata_after_listing
+
+            def _record(package: str, records: object) -> None:
+                tail_idents.append(threading.get_ident())
+                original(package, records)  # type: ignore[arg-type]
+                done.set()
+
+            coord._prefetch_metadata_after_listing = _record  # type: ignore[method-assign]
+
+            meta_idents: list[int] = []
+
+            def _spy_meta(*args: object, **kwargs: object) -> threading.Event:
+                meta_idents.append(threading.get_ident())
+                ev = threading.Event()
+                ev.set()
+                return ev
+
+            coord.request_metadata = _spy_meta  # type: ignore[method-assign]
+
+            calls = _spy_submit(coord)
+            event = coord.request_listing("pkg")
+
+            assert event.is_set()
+            assert coord.index.get_listing("pkg") == files
+            assert _listing_submits(calls) == []
+            assert done.wait(timeout=5)
+
+            assert tail_idents == [fetcher_ident]
+            assert fetcher_ident != caller_ident
+            assert meta_idents
+            assert all(ident == fetcher_ident for ident in meta_idents)
+            assert caller_ident not in meta_idents
+
+    @respx.mock
+    def test_offloaded_tail_prefetches_metadata(self, tmp_path: Path) -> None:
+        """The offloaded tail enqueues the newest-N metadata and it lands."""
+        respx.get(url__regex=r".*\.whl\.metadata$").mock(
+            return_value=httpx.Response(200, text="Metadata-Version: 2.1\n")
+        )
+        cache = OnDiskCache(tmp_path, _PYPI)
+        files: list[WheelFile | SdistFile] = [_sync_wheel("1.0"), _sync_wheel("2.0")]
+        _warm_parsed(cache, "pkg", files)
+
+        with _coord(cache_dir=tmp_path) as coord:
+            done = threading.Event()
+            original = coord._prefetch_metadata_after_listing
+
+            def _wrap(package: str, records: object) -> None:
+                original(package, records)  # type: ignore[arg-type]
+                done.set()
+
+            coord._prefetch_metadata_after_listing = _wrap  # type: ignore[method-assign]
+            calls = _spy_submit(coord)
+
+            coord.request_listing("pkg")
+            assert done.wait(timeout=5)
+
+            meta_submits = {
+                (item.package, item.version, item.url)
+                for item in calls
+                if isinstance(item, FetchRequest) and item.kind is FetchKind.METADATA
+            }
+            assert meta_submits == {
+                ("pkg", "1.0", "https://f.example/pkg-1.0-py3-none-any.whl.metadata"),
+                ("pkg", "2.0", "https://f.example/pkg-2.0-py3-none-any.whl.metadata"),
+            }
+
+            for version in ("1.0", "2.0"):
+                sidecar = f"https://f.example/pkg-{version}-py3-none-any.whl.metadata"
+                deadline = time.monotonic() + 5
+                while time.monotonic() < deadline and not coord.index.has_metadata(
+                    "pkg", version, sidecar
+                ):
+                    time.sleep(0.01)
+                assert coord.index.has_metadata("pkg", version, sidecar)
+
+    @respx.mock
+    def test_dead_loop_runs_tail_inline(self, tmp_path: Path) -> None:
+        """No live loop: the tail is a last-resort inline run on the caller."""
+        cache = OnDiskCache(tmp_path, _PYPI)
+        files: list[WheelFile | SdistFile] = [_sync_sdist("1.0")]
+        _warm_parsed(cache, "pkg", files)
+
+        # An unstarted coordinator has no loop, so _post_to_loop declines.
+        coord = _coord(cache_dir=tmp_path)
+        caller_ident = threading.get_ident()
+        idents: list[int] = []
+        coord._prefetch_metadata_after_listing = (  # type: ignore[method-assign]
+            lambda package, records: idents.append(threading.get_ident())
+        )
+        try:
+            event = coord.request_listing("pkg")
+
+            assert event.is_set()
+            assert coord.index.get_listing("pkg") == files
+            assert idents == [caller_ident]
+            assert coord.warm_sync_stats.listing_hits == 1
+            assert not coord._crashed
+        finally:
+            coord.shutdown()
+
+    def test_post_to_loop_false_on_closed_loop(self, tmp_path: Path) -> None:
+        """A closed loop makes call_soon_threadsafe raise; the post declines."""
+        coord = _coord(cache_dir=tmp_path)
+        loop = asyncio.new_event_loop()
+        loop.close()
+        coord._loop = loop
+        try:
+            assert coord._post_to_loop(lambda: None) is False
+        finally:
+            coord._loop = None
+            coord.shutdown()
+
+    @respx.mock
+    def test_offloaded_tail_exception_logged_and_listing_survives(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A raising tail logs WARNING and leaves the served listing intact."""
+        cache = OnDiskCache(tmp_path, _PYPI)
+        files: list[WheelFile | SdistFile] = [_sync_sdist("1.0")]
+        _warm_parsed(cache, "pkg", files)
+
+        ran = threading.Event()
+
+        def _boom(package: str, records: object) -> None:
+            ran.set()
+            raise RuntimeError("boom")
+
+        with _coord(cache_dir=tmp_path) as coord:
+            coord._prefetch_metadata_after_listing = _boom  # type: ignore[method-assign]
+            with caplog.at_level(logging.WARNING):
+                event = coord.request_listing("pkg")
+                assert ran.wait(timeout=5)
+                coord.shutdown()
+
+            assert event.is_set()
+            assert coord.index.get_listing("pkg") == files
+
+        assert any(
+            "listing prefetch tail failed" in record.getMessage()
+            for record in caplog.records
+        )

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -19,7 +19,7 @@ import httpx
 import pytest
 import respx
 
-from nab_index.cache import NullCache
+from nab_index.cache import CachePolicy, NullCache, OnDiskCache
 from nab_index.cached_client import CachedAsyncSimpleClient
 from nab_index.client import (
     MalformedSimpleResponseError,
@@ -32,13 +32,15 @@ from nab_index.httpx_async_transport import HttpxAsyncTransport
 from nab_index.lazy_wheel import RangeOutcome
 from nab_index.local_index import LocalIndexClient
 from nab_index.multi_index import IndexConfig, MultiIndexClient
-from nab_index.transport import HttpError
+from nab_index.parsed_listing import encode as encode_parsed
+from nab_index.transport import HttpError, HttpResponse
 from nab_python.fetch import (
     FetchCoordinator,
     FetchKind,
     FetchRequest,
     IndexRoute,
     InMemoryIndex,
+    WarmSyncStats,
     _resolve_routes,
 )
 
@@ -2545,3 +2547,407 @@ class TestRangeMetadataCoordinator:
         assert event.is_set()
         assert coord.index.get_metadata("widget", "1.0", _RANGE_URL) is None
         assert coord.index.get_metadata_error("widget", "1.0", _RANGE_URL) is None
+
+
+_PYPI = "https://pypi.org/simple/"
+
+
+class _RaiseOnGetTransport:
+    """A transport whose ``get`` raises: proves a warm hit touches no network."""
+
+    async def get(
+        self, url: str, *, headers: dict[str, str] | None = None
+    ) -> HttpResponse:
+        msg = f"unexpected network fetch: {url}"
+        raise HttpError(msg)
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _sync_sdist(version: str = "1.0", name: str = "pkg") -> SdistFile:
+    """A minimal SdistFile for warm parsed-listing round trips."""
+    return SdistFile(
+        filename=f"{name}-{version}.tar.gz",
+        url=f"https://f.example/{name}-{version}.tar.gz",
+        version=version,
+        requires_python=None,
+        upload_time=None,
+    )
+
+
+def _warm_parsed(
+    cache: OnDiskCache,
+    package: str,
+    files: Sequence[WheelFile | SdistFile],
+    *,
+    body: bytes | None = None,
+    fresh: bool = True,
+    blob: bool = True,
+    digest_override: str | None = None,
+) -> None:
+    """Write a policy sidecar, raw body, and parsed blob for ``package``.
+
+    ``fresh`` controls the freshness window; ``blob`` omits the parsed blob;
+    ``digest_override`` binds the blob to a foreign body so ``decode`` misses.
+    """
+    if body is None:
+        body = json.dumps(LISTING_JSON).encode()
+    now = int(time.time())
+    if fresh:
+        policy = CachePolicy(fetched_at=now, max_age=3600, etag="x")
+    else:
+        policy = CachePolicy(fetched_at=now - 10_000, max_age=1, etag="x")
+    digest = cache.put_simple(package, body, policy)
+    if blob:
+        bound = digest_override if digest_override is not None else digest
+        cache.put_simple_parsed(package, encode_parsed(list(files), bound))
+
+
+def _spy_submit(coord: FetchCoordinator) -> list[object]:
+    """Record every ``_submit`` item, still delegating to the real submit."""
+    calls: list[object] = []
+    original = coord._submit
+
+    def wrapper(item: object) -> None:
+        calls.append(item)
+        original(item)  # type: ignore[arg-type]
+
+    coord._submit = wrapper  # type: ignore[method-assign]
+    return calls
+
+
+def _listing_submits(calls: Sequence[object]) -> list[object]:
+    """The recorded submits that are LISTING requests."""
+    return [
+        item
+        for item in calls
+        if isinstance(item, FetchRequest) and item.kind is FetchKind.LISTING
+    ]
+
+
+class TestWarmSyncListingPath:
+    """The synchronous warm-hit fast path for ``request_listing`` (C5, S-ALL)."""
+
+    def test_eligibility_gate_single_index_ondisk(self, tmp_path: Path) -> None:
+        """The gate is on for a single non-file index over an OnDiskCache."""
+        coord = _coord(cache_dir=tmp_path)
+        try:
+            assert coord._sync_listing_enabled is True
+        finally:
+            coord.shutdown()
+
+    def test_eligibility_off_for_null_cache(self) -> None:
+        coord = _coord()
+        try:
+            assert coord._sync_listing_enabled is False
+        finally:
+            coord.shutdown()
+
+    def test_eligibility_off_for_multi_index(self, tmp_path: Path) -> None:
+        coord = _coord(
+            cache_dir=tmp_path,
+            indexes=[
+                IndexConfig("pypi", _PYPI),
+                IndexConfig("alt", "https://alt.example/"),
+            ],
+        )
+        try:
+            assert coord._sync_listing_enabled is False
+        finally:
+            coord.shutdown()
+
+    def test_eligibility_off_for_file_index(self, tmp_path: Path) -> None:
+        wheelhouse = tmp_path / "wheelhouse"
+        wheelhouse.mkdir()
+        coord = _coord(
+            cache_dir=tmp_path / "cache",
+            indexes=[IndexConfig("local", wheelhouse.as_uri())],
+        )
+        try:
+            assert coord._sync_listing_enabled is False
+        finally:
+            coord.shutdown()
+
+    def test_eligibility_off_for_routed(self, tmp_path: Path) -> None:
+        coord = _coord(
+            cache_dir=tmp_path,
+            index_routes=[IndexRoute(name="pkg", index="pypi")],
+        )
+        try:
+            assert coord._sync_listing_enabled is False
+        finally:
+            coord.shutdown()
+
+    @respx.mock
+    def test_warm_hit_serves_without_listing_fetch(self, tmp_path: Path) -> None:
+        """A fresh parsed hit is served inline: no LISTING submit, prefetch fired."""
+        cache = OnDiskCache(tmp_path, _PYPI)
+        files: list[WheelFile | SdistFile] = [_sync_sdist("1.0"), _sync_sdist("2.0")]
+        _warm_parsed(cache, "pkg", files)
+
+        prefetched: list[tuple[str, object]] = []
+
+        with _coord(cache_dir=tmp_path) as coord:
+            coord._prefetch_metadata_after_listing = (  # type: ignore[method-assign]
+                lambda package, records: prefetched.append((package, list(records)))
+            )
+            calls = _spy_submit(coord)
+            event = coord.request_listing("pkg")
+
+            assert event.is_set()
+            assert coord.index.get_listing("pkg") == files
+            assert coord.index.get_listing_index("pkg") == "pypi"
+            assert prefetched == [("pkg", files)]
+            assert _listing_submits(calls) == []
+            assert coord.warm_sync_stats.listing_hits == 1
+            assert coord.warm_sync_stats.listing_declines == 0
+
+    @respx.mock
+    def test_warm_hit_fires_progress_hook(self, tmp_path: Path) -> None:
+        """A sync hit ticks ``on_fetch`` once, matching the async path's count."""
+        cache = OnDiskCache(tmp_path, _PYPI)
+        _warm_parsed(cache, "pkg", [_sync_sdist("1.0")])
+
+        ticks: list[int] = []
+        with _coord(cache_dir=tmp_path, on_fetch=lambda: ticks.append(1)) as coord:
+            coord.request_listing("pkg")
+            assert ticks == [1]
+            assert coord.warm_sync_stats.listing_hits == 1
+
+    @respx.mock
+    def test_warm_hit_no_network(self, tmp_path: Path) -> None:
+        """A warm hit touches no transport at all."""
+        cache = OnDiskCache(tmp_path, _PYPI)
+        files: list[WheelFile | SdistFile] = [_sync_sdist("1.0")]
+        _warm_parsed(cache, "pkg", files)
+
+        coord = FetchCoordinator(
+            transport=_RaiseOnGetTransport(),  # type: ignore[arg-type]
+            cache_dir=tmp_path,
+        )
+        with coord:
+            coord._prefetch_metadata_after_listing = (  # type: ignore[method-assign]
+                lambda package, records: None
+            )
+            event = coord.request_listing("pkg")
+            assert event.is_set()
+            assert coord.index.get_listing("pkg") == files
+            assert not coord._crashed
+
+    @respx.mock
+    def test_preexisting_pending_joins_without_probe(self, tmp_path: Path) -> None:
+        """A pending key joins the existing event: no probe, store, or submit."""
+        cache = OnDiskCache(tmp_path, _PYPI)
+        _warm_parsed(cache, "pkg", [_sync_sdist("1.0")])
+
+        with _coord(cache_dir=tmp_path) as coord:
+            probed: list[str] = []
+
+            def _probe(package: str) -> None:
+                probed.append(package)
+
+            coord._try_listing_sync = _probe  # type: ignore[method-assign]
+            calls = _spy_submit(coord)
+            pending, _ = coord.index.get_or_create_pending("listing:pkg")
+
+            event = coord.request_listing("pkg")
+
+            assert event is pending.event
+            assert probed == []
+            assert _listing_submits(calls) == []
+            assert coord.index.get_listing("pkg") is None
+            assert coord.warm_sync_stats.listing_hits == 0
+            assert coord.warm_sync_stats.listing_declines == 0
+
+    @respx.mock
+    def test_decline_stale_online(self, tmp_path: Path) -> None:
+        """A stale entry online declines to async and revalidates."""
+        respx.get(f"{_PYPI}pkg/").mock(
+            return_value=httpx.Response(200, json=LISTING_JSON, headers={"etag": "v2"})
+        )
+        cache = OnDiskCache(tmp_path, _PYPI)
+        _warm_parsed(cache, "pkg", [_sync_sdist("1.0")], fresh=False)
+
+        with _coord(cache_dir=tmp_path) as coord:
+            calls = _spy_submit(coord)
+            coord.request_listing("pkg").wait(timeout=5)
+
+            assert coord.index.get_listing("pkg") is not None
+            assert len(_listing_submits(calls)) == 1
+            assert coord.warm_sync_stats.declined_stale_online == 1
+            assert coord.warm_sync_stats.listing_declines == 1
+            assert coord.warm_sync_stats.listing_hits == 0
+
+    @respx.mock
+    def test_decline_no_policy_cold(self, tmp_path: Path) -> None:
+        """A cold cache has no policy: decline to async fetch."""
+        respx.get(f"{_PYPI}pkg/").mock(
+            return_value=httpx.Response(200, json=LISTING_JSON)
+        )
+        with _coord(cache_dir=tmp_path) as coord:
+            calls = _spy_submit(coord)
+            coord.request_listing("pkg").wait(timeout=5)
+
+            assert coord.index.get_listing("pkg") is not None
+            assert len(_listing_submits(calls)) == 1
+            assert coord.warm_sync_stats.declined_no_policy == 1
+            assert coord.warm_sync_stats.listing_declines == 1
+
+    @respx.mock
+    def test_decline_no_blob(self, tmp_path: Path) -> None:
+        """A fresh policy with no parsed blob declines; async rebuilds from body."""
+        cache = OnDiskCache(tmp_path, _PYPI)
+        _warm_parsed(cache, "testpkg", [_sync_sdist("1.0")], blob=False)
+
+        with _coord(cache_dir=tmp_path) as coord:
+            calls = _spy_submit(coord)
+            coord.request_listing("testpkg").wait(timeout=5)
+
+            assert coord.index.get_listing("testpkg") is not None
+            assert len(_listing_submits(calls)) == 1
+            assert coord.warm_sync_stats.declined_no_blob == 1
+            assert coord.warm_sync_stats.listing_declines == 1
+
+    @respx.mock
+    def test_decline_digest_mismatch(self, tmp_path: Path) -> None:
+        """A blob bound to a foreign body declines; the sync path never rebuilds."""
+        cache = OnDiskCache(tmp_path, _PYPI)
+        _warm_parsed(
+            cache,
+            "testpkg",
+            [_sync_sdist("1.0")],
+            digest_override="0" * 64,
+        )
+
+        with _coord(cache_dir=tmp_path) as coord:
+            calls = _spy_submit(coord)
+            coord.request_listing("testpkg").wait(timeout=5)
+
+            assert coord.index.get_listing("testpkg") is not None
+            assert len(_listing_submits(calls)) == 1
+            assert coord.warm_sync_stats.declined_no_blob == 1
+            assert not coord._crashed
+
+    @respx.mock
+    def test_decline_multi_index(self, tmp_path: Path) -> None:
+        """A multi-index config is ineligible; it declines to async."""
+        respx.get(f"{_PYPI}pkg/").mock(
+            return_value=httpx.Response(200, json=LISTING_JSON)
+        )
+        cache = OnDiskCache(tmp_path, _PYPI)
+        _warm_parsed(cache, "pkg", [_sync_sdist("1.0")])
+
+        with _coord(
+            cache_dir=tmp_path,
+            indexes=[
+                IndexConfig("pypi", _PYPI),
+                IndexConfig("alt", "https://alt.example/"),
+            ],
+        ) as coord:
+            calls = _spy_submit(coord)
+            coord.request_listing("pkg").wait(timeout=5)
+
+            assert len(_listing_submits(calls)) == 1
+            assert coord.warm_sync_stats.declined_ineligible == 1
+            assert coord.warm_sync_stats.listing_declines == 1
+
+    @respx.mock
+    def test_decline_file_index(self, tmp_path: Path) -> None:
+        """A file:// index is ineligible; it declines to the local async path."""
+        wheelhouse = tmp_path / "wheelhouse"
+        wheelhouse.mkdir()
+        with _coord(
+            cache_dir=tmp_path / "cache",
+            indexes=[IndexConfig("local", wheelhouse.as_uri())],
+        ) as coord:
+            calls = _spy_submit(coord)
+            coord.request_listing("pkg").wait(timeout=5)
+
+            assert len(_listing_submits(calls)) == 1
+            assert coord.warm_sync_stats.declined_ineligible == 1
+
+    @respx.mock
+    def test_decline_null_cache(self) -> None:
+        """No cache dir means a NullCache: ineligible, declines to async."""
+        respx.get(f"{_PYPI}pkg/").mock(
+            return_value=httpx.Response(200, json=LISTING_JSON)
+        )
+        with _coord() as coord:
+            calls = _spy_submit(coord)
+            coord.request_listing("pkg").wait(timeout=5)
+
+            assert coord.index.get_listing("pkg") is not None
+            assert len(_listing_submits(calls)) == 1
+            assert coord.warm_sync_stats.declined_ineligible == 1
+
+    @respx.mock
+    def test_decline_offline_cold_stores_empty(self, tmp_path: Path) -> None:
+        """Offline with a cold cache declines (no policy) and records empty."""
+        with _coord(cache_dir=tmp_path, offline=True) as coord:
+            calls = _spy_submit(coord)
+            coord.request_listing("missing").wait(timeout=5)
+
+            assert coord.index.get_listing("missing") == []
+            assert len(_listing_submits(calls)) == 1
+            assert coord.warm_sync_stats.declined_no_policy == 1
+            assert not coord._crashed
+
+    def test_start_resets_stats(self, tmp_path: Path) -> None:
+        """``start`` zeroes the warm-sync counters for a reused coordinator."""
+        coord = _coord(cache_dir=tmp_path)
+        try:
+            coord.start()
+            coord._warm_sync_stats.listing_hits = 7
+            coord._warm_sync_stats.declined_no_blob = 3
+            coord.shutdown()
+            coord.start()
+            assert coord.warm_sync_stats == WarmSyncStats()
+        finally:
+            coord.shutdown()
+
+    def test_skew_reader_never_serves_torn_pair(self, tmp_path: Path) -> None:
+        """Interleaved writer/reader: every non-None probe is a bound pair."""
+        cache = OnDiskCache(tmp_path, _PYPI)
+        files_a: list[WheelFile | SdistFile] = [_sync_sdist("1.0")]
+        files_b: list[WheelFile | SdistFile] = [_sync_sdist("2.0")]
+        _warm_parsed(cache, "pkg", files_a)
+
+        coord = _coord(cache_dir=tmp_path)
+        stop = threading.Event()
+        errors: list[BaseException] = []
+        results: list[object] = []
+
+        def writer() -> None:
+            toggle = False
+            while not stop.is_set():
+                if toggle:
+                    _warm_parsed(cache, "pkg", files_b)
+                    _warm_parsed(cache, "pkg", files_a, blob=False)
+                else:
+                    _warm_parsed(cache, "pkg", files_a)
+                    _warm_parsed(cache, "pkg", files_b, blob=False)
+                toggle = not toggle
+
+        def reader() -> None:
+            try:
+                for _ in range(3000):
+                    results.append(coord._try_listing_sync("pkg"))
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        try:
+            w = threading.Thread(target=writer)
+            r = threading.Thread(target=reader)
+            w.start()
+            r.start()
+            r.join(timeout=30)
+            stop.set()
+            w.join(timeout=5)
+
+            assert not errors
+            for value in results:
+                assert value is None or value in (files_a, files_b)
+        finally:
+            stop.set()
+            coord.shutdown()

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -189,6 +189,14 @@ class TestPrefetchListings:
         versions = [v for v, _ in provider.fetch_versions("foo")]
         assert versions == [V("1.0")]
 
+    def test_prefetch_new_deps_requests_listing_speculatively(self) -> None:
+        """The prefetch cascade marks its listing requests speculative (S-CRIT)."""
+        coordinator = make_coordinator([make_wheel("1.0")], package="foo")
+        provider = Provider(coordinator, target=_PY312)
+        coordinator.request_listing.reset_mock()
+        provider.prefetch_new_deps({"bar": SpecifierSet(">=1.0").to_range()})
+        coordinator.request_listing.assert_called_once_with("bar", speculative=True)
+
 
 class TestSpeculativePrefetch:
     def test_metadata_prefetched_after_listing(self) -> None:
@@ -2958,7 +2966,9 @@ class TestLookAhead:
 
         coordinator = MagicMock()
         coordinator.index = index
-        coordinator.request_listing.side_effect = lambda pkg: _done_event()
+        coordinator.request_listing.side_effect = lambda pkg, *, speculative=False: (
+            _done_event()
+        )
 
         call_count = [0]
 
@@ -4507,7 +4517,7 @@ class TestSkipFetch:
 
     def test_prefetches_override_dependencies(self) -> None:
         # The override introduces dep-a, so its listing is background-fetched
-        # even though foo itself skips the metadata fetch.
+        # speculatively even though foo itself skips the metadata fetch.
         coordinator = make_coordinator([make_wheel("1.0")], package="foo")
         provider = Provider(
             coordinator,
@@ -4517,7 +4527,7 @@ class TestSkipFetch:
             ),
         )
         provider.get_dependencies("foo", V("1.0"))
-        coordinator.request_listing.assert_any_call("dep-a")
+        coordinator.request_listing.assert_any_call("dep-a", speculative=True)
 
     def test_does_not_fire_for_requires_python_only(self) -> None:
         # A partial override (only requires-python) still needs the artifact
@@ -6370,7 +6380,7 @@ class TestFetchVersionsNotInIndex:
         coordinator = MagicMock()
         coordinator.index = index
 
-        def _request_listing(pkg: str) -> threading.Event:
+        def _request_listing(pkg: str, *, speculative: bool = False) -> threading.Event:
             # Simulate the coordinator populating the index after request.
             index.store_listing(pkg, wheels)
             return _done_event()

--- a/nab-python/tests/test_provider_declared_target.py
+++ b/nab-python/tests/test_provider_declared_target.py
@@ -495,7 +495,9 @@ def _index_with_files(
     index.store_listing(package, files)
     coordinator = MagicMock()
     coordinator.index = index
-    coordinator.request_listing.side_effect = lambda _pkg: _done_event()
+    coordinator.request_listing.side_effect = lambda _pkg, *, speculative=False: (
+        _done_event()
+    )
     return coordinator
 
 


### PR DESCRIPTION
On a warm resolve, a fresh parsed-listing cache hit is now served on the caller's thread when its parsed blob is at least 64 KiB, instead of dispatching every listing to the fetcher loop; smaller blobs and speculative prefetches keep the async path so their read work still overlaps resolver CPU. Serving the large critical-path listings inline relieves the single fetcher thread's serialization of big listings, while declining small blobs avoids exposing main-thread work on CPU-bound resolves. On the 20-scenario warm rung this wins on 12 scenarios (pdm-sentry -192 ms, winpython -183 ms, zamba -101 ms) with no scenario regressing beyond its noise floor and identical pins throughout. Stacked on opt/parsed-listing-cache.
