### PR TITLE
docs: an unreadable source ends the resolve

### DIFF
--- a/docs/how-to/local-sources.md
+++ b/docs/how-to/local-sources.md
@@ -55,8 +55,10 @@ require `build-policy = "build-local"` (the default) or
 `"build-remote"`.  nab spins up an isolated venv, installs the
 declared build requirements, and invokes the PEP 517 backend
 through `pyproject_hooks` to extract the live dependency list.
-Setting `"never"` instead skips the version with
-`UnsupportedSdistError` so the resolver moves on.
+Setting `"never"` instead ends the resolve.  nab reads the source
+while listing its one version, so there is no candidate to
+reject.  The error names the source and the policy that forbade
+the build.
 
 ## Lockfile shape
 

--- a/docs/reference/build-policy.md
+++ b/docs/reference/build-policy.md
@@ -32,15 +32,17 @@ Static metadata only, from any source:
   look-ahead and surfaces as a no-version diagnostic if no
   candidate ultimately works.
 * Local checkouts declared via `[[tool.nab.local-sources]]`:
-  the directory's `pyproject.toml` is read statically.  A
-  member that requires `dynamic = ["dependencies"]` is skipped.
+  the directory's `pyproject.toml` is read statically.  A missing
+  or malformed `[project]`, or a `dynamic` list covering
+  `version`, `requires-python`, `dependencies`, or
+  `optional-dependencies`, ends the resolve.
 * VCS clones declared via `[[tool.nab.vcs-sources]]`: the clone
   is fetched and its `pyproject.toml` is read statically.  Same
-  skip behaviour for dynamic deps.
+  failure when the static read comes up empty.
 * Archive sources declared via `[[tool.nab.archive-sources]]`:
   the `.tar.gz` is downloaded, hash-verified, and extracted, then
-  its `pyproject.toml` is read statically.  Same skip behaviour
-  for dynamic deps.
+  its `pyproject.toml` is read statically.  Same failure when the
+  static read comes up empty.
 
 Picks the most reproducible posture: every input to the SAT
 problem is a file read, not a sandboxed subprocess.  Use `never`
@@ -72,12 +74,28 @@ sdists.  On top of `build-local`:
   temp directory, and built.
 
 A backend failure on any of these surfaces as
-`UnsupportedSdistError`; the resolver skips that version, then
-either picks the next candidate or, if no candidate works,
-reports the accumulated build failures as a no-version
+`UnsupportedSdistError`; for a PyPI sdist the resolver skips that
+version, then either picks the next candidate or, if no candidate
+works, reports the accumulated build failures as a no-version
 diagnostic.  Honesty over silence: a version that needs a build
 which fails is treated as unbuildable, not as having zero
-dependencies.
+dependencies.  A VCS clone or an archive source ends the resolve
+instead; see below.
+
+## A source that cannot be read ends the resolve
+
+A declared source (`[[tool.nab.local-sources]]`,
+`[[tool.nab.vcs-sources]]`, `[[tool.nab.archive-sources]]`, or a
+workspace member) is the only candidate for its name, and nab
+reads its metadata while listing that one version.  If the
+effective policy forbids the build that read needs, or the
+backend runs and fails, nab names the source it could not read
+and exits non-zero.  No candidate was formed, so there is nothing
+to skip and no no-version diagnostic to report.
+
+A PyPI sdist is one candidate among many, read at look-ahead, so
+a forbidden or failed build rejects that version alone and the
+resolver moves on to the next.
 
 ## Choosing a level
 

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -193,8 +193,10 @@ class BuildPolicy(enum.Enum):
     Wheels, PEP 643 sdists, sdists with a static ``pyproject.toml`` fallback,
     local checkouts via ``[[tool.nab.local-sources]]``, VCS clones via
     ``[[tool.nab.vcs-sources]]``, and archive sources via
-    ``[[tool.nab.archive-sources]]`` are all read statically.  Sources whose
-    metadata is dynamic without a static fallback are skipped.
+    ``[[tool.nab.archive-sources]]`` are all read statically.  A source whose
+    metadata cannot be read statically raises :class:`UnsupportedSdistError`,
+    which skips a PyPI sdist version but ends the resolve for a declared
+    source.
     """
 
     BUILD_LOCAL = "build-local"
@@ -293,9 +295,11 @@ class UnsupportedSdistError(MetadataError):
     :class:`BuildPolicy` (or its per-package override) does not permit:
     dynamic metadata under :attr:`BuildPolicy.NEVER`, a VCS clone under
     :attr:`BuildPolicy.BUILD_LOCAL`, or a remote sdist build failure
-    under :attr:`BuildPolicy.BUILD_REMOTE`.  Caught by
-    :meth:`Provider._look_ahead_ok` so the resolver skips the
-    version instead of failing.
+    under :attr:`BuildPolicy.BUILD_REMOTE`.  For a PyPI sdist it is
+    caught by :meth:`Provider._look_ahead_ok`, so the resolver skips
+    the version.  A declared source (local, VCS, archive, or workspace
+    member) is read while listing its one version, so the error ends
+    the resolve instead.
     """
 
 

--- a/nab-python/tests/test_archive.py
+++ b/nab-python/tests/test_archive.py
@@ -840,7 +840,7 @@ class TestArchiveBuildPolicyLevels:
 
     Pins the behaviour the BuildPolicy attribute docstrings enumerate: a
     static ``[project]`` archive is read at every level, and a dynamic
-    archive is skipped until build-remote, where the backend is invoked.
+    archive raises until build-remote, where the backend is invoked.
     """
 
     def _extract(self, policy: BuildPolicy, path: Path) -> WheelMetadata:
@@ -869,7 +869,7 @@ class TestArchiveBuildPolicyLevels:
         assert [str(r) for r in metadata.requires_dist] == ["requests>=2"]
 
     @pytest.mark.parametrize("policy", [BuildPolicy.NEVER, BuildPolicy.BUILD_LOCAL])
-    def test_dynamic_archive_skipped_below_build_remote(
+    def test_dynamic_archive_raises_below_build_remote(
         self, policy: BuildPolicy, tmp_path: Path
     ) -> None:
         (tmp_path / "pyproject.toml").write_text(

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -2553,8 +2553,8 @@ class TestLocalSources:
         """Dynamic LocalSource deps under NEVER raise UnsupportedSdistError.
 
         Static-only reads are fine; once ``dynamic = ["dependencies"]``
-        appears, NEVER cannot satisfy the request and the version is
-        skipped (or, on a forced fetch, surfaces as an error).
+        appears, NEVER cannot satisfy the request and listing the source
+        raises.
         """
 
         self._write_local(


### PR DESCRIPTION
The docs said a local, VCS, or archive source with dynamic metadata under `build-policy = "never"` is skipped so the resolver moves on. It is not. A declared source is the only candidate for its name, and nab reads its metadata while listing that one version, so `UnsupportedSdistError` propagates out and nab exits 1. The skip path belongs to PyPI sdists, which are one candidate among many and are read at look-ahead.

This corrects the local-sources how-to and the build-policy reference, and adds a section to the reference separating the two paths. The `BuildPolicy` and `UnsupportedSdistError` docstrings and the test wording repeated the same claim, so they are corrected too.

Docs, docstrings, and one test name. No behaviour change.
