### PR TITLE
narrow sibling wheels by the target's python

### DIFF
--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -127,7 +127,7 @@ def wheel_by_version(
             grouped.setdefault(version, []).append(dist)
 
         cached = {
-            version: pick_dist(dists, provider.wheel_tags)
+            version: pick_dist(dists, provider.wheel_tags, provider.target)
             for version, dists in grouped.items()
         }
         provider.wheel_by_version_cache[normalized] = cached
@@ -218,7 +218,9 @@ def prefetch_transitive_best(
         return
 
     # Prefetch the artifact the read picks, not the listing's first at that version.
-    dist = pick_dist_for_metadata(versions, version, provider.wheel_tags)
+    dist = pick_dist_for_metadata(
+        versions, version, provider.wheel_tags, provider.target
+    )
 
     cache_key = (normalized, version)
     if (

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -79,7 +79,9 @@ def resolve_metadata(
     # sidecar wheel keys on its sidecar URL; a bare remote wheel (rung 4) keys
     # on its own wheel URL, so its range-recovered text stays independent of a
     # sibling wheel's.
-    dist = pick_dist_for_metadata(versions, version, provider.wheel_tags)
+    dist = pick_dist_for_metadata(
+        versions, version, provider.wheel_tags, provider.target
+    )
     if _is_bare_remote_wheel(dist):
         metadata_url = dist.url
     elif isinstance(dist, WheelFile):
@@ -230,13 +232,18 @@ def pick_dist_for_metadata(
     versions: Sequence[tuple[Version, DistFile]],
     version: Version,
     tags: TagSet | None,
+    target: ResolveTarget | None = None,
 ) -> DistFile | None:
     """Pick the dist whose metadata answers for ``version``. See :func:`pick_dist`."""
     dists = [d for v, d in versions if v == version]
-    return pick_dist(dists, tags) if dists else None
+    return pick_dist(dists, tags, target) if dists else None
 
 
-def pick_dist(dists: Sequence[DistFile], tags: TagSet | None) -> DistFile:
+def pick_dist(
+    dists: Sequence[DistFile],
+    tags: TagSet | None,
+    target: ResolveTarget | None = None,
+) -> DistFile:
     """Pick the dist of one version whose metadata answers for the target.
 
     ``dists`` are the artifacts of a single version, and must be non-empty.
@@ -246,13 +253,17 @@ def pick_dist(dists: Sequence[DistFile], tags: TagSet | None) -> DistFile:
     installer picks by, so that wheel's METADATA is the one the pin has to
     satisfy.  ``tags`` is ``None`` when there is no tag axis to rank by,
     either because nothing said which machine the resolve is for or because
-    a marker overlay moved the target off its tags.
+    a marker overlay moved the target off its tags.  ``target`` still names
+    the Python, so wheels built for another interpreter drop out: reading a
+    release's dependencies out of a wheel the target could never install is
+    the unsoundness :func:`check_sibling_metadata_divergence` guards against,
+    one layer earlier.  When that leaves nothing, the whole listing stands.
 
-    Without tags, and between wheels the tags rank equally, the cheapest
-    metadata source wins: a wheel with a :pep:`658` ``metadata_url``, then
-    any wheel.  Only a version publishing no wheel is read from its sdist,
-    which lets :attr:`~nab_python.provider.DistPolicy.SDIST_INSTALL` keep
-    wheels in the listing purely as a metadata source.
+    Among the wheels that remain the cheapest metadata source wins: a wheel
+    with a :pep:`658` ``metadata_url``, then any wheel.  Only a version
+    publishing no wheel is read from its sdist, which lets
+    :attr:`~nab_python.provider.DistPolicy.SDIST_INSTALL` keep wheels in the
+    listing purely as a metadata source.
     """
     if len(dists) == 1:
         return dists[0]
@@ -261,12 +272,13 @@ def pick_dist(dists: Sequence[DistFile], tags: TagSet | None) -> DistFile:
     if not wheels:
         return dists[0]
 
-    # Sidecars first: ``pick`` keeps input order among wheels it ranks equally.
-    installed = (
-        tags.pick(sorted(wheels, key=lambda w: not w.has_metadata))
-        if tags is not None
-        else None
-    )
+    if tags is None:
+        admitted = [w for w in wheels if _python_axis_admits(target, w.filename)]
+        wheels = admitted or wheels
+        installed = None
+    else:
+        # Sidecars first: ``pick`` keeps input order among wheels it ranks equally.
+        installed = tags.pick(sorted(wheels, key=lambda w: not w.has_metadata))
     return installed or next((w for w in wheels if w.has_metadata), wheels[0])
 
 
@@ -842,7 +854,7 @@ def check_sibling_metadata_divergence(
     from ..provider import SiblingMetadataDivergenceError
 
     tags = provider.wheel_tags
-    pick = pick_dist_for_metadata(versions, version, tags)
+    pick = pick_dist_for_metadata(versions, version, tags, provider.target)
     if not isinstance(pick, WheelFile):
         return
 
@@ -955,11 +967,10 @@ def _wheels_tie(
     Python axis admits it.  A marker overlay disowns the platform tags but
     keeps ``python_version`` and ``implementation_name``, so a wheel built for
     another interpreter is a choice no installer on this target could make,
-    and comparing it would crash on an ambiguity that does not exist.  This is
-    the ``Requires-Python`` guard in :func:`_tie_sibling_metadata` read off the
-    tags the filename carries, which is where a release published one wheel
-    per interpreter needs it: such a release declares one Requires-Python
-    spanning them all, so the metadata guard admits every sibling.
+    and comparing it would crash on an ambiguity that does not exist.  The
+    ``Requires-Python`` guard in :func:`_tie_sibling_metadata` cannot catch
+    that: a release publishing one wheel per interpreter declares one
+    ``Requires-Python`` spanning them all, so that guard admits every sibling.
 
     Otherwise a sibling ties only when its
     :meth:`~nab_python.tags.TagSet.wheel_rank` key equals the pick's and is not

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -32,6 +32,7 @@ from ..requirements_file import (
     _parse_requirements,
     _require_string_list,
 )
+from ..tags import python_axis_accepts
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -42,6 +43,7 @@ if TYPE_CHECKING:
     from ..fetch import InMemoryIndex
     from ..provider import DistFile, Provider
     from ..tags import TagSet
+    from ..target import ResolveTarget
 
 TargetDepSignature = tuple[
     dict[str, VersionRange],
@@ -859,7 +861,9 @@ def check_sibling_metadata_divergence(
     pick_key = None if tags is None else tags.wheel_rank(pick.filename)
     pick_sig: TargetDepSignature | None = None
     for sibling in wheels:
-        if sibling is pick or not _wheels_tie(tags, pick_key, sibling.filename):
+        if sibling is pick or not _wheels_tie(
+            tags, provider.target, pick_key, sibling.filename
+        ):
             continue
         sibling_metadata = _tie_sibling_metadata(
             provider, index, normalized, version, sibling
@@ -941,21 +945,42 @@ def _resident_wheel_text(
 
 def _wheels_tie(
     tags: TagSet | None,
+    target: ResolveTarget | None,
     pick_key: tuple[int, tuple[int, str]] | None,
     sibling_filename: str,
 ) -> bool:
     """Whether a sibling wheel ties the pick under the target's install rules.
 
-    With no tag axis every resident sibling wheel is a real ambiguity, so any
-    sibling ties.  Otherwise a sibling ties only when its
+    With no tag axis a sibling is a real ambiguity only when the target's
+    Python axis admits it.  A marker overlay disowns the platform tags but
+    keeps ``python_version`` and ``implementation_name``, so a wheel built for
+    another interpreter is a choice no installer on this target could make,
+    and comparing it would crash on an ambiguity that does not exist.  This is
+    the ``Requires-Python`` guard in :func:`_tie_sibling_metadata` read off the
+    tags the filename carries, which is where a release published one wheel
+    per interpreter needs it: such a release declares one Requires-Python
+    spanning them all, so the metadata guard admits every sibling.
+
+    Otherwise a sibling ties only when its
     :meth:`~nab_python.tags.TagSet.wheel_rank` key equals the pick's and is not
     None; a sibling the pick ranks strictly below is never installed and is
     exempt.
     """
     if tags is None:
-        return True
+        return _python_axis_admits(target, sibling_filename)
     sibling_key = tags.wheel_rank(sibling_filename)
     return sibling_key is not None and sibling_key == pick_key
+
+
+def _python_axis_admits(target: ResolveTarget | None, filename: str) -> bool:
+    """Whether a target's Python axis admits a wheel filename's tags.
+
+    Without a target nothing has said which Python the resolve is for, so
+    every wheel is admitted.
+    """
+    if target is None:
+        return True
+    return python_axis_accepts(target.python_version, target.implementation, filename)
 
 
 def _divergent_dep_labels(

--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -773,12 +773,12 @@ def python_axis_accepts(
 ) -> bool:
     """Whether a Python axis accepts a wheel filename's tags, on any platform.
 
-    The platform axis is ignored, which is the question a target whose tags a
-    marker overlay disowned can still answer: an overlay cannot rebuild the
+    The platform axis is ignored.  That is what a target whose tags a marker
+    overlay disowned can still be asked: an overlay cannot rebuild the
     platform tags, but ``python_version`` and ``implementation_name`` survive
     it (see :meth:`~nab_python.target.ResolveTarget.with_marker_overrides`).
-    A filename that does not parse as a wheel is admitted, since nothing was
-    read off it to reject it by.
+    A filename that does not parse as a wheel is admitted; it carries no tags
+    to reject it by.
     """
     tags = wheel_tag_set(wheel_filename)
     if not tags:

--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -48,6 +48,7 @@ __all__ = [
     "TagSet",
     "TagsSource",
     "platform_kind",
+    "python_axis_accepts",
     "supports_free_threading",
     "wheel_tag_set",
 ]
@@ -740,3 +741,47 @@ def _tags_in_order(
         interpreter=compat_interpreter,
         platforms=platforms,
     )
+
+
+@cache
+def _python_axis_tags(
+    python_version: str, implementation: str
+) -> frozenset[tuple[str, str]]:
+    """Return the ``(interpreter, abi)`` pairs one Python axis accepts.
+
+    :func:`_tags_in_order` pairs the same interpreters and abis with every
+    platform it is given, so projecting the platform away leaves exactly the
+    axes the Python version and the implementation decide.  Both builds are
+    admitted where :pep:`703` offers one, since free-threading is a property
+    of the interpreter binary that a marker environment does not name.
+    """
+    builds = (False, True) if supports_free_threading(python_version) else (False,)
+    return frozenset(
+        (tag.interpreter, tag.abi)
+        for free_threaded in builds
+        for tag in _tags_in_order(
+            python_version,
+            (_ANY_PLATFORM,),
+            implementation,
+            free_threaded=free_threaded,
+        )
+    )
+
+
+def python_axis_accepts(
+    python_version: str, implementation: str, wheel_filename: str
+) -> bool:
+    """Whether a Python axis accepts a wheel filename's tags, on any platform.
+
+    The platform axis is ignored, which is the question a target whose tags a
+    marker overlay disowned can still answer: an overlay cannot rebuild the
+    platform tags, but ``python_version`` and ``implementation_name`` survive
+    it (see :meth:`~nab_python.target.ResolveTarget.with_marker_overrides`).
+    A filename that does not parse as a wheel is admitted, since nothing was
+    read off it to reject it by.
+    """
+    tags = wheel_tag_set(wheel_filename)
+    if not tags:
+        return True
+    accepted = _python_axis_tags(python_version, implementation)
+    return any((tag.interpreter, tag.abi) in accepted for tag in tags)

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -9330,3 +9330,113 @@ class TestSiblingMetadataDivergence:
                 [Requirement("pkg")],
                 config=NabProjectConfig(build_policy=BuildPolicy.NEVER),
             )
+
+
+# A release published as one wheel per interpreter, one of which declares an
+# extra unmarked dependency: the torch 1.4.0 shape, whose Requires-Python
+# spans every interpreter it built for, so the Requires-Python guard admits
+# them all.
+_SPLIT_RP = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+
+def _split_wheel(tag: str) -> WheelFile:
+    """A pkg 1.0 wheel for one interpreter, admitting every Python it built for."""
+    filename = f"pkg-1.0-{tag}.whl"
+    return WheelFile(
+        filename=filename,
+        url=f"https://example.com/{filename}",
+        version="1.0",
+        requires_python=_SPLIT_RP,
+        has_metadata=True,
+        upload_time=None,
+    )
+
+
+def _split_meta(*requires_dist: str) -> str:
+    """A METADATA blob carrying the split release's Requires-Python."""
+    return (
+        f"Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n"
+        f"Requires-Python: {_SPLIT_RP}\n"
+        + "".join(f"Requires-Dist: {line}\n" for line in requires_dist)
+        + "\n"
+    )
+
+
+def _overlay_target(python_version: str = "3.7") -> ResolveTarget:
+    """A declared linux target moved off its tags by a marker overlay."""
+    target = ResolveTarget.for_declared(
+        python_version=python_version, spec=PlatformSpec("linux_x86_64")
+    ).with_marker_overrides({"platform_system": "Windows"})
+    assert not target.tags_faithful
+    return target
+
+
+class TestNoTagAxisPythonNarrowing:
+    """A disowned tag axis still narrows siblings by the target's Python.
+
+    A marker overlay cannot rebuild the platform tags, so the provider filters
+    no wheel by tag under one.  It does keep ``python_version`` and
+    ``implementation_name``, so a wheel built for another interpreter is still
+    a wheel this target can never install, and neither the tie set nor the pick
+    may treat it as a candidate.
+    """
+
+    _V = V("1.0")
+
+    def test_other_interpreter_siblings_never_tie(self) -> None:
+        """A release split across interpreters resolves under an overlay.
+
+        The divergent wheel is built for another interpreter, so it is no
+        ambiguity for this target and the version stays resolvable.
+        """
+        cp27 = _split_wheel("cp27-cp27m-manylinux1_x86_64")
+        cp35 = _split_wheel("cp35-cp35m-manylinux1_x86_64")
+        cp37 = _split_wheel("cp37-cp37m-manylinux1_x86_64")
+        coordinator = make_coordinator([cp27, cp35, cp37], package="pkg")
+        for wheel in (cp27, cp37):
+            coordinator.index.store_metadata(
+                "pkg", "1.0", _split_meta("common>=1"), wheel.metadata_url
+            )
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _split_meta("common>=1", "numpy"), cp35.metadata_url
+        )
+        provider = Provider(coordinator, target=_overlay_target())
+        deps = provider.get_dependencies("pkg", self._V)
+        assert "common" in deps
+        assert "numpy" not in deps
+
+    def test_same_interpreter_divergence_still_crashes(self) -> None:
+        """Two wheels for the target's own interpreter remain a real ambiguity.
+
+        Only the platform separates them, and the platform is the axis the
+        overlay disowned, so nothing can rank them and the crash must stand.
+        """
+        linux = _split_wheel("cp37-cp37m-manylinux1_x86_64")
+        macos = _split_wheel("cp37-none-macosx_10_9_x86_64")
+        coordinator = make_coordinator([linux, macos], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _split_meta("common>=1"), linux.metadata_url
+        )
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _split_meta("common>=1", "numpy"), macos.metadata_url
+        )
+        provider = Provider(coordinator, target=_overlay_target())
+        with pytest.raises(SiblingMetadataDivergenceError) as exc:
+            provider.get_dependencies("pkg", self._V)
+        assert "numpy" in str(exc.value)
+
+    def test_abi3_sibling_of_an_older_interpreter_still_ties(self) -> None:
+        """An abi3 wheel below the target's interpreter is installable, so it ties."""
+        pick = _split_wheel("cp37-cp37m-manylinux1_x86_64")
+        abi3 = _split_wheel("cp35-abi3-manylinux1_x86_64")
+        coordinator = make_coordinator([pick, abi3], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _split_meta("common>=1"), pick.metadata_url
+        )
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _split_meta("common>=1", "numpy"), abi3.metadata_url
+        )
+        provider = Provider(coordinator, target=_overlay_target())
+        with pytest.raises(SiblingMetadataDivergenceError) as exc:
+            provider.get_dependencies("pkg", self._V)
+        assert "numpy" in str(exc.value)

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -9332,15 +9332,14 @@ class TestSiblingMetadataDivergence:
             )
 
 
-# A release published as one wheel per interpreter, one of which declares an
-# extra unmarked dependency: the torch 1.4.0 shape, whose Requires-Python
-# spans every interpreter it built for, so the Requires-Python guard admits
-# them all.
+# One Requires-Python spanning every interpreter a release built for, the
+# torch 1.4.0 shape: it admits every sibling wheel, so the Requires-Python
+# guard on the tie set never fires and the tags have to do the narrowing.
 _SPLIT_RP = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 
 def _split_wheel(tag: str) -> WheelFile:
-    """A pkg 1.0 wheel for one interpreter, admitting every Python it built for."""
+    """A pkg 1.0 wheel for one interpreter, carrying the release's Requires-Python."""
     filename = f"pkg-1.0-{tag}.whl"
     return WheelFile(
         filename=filename,
@@ -9362,10 +9361,10 @@ def _split_meta(*requires_dist: str) -> str:
     )
 
 
-def _overlay_target(python_version: str = "3.7") -> ResolveTarget:
-    """A declared linux target moved off its tags by a marker overlay."""
+def _overlay_target() -> ResolveTarget:
+    """A declared python 3.7 linux target moved off its tags by a marker overlay."""
     target = ResolveTarget.for_declared(
-        python_version=python_version, spec=PlatformSpec("linux_x86_64")
+        python_version="3.7", spec=PlatformSpec("linux_x86_64")
     ).with_marker_overrides({"platform_system": "Windows"})
     assert not target.tags_faithful
     return target
@@ -9374,8 +9373,8 @@ def _overlay_target(python_version: str = "3.7") -> ResolveTarget:
 class TestNoTagAxisPythonNarrowing:
     """A disowned tag axis still narrows siblings by the target's Python.
 
-    A marker overlay cannot rebuild the platform tags, so the provider filters
-    no wheel by tag under one.  It does keep ``python_version`` and
+    A marker overlay cannot rebuild the platform tags, so under one the
+    provider filters no wheel by tag.  It does keep ``python_version`` and
     ``implementation_name``, so a wheel built for another interpreter is still
     a wheel this target can never install, and neither the tie set nor the pick
     may treat it as a candidate.
@@ -9424,6 +9423,80 @@ class TestNoTagAxisPythonNarrowing:
         with pytest.raises(SiblingMetadataDivergenceError) as exc:
             provider.get_dependencies("pkg", self._V)
         assert "numpy" in str(exc.value)
+
+    def test_the_pick_reads_a_wheel_the_target_could_install(self) -> None:
+        """Listing order does not decide which wheel a version's deps come from.
+
+        The interpreter wheels are listed oldest first, as an index serves
+        them, so an order-driven pick would read this target's dependencies
+        out of a wheel built for another Python.
+        """
+        cp27 = _split_wheel("cp27-cp27m-manylinux1_x86_64")
+        cp35 = _split_wheel("cp35-cp35m-manylinux1_x86_64")
+        cp37 = _split_wheel("cp37-cp37m-manylinux1_x86_64")
+        coordinator = make_coordinator([cp27, cp35, cp37], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _split_meta("py27dep>=1"), cp27.metadata_url
+        )
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _split_meta("py35dep>=1"), cp35.metadata_url
+        )
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _split_meta("py37dep>=1"), cp37.metadata_url
+        )
+        provider = Provider(coordinator, target=_overlay_target())
+        assert (
+            metadata_resolver.pick_dist_for_metadata(
+                [(self._V, cp27), (self._V, cp35), (self._V, cp37)],
+                self._V,
+                provider.wheel_tags,
+                provider.target,
+            )
+            is cp37
+        )
+        assert "py37dep" in provider.get_dependencies("pkg", self._V)
+
+    def test_a_split_release_resolves_end_to_end_under_an_overlay(self) -> None:
+        """The whole resolve completes, rather than aborting on the ambiguity.
+
+        Every wheel built for another interpreter declares a dependency the
+        pick does not, and the index does not carry it, so treating any of
+        them as this target's wheel fails the resolve just as loudly as the
+        crash did.
+        """
+        cp27 = _split_wheel("cp27-cp27m-manylinux1_x86_64")
+        cp35 = _split_wheel("cp35-cp35m-manylinux1_x86_64")
+        cp37 = _split_wheel("cp37-cp37m-manylinux1_x86_64")
+        coordinator = make_coordinator([cp27, cp35, cp37], package="pkg")
+        coordinator.index.store_metadata("pkg", "1.0", _split_meta(), cp37.metadata_url)
+        for wheel in (cp27, cp35):
+            coordinator.index.store_metadata(
+                "pkg", "1.0", _split_meta("numpy"), wheel.metadata_url
+            )
+        result = resolve_with_coordinator(
+            coordinator,
+            [_overlay_target()],
+            [Requirement("pkg")],
+            config=NabProjectConfig(build_policy=BuildPolicy.NEVER),
+        )
+        assert result.success
+        assert result.target_results[0].pins == {"pkg": self._V}
+
+    def test_a_version_built_for_no_admitted_interpreter_keeps_listing_order(
+        self,
+    ) -> None:
+        """Narrowing to no wheel at all decides nothing, so listing order stands."""
+        cp27 = _split_wheel("cp27-cp27m-manylinux1_x86_64")
+        cp35 = _split_wheel("cp35-cp35m-manylinux1_x86_64")
+        assert (
+            metadata_resolver.pick_dist_for_metadata(
+                [(self._V, cp27), (self._V, cp35)],
+                self._V,
+                None,
+                _overlay_target(),
+            )
+            is cp27
+        )
 
     def test_abi3_sibling_of_an_older_interpreter_still_ties(self) -> None:
         """An abi3 wheel below the target's interpreter is installable, so it ties."""

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -28,6 +28,7 @@ from nab_python.tags import (
     _ordered_tags_for_spec,
     _parse_tag_str,
     _platform_tags_for_spec,
+    python_axis_accepts,
     wheel_tag_set,
 )
 from nab_python.target import PLATFORM_MARKERS
@@ -1187,6 +1188,69 @@ class TestTagSetAccepts:
         specific = Tag("cp311", "cp311", "manylinux_2_28_x86_64")
         generic = Tag("py3", "none", "any")
         assert self._TAGS.rank[specific] < self._TAGS.rank[generic]
+
+
+class TestPythonAxisAccepts:
+    """``python_axis_accepts`` answers the Python axis alone, any platform.
+
+    It is what a target whose tags a marker overlay disowned can still ask:
+    the overlay cannot rebuild the platform tags, but the Python version and
+    the implementation survive it.
+    """
+
+    def test_the_targets_own_interpreter_is_accepted(self) -> None:
+        assert python_axis_accepts(
+            "3.7", "cpython", "pkg-1.0-cp37-cp37m-manylinux1_x86_64.whl"
+        )
+
+    def test_a_foreign_platform_is_still_accepted(self) -> None:
+        """The platform axis is projected out, so it decides nothing."""
+        assert python_axis_accepts("3.7", "cpython", "pkg-1.0-cp37-cp37m-win_amd64.whl")
+
+    def test_another_interpreter_is_rejected(self) -> None:
+        assert not python_axis_accepts(
+            "3.7", "cpython", "pkg-1.0-cp27-cp27m-manylinux1_x86_64.whl"
+        )
+        assert not python_axis_accepts(
+            "3.7", "cpython", "pkg-1.0-cp35-cp35m-manylinux1_x86_64.whl"
+        )
+
+    def test_an_older_abi3_wheel_is_accepted(self) -> None:
+        """PEP 384's stable ABI runs forward, so an older abi3 wheel installs."""
+        assert python_axis_accepts(
+            "3.7", "cpython", "pkg-1.0-cp35-abi3-manylinux1_x86_64.whl"
+        )
+
+    def test_a_newer_abi3_wheel_is_rejected(self) -> None:
+        assert not python_axis_accepts(
+            "3.7", "cpython", "pkg-1.0-cp38-abi3-manylinux1_x86_64.whl"
+        )
+
+    def test_generic_wheels_track_the_major(self) -> None:
+        assert python_axis_accepts("3.7", "cpython", "pkg-1.0-py2.py3-none-any.whl")
+        assert python_axis_accepts("3.7", "cpython", "pkg-1.0-py3-none-any.whl")
+        assert not python_axis_accepts("3.7", "cpython", "pkg-1.0-py2-none-any.whl")
+
+    def test_the_implementation_separates_the_axes(self) -> None:
+        """A PyPy target loads no CPython ABI, and the reverse."""
+        pypy = "pkg-1.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.whl"
+        cpython = "pkg-1.0-cp310-cp310-manylinux_2_17_x86_64.whl"
+        assert python_axis_accepts("3.10", "pypy", pypy)
+        assert not python_axis_accepts("3.10", "cpython", pypy)
+        assert not python_axis_accepts("3.10", "pypy", cpython)
+
+    def test_both_free_threaded_builds_are_accepted(self) -> None:
+        """A marker environment does not name the build, so neither is excluded."""
+        assert python_axis_accepts(
+            "3.13", "cpython", "pkg-1.0-cp313-cp313-manylinux_2_17_x86_64.whl"
+        )
+        assert python_axis_accepts(
+            "3.13", "cpython", "pkg-1.0-cp313-cp313t-manylinux_2_17_x86_64.whl"
+        )
+
+    def test_an_unparseable_filename_is_accepted(self) -> None:
+        """Nothing was read off it to reject it by."""
+        assert python_axis_accepts("3.7", "cpython", "pkg-1.0.tar.gz")
 
 
 class TestLinuxPlatformOrderMatchesSysTags:

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -1249,7 +1249,7 @@ class TestPythonAxisAccepts:
         )
 
     def test_an_unparseable_filename_is_accepted(self) -> None:
-        """Nothing was read off it to reject it by."""
+        """It carries no tags to reject it by."""
         assert python_axis_accepts("3.7", "cpython", "pkg-1.0.tar.gz")
 
 


### PR DESCRIPTION
A `platform_system` marker overlay moves a target off its wheel tags, and with no tag axis every sibling wheel of a version counted as installable. A release publishing one wheel per interpreter, such as torch 1.4.0, then aborted a python 3.7 resolve with a `SiblingMetadataDivergenceError` between its cp27 and cp35 wheels, neither of which that target can install.

The same gap left the metadata pick on listing order, so a version's dependencies could be read out of a wheel built for another python. An overlay cannot rebuild the platform tags but it does keep `python_version` and `implementation_name`, so the tie set and the pick now drop wheels whose filename tags that python does not accept, and keep the whole listing when that leaves nothing.
