### PR TITLE
assert exactly one close in the multi-index alias dedup test

### DIFF
--- a/nab-python/tests/test_multi_index.py
+++ b/nab-python/tests/test_multi_index.py
@@ -48,7 +48,11 @@ class FakeClient:
         self.metadata_calls: list[tuple[str, str, str]] = []
         self.sdist_calls: list[tuple[str, str, str]] = []
         self.range_calls: list[tuple[str, str, str]] = []
-        self.closed = False
+        self.close_count = 0
+
+    @property
+    def closed(self) -> bool:
+        return self.close_count > 0
 
     async def get_files(self, package: str) -> list[WheelFile | SdistFile]:
         self.get_files_calls.append(package)
@@ -94,7 +98,7 @@ class FakeClient:
         return RangeMetadataResult(f"range:{package}:{version}", RangeOutcome.PARTIAL)
 
     async def aclose(self) -> None:
-        self.closed = True
+        self.close_count += 1
 
 
 class _NoNetworkTransport:
@@ -367,7 +371,7 @@ class TestAClose:
         assert c.closed
 
     def test_dedup_repeat_close(self) -> None:
-        # Same client appearing under two names should only close once.
+        # A client shared under two names must close exactly once.
         shared = FakeClient({})
         client = MultiIndexClient(
             {"a": shared, "alias": shared},
@@ -375,7 +379,7 @@ class TestAClose:
             {},
         )
         run(client.aclose())
-        assert shared.closed
+        assert shared.close_count == 1
 
     def test_async_with(self) -> None:
         a = FakeClient({})


### PR DESCRIPTION
`MultiIndexClient.aclose` closes a client once even when it is registered under several names, but `test_dedup_repeat_close` only checked the boolean `closed` flag. That flag is true after one close or two, so the test stayed green even against a version of `aclose` that dropped the dedup and closed an aliased client twice.

`FakeClient` now counts `aclose` calls in `close_count` and exposes `closed` as a property derived from it, and the dedup test asserts the shared client's `close_count` is 1. The other close tests keep reading `closed` and are unaffected.
