### PR TITLE
fix --no-cache failing declared VCS and archive sources

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -232,7 +232,7 @@ Both subcommands accept the same runtime knobs:
 | Flag | Default | Effect |
 | ---- | ------- | ------ |
 | `--cache-dir PATH` | `~/.cache/nab` | Override the on-disk cache root. |
-| `--no-cache` | off | Disable cache for this run. Combine with `--offline` only if the cache already has every file. |
+| `--no-cache` | off | Disable cache for this run. A declared VCS or archive source is materialised into a temporary directory instead, so it is refetched every run. Combine with `--offline` only if the cache already has every file. |
 | `--offline {True,False}` | unset | Use cache only, never hit the network. Layered: `--offline True` forces offline, `--offline False` forces network even over a lower `offline = true`. Bare `--offline` / `--no-offline` are shorthands for `True` / `False`. |
 | `--http-backend {urllib3,httpx}` | `urllib3` | Pick the async transport for fetches. Layered, so it can also be set in an `nab.toml` or `NAB_HTTP_BACKEND`. `httpx` needs its extra (see [Install nab](../how-to/install.md)). |
 

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -21,9 +21,12 @@ from __future__ import annotations
 
 import itertools
 import logging
+import tempfile
 import time
 from collections import defaultdict
+from contextlib import contextmanager
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
 from nab_index.cache import ARCHIVE_BUCKET, VCS_BUCKET
@@ -86,8 +89,7 @@ from .target import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
-    from pathlib import Path
+    from collections.abc import Iterator, Mapping, Sequence
 
     from nab_index.transport import AsyncHttpTransport
 
