### PR TITLE
catch HttpError in the constraint look-ahead probe

### DIFF
--- a/nab-index/src/nab_index/transport.py
+++ b/nab-index/src/nab_index/transport.py
@@ -12,6 +12,8 @@ import zlib
 from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING, Any, Final, Protocol
 
+from .retry import RETRY_STATUSES
+
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
@@ -23,6 +25,7 @@ __all__ = [
     "ContentDecodingError",
     "HttpError",
     "HttpResponse",
+    "UnserveableUrlError",
     "accepts_gzip",
     "decode_body",
     "raise_for_error_status",
@@ -50,6 +53,7 @@ DEFAULT_HEADERS: Final[dict[str, str]] = {
 IDENTITY_HEADERS: Final[dict[str, str]] = {"Accept-Encoding": "identity"}
 
 _HTTP_BAD_REQUEST: Final = 400
+_HTTP_SERVER_ERROR: Final = 500
 _CONTENT_STATUSES: Final[frozenset[int]] = frozenset({200, 203})
 
 # RFC 9110 8.4.1.3: "x-gzip" is the same coding as "gzip".
@@ -61,6 +65,20 @@ class HttpError(Exception):
 
     Transports raise this from ``get`` and ``raise_for_status`` so callers
     can handle index failures without importing a specific HTTP backend.
+    """
+
+
+class UnserveableUrlError(HttpError):
+    """The index reached a verdict that it will not serve this URL.
+
+    Raised for a client-error status the retry policy does not treat as a
+    blip, so not a 408 or a 429: a 404 on an advertised PEP 658 sidecar, a
+    403, a 410.  The status is a property of the URL, so asking again gets
+    the same answer, and a caller may treat the artifact as unavailable.
+
+    A 5xx that outlived the retry budget, and a connection that failed,
+    stay a bare :class:`HttpError`.  Those say nothing about the URL, so a
+    caller must not read them as a verdict.
     """
 
 
@@ -186,10 +204,18 @@ class AsyncHttpTransport(Protocol):
 
 
 def raise_for_error_status(status: int, url: str) -> None:
-    """Raise :class:`HttpError` for a 4xx/5xx ``status``."""
-    if status >= _HTTP_BAD_REQUEST:
-        msg = f"HTTP {status} for {url}"
-        raise HttpError(msg)
+    """Raise :class:`HttpError` for a 4xx/5xx ``status``.
+
+    A client error outside :data:`~nab_index.retry.RETRY_STATUSES` raises the
+    :class:`UnserveableUrlError` subclass: the retry policy calls those the
+    index's answer rather than a blip, so they name the URL, not the moment.
+    """
+    if status < _HTTP_BAD_REQUEST:
+        return
+    msg = f"HTTP {status} for {url}"
+    if status < _HTTP_SERVER_ERROR and status not in RETRY_STATUSES:
+        raise UnserveableUrlError(msg)
+    raise HttpError(msg)
 
 
 def raise_unless_ok(response: HttpResponse, url: str) -> None:

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -1382,10 +1382,11 @@ class Provider:
 
         The un-narrowed range spans versions the constraint clipped away, so
         look-ahead can reach one whose metadata raises a hard error the narrowed
-        resolve never touched (a failed integrity check, or a tie-ranked-wheel
-        divergence).  The probe catches those and returns ``False`` rather than
-        aborting; the crash still fires when the version is pinned for real.  The
-        ``finally`` restores the snapshot either way.
+        resolve never touched (a failed integrity check, a tie-ranked-wheel
+        divergence, or an advertised sidecar the index cannot serve).  The probe
+        catches those and returns ``False`` rather than aborting; the crash still
+        fires when the version is pinned for real.  The ``finally`` restores the
+        snapshot either way.
         """
         # Late import: config imports provider at module load.
         from .config import OverrideConflictError  # noqa: PLC0415
@@ -1407,6 +1408,7 @@ class Provider:
             OverrideConflictError,
             SiblingMetadataDivergenceError,
             NotImplementedError,
+            HttpError,
         ):
             return False
         finally:

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -17,13 +17,14 @@ from dataclasses import dataclass, fields
 from typing import TYPE_CHECKING, cast
 
 from nab_index.client import (
+    MalformedSimpleResponseError,
     MetadataHashMismatchError,
     SdistFile,
     SdistHashMismatchError,
     WheelFile,
     WheelHashMismatchError,
 )
-from nab_index.transport import HttpError
+from nab_index.transport import HttpError, UnserveableUrlError
 
 from ._conflict_kind import EMPTY_MEMBERSHIP_SETS
 from ._provider import extras as _extras
@@ -1383,10 +1384,17 @@ class Provider:
         The un-narrowed range spans versions the constraint clipped away, so
         look-ahead can reach one whose metadata raises a hard error the narrowed
         resolve never touched (a failed integrity check, a tie-ranked-wheel
-        divergence, or an advertised sidecar the index cannot serve).  The probe
-        catches those and returns ``False`` rather than aborting; the crash still
-        fires when the version is pinned for real.  The ``finally`` restores the
-        snapshot either way.
+        divergence, or an advertised sidecar the index answered it will not
+        serve).  Each names a fault of that one version, so the probe catches
+        them and returns ``False`` rather than aborting; the crash still fires
+        when the version is pinned for real.
+
+        A transient transport failure is deliberately not in that tuple.  A 5xx
+        that outlived the retry budget, or a dropped connection, says nothing
+        about the version, and swallowing it would report "no satisfying
+        candidate" for a version that has one and hand back a different
+        resolution instead of failing.  The ``finally`` restores the snapshot
+        either way.
         """
         # Late import: config imports provider at module load.
         from .config import OverrideConflictError  # noqa: PLC0415
@@ -1408,7 +1416,8 @@ class Provider:
             OverrideConflictError,
             SiblingMetadataDivergenceError,
             NotImplementedError,
-            HttpError,
+            MalformedSimpleResponseError,
+            UnserveableUrlError,
         ):
             return False
         finally:

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -48,8 +48,10 @@ from nab_index.transport import (
     ContentDecodingError,
     HttpError,
     HttpResponse,
+    UnserveableUrlError,
     accepts_gzip,
     decode_body,
+    raise_for_error_status,
 )
 from nab_index.urllib3_async_transport import (
     Urllib3AsyncTransport,
@@ -402,6 +404,41 @@ def _urllib3_response(status: int, retry_after: str | None) -> urllib3.BaseHTTPR
     response.status = status
     response.headers = {} if retry_after is None else {"Retry-After": retry_after}
     return response
+
+
+class TestRaiseForErrorStatus:
+    """Which statuses name the URL, and which only name the moment."""
+
+    @pytest.mark.parametrize("status", [200, 203, 204, 301, 304, 399])
+    def test_status_under_400_does_not_raise(self, status: int) -> None:
+        assert raise_for_error_status(status, "https://example.com/") is None
+
+    @pytest.mark.parametrize("status", [400, 401, 403, 404, 410, 451])
+    def test_non_retried_client_error_is_a_verdict_on_the_url(
+        self, status: int
+    ) -> None:
+        """A 4xx the retry policy leaves alone raises the narrow subclass."""
+        assert status not in RETRY_STATUSES
+        with pytest.raises(UnserveableUrlError, match=f"HTTP {status} for"):
+            raise_for_error_status(status, "https://example.com/pkg.metadata")
+
+    @pytest.mark.parametrize("status", sorted(RETRY_STATUSES))
+    def test_retried_status_stays_a_bare_http_error(self, status: int) -> None:
+        """A status the retry policy calls a blip must not read as a verdict.
+
+        Includes the two transient client errors, 408 and 429, which are 4xx
+        but say nothing about the URL.
+        """
+        with pytest.raises(HttpError) as excinfo:
+            raise_for_error_status(status, "https://example.com/pkg.metadata")
+        assert not isinstance(excinfo.value, UnserveableUrlError)
+
+    @pytest.mark.parametrize("status", [501, 505])
+    def test_unretried_server_error_stays_a_bare_http_error(self, status: int) -> None:
+        """A 5xx is the server's state, never a verdict on the URL."""
+        with pytest.raises(HttpError) as excinfo:
+            raise_for_error_status(status, "https://example.com/pkg.metadata")
+        assert not isinstance(excinfo.value, UnserveableUrlError)
 
 
 class TestDecodeBody:

