### PR TITLE
name the candidate's real requirement in the no-versions diagnostic

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -781,8 +781,8 @@ class Provider:
 
         # The dep range each rejected candidate declared for the blocker,
         # unioned per group.  Feeds the membership widening of the flushed
-        # blocker term; the range-keyed union also feeds the no-versions
-        # message.
+        # blocker term, and the no-versions message, which names the range the
+        # candidate declared rather than negating the blocker it hit.
         self.pending_decision_dep_ranges: defaultdict[
             tuple[str, str, Version], _lookahead.DepRangeUnion
         ] = defaultdict(_lookahead.DepRangeUnion.zero)
@@ -1780,7 +1780,14 @@ class Provider:
         for cand, blocker_pkg, blocker_version in self.pending_blocks:
             if cand != normalized:
                 continue
-            out.append(f"requires {blocker_pkg} != {blocker_version}")
+            dep_range = self.pending_decision_dep_ranges[
+                (cand, blocker_pkg, blocker_version)
+            ].union
+            out.append(
+                f"requires {blocker_pkg} in {self.format_range(dep_range)}"
+                " but solution has it in "
+                f"{self.format_range(VersionRange.singleton(blocker_version))}"
+            )
 
         for cand, blocker_pkg, pos_range in self.pending_range_blocks:
             if cand != normalized:

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -1669,9 +1669,9 @@ class TestNoVersionsReasons:
         # Nothing falls in this range, so the second ask has no blockers.
         assert provider.choose_version("foo", SpecifierSet(">=5.0").to_range()) is None
 
-        assert (
-            provider.get_no_versions_reason("foo")
-            == "every version in range was rejected: requires bar != 1.0"
+        assert provider.get_no_versions_reason("foo") == (
+            "every version in range was rejected:"
+            " requires bar in [2.0, 2.0] but solution has it in [1.0, 1.0]"
         )
 
     def test_sdist_only_under_dynamic_local_names_build_policy(self) -> None:
@@ -1831,6 +1831,42 @@ class TestNoVersionsReasons:
             "requires bar in (2.0.post*, +inf)"
             " but solution has it in [2.0.post1, 2.0.post1]" in reason
         )
+
+    def test_decision_block_rejection_names_the_requirement(self) -> None:
+        """The decision-block diagnostic names the candidate's real
+        requirement, mirroring the range-block path.  ``foo`` 1.0 requires
+        ``bar==2.0`` and the resolver has already decided ``bar==1.0``, so
+        every ``foo`` candidate is rejected.  The message must name the
+        ``bar==2.0`` foo needs, not ``requires bar != 1.0`` (which wrongly
+        implies any bar other than 1.0 would satisfy foo).
+
+        The ranges are spelled out rather than interpolated, so the
+        assertion fails if the message ever prints the debug repr again.
+        """
+        coordinator = make_coordinator(
+            [make_wheel("1.0")],
+            metadata_text=(
+                "Metadata-Version: 2.1\n"
+                "Name: foo\n"
+                "Version: 1.0\n"
+                "Requires-Dist: bar==2.0\n"
+            ),
+            package="foo",
+        )
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            root_requirements={"foo": VersionRange.full(admit_arbitrary=False)},
+        )
+        provider.solution_decisions["bar"] = V("1.0")
+        result = provider.choose_version("foo", VersionRange.full())
+        assert result is None
+        reason = provider.get_no_versions_reason("foo")
+        assert reason is not None
+        assert "<VersionRange" not in reason
+        assert "AFTER_LOCALS" not in reason
+        assert "requires bar in [2.0, 2.0] but solution has it in [1.0, 1.0]" in reason
+        assert "requires bar != 1.0" not in reason
 
 
 def _sdist_entry(version: str) -> dict[str, object]:

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -3266,10 +3266,13 @@ class TestAugmentResolutionError:
                 _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
 
         diagnostics = str(info.value).split("Diagnostics:")[1]
+        assert "<VersionRange" not in diagnostics
         assert (
-            "foo: every version in range was rejected: requires lib != 9.0"
+            "foo: every version in range was rejected:"
+            " requires lib in [5.0, 5.0] but solution has it in [9.0, 9.0]"
             in diagnostics
         )
+        assert "requires lib != 9.0" not in diagnostics
         assert "foo: no version matches the requirement" not in diagnostics
 
     def test_blocker_diagnostics_render_readable_ranges(self, tmp_path: Path) -> None:


### PR DESCRIPTION
When every version of a package is rejected because it needs a version of a dependency that conflicts with one the resolver has already decided, the no-versions diagnostic printed `requires bar != 1.0`. That reads as though any `bar` other than 1.0 would satisfy the candidate, which points away from the real conflict: the candidate actually needs a specific range (for example `bar==2.0`) that happens to exclude the decided 1.0.

The range-block and root-block paths already print `requires X in <range> but solution has it in <...>`. The decision-block path now does the same, reading the declared dep range out of the `pending_decision_dep_ranges` union the look-ahead already keeps, so it prints `requires bar in [2.0, 2.0] but solution has it in [1.0, 1.0]`.

That accumulator arrived on main with #590 for blocker membership widening. This PR originally added a second one of its own; that half is dropped, and what is left is the diagnostic.

Stacked on #472, so both ranges render through `format_range` rather than the internal debug repr.