### PR TITLE
report every fork when a specific-mode conflict resolve fails

### DIFF
--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -8,13 +8,14 @@ single-environment resolve against a shared
 :class:`~nab_python.fetch.FetchCoordinator`, so metadata is fetched once
 across them.
 
-A declared conflict is the one place the two differ, and it differs by
-what the project declared rather than by how many targets it has: a
-matrix *forks* (it resolves each conflicting member separately and marks
-the pins with a membership clause, so one lock serves both selections),
-while a project resolving for a single environment *refuses* a selection
-that activates two members of one exclusive set, because a single
-environment's lock has nowhere to put the second one.
+A declared conflict is the one place a resolve can produce more than one
+result for an environment, and it turns on what the selection reaches,
+not on how many environments the project targets.  Directly co-selecting
+two members of an exclusive set *forks*: each member gets its own resolve
+and its pins carry a membership clause, so one lock serves both
+selections.  A selection that reaches two members only transitively (an
+umbrella extra or group) has no fork to carry the second, so it is
+*refused*.  Both hold whether or not a matrix is declared.
 """
 
 from __future__ import annotations

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -634,22 +634,24 @@ def _resolve(  # noqa: PLR0913, PLR0912, C901 - one wrapper per resolve_for_targ
         sys.exit(1)
 
     if not result.success:
-        _report_failures(result, matrix=config.matrix is not None)
+        _report_failures(result)
         sys.exit(1)
     return result
 
 
-def _report_failures(result: ResolveResult, *, matrix: bool) -> None:
+def _report_failures(result: ResolveResult) -> None:
     """Report the targets that did not resolve.
 
