### PR TITLE
Render full-coverage ranges as all versions

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -1879,6 +1879,11 @@ class Provider:
     ) -> RangeProtocol[Version]:
         """Map a possibly-widened ``constraint`` back onto listed versions.
 
+        A constraint containing every listed version is promoted to the full
+        range rather than snapped, so it reads as "any version".  An empty
+        universe never promotes: that would widen a constraint no version
+        satisfies.
+
         Render-time only and cache-only: the ROOT sentinel (a non-str
         package) and packages whose listing is not cached return
         ``constraint`` unchanged, and nothing is ever fetched.
@@ -1890,9 +1895,14 @@ class Provider:
         if version_list is None:
             return constraint
         assert isinstance(constraint, VersionRange)
-        return constraint.snap_bounds(
-            self._ascending_versions(normalized, version_list)
-        )
+        universe = self._ascending_versions(normalized, version_list)
+        if (
+            universe
+            and universe[-1] in constraint
+            and all(version in constraint for version in universe)
+        ):
+            return VersionRange.full(admit_arbitrary=False)
+        return constraint.snap_bounds(universe)
 
     def get_dependencies(
         self, package: str, version: Version

--- a/nab-python/tests/test_widen_decision.py
+++ b/nab-python/tests/test_widen_decision.py
@@ -177,6 +177,48 @@ class TestNarrowForDisplay:
         constraint = SpecifierSet(">=1,<2").to_range()
         assert provider.narrow_for_display("ghost", constraint) is constraint
 
+    def test_full_coverage_promotes_to_full_range(self) -> None:
+        provider = _listing_provider("p", ["3.0", "2.0", "1.0"])
+        constraint = SpecifierSet(">=0.5,<9").to_range()
+        assert provider.narrow_for_display("p", constraint) == VersionRange.full(
+            admit_arbitrary=False
+        )
+
+    def test_multi_segment_full_coverage_promotes(self) -> None:
+        """A hole between listed versions still covers the whole listing."""
+        provider = _listing_provider("p", ["3.0", "2.0", "1.0"])
+        constraint = SpecifierSet(">=0.5,<9,!=2.5").to_range()
+        assert provider.narrow_for_display("p", constraint) == VersionRange.full(
+            admit_arbitrary=False
+        )
+
+    def test_excluded_middle_version_does_not_promote(self) -> None:
+        provider = _listing_provider("p", ["3.0", "2.0", "1.0"])
+        constraint = SpecifierSet(">=0.5,<9,!=2.0").to_range()
+        narrowed = provider.narrow_for_display("p", constraint)
+        assert V("1.0") in narrowed
+        assert V("2.0") not in narrowed
+        assert V("3.0") in narrowed
+        assert V("9.5") not in narrowed
+
+    def test_excluded_top_version_does_not_promote(self) -> None:
+        provider = _listing_provider("p", ["3.0", "2.0", "1.0"])
+        narrowed = provider.narrow_for_display("p", SpecifierSet("<3.0").to_range())
+        assert V("2.0") in narrowed
+        assert V("3.0") not in narrowed
+
+    def test_excluded_bottom_version_does_not_promote(self) -> None:
+        provider = _listing_provider("p", ["3.0", "2.0", "1.0"])
+        narrowed = provider.narrow_for_display("p", SpecifierSet(">1.0").to_range())
+        assert V("1.0") not in narrowed
+        assert V("3.0") in narrowed
+
+    def test_empty_universe_does_not_promote(self) -> None:
+        provider = _listing_provider("p", ["1.0"])
+        provider.versions_cache["empty"] = []
+        constraint = SpecifierSet(">=1,<2").to_range()
+        assert provider.narrow_for_display("empty", constraint) == constraint
+
     def test_never_triggers_a_fetch(self) -> None:
         coordinator = _graph_coordinator({"p": {"3.0": [], "2.0": [], "1.0": []}})
         provider = Provider(coordinator, target=ResolveTarget.for_host_python("3.12.0"))

--- a/nab-python/tests/test_widen_decision.py
+++ b/nab-python/tests/test_widen_decision.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 from nab_index.client import WheelFile
 from nab_python._packaging_provider import PackagingProvider
 from nab_python._testing.coordinator_fake import make_coordinator
@@ -25,7 +27,7 @@ from nab_python.provider import (
     VcsSource,
 )
 from nab_python.target import ResolveTarget
-from nab_resolver.resolver import Resolver
+from nab_resolver.resolver import ResolutionError, Resolver
 from nab_resolver.root import ROOT
 
 if TYPE_CHECKING:
@@ -218,6 +220,52 @@ class TestNarrowForDisplay:
         provider.versions_cache["empty"] = []
         constraint = SpecifierSet(">=1,<2").to_range()
         assert provider.narrow_for_display("empty", constraint) == constraint
+
+    def test_availability_line_keeps_its_range(self) -> None:
+        """``a`` is rejected only against pinned ``c``, so the line keeps its range."""
+        coordinator = _graph_coordinator(
+            {
+                "a": {"2.0": ["c==1.0"], "1.0": ["c==1.0"]},
+                "c": {"5.0": [], "1.0": []},
+            }
+        )
+        root_reqs = {
+            "a": SpecifierSet(">=1,<9").to_range(),
+            "c": SpecifierSet("==5.0").to_range(),
+        }
+        provider = Provider(
+            coordinator,
+            target=ResolveTarget.for_host_python("3.12.0"),
+            root_requirements=root_reqs,
+        )
+        resolver = Resolver(provider, range_type=VersionRange, root_version="0")
+        with pytest.raises(ResolutionError) as exc_info:
+            resolver.resolve(dict(root_reqs))
+
+        expected = f"because no versions of a {root_reqs['a']} are available"
+        assert expected in str(exc_info.value).splitlines()
+
+    def test_promoted_parent_reads_as_all_versions(self) -> None:
+        """A promoted depending side takes the plural prose and verb."""
+        coordinator = _graph_coordinator(
+            {
+                "a": {"2.0": ["c>=2"], "1.0": ["c>=2"]},
+                "c": {"1.0": []},
+            }
+        )
+        root_reqs = {"a": SpecifierSet(">=1,<9").to_range()}
+        provider = Provider(
+            coordinator,
+            target=ResolveTarget.for_host_python("3.12.0"),
+            root_requirements=root_reqs,
+        )
+        resolver = Resolver(provider, range_type=VersionRange, root_version="0")
+        with pytest.raises(ResolutionError) as exc_info:
+            resolver.resolve(dict(root_reqs))
+
+        lines = str(exc_info.value).splitlines()
+        assert lines[0].startswith("because all versions of a depend on c ")
+        assert "so all versions of a" in lines
 
     def test_never_triggers_a_fetch(self) -> None:
         coordinator = _graph_coordinator({"p": {"3.0": [], "2.0": [], "1.0": []}})

--- a/nab-resolver/src/nab_resolver/report.py
+++ b/nab-resolver/src/nab_resolver/report.py
@@ -37,8 +37,10 @@ def format_error(
 
     ``narrow`` maps ``(package, constraint)`` to a display constraint and is
     applied to originally-positive terms only; a negative dependency-side
-    term renders as requested even when displayed negated.  Narrowing
-    happens at render time only, never mutating the derivation tree.
+    term renders as requested even when displayed negated.  On a
+    ``NO_VERSIONS`` line a narrowing to the full range is ignored, since the
+    range is what keeps the sentence true.  Narrowing happens at render time
+    only, never mutating the derivation tree.
     """
     lines: list[str] = []
     explain_incompatibility(root_incompatibility, lines, set(), narrow)
