### PR TITLE
Keep package selection stable within one scan

### DIFF
--- a/nab-python/src/nab_python/_packaging_provider.py
+++ b/nab-python/src/nab_python/_packaging_provider.py
@@ -66,6 +66,9 @@ class PackagingProvider:
 
     _CONFLICT_THRESHOLD = 5
 
+    def begin_decision_scan(self) -> None:
+        """No-op: nothing this in-memory provider answers arrives async."""
+
     def prioritize(
         self,
         package: str,

--- a/nab-python/src/nab_python/_provider/priority.py
+++ b/nab-python/src/nab_python/_provider/priority.py
@@ -66,7 +66,9 @@ def compute_matching(
 
     Also fires speculative metadata prefetch when this is the first time we
     notice the listing has arrived in the coordinator index.  Returns
-    :data:`_NO_LISTING_PRIOR` while the listing is still in flight.
+    :data:`_NO_LISTING_PRIOR` while the listing is still in flight, reading
+    arrival through ``arrived_listing`` so it agrees with ``is_ready`` for the
+    whole decision scan.
     """
     per_pkg = provider.matching_cache.get(normalized)
     if per_pkg is not None:
@@ -82,7 +84,7 @@ def compute_matching(
         or normalized in provider.archive_sources
     )
     if normalized not in provider.versions_cache and not has_local_source:
-        files = provider.coordinator.index.get_listing(normalized)
+        files = provider.arrived_listing(normalized)
         if files is not None:
             versions = provider.filter_distributions(normalized, files)
             provider.versions_cache[normalized] = versions
@@ -95,7 +97,7 @@ def compute_matching(
     elif has_local_source:
         matching = 1
     else:
-        # Not cached, so the next call re-checks the index and the
+        # Not cached, so a later scan re-checks the index and the
         # listing-arrival side effect above can still fire.
         return _NO_LISTING_PRIOR
 

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -702,6 +702,9 @@ class Provider:
         # so the per-call (normalized, range) tuple alloc is worth avoiding.
         self.matching_cache: dict[str, dict[RangeProtocol[Version], int]] = {}
 
+        # Counts the decision scans the resolver has opened.
+        self._scan_generation = 0
+
         # Requires-Python compatibility, keyed by the raw specifier string.
         self.requires_python_cache: dict[str, bool] = {}
 
@@ -2176,6 +2179,10 @@ class Provider:
         result = (base, extra, normalized)
         self._package_parts[package] = result
         return result
+
+    def begin_decision_scan(self) -> None:
+        """Count the decision scan the resolver is about to run."""
+        self._scan_generation += 1
 
     def is_ready(self, package: str) -> bool:
         """Check if a package's listing is available without blocking.

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -702,8 +702,10 @@ class Provider:
         # so the per-call (normalized, range) tuple alloc is worth avoiding.
         self.matching_cache: dict[str, dict[RangeProtocol[Version], int]] = {}
 
-        # Counts the decision scans the resolver has opened.
+        # Scan counter, plus the scan in which each name was last seen with its
+        # listing still in flight.  See ``arrived_listing``.
         self._scan_generation = 0
+        self._absent_listing_scan: dict[str, int] = {}
 
         # Requires-Python compatibility, keyed by the raw specifier string.
         self.requires_python_cache: dict[str, bool] = {}
@@ -2181,8 +2183,29 @@ class Provider:
         return result
 
     def begin_decision_scan(self) -> None:
-        """Count the decision scan the resolver is about to run."""
+        """Open a decision scan, expiring the last one's in-flight answers.
+
+        The coming scan re-reads the index, then holds any name it finds still
+        in flight that way until the next call.
+        """
         self._scan_generation += 1
+
+    def arrived_listing(self, normalized: str) -> list[DistFile] | None:
+        """Return ``normalized``'s listing, or None while it is in flight.
+
+        The fetcher thread publishes listings asynchronously, so a bare index
+        read can answer differently for two packages compared inside one
+        decision scan, and differently for the two halves of one package's
+        sort key.  A name first seen in flight stays in flight until the next
+        ``begin_decision_scan``, so one scan sorts against one view of what
+        has landed.
+        """
+        if self._absent_listing_scan.get(normalized) == self._scan_generation:
+            return None
+        listing = self.coordinator.index.get_listing(normalized)
+        if listing is None:
+            self._absent_listing_scan[normalized] = self._scan_generation
+        return listing
 
     def is_ready(self, package: str) -> bool:
         """Check if a package's listing is available without blocking.
@@ -2195,7 +2218,7 @@ class Provider:
             return normalized in self.versions_cache
         if normalized in self.versions_cache:
             return True
-        return self.coordinator.index.get_listing(normalized) is not None
+        return self.arrived_listing(normalized) is not None
 
     def prioritize(
         self,

--- a/nab-python/tests/test_decision_scan.py
+++ b/nab-python/tests/test_decision_scan.py
@@ -1,0 +1,210 @@
+"""Tests for the decision scan's frozen view of listing arrival.
+
+``choose_package_to_decide`` builds one sort key per undecided package out of
+``prioritize`` and ``is_ready``, and both halves read whether a listing has
+landed in the coordinator index.  The fetcher thread writes there while the
+scan runs, so without a per-scan freeze two halves of one key, or two keys
+compared against each other, can answer from different moments.
+
+The index double below lands a listing on the first read that asks for it,
+which is the race a traced resolve caught: the listing arrives between
+``prioritize`` and ``is_ready`` for one package.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from nab_index.client import WheelFile
+from nab_python._provider.priority import _NO_LISTING_PRIOR
+from nab_python._testing.coordinator_fake import make_coordinator
+from nab_python._vendor.packaging.ranges import VersionRange
+from nab_python._vendor.packaging.version import Version
+from nab_python.fetch import InMemoryIndex
+from nab_python.provider import Provider
+from nab_resolver import decide
+from nab_resolver.resolver import Resolver
+from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from unittest.mock import MagicMock
+
+    from nab_index.client import SdistFile
+    from nab_resolver.types import RangeProtocol
+
+
+def _wheel(package: str, version: str = "1.0") -> WheelFile:
+    """Build a WheelFile for ``package``."""
+    return WheelFile(
+        filename=f"{package}-{version}-py3-none-any.whl",
+        url=f"https://example.com/{package}-{version}-py3-none-any.whl",
+        version=version,
+        requires_python=None,
+        has_metadata=True,
+        upload_time=None,
+    )
+
+
+class _ArrivesOnReadIndex(InMemoryIndex):
+    """Index whose queued listings land on the first read that asks for them.
+
+    Stands in for the fetcher thread publishing a listing in the middle of a
+    decision scan: the read that first misses is the one that makes the next
+    read hit.
+    """
+
+    def __init__(self, arrivals: Mapping[str, Sequence[WheelFile | SdistFile]]) -> None:
+        super().__init__()
+        self._arrivals = dict(arrivals)
+
+    def get_listing(self, package: str) -> list[WheelFile | SdistFile] | None:
+        listing = super().get_listing(package)
+        queued = self._arrivals.pop(package, None)
+        if queued is not None:
+            self.store_listing(package, queued)
+        return listing
+
+
+class _ScanRecordingProvider(Provider):
+    """Records both halves of every sort key a scan builds, in scan order."""
+
+    def __init__(self, coordinator: MagicMock) -> None:
+        super().__init__(coordinator)
+        self.scan_reads: list[tuple[str, int, bool]] = []
+        self._matching: dict[str, int] = {}
+
+    def prioritize(
+        self,
+        package: str,
+        version_range: RangeProtocol[Version],
+        conflict_counts: Mapping[str, int],
+        culprit_counts: Mapping[str, int] | None = None,
+    ) -> tuple[int, int, bool]:
+        priority = super().prioritize(
+            package, version_range, conflict_counts, culprit_counts
+        )
+        self._matching[package] = priority[1]
+        return priority
+
+    def is_ready(self, package: str) -> bool:
+        ready = super().is_ready(package)
+        self.scan_reads.append((package, self._matching[package], ready))
+        return ready
+
+
+def _coordinator(
+    arrivals: Mapping[str, Sequence[WheelFile | SdistFile]],
+    resident: Mapping[str, Sequence[WheelFile | SdistFile]] | None = None,
+) -> MagicMock:
+    """Coordinator whose index holds ``resident`` and queues ``arrivals``."""
+    coordinator = make_coordinator(None)
+    index = _ArrivesOnReadIndex(arrivals)
+    for package, files in (resident or {}).items():
+        index.store_listing(package, files)
+    coordinator.index = index
+    return coordinator
+
+
+def _cause() -> Incompatibility[str, Version]:
+    return Incompatibility(
+        [Term("root", VersionRange.full(), positive=True)],
+        cause=IncompatibilityCause.DEPENDENCY,
+    )
+
+
+class TestOneKeyHoldsTogether:
+    """A listing landing between the two halves of a key is not seen by either."""
+
+    def test_priority_and_readiness_agree_within_a_scan(self) -> None:
+        """The half that misses first makes the other half miss too."""
+        coordinator = _coordinator({"foo": [_wheel("foo")]})
+        provider = Provider(coordinator)
+        rng = VersionRange.full()
+
+        provider.begin_decision_scan()
+        priority = provider.prioritize("foo", rng, {})
+
+        assert priority[1] == _NO_LISTING_PRIOR
+        assert provider.is_ready("foo") is False
+
+    def test_readiness_holds_for_the_rest_of_the_scan(self) -> None:
+        """A name seen in flight stays in flight however often it is read."""
+        coordinator = _coordinator({"foo": [_wheel("foo")]})
+        provider = Provider(coordinator)
+
+        provider.begin_decision_scan()
+        assert provider.is_ready("foo") is False
+        assert provider.is_ready("foo") is False
+        priority = provider.prioritize("foo", VersionRange.full(), {})
+
+        assert priority[1] == _NO_LISTING_PRIOR
+
+    def test_the_extras_proxy_reads_like_its_base(self) -> None:
+        """A proxy and its base answer from the same frozen view."""
+        coordinator = _coordinator({"foo": [_wheel("foo")]})
+        provider = Provider(coordinator)
+        rng = VersionRange.full()
+
+        provider.begin_decision_scan()
+        assert provider.prioritize("foo[socks]", rng, {})[1] == _NO_LISTING_PRIOR
+        assert provider.is_ready("foo[socks]") is False
+        assert provider.prioritize("foo", rng, {})[1] == _NO_LISTING_PRIOR
+        assert provider.is_ready("foo") is False
+
+    def test_the_next_scan_picks_the_arrival_up(self) -> None:
+        """The freeze lasts one scan, so the listing is not lost."""
+        coordinator = _coordinator({"foo": [_wheel("foo"), _wheel("foo", "2.0")]})
+        provider = Provider(coordinator)
+        rng = VersionRange.full()
+
+        provider.begin_decision_scan()
+        assert provider.is_ready("foo") is False
+
+        provider.begin_decision_scan()
+        assert provider.is_ready("foo") is True
+        assert provider.prioritize("foo", rng, {})[1] == 2
+
+
+class TestScanKeysShareOneView:
+    """Every key a scan compares is built against one view of what has landed."""
+
+    def _resolver(self) -> tuple[Resolver[str, Version], _ScanRecordingProvider]:
+        coordinator = _coordinator(
+            {"pending-a": [_wheel("pending-a")], "pending-b": [_wheel("pending-b")]},
+            {"arriving": [_wheel("arriving")]},
+        )
+        provider = _ScanRecordingProvider(coordinator)
+        provider.versions_cache["cached"] = [(Version("1.0"), _wheel("cached"))]
+        resolver: Resolver[str, Version] = Resolver(
+            provider, range_type=VersionRange, root_version="0"
+        )
+        for package in ("cached", "arriving", "pending-a", "pending-b"):
+            resolver.solution.derive(
+                package, VersionRange.full(), positive=True, cause=_cause()
+            )
+        return resolver, provider
+
+    def test_every_key_agrees_with_itself(self) -> None:
+        """No package is compared as ready while its matching count says in flight."""
+        resolver, provider = self._resolver()
+
+        assert decide.choose_package_to_decide(resolver) is not None
+
+        assert len(provider.scan_reads) == 4
+        for package, matching, ready in provider.scan_reads:
+            assert ready is (matching != _NO_LISTING_PRIOR), package
+
+    def test_a_package_that_lands_mid_scan_waits_for_the_next_one(self) -> None:
+        """The scan's view does not move under it, and the next scan sees the rest."""
+        resolver, provider = self._resolver()
+
+        decide.choose_package_to_decide(resolver)
+        in_flight = {name for name, _, ready in provider.scan_reads if not ready}
+        assert in_flight == {"pending-a", "pending-b"}
+        assert all(provider.is_ready(name) is False for name in in_flight)
+
+        provider.scan_reads.clear()
+        decide.choose_package_to_decide(resolver)
+
+        assert all(ready for _, _, ready in provider.scan_reads)

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -7435,10 +7435,11 @@ class TestPrioritizeMatchingFromIndex:
         assert result == (Provider.TIER_NORMAL, 1000, True)
 
     def test_matching_recomputed_after_listing_arrives(self) -> None:
-        """The in-flight placeholder is not cached; arrival recomputes."""
+        """The in-flight placeholder is not cached; the next scan recomputes."""
         coordinator = make_coordinator(None, package="foo")
         provider = Provider(coordinator)
         rng = SpecifierSet(">=1.0").to_range()
+        provider.begin_decision_scan()
         assert provider.prioritize("foo", rng, {}) == (
             Provider.TIER_NORMAL,
             1000,
@@ -7447,6 +7448,7 @@ class TestPrioritizeMatchingFromIndex:
         wheels = [make_wheel(v) for v in ("1.0", "2.0", "3.0")]
         # Store directly into the index, as the fetcher thread would.
         coordinator.index.store_listing("foo", wheels)
+        provider.begin_decision_scan()
         assert provider.prioritize("foo", rng, {}) == (
             Provider.TIER_NORMAL,
             3,

--- a/nab-resolver/src/nab_resolver/decide.py
+++ b/nab-resolver/src/nab_resolver/decide.py
@@ -30,12 +30,17 @@ def choose_package_to_decide(resolver: Resolver[Any, Any]) -> Any | None:
     """Choose the next undecided package, or None if all decided.
 
     Prefers ``is_ready`` packages so resolution keeps making progress while
-    other listings/metadata are still in flight.
+    other listings/metadata are still in flight.  ``begin_decision_scan`` marks
+    the start of the scan so a provider fed by another thread can hold the
+    state behind its sort key still: ``min`` only picks correctly over a key
+    that does not move while it runs.
     """
     undecided = resolver.solution.undecided_packages()
     undecided.discard(ROOT)
     if not undecided:
         return None
+
+    resolver.provider.begin_decision_scan()
 
     conflict_counts = resolver.stats.package_conflict_counts
     culprit_counts = resolver.stats.package_culprit_counts

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -91,6 +91,17 @@ class ResolverProvider(Protocol[PackageType, VersionType]):
         """Return ``{dependency_package: required_range}`` for this version."""
         ...
 
+    def begin_decision_scan(self) -> None:
+        """Announce the start of one decision scan.
+
+        ``choose_package_to_decide`` builds every undecided package's sort key
+        from ``prioritize`` and ``is_ready``, so both must answer from state
+        that does not move until the next call.  Providers whose answers depend
+        on another thread freeze that state here; for providers with no such
+        state this is a no-op.
+        """
+        ...
+
     def prioritize(
         self,
         package: PackageType,

--- a/nab-resolver/tests/property/providers.py
+++ b/nab-resolver/tests/property/providers.py
@@ -51,6 +51,9 @@ class FuzzProvider:
         """Return dependencies for a specific version."""
         return self._graph.get(package, {}).get(version, {})
 
+    def begin_decision_scan(self) -> None:
+        """No-op: nothing in this stub moves under a scan."""
+
     def prioritize(
         self,
         package: str,
@@ -139,6 +142,9 @@ class PromotingFuzzProvider:
         """Return dependencies for a specific version."""
         return self._graph.get(package, {}).get(version, {})
 
+    def begin_decision_scan(self) -> None:
+        """No-op: nothing in this stub moves under a scan."""
+
     def prioritize(
         self,
         package: str,
@@ -225,6 +231,9 @@ class OldestFirstProvider:
     def get_dependencies(self, package: str, version: int) -> dict[str, Range[int]]:
         """Return dependencies for a specific version."""
         return self._graph.get(package, {}).get(version, {})
+
+    def begin_decision_scan(self) -> None:
+        """No-op: nothing in this stub moves under a scan."""
 
     def prioritize(
         self,

--- a/nab-resolver/tests/property/test_resolver_oracle.py
+++ b/nab-resolver/tests/property/test_resolver_oracle.py
@@ -116,6 +116,9 @@ class ConstantPriorityProvider:
         """Return dependencies for a specific version."""
         return self._deps.get((package, version), {})
 
+    def begin_decision_scan(self) -> None:
+        """No-op: nothing in this stub moves under a scan."""
+
     def prioritize(
         self,
         package: str,
@@ -221,6 +224,9 @@ class LookaheadProvider:
     def get_dependencies(self, package: str, version: int) -> dict[str, Range[int]]:
         """Return dependencies for a specific version."""
         return self._deps.get((package, version), {})
+
+    def begin_decision_scan(self) -> None:
+        """No-op: nothing in this stub moves under a scan."""
 
     def prioritize(
         self,

--- a/nab-resolver/tests/test_decide.py
+++ b/nab-resolver/tests/test_decide.py
@@ -1,9 +1,14 @@
-"""Unit tests for :func:`nab_resolver.decide.absorb_redundant_requirement`.
+"""Unit tests for :mod:`nab_resolver.decide`.
 
-The generic solver re-derives a requirement that is redundant on a package's
-version set yet still changes its range. Packaging's pre-release opt-in is one
-such refinement. Here a range double carries a plain passenger flag that rides
-set algebra, so the contract can be exercised without any PEP 440 semantics.
+``absorb_redundant_requirement`` re-derives a requirement that is redundant on
+a package's version set yet still changes its range. Packaging's pre-release
+opt-in is one such refinement. Here a range double carries a plain passenger
+flag that rides set algebra, so the contract can be exercised without any
+PEP 440 semantics.
+
+``choose_package_to_decide`` calls ``begin_decision_scan`` once before it reads
+any sort key, which is how a provider fed by another thread knows when its
+answers may move.
 """
 
 from __future__ import annotations
@@ -105,6 +110,9 @@ class _InertProvider:
     ) -> Mapping[Any, RangeProtocol[int]]:
         return {}
 
+    def begin_decision_scan(self) -> None:
+        pass
+
     def prioritize(
         self,
         package: Any,
@@ -139,16 +147,46 @@ class _InertProvider:
         return constraint
 
 
-def _resolver() -> tuple[Resolver[Any, int], _RecordingObserver]:
+class _ScanOrderProvider(_InertProvider):
+    """Records the scan-boundary and sort-key calls in the order they arrive."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def begin_decision_scan(self) -> None:
+        self.calls.append("begin")
+
+    def prioritize(
+        self,
+        package: Any,
+        version_range: RangeProtocol[int],
+        conflict_counts: Mapping[Any, int],
+        culprit_counts: Mapping[Any, int] | None = None,
+    ) -> Any:
+        self.calls.append(f"prioritize {package}")
+        return 0
+
+    def is_ready(self, package: Any) -> bool:
+        self.calls.append(f"is_ready {package}")
+        return True
+
+
+def _resolver_with(
+    provider: _InertProvider,
+) -> tuple[Resolver[Any, int], _RecordingObserver]:
     observer = _RecordingObserver()
     # RefiningRange is a valid range at runtime; the cast satisfies the
     # Self-typed RangeProtocol that a plain subclass cannot express.
     resolver = Resolver(
-        _InertProvider(),
+        provider,
         observer=observer,
         range_type=cast("type[RangeProtocol[int]]", RefiningRange),
     )
     return resolver, observer
+
+
+def _resolver() -> tuple[Resolver[Any, int], _RecordingObserver]:
+    return _resolver_with(_InertProvider())
 
 
 def _dependency_cause() -> Incompatibility[Any, int]:
@@ -244,3 +282,45 @@ class TestAbsorbRedundantRequirement:
         reverted = resolver.solution.positive_range("c")
         assert isinstance(reverted, RefiningRange)
         assert reverted.flag is False
+
+
+class TestScanBoundary:
+    """One ``begin_decision_scan`` opens each scan, ahead of every key read."""
+
+    def test_scan_opens_once_before_any_key_is_read(self) -> None:
+        """The boundary call comes first and does not repeat inside the scan."""
+        provider = _ScanOrderProvider()
+        resolver, _ = _resolver_with(provider)
+        for package in ("a", "b", "c"):
+            resolver.solution.derive(
+                package,
+                RefiningRange.at_least(1),
+                positive=True,
+                cause=_dependency_cause(),
+            )
+
+        assert decide.choose_package_to_decide(resolver) is not None
+        assert provider.calls[0] == "begin"
+        assert provider.calls.count("begin") == 1
+        assert len(provider.calls) == 1 + 2 * 3
+
+    def test_each_scan_opens_a_new_one(self) -> None:
+        """A second scan gets its own boundary call."""
+        provider = _ScanOrderProvider()
+        resolver, _ = _resolver_with(provider)
+        resolver.solution.derive(
+            "a", RefiningRange.at_least(1), positive=True, cause=_dependency_cause()
+        )
+
+        decide.choose_package_to_decide(resolver)
+        decide.choose_package_to_decide(resolver)
+
+        assert provider.calls.count("begin") == 2
+
+    def test_nothing_undecided_opens_no_scan(self) -> None:
+        """With every package decided the provider is left alone."""
+        provider = _ScanOrderProvider()
+        resolver, _ = _resolver_with(provider)
+
+        assert decide.choose_package_to_decide(resolver) is None
+        assert provider.calls == []

--- a/nab-resolver/tests/test_priority.py
+++ b/nab-resolver/tests/test_priority.py
@@ -35,6 +35,9 @@ class _TrackingProvider:
         """Return dependencies for a specific version."""
         return self._packages.get(package, {}).get(version, {})
 
+    def begin_decision_scan(self) -> None:
+        """No-op: nothing in this stub moves under a scan."""
+
     def prioritize(
         self,
         package: str,
@@ -101,6 +104,9 @@ class _PromotingProvider:
     def get_dependencies(self, package: str, version: int) -> dict[str, Range]:
         """Return dependencies for a specific version."""
         return self._packages.get(package, {}).get(version, {})
+
+    def begin_decision_scan(self) -> None:
+        """No-op: nothing in this stub moves under a scan."""
 
     def prioritize(
         self,

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -76,6 +76,9 @@ class DictProvider:
     def get_dependencies(self, package: str, version: int) -> dict[str, Range]:
         return self._packages.get(package, {}).get(version, {})
 
+    def begin_decision_scan(self) -> None:
+        """No-op: nothing in this stub moves under a scan."""
+
     def prioritize(
         self,
         package: str,

--- a/nab-resolver/tests/test_widen_hook.py
+++ b/nab-resolver/tests/test_widen_hook.py
@@ -56,6 +56,9 @@ class _BaseProvider:
     def get_dependencies(self, package: str, version: int) -> dict[str, Range]:
         return self._packages.get(package, {}).get(version, {})
 
+    def begin_decision_scan(self) -> None:
+        """No-op: nothing in this stub moves under a scan."""
+
     def prioritize(
         self,
         package: str,


### PR DESCRIPTION
Choosing the next package to decide compares every undecided package on a key built from `prioritize` and `is_ready`, and both halves read whether a listing has arrived in the coordinator index. The fetcher thread publishes listings while that scan runs, so a package could be read as in flight by one half of its key and ready by the other, and the resulting order depended on when a listing landed rather than on the key itself. The provider now answers listing arrival from a per-scan view: a name first seen in flight stays in flight until the next scan opens, so a scan sorts against one view and the arrival is picked up on the following pass.

This adds `begin_decision_scan` to the resolver provider protocol; a provider with nothing moving behind its answers implements it as a no-op.
