### PR TITLE
resolve a pinned X.Y.0 python-patches micro as a whole target

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -138,6 +138,10 @@ _PEP508_MARKER_VARIABLES = frozenset(
 # Marker variables whose values must parse as PEP 440 versions.
 _VERSION_MARKER_VARIABLES = frozenset({"python_version", "python_full_version"})
 
+# Release-component count of a bare ``major.minor`` python declaration; more
+# parts name a concrete patch level.
+_PYTHON_MINOR_PARTS = 2
+
 # How a ``requires-python`` declaration is named back to the user.  The
 # [tool.nab] key stays bare because the CLI's error prefix already names that
 # table; the [project] fallback has to name its own.
@@ -985,11 +989,16 @@ def _declared_target(environment: EnvironmentConfig) -> ResolveTarget:
         environment, (axis["python_version"],) if environment.python else ()
     )
 
+    # More than major.minor ("3.10.5", "3.12.0", or the host's release) names a
+    # concrete micro, resolved whole.  A bare minor ("3.12") gets a synthetic
+    # .0 floor and resolves as a micro interval.
+    pinned_micro = len(Version(python).release) > _PYTHON_MINOR_PARTS
+
     return ResolveTarget.for_declared(
         python_version=axis["python_version"],
         spec=environment.platform,
         implementation=implementation,
-        python_full_version=axis["python_full_version"],
+        python_full_version=axis["python_full_version"] if pinned_micro else None,
     )
 
 

--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -728,6 +728,11 @@ class ResolveTarget:
     platform_spec: PlatformSpec | None = field(default=None, compare=False)
     multi_implementation: bool = field(default=False, compare=False)
     tags_faithful: bool = field(default=True, compare=False)
+    # python_full_version was pinned to a concrete micro (a matrix python-patches
+    # value or a declared patch level), not synthesized as a bare minor's ``.0``
+    # floor.  A pinned ``X.Y.0`` equals that floor by value, so only this flag
+    # tells the two apart.
+    concrete_micro: bool = field(default=False, compare=False)
     # The python_full_version clauses bounding this target's micro slice, set
     # by :func:`slices_from_points` when a consulted marker splits the minor.
     # Empty for an ordinary target.  Appended to
@@ -785,8 +790,12 @@ class ResolveTarget:
         minor carries ``micro_clauses`` and still stands for every interpreter
         its bounds admit, so it too is an interval answering Requires-Python at
         the same whole minor.
+
+        A pinned ``X.Y.0`` reads as the synthetic floor by string alone, so the
+        concrete-micro flag, not the value, decides: a python-patches pin is
+        whole even when its micro is ``.0``.
         """
-        if self.host_faithful:
+        if self.host_faithful or self.concrete_micro:
             return False
         if self.micro_clauses:
             return True
@@ -1011,6 +1020,10 @@ class ResolveTarget:
         over, and only the python axis (``python_version``,
         ``python_full_version``, and the tags' interpreter/abi) moves.
         This is what pip's ``--python-version`` targets.
+
+        A bare minor ("3.10") resolves as a micro interval off its ``.0``
+        floor; a named patch level ("3.10.5", "3.13.0") is one concrete
+        micro resolved whole, so an ``X.Y.0`` pin is not the synthetic floor.
         """
         env = host_environment(env_source)
         apply_python_axis_overlay(env, python_axis_environment(python))
@@ -1020,6 +1033,7 @@ class ResolveTarget:
             marker_env=env,
             tags=TagSet.for_host_python(python, tags_source=tags_source),
             host_faithful=False,
+            concrete_micro=len(Version(python).release) >= _PYTHON_FULL_VERSION_PARTS,
         )
 
     @classmethod
@@ -1053,6 +1067,7 @@ class ResolveTarget:
             host_faithful=False,
             platform_spec=spec,
             multi_implementation=multi_implementation,
+            concrete_micro=python_full_version is not None,
         )
 
 

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -1542,6 +1542,48 @@ class TestEnvironment:
         assert target.implementation == "pypy"
         assert target.platform_id == "macos_arm64"
 
