### PR TITLE
guard post-release python_full_version literals when slicing a minor

### DIFF
--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -373,6 +373,12 @@ _NON_INTERVAL_OPERATORS = frozenset({"===", "in", "not in"})
 # release, so a prerelease there maps cleanly to that release.
 _AT_LITERAL_OPERATORS = frozenset({"<", ">=", "==", "!=", "~="})
 
+# ``<`` is dropped: a post-release sorts just above its release, so
+# ``< "3.12.4.post1"`` lands its boundary on the next real micro (3.12.5) and
+# tiles cleanly.  The other at-literal operators snap a post's boundary onto a
+# micro whose truth does not flip there, so a post-release crashes on those.
+_POST_AT_LITERAL_OPERATORS = _AT_LITERAL_OPERATORS - frozenset({"<"})
+
 # PEP 508 lets either operand be the variable, and packaging preserves the
 # written order, so ``python_full_version < "3.10.2"`` and its literal-first
 # equivalent ``"3.10.2" > python_full_version`` both reach the scanner.  When
@@ -398,10 +404,11 @@ class NonIntervalMarkerError(ValueError):
     comparison has to partition that interval so every real interpreter reads
     it the same way its slice does.  A membership (``in``/``not in``), a
     verbatim ``===``, a non-version string comparison, a comparison against
-    another variable, a prerelease-version literal that would carve a slice
-    off a real micro, or a literal PEP 440 refuses under the operator it is
-    written with (``< "3.12.*"``, ``~= "3"``) cannot be tiled, so the resolve
-    stops loudly rather than pin the whole minor to one synthetic answer.
+    another variable, a pre- or post-release version literal that would carve
+    a slice off a real micro, or a literal PEP 440 refuses under the operator
+    it is written with (``< "3.12.*"``, ``~= "3"``) cannot be tiled, so the
+    resolve stops loudly rather than pin the whole minor to one synthetic
+    answer.
     """
 
 
@@ -414,8 +421,8 @@ def _non_interval(
         f"consulted marker clause {lhs} {op} {rhs} cannot tile the"
         f" {target.label} minor interval: no micro boundary the lock can"
         " render comes from a python_full_version membership, a verbatim ===,"
-        " a comparison against a variable, a prerelease comparison, or a"
-        " literal the operator cannot spell as a version bound"
+        " a comparison against a variable, a pre- or post-release comparison,"
+        " or a literal the operator cannot spell as a version bound"
     )
 
 
@@ -545,12 +552,17 @@ def _clause_boundary_points(
         return set()
     op, specifier, version = parsed
 
-    if version.is_prerelease and op in _AT_LITERAL_OPERATORS:
-        # The boundary lands at the prerelease itself; only a strictly interior
-        # one carves a slice whose release floor sits outside it.  A prerelease
-        # of the minor's floor, or one outside the minor, is uniform under the
-        # rides-with-X convention and splits nothing.
-        if _in_minor(Version(version.base_version), minor_release, floor):
+    if (version.is_prerelease and op in _AT_LITERAL_OPERATORS) or (
+        version.is_postrelease and op in _POST_AT_LITERAL_OPERATORS
+    ):
+        # An at-literal boundary lands on the literal, and a pre- or post-release
+        # literal falls between two micros, so no micro reads it the way its slice
+        # would.  Interior to the minor that cannot be tiled and crashes; below the
+        # floor or in another minor it is uniform and splits nothing.  The literal
+        # itself decides which, not its release form: a prerelease sorts just below
+        # its release and a post just above, so ``3.12.0a1`` sits below the floor
+        # while ``3.12.0.post1`` sits above it.
+        if _in_minor(version, minor_release, floor):
             raise _non_interval(parts, target)
         return set()
 

--- a/nab-python/tests/test_target.py
+++ b/nab-python/tests/test_target.py
@@ -1289,6 +1289,7 @@ class TestMicroBoundarySplitting:
             'python_full_version ~= "1!3.12.4"',
             'python_full_version == "1!3.12.*"',
             'python_full_version < "1!3.12.4rc1"',
+            'python_full_version >= "1!3.12.4.post1"',
             '"1!3.12.4" > python_full_version',
             'implementation_version >= "1!3.12.4"',
         ],
@@ -1329,6 +1330,35 @@ class TestMicroBoundarySplitting:
             == []
         )
 
+    def test_a_post_release_literal_of_the_floor_crashes(self) -> None:
+        """A post release sorts above its release, so ``>= "3.12.0.post1"``
+        splits 3.12.0 (False) off 3.12.1 (True) at a boundary no micro sits on.
+        Unlike the prerelease of the floor ``>= "3.12.0a1"``, which is uniform,
+        the post-release of the floor is a loud crash."""
+        with pytest.raises(NonIntervalMarkerError):
+            micro_boundary_points(
+                self._target(), [Marker('python_full_version >= "3.12.0.post1"')]
+            )
+
+    def test_a_post_release_literal_outside_the_minor_does_not_split(self) -> None:
+        """A post release of another minor is uniform across this one, so it
+        crashes nothing: ``>= "3.13.4.post1"`` is False for every 3.12 micro."""
+        assert (
+            micro_boundary_points(
+                self._target(), [Marker('python_full_version >= "3.13.4.post1"')]
+            )
+            == []
+        )
+
+    def test_a_before_literal_post_release_splits_at_the_next_micro(self) -> None:
+        """A post release sorts above its release, so the exclusive-upper
+        ``< "3.12.4.post1"`` pushes its boundary to the next real micro and
+        tiles cleanly, cutting at 3.12.5 like ``<= "3.12.4"``."""
+        found = micro_boundary_points(
+            self._target(), [Marker('python_full_version < "3.12.4.post1"')]
+        )
+        assert [str(point) for point in found] == ["3.12.5"]
+
     @pytest.mark.parametrize(
         "marker",
         [
@@ -1344,12 +1374,20 @@ class TestMicroBoundarySplitting:
             'python_full_version ~= "3.12.4b1"',
             '"3.12.4" ~= python_full_version',
             '"3.12.4rc1" == python_full_version',
+            'python_full_version >= "3.12.4.post1"',
+            'python_full_version ~= "3.12.4.post1"',
+            'python_full_version == "3.12.4.post1"',
+            'python_full_version != "3.12.4.post1"',
+            '"3.12.4.post1" == python_full_version',
         ],
     )
     def test_an_untileable_marker_crashes(self, marker: str) -> None:
         """A membership, verbatim ===, non-version, variable, or interior
