### PR TITLE
exit 1 instead of crashing when the --locked lockfile is unreadable

### DIFF
--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -339,8 +339,9 @@ def _locked_target_path(output: Path | None) -> Path:
 def _read_committed_pylock(target: Path) -> Pylock:
     """Read and parse the committed pylock, exiting on a precondition failure.
 
-    A missing lock, a non-TOML file, and a file that parses as TOML but not
-    as a PEP 751 lock each exit non-zero here, before any resolve runs.
+    A missing lock, an unreadable lock (a directory or a permission-denied
+    file), a non-TOML file, and a file that parses as TOML but not as a PEP 751
+    lock each exit non-zero here, before any resolve runs.
     """
     if not target.exists():
         _cli.printer().error(
@@ -349,6 +350,9 @@ def _read_committed_pylock(target: Path) -> Pylock:
         sys.exit(1)
     try:
         data = tomli.loads(target.read_text(encoding="utf-8"))
+    except OSError as e:
+        _cli.printer().error(f"--locked: cannot read lockfile {target}: {e}.")
+        sys.exit(1)
     except (UnicodeDecodeError, tomli.TOMLDecodeError) as e:
         _cli.printer().error(
             f"--locked: lockfile {target} is not valid TOML: {e};"

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -462,3 +462,20 @@ def test_non_pep751_precondition(
     assert exc.value.code == 1
     assert "not a valid PEP 751 lockfile" in capsys.readouterr().err
     mock.assert_not_called()
+
+
+def test_unreadable_lock_precondition(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Reading a directory raises OSError, exercising the unreadable-lock branch.
+    pyproject = _write_pyproject(tmp_path, '[project]\ndependencies = ["foo"]\n')
+    out = tmp_path / "pylock.toml"
+    out.mkdir()
+
+    mock = _locked_mock()
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock)
+
+    assert exc.value.code == 1
+    assert "cannot read lockfile" in capsys.readouterr().err
+    mock.assert_not_called()


### PR DESCRIPTION
`nab lock --locked` reads the committed lockfile before running any resolve. When that file could not be read, because a directory sat in its place or the file was permission-denied, reading it raised an uncaught OSError (IsADirectoryError / PermissionError) and nab exited with a traceback instead of the clean exit-1 the other precondition failures give.

This catches OSError at that read and prints `--locked: cannot read lockfile ...` before exiting 1, matching the handling for a missing lockfile, invalid TOML, and a lock that is not valid PEP 751.
