### PR TITLE
report the real error when a selection flag can't read pyproject

### DIFF
--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -934,9 +934,13 @@ def _read_selection_table_or_exit(
     """
     try:
         return reader(path)
-    except OSError:
-        reason = "is a directory" if path.is_dir() else "not found"
-        _cli.printer().error(f"{path} {reason}")
+    except OSError as e:
+        if e.errno == errno.ENOENT:
+            _cli.printer().error(f"{path} not found")
+        elif path.is_dir():
+            _cli.printer().error(f"{path} is a directory")
+        else:
+            _cli.printer().error(f"cannot read {path}: {e}")
         sys.exit(1)
     except (UnicodeDecodeError, tomli.TOMLDecodeError) as e:
         _cli.printer().error(f"{path} is not valid TOML: {e}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import builtins
 import contextlib
+import errno
 import importlib
 import io
 import json
@@ -3335,6 +3336,40 @@ class TestGroupAndExtraSelection:
                 tmp_path / "missing.toml", extras=(), all_extras=True
             )
         assert "not found" in capsys.readouterr().err
+
+    def test_all_groups_unreadable_file_surfaces_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A regular file that still raises OSError reports the real error.
+
+        Neither ``not found`` nor ``is a directory`` applies, so the errno
+        must reach the message rather than default to ``not found``.
+        """
+        pyproject = _make_pyproject(tmp_path)
+        denied = PermissionError(errno.EACCES, "Permission denied", str(pyproject))
+        with (
+            patch("nab._lock.read_pyproject_groups", side_effect=denied),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            resolve_group_selection(pyproject, groups=(), all_groups=True)
+        err = capsys.readouterr().err
+        assert "not found" not in err
+        assert "Permission denied" in err
+
+    def test_all_extras_unreadable_file_surfaces_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Symmetric guard for ``--all-extras`` on an unreadable pyproject."""
+        pyproject = _make_pyproject(tmp_path)
+        denied = PermissionError(errno.EACCES, "Permission denied", str(pyproject))
+        with (
+            patch("nab._lock.read_pyproject_optional_dependencies", side_effect=denied),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            resolve_extra_selection(pyproject, extras=(), all_extras=True)
+        err = capsys.readouterr().err
+        assert "not found" not in err
+        assert "Permission denied" in err
 
     def test_all_groups_reads_defined_groups(self, tmp_path: Path) -> None:
         """Selection equals the keys of ``[dependency-groups]``.


### PR DESCRIPTION
When `nab lock` or `nab download` expands a group or extra selection, it reads the pyproject before the config loads. That read caught every OSError and printed "<path> not found" unless the path was a directory, so a permission-denied, ENOTDIR, or symlink-loop error on a file that does exist was reported as if the file were missing, and the real errno was thrown away.

Now the reader only says "not found" when the errno is ENOENT, keeps the directory case, and prints the actual OS error for anything else.
