### PR TITLE
stop --offline from cloning a VCS source over the network

### DIFF
--- a/docs/how-to/vcs.md
+++ b/docs/how-to/vcs.md
@@ -87,10 +87,11 @@ reaching the remote.  An unpinned ref fails even with a warm
 cache, because resolving a branch or tag to a commit needs
 `git ls-remote`.
 
-A `git+file` repo is on local disk rather than the network, so it
-still clones, as long as its URL names no host.
-`git+file:///srv/repo.git` clones offline;
-`git+file://server/srv/repo.git` is a UNC share and does not.
+A `git+file` repo is reached through the filesystem rather than
+the network, so it still clones offline, and a floating ref on
+one still resolves.  Where that path leads is left to the
+operating system, exactly as it is for a `file:` index: a `git+file`
+URL under an NFS or SMB mount clones offline too.
 
 ## `pkg @ git+...` at the project root
 

--- a/docs/how-to/vcs.md
+++ b/docs/how-to/vcs.md
@@ -79,6 +79,19 @@ require `build-policy = "build-remote"` (a clone is considered
 network-fetched, even though they end up on disk before the
 backend runs).  See the [build policy](../reference/build-policy.md) page.
 
+## Offline runs
+
+`--offline` stops nab from cloning.  A commit already in the
+clone cache is served from there; anything else fails instead of
+reaching the remote.  An unpinned ref fails even with a warm
+cache, because resolving a branch or tag to a commit needs
+`git ls-remote`.
+
+A `git+file` repo is on local disk rather than the network, so it
+still clones, as long as its URL names no host.
+`git+file:///srv/repo.git` clones offline;
+`git+file://server/srv/repo.git` is a UNC share and does not.
+
 ## `pkg @ git+...` at the project root
 
 PEP 508 lets you write a direct-URL requirement under

--- a/nab-index/src/nab_index/vcs.py
+++ b/nab-index/src/nab_index/vcs.py
@@ -27,6 +27,7 @@ import subprocess
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import urlsplit
 
 from .subdir import subdirectory_escapes
 
@@ -153,11 +154,23 @@ def _repo_key(repo_url: str) -> str:
     return hashlib.sha256(repo_url.encode("utf-8")).hexdigest()[:16]
 
 
+def _is_local_repo(repo_url: str) -> bool:
+    """Return True when ``repo_url`` names a repo on this machine's disk.
+
+    Matches what :func:`nab_index.local_index.parse_file_url` does for
+    artifact URLs: an empty or ``localhost`` authority (RFC 8089) is the
+    local machine; any other host is a UNC share.
+    """
+    split = urlsplit(repo_url)
+    return split.scheme == "file" and split.netloc in ("", "localhost")
+
+
 def prepare_clone(
     cache_root: Path,
     request: VcsRequest,
     *,
     require_pin: bool,
+    offline: bool = False,
 ) -> VcsClone:
     """Resolve ``request.ref`` to a SHA and ensure a clone exists at it.
 
@@ -167,13 +180,22 @@ def prepare_clone(
     the named ref to a SHA, then performs a shallow clone of that
     commit.
 
+    ``offline`` withholds every git call that would reach the remote: a
+    complete cached clone is still served; anything else raises
+    :class:`VcsCloneError`.  A ``file://`` repo on this machine's disk
+    still clones.
+
     Idempotent: a destination carrying the completion marker is reused
     without a fetch.  A fresh clone lands in a temporary sibling
     directory and is renamed into place only once fully checked out, so
     a concurrent or interrupted run never leaves a partial tree at the
     cache path.
     """
