### PR TITLE
raise HttpError on missing or unreadable local artifact file

### DIFF
--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -129,6 +129,20 @@ def _resolve_served_path(url: str) -> Path:
         raise NonLocalArtifactError(msg) from exc
 
 
+def _read_served_bytes(path: Path, kind: str) -> bytes:
+    """Read a served local artifact's bytes, mapping a read failure.
+
+    A missing or unreadable file raises :class:`MalformedLocalListingError`
+    (an :class:`HttpError` subclass) so the fetch fails through the index-error
+    path, matching a remote index's 404 rather than a raw :class:`OSError`.
+    """
+    try:
+        return path.read_bytes()
+    except OSError as exc:
+        msg = f"cannot read local {kind} {path}: {exc}"
+        raise MalformedLocalListingError(msg) from exc
+
+
 _REQUIRES_PYTHON_ATTR = "data-requires-python"
 _YANKED_ATTR = "data-yanked"
 _CORE_METADATA_ATTR = "data-core-metadata"
@@ -552,14 +566,15 @@ class LocalIndexClient:
 
         The on-disk sidecar is trusted, so ``metadata_hash`` is accepted
         only to match the remote client signature and is not verified.  A
-        sidecar that is not valid UTF-8 raises
+        sidecar that is missing, unreadable, or not valid UTF-8 raises
         :class:`MalformedLocalListingError` (an :class:`HttpError` subclass)
-        rather than a raw :class:`UnicodeDecodeError`, matching the
-        ``index.html`` reader.
+        rather than a raw :class:`OSError` or :class:`UnicodeDecodeError`,
+        matching the ``index.html`` reader.
         """
         path = _resolve_served_path(metadata_url)
+        data = _read_served_bytes(path, "metadata sidecar")
         try:
-            return path.read_text(encoding="utf-8")
+            return data.decode("utf-8")
         except UnicodeDecodeError as exc:
             msg = f"{path} is not valid UTF-8: {exc}"
             raise MalformedLocalListingError(msg) from exc
@@ -577,7 +592,7 @@ class LocalIndexClient:
         client signature but is not verified.
         """
         path = _resolve_served_path(sdist_url)
-        return _extract_sdist_files(path.read_bytes())
+        return _extract_sdist_files(_read_served_bytes(path, "sdist"))
 
     async def get_sdist_archive(
         self,
@@ -592,7 +607,7 @@ class LocalIndexClient:
         client signature but is not verified.
         """
         path = _resolve_served_path(sdist_url)
-        return path.read_bytes()
+        return _read_served_bytes(path, "sdist")
 
     async def get_range_metadata(
         self,

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -855,6 +855,16 @@ class TestMetadataAndSdist:
         assert isinstance(caught.value, HttpError)
         assert "not valid UTF-8" in str(caught.value)
 
+    def test_missing_metadata_sidecar_raises_http_error(self, tmp_path: Path) -> None:
+        # An advertised-but-absent sidecar must fail through HttpError, not a
+        # raw FileNotFoundError, matching a remote 404.
+        meta_path = tmp_path / "foo-1.0.metadata"
+        client = LocalIndexClient(tmp_path.as_uri())
+        with pytest.raises(MalformedLocalListingError) as caught:
+            run(client.get_metadata_text("foo", "1.0", meta_path.as_uri()))
+        assert isinstance(caught.value, HttpError)
+        assert not isinstance(caught.value, OSError)
+
     def test_get_sdist_files(self, tmp_path: Path) -> None:
         sdist_path = tmp_path / "foo-1.0.tar.gz"
         buf = io.BytesIO()
@@ -876,6 +886,24 @@ class TestMetadataAndSdist:
         assert "foo" in pkg_info
         assert pyproject is not None
         assert 'name = "foo"' in pyproject
+
+    def test_missing_sdist_files_raises_http_error(self, tmp_path: Path) -> None:
+        # An advertised-but-absent sdist must fail through HttpError, not a
+        # raw FileNotFoundError, matching a remote 404.
+        sdist_path = tmp_path / "foo-1.0.tar.gz"
+        client = LocalIndexClient(tmp_path.as_uri())
+        with pytest.raises(MalformedLocalListingError) as caught:
+            run(client.get_sdist_files("foo", "1.0", sdist_path.as_uri()))
+        assert isinstance(caught.value, HttpError)
+        assert not isinstance(caught.value, OSError)
+
+    def test_missing_sdist_archive_raises_http_error(self, tmp_path: Path) -> None:
+        sdist_path = tmp_path / "foo-1.0.tar.gz"
+        client = LocalIndexClient(tmp_path.as_uri())
+        with pytest.raises(MalformedLocalListingError) as caught:
+            run(client.get_sdist_archive("foo", "1.0", sdist_path.as_uri()))
+        assert isinstance(caught.value, HttpError)
+        assert not isinstance(caught.value, OSError)
 
     def test_https_metadata_url_raises_http_error(self, tmp_path: Path) -> None:
         # An absolute-href record admitted by get_files must fetch through


### PR DESCRIPTION
A local file:// metadata sidecar or sdist that an index page advertises but that is missing or unreadable crashed nab lock with a raw OSError (a FileNotFoundError in the common missing-file case). LocalIndexClient read the served path with read_text/read_bytes and let the OSError escape, even though the index.html reader on the same client already turns a bad body into MalformedLocalListingError.

Read the served bytes through a helper that maps an OSError to MalformedLocalListingError (an HttpError subclass) naming the path, so a missing or unreadable local artifact fails through the index-error path like a remote 404 instead of surfacing as a bare OSError. This covers get_metadata_text, get_sdist_files, and get_sdist_archive.

Sibling of #512, which handled the non-UTF-8 sidecar case.
