### PR TITLE
raise HttpError on a redirect to a malformed-IPv6 Location

### DIFF
--- a/nab-index/src/nab_index/urllib3_async_transport.py
+++ b/nab-index/src/nab_index/urllib3_async_transport.py
@@ -183,7 +183,10 @@ class Urllib3AsyncTransport:
             request_headers.update(headers)
         try:
             return await asyncio.to_thread(self._request, url, request_headers)
-        except (urllib3.exceptions.HTTPError, ContentDecodingError) as exc:
+        except Exception as exc:
+            # A malformed IPv6 host in a redirect's Location makes urllib3's
+            # urljoin re-parse raise a bare ValueError, outside its HTTPError
+            # hierarchy.
             msg = f"GET {url} failed: {exc}"
             raise HttpError(msg) from exc
 

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -14,6 +14,7 @@ from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 from unittest.mock import MagicMock
+from urllib.parse import urljoin
 
 import httpx
 import pytest
@@ -803,6 +804,34 @@ class TestUrllib3AsyncTransport:
 
         with pytest.raises(HttpError, match="GET https://x/ failed"):
             asyncio.run(go())
+
+    def test_get_wraps_malformed_ipv6_redirect(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A redirect to a malformed-IPv6 Location maps to HttpError."""
+        pool = MagicMock(spec=urllib3.PoolManager)
+
+        def follow_redirect(method: str, url: str, **kwargs: object) -> object:
+            return urljoin(url, "https://[::1/pkg/")
+
+        pool.request.side_effect = follow_redirect
+        monkeypatch.setattr(
+            "nab_index.urllib3_async_transport.urllib3.PoolManager",
+            lambda **kw: pool,
+        )
+
+        async def go() -> None:
+            transport = Urllib3AsyncTransport()
+            try:
+                await transport.get("https://example.com/simple/pkg/")
+            finally:
+                await transport.aclose()
+
+        with pytest.raises(
+            HttpError, match="GET https://example.com/simple/pkg/ failed"
+        ) as excinfo:
+            asyncio.run(go())
+        assert isinstance(excinfo.value.__cause__, ValueError)
 
     def test_get_requests_gzip_without_caller_headers(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
The urllib3 transport's `get()` only wrapped `urllib3.exceptions.HTTPError` and `ContentDecodingError`. When a server redirects to a `Location` whose host is a malformed IPv6 literal, urllib3 re-parses the URL through `urljoin` and raises a bare `ValueError`, which slipped past that except clause. Callers then saw a raw `ValueError` instead of the `HttpError` that the `AsyncHttpTransport.get` protocol documents on a transport failure.

Broaden the except to catch any error from the request and re-raise it as `HttpError`, keeping the original as the cause, so a transport-layer failure always reaches the caller as `HttpError`.
