### PR TITLE
reject constraint extras and direct-reference URLs at config load

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -14,8 +14,10 @@ single run with a `--project-<key>` flag.
 # lockfile format is experimental).
 mode = "specific"
 
-# PEP 508 constraint strings.  Bound versions but never pull packages
-# into the resolution.
+# Constraint strings: a package name with an optional version
+# specifier and optional marker.  Bound versions but never pull
+# packages into the resolution, so extras and direct-reference URLs
+# are rejected.
 constraints = ["urllib3<2"]
 
 # Dependency-group names recorded in the lockfile's

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -1229,18 +1229,32 @@ def _parse_string_list(key: str, value: object) -> tuple[str, ...]:
     return tuple(out)
 
 
-def _require_pep508(key: str, item: str) -> None:
+def _require_constraint(key: str, item: str) -> None:
+    """Validate one ``constraints`` entry's shape.
+
+    A constraint is a name with an optional specifier and marker; it bounds
+    versions but never pulls a package in, so extras and direct-reference
+    URLs are rejected here rather than only at resolve.
+    """
     try:
-        Requirement(item)
+        req = Requirement(item)
     except InvalidRequirement as exc:
         msg = f"{key} is not a valid requirement: {exc}"
         raise ConfigError(msg) from exc
+
+    if req.extras:
+        msg = f"{key} cannot have extras: {item}"
+        raise ConfigError(msg)
+
+    if req.url is not None:
+        msg = f"{key} cannot be a direct reference (URL): {item}"
+        raise ConfigError(msg)
 
 
 def _parse_constraints(value: object) -> tuple[str, ...]:
     items = _parse_string_list("constraints", value)
     for i, item in enumerate(items):
-        _require_pep508(f"constraints[{i}]", item)
+        _require_constraint(f"constraints[{i}]", item)
     return items
 
 

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -724,6 +724,45 @@ class TestConstraints:
         ):
             read_pyproject_config(path)
 
+    def test_constraints_entry_cannot_carry_extras(self, tmp_path: Path) -> None:
+        """Config load rejects extras, matching the resolve path."""
+        path = write(tmp_path, '[tool.nab]\nconstraints = ["httpx[http2]>=0.27"]\n')
+        with pytest.raises(
+            ConfigError,
+            match="constraints\\[0\\] cannot have extras: httpx\\[http2\\]>=0.27",
+        ):
+            read_pyproject_config(path)
+
+    def test_constraints_entry_cannot_be_direct_url(self, tmp_path: Path) -> None:
+        """Config load rejects a direct reference, matching the resolve path."""
+        path = write(
+            tmp_path, '[tool.nab]\nconstraints = ["torch @ https://ex.com/t.whl"]\n'
+        )
+        with pytest.raises(
+            ConfigError,
+            match="constraints\\[0\\] cannot be a direct reference",
+        ):
+            read_pyproject_config(path)
+
+    def test_constraints_entry_may_carry_a_marker(self, tmp_path: Path) -> None:
+        """A name with a specifier and a marker is still a valid constraint."""
+        path = write(
+            tmp_path,
+            "[tool.nab]\nconstraints = ['urllib3<2 ; python_version < \"3.12\"']\n",
+        )
+        config = read_pyproject_config(path)
+        assert config.constraints == ('urllib3<2 ; python_version < "3.12"',)
+
+    def test_constraints_entry_vcs_url_is_rejected(self, tmp_path: Path) -> None:
+        """A VCS reference is a direct reference, so it is rejected too."""
+        url = "foo @ git+https://github.com/foo/bar.git"
+        path = write(tmp_path, f'[tool.nab]\nconstraints = ["{url}"]\n')
+        with pytest.raises(
+            ConfigError,
+            match="constraints\\[0\\] cannot be a direct reference",
+        ):
+            read_pyproject_config(path)
+
 
 class TestDefaultGroups:
     def test_default_is_empty(self, tmp_path: Path) -> None:

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -1778,17 +1778,6 @@ class TestResolvePyprojectVcs:
         with pytest.raises(UnsupportedVcsError, match='vcs.policy is "block"'):
             _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
 
-    def test_block_default_refuses_vcs_constraint(self, tmp_path: Path) -> None:
-        pyproject = tmp_path / "pyproject.toml"
-        pyproject.write_text(
-            "[project]\ndependencies = []\n"
-            "[tool.nab]\nconstraints = "
-            f'["foo @ git+https://github.com/foo/bar.git@{_FORTY}"]\n',
-        )
-
-        with pytest.raises(UnsupportedVcsError, match='vcs.policy is "block"'):
-            _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
-
     def test_admitted_vcs_dependency_raises_not_implemented(
         self, tmp_path: Path
     ) -> None:
@@ -1809,9 +1798,8 @@ class TestResolvePyprojectVcs:
                 python_version="3.12.0",
             )
 
-    def test_admitted_vcs_constraint_raises_not_implemented(
-        self, tmp_path: Path
-    ) -> None:
+    def test_vcs_constraint_refused_at_config_load(self, tmp_path: Path) -> None:
+        """An admitting VCS policy does not matter: config load refuses it first."""
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text(
             "[project]\ndependencies = []\n"
@@ -1823,12 +1811,8 @@ class TestResolvePyprojectVcs:
             'allowed-repos = ["https://github.com/"]\n',
         )
 
-        with pytest.raises(NotImplementedError, match="not implemented"):
-            _resolved(
-                pyproject,
-                _FAKE_TRANSPORT,
-                python_version="3.12.0",
-            )
+        with pytest.raises(ConfigError, match="cannot be a direct reference"):
+            _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
 
 
 class TestResolvePyprojectLockShape:


### PR DESCRIPTION
A `[tool.nab].constraints` entry that carried extras (`httpx[http2]>=0.27`) or a direct reference (`torch @ https://...`, including a `git+https` VCS URL) passed `nab config` as valid, then failed later at `nab lock` and `nab download` once the resolve reached it. The config check and the resolve disagreed about what a constraint may be.

A constraint bounds versions and never pulls a package into the resolution, so extras and direct references have no meaning there. The check now runs where the config is loaded, so a bad constraint is reported up front instead of partway through a resolve. A name with a version specifier and an optional marker is still accepted.
