### PR TITLE
Keep base dependency edges when --no-emit-workspace drops pins

### DIFF
--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -464,8 +464,10 @@ def drop_workspace_pins(lock_input: LockInput, exclude: frozenset[str]) -> LockI
     ``exclude`` holds canonical workspace member names; pin keys are already
     canonical.  An empty set returns ``lock_input`` unchanged.  Each target's
     pins are filtered, and its forward dependency graph and membership gates
-    with them, so no edge or gate names a dropped member with no
-    ``[[packages]]`` entry.
+    with them, so no emitted edge or gate names a dropped member with no
+    ``[[packages]]`` entry.  ``base_dependencies`` carries through untouched:
+    it is never emitted, and cutting the member out of it would strip base
+    status from everything reached only through that member.
     """
     if not exclude:
         return lock_input
@@ -474,8 +476,8 @@ def drop_workspace_pins(lock_input: LockInput, exclude: frozenset[str]) -> LockI
         return canonicalize_name(name) not in exclude
 
     targets = {
-        label: TargetLock(
-            target=lock.target,
+        label: replace(
+            lock,
             pins={name: pin for name, pin in lock.pins.items() if keep(name)},
             dependencies={
                 name: kept

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -67,6 +67,7 @@ from nab_python.lockfile import (
     WheelArtifact,
     build_pylock,
     build_target_lock,
+    drop_workspace_pins,
     package_metadata_override_records,
     read_lockfile_anchor,
     read_lockfile_packages,
@@ -1125,6 +1126,37 @@ class TestConflictForkBaseDepDivergentClosure:
             marker = by_name[name].marker
             assert "in extras" not in str(marker)
             assert marker is None or marker.evaluate(no_member)
+
+    def test_workspace_drop_keeps_base_closure(self) -> None:
+        # app -> member -> foo, all unconditional, and app is the only
+        # declared base name.  foo is base only through the member, so
+        # dropping the member must not cut the closure walk short.
+        fork_pins: dict[str, PinShape] = {
+            "app": _index_pin(name="app", version="2.0"),
+            "member": LocalPin(name="member", version="1.0", path="packages/member"),
+            "foo": _index_pin(name="foo", version="1.0"),
+        }
+        fork_deps = {"app": ("member",), "member": ("foo",)}
+
+        lock_input = self._lock_input_with(
+            cpu_pins=fork_pins,
+            cpu_deps=fork_deps,
+            cpu_base_deps=fork_deps,
+            gpu_pins=fork_pins,
+            gpu_deps=fork_deps,
+            gpu_base_deps=fork_deps,
+            base_names=frozenset({"app"}),
+        )
+
+        pylock = build_pylock(drop_workspace_pins(lock_input, frozenset({"member"})))
+        by_name = {str(p.name): p for p in pylock.packages}
+
+        assert "member" not in by_name
+        foo = by_name["foo"]
+        assert "in extras" not in str(foo.marker)
+        assert foo.marker is None or foo.marker.evaluate(
+            self._LINUX.env_with_membership()
+        )
 
 
 class TestConflictForksWithoutBaseAttribution:

--- a/nab-python/tests/test_lockfile_locked.py
+++ b/nab-python/tests/test_lockfile_locked.py
@@ -62,6 +62,7 @@ def _lock_input(
     pins: Mapping[str, IndexPin],
     *,
     dependencies: Mapping[str, tuple[str, ...]] | None = None,
+    base_dependencies: Mapping[str, tuple[str, ...]] | None = None,
 ) -> LockInput:
     return LockInput(
         targets={
@@ -69,6 +70,7 @@ def _lock_input(
                 target=TARGET,
                 pins=dict(pins),
                 dependencies=dict(dependencies or {}),
+                base_dependencies=dict(base_dependencies or {}),
             )
         }
     )
@@ -240,6 +242,17 @@ class TestDropWorkspacePins:
         target = dropped.targets[TARGET.label]
         assert set(target.pins) == {"foo"}
         assert target.dependencies == {"foo": ("bar",)}
+
+    def test_drop_carries_base_dependency_edges(self) -> None:
+        edges = {"foo": ("alpha", "bar"), "alpha": ("bar",)}
+        lock_input = _lock_input(
+            {"foo": _pin("foo", "1.0"), "alpha": _pin("alpha", "2.0")},
+            dependencies=edges,
+            base_dependencies=edges,
+        )
+
+        dropped = drop_workspace_pins(lock_input, frozenset({"alpha"}))
+        assert dropped.targets[TARGET.label].base_dependencies == edges
 
 
 class TestSummarizeLock:


### PR DESCRIPTION
`nab lock --no-emit-workspace` rebuilt each target lock from scratch when it filtered the workspace members out, passing only four of the fields, so `base_dependencies` fell back to its empty default.

The writer closes a conflict environment's no-member base names over that set. With it empty the closure stops at the declared base names, so a package reached only through a base edge keeps its `'name' in extras` membership clause and drops out of a default install.

The filter now copies the target lock and replaces just the fields it prunes. `base_dependencies` passes through untouched: it is never emitted, and cutting the dropped member out of it would truncate the closure the same way.
