### PR TITLE
distinguish an offline cold-cache miss from a missing package

### DIFF
--- a/nab-index/src/nab_index/multi_index.py
+++ b/nab-index/src/nab_index/multi_index.py
@@ -6,7 +6,9 @@ the router walks the list left-to-right and stops at the first index
 whose listing for the package is non-empty (presence-based first-index,
 matching uv's ``--index-strategy first-index``).  An index that raises
 :class:`~nab_index.cache.OfflineError` (offline mode, cold cache) is
-treated as having no listing, so later indexes are still consulted.
+skipped so later indexes are still consulted.  If no index then serves
+a listing, that error is re-raised, since an empty result would read as
+an absent package.
 
 Per-package overrides route a package to a *named* index regardless
 of order; when an override matches, *only* that index is consulted
@@ -196,7 +198,8 @@ class MultiIndexClient:
 
         See module docstring for routing.  The chosen index name is
         cached so subsequent metadata / sdist calls hit the same
-        client.
+        client.  Raises :class:`~nab_index.cache.OfflineError` when no
+        index served a listing and at least one was skipped offline.
         """
         override = self._override_index(package)
         if override is not None:
@@ -209,12 +212,13 @@ class MultiIndexClient:
         if cached is not None:
             return await self._clients[cached].get_files(package)
 
+        skipped_offline: OfflineError | None = None
         for index_name in self._order:
             client = self._clients[index_name]
             try:
                 files = await client.get_files(package)
-            except OfflineError:
-                # Offline with a cold cache: treat as no listing.
+            except OfflineError as exc:
+                skipped_offline = exc
                 continue
             if files:
                 self._record_route(package, index_name)
@@ -224,6 +228,9 @@ class MultiIndexClient:
         # subsequent metadata calls (which will also miss) hit a
         # stable client.
         self._record_route(package, self._order[0])
+
+        if skipped_offline is not None:
+            raise skipped_offline
         return []
 
     async def get_metadata_text(

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -148,6 +148,8 @@ class InMemoryIndex:
         self._listings: dict[str, list[WheelFile | SdistFile]] = {}
         self._listing_errors: dict[str, BaseException] = {}
         self._listing_indexes: dict[str, str] = {}
+        # Packages whose empty listing stands for an index skipped offline.
+        self._offline_listing_misses: set[str] = set()
         # Metadata text is keyed by the artifact it came from: the sidecar URL
         # for a wheel's METADATA, or None for text that stands for the version
         # itself (sdist PKG-INFO, an injected override).  Two wheels of one
@@ -189,22 +191,36 @@ class InMemoryIndex:
             return self._listings.get(package)
 
     def store_listing(
-        self, package: str, data: Sequence[WheelFile | SdistFile]
+        self,
+        package: str,
+        data: Sequence[WheelFile | SdistFile],
+        *,
+        offline_miss: bool = False,
     ) -> None:
         """Cache the listing for ``package`` and unblock any waiter.
 
         ``data`` is accepted as a Sequence (covariant) so callers can pass
         homogeneous ``list[WheelFile]`` lists; it is materialised into the
         internal ``list[WheelFile | SdistFile]`` cache.
+
+        ``offline_miss`` marks the empty listing as an index skipped offline
+        rather than one that served no files.
         """
         key = f"listing:{package}"
         materialised = list(data)
         with self._lock:
             self._listings[package] = materialised
+            if offline_miss:
+                self._offline_listing_misses.add(package)
             pending = self._pending.get(key)
         if pending is not None:
             pending.result = materialised
             pending.event.set()
+
+    def is_offline_listing_miss(self, package: str) -> bool:
+        """Whether ``package``'s empty listing is an offline cold-cache miss."""
+        with self._lock:
+            return package in self._offline_listing_misses
 
     def store_listing_error(self, package: str, error: BaseException) -> None:
         """Record a failed listing fetch and unblock any waiter.
@@ -1169,7 +1185,7 @@ class FetchCoordinator:
                 # Record the serving index before the empty listing fires the
                 # pending event (see _fetch_listing).
                 self._record_serving_index(client, req.package)
-                self.index.store_listing(req.package, [])
+                self.index.store_listing(req.package, [], offline_miss=True)
             elif self.index.get_listing(req.package) is None:
                 self.index.store_listing_error(req.package, exc)
             return

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -1641,7 +1641,9 @@ class Provider:
         ``all_versions`` is post-filter, so an empty one means either the
         index served no files or every file it served was dropped by the
         wheel-tag filter, requires-python, dist-policy, or the upload-time
-        cutoff.  The raw listing tells absence from incompatibility apart.
+        cutoff.  The raw listing tells absence from incompatibility apart,
+        except that an index skipped offline also stores an empty listing,
+        so that case is reported as offline rather than absence.
         The wheel-tag case (a Windows-only package on a Linux target) is
         named only when the base pass dropped nothing, or when the file
         it dropped was an sdist: there the reason names both the rejected
@@ -1659,7 +1661,10 @@ class Provider:
             raw_listing = self.coordinator.index.get_listing(normalized)
             tag_excluded = self.tag_excluded_wheels.get(normalized, 0)
             if not raw_listing:
-                reason = "package not found on any configured index"
+                if self.coordinator.index.is_offline_listing_miss(normalized):
+                    reason = "offline mode skipped an index with no cached listing"
+                else:
+                    reason = "package not found on any configured index"
             elif tag_excluded and normalized not in self.base_filtered_packages:
                 reason = (
                     f"found on index but none of the wheel's tags are compatible"

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -74,6 +74,23 @@ class TestInMemoryIndex:
         idx.store_listing("foo", wheels)
         assert idx.get_listing("foo") == wheels
 
+    def test_offline_listing_miss_roundtrip(self) -> None:
+        idx = InMemoryIndex()
+        idx.store_listing("foo", [], offline_miss=True)
+        assert idx.get_listing("foo") == []
+        assert idx.is_offline_listing_miss("foo")
+
+    def test_served_empty_listing_is_not_an_offline_miss(self) -> None:
+        idx = InMemoryIndex()
+        idx.store_listing("foo", [])
+        assert not idx.is_offline_listing_miss("foo")
+
+    def test_offline_listing_miss_fires_listing_pending(self) -> None:
+        idx = InMemoryIndex()
+        pending, _ = idx.get_or_create_pending("listing:foo")
+        idx.store_listing("foo", [], offline_miss=True)
+        assert pending.event.is_set()
+
     def test_metadata_roundtrip(self) -> None:
         idx = InMemoryIndex()
         assert idx.get_metadata("foo", "1.0") is None
@@ -1593,6 +1610,7 @@ class TestFetchCoordinatorCache:
             # Empty list, not None: the handler caught OfflineError and
             # stored an empty listing so the resolver can proceed.
             assert listing == []
+            assert coord.index.is_offline_listing_miss("missing")
         assert not coord._crashed
 
     @respx.mock

--- a/nab-python/tests/test_multi_index.py
+++ b/nab-python/tests/test_multi_index.py
@@ -205,7 +205,7 @@ class TestOfflinePresenceWalk:
         assert [f.filename for f in files] == ["foo-1.0-py3-none-any.whl"]
         assert client.route_for("foo") == "local"
 
-    def test_cold_offline_all_indexes_returns_empty(self, tmp_path: Path) -> None:
+    def test_cold_offline_all_indexes_raises(self, tmp_path: Path) -> None:
         client = MultiIndexClient(
             {
                 "a": _offline_client(tmp_path, "a"),
@@ -215,8 +215,20 @@ class TestOfflinePresenceWalk:
             {},
         )
 
-        assert run(client.get_files("foo")) == []
+        with pytest.raises(OfflineError):
+            run(client.get_files("foo"))
         assert client.route_for("foo") == "a"
+
+    def test_answering_index_does_not_mask_a_cold_one(self, tmp_path: Path) -> None:
+        """One index answering absent does not settle it while another is cold."""
+        client = MultiIndexClient(
+            {"answers": FakeClient({}), "cold": _offline_client(tmp_path, "cold")},
+            ["answers", "cold"],
+            {},
+        )
+
+        with pytest.raises(OfflineError):
+            run(client.get_files("foo"))
 
     def test_override_pin_to_cold_offline_index_raises(self, tmp_path: Path) -> None:
         wheelhouse = tmp_path / "wheelhouse"

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from nab_index.cache import CachePolicy, OnDiskCache
 from nab_index.client import (
     MalformedSimpleResponseError,
     MetadataHashMismatchError,
@@ -24,7 +25,9 @@ from nab_index.client import (
 )
 from nab_index.lazy_wheel import RangeMetadataResult, RangeOutcome
 from nab_index.local_index import LocalIndexClient
+from nab_index.multi_index import IndexConfig
 from nab_index.transport import HttpError
+from nab_index.urllib3_async_transport import Urllib3AsyncTransport
 from nab_python._provider import build_remote, metadata_resolver
 from nab_python._provider import listing as listing_mod
 from nab_python._provider.metadata_resolver import (
@@ -48,7 +51,12 @@ from nab_python.config import (
     OverrideConflictError,
     PackageOverride,
 )
-from nab_python.fetch import InMemoryIndex
+from nab_python.fetch import (
+    DEFAULT_INDEX_URL,
+    FetchCoordinator,
+    IndexRoute,
+    InMemoryIndex,
+)
 from nab_python.metadata import WheelMetadata
 from nab_python.provider import (
     BuildPolicy,
@@ -1066,6 +1074,64 @@ class TestNoVersionsReasons:
         coordinator = make_coordinator([], package="foo")
         provider = Provider(coordinator)
         provider.choose_version("foo", SpecifierSet("").to_range())
+        assert (
+            provider.get_no_versions_reason("foo")
+            == "package not found on any configured index"
+        )
+
+    @pytest.mark.parametrize(
+        ("indexes", "routes"),
+        [
+            pytest.param(None, None, id="single-index"),
+            pytest.param(
+                [
+                    IndexConfig("pypi", DEFAULT_INDEX_URL),
+                    IndexConfig("extra", "https://extra.example/simple/"),
+                ],
+                None,
+                id="two-indexes",
+            ),
+            pytest.param(None, [IndexRoute("other", "pypi")], id="one-index-one-route"),
+        ],
+    )
+    def test_offline_cold_cache_miss_reports_offline_not_absence(
+        self,
+        tmp_path: Path,
+        indexes: list[IndexConfig] | None,
+        routes: list[IndexRoute] | None,
+    ) -> None:
+        """An offline miss is reported as offline rather than absence.
+
+        The parameters cover each client shape: a second index or any route
+        swaps the lone client for the multi-index router.
+        """
+        with FetchCoordinator(
+            transport=Urllib3AsyncTransport(),
+            cache_dir=tmp_path,
+            offline=True,
+            indexes=indexes,
+            index_routes=routes,
+        ) as coordinator:
+            provider = Provider(coordinator)
+            provider.choose_version("foo", SpecifierSet("").to_range())
+        assert provider.get_no_versions_reason("foo") == (
+            "offline mode skipped an index with no cached listing"
+        )
+
+    def test_offline_with_cached_absence_still_reports_not_found(
+        self, tmp_path: Path
+    ) -> None:
+        """Offline over a cached 404 still names absence: an index did answer."""
+        OnDiskCache(tmp_path, DEFAULT_INDEX_URL).put_negative(
+            "foo", CachePolicy(fetched_at=0, max_age=1, etag=None)
+        )
+        with FetchCoordinator(
+            transport=Urllib3AsyncTransport(),
+            cache_dir=tmp_path,
+            offline=True,
+        ) as coordinator:
+            provider = Provider(coordinator)
+            provider.choose_version("foo", SpecifierSet("").to_range())
         assert (
             provider.get_no_versions_reason("foo")
             == "package not found on any configured index"


### PR DESCRIPTION
Resolving with `--offline` against a cold cache reports `package not found on any configured index` in the failure diagnostics. The package is on the index and was never fetched, so the message blames the user's index setup for a cache miss.

The offline branch of `FetchCoordinator._record_fetch_failure` stores an empty listing, the same signal a 404 leaves behind, so `Provider._record_no_versions_reason` reads it as absence. The empty listing now carries a flag marking it as an offline miss, and the diagnostic says `offline mode skipped an index with no cached listing` instead.

`MultiIndexClient.get_files` had the same ambiguity one level down: it skipped an index that raised `OfflineError` and still returned an empty list when no index had served a listing. It now re-raises that error when the walk ends without one.
