### PR TITLE
fix raw traceback when build-system is not a table

### DIFF
--- a/nab-python/src/nab_python/_build/runner.py
+++ b/nab-python/src/nab_python/_build/runner.py
@@ -159,10 +159,22 @@ def run_build_backend(
 def _read_build_system(
     data: dict,
 ) -> tuple[str, tuple[str, ...], tuple[str, ...] | None]:
-    """Return ``(backend, requires, backend_path)`` per PEP 517 / 518."""
-    table = data.get("build-system")
-    if not isinstance(table, dict):
+    """Return ``(backend, requires, backend_path)`` per PEP 517 / 518.
+
+    A missing ``[build-system]`` takes the PEP 517 defaults; a
+    ``build-system`` that is not a table is malformed, not absent.
+    """
+    if "build-system" not in data:
         return _DEFAULT_BACKEND, _DEFAULT_REQUIRES, None
+
+    table = data["build-system"]
+    if not isinstance(table, dict):
+        msg = (
+            "build-system in pyproject.toml must be a table,"
+            f" not {type(table).__name__}"
+        )
+        raise BuildBackendError(msg)
+
     backend = table.get("build-backend")
     if not isinstance(backend, str):
         backend = _DEFAULT_BACKEND

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -407,6 +407,16 @@ class TestRunBuildBackend:
         ):
             run_build_backend(tmp_path, config=config)
 
+    def test_build_system_not_a_table(
+        self, tmp_path: Path, config: NabProjectConfig
+    ) -> None:
+        """A scalar build-system key fails the build."""
+        (tmp_path / "pyproject.toml").write_text(
+            'build-system = "hatchling.build"\n', encoding="utf-8"
+        )
+        with pytest.raises(BuildBackendError, match="must be a table"):
+            run_build_backend(tmp_path, config=config)
+
     def test_venv_creation_oserror_wrapped(
         self,
         tmp_path: Path,
@@ -529,6 +539,14 @@ class TestReadBuildSystem:
         )
 
         assert _read_build_system({}) == (_DEFAULT_BACKEND, _DEFAULT_REQUIRES, None)
+
+    @pytest.mark.parametrize("value", ["hatchling.build", ["setuptools>=61"], 1])
+    def test_build_system_not_a_table_raises(self, value: object) -> None:
+        """PEP 518 defines build-system as a table."""
+        from nab_python._build.runner import _read_build_system
+
+        with pytest.raises(BuildBackendError, match="must be a table"):
+            _read_build_system({"build-system": value})
 
     def test_build_backend_wrong_type_uses_default(self) -> None:
         from nab_python._build.runner import _DEFAULT_BACKEND, _read_build_system


### PR DESCRIPTION
`nab lock` crashes with a raw ValueError or TypeError traceback instead of reporting a build failure when it builds a source whose pyproject.toml sets `build-system` to a string or an array.

`_read_build_system` treated a non-table `build-system` as an absent one and fell back to the PEP 517 defaults. The `build` package then re-reads the file and calls `dict()` on the value, raising a bare ValueError or TypeError that the `build.BuildException` handler around the builder does not catch.

A `build-system` that is present but not a table now raises `BuildBackendError` naming the type it got. A missing `build-system` still takes the defaults.
