### PR TITLE
keep an explicit build-policy never under a workspace

### DIFF
--- a/docs/how-to/workspaces.md
+++ b/docs/how-to/workspaces.md
@@ -1,8 +1,8 @@
 # Lock a workspace
 
 > [!WARNING]
-> Workspace support is experimental. Discovery rules, member
-> validation, and the auto-promoted build policy may change.
+> Workspace support is experimental. Discovery rules and member
+> validation may change.
 
 A workspace is a parent project that declares one or more in-tree
 members. When `nab lock` runs against a member (or the root itself),
@@ -76,21 +76,23 @@ logged at INFO so it can be audited. Use this to point a workspace
 member at a checkout outside the tree without removing it from the
 `members` list.
 
-## Build policy floor
+## Build policy
 
 Workspace members frequently declare `dynamic = ["version"]` or
-similar. nab promotes the active `[tool.nab].build-policy` to at
-least `build-local` whenever a workspace is in scope, so PEP 517
-metadata extraction runs even when the user-set policy is stricter.
-A policy that is already `build-local` or `build-remote` is left
-alone.
+similar, which nab can only read by running the PEP 517 local
+backend. The default `build-policy` is `build-local`, so that build
+runs without any extra configuration.
+
+A workspace does not raise the policy. Under `build-policy = "never"`
+a member with dynamic metadata and no static fallback cannot be read,
+and the lock fails naming it. Give every member static metadata to
+lock a workspace with no backend invocations.
 
 ## Scope of `[tool.nab]` keys
 
 Workspace discovery flows these from the root into the file being
