### PR TITLE
exit 1 when a wheel body fails its published hash

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -21,6 +21,7 @@ from nab_index.client import (
     SdistFile,
     SdistHashMismatchError,
     WheelFile,
+    WheelHashMismatchError,
 )
 from nab_index.transport import HttpError
 
@@ -1361,6 +1362,7 @@ class Provider:
         except (
             MetadataHashMismatchError,
             SdistHashMismatchError,
+            WheelHashMismatchError,
             UnsupportedVcsError,
             InvalidUploadTimeError,
             OverrideConflictError,

--- a/nab-python/tests/test_constraint_probe_hard_error.py
+++ b/nab-python/tests/test_constraint_probe_hard_error.py
@@ -4,14 +4,18 @@
 un-narrowed range to decide whether a user constraint is what hid a version.
 That range includes the versions the constraint clipped away, so look-ahead can
 reach one whose metadata is a hard integrity error (a failed PEP 658 sidecar
-hash).  The probe only labels a ``NO_VERSIONS`` clause, so that error must not
-escape and abort the resolve, and the snapshot the probe restores must survive
-the failure path.
+hash, or a bare wheel whose full body fails its published hash).  The probe only
+labels a ``NO_VERSIONS`` clause, so that error must not escape and abort the
+resolve, and the snapshot the probe restores must survive the failure path.
 """
 
 from __future__ import annotations
 
-from nab_index.client import MetadataHashMismatchError, WheelFile
+from nab_index.client import (
+    MetadataHashMismatchError,
+    WheelFile,
+    WheelHashMismatchError,
+)
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.specifiers import SpecifierSet
@@ -24,13 +28,13 @@ V = Version
 _PY312 = ResolveTarget.for_host_python("3.12.0")
 
 
-def _wheel(name: str, version: str) -> WheelFile:
+def _wheel(name: str, version: str, *, has_metadata: bool = True) -> WheelFile:
     return WheelFile(
         filename=f"{name}-{version}-py3-none-any.whl",
         url=f"https://example.com/{name}-{version}-py3-none-any.whl",
         version=version,
         requires_python=None,
-        has_metadata=True,
+        has_metadata=has_metadata,
         upload_time=None,
     )
 
@@ -73,6 +77,40 @@ class TestConstraintProbeContainsHardError:
         coordinator = make_coordinator(listings=listings, metadata_by_version=metadata)
         coordinator.index.store_metadata_error(
             "foo", "3.0", MetadataHashMismatchError("metadata sha256 mismatch")
+        )
+        root_reqs = {"baz": VersionRange.full(admit_arbitrary=False)}
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
+        resolver = Resolver(provider, range_type=VersionRange, root_version="0")
+
+        pins = resolver.resolve(
+            root_reqs, constraints={"foo": SpecifierSet("<3.0").to_range()}
+        )
+
+        assert pins == {"baz": V("1.0")}
+
+    def test_excluded_version_wheel_hash_error_does_not_abort_resolve(self) -> None:
+        """A bare wheel failing its published hash stays out of play too.
+
+        Same shape as the sidecar case, but ``foo==3.0`` publishes no
+        ``core-metadata``, so the probe reaches it through rung 4 and the
+        full-body read fails the listing's digest.
+        """
+        listings = {
+            "baz": [_wheel("baz", "2.0"), _wheel("baz", "1.0")],
+            "foo": [_wheel("foo", "3.0", has_metadata=False)],
+        }
+        metadata = {
+            "2.0": (
+                "Metadata-Version: 2.1\nName: baz\nVersion: 2.0\nRequires-Dist: foo\n\n"
+            ),
+            "1.0": "Metadata-Version: 2.1\nName: baz\nVersion: 1.0\n\n",
+        }
+        coordinator = make_coordinator(
+            listings=listings,
+            metadata_by_version=metadata,
+            range_error=WheelHashMismatchError(
+                "wheel sha256 mismatch: expected 0, got 1"
+            ),
         )
         root_reqs = {"baz": VersionRange.full(admit_arbitrary=False)}
         provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -24,7 +24,11 @@ import tyro
 from tyro.extras import SubcommandApp
 
 from nab._version import __version__
-from nab_index.client import MetadataHashMismatchError, SdistHashMismatchError
+from nab_index.client import (
+    MetadataHashMismatchError,
+    SdistHashMismatchError,
+    WheelHashMismatchError,
+)
 from nab_index.transport import HttpError
 from nab_index.urllib3_async_transport import Urllib3AsyncTransport
 from nab_python.config import (
@@ -604,6 +608,7 @@ def _resolve(  # noqa: PLR0913, PLR0912, C901 - one wrapper per resolve_for_targ
         MetadataError,
         MetadataHashMismatchError,
         SdistHashMismatchError,
+        WheelHashMismatchError,
     ) as e:
         printer().error(f"{failure_prefix}: {e}")
         sys.exit(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ import json
 import runpy
 import stat
 import sys
+import zipfile
 from collections.abc import Callable
 from contextlib import AbstractContextManager
 from datetime import datetime, timezone
@@ -193,6 +194,19 @@ def _hashless_resolve_result() -> ResolveResult:
     )
 
 
+def _sidecarless_wheel(name: str = "foo", version: str = "1.0") -> bytes:
+    """Build wheel bytes whose METADATA sits inside the archive."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(f"{name}/__init__.py", b"value = 1\n")
+        zf.writestr(
+            f"{name}-{version}.dist-info/METADATA",
+            f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n\nBody.\n",
+        )
+        zf.writestr(f"{name}-{version}.dist-info/WHEEL", b"Wheel-Version: 1.0\n")
+    return buf.getvalue()
+
+
 def _make_pyproject(tmp_path: Path, body: str = "") -> Path:
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(body or '[project]\ndependencies = ["foo"]\n')
@@ -245,7 +259,11 @@ class _SidecarResponse:
 
 
 class _SidecarTransport:
