### PR TITLE
give local index failures their own error type

### DIFF
--- a/nab-index/src/nab_index/errors.py
+++ b/nab-index/src/nab_index/errors.py
@@ -1,0 +1,14 @@
+"""The error root every index backend fails through."""
+
+from __future__ import annotations
+
+__all__ = ["IndexAccessError"]
+
+
+class IndexAccessError(Exception):
+    """An index could not produce a usable answer.
+
+    A remote index fails with :class:`~nab_index.transport.HttpError`, a
+    ``file://`` index with :class:`~nab_index.local_index.LocalIndexError`.
+    Catching this covers both without naming a backend.
+    """

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import lzma
 import re
+import stat
 import sys
 import zipfile
 import zlib
@@ -43,7 +44,7 @@ from .client import (
     _parse_wheel_filename,
     is_readable_filename,
 )
-from .transport import HttpError
+from .errors import IndexAccessError
 
 if TYPE_CHECKING:
     from packaging.utils import NormalizedName
@@ -53,8 +54,10 @@ if TYPE_CHECKING:
 
 __all__ = [
     "LocalIndexClient",
+    "LocalIndexError",
     "MalformedLocalListingError",
     "NonLocalArtifactError",
+    "UnreadableLocalIndexError",
     "UnsupportedWheelError",
     "is_file_url",
     "parse_file_url",
@@ -72,25 +75,34 @@ class UnsupportedWheelError(Exception):
     """
 
 
-class MalformedLocalListingError(HttpError):
-    """A local ``file://`` index's ``index.html`` or metadata sidecar is unreadable.
+class LocalIndexError(IndexAccessError):
+    """A ``file://`` index could not produce a listing or serve an artifact.
 
-    Subclasses :class:`~nab_index.transport.HttpError` so a broken local
-    listing or PEP 658 sidecar fails through the same path as a remote
-    index error rather than surfacing a raw decode error.  Raising, rather
-    than returning an empty listing, keeps a malformed index from reading
-    as an absent package.
+    Raising, rather than returning an empty listing, keeps an index that
+    failed from reading as an absent package.
     """
 
 
-class NonLocalArtifactError(HttpError):
+class UnreadableLocalIndexError(LocalIndexError):
+    """A path under a ``file://`` index could not be read.
+
+    Distinct from :class:`MalformedLocalListingError` because the content was
+    never seen: a wheelhouse the process cannot list, or an ``index.html`` it
+    cannot stat or open, is a permission or mount fault rather than a bad
+    listing.
+    """
+
+
+class MalformedLocalListingError(LocalIndexError):
+    """A ``file://`` index's ``index.html`` or metadata sidecar does not parse."""
+
+
+class NonLocalArtifactError(LocalIndexError):
     """A ``file://`` index advertised an artifact URL a local client cannot serve.
 
     A :pep:`503` repository page may link to absolute ``http(s)`` artifact
     URLs, so the listing is legal, but a filesystem-backed index cannot fetch
-    a remote artifact.  Subclasses :class:`~nab_index.transport.HttpError` so
-    the fetch fails through the same path as a remote index error rather than a
-    raw :class:`ValueError` from :func:`parse_file_url`.
+    a remote artifact.
     """
 
 
@@ -156,15 +168,40 @@ def _resolve_served_path(url: str) -> Path:
 def _read_served_bytes(path: Path, kind: str) -> bytes:
     """Read a served local artifact's bytes, mapping a read failure.
 
-    A missing or unreadable file raises :class:`MalformedLocalListingError`
-    (an :class:`HttpError` subclass) so the fetch fails through the index-error
-    path, matching a remote index's 404 rather than a raw :class:`OSError`.
+    A missing or unreadable file raises :class:`UnreadableLocalIndexError` so
+    the fetch fails through the index-error path, matching a remote index's
+    404 rather than a raw :class:`OSError`.
     """
     try:
         return path.read_bytes()
     except OSError as exc:
         msg = f"cannot read local {kind} {path}: {exc}"
-        raise MalformedLocalListingError(msg) from exc
+        raise UnreadableLocalIndexError(msg) from exc
+
+
+def _stat_mode(path: Path) -> int | None:
+    """Return ``path``'s ``st_mode``, or ``None`` when it does not exist.
+
+    Any other failure raises. From Python 3.14 ``Path.exists`` and
+    ``Path.is_file`` swallow every :class:`OSError`, so an unreadable path
+    would read as absent.
+    """
+    try:
+        return path.stat().st_mode
+    except (FileNotFoundError, NotADirectoryError):
+        return None
+
+
+def _is_file(path: Path) -> bool:
+    """Return whether ``path`` is an existing regular file."""
+    mode = _stat_mode(path)
+    return mode is not None and stat.S_ISREG(mode)
+
+
+def _is_dir(path: Path) -> bool:
+    """Return whether ``path`` is an existing directory."""
+    mode = _stat_mode(path)
+    return mode is not None and stat.S_ISDIR(mode)
 
 
 _FLAT_EXTS = re.compile(r"\.(whl|tar\.gz)$", re.IGNORECASE)
@@ -180,7 +217,7 @@ def _scan_pep503_directory(
     not read, which tells a page of ``.zip`` sdists from an empty one.
     """
     index_html = package_dir / "index.html"
-    if not index_html.exists():
+    if not _is_file(index_html):
         return [], False
 
     try:
@@ -529,16 +566,26 @@ class LocalIndexClient:
         """No-op exit."""
 
     async def get_files(self, package: str) -> list[WheelFile | SdistFile]:
-        """Return all distribution files known for ``package``."""
+        """Return all distribution files known for ``package``.
+
+        An index directory or listing the process cannot read raises
+        :class:`UnreadableLocalIndexError` so the listing fails through the
+        index-error path rather than raising a raw :class:`OSError` or
+        returning an empty list that reads as "package absent".
+        """
         canonical = _canonical(package)
         package_dir = self._root / canonical
 
-        if (package_dir / "index.html").is_file():
-            files, unreadable = _scan_pep503_directory(package_dir, canonical)
-        elif not self._root.is_dir():
-            files, unreadable = [], False
-        else:
-            files, unreadable = _scan_flat_wheelhouse(self._root, package)
+        try:
+            if _is_file(package_dir / "index.html"):
+                files, unreadable = _scan_pep503_directory(package_dir, canonical)
+            elif not _is_dir(self._root):
+                files, unreadable = [], False
+            else:
+                files, unreadable = _scan_flat_wheelhouse(self._root, package)
+        except OSError as exc:
+            msg = f"cannot read local index {self._root}: {exc}"
+            raise UnreadableLocalIndexError(msg) from exc
 
         if not files and unreadable:
             self._unreadable_only.add(package)
@@ -557,12 +604,11 @@ class LocalIndexClient:
     ) -> str:
         """Return PEP 658 metadata text for a wheel sitting on disk.
 
-        The on-disk sidecar is trusted, so ``metadata_hash`` is accepted
-        only to match the remote client signature and is not verified.  A
-        sidecar that is missing, unreadable, or not valid UTF-8 raises
-        :class:`MalformedLocalListingError` (an :class:`HttpError` subclass)
-        rather than a raw :class:`OSError` or :class:`UnicodeDecodeError`,
-        matching the ``index.html`` reader.
+        The on-disk sidecar is trusted, so ``metadata_hash`` is accepted only
+        to match the remote client signature and is not verified.  A missing
+        or unreadable sidecar raises :class:`UnreadableLocalIndexError` and a
+        non-UTF-8 one :class:`MalformedLocalListingError`, so no raw
+        :class:`OSError` or :class:`UnicodeDecodeError` escapes.
         """
         path = _resolve_served_path(metadata_url)
         data = _read_served_bytes(path, "metadata sidecar")

--- a/nab-index/src/nab_index/transport.py
+++ b/nab-index/src/nab_index/transport.py
@@ -12,6 +12,7 @@ import zlib
 from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING, Any, Final, Protocol
 
+from .errors import IndexAccessError
 from .retry import RETRY_STATUSES
 
 if TYPE_CHECKING:
@@ -60,7 +61,7 @@ _CONTENT_STATUSES: Final[frozenset[int]] = frozenset({200, 203})
 _GZIP_CODINGS: Final[frozenset[str]] = frozenset({"gzip", "x-gzip"})
 
 
-class HttpError(Exception):
+class HttpError(IndexAccessError):
     """A request failed, or answered with a status the caller cannot use.
 
     Transports raise this from ``get`` and ``raise_for_status`` so callers

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -24,7 +24,8 @@ from nab_index.client import (
     WheelFile,
     WheelHashMismatchError,
 )
-from nab_index.transport import HttpError, UnserveableUrlError
+from nab_index.errors import IndexAccessError
+from nab_index.transport import UnserveableUrlError
 
 from ._conflict_kind import EMPTY_MEMBERSHIP_SETS
 from ._provider import extras as _extras
@@ -2145,7 +2146,7 @@ class Provider:
         except (
             SdistHashMismatchError,
             MetadataHashMismatchError,
-            HttpError,
+            IndexAccessError,
             UnsupportedVcsError,
             NotImplementedError,
             InvalidUploadTimeError,

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import io
 import struct
 import sys
@@ -15,9 +16,13 @@ from typing import TYPE_CHECKING, TypeVar
 import pytest
 
 from nab_index.client import SdistFile, WheelFile
+from nab_index.errors import IndexAccessError
 from nab_index.local_index import (
     LocalIndexClient,
+    LocalIndexError,
     MalformedLocalListingError,
+    NonLocalArtifactError,
+    UnreadableLocalIndexError,
     UnsupportedWheelError,
     _is_zip_sdist,
     _make_record,
@@ -36,6 +41,21 @@ _T = TypeVar("_T")
 
 def run(coro: Coroutine[Any, Any, _T]) -> _T:
     return asyncio.run(coro)
+
+
+def _deny_access(monkeypatch: pytest.MonkeyPatch, method: str, target: Path) -> None:
+    """Make one ``Path`` call on ``target`` fail with EACCES.
+
+    A real chmod would not do: root ignores the mode bits and Windows has none.
+    """
+    original = getattr(Path, method)
+
+    def denied(self: Path, *args: Any, **kwargs: Any) -> Any:
+        if self == target:
+            raise PermissionError(errno.EACCES, "Permission denied", str(self))
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, method, denied)
 
 
 def _write_wheel(
@@ -241,6 +261,35 @@ def _write_encrypted_metadata_wheel(path: Path, name: str, version: str) -> None
     _patch_wheel_member(path, member, encrypt=True)
 
 
+_LOCAL_ERRORS = [
+    UnreadableLocalIndexError,
+    MalformedLocalListingError,
+    NonLocalArtifactError,
+]
+
+
+class TestErrorHierarchy:
+    """What a caller catches for either index backend, and what it does not."""
+
+    @pytest.mark.parametrize("error", _LOCAL_ERRORS)
+    def test_local_errors_are_index_access_errors(
+        self, error: type[LocalIndexError]
+    ) -> None:
+        assert issubclass(error, LocalIndexError)
+        assert issubclass(error, IndexAccessError)
+
+    @pytest.mark.parametrize("error", _LOCAL_ERRORS)
+    def test_local_errors_are_not_http_errors(
+        self, error: type[LocalIndexError]
+    ) -> None:
+        # A file:// index makes no request, so naming one of these an HTTP
+        # failure would send a reader looking for a server that isn't there.
+        assert not issubclass(error, HttpError)
+
+    def test_http_errors_are_index_access_errors(self) -> None:
+        assert issubclass(HttpError, IndexAccessError)
+
+
 class TestParseFileUrl:
     def test_absolute_path(self, tmp_path: Path) -> None:
         url = tmp_path.as_uri()
@@ -407,6 +456,20 @@ class TestFlatWheelhouse:
         wheelhouse = run(client.get_files("bar"))
         assert [f.url for f in wheelhouse] == [flat.as_uri()]
         assert [f.local_path for f in wheelhouse] == [flat]
+
+    def test_unreadable_root_raises_index_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A wheelhouse that cannot be listed must raise, not return an empty
+        # list: an empty result would read as "package absent".
+        (tmp_path / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+        _deny_access(monkeypatch, "iterdir", tmp_path)
+        client = LocalIndexClient(tmp_path.as_uri())
+        with pytest.raises(UnreadableLocalIndexError) as caught:
+            run(client.get_files("foo"))
+        assert isinstance(caught.value, IndexAccessError)
+        assert not isinstance(caught.value, OSError)
+        assert "Permission denied" in str(caught.value)
 
     def test_listing_order_independent_of_readdir_order(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -789,7 +852,7 @@ class TestPep503Directory:
         result = run(client.get_files("foo"))
         assert result == []
 
-    def test_non_utf8_index_html_raises_http_error(self, tmp_path: Path) -> None:
+    def test_non_utf8_index_html_raises_index_error(self, tmp_path: Path) -> None:
         # A non-UTF-8 listing must raise, not return an empty list: an empty
         # result would read as "package absent".
         package_dir = tmp_path / "foo"
@@ -800,8 +863,38 @@ class TestPep503Directory:
         client = LocalIndexClient(tmp_path.as_uri())
         with pytest.raises(MalformedLocalListingError) as caught:
             run(client.get_files("foo"))
-        assert isinstance(caught.value, HttpError)
+        assert isinstance(caught.value, IndexAccessError)
         assert "not valid UTF-8" in str(caught.value)
+
+    def test_unreadable_index_html_raises_index_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        package_dir = self._make_index(
+            tmp_path, '<a href="foo-1.0-py3-none-any.whl">foo-1.0</a>'
+        )
+        _deny_access(monkeypatch, "read_text", package_dir / "index.html")
+        client = LocalIndexClient(tmp_path.as_uri())
+        with pytest.raises(UnreadableLocalIndexError) as caught:
+            run(client.get_files("foo"))
+        assert isinstance(caught.value, IndexAccessError)
+        assert not isinstance(caught.value, OSError)
+        assert "Permission denied" in str(caught.value)
+
+    def test_unreadable_package_dir_raises_index_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The layout probe stats <package>/index.html, so an unreadable package
+        # directory fails there.
+        package_dir = self._make_index(
+            tmp_path, '<a href="foo-1.0-py3-none-any.whl">foo-1.0</a>'
+        )
+        _deny_access(monkeypatch, "stat", package_dir / "index.html")
+        client = LocalIndexClient(tmp_path.as_uri())
+        with pytest.raises(UnreadableLocalIndexError) as caught:
+            run(client.get_files("foo"))
+        assert isinstance(caught.value, IndexAccessError)
+        assert not isinstance(caught.value, OSError)
+        assert "Permission denied" in str(caught.value)
 
     def test_pep503_non_local_file_href_dropped(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1116,25 +1209,25 @@ class TestMetadataAndSdist:
         text = run(client.get_metadata_text("foo", "1.0", meta_path.as_uri()))
         assert text.startswith("Name: foo")
 
-    def test_non_utf8_metadata_sidecar_raises_http_error(self, tmp_path: Path) -> None:
-        # A non-UTF-8 sidecar must fail through HttpError like the
+    def test_non_utf8_metadata_sidecar_raises_index_error(self, tmp_path: Path) -> None:
+        # A non-UTF-8 sidecar must fail through the index-error path like the
         # index.html reader, not a raw UnicodeDecodeError.
         meta_path = tmp_path / "foo-1.0.metadata"
         meta_path.write_bytes(b"Author: J\xe9an\n")
         client = LocalIndexClient(tmp_path.as_uri())
         with pytest.raises(MalformedLocalListingError) as caught:
             run(client.get_metadata_text("foo", "1.0", meta_path.as_uri()))
-        assert isinstance(caught.value, HttpError)
+        assert isinstance(caught.value, IndexAccessError)
         assert "not valid UTF-8" in str(caught.value)
 
-    def test_missing_metadata_sidecar_raises_http_error(self, tmp_path: Path) -> None:
-        # An advertised-but-absent sidecar must fail through HttpError, not a
-        # raw FileNotFoundError, matching a remote 404.
+    def test_missing_metadata_sidecar_raises_index_error(self, tmp_path: Path) -> None:
+        # An advertised-but-absent sidecar must fail through the index-error
+        # path, not a raw FileNotFoundError, matching a remote 404.
         meta_path = tmp_path / "foo-1.0.metadata"
         client = LocalIndexClient(tmp_path.as_uri())
-        with pytest.raises(MalformedLocalListingError) as caught:
+        with pytest.raises(UnreadableLocalIndexError) as caught:
             run(client.get_metadata_text("foo", "1.0", meta_path.as_uri()))
-        assert isinstance(caught.value, HttpError)
+        assert isinstance(caught.value, IndexAccessError)
         assert not isinstance(caught.value, OSError)
 
     def test_get_sdist_files(self, tmp_path: Path) -> None:
@@ -1159,27 +1252,27 @@ class TestMetadataAndSdist:
         assert pyproject is not None
         assert 'name = "foo"' in pyproject
 
-    def test_missing_sdist_files_raises_http_error(self, tmp_path: Path) -> None:
-        # An advertised-but-absent sdist must fail through HttpError, not a
-        # raw FileNotFoundError, matching a remote 404.
+    def test_missing_sdist_files_raises_index_error(self, tmp_path: Path) -> None:
+        # An advertised-but-absent sdist must fail through the index-error
+        # path, not a raw FileNotFoundError, matching a remote 404.
         sdist_path = tmp_path / "foo-1.0.tar.gz"
         client = LocalIndexClient(tmp_path.as_uri())
-        with pytest.raises(MalformedLocalListingError) as caught:
+        with pytest.raises(UnreadableLocalIndexError) as caught:
             run(client.get_sdist_files("foo", "1.0", sdist_path.as_uri()))
-        assert isinstance(caught.value, HttpError)
+        assert isinstance(caught.value, IndexAccessError)
         assert not isinstance(caught.value, OSError)
 
-    def test_missing_sdist_archive_raises_http_error(self, tmp_path: Path) -> None:
+    def test_missing_sdist_archive_raises_index_error(self, tmp_path: Path) -> None:
         sdist_path = tmp_path / "foo-1.0.tar.gz"
         client = LocalIndexClient(tmp_path.as_uri())
-        with pytest.raises(MalformedLocalListingError) as caught:
+        with pytest.raises(UnreadableLocalIndexError) as caught:
             run(client.get_sdist_archive("foo", "1.0", sdist_path.as_uri()))
-        assert isinstance(caught.value, HttpError)
+        assert isinstance(caught.value, IndexAccessError)
         assert not isinstance(caught.value, OSError)
 
-    def test_https_metadata_url_raises_http_error(self, tmp_path: Path) -> None:
-        # An absolute-href record admitted by get_files must fetch through
-        # HttpError, not a raw ValueError, when its sidecar is fetched.
+    def test_https_metadata_url_raises_index_error(self, tmp_path: Path) -> None:
+        # An absolute-href record admitted by get_files must fetch through the
+        # index-error path, not a raw ValueError, when its sidecar is fetched.
         package_dir = tmp_path / "foo"
         package_dir.mkdir()
         (package_dir / "index.html").write_text(
@@ -1195,10 +1288,10 @@ class TestMetadataAndSdist:
         assert metadata_url == (
             "https://files.example.com/foo-1.0-py3-none-any.whl.metadata"
         )
-        with pytest.raises(HttpError):
+        with pytest.raises(NonLocalArtifactError):
             run(client.get_metadata_text("foo", "1.0", metadata_url))
 
-    def test_https_sdist_url_raises_http_error(self, tmp_path: Path) -> None:
+    def test_https_sdist_url_raises_index_error(self, tmp_path: Path) -> None:
         package_dir = tmp_path / "foo"
         package_dir.mkdir()
         (package_dir / "index.html").write_text(
@@ -1210,9 +1303,9 @@ class TestMetadataAndSdist:
         assert isinstance(record, SdistFile)
         assert record.local_path is None
         assert record.url == "https://files.example.com/foo-1.0.tar.gz"
-        with pytest.raises(HttpError):
+        with pytest.raises(NonLocalArtifactError):
             run(client.get_sdist_files("foo", "1.0", record.url))
-        with pytest.raises(HttpError):
+        with pytest.raises(NonLocalArtifactError):
             run(client.get_sdist_archive("foo", "1.0", record.url))
 
 

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -31,7 +31,7 @@ from nab_index.client import (
 )
 from nab_index.httpx_async_transport import HttpxAsyncTransport
 from nab_index.lazy_wheel import RangeMetadataResult, RangeOutcome
-from nab_index.local_index import LocalIndexClient
+from nab_index.local_index import LocalIndexClient, UnreadableLocalIndexError
 from nab_index.multi_index import IndexConfig
 from nab_index.transport import HttpError
 from nab_index.urllib3_async_transport import Urllib3AsyncTransport
@@ -9438,6 +9438,49 @@ class TestStaticSdistMetadata:
             build_policy=BuildPolicy.BUILD_REMOTE,
         )
         with pytest.raises(HttpError):
+            provider.get_dependencies("pkg", V("1.0"))
+        assert ("pkg", V("1.0")) not in provider.deps_cache
+        assert ("pkg", V("1.0")) not in provider._invalid_metadata
+
+    def test_build_remote_archive_local_index_error_aborts_get_dependencies(
+        self,
+    ) -> None:
+        """A local index that cannot serve the archive aborts, not skips.
+
+        A local failure is not an HTTP error, so the hard-error arm has to name
+        the family both backends share; otherwise a wheelhouse that goes
+        unreadable mid-resolve is cached as a bad-metadata skip.
+        """
+        coordinator = make_coordinator(
+            [make_sdist("1.0")],
+            sdist_pkg_info=PKG_INFO_DYNAMIC_DEPS,
+        )
+
+        def _unreadable_archive(
+            pkg: str,
+            ver: str,
+            _url: str,
+            _hashes: tuple[tuple[str, str], ...],
+        ) -> threading.Event:
+            coordinator.index.store_sdist_archive_error(
+                pkg,
+                ver,
+                UnreadableLocalIndexError(
+                    "cannot read local sdist /wheelhouse/pkg-1.0.tar.gz:"
+                    " [Errno 13] Permission denied"
+                ),
+            )
+            return _done_event()
+
+        coordinator.request_sdist_archive.side_effect = _unreadable_archive
+
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            dist_policy=DistPolicy.WHEEL_OR_SDIST,
+            build_policy=BuildPolicy.BUILD_REMOTE,
+        )
+        with pytest.raises(UnreadableLocalIndexError):
             provider.get_dependencies("pkg", V("1.0"))
         assert ("pkg", V("1.0")) not in provider.deps_cache
         assert ("pkg", V("1.0")) not in provider._invalid_metadata

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -30,7 +30,7 @@ from nab_index.client import (
     SdistHashMismatchError,
     WheelHashMismatchError,
 )
-from nab_index.transport import HttpError
+from nab_index.errors import IndexAccessError
 from nab_index.urllib3_async_transport import Urllib3AsyncTransport
 from nab_python.config import (
     ConfigError,
@@ -639,7 +639,7 @@ def _resolve(  # noqa: PLR0913, PLR0912, C901 - one wrapper per resolve_for_targ
     except ConfigError as e:
         printer().error(f"in [tool.nab]: {e}")
         sys.exit(1)
-    except HttpError as e:
+    except IndexAccessError as e:
         printer().error(f"{failure_prefix}: {e}")
         sys.exit(1)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,7 @@ import stat
 import sys
 import tarfile
 import zipfile
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from contextlib import AbstractContextManager
 from datetime import datetime, timedelta, timezone
 from importlib.metadata import PackageNotFoundError
@@ -48,6 +48,7 @@ from nab.cli import (
 )
 from nab.output import Printer, Verbosity
 from nab_index.httpx_async_transport import HttpxAsyncTransport
+from nab_index.local_index import LocalIndexClient, UnreadableLocalIndexError
 from nab_index.transport import HttpError
 from nab_index.urllib3_async_transport import Urllib3AsyncTransport
 from nab_python._vendor.packaging.pylock import Pylock
@@ -850,6 +851,48 @@ class TestLockCommandSpecific:
             lock(pyproject)
         err = capsys.readouterr().err
         assert "malformed Simple-API" in err
+        assert "Traceback" not in err
+
+    def test_unreadable_local_index_exits(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """An unreadable file:// index exits 1 cleanly, not a raw traceback.
+
+        A local index makes no request, so its failures are not HTTP errors.
+        Raises the local client's real error so the test tracks whatever type
+        a wheelhouse the process cannot list produces.
+        """
+        wheelhouse = tmp_path / "wheelhouse"
+        wheelhouse.mkdir()
+        (wheelhouse / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+
+        # A real chmod would not do: root ignores the mode bits and Windows
+        # has none.
+        real_iterdir = Path.iterdir
+
+        def denied(self: Path) -> Iterator[Path]:
+            if self == wheelhouse:
+                raise PermissionError(errno.EACCES, "Permission denied", str(self))
+            return real_iterdir(self)
+
+        monkeypatch.setattr(Path, "iterdir", denied)
+
+        client = LocalIndexClient(wheelhouse.as_uri())
+        with pytest.raises(UnreadableLocalIndexError) as caught:
+            asyncio.run(client.get_files("foo"))
+
+        pyproject = _make_pyproject(tmp_path)
+        with (
+            patch("nab.cli.resolve_for_targets", side_effect=caught.value),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject)
+
+        err = capsys.readouterr().err
+        assert "Permission denied" in err
         assert "Traceback" not in err
 
     def test_missing_sdist_exits(


### PR DESCRIPTION
An unreadable `file://` index, the kind you get from a wheelhouse copied with the wrong mode, fails differently on every interpreter: on Python 3.10 through 3.13 the `PermissionError` escapes `nab lock` as a traceback, and on 3.14 `Path.exists` swallows it so the package reads as absent. The layout probe now goes through `stat`, and a read the process is refused raises `UnreadableLocalIndexError`.

That error needed somewhere to live. `HttpError` had drifted into the label for any index failure, so a `file://` listing that never makes a request was already raising it. `IndexAccessError` is the root both backends fail through now, with `HttpError` and `LocalIndexError` under it.
