### PR TITLE
Retry Cloudflare 521-524 origin errors

### DIFF
--- a/nab-index/src/nab_index/retry.py
+++ b/nab-index/src/nab_index/retry.py
@@ -27,8 +27,8 @@ MAX_RETRIES = 3
 MAX_REDIRECTS = 20
 """Redirects followed per GET, matching httpx's default."""
 
-# 520 and 527 are Cloudflare's transient origin errors, not the index's answer.
-RETRY_STATUSES = frozenset({429, 500, 502, 503, 504, 520, 527})
+# 520-524 and 527 are Cloudflare's transient origin errors, not the index's answer.
+RETRY_STATUSES = frozenset({429, 500, 502, 503, 504, 520, 521, 522, 523, 524, 527})
 """Statuses that are retried; any other status is served to the caller."""
 
 _BACKOFF_FACTOR = 0.25

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -181,8 +181,8 @@ class TestRetryPolicy:
         assert not GET_RETRY.is_retry("GET", 403, has_retry_after=False)
 
     def test_cloudflare_transient_5xx_is_retried(self) -> None:
-        """520 and 527 are Cloudflare's transient origin errors, so they retry."""
-        for status in (520, 527):
+        """Cloudflare's 520-524 and 527 origin errors are blips, so they retry."""
+        for status in (520, 521, 522, 523, 524, 527):
             assert status in RETRY_STATUSES
             assert GET_RETRY.is_retry("GET", status, has_retry_after=False)
 
@@ -479,12 +479,12 @@ class TestHttpxAsyncTransport:
         assert route.call_count == 2
         assert slept == [0.0]
 
-    @pytest.mark.parametrize("status", [520, 527])
+    @pytest.mark.parametrize("status", [520, 521, 522, 523, 524, 527])
     @respx.mock
     def test_get_retries_a_cloudflare_transient_status(
         self, status: int, slept: list[float]
     ) -> None:
-        """A Cloudflare 520/527 is a blip, so ask again before believing it."""
+        """A Cloudflare 52x origin error is a blip, so ask again before believing it."""
         route = respx.get("https://example.com/pkg").mock(
             side_effect=[httpx.Response(status), httpx.Response(200, json={"ok": True})]
         )
@@ -920,9 +920,9 @@ class TestUrllib3AsyncTransport:
             assert resp.status_code == 200
             assert len(index.seen) == 2
 
-    @pytest.mark.parametrize("status", [520, 527])
+    @pytest.mark.parametrize("status", [520, 521, 522, 523, 524, 527])
     def test_get_retries_a_cloudflare_transient_status(self, status: int) -> None:
-        """One Cloudflare 520/527 with no Retry-After must not end the fetch."""
+        """One Cloudflare 52x origin error with no Retry-After must not end the fetch."""
         with _stub_index([status]) as index:
             url = f"http://127.0.0.1:{index.server_port}/pkg/pkg-1.0.whl.metadata"
 


### PR DESCRIPTION
The index retry set covered Cloudflare's 520 and 527 origin errors but not 521, 522, 523, and 524. A transient origin timeout from a Cloudflare-fronted index then came back to the resolver as a hard failure with no retry.

This adds 521 through 524 to the retried statuses. They report origin-side problems (web server down, connection timed out, origin unreachable, a timeout occurred) rather than the index's own response, so they get the same retry and backoff as 520 and 527.