--- a/nab-python/tests/test_constraint_probe_hard_error.py
+++ b/nab-python/tests/test_constraint_probe_hard_error.py
@@ -7,6 +7,10 @@ reach one whose metadata is a hard integrity error (a failed PEP 658 sidecar
 hash, or a bare wheel whose full body fails its published hash).  The probe only
 labels a ``NO_VERSIONS`` clause, so that error must not escape and abort the
 resolve, and the snapshot the probe restores must survive the failure path.
+
+What the probe contains is bounded by what the error says.  A fault of the one
+version is contained; a transient transport failure, which names the moment and
+not the version, still escapes and aborts.
 """
 
 from __future__ import annotations
@@ -19,7 +23,7 @@ from nab_index.client import (
     WheelFile,
     WheelHashMismatchError,
 )
-from nab_index.transport import HttpError
+from nab_index.transport import HttpError, UnserveableUrlError
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.specifiers import SpecifierSet
@@ -146,15 +150,15 @@ class TestConstraintProbeContainsHardError:
     @pytest.mark.parametrize(
         "error",
         [
-            HttpError("advertised sidecar returned 404"),
+            UnserveableUrlError("HTTP 404 for https://example.com/foo-3.0.metadata"),
             MalformedSimpleResponseError("sidecar body is not valid UTF-8"),
         ],
     )
     def test_unserveable_sidecar_probe_returns_false(self, error: HttpError) -> None:
-        """An advertised sidecar that fails to serve is absorbed by the probe.
+        """An advertised sidecar the index will not serve is absorbed.
 
-        Fetching an advertised PEP 658 sidecar that 404s or 5xxs (or hands back
-        a non-UTF-8 body) raises an ``HttpError`` out of ``get_dependencies``.
+        A sidecar the listing advertised and the index then answered a 404 for,
+        or handed back a non-UTF-8 body for, is a fault of that one version.
         Over the un-narrowed probe range this is a version the constraint
         clipped away, so ``has_satisfying_version`` must return ``False`` rather
         than abort the resolve, and the snapshot must survive.
@@ -170,6 +174,29 @@ class TestConstraintProbeContainsHardError:
         found = provider.has_satisfying_version("foo", VersionRange.full())
 
         assert found is False
+        assert provider._lookahead_aborted == sentinel
+
+    def test_transient_transport_failure_propagates_out_of_probe(self) -> None:
+        """A 5xx that outlived the retry budget aborts, it is not absorbed.
+
+        A bare ``HttpError`` names the moment, not the version.  Reading it as
+        "this version has no satisfying candidate" would let the resolve carry
+        on and pin a different-but-valid answer, so it must escape the probe.
+        The snapshot is still restored on the way out.
+        """
+        listings = {"foo": [_wheel("foo", "3.0")]}
+        coordinator = make_coordinator(listings=listings)
+        coordinator.index.store_metadata_error(
+            "foo", "3.0", HttpError("HTTP 503 for https://example.com/foo-3.0.metadata")
+        )
+        root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
+        sentinel = {"sentinel-blocker": ("x", V("1.0"))}
+        provider._lookahead_aborted = dict(sentinel)
+
+        with pytest.raises(HttpError, match="HTTP 503"):
+            provider.has_satisfying_version("foo", VersionRange.full())
+
         assert provider._lookahead_aborted == sentinel
 
     def test_tie_divergence_on_probed_version_returns_false(self) -> None:

--- a/nab-python/tests/test_constraint_probe_hard_error.py
+++ b/nab-python/tests/test_constraint_probe_hard_error.py
@@ -11,11 +11,15 @@ resolve, and the snapshot the probe restores must survive the failure path.
 
 from __future__ import annotations
 
+import pytest
+
 from nab_index.client import (
+    MalformedSimpleResponseError,
     MetadataHashMismatchError,
     WheelFile,
     WheelHashMismatchError,
 )
+from nab_index.transport import HttpError
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.specifiers import SpecifierSet
@@ -129,6 +133,35 @@ class TestConstraintProbeContainsHardError:
         coordinator.index.store_metadata_error(
             "foo", "3.0", MetadataHashMismatchError("metadata sha256 mismatch")
         )
+        root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
+        sentinel = {"sentinel-blocker": ("x", V("1.0"))}
+        provider._lookahead_aborted = dict(sentinel)
+
+        found = provider.has_satisfying_version("foo", VersionRange.full())
+
+        assert found is False
+        assert provider._lookahead_aborted == sentinel
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            HttpError("advertised sidecar returned 404"),
+            MalformedSimpleResponseError("sidecar body is not valid UTF-8"),
+        ],
+    )
+    def test_unserveable_sidecar_probe_returns_false(self, error: HttpError) -> None:
+        """An advertised sidecar that fails to serve is absorbed by the probe.
+
+        Fetching an advertised PEP 658 sidecar that 404s or 5xxs (or hands back
+        a non-UTF-8 body) raises an ``HttpError`` out of ``get_dependencies``.
+        Over the un-narrowed probe range this is a version the constraint
+        clipped away, so ``has_satisfying_version`` must return ``False`` rather
+        than abort the resolve, and the snapshot must survive.
+        """
+        listings = {"foo": [_wheel("foo", "3.0")]}
+        coordinator = make_coordinator(listings=listings)
+        coordinator.index.store_metadata_error("foo", "3.0", error)
         root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
         provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
         sentinel = {"sentinel-blocker": ("x", V("1.0"))}


### PR DESCRIPTION
The look-ahead probe in `has_satisfying_version` runs `choose_version` over the un-narrowed constraint range and catches the hard errors a clipped-away version can raise, returning False instead of aborting. Nothing in that tuple covered a version whose advertised PEP 658 sidecar the index will not serve, so a 404 on a sidecar for a version the constraint had already clipped away raised out of `get_dependencies` and aborted a resolve that would otherwise have continued.

Catching `HttpError` there is too wide: it is the base class of every transport failure, so a 503 that outlived the retry budget or a dropped connection would read as "this version has no satisfying candidate" and the resolve would carry on. Every other member of the tuple is a deterministic per-version fault.

`nab_index.transport` gains `UnserveableUrlError(HttpError)` for a status that is the index's verdict on a URL rather than a blip. `raise_for_error_status` raises it for a 4xx that is not in `RETRY_STATUSES`, so 400, 401, 403, 404, 410 and 451 land there while 408 and 429 stay bare, which is the split `retry.py` already documents. Every 5xx and every connection-level failure stays a bare `HttpError`. The probe catches `UnserveableUrlError` and `MalformedSimpleResponseError` (a malformed 200 body, not a status verdict) and nothing wider.

A transient transport failure on a probed version still propagates. The crash also still fires if such a version is actually pinned.