### PR TITLE
reject vcs-sources under the default vcs.policy = block at parse time

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -531,8 +531,10 @@ every `build-policy` level.  Dynamic dependencies require
 
 ## Pinned VCS sources
 
-`[[tool.nab.vcs-sources]]` pins a package to a VCS URL.  Each URL
-passes the same `[tool.nab.vcs]` gate as a direct-URL requirement:
+`[[tool.nab.vcs-sources]]` pins a package to a VCS URL.  Declaring one
+while `vcs.policy` is left at its default `block` is a contradiction and
+is rejected when the config is read, before any resolve starts.  Each URL
+then passes the same `[tool.nab.vcs]` gate as a direct-URL requirement:
 beyond `vcs.policy = "allow"`, the URL's scheme must be listed in
 `vcs.allowed-schemes` and its repository in `vcs.allowed-repos`, both
 empty by default so each denies every URL until an entry is added, and

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -754,6 +754,8 @@ def _config_from_effective(
     vcs_sources = effective["vcs-sources"].value
     archive_sources = effective["archive-sources"].value
     _reject_duplicate_source_names(local_sources, vcs_sources, archive_sources)
+    vcs_config = effective["vcs"].value
+    _reject_vcs_sources_under_block(vcs_sources, vcs_config)
 
     del pyproject_dir  # paths were resolved per-layer by the registry.
     return NabProjectConfig(
@@ -768,7 +770,7 @@ def _config_from_effective(
         trust_unverified_sdist_deps=trust_unverified,
         environment=environment,
         indexes=indexes,
-        vcs=effective["vcs"].value,
+        vcs=vcs_config,
         local_sources=local_sources,
         vcs_sources=vcs_sources,
         archive_sources=archive_sources,
@@ -2582,6 +2584,32 @@ def _reject_duplicate_source_names(
             )
             raise ConfigError(msg)
         seen[canonical] = source.name
+
+
+def _reject_vcs_sources_under_block(
+    vcs_sources: tuple[VcsSource, ...],
+    vcs_config: VcsConfig,
+) -> None:
+    """Reject vcs-sources declared while the VCS policy blocks cloning.
+
+    Cloning is opt-in, so a ``[[tool.nab.vcs-sources]]`` entry under the
+    default ``policy = "block"`` is contradictory. Raising ConfigError here
+    fails at parse time and names the token to set.
+
+    ``policy = "allow"`` opens the gate but does not on its own admit a
+    URL: ``allowed-schemes`` and ``allowed-repos`` are empty by default
+    and each denies every URL until an entry is added, so the message
+    points at the whole gate rather than promising that one key is enough.
+    """
+    if vcs_sources and vcs_config.policy is VcsPolicy.BLOCK:
+        msg = (
+            "[[tool.nab.vcs-sources]] is declared but [tool.nab.vcs].policy is"
+            f" {vcs_config.policy.value!r}, which refuses every clone; remove"
+            ' the sources, or set [tool.nab.vcs].policy = "allow" and open the'
+            " rest of the gate (vcs.allowed-schemes and vcs.allowed-repos are"
+            " empty by default and each denies every URL)"
+        )
+        raise ConfigError(msg)
 
 
 def _parse_python_patches(value: object) -> dict[str, str] | None:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -2125,6 +2125,7 @@ class TestVcsSources:
     def test_round_trip(self, tmp_path: Path) -> None:
         path = write(
             tmp_path,
+            '[tool.nab.vcs]\npolicy = "allow"\n'
             "[[tool.nab.vcs-sources]]\n"
             'name = "my-fork"\n'
             'url = "git+https://github.com/me/x.git@abc"\n',
@@ -2133,6 +2134,15 @@ class TestVcsSources:
         assert srcs == (
             VcsSource(name="my-fork", url="git+https://github.com/me/x.git@abc"),
         )
+
+    def test_declared_under_block_policy_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[[tool.nab.vcs-sources]]\nname = "pkg"\n'
+            'url = "git+https://github.com/org/pkg.git@abc"\n',
+        )
+        with pytest.raises(ConfigError, match=r'\[tool\.nab\.vcs\]\.policy = "allow"'):
+            read_pyproject_config(path)
 
     def test_must_be_array(self, tmp_path: Path) -> None:
         path = write(tmp_path, '[tool.nab]\nvcs-sources = "x"\n')
@@ -3938,6 +3948,7 @@ class TestWorkspaceDiscoveryIntegration:
             '[project]\nname = "ws"\nversion = "0"\n'
             "[tool.nab.workspace]\n"
             'members = ["pkg"]\n'
+            '[tool.nab.vcs]\npolicy = "allow"\n'
             "[[tool.nab.vcs-sources]]\n"
             'name = "Alpha"\n'
             'url = "git+https://github.com/me/alpha.git@abc"\n',


### PR DESCRIPTION
Declaring `[[tool.nab.vcs-sources]]` while `[tool.nab.vcs].policy` is left at its default `block` did not fail until resolution started. At that point the provider raised a bare `ValueError`, so `nab lock` and `nab download` printed a raw traceback instead of a config error.

Cloning is opt-in, so the two settings contradict each other. The check now runs when the config is parsed and raises a `ConfigError` that names the fix: set `[tool.nab.vcs].policy = "allow"` to permit cloning the declared sources, or remove them.
