### PR TITLE
docs: name archive sources in the bare-name override rules

### DIFF
--- a/docs/reference/build-policy.md
+++ b/docs/reference/build-policy.md
@@ -130,12 +130,13 @@ per-index override instead:
 build-policy = "build-remote"
 ```
 
-A build-policy override for a local checkout or VCS clone is matched by
-bare name only.  A source build is decided before any version is
-resolved, so a version-scoped per-package override (a quoted
-`"name <specifier>"` key) does not govern a local or VCS source build,
-and per-index overrides do not apply to sources (a local source has no
-serving index).  Use a bare-name key to govern a source build.
+A build-policy override for a local checkout, VCS clone, or archive
+source is matched by bare name only.  A source build is decided before
+any version is resolved, so a version-scoped per-package override (a
+quoted `"name <specifier>"` key) does not govern a local, VCS, or
+archive source build, and per-index overrides do not apply to sources
+(a local source has no serving index).  Use a bare-name key to govern
+a source build.
 
 ## A declared platform forbids host builds
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -404,11 +404,11 @@ for all of them is meaningless.  Writing any of them under
 
 A metadata override annotates versions the resolve already reaches; it
 never introduces a version.  An override scoped to a version no candidate
-has, or a package the resolve never visits, does nothing.  Local-path and
-VCS sources have no listing and their version is not known until the
-source is materialised, so a metadata override governs a source only when
-it uses a bare-name selector (full range); a version-scoped override does
-not match a source.
+has, or a package the resolve never visits, does nothing.  Local-path,
+VCS, and archive sources have no listing and their version is not known
+until the source is materialised, so a metadata override governs a source
+only when it uses a bare-name selector (full range); a version-scoped
+override does not match a source.
 
 ### Per-index overrides
 

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -4817,6 +4817,25 @@ class TestEffectiveFieldResolution:
         )
         assert provider.effective_build_policy_for_source("foo") is BuildPolicy.NEVER
 
+    def test_overrides_doc_names_every_source_kind(self) -> None:
+        # The bare-name-only override rule covers local, VCS, and archive
+        # sources alike, so the doc must name every kind.
+        build_policy_doc = (
+            Path(__file__).resolve().parents[2]
+            / "docs"
+            / "reference"
+            / "build-policy.md"
+        )
+        text = build_policy_doc.read_text()
+        section = text[text.index("## Overrides") :].split("\n## ", 1)[0]
+        paragraph = next(
+            block for block in section.split("\n\n") if "bare name" in block
+        ).lower()
+
+        assert "local" in paragraph
+        assert "vcs" in paragraph
+        assert "archive" in paragraph
+
 
 def _make_sdist(version: str, package: str = "foo") -> SdistFile:
     """Build a minimal :class:`SdistFile`."""


### PR DESCRIPTION
The "Overrides" section of the build-policy reference said a source-build override is matched by bare name only for a local checkout or VCS clone, but left archive sources out. Archive sources build the same way: the build is decided before any version is resolved, so a version-scoped or per-index override cannot govern them and only a bare-name key does. The metadata-override note in the configuration reference had the same gap.

Add archive sources to both lists so the rule names every source kind it covers.
