### PR TITLE
document that workspace members lock as editable by default

### DIFF
--- a/docs/how-to/workspaces.md
+++ b/docs/how-to/workspaces.md
@@ -58,6 +58,15 @@ Each member of the matched workspace contributes a local source. The
 provider prefers those local sources over PyPI for any requirement
 whose canonical name matches.
 
+## Members lock as editable installs
+
+Each member is recorded as an editable install by default, matching
+uv. Its pin renders as a PEP 660 editable entry: `editable = true`
+in `pylock.toml`, and `-e file://...` in the two requirements
+formats. An explicit `[[tool.nab.local-sources]]` entry defaults the
+other way, non-editable, and becomes editable only when its
+`editable` key is set to `true`.
+
 ## Interaction with `[[tool.nab.local-sources]]`
 
 Explicit `[[tool.nab.local-sources]]` entries always win. When a

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -521,7 +521,10 @@ path = "../my-fork"
 ```
 
 Two optional keys are accepted.  `editable` (boolean, default
-`false`) records a PEP 660 editable install in the lockfile.
+`false`) records a PEP 660 editable install in the lockfile.  This
+default is specific to `[[tool.nab.local-sources]]`; workspace
+members discovered from `[tool.nab.workspace]` are recorded as
+editable by default (see [Lock a workspace](../how-to/workspaces.md)).
 `subdirectory` locates the package below `path`, for monorepo
 layouts.
 

--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -269,7 +269,9 @@ match what pip-compile emits.
 
 Local and VCS pins are rendered without hashes, mirroring pip's
 behaviour. An editable local pin becomes a `-e` line and a
-`subdirectory` a `#subdirectory=` fragment. An archive pin is a
+`subdirectory` a `#subdirectory=` fragment. Workspace members are
+editable by default, so they render as `-e`; a `[[tool.nab.local-sources]]`
+pin is non-editable unless its `editable` key is set. An archive pin is a
 third form, `name @ <url>#sha256=...`, carrying its hash in the
 URL fragment so the line stays hash-checkable. Any
 `subdirectory` is appended to that fragment with `&`. Local,


### PR DESCRIPTION
The docs never said that workspace members are pinned as editable (PEP 660, `-e`) installs by default. The one editable default they did document was `[[tool.nab.local-sources]]` with `editable = false`, which implies workspace members are non-editable too. They are not, and the resolver has always matched uv here.

This adds a "Members lock as editable installs" section to the workspaces how-to that spells out the default and how the pin renders. The `local-sources` `editable` key in the configuration reference and the local-pin rendering note in the lockfile reference now cross-reference it, so the two editable defaults no longer read as one.