-    sha = _resolve_sha(request, require_pin=require_pin)
+    may_reach_remote = not offline or _is_local_repo(request.repo_url)
+    sha = _resolve_sha(
+        request, require_pin=require_pin, may_reach_remote=may_reach_remote
+    )
+
     dest = cache_root / "vcs" / _repo_key(request.repo_url) / sha
     if _clone_complete(dest):
         return VcsClone(
@@ -181,6 +203,10 @@ def prepare_clone(
             commit_sha=sha,
             subdirectory=request.subdirectory,
         )
+
+    if not may_reach_remote:
+        msg = f"no cached clone of {request.repo_url} @ {sha} (offline mode)"
+        raise VcsCloneError(msg)
 
     dest.parent.mkdir(parents=True, exist_ok=True)
     if dest.exists() and not _clone_complete(dest):
@@ -214,11 +240,18 @@ def _clone_complete(dest: Path) -> bool:
     return (dest / ".git" / _COMPLETE_MARKER).is_file()
 
 
-def _resolve_sha(request: VcsRequest, *, require_pin: bool) -> str:
+def _resolve_sha(
+    request: VcsRequest,
+    *,
+    require_pin: bool,
+    may_reach_remote: bool = True,
+) -> str:
     """Return a 40-char SHA for ``request.ref``.
 
     Raises when ``require_pin`` is True and ``ref`` is not already a
-    SHA.  Otherwise consults ``git ls-remote`` to look up the ref.
+    SHA.  Otherwise consults ``git ls-remote`` to look up the ref, which
+    ``may_reach_remote=False`` refuses: no cache holds a ref-to-SHA
+    mapping.
     """
     if request.ref and FULL_GIT_SHA_RE.match(request.ref):
         return request.ref
@@ -231,6 +264,13 @@ def _resolve_sha(request: VcsRequest, *, require_pin: bool) -> str:
         raise VcsCloneError(msg)
 
     target = request.ref or "HEAD"
+    if not may_reach_remote:
+        msg = (
+            f"cannot resolve ref {target!r} at {request.repo_url}"
+            f" (offline mode): only a pinned commit resolves from cache"
+        )
+        raise VcsCloneError(msg)
+
     # Also request the peeled form: an exact-ref ls-remote omits the
     # companion refs/tags/<name>^{} line, so without it an annotated tag
     # would resolve to the tag object rather than the commit it points at.

--- a/nab-index/src/nab_index/vcs.py
+++ b/nab-index/src/nab_index/vcs.py
@@ -155,14 +155,17 @@ def _repo_key(repo_url: str) -> str:
 
 
 def _is_local_repo(repo_url: str) -> bool:
-    """Return True when ``repo_url`` names a repo on this machine's disk.
+    """Return True when ``repo_url`` reaches its repo through the filesystem.
 
-    Matches what :func:`nab_index.local_index.parse_file_url` does for
-    artifact URLs: an empty or ``localhost`` authority (RFC 8089) is the
-    local machine; any other host is a UNC share.
+    Offline means nab issues no network request of its own.  A ``file``
+    URL is read by path, so it stays available offline whatever the
+    authority says: git drops the authority outright on POSIX, and on
+    Windows turns it into a UNC path, which is a filesystem call like
+    any other.  Whether that path is backed by a local disk, NFS, or SMB
+    is the operating system's business, the same as it is for a
+    ``file:`` index.
     """
-    split = urlsplit(repo_url)
-    return split.scheme == "file" and split.netloc in ("", "localhost")
+    return urlsplit(repo_url).scheme == "file"
 
 
 def prepare_clone(
@@ -182,8 +185,8 @@ def prepare_clone(
 
     ``offline`` withholds every git call that would reach the remote: a
     complete cached clone is still served; anything else raises
-    :class:`VcsCloneError`.  A ``file://`` repo on this machine's disk
-    still clones.
+    :class:`VcsCloneError`.  A ``file://`` repo is read through the
+    filesystem rather than the network, so it still clones.
 
     Idempotent: a destination carrying the completion marker is reused
     without a fetch.  A fresh clone lands in a temporary sibling

--- a/nab-python/src/nab_python/_provider/sources.py
+++ b/nab-python/src/nab_python/_provider/sources.py
@@ -227,6 +227,7 @@ def materialize_vcs_source(
             provider.vcs_cache_dir,
             request,
             require_pin=provider.vcs_config.require_pin,
+            offline=provider.coordinator.offline,
         )
     except VcsCloneError as exc:
         msg = f"vcs source {source.name!r}: {exc}"

--- a/nab-python/src/nab_python/_testing/coordinator_fake.py
+++ b/nab-python/src/nab_python/_testing/coordinator_fake.py
@@ -236,7 +236,8 @@ def make_coordinator(  # noqa: PLR0913 - one keyword per index slot a test pre-l
     wires up (for example ``request_sdist_archive``) can reassign
     ``.side_effect`` on the returned mock; the index is exposed at
     ``coordinator.index`` for direct manipulation.  ``coordinator.indexes``
-    defaults to the single default-PyPI :class:`IndexConfig` list.
+    defaults to the single default-PyPI :class:`IndexConfig` list, and
+    ``coordinator.offline`` to False.
     """
     index = InMemoryIndex()
 
@@ -245,6 +246,7 @@ def make_coordinator(  # noqa: PLR0913 - one keyword per index slot a test pre-l
     coordinator = MagicMock()
     coordinator.index = index
     coordinator.indexes = [IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL)]
+    coordinator.offline = False
 
     resolve_metadata = _make_metadata_resolver(
         metadata_text=metadata_text,

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -727,6 +727,11 @@ class FetchCoordinator:
         self._async_q: asyncio.Queue[_QueueItem] | None = None
         self._queue_ready = threading.Event()
 
+    @property
+    def offline(self) -> bool:
+        """Whether this run may read the cache only, never the network."""
+        return self._offline
+
     def __enter__(self) -> Self:
         """Start the fetcher thread and return self."""
         self.start()

--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -1342,10 +1342,16 @@ class TestVcsConfigPlumbing:
         real_prepare_clone = vcs_mod.prepare_clone
 
         def spy_prepare_clone(
-            cache_root: Path, request: VcsRequest, *, require_pin: bool
+            cache_root: Path,
+            request: VcsRequest,
+            *,
+            require_pin: bool,
+            offline: bool = False,
         ) -> VcsClone:
             roots.append(cache_root)
-            return real_prepare_clone(cache_root, request, require_pin=require_pin)
+            return real_prepare_clone(
+                cache_root, request, require_pin=require_pin, offline=offline
+            )
 
         def fake_run(cmd: list[str], **kwargs: object) -> object:
             cwd = Path(str(kwargs["cwd"]))

--- a/nab-python/tests/test_vcs.py
+++ b/nab-python/tests/test_vcs.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from nab_index.client import SdistFile, WheelFile  # noqa: F401 - re-exported by helpers
+from nab_index.httpx_async_transport import HttpxAsyncTransport
 from nab_index.vcs import (
     _COMPLETE_MARKER,
     VcsCloneError,
@@ -23,7 +24,7 @@ from nab_index.vcs import (
     prepare_clone,
 )
 from nab_python._vendor.packaging.version import Version
-from nab_python.fetch import InMemoryIndex
+from nab_python.fetch import FetchCoordinator, InMemoryIndex
 from nab_python.lockfile import VcsPin, build_target_lock
 from nab_python.provider import (
     BuildPolicy,
@@ -51,6 +52,12 @@ _STALLED_REPO_URLS = [
     "ssh://git@example.invalid/x/y.git",
     "git://example.invalid/x/y.git",
 ]
+
+
+def _refuse_git(*_args: object, **_kwargs: object) -> object:
+    """Stand in for git on a path that must not shell out at all."""
+    msg = "offline mode must not invoke git"
+    raise AssertionError(msg)
 
 
 def _stalled_remote(cmd: list[str], **kwargs: object) -> object:
@@ -598,11 +605,136 @@ class TestPrepareClone:
         assert payload.read_text() == "kept"
 
 
+class TestOfflineClone:
+    """``offline`` withholds every git call that would reach the remote."""
+
+    def test_cold_cache_fails_without_touching_the_remote(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(subprocess, "run", _refuse_git)
+        req = VcsRequest("git", "https://example.com/repo.git", "a" * 40, "")
+        with pytest.raises(VcsCloneError, match="offline"):
+            prepare_clone(tmp_path, req, require_pin=True, offline=True)
+
+    def test_warm_cache_is_served(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        sha = "b" * 40
+        dest = tmp_path / "vcs" / "k" / sha
+        _mark_complete(dest)
+        monkeypatch.setattr("nab_index.vcs._repo_key", lambda _url: "k")
+        monkeypatch.setattr(subprocess, "run", _refuse_git)
+        req = VcsRequest("git", "https://example.com/repo.git", sha, "")
+        clone = prepare_clone(tmp_path, req, require_pin=True, offline=True)
+        assert clone.path == dest
+        assert clone.commit_sha == sha
+
+    def test_floating_ref_is_not_resolved(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A warm clone cache does not allow an ls-remote for a branch."""
+        sha = "c" * 40
+        _mark_complete(tmp_path / "vcs" / "k" / sha)
+        monkeypatch.setattr("nab_index.vcs._repo_key", lambda _url: "k")
+        monkeypatch.setattr(subprocess, "run", _refuse_git)
+        req = VcsRequest("git", "https://example.com/repo.git", "main", "")
+        with pytest.raises(VcsCloneError, match="offline"):
+            prepare_clone(tmp_path, req, require_pin=False, offline=True)
+
+    def test_file_url_repo_still_clones(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A ``file://`` repo is local disk, like a ``file:`` archive URL."""
+        sha = "d" * 40
+        commands: list[str] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> object:
+            commands.append(cmd[1])
+            cwd = Path(str(kwargs["cwd"]))
+            if cmd[:2] == ["git", "init"]:
+                (cwd / ".git").mkdir(exist_ok=True)
+            return type("P", (), {"returncode": 0})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        req = VcsRequest("git", (tmp_path / "repo").as_uri(), sha, "")
+        clone = prepare_clone(tmp_path, req, require_pin=True, offline=True)
+        assert clone.commit_sha == sha
+        assert commands == ["init", "fetch", "checkout"]
+
+    def test_file_url_with_a_host_is_refused(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A ``file://`` URL naming a host is a UNC share, not local disk."""
+        monkeypatch.setattr(subprocess, "run", _refuse_git)
+        req = VcsRequest("git", "file://server/share/repo.git", "f" * 40, "")
+        with pytest.raises(VcsCloneError, match="offline"):
+            prepare_clone(tmp_path, req, require_pin=True, offline=True)
+
+    def test_file_url_floating_ref_still_resolves(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        sha = "e" * 40
+        _mark_complete(tmp_path / "vcs" / "k" / sha)
+        monkeypatch.setattr("nab_index.vcs._repo_key", lambda _url: "k")
+
+        def fake_run(cmd: list[str], **_kwargs: object) -> object:
+            assert cmd[:2] == ["git", "ls-remote"]
+            return type("P", (), {"stdout": f"{sha}\trefs/heads/main\n"})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        req = VcsRequest("git", (tmp_path / "repo").as_uri(), "main", "")
+        clone = prepare_clone(tmp_path, req, require_pin=False, offline=True)
+        assert clone.commit_sha == sha
+
+
 class TestProviderVcsIntegration:
     def coordinator(self) -> MagicMock:
         coordinator = MagicMock()
         coordinator.index = InMemoryIndex()
+        coordinator.offline = False
         return coordinator
+
+    def test_declared_source_is_not_cloned_offline(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Offline gates a declared VCS source, as it already gates archives.
+
+        Uses a real coordinator so the run's own ``offline`` setting
+        drives the check rather than a mock attribute.
+        """
+        monkeypatch.setattr(subprocess, "run", _refuse_git)
+        sha = "a" * 40
+
+        provider = Provider(
+            FetchCoordinator(transport=HttpxAsyncTransport(), offline=True),
+            vcs_config=VcsConfig(
+                policy=VcsPolicy.ALLOW,
+                allowed_schemes=frozenset({"git+https"}),
+                allowed_repos=("https://example.com/",),
+                require_pin=True,
+            ),
+            vcs_sources=[
+                VcsSource(name="foo", url=f"git+https://example.com/foo.git@{sha}"),
+            ],
+            vcs_cache_dir=tmp_path / "cache",
+            build_policy=BuildPolicy.NEVER,
+        )
+        with pytest.raises(UnsupportedSdistError, match="offline"):
+            provider.fetch_versions("foo")
 
     def test_pinned_clone_resolves(
         self,

--- a/nab-python/tests/test_vcs.py
+++ b/nab-python/tests/test_vcs.py
@@ -652,7 +652,7 @@ class TestOfflineClone:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A ``file://`` repo is local disk, like a ``file:`` archive URL."""
+        """A ``file://`` repo is read by path, like a ``file:`` archive URL."""
         sha = "d" * 40
         commands: list[str] = []
 
@@ -669,16 +669,32 @@ class TestOfflineClone:
         assert clone.commit_sha == sha
         assert commands == ["init", "fetch", "checkout"]
 
-    def test_file_url_with_a_host_is_refused(
+    def test_file_url_with_a_host_still_clones(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A ``file://`` URL naming a host is a UNC share, not local disk."""
-        monkeypatch.setattr(subprocess, "run", _refuse_git)
-        req = VcsRequest("git", "file://server/share/repo.git", "f" * 40, "")
-        with pytest.raises(VcsCloneError, match="offline"):
-            prepare_clone(tmp_path, req, require_pin=True, offline=True)
+        """An authority does not make a ``file://`` repo a network fetch.
+
+        git drops it on POSIX and reads a UNC path on Windows, both
+        filesystem calls.  Offline gates the requests nab issues, not
+        what the mount behind a path happens to do.
+        """
+        sha = "f" * 40
+        commands: list[str] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> object:
+            commands.append(cmd[1])
+            cwd = Path(str(kwargs["cwd"]))
+            if cmd[:2] == ["git", "init"]:
+                (cwd / ".git").mkdir(exist_ok=True)
+            return type("P", (), {"returncode": 0})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        req = VcsRequest("git", "file://server/share/repo.git", sha, "")
+        clone = prepare_clone(tmp_path, req, require_pin=True, offline=True)
+        assert clone.commit_sha == sha
+        assert commands == ["init", "fetch", "checkout"]
 
     def test_file_url_floating_ref_still_resolves(
         self,


### PR DESCRIPTION
`--offline` was only honored on the archive-source path. With a cold clone cache, a `[[tool.nab.vcs-sources]]` entry still ran `git ls-remote` and `git fetch` against the remote under `nab lock --offline`.

`prepare_clone` now takes the run's offline setting. A complete cached clone is used as before; anything else fails instead of reaching the network. A floating ref fails even with a warm cache, because resolving a branch or tag to a commit needs `git ls-remote` and no cache holds that mapping.

A `git+file` repo is reached through the filesystem rather than the network, so it still clones offline, the same as a `file:` archive URL. The authority makes no difference: git drops it on POSIX and reads a UNC path on Windows, both filesystem calls. What the mount behind a path does is the operating system's business, not something offline mode gates.
