### PR TITLE
answer range subset and disjointness without an intermediate range

### DIFF
--- a/nab-python/src/nab_python/_provider/lookahead.py
+++ b/nab-python/src/nab_python/_provider/lookahead.py
@@ -95,7 +95,7 @@ def look_ahead_ok(
         # already has the clause via its root_requirements input).
         if dep_normalized in provider.root_requirements:
             root_range = provider.root_requirements[dep_normalized]
-            if (dep_range & root_range).is_empty:
+            if dep_range.is_disjoint(root_range):
                 provider.pending_root_blocks[
                     (package, dep_normalized, dep_range, root_range)
                 ].append(version)
@@ -119,7 +119,7 @@ def look_ahead_ok(
             if (
                 pos_range is not None
                 and decided_version is None
-                and (dep_range & pos_range).is_empty
+                and dep_range.is_disjoint(pos_range)
             ):
                 range_key = (package, dep_normalized, pos_range)
                 provider.pending_range_blocks[range_key].append(version)

--- a/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
+++ b/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
@@ -11,12 +11,26 @@ plus at most one checked-in patch, and nothing else.
   to.
 - `tasks/vendoring/packaging.patch`, when present, is the only divergence from
   pristine; the rebuild reapplies it after refreshing. With no patch file the
-  tree is byte-identical to upstream at the pin. The current patch adds
-  `VersionRange.from_bounds` and `VersionRange.snap_bounds` to `ranges.py`,
-  generated from the `range-from-bounds` branch of the packaging fork
-  (`git diff upstream/main..range-from-bounds -- src/packaging/ranges.py`,
-  paths rewritten to this directory). An upstream PR is planned; until it
-  lands the patch carries the two methods.
+  tree is byte-identical to upstream at the pin. The patch carries:
+  - `ranges.py`: `VersionRange.from_bounds`, `snap_bounds`,
+    `release_intervals`, and `relation`; `is_subset` and `is_disjoint`
+    answered by a direct walk over the interval lists instead of an
+    intermediate range; the module-level helpers they need (`_relate_bounds`,
+    `_subset_bounds`, `_disjoint_bounds`, `_bisect_predicate`,
+    `_partition_indexes`, `_lattice_release`, `_release_boundary_point`); and
+    the class-docstring lines naming them.
+  - `_ranges.py`: an unbounded end canonicalizes its inclusivity, and
+    `LowerBound.__gt__`, `LowerBound.__le__`, and `UpperBound.__gt__` are
+    written out beside `functools.total_ordering`, which still derives the
+    rest.
+  - `markersets.py` and `_markersets.py`: the marker-algebra module and the
+    private engine behind it, both new files, plus the `Marker.to_set`
+    accessor they need on `markers.py`.
+
+  Upstream PRs are planned for the bound ordering, the direct subset and
+  disjoint walks, and `from_bounds`/`snap_bounds`/`release_intervals`.
+  `relation` is deliberately not proposed yet: most of its win is available
+  from the direct walks alone, and what is left depends on the interval shapes.
 - `tasks/vendor-packaging.sh` fetches `pypa/packaging` at the pin, replaces this
   package with the pristine `src/packaging/` tree plus the repo-root license
   texts, and reapplies the patch. `--check` rebuilds into a temp location and
@@ -28,8 +42,12 @@ plus at most one checked-in patch, and nothing else.
 ## Refreshing
 
 1. Bump `tasks/vendoring/packaging.pin` to the new upstream commit.
-2. If the patch no longer applies, rebase its source branch onto the new pin
-   and regenerate `packaging.patch` from it.
+2. If the patch no longer applies, regenerate it from the committed vendored
+   tree rather than from any fork branch: the patch is the accumulated
+   divergence and no single branch carries all of it. Copy the committed
+   `_vendor/packaging/` over pristine-at-pin in a local `packaging` clone,
+   diff, and rewrite the paths back to this directory. Drop from the diff
+   whatever the new pin has absorbed.
 3. Run `tasks/vendor-packaging.sh`, then the test suite.
 
 ## License

--- a/nab-python/src/nab_python/_vendor/packaging/_ranges.py
+++ b/nab-python/src/nab_python/_vendor/packaging/_ranges.py
@@ -187,6 +187,11 @@ class LowerBound:
     __slots__ = ("_above", "inclusive", "version")
 
     def __init__(self, version: _VersionOrBoundary, inclusive: bool) -> None:
+        # -inf is not a version, so "inclusive of -inf" has no content;
+        # canonicalizing it keeps the bound order total.
+        if version is None:
+            inclusive = False
+
         self.version = version
         self.inclusive = inclusive
         # Pre-bind a predicate "is parsed at or above this lower
@@ -224,6 +229,30 @@ class LowerBound:
         # [v < (v: inclusive starts earlier.
         return self.inclusive and not other.inclusive
 
+    # Written out rather than left to functools.total_ordering, whose shims
+    # reach the same answer through ``__lt__`` and ``__eq__``.
+    def __gt__(self, other: LowerBound) -> bool:
+        if not isinstance(other, LowerBound):
+            return NotImplemented
+        if self.version is None:
+            return False
+        if other.version is None:
+            return True
+        if self.version != other.version:
+            return not self.version < other.version
+        return other.inclusive and not self.inclusive
+
+    def __le__(self, other: LowerBound) -> bool:
+        if not isinstance(other, LowerBound):
+            return NotImplemented
+        if self.version is None:
+            return True
+        if other.version is None:
+            return False
+        if self.version != other.version:
+            return self.version < other.version
+        return self.inclusive or not other.inclusive
+
     def __hash__(self) -> int:
         return hash((self.version, self.inclusive))
 
@@ -244,6 +273,10 @@ class UpperBound:
     __slots__ = ("_below", "inclusive", "version")
 
     def __init__(self, version: _VersionOrBoundary, inclusive: bool) -> None:
+        # See LowerBound: +inf carries no inclusivity either.
+        if version is None:
+            inclusive = False
+
         self.version = version
         self.inclusive = inclusive
         # Pre-bind a predicate "is parsed at or below this upper
@@ -282,6 +315,18 @@ class UpperBound:
             return self.version < other.version
         # v) < v]: exclusive ends earlier.
         return not self.inclusive and other.inclusive
+
+    # Written out for the same reason as on ``LowerBound``.
+    def __gt__(self, other: UpperBound) -> bool:
+        if not isinstance(other, UpperBound):
+            return NotImplemented
+        if self.version is None:
+            return other.version is not None
+        if other.version is None:
+            return False
+        if self.version != other.version:
+            return not self.version < other.version
+        return self.inclusive and not other.inclusive
 
     def __hash__(self) -> int:
         return hash((self.version, self.inclusive))

--- a/nab-python/src/nab_python/_vendor/packaging/ranges.py
+++ b/nab-python/src/nab_python/_vendor/packaging/ranges.py
@@ -131,6 +131,95 @@ def _union_ranges(
     return merged
 
 
+def _relate_bounds(
+    left: Sequence[Interval],
+    right: Sequence[Interval],
+) -> tuple[bool, bool]:
+    """Return ``(is_subset, is_disjoint)`` for two sorted interval lists.
+
+    One two-pointer merge answers both without building the intersection or the
+    complement. The lists are canonical (sorted, non-overlapping, and
+    non-touching, since :func:`_union_ranges` merges across empty gaps), so a
+    covered left interval sits wholly inside one right interval rather than
+    spanning two: ``left`` is a subset when every one of its intervals is
+    covered, and the two are disjoint when no overlap is found at all. A partial
+    overlap rules out both, so the walk stops there.
+    """
+    matched = 0
+    left_index = right_index = 0
+    disjoint = True
+    while left_index < len(left) and right_index < len(right):
+        left_lower, left_upper = left[left_index]
+        right_lower, right_upper = right[right_index]
+
+        # ``max`` and ``min`` return their first argument on a tie, so both cuts
+        # are the left ones exactly when the overlap is the whole left interval.
+        lower = max(left_lower, right_lower)
+        upper = min(left_upper, right_upper)
+
+        if not range_is_empty(lower, upper):
+            if lower is left_lower and upper is left_upper:
+                matched += 1
+            else:
+                return False, False
+            disjoint = False
+
+        # Advance whichever side has the smaller upper bound.
+        if left_upper < right_upper:
+            left_index += 1
+        else:
+            right_index += 1
+
+    return matched == len(left), disjoint
+
+
+def _subset_bounds(left: Sequence[Interval], right: Sequence[Interval]) -> bool:
+    """Return whether every version in ``left`` is also in ``right``.
+
+    The canonical lists let one two-pointer walk decide containment: skip the
+    right intervals that end too early, then check that the surviving one starts
+    early enough.
+    """
+    right_index = 0
+    right_len = len(right)
+    for left_lower, left_upper in left:
+        # A right interval ending below this one cannot cover it, and the left
+        # list ascends, so it cannot cover any later one either.
+        while right_index < right_len and right[right_index][1] < left_upper:
+            right_index += 1
+        if right_index == right_len:
+            return False
+        if right[right_index][0] > left_lower:
+            return False
+    return True
+
+
+def _disjoint_bounds(left: Sequence[Interval], right: Sequence[Interval]) -> bool:
+    """Return whether no version lies in both ``left`` and ``right``.
+
+    A two-pointer merge that stops at the first overlap.
+    """
+    left_index = right_index = 0
+    left_len = len(left)
+    right_len = len(right)
+    while left_index < left_len and right_index < right_len:
+        left_lower, left_upper = left[left_index]
+        right_lower, right_upper = right[right_index]
+
+        lower = max(left_lower, right_lower)
+        upper = min(left_upper, right_upper)
+        if not range_is_empty(lower, upper):
+            return False
+
+        # Advance whichever side has the smaller upper bound.
+        if left_upper < right_upper:
+            left_index += 1
+        else:
+            right_index += 1
+
+    return True
+
+
 def _complement_ranges(ranges: Sequence[Interval]) -> list[Interval]:
     """Complement a sorted, non-overlapping interval list.
 
@@ -410,9 +499,9 @@ class VersionRange:
     that opt-in scoped to those versions, so unrelated pre-releases are not
     admitted wholesale.
 
-    :meth:`intersection`, :meth:`union`, :meth:`difference`, and the
-    :meth:`is_subset` / :meth:`is_superset` / :meth:`is_disjoint` predicates
-    require both operands to share the same configured policy.
+    :meth:`intersection`, :meth:`union`, :meth:`difference`, :meth:`relation`,
+    and the :meth:`is_subset` / :meth:`is_superset` / :meth:`is_disjoint`
+    predicates require both operands to share the same configured policy.
 
     >>> r = SpecifierSet(">=1.0,<2.0").to_range()
     >>> "1.5" in r
@@ -1027,6 +1116,15 @@ class VersionRange:
         False
         >>> VersionRange.empty().is_subset(outer)
         True
+
+        A range with an exclusion is a subset of its span, but the span is not a
+        subset of it:
+
+        >>> punctured = SpecifierSet(">=1.0,<2.0,!=1.5").to_range()
+        >>> punctured.is_subset(outer)
+        True
+        >>> outer.is_subset(punctured)
+        False
         """
         self._check_policy_compat(other)
 
@@ -1037,11 +1135,51 @@ class VersionRange:
 
         # Plain ranges: subset reduces to bounds containment, no algebra needed.
         if self._is_plain() and other._is_plain():
-            return not intersect_ranges(self._bounds, _complement_ranges(other._bounds))
+            return _subset_bounds(self._bounds, other._bounds)
 
         # difference (unlike intersection with the one-way complement) resolves
         # ``===`` literals against both operands, so it stays correct for them.
         return self.difference(other).is_empty
+
+    def relation(self, other: VersionRange) -> tuple[bool, bool]:
+        """Return ``(is_subset, is_disjoint)`` against ``other``.
+
+        Subset-only is containment, disjoint-only is separation, and neither is
+        overlap. Both hold together only when self is empty, which is a subset
+        of everything and shares a member with nothing.
+
+        Both operands must share the same configured pre-release policy;
+        otherwise :exc:`ValueError` is raised.
+
+        >>> inner = SpecifierSet(">=1.5,<1.8").to_range()
+        >>> outer = SpecifierSet(">=1.0,<2.0").to_range()
+        >>> inner.relation(outer)
+        (True, False)
+        >>> outer.relation(SpecifierSet(">=5.0").to_range())
+        (False, True)
+        >>> VersionRange.empty().relation(outer)
+        (True, True)
+        """
+        # Identity settles both answers and the policy check with it.
+        if self is other:
+            if self.is_empty:
+                return True, True
+            return True, False
+
+        self._check_policy_compat(other)
+
+        if self._is_plain() and other._is_plain():
+            # On plain ranges the bounds decide membership, so equal bounds
+            # settle both answers without a walk.
+            if self._bounds == other._bounds:
+                if self._bounds:
+                    return True, False
+                return True, True
+            return _relate_bounds(self._bounds, other._bounds)
+
+        # Literals, a live arbitrary admission, or a pre-release-excluding
+        # policy all put members outside the bounds, so defer to the algebra.
+        return self.is_subset(other), self.is_disjoint(other)
 
     def is_superset(self, other: VersionRange) -> bool:
         """Return whether every member of other is also a member of self.
@@ -1073,12 +1211,19 @@ class VersionRange:
         True
         >>> a.is_disjoint(SpecifierSet(">=1.5,<2.5").to_range())
         False
+
+        A range pinned to a version the other excludes is disjoint from it:
+
+        >>> SpecifierSet("==1.5").to_range().is_disjoint(
+        ...     SpecifierSet(">=1.0,<2.0,!=1.5").to_range()
+        ... )
+        True
         """
         self._check_policy_compat(other)
 
         # Plain ranges: disjointness is an empty bounds intersection.
         if self._is_plain() and other._is_plain():
-            return not intersect_ranges(self._bounds, other._bounds)
+            return _disjoint_bounds(self._bounds, other._bounds)
         return self.intersection(other).is_empty
 
     @typing.overload

--- a/nab-python/tests/property_python/strategies.py
+++ b/nab-python/tests/property_python/strategies.py
@@ -11,6 +11,9 @@ tests exercise:
   comparison.
 * ``canonical_names``/``versions``/``sha256s``: primitives for the
   PEP 751 lockfile property tests.
+* ``range_clauses``/``range_specs``: specifier text over a version pool
+  spanning pre-release, post, local, and epoch shapes, for the
+  ``VersionRange`` differential tests.
 """
 
 from __future__ import annotations
@@ -257,3 +260,58 @@ def package_overrides(draw: st.DrawFn, *, name: str) -> PackageOverride:
         uploaded_prior_to=uploaded_prior_to,
         uploaded_prior_to_disabled=uploaded_prior_to_disabled,
     )
+
+
+# A version pool wide enough that random bounds over it land on every
+# interesting shape: pre-release, dev, post, local, and a second epoch.
+RANGE_VERSION_POOL = [
+    "0.9",
+    "1.0.dev1",
+    "1.0a1",
+    "1.0rc1",
+    "1.0",
+    "1.0+local",
+    "1.0.post1",
+    "1.4",
+    "1.5",
+    "1.8",
+    "1.9.9",
+    "2.0",
+    "3.0",
+    "1!0.5",
+    "1!1.0",
+]
+
+_ORDERED_OPERATORS = [">=", "<=", ">", "<"]
+_EQUALITY_OPERATORS = ["==", "!="]
+
+
+@st.composite
+def range_clauses(draw: st.DrawFn) -> str:
+    """One specifier clause over ``RANGE_VERSION_POOL``.
+
+    Local versions and ``.*`` wildcards are only legal on some operators,
+    so each operator is paired with versions it accepts.
+    """
+    kind = draw(st.integers(min_value=0, max_value=3))
+    if kind == 0:
+        operator = draw(st.sampled_from(_ORDERED_OPERATORS))
+        version = draw(st.sampled_from([v for v in RANGE_VERSION_POOL if "+" not in v]))
+        return f"{operator}{version}"
+    if kind == 1:
+        operator = draw(st.sampled_from(_EQUALITY_OPERATORS))
+        return f"{operator}{draw(st.sampled_from(RANGE_VERSION_POOL))}"
+    if kind == 2:
+        operator = draw(st.sampled_from(_EQUALITY_OPERATORS))
+        base = draw(st.sampled_from(["1", "1.0", "2", "1!1"]))
+        return f"{operator}{base}.*"
+    return f"~={draw(st.sampled_from(['1.4', '1.0.0', '2.0']))}"
+
+
+@st.composite
+def range_specs(draw: st.DrawFn) -> str:
+    """A specifier set of zero to three clauses, or a ``===`` literal."""
+    if draw(st.integers(min_value=0, max_value=7)) == 0:
+        literal = draw(st.sampled_from([*RANGE_VERSION_POOL, "frobnicate"]))
+        return f"==={literal}"
+    return ",".join(draw(st.lists(range_clauses(), min_size=0, max_size=3)))

--- a/nab-python/tests/property_python/test_relation_differential.py
+++ b/nab-python/tests/property_python/test_relation_differential.py
@@ -1,0 +1,53 @@
+"""Differential property tests for ``VersionRange.relation``.
+
+Over random ranges, ``relation`` is checked against both equivalent
+expressions: ``(is_subset, is_disjoint)`` asked separately, and
+``(is_subset, (self & other).is_empty)``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_python._vendor.packaging.ranges import VersionRange
+from nab_python._vendor.packaging.specifiers import SpecifierSet
+
+from .strategies import PROPERTY_SETTINGS, range_specs
+
+pytestmark = pytest.mark.property
+
+
+@st.composite
+def _ranges(draw: st.DrawFn) -> VersionRange:
+    """A range under the default pre-release policy."""
+    return SpecifierSet(draw(range_specs())).to_range()
+
+
+@given(left=_ranges(), right=_ranges())
+@PROPERTY_SETTINGS
+def test_relation_matches_the_separate_predicates(
+    left: VersionRange, right: VersionRange
+) -> None:
+    """relation agrees with is_subset and is_disjoint asked separately."""
+    assert left.relation(right) == (left.is_subset(right), left.is_disjoint(right))
+
+
+@given(left=_ranges(), right=_ranges())
+@PROPERTY_SETTINGS
+def test_relation_matches_the_intersection_form(
+    left: VersionRange, right: VersionRange
+) -> None:
+    """relation agrees with subset plus an empty intersection."""
+    assert left.relation(right) == (left.is_subset(right), (left & right).is_empty)
+
+
+@given(left=_ranges(), right=_ranges())
+@PROPERTY_SETTINGS
+def test_relation_reports_both_only_for_an_empty_left(
+    left: VersionRange, right: VersionRange
+) -> None:
+    """Subset and disjoint hold together exactly when left is empty."""
+    subset, disjoint = left.relation(right)
+    assert (subset and disjoint) == left.is_empty

--- a/nab-python/tests/test_vendor_bound_ordering.py
+++ b/nab-python/tests/test_vendor_bound_ordering.py
@@ -1,0 +1,211 @@
+"""Tests for the vendored patch's ``LowerBound`` / ``UpperBound`` ordering.
+
+The bounds order under ``functools.total_ordering``, with ``LowerBound.__gt__``,
+``LowerBound.__le__``, and ``UpperBound.__gt__`` written out because the interval
+walks call those three directly. Every pair over a bound pool is checked against
+the shim's expansion of ``__lt__`` and ``__eq__``, against the total-order laws,
+and against the ``_above`` / ``_below`` predicates the same bounds carry. The
+pool holds an unbounded bound spelled both inclusive and exclusive, the pair the
+constructor collapses to one point.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import TYPE_CHECKING, TypeVar
+
+import pytest
+
+from nab_python._vendor.packaging._ranges import (
+    NEG_INF,
+    POS_INF,
+    BoundaryKind,
+    BoundaryVersion,
+    LowerBound,
+    UpperBound,
+)
+from nab_python._vendor.packaging.ranges import _relate_bounds, _subset_bounds
+from nab_python._vendor.packaging.version import Version
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+V = Version
+
+BoundT = TypeVar("BoundT", LowerBound, UpperBound)
+
+BOUND_VERSIONS = [
+    None,
+    V("1.0"),
+    V("1.0+local"),
+    V("1.0.post1"),
+    V("2.0"),
+    BoundaryVersion(V("1.0"), BoundaryKind.AFTER_LOCALS),
+    BoundaryVersion(V("1.0"), BoundaryKind.AFTER_POSTS),
+]
+
+LOWER_BOUNDS = [
+    LowerBound(version, inclusive)
+    for version in BOUND_VERSIONS
+    for inclusive in (True, False)
+]
+UPPER_BOUNDS = [
+    UpperBound(version, inclusive)
+    for version in BOUND_VERSIONS
+    for inclusive in (True, False)
+]
+
+#: Versions straddling every point the pool's bounds can cut at.
+PROBE_VERSIONS = [
+    V(text)
+    for text in (
+        "0.dev0",
+        "0",
+        "1.0.dev0",
+        "1.0a1",
+        "1.0",
+        "1.0+local",
+        "1.0+zzz",
+        "1.0.post0",
+        "1.0.post1",
+        "1.0.post1+local",
+        "1.0.1",
+        "2.0",
+        "2.0+local",
+        "3.0",
+    )
+]
+
+
+def _shim(left: BoundT, right: BoundT) -> tuple[bool, bool, bool]:
+    """``(gt, ge, le)`` as ``functools.total_ordering`` derives them."""
+    less = left < right
+    equal = left == right
+    return (not less and not equal), (not less), (less or equal)
+
+
+def _admits_lower(bound: LowerBound, version: Version) -> bool:
+    return bound._above is None or bound._above(version)
+
+
+def _admits_upper(bound: UpperBound, version: Version) -> bool:
+    return bound._below is None or bound._below(version)
+
+
+def _check_total_order(pool: list[BoundT]) -> None:
+    for left, right in itertools.product(pool, pool):
+        less, equal, greater = left < right, left == right, left > right
+        assert [less, equal, greater].count(True) == 1, (left, right)
+        assert not (greater and right > left), (left, right)
+        assert left <= right or right <= left, (left, right)
+    for left, middle, right in itertools.product(pool, pool, pool):
+        if left < middle < right:
+            assert left < right, (left, middle, right)
+        if left <= middle <= right:
+            assert left <= right, (left, middle, right)
+
+
+class TestBoundOrdering:
+    @pytest.mark.parametrize(
+        ("left", "right"), list(itertools.product(LOWER_BOUNDS, LOWER_BOUNDS))
+    )
+    def test_lower_bound_matches_total_ordering(
+        self, left: LowerBound, right: LowerBound
+    ) -> None:
+        assert (left > right, left >= right, left <= right) == _shim(left, right)
+
+    @pytest.mark.parametrize(
+        ("left", "right"), list(itertools.product(UPPER_BOUNDS, UPPER_BOUNDS))
+    )
+    def test_upper_bound_matches_total_ordering(
+        self, left: UpperBound, right: UpperBound
+    ) -> None:
+        assert (left > right, left >= right, left <= right) == _shim(left, right)
+
+    def test_the_lower_bound_order_is_total(self) -> None:
+        _check_total_order(LOWER_BOUNDS)
+
+    def test_the_upper_bound_order_is_total(self) -> None:
+        _check_total_order(UPPER_BOUNDS)
+
+    def test_the_greater_lower_bound_admits_the_narrower_set(self) -> None:
+        # intersect_ranges takes max() of two lower bounds as the intersection's
+        # floor, which is only the intersection while the order tracks _above.
+        for left, right in itertools.product(LOWER_BOUNDS, LOWER_BOUNDS):
+            picked = max(left, right)
+            for version in PROBE_VERSIONS:
+                both = _admits_lower(left, version) and _admits_lower(right, version)
+                assert _admits_lower(picked, version) == both, (left, right, version)
+
+    def test_the_lesser_upper_bound_admits_the_narrower_set(self) -> None:
+        for left, right in itertools.product(UPPER_BOUNDS, UPPER_BOUNDS):
+            picked = min(left, right)
+            for version in PROBE_VERSIONS:
+                both = _admits_upper(left, version) and _admits_upper(right, version)
+                assert _admits_upper(picked, version) == both, (left, right, version)
+
+    def test_unbounded_lower_bounds_ignore_inclusivity(self) -> None:
+        # -inf is not a version, so "inclusive of it" has no content: the
+        # constructor drops the flag and the two spellings are one point.
+        inclusive = LowerBound(None, inclusive=True)
+        exclusive = LowerBound(None, inclusive=False)
+        assert inclusive.inclusive is False
+        assert inclusive == exclusive
+        assert not inclusive > exclusive
+        assert not exclusive > inclusive
+        assert inclusive <= exclusive
+        assert exclusive <= inclusive
+        assert hash(inclusive) == hash(exclusive)
+
+    def test_unbounded_upper_bounds_ignore_inclusivity(self) -> None:
+        inclusive = UpperBound(None, inclusive=True)
+        exclusive = UpperBound(None, inclusive=False)
+        assert inclusive.inclusive is False
+        assert inclusive == exclusive
+        assert not inclusive > exclusive
+        assert not exclusive > inclusive
+        assert inclusive <= exclusive
+        assert exclusive <= inclusive
+        assert hash(inclusive) == hash(exclusive)
+
+    def test_the_module_infinities_are_canonical(self) -> None:
+        assert LowerBound(None, inclusive=True) == NEG_INF
+        assert UpperBound(None, inclusive=True) == POS_INF
+
+    def test_max_and_min_keep_the_first_argument_on_a_tie(self) -> None:
+        # intersect_ranges reuses whichever bound object won, so a tie must not
+        # swap them out.
+        pools: list[tuple[list[LowerBound] | list[UpperBound], Callable[..., object]]]
+        pools = [(LOWER_BOUNDS, max), (UPPER_BOUNDS, min)]
+        for pool, pick in pools:
+            for left in pool:
+                right = type(left)(left.version, left.inclusive)
+                assert pick(left, right) is left
+                assert pick(right, left) is right
+
+    def test_the_interval_walks_see_one_unbounded_point(self) -> None:
+        # _relate_bounds reads coverage off the identity max() and min() hand
+        # back, and _subset_bounds compares the lower bounds outright, so an
+        # unbounded end spelled either way has to be the same point to both.
+        left = [
+            (LowerBound(None, inclusive=True), UpperBound(V("2.0"), inclusive=False))
+        ]
+        right = [(NEG_INF, POS_INF)]
+        assert _relate_bounds(left, right) == (True, False)
+        assert _relate_bounds(right, left) == (False, False)
+        assert _subset_bounds(left, right)
+
+    @pytest.mark.parametrize("operator", ["__lt__", "__gt__", "__ge__", "__le__"])
+    @pytest.mark.parametrize("cls", [LowerBound, UpperBound])
+    def test_bound_returns_not_implemented_for_other_types(
+        self, cls: type[LowerBound | UpperBound], operator: str
+    ) -> None:
+        bound = cls(V("1.0"), inclusive=True)
+        assert getattr(bound, operator)("1.0") is NotImplemented
+        assert bound != "1.0"
+
+    def test_mixing_bound_kinds_is_a_type_error(self) -> None:
+        lower = LowerBound(V("1.0"), inclusive=True)
+        upper = UpperBound(V("1.0"), inclusive=True)
+        with pytest.raises(TypeError):
+            _ = lower > upper  # type: ignore[operator]

--- a/nab-python/tests/test_vendor_relation.py
+++ b/nab-python/tests/test_vendor_relation.py
@@ -1,0 +1,120 @@
+"""Tests for the vendored patch's ``VersionRange.relation``.
+
+``relation`` answers subset and disjointness in one interval walk, so a spec
+grid checks it against both the separate predicates and the intersection
+form, alongside hand-written expectations.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from nab_python._vendor.packaging.ranges import VersionRange
+from nab_python._vendor.packaging.specifiers import SpecifierSet
+
+# Single and double bounds, exclusions, wildcards, an epoch, a post, a local,
+# a pre-release naming clause, and the two ``===`` shapes.
+SPECS = [
+    "",
+    ">=1.0",
+    ">1.0",
+    "<2.0",
+    "<=2.0",
+    ">=1.0,<2.0",
+    ">1.0,<=2.0",
+    ">=1.5,<1.8",
+    ">=2.0,<1.0",
+    "==1.5",
+    "!=1.5",
+    "==1.*",
+    "!=1.*",
+    "~=1.4",
+    ">=1.0.post1",
+    "==1.0+local",
+    ">=1!0.5",
+    ">=1.0a1",
+    "===1.5",
+    "===frobnicate",
+]
+
+
+def _range(spec: str) -> VersionRange:
+    return SpecifierSet(spec).to_range()
+
+
+class TestRelation:
+    def test_containment(self) -> None:
+        assert _range(">=1.5,<1.8").relation(_range(">=1.0,<2.0")) == (True, False)
+
+    def test_separation(self) -> None:
+        assert _range(">=1.0,<2.0").relation(_range(">=5.0")) == (False, True)
+
+    def test_overlap(self) -> None:
+        assert _range(">=1.0,<2.0").relation(_range(">=1.5,<3.0")) == (False, False)
+
+    def test_empty_self_is_subset_and_disjoint(self) -> None:
+        assert VersionRange.empty().relation(_range(">=1.0")) == (True, True)
+
+    def test_identity_non_empty(self) -> None:
+        r = _range(">=1.0,<2.0")
+        assert r.relation(r) == (True, False)
+
+    def test_identity_empty(self) -> None:
+        empty = VersionRange.empty()
+        assert empty.relation(empty) == (True, True)
+
+    def test_structurally_equal_ranges(self) -> None:
+        assert _range(">=1.0,<2.0").relation(_range(">=1.0,<2.0")) == (True, False)
+
+    def test_structurally_equal_empty_ranges(self) -> None:
+        assert _range(">=2.0,<1.0").relation(_range(">=3.0,<1.0")) == (True, True)
+
+    def test_multi_interval_subset_of_full(self) -> None:
+        assert _range("!=1.5").relation(VersionRange.full()) == (True, False)
+
+    def test_full_is_not_subset_of_punctured(self) -> None:
+        assert VersionRange.full().relation(_range("!=1.5")) == (False, False)
+
+    def test_interval_spanning_a_gap_is_not_a_subset(self) -> None:
+        # >=1.0,<=3.0 covers 2.0, which !=2.0 removes, so the left interval
+        # spans both right intervals rather than sitting inside either.
+        assert _range(">=1.0,<=3.0").relation(_range("!=2.0")) == (False, False)
+
+    def test_touching_intervals_stay_disjoint(self) -> None:
+        assert _range("<1.0").relation(_range(">=1.0")) == (False, True)
+
+    def test_differently_spelled_equal_ranges(self) -> None:
+        assert _range(">=1.0,<2.0").relation(_range(">=1.0,<2.0,<3.0")) == (True, False)
+
+    def test_policy_mismatch_raises(self) -> None:
+        configured = SpecifierSet(">=1.0", prereleases=True).to_range()
+        with pytest.raises(ValueError, match="pre-release"):
+            configured.relation(_range(">=1.0"))
+
+    def test_literal_range_defers_to_the_algebra(self) -> None:
+        literal = _range("===1.5")
+        outer = _range(">=1.0,<2.0")
+        assert literal.relation(outer) == (
+            literal.is_subset(outer),
+            literal.is_disjoint(outer),
+        )
+
+    def test_prerelease_excluding_policy_defers_to_the_algebra(self) -> None:
+        strict = SpecifierSet(">=1.0", prereleases=False).to_range()
+        other = SpecifierSet(">=1.0,<2.0", prereleases=False).to_range()
+        assert strict.relation(other) == (
+            strict.is_subset(other),
+            strict.is_disjoint(other),
+        )
+
+    @pytest.mark.parametrize(("left", "right"), list(itertools.product(SPECS, SPECS)))
+    def test_matches_the_intersection_form(self, left: str, right: str) -> None:
+        a, b = _range(left), _range(right)
+        assert a.relation(b) == (a.is_subset(b), (a & b).is_empty)
+
+    @pytest.mark.parametrize(("left", "right"), list(itertools.product(SPECS, SPECS)))
+    def test_matches_the_separate_predicates(self, left: str, right: str) -> None:
+        a, b = _range(left), _range(right)
+        assert a.relation(b) == (a.is_subset(b), a.is_disjoint(b))

--- a/nab-python/tests/test_vendor_subset_disjoint.py
+++ b/nab-python/tests/test_vendor_subset_disjoint.py
@@ -1,0 +1,193 @@
+"""Tests for the vendored patch's bounds-only subset and disjointness walks.
+
+``is_subset`` and ``is_disjoint`` take a two-pointer walk over the interval
+lists whenever both operands are plain, so every answer is checked against the
+set-algebra oracle it replaces (``(a - b).is_empty`` and ``(a & b).is_empty``)
+and against pointwise membership over a version pool. The population runs the
+algebra over specifier-built ranges first, which reaches interval shapes no
+specifier writes.
+"""
+
+from __future__ import annotations
+
+import functools
+import itertools
+from typing import TYPE_CHECKING
+
+from nab_python._vendor.packaging.ranges import VersionRange
+from nab_python._vendor.packaging.specifiers import SpecifierSet
+from nab_python._vendor.packaging.version import Version
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+# Finals, every pre-release phase, dev, post, local, and a second epoch.
+POOL = [
+    Version(text)
+    for text in (
+        "0",
+        "0.dev0",
+        "1.0.dev1",
+        "1.0a1",
+        "1.0b2",
+        "1.0rc1",
+        "1.0",
+        "1.0+local",
+        "1.0.post1",
+        "1.5",
+        "2.0a1",
+        "2.0",
+        "3.0",
+        "1!0.5",
+        "1!1.0",
+    )
+]
+
+SPECIFIERS = [
+    "",
+    ">=1.0",
+    "<2.0",
+    ">=1.0,<2.0",
+    "==1.0",
+    "!=1.0",
+    "~=1.0.1",
+    ">=1.0,<3.0,!=1.5",
+    "==1.0.*",
+    ">1.0",
+    "<=1.0",
+    ">=1.0.dev0,<2.0a1",
+    "!=1.0,!=1.5,!=2.0",
+    ">=1!0.5",
+    "===frobnitz",
+    "===1.0",
+    "==1.0+local",
+]
+
+
+def _seed_ranges() -> Iterator[VersionRange]:
+    for text in SPECIFIERS:
+        for prereleases in (None, True, False):
+            yield SpecifierSet(text, prereleases=prereleases).to_range()
+    yield VersionRange.full()
+    yield VersionRange.full(admit_arbitrary=False)
+    yield VersionRange.empty()
+    yield VersionRange.singleton(Version("1.0"))
+    yield VersionRange.from_bounds(Version("1.0"), Version("2.0"))
+    yield VersionRange.from_bounds(None, Version("2.0"), include_upper=True)
+    yield VersionRange.from_bounds(Version("1.0"), None)
+
+
+@functools.lru_cache(maxsize=1)
+def _population() -> tuple[VersionRange, ...]:
+    """Seeds plus complements and pairwise algebra over a sample of them."""
+    seeds = list(_seed_ranges())
+    built = list(seeds)
+    built.extend(~r for r in seeds)
+    sample = seeds[::4]
+    for a, b in itertools.product(sample, sample):
+        if a._prereleases_configured is not b._prereleases_configured:
+            continue
+        built.extend((a & b, a | b, a - b, ~(a - b)))
+    return tuple(built)
+
+
+def _same_policy_pairs() -> Iterator[tuple[VersionRange, VersionRange]]:
+    population = _population()
+    for a, b in itertools.product(population, population):
+        if a._prereleases_configured is b._prereleases_configured:
+            yield a, b
+
+
+class TestSubsetAndDisjointMatchTheAlgebra:
+    def test_population_covers_the_required_shapes(self) -> None:
+        population = _population()
+        interval_counts = {len(r._bounds) for r in population}
+        assert len(population) > 400
+        assert {0, 1, 2} <= interval_counts
+        assert max(interval_counts) >= 4
+        assert any(r._admit or r._reject for r in population)
+        assert any(r._arbitrary_active() for r in population)
+        assert any(r.is_empty for r in population)
+        assert VersionRange.full() in population
+
+    def test_subset_matches_the_difference_algebra(self) -> None:
+        for a, b in _same_policy_pairs():
+            if a._arbitrary_active() and not b._arbitrary_active():
+                # Carved out below: a live arbitrary admission holds non-version
+                # strings, which the interval difference does not model.
+                continue
+            assert a.is_subset(b) == (a - b).is_empty, (a, b)
+
+    def test_a_live_arbitrary_admission_is_never_a_subset_of_a_dead_one(self) -> None:
+        live, dead = VersionRange.full(), VersionRange.full(admit_arbitrary=False)
+        assert (live - dead).is_empty
+        assert not live.is_subset(dead)
+        assert dead.is_subset(live)
+        witnessed = 0
+        for a, b in _same_policy_pairs():
+            if a._arbitrary_active() and not b._arbitrary_active():
+                assert not a.is_subset(b), (a, b)
+                witnessed += 1
+        assert witnessed > 0
+
+    def test_disjoint_matches_the_intersection_algebra(self) -> None:
+        for a, b in _same_policy_pairs():
+            assert a.is_disjoint(b) == (a & b).is_empty, (a, b)
+
+    def test_superset_mirrors_subset(self) -> None:
+        for a, b in _same_policy_pairs():
+            assert a.is_superset(b) == b.is_subset(a), (a, b)
+
+    def test_subset_implies_pointwise_membership(self) -> None:
+        for a, b in _same_policy_pairs():
+            if not a.is_subset(b):
+                continue
+            for version in POOL:
+                assert version not in a or version in b, (a, b, version)
+
+    def test_disjoint_implies_no_shared_member(self) -> None:
+        for a, b in _same_policy_pairs():
+            if not a.is_disjoint(b):
+                continue
+            for version in POOL:
+                assert version not in a or version not in b, (a, b, version)
+
+    def test_overlap_exhibits_a_shared_member_or_a_gap(self) -> None:
+        witnessed = 0
+        for a, b in _same_policy_pairs():
+            if a.is_subset(b) or a.is_disjoint(b):
+                continue
+            shared = [v for v in POOL if v in a and v in b]
+            only_a = [v for v in POOL if v in a and v not in b]
+            if shared and only_a:
+                witnessed += 1
+        assert witnessed > 0
+
+    def test_empty_is_a_subset_of_and_disjoint_from_everything(self) -> None:
+        empty = VersionRange.empty()
+        for other in _population():
+            if other._prereleases_configured is not empty._prereleases_configured:
+                continue
+            assert empty.is_subset(other)
+            assert empty.is_disjoint(other)
+
+    def test_a_punctured_range_is_a_subset_of_its_span(self) -> None:
+        punctured = SpecifierSet(">=1.0,<2.0,!=1.5").to_range()
+        span = SpecifierSet(">=1.0,<2.0").to_range()
+        assert punctured.is_subset(span)
+        assert not span.is_subset(punctured)
+
+    def test_a_pin_on_an_excluded_version_is_disjoint(self) -> None:
+        pin = SpecifierSet("==1.5").to_range()
+        punctured = SpecifierSet(">=1.0,<2.0,!=1.5").to_range()
+        assert pin.is_disjoint(punctured)
+        assert punctured.is_disjoint(pin)
+
+    def test_an_interval_running_past_the_right_list_is_not_a_subset(self) -> None:
+        # The walk exhausts the right list before the left one, which is the
+        # branch a left interval above every right interval takes.
+        assert (
+            not SpecifierSet(">=3.0")
+            .to_range()
+            .is_subset(SpecifierSet(">=1.0,<2.0").to_range())
+        )

--- a/nab-resolver/src/nab_resolver/propagate.py
+++ b/nab-resolver/src/nab_resolver/propagate.py
@@ -17,10 +17,10 @@ from .types import IncompatibilityState, SetRelation, Term
 
 if TYPE_CHECKING:
     from .resolver import Resolver
-    from .types import Incompatibility, RangeProtocol
+    from .types import Incompatibility
 
 __all__ = [
-    "classify_intersection",
+    "classify_relation",
     "evaluate_incompatibility",
     "term_relation",
     "unit_propagation",
@@ -127,8 +127,8 @@ def term_relation(resolver: Resolver[Any, Any], term: Term[Any, Any]) -> SetRela
     key = (positive, assignment, term.constraint)
     result = cache.get(key)
     if result is None:
-        intersection = assignment & term.constraint
-        result = classify_intersection(term, assignment, intersection)
+        subset, disjoint = assignment.relation(term.constraint)
+        result = classify_relation(term, subset=subset, disjoint=disjoint)
         if len(cache) >= RELATION_CACHE_MAX:
             cache.clear()
         cache[key] = result
@@ -142,24 +142,26 @@ def term_relation(resolver: Resolver[Any, Any], term: Term[Any, Any]) -> SetRela
     return result
 
 
-def classify_intersection(
+def classify_relation(
     term: Term[Any, Any],
-    assignment: RangeProtocol[Any],
-    intersection: RangeProtocol[Any],
+    *,
+    subset: bool,
+    disjoint: bool,
 ) -> SetRelation:
-    """Classify a term against its precomputed assignment intersection.
+    """Classify a term from the assignment's relation to its constraint.
+
+    ``subset`` and ``disjoint`` describe the assignment against
+    ``term.constraint``, as returned by ``RangeProtocol.relation``.
 
     Positive term: satisfied when the assignment is a subset of the
-    constraint; contradicted when the intersection is empty.
-    Negative term: satisfied when the intersection is empty; contradicted
-    when the assignment falls entirely inside the forbidden range.
+    constraint; contradicted when the two are disjoint.
+    Negative term: the two swap, since a negative term forbids the
+    constraint's versions.
     """
     if term.is_positive():
-        satisfied = assignment.is_subset(term.constraint)
-        contradicted = intersection.is_empty
+        satisfied, contradicted = subset, disjoint
     else:
-        satisfied = intersection.is_empty
-        contradicted = assignment.is_subset(term.constraint)
+        satisfied, contradicted = disjoint, subset
 
     if satisfied:
         return SetRelation.SATISFIED

--- a/nab-resolver/src/nab_resolver/ranges.py
+++ b/nab-resolver/src/nab_resolver/ranges.py
@@ -347,6 +347,13 @@ class Range(Generic[VersionType]):
         """Return whether self and other share no version."""
         return (self & other).is_empty
 
+    def relation(self, other: Range[VersionType]) -> tuple[bool, bool]:
+        """Return ``(is_subset, is_disjoint)`` against other.
+
+        Asked separately here; an implementation may answer both in one walk.
+        """
+        return self.is_subset(other), self.is_disjoint(other)
+
     @override
     def __eq__(self, other: object) -> bool:
         """Test equality by comparing interval tuples."""

--- a/nab-resolver/src/nab_resolver/types.py
+++ b/nab-resolver/src/nab_resolver/types.py
@@ -96,6 +96,13 @@ class RangeProtocol(Protocol[VersionType_contra]):
         """Return whether self and other share no version."""
         ...
 
+    def relation(self, other: Self) -> tuple[bool, bool]:
+        """Return ``(is_subset, is_disjoint)`` against other.
+
+        Both answers hold at once only for an empty self.
+        """
+        ...
+
     # __eq__ and __hash__ come from object; redeclaring them in the
     # Protocol adds no constraint and mypy and zuban disagree on @override.
 

--- a/nab-resolver/tests/property/test_term_relation_oracle.py
+++ b/nab-resolver/tests/property/test_term_relation_oracle.py
@@ -75,7 +75,7 @@ def _oracle_acceptable(
         return {SetRelation.SATISFIED}
     if all_false:
         if can_be_absent and rep_is_empty(present):
-            # Only the absent scenario exists.  classify_intersection's
+            # Only the absent scenario exists.  classify_relation's
             # covers-before-empty tie-break reports SATISFIED, which the
             # needs_positive gate downgrades to UNDETERMINED, so the
             # truthful CONTRADICTED is unreachable here.  Sound but lossy.

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -1695,6 +1695,83 @@ index 0000000..ca941f5
 +        _clause_formula(sorted(clause, key=_atom_key)) for clause in residual
 +    )
 +    return make_and([*lead, inner])
+diff --git a/nab-python/src/nab_python/_vendor/packaging/_ranges.py b/nab-python/src/nab_python/_vendor/packaging/_ranges.py
+index 5370ec8..b305068 100644
+--- a/nab-python/src/nab_python/_vendor/packaging/_ranges.py
++++ b/nab-python/src/nab_python/_vendor/packaging/_ranges.py
+@@ -187,6 +187,11 @@ class LowerBound:
+     __slots__ = ("_above", "inclusive", "version")
+ 
+     def __init__(self, version: _VersionOrBoundary, inclusive: bool) -> None:
++        # -inf is not a version, so "inclusive of -inf" has no content;
++        # canonicalizing it keeps the bound order total.
++        if version is None:
++            inclusive = False
++
+         self.version = version
+         self.inclusive = inclusive
+         # Pre-bind a predicate "is parsed at or above this lower
+@@ -224,6 +229,30 @@ class LowerBound:
+         # [v < (v: inclusive starts earlier.
+         return self.inclusive and not other.inclusive
+ 
++    # Written out rather than left to functools.total_ordering, whose shims
++    # reach the same answer through ``__lt__`` and ``__eq__``.
++    def __gt__(self, other: LowerBound) -> bool:
++        if not isinstance(other, LowerBound):
++            return NotImplemented
++        if self.version is None:
++            return False
++        if other.version is None:
++            return True
++        if self.version != other.version:
++            return not self.version < other.version
++        return other.inclusive and not self.inclusive
++
++    def __le__(self, other: LowerBound) -> bool:
++        if not isinstance(other, LowerBound):
++            return NotImplemented
++        if self.version is None:
++            return True
++        if other.version is None:
++            return False
++        if self.version != other.version:
++            return self.version < other.version
++        return self.inclusive or not other.inclusive
++
+     def __hash__(self) -> int:
+         return hash((self.version, self.inclusive))
+ 
+@@ -244,6 +273,10 @@ class UpperBound:
+     __slots__ = ("_below", "inclusive", "version")
+ 
+     def __init__(self, version: _VersionOrBoundary, inclusive: bool) -> None:
++        # See LowerBound: +inf carries no inclusivity either.
++        if version is None:
++            inclusive = False
++
+         self.version = version
+         self.inclusive = inclusive
+         # Pre-bind a predicate "is parsed at or below this upper
+@@ -283,6 +316,18 @@ class UpperBound:
+         # v) < v]: exclusive ends earlier.
+         return not self.inclusive and other.inclusive
+ 
++    # Written out for the same reason as on ``LowerBound``.
++    def __gt__(self, other: UpperBound) -> bool:
++        if not isinstance(other, UpperBound):
++            return NotImplemented
++        if self.version is None:
++            return other.version is not None
++        if other.version is None:
++            return False
++        if self.version != other.version:
++            return not self.version < other.version
++        return self.inclusive and not other.inclusive
++
+     def __hash__(self) -> int:
+         return hash((self.version, self.inclusive))
+ 
 diff --git a/nab-python/src/nab_python/_vendor/packaging/markers.py b/nab-python/src/nab_python/_vendor/packaging/markers.py
 index c78fd5d..0d7ee1d 100644
 --- a/nab-python/src/nab_python/_vendor/packaging/markers.py
@@ -2087,10 +2164,106 @@ index 0000000..74930e7
 +    def __repr__(self) -> str:
 +        return f"<{type(self).__name__} {_markersets.describe(self._tree)!r}>"
 diff --git a/nab-python/src/nab_python/_vendor/packaging/ranges.py b/nab-python/src/nab_python/_vendor/packaging/ranges.py
-index 8dd5e66..512cc2f 100644
+index 8dd5e66..66224b4 100644
 --- a/nab-python/src/nab_python/_vendor/packaging/ranges.py
 +++ b/nab-python/src/nab_python/_vendor/packaging/ranges.py
-@@ -280,6 +280,85 @@ def _struct_admits(
+@@ -131,6 +131,95 @@ def _union_ranges(
+     return merged
+ 
+ 
++def _relate_bounds(
++    left: Sequence[Interval],
++    right: Sequence[Interval],
++) -> tuple[bool, bool]:
++    """Return ``(is_subset, is_disjoint)`` for two sorted interval lists.
++
++    One two-pointer merge answers both without building the intersection or the
++    complement. The lists are canonical (sorted, non-overlapping, and
++    non-touching, since :func:`_union_ranges` merges across empty gaps), so a
++    covered left interval sits wholly inside one right interval rather than
++    spanning two: ``left`` is a subset when every one of its intervals is
++    covered, and the two are disjoint when no overlap is found at all. A partial
++    overlap rules out both, so the walk stops there.
++    """
++    matched = 0
++    left_index = right_index = 0
++    disjoint = True
++    while left_index < len(left) and right_index < len(right):
++        left_lower, left_upper = left[left_index]
++        right_lower, right_upper = right[right_index]
++
++        # ``max`` and ``min`` return their first argument on a tie, so both cuts
++        # are the left ones exactly when the overlap is the whole left interval.
++        lower = max(left_lower, right_lower)
++        upper = min(left_upper, right_upper)
++
++        if not range_is_empty(lower, upper):
++            if lower is left_lower and upper is left_upper:
++                matched += 1
++            else:
++                return False, False
++            disjoint = False
++
++        # Advance whichever side has the smaller upper bound.
++        if left_upper < right_upper:
++            left_index += 1
++        else:
++            right_index += 1
++
++    return matched == len(left), disjoint
++
++
++def _subset_bounds(left: Sequence[Interval], right: Sequence[Interval]) -> bool:
++    """Return whether every version in ``left`` is also in ``right``.
++
++    The canonical lists let one two-pointer walk decide containment: skip the
++    right intervals that end too early, then check that the surviving one starts
++    early enough.
++    """
++    right_index = 0
++    right_len = len(right)
++    for left_lower, left_upper in left:
++        # A right interval ending below this one cannot cover it, and the left
++        # list ascends, so it cannot cover any later one either.
++        while right_index < right_len and right[right_index][1] < left_upper:
++            right_index += 1
++        if right_index == right_len:
++            return False
++        if right[right_index][0] > left_lower:
++            return False
++    return True
++
++
++def _disjoint_bounds(left: Sequence[Interval], right: Sequence[Interval]) -> bool:
++    """Return whether no version lies in both ``left`` and ``right``.
++
++    A two-pointer merge that stops at the first overlap.
++    """
++    left_index = right_index = 0
++    left_len = len(left)
++    right_len = len(right)
++    while left_index < left_len and right_index < right_len:
++        left_lower, left_upper = left[left_index]
++        right_lower, right_upper = right[right_index]
++
++        lower = max(left_lower, right_lower)
++        upper = min(left_upper, right_upper)
++        if not range_is_empty(lower, upper):
++            return False
++
++        # Advance whichever side has the smaller upper bound.
++        if left_upper < right_upper:
++            left_index += 1
++        else:
++            right_index += 1
++
++    return True
++
++
+ def _complement_ranges(ranges: Sequence[Interval]) -> list[Interval]:
+     """Complement a sorted, non-overlapping interval list.
+ 
+@@ -280,6 +369,85 @@ def _struct_admits(
      return matches_bounds_only(bounds, parsed)
  
  
@@ -2176,7 +2349,7 @@ index 8dd5e66..512cc2f 100644
  # Repr helpers:
  
  
-@@ -316,7 +395,8 @@ class VersionRange:
+@@ -316,7 +484,8 @@ class VersionRange:
      :class:`~packaging.specifiers.SpecifierSet`.
  
      Construct via :meth:`~packaging.specifiers.SpecifierSet.to_range`, or with
@@ -2186,7 +2359,20 @@ index 8dd5e66..512cc2f 100644
      Compose with :meth:`intersection`, :meth:`union`, :meth:`complement`, and
      :meth:`difference` (or the ``&`` / ``|`` / ``~`` / ``-`` operators). Test
      membership with ``in`` or :meth:`contains`, filter an iterable with
-@@ -407,7 +487,8 @@ class VersionRange:
+@@ -330,9 +499,9 @@ class VersionRange:
+     that opt-in scoped to those versions, so unrelated pre-releases are not
+     admitted wholesale.
+ 
+-    :meth:`intersection`, :meth:`union`, :meth:`difference`, and the
+-    :meth:`is_subset` / :meth:`is_superset` / :meth:`is_disjoint` predicates
+-    require both operands to share the same configured policy.
++    :meth:`intersection`, :meth:`union`, :meth:`difference`, :meth:`relation`,
++    and the :meth:`is_subset` / :meth:`is_superset` / :meth:`is_disjoint`
++    predicates require both operands to share the same configured policy.
+ 
+     >>> r = SpecifierSet(">=1.0,<2.0").to_range()
+     >>> "1.5" in r
+@@ -407,7 +576,8 @@ class VersionRange:
          raise TypeError(
              "cannot create 'VersionRange' instances directly; use "
              "SpecifierSet.to_range(), VersionRange.full(), "
@@ -2196,7 +2382,7 @@ index 8dd5e66..512cc2f 100644
          )
  
      @classmethod
-@@ -599,6 +680,73 @@ class VersionRange:
+@@ -599,6 +769,73 @@ class VersionRange:
              prereleases_configured=prereleases,
          )
  
@@ -2270,7 +2456,98 @@ index 8dd5e66..512cc2f 100644
      def intersection(self, other: VersionRange) -> VersionRange:
          """Range containing exactly the versions in both self and other.
  
-@@ -1078,6 +1226,123 @@ class VersionRange:
+@@ -879,6 +1116,15 @@ class VersionRange:
+         False
+         >>> VersionRange.empty().is_subset(outer)
+         True
++
++        A range with an exclusion is a subset of its span, but the span is not a
++        subset of it:
++
++        >>> punctured = SpecifierSet(">=1.0,<2.0,!=1.5").to_range()
++        >>> punctured.is_subset(outer)
++        True
++        >>> outer.is_subset(punctured)
++        False
+         """
+         self._check_policy_compat(other)
+ 
+@@ -889,12 +1135,52 @@ class VersionRange:
+ 
+         # Plain ranges: subset reduces to bounds containment, no algebra needed.
+         if self._is_plain() and other._is_plain():
+-            return not intersect_ranges(self._bounds, _complement_ranges(other._bounds))
++            return _subset_bounds(self._bounds, other._bounds)
+ 
+         # difference (unlike intersection with the one-way complement) resolves
+         # ``===`` literals against both operands, so it stays correct for them.
+         return self.difference(other).is_empty
+ 
++    def relation(self, other: VersionRange) -> tuple[bool, bool]:
++        """Return ``(is_subset, is_disjoint)`` against ``other``.
++
++        Subset-only is containment, disjoint-only is separation, and neither is
++        overlap. Both hold together only when self is empty, which is a subset
++        of everything and shares a member with nothing.
++
++        Both operands must share the same configured pre-release policy;
++        otherwise :exc:`ValueError` is raised.
++
++        >>> inner = SpecifierSet(">=1.5,<1.8").to_range()
++        >>> outer = SpecifierSet(">=1.0,<2.0").to_range()
++        >>> inner.relation(outer)
++        (True, False)
++        >>> outer.relation(SpecifierSet(">=5.0").to_range())
++        (False, True)
++        >>> VersionRange.empty().relation(outer)
++        (True, True)
++        """
++        # Identity settles both answers and the policy check with it.
++        if self is other:
++            if self.is_empty:
++                return True, True
++            return True, False
++
++        self._check_policy_compat(other)
++
++        if self._is_plain() and other._is_plain():
++            # On plain ranges the bounds decide membership, so equal bounds
++            # settle both answers without a walk.
++            if self._bounds == other._bounds:
++                if self._bounds:
++                    return True, False
++                return True, True
++            return _relate_bounds(self._bounds, other._bounds)
++
++        # Literals, a live arbitrary admission, or a pre-release-excluding
++        # policy all put members outside the bounds, so defer to the algebra.
++        return self.is_subset(other), self.is_disjoint(other)
++
+     def is_superset(self, other: VersionRange) -> bool:
+         """Return whether every member of other is also a member of self.
+ 
+@@ -925,12 +1211,19 @@ class VersionRange:
+         True
+         >>> a.is_disjoint(SpecifierSet(">=1.5,<2.5").to_range())
+         False
++
++        A range pinned to a version the other excludes is disjoint from it:
++
++        >>> SpecifierSet("==1.5").to_range().is_disjoint(
++        ...     SpecifierSet(">=1.0,<2.0,!=1.5").to_range()
++        ... )
++        True
+         """
+         self._check_policy_compat(other)
+ 
+         # Plain ranges: disjointness is an empty bounds intersection.
+         if self._is_plain() and other._is_plain():
+-            return not intersect_ranges(self._bounds, other._bounds)
++            return _disjoint_bounds(self._bounds, other._bounds)
+         return self.intersection(other).is_empty
+ 
+     @typing.overload
+@@ -1078,6 +1371,123 @@ class VersionRange:
          if not found_final:
              yield from all_nonfinal
  


### PR DESCRIPTION
`is_subset` built the difference and asked whether it was empty, and `is_disjoint` materialised the intersection with no early return. Both now walk the two interval lists directly and stop at the first answer. `VersionRange.relation(other)` returns `(is_subset, is_disjoint)` from a single walk, which is what unit propagation wants when it classifies a term, and the look-ahead asks `is_disjoint` instead of building `a & b` to test it for emptiness.

In `_ranges.py` an unbounded end now canonicalizes its inclusivity. That makes the bound ordering antisymmetric: previously `LowerBound(None, True)` and `NEG_INF` were each greater than the other and neither was less than or equal to the other, which the interval walks rely on not happening. The three bound comparisons that have callers are written out beside `functools.total_ordering`, which still derives the rest.

The vendored `packaging` divergence is carried in `tasks/vendoring/packaging.patch`, per the pinned-tree-plus-one-patch model in `PROVENANCE.md`.