-        prerelease comparison on a minor interval is a loud crash: the
-        whole-minor pin that once absorbed it is gone."""
+        pre- or post-release comparison on a minor interval is a loud crash:
+        the whole-minor pin that once absorbed it is gone. ``>= "3.12.4.post1"``
+        flips between the 3.12.4 and 3.12.5 micros just as ``>= "3.12.4rc1"``
+        flips between 3.12.3 and 3.12.4, so neither lands on a release the lock
+        can render."""
         with pytest.raises(NonIntervalMarkerError):
             micro_boundary_points(self._target(), [Marker(marker)])
 


### PR DESCRIPTION
Locking for a whole minor like 3.12 runs one resolve that has to stand in for every micro release: 3.12.0, 3.12.1, and so on. When a marker's answer changes partway through the minor, nab splits the minor at the release where it changes and resolves each piece on its own, reading markers at the lowest version in the piece.

For that to work the split has to land on the release where the answer really changes, and for `python_full_version >= "3.12.4.post1"` it doesn't. A post release sorts above its release, so the marker is False on 3.12.4 and only turns True at 3.12.5, but nab splits at 3.12.4. The piece starting there is read at 3.12.4, gets False, and the dependency the marker gates is dropped for 3.12.5 and every release above it.

`>= "3.12.0.post1"` is worse. The split lands on 3.12.0, the minor's own floor, so nothing splits at all and the dependency disappears from 3.12 entirely. Either way you get a lock missing a dependency and nothing that says so.

The same mistake written with a prerelease already stops the resolve. This extends that guard to post releases, for `>=`, `~=`, `==` and `!=`. `<` is left alone, since `< "3.12.4.post1"` already splits at 3.12.5, the same place `<= "3.12.4"` does.

No real interpreter reports a post-release version, so only a hand-written or generated marker can hit this.
