### PR TITLE
drop unresolvable hrefs in a local index instead of erroring out

### DIFF
--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -233,10 +233,17 @@ def _scan_pep503_directory(
 
     parser = _Pep503Parser()
     parser.feed(text)
+    base_url: str | None = None
     if parser.base_href is not None:
-        base_url: str | None = urljoin(index_html.as_uri(), parser.base_href)
-    else:
-        base_url = None
+        # A base href every relative anchor resolves against, so one that
+        # cannot be parsed leaves the whole page's targets unknown. Fail
+        # loudly rather than fall back to the package directory, which
+        # would resolve each link to a different file than the page names.
+        try:
+            base_url = urljoin(index_html.as_uri(), parser.base_href)
+        except ValueError as exc:
+            msg = f"{index_html} has an unparseable <base href>: {exc}"
+            raise MalformedLocalListingError(msg) from exc
 
     files: list[WheelFile | SdistFile] = []
     for href, requires_python, has_metadata in parser.links:
@@ -282,9 +289,16 @@ def _resolve_local_link(
     """
     href_no_frag, _, fragment = href.partition("#")
     hashes = _parse_pep503_hash_fragment(fragment)
-    if base_url is not None:
-        href_no_frag = urljoin(base_url, href_no_frag)
-    parsed = urlparse(href_no_frag)
+
+    # A malformed authority (an unterminated IPv6 bracket) makes both of
+    # these raise, so the drop guard has to start here rather than at the
+    # path resolution below.
+    try:
+        if base_url is not None:
+            href_no_frag = urljoin(base_url, href_no_frag)
+        parsed = urlparse(href_no_frag)
+    except ValueError:
+        return (None, href_no_frag, None, hashes)
 
     if parsed.scheme in {"http", "https"}:
         filename = unquote(parsed.path.rsplit("/", 1)[-1]) or None

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -289,14 +289,19 @@ def _resolve_local_link(
     if parsed.scheme in {"http", "https"}:
         filename = unquote(parsed.path.rsplit("/", 1)[-1]) or None
         return (filename, href_no_frag, None, hashes)
-    if parsed.scheme == "file":
-        path = parse_file_url(href_no_frag)
-        return (path.name, href_no_frag, path, hashes)
 
-    # Without a base href a relative link resolves against the package page;
-    # the standard mirror layout links to a shared ../../packages/ tree, so the
-    # target legitimately sits outside the package directory.
-    target = (package_dir.resolve() / unquote(href_no_frag)).resolve()
+    # Drop an anchor we cannot turn into a path (non-local file:// authority,
+    # or a percent-encoded null byte) rather than fail the whole listing.
+    try:
+        if parsed.scheme == "file":
+            path = parse_file_url(href_no_frag)
+            return (path.name, href_no_frag, path, hashes)
+        # Without a base href a relative link resolves against the package page;
+        # the standard mirror layout links to a shared ../../packages/ tree, so
+        # the target legitimately sits outside the package directory.
+        target = (package_dir.resolve() / unquote(href_no_frag)).resolve()
+    except ValueError:
+        return (None, href_no_frag, None, hashes)
     return (target.name, target.as_uri(), target, hashes)
 
 

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -680,6 +680,45 @@ class TestPep503Directory:
         result = run(client.get_files("foo"))
         assert [r.version for r in result] == ["2.0"]
 
+    def test_pep503_malformed_ipv6_href_dropped(self, tmp_path: Path) -> None:
+        # An unterminated IPv6 bracket makes urlparse raise ValueError before
+        # the scheme is even known; drop that anchor and keep the sibling.
+        body = (
+            '<a href="http://[bad">foo-bad</a>'
+            '<a href="foo-2.0-py3-none-any.whl">foo-2.0</a>'
+        )
+        package_dir = self._make_index(tmp_path, body)
+        (package_dir / "foo-2.0-py3-none-any.whl").write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        result = run(client.get_files("foo"))
+        assert [r.version for r in result] == ["2.0"]
+
+    def test_pep503_malformed_ipv6_href_under_valid_base_dropped(
+        self, tmp_path: Path
+    ) -> None:
+        # Under a usable <base href> the join is what raises, one call earlier
+        # than urlparse. Both sit under the same guard, so the anchor is dropped
+        # and its good sibling is kept.
+        body = (
+            '<base href="https://mirror.example/simple/foo/">'
+            '<a href="http://[bad">foo-bad</a>'
+            '<a href="foo-2.0-py3-none-any.whl">foo-2.0</a>'
+        )
+        self._make_index(tmp_path, body)
+        client = LocalIndexClient(tmp_path.as_uri())
+        result = run(client.get_files("foo"))
+        assert [r.version for r in result] == ["2.0"]
+
+    def test_pep503_malformed_base_href_raises(self, tmp_path: Path) -> None:
+        # A <base href> that cannot be parsed leaves every relative anchor's
+        # target unknown, so the page fails rather than silently resolving
+        # links against the package directory instead.
+        body = '<base href="http://[bad"><a href="foo-1.0-py3-none-any.whl">foo-1.0</a>'
+        self._make_index(tmp_path, body)
+        client = LocalIndexClient(tmp_path.as_uri())
+        with pytest.raises(MalformedLocalListingError, match="base href"):
+            run(client.get_files("foo"))
+
     def test_file_scheme_href(self, tmp_path: Path) -> None:
         # Uncommon but legal: a file:// scheme on the anchor
         wheel_path = tmp_path / "foo" / "foo-1.0-py3-none-any.whl"

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -651,6 +651,35 @@ class TestPep503Directory:
         assert isinstance(caught.value, HttpError)
         assert "not valid UTF-8" in str(caught.value)
 
+    def test_pep503_non_local_file_href_dropped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A file:// href a local client cannot serve (non-local authority)
+        # drops just that anchor; the rest of the listing is kept.
+        monkeypatch.setattr(sys, "platform", "linux")
+        body = (
+            '<a href="file://otherhost/foo-1.0-py3-none-any.whl">foo-1.0</a>'
+            '<a href="foo-2.0-py3-none-any.whl">foo-2.0</a>'
+        )
+        package_dir = self._make_index(tmp_path, body)
+        (package_dir / "foo-2.0-py3-none-any.whl").write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        result = run(client.get_files("foo"))
+        assert [r.version for r in result] == ["2.0"]
+
+    def test_pep503_null_byte_href_dropped(self, tmp_path: Path) -> None:
+        # A percent-encoded null byte makes path resolution raise ValueError;
+        # drop that anchor and keep the good sibling wheel.
+        body = (
+            '<a href="foo%001.0.whl">foo-bad</a>'
+            '<a href="foo-2.0-py3-none-any.whl">foo-2.0</a>'
+        )
+        package_dir = self._make_index(tmp_path, body)
+        (package_dir / "foo-2.0-py3-none-any.whl").write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        result = run(client.get_files("foo"))
+        assert [r.version for r in result] == ["2.0"]
+
     def test_file_scheme_href(self, tmp_path: Path) -> None:
         # Uncommon but legal: a file:// scheme on the anchor
         wheel_path = tmp_path / "foo" / "foo-1.0-py3-none-any.whl"


### PR DESCRIPTION
A local `file://` index whose `index.html` has an artifact href that can't be turned into a path made nab raise a bare `ValueError` out of `lock` and `download`. Two hrefs hit this: a `file://` link pointing at a non-local host, and a relative link with a percent-encoded null byte. Both raise `ValueError` during path resolution, and nothing caught it, so one bad anchor failed the entire listing.

Now that anchor is dropped and the rest of the listing is kept, the same way an `http` href with no filename is already skipped.