-    A project resolving for one environment has one error, and it is the
-    run's error.  A matrix has one per tuple, and the pins that did
-    resolve are as informative as the failures, so each tuple gets a
-    labelled block.  Both go to stderr: a failed run exits non-zero, so
-    the report is a diagnostic, not the requested lock, and stdout stays
-    clean for a caller that piped it.
+    A resolve with one target has one error, and it is the run's error.
+    A resolve with several (a matrix's tuples, or a conflict fork's
+    members, which fork in specific mode too) has one error per target,
+    and the pins that did resolve are as informative as the failures, so
+    each target gets a labelled block.  The check keys on the target
+    count, matching the lock-emission paths.  Both go to stderr: the
+    report is a diagnostic, not the requested lock, so stdout stays clean
+    for a caller that piped it.
     """
-    if not matrix:
+    if len(result.target_results) <= 1:
         first = next(tr.error for tr in result.every_result if tr.error is not None)
         printer().error(f"resolution failed: {first}")
         return

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -367,6 +367,15 @@ def _multi_tuple_universal_result() -> ResolveResult:
     )
 
 
+def _multi_tuple_failed_result(error: ResolutionError | None) -> ResolveResult:
+    """Two tuples where the second fails with ``error``; the first resolves."""
+    ok, bad = (_target(py_minor) for py_minor in ("3.11", "3.12"))
+    return ResolveResult(
+        targets=(ok, bad),
+        target_results=[_resolved(ok, {"foo": V("1.0")}), _failed(bad, error)],
+    )
+
+
 def _forked_universal_result() -> ResolveResult:
     """One matrix tuple that ``[tool.nab].conflicts`` forked into two."""
     tuples = tuple(_target(selection=(("extra", extra),)) for extra in ("cpu", "gpu"))
@@ -580,6 +589,50 @@ class TestLockCommandSpecific:
         ):
             lock(pyproject, output=tmp_path / "pylock.toml")
         assert "resolution failed: conflict" in capsys.readouterr().err
+
+    def test_forked_specific_failure_reports_per_fork_blocks(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A conflict fork in specific mode reports every fork, not one error.
+
+        Directly co-selecting two members of a declared conflict set
+        forks a single-environment resolve into one target per member,
+        so a failed fork has a sibling that resolved.  The report labels
+        each fork and keeps the succeeded fork's pins, as a matrix does.
+        """
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\nname = "x"\nversion = "1"\ndependencies = ["torch"]\n'
+            "[project.optional-dependencies]\n"
+            'cpu = ["torch"]\n'
+            'gpu = ["torch"]\n'
+            "[tool.nab]\n"
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n',
+        )
+        host = ResolveTarget.for_host()
+        cpu = host.with_selection((("extra", "cpu"),))
+        gpu = host.with_selection((("extra", "gpu"),))
+        result = ResolveResult(
+            targets=(cpu, gpu),
+            target_results=[
+                _resolved(cpu, {"torch": V("2.3.0")}),
+                _failed(gpu, ResolutionError("no compatible torch-cuda wheel")),
+            ],
+        )
+        with (
+            patch("nab.cli.resolve_for_targets", return_value=result),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(
+                pyproject,
+                format="requirements-without-hashes",
+                extras=("cpu", "gpu"),
+            )
+        err = capsys.readouterr().err
+        assert "# host-extra-cpu" in err
+        assert "torch==2.3.0" in err
+        assert "# host-extra-gpu: FAILED" in err
+        assert "#   ResolutionError: no compatible torch-cuda wheel" in err
 
     def test_pylock_to_stdout(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -1942,9 +1995,7 @@ class TestLockCommandUniversal:
         with (
             patch(
                 "nab.cli.resolve_for_targets",
-                return_value=_universal_result(
-                    success=False, error=ResolutionError("conflict")
-                ),
+                return_value=_multi_tuple_failed_result(ResolutionError("conflict")),
             ),
             pytest.raises(SystemExit, match="1"),
         ):
@@ -1962,9 +2013,7 @@ class TestLockCommandUniversal:
         with (
             patch(
                 "nab.cli.resolve_for_targets",
-                return_value=_universal_result(
-                    success=False, error=ResolutionError(multi)
-                ),
+                return_value=_multi_tuple_failed_result(ResolutionError(multi)),
             ),
             pytest.raises(SystemExit, match="1"),
         ):
@@ -1982,12 +2031,36 @@ class TestLockCommandUniversal:
         with (
             patch(
                 "nab.cli.resolve_for_targets",
-                return_value=_universal_result(success=False, error=None),
+                return_value=_multi_tuple_failed_result(None),
             ),
             pytest.raises(SystemExit, match="1"),
         ):
             lock(pyproject, format="requirements-without-hashes")
         assert "FAILED" in capsys.readouterr().err
+
+    def test_single_tuple_matrix_failure_is_single_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A one-tuple matrix failure reads as one error, not a block.
+
+        A single-tuple matrix pins under one target on every surface (see
+        ``test_per_tuple_pins_to_explicit_file_single_tuple``), so its
+        failure is the run's error, matching a single-environment resolve.
+        """
+        pyproject = _universal_pyproject(tmp_path)
+        with (
+            patch(
+                "nab.cli.resolve_for_targets",
+                return_value=_universal_result(
+                    success=False, error=ResolutionError("conflict")
+                ),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, format="requirements-without-hashes")
+        err = capsys.readouterr().err
+        assert "resolution failed: conflict" in err
+        assert "FAILED" not in err
 
     def test_missing_dependencies_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
When a single-environment resolve directly co-selects two members of a declared conflict set, it forks into one resolve per member. If one fork failed, the failure report collapsed to a single "resolution failed: ..." line and dropped the pins from the fork that did resolve, so you could not tell which selection failed or what the other one pinned.

_report_failures chose between a single error and per-fork blocks based on whether a matrix was declared, but a conflict fork produces several targets with no matrix. It now keys the report on the number of target results, the count every lock-emission path already uses, so each fork gets a labelled block and the fork that resolved keeps its pins. A single-tuple matrix now reads as one error as well, since it pins under one target.
