### PR TITLE
stop reading a 204 or unfollowed 3xx index response as content

### DIFF
--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -34,7 +34,7 @@ from .lazy_wheel import (
     RangeOutcome,
     read_wheel_metadata_over_range,
 )
-from .transport import IDENTITY_HEADERS
+from .transport import IDENTITY_HEADERS, raise_unless_ok
 
 if TYPE_CHECKING:
     from packaging.utils import NormalizedName
@@ -235,7 +235,7 @@ class CachedAsyncSimpleClient:
         if response.status_code == _HTTP_NOT_FOUND:
             self._cache.put_negative(package, self._negative_policy(response))
             return []
-        response.raise_for_status()
+        raise_unless_ok(response, url)
         new_body = response.content
 
         # Parse before caching so a bad body never poisons the cache.
@@ -255,7 +255,7 @@ class CachedAsyncSimpleClient:
         if response.status_code == _HTTP_NOT_FOUND:
             self._cache.put_negative(package, self._negative_policy(response))
             return []
-        response.raise_for_status()
+        raise_unless_ok(response, url)
         body = response.content
 
         # Parse before caching so a bad body never poisons the cache.
@@ -305,7 +305,7 @@ class CachedAsyncSimpleClient:
             raise OfflineError(msg)
 
         response = await self._transport.get(metadata_url)
-        response.raise_for_status()
+        raise_unless_ok(response, metadata_url)
         content = response.content
         if metadata_hash is not None:
             _verify_metadata_hash(content, metadata_hash)
@@ -391,7 +391,7 @@ class CachedAsyncSimpleClient:
             raise OfflineError(msg)
 
         response = await self._transport.get(sdist_url, headers=IDENTITY_HEADERS)
-        response.raise_for_status()
+        raise_unless_ok(response, sdist_url)
         selected = _select_artifact_hash(sdist_hashes)
         if selected is not None:
             _verify_sdist_hash(response.content, selected)
@@ -426,7 +426,7 @@ class CachedAsyncSimpleClient:
             msg = f"sdist archive fetch unavailable in offline mode ({sdist_url})"
             raise OfflineError(msg)
         response = await self._transport.get(sdist_url, headers=IDENTITY_HEADERS)
-        response.raise_for_status()
+        raise_unless_ok(response, sdist_url)
         selected = _select_artifact_hash(sdist_hashes)
         if selected is not None:
             _verify_sdist_hash(response.content, selected)

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -25,7 +25,7 @@ from packaging.utils import (
 )
 from packaging.version import InvalidVersion, Version
 
-from .transport import IDENTITY_HEADERS, HttpError
+from .transport import IDENTITY_HEADERS, HttpError, raise_unless_ok
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -273,19 +273,19 @@ class AsyncSimpleClient:
         response = await self._transport.get(url, headers={"Accept": _JSON_ACCEPT})
         if response.status_code == _HTTP_NOT_FOUND:
             return []
-        response.raise_for_status()
+        raise_unless_ok(response, url)
         return _parse_files(response.json(), self._index_url, package)
 
     async def get_metadata_text(self, metadata_url: str) -> str:
         """Fetch metadata text from a known PEP 658/714 metadata URL."""
         response = await self._transport.get(metadata_url)
-        response.raise_for_status()
+        raise_unless_ok(response, metadata_url)
         return response.text
 
     async def download(self, url: str) -> bytes:
         """Fetch a distribution artefact (wheel or sdist) as raw bytes."""
         response = await self._transport.get(url, headers=IDENTITY_HEADERS)
-        response.raise_for_status()
+        raise_unless_ok(response, url)
         return response.content
 
 

--- a/nab-index/src/nab_index/httpx_async_transport.py
+++ b/nab-index/src/nab_index/httpx_async_transport.py
@@ -11,7 +11,13 @@ import httpx
 import truststore
 
 from .retry import MAX_REDIRECTS, MAX_RETRIES, RETRY_STATUSES, next_delay
