### PR TITLE
Widen look-ahead pending clause terms

### DIFF
--- a/nab-python/src/nab_python/_provider/extras.py
+++ b/nab-python/src/nab_python/_provider/extras.py
@@ -162,8 +162,8 @@ def _record_base_range_blocks(
 ) -> None:
     """Push binary clauses for proxy candidates filtered by base's range.
 
-    Each excluded version V records ``{proxy_pkg == V, base ==
-    base_decision}`` (or the range-block analogue) impossible.
+    Each excluded version V records ``proxy_pkg`` at V with ``base`` at
+    ``base_decision`` (or the range-block analogue) impossible.
     Without these, the resolver only sees a single-term NO_VERSIONS
     clause for the proxy and cannot connect the proxy's
     unsatisfiability to the base decision that caused it; with them,
@@ -173,7 +173,8 @@ def _record_base_range_blocks(
     populates it when ``base_range`` is set, so the range-block path
     always has a target to record against.  When the resolver has
     already decided the base, recording against the decision is
-    tighter (a singleton blocker) than recording against the range.
+    tighter (the blocker names one selectable version) than recording
+    against the range.
     """
     # Late import: ``lookahead`` shares state with this module
     # through ``provider`` and importing it at module load creates a cycle.

--- a/nab-python/src/nab_python/_provider/lookahead.py
+++ b/nab-python/src/nab_python/_provider/lookahead.py
@@ -3,8 +3,10 @@
 Owns ``_look_ahead_ok`` and the pending-block tables that record
 "this candidate is incompatible with this decision/positive range"
 rejections.  Each rejection becomes a grouped binary
-incompatibility (``{candidate range, decision==w}``) when
+incompatibility (``{candidate range, blocker range}``) when
 ``flush_pending_blocks`` runs at the end of ``choose_version``.
+Version-derived terms are widened onto the listing's gaps, which
+leaves the selectable versions they name unchanged.
 """
 
 from __future__ import annotations
@@ -98,15 +100,26 @@ def look_ahead_ok(
     return True
 
 
+def _widen_or_singleton(
+    provider: Provider, package: str, version: Version
+) -> VersionRange:
+    """Return ``version``'s widened gap, or its singleton without one."""
+    widened = provider.widen_decision(package, version)
+    return VersionRange.singleton(version) if widened is None else widened
+
+
 def flush_pending_blocks(provider: Provider) -> None:
     """Convert queued rejections into grouped binary incompatibilities.
 
     For each ``(candidate_pkg, blocker_pkg, blocker_version)`` group we add
-    ``{candidate_pkg in {v1,v2,...}, blocker_pkg==w}``.  Sound across
-    backjumps because the blocker term goes UNDETERMINED when the supporting
-    decision is reverted, so the candidate range can be reconsidered.
+    ``{candidate_pkg in {v1,v2,...}, blocker_pkg==w}``, with each version
+    widened through ``widen_decision``: a version's open neighbor gap holds
+    no other listed version, so adjacent gaps coalesce without changing which
+    versions the clause names.  Sound across backjumps because the blocker
+    term goes UNDETERMINED when the supporting decision is reverted, so the
+    candidate range can be reconsidered.
     """
-    # Decision-keyed rejections: pin the blocker to one exact version.
+    # Decision-keyed rejections: the blocker term names one selectable version.
     for (
         candidate_pkg,
         blocker_pkg,
@@ -114,14 +127,14 @@ def flush_pending_blocks(provider: Provider) -> None:
     ), versions in provider.pending_blocks.items():
         range_union = VersionRange.empty()
         for v in versions:
