### PR TITLE
report unreadable sdist PKG-INFO instead of "no sdist available"

### DIFF
--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -119,10 +119,14 @@ def resolve_metadata(
     if metadata_text is not None:
         return (metadata_text, from_sdist)
 
-    msg = (
-        f"No metadata for {package}=={version}: "
-        f"no PEP 658 metadata and no sdist available"
+    # A fetched sdist with no PKG-INFO is a distinct failure from no sdist at all.
+    reason = (
+        "the sdist has no readable PKG-INFO"
+        if sdist is not None
+        else "no sdist available"
     )
+
+    msg = f"No metadata for {package}=={version}: no PEP 658 metadata and {reason}"
     raise MetadataError(msg)
 
 

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -6191,7 +6191,7 @@ class TestDistPolicy:
         assert not provider.has_invalid_metadata("pkg", V("1.0"))
 
     def test_sdist_no_pkg_info_raises(self) -> None:
-        """Raise MetadataError when PKG-INFO cannot be extracted."""
+        """Report an unreadable sdist PKG-INFO, not a missing sdist."""
         coordinator = make_coordinator(
             [make_sdist("1.0")],
             sdist_pkg_info=None,
@@ -6201,8 +6201,11 @@ class TestDistPolicy:
             target=_PY312,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
         )
-        with pytest.raises(MetadataError):
+        with pytest.raises(
+            MetadataError, match="the sdist has no readable PKG-INFO"
+        ) as excinfo:
             provider.get_dependencies("pkg", V("1.0"))
+        assert "no sdist available" not in str(excinfo.value)
 
     def test_no_pep658_with_no_dist_policy_raises(self) -> None:
         """Raise MetadataError when no PEP 658 and sdists disabled."""


### PR DESCRIPTION
When an sdist is published but its PKG-INFO cannot be read, the metadata-ladder error said "no sdist available". That is misleading: the sdist is there, it just has no usable metadata, so the message points at the wrong problem.

The final rung now checks whether an sdist was found. If one was, it reports "the sdist has no readable PKG-INFO"; the "no sdist available" wording stays for the case where no sdist exists at all.