+    def test_environment_zero_micro_pins_whole(self, tmp_path: Path) -> None:
+        """A ``python = "3.12.0"`` environment names one micro, resolved whole."""
+        path = write(
+            tmp_path,
+            '[tool.nab.environment]\npython = "3.12.0"\n'
+            'platform = "linux_x86_64"\n'
+            '[tool.nab]\nbuild-policy = "never"\n',
+        )
+        (target,) = plan_targets(read_pyproject_config(path))
+        assert not target.is_minor_interval
+        assert not target.admits_requires_python(SpecifierSet(">=3.12.5"))
+
+    def test_environment_bare_minor_is_an_interval(self, tmp_path: Path) -> None:
+        """A ``python = "3.12"`` environment is a bare minor, resolved as a range."""
+        path = write(
+            tmp_path,
+            '[tool.nab.environment]\npython = "3.12"\n'
+            'platform = "linux_x86_64"\n'
+            '[tool.nab]\nbuild-policy = "never"\n',
+        )
+        (target,) = plan_targets(read_pyproject_config(path))
+        assert target.is_minor_interval
+        assert target.admits_requires_python(SpecifierSet(">=3.12.5"))
+
+    def test_environment_no_platform_zero_micro_pins_whole(
+        self, tmp_path: Path
+    ) -> None:
+        """A ``python = "3.12.0"`` with no platform still names one whole micro."""
+        path = write(tmp_path, '[tool.nab.environment]\npython = "3.12.0"\n')
+        (target,) = plan_targets(read_pyproject_config(path))
+        assert not target.is_minor_interval
+        assert not target.admits_requires_python(SpecifierSet(">=3.12.5"))
+
+    def test_environment_no_platform_bare_minor_is_an_interval(
+        self, tmp_path: Path
+    ) -> None:
+        """A ``python = "3.12"`` with no platform is a bare-minor interval."""
+        path = write(tmp_path, '[tool.nab.environment]\npython = "3.12"\n')
+        (target,) = plan_targets(read_pyproject_config(path))
+        assert target.is_minor_interval
+        assert target.admits_requires_python(SpecifierSet(">=3.12.5"))
+
     def test_windows_arm64_bare_id_declares_a_target(self, tmp_path: Path) -> None:
         path = write(
             tmp_path,

--- a/nab-python/tests/test_matrix.py
+++ b/nab-python/tests/test_matrix.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from nab_python._vendor.packaging.markers import Marker, default_environment
+from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python.tags import PlatformSpec
 from nab_python.target import (
     KNOWN_PYTHON_MINORS,
@@ -166,6 +167,17 @@ class TestMatrixExpand:
         matrix = Matrix(python="==3.11", platforms=(PlatformSpec("linux_x86_64"),))
         tuples = matrix.expand()
         assert tuples[0].marker_env["python_full_version"] == "3.11.0"
+
+    def test_python_patches_zero_micro_pins_whole(self) -> None:
+        """A ``.0`` pin is a concrete micro resolved whole, not a bare minor."""
+        matrix = Matrix(
+            python="==3.13",
+            platforms=(PlatformSpec("linux_x86_64"),),
+            python_patches={"3.13": "3.13.0"},
+        )
+        target = matrix.expand()[0]
+        assert not target.is_minor_interval
+        assert not target.admits_requires_python(SpecifierSet(">=3.13.5"))
 
     def test_python_patches_partial_mapping(self) -> None:
         """A partial mapping uses overrides for declared minors only."""

--- a/nab-python/tests/test_target.py
+++ b/nab-python/tests/test_target.py
@@ -213,6 +213,22 @@ class TestForHostPython:
                 "not-a-version", env_source=_host_env, tags_source=_host_tags
             )
 
+    def test_zero_micro_pins_whole(self) -> None:
+        """A ``3.13.0`` target names one micro, resolved whole."""
+        target = ResolveTarget.for_host_python(
+            "3.13.0", env_source=_host_env, tags_source=_host_tags
+        )
+        assert not target.is_minor_interval
+        assert not target.admits_requires_python(SpecifierSet(">=3.13.5"))
+
+    def test_bare_minor_is_an_interval(self) -> None:
+        """A bare ``3.13`` target is a micro interval off its ``.0`` floor."""
+        target = ResolveTarget.for_host_python(
+            "3.13", env_source=_host_env, tags_source=_host_tags
+        )
+        assert target.is_minor_interval
+        assert target.admits_requires_python(SpecifierSet(">=3.13.5"))
+
     def test_live_sources_smoke(self) -> None:
         """The default sources are the running interpreter's."""
         target = ResolveTarget.for_host_python("3.10")
@@ -316,6 +332,17 @@ class TestAdmitsRequiresPython:
         )
         assert not target.is_minor_interval
         assert target.admits_requires_python(SpecifierSet(">=3.13.2"))
+        assert not target.admits_requires_python(SpecifierSet(">=3.13.5"))
+
+    def test_a_python_patches_zero_micro_is_whole(self) -> None:
+        """A ``.0`` pin is a concrete deployment micro, not a bare minor floor."""
+        target = ResolveTarget.for_declared(
+            python_version="3.13",
+            spec=PlatformSpec("linux_x86_64"),
+            python_full_version="3.13.0",
+        )
+        assert not target.is_minor_interval
+        assert target.admits_requires_python(SpecifierSet(">=3.13.0"))
         assert not target.admits_requires_python(SpecifierSet(">=3.13.5"))
 
     def test_every_slice_of_a_split_minor_agrees(self) -> None:


### PR DESCRIPTION
A matrix `python-patches` value that pins a micro ending in `.0`, like `3.13.0`, resolved as a bare minor rather than one concrete micro. The target became a minor interval and admitted candidates that require a later micro (`>=3.13.5`), which is not what a pinned patch level asks for. A declared `[tool.nab.environment]` with `python = "3.12.0"` went the same way.

`is_minor_interval` took the whole-versus-interval decision off the `python_full_version` string, and a pinned `X.Y.0` is identical by value to the synthetic `.0` floor nab gives a bare minor, so nothing told the two apart.

The target now carries a flag recording that its micro was pinned rather than synthesized, and that flag decides. An `X.Y.0` pin resolves whole, and a bare `X.Y` still resolves as a micro interval.
