### PR TITLE
resolve relative PEP 691 URLs against the page's post-redirect URL

### DIFF
--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -98,10 +98,9 @@ class CachePolicy:
     ``fetched_at`` is the start of the freshness window: when nab received the
     response, less any Age a relaying shared cache reported.
 
-    ``page_url`` is the URL the stored body was retrieved from, which its
-    relative entries resolve against. It differs from the requested URL when
-    the index redirected, and is ``None`` for an entry written before it was
-    recorded and for the negative sentinel, which has no body.
+    ``page_url`` is the URL the stored body was retrieved from, the base its
+    relative entries resolve against. It is ``None`` for the negative
+    sentinel, which has no body, and for an entry cached without it.
     """
 
     fetched_at: int
@@ -464,6 +463,11 @@ def _encode_policy(policy: CachePolicy) -> bytes:
     ).encode("utf-8")
 
 
+def _policy_page_url(value: object) -> str | None:
+    """Page URL from a decoded policy, or None when it is unusable as a base."""
+    return value if isinstance(value, str) and value else None
+
+
 def _decode_policy(policy_bytes: bytes) -> CachePolicy | None:
     try:
         doc = json.loads(policy_bytes)
@@ -471,7 +475,7 @@ def _decode_policy(policy_bytes: bytes) -> CachePolicy | None:
             fetched_at=int(doc["fetched_at"]),
             max_age=int(doc["max_age"]),
             etag=doc.get("etag"),
-            page_url=doc.get("page_url"),
+            page_url=_policy_page_url(doc.get("page_url")),
         )
     except (ValueError, KeyError, TypeError):
         return None

--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -8,7 +8,8 @@ before any HTTP transport call.
 Layout under ``root``:
 
     simple-v1/<index>[-<serialization>]/<package>.json    <- PEP 691 JSON body
-    simple-v1/<index>[-<serialization>]/<package>.policy  <- {fetched_at, max_age, etag}
+    simple-v1/<index>[-<serialization>]/<package>.policy  <- {fetched_at, max_age,
+                                                              etag, page_url}
     simple-neg-v0/<index>[-<serialization>]/<package>.neg <- {fetched_at, max_age, etag}
     metadata-v1/<index>/<package>/<url digest>.metadata
     sdist-v1/<index>/<package>/<version>.json  <- {pkg_info, pyproject}
@@ -96,11 +97,17 @@ class CachePolicy:
 
     ``fetched_at`` is the start of the freshness window: when nab received the
     response, less any Age a relaying shared cache reported.
+
+    ``page_url`` is the URL the stored body was retrieved from, which its
+    relative entries resolve against. It differs from the requested URL when
+    the index redirected, and is ``None`` for an entry written before it was
+    recorded and for the negative sentinel, which has no body.
     """
 
     fetched_at: int
     max_age: int
     etag: str | None
+    page_url: str | None = None
 
     def is_fresh(self, now: int | None = None) -> bool:
         """Return True if the entry is still within its freshness window."""
@@ -452,6 +459,7 @@ def _encode_policy(policy: CachePolicy) -> bytes:
             "fetched_at": policy.fetched_at,
             "max_age": policy.max_age,
             "etag": policy.etag,
+            "page_url": policy.page_url,
         }
     ).encode("utf-8")
 
@@ -463,6 +471,7 @@ def _decode_policy(policy_bytes: bytes) -> CachePolicy | None:
             fetched_at=int(doc["fetched_at"]),
             max_age=int(doc["max_age"]),
             etag=doc.get("etag"),
+            page_url=doc.get("page_url"),
         )
     except (ValueError, KeyError, TypeError):
         return None

--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -260,9 +260,9 @@ class CachedAsyncSimpleClient:
             data = self._decode_cached_listing(body, package)
             if data is not None:
                 if policy.is_fresh() or self._offline:
-                    return self._parse_body(data, package)
+                    return self._parse_body(data, package, page_url=policy.page_url)
                 if self._floor_keeps_fresh(policy, package, "listing"):
-                    return self._parse_body(data, package)
+                    return self._parse_body(data, package, page_url=policy.page_url)
                 return await self._revalidate_simple(package, body, policy)
             corrupt_positive = True
 
@@ -328,8 +328,10 @@ class CachedAsyncSimpleClient:
             )
             return None
 
-    def _parse_listing(self, body: bytes, package: str) -> list[WheelFile | SdistFile]:
-        """Parse a Simple-API listing body.
+    def _parse_listing(
+        self, body: bytes, package: str, page_url: str
+    ) -> list[WheelFile | SdistFile]:
+        """Parse a Simple-API listing body served from ``page_url``.
 
         A body that is not valid JSON raises the same
         :class:`MalformedSimpleResponseError` as a valid-JSON body of the
@@ -345,11 +347,17 @@ class CachedAsyncSimpleClient:
                 f"{package!r}: body is not valid JSON"
             )
             raise MalformedSimpleResponseError(msg) from exc
-        return self._parse_body(data, package)
+        return self._parse_body(data, package, page_url=page_url)
 
-    def _parse_body(self, data: object, package: str) -> list[WheelFile | SdistFile]:
-        """Parse a decoded listing body, marking one with no readable file."""
-        files = _parse_files(data, self._index_url, package)
+    def _parse_body(
+        self, data: object, package: str, *, page_url: str | None = None
+    ) -> list[WheelFile | SdistFile]:
+        """Parse a decoded listing body, marking one with no readable file.
+
+        ``page_url`` is the URL the body was served from, which its relative
+        entries resolve against.
+        """
+        files = _parse_files(data, self._index_url, package, page_url=page_url)
         if not files and holds_unreadable_format(data):
             self._unreadable_only.add(package)
         return files
@@ -376,9 +384,10 @@ class CachedAsyncSimpleClient:
                     else policy.max_age
                 ),
                 etag=_header(response, "etag") or policy.etag,
+                page_url=response.url,
             )
             self._cache.refresh_simple_policy(package, new_policy)
-            return self._parse_listing(body, package)
+            return self._parse_listing(body, package, response.url)
 
         if response.status_code == _HTTP_NOT_FOUND:
             self._cache.put_negative(package, self._negative_policy(response))
@@ -389,12 +398,13 @@ class CachedAsyncSimpleClient:
         )
 
         # Parse before caching so a bad body never poisons the cache.
