### PR TITLE
reject index metadata that declares a different Name or Version

### DIFF
--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -725,7 +725,7 @@ def await_metadata_batch(
 ) -> None:
     """Wait for all submitted metadata to arrive, then parse into cache."""
     # Imported lazily: provider.py imports this module.
-    from ..provider import IncompatiblePythonError
+    from ..provider import ForeignMetadataError, IncompatiblePythonError
 
     for version, ver_str, metadata_url, event in submitted:
         cache_key = (package, version)
@@ -759,12 +759,14 @@ def await_metadata_batch(
             ValueError,
             InvalidVersion,
             InvalidSpecifier,
+            ForeignMetadataError,
             IncompatiblePythonError,
             UnsupportedVcsError,
             NotImplementedError,
         ):
-            # Malformed metadata, a Python-incompatible Requires-Python, or a
-            # refused base direct-URL/VCS dep: leave the version un-cached so
+            # Malformed metadata, metadata declaring another release, a
+            # Python-incompatible Requires-Python, or a refused base
+            # direct-URL/VCS dep: leave the version un-cached so
             # get_dependencies re-raises at selection time instead of aborting
             # the speculative prefetch of a candidate the scan may never pick.
             continue

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -568,6 +568,8 @@ def parse_and_cache_metadata(
             package, version_str, metadata, metadata_text
         )
 
