### PR TITLE
raise BuildBackendError on a non-string build requirement

### DIFF
--- a/nab-python/src/nab_python/_build/runner.py
+++ b/nab-python/src/nab_python/_build/runner.py
@@ -107,6 +107,15 @@ def run_build_backend(
 
             extra = list(project.get_requires_for_build("wheel"))
             if extra:
+                # PEP 517 requires the hook to return a list of strings.
+                non_str = [item for item in extra if not isinstance(item, str)]
+                if non_str:
+                    msg = (
+                        f"build backend {backend!r} returned a non-string build"
+                        f" requirement from get_requires_for_build_wheel: {non_str!r}"
+                    )
+                    raise BuildBackendError(msg)
+
                 logger.debug("build backend asked for extras: %s", extra)
                 env.install(extra)
 

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -431,6 +431,48 @@ class TestRunBuildBackend:
         with pytest.raises(BuildBackendError, match="build env setup"):
             run_build_backend(tmp_path, config=config)
 
+    def test_non_string_build_requirement_wrapped(
+        self,
+        tmp_path: Path,
+        config: NabProjectConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A non-string build requirement is wrapped as BuildBackendError."""
+        from nab_python._build import env as env_mod
+
+        class _Builder:
+            def __init__(self, **_kw: object) -> None:
+                pass
+
+            def create(self, path: Path) -> None:
+                path.mkdir(parents=True, exist_ok=True)
+                (path / "bin").mkdir(exist_ok=True)
+                (path / "bin" / "python").touch()
+
+        import venv as venv_mod
+
+        monkeypatch.setattr(venv_mod, "EnvBuilder", _Builder)
+        monkeypatch.setattr(
+            env_mod, "_venv_scheme_paths", lambda _python: {"purelib": str(tmp_path)}
+        )
+
+        (tmp_path / "pyproject.toml").write_text(
+            '[build-system]\nrequires = []\nbuild-backend = "setuptools.build_meta"\n',
+            encoding="utf-8",
+        )
+
+        project = MagicMock()
+        project.get_requires_for_build.return_value = ["setuptools", None]
+
+        with (
+            patch(
+                "nab_python._build.runner.build.ProjectBuilder.from_isolated_env",
+                return_value=project,
+            ),
+            pytest.raises(BuildBackendError, match="non-string"),
+        ):
+            run_build_backend(tmp_path, config=config)
+
 
 class TestShouldSkipPrepare:
     """Unit tests for the hatchling+dynamic-deps detection predicate."""


### PR DESCRIPTION
When a build backend's `get_requires_for_build_wheel` hook returned a list with a non-string element (for example `None`), `run_build_backend` handed it straight to the isolated env's install step, which raised a raw `TypeError`. That type isn't among the exceptions the function catches, so it escaped the documented contract that `run_build_backend` raises `BuildBackendError` on any failure. On a source with dynamic build requirements this crashed `nab lock` outright, and under `BUILD_REMOTE` the failure was mislabeled and the version silently dropped instead of rejected.

Check every element the hook returns before installing, and raise `BuildBackendError` naming the backend and the offending values when one isn't a string.