-from .transport import ContentDecodingError, HttpError, accepts_gzip, decode_body
+from .transport import (
+    ContentDecodingError,
+    HttpError,
+    accepts_gzip,
+    decode_body,
+    raise_for_error_status,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -27,7 +33,9 @@ class _HttpxResponse:
     The body is fetched undecoded, and decoded by the transport when the
     request asked for gzip (see :func:`~nab_index.transport.decode_body`),
     so it is carried here rather than read from the httpx response.
-    raise_for_status is translated so callers see one error type.
+
+    ``raise_for_status`` follows the shared 4xx/5xx rule; httpx's own raises
+    on every non-2xx.
     """
 
     __slots__ = ("_content", "_response")
@@ -56,10 +64,7 @@ class _HttpxResponse:
         return _json.loads(self._content)
 
     def raise_for_status(self) -> None:
-        try:
-            self._response.raise_for_status()
-        except httpx.HTTPStatusError as exc:
-            raise HttpError(str(exc)) from exc
+        raise_for_error_status(self._response.status_code, str(self._response.url))
 
 
 class HttpxAsyncTransport:

--- a/nab-index/src/nab_index/transport.py
+++ b/nab-index/src/nab_index/transport.py
@@ -22,14 +22,19 @@ __all__ = [
     "HttpResponse",
     "accepts_gzip",
     "decode_body",
+    "raise_for_error_status",
+    "raise_unless_ok",
 ]
 
 # For a caller that needs the body exactly as stored, undecoded.
 IDENTITY_HEADERS: Final[dict[str, str]] = {"Accept-Encoding": "identity"}
 
+_HTTP_BAD_REQUEST: Final = 400
+_CONTENT_STATUSES: Final[frozenset[int]] = frozenset({200, 203})
+
 
 class HttpError(Exception):
-    """A request failed: a connection/transport error or a 4xx/5xx status.
+    """A request failed, or answered with a status the caller cannot use.
 
     Transports raise this from ``get`` and ``raise_for_status`` so callers
     can handle index failures without importing a specific HTTP backend.
@@ -125,7 +130,10 @@ class HttpResponse(Protocol):
         ...
 
     def raise_for_status(self) -> None:
-        """Raise :class:`HttpError` for 4xx/5xx responses."""
+        """Raise :class:`HttpError` for 4xx/5xx responses.
+
+        Not a gate on reading the body; see :func:`raise_unless_ok`.
+        """
         ...
 
 
@@ -152,3 +160,25 @@ class AsyncHttpTransport(Protocol):
     async def aclose(self) -> None:
         """Release resources."""
         ...
+
+
+def raise_for_error_status(status: int, url: str) -> None:
+    """Raise :class:`HttpError` for a 4xx/5xx ``status``."""
+    if status >= _HTTP_BAD_REQUEST:
+        msg = f"HTTP {status} for {url}"
+        raise HttpError(msg)
+
+
+def raise_unless_ok(response: HttpResponse, url: str) -> None:
+    """Raise :class:`HttpError` unless ``response`` carries the requested content.
+
+    :meth:`HttpResponse.raise_for_status` clears everything under 400, but a
+    204 has no content (RFC 9110 section 15.3.5) and a 3xx a transport did not
+    follow names another resource (section 15.4). A 203 passes with the 200:
+    its body is the representation a transforming proxy rewrote (section
+    15.3.4).
+    """
+    response.raise_for_status()
+    if response.status_code not in _CONTENT_STATUSES:
+        msg = f"HTTP {response.status_code} for {url} is not the requested content"
+        raise HttpError(msg)

--- a/nab-index/src/nab_index/urllib3_async_transport.py
+++ b/nab-index/src/nab_index/urllib3_async_transport.py
@@ -19,7 +19,13 @@ import truststore
 import urllib3
 
 from .retry import GET_RETRY, MAX_RETRIES, next_delay
-from .transport import ContentDecodingError, HttpError, accepts_gzip, decode_body
+from .transport import (
+    ContentDecodingError,
+    HttpError,
+    accepts_gzip,
+    decode_body,
+    raise_for_error_status,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -28,8 +34,6 @@ __all__ = [
     "Urllib3AsyncTransport",
 ]
 
-
-_HTTP_BAD_REQUEST = 400
 
 # urllib3's default read timeout is None, so bound it against a stalled index.
 _DEFAULT_TIMEOUT_SECONDS = 5.0
@@ -88,10 +92,9 @@ class _Urllib3Response:
         return _json.loads(self._content)
 
     def raise_for_status(self) -> None:
-        status = self._response.status
-        if status >= _HTTP_BAD_REQUEST:
-            msg = f"HTTP {status} for {self._response.geturl() or '<unknown>'}"
-            raise HttpError(msg)
+        raise_for_error_status(
+            self._response.status, self._response.geturl() or "<unknown>"
+        )
 
 
 class Urllib3AsyncTransport:

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -27,7 +27,7 @@ from nab_index.client import SdistFile, WheelFile
 from nab_index.lazy_wheel import RangeCapabilityMemo, RangeOutcome
 from nab_index.local_index import LocalIndexClient, parse_file_url
 from nab_index.multi_index import IndexConfig, MultiIndexClient
-from nab_index.transport import IDENTITY_HEADERS
+from nab_index.transport import IDENTITY_HEADERS, raise_unless_ok
 
 from ._vendor.packaging.utils import canonicalize_name
 
@@ -1359,7 +1359,7 @@ class FetchCoordinator:
                 msg = f"archive fetch unavailable in offline mode ({req.url})"
                 raise OfflineError(msg)
             response = await self._transport.get(req.url, headers=IDENTITY_HEADERS)
-            response.raise_for_status()
+            raise_unless_ok(response, req.url)
             data = response.content
 
         self.index.store_sdist_archive(req.package, req.version, data)

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -38,6 +38,7 @@ from nab_index.transport import (
     AsyncHttpTransport,
     ContentDecodingError,
     HttpError,
+    HttpResponse,
     accepts_gzip,
     decode_body,
 )
@@ -1489,6 +1490,49 @@ class TestArtifactContentEncoding:
             assert coord.index.get_sdist_archive("demo", SDIST_SHA256) == SDIST_BODY
 
         assert server.accept_encoding == ["identity"]
+
+
+class TestUnfollowedRedirectAcrossBackends:
+    """Both backends treat a 300 they did not follow the same way.
+
+    ``raise_for_status`` is the 4xx/5xx line, so it clears the 300 on either
+    backend; the body-reading calls are what reject it.
+    """
+
+    @pytest.mark.parametrize("make_transport", TRANSPORTS)
+    def test_raise_for_status_clears_a_300(
+        self, make_transport: Callable[[], AsyncHttpTransport]
+    ) -> None:
+        with _stub_index([300]) as index:
+            url = f"http://127.0.0.1:{index.server_port}/pkg/"
+
+            async def go() -> HttpResponse:
+                transport = make_transport()
+                try:
+                    return await transport.get(url)
+                finally:
+                    await transport.aclose()
+
+            response = asyncio.run(go())
+
+        assert response.status_code == 300
+        response.raise_for_status()
+
+    @pytest.mark.parametrize("make_transport", TRANSPORTS)
+    def test_metadata_sidecar_300_raises(
+        self, make_transport: Callable[[], AsyncHttpTransport]
+    ) -> None:
+        with _stub_index([300]) as index:
+            url = f"http://127.0.0.1:{index.server_port}/demo-1.0.whl.metadata"
+
+            async def go() -> str:
+                async with CachedAsyncSimpleClient(
+                    make_transport(), NullCache()
+                ) as client:
+                    return await client.get_metadata_text("demo", "1.0", url)
+
+            with pytest.raises(HttpError, match="300"):
+                asyncio.run(go())
 
 
 class TestExtractSdistFiles:

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -1487,6 +1487,143 @@ class TestNonUtf8MetadataSidecar:
         assert cache.get_metadata("pkg", "https://x/pkg.metadata") is None
 
 
+class TestNonOkStatusIsNotContent:
+    """Only a 200 or a 203 carries content a body-reading call may use.
+
+    ``raise_for_status`` draws its line at 400, so a 204 and a 3xx the
+    transport did not follow reach the caller unflagged; neither is the
+    artifact. A 203 reads like a 200.
+    """
+
+    def test_metadata_sidecar_203_is_content(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport([_FakeResponse(b"Name: pkg\n", status=203)])
+
+        async def go() -> str:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_metadata_text(
+                    "pkg", "1.0", "https://x/pkg.metadata"
+                )
+            finally:
+                await client.aclose()
+
+        assert asyncio.run(go()) == "Name: pkg\n"
+        assert cache.get_metadata("pkg", "https://x/pkg.metadata") == "Name: pkg\n"
+
+    def test_metadata_sidecar_204_raises_and_caches_nothing(
+        self, tmp_path: Path
+    ) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport([_FakeResponse(b"", status=204)])
+
+        async def go() -> str:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_metadata_text(
+                    "pkg", "1.0", "https://x/pkg.metadata"
+                )
+            finally:
+                await client.aclose()
+
+        with pytest.raises(HttpError, match="204"):
+            asyncio.run(go())
+        assert cache.get_metadata("pkg", "https://x/pkg.metadata") is None
+
+    def test_metadata_sidecar_300_raises_and_caches_nothing(
+        self, tmp_path: Path
+    ) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport(
+            [_FakeResponse(b"<html>pick one</html>", status=300)]
+        )
+
+        async def go() -> str:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_metadata_text(
+                    "pkg", "1.0", "https://x/pkg.metadata"
+                )
+            finally:
+                await client.aclose()
+
+        with pytest.raises(HttpError, match="300"):
+            asyncio.run(go())
+        assert cache.get_metadata("pkg", "https://x/pkg.metadata") is None
+
+    def test_listing_300_raises_and_caches_nothing(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport([_FakeResponse(LISTING_BYTES, status=300)])
+
+        async def go() -> list:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_files("pkg")
+            finally:
+                await client.aclose()
+
+        with pytest.raises(HttpError, match="300"):
+            asyncio.run(go())
+        assert cache.get_simple("pkg") is None
+
+    def test_revalidated_listing_300_raises_and_keeps_the_stored_body(
+        self, tmp_path: Path
+    ) -> None:
+        cache = _make_cache(tmp_path)
+        cache.put_simple(
+            "pkg",
+            LISTING_BYTES,
+            CachePolicy(fetched_at=0, max_age=1, etag="old-etag"),
+        )
+        transport = _FakeTransport([_FakeResponse(b"", status=300)])
+
+        async def go() -> list:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_files("pkg")
+            finally:
+                await client.aclose()
+
+        with pytest.raises(HttpError, match="300"):
+            asyncio.run(go())
+        cached = cache.get_simple("pkg")
+        assert cached is not None
+        assert cached[0] == LISTING_BYTES
+
+    def test_sdist_files_204_raises_and_caches_nothing(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport([_FakeResponse(b"", status=204)])
+
+        async def go() -> tuple[str | None, str | None]:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_sdist_files(
+                    "pkg", "1.0", "https://x/pkg.tar.gz"
+                )
+            finally:
+                await client.aclose()
+
+        with pytest.raises(HttpError, match="204"):
+            asyncio.run(go())
+        assert cache.get_sdist_files("pkg", "1.0") is None
+
+    def test_sdist_archive_204_raises(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport([_FakeResponse(b"", status=204)])
+
+        async def go() -> bytes:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_sdist_archive(
+                    "pkg", "1.0", "https://x/pkg.tar.gz"
+                )
+            finally:
+                await client.aclose()
+
+        with pytest.raises(HttpError, match="204"):
+            asyncio.run(go())
+
+
 class TestGetSdistFiles:
     def test_cold_cache_fetches_and_stores_both(self, tmp_path: Path) -> None:
         cache = _make_cache(tmp_path)


### PR DESCRIPTION
A metadata sidecar that answers 204, or a 300 the transport did not follow, was read as the wheel's METADATA on the default urllib3 backend and cached against that URL, so every later resolve read the same empty or unrelated body back. The same held for a simple listing and for an sdist fetch.

The two backends did not agree on what raise_for_status covers: urllib3 cleared everything under 400, httpx raised on anything that was not 2xx. Neither is the right gate for reading a body.

Body-reading calls now go through raise_unless_ok, which accepts 200 and 203 and raises HttpError on anything else. Both transports share one raise_for_status that raises on 4xx/5xx only. A rejected response is not parsed and not cached, and a stale cached listing survives a bad revalidation.
