### PR TITLE
Document nab download's selection flags

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -172,6 +172,12 @@ wheel shared across tuples is fetched once.
 * `--max-concurrency` controls parallel HTTP fetches (default `8`,
   minimum `1`). Layered, so it can also be set in an `nab.toml` or
   `NAB_MAX_CONCURRENCY`.
+* `--groups foo bar` / `--all-groups` and `--extras foo bar` /
+  `--all-extras` fold dependency groups and extras into the resolve as
+  they do on `nab lock`, so they decide which artefacts are downloaded.
+* `--python X.Y` resolves for that Python on this machine instead of
+  the running interpreter, as on `nab lock`. It is rejected in
+  universal mode, where the matrix declares the Python axis.
 * `--workspace-discovery` (default) mirrors `nab lock`: it finds a
   `[tool.nab.workspace]` root and resolves against the in-tree
   members. `--no-workspace-discovery` turns that off. See

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,8 +7,10 @@ import builtins
 import contextlib
 import errno
 import importlib
+import inspect
 import io
 import json
+import re
 import runpy
 import stat
 import sys
@@ -2783,6 +2785,45 @@ class TestConflictsDocTranscript:
         block = _console_block(_CONFLICTS_DOC.read_text(encoding="utf-8"))
         assert block[0] == "$ nab lock --extras all"
         assert printed in block[1:]
+
+
+_CLI_REFERENCE_DOC = (
+    Path(__file__).resolve().parents[1] / "docs" / "reference" / "cli.md"
+)
+
+
+def _doc_section(text: str, heading: str) -> str:
+    return text.partition(f"\n{heading}\n")[2].partition("\n## ")[0]
+
+
+def _names_flag(text: str, flag: str) -> bool:
+    """Whether ``text`` names ``flag``, its ``--no-`` form, or a covering wildcard."""
+    forms = [flag, f"--no-{flag.removeprefix('--')}"]
+    if flag.startswith("--project-"):
+        forms.append("--project-*")
+    return any(re.search(rf"`{re.escape(form)}(?![\w-])", text) for form in forms)
+
+
+class TestCliReferenceFlagCoverage:
+    """Each run subcommand's reference section names every flag it accepts."""
+
+    @pytest.mark.parametrize(
+        ("heading", "command"),
+        [("## `nab lock`", lock), ("## `nab download`", download)],
+    )
+    def test_section_names_every_flag(
+        self, heading: str, command: Callable[..., None]
+    ) -> None:
+        text = _CLI_REFERENCE_DOC.read_text(encoding="utf-8")
+
+        # Flags shared by both commands are documented once, in their own section.
+        scope = _doc_section(text, heading) + _doc_section(text, "## Runtime flags")
+
+        for name, param in inspect.signature(command).parameters.items():
+            if param.kind is not inspect.Parameter.KEYWORD_ONLY:
+                continue
+            flag = "--" + name.replace("_", "-")
+            assert _names_flag(scope, flag), f"{heading} omits {flag}"
 
 
 class TestDetermineLockAnchor:


### PR DESCRIPTION
The `nab download` section of the CLI reference only listed `--output`, `--max-concurrency` and `--workspace-discovery`. `--extras`/`--all-extras`, `--groups`/`--all-groups` and `--python` were documented under `nab lock` only, so they read as lock-only flags even though `nab download` takes them and they decide which artefacts get downloaded. A project with an `exactly-one` conflict group needs one of them before a download will start at all.

This documents them in that section. It also adds a test that reads the flags `nab lock` and `nab download` accept and asserts each one is named in its reference section, so a new flag cannot ship undocumented.