-            range_union = range_union | VersionRange.singleton(v)
+            range_union = range_union | _widen_or_singleton(provider, candidate_pkg, v)
         provider.pending_clauses.append(
             Incompatibility(
                 [
                     Term(candidate_pkg, range_union, positive=True),
                     Term(
                         blocker_pkg,
-                        VersionRange.singleton(blocker_version),
+                        _widen_or_singleton(provider, blocker_pkg, blocker_version),
                         positive=True,
                     ),
                 ],
@@ -138,7 +151,7 @@ def flush_pending_blocks(provider: Provider) -> None:
     ), versions in provider.pending_range_blocks.items():
         range_union = VersionRange.empty()
         for v in versions:
-            range_union = range_union | VersionRange.singleton(v)
+            range_union = range_union | _widen_or_singleton(provider, candidate_pkg, v)
         provider.pending_clauses.append(
             Incompatibility(
                 [

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -446,6 +446,9 @@ def _source_root(
 # a hang.
 _MAX_MICRO_SPLIT_PASSES = 10
 
+# Terms in a look-ahead grouped clause.
+_GROUPED_CLAUSE_TERMS = 2
+
 
 def _resolve_with_micro_narrowing(
     targets: Sequence[ResolveTarget],
@@ -1538,13 +1541,18 @@ def _raise_for_source_python(
 
 
 def _augment_resolution_error(exc: ResolutionError, provider: Provider) -> None:
-    """Append per-package NO_VERSIONS diagnostics to ``exc`` in-place.
+    """Append per-package no-versions diagnostics to ``exc`` in-place.
 
-    Walks the derivation tree carried on the exception, collects
-    every package that appears in a NO_VERSIONS clause, and looks up
-    the provider-side reason for each.  When at least one reason is
-    available, rewrites the exception's args so that ``str(exc)``
-    surfaces the diagnostics alongside the original derivation tree.
+    Walks the derivation tree carried on the exception, collects every
+    package a rejection clause names (see
+    :func:`_walk_no_versions_packages`), and looks up the provider-side
+    reason for each.  When at least one reason is available, rewrites the
+    exception's args so that ``str(exc)`` surfaces the diagnostics
+    alongside the original derivation tree.
+
+    Best-effort: reasons are keyed by package name and outlive the ask
+    that recorded them, so a package whose earlier ask found no version
+    keeps its hint even when the tree names it over a later range.
     """
     if exc.incompatibility is None:
         return
@@ -1570,7 +1578,13 @@ def _augment_resolution_error(exc: ResolutionError, provider: Provider) -> None:
 def _walk_no_versions_packages(
     incompatibility: Incompatibility[Any, Any],
 ) -> list[str]:
-    """Return package names from every NO_VERSIONS clause in the tree.
+    """Return the packages a no-versions diagnostic may name.
+
+    NO_VERSIONS clauses name every package they carry.  Look-ahead grouped
+    clauses (DEPENDENCY cause, two positive terms) name their candidate: a
+    widened union covering the whole listing conflicts by propagation, with
+    no second ``choose_version`` ask to raise a NO_VERSIONS clause.  The
+    caller drops packages with no recorded reason.
 
     The walk is iterative: the tree gains a level per conflict, so a deeply
     backtracked resolve overflows the recursion limit.
@@ -1590,6 +1604,15 @@ def _walk_no_versions_packages(
                 pkg = term.package
                 if isinstance(pkg, str):
                     out.append(pkg)
+        elif (
+            node.cause is IncompatibilityCause.DEPENDENCY
+            and len(node.terms) == _GROUPED_CLAUSE_TERMS
+            and node.terms[0].is_positive()
+            and node.terms[1].is_positive()
+        ):
+            pkg = node.terms[0].package
+            if isinstance(pkg, str):
+                out.append(pkg)
 
         # Right before left, so the left cause pops first and names keep their order.
         if node.cause_right is not None:

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -3152,6 +3152,102 @@ class TestDecisionLookAhead:
         terms = clauses[0].terms
         assert {t.package for t in terms} == {"foo", "bar"}
 
+    def test_flush_widens_terms_onto_listed_gaps(self) -> None:
+        """Consecutive rejected candidates coalesce into one segment and the
+        blocker spans its neighbor gap, admitting no other listed version."""
+        foo_wheels = [make_wheel(v) for v in ("3.0", "2.0", "1.0", "0.5")]
+        bar_wheels = [make_wheel(v) for v in ("5.0", "3.0", "1.0")]
+        meta_template = "Metadata-Version: 2.1\nName: foo\nVersion: {ver}\nRequires-Dist: bar>=5.0\n"
+        coordinator = make_coordinator(
+            listings={"foo": foo_wheels, "bar": bar_wheels},
+            metadata_by_version={
+                v: meta_template.format(ver=v) for v in ("3.0", "2.0", "1.0", "0.5")
+            },
+        )
+        provider = Provider(coordinator, target=_PY312)
+        provider.fetch_versions("bar")
+        provider.receive_partial_solution_hint({}, {"bar": V("3.0")})
+        assert provider.choose_version("foo", SpecifierSet(">=1.0").to_range()) is None
+        clauses = provider.consume_pending_clauses()
+        assert len(clauses) == 1
+        candidate, blocker = clauses[0].terms
+        assert candidate.package == "foo"
+        assert isinstance(candidate.constraint, VersionRange)
+        assert len(candidate.constraint._bounds) == 1
+        assert V("1.0") in candidate.constraint
+        assert V("2.0") in candidate.constraint
+        assert V("3.0") in candidate.constraint
+        assert V("0.5") not in candidate.constraint
+        assert blocker.package == "bar"
+        assert V("3.0") in blocker.constraint
+        assert V("4.0") in blocker.constraint
+        assert V("1.0") not in blocker.constraint
+        assert V("5.0") not in blocker.constraint
+
+    def test_flush_widening_keeps_a_live_hole_version_out(self) -> None:
+        """A still-selectable version inside a hole of the asked range stays
+        out of the widened union, so the candidates keep separate segments."""
+        foo_wheels = [make_wheel(v) for v in ("3.0", "2.0", "1.0", "0.5")]
+        bar_wheels = [make_wheel(v) for v in ("5.0", "3.0", "1.0")]
+        meta_template = "Metadata-Version: 2.1\nName: foo\nVersion: {ver}\nRequires-Dist: bar>=5.0\n"
+        coordinator = make_coordinator(
+            listings={"foo": foo_wheels, "bar": bar_wheels},
+            metadata_by_version={
+                v: meta_template.format(ver=v) for v in ("3.0", "2.0", "1.0", "0.5")
+            },
+        )
+        provider = Provider(coordinator, target=_PY312)
+        provider.fetch_versions("bar")
+        provider.receive_partial_solution_hint({}, {"bar": V("3.0")})
+        asked = SpecifierSet(">=1.0,!=2.0").to_range()
+        assert provider.choose_version("foo", asked) is None
+        clauses = provider.consume_pending_clauses()
+        assert len(clauses) == 1
+        candidate = clauses[0].terms[0]
+        assert candidate.package == "foo"
+        assert isinstance(candidate.constraint, VersionRange)
+        assert len(candidate.constraint._bounds) == 2
+        assert V("1.0") in candidate.constraint
+        assert V("3.0") in candidate.constraint
+        assert V("2.0") not in candidate.constraint
+        assert V("0.5") not in candidate.constraint
+
+    def test_flush_widens_range_block_candidates_only(self) -> None:
+        """Range-keyed flush widens the candidate union; the blocker term
+        keeps the captured positive-range object."""
+        wheels = [make_wheel(v) for v in ("3.0", "2.0", "1.0")]
+        coordinator = make_coordinator(wheels, package="foo")
+        provider = Provider(coordinator, target=_PY312)
+        provider.fetch_versions("foo")
+        blocker_range = SpecifierSet("<2.0").to_range()
+        provider.pending_range_blocks[("foo", "bar", blocker_range)].extend(
+            [V("2.0"), V("3.0")]
+        )
+        provider._flush_pending_blocks()
+        clauses = provider.consume_pending_clauses()
+        assert len(clauses) == 1
+        candidate, blocker = clauses[0].terms
+        assert isinstance(candidate.constraint, VersionRange)
+        assert len(candidate.constraint._bounds) == 1
+        assert V("2.0") in candidate.constraint
+        assert V("3.0") in candidate.constraint
+        assert V("1.0") not in candidate.constraint
+        assert blocker.constraint is blocker_range
+
+    def test_flush_keeps_singletons_when_widening_unavailable(self) -> None:
+        """No cached listing: the flushed terms are exact singletons."""
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(coordinator)
+        provider.pending_blocks[("foo", "bar", V("2.0"))].extend([V("1.0"), V("3.0")])
+        provider._flush_pending_blocks()
+        clauses = provider.consume_pending_clauses()
+        assert len(clauses) == 1
+        candidate, blocker = clauses[0].terms
+        assert candidate.constraint == (
+            VersionRange.singleton(V("1.0")) | VersionRange.singleton(V("3.0"))
+        )
+        assert blocker.constraint == VersionRange.singleton(V("2.0"))
+
     def test_full_resolve_reports_lookahead_clause_as_incompatible(self) -> None:
         """The look-ahead grouped clause renders as an incompatibility.
 

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -2706,6 +2706,58 @@ class TestAugmentResolutionError:
         )
         assert _walk_no_versions_packages(clause) == []
 
+    def test_walk_names_lookahead_grouped_clause_candidate(self) -> None:
+        """A look-ahead grouped clause (two positive terms) names its
+        candidate package; the blocker package is not collected."""
+        clause = Incompatibility(
+            [
+                Term("cand", Range.full(), positive=True),
+                Term("blocker", Range.singleton(1), positive=True),
+            ],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+        assert _walk_no_versions_packages(clause) == ["cand"]
+
+    def test_grouped_clause_hint_survives_a_later_range(self) -> None:
+        """Accepted tolerance: reasons are keyed by package name, so a later
+        range still surfaces the reason an earlier ask recorded."""
+        clause = Incompatibility(
+            [
+                Term("cand", Range.full(), positive=True),
+                Term("blocker", Range.singleton(1), positive=True),
+            ],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+        exc = ResolutionError("base message", incompatibility=clause)
+        provider = MagicMock()
+        provider.get_no_versions_reason.side_effect = lambda pkg: (
+            "no version matches the requirement" if pkg == "cand" else None
+        )
+        _augment_resolution_error(exc, provider)
+        assert "cand: no version matches the requirement" in str(exc)
+
+    def test_walk_skips_real_dependency_clauses(self) -> None:
+        """A dependency clause with a negative dep term is not collected."""
+        clause = Incompatibility(
+            [
+                Term("parent", Range.singleton(1), positive=True),
+                Term("dep", Range.full(), positive=False),
+            ],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+        assert _walk_no_versions_packages(clause) == []
+
+    def test_walk_skips_non_string_grouped_candidate(self) -> None:
+        """Grouped clauses with a non-str candidate package are filtered."""
+        clause = Incompatibility(
+            [
+                Term(object(), Range.full(), positive=True),
+                Term("blocker", Range.singleton(1), positive=True),
+            ],
+            cause=IncompatibilityCause.DEPENDENCY,
+        )
+        assert _walk_no_versions_packages(clause) == []
+
     def test_walk_visits_each_node_once(self) -> None:
         """A diamond-shaped derivation visits the shared leaf only once."""
         leaf = self._no_versions_clause("shared")


### PR DESCRIPTION
Look-ahead pending clause terms, both the candidate term and the decision-keyed blocker term, now widen through the same contract as decided-parent widening: a term may name any range that holds the same listed versions of its package. Adjacent gaps overlap, so consecutive rejected candidates coalesce into a single segment as the union is built, and the union stops accumulating a hole per rejection instead of growing quadratically.

The payoff shows up on conflict-heavy warm resolves. The `uv-issue-10344-airflow-py312` scenario goes from roughly 19s to roughly 8s of wall time with an identical pin set.

One behaviour changes as a result. When a widened candidate union covers a package's whole listing, the ask now conflicts by propagation rather than reporting no versions, so the terminal diagnostics walk also names candidate packages carried by look-ahead grouped clauses.
