### PR TITLE
fix raw traceback when a marker cannot tile a minor interval

### DIFF
--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -82,6 +82,7 @@ from nab_python.resolve import (
     build_lock_input,  # noqa: F401 - referenced as _cli.build_lock_input in _lock
     resolve_for_targets,
 )
+from nab_python.target import NonIntervalMarkerError
 from nab_python.workspace import WorkspaceDiscoveryError
 from nab_resolver.resolver import ResolutionError
 
@@ -584,6 +585,7 @@ def _resolve(  # noqa: PLR0913, PLR0912, C901 - one wrapper per resolve_for_targ
         MissingExtraError,
         SiblingMetadataDivergenceError,
         SourceNameMismatchError,
+        NonIntervalMarkerError,
     ) as e:
         printer().error(f"{failure_prefix}: {e}")
         sys.exit(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1524,6 +1524,28 @@ class TestLockCommandUniversal:
         assert "'alpha' and 'beta' conflict on 'idna'" in err
         assert "Traceback" not in err
 
+    def test_untileable_micro_marker_exits_cleanly(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A consulted marker that cannot tile a minor exits 1, not a traceback."""
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\nname = "probe"\nversion = "0.1.0"\n'
+            "dependencies = [\"somepkg; python_full_version in '3.12.1 3.12.2'\"]\n"
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            "[tool.nab.matrix]\n"
+            'python = ">=3.12,<3.13"\n'
+            'platforms = ["linux_x86_64"]\n',
+        )
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, output=Path("-"), offline=True)
+
+        err = capsys.readouterr().err
+        assert "cannot lock: consulted marker clause" in err
+        assert "cannot tile the py312-linux_x86_64 minor interval" in err
+        assert "Traceback" not in err
+
     def test_pylock_writes_universal_lock(self, tmp_path: Path) -> None:
         """Universal + pylock format runs the real merge + write pipeline."""
         pyproject = _universal_pyproject(tmp_path)


### PR DESCRIPTION
Universal mode deliberately aborts when a consulted `python_full_version` clause cannot tile a target's minor interval. `NonIntervalMarkerError` was missing from the except tuple in `_resolve` that maps errors onto exit 1, so it reached the user as a raw traceback from `nab lock` and `nab download`.

Adding it to the tuple prints `cannot lock: consulted marker clause ... cannot tile the py312-linux_x86_64 minor interval` and exits 1, with the `cannot download` prefix on the download path.