@@ -48,6 +50,12 @@ def format_error(
 # DEPENDENCY/ROOT clauses always have two terms (parent + dependency);
 # synthetic single-term test clauses fall through to the prefix renderer.
 _ATTRIBUTION_CLAUSE_TERMS = 2
+
+# Prefixes that name the package themselves ("no versions of a"), so their
+# terms render as requirements.
+_REQUIREMENT_PREFIX_CAUSES = frozenset(
+    {IncompatibilityCause.ROOT, IncompatibilityCause.NO_VERSIONS}
+)
 
 
 def explain_incompatibility(
@@ -84,11 +92,20 @@ def explain_incompatibility(
                 stack.append((node.cause_left, False))
 
 
-def _narrow_positive(term: Term[Any, Any], narrow: _NarrowFn) -> Term[Any, Any]:
-    """Return ``term`` with a narrowed constraint when originally positive."""
+def _narrow_positive(
+    term: Term[Any, Any], narrow: _NarrowFn, *, allow_full: bool
+) -> Term[Any, Any]:
+    """Return ``term`` with a narrowed constraint when originally positive.
+
+    Unless ``allow_full``, a narrowing to the full range is refused and the
+    term renders as requested.
+    """
     if not term.is_positive():
         return term
-    return Term(term.package, narrow(term.package, term.constraint), positive=True)
+    shown = Term(term.package, narrow(term.package, term.constraint), positive=True)
+    if allow_full or not _is_full(shown):
+        return shown
+    return term
 
 
 def _render_line(
@@ -99,7 +116,12 @@ def _render_line(
     cause = incompatibility.cause
     terms = incompatibility.terms
     if narrow is not None:
-        terms = [_narrow_positive(term, narrow) for term in terms]
+        # Without its range the line would claim the package has no versions
+        # at all, not that the ones it has were rejected here.
+        allow_full = cause is not IncompatibilityCause.NO_VERSIONS
+        terms = [
+            _narrow_positive(term, narrow, allow_full=allow_full) for term in terms
+        ]
 
     # Attribution form for the two standard two-term clauses.
     if (
@@ -107,18 +129,23 @@ def _render_line(
         and len(terms) == _ATTRIBUTION_CLAUSE_TERMS
     ):
         parent, dep = terms
+        plural = _is_full(parent)
         # A negative dep term holds the parent's required range (negate to
         # show it); a positive dep term holds a version the parent forbids.
         if dep.is_positive():
+            verb = "are" if plural else "is"
             return (
-                f"because {format_term(parent)} is incompatible with {format_term(dep)}"
+                f"because {format_term(parent)} {verb} incompatible with "
+                f"{format_term(dep)}"
             )
-        return f"because {format_term(parent)} depends on {format_term(dep.negate())}"
+        verb = "depend on" if plural else "depends on"
+        requirement = _format_requirement(dep.negate())
+        return f"because {format_term(parent)} {verb} {requirement}"
 
     if cause is IncompatibilityCause.ROOT and len(terms) == _ATTRIBUTION_CLAUSE_TERMS:
         _, dep = terms
         positive_dep = dep if dep.is_positive() else dep.negate()
-        return f"because your project depends on {format_term(positive_dep)}"
+        return f"because your project depends on {_format_requirement(positive_dep)}"
 
     if cause is IncompatibilityCause.CONSTRAINT:
         (term,) = terms
@@ -133,15 +160,37 @@ def _render_line(
         IncompatibilityCause.NO_VERSIONS: "because no versions of",
         IncompatibilityCause.DERIVED: "so",
     }.get(cause, "")
-    body = " and ".join(format_term(term) for term in terms)
+    render = _format_requirement if cause in _REQUIREMENT_PREFIX_CAUSES else format_term
+    body = " and ".join(render(term) for term in terms)
 
     if cause is IncompatibilityCause.NO_VERSIONS:
         return f"{prefix} {body} are available"
     return f"{prefix} {body}"
 
 
+def _is_full(term: Term[Any, Any]) -> bool:
+    """Return whether ``term`` is positive over a range with an empty complement."""
+    return term.is_positive() and (~term.constraint).is_empty
+
+
+def _format_requirement(term: Term[Any, Any]) -> str:
+    """Render a term in object position ("depends on b").
+
+    A full term there is the package name alone.
+    """
+    if _is_full(term):
+        return str(term.package)
+    return format_term(term)
+
+
 def format_term(term: Term[Any, Any]) -> str:
-    """Render a single term as ``[not ]package range``."""
+    """Render a single term as ``[not ]package range``.
+
+    A full term reads as "all versions of package"; :func:`_format_requirement`
+    renders the object form.
+    """
+    if _is_full(term):
+        return f"all versions of {term.package}"
     sign = "" if term.is_positive() else "not "
     return f"{sign}{term.package} {term.constraint}"
 

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -1855,6 +1855,109 @@ class TestErrorMessages:
         assert positive == "a [1, +inf)"
         assert negative == "not a [1, +inf)"
 
+
+class TestFullRangeWording:
+    """A term admitting every version reads as prose, not as an interval.
+
+    The wording depends on where in the sentence the term sits.
+    """
+
+    def test_format_term_renders_a_full_positive_term_as_all_versions(self) -> None:
+        assert (
+            format_term(Term("a", Range.full(), positive=True)) == "all versions of a"
+        )
+
+    def test_format_term_keeps_the_range_on_a_full_negative_term(self) -> None:
+        """A negated full term is not "all versions"; it excludes them all."""
+        assert format_term(Term("a", Range.full(), positive=False)) == "not a *"
+
+    def test_a_gapless_union_reads_as_full(self) -> None:
+        """A union whose parts meet admits every version."""
+        gapless = Range.less_than(3) | Range.at_least(3)
+        assert format_term(Term("a", gapless, positive=True)) == "all versions of a"
+
+    def test_no_versions_clause_drops_the_range(self) -> None:
+        clause = Incompatibility(
+            [Term("qux", Range.full(), positive=True)],
+            cause=IncompatibilityCause.NO_VERSIONS,
+        )
+        assert format_error(clause) == "because no versions of qux are available"
+
+    def test_root_requires_clause_drops_the_range(self) -> None:
+        """The prefix form, reached by a ROOT clause that is not the two-term one."""
+        clause = Incompatibility(
+            [Term("baz", Range.full(), positive=True)],
+            cause=IncompatibilityCause.ROOT,
+        )
+        assert format_error(clause) == "because root requires baz"
+
+    def test_project_dependency_clause_drops_the_range(self) -> None:
+        clause = Incompatibility(
+            [
+                Term("root", Range.singleton(0), positive=True),
+                Term("baz", Range.full(), positive=False),
+            ],
+            cause=IncompatibilityCause.ROOT,
+        )
+        assert format_error(clause) == "because your project depends on baz"
+
+    def test_dependency_side_drops_the_range(self) -> None:
+        clause = Incompatibility(
+            [
+                Term("foo", Range.singleton(2), positive=True),
+                Term("bar", Range.full(), positive=False),
+            ],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+        assert format_error(clause) == "because foo 2 depends on bar"
+
+    def test_full_parent_takes_a_plural_verb(self) -> None:
+        clause = Incompatibility(
+            [
+                Term("foo", Range.full(), positive=True),
+                Term("bar", Range.at_least(3), positive=False),
+            ],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+        assert format_error(clause) == (
+            "because all versions of foo depend on bar [3, +inf)"
+        )
+
+    def test_full_parent_takes_a_plural_verb_on_the_incompatible_form(self) -> None:
+        clause = Incompatibility(
+            [
+                Term("app", Range.full(), positive=True),
+                Term("lib", Range.singleton(9), positive=True),
+            ],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+        assert format_error(clause) == (
+            "because all versions of app are incompatible with lib 9"
+        )
+
+    def test_full_blocker_keeps_the_all_versions_form(self) -> None:
+        """The blocker is not a requirement, so it keeps the subject wording."""
+        clause = Incompatibility(
+            [
+                Term("app", Range.singleton(3), positive=True),
+                Term("lib", Range.full(), positive=True),
+            ],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+        assert format_error(clause) == (
+            "because app 3 is incompatible with all versions of lib"
+        )
+
+    def test_derived_clause_keeps_the_all_versions_form(self) -> None:
+        clause = Incompatibility(
+            [
+                Term("a", Range.full(), positive=True),
+                Term("b", Range.between(1, 9), positive=False),
+            ],
+            cause=IncompatibilityCause.DERIVED,
+        )
+        assert format_error(clause) == "so all versions of a and not b [1, 9)"
+
     def test_derivation_deeper_than_the_recursion_limit_renders(self) -> None:
         """A chain longer than the recursion limit renders instead of overflowing."""
         depth = sys.getrecursionlimit() + 100
@@ -2119,7 +2222,7 @@ class TestConstraints:
             )
         message = str(exc_info.value)
         assert "the user constrained" not in message
-        assert "no versions of foo * are available" in message
+        assert "no versions of foo are available" in message
 
     def test_out_of_range_version_not_blamed_on_constraint(self) -> None:
         """foo publishes only v5 but is required ``>= 10``. A ``!= 50``

--- a/nab-resolver/tests/test_widen_hook.py
+++ b/nab-resolver/tests/test_widen_hook.py
@@ -289,6 +289,23 @@ class TestFormatErrorNarrow:
         )
         assert message == "because no versions of qux 7 are available"
 
+    def test_no_versions_term_is_not_narrowed_to_full(self) -> None:
+        """Without the range the line would claim qux has no versions at all."""
+        clause = Incompatibility(
+            [Term("qux", Range.at_least(5), positive=True)],
+            cause=IncompatibilityCause.NO_VERSIONS,
+        )
+        message = format_error(clause, narrow=lambda package, constraint: Range.full())
+        assert message == "because no versions of qux [5, +inf) are available"
+
+    def test_other_causes_accept_a_narrowing_to_full(self) -> None:
+        clause = Incompatibility(
+            [Term("a", Range.between(1, 9), positive=True)],
+            cause=IncompatibilityCause.DERIVED,
+        )
+        message = format_error(clause, narrow=lambda package, constraint: Range.full())
+        assert message == "so all versions of a"
+
     def test_narrow_applies_to_derived_positive_terms(self) -> None:
         clause = Incompatibility(
             [
@@ -318,7 +335,8 @@ class TestFormatErrorNarrow:
             resolver.resolve({"root": Range.singleton(1)})
         message = str(exc_info.value)
         assert "because no versions of foo [5, 7) are available" in message
-        assert "depends on foo *" in message
+        # Pinned as a whole line: a narrowed dep side would print [5, 7).
+        assert "because root 1 depends on foo" in message.splitlines()
         assert provider.narrow_calls
 
     def test_identity_narrow_keeps_message_byte_identical(self) -> None:
@@ -329,8 +347,8 @@ class TestFormatErrorNarrow:
         with pytest.raises(ResolutionError) as exc_info:
             resolver.resolve({"root": Range.singleton(1)})
         assert str(exc_info.value) == (
-            "because no versions of foo * are available\n"
-            "because root 1 depends on foo *\n"
+            "because no versions of foo are available\n"
+            "because root 1 depends on foo\n"
             "so root 1\n"
             "because your project depends on root 1\n"
             "so <root> 1"


### PR DESCRIPTION
A term that admits every version of a package now reads as prose rather than as an interval:

```diff
-because a <VersionRange '(-inf, +inf)'> depends on c <VersionRange '[2, +inf)'>
+because all versions of a depend on c <VersionRange '[2, +inf)'>
```

This matches uv, which promotes a display range covering every known version of a package to the full range before rendering. The interval it replaces is the absence of a constraint, not one the resolver had to satisfy, so printing it invites the reader to look for a bound that was never there.

The promotion happens in `Provider.narrow_for_display`, which runs at render time and reads caches only, so no solver state and no derivation tree changes. One position keeps its range: the availability line, where dropping the range would claim a package has no versions at all when its versions were rejected only against the rest of the solution.