@@ -387,31 +389,53 @@ def resolve_with_coordinator(  # noqa: PLR0913 - the knobs a caller drives a bar
     conflict forks ran.
     """
     effective = config if config is not None else NabProjectConfig()
-    settings = _EngineSettings(
-        coordinator=coordinator,
-        config=effective,
-        cache_dir=cache_dir,
-        align=align_across_targets,
-        resolution=(
-            resolution_strategy
-            if resolution_strategy is not None
-            else effective.resolution
-        ),
-        progress=progress,
-    )
-    fork_list = (
-        list(forks) if forks is not None else [ResolveFork((), tuple(requirements))]
-    )
-    constraints = [Requirement(text) for text in effective.constraints]
+    with _source_root(cache_dir, effective) as source_root:
+        settings = _EngineSettings(
+            coordinator=coordinator,
+            config=effective,
+            source_root=source_root,
+            align=align_across_targets,
+            resolution=(
+                resolution_strategy
+                if resolution_strategy is not None
+                else effective.resolution
+            ),
+            progress=progress,
+        )
 
-    return _resolve_with_micro_narrowing(
-        list(targets),
-        fork_list,
-        constraints,
-        settings,
-        preferences,
-        base_requirements,
-    )
+        fork_list = (
+            list(forks) if forks is not None else [ResolveFork((), tuple(requirements))]
+        )
+        constraints = [Requirement(text) for text in effective.constraints]
+
+        return _resolve_with_micro_narrowing(
+            list(targets),
+            fork_list,
+            constraints,
+            settings,
+            preferences,
+            base_requirements,
+        )
+
+
+@contextmanager
+def _source_root(
+    cache_dir: Path | None, config: NabProjectConfig
+) -> Iterator[Path | None]:
+    """Yield the directory a declared VCS or archive source materialises under.
+
+    With caching off there is no cache root, but the source still has to
+    be materialised to read its version and dependencies, so the run gets
+    a temporary directory instead.
+    """
+    if cache_dir is not None or not (config.vcs_sources or config.archive_sources):
+        yield cache_dir
+        return
+
+    with tempfile.TemporaryDirectory(
+        prefix="nab-sources-", ignore_cleanup_errors=True
+    ) as scratch:
+        yield Path(scratch)
 
 
 # The number of split-and-resolve passes the micro-narrowing fixpoint runs
@@ -725,7 +749,9 @@ class _EngineSettings:
 
     coordinator: FetchCoordinator
     config: NabProjectConfig
-    cache_dir: Path | None
+    # Where a declared VCS clone or archive extraction lands, the cache root
+    # unless caching is off.
+    source_root: Path | None
     align: bool
     resolution: ResolutionStrategy
     progress: ProgressSink | None = None
@@ -819,7 +845,7 @@ def _resolve_one_target(
     except ResolutionError as exc:
         return TargetResult(target=target, success=False, error=exc)
 
-    cache_dir = settings.cache_dir
+    source_root = settings.source_root
     provider = Provider(
         settings.coordinator,
         target=target,
@@ -834,9 +860,11 @@ def _resolve_one_target(
         vcs_config=config.vcs,
         local_sources=list(config.local_sources) or None,
         vcs_sources=list(config.vcs_sources) or None,
-        vcs_cache_dir=cache_dir / VCS_BUCKET if cache_dir is not None else None,
+        vcs_cache_dir=source_root / VCS_BUCKET if source_root is not None else None,
         archive_sources=list(config.archive_sources) or None,
-        archive_cache_dir=cache_dir / ARCHIVE_BUCKET if cache_dir is not None else None,
+        archive_cache_dir=(
+            source_root / ARCHIVE_BUCKET if source_root is not None else None
+        ),
         build_config=config,
         resolution_strategy=settings.resolution,
         direct_packages=frozenset(

--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -11,12 +11,15 @@ from __future__ import annotations
 import hashlib
 import io
 import logging
+import subprocess
 import tarfile
+from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from nab_index import vcs as vcs_mod
 from nab_index.client import SdistFile, WheelFile
 from nab_python import resolve as resolve_mod
 from nab_python._provider import listing as listing_mod
@@ -81,7 +84,8 @@ from nab_resolver.errors import ResolutionError
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from pathlib import Path
+
+    from nab_index.vcs import VcsClone, VcsRequest
 
 
 def _make_wheel(version: str, *, package: str) -> WheelFile:
@@ -132,14 +136,14 @@ def _settings(
     config: NabProjectConfig | None = None,
     *,
     align: bool = True,
-    cache_dir: Path | None = None,
+    source_root: Path | None = None,
 ) -> _EngineSettings:
     """The settings one bare ``_resolve_one_target`` or ``_run_pass`` needs."""
     effective = config if config is not None else NabProjectConfig()
     return _EngineSettings(
         coordinator=coordinator,
         config=effective,
-        cache_dir=cache_dir,
+        source_root=source_root,
         align=align,
         resolution=effective.resolution,
     )
@@ -1274,7 +1278,7 @@ class TestVcsConfigPlumbing:
 
         The resolver requests no VCS package so the materialise path is
         not exercised.  Reaching a non-error :class:`TargetResult` is
-        sufficient evidence that the VCS config and the cache dir both
+        sufficient evidence that the VCS config and the source root both
         reached the provider (the BLOCK fast-fail in
         ``index_vcs_sources`` would have raised at construction time).
         """
@@ -1284,18 +1288,18 @@ class TestVcsConfigPlumbing:
         settings = _settings(
             coordinator,
             _no_build(vcs=self._allow(), vcs_sources=(self._source(),)),
-            cache_dir=tmp_path,
+            source_root=tmp_path,
         )
         tr = _resolve_one_target(_linux_311(), _reqs("other"), (), settings, {})
         assert tr.success
         assert tr.pins == {"other": Version("1.0")}
 
-    def test_cache_dir_required_for_vcs_materialize(self) -> None:
-        """Without a cache dir, vcs materialisation raises cleanly.
+    def test_source_root_required_for_vcs_materialize(self) -> None:
+        """Without a source root, vcs materialisation raises cleanly.
 
         When the resolver requests the VCS-backed package the provider
         raises ``UnsupportedSdistError`` mentioning ``vcs_cache_dir``.
-        Catching that diagnostic confirms the cache dir the engine
+        Catching that diagnostic confirms the directory the engine
         derives reaches the provider attribute the materialise path
         reads.  Without the plumbing the resolver would attribute-error
         on ``provider.vcs_cache_dir`` instead.
@@ -1303,7 +1307,7 @@ class TestVcsConfigPlumbing:
         settings = _settings(
             _make_coordinator({}),
             _no_build(vcs=self._allow(), vcs_sources=(self._source(),)),
-            cache_dir=None,
+            source_root=None,
         )
         with pytest.raises(UnsupportedSdistError, match="vcs_cache_dir"):
             _resolve_one_target(_linux_311(), _reqs("pkg"), (), settings, {})
@@ -1324,6 +1328,51 @@ class TestVcsConfigPlumbing:
                     vcs_sources=(self._source(),),
                 ),
             )
