### PR TITLE
fail the resolve when a build-remote sdist archive fails to fetch

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -21,6 +21,7 @@ from nab_index.client import (
     SdistHashMismatchError,
     WheelFile,
 )
+from nab_index.transport import HttpError
 
 from ._conflict_kind import EMPTY_MEMBERSHIP_SETS
 from ._provider import extras as _extras
@@ -1978,13 +1979,15 @@ class Provider:
         except (
             SdistHashMismatchError,
             MetadataHashMismatchError,
+            HttpError,
             UnsupportedVcsError,
             NotImplementedError,
             InvalidUploadTimeError,
             OverrideConflictError,
         ):
-            # A hash mismatch, refused direct-URL dep, naive upload-time hit, or
-            # a contradictory config override while building an sdist is a hard
+            # A hash mismatch, a build-remote archive the index failed to serve,
+            # a refused direct-URL dep, a naive upload-time hit, or a
+            # contradictory config override while building an sdist is a hard
             # error, not a skip.
             raise
         except Exception as exc:

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -24,6 +24,7 @@ from nab_index.client import (
 )
 from nab_index.lazy_wheel import RangeMetadataResult, RangeOutcome
 from nab_index.local_index import LocalIndexClient
+from nab_index.transport import HttpError
 from nab_python._provider import build_remote, metadata_resolver
 from nab_python._provider import listing as listing_mod
 from nab_python._provider.metadata_resolver import (
@@ -7841,6 +7842,39 @@ class TestStaticSdistMetadata:
             build_policy=BuildPolicy.BUILD_REMOTE,
         )
         with pytest.raises(SdistHashMismatchError):
+            provider.get_dependencies("pkg", V("1.0"))
+        assert ("pkg", V("1.0")) not in provider.deps_cache
+        assert ("pkg", V("1.0")) not in provider._invalid_metadata
+
+    def test_build_remote_archive_http_error_aborts_get_dependencies(
+        self,
+    ) -> None:
+        """A build-remote archive HTTP error aborts get_dependencies, not skips."""
+        coordinator = make_coordinator(
+            [make_sdist("1.0")],
+            sdist_pkg_info=PKG_INFO_DYNAMIC_DEPS,
+        )
+
+        def _unserved_archive(
+            pkg: str,
+            ver: str,
+            _url: str,
+            _hashes: tuple[tuple[str, str], ...] = (),
+        ) -> threading.Event:
+            coordinator.index.store_sdist_archive_error(
+                pkg, ver, HttpError("503 Server Error fetching sdist archive")
+            )
+            return _done_event()
+
+        coordinator.request_sdist_archive.side_effect = _unserved_archive
+
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            dist_policy=DistPolicy.WHEEL_OR_SDIST,
+            build_policy=BuildPolicy.BUILD_REMOTE,
+        )
+        with pytest.raises(HttpError):
             provider.get_dependencies("pkg", V("1.0"))
         assert ("pkg", V("1.0")) not in provider.deps_cache
         assert ("pkg", V("1.0")) not in provider._invalid_metadata


### PR DESCRIPTION
With `build_policy = BUILD_REMOTE`, an HTTP error fetching an sdist archive, whether transient or persistent, fell into the generic metadata-parse handler in `_parse_and_cache_metadata_guarded`. That path records the version as invalid metadata and re-raises it as a soft skip, so the resolver dropped the version and pinned an older one. The result is a stale lock with no sign the download had failed.

`HttpError` now sits in the hard-error group next to hash mismatches and the other build-time failures, so a failed archive fetch aborts the resolve instead of masking itself as unusable metadata.