-        files = self._parse_listing(new_body, package)
+        files = self._parse_listing(new_body, package, response.url)
 
         new_policy = CachePolicy(
             fetched_at=_freshness_start(response),
             max_age=_freshness_lifetime(response),
             etag=_header(response, "etag"),
+            page_url=response.url,
         )
         self._cache.put_simple(package, new_body, new_policy)
         return files
@@ -410,12 +420,13 @@ class CachedAsyncSimpleClient:
         body = _listing_body(response, self._index_url, package, self._serialization)
 
         # Parse before caching so a bad body never poisons the cache.
-        files = self._parse_listing(body, package)
+        files = self._parse_listing(body, package, response.url)
 
         policy = CachePolicy(
             fetched_at=_freshness_start(response),
             max_age=_freshness_lifetime(response),
             etag=_header(response, "etag"),
+            page_url=response.url,
         )
         self._cache.put_simple(package, body, policy)
         self._cache.drop_negative(package)

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -250,6 +250,9 @@ def _listing_body(
     so the parser and the cache only ever see one shape; any other body is
     passed through untouched. A pinned index that answers in the other
     serialization raises instead.
+
+    An HTML page's hrefs resolve against the URL that served the page, which
+    is not the requested one when the index redirected.
     """
     body = response.content
     content_type = _header(response, "content-type")
@@ -289,7 +292,7 @@ def _listing_body(
         raise MalformedSimpleResponseError(msg) from exc
 
     try:
-        return json_listing(text, f"{index_url}{package}/")
+        return json_listing(text, response.url)
     except ValueError as exc:
         msg = (
             f"{index_url} served a malformed Simple-API response for {package!r}: {exc}"
@@ -411,7 +414,7 @@ class AsyncSimpleClient:
                 f"{package!r}: body is not valid JSON"
             )
             raise MalformedSimpleResponseError(msg) from exc
-        return _parse_files(data, self._index_url, package)
+        return _parse_files(data, self._index_url, package, page_url=response.url)
 
     async def get_metadata_text(self, metadata_url: str) -> str:
         """Fetch metadata text from a known PEP 658/714 metadata URL."""
@@ -427,7 +430,7 @@ class AsyncSimpleClient:
 
 
 def _parse_files(
-    data: object, index_url: str, package: str
+    data: object, index_url: str, package: str, *, page_url: str | None = None
 ) -> list[WheelFile | SdistFile]:
     """Parse distribution files from a Simple API JSON response.
 
@@ -439,6 +442,10 @@ def _parse_files(
     different project (``cffi-1-0-2`` at version ``2``).  Without the
     name check those leak into the listing as a phantom version, and
     show up in the resolved lockfile as ``cffi==2``.
+
+    ``page_url`` is the URL the project page was retrieved from, which a
+    relative entry resolves against; ``None`` means it was retrieved from
+    the URL ``index_url`` and ``package`` name, with no redirect between.
 
     PEP 592 ``yanked`` files are dropped unconditionally.
 
@@ -453,7 +460,7 @@ def _parse_files(
     """
     expected = canonicalize_name(package)
     # PEP 691: relative URLs resolve against the package page, not the index root.
-    base_url = f"{index_url}{package}/"
+    base_url = page_url if page_url is not None else f"{index_url}{package}/"
     files: list[WheelFile | SdistFile] = []
     if not isinstance(data, dict):
         msg = (

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -443,9 +443,9 @@ def _parse_files(
     name check those leak into the listing as a phantom version, and
     show up in the resolved lockfile as ``cffi==2``.
 
-    ``page_url`` is the URL the project page was retrieved from, which a
-    relative entry resolves against; ``None`` means it was retrieved from
-    the URL ``index_url`` and ``package`` name, with no redirect between.
+    ``page_url`` is the URL the project page was retrieved from, the base a
+    relative entry resolves against. ``None`` falls back to the page URL
+    built from ``index_url`` and ``package``.
 
     PEP 592 ``yanked`` files are dropped unconditionally.
 

--- a/nab-index/src/nab_index/httpx_async_transport.py
+++ b/nab-index/src/nab_index/httpx_async_transport.py
@@ -50,6 +50,10 @@ class _HttpxResponse:
         return self._response.status_code
 
     @property
+    def url(self) -> str:
+        return str(self._response.url)
+
+    @property
     def headers(self) -> Mapping[str, str]:
         return self._response.headers
 
@@ -65,7 +69,7 @@ class _HttpxResponse:
         return _json.loads(self._content)
 
     def raise_for_status(self) -> None:
-        raise_for_error_status(self._response.status_code, str(self._response.url))
+        raise_for_error_status(self._response.status_code, self.url)
 
 
 class HttpxAsyncTransport:

--- a/nab-index/src/nab_index/transport.py
+++ b/nab-index/src/nab_index/transport.py
@@ -134,6 +134,15 @@ class HttpResponse(Protocol):
         ...
 
     @property
+    def url(self) -> str:
+        """Absolute URL the body was retrieved from, after any redirect.
+
+        RFC 3986 section 5.1.3: this, not the requested URL, is the base a
+        relative URL inside the body resolves against.
+        """
+        ...
+
+    @property
     def headers(self) -> Mapping[str, str]:
         """Response headers, case-insensitive lookup by lowercased key."""
         ...

--- a/nab-index/src/nab_index/urllib3_async_transport.py
+++ b/nab-index/src/nab_index/urllib3_async_transport.py
@@ -14,6 +14,7 @@ import ssl
 import threading
 import time
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urljoin
 
 import truststore
 import urllib3
@@ -59,6 +60,20 @@ class _SSLContext(truststore.SSLContext):
         return {"x509_ca": 1, "x509": 1, "crl": 0}
 
 
+def _final_url(response: urllib3.BaseHTTPResponse, requested_url: str) -> str:
+    """Return the absolute URL ``response`` was retrieved from.
+
+    urllib3 reports a redirect's ``Location`` verbatim, and a relative one is
+    legal, so the last hop's location is resolved against the URL that served
+    it (RFC 3986 section 5.1.3).
+    """
+    history = response.retries.history if response.retries is not None else ()
+    if not history:
+        return requested_url
+    last = history[-1]
+    return urljoin(last.url or requested_url, last.redirect_location or "")
+
+
 class _Urllib3Response:
     """Adapter that gives a urllib3 response the HttpResponse shape.
 
@@ -67,15 +82,22 @@ class _Urllib3Response:
     so it is carried here rather than read from the urllib3 response.
     """
 
-    __slots__ = ("_content", "_response")
+    __slots__ = ("_content", "_requested_url", "_response")
 
-    def __init__(self, response: urllib3.BaseHTTPResponse, content: bytes) -> None:
+    def __init__(
+        self, response: urllib3.BaseHTTPResponse, content: bytes, requested_url: str
+    ) -> None:
         self._response = response
         self._content = content
+        self._requested_url = requested_url
 
     @property
     def status_code(self) -> int:
         return self._response.status
+
+    @property
+    def url(self) -> str:
+        return _final_url(self._response, self._requested_url)
 
     @property
     def headers(self) -> Mapping[str, str]:
@@ -93,9 +115,7 @@ class _Urllib3Response:
         return _json.loads(self._content)
 
     def raise_for_status(self) -> None:
-        raise_for_error_status(
-            self._response.status, self._response.geturl() or "<unknown>"
-        )
+        raise_for_error_status(self._response.status, self.url)
 
 
 class Urllib3AsyncTransport:
@@ -164,7 +184,7 @@ class Urllib3AsyncTransport:
             )
 
             if not decode:
-                return _Urllib3Response(response, response.data)
+                return _Urllib3Response(response, response.data, url)
 
             try:
                 content = decode_body(
@@ -177,7 +197,7 @@ class Urllib3AsyncTransport:
                 time.sleep(next_delay(failures))
                 continue
 
-            return _Urllib3Response(response, content)
+            return _Urllib3Response(response, content, url)
 
     async def get(
         self, url: str, *, headers: dict[str, str] | None = None

--- a/nab-index/src/nab_index/urllib3_async_transport.py
+++ b/nab-index/src/nab_index/urllib3_async_transport.py
@@ -63,15 +63,19 @@ class _SSLContext(truststore.SSLContext):
 def _final_url(response: urllib3.BaseHTTPResponse, requested_url: str) -> str:
     """Return the absolute URL ``response`` was retrieved from.
 
-    urllib3 reports a redirect's ``Location`` verbatim, and a relative one is
-    legal, so the last hop's location is resolved against the URL that served
-    it (RFC 3986 section 5.1.3).
+    urllib3 records status, connect, and read retries in the same history as
+    redirects, and records them with the request path alone, so only a hop
+    carrying a ``Location`` moves the URL. A ``Location`` is reported verbatim
+    and may be relative, so each is resolved against the URL that served it
+    (RFC 3986 section 5.1.3).
     """
     history = response.retries.history if response.retries is not None else ()
-    if not history:
-        return requested_url
-    last = history[-1]
-    return urljoin(last.url or requested_url, last.redirect_location or "")
+
+    url = requested_url
+    for hop in history:
+        if hop.redirect_location:
+            url = urljoin(hop.url or url, hop.redirect_location)
+    return url
 
 
 class _Urllib3Response:

--- a/nab-python/tests/property_python/test_cached_client_equiv.py
+++ b/nab-python/tests/property_python/test_cached_client_equiv.py
@@ -46,10 +46,13 @@ INDEX = "https://idx.example/simple/"
 class FakeResponse:
     """Minimal ``HttpResponse`` stand-in over canned bytes."""
 
-    def __init__(self, status: int, headers: dict[str, str], body: bytes) -> None:
+    def __init__(
+        self, status: int, headers: dict[str, str], body: bytes, url: str = INDEX
+    ) -> None:
         self.status_code = status
         self.headers = headers
         self.content = body
+        self.url = url
 
     @property
     def text(self) -> str:
@@ -79,7 +82,7 @@ class FakeTransport:
         self.calls.append((url, headers))
         responses = self.script[url]
         entry = responses.pop(0) if len(responses) > 1 else responses[0]
-        return FakeResponse(*entry)
+        return FakeResponse(*entry, url=url)
 
     async def aclose(self) -> None:
         pass

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -15,6 +15,7 @@ import threading
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 from urllib.parse import urljoin
@@ -24,12 +25,15 @@ import pytest
 import respx
 import truststore
 import urllib3
+from urllib3.util.retry import RequestHistory
 
-from nab_index.cache import NullCache
+from nab_index.cache import NullCache, OnDiskCache
 from nab_index.cached_client import CachedAsyncSimpleClient
 from nab_index.client import (
     AsyncSimpleClient,
     MalformedSimpleResponseError,
+    SdistFile,
+    WheelFile,
     _extract_sdist_files,
 )
 from nab_index.httpx_async_transport import HttpxAsyncTransport, _HttpxResponse
@@ -246,6 +250,53 @@ class _UserAgentStubIndexHandler(BaseHTTPRequestHandler):
 def _user_agent_stub_index() -> Iterator[_UserAgentStubIndex]:
     server = _UserAgentStubIndex(("127.0.0.1", 0), _UserAgentStubIndexHandler)
     server.user_agents = []
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+class _MovedIndex(ThreadingHTTPServer):
+    """Loopback index that moves its project page, mapping path to Location."""
+
+    hops: dict[str, str]
+    body: bytes
+    seen: list[str]
+
+
+class _MovedIndexHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        assert isinstance(self.server, _MovedIndex)
+        self.server.seen.append(self.path)
+        location = self.server.hops.get(self.path)
+        if location is not None:
+            self.send_response(301)
+            self.send_header("Location", location)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+
+        body = self.server.body
+        self.send_response(200)
+        self.send_header("Content-Type", "application/vnd.pypi.simple.v1+json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        """Drop the handler's stderr access log."""
+
+
+@contextmanager
+def _moved_index(hops: dict[str, str], body: bytes) -> Iterator[_MovedIndex]:
+    server = _MovedIndex(("127.0.0.1", 0), _MovedIndexHandler)
+    server.hops = dict(hops)
+    server.body = body
+    server.seen = []
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
@@ -1015,13 +1066,34 @@ class TestHttpxAsyncTransport:
         assert route.calls[0].request.headers["Accept-Encoding"] == "identity"
 
 
+_REQUESTED_URL = "https://example.com/simple/pkg/"
+
+
+def _unredirected_response(status: int) -> MagicMock:
+    """A urllib3 response that followed no redirect, so it carries no history."""
+    response = MagicMock(spec=urllib3.BaseHTTPResponse)
+    response.status = status
+    response.retries = None
+    return response
+
+
+def _redirected_response(status: int, hops: list[tuple[str, str]]) -> MagicMock:
+    """A urllib3 response whose retry history holds ``(hop url, raw Location)``."""
+    response = MagicMock(spec=urllib3.BaseHTTPResponse)
+    response.status = status
+    response.retries = urllib3.Retry(
+        history=tuple(
+            RequestHistory("GET", url, None, 301, location) for url, location in hops
+        )
+    )
+    return response
+
+
 class TestUrllib3AsyncTransport:
     def _fake_pool(self, body: bytes, status: int = 200) -> MagicMock:
-        fake_response = MagicMock(spec=urllib3.BaseHTTPResponse)
+        fake_response = _unredirected_response(status)
         fake_response.data = body
-        fake_response.status = status
         fake_response.headers = urllib3.HTTPHeaderDict()
-        fake_response.geturl.return_value = "https://example.com/"
         pool = MagicMock(spec=urllib3.PoolManager)
         pool.request.return_value = fake_response
         return pool
@@ -1440,38 +1512,46 @@ class TestUrllib3AsyncTransport:
             _assert_jittered_backoff_schedule(thread_slept)
 
     def test_response_json(self) -> None:
-        fake = MagicMock(spec=urllib3.BaseHTTPResponse)
-        fake.status = 200
+        fake = _unredirected_response(200)
         body = json.dumps({"a": 1}).encode()
-        assert _Urllib3Response(fake, body).json() == {"a": 1}
+        assert _Urllib3Response(fake, body, _REQUESTED_URL).json() == {"a": 1}
 
     def test_response_raise_for_status(self) -> None:
-        fake = MagicMock(spec=urllib3.BaseHTTPResponse)
-        fake.status = 404
-        fake.geturl.return_value = "https://example.com/missing"
-        with pytest.raises(HttpError, match="404"):
-            _Urllib3Response(fake, b"").raise_for_status()
+        fake = _unredirected_response(404)
+        with pytest.raises(HttpError, match=f"404 for {_REQUESTED_URL}"):
+            _Urllib3Response(fake, b"", _REQUESTED_URL).raise_for_status()
 
-    def test_response_raise_for_status_no_url(self) -> None:
-        """raise_for_status falls back when geturl returns None."""
-        fake = MagicMock(spec=urllib3.BaseHTTPResponse)
-        fake.status = 500
-        fake.geturl.return_value = None
-        with pytest.raises(HttpError, match="<unknown>"):
-            _Urllib3Response(fake, b"").raise_for_status()
+    def test_response_raise_for_status_names_the_redirect_target(self) -> None:
+        fake = _redirected_response(500, [(_REQUESTED_URL, "/moved/")])
+        with pytest.raises(HttpError, match="500 for https://example.com/moved/"):
+            _Urllib3Response(fake, b"", _REQUESTED_URL).raise_for_status()
 
     def test_response_raise_for_status_ok(self) -> None:
-        fake = MagicMock(spec=urllib3.BaseHTTPResponse)
-        fake.status = 200
-        _Urllib3Response(fake, b"").raise_for_status()  # no exception
+        fake = _unredirected_response(200)
+        _Urllib3Response(fake, b"", _REQUESTED_URL).raise_for_status()  # no exception
 
     def test_response_status_code_and_headers(self) -> None:
-        fake = MagicMock(spec=urllib3.BaseHTTPResponse)
-        fake.status = 304
+        fake = _unredirected_response(304)
         fake.headers = {"etag": "abc"}
-        adapter = _Urllib3Response(fake, b"")
+        adapter = _Urllib3Response(fake, b"", _REQUESTED_URL)
         assert adapter.status_code == 304
         assert adapter.headers["etag"] == "abc"
+
+    def test_url_without_a_redirect_is_the_requested_url(self) -> None:
+        fake = _unredirected_response(200)
+        assert _Urllib3Response(fake, b"", _REQUESTED_URL).url == _REQUESTED_URL
+
+    def test_url_resolves_a_relative_location_against_its_own_hop(self) -> None:
+        """Each Location is verbatim, so the chain is walked, not just the first hop."""
+        fake = _redirected_response(
+            200,
+            [
+                (_REQUESTED_URL, "https://mirror.example.com/pypi/simple/pkg/"),
+                ("https://mirror.example.com/pypi/simple/pkg/", "moved/"),
+            ],
+        )
+        adapter = _Urllib3Response(fake, b"", _REQUESTED_URL)
+        assert adapter.url == "https://mirror.example.com/pypi/simple/pkg/moved/"
 
     def test_uses_truststore_ssl_context(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Each per-thread PoolManager gets a truststore SSLContext."""
@@ -1525,14 +1605,20 @@ class TestAsyncSimpleClient:
             body: bytes,
             status: int = 200,
             headers: Mapping[str, str] | None = None,
+            url: str = "",
         ) -> None:
             self._content = body
             self._status = status
             self._headers = headers or {}
+            self._url = url
 
         @property
         def status_code(self) -> int:
             return self._status
+
+        @property
+        def url(self) -> str:
+            return self._url
 
         @property
         def headers(self) -> Mapping[str, str]:
@@ -1571,7 +1657,7 @@ class TestAsyncSimpleClient:
         ) -> TestAsyncSimpleClient._FakeResponse:
             self.calls.append((url, headers))
             return TestAsyncSimpleClient._FakeResponse(
-                self._body, self._status, self._headers
+                self._body, self._status, self._headers, url
             )
 
         async def aclose(self) -> None:
@@ -1851,6 +1937,89 @@ class TestUserAgentAcrossBackends:
             asyncio.run(go())
 
         assert index.user_agents == [USER_AGENT]
+
+
+RELATIVE_LISTING = (
+    b'{"meta": {"api-version": "1.1"}, "name": "pkg", "files": ['
+    b'{"filename": "pkg-1.0-py3-none-any.whl", "url": "pkg-1.0-py3-none-any.whl", '
+    b'"hashes": {"sha256": "' + b"0" * 64 + b'"}, "core-metadata": true}]}'
+)
+
+
+class TestMovedProjectPage:
+    """A relative file URL resolves against the page the index redirected to.
+
+    RFC 3986 section 5.1.3: the base is the URL the representation was
+    retrieved from, which after a redirect is the target rather than the
+    requested URL.
+    """
+
+    @pytest.mark.parametrize("make_transport", TRANSPORTS)
+    def test_relative_file_url_resolves_against_the_redirect_target(
+        self, make_transport: Callable[[], AsyncHttpTransport]
+    ) -> None:
+        with _moved_index(
+            {"/simple/pkg/": "/pypi/simple/pkg/"}, RELATIVE_LISTING
+        ) as index:
+            root = f"http://127.0.0.1:{index.server_port}"
+
+            async def go() -> list[WheelFile | SdistFile]:
+                async with AsyncSimpleClient(
+                    make_transport(), f"{root}/simple/"
+                ) as client:
+                    return await client.get_files("pkg")
+
+            (wheel,) = asyncio.run(go())
+            assert index.seen == ["/simple/pkg/", "/pypi/simple/pkg/"]
+
+        assert isinstance(wheel, WheelFile)
+        assert wheel.url == f"{root}/pypi/simple/pkg/pkg-1.0-py3-none-any.whl"
+        assert wheel.metadata_url == f"{wheel.url}.metadata"
+
+    @pytest.mark.parametrize("make_transport", TRANSPORTS)
+    def test_relative_location_resolves_against_the_hop_that_served_it(
+        self, make_transport: Callable[[], AsyncHttpTransport]
+    ) -> None:
+        """The second hop's ``Location`` is relative to the first hop's target."""
+        with _moved_index(
+            {"/simple/pkg/": "/pypi/simple/", "/pypi/simple/": "pkg/"},
+            RELATIVE_LISTING,
+        ) as index:
+            root = f"http://127.0.0.1:{index.server_port}"
+
+            async def go() -> list[WheelFile | SdistFile]:
+                async with AsyncSimpleClient(
+                    make_transport(), f"{root}/simple/"
+                ) as client:
+                    return await client.get_files("pkg")
+
+            (wheel,) = asyncio.run(go())
+
+        assert wheel.url == f"{root}/pypi/simple/pkg/pkg-1.0-py3-none-any.whl"
+
+    @pytest.mark.parametrize("make_transport", TRANSPORTS)
+    def test_redirect_target_survives_a_warm_cache_hit(
+        self, make_transport: Callable[[], AsyncHttpTransport], tmp_path: Path
+    ) -> None:
+        with _moved_index(
+            {"/simple/pkg/": "/pypi/simple/pkg/"}, RELATIVE_LISTING
+        ) as index:
+            root = f"http://127.0.0.1:{index.server_port}"
+            index_url = f"{root}/simple/"
+
+            async def go() -> list[WheelFile | SdistFile]:
+                cache = OnDiskCache(tmp_path, index_url)
+                async with CachedAsyncSimpleClient(
+                    make_transport(), cache, index_url
+                ) as client:
+                    return await client.get_files("pkg")
+
+            (cold,) = asyncio.run(go())
+            (warm,) = asyncio.run(go())
+            assert index.seen == ["/simple/pkg/", "/pypi/simple/pkg/"]
+
+        assert warm.url == cold.url
+        assert warm.url == f"{root}/pypi/simple/pkg/pkg-1.0-py3-none-any.whl"
 
 
 class TestExtractSdistFiles:

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -261,11 +261,16 @@ def _user_agent_stub_index() -> Iterator[_UserAgentStubIndex]:
 
 
 class _MovedIndex(ThreadingHTTPServer):
-    """Loopback index that moves its project page, mapping path to Location."""
+    """Loopback index that moves its project page, mapping path to Location.
+
+    ``transient`` queues statuses served once each after the hops are done,
+    for a retryable blip between the final redirect and the body.
+    """
 
     hops: dict[str, str]
     body: bytes
     seen: list[str]
+    transient: list[int]
 
 
 class _MovedIndexHandler(BaseHTTPRequestHandler):
@@ -276,6 +281,12 @@ class _MovedIndexHandler(BaseHTTPRequestHandler):
         if location is not None:
             self.send_response(301)
             self.send_header("Location", location)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+
+        if self.server.transient:
+            self.send_response(self.server.transient.pop(0))
             self.send_header("Content-Length", "0")
             self.end_headers()
             return
@@ -292,11 +303,14 @@ class _MovedIndexHandler(BaseHTTPRequestHandler):
 
 
 @contextmanager
-def _moved_index(hops: dict[str, str], body: bytes) -> Iterator[_MovedIndex]:
+def _moved_index(
+    hops: dict[str, str], body: bytes, transient: Sequence[int] = ()
+) -> Iterator[_MovedIndex]:
     server = _MovedIndex(("127.0.0.1", 0), _MovedIndexHandler)
     server.hops = dict(hops)
     server.body = body
     server.seen = []
+    server.transient = list(transient)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
@@ -1553,6 +1567,15 @@ class TestUrllib3AsyncTransport:
         adapter = _Urllib3Response(fake, b"", _REQUESTED_URL)
         assert adapter.url == "https://mirror.example.com/pypi/simple/pkg/moved/"
 
+    def test_url_ignores_a_retried_status(self) -> None:
+        """urllib3 records a status retry with the request path and no Location."""
+        fake = MagicMock(spec=urllib3.BaseHTTPResponse)
+        fake.status = 200
+        fake.retries = urllib3.Retry(
+            history=(RequestHistory("GET", "/simple/pkg/", None, 503, None),)
+        )
+        assert _Urllib3Response(fake, b"", _REQUESTED_URL).url == _REQUESTED_URL
+
     def test_uses_truststore_ssl_context(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Each per-thread PoolManager gets a truststore SSLContext."""
         captured: dict[str, Any] = {}
@@ -2020,6 +2043,57 @@ class TestMovedProjectPage:
 
         assert warm.url == cold.url
         assert warm.url == f"{root}/pypi/simple/pkg/pkg-1.0-py3-none-any.whl"
+
+
+class TestRetriedProjectPage:
+    """A retried status is not a redirect, so it leaves the base alone.
+
+    urllib3 puts a status, connect, or read retry in the same history as a
+    redirect, recorded with the request path rather than an absolute URL.
+    """
+
+    @pytest.mark.parametrize("make_transport", TRANSPORTS)
+    def test_relative_file_url_survives_a_retried_status(
+        self, make_transport: Callable[[], AsyncHttpTransport]
+    ) -> None:
+        with _moved_index({}, RELATIVE_LISTING, transient=[503]) as index:
+            root = f"http://127.0.0.1:{index.server_port}"
+
+            async def go() -> list[WheelFile | SdistFile]:
+                async with AsyncSimpleClient(
+                    make_transport(), f"{root}/simple/"
+                ) as client:
+                    return await client.get_files("pkg")
+
+            (wheel,) = asyncio.run(go())
+            assert index.seen == ["/simple/pkg/", "/simple/pkg/"]
+
+        assert isinstance(wheel, WheelFile)
+        assert wheel.url == f"{root}/simple/pkg/pkg-1.0-py3-none-any.whl"
+        assert wheel.metadata_url == f"{wheel.url}.metadata"
+
+    @pytest.mark.parametrize("make_transport", TRANSPORTS)
+    def test_status_retried_after_a_redirect_keeps_the_redirect_target(
+        self, make_transport: Callable[[], AsyncHttpTransport]
+    ) -> None:
+        with _moved_index(
+            {"/simple/pkg/": "/pypi/simple/pkg/"}, RELATIVE_LISTING, transient=[503]
+        ) as index:
+            root = f"http://127.0.0.1:{index.server_port}"
+
+            async def go() -> list[WheelFile | SdistFile]:
+                async with AsyncSimpleClient(
+                    make_transport(), f"{root}/simple/"
+                ) as client:
+                    return await client.get_files("pkg")
+
+            (wheel,) = asyncio.run(go())
+
+            # Backends resume at different points, so pin the outcome, not the order.
+            assert index.transient == []
+            assert index.seen[-1] == "/pypi/simple/pkg/"
+
+        assert wheel.url == f"{root}/pypi/simple/pkg/pkg-1.0-py3-none-any.whl"
 
 
 class TestExtractSdistFiles:

--- a/nab-python/tests/test_cache.py
+++ b/nab-python/tests/test_cache.py
@@ -553,12 +553,32 @@ class TestEncodePolicy:
             "page_url": None,
         }
 
-    def test_policy_written_before_page_url_decodes(self, tmp_path: Path) -> None:
+    def test_policy_without_a_page_url_decodes(self, tmp_path: Path) -> None:
         cache = OnDiskCache(tmp_path, "https://pypi.org/simple")
         cache.put_simple("foo", b"{}", _FRESH)
         path = tmp_path / "simple-v0" / "pypi" / "foo.policy"
         path.write_bytes(b'{"fetched_at":1,"max_age":600,"etag":"x"}')
+
         entry = cache.get_simple("foo")
+
+        assert entry is not None
+        assert entry[1].page_url is None
+
+    @pytest.mark.parametrize("page_url", [123, "", []])
+    def test_unusable_page_url_is_dropped(
+        self, tmp_path: Path, page_url: object
+    ) -> None:
+        cache = OnDiskCache(tmp_path, "https://pypi.org/simple")
+        cache.put_simple("foo", b"{}", _FRESH)
+        path = tmp_path / "simple-v0" / "pypi" / "foo.policy"
+        path.write_bytes(
+            json.dumps(
+                {"fetched_at": 1, "max_age": 600, "etag": "x", "page_url": page_url}
+            ).encode()
+        )
+
+        entry = cache.get_simple("foo")
+
         assert entry is not None
         assert entry[1].page_url is None
 

--- a/nab-python/tests/test_cache.py
+++ b/nab-python/tests/test_cache.py
@@ -532,14 +532,35 @@ class TestCorruptEntryLogging:
 
 class TestEncodePolicy:
     def test_round_trip_with_etag(self) -> None:
-        policy = CachePolicy(fetched_at=10, max_age=20, etag="x")
+        policy = CachePolicy(
+            fetched_at=10, max_age=20, etag="x", page_url="https://e.test/simple/foo/"
+        )
         decoded = json.loads(_encode_policy(policy))
-        assert decoded == {"fetched_at": 10, "max_age": 20, "etag": "x"}
+        assert decoded == {
+            "fetched_at": 10,
+            "max_age": 20,
+            "etag": "x",
+            "page_url": "https://e.test/simple/foo/",
+        }
 
     def test_round_trip_without_etag(self) -> None:
         policy = CachePolicy(fetched_at=10, max_age=20, etag=None)
         decoded = json.loads(_encode_policy(policy))
-        assert decoded == {"fetched_at": 10, "max_age": 20, "etag": None}
+        assert decoded == {
+            "fetched_at": 10,
+            "max_age": 20,
+            "etag": None,
+            "page_url": None,
+        }
+
+    def test_policy_written_before_page_url_decodes(self, tmp_path: Path) -> None:
+        cache = OnDiskCache(tmp_path, "https://pypi.org/simple")
+        cache.put_simple("foo", b"{}", _FRESH)
+        path = tmp_path / "simple-v0" / "pypi" / "foo.policy"
+        path.write_bytes(b'{"fetched_at":1,"max_age":600,"etag":"x"}')
+        entry = cache.get_simple("foo")
+        assert entry is not None
+        assert entry[1].page_url is None
 
 
 class TestReadCacheEntry:

--- a/nab-python/tests/test_cache.py
+++ b/nab-python/tests/test_cache.py
@@ -556,7 +556,7 @@ class TestEncodePolicy:
     def test_policy_without_a_page_url_decodes(self, tmp_path: Path) -> None:
         cache = OnDiskCache(tmp_path, "https://pypi.org/simple")
         cache.put_simple("foo", b"{}", _FRESH)
-        path = tmp_path / "simple-v0" / "pypi" / "foo.policy"
+        path = tmp_path / SIMPLE_BUCKET / "pypi" / "foo.policy"
         path.write_bytes(b'{"fetched_at":1,"max_age":600,"etag":"x"}')
 
         entry = cache.get_simple("foo")
@@ -570,7 +570,7 @@ class TestEncodePolicy:
     ) -> None:
         cache = OnDiskCache(tmp_path, "https://pypi.org/simple")
         cache.put_simple("foo", b"{}", _FRESH)
-        path = tmp_path / "simple-v0" / "pypi" / "foo.policy"
+        path = tmp_path / SIMPLE_BUCKET / "pypi" / "foo.policy"
         path.write_bytes(
             json.dumps(
                 {"fetched_at": 1, "max_age": 600, "etag": "x", "page_url": page_url}

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -76,8 +76,8 @@ class _FakeResponse:
         self.content = body
         self.status_code = status
         self.headers = headers or {}
-        # A non-empty ``url`` stands for a page the index redirected to; the
-        # transport otherwise stamps the requested URL, as a real one reports it.
+        # Empty means the transport fills in the requested URL. Set it to
+        # stand in for a page the index redirected to.
         self.url = url
 
     @property
@@ -1677,12 +1677,11 @@ class TestExpiresFreshness:
 
 
 class TestRedirectedProjectPage:
-    """A relative file URL resolves against the page the index actually served.
+    """A relative file URL resolves against the page the index served.
 
-    An index is free to redirect a project page (a path-rewriting proxy, an
-    http-to-https upgrade, a CDN host move) and free to publish a relative
-    ``files[].url``. RFC 3986 section 5.1.3 makes the redirect target the base,
-    so the resolved URL must not point back at the requested path.
+    An index may redirect a project page and still publish a relative
+    ``files[].url``. RFC 3986 section 5.1.3 makes the redirect target the
+    base, so the resolved URL must not point back at the requested path.
     """
 
     _MOVED_PAGE = "https://mirror.example.com/pypi/simple/pkg/"
@@ -1761,6 +1760,7 @@ class TestRedirectedProjectPage:
                 await client.aclose()
 
         (wheel,) = asyncio.run(go())
+
         assert wheel.url == self._EXPECTED_URL
 
     def test_304_revalidation_adopts_the_redirect_target(self, tmp_path: Path) -> None:

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -71,10 +71,14 @@ class _FakeResponse:
         body: bytes,
         status: int = 200,
         headers: Mapping[str, str] | None = None,
+        url: str = "",
     ) -> None:
         self.content = body
         self.status_code = status
         self.headers = headers or {}
+        # A non-empty ``url`` stands for a page the index redirected to; the
+        # transport otherwise stamps the requested URL, as a real one reports it.
+        self.url = url
 
     @property
     def text(self) -> str:
@@ -114,7 +118,10 @@ class _FakeTransport:
         if not self._responses:
             msg = f"unexpected request to {url}"
             raise AssertionError(msg)
-        return self._responses.pop(0)
+        response = self._responses.pop(0)
+        if not response.url:
+            response.url = url
+        return response
 
     async def aclose(self) -> None:
         return None
@@ -485,6 +492,25 @@ class TestRelativeUrlResolution:
         }
         files = _parse_files(data, "https://example.com/simple/", "foo")
         expected = "https://example.com/simple/foo/foo-1.0-py3-none-any.whl"
+        assert files[0].url == expected
+
+    def test_relative_url_resolves_against_the_page_that_was_served(self) -> None:
+        """A redirect moves the project page, and with it the base."""
+        data = {
+            "files": [
+                {
+                    "filename": "foo-1.0-py3-none-any.whl",
+                    "url": "foo-1.0-py3-none-any.whl",
+                },
+            ],
+        }
+        files = _parse_files(
+            data,
+            "https://example.com/simple/",
+            "foo",
+            page_url="https://example.com/pypi/simple/foo/",
+        )
+        expected = "https://example.com/pypi/simple/foo/foo-1.0-py3-none-any.whl"
         assert files[0].url == expected
 
     def test_dot_dot_relative_url_is_normalised(self) -> None:
@@ -1648,6 +1674,146 @@ class TestExpiresFreshness:
         cached = cache.get_simple("pkg")
         assert cached is not None
         assert cached[1].max_age == 1800
+
+
+class TestRedirectedProjectPage:
+    """A relative file URL resolves against the page the index actually served.
+
+    An index is free to redirect a project page (a path-rewriting proxy, an
+    http-to-https upgrade, a CDN host move) and free to publish a relative
+    ``files[].url``. RFC 3986 section 5.1.3 makes the redirect target the base,
+    so the resolved URL must not point back at the requested path.
+    """
+
+    _MOVED_PAGE = "https://mirror.example.com/pypi/simple/pkg/"
+    _EXPECTED_URL = f"{_MOVED_PAGE}pkg-1.0-py3-none-any.whl"
+    _RELATIVE_LISTING = json.dumps(
+        {
+            "meta": {"api-version": "1.1"},
+            "name": "pkg",
+            "files": [
+                {
+                    "filename": "pkg-1.0-py3-none-any.whl",
+                    "url": "pkg-1.0-py3-none-any.whl",
+                    "hashes": {"sha256": "0" * 64},
+                    "core-metadata": True,
+                }
+            ],
+        }
+    ).encode()
+
+    def _run(self, transport: _FakeTransport, cache: OnDiskCache) -> list:
+        async def go() -> list:
+            client = CachedAsyncSimpleClient(transport, cache)
+            try:
+                return await client.get_files("pkg")
+            finally:
+                await client.aclose()
+
+        return asyncio.run(go())
+
+    def test_cold_fetch_resolves_against_the_redirect_target(
+        self, tmp_path: Path
+    ) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport(
+            [_FakeResponse(self._RELATIVE_LISTING, url=self._MOVED_PAGE)]
+        )
+
+        (wheel,) = self._run(transport, cache)
+
+        assert wheel.url == self._EXPECTED_URL
+        assert isinstance(wheel, WheelFile)
+        assert wheel.metadata_url == f"{self._EXPECTED_URL}.metadata"
+
+    def test_warm_hit_reuses_the_recorded_page(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport(
+            [
+                _FakeResponse(
+                    self._RELATIVE_LISTING,
+                    headers={"cache-control": "max-age=600"},
+                    url=self._MOVED_PAGE,
+                )
+            ]
+        )
+        self._run(transport, cache)
+
+        # A second transport with nothing queued fails any request it gets.
+        (wheel,) = self._run(_FakeTransport(), cache)
+
+        assert wheel.url == self._EXPECTED_URL
+        assert len(transport.calls) == 1
+
+    def test_offline_hit_reuses_the_recorded_page(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        cache.put_simple(
+            "pkg",
+            self._RELATIVE_LISTING,
+            CachePolicy(fetched_at=0, max_age=1, etag=None, page_url=self._MOVED_PAGE),
+        )
+
+        async def go() -> list:
+            client = CachedAsyncSimpleClient(_FakeTransport(), cache, offline=True)
+            try:
+                return await client.get_files("pkg")
+            finally:
+                await client.aclose()
+
+        (wheel,) = asyncio.run(go())
+        assert wheel.url == self._EXPECTED_URL
+
+    def test_304_revalidation_adopts_the_redirect_target(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        cache.put_simple(
+            "pkg",
+            self._RELATIVE_LISTING,
+            CachePolicy(fetched_at=0, max_age=1, etag="v1"),
+        )
+        transport = _FakeTransport(
+            [
+                _FakeResponse(
+                    b"", status=304, headers={"etag": "v1"}, url=self._MOVED_PAGE
+                )
+            ]
+        )
+
+        (wheel,) = self._run(transport, cache)
+
+        assert wheel.url == self._EXPECTED_URL
+        cached = cache.get_simple("pkg")
+        assert cached is not None
+        assert cached[1].page_url == self._MOVED_PAGE
+
+    def test_200_revalidation_adopts_the_redirect_target(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        cache.put_simple(
+            "pkg",
+            b'{"files": []}',
+            CachePolicy(fetched_at=0, max_age=1, etag="old"),
+        )
+        transport = _FakeTransport(
+            [_FakeResponse(self._RELATIVE_LISTING, url=self._MOVED_PAGE)]
+        )
+
+        (wheel,) = self._run(transport, cache)
+
+        assert wheel.url == self._EXPECTED_URL
+
+    def test_entry_stored_without_a_page_falls_back_to_the_index(
+        self, tmp_path: Path
+    ) -> None:
+        """A cache written before the page URL was recorded keeps working."""
+        cache = _make_cache(tmp_path)
+        cache.put_simple(
+            "pkg",
+            self._RELATIVE_LISTING,
+            CachePolicy(fetched_at=2_000_000_000, max_age=99999, etag=None),
+        )
+
+        (wheel,) = self._run(_FakeTransport(), cache)
+
+        assert wheel.url == "https://pypi.org/simple/pkg/pkg-1.0-py3-none-any.whl"
 
 
 class TestNonJsonListingBody:

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -2040,6 +2040,29 @@ class TestHtmlListing:
         files, _ = self._fetch(_make_cache(tmp_path), page, "text/html")
         assert files[0].hashes == (("sha256", self._DIGEST), ("sha512", sha512))
 
+    def test_relative_href_resolves_against_the_redirect_target(
+        self, tmp_path: Path
+    ) -> None:
+        """A moved HTML page is the base for its own relative hrefs."""
+        moved = "https://mirror.example.com/whl/cpu/torch/"
+        page = b'<a href="torch-2.7.0-py3-none-any.whl">torch</a>'
+        transport = _FakeTransport(
+            [_FakeResponse(page, headers={"content-type": "text/html"}, url=moved)]
+        )
+
+        async def go() -> list:
+            client = CachedAsyncSimpleClient(
+                transport, _make_cache(tmp_path), self._INDEX
+            )
+            try:
+                return await client.get_files("torch")
+            finally:
+                await client.aclose()
+
+        (wheel,) = asyncio.run(go())
+
+        assert wheel.url == f"{moved}torch-2.7.0-py3-none-any.whl"
+
     def test_malformed_ipv6_href_is_dropped(self, tmp_path: Path) -> None:
         # An unterminated IPv6 bracket makes the href join and split raise;
         # that anchor is dropped and its good sibling still resolves.

--- a/nab-python/tests/test_range_metadata_integration.py
+++ b/nab-python/tests/test_range_metadata_integration.py
@@ -76,14 +76,21 @@ def _parse_range(value: str) -> tuple[str, int, int]:
 
 
 class _FakeResponse:
-    def __init__(self, status: int, headers: dict[str, str], content: bytes) -> None:
+    def __init__(
+        self, status: int, headers: dict[str, str], content: bytes, url: str
+    ) -> None:
         self._status = status
         self._headers = headers
         self._content = content
+        self._url = url
 
     @property
     def status_code(self) -> int:
         return self._status
+
+    @property
+    def url(self) -> str:
+        return self._url
 
     @property
     def headers(self) -> dict[str, str]:
@@ -138,11 +145,11 @@ class FakeRangeTransport:
         rng = headers.get("Range")
         self.requests.append((url, rng))
         if url != _WHEEL_URL:
-            return _FakeResponse(200, {"content-type": _JSON_MEDIA}, self.listing)
+            return _FakeResponse(200, {"content-type": _JSON_MEDIA}, self.listing, url)
         if self.wheel_status is not None:
-            return _FakeResponse(self.wheel_status, {}, b"")
+            return _FakeResponse(self.wheel_status, {}, b"", url)
         if rng is None or self.ignore_range:
-            return _FakeResponse(200, {}, self.wheel)
+            return _FakeResponse(200, {}, self.wheel, url)
         return self._range(rng)
 
     async def aclose(self) -> None:
@@ -163,7 +170,7 @@ class FakeRangeTransport:
         else:
             start, end = a, min(b, self.total - 1)
         headers = {"content-range": f"bytes {start}-{end}/{self.total}"}
-        return _FakeResponse(206, headers, self.wheel[start : end + 1])
+        return _FakeResponse(206, headers, self.wheel[start : end + 1], _WHEEL_URL)
 
 
 _TARGET = ResolveTarget.for_declared(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -275,9 +275,10 @@ def _source_name_mismatch_message(tmp_path: Path, prefix: str) -> str:
 class _SidecarResponse:
     """Minimal HttpResponse for the fake index transport."""
 
-    def __init__(self, body: bytes) -> None:
+    def __init__(self, body: bytes, url: str) -> None:
         self.content = body
         self.status_code = 200
+        self.url = url
 
     @property
     def headers(self) -> dict[str, str]:
@@ -311,7 +312,7 @@ class _SidecarTransport:
         if url not in self._bodies:
             msg = f"unexpected request to {url}"
             raise AssertionError(msg)
-        return _SidecarResponse(self._bodies[url])
+        return _SidecarResponse(self._bodies[url], url)
 
     async def aclose(self) -> None:
         return None


### PR DESCRIPTION
When an index redirects a project page, every relative `url` in the PEP 691 listing was resolved against the URL we requested instead of the one that actually served the body. Artifact URLs and the PEP 658 metadata sidecars derived from them pointed at paths that 404.

RFC 3986 section 5.1.3 makes the retrieval URL the base. `HttpResponse` now exposes the URL the body came from, and the listing parser resolves relative entries against it. The cache policy records that URL next to the cached body, so a listing read back from disk resolves the same way as a fresh fetch.

The urllib3 transport rebuilds the URL from the retry history. Status, connect, and read retries share that history with redirects and are recorded with the request path alone, so only a hop carrying a `Location` moves the base, and a relative `Location` is joined against the URL that served it.