+
+    def test_vcs_source_resolves_with_caching_off(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A resolve without a cache root clones into scratch space it then drops.
+
+        ``nab lock --no-cache`` arrives with ``cache_dir=None``.  Only
+        ``git`` is faked, so the real ``prepare_clone`` has to cope with a
+        root that does not exist yet.
+        """
+        roots: list[Path] = []
+        real_prepare_clone = vcs_mod.prepare_clone
+
+        def spy_prepare_clone(
+            cache_root: Path, request: VcsRequest, *, require_pin: bool
+        ) -> VcsClone:
+            roots.append(cache_root)
+            return real_prepare_clone(cache_root, request, require_pin=require_pin)
+
+        def fake_run(cmd: list[str], **kwargs: object) -> object:
+            cwd = Path(str(kwargs["cwd"]))
+            if cmd[:2] == ["git", "init"]:
+                (cwd / ".git").mkdir(exist_ok=True)
+            if cmd[:2] == ["git", "checkout"]:
+                (cwd / "pyproject.toml").write_text(
+                    '[project]\nname = "pkg"\nversion = "1.0"\n', encoding="utf-8"
+                )
+            return type("P", (), {"returncode": 0})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(vcs_mod, "prepare_clone", spy_prepare_clone)
+
+        result = resolve_with_coordinator(
+            _make_coordinator({}),
+            _one_target(),
+            _reqs("pkg"),
+            config=_no_build(vcs=self._allow(), vcs_sources=(self._source(),)),
+            cache_dir=None,
+        )
+
+        assert result.success
+        assert result.target_results[0].pins == {"pkg": Version("1.0")}
+
+        assert len(roots) == 1
+        assert not roots[0].exists()
 
 
 class TestRunPassSerial:
@@ -1745,6 +1794,28 @@ class TestArchiveSourceAcrossTargets:
         for target_result in result.target_results:
             assert str(target_result.pins["foo"]) == "1.0"
             assert str(target_result.pins["bar"]) == "2.0"
+
+    def test_resolves_with_caching_off(self) -> None:
+        """``nab lock --no-cache`` still extracts and pins the declared archive."""
+        pyproject = '[project]\nname = "foo"\nversion = "1.0"\n'
+        data = _archive_bytes("foo", "1.0", pyproject)
+        digest = hashlib.sha256(data).hexdigest()
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.tar.gz#sha256={digest}"
+        )
+        coord = make_coordinator([], package="foo")
+        coord.index.store_sdist_archive("foo", digest, data)
+
+        result = resolve_with_coordinator(
+            coord,
+            _one_target(),
+            _reqs("foo"),
+            config=NabProjectConfig(archive_sources=(source,)),
+            cache_dir=None,
+        )
+
+        assert result.success
+        assert str(result.target_results[0].pins["foo"]) == "1.0"
 
     def test_requires_python_excluding_target_fails(self, tmp_path: Path) -> None:
         # An archive skips the listing Requires-Python filter, so the source


### PR DESCRIPTION
With `--no-cache` there is no cache root to hand the provider, so any declared VCS or archive source fails the resolve with an internal guard message ("vcs source 'x' declared but no vcs_cache_dir was supplied to Provider", and the archive equivalent). Cloning or extracting a declared source is the only way to read its version and dependencies, so turning the cache off should not turn the source off.

The resolve now materialises declared sources into a temporary directory when caching is off and drops it when the run finishes, so the source is refetched each run. Runs with a cache directory are unchanged. The `--no-cache` row in the CLI reference is updated to match.
