### PR TITLE
Sort extras in benchmark root requirements

### DIFF
--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -162,7 +162,7 @@ def parse_requirements(
             else VersionRange.full(admit_arbitrary=False)
         )
         reqs[name] = reqs.get(name, VersionRange.full()) & term
-        for extra in req.extras:
+        for extra in sorted(req.extras):
             reqs[f"{name}[{extra}]"] = VersionRange.full(admit_arbitrary=False)
     return reqs
 

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -145,7 +145,7 @@ def parse_requirements(
             else VersionRange.full(admit_arbitrary=False)
         )
         reqs[name] = reqs.get(name, VersionRange.full()) & term
-        for extra in req.extras:
+        for extra in sorted(req.extras):
             reqs[f"{name}[{extra}]"] = VersionRange.full(admit_arbitrary=False)
     return reqs
 

--- a/nab-python/tests/test_benchmark_parse_requirements.py
+++ b/nab-python/tests/test_benchmark_parse_requirements.py
@@ -4,6 +4,9 @@ A scenario may list a package both pinned and with a bare extra, e.g.
 ``inmanta-core==6.0.0`` followed by ``inmanta-core[pytest-inmanta-extensions]``.
 The harness must keep the pin (as pip and uv do), not let the later bare
 requirement widen the range back to any version.
+
+It must also enter a requirement's extras in a fixed order, so a multi-extra
+root seeds the resolver the same way in every process.
 """
 
 from __future__ import annotations
@@ -11,11 +14,16 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 from types import ModuleType
+from typing import TYPE_CHECKING
 
 import pytest
 
 from nab_python._vendor.packaging.ranges import VersionRange
+from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.version import Version
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 _BENCH = Path(__file__).resolve().parents[1] / "benchmarks"
 
@@ -41,3 +49,33 @@ def test_repeated_name_keeps_pin(harness: str) -> None:
     assert reqs["inmanta-core[pytest-inmanta-extensions]"] == VersionRange.full(
         admit_arbitrary=False
     )
+
+
+class _ReverseOrderedExtras(set[str]):
+    """A ``set`` that iterates in reverse-sorted order."""
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(sorted(super().__iter__(), reverse=True))
+
+
+class _ReverseExtrasRequirement(Requirement):
+    """A ``Requirement`` whose extras iterate in reverse-sorted order."""
+
+    def __init__(self, requirement_string: str) -> None:
+        super().__init__(requirement_string)
+        self.extras = _ReverseOrderedExtras(self.extras)
+
+
+@pytest.mark.parametrize("harness", ["scenarios", "canary"])
+def test_extras_enter_in_sorted_order(
+    harness: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _harness(harness)
+    monkeypatch.setattr(module, "Requirement", _ReverseExtrasRequirement)
+    reqs = module.parse_requirements(["pkg[web,api,dev,cli]"])
+    assert [name for name in reqs if "[" in name] == [
+        "pkg[api]",
+        "pkg[cli]",
+        "pkg[dev]",
+        "pkg[web]",
+    ]


### PR DESCRIPTION
Both benchmark harnesses expanded a root requirement's extras by iterating `Requirement.extras`, which is a set, so a multi-extra root entered the resolver in string-hash order and that order changed from one process to the next. Root order is the last tiebreak when the resolver picks the next package to decide, so uv-issue-10344-airflow-py312 answered with 263 pins in some processes and 264 in others, which split its recorded numbers into families that cannot be compared. Sorting the expansion makes root order stable across processes and matches what these files already do for project extras and what `nab lock` does for requirement files.