-locked: the workspace `members` (merged into `local-sources`), and
-the build-policy floor described above. Everything else under
-`[tool.nab]` is scoped to the pyproject being locked: `conflicts`,
+locked: the workspace `members`, merged into `local-sources`. Everything
+else under `[tool.nab]` is scoped to the pyproject being locked: `conflicts`,
 `default-groups`, `constraints`, `matrix`, `mode`, `requires-python`,
 `uploaded-prior-to`, `build-policy` itself, `dist-policy`, `vcs`,
 `indexes`, and `environment`. Locking a member with `nab lock

--- a/docs/reference/build-policy.md
+++ b/docs/reference/build-policy.md
@@ -157,7 +157,6 @@ This matches pip, which requires `--only-binary=:all:` under `--platform`,
 A retarget of the **python axis alone** (`[tool.nab.environment].python`,
 or `--python X.Y`) is different: the machine is still the host.  nab warns
 that a build would report the host interpreter's metadata, and permits it.
-This is a deliberate deviation from pip: the workspace `build-local` floor
-exists for members with dynamic metadata, and forbidding a build here would
-break every workspace that also pins a Python.  Set `build-policy = "never"`
-to forbid it.
+This is a deliberate deviation from pip: the machine is still the host, so a
+build can run at all, and refusing every one of them would take the default
+case with it.  Set `build-policy = "never"` to forbid it.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -831,11 +831,10 @@ only; there is no walk-up.
 
 `nab config` reports the *configured* value for each key. Two keys take
 a value derived from other config at resolve time, so the resolved
-value can differ from what `nab config` shows: `build-policy` floors to
-`never` under `mode = "universal"` (and promotes workspace members to
-`build-local`), and `local-sources` gains the workspace members found
-by discovery. `nab config` shows the value as written, like
-`git config` reporting configured rather than derived state.
+value can differ from what `nab config` shows: `build-policy` is forced
+to `never` under `mode = "universal"`, and `local-sources` gains the
+workspace members found by discovery. `nab config` shows the value as
+written, like `git config` reporting configured rather than derived state.
 
 ### Environment variables
 

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -70,7 +70,6 @@ from .target import (
 )
 from .workspace import (
     WorkspaceConfig,
-    auto_promote_build_policy_for_workspace,
     discover_workspace_root,
     merge_workspace_local_sources,
     read_workspace_members,
@@ -588,13 +587,12 @@ def read_pyproject_config(
     own walks up from ``path`` for the first ancestor project file that
     declares one.  Either way every member is materialised as an
     additional :class:`LocalSource` (explicit
-    ``[[tool.nab.local-sources]]`` entries win on collision) and the
-    effective ``build-policy`` is floored at
-    :attr:`BuildPolicy.BUILD_LOCAL`, except under ``mode = "universal"``,
-    where ``build-policy`` stays at ``never`` (host builds are forbidden)
-    and the floor is not applied.  Pass ``discover_workspace=False``
-    to skip discovery; useful for tests or for callers that layer their
-    own workspace logic on top of a base config.
+    ``[[tool.nab.local-sources]]`` entries win on collision).  A workspace
+    does not change the effective ``build-policy``: a member with dynamic
+    metadata needs a build, and under ``never`` it is refused like any
+    other source.  Pass ``discover_workspace=False`` to skip discovery;
+    useful for tests or for callers that layer their own workspace logic
+    on top of a base config.
 
     The ``[tool.nab]``-config portion is sourced from the registry merged
     ladder (pyproject ``[tool.nab]`` plus a project-dir ``nab.toml``,
@@ -602,7 +600,7 @@ def read_pyproject_config(
     cross-file conflict check, and category gate), so a project-dir
     ``nab.toml`` value configures the resolve exactly as the inspector
     reports it.  The
-    cross-field transforms (mode/matrix, build-policy floors,
+    cross-field transforms (mode/matrix, the build-policy host-build gate,
     universal marker-environment ban, source-name uniqueness, declared
     index references) then run on the merged config; workspace discovery
     runs last.
@@ -830,7 +828,7 @@ _logger = logging.getLogger(__name__)
 def _apply_workspace_discovery(
     path: Path, config: NabProjectConfig, *, declared_in: str
 ) -> NabProjectConfig:
-    """Materialise the workspace members and floor the build policy.
+    """Materialise the workspace members as local sources.
 
     The project's own ``workspace`` table wins, whichever project file
     declared it (``declared_in`` names that file), and its members
@@ -839,7 +837,6 @@ def _apply_workspace_discovery(
     <member>`` still resolves against the workspace root.
     """
     if config.workspace is not None:
-        root_label = declared_in
         discovered = workspace_local_sources(
             config.workspace.members,
             root_dir=path.parent.resolve(),
@@ -849,7 +846,6 @@ def _apply_workspace_discovery(
         root_file = discover_workspace_root(path)
         if root_file is None:
             return config
-        root_label = str(root_file)
         discovered = read_workspace_members(root_file)
 
     if not discovered:
@@ -858,28 +854,9 @@ def _apply_workspace_discovery(
     merged = merge_workspace_local_sources(config.local_sources, discovered)
     _reject_duplicate_source_names(merged, config.vcs_sources, config.archive_sources)
     explicit_names = {canonicalize_name(src.name) for src in config.local_sources}
-    # A target that impersonates a machine forbids host builds, so the
-    # workspace BUILD_LOCAL floor does not apply there: keep never.  A
-    # python-only retarget stays on the host machine, so the floor still
-    # applies and a workspace member with dynamic metadata still builds.
-    #
-    # The planner without the requires-python check: the config is still
-    # being read, and --python has not moved the target yet.
-    promoted_policy = config.build_policy
-    if not _forbids_host_builds(_plan_targets(config.matrix, config.environment)):
-        promoted_policy = auto_promote_build_policy_for_workspace(config.build_policy)
-    if promoted_policy is not config.build_policy:
-        _logger.info(
-            "workspace discovery promoted build-policy from %r to %r"
-            " (workspace root: %s)",
-            config.build_policy.value,
-            promoted_policy.value,
-            root_label,
-        )
     return replace(
         config,
         local_sources=merged,
-        build_policy=promoted_policy,
         workspace_member_names=frozenset(
             canonicalize_name(src.name)
             for src in discovered
@@ -1043,9 +1020,10 @@ def enforce_build_policy_for_targets(
       value, global or in any override, is an error.  This matches pip,
       which requires ``--only-binary=:all:`` under ``--platform``.
     * A python-axis-only retarget on the host machine warns and permits:
-      the workspace ``build-local`` floor exists for members with dynamic
-      metadata, and forbidding a build here would break every workspace
-      that also pins a Python.  A deliberate deviation from pip.
+      the machine is still the host, so a build can run at all, and
+      refusing every one of them would take the default case with it.  A
+      deliberate deviation from pip.  Set ``build-policy = "never"`` to
+      forbid it.
 
     The host target permits, so the default case builds freely.
     """

--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -429,9 +429,9 @@ def _parse_dist_policy(value: Any, where: str) -> tuple[DistPolicy, bool]:
 
 
 def _parse_build_policy(value: Any, where: str) -> BuildPolicy:
-    # The plain scalar last-wins value only.  The universal and workspace
-    # floors are post-merge transforms applied over the merged config, not
-    # this row.
+    # The plain scalar last-wins value only.  The host-build gate that forces
+    # never for a declared target is a post-merge transform applied over the
+    # merged config, not this row.
     del where
     from .config import _parse_enum as _impl  # noqa: PLC0415 (config import cycle)
 

--- a/nab-python/src/nab_python/workspace.py
+++ b/nab-python/src/nab_python/workspace.py
@@ -27,7 +27,7 @@ import tomli
 
 from ._toml import tool_nab_section
 from ._vendor.packaging.utils import canonicalize_name
-from .provider import BuildPolicy, LocalSource
+from .provider import LocalSource
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -37,7 +37,6 @@ if TYPE_CHECKING:
 __all__ = [
     "WorkspaceConfig",
     "WorkspaceDiscoveryError",
-    "auto_promote_build_policy_for_workspace",
     "discover_workspace_root",
     "merge_workspace_local_sources",
     "read_workspace_members",
@@ -46,13 +45,6 @@ __all__ = [
 
 
 logger = logging.getLogger(__name__)
-
-
-_PERMISSIVENESS = {
-    BuildPolicy.NEVER: 0,
-    BuildPolicy.BUILD_LOCAL: 1,
-    BuildPolicy.BUILD_REMOTE: 2,
-}
 
 
 class WorkspaceDiscoveryError(ValueError):
@@ -278,16 +270,3 @@ def merge_workspace_local_sources(
             continue
         out.append(src)
     return tuple(out)
-
-
-def auto_promote_build_policy_for_workspace(current: BuildPolicy) -> BuildPolicy:
-    """Floor ``current`` at :attr:`BuildPolicy.BUILD_LOCAL`.
-
-    Workspace members frequently use ``dynamic = ["version"]`` (hatch's
-    pattern) and other dynamic fields, which require the local backend
-    path.  The user's setting wins when it is already at least as
-    permissive as :attr:`BuildPolicy.BUILD_LOCAL`.
-    """
-    if _PERMISSIVENESS[current] < _PERMISSIVENESS[BuildPolicy.BUILD_LOCAL]:
-        return BuildPolicy.BUILD_LOCAL
-    return current

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -4040,13 +4040,10 @@ class TestWorkspaceDiscoveryIntegration:
         with pytest.raises(ConfigError, match="duplicate canonical name"):
             read_pyproject_config(root)
 
-    def test_workspace_promotes_never_to_build_local_and_logs(
+    def test_workspace_keeps_an_explicit_never(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """An explicit ``never`` is floored at ``build-local`` for workspaces.
-
-        The log line is informational so users can audit the auto-promote.
-        """
+        """A workspace does not raise an explicit ``never``."""
         member = self._ws(tmp_path)
         member.write_text(
             '[project]\nname = "alpha"\nversion = "0"\n'
@@ -4055,10 +4052,10 @@ class TestWorkspaceDiscoveryIntegration:
         )
         with caplog.at_level("INFO", logger="nab_python.config"):
             config = read_pyproject_config(member)
-        assert config.build_policy is BuildPolicy.BUILD_LOCAL
-        assert any(
-            "promoted build-policy" in record.getMessage() for record in caplog.records
-        )
+        assert config.build_policy is BuildPolicy.NEVER
+        assert not [
+            record for record in caplog.records if "build-policy" in record.getMessage()
+        ]
 
     def test_user_build_remote_policy_not_downgraded(self, tmp_path: Path) -> None:
         member = self._ws(tmp_path)
@@ -4070,12 +4067,8 @@ class TestWorkspaceDiscoveryIntegration:
         config = read_pyproject_config(member)
         assert config.build_policy is BuildPolicy.BUILD_REMOTE
 
-    def test_universal_member_not_promoted(self, tmp_path: Path) -> None:
-        """Universal mode keeps never; workspace discovery does not promote it.
-
-        A host build cannot reflect a non-host matrix tuple, so the
-        BUILD_LOCAL floor applied to workspace members is skipped.
-        """
+    def test_universal_member_keeps_never(self, tmp_path: Path) -> None:
+        """Universal mode forces never, and a workspace does not lift it."""
         member = self._ws(tmp_path)
         member.write_text(
             '[project]\nname = "alpha"\nversion = "0"\n'
@@ -4085,12 +4078,8 @@ class TestWorkspaceDiscoveryIntegration:
         config = read_pyproject_config(member)
         assert config.build_policy is BuildPolicy.NEVER
 
-    def test_declared_platform_member_not_promoted(self, tmp_path: Path) -> None:
-        """A declared platform keeps never; discovery does not promote it.
-
-        A host build cannot reflect the declared machine, so the BUILD_LOCAL
-        floor applied to workspace members is skipped.
-        """
+    def test_declared_platform_member_keeps_never(self, tmp_path: Path) -> None:
+        """A declared platform forbids host builds, workspace or not."""
         member = self._ws(tmp_path)
         member.write_text(
             '[project]\nname = "alpha"\nversion = "0"\n'
@@ -4102,18 +4091,29 @@ class TestWorkspaceDiscoveryIntegration:
         config = read_pyproject_config(member)
         assert config.build_policy is BuildPolicy.NEVER
 
-    def test_declared_python_member_still_promoted(self, tmp_path: Path) -> None:
-        """A python-only retarget keeps the BUILD_LOCAL floor.
-
-        The machine is still the host, and a workspace member with dynamic
-        metadata has to build, so the floor applies and the build is
-        permitted (with a warning).  A deliberate deviation from pip.
-        """
+    def test_declared_python_member_keeps_never(self, tmp_path: Path) -> None:
+        """A python-only retarget stays on the host but still honours ``never``."""
         member = self._ws(tmp_path)
         member.write_text(
             '[project]\nname = "alpha"\nversion = "0"\n'
             "[tool.nab]\n"
             'build-policy = "never"\n'
+            "[tool.nab.environment]\n"
+            'python = "3.9"\n',
+        )
+        config = read_pyproject_config(member)
+        assert config.build_policy is BuildPolicy.NEVER
+
+    def test_declared_python_member_still_permits_a_build(self, tmp_path: Path) -> None:
+        """A python-only retarget does not force ``never`` on its own.
+
+        The platform axis is what forbids host builds; moving only the
+        python axis leaves the default policy alone, so a member with
+        dynamic metadata still builds.
+        """
+        member = self._ws(tmp_path)
+        member.write_text(
+            '[project]\nname = "alpha"\nversion = "0"\n'
             "[tool.nab.environment]\n"
             'python = "3.9"\n',
         )
@@ -4133,9 +4133,9 @@ class TestWorkspaceDiscoveryIntegration:
         config = read_pyproject_config(path)
         assert config == NabProjectConfig()
 
-    def test_empty_members_does_not_promote(self, tmp_path: Path) -> None:
+    def test_empty_members_adds_no_sources(self, tmp_path: Path) -> None:
         # A workspace root with members = [] is still a workspace, but
-        # there are no LocalSources to add and no policy to promote.
+        # there are no LocalSources to add.
         ws_pyproject = tmp_path / "pyproject.toml"
         ws_pyproject.write_text(
             '[project]\nname = "ws"\nversion = "0"\n'
@@ -4152,10 +4152,9 @@ class TestWorkspaceDiscoveryIntegration:
     def test_root_conflicts_and_defaults_do_not_flow_to_member(
         self, tmp_path: Path
     ) -> None:
-        # Per the documented scope, only workspace members and the
-        # build-policy floor cross the root/member boundary; conflicts,
-        # default-groups, and constraints stay scoped to the file being
-        # locked.
+        # Per the documented scope, only workspace members cross the
+        # root/member boundary; conflicts, default-groups, and constraints
+        # stay scoped to the file being locked.
         ws_pyproject = tmp_path / "pyproject.toml"
         ws_pyproject.write_text(
             '[project]\nname = "ws"\nversion = "0"\n'
@@ -4201,7 +4200,7 @@ class TestWorkspaceDiscoveryIntegration:
 
     def test_member_lock_finds_root_workspace_in_nab_toml(self, tmp_path: Path) -> None:
         # The root declares its workspace in nab.toml, so locking a member
-        # has to walk up to it: members and build-policy floor included.
+        # has to walk up to it.
         (tmp_path / "pyproject.toml").write_text(
             '[project]\nname = "ws"\nversion = "0"\n',
         )
@@ -4222,7 +4221,7 @@ class TestWorkspaceDiscoveryIntegration:
             LocalSource(name="alpha", path=str(member_dir), editable=True),
         )
         assert config.workspace_member_names == frozenset({"alpha"})
-        assert config.build_policy is BuildPolicy.BUILD_LOCAL
+        assert config.build_policy is BuildPolicy.NEVER
 
 
 def _inspect(path: Path, key: str) -> str:
@@ -4378,8 +4377,8 @@ class TestProjectNabTomlConfiguresResolve:
         assert config.mode is ResolveMode.UNIVERSAL
         assert config.matrix is not None
         assert config.matrix.platforms == (PlatformSpec("linux_x86_64"),)
-        # Universal mode forces the build-policy floor to never even though
-        # the project-nab.toml set no build-policy.
+        # Universal mode forces build-policy to never even though the
+        # project-nab.toml set no build-policy.
         assert config.build_policy is BuildPolicy.NEVER
         assert _inspect(path, "mode") == "universal"
 
@@ -4413,7 +4412,7 @@ class TestProjectNabTomlConfiguresResolve:
             LocalSource(name="foo", path=str(member_dir), editable=True),
         )
         assert config.workspace_member_names == frozenset({"foo"})
-        assert config.build_policy is BuildPolicy.BUILD_LOCAL
+        assert config.build_policy is BuildPolicy.NEVER
         assert "members=['libs/foo']" in _inspect(path, "workspace")
 
 

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -2230,8 +2230,8 @@ class TestCrossFieldProjectOptions:
     its member-uniqueness check over the merged whole; ``matrix`` is a
     nested table that is scalar last-wins.  The cross-field rules they take
     part in (mode/matrix, default-groups-vs-conflicts,
-    marker-environment-under-universal, the build-policy floors) run as
-    whole-config transforms over the merged config, not registry rows.
+    marker-environment-under-universal, the build-policy host-build gate)
+    run as whole-config transforms over the merged config, not registry rows.
     """
 
     def test_conflicts_from_pyproject(self, tmp_path: Path) -> None:

--- a/nab-python/tests/test_workspace.py
+++ b/nab-python/tests/test_workspace.py
@@ -8,10 +8,9 @@ from pathlib import Path
 
 import pytest
 
-from nab_python.provider import BuildPolicy, LocalSource
+from nab_python.provider import LocalSource
 from nab_python.workspace import (
     WorkspaceDiscoveryError,
-    auto_promote_build_policy_for_workspace,
     discover_workspace_root,
     merge_workspace_local_sources,
     read_workspace_members,
@@ -455,25 +454,3 @@ class TestMergeWorkspaceLocalSources:
         # The explicit entry survives; the canonically-equal discovered
         # entry is shadowed.
         assert out == explicit
-
-
-class TestAutoPromoteBuildPolicy:
-    def test_never_promotes_to_build_local(self) -> None:
-        assert (
-            auto_promote_build_policy_for_workspace(BuildPolicy.NEVER)
-            is BuildPolicy.BUILD_LOCAL
-        )
-
-    def test_build_local_unchanged(self) -> None:
-        assert (
-            auto_promote_build_policy_for_workspace(BuildPolicy.BUILD_LOCAL)
-            is BuildPolicy.BUILD_LOCAL
-        )
-
-    def test_build_remote_unchanged(self) -> None:
-        # User explicitly opted into the more permissive policy; do not
-        # downgrade.
-        assert (
-            auto_promote_build_policy_for_workspace(BuildPolicy.BUILD_REMOTE)
-            is BuildPolicy.BUILD_REMOTE
-        )


### PR DESCRIPTION
`build-policy = "never"` is meant to give a resolve with no backend invocations at all, but a workspace quietly overrode it. Locking a workspace member with `never` set still ran PEP 517 builds for every member with dynamic metadata.

Workspace discovery floored the effective policy at `build-local`. Because `build-local` is already the default, that floor could only ever do one thing: rewrite an explicit `never`. It left `build-local` and `build-remote` untouched, so its whole behaviour was to reverse the one value a user sets deliberately.

The floor is gone, so `never` reaches the resolve as written. A member with dynamic metadata and no static fallback is now refused like any other source that needs a build the policy forbids, and the resolve fails naming the source, its path, and the policy it would need. A workspace that has not set `build-policy` keeps building its members exactly as before, and a single member can still be lifted with `[tool.nab.packages.<name>] build-policy = "build-local"`.

The separate rule that a target impersonating a machine forces `never` is unchanged.
