### PR TITLE
point build-policy diagnostics at the config token, not the enum

### DIFF
--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -368,8 +368,9 @@ def resolve_dynamic_sdist(
     provider.stats.excluded_by_build_policy += 1
     msg = (
         f"{package}=={version} sdist has dynamic dependencies and no static"
-        f" pyproject.toml fallback; building requires BuildPolicy.BUILD_REMOTE"
-        f" but the effective policy is {effective.value}"
+        f" pyproject.toml fallback; building requires build-policy"
+        f" '{BuildPolicy.BUILD_REMOTE.value}' but the effective policy is"
+        f" '{effective.value}'"
     )
     raise UnsupportedSdistError(msg)
 

--- a/nab-python/src/nab_python/_provider/sources.py
+++ b/nab-python/src/nab_python/_provider/sources.py
@@ -123,8 +123,8 @@ def extract_source_metadata(
         provider.stats.excluded_by_build_policy += 1
         msg = (
             f"{descriptor} at {path} has dynamic metadata; building requires"
-            f" BuildPolicy.{minimum.name} but the effective policy is"
-            f" {effective.value}"
+            f" build-policy '{minimum.value}' but the effective policy is"
+            f" '{effective.value}'"
         )
         raise UnsupportedSdistError(msg)
     try:

--- a/nab-python/tests/test_archive.py
+++ b/nab-python/tests/test_archive.py
@@ -1064,8 +1064,12 @@ class TestArchiveBuildPolicyLevels:
             '[project]\nname = "pkg"\nversion = "1.0.0"\ndynamic = ["dependencies"]\n',
             encoding="utf-8",
         )
-        with pytest.raises(UnsupportedSdistError, match="BuildPolicy.BUILD_REMOTE"):
+        with pytest.raises(UnsupportedSdistError) as excinfo:
             self._extract(policy, tmp_path)
+        msg = str(excinfo.value)
+        assert "building requires build-policy 'build-remote'" in msg
+        assert f"effective policy is '{policy.value}'" in msg
+        assert "BuildPolicy." not in msg
 
     def test_dynamic_archive_builds_at_build_remote(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -3094,8 +3094,12 @@ class TestLocalSources:
             local_sources=[LocalSource("foo", str(tmp_path))],
             build_policy=BuildPolicy.NEVER,
         )
-        with pytest.raises(UnsupportedSdistError, match="BUILD_LOCAL"):
+        with pytest.raises(UnsupportedSdistError) as excinfo:
             provider.fetch_versions("foo")
+        msg = str(excinfo.value)
+        assert "building requires build-policy 'build-local'" in msg
+        assert "effective policy is 'never'" in msg
+        assert "BuildPolicy." not in msg
 
     def test_non_utf8_pyproject_raises_unsupported(self, tmp_path: Path) -> None:
         """A local source with a non-UTF-8 ``pyproject.toml`` is unbuildable.
@@ -8980,6 +8984,24 @@ class TestStaticSdistMetadata:
         # excluded_by_build_policy is incremented inside _resolve_dynamic_sdist;
         # the cache hit re-raises without going through that path.
         assert provider.stats.excluded_by_build_policy == 1
+
+    def test_dynamic_sdist_diagnostic_names_config_build_policy(self) -> None:
+        """The build-policy hint names the config token, not the enum symbol."""
+        coordinator = make_coordinator(
+            [make_sdist("1.0")],
+            sdist_pkg_info=PKG_INFO_DYNAMIC_DEPS,
+        )
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            dist_policy=DistPolicy.WHEEL_OR_SDIST,
+        )
+        with pytest.raises(UnsupportedSdistError) as excinfo:
+            provider.get_dependencies("pkg", V("1.0"))
+        msg = str(excinfo.value)
+        assert "build-policy 'build-remote'" in msg
+        assert "effective policy is 'build-local'" in msg
+        assert "BuildPolicy." not in msg
 
     def test_dynamic_pkg_info_with_static_pyproject(self) -> None:
         """Static pyproject.toml replaces dynamic Requires-Dist."""

--- a/nab-python/tests/test_vcs.py
+++ b/nab-python/tests/test_vcs.py
@@ -1091,7 +1091,7 @@ class TestProviderVcsIntegration:
             vcs_cache_dir=tmp_path / "cache",
             build_policy=BuildPolicy.BUILD_LOCAL,
         )
-        with pytest.raises(UnsupportedSdistError, match="BUILD_REMOTE"):
+        with pytest.raises(UnsupportedSdistError, match="build-policy 'build-remote'"):
             provider.fetch_versions("foo")
 
     def test_duplicate_source_across_local_vcs_raises(self, tmp_path: Path) -> None:


### PR DESCRIPTION
When a source has dynamic metadata and the effective build policy is too strict to build it, the diagnostic named the internal enum symbol, for example `BuildPolicy.BUILD_REMOTE`. That points the user at a knob that does not exist: the config and CLI accept `build-remote`, not `BuildPolicy.BUILD_REMOTE`. Run `nab lock` under the default `build-local` against a package whose sdist has dynamic dependencies and no static `pyproject.toml` fallback, and the error tells you to set something you cannot type.

Both places that raise it, the dynamic remote sdist in `metadata_resolver.py` and the dynamic local, VCS or archive source in `sources.py`, now print the config token for the required and for the effective policy, so the message matches what you would set in `[tool.nab]` or on the command line. The provider stores the rejection text and re-raises it on a repeat lookup, so the cached path picks up the new wording without a change there. The `BuildPolicy` references that remain are Sphinx cross-references in docstrings rather than error text, and they stay.
