### PR TITLE
read a file:/path index URL as a local index

### DIFF
--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -1045,12 +1045,12 @@ class FetchCoordinator:
     ) -> CachedAsyncSimpleClient | LocalIndexClient:
         """Build a single index client for ``url``.
 
-        ``file://`` URLs go to :class:`LocalIndexClient` (no caching;
-        the filesystem is the cache).  Everything else goes to
-        :class:`CachedAsyncSimpleClient` with a per-URL
-        :class:`OnDiskCache` when ``cache_dir`` is set.
+        A ``file:`` URL goes to :class:`LocalIndexClient` (no caching;
+        the filesystem is the cache), whichever RFC 8089 spelling it uses.
+        Everything else goes to :class:`CachedAsyncSimpleClient` with a
+        per-URL :class:`OnDiskCache` when ``cache_dir`` is set.
         """
-        if url.startswith("file://"):
+        if urlsplit(url).scheme == "file":
             return LocalIndexClient(url)
         backend: CacheBackend
         if self._cache_dir is not None:

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -1021,7 +1021,7 @@ class FetchCoordinator:
 
         Single-index configurations return a plain
         :class:`CachedAsyncSimpleClient` (or a :class:`LocalIndexClient`
-        for ``file://``).  Multi-index configurations wire up a
+        for a ``file:`` URL).  Multi-index configurations wire up a
         :class:`MultiIndexClient` whose underlying clients share the
         coordinator's transport but get their own per-URL cache.
         """
@@ -1045,13 +1045,21 @@ class FetchCoordinator:
     ) -> CachedAsyncSimpleClient | LocalIndexClient:
         """Build a single index client for ``url``.
 
-        A ``file:`` URL goes to :class:`LocalIndexClient` (no caching;
-        the filesystem is the cache), whichever RFC 8089 spelling it uses.
-        Everything else goes to :class:`CachedAsyncSimpleClient` with a
-        per-URL :class:`OnDiskCache` when ``cache_dir`` is set.
+        A ``file:`` URL in either RFC 8089 spelling goes to
+        :class:`LocalIndexClient` (no caching; the filesystem is the
+        cache).  Everything else goes to :class:`CachedAsyncSimpleClient`
+        with a per-URL :class:`OnDiskCache` when ``cache_dir`` is set.
         """
-        if urlsplit(url).scheme == "file":
+        # urlsplit raises on an authority it cannot parse, such as an
+        # unterminated IPv6 bracket.
+        try:
+            is_file = urlsplit(url).scheme == "file"
+        except ValueError:
+            is_file = False
+
+        if is_file:
             return LocalIndexClient(url)
+
         backend: CacheBackend
         if self._cache_dir is not None:
             backend = OnDiskCache(self._cache_dir, url)

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -2025,19 +2025,44 @@ class TestMultiIndexCoordinator:
             coord.shutdown()
 
     def test_local_index_without_authority(self, tmp_path: Path) -> None:
-        """An RFC 8089 file:/path index URL is local too, not a remote one."""
+        """A file:/path index URL without an authority is still a local index."""
         wheelhouse = tmp_path / "wheelhouse"
         wheelhouse.mkdir()
         (wheelhouse / "foo-1.0-py3-none-any.whl").write_bytes(b"")
         url = wheelhouse.as_uri().replace("file://", "file:", 1)
         assert not url.startswith("file://")
-        with _coord(indexes=[IndexConfig("local", url)]) as coord:
+
+        coord = _coord(indexes=[IndexConfig("local", url)])
+        try:
             assert isinstance(coord._build_client(), LocalIndexClient)
+        finally:
+            coord.shutdown()
+
+        with _coord(indexes=[IndexConfig("local", url)]) as coord:
             coord.request_listing("foo").wait(timeout=5)
             listing = coord.index.get_listing("foo")
             assert coord.index.get_listing_error("foo") is None
-        assert listing is not None
-        assert [f.filename for f in listing] == ["foo-1.0-py3-none-any.whl"]
+            assert listing is not None
+            assert [f.filename for f in listing] == ["foo-1.0-py3-none-any.whl"]
+
+    def test_unparseable_index_url_is_not_local(self, tmp_path: Path) -> None:
+        """An index URL urlsplit cannot parse falls through to the remote client."""
+        wheelhouse = tmp_path / "wheelhouse"
+        wheelhouse.mkdir()
+        (wheelhouse / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+
+        with _coord(
+            indexes=[
+                IndexConfig("local", wheelhouse.as_uri()),
+                # An unterminated IPv6 bracket has been a urlsplit ValueError
+                # for far longer than a bracketed IPv4 address, which only
+                # started raising after the oldest 3.10 nab supports.
+                IndexConfig("bad", "https://[::1/simple/"),
+            ],
+        ) as coord:
+            coord.request_listing("foo").wait(timeout=5)
+            assert coord.index.get_listing_error("foo") is None
+            assert coord.index.get_listing_index("foo") == "local"
 
     def test_single_index_short_circuit(self, tmp_path: Path) -> None:
         """Single index + no overrides returns a plain client."""

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -2024,6 +2024,21 @@ class TestMultiIndexCoordinator:
         finally:
             coord.shutdown()
 
+    def test_local_index_without_authority(self, tmp_path: Path) -> None:
+        """An RFC 8089 file:/path index URL is local too, not a remote one."""
+        wheelhouse = tmp_path / "wheelhouse"
+        wheelhouse.mkdir()
+        (wheelhouse / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+        url = wheelhouse.as_uri().replace("file://", "file:", 1)
+        assert not url.startswith("file://")
+        with _coord(indexes=[IndexConfig("local", url)]) as coord:
+            assert isinstance(coord._build_client(), LocalIndexClient)
+            coord.request_listing("foo").wait(timeout=5)
+            listing = coord.index.get_listing("foo")
+            assert coord.index.get_listing_error("foo") is None
+        assert listing is not None
+        assert [f.filename for f in listing] == ["foo-1.0-py3-none-any.whl"]
+
     def test_single_index_short_circuit(self, tmp_path: Path) -> None:
         """Single index + no overrides returns a plain client."""
         coord = FetchCoordinator(


### PR DESCRIPTION
Index URLs were routed with a `file://` prefix test, so an index URL in the RFC 8089 no-authority form, `file:/srv/wheels`, was handed to the HTTP client instead of the local index client and the resolve failed with `GET file:/srv/wheels/foo/ failed: No host specified`. nab's own `parse_file_url` accepts both spellings, and `[[tool.nab.archive-sources]]` already dispatches on the parsed scheme, so indexes now do the same.

`urlsplit` can raise on an authority it cannot parse, such as an unterminated IPv6 bracket, so that case falls back to the remote client instead of raising ValueError while the client is built.
