### PR TITLE
Narrow wheels by Python only when it decides

### DIFF
--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -254,10 +254,11 @@ def pick_dist(
     satisfy.  ``tags`` is ``None`` when there is no tag axis to rank by,
     either because nothing said which machine the resolve is for or because
     a marker overlay moved the target off its tags.  ``target`` still names
-    the Python, so wheels built for another interpreter drop out: reading a
-    release's dependencies out of a wheel the target could never install is
-    the unsoundness :func:`check_sibling_metadata_divergence` guards against,
-    one layer earlier.  When that leaves nothing, the whole listing stands.
+    the Python, so wheels built for another interpreter drop out
+    (:func:`_python_axis_narrowed`): reading a release's dependencies out of a
+    wheel the target could never install is the unsoundness
+    :func:`check_sibling_metadata_divergence` guards against, one layer
+    earlier.
 
     Among the wheels that remain the cheapest metadata source wins: a wheel
     with a :pep:`658` ``metadata_url``, then any wheel.  Only a version
@@ -273,8 +274,7 @@ def pick_dist(
         return dists[0]
 
     if tags is None:
-        admitted = [w for w in wheels if _python_axis_admits(target, w.filename)]
-        wheels = admitted or wheels
+        wheels = _python_axis_narrowed(target, wheels)
         installed = None
     else:
         # Sidecars first: ``pick`` keeps input order among wheels it ranks equally.
@@ -867,15 +867,16 @@ def check_sibling_metadata_divergence(
         return
 
     wheels = [d for v, d in versions if v == version and isinstance(d, WheelFile)]
+    if tags is None:
+        # The pick came off the same narrowing, so it is one of these.
+        wheels = _python_axis_narrowed(provider.target, wheels)
     if len(wheels) <= 1:
         return
 
     pick_key = None if tags is None else tags.wheel_rank(pick.filename)
     pick_sig: TargetDepSignature | None = None
     for sibling in wheels:
-        if sibling is pick or not _wheels_tie(
-            tags, provider.target, pick_key, sibling.filename
-        ):
+        if sibling is pick or not _wheels_tie(tags, pick_key, sibling.filename):
             continue
         sibling_metadata = _tie_sibling_metadata(
             provider, index, normalized, version, sibling
@@ -957,41 +958,53 @@ def _resident_wheel_text(
 
 def _wheels_tie(
     tags: TagSet | None,
-    target: ResolveTarget | None,
     pick_key: tuple[int, tuple[int, str]] | None,
     sibling_filename: str,
 ) -> bool:
     """Whether a sibling wheel ties the pick under the target's install rules.
 
-    With no tag axis a sibling is a real ambiguity only when the target's
-    Python axis admits it.  A marker overlay disowns the platform tags but
-    keeps ``python_version`` and ``implementation_name``, so a wheel built for
-    another interpreter is a choice no installer on this target could make,
-    and comparing it would crash on an ambiguity that does not exist.  The
-    ``Requires-Python`` guard in :func:`_tie_sibling_metadata` cannot catch
-    that: a release publishing one wheel per interpreter declares one
-    ``Requires-Python`` spanning them all, so that guard admits every sibling.
-
-    Otherwise a sibling ties only when its
-    :meth:`~nab_python.tags.TagSet.wheel_rank` key equals the pick's and is not
-    None; a sibling the pick ranks strictly below is never installed and is
-    exempt.
+    With no tag axis nothing ranks the wheels that :func:`_python_axis_narrowed`
+    left standing, so each of them is a real ambiguity.  Otherwise a sibling
+    ties only when its :meth:`~nab_python.tags.TagSet.wheel_rank` key equals
+    the pick's and is not None; a sibling the pick ranks strictly below is
+    never installed and is exempt.
     """
     if tags is None:
-        return _python_axis_admits(target, sibling_filename)
+        return True
     sibling_key = tags.wheel_rank(sibling_filename)
     return sibling_key is not None and sibling_key == pick_key
 
 
-def _python_axis_admits(target: ResolveTarget | None, filename: str) -> bool:
-    """Whether a target's Python axis admits a wheel filename's tags.
+def _python_axis_narrowed(
+    target: ResolveTarget | None, wheels: list[WheelFile]
+) -> list[WheelFile]:
+    """Keep the wheels the target's Python axis admits, all of them if none.
 
-    Without a target nothing has said which Python the resolve is for, so
-    every wheel is admitted.
+    A marker overlay cannot rebuild the platform tags, but the target still
+    names a Python: whichever ``python_version`` and ``implementation_name``
+    the overlay leaves in force.  A wheel built for another interpreter is a
+    choice no installer on that Python makes, so it neither answers for the
+    version's dependencies nor ties the wheel that does.  The
+    ``Requires-Python`` guard in :func:`_tie_sibling_metadata` cannot do this
+    work: a release publishing one wheel per interpreter declares one
+    ``Requires-Python`` spanning them all, so it admits every sibling.
+
+    Admitting nothing decides nothing, so every wheel stands: the pick keeps
+    its listing-order fallback, and the tie set keeps the pick's siblings
+    rather than disarming the divergence check over a pick this target cannot
+    install either.  Without a target nothing has said which Python the
+    resolve is for, so again every wheel stands.
     """
     if target is None:
-        return True
-    return python_axis_accepts(target.python_version, target.implementation, filename)
+        return wheels
+    admitted = [
+        wheel
+        for wheel in wheels
+        if python_axis_accepts(
+            target.python_version, target.implementation, wheel.filename
+        )
+    ]
+    return admitted or wheels
 
 
 def _divergent_dep_labels(

--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -422,6 +422,10 @@ _IMPLEMENTATION_FOR_PREFIX: Mapping[str, str] = MappingProxyType(
 _INTERPRETER_PREFIX_LEN = 2
 _FREE_THREADED_ABI_SUFFIX = "t"
 
+# The implementations nab has tag rules for, read off the prefix map so the
+# two never name different sets.
+_TAG_RULE_IMPLEMENTATIONS = frozenset(_IMPLEMENTATION_FOR_PREFIX.values())
+
 # The platform tag of an interpreter-agnostic wheel.  It is not a
 # machine, so it never seeds the platform axis of another target.
 _ANY_PLATFORM = "any"
@@ -779,7 +783,15 @@ def python_axis_accepts(
     it (see :meth:`~nab_python.target.ResolveTarget.with_marker_overrides`).
     A filename that does not parse as a wheel is admitted; it carries no tags
     to reject it by.
+
+    An implementation nab has no tag rules for gets no opinion either, for the
+    same reason :func:`_host_implementation` refuses to guess one: CPython's
+    tag rules would admit the wheels such a target cannot load and reject the
+    ones it can.  Only a marker overlay reaches here with one; every other
+    route builds the Python axis from an interpreter nab has rules for.
     """
+    if implementation not in _TAG_RULE_IMPLEMENTATIONS:
+        return True
     tags = wheel_tag_set(wheel_filename)
     if not tags:
         return True

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -9747,10 +9747,12 @@ class TestNoTagAxisPythonNarrowing:
     """A disowned tag axis still narrows siblings by the target's Python.
 
     A marker overlay cannot rebuild the platform tags, so under one the
-    provider filters no wheel by tag.  It does keep ``python_version`` and
-    ``implementation_name``, so a wheel built for another interpreter is still
-    a wheel this target can never install, and neither the tie set nor the pick
-    may treat it as a candidate.
+    provider filters no wheel by tag.  The target still names a Python,
+    whichever ``python_version`` and ``implementation_name`` the overlay leaves
+    in force, so a wheel built for another interpreter is still a wheel this
+    target can never install, and neither the tie set nor the pick may treat it
+    as a candidate.  Where the Python axis admits no wheel of a version it
+    decides nothing, and both fall back to the whole listing.
     """
 
     _V = V("1.0")
@@ -9870,6 +9872,26 @@ class TestNoTagAxisPythonNarrowing:
             )
             is cp27
         )
+
+    def test_a_version_admitting_no_wheel_still_crashes_on_divergence(self) -> None:
+        """A pick the target cannot install either leaves every sibling a tie.
+
+        Narrowing to nothing decides nothing, so the pick falls back to listing
+        order and the divergence it would read past has to stay loud.
+        """
+        cp27 = _split_wheel("cp27-cp27m-manylinux1_x86_64")
+        cp35 = _split_wheel("cp35-cp35m-manylinux1_x86_64")
+        coordinator = make_coordinator([cp27, cp35], package="pkg")
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _split_meta("common>=1"), cp27.metadata_url
+        )
+        coordinator.index.store_metadata(
+            "pkg", "1.0", _split_meta("common>=1", "numpy"), cp35.metadata_url
+        )
+        provider = Provider(coordinator, target=_overlay_target())
+        with pytest.raises(SiblingMetadataDivergenceError) as exc:
+            provider.get_dependencies("pkg", self._V)
+        assert "numpy" in str(exc.value)
 
     def test_abi3_sibling_of_an_older_interpreter_still_ties(self) -> None:
         """An abi3 wheel below the target's interpreter is installable, so it ties."""

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -1252,6 +1252,17 @@ class TestPythonAxisAccepts:
         """It carries no tags to reject it by."""
         assert python_axis_accepts("3.7", "cpython", "pkg-1.0.tar.gz")
 
+    def test_an_implementation_without_tag_rules_has_no_opinion(self) -> None:
+        """nab has no tag rules for it, and guessing CPython's would invert them."""
+        assert python_axis_accepts(
+            "3.10",
+            "graalpy",
+            "pkg-1.0-graalpy310-graalpy240_310_native-manylinux_2_17_x86_64.whl",
+        )
+        assert python_axis_accepts(
+            "3.10", "graalpy", "pkg-1.0-cp310-cp310-manylinux_2_17_x86_64.whl"
+        )
+
 
 class TestLinuxPlatformOrderMatchesSysTags:
     """A declared linux target ranks platform tags the way ``sys_tags`` does.


### PR DESCRIPTION
When a resolve target's Python admits none of a version's wheels, narrowing the sibling set by that Python left nothing behind, which disarmed the divergence check while the metadata pick fell back to listing order.

A version whose wheels really do declare different dependencies for the target then resolved off whichever wheel the index listed first, with no error.

Narrowing that admits nothing now decides nothing, so every wheel of the version stands and the check stays loud. An implementation nab has no tag rules for gets no opinion either, rather than being judged by CPython's rules, which would admit the wheels it cannot load and reject the ones it can.
