### PR TITLE
Bound the conflict-resolution loop

### DIFF
--- a/nab-resolver/src/nab_resolver/conflict.py
+++ b/nab-resolver/src/nab_resolver/conflict.py
@@ -50,6 +50,14 @@ _MIN_RESOLVED_TERMS = 2
 # removing ROOT (decided at level 1 in _add_root_requirements).
 _TARGETED_BT_MIN_LEVEL = 2
 
+# Each resolution step replaces the satisfier's term with terms satisfied
+# strictly earlier, so the most recent satisfier moves down the trail every
+# step and one step per trail entry bounds a coherent loop.  The multiplier is
+# headroom over that bound and the floor covers short trails, so only a state
+# that has stopped making progress reaches the budget.
+_STEPS_PER_TRAIL_ENTRY = 4
+_MIN_CONFLICT_STEPS = 32
+
 
 def conflict_resolution(
     resolver: Resolver[Any, Any],
@@ -62,12 +70,20 @@ def conflict_resolution(
     until the learned clause has at most one term at the current
     decision level.
 
+    Raises ``ResolutionError`` when the conflict proves the requirements
+    unsatisfiable, and also when the loop exceeds its step budget, which
+    signals a resolver bug rather than an unsatisfiable input.
+
     Reference: https://github.com/dart-lang/pub/blob/master/doc/solver.md#conflict-resolution
     """
     current_incompatibility = conflicting_incompatibility
     is_derived = False
+    step_budget = max(
+        _MIN_CONFLICT_STEPS,
+        resolver.solution.trail_length * _STEPS_PER_TRAIL_ENTRY,
+    )
 
-    while True:
+    for _ in range(step_budget):
         if is_terminal_incompatibility(current_incompatibility):
             raise ResolutionError(
                 format_error(
@@ -176,6 +192,13 @@ def conflict_resolution(
             cause_left=current_incompatibility,
             cause_right=most_recent_satisfier.cause,
         )
+
+    stalled_message = (
+        f"Conflict resolution made no progress in {step_budget} steps; this is "
+        "a resolver bug rather than an unsatisfiable requirement. Stalled on "
+        f"{current_incompatibility!r}"
+    )
+    raise ResolutionError(stalled_message, incompatibility=current_incompatibility)
 
 
 def update_culprit_counts(

--- a/nab-resolver/src/nab_resolver/partial_solution.py
+++ b/nab-resolver/src/nab_resolver/partial_solution.py
@@ -109,6 +109,11 @@ class PartialSolution(Generic[PackageType, VersionType]):
         """Return the current decision depth."""
         return self._decision_level
 
+    @property
+    def trail_length(self) -> int:
+        """Return the number of assignments currently on the trail."""
+        return len(self._assignments)
+
     def assignments_for(
         self, package: PackageType
     ) -> Sequence[Assignment[PackageType, VersionType]]:

--- a/nab-resolver/tests/test_partial_solution.py
+++ b/nab-resolver/tests/test_partial_solution.py
@@ -13,6 +13,21 @@ class TestAssignments:
         assert ps.decision_level == 0
         assert ps.get("foo") is None
 
+    def test_trail_length_counts_assignments(self) -> None:
+        ps = PartialSolution()
+        inc = Incompatibility(
+            [Term("bar", Range.at_least(5))],
+            cause=IncompatibilityCause.NO_VERSIONS,
+        )
+        assert ps.trail_length == 0
+
+        ps.decide("foo", 5)
+        ps.derive("bar", Range.at_least(5), positive=False, cause=inc)
+        assert ps.trail_length == 2
+
+        ps.backtrack(0)
+        assert ps.trail_length == 0
+
     def test_decide(self) -> None:
         ps = PartialSolution()
         ps.decide("foo", 5)

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -612,6 +612,108 @@ class TestMaxIterations:
             resolver.resolve({"root": Range.singleton(1)})
 
 
+class ConflictStepObserver(ResolverObserver[str, int]):
+    """Records how many conflict-resolution steps each conflict took."""
+
+    def __init__(self) -> None:
+        self.steps_per_conflict: list[int] = []
+
+    def on_conflict(self, incompatibility: Incompatibility[str, int]) -> None:
+        self.steps_per_conflict.append(0)
+
+    def on_conflict_step(
+        self,
+        incompatibility: Incompatibility[str, int],
+        *,
+        satisfier_package: str,
+        satisfier_is_decision: bool,
+        satisfier_level: int,
+        previous_level: int,
+        can_backjump: bool,
+    ) -> None:
+        self.steps_per_conflict[-1] += 1
+
+
+def stalled_solution(
+    padding: int,
+) -> tuple[PartialSolution[str, int], Incompatibility[str, int]]:
+    """Build a trail on which one clause resolves with itself forever.
+
+    ``app``'s only assignment is a derivation whose cause is the clause under
+    resolution and whose accumulated range is empty.  An empty range satisfies
+    both polarities, so the clause is satisfied by the derivation it caused:
+    the loop resolves the clause with itself, :func:`prior_cause` returns the
+    same term every time, and no trail depth is consumed.  ``padding``
+    lengthens the trail without disturbing that fixed point.
+    """
+    solution: PartialSolution[str, int] = PartialSolution()
+    solution.decide("root", 1)
+    seed: Incompatibility[str, int] = Incompatibility(
+        [Term("root", Range.singleton(1))], cause=IncompatibilityCause.ROOT
+    )
+    for index in range(padding):
+        solution.derive(f"pad{index}", Range.at_least(1), positive=True, cause=seed)
+
+    stalled: Incompatibility[str, int] = Incompatibility(
+        [Term("app", Range.singleton(3))], cause=IncompatibilityCause.DERIVED
+    )
+    solution.derive("app", Range.empty(), positive=True, cause=stalled)
+    return solution, stalled
+
+
+# A regressed guard would hang the stall tests instead of failing them.
+STALL_TIMEOUT_SECONDS = 60
+
+
+class TestConflictProgressGuard:
+    @pytest.mark.timeout(STALL_TIMEOUT_SECONDS)
+    def test_self_resolving_clause_raises_instead_of_spinning(self) -> None:
+        """A clause that resolves with itself hits the step budget."""
+        solution, stalled = stalled_solution(padding=0)
+        resolver: Resolver[str, int] = Resolver(DictProvider({}))
+        resolver.solution = solution
+        assert solution.trail_length == 2
+
+        with pytest.raises(ResolutionError) as excinfo:
+            conflict_resolution(resolver, stalled)
+
+        message = str(excinfo.value)
+        assert "no progress in 32 steps" in message
+        assert "resolver bug" in message
+        assert "app" in message
+        assert excinfo.value.incompatibility is not None
+
+    @pytest.mark.timeout(STALL_TIMEOUT_SECONDS)
+    def test_step_budget_scales_with_trail_depth(self) -> None:
+        """A deeper trail buys proportionally more steps before the raise."""
+        solution, stalled = stalled_solution(padding=30)
+        resolver: Resolver[str, int] = Resolver(DictProvider({}))
+        resolver.solution = solution
+        assert solution.trail_length == 32
+
+        with pytest.raises(ResolutionError, match="no progress in 128 steps"):
+            conflict_resolution(resolver, stalled)
+
+    def test_backtracking_resolve_stays_far_inside_the_budget(self) -> None:
+        """A conflict-heavy resolve never approaches the step budget."""
+        provider = DictProvider(
+            {
+                "root": {1: {"a": Range.full(), "b": Range.full()}},
+                "a": {v: {"c": Range.singleton(v)} for v in range(20, 0, -1)},
+                "b": {v: {"c": Range.less_than(3)} for v in range(20, 0, -1)},
+                "c": {v: {} for v in range(20, 0, -1)},
+            }
+        )
+        observer = ConflictStepObserver()
+        resolver = Resolver(provider, observer=observer)
+
+        result = resolver.resolve({"root": Range.singleton(1)})
+
+        assert result["c"] < 3
+        assert resolver.stats.conflicts > 0
+        assert max(observer.steps_per_conflict) < 32
+
+
 class EventTrackingObserver(ResolverObserver):
     """Observer that records all events to a list for test assertions."""
 


### PR DESCRIPTION
Conflict resolution looped until the learned clause was ready to backjump, with nothing bounding the number of steps it took to get there. A clause that resolves with itself is a fixed point of that loop, so a bug producing one turned into a run that consumed gigabytes of memory and never failed. The loop now takes a step budget from the trail depth, four steps per assignment with a floor of 32, and raises a ResolutionError naming the stalled clause when it runs out. Each step moves the most recent satisfier earlier on the trail, so one step per trail entry already bounds a coherent conflict and only a resolver bug can reach the budget.
