### PR TITLE
drop stale --resolution rename note from cli reference

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -138,8 +138,7 @@ flag: `--project-resolution`, `--project-mode`, `--project-requires-python`,
 `--project-default-group`. Each changes the resolved set, so passing one
 prints a reproducibility notice on stderr and records the override in the
 lockfile's `[tool.nab]` block, since the lock no longer derives from the
-committed files alone. `--project-resolution` was previously named
-`--resolution`.
+committed files alone.
 
 `--locked` re-resolves and checks that the committed `pylock.toml` is
 already up to date, writing nothing. It exits non-zero if the lock would


### PR DESCRIPTION
The CLI reference described `--project-resolution` with a trailing note that it was previously named `--resolution`. The reference pages describe only what nab ships today, so that note does not belong there. This removes it; the flag documentation is unchanged.
