### PR TITLE
add an assume_sorted keyword to VersionRange.filter

### DIFF
--- a/nab-python/src/nab_python/_provider/extras.py
+++ b/nab-python/src/nab_python/_provider/extras.py
@@ -56,12 +56,13 @@ def choose_extra_version(
             normalized,
             package,
         )
-        candidates = list(version_range.filter(all_versions))
+        admit_range = version_range
     else:
-        candidates = list((version_range & base_range).filter(all_versions))
+        admit_range = version_range & base_range
+    candidates = list(admit_range.filter(all_versions, assume_sorted="descending"))
 
     if provider.wants_lowest(normalized):
-        candidates = list(reversed(candidates))
+        candidates.reverse()
 
     chosen = _pick_in_mode(provider, base, extra, candidates)
     if chosen is not None and (normalized, extra) in provider.root_extras:
@@ -80,7 +81,9 @@ def choose_extra_version(
         and (
             excluded_by_base := [
                 v
-                for v in version_range.filter(all_versions, prereleases=True)
+                for v in version_range.filter(
+                    all_versions, prereleases=True, assume_sorted="descending"
+                )
                 if v not in base_range
             ]
         )

--- a/nab-python/src/nab_python/_provider/priority.py
+++ b/nab-python/src/nab_python/_provider/priority.py
@@ -10,13 +10,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from .._vendor.packaging.ranges import VersionRange
+
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from nab_resolver.types import RangeProtocol
 
     from .._vendor.packaging.version import Version
-    from ..provider import Provider
+    from ..provider import DistFile, Provider
 
 
 CONFLICT_THRESHOLD = 5
@@ -33,6 +35,11 @@ TIER_CULPRIT = 2
 # Matching count used while a listing is in flight, so not-yet-fetched
 # packages sort behind ready ones.
 _NO_LISTING_PRIOR = 1000
+
+
+def _version_of(entry: tuple[Version, DistFile]) -> Version:
+    """Return the version half of a ``versions_cache`` entry."""
+    return entry[0]
 
 
 def compute_tier(
@@ -92,8 +99,17 @@ def compute_matching(
             provider.speculative_prefetch(normalized, versions)
 
     if normalized in provider.versions_cache:
+        assert isinstance(version_range, VersionRange)
         versions = provider.versions_cache[normalized]
-        matching = sum(1 for v, _ in versions if v in version_range)
+
+        # prereleases=True counts every in-bounds version; the default policy
+        # would buffer in-bounds pre-releases out of the count.
+        matching = sum(
+            1
+            for _ in version_range.filter(
+                versions, prereleases=True, key=_version_of, assume_sorted="descending"
+            )
+        )
     elif has_local_source:
         matching = 1
     else:

--- a/nab-python/src/nab_python/_provider/priority.py
+++ b/nab-python/src/nab_python/_provider/priority.py
@@ -8,6 +8,7 @@ first inside a conflict cluster); runaway top culprits get tier 2
 
 from __future__ import annotations
 
+from operator import itemgetter
 from typing import TYPE_CHECKING
 
 from .._vendor.packaging.ranges import VersionRange
@@ -18,7 +19,7 @@ if TYPE_CHECKING:
     from nab_resolver.types import RangeProtocol
 
     from .._vendor.packaging.version import Version
-    from ..provider import DistFile, Provider
+    from ..provider import Provider
 
 
 CONFLICT_THRESHOLD = 5
@@ -35,11 +36,6 @@ TIER_CULPRIT = 2
 # Matching count used while a listing is in flight, so not-yet-fetched
 # packages sort behind ready ones.
 _NO_LISTING_PRIOR = 1000
-
-
-def _version_of(entry: tuple[Version, DistFile]) -> Version:
-    """Return the version half of a ``versions_cache`` entry."""
-    return entry[0]
 
 
 def compute_tier(
@@ -107,7 +103,10 @@ def compute_matching(
         matching = sum(
             1
             for _ in version_range.filter(
-                versions, prereleases=True, key=_version_of, assume_sorted="descending"
+                versions,
+                prereleases=True,
+                key=itemgetter(0),
+                assume_sorted="descending",
             )
         )
     elif has_local_source:

--- a/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
+++ b/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
@@ -19,8 +19,8 @@ plus at most one checked-in patch, and nothing else.
     an intermediate range; the module-level helpers they need (`_relate_bounds`,
     `_subset_bounds`, `_disjoint_bounds`, `_bisect_predicate`,
     `_partition_indexes`, `_make_project`, `_check_order`, `_lattice_release`,
-    `_release_boundary_point`); the `SortedOrder` alias; and the
-    class-docstring lines naming them.
+    `_release_boundary_point`); the `SortedOrder` alias and its `__all__`
+    entry; and the class-docstring lines naming them.
   - `_ranges.py`: an unbounded end canonicalizes its inclusivity, and
     `LowerBound.__gt__`, `LowerBound.__le__`, and `UpperBound.__gt__` are
     written out beside `functools.total_ordering`, which still derives the

--- a/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
+++ b/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
@@ -13,12 +13,14 @@ plus at most one checked-in patch, and nothing else.
   pristine; the rebuild reapplies it after refreshing. With no patch file the
   tree is byte-identical to upstream at the pin. The patch carries:
   - `ranges.py`: `VersionRange.from_bounds`, `snap_bounds`,
-    `release_intervals`, and `relation`; `is_subset` and `is_disjoint`
-    answered by a direct walk over the interval lists instead of an
-    intermediate range; the module-level helpers they need (`_relate_bounds`,
+    `release_intervals`, and `relation`; an `assume_sorted` keyword on `filter`
+    and the `VersionRange._filter_sorted` it dispatches to; `is_subset` and
+    `is_disjoint` answered by a direct walk over the interval lists instead of
+    an intermediate range; the module-level helpers they need (`_relate_bounds`,
     `_subset_bounds`, `_disjoint_bounds`, `_bisect_predicate`,
-    `_partition_indexes`, `_lattice_release`, `_release_boundary_point`); and
-    the class-docstring lines naming them.
+    `_partition_indexes`, `_make_project`, `_check_order`, `_lattice_release`,
+    `_release_boundary_point`); the `SortedOrder` alias; and the
+    class-docstring lines naming them.
   - `_ranges.py`: an unbounded end canonicalizes its inclusivity, and
     `LowerBound.__gt__`, `LowerBound.__le__`, and `UpperBound.__gt__` are
     written out beside `functools.total_ordering`, which still derives the
@@ -28,7 +30,8 @@ plus at most one checked-in patch, and nothing else.
     accessor they need on `markers.py`.
 
   Upstream PRs are planned for the bound ordering, the direct subset and
-  disjoint walks, and `from_bounds`/`snap_bounds`/`release_intervals`.
+  disjoint walks, `filter`'s `assume_sorted` fast path, and
+  `from_bounds`/`snap_bounds`/`release_intervals`.
   `relation` is deliberately not proposed yet: most of its win is available
   from the direct walks alone, and what is left depends on the interval shapes.
 - `tasks/vendor-packaging.sh` fetches `pypa/packaging` at the pin, replaces this

--- a/nab-python/src/nab_python/_vendor/packaging/ranges.py
+++ b/nab-python/src/nab_python/_vendor/packaging/ranges.py
@@ -22,6 +22,7 @@ import typing
 from typing import (
     TYPE_CHECKING,
     Any,
+    Literal,
     TypeVar,
     Union,
 )
@@ -57,6 +58,7 @@ __all__ = ["VersionRange"]
 T = TypeVar("T")
 UnparsedVersion = Union[Version, str]
 UnparsedVersionVar = TypeVar("UnparsedVersionVar", bound=UnparsedVersion)
+SortedOrder = Literal["ascending", "descending"]
 
 
 class _SetOp(enum.Enum):
@@ -370,18 +372,23 @@ def _struct_admits(
 
 
 def _bisect_predicate(
-    versions: Sequence[Version], predicate: Callable[[Version], bool]
+    items: Sequence[Any],
+    predicate: Callable[[Version], bool],
+    project: Callable[[Any], Version] | None = None,
 ) -> int:
     """First index whose ``predicate`` is true over an ascending list.
 
     The predicate must be monotonic (false runs then true runs). Equivalent to
     ``bisect.bisect_left`` on the mapped booleans, done by hand because the
     ``key`` parameter for :mod:`bisect` only exists on Python 3.10 and later.
+    ``project`` maps a probed item to the version it sorts by; ``None`` means
+    the items are already :class:`~packaging.version.Version` instances.
     """
-    low, high = 0, len(versions)
+    low, high = 0, len(items)
     while low < high:
         mid = (low + high) // 2
-        if predicate(versions[mid]):
+        item = items[mid]
+        if predicate(item if project is None else project(item)):
             high = mid
         else:
             low = mid + 1
@@ -389,25 +396,77 @@ def _bisect_predicate(
 
 
 def _partition_indexes(
-    versions: Sequence[Version], lower: LowerBound, upper: UpperBound
+    items: Sequence[Any],
+    lower: LowerBound,
+    upper: UpperBound,
+    project: Callable[[Any], Version] | None = None,
+    *,
+    descending: bool = False,
 ) -> tuple[int, int]:
-    """Locate one interval's bounds in an ascending version list.
+    """Locate one interval's entries in a version-ordered list.
 
-    Returns ``(first_inside, first_above)``: the index of the first version at
-    or above ``lower`` and of the first version strictly above ``upper``, so
-    ``versions[first_inside:first_above]`` are the versions the interval
-    contains. The bound predicates are monotonic over an ascending list, so
-    both cuts bisect on the predicate value.
+    Returns the half-open index pair bounding the entries the interval
+    contains, so ``items[start:stop]`` are those entries in list order. On an
+    ascending list ``lower`` cuts the start and ``upper`` cuts the stop; a
+    descending list swaps which bound cuts which end. Both bound predicates
+    are monotonic over a version-ordered list either way, so each cut is one
+    bisection. ``project`` maps an item to the version it sorts by.
     """
     above = lower._above
     below = upper._below
+    start_bound, stop_bound = (below, above) if descending else (above, below)
 
-    first_inside = 0 if above is None else _bisect_predicate(versions, above)
-    if below is None:
-        first_above = len(versions)
+    start = 0 if start_bound is None else _bisect_predicate(items, start_bound, project)
+    if stop_bound is None:
+        stop = len(items)
     else:
-        first_above = _bisect_predicate(versions, lambda v: not below(v))
-    return first_inside, first_above
+        stop = _bisect_predicate(items, lambda v: not stop_bound(v), project)
+    return start, stop
+
+
+def _make_project(
+    key: Callable[[Any], Version | str] | None,
+) -> Callable[[Any], Version]:
+    """Build the item-to-:class:`~packaging.version.Version` map for a sorted walk.
+
+    The bisections compare against bound predicates that only accept a
+    :class:`~packaging.version.Version`, so every probed item is coerced. An
+    item that does not parse cannot sit in version order at all, which is a
+    broken precondition rather than a non-match, so it raises rather than being
+    dropped the way :meth:`VersionRange.filter` drops it.
+    """
+
+    def project(item: Any) -> Version:  # noqa: ANN401
+        raw: Version | str = item if key is None else key(item)
+        parsed = raw if isinstance(raw, Version) else coerce_version(raw)
+        if parsed is None:
+            raise ValueError(
+                f"{raw!r} does not parse as a version, so the given sequence "
+                f"is not in version order"
+            )
+        return parsed
+
+    return project
+
+
+def _check_order(
+    items: Sequence[Any], project: Callable[[Any], Version], *, descending: bool
+) -> None:
+    """Reject a sequence whose endpoints contradict the declared order.
+
+    One comparison of the two ends, which catches a list handed over in the
+    opposite order to the one named. It cannot prove the whole sequence is
+    ordered, and equal endpoints are accepted under either order.
+    """
+    if len(items) < 2:
+        return
+    first = project(items[0])
+    last = project(items[-1])
+    if last < first if not descending else first < last:
+        expected = "descending" if descending else "ascending"
+        raise ValueError(
+            f"assume_sorted={expected!r} but the sequence runs from {first} to {last}"
+        )
 
 
 def _lattice_release(version: Version, parts: int, *, above: bool) -> Version:
@@ -1232,6 +1291,8 @@ class VersionRange:
         iterable: Iterable[UnparsedVersionVar],
         prereleases: bool | None = None,
         key: None = ...,
+        *,
+        assume_sorted: None = None,
     ) -> Iterator[UnparsedVersionVar]: ...
 
     @typing.overload
@@ -1240,6 +1301,28 @@ class VersionRange:
         iterable: Iterable[T],
         prereleases: bool | None = None,
         key: Callable[[T], UnparsedVersion] = ...,
+        *,
+        assume_sorted: None = None,
+    ) -> Iterator[T]: ...
+
+    @typing.overload
+    def filter(
+        self,
+        iterable: Sequence[UnparsedVersionVar],
+        prereleases: bool | None = None,
+        key: None = ...,
+        *,
+        assume_sorted: SortedOrder,
+    ) -> Iterator[UnparsedVersionVar]: ...
+
+    @typing.overload
+    def filter(
+        self,
+        iterable: Sequence[T],
+        prereleases: bool | None = None,
+        key: Callable[[T], UnparsedVersion] = ...,
+        *,
+        assume_sorted: SortedOrder,
     ) -> Iterator[T]: ...
 
     def filter(
@@ -1247,6 +1330,8 @@ class VersionRange:
         iterable: Iterable[Any],
         prereleases: bool | None = None,
         key: Callable[[Any], Version | str] | None = None,
+        *,
+        assume_sorted: SortedOrder | None = None,
     ) -> Iterator[Any]:
         """Yield items from iterable whose version falls inside the range.
 
@@ -1257,12 +1342,45 @@ class VersionRange:
         ``prereleases=True`` would yield it). A flushed buffer comes after
         every in-place yield, so the output is not version-sorted.
 
-        The signature mirrors
+        ``assume_sorted`` names the version order ``iterable`` is already in. It
+        promises ``iterable`` is a sequence in that order and that every entry
+        parses as a version; break either half and the result is undefined, the
+        way :func:`itertools.groupby` is on unsorted input, and a ``ValueError``
+        may come back in place of an answer. Each interval's matching entries
+        form one contiguous slice of an ordered sequence, so two bisections per
+        interval locate them and the pre-release policy runs over those alone;
+        that is ``O(intervals * log(len(iterable)))`` plus the matches, rather
+        than a bound test per entry, which tells on a long listing. The yielded
+        items, and their order, are the same either way. A range carrying ``===``
+        literals or live arbitrary admission decides membership for strings the
+        bounds do not describe, so it falls back to a test per entry and ignores
+        ``assume_sorted`` altogether.
+
+        The signature otherwise mirrors
         :meth:`~packaging.specifiers.SpecifierSet.filter`.
 
         >>> r = SpecifierSet(">=1.0,<2.0").to_range()
         >>> list(r.filter(["0.9", "1.5", "2.0"]))
         ['1.5']
+
+        The same listing, newest first, filtered by bisection:
+
+        >>> listing = [Version(v) for v in ("3.0", "2.0", "1.5", "1.0")]
+        >>> list(r.filter(listing, assume_sorted="descending"))
+        [<Version('1.5')>, <Version('1.0')>]
+
+        ``key`` reaches the version inside a richer entry, on either path:
+
+        >>> files = [("1.5", "b.whl"), ("1.0", "a.whl")]
+        >>> list(r.filter(files, key=lambda f: f[0], assume_sorted="descending"))
+        [('1.5', 'b.whl'), ('1.0', 'a.whl')]
+
+        :raises ValueError: if ``assume_sorted`` is neither ``"ascending"`` nor
+            ``"descending"``, or the two end entries contradict it. Both are
+            checked before the iterator is returned.
+
+        .. versionchanged:: 26.4
+            Added the ``assume_sorted`` keyword.
         """
         region: tuple[Interval, ...] = ()
         if prereleases is None:
@@ -1277,12 +1395,89 @@ class VersionRange:
             # pre-release, i.e. ``prereleases=True``; take the cheaper no-buffer
             # path. (Confined to this branch: the admission path orders arbitrary
             # strings differently under True than under the region.)
-            if region and region == self._bounds:
+            whole_region = bool(region) and region == self._bounds
+            if assume_sorted is not None:
+                if assume_sorted not in ("ascending", "descending"):
+                    raise ValueError(
+                        f"assume_sorted must be 'ascending' or 'descending', "
+                        f"not {assume_sorted!r}"
+                    )
+                descending = assume_sorted == "descending"
+                sequence = typing.cast("Sequence[Any]", iterable)
+                project = _make_project(key)
+                _check_order(sequence, project, descending=descending)
+                if whole_region:
+                    return self._filter_sorted(
+                        sequence, project, key, True, (), descending=descending
+                    )
+                return self._filter_sorted(
+                    sequence, project, key, prereleases, region, descending=descending
+                )
+            if whole_region:
                 return filter_by_ranges(self._bounds, iterable, key, True)
             return filter_by_ranges(self._bounds, iterable, key, prereleases, region)
         return self._filter_with_admission(
             iterable, key, prereleases, arbitrary_active, region
         )
+
+    def _filter_sorted(
+        self,
+        versions: Sequence[Any],
+        project: Callable[[Any], Version],
+        key: Callable[[Any], Version | str] | None,
+        prereleases: bool | None,
+        region: tuple[Interval, ...],
+        *,
+        descending: bool,
+    ) -> Iterator[Any]:
+        """Filter a version-ordered sequence by bisecting each interval.
+
+        The bounds ascend, so a descending sequence walks them backwards; either
+        way the located slices concatenate in sequence order, which is what
+        :meth:`filter` yields.
+        """
+        bounds = tuple(reversed(self._bounds)) if descending else self._bounds
+
+        # An interval is located only once the previous one is exhausted, so a
+        # caller taking a prefix pays for the prefix.
+        if prereleases is True:
+            for lower, upper in bounds:
+                start, stop = _partition_indexes(
+                    versions, lower, upper, project, descending=descending
+                )
+                for index in range(start, stop):
+                    yield versions[index]
+            return
+
+        exclude_prereleases = prereleases is False
+        plain = key is None
+        buffered: list[Any] = []
+        found_final = False
+        for lower, upper in bounds:
+            start, stop = _partition_indexes(
+                versions, lower, upper, project, descending=descending
+            )
+            for index in range(start, stop):
+                item = versions[index]
+                # Skip re-coercing an entry that is already a ``Version``.
+                parsed = item if plain and item.__class__ is Version else project(item)
+                if not parsed.is_prerelease:
+                    found_final = True
+                    yield item
+                elif exclude_prereleases:
+                    continue
+                # PEP 440 default, mirroring ``filter_by_ranges``: buffer the
+                # pre-releases and release the buffer only if no final matches.
+                # One inside the opt-in region is force-admitted in place, so
+                # the region is consulted per entry rather than folded into the
+                # cuts.
+                elif region and matches_bounds_only(region, parsed):
+                    yield item
+                elif not found_final:
+                    buffered.append(item)
+
+        if not found_final:
+            yield from buffered
 
     def _filter_with_admission(
         self,

--- a/nab-python/src/nab_python/_vendor/packaging/ranges.py
+++ b/nab-python/src/nab_python/_vendor/packaging/ranges.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
     from .specifiers import SpecifierSet
 
 
-__all__ = ["VersionRange"]
+__all__ = ["SortedOrder", "VersionRange"]
 
 T = TypeVar("T")
 UnparsedVersion = Union[Version, str]
@@ -432,8 +432,8 @@ def _make_project(
     The bisections compare against bound predicates that only accept a
     :class:`~packaging.version.Version`, so every probed item is coerced. An
     item that does not parse cannot sit in version order at all, which is a
-    broken precondition rather than a non-match, so it raises rather than being
-    dropped the way :meth:`VersionRange.filter` drops it.
+    broken precondition rather than a non-match, so this raises rather than
+    dropping the item the way :meth:`VersionRange.filter` drops it.
     """
 
     def project(item: Any) -> Version:  # noqa: ANN401
@@ -1342,19 +1342,19 @@ class VersionRange:
         ``prereleases=True`` would yield it). A flushed buffer comes after
         every in-place yield, so the output is not version-sorted.
 
-        ``assume_sorted`` names the version order ``iterable`` is already in. It
-        promises ``iterable`` is a sequence in that order and that every entry
-        parses as a version; break either half and the result is undefined, the
-        way :func:`itertools.groupby` is on unsorted input, and a ``ValueError``
-        may come back in place of an answer. Each interval's matching entries
-        form one contiguous slice of an ordered sequence, so two bisections per
-        interval locate them and the pre-release policy runs over those alone;
-        that is ``O(intervals * log(len(iterable)))`` plus the matches, rather
-        than a bound test per entry, which tells on a long listing. The yielded
-        items, and their order, are the same either way. A range carrying ``===``
-        literals or live arbitrary admission decides membership for strings the
-        bounds do not describe, so it falls back to a test per entry and ignores
-        ``assume_sorted`` altogether.
+        ``assume_sorted`` names the version order ``iterable`` is already in,
+        and ``iterable`` must then be a sequence in that order whose every entry
+        parses as a version. Each interval's matching entries form one
+        contiguous slice of an ordered sequence, so two bisections per interval
+        locate them and the pre-release policy runs over those alone; that is
+        ``O(intervals * log(len(iterable)))`` plus the matches, rather than a
+        bound test per entry. The yielded items, and their order, are the same
+        either way. A sequence not in the named order gives a wrong answer, in
+        the way :func:`itertools.groupby` does on unsorted input; only a
+        contradiction between the two end entries is caught. A range carrying
+        ``===`` literals decides membership for strings the bounds do not
+        describe, so it falls back to a test per entry and ignores
+        ``assume_sorted``.
 
         The signature otherwise mirrors
         :meth:`~packaging.specifiers.SpecifierSet.filter`.
@@ -1376,12 +1376,22 @@ class VersionRange:
         [('1.5', 'b.whl'), ('1.0', 'a.whl')]
 
         :raises ValueError: if ``assume_sorted`` is neither ``"ascending"`` nor
-            ``"descending"``, or the two end entries contradict it. Both are
-            checked before the iterator is returned.
+            ``"descending"``, or if the two end entries contradict it; both come
+            from the call rather than the iterator. An entry the walk coerces
+            that does not parse as a version raises as it is reached.
 
         .. versionchanged:: 26.4
             Added the ``assume_sorted`` keyword.
         """
+        if assume_sorted is not None and assume_sorted not in (
+            "ascending",
+            "descending",
+        ):
+            raise ValueError(
+                f"assume_sorted must be 'ascending' or 'descending', "
+                f"not {assume_sorted!r}"
+            )
+
         region: tuple[Interval, ...] = ()
         if prereleases is None:
             # The region applies only under the autodetect default; a configured
@@ -1389,30 +1399,30 @@ class VersionRange:
             prereleases = self._prereleases_configured
             region = self._pre_region
 
+        # A region spanning the whole bounds force-admits every in-bounds
+        # pre-release, i.e. ``prereleases=True``; take the cheaper no-buffer
+        # path. (Confined to the no-literal branches: the admission path orders
+        # arbitrary strings differently under True than under the region.)
+        whole_region = bool(region) and region == self._bounds
+
+        if assume_sorted is not None and not self._admit and not self._reject:
+            # Arbitrary admission needs no gate: it only concerns strings that
+            # do not parse as a version, which ``_make_project`` rejects.
+            descending = assume_sorted == "descending"
+            sequence = typing.cast("Sequence[Any]", iterable)
+            project = _make_project(key)
+            _check_order(sequence, project, descending=descending)
+
+            if whole_region:
+                return self._filter_sorted(
+                    sequence, project, key, True, (), descending=descending
+                )
+            return self._filter_sorted(
+                sequence, project, key, prereleases, region, descending=descending
+            )
+
         arbitrary_active = self._arbitrary_active()
         if not self._admit and not self._reject and not arbitrary_active:
-            # A region spanning the whole bounds force-admits every in-bounds
-            # pre-release, i.e. ``prereleases=True``; take the cheaper no-buffer
-            # path. (Confined to this branch: the admission path orders arbitrary
-            # strings differently under True than under the region.)
-            whole_region = bool(region) and region == self._bounds
-            if assume_sorted is not None:
-                if assume_sorted not in ("ascending", "descending"):
-                    raise ValueError(
-                        f"assume_sorted must be 'ascending' or 'descending', "
-                        f"not {assume_sorted!r}"
-                    )
-                descending = assume_sorted == "descending"
-                sequence = typing.cast("Sequence[Any]", iterable)
-                project = _make_project(key)
-                _check_order(sequence, project, descending=descending)
-                if whole_region:
-                    return self._filter_sorted(
-                        sequence, project, key, True, (), descending=descending
-                    )
-                return self._filter_sorted(
-                    sequence, project, key, prereleases, region, descending=descending
-                )
             if whole_region:
                 return filter_by_ranges(self._bounds, iterable, key, True)
             return filter_by_ranges(self._bounds, iterable, key, prereleases, region)
@@ -1434,12 +1444,11 @@ class VersionRange:
 
         The bounds ascend, so a descending sequence walks them backwards; either
         way the located slices concatenate in sequence order, which is what
-        :meth:`filter` yields.
+        :meth:`filter` yields. An interval is located only once the previous one
+        is exhausted, so a caller taking a prefix pays for the prefix.
         """
         bounds = tuple(reversed(self._bounds)) if descending else self._bounds
 
-        # An interval is located only once the previous one is exhausted, so a
-        # caller taking a prefix pays for the prefix.
         if prereleases is True:
             for lower, upper in bounds:
                 start, stop = _partition_indexes(
@@ -1453,24 +1462,22 @@ class VersionRange:
         plain = key is None
         buffered: list[Any] = []
         found_final = False
+
         for lower, upper in bounds:
             start, stop = _partition_indexes(
                 versions, lower, upper, project, descending=descending
             )
             for index in range(start, stop):
                 item = versions[index]
-                # Skip re-coercing an entry that is already a ``Version``.
                 parsed = item if plain and item.__class__ is Version else project(item)
                 if not parsed.is_prerelease:
                     found_final = True
                     yield item
                 elif exclude_prereleases:
                     continue
-                # PEP 440 default, mirroring ``filter_by_ranges``: buffer the
-                # pre-releases and release the buffer only if no final matches.
-                # One inside the opt-in region is force-admitted in place, so
-                # the region is consulted per entry rather than folded into the
-                # cuts.
+                # PEP 440 default, mirroring ``filter_by_ranges``: buffer
+                # pre-releases and flush only if no final matches. One inside
+                # the opt-in region is force-admitted in place.
                 elif region and matches_bounds_only(region, parsed):
                     yield item
                 elif not found_final:

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -1285,7 +1285,9 @@ class Provider:
 
         version_list = self.fetch_versions(package)
         all_versions = self.versions_only(normalized, version_list)
-        candidates = list(version_range.filter(all_versions))
+        candidates = list(
+            version_range.filter(all_versions, assume_sorted="descending")
+        )
 
         # VersionRange.filter yields newest-first; reverse for LOWEST so
         # look-ahead walks oldest -> newest.
@@ -1341,7 +1343,8 @@ class Provider:
             if base_range is not None:
                 admit_range = version_range & base_range
 
-        if preferred not in set(admit_range.filter(all_versions)):
+        in_range = admit_range.filter(all_versions, assume_sorted="descending")
+        if preferred not in in_range:
             return None
 
         usable = (

--- a/nab-python/tests/property_python/test_sorted_filter_differential.py
+++ b/nab-python/tests/property_python/test_sorted_filter_differential.py
@@ -36,11 +36,7 @@ def _first(entry: tuple[Version, str]) -> Version:
 
 def _bisects(version_range: VersionRange) -> bool:
     """True when the range decides membership from its bounds alone."""
-    return (
-        not version_range._admit
-        and not version_range._reject
-        and not version_range._arbitrary_active()
-    )
+    return not version_range._admit and not version_range._reject
 
 
 def _check_every_shape(
@@ -140,10 +136,8 @@ def test_a_contradicted_direction_raises(versions: list[Version], spec: str) -> 
 @given(versions=_listings(), spec=range_specs())
 @PROPERTY_SETTINGS
 def test_an_unrecognised_direction_raises(versions: list[Version], spec: str) -> None:
-    """Only the two named orders reach the bisection."""
+    """Only the two named orders are accepted, whatever the range holds."""
     version_range = SpecifierSet(spec).to_range()
-    if not _bisects(version_range):
-        return
     with pytest.raises(ValueError, match="must be 'ascending' or 'descending'"):
         version_range.filter(versions, assume_sorted="Ascending")  # type: ignore[arg-type]
 
@@ -161,15 +155,18 @@ def test_string_entries_filter_by_version(versions: list[Version], spec: str) ->
 
 @given(versions=_listings(), spec=range_specs())
 @PROPERTY_SETTINGS
-def test_arbitrary_admission_keeps_a_non_version_member(
+def test_an_arbitrarily_admitted_member_breaks_the_precondition(
     versions: list[Version], spec: str
 ) -> None:
-    """A range that admits arbitrary strings yields them on either spelling."""
+    """A string the bounds do not describe has no place in version order.
+
+    The entry walk yields it, but nothing says where it sits, so the sorted
+    path refuses the sequence rather than guessing.
+    """
     version_range = SpecifierSet(spec).to_range()
     if not version_range._arbitrary_active():
         return
     texts: list[str] = [*[str(v) for v in versions], "frobnicate"]
-    assert list(version_range.filter(texts, assume_sorted="ascending")) == list(
-        version_range.filter(texts)
-    )
-    assert "frobnicate" in list(version_range.filter(texts, assume_sorted="ascending"))
+    assert "frobnicate" in list(version_range.filter(texts))
+    with pytest.raises(ValueError, match="does not parse as a version"):
+        list(version_range.filter(texts, assume_sorted="ascending"))

--- a/nab-python/tests/property_python/test_sorted_filter_differential.py
+++ b/nab-python/tests/property_python/test_sorted_filter_differential.py
@@ -1,0 +1,175 @@
+"""Differential property tests for ``filter(assume_sorted=...)``.
+
+What the sorted path yields is the candidate order ``choose_version`` walks, so
+it has to equal the entry-by-entry filter element for element: every property
+compares the two over random ordered listings and random ranges, in both
+declared orders, under each pre-release policy, and through ``key``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from nab_python._vendor.packaging.ranges import VersionRange
+from nab_python._vendor.packaging.specifiers import SpecifierSet
+from nab_python._vendor.packaging.version import Version
+
+from .strategies import PROPERTY_SETTINGS, RANGE_VERSION_POOL, range_specs
+
+pytestmark = pytest.mark.property
+
+_VERSIONS = [Version(text) for text in RANGE_VERSION_POOL]
+
+
+@st.composite
+def _listings(draw: st.DrawFn) -> list[Version]:
+    """An ascending listing over the pool, duplicates allowed."""
+    picked = draw(st.lists(st.sampled_from(_VERSIONS), min_size=0, max_size=12))
+    return sorted(picked)
+
+
+def _first(entry: tuple[Version, str]) -> Version:
+    return entry[0]
+
+
+def _bisects(version_range: VersionRange) -> bool:
+    """True when the range decides membership from its bounds alone."""
+    return (
+        not version_range._admit
+        and not version_range._reject
+        and not version_range._arbitrary_active()
+    )
+
+
+def _check_every_shape(
+    version_range: VersionRange, versions: list[Version], prereleases: bool | None
+) -> None:
+    """Every sorted calling shape equals the entry-by-entry filter."""
+    descending = list(reversed(versions))
+    ascending_paired = [(v, f"pkg-{v}.whl") for v in versions]
+    descending_paired = list(reversed(ascending_paired))
+
+    assert list(
+        version_range.filter(versions, prereleases, assume_sorted="ascending")
+    ) == list(version_range.filter(versions, prereleases))
+    assert list(
+        version_range.filter(descending, prereleases, assume_sorted="descending")
+    ) == list(version_range.filter(descending, prereleases))
+    assert list(
+        version_range.filter(
+            ascending_paired, prereleases, _first, assume_sorted="ascending"
+        )
+    ) == list(version_range.filter(ascending_paired, prereleases, _first))
+    assert list(
+        version_range.filter(
+            descending_paired, prereleases, _first, assume_sorted="descending"
+        )
+    ) == list(version_range.filter(descending_paired, prereleases, _first))
+
+
+@given(versions=_listings(), spec=range_specs())
+@PROPERTY_SETTINGS
+def test_sorted_filter_matches_the_entry_walk(
+    versions: list[Version], spec: str
+) -> None:
+    """The sorted path equals the entry-by-entry filter."""
+    _check_every_shape(SpecifierSet(spec).to_range(), versions, None)
+
+
+@given(
+    versions=_listings(),
+    spec=range_specs(),
+    prereleases=st.sampled_from([True, False]),
+)
+@PROPERTY_SETTINGS
+def test_sorted_filter_matches_under_a_configured_policy(
+    versions: list[Version], spec: str, prereleases: bool
+) -> None:
+    """The result stays exact once a pre-release policy is configured."""
+    configured = SpecifierSet(spec, prereleases=prereleases).to_range()
+    _check_every_shape(configured, versions, None)
+
+
+@given(
+    versions=_listings(),
+    spec=range_specs(),
+    prereleases=st.sampled_from([True, False, None]),
+)
+@PROPERTY_SETTINGS
+def test_sorted_filter_matches_under_an_argument_policy(
+    versions: list[Version], spec: str, prereleases: bool | None
+) -> None:
+    """The ``prereleases`` argument governs both paths alike."""
+    _check_every_shape(SpecifierSet(spec).to_range(), versions, prereleases)
+
+
+@given(versions=_listings(), left=range_specs(), right=range_specs())
+@PROPERTY_SETTINGS
+def test_sorted_filter_matches_on_algebra_derived_ranges(
+    versions: list[Version], left: str, right: str
+) -> None:
+    """Set algebra reaches shapes no single specifier writes.
+
+    It is the only way to produce an opt-in region that covers part of the
+    bounds rather than all of them.
+    """
+    a: VersionRange = SpecifierSet(left).to_range()
+    b: VersionRange = SpecifierSet(right).to_range()
+    for derived in (a & b, a | b, a - b, ~a):
+        _check_every_shape(derived, versions, None)
+
+
+@given(versions=_listings(), spec=range_specs())
+@PROPERTY_SETTINGS
+def test_a_contradicted_direction_raises(versions: list[Version], spec: str) -> None:
+    """A bisected sequence whose ends contradict the declared order is refused."""
+    version_range = SpecifierSet(spec).to_range()
+    if not _bisects(version_range) or len(versions) < 2 or versions[0] == versions[-1]:
+        assert list(version_range.filter(versions, assume_sorted="descending")) == list(
+            version_range.filter(versions)
+        )
+        return
+    with pytest.raises(ValueError, match="assume_sorted='descending'"):
+        version_range.filter(versions, assume_sorted="descending")
+    with pytest.raises(ValueError, match="assume_sorted='ascending'"):
+        version_range.filter(list(reversed(versions)), assume_sorted="ascending")
+
+
+@given(versions=_listings(), spec=range_specs())
+@PROPERTY_SETTINGS
+def test_an_unrecognised_direction_raises(versions: list[Version], spec: str) -> None:
+    """Only the two named orders reach the bisection."""
+    version_range = SpecifierSet(spec).to_range()
+    if not _bisects(version_range):
+        return
+    with pytest.raises(ValueError, match="must be 'ascending' or 'descending'"):
+        version_range.filter(versions, assume_sorted="Ascending")  # type: ignore[arg-type]
+
+
+@given(versions=_listings(), spec=range_specs())
+@PROPERTY_SETTINGS
+def test_string_entries_filter_by_version(versions: list[Version], spec: str) -> None:
+    """A sorted sequence of version strings filters as its parsed versions."""
+    version_range = SpecifierSet(spec).to_range()
+    texts = [str(v) for v in versions]
+    assert list(version_range.filter(texts, assume_sorted="ascending")) == list(
+        version_range.filter(texts)
+    )
+
+
+@given(versions=_listings(), spec=range_specs())
+@PROPERTY_SETTINGS
+def test_arbitrary_admission_keeps_a_non_version_member(
+    versions: list[Version], spec: str
+) -> None:
+    """A range that admits arbitrary strings yields them on either spelling."""
+    version_range = SpecifierSet(spec).to_range()
+    if not version_range._arbitrary_active():
+        return
+    texts: list[str] = [*[str(v) for v in versions], "frobnicate"]
+    assert list(version_range.filter(texts, assume_sorted="ascending")) == list(
+        version_range.filter(texts)
+    )
+    assert "frobnicate" in list(version_range.filter(texts, assume_sorted="ascending"))

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -6281,9 +6281,9 @@ class TestExtras:
     ) -> None:
         """The pre-release enumeration reads the same descending listing.
 
-        Both the candidate filter and the ``prereleases=True`` fallback bisect
-        ``versions_only``, so this pins that a pre-release the base's range
-        excludes still reaches the block recorder.
+        The proxy range's bounds are wider than its opt-in region, so the
+        default policy buffers 2.0a1 behind 2.0 and drops it; only the
+        ``prereleases=True`` pass reaches the block recorder with it.
         """
         wheels = [make_wheel(v) for v in ("2.0", "2.0a1", "1.0")]
         coordinator = make_coordinator(
@@ -6293,11 +6293,11 @@ class TestExtras:
         all_versions = provider.versions_only("foo", provider.fetch_versions("foo"))
         assert all_versions == sorted(all_versions, reverse=True)
         provider.receive_partial_solution_hint(
-            {"foo": SpecifierSet("<2.0a1").to_range()},
+            {"foo": SpecifierSet("<1.0").to_range()},
             {},
         )
         result = provider.choose_version(
-            "foo[security]", SpecifierSet(">=2.0a1").to_range()
+            "foo[security]", SpecifierSet(">=1.0,<3.0").to_range()
         )
         assert result is None
         clauses = provider.consume_pending_clauses()
@@ -8255,20 +8255,19 @@ class TestPrioritizeMatchingFromIndex:
         assert result[1] == 2
 
     def test_matching_counts_an_in_bounds_prerelease(self) -> None:
-        """The count is the membership test, which admits in-bounds pre-releases.
+        """The count admits an in-bounds pre-release the default policy would drop.
 
-        The default filtering policy would buffer 2.0a1 behind the matching
-        final release and drop it, so only the admitting policy agrees.
+        The range's bounds are wider than its pre-release opt-in region, so the
+        default policy buffers 2.0a1 behind the matching final release and drops
+        it; only the admitting policy counts all three.
         """
         wheels = [make_wheel(v) for v in ("2.0", "2.0a1", "1.0")]
         coordinator = make_coordinator(wheels, package="foo")
         provider = Provider(coordinator)
-        version_range = SpecifierSet(">=2.0a1").to_range()
+        version_range = SpecifierSet(">=1.0,<3.0").to_range()
         result = provider.prioritize("foo", version_range, {})
-        cached = provider.versions_cache["foo"]
         assert V("2.0a1") in version_range
-        assert result[1] == sum(1 for v, _ in cached if v in version_range)
-        assert result[1] == 2
+        assert result[1] == 3
 
     def test_versions_only_cache_hit(self) -> None:
         """Calling versions_only twice returns the same cached list."""
@@ -8284,8 +8283,8 @@ class TestPrioritizeMatchingFromIndex:
         """The listing view is newest-first, which choose_version's filter asserts.
 
         ``filter(assume_sorted="descending")`` bisects the view rather than
-        testing every entry, so an index that lists files in any other order
-        must still reach the provider sorted.
+        testing every entry, so an index listing files in any other order must
+        still reach the provider sorted.
         """
         wheels = [make_wheel(v) for v in ("1.0", "3.0", "1.0a1", "2.0", "0.9")]
         coordinator = make_coordinator(wheels, package="foo")

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -700,6 +700,44 @@ class TestChooseVersion:
         spec = SpecifierSet("")
         assert provider.choose_version("foo", spec.to_range()) is None
 
+    _PREFERENCE_META = "Metadata-Version: 2.1\nName: foo\nVersion: {ver}\n\n"
+
+    def _preference_provider(
+        self, preferred: str, versions: tuple[str, ...] = ("1.0", "2.0", "3.0")
+    ) -> Provider:
+        coordinator = make_coordinator(
+            [make_wheel(v) for v in versions],
+            metadata_by_version={
+                v: self._PREFERENCE_META.format(ver=v) for v in versions
+            },
+            package="foo",
+        )
+        return Provider(coordinator, target=_PY312, preferences={"foo": V(preferred)})
+
+    def test_a_preference_inside_the_range_wins(self) -> None:
+        """The membership walk stops at the preference wherever it sits."""
+        provider = self._preference_provider("1.0")
+        spec = SpecifierSet(">=1.0")
+        assert provider.choose_version("foo", spec.to_range()) == V("1.0")
+
+    def test_a_preference_outside_the_range_is_dropped(self) -> None:
+        """A preference the range excludes falls through to the strategy."""
+        provider = self._preference_provider("1.0")
+        spec = SpecifierSet(">=2.0")
+        assert provider.choose_version("foo", spec.to_range()) == V("3.0")
+
+    def test_a_preference_the_index_never_listed_is_dropped(self) -> None:
+        """A preference absent from the listing exhausts the walk and loses."""
+        provider = self._preference_provider("9.9")
+        spec = SpecifierSet(">=1.0")
+        assert provider.choose_version("foo", spec.to_range()) == V("3.0")
+
+    def test_a_preference_buffered_out_by_the_default_policy_is_dropped(self) -> None:
+        """The membership question honours the filter's pre-release policy."""
+        provider = self._preference_provider("2.0a1", ("1.0", "2.0a1", "2.0"))
+        spec = SpecifierSet(">=1.0")
+        assert provider.choose_version("foo", spec.to_range()) == V("2.0")
+
 
 class TestHasSatisfyingVersion:
     def test_true_when_a_version_is_in_range(self) -> None:
@@ -8204,6 +8242,33 @@ class TestPrioritizeMatchingFromIndex:
         per_pkg = provider.matching_cache["foo"]
         assert spec_a in per_pkg
         assert spec_b in per_pkg
+
+    def test_matching_counts_one_entry_per_file(self) -> None:
+        """versions_cache holds a row per file, so a dual-artifact release counts twice."""
+        files = [make_wheel("2.0"), make_sdist("2.0"), make_wheel("1.0")]
+        coordinator = make_coordinator(files, package="foo")
+        provider = Provider(coordinator)
+        version_range = SpecifierSet(">=2.0").to_range()
+        result = provider.prioritize("foo", version_range, {})
+        cached = provider.versions_cache["foo"]
+        assert result[1] == sum(1 for v, _ in cached if v in version_range)
+        assert result[1] == 2
+
+    def test_matching_counts_an_in_bounds_prerelease(self) -> None:
+        """The count is the membership test, which admits in-bounds pre-releases.
+
+        The default filtering policy would buffer 2.0a1 behind the matching
+        final release and drop it, so only the admitting policy agrees.
+        """
+        wheels = [make_wheel(v) for v in ("2.0", "2.0a1", "1.0")]
+        coordinator = make_coordinator(wheels, package="foo")
+        provider = Provider(coordinator)
+        version_range = SpecifierSet(">=2.0a1").to_range()
+        result = provider.prioritize("foo", version_range, {})
+        cached = provider.versions_cache["foo"]
+        assert V("2.0a1") in version_range
+        assert result[1] == sum(1 for v, _ in cached if v in version_range)
+        assert result[1] == 2
 
     def test_versions_only_cache_hit(self) -> None:
         """Calling versions_only twice returns the same cached list."""

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -6238,6 +6238,36 @@ class TestExtras:
         assert V("2.0") in proxy_terms[0].constraint
         assert V("1.0") in base_terms[0].constraint
 
+    def test_choose_extra_version_blocks_a_prerelease_excluded_by_the_base(
+        self,
+    ) -> None:
+        """The pre-release enumeration reads the same descending listing.
+
+        Both the candidate filter and the ``prereleases=True`` fallback bisect
+        ``versions_only``, so this pins that a pre-release the base's range
+        excludes still reaches the block recorder.
+        """
+        wheels = [make_wheel(v) for v in ("2.0", "2.0a1", "1.0")]
+        coordinator = make_coordinator(
+            wheels, metadata_text=EXTRA_METADATA, package="foo"
+        )
+        provider = Provider(coordinator)
+        all_versions = provider.versions_only("foo", provider.fetch_versions("foo"))
+        assert all_versions == sorted(all_versions, reverse=True)
+        provider.receive_partial_solution_hint(
+            {"foo": SpecifierSet("<2.0a1").to_range()},
+            {},
+        )
+        result = provider.choose_version(
+            "foo[security]", SpecifierSet(">=2.0a1").to_range()
+        )
+        assert result is None
+        clauses = provider.consume_pending_clauses()
+        proxy_terms = [
+            t for c in clauses for t in c.terms if t.package == "foo[security]"
+        ]
+        assert any(V("2.0a1") in t.constraint for t in proxy_terms)
+
     def test_choose_extra_version_records_range_block_when_base_undecided(
         self,
     ) -> None:
@@ -8184,6 +8214,32 @@ class TestPrioritizeMatchingFromIndex:
         first = provider.versions_only("foo", version_list)
         second = provider.versions_only("foo", version_list)
         assert first is second
+
+    def test_versions_only_is_descending_whatever_the_index_order(self) -> None:
+        """The listing view is newest-first, which choose_version's filter asserts.
+
+        ``filter(assume_sorted="descending")`` bisects the view rather than
+        testing every entry, so an index that lists files in any other order
+        must still reach the provider sorted.
+        """
+        wheels = [make_wheel(v) for v in ("1.0", "3.0", "1.0a1", "2.0", "0.9")]
+        coordinator = make_coordinator(wheels, package="foo")
+        provider = Provider(coordinator)
+        versions = provider.versions_only("foo", provider.fetch_versions("foo"))
+        assert versions == sorted(versions, reverse=True)
+        assert versions[0] == V("3.0")
+
+    def test_choose_version_candidates_match_the_entry_wise_filter(self) -> None:
+        """The bisected candidate list equals what the plain filter yields."""
+        wheels = [make_wheel(v) for v in ("0.9", "1.0a1", "1.0", "1.5", "2.0")]
+        coordinator = make_coordinator(wheels, package="foo")
+        provider = Provider(coordinator)
+        version_list = provider.fetch_versions("foo")
+        all_versions = provider.versions_only("foo", version_list)
+        for spec in ("", ">=1.0", ">=1.0,<2.0", "!=1.0", ">=1.0a1", "===1.0"):
+            version_range = SpecifierSet(spec).to_range()
+            bisected = version_range.filter(all_versions, assume_sorted="descending")
+            assert list(bisected) == list(version_range.filter(all_versions))
 
     def test_wheel_by_version_cache_hit(self) -> None:
         """Calling _wheel_by_version twice returns the same cached dict."""

--- a/nab-python/tests/test_vendor_sorted_filter.py
+++ b/nab-python/tests/test_vendor_sorted_filter.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import pytest
 
+from nab_python._vendor.packaging import ranges
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.version import Version
@@ -168,15 +169,26 @@ class TestSortedFilter:
         filtered = _range("<0.5").filter(listing, assume_sorted="descending")
         assert list(filtered) == []
 
-    def test_the_result_is_lazy(self) -> None:
-        """A caller taking one candidate does not pay for the whole listing."""
-        full = VersionRange.full(admit_arbitrary=False)
-        filtered = full.filter(DESCENDING, assume_sorted="descending")
+    def test_the_result_is_lazy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A caller taking one candidate locates one interval, not all of them."""
+        located: list[tuple[int, int]] = []
+        real = ranges._partition_indexes
+
+        def spy(*args: Any, **kwargs: Any) -> tuple[int, int]:
+            result = real(*args, **kwargs)
+            located.append(result)
+            return result
+
+        monkeypatch.setattr(ranges, "_partition_indexes", spy)
+        multi = _range("!=1.5,!=2.0")
+        assert len(multi._bounds) == 3
+        filtered = multi.filter(DESCENDING, assume_sorted="descending")
         assert next(iter(filtered)) == DESCENDING[0]
+        assert len(located) == 1
 
 
 class TestSortedFilterLiterals:
-    """``===`` names members the bounds do not describe, so the cuts stand down."""
+    """``===`` names members the bounds do not describe, so bisection is off."""
 
     def test_admit_literal_falls_back_to_the_entry_walk(self) -> None:
         listing = [V(v) for v in ("2.0", "1.5", "1.0")]
@@ -205,30 +217,35 @@ class TestSortedFilterLiterals:
 
 
 class TestSortedFilterArbitraryAdmission:
-    """Live arbitrary admission takes non-version members, so the cuts stand down.
+    """Live arbitrary admission does not turn bisection off.
 
-    Those strings have no place in version order, and refusing a legitimate
-    member would be the wrong answer, so such a range ignores the keyword the
-    same way a ``===`` literal does.
+    It only takes strings that do not parse as a version, and those have no
+    place in version order, so the sorted walk rejects one rather than gating
+    on the flag.
     """
 
-    def test_live_admission_falls_back_to_the_entry_walk(self) -> None:
+    def test_live_admission_still_bisects(self) -> None:
         full = VersionRange.full()
         assert full._arbitrary_active()
-        listing = ["3.0", "2.0", "frobnicate", "1.0"]
+        listing = [V(v) for v in ("3.0", "2.0", "1.0")]
         assert list(full.filter(listing, assume_sorted="descending")) == listing
+
+    def test_an_admitted_string_has_no_place_in_version_order(self) -> None:
+        full = VersionRange.full()
+        listing = ["3.0", "2.0", "frobnicate", "1.0"]
+        with pytest.raises(ValueError, match="does not parse as a version"):
+            list(full.filter(listing, assume_sorted="descending"))
         assert list(full.filter(listing)) == listing
 
-    def test_the_fallback_ignores_a_wrong_declared_order(self) -> None:
+    def test_a_wrong_declared_order_is_caught_here_too(self) -> None:
         full = VersionRange.full()
-        assert list(full.filter(LISTING, assume_sorted="descending")) == list(
-            full.filter(LISTING)
-        )
+        with pytest.raises(ValueError, match="assume_sorted='descending'"):
+            full.filter(LISTING, assume_sorted="descending")
 
-    def test_the_empty_specifier_set_admits_arbitrary_strings(self) -> None:
+    def test_the_empty_specifier_set_bisects_too(self) -> None:
         universal = _range("")
         assert universal._arbitrary_active()
-        listing = ["3.0", "2.0", "weird", "1.0"]
+        listing = [V(v) for v in ("3.0", "2.0", "1.0")]
         assert list(universal.filter(listing, assume_sorted="descending")) == listing
 
     def test_an_inert_arbitrary_flag_still_bisects(self) -> None:

--- a/nab-python/tests/test_vendor_sorted_filter.py
+++ b/nab-python/tests/test_vendor_sorted_filter.py
@@ -1,0 +1,451 @@
+"""Tests for the vendored patch's ``assume_sorted`` keyword on ``filter``.
+
+Given ``assume_sorted`` the range bisects each interval instead of testing every
+entry. The items yielded and the order they come in are the contract, and the
+order is the candidate order ``choose_version`` walks, so the grid tests compare
+every calling shape against the same call without the keyword.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from nab_python._vendor.packaging.ranges import VersionRange
+from nab_python._vendor.packaging.specifiers import SpecifierSet
+from nab_python._vendor.packaging.version import Version
+
+V = Version
+
+# Single and double bounds, exclusions, wildcards, an epoch, a post, a local,
+# pre-release naming clauses, and the two ``===`` shapes.
+SPECS = [
+    "",
+    ">=1.0",
+    ">1.0",
+    "<2.0",
+    "<=2.0",
+    ">=1.0,<2.0",
+    ">1.0,<=2.0",
+    ">=1.5,<1.8",
+    ">=2.0,<1.0",
+    "==1.5",
+    "!=1.5",
+    "==1.*",
+    "!=1.*",
+    "~=1.4",
+    ">=1.0.post1",
+    "==1.0+local",
+    ">=1!0.5",
+    ">=1.0a1",
+    ">1.0a1",
+    "==1.0a1",
+    "<1.0.post0.dev0",
+    ">=1.0.dev0,<1.0",
+    "===1.5",
+    "===frobnicate",
+]
+
+# Ascending, with the repeats a real listing carries when one version ships
+# both a wheel and an sdist.
+LISTING = [
+    V(text)
+    for text in (
+        "0.9",
+        "1.0.dev1",
+        "1.0a1",
+        "1.0rc1",
+        "1.0",
+        "1.0+local",
+        "1.0.post1",
+        "1.4",
+        "1.5",
+        "1.5",
+        "1.8",
+        "1.9.9",
+        "2.0",
+        "2.0",
+        "2.0",
+        "3.0",
+        "1!0.5",
+        "1!1.0",
+    )
+]
+
+DESCENDING = list(reversed(LISTING))
+
+
+def _range(spec: str) -> VersionRange:
+    return SpecifierSet(spec).to_range()
+
+
+def _paired(versions: list[Version]) -> list[tuple[Version, str]]:
+    """The listing shape nab holds: a version paired with its file."""
+    return [(version, f"pkg-{version}.whl") for version in versions]
+
+
+def _first(entry: tuple[Any, str]) -> Any:
+    return entry[0]
+
+
+def _split_region() -> VersionRange:
+    """A range whose opt-in region covers only part of its bounds.
+
+    A plain specifier set always autodetects a region equal to its own bounds,
+    so the interesting shape only arises from set algebra: unioning a
+    pre-release-naming range with one that names none leaves the opt-in
+    confined to the first interval.
+    """
+    return _range(">=1.0a1,<1.5") | _range(">=2.0,<3.0")
+
+
+class TestSortedFilter:
+    def test_filters_a_closed_interval(self) -> None:
+        listing = [V(v) for v in ("3.0", "2.0", "1.5", "1.0")]
+        filtered = _range(">=1.0,<2.0").filter(listing, assume_sorted="descending")
+        assert list(filtered) == [V("1.5"), V("1.0")]
+
+    def test_filters_the_same_listing_ascending(self) -> None:
+        listing = [V(v) for v in ("1.0", "1.5", "2.0", "3.0")]
+        filtered = _range(">=1.0,<2.0").filter(listing, assume_sorted="ascending")
+        assert list(filtered) == [V("1.0"), V("1.5")]
+
+    def test_keeps_duplicate_entries(self) -> None:
+        listing = [V(v) for v in ("2.0", "1.5", "1.5", "1.0")]
+        filtered = _range(">=1.0,<2.0").filter(listing, assume_sorted="descending")
+        assert list(filtered) == [V("1.5"), V("1.5"), V("1.0")]
+
+    def test_empty_sequence_in_both_directions(self) -> None:
+        assert list(_range(">=1.0").filter([], assume_sorted="ascending")) == []
+        assert list(_range(">=1.0").filter([], assume_sorted="descending")) == []
+
+    def test_single_entry_is_sorted_either_way(self) -> None:
+        listing = [V("1.5")]
+        assert list(_range(">=1.0").filter(listing, assume_sorted="ascending")) == (
+            listing
+        )
+        assert list(_range(">=1.0").filter(listing, assume_sorted="descending")) == (
+            listing
+        )
+
+    def test_all_equal_entries_are_sorted_either_way(self) -> None:
+        listing = [V("1.5")] * 4
+        assert list(_range(">=1.0").filter(listing, assume_sorted="ascending")) == (
+            listing
+        )
+        assert list(_range(">=1.0").filter(listing, assume_sorted="descending")) == (
+            listing
+        )
+
+    def test_empty_range(self) -> None:
+        filtered = VersionRange.empty().filter(DESCENDING, assume_sorted="descending")
+        assert list(filtered) == []
+
+    def test_full_range_keeps_every_entry(self) -> None:
+        finals = [v for v in DESCENDING if not v.is_prerelease]
+        full = VersionRange.full(admit_arbitrary=False)
+        assert list(full.filter(finals, assume_sorted="descending")) == finals
+
+    def test_multi_interval_range_stays_in_sequence_order(self) -> None:
+        """The bounds ascend and the listing descends, so the walk runs backwards."""
+        listing = [V(v) for v in ("3.0", "2.0", "1.5", "1.0")]
+        filtered = _range("!=1.5").filter(listing, assume_sorted="descending")
+        assert list(filtered) == [V("3.0"), V("2.0"), V("1.0")]
+
+    def test_exclusive_bounds(self) -> None:
+        listing = [V(v) for v in ("2.0", "1.5", "1.0")]
+        filtered = _range(">1.0,<2.0").filter(listing, assume_sorted="descending")
+        assert list(filtered) == [V("1.5")]
+
+    def test_every_entry_below_the_range(self) -> None:
+        listing = [V(v) for v in ("1.5", "1.0")]
+        filtered = _range(">=5.0").filter(listing, assume_sorted="descending")
+        assert list(filtered) == []
+
+    def test_every_entry_above_the_range(self) -> None:
+        listing = [V(v) for v in ("1.5", "1.0")]
+        filtered = _range("<0.5").filter(listing, assume_sorted="descending")
+        assert list(filtered) == []
+
+    def test_the_result_is_lazy(self) -> None:
+        """A caller taking one candidate does not pay for the whole listing."""
+        full = VersionRange.full(admit_arbitrary=False)
+        filtered = full.filter(DESCENDING, assume_sorted="descending")
+        assert next(iter(filtered)) == DESCENDING[0]
+
+
+class TestSortedFilterLiterals:
+    """``===`` names members the bounds do not describe, so the cuts stand down."""
+
+    def test_admit_literal_falls_back_to_the_entry_walk(self) -> None:
+        listing = [V(v) for v in ("2.0", "1.5", "1.0")]
+        literal = _range("===1.5")
+        assert literal._admit
+        assert list(literal.filter(listing, assume_sorted="descending")) == [V("1.5")]
+
+    def test_reject_literal_falls_back_to_the_entry_walk(self) -> None:
+        listing = [V(v) for v in ("2.0", "1.5", "1.0")]
+        rejecting = ~_range("===1.5")
+        assert rejecting._reject
+        filtered = list(rejecting.filter(listing, assume_sorted="descending"))
+        assert filtered == [V("2.0"), V("1.0")]
+
+    def test_the_fallback_ignores_a_wrong_declared_order(self) -> None:
+        literal = _range("===1.5")
+        assert list(literal.filter(LISTING, assume_sorted="descending")) == [
+            V("1.5"),
+            V("1.5"),
+        ]
+
+    def test_non_version_admit_literal(self) -> None:
+        literal = _range("===frobnicate")
+        filtered = literal.filter(["1.5", "frobnicate"], assume_sorted="ascending")
+        assert list(filtered) == ["frobnicate"]
+
+
+class TestSortedFilterArbitraryAdmission:
+    """Live arbitrary admission takes non-version members, so the cuts stand down.
+
+    Those strings have no place in version order, and refusing a legitimate
+    member would be the wrong answer, so such a range ignores the keyword the
+    same way a ``===`` literal does.
+    """
+
+    def test_live_admission_falls_back_to_the_entry_walk(self) -> None:
+        full = VersionRange.full()
+        assert full._arbitrary_active()
+        listing = ["3.0", "2.0", "frobnicate", "1.0"]
+        assert list(full.filter(listing, assume_sorted="descending")) == listing
+        assert list(full.filter(listing)) == listing
+
+    def test_the_fallback_ignores_a_wrong_declared_order(self) -> None:
+        full = VersionRange.full()
+        assert list(full.filter(LISTING, assume_sorted="descending")) == list(
+            full.filter(LISTING)
+        )
+
+    def test_the_empty_specifier_set_admits_arbitrary_strings(self) -> None:
+        universal = _range("")
+        assert universal._arbitrary_active()
+        listing = ["3.0", "2.0", "weird", "1.0"]
+        assert list(universal.filter(listing, assume_sorted="descending")) == listing
+
+    def test_an_inert_arbitrary_flag_still_bisects(self) -> None:
+        narrowed = VersionRange.full() & _range(">=1.0,<2.0")
+        assert not narrowed._arbitrary_active()
+        listing = [V(v) for v in ("2.0", "1.5", "1.0")]
+        filtered = narrowed.filter(listing, assume_sorted="descending")
+        assert list(filtered) == [V("1.5"), V("1.0")]
+
+    def test_an_inert_flag_rejects_a_string_with_no_place_in_order(self) -> None:
+        narrowed = VersionRange.full() & _range(">=1.0,<2.0")
+        with pytest.raises(ValueError, match="does not parse as a version"):
+            narrowed.filter(["frobnicate", "1.5"], assume_sorted="ascending")
+
+
+class TestSortedFilterPrereleasePolicy:
+    def test_configured_excluding_policy_drops_prereleases(self) -> None:
+        listing = [V(v) for v in ("1.5", "1.0", "1.0a1")]
+        strict = SpecifierSet(">=1.0.dev0", prereleases=False).to_range()
+        filtered = strict.filter(listing, assume_sorted="descending")
+        assert list(filtered) == [V("1.5"), V("1.0")]
+
+    def test_configured_admitting_policy_keeps_prereleases(self) -> None:
+        listing = [V(v) for v in ("1.5", "1.0", "1.0a1")]
+        loose = SpecifierSet(">=1.0.dev0", prereleases=True).to_range()
+        assert list(loose.filter(listing, assume_sorted="descending")) == listing
+
+    def test_prereleases_argument_overrides_the_configured_policy(self) -> None:
+        listing = [V(v) for v in ("1.5", "1.0", "1.0a1")]
+        strict = SpecifierSet(">=1.0.dev0", prereleases=False).to_range()
+        filtered = strict.filter(listing, prereleases=True, assume_sorted="descending")
+        assert list(filtered) == listing
+        loose = SpecifierSet(">=1.0.dev0", prereleases=True).to_range()
+        relaxed = loose.filter(listing, prereleases=False, assume_sorted="descending")
+        assert list(relaxed) == [V("1.5"), V("1.0")]
+
+    def test_default_policy_drops_a_prerelease_behind_a_final(self) -> None:
+        listing = [V(v) for v in ("1.5", "1.0", "1.0a1")]
+        plain = _range(">=0.9,<2.0")
+        assert not plain._pre_region
+        filtered = plain.filter(listing, assume_sorted="descending")
+        assert list(filtered) == [V("1.5"), V("1.0")]
+
+    def test_default_policy_flushes_the_buffer_with_no_final(self) -> None:
+        listing = [V(v) for v in ("1.5rc1", "1.0a1")]
+        plain = _range(">=0.9,<2.0")
+        assert not plain._pre_region
+        assert list(plain.filter(listing, assume_sorted="descending")) == listing
+
+    def test_a_region_spanning_the_bounds_keeps_every_entry(self) -> None:
+        listing = [V(v) for v in ("1.5", "1.0", "1.0a1")]
+        spanning = _range(">=1.0a1,<2.0")
+        assert spanning._pre_region == spanning._bounds
+        assert list(spanning.filter(listing, assume_sorted="descending")) == listing
+
+    def test_an_in_region_prerelease_is_admitted_in_place(self) -> None:
+        """Force-admission keeps position; a buffered one would move to the tail."""
+        split = _split_region()
+        assert split._pre_region != split._bounds
+        listing = [V(v) for v in ("2.5", "2.5rc1", "2.0", "1.4", "1.0", "1.0rc1")]
+        assert list(split.filter(listing, assume_sorted="descending")) == [
+            V("2.5"),
+            V("2.0"),
+            V("1.4"),
+            V("1.0"),
+            V("1.0rc1"),
+        ]
+
+    def test_out_of_region_prereleases_buffer_behind_the_in_region_ones(self) -> None:
+        """With no final in range the buffer flushes, reordering the output."""
+        split = _split_region()
+        listing = [V(v) for v in ("2.5rc1", "1.0rc1", "1.0a1")]
+        assert list(split.filter(listing, assume_sorted="descending")) == [
+            V("1.0rc1"),
+            V("1.0a1"),
+            V("2.5rc1"),
+        ]
+
+
+class TestSortedFilterKey:
+    def test_filters_paired_entries(self) -> None:
+        listing = _paired([V(v) for v in ("2.0", "1.5", "1.0")])
+        filtered = _range(">=1.0,<2.0").filter(
+            listing, key=_first, assume_sorted="descending"
+        )
+        assert list(filtered) == listing[1:]
+
+    def test_filters_paired_entries_ascending(self) -> None:
+        listing = _paired([V(v) for v in ("1.0", "1.5", "2.0")])
+        filtered = _range(">=1.0,<2.0").filter(
+            listing, key=_first, assume_sorted="ascending"
+        )
+        assert list(filtered) == listing[:2]
+
+    def test_key_over_a_literal_range_falls_back_to_the_entry_walk(self) -> None:
+        listing = _paired([V(v) for v in ("2.0", "1.5", "1.0")])
+        filtered = _range("===1.5").filter(
+            listing, key=_first, assume_sorted="descending"
+        )
+        assert list(filtered) == [listing[1]]
+
+    def test_key_returning_a_string(self) -> None:
+        listing = [("2.0", "c.whl"), ("1.5", "b.whl"), ("1.0", "a.whl")]
+        filtered = _range(">=1.0,<2.0").filter(
+            listing, key=_first, assume_sorted="descending"
+        )
+        assert list(filtered) == listing[1:]
+
+    def test_key_projected_entries_decide_the_order(self) -> None:
+        with pytest.raises(ValueError, match="assume_sorted='ascending'"):
+            _range(">=1.0").filter(
+                _paired(DESCENDING), key=_first, assume_sorted="ascending"
+            )
+
+
+class TestSortedFilterOrderContract:
+    """The order and parse promises are checked before the iterator is handed back."""
+
+    def test_ascending_claim_over_a_descending_sequence(self) -> None:
+        with pytest.raises(ValueError, match="assume_sorted='ascending'"):
+            _range(">=1.0").filter(DESCENDING, assume_sorted="ascending")
+
+    def test_descending_claim_over_an_ascending_sequence(self) -> None:
+        with pytest.raises(ValueError, match="assume_sorted='descending'"):
+            _range(">=1.0").filter(LISTING, assume_sorted="descending")
+
+    def test_unparsable_endpoint_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="'frobnicate' does not parse"):
+            _range(">=1.0").filter(["1.0", "frobnicate"], assume_sorted="ascending")
+
+    def test_an_unrecognised_order_is_rejected(self) -> None:
+        for claimed in ("Descending", "desc", "sorted", ""):
+            with pytest.raises(ValueError, match="must be 'ascending' or 'descending'"):
+                _range(">=1.0").filter(DESCENDING, assume_sorted=claimed)  # type: ignore[arg-type]
+
+    def test_an_unrecognised_order_is_rejected_before_the_length_check(self) -> None:
+        with pytest.raises(ValueError, match="must be 'ascending' or 'descending'"):
+            _range(">=1.0").filter([V("1.5")], assume_sorted="desc")  # type: ignore[arg-type]
+
+    def test_a_string_sequence_filters_by_version(self) -> None:
+        # ``Version.__le__(str)`` returns the truthy ``NotImplemented``, so a
+        # bisection over raw entries would read every string as in bounds.
+        r = _range(">=1.0")
+        assert list(r.filter(["0.1", "0.2"], assume_sorted="ascending")) == []
+        assert list(r.filter(["1.1", "1.2"], assume_sorted="ascending")) == [
+            "1.1",
+            "1.2",
+        ]
+
+
+class TestSortedFilterMatchesTheEntryWalk:
+    """Every calling shape agrees with the same call without the keyword."""
+
+    @pytest.mark.parametrize("spec", SPECS)
+    def test_ascending(self, spec: str) -> None:
+        r = _range(spec)
+        assert list(r.filter(LISTING, assume_sorted="ascending")) == list(
+            r.filter(LISTING)
+        )
+
+    @pytest.mark.parametrize("spec", SPECS)
+    def test_descending(self, spec: str) -> None:
+        r = _range(spec)
+        assert list(r.filter(DESCENDING, assume_sorted="descending")) == list(
+            r.filter(DESCENDING)
+        )
+
+    @pytest.mark.parametrize("spec", SPECS)
+    @pytest.mark.parametrize("prereleases", [None, True, False])
+    def test_every_prefix_under_every_policy(
+        self, spec: str, prereleases: bool | None
+    ) -> None:
+        r = _range(spec)
+        for cut in range(len(LISTING) + 1):
+            window = LISTING[:cut]
+            expected = list(r.filter(window, prereleases))
+            assert list(r.filter(window, prereleases, assume_sorted="ascending")) == (
+                expected
+            )
+            reverse = list(reversed(window))
+            assert list(
+                r.filter(reverse, prereleases, assume_sorted="descending")
+            ) == list(r.filter(reverse, prereleases))
+
+    @pytest.mark.parametrize("spec", SPECS)
+    def test_key_over_every_prefix(self, spec: str) -> None:
+        r = _range(spec)
+        for cut in range(len(LISTING) + 1):
+            paired = _paired(LISTING[:cut])
+            assert list(r.filter(paired, key=_first, assume_sorted="ascending")) == (
+                list(r.filter(paired, key=_first))
+            )
+            reverse = _paired(list(reversed(LISTING[:cut])))
+            assert list(r.filter(reverse, key=_first, assume_sorted="descending")) == (
+                list(r.filter(reverse, key=_first))
+            )
+
+    @pytest.mark.parametrize("spec", SPECS)
+    def test_configured_policies_over_every_prefix(self, spec: str) -> None:
+        for prereleases in (True, False):
+            r = SpecifierSet(spec, prereleases=prereleases).to_range()
+            for cut in range(len(LISTING) + 1):
+                window = LISTING[:cut]
+                assert list(r.filter(window, assume_sorted="ascending")) == list(
+                    r.filter(window)
+                )
+                reverse = list(reversed(window))
+                assert list(r.filter(reverse, assume_sorted="descending")) == list(
+                    r.filter(reverse)
+                )
+
+    @pytest.mark.parametrize("spec", SPECS)
+    def test_algebra_derived_ranges(self, spec: str) -> None:
+        base = _range(spec)
+        others = (_range(">=1.0a1,<1.5"), _range(">=2.0,<3.0"), _range("!=1.5"))
+        for other in others:
+            for derived in (base & other, base | other, base - other, ~base):
+                assert list(derived.filter(DESCENDING, assume_sorted="descending")) == (
+                    list(derived.filter(DESCENDING))
+                )

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -2164,7 +2164,7 @@ index 0000000..74930e7
 +    def __repr__(self) -> str:
 +        return f"<{type(self).__name__} {_markersets.describe(self._tree)!r}>"
 diff --git a/nab-python/src/nab_python/_vendor/packaging/ranges.py b/nab-python/src/nab_python/_vendor/packaging/ranges.py
-index 8dd5e66..facf327 100644
+index 8dd5e66..89ec33a 100644
 --- a/nab-python/src/nab_python/_vendor/packaging/ranges.py
 +++ b/nab-python/src/nab_python/_vendor/packaging/ranges.py
 @@ -22,6 +22,7 @@ import typing
@@ -2175,7 +2175,13 @@ index 8dd5e66..facf327 100644
      TypeVar,
      Union,
  )
-@@ -57,6 +58,7 @@ __all__ = ["VersionRange"]
+@@ -52,11 +53,12 @@ if TYPE_CHECKING:
+     from .specifiers import SpecifierSet
+ 
+ 
+-__all__ = ["VersionRange"]
++__all__ = ["SortedOrder", "VersionRange"]
+ 
  T = TypeVar("T")
  UnparsedVersion = Union[Version, str]
  UnparsedVersionVar = TypeVar("UnparsedVersionVar", bound=UnparsedVersion)
@@ -2344,8 +2350,8 @@ index 8dd5e66..facf327 100644
 +    The bisections compare against bound predicates that only accept a
 +    :class:`~packaging.version.Version`, so every probed item is coerced. An
 +    item that does not parse cannot sit in version order at all, which is a
-+    broken precondition rather than a non-match, so it raises rather than being
-+    dropped the way :meth:`VersionRange.filter` drops it.
++    broken precondition rather than a non-match, so this raises rather than
++    dropping the item the way :meth:`VersionRange.filter` drops it.
 +    """
 +
 +    def project(item: Any) -> Version:  # noqa: ANN401
@@ -2667,24 +2673,24 @@ index 8dd5e66..facf327 100644
      ) -> Iterator[Any]:
          """Yield items from iterable whose version falls inside the range.
  
-@@ -964,12 +1342,45 @@ class VersionRange:
+@@ -964,13 +1342,56 @@ class VersionRange:
          ``prereleases=True`` would yield it). A flushed buffer comes after
          every in-place yield, so the output is not version-sorted.
  
 -        The signature mirrors
-+        ``assume_sorted`` names the version order ``iterable`` is already in. It
-+        promises ``iterable`` is a sequence in that order and that every entry
-+        parses as a version; break either half and the result is undefined, the
-+        way :func:`itertools.groupby` is on unsorted input, and a ``ValueError``
-+        may come back in place of an answer. Each interval's matching entries
-+        form one contiguous slice of an ordered sequence, so two bisections per
-+        interval locate them and the pre-release policy runs over those alone;
-+        that is ``O(intervals * log(len(iterable)))`` plus the matches, rather
-+        than a bound test per entry, which tells on a long listing. The yielded
-+        items, and their order, are the same either way. A range carrying ``===``
-+        literals or live arbitrary admission decides membership for strings the
-+        bounds do not describe, so it falls back to a test per entry and ignores
-+        ``assume_sorted`` altogether.
++        ``assume_sorted`` names the version order ``iterable`` is already in,
++        and ``iterable`` must then be a sequence in that order whose every entry
++        parses as a version. Each interval's matching entries form one
++        contiguous slice of an ordered sequence, so two bisections per interval
++        locate them and the pre-release policy runs over those alone; that is
++        ``O(intervals * log(len(iterable)))`` plus the matches, rather than a
++        bound test per entry. The yielded items, and their order, are the same
++        either way. A sequence not in the named order gives a wrong answer, in
++        the way :func:`itertools.groupby` does on unsorted input; only a
++        contradiction between the two end entries is caught. A range carrying
++        ``===`` literals decides membership for strings the bounds do not
++        describe, so it falls back to a test per entry and ignores
++        ``assume_sorted``.
 +
 +        The signature otherwise mirrors
          :meth:`~packaging.specifiers.SpecifierSet.filter`.
@@ -2706,37 +2712,58 @@ index 8dd5e66..facf327 100644
 +        [('1.5', 'b.whl'), ('1.0', 'a.whl')]
 +
 +        :raises ValueError: if ``assume_sorted`` is neither ``"ascending"`` nor
-+            ``"descending"``, or the two end entries contradict it. Both are
-+            checked before the iterator is returned.
++            ``"descending"``, or if the two end entries contradict it; both come
++            from the call rather than the iterator. An entry the walk coerces
++            that does not parse as a version raises as it is reached.
 +
 +        .. versionchanged:: 26.4
 +            Added the ``assume_sorted`` keyword.
          """
++        if assume_sorted is not None and assume_sorted not in (
++            "ascending",
++            "descending",
++        ):
++            raise ValueError(
++                f"assume_sorted must be 'ascending' or 'descending', "
++                f"not {assume_sorted!r}"
++            )
++
          region: tuple[Interval, ...] = ()
          if prereleases is None:
-@@ -984,13 +1395,90 @@ class VersionRange:
-             # pre-release, i.e. ``prereleases=True``; take the cheaper no-buffer
-             # path. (Confined to this branch: the admission path orders arbitrary
-             # strings differently under True than under the region.)
--            if region and region == self._bounds:
-+            whole_region = bool(region) and region == self._bounds
-+            if assume_sorted is not None:
-+                if assume_sorted not in ("ascending", "descending"):
-+                    raise ValueError(
-+                        f"assume_sorted must be 'ascending' or 'descending', "
-+                        f"not {assume_sorted!r}"
-+                    )
-+                descending = assume_sorted == "descending"
-+                sequence = typing.cast("Sequence[Any]", iterable)
-+                project = _make_project(key)
-+                _check_order(sequence, project, descending=descending)
-+                if whole_region:
-+                    return self._filter_sorted(
-+                        sequence, project, key, True, (), descending=descending
-+                    )
+             # The region applies only under the autodetect default; a configured
+@@ -978,19 +1399,93 @@ class VersionRange:
+             prereleases = self._prereleases_configured
+             region = self._pre_region
+ 
++        # A region spanning the whole bounds force-admits every in-bounds
++        # pre-release, i.e. ``prereleases=True``; take the cheaper no-buffer
++        # path. (Confined to the no-literal branches: the admission path orders
++        # arbitrary strings differently under True than under the region.)
++        whole_region = bool(region) and region == self._bounds
++
++        if assume_sorted is not None and not self._admit and not self._reject:
++            # Arbitrary admission needs no gate: it only concerns strings that
++            # do not parse as a version, which ``_make_project`` rejects.
++            descending = assume_sorted == "descending"
++            sequence = typing.cast("Sequence[Any]", iterable)
++            project = _make_project(key)
++            _check_order(sequence, project, descending=descending)
++
++            if whole_region:
 +                return self._filter_sorted(
-+                    sequence, project, key, prereleases, region, descending=descending
++                    sequence, project, key, True, (), descending=descending
 +                )
++            return self._filter_sorted(
++                sequence, project, key, prereleases, region, descending=descending
++            )
++
+         arbitrary_active = self._arbitrary_active()
+         if not self._admit and not self._reject and not arbitrary_active:
+-            # A region spanning the whole bounds force-admits every in-bounds
+-            # pre-release, i.e. ``prereleases=True``; take the cheaper no-buffer
+-            # path. (Confined to this branch: the admission path orders arbitrary
+-            # strings differently under True than under the region.)
+-            if region and region == self._bounds:
 +            if whole_region:
                  return filter_by_ranges(self._bounds, iterable, key, True)
              return filter_by_ranges(self._bounds, iterable, key, prereleases, region)
@@ -2758,12 +2785,11 @@ index 8dd5e66..facf327 100644
 +
 +        The bounds ascend, so a descending sequence walks them backwards; either
 +        way the located slices concatenate in sequence order, which is what
-+        :meth:`filter` yields.
++        :meth:`filter` yields. An interval is located only once the previous one
++        is exhausted, so a caller taking a prefix pays for the prefix.
 +        """
 +        bounds = tuple(reversed(self._bounds)) if descending else self._bounds
 +
-+        # An interval is located only once the previous one is exhausted, so a
-+        # caller taking a prefix pays for the prefix.
 +        if prereleases is True:
 +            for lower, upper in bounds:
 +                start, stop = _partition_indexes(
@@ -2777,24 +2803,22 @@ index 8dd5e66..facf327 100644
 +        plain = key is None
 +        buffered: list[Any] = []
 +        found_final = False
++
 +        for lower, upper in bounds:
 +            start, stop = _partition_indexes(
 +                versions, lower, upper, project, descending=descending
 +            )
 +            for index in range(start, stop):
 +                item = versions[index]
-+                # Skip re-coercing an entry that is already a ``Version``.
 +                parsed = item if plain and item.__class__ is Version else project(item)
 +                if not parsed.is_prerelease:
 +                    found_final = True
 +                    yield item
 +                elif exclude_prereleases:
 +                    continue
-+                # PEP 440 default, mirroring ``filter_by_ranges``: buffer the
-+                # pre-releases and release the buffer only if no final matches.
-+                # One inside the opt-in region is force-admitted in place, so
-+                # the region is consulted per entry rather than folded into the
-+                # cuts.
++                # PEP 440 default, mirroring ``filter_by_ranges``: buffer
++                # pre-releases and flush only if no final matches. One inside
++                # the opt-in region is force-admitted in place.
 +                elif region and matches_bounds_only(region, parsed):
 +                    yield item
 +                elif not found_final:
@@ -2806,7 +2830,7 @@ index 8dd5e66..facf327 100644
      def _filter_with_admission(
          self,
          iterable: Iterable[Any],
-@@ -1078,6 +1566,123 @@ class VersionRange:
+@@ -1078,6 +1573,123 @@ class VersionRange:
          if not found_final:
              yield from all_nonfinal
  

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -2164,10 +2164,26 @@ index 0000000..74930e7
 +    def __repr__(self) -> str:
 +        return f"<{type(self).__name__} {_markersets.describe(self._tree)!r}>"
 diff --git a/nab-python/src/nab_python/_vendor/packaging/ranges.py b/nab-python/src/nab_python/_vendor/packaging/ranges.py
-index 8dd5e66..66224b4 100644
+index 8dd5e66..facf327 100644
 --- a/nab-python/src/nab_python/_vendor/packaging/ranges.py
 +++ b/nab-python/src/nab_python/_vendor/packaging/ranges.py
-@@ -131,6 +131,95 @@ def _union_ranges(
+@@ -22,6 +22,7 @@ import typing
+ from typing import (
+     TYPE_CHECKING,
+     Any,
++    Literal,
+     TypeVar,
+     Union,
+ )
+@@ -57,6 +58,7 @@ __all__ = ["VersionRange"]
+ T = TypeVar("T")
+ UnparsedVersion = Union[Version, str]
+ UnparsedVersionVar = TypeVar("UnparsedVersionVar", bound=UnparsedVersion)
++SortedOrder = Literal["ascending", "descending"]
+ 
+ 
+ class _SetOp(enum.Enum):
+@@ -131,6 +133,95 @@ def _union_ranges(
      return merged
  
  
@@ -2263,23 +2279,28 @@ index 8dd5e66..66224b4 100644
  def _complement_ranges(ranges: Sequence[Interval]) -> list[Interval]:
      """Complement a sorted, non-overlapping interval list.
  
-@@ -280,6 +369,85 @@ def _struct_admits(
+@@ -280,6 +371,142 @@ def _struct_admits(
      return matches_bounds_only(bounds, parsed)
  
  
 +def _bisect_predicate(
-+    versions: Sequence[Version], predicate: Callable[[Version], bool]
++    items: Sequence[Any],
++    predicate: Callable[[Version], bool],
++    project: Callable[[Any], Version] | None = None,
 +) -> int:
 +    """First index whose ``predicate`` is true over an ascending list.
 +
 +    The predicate must be monotonic (false runs then true runs). Equivalent to
 +    ``bisect.bisect_left`` on the mapped booleans, done by hand because the
 +    ``key`` parameter for :mod:`bisect` only exists on Python 3.10 and later.
++    ``project`` maps a probed item to the version it sorts by; ``None`` means
++    the items are already :class:`~packaging.version.Version` instances.
 +    """
-+    low, high = 0, len(versions)
++    low, high = 0, len(items)
 +    while low < high:
 +        mid = (low + high) // 2
-+        if predicate(versions[mid]):
++        item = items[mid]
++        if predicate(item if project is None else project(item)):
 +            high = mid
 +        else:
 +            low = mid + 1
@@ -2287,25 +2308,77 @@ index 8dd5e66..66224b4 100644
 +
 +
 +def _partition_indexes(
-+    versions: Sequence[Version], lower: LowerBound, upper: UpperBound
++    items: Sequence[Any],
++    lower: LowerBound,
++    upper: UpperBound,
++    project: Callable[[Any], Version] | None = None,
++    *,
++    descending: bool = False,
 +) -> tuple[int, int]:
-+    """Locate one interval's bounds in an ascending version list.
++    """Locate one interval's entries in a version-ordered list.
 +
-+    Returns ``(first_inside, first_above)``: the index of the first version at
-+    or above ``lower`` and of the first version strictly above ``upper``, so
-+    ``versions[first_inside:first_above]`` are the versions the interval
-+    contains. The bound predicates are monotonic over an ascending list, so
-+    both cuts bisect on the predicate value.
++    Returns the half-open index pair bounding the entries the interval
++    contains, so ``items[start:stop]`` are those entries in list order. On an
++    ascending list ``lower`` cuts the start and ``upper`` cuts the stop; a
++    descending list swaps which bound cuts which end. Both bound predicates
++    are monotonic over a version-ordered list either way, so each cut is one
++    bisection. ``project`` maps an item to the version it sorts by.
 +    """
 +    above = lower._above
 +    below = upper._below
++    start_bound, stop_bound = (below, above) if descending else (above, below)
 +
-+    first_inside = 0 if above is None else _bisect_predicate(versions, above)
-+    if below is None:
-+        first_above = len(versions)
++    start = 0 if start_bound is None else _bisect_predicate(items, start_bound, project)
++    if stop_bound is None:
++        stop = len(items)
 +    else:
-+        first_above = _bisect_predicate(versions, lambda v: not below(v))
-+    return first_inside, first_above
++        stop = _bisect_predicate(items, lambda v: not stop_bound(v), project)
++    return start, stop
++
++
++def _make_project(
++    key: Callable[[Any], Version | str] | None,
++) -> Callable[[Any], Version]:
++    """Build the item-to-:class:`~packaging.version.Version` map for a sorted walk.
++
++    The bisections compare against bound predicates that only accept a
++    :class:`~packaging.version.Version`, so every probed item is coerced. An
++    item that does not parse cannot sit in version order at all, which is a
++    broken precondition rather than a non-match, so it raises rather than being
++    dropped the way :meth:`VersionRange.filter` drops it.
++    """
++
++    def project(item: Any) -> Version:  # noqa: ANN401
++        raw: Version | str = item if key is None else key(item)
++        parsed = raw if isinstance(raw, Version) else coerce_version(raw)
++        if parsed is None:
++            raise ValueError(
++                f"{raw!r} does not parse as a version, so the given sequence "
++                f"is not in version order"
++            )
++        return parsed
++
++    return project
++
++
++def _check_order(
++    items: Sequence[Any], project: Callable[[Any], Version], *, descending: bool
++) -> None:
++    """Reject a sequence whose endpoints contradict the declared order.
++
++    One comparison of the two ends, which catches a list handed over in the
++    opposite order to the one named. It cannot prove the whole sequence is
++    ordered, and equal endpoints are accepted under either order.
++    """
++    if len(items) < 2:
++        return
++    first = project(items[0])
++    last = project(items[-1])
++    if last < first if not descending else first < last:
++        expected = "descending" if descending else "ascending"
++        raise ValueError(
++            f"assume_sorted={expected!r} but the sequence runs from {first} to {last}"
++        )
 +
 +
 +def _lattice_release(version: Version, parts: int, *, above: bool) -> Version:
@@ -2349,7 +2422,7 @@ index 8dd5e66..66224b4 100644
  # Repr helpers:
  
  
-@@ -316,7 +484,8 @@ class VersionRange:
+@@ -316,7 +543,8 @@ class VersionRange:
      :class:`~packaging.specifiers.SpecifierSet`.
  
      Construct via :meth:`~packaging.specifiers.SpecifierSet.to_range`, or with
@@ -2359,7 +2432,7 @@ index 8dd5e66..66224b4 100644
      Compose with :meth:`intersection`, :meth:`union`, :meth:`complement`, and
      :meth:`difference` (or the ``&`` / ``|`` / ``~`` / ``-`` operators). Test
      membership with ``in`` or :meth:`contains`, filter an iterable with
-@@ -330,9 +499,9 @@ class VersionRange:
+@@ -330,9 +558,9 @@ class VersionRange:
      that opt-in scoped to those versions, so unrelated pre-releases are not
      admitted wholesale.
  
@@ -2372,7 +2445,7 @@ index 8dd5e66..66224b4 100644
  
      >>> r = SpecifierSet(">=1.0,<2.0").to_range()
      >>> "1.5" in r
-@@ -407,7 +576,8 @@ class VersionRange:
+@@ -407,7 +635,8 @@ class VersionRange:
          raise TypeError(
              "cannot create 'VersionRange' instances directly; use "
              "SpecifierSet.to_range(), VersionRange.full(), "
@@ -2382,7 +2455,7 @@ index 8dd5e66..66224b4 100644
          )
  
      @classmethod
-@@ -599,6 +769,73 @@ class VersionRange:
+@@ -599,6 +828,73 @@ class VersionRange:
              prereleases_configured=prereleases,
          )
  
@@ -2456,7 +2529,7 @@ index 8dd5e66..66224b4 100644
      def intersection(self, other: VersionRange) -> VersionRange:
          """Range containing exactly the versions in both self and other.
  
-@@ -879,6 +1116,15 @@ class VersionRange:
+@@ -879,6 +1175,15 @@ class VersionRange:
          False
          >>> VersionRange.empty().is_subset(outer)
          True
@@ -2472,7 +2545,7 @@ index 8dd5e66..66224b4 100644
          """
          self._check_policy_compat(other)
  
-@@ -889,12 +1135,52 @@ class VersionRange:
+@@ -889,12 +1194,52 @@ class VersionRange:
  
          # Plain ranges: subset reduces to bounds containment, no algebra needed.
          if self._is_plain() and other._is_plain():
@@ -2526,7 +2599,7 @@ index 8dd5e66..66224b4 100644
      def is_superset(self, other: VersionRange) -> bool:
          """Return whether every member of other is also a member of self.
  
-@@ -925,12 +1211,19 @@ class VersionRange:
+@@ -925,12 +1270,19 @@ class VersionRange:
          True
          >>> a.is_disjoint(SpecifierSet(">=1.5,<2.5").to_range())
          False
@@ -2547,7 +2620,193 @@ index 8dd5e66..66224b4 100644
          return self.intersection(other).is_empty
  
      @typing.overload
-@@ -1078,6 +1371,123 @@ class VersionRange:
+@@ -939,6 +1291,8 @@ class VersionRange:
+         iterable: Iterable[UnparsedVersionVar],
+         prereleases: bool | None = None,
+         key: None = ...,
++        *,
++        assume_sorted: None = None,
+     ) -> Iterator[UnparsedVersionVar]: ...
+ 
+     @typing.overload
+@@ -947,6 +1301,28 @@ class VersionRange:
+         iterable: Iterable[T],
+         prereleases: bool | None = None,
+         key: Callable[[T], UnparsedVersion] = ...,
++        *,
++        assume_sorted: None = None,
++    ) -> Iterator[T]: ...
++
++    @typing.overload
++    def filter(
++        self,
++        iterable: Sequence[UnparsedVersionVar],
++        prereleases: bool | None = None,
++        key: None = ...,
++        *,
++        assume_sorted: SortedOrder,
++    ) -> Iterator[UnparsedVersionVar]: ...
++
++    @typing.overload
++    def filter(
++        self,
++        iterable: Sequence[T],
++        prereleases: bool | None = None,
++        key: Callable[[T], UnparsedVersion] = ...,
++        *,
++        assume_sorted: SortedOrder,
+     ) -> Iterator[T]: ...
+ 
+     def filter(
+@@ -954,6 +1330,8 @@ class VersionRange:
+         iterable: Iterable[Any],
+         prereleases: bool | None = None,
+         key: Callable[[Any], Version | str] | None = None,
++        *,
++        assume_sorted: SortedOrder | None = None,
+     ) -> Iterator[Any]:
+         """Yield items from iterable whose version falls inside the range.
+ 
+@@ -964,12 +1342,45 @@ class VersionRange:
+         ``prereleases=True`` would yield it). A flushed buffer comes after
+         every in-place yield, so the output is not version-sorted.
+ 
+-        The signature mirrors
++        ``assume_sorted`` names the version order ``iterable`` is already in. It
++        promises ``iterable`` is a sequence in that order and that every entry
++        parses as a version; break either half and the result is undefined, the
++        way :func:`itertools.groupby` is on unsorted input, and a ``ValueError``
++        may come back in place of an answer. Each interval's matching entries
++        form one contiguous slice of an ordered sequence, so two bisections per
++        interval locate them and the pre-release policy runs over those alone;
++        that is ``O(intervals * log(len(iterable)))`` plus the matches, rather
++        than a bound test per entry, which tells on a long listing. The yielded
++        items, and their order, are the same either way. A range carrying ``===``
++        literals or live arbitrary admission decides membership for strings the
++        bounds do not describe, so it falls back to a test per entry and ignores
++        ``assume_sorted`` altogether.
++
++        The signature otherwise mirrors
+         :meth:`~packaging.specifiers.SpecifierSet.filter`.
+ 
+         >>> r = SpecifierSet(">=1.0,<2.0").to_range()
+         >>> list(r.filter(["0.9", "1.5", "2.0"]))
+         ['1.5']
++
++        The same listing, newest first, filtered by bisection:
++
++        >>> listing = [Version(v) for v in ("3.0", "2.0", "1.5", "1.0")]
++        >>> list(r.filter(listing, assume_sorted="descending"))
++        [<Version('1.5')>, <Version('1.0')>]
++
++        ``key`` reaches the version inside a richer entry, on either path:
++
++        >>> files = [("1.5", "b.whl"), ("1.0", "a.whl")]
++        >>> list(r.filter(files, key=lambda f: f[0], assume_sorted="descending"))
++        [('1.5', 'b.whl'), ('1.0', 'a.whl')]
++
++        :raises ValueError: if ``assume_sorted`` is neither ``"ascending"`` nor
++            ``"descending"``, or the two end entries contradict it. Both are
++            checked before the iterator is returned.
++
++        .. versionchanged:: 26.4
++            Added the ``assume_sorted`` keyword.
+         """
+         region: tuple[Interval, ...] = ()
+         if prereleases is None:
+@@ -984,13 +1395,90 @@ class VersionRange:
+             # pre-release, i.e. ``prereleases=True``; take the cheaper no-buffer
+             # path. (Confined to this branch: the admission path orders arbitrary
+             # strings differently under True than under the region.)
+-            if region and region == self._bounds:
++            whole_region = bool(region) and region == self._bounds
++            if assume_sorted is not None:
++                if assume_sorted not in ("ascending", "descending"):
++                    raise ValueError(
++                        f"assume_sorted must be 'ascending' or 'descending', "
++                        f"not {assume_sorted!r}"
++                    )
++                descending = assume_sorted == "descending"
++                sequence = typing.cast("Sequence[Any]", iterable)
++                project = _make_project(key)
++                _check_order(sequence, project, descending=descending)
++                if whole_region:
++                    return self._filter_sorted(
++                        sequence, project, key, True, (), descending=descending
++                    )
++                return self._filter_sorted(
++                    sequence, project, key, prereleases, region, descending=descending
++                )
++            if whole_region:
+                 return filter_by_ranges(self._bounds, iterable, key, True)
+             return filter_by_ranges(self._bounds, iterable, key, prereleases, region)
+         return self._filter_with_admission(
+             iterable, key, prereleases, arbitrary_active, region
+         )
+ 
++    def _filter_sorted(
++        self,
++        versions: Sequence[Any],
++        project: Callable[[Any], Version],
++        key: Callable[[Any], Version | str] | None,
++        prereleases: bool | None,
++        region: tuple[Interval, ...],
++        *,
++        descending: bool,
++    ) -> Iterator[Any]:
++        """Filter a version-ordered sequence by bisecting each interval.
++
++        The bounds ascend, so a descending sequence walks them backwards; either
++        way the located slices concatenate in sequence order, which is what
++        :meth:`filter` yields.
++        """
++        bounds = tuple(reversed(self._bounds)) if descending else self._bounds
++
++        # An interval is located only once the previous one is exhausted, so a
++        # caller taking a prefix pays for the prefix.
++        if prereleases is True:
++            for lower, upper in bounds:
++                start, stop = _partition_indexes(
++                    versions, lower, upper, project, descending=descending
++                )
++                for index in range(start, stop):
++                    yield versions[index]
++            return
++
++        exclude_prereleases = prereleases is False
++        plain = key is None
++        buffered: list[Any] = []
++        found_final = False
++        for lower, upper in bounds:
++            start, stop = _partition_indexes(
++                versions, lower, upper, project, descending=descending
++            )
++            for index in range(start, stop):
++                item = versions[index]
++                # Skip re-coercing an entry that is already a ``Version``.
++                parsed = item if plain and item.__class__ is Version else project(item)
++                if not parsed.is_prerelease:
++                    found_final = True
++                    yield item
++                elif exclude_prereleases:
++                    continue
++                # PEP 440 default, mirroring ``filter_by_ranges``: buffer the
++                # pre-releases and release the buffer only if no final matches.
++                # One inside the opt-in region is force-admitted in place, so
++                # the region is consulted per entry rather than folded into the
++                # cuts.
++                elif region and matches_bounds_only(region, parsed):
++                    yield item
++                elif not found_final:
++                    buffered.append(item)
++
++        if not found_final:
++            yield from buffered
++
+     def _filter_with_admission(
+         self,
+         iterable: Iterable[Any],
+@@ -1078,6 +1566,123 @@ class VersionRange:
          if not found_final:
              yield from all_nonfinal
  


### PR DESCRIPTION
`VersionRange.filter` now takes a keyword-only `assume_sorted="ascending"` or `assume_sorted="descending"` for callers that already hold their listing in version order. Each interval's matches are one contiguous slice of an ordered sequence, so two bisections per interval locate them and the pre-release policy runs over those slices instead of over every entry. The result stays a lazy iterator and `key=` and `prereleases=` keep working, so a caller that only wants the first match stops paying for the rest of the listing.

Real listings are median 34 distinct versions with a p99 of 1023, and the crossover against the per-entry test sits around a dozen entries, so most packages move little either way and the saving lands on the long tail. The provider passes the keyword everywhere it filters a listing it already holds newest first: candidate selection, extras, the preferred-version check, and the match count behind the priority heuristic.

One keyword serves both directions, which is what keeps this from being a second filtering method with its own hard-coded order contract. The direction the caller names is checked against the two end entries rather than assumed. Ranges carrying `===` literals decide membership for strings the bounds do not describe, so they stay on the per-entry path.

The divergence from the pinned vendored packaging tree is carried in `tasks/vendoring/packaging.patch`, per the pinned-tree-plus-one-patch model in `PROVENANCE.md`.

Stacks on #603.