### PR TITLE
document that default-groups activates its groups on every resolve

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -18,8 +18,10 @@ mode = "specific"
 # into the resolution.
 constraints = ["urllib3<2"]
 
-# Dependency-group names recorded in the lockfile's
-# default-groups array.
+# PEP 735 dependency groups activated on every resolve, unioned
+# with any --groups selection: their dependencies are resolved
+# and pinned into the lock.  The names are also recorded in the
+# lockfile's default-groups array.
 default-groups = ["dev"]
 
 # The Python range this project supports.  A declaration: it is

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -88,6 +88,20 @@ def universal_mode_section() -> str:
     return match.group(0)
 
 
+def default_groups_doc_comment() -> str:
+    """Return the comment above ``default-groups`` in the config reference."""
+    lines = first_tool_nab_example().splitlines()
+    for i, line in enumerate(lines):
+        if line.startswith("default-groups"):
+            comment: list[str] = []
+            j = i - 1
+            while j >= 0 and lines[j].lstrip().startswith("#"):
+                comment.insert(0, lines[j].lstrip("# ").rstrip())
+                j -= 1
+            return " ".join(comment)
+    raise AssertionError("no default-groups key in the config reference example")
+
+
 class TestCliOverridesFold:
     """``--project-*`` overrides fold into the resolved config."""
 
@@ -743,6 +757,12 @@ class TestDefaultGroups:
         path = write(tmp_path, "[tool.nab]\ndefault-groups = [1]\n")
         with pytest.raises(ConfigError, match="default-groups\\[0\\] must be a string"):
             read_pyproject_config(path)
+
+    def test_doc_describes_resolve_activation(self) -> None:
+        # default-groups activates the groups for the resolve, not just records
+        # them in the lockfile, so the reference has to say so.
+        comment = default_groups_doc_comment().lower()
+        assert any(word in comment for word in ("resolve", "activat")), comment
 
 
 class TestRequiresPython:


### PR DESCRIPTION
The config reference described `default-groups` only as names recorded in the lockfile's `default-groups` array, which reads like passive lockfile metadata. In fact those PEP 735 groups are activated on every resolve: they are unioned with any `--groups` selection, and their dependencies are resolved and pinned into the lock.

Reword the comment above the key to say so, and add a config test that checks the reference mentions the resolve activation.
