### PR TITLE
stop suggesting an --output template that still collides

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -99,7 +99,10 @@ Wrote req-3.12-extra-gpu.txt (14 packages, tuple py312-linux_x86_64-extra-gpu)
 ```
 
 A template that maps two tuples onto one path is rejected, naming the
-variable that would separate them.
+variables that would give every tuple its own file. When the tuples
+split on an axis no variable names, such as the libc or the
+implementation, no template separates them and the message points at
+pylock output instead.
 
 Exits non-zero on resolution failure; the message starts with
 `error: resolution failed:` followed by a derivation tree, and any

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -619,19 +619,23 @@ def _template_values(target: ResolveTarget) -> dict[str, str]:
     }
 
 
-def _varying_vars(targets: Sequence[ResolveTarget]) -> list[str]:
-    """Return the template variables whose value differs across ``targets``.
+def _separating_vars(targets: Sequence[ResolveTarget]) -> list[str]:
+    """Return the template variables that give each tuple its own file.
 
-    These are the variables an ``--output`` template has to name to give
-    each tuple its own file.  The list can be empty: two tuples can
-    differ in a tag knob no variable names (a musl and a glibc target
-    share one ``platform_id``), and then no template separates them.
+    These are the variables whose value differs across ``targets``, but
+    only when naming all of them lands every tuple on its own path.  The
+    list is empty otherwise: tuples can differ in an axis no variable
+    names, so a musl and a glibc target share one ``platform_id``, and a
+    CPython and a PyPy target share all three.
     """
     values = [_template_values(target) for target in targets]
     first = values[0]
-    return [
+    varying = [
         name for name in first if any(other[name] != first[name] for other in values)
     ]
+
+    rendered = {tuple(value[name] for name in varying) for value in values}
+    return varying if len(rendered) == len(values) else []
 
 
 def _and_list(names: Sequence[str]) -> str:
@@ -750,23 +754,23 @@ def _emit_requirements(
 def _refuse_untemplated(lock_input: LockInput, output: Path) -> NoReturn:
     """Exit 1: several tuples, and one plain ``--output`` path for them all.
 
-    Names the variables that actually vary across the tuples, which for a
-    resolve forked by ``[tool.nab].conflicts`` is ``{selection}`` alone:
-    the fork is a dimension of its own, and the tuples it produces can
-    share every other axis.
+    Names the variables that separate the tuples, which for a resolve
+    forked by ``[tool.nab].conflicts`` is ``{selection}`` alone: the fork
+    is a dimension of its own, and the tuples it produces can share every
+    other axis.
     """
     targets = [lock.target for lock in lock_input.targets.values()]
     count = len(targets)
-    varying = _varying_vars(targets)
-    if not varying:
+    separating = _separating_vars(targets)
+    if not separating:
         _cli.printer().error(
             f"the resolve produced {count} tuples and no --output template"
             f" variable tells them apart, so {output} cannot hold them."
             "  Emit pylock output instead."
         )
         sys.exit(1)
-    placeholders = _and_list([f"{{{name}}}" for name in varying])
-    example = "constraints" + "".join(f"-{{{name}}}" for name in varying) + ".txt"
+    placeholders = _and_list([f"{{{name}}}" for name in separating])
+    example = "constraints" + "".join(f"-{{{name}}}" for name in separating) + ".txt"
     _cli.printer().error(
         f"the resolve produced {count} tuples but --output {output} has no"
         f" template variable to disambiguate.  Use {placeholders} in the path,"
@@ -776,14 +780,25 @@ def _refuse_untemplated(lock_input: LockInput, output: Path) -> NoReturn:
 
 
 def _refuse_collision(
-    first: TargetLock, second: TargetLock, *, output: Path, template: str, path: str
+    lock_input: LockInput,
+    first: TargetLock,
+    second: TargetLock,
+    *,
+    output: Path,
+    template: str,
+    path: str,
 ) -> NoReturn:
-    """Exit 1: two tuples render one path under this template."""
+    """Exit 1: two tuples render one path under this template.
+
+    The separating set covers every tuple in the lock, not just the
+    colliding pair: a variable that tells those two apart can still leave
+    another pair sharing a path, so offering it would only move the error.
+    """
+    targets = [lock.target for lock in lock_input.targets.values()]
     missing = [
-        name
-        for name in _varying_vars([first.target, second.target])
-        if f"{{{name}}}" not in template
+        name for name in _separating_vars(targets) if f"{{{name}}}" not in template
     ]
+
     head = (
         f"tuples {first.target.label!r} and {second.target.label!r}"
         f" both map to {path!r};"
@@ -812,6 +827,7 @@ def _substituted_paths(
         substituted = template.format(**_template_values(lock.target))
         if substituted in by_path:
             _refuse_collision(
+                lock_input,
                 by_path[substituted],
                 lock,
                 output=output,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -337,6 +337,54 @@ def _two_libc_universal_result() -> ResolveResult:
     )
 
 
+def _two_implementation_universal_result() -> ResolveResult:
+    """Two Pythons on one platform, each in a CPython and a PyPy flavour.
+
+    ``python_version`` varies, so a template can name it, but the
+    implementation pairs still land on one path.
+    """
+    tuples = tuple(
+        ResolveTarget.for_declared(
+            python_version=py_minor,
+            spec=PlatformSpec("linux_x86_64"),
+            implementation=implementation,
+            multi_implementation=True,
+        )
+        for py_minor in ("3.11", "3.12")
+        for implementation in ("cpython", "pypy")
+    )
+    return ResolveResult(
+        targets=tuples,
+        target_results=[_resolved(tup, {"foo": V("1.0")}) for tup in tuples],
+    )
+
+
+def _mixed_implementation_universal_result() -> ResolveResult:
+    """A CPython 3.11 tuple, plus a CPython and a PyPy 3.12 tuple.
+
+    The first pair to collide under a ``{platform_id}`` template differs
+    in ``python_version``, but naming it leaves the two 3.12 tuples on
+    one path.
+    """
+    tuples = tuple(
+        ResolveTarget.for_declared(
+            python_version=py_minor,
+            spec=PlatformSpec("linux_x86_64"),
+            implementation=implementation,
+            multi_implementation=True,
+        )
+        for py_minor, implementation in (
+            ("3.11", "cpython"),
+            ("3.12", "cpython"),
+            ("3.12", "pypy"),
+        )
+    )
+    return ResolveResult(
+        targets=tuples,
+        target_results=[_resolved(tup, {"foo": V("1.0")}) for tup in tuples],
+    )
+
+
 def _late_hashless_universal_result() -> ResolveResult:
     """Two tuples, where only the second one pins a hashless artefact.
 
@@ -2203,6 +2251,48 @@ class TestLockCommandUniversal:
         err = capsys.readouterr().err
         assert "tells them apart" in err
         assert not out.exists()
+
+    def test_plain_output_offers_no_template_that_would_collide(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A variable that varies but leaves a collision is not offered as a fix."""
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "requirements.txt"
+        with (
+            patch(
+                "nab.cli.resolve_for_targets",
+                return_value=_two_implementation_universal_result(),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, format="requirements-without-hashes", output=out)
+        err = capsys.readouterr().err
+        assert "4 tuples" in err
+        assert "tells them apart" in err
+        assert "Emit pylock output instead" in err
+        assert "{python_version}" not in err
+        assert not out.exists()
+
+    def test_collision_offers_no_template_that_would_collide(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A variable that separates the colliding pair only is not offered."""
+        pyproject = _universal_pyproject(tmp_path)
+        out = tmp_path / "req-{platform_id}.txt"
+        with (
+            patch(
+                "nab.cli.resolve_for_targets",
+                return_value=_mixed_implementation_universal_result(),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, format="requirements-without-hashes", output=out)
+        err = capsys.readouterr().err
+        assert "both map to" in err
+        assert "tells them apart" in err
+        assert "Emit pylock output instead" in err
+        assert "{python_version}" not in err
+        assert list(tmp_path.glob("req-*.txt")) == []
 
     def test_template_missing_hash_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
When `nab lock` produces several tuples and `--output` is a plain path, the error names the template variables to add to the path, but it picks the variables whose values differ across the tuples rather than the ones that separate them. If the tuples split on an axis no variable names, such as the implementation or the libc, adding every varying variable still lands two tuples on one file, so following the suggestion hits the collision error.

The collision message has the same fault from the other side: it looks only at the two tuples that map to one path, so it can name a variable that tells those two apart while another pair keeps sharing a file.

Both messages now work from the variables that give every tuple in the lock its own path, and point at pylock output when no set of variables does that.
