### PR TITLE
workspaces doc: build-policy floor skipped for any impersonated target

### DIFF
--- a/docs/how-to/workspaces.md
+++ b/docs/how-to/workspaces.md
@@ -70,11 +70,23 @@ member at a checkout outside the tree without removing it from the
 ## Build policy floor
 
 Workspace members frequently declare `dynamic = ["version"]` or
-similar. nab promotes the active `[tool.nab].build-policy` to at
-least `build-local` whenever a workspace is in scope, so PEP 517
-metadata extraction runs even when the user-set policy is stricter.
-A policy that is already `build-local` or `build-remote` is left
-alone.
+similar, which needs a PEP 517 build to read the metadata. When the
+resolve runs on the host machine, nab promotes the active
+`[tool.nab].build-policy` to at least `build-local` so that build can
+run even when the user-set policy is stricter. A policy that is
+already `build-local` or `build-remote` is left alone.
+
+The floor holds only while the resolve stays on the host. A target
+that declares a machine forbids host builds, so `build-policy` is
+forced to `never` and the floor does not apply: `mode = "universal"`,
+or a `[tool.nab.environment]` naming a `platform` or `implementation`.
+A workspace member with dynamic metadata and no static fallback
+cannot be read there, so its only version is skipped and the lock
+fails rather than quietly dropping the member. Retargeting the
+Python axis alone
+(`[tool.nab.environment].python` or `--python`) stays on the host, so
+the floor still applies. See [Build policy](../reference/build-policy.md)
+for the full rule.
 
 ## Scope of `[tool.nab]` keys
 

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -590,11 +590,13 @@ def read_pyproject_config(
     additional :class:`LocalSource` (explicit
     ``[[tool.nab.local-sources]]`` entries win on collision) and the
     effective ``build-policy`` is floored at
-    :attr:`BuildPolicy.BUILD_LOCAL`, except under ``mode = "universal"``,
-    where ``build-policy`` stays at ``never`` (host builds are forbidden)
-    and the floor is not applied.  Pass ``discover_workspace=False``
-    to skip discovery; useful for tests or for callers that layer their
-    own workspace logic on top of a base config.
+    :attr:`BuildPolicy.BUILD_LOCAL`, except for a target that forbids
+    host builds (``mode = "universal"``, or a ``[tool.nab.environment]``
+    naming a ``platform`` or ``implementation``), where ``build-policy``
+    stays at ``never`` and the floor is not applied.  Pass
+    ``discover_workspace=False`` to skip discovery; useful for tests or
+    for callers that layer their own workspace logic on top of a base
+    config.
 
     The ``[tool.nab]``-config portion is sourced from the registry merged
     ladder (pyproject ``[tool.nab]`` plus a project-dir ``nab.toml``,


### PR DESCRIPTION
The workspaces how-to said nab promotes `build-policy` to at least `build-local` whenever a workspace is in scope, and named `mode = "universal"` as the only case where the floor is skipped. The code actually skips it for any target that forbids host builds, which also covers a `[tool.nab.environment]` naming a `platform` or `implementation`. Under one of those targets a workspace member with dynamic metadata and no static fallback is skipped rather than built, and the docs did not say so.

This updates the workspaces page and the `read_pyproject_config` docstring to state the real condition, and adds that moving only the Python axis (`[tool.nab.environment].python` or `--python`) stays on the host, so the floor still applies there.
