### PR TITLE
make nab config reject a non-table [tool.nab] like lock and download

### DIFF
--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -40,6 +40,7 @@ import tomli
 
 from nab_index.multi_index import IndexConfig
 
+from ._toml import tool_nab_section
 from .fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL
 from .provider import (
     ArchiveSource,
@@ -1342,9 +1343,12 @@ def _read_raw_table(path: Path, kind: SourceKind) -> Mapping[str, Any]:
         msg = f"{path} is not valid TOML: {exc}"
         raise SourceConfigError(msg) from exc
     if kind is SourceKind.PYPROJECT:
-        tool = data.get("tool", {})
-        section = tool.get("nab", {}) if isinstance(tool, dict) else {}
-        return section if isinstance(section, dict) else {}
+        section = tool_nab_section(data)
+        # A non-table [tool.nab] is malformed, not an empty config.
+        if not isinstance(section, dict):
+            msg = f"{path}: [tool.nab] must be a table, got {type(section).__name__}"
+            raise SourceConfigError(msg)
+        return section
     return data
 
 

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -585,8 +585,8 @@ class TestLoadTomlLayerDirect:
 
     def test_pyproject_tool_nab_not_table(self, tmp_path: Path) -> None:
         path = _write(tmp_path / "pyproject.toml", "[tool]\nnab = 3\n")
-        layer = _load_toml_layer(path, SourceKind.PYPROJECT)
-        assert layer.values == {}
+        with pytest.raises(SourceConfigError, match="must be a table, got int"):
+            _load_toml_layer(path, SourceKind.PYPROJECT)
 
 
 class TestDiscoverAndMissing:

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -395,6 +395,35 @@ class TestConfigErrors:
             config_command("list", path=hermetic_roots / "pyproject.toml")
         assert "project-scope only" in capsys.readouterr().err
 
+    @pytest.mark.parametrize(
+        ("body", "type_name"),
+        [
+            ('[tool]\nnab = "oops"\n', "str"),
+            ("[tool]\nnab = 5\n", "int"),
+            ("[[tool.nab]]\nx = 1\n", "list"),
+        ],
+    )
+    @pytest.mark.parametrize("action", ["list", "get"])
+    def test_non_table_tool_nab_exits(
+        self,
+        hermetic_roots: Path,
+        capsys: pytest.CaptureFixture[str],
+        action: str,
+        body: str,
+        type_name: str,
+    ) -> None:
+        _write(
+            hermetic_roots / "pyproject.toml",
+            '[project]\nname = "x"\nversion = "0"\ndependencies = []\n' + body,
+        )
+        args = (action, "mode") if action == "get" else (action,)
+        with pytest.raises(SystemExit) as exc:
+            config_command(*args, path=hermetic_roots / "pyproject.toml")
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "[tool.nab] must be a table" in err
+        assert type_name in err
+
     def test_cli_offline_override_layer(self, hermetic_roots: Path) -> None:
         _project(hermetic_roots)
         buf = io.StringIO()


### PR DESCRIPTION
`nab config list` and `nab config get` treat a pyproject whose `[tool.nab]` is not a table (for example `nab = 3`) as an empty section and print the built-in defaults. But `nab lock` and `nab download` reject that same file, so the inspector reports all-defaults for a config the rest of nab refuses to load.

The config inspector now raises on a non-table `[tool.nab]` with the same "must be a table" message those commands already use, so it surfaces the malformed config instead of hiding it behind the defaults.