+    _reject_foreign_metadata(cache_key, metadata)
+
     if from_sdist and _sdist_deps_need_dynamic(
         metadata,
         trust_unverified=provider.effective_trust_unverified(
@@ -578,6 +580,37 @@ def parse_and_cache_metadata(
 
     _reject_incompatible_python(provider, cache_key, metadata)
     cache_deps_from_metadata(provider, cache_key, metadata)
+
+
+def _declares_served_release(
+    cache_key: tuple[str, Version], metadata: WheelMetadata
+) -> bool:
+    """Whether ``metadata`` claims the release the artifact was served as."""
+    package, version = cache_key
+    return canonicalize_name(metadata.name) == package and metadata.version == version
+
+
+def _reject_foreign_metadata(
+    cache_key: tuple[str, Version], metadata: WheelMetadata
+) -> None:
+    """Reject an index candidate whose METADATA declares a different release.
+
+    Nothing binds a :pep:`658` sidecar or an artifact's own METADATA fields
+    to the project and version it was served under.  Checked ahead of the
+    sdist reconciliation so a contradicting sdist is never built.
+    """
+    # Late import: ``provider`` imports this module at module load.
+    from ..provider import ForeignMetadataError
+
+    if _declares_served_release(cache_key, metadata):
+        return
+
+    package, version = cache_key
+    msg = (
+        f"{package} {version} metadata declares"
+        f" {metadata.name}=={metadata.version}, not {package}=={version}"
+    )
+    raise ForeignMetadataError(msg)
 
 
 def _reject_incompatible_python(
@@ -765,6 +798,7 @@ def _classify_requirement_uncached(
 
 def target_dep_signature(
     provider: Provider,
+    cache_key: tuple[str, Version],
     metadata: WheelMetadata,
 ) -> TargetDepSignature:
     """Project ``metadata`` to a target-effective dependency signature.
@@ -778,9 +812,10 @@ def target_dep_signature(
     the marker caches or ``consulted_markers``: see
     :func:`_classify_requirement_uncached`.
 
-    The per-package override is applied first, so a ``provides-extra`` override
-    is compared in the same view the resolver pins from.  A complete
-    ``dependencies`` override takes the skip-fetch path in
+    ``cache_key`` is the release the wheel was served as, not whatever the
+    wheel declares for itself.  The per-package override is applied first, so a
+    ``provides-extra`` override is compared in the same view the resolver pins
+    from.  A complete ``dependencies`` override takes the skip-fetch path in
     :meth:`nab_python.provider.Provider.get_dependencies` and never reaches
     here.  ``Requires-Python`` is left out: it gates admission, not the
     dependency edges a lock records.
@@ -793,7 +828,6 @@ def target_dep_signature(
     # Late import: ``provider`` imports this module at module load.
     from ..provider import _normalize_extra
 
-    cache_key = (canonicalize_name(metadata.name), metadata.version)
     metadata = effective_metadata(provider, cache_key, metadata)
     provided_extras = {_normalize_extra(e) for e in metadata.provides_extra}
     base_deps: dict[str, VersionRange] = {}
@@ -857,6 +891,7 @@ def check_sibling_metadata_divergence(
         return
 
     pick_key = None if tags is None else tags.wheel_rank(pick.filename)
+    sig_key = (normalized, version)
     pick_sig: TargetDepSignature | None = None
     for sibling in wheels:
         if sibling is pick or not _wheels_tie(tags, pick_key, sibling.filename):
@@ -867,8 +902,10 @@ def check_sibling_metadata_divergence(
         if sibling_metadata is None:
             continue
         if pick_sig is None:
-            pick_sig = target_dep_signature(provider, parse_metadata(pick_text))
-        sibling_sig = target_dep_signature(provider, sibling_metadata)
+            pick_sig = target_dep_signature(
+                provider, sig_key, parse_metadata(pick_text)
+            )
+        sibling_sig = target_dep_signature(provider, sig_key, sibling_metadata)
         if sibling_sig == pick_sig:
             continue
         labels = _divergent_dep_labels(pick_sig, sibling_sig)
@@ -890,12 +927,13 @@ def _tie_sibling_metadata(
 ) -> WheelMetadata | None:
     """Parse a resident tie sibling's own METADATA, or None to skip it.
 
-    Skipped when the text is not resident, does not parse, or its effective
-    Requires-Python excludes the target.  Tags rank by :pep:`425` and say
-    nothing about the Python floor, so a tie sibling can still declare a
-    Requires-Python an installer would reject for this target; comparing it
-    would false-crash a version an installer resolves fine.  A per-package
-    override wins over the parsed floor.
+    Skipped when the text is not resident, does not parse, declares a
+    different release, or its effective Requires-Python excludes the target.
+    Tags rank by :pep:`425` and say nothing about the Python floor, so a tie
+    sibling can still declare a Requires-Python an installer would reject for
+    this target, and a sibling declaring another release is no candidate for
+    this one at all; comparing either would false-crash a version an installer
+    resolves fine.  A per-package override wins over the parsed floor.
     """
     text = _resident_wheel_text(index, package, str(version), sibling)
     if text is None:
@@ -903,6 +941,8 @@ def _tie_sibling_metadata(
     try:
         metadata = parse_metadata(text)
     except ValueError:
+        return None
+    if not _declares_served_release((package, version), metadata):
         return None
     target = provider.target
     override_rp = provider.effective_requires_python(package, version)

--- a/nab-python/src/nab_python/_testing/coordinator_fake.py
+++ b/nab-python/src/nab_python/_testing/coordinator_fake.py
@@ -124,6 +124,7 @@ def _wire_sdist_side_effects(
     index: InMemoryIndex,
     *,
     sdist_pkg_info: str | None,
+    sdist_pkg_info_by_version: Mapping[str, str | None] | None,
     sdist_pyproject_toml: str | None,
 ) -> None:
     """Attach the ``request_sdist`` side effect."""
@@ -134,10 +135,16 @@ def _wire_sdist_side_effects(
         _url: str,
         _hashes: tuple[tuple[str, str], ...] = (),
     ) -> threading.Event:
+        pkg_info = (
+            sdist_pkg_info
+            if sdist_pkg_info_by_version is None
+            else sdist_pkg_info_by_version.get(ver)
+        )
+
         # ``store_sdist_metadata`` is always called; passing ``None``
         # poisons the cache slot, matching the original test_provider
         # helper's contract for sdist-fetch failures.
-        index.store_sdist_metadata(pkg, ver, sdist_pkg_info)
+        index.store_sdist_metadata(pkg, ver, pkg_info)
         if sdist_pyproject_toml is not None:
             index.store_sdist_pyproject(pkg, ver, sdist_pyproject_toml)
         return _done_event()
@@ -197,6 +204,7 @@ def make_coordinator(  # noqa: PLR0913 - one keyword per index slot a test pre-l
     metadata_by_url: Mapping[str, str | None] | None = None,
     auto_metadata: bool = False,
     sdist_pkg_info: str | None = None,
+    sdist_pkg_info_by_version: Mapping[str, str | None] | None = None,
     sdist_pyproject_toml: str | None = None,
     range_result: RangeMetadataResult | None = None,
     range_error: BaseException | None = None,
@@ -223,8 +231,9 @@ def make_coordinator(  # noqa: PLR0913 - one keyword per index slot a test pre-l
       slot, so the fetched-but-empty slot reads back the way it would in
       production.  ``metadata_by_url`` is how sibling wheels of one
       version are given different dependencies.
-    * ``request_sdist`` writes ``sdist_pkg_info`` and, if not ``None``,
-      ``sdist_pyproject_toml``.
+    * ``request_sdist`` writes ``sdist_pkg_info``, or the entry from
+      ``sdist_pkg_info_by_version`` when sdists of several versions each need
+      their own PKG-INFO, and, if not ``None``, ``sdist_pyproject_toml``.
     * ``request_range_metadata`` records the recovered METADATA (or an absent
       read when its text is ``None``), or lands ``range_error`` as a per-wheel
       metadata error.  ``range_by_url`` picks a result per wheel URL, so sibling
@@ -257,6 +266,7 @@ def make_coordinator(  # noqa: PLR0913 - one keyword per index slot a test pre-l
         coordinator,
         index,
         sdist_pkg_info=sdist_pkg_info,
+        sdist_pkg_info_by_version=sdist_pkg_info_by_version,
         sdist_pyproject_toml=sdist_pyproject_toml,
     )
     _wire_range_side_effects(

--- a/nab-python/src/nab_python/metadata.py
+++ b/nab-python/src/nab_python/metadata.py
@@ -159,6 +159,8 @@ def parse_metadata(data: str | bytes) -> WheelMetadata:
     if name is None:
         err = "METADATA missing required Name field"
         raise ValueError(err)
+    # RFC 822 makes the whitespace around a header value insignificant.
+    name = name.strip()
 
     version_str = msg.get("Version")
     if version_str is None:

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -63,6 +63,7 @@ __all__ = [
     "DistFile",
     "DistPolicy",
     "ExtrasMode",
+    "ForeignMetadataError",
     "IncompatiblePythonError",
     "InvalidUploadTimeError",
     "ListingFilterCache",
@@ -295,6 +296,16 @@ class UnsupportedSdistError(MetadataError):
     under :attr:`BuildPolicy.BUILD_REMOTE`.  Caught by
     :meth:`Provider._look_ahead_ok` so the resolver skips the
     version instead of failing.
+    """
+
+
+class ForeignMetadataError(MetadataError):
+    """An index candidate's METADATA declares a different release.
+
+    Core metadata ``Name`` and ``Version`` say which release an artifact is, so
+    a candidate whose METADATA (or :pep:`658` sidecar) names another project or
+    version describes some other release's dependencies.  Caught by
+    :meth:`Provider._look_ahead_ok` so the resolver skips the version.
     """
 
 
@@ -1960,9 +1971,9 @@ class Provider:
     ) -> None:
         """Parse fetched metadata, routing each failure to its own cache.
 
-        A disallowed build, a Python-incompatible candidate, and an unparseable
-        payload each record their own failure kind so a re-query is answered
-        from cache. Hard errors propagate unrecorded.
+        A disallowed build, a candidate ruled out by its own metadata, and an
+        unparseable payload each record their own failure kind so a re-query
+        is answered from cache. Hard errors propagate unrecorded.
         """
         package, version = cache_key
         from .config import OverrideConflictError  # noqa: PLC0415 (config import cycle)
@@ -1974,7 +1985,7 @@ class Provider:
         except UnsupportedSdistError:
             self._unsupported_sdists.add(cache_key)
             raise
-        except IncompatiblePythonError as exc:
+        except (ForeignMetadataError, IncompatiblePythonError) as exc:
             self._invalid_metadata[cache_key] = str(exc)
             raise
         except (

--- a/nab-python/tests/test_metadata.py
+++ b/nab-python/tests/test_metadata.py
@@ -29,6 +29,12 @@ def test_accepts_bytes_input() -> None:
     assert md.version == Version("1.0")
 
 
+def test_name_surrounding_whitespace_stripped() -> None:
+    """RFC 822 whitespace around ``Name`` is insignificant."""
+    md = parse_metadata("Metadata-Version: 2.1\nName:  foo \nVersion: 1.0\n")
+    assert md.name == "foo"
+
+
 def test_missing_name_raises() -> None:
     """Absent ``Name`` is a parser error, not a silent default."""
     text = "Metadata-Version: 2.1\nVersion: 1.0\n"

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -28,6 +28,7 @@ from nab_index.transport import HttpError
 from nab_python._provider import build_remote, metadata_resolver
 from nab_python._provider import listing as listing_mod
 from nab_python._provider.metadata_resolver import (
+    TargetDepSignature,
     add_classified_dep,
     cache_deps_from_metadata,
     classify_requirement,
@@ -54,6 +55,7 @@ from nab_python.provider import (
     BuildPolicy,
     DistPolicy,
     ExtrasMode,
+    ForeignMetadataError,
     IncompatiblePythonError,
     InvalidUploadTimeError,
     LocalSource,
@@ -1334,7 +1336,10 @@ class TestNoVersionsReasons:
         """
         coordinator = make_coordinator(
             [make_sdist("1.0"), make_sdist("2.0")],
-            sdist_pkg_info=PKG_INFO_DYNAMIC_DEPS,
+            sdist_pkg_info_by_version={
+                "1.0": PKG_INFO_DYNAMIC_DEPS,
+                "2.0": PKG_INFO_DYNAMIC_DEPS.replace("Version: 1.0", "Version: 2.0"),
+            },
             package="pkg",
         )
         provider = Provider(
@@ -2245,47 +2250,51 @@ class TestTargetDepSignature:
             provides_extra=list(provides_extra),
         )
 
+    def _sig(self, provider: Provider, metadata: WheelMetadata) -> TargetDepSignature:
+        """Project ``metadata`` under the release the wheel was served as."""
+        return target_dep_signature(provider, ("pkg", V("1.0")), metadata)
+
     def test_permuted_lines_equal(self) -> None:
         """Line order does not change the signature."""
         provider = self._provider()
         a = self._md(["foo>=1", "bar<2"])
         b = self._md(["bar<2", "foo>=1"])
-        assert target_dep_signature(provider, a) == target_dep_signature(provider, b)
+        assert self._sig(provider, a) == self._sig(provider, b)
 
     def test_specifier_spelling_equal(self) -> None:
         """Whitespace and specifier spelling normalize equal."""
         provider = self._provider()
         a = self._md(["foo>=1,<2"])
         b = self._md(["foo >= 1, < 2"])
-        assert target_dep_signature(provider, a) == target_dep_signature(provider, b)
+        assert self._sig(provider, a) == self._sig(provider, b)
 
     def test_target_equal_marker_equal(self) -> None:
         """Markers that evaluate the same for the target project equal."""
         provider = self._provider()
         a = self._md(['foo; python_version >= "3.0"'])
         b = self._md(['foo; python_version >= "3.5"'])
-        assert target_dep_signature(provider, a) == target_dep_signature(provider, b)
+        assert self._sig(provider, a) == self._sig(provider, b)
 
     def test_genuine_dep_difference_unequal(self) -> None:
         """A real base-dep range difference is unequal."""
         provider = self._provider()
         a = self._md(["foo>=1"])
         b = self._md(["foo>=2"])
-        assert target_dep_signature(provider, a) != target_dep_signature(provider, b)
+        assert self._sig(provider, a) != self._sig(provider, b)
 
     def test_extra_only_difference_unequal(self) -> None:
         """A difference confined to an extra-gated dep is unequal."""
         provider = self._provider()
         a = self._md(['foo; extra == "e"'], provides_extra=("e",))
         b = self._md(['foo>=2; extra == "e"'], provides_extra=("e",))
-        assert target_dep_signature(provider, a) != target_dep_signature(provider, b)
+        assert self._sig(provider, a) != self._sig(provider, b)
 
     def test_url_dep_only_difference_unequal(self) -> None:
         """A difference confined to a URL dep is unequal."""
         provider = self._provider()
         a = self._md(["foo @ https://example.com/a.whl"])
         b = self._md(["foo @ https://example.com/b.whl"])
-        assert target_dep_signature(provider, a) != target_dep_signature(provider, b)
+        assert self._sig(provider, a) != self._sig(provider, b)
 
     def test_requires_python_difference_folds(self) -> None:
         """A Requires-Python difference alone does not change the signature.
@@ -2297,27 +2306,25 @@ class TestTargetDepSignature:
         provider = self._provider()
         a = self._md(["foo"], requires_python=">=3.8")
         b = self._md(["foo"], requires_python=">=3.9")
-        assert target_dep_signature(provider, a) == target_dep_signature(provider, b)
+        assert self._sig(provider, a) == self._sig(provider, b)
 
     def test_marker_dropped_dep_absent(self) -> None:
         """A dep whose marker fails for the target is not projected."""
         provider = self._provider()
-        base_deps = target_dep_signature(
-            provider, self._md(['foo; python_version < "3.0"'])
-        )[0]
+        base_deps = self._sig(provider, self._md(['foo; python_version < "3.0"']))[0]
         assert base_deps == {}
 
     def test_duplicate_name_intersected(self) -> None:
         """A name on two base lines folds to the range intersection."""
         provider = self._provider()
-        base_deps = target_dep_signature(provider, self._md(["foo>=1", "foo<5"]))[0]
+        base_deps = self._sig(provider, self._md(["foo>=1", "foo<5"]))[0]
         assert V("3") in base_deps["foo"]
         assert V("6") not in base_deps["foo"]
 
     def test_extra_gated_url_dep_bucketed_by_extra(self) -> None:
         """An extra-gated URL dep buckets under its extra name."""
         provider = self._provider()
-        url_buckets = target_dep_signature(
+        url_buckets = self._sig(
             provider,
             self._md(
                 ['foo @ https://example.com/a.whl ; extra == "e"'],
@@ -2329,7 +2336,7 @@ class TestTargetDepSignature:
     def test_base_url_dep_bucketed(self) -> None:
         """A base URL dep buckets under the base key, not an extra."""
         provider = self._provider()
-        url_buckets = target_dep_signature(
+        url_buckets = self._sig(
             provider, self._md(["foo @ https://example.com/a.whl"])
         )[2]
         assert list(url_buckets) == [None]
@@ -2337,7 +2344,7 @@ class TestTargetDepSignature:
     def test_per_extra_dep_projected(self) -> None:
         """An extra-gated non-URL dep lands in the per-extra map."""
         provider = self._provider()
-        extra_map = target_dep_signature(
+        extra_map = self._sig(
             provider, self._md(['foo>=2; extra == "e"'], provides_extra=("e",))
         )[1]
         assert V("3") in extra_map["e"]["foo"]
@@ -2346,7 +2353,7 @@ class TestTargetDepSignature:
     def test_extra_marker_matches_only_named_extra(self) -> None:
         """An extra-gated dep lands only under the extras its marker matches."""
         provider = self._provider()
-        extra_map = target_dep_signature(
+        extra_map = self._sig(
             provider, self._md(['foo; extra == "e"'], provides_extra=("e", "f"))
         )[1]
         assert "foo" in extra_map["e"]
@@ -2367,7 +2374,7 @@ class TestTargetDepSignature:
         )
         a = self._md(['foo; extra == "e"'], provides_extra=("e",))
         b = self._md(['foo; extra == "e"'], provides_extra=("e", "f"))
-        assert target_dep_signature(provider, a) == target_dep_signature(provider, b)
+        assert self._sig(provider, a) == self._sig(provider, b)
 
 
 class TestLocalSources:
@@ -4479,6 +4486,95 @@ class TestRequiresPythonMetadataGate:
         assert provider.has_invalid_metadata("foo", V("2.0"))
 
 
+class TestForeignMetadataGate:
+    """An index candidate's METADATA must declare the release it was served as.
+
+    Otherwise a wheel (or its :pep:`658` sidecar) naming another release
+    supplies that release's dependencies as the served candidate's.
+    """
+
+    @staticmethod
+    def _coordinator(name: str, version: str = "1.0") -> MagicMock:
+        return make_coordinator(
+            [make_wheel("1.0")],
+            package="foo",
+            metadata_text=(
+                f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n"
+                "Requires-Dist: leftpad\n\n"
+            ),
+        )
+
+    def test_rejects_foreign_name(self) -> None:
+        provider = Provider(self._coordinator("bar"), target=_PY312)
+        with pytest.raises(ForeignMetadataError, match="declares bar==1.0"):
+            provider.get_dependencies("foo", V("1.0"))
+
+    def test_rejects_foreign_version(self) -> None:
+        provider = Provider(self._coordinator("foo", "99.0"), target=_PY312)
+        with pytest.raises(ForeignMetadataError, match="declares foo==99.0"):
+            provider.get_dependencies("foo", V("1.0"))
+
+    def test_foreign_name_deps_never_cached(self) -> None:
+        provider = Provider(self._coordinator("bar"), target=_PY312)
+        with pytest.raises(ForeignMetadataError):
+            provider.get_dependencies("foo", V("1.0"))
+        assert ("foo", V("1.0")) not in provider.deps_cache
+        assert ("foo", V("1.0")) not in provider.metadata_cache
+        assert provider.has_invalid_metadata("foo", V("1.0"))
+        with pytest.raises(MetadataError, match="declares bar==1.0"):
+            provider.get_dependencies("foo", V("1.0"))
+
+    def test_admits_equivalent_spelling(self) -> None:
+        """Case, separator, whitespace, and zero-padding differences still match."""
+        coordinator = make_coordinator(
+            [make_wheel("1.0")],
+            package="foo-bar",
+            metadata_text=(
+                "Metadata-Version: 2.1\nName:  Foo_Bar \nVersion: 1.0.0\n"
+                "Requires-Dist: leftpad\n\n"
+            ),
+        )
+        provider = Provider(coordinator, target=_PY312)
+        assert "leftpad" in provider.get_dependencies("foo-bar", V("1.0"))
+
+    def test_rejects_foreign_name_from_sdist_pkg_info(self) -> None:
+        coordinator = make_coordinator(
+            [make_sdist("1.0")],
+            package="foo",
+            sdist_pkg_info=(
+                "Metadata-Version: 2.2\nName: bar\nVersion: 1.0\n"
+                "Requires-Dist: leftpad\n"
+            ),
+        )
+        provider = Provider(coordinator, target=_PY312, build_policy=BuildPolicy.NEVER)
+        with pytest.raises(ForeignMetadataError, match="declares bar==1.0"):
+            provider.get_dependencies("foo", V("1.0"))
+
+    def test_prefetch_batch_continues_past_foreign_metadata(self) -> None:
+        """A rejected candidate the scan may never pick does not abort the batch."""
+
+        def _meta(name: str, version: str) -> str:
+            return f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n\n"
+
+        coordinator = make_coordinator(
+            [make_wheel("3.0"), make_wheel("2.0"), make_wheel("1.0")],
+            metadata_by_version={
+                "3.0": _meta("bar", "3.0"),
+                "2.0": _meta("foo", "9.0"),
+                "1.0": _meta("foo", "1.0"),
+            },
+            package="foo",
+        )
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            root_requirements={"foo": VersionRange.full()},
+        )
+        assert provider.choose_version("foo", VersionRange.full()) == V("1.0")
+        assert ("foo", V("3.0")) not in provider.deps_cache
+        assert ("foo", V("2.0")) not in provider.deps_cache
+
+
 class TestSkipFetch:
     """A complete ``dependencies`` override skips the metadata fetch/build."""
 
@@ -5097,7 +5193,12 @@ class TestExtras:
         """choose_version for extras returns the base's best version."""
         wheels = [make_wheel("2.0"), make_wheel("1.0")]
         coordinator = make_coordinator(
-            wheels, metadata_text=EXTRA_METADATA, package="foo"
+            wheels,
+            metadata_by_version={
+                "2.0": EXTRA_METADATA.replace("Version: 1.0", "Version: 2.0"),
+                "1.0": EXTRA_METADATA,
+            },
+            package="foo",
         )
         provider = Provider(coordinator)
         spec = SpecifierSet("")
@@ -8031,7 +8132,11 @@ class TestStaticSdistMetadata:
             url: str,
             hashes: tuple[tuple[str, str], ...] = (),
         ) -> threading.Event:
-            coordinator.index.store_sdist_metadata(pkg, ver, PKG_INFO_DYNAMIC_DEPS)
+            coordinator.index.store_sdist_metadata(
+                pkg,
+                ver,
+                PKG_INFO_DYNAMIC_DEPS.replace("Version: 1.0", f"Version: {ver}"),
+            )
             coordinator.index.store_sdist_pyproject(pkg, ver, None)
             return _done_event()
 
@@ -8525,7 +8630,9 @@ class TestExtrasInvalidMetadata:
         coordinator = make_coordinator(
             dists,
             metadata_by_version={"1.0": EXTRA_METADATA},
-            sdist_pkg_info=PRE_22_SDIST_PKG_INFO,
+            sdist_pkg_info=PRE_22_SDIST_PKG_INFO.replace(
+                "Name: pkg\nVersion: 1.0", "Name: foo\nVersion: 2.0"
+            ),
             package="foo",
         )
         provider = Provider(
@@ -8934,6 +9041,29 @@ class TestSiblingMetadataDivergence:
         message = str(exc.value)
         assert "alpha" in message
         assert "beta" in message
+
+    def test_foreign_named_sibling_skipped(self) -> None:
+        """A tie sibling declaring another project is not compared at all.
+
+        Its deps differ, but it is not a candidate for pkg 1.0, so the pick's
+        deps stand instead of aborting the resolve.
+        """
+        wheel_a = _sib_wheel("py2.py3-none-any")
+        wheel_b = _sib_wheel("py3-none-any")
+        coordinator = make_coordinator([wheel_a, wheel_b], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _sib_meta("alpha>=1"), wheel_a.metadata_url
+        )
+        coordinator.index.store_metadata(
+            "pkg",
+            "1.0",
+            _sib_meta("beta>=1").replace("Name: pkg", "Name: other"),
+            wheel_b.metadata_url,
+        )
+        provider = Provider(coordinator, target=_LINUX311)
+        deps = provider.get_dependencies("pkg", self._V)
+        assert "alpha" in deps
+        assert "beta" not in deps
 
     def test_absent_sibling_text_skipped(self) -> None:
         """A tie sibling with no resident text is skipped, not fetched."""


### PR DESCRIPTION
nab never checked that a wheel's METADATA, or its PEP 658 sidecar, matches the project and version the index served it under. A wheel served as foo 1.0 whose METADATA says `Name: bar` supplied bar's requirements as foo 1.0's, and the resolve used them to produce a lock pip refuses to install. pip and uv both reject that candidate.

`parse_and_cache_metadata` now rejects a candidate whose Name does not canonicalize to the requested project, or whose Version is not the requested one, the same pair the built-sdist path already checked. It runs ahead of the sdist reconciliation, so a contradicting sdist is never built, and a tie sibling declaring another release is skipped rather than reported as a dependency divergence. Equivalent spellings still match, so `Foo_Bar` 1.0.0 served as foo-bar 1.0 is fine.

`parse_metadata` also strips whitespace around Name, which RFC 822 treats as insignificant.