-    """Serves a Simple-API listing and its PEP 658 sidecar bytes, keyed by URL."""
+    """Serves Simple-API listing, sidecar, and wheel bytes keyed by URL.
+
+    Every request gets the whole body, ignoring ``Range`` like a host with no
+    range support.
+    """
 
     def __init__(self, bodies: dict[str, bytes]) -> None:
         self._bodies = bodies
@@ -823,6 +841,53 @@ class TestLockCommandSpecific:
         err = capsys.readouterr().err
         assert "cannot lock" in err
         assert "sha256 mismatch" in err
+        assert "0" * 64 in err
+        assert "Traceback" not in err
+
+    def test_wheel_hash_mismatch_exits(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A full-body wheel failing its published hash exits 1, not a traceback.
+
+        Drives a real resolve against a fake index that publishes a sha256 for
+        a sidecar-less wheel.  The transport ignores ``Range``, so the read
+        steps down to the whole body and checks it against that digest.
+        """
+        monkeypatch.setattr(
+            "nab.cli._config_search_roots",
+            lambda p: SourceRoots(project_dir=p.parent, pyproject=p),
+        )
+        pyproject = _make_pyproject(tmp_path)
+
+        wheel_url = "https://files.example.com/foo-1.0-py3-none-any.whl"
+        listing = {
+            "files": [
+                {
+                    "filename": "foo-1.0-py3-none-any.whl",
+                    "url": wheel_url,
+                    "hashes": {"sha256": "0" * 64},
+                }
+            ]
+        }
+        transport = _SidecarTransport(
+            {
+                "https://pypi.org/simple/foo/": json.dumps(listing).encode(),
+                wheel_url: _sidecarless_wheel(),
+            }
+        )
+
+        with (
+            patch("nab.cli._make_transport", return_value=transport),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, output=tmp_path / "pylock.toml", cache=False)
+
+        err = capsys.readouterr().err
+        assert "cannot lock" in err
+        assert "wheel sha256 mismatch" in err
         assert "0" * 64 in err
         assert "Traceback" not in err
 


### PR DESCRIPTION
When a wheel publishes no PEP 658 sidecar, nab reads METADATA out of the wheel itself. If the host refuses Range requests, that read steps down to the whole body, which nab checks against the digest in the listing. A failed check killed `nab lock` and `nab download` with a traceback: `WheelHashMismatchError` was missing from the CLI's exit mapping, though the sidecar and sdist equivalents were already in it. It now prints the same one-line error and exits 1.

The provider's constraint-attribution probe had the same gap. It re-runs `choose_version` over the un-narrowed range, so it reaches versions a user constraint clipped away, and a bad wheel on one of those aborted a resolve that should have pinned the surviving version. The probe now tolerates the error alongside the other integrity failures. The failure still surfaces when such a version is actually pinned.
