### PR TITLE
state the versions a narrowed error line leaves out

### DIFF
--- a/nab-resolver/src/nab_resolver/report.py
+++ b/nab-resolver/src/nab_resolver/report.py
@@ -35,6 +35,10 @@ def format_error(
 ) -> str:
     """Format a human-readable error from an incompatibility derivation tree.
 
+    Where narrowing leaves a line ruling out versions its causes no longer
+    account for, the range it dropped is stated once for that package, as the
+    resolver states it when it looks for a version in a range and finds none.
+
     ``narrow`` maps ``(package, constraint)`` to a display constraint and is
     applied to originally-positive terms only; a negative dependency-side
     term renders as requested even when displayed negated.  On a
@@ -72,9 +76,19 @@ def explain_incompatibility(
     # The flag marks a node whose children are already pushed: it renders after them.
     stack: list[tuple[Incompatibility[Any, Any], bool]] = [(incompatibility, False)]
 
+    needed, unstated = (
+        ({}, {}) if narrow is None else _unstated_ranges(incompatibility, narrow)
+    )
+
     while stack:
         node, expanded = stack.pop()
         if expanded:
+            for package in needed.get(id(node), ()):
+                gap = unstated.pop(package, None)
+                if gap is not None:
+                    lines.append(
+                        f"because no versions of {package} {gap} are available"
+                    )
             lines.append(_render_line(node, narrow))
             continue
 
@@ -92,20 +106,131 @@ def explain_incompatibility(
                 stack.append((node.cause_left, False))
 
 
-def _narrow_positive(
-    term: Term[Any, Any], narrow: _NarrowFn, *, allow_full: bool
-) -> Term[Any, Any]:
-    """Return ``term`` with a narrowed constraint when originally positive.
-
-    Unless ``allow_full``, a narrowing to the full range is refused and the
-    term renders as requested.
-    """
+def _narrow_positive(term: Term[Any, Any], narrow: _NarrowFn) -> Term[Any, Any]:
+    """Return ``term`` with a narrowed constraint when originally positive."""
     if not term.is_positive():
         return term
-    shown = Term(term.package, narrow(term.package, term.constraint), positive=True)
-    if allow_full or not _is_full(shown):
-        return shown
-    return term
+    return Term(term.package, narrow(term.package, term.constraint), positive=True)
+
+
+def _shown_terms(
+    incompatibility: Incompatibility[Any, Any], narrow: _NarrowFn
+) -> dict[Any, Term[Any, Any]]:
+    """Return the terms of ``incompatibility`` as its line renders them.
+
+    The comparison runs on exactly what the reader sees, so a requirement is
+    read as printed, un-narrowed, the way the line states it.
+    """
+    if incompatibility.cause is IncompatibilityCause.NO_VERSIONS:
+        return {term.package: term for term in incompatibility.terms}
+    return {
+        term.package: _narrow_positive(term, narrow) for term in incompatibility.terms
+    }
+
+
+def _satisfying(term: Term[Any, Any] | None) -> Any:
+    """Return the versions that satisfy ``term``, or None for no restriction."""
+    if term is None:
+        return None
+    return term.constraint if term.is_positive() else ~term.constraint
+
+
+def _shortfall(
+    conclusion: Term[Any, Any] | None,
+    left: Term[Any, Any] | None,
+    right: Term[Any, Any] | None,
+) -> Any:
+    """Return what a step rules out for one package that its causes do not.
+
+    A step rules out the union of what its causes rule out.  Absent from one
+    cause the package carries the other's term; absent from the step it was
+    resolved away, which needs the causes to leave nothing.
+    """
+    joint = (
+        left if right is None else right if left is None else union_terms(left, right)
+    )
+    covered = _satisfying(joint)
+    stated = _satisfying(conclusion)
+    if covered is None:
+        return None
+    return ~covered if stated is None else stated - covered
+
+
+def _unstated_ranges(
+    root: Incompatibility[Any, Any], narrow: _NarrowFn
+) -> tuple[dict[int, list[Any]], dict[Any, Any]]:
+    """Return which line needs a package's listing stated, and what to state.
+
+    The first mapping is node id to packages, the second is package to the whole
+    range to state for it.  A derivation can reach past its causes at more than
+    one line over gaps of one listing, so the ranges are unioned per package and
+    the caller states each once, at the first line that needs it.
+    """
+    needed: dict[int, list[Any]] = {}
+    unstated: dict[Any, Any] = {}
+    seen_ids: set[int] = set()
+    stack: list[Incompatibility[Any, Any]] = [root]
+
+    while stack:
+        node = stack.pop()
+        if id(node) in seen_ids:
+            continue
+        seen_ids.add(id(node))
+
+        for package, gap in _narrowed_away(node, narrow):
+            needed.setdefault(id(node), []).append(package)
+            previous = unstated.get(package)
+            unstated[package] = gap if previous is None else previous | gap
+
+        if node.cause_left is not None:
+            stack.append(node.cause_left)
+        if node.cause_right is not None:
+            stack.append(node.cause_right)
+
+    return needed, unstated
+
+
+def _narrowed_away(
+    incompatibility: Incompatibility[Any, Any], narrow: _NarrowFn
+) -> list[tuple[Any, Any]]:
+    """Return the packages and ranges narrowing drops from a line's support.
+
+    Narrowing a widened term back onto the listed versions drops the versions the
+    widening added, so a line can rule out, or resolve a requirement over, a range
+    its causes no longer account for.  Only a shortfall the un-narrowed terms do
+    not have is reported, so what is stated is what narrowing dropped: a range
+    holding no listed version, since narrowing keeps which listed versions a
+    constraint contains.
+    """
+    left = incompatibility.cause_left
+    right = incompatibility.cause_right
+    if (
+        incompatibility.cause is not IncompatibilityCause.DERIVED
+        or left is None
+        or right is None
+    ):
+        return []
+
+    raw_left = {term.package: term for term in left.terms}
+    raw_right = {term.package: term for term in right.terms}
+    raw_node = {term.package: term for term in incompatibility.terms}
+    shown_left = _shown_terms(left, narrow)
+    shown_right = _shown_terms(right, narrow)
+    shown_node = _shown_terms(incompatibility, narrow)
+
+    found: list[tuple[Any, Any]] = []
+    for package in {**raw_left, **raw_right}:
+        raw_gap = _shortfall(
+            raw_node.get(package), raw_left.get(package), raw_right.get(package)
+        )
+        if raw_gap is not None and not raw_gap.is_empty:
+            continue
+        gap = _shortfall(
+            shown_node.get(package), shown_left.get(package), shown_right.get(package)
+        )
+        if gap is not None and not gap.is_empty:
+            found.append((package, gap))
+    return found
 
 
 def _render_line(
@@ -115,13 +240,10 @@ def _render_line(
     """Render a single incompatibility as one explanation line."""
     cause = incompatibility.cause
     terms = incompatibility.terms
-    if narrow is not None:
-        # Without its range the line would claim the package has no versions
-        # at all, not that the ones it has were rejected here.
-        allow_full = cause is not IncompatibilityCause.NO_VERSIONS
-        terms = [
-            _narrow_positive(term, narrow, allow_full=allow_full) for term in terms
-        ]
+    # An availability line renders its own range: narrowing it onto the listing
+    # is what let it stop covering the requirement it closes against.
+    if narrow is not None and cause is not IncompatibilityCause.NO_VERSIONS:
+        terms = [_narrow_positive(term, narrow) for term in terms]
 
     # Attribution form for the two standard two-term clauses.
     if (

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -196,6 +196,10 @@ class ResolverProvider(Protocol[PackageType, VersionType]):
         ``package`` may be the virtual root sentinel or another package
         outside the provider's namespace; return such constraints
         unchanged, as providers that do not widen do for all input.
+
+        Soundness contract: the result must hold the same known versions as
+        ``constraint``.  The renderer reports what a narrowing drops as a range
+        holding no version, so dropping one that exists states a falsehood.
         """
         ...
 

--- a/nab-resolver/tests/test_widen_hook.py
+++ b/nab-resolver/tests/test_widen_hook.py
@@ -127,6 +127,23 @@ class _WideningProvider(_BaseProvider):
         return widened
 
 
+class _SnappingProvider(_WideningProvider):
+    """Widens to the neighbor gap and snaps displayed constraints onto the listing."""
+
+    def narrow_for_display(
+        self, package: str, constraint: RangeProtocol[int]
+    ) -> RangeProtocol[int]:
+        universe = sorted(self._packages.get(package, {}))
+        inside = [version for version in universe if version in constraint]
+        if not inside:
+            return constraint
+        if len(inside) == len(universe):
+            return Range.full()
+        if len(inside) == 1:
+            return Range.singleton(inside[0])
+        return Range.between(inside[0], inside[-1] + 1)
+
+
 class _SpanWideningProvider(_BaseProvider):
     """Widens a decided version across adjacent versions with equal deps."""
 
@@ -385,24 +402,17 @@ class TestFormatErrorNarrow:
         assert message == "because foo 2 depends on bar [3, +inf)"
         assert narrowed_packages == ["foo"]
 
-    def test_narrow_applies_to_no_versions_term(self) -> None:
+    def test_no_versions_term_renders_its_own_range(self) -> None:
+        """Narrowing it is what let it stop covering the requirement below."""
         clause = Incompatibility(
             [Term("qux", Range.at_least(5), positive=True)],
             cause=IncompatibilityCause.NO_VERSIONS,
         )
-        message = format_error(
-            clause, narrow=lambda package, constraint: Range.singleton(7)
-        )
-        assert message == "because no versions of qux 7 are available"
-
-    def test_no_versions_term_is_not_narrowed_to_full(self) -> None:
-        """Without the range the line would claim qux has no versions at all."""
-        clause = Incompatibility(
-            [Term("qux", Range.at_least(5), positive=True)],
-            cause=IncompatibilityCause.NO_VERSIONS,
-        )
-        message = format_error(clause, narrow=lambda package, constraint: Range.full())
-        assert message == "because no versions of qux [5, +inf) are available"
+        for narrowed in (Range.singleton(7), Range.full()):
+            message = format_error(
+                clause, narrow=lambda package, constraint, r=narrowed: r
+            )
+            assert message == "because no versions of qux [5, +inf) are available"
 
     def test_other_causes_accept_a_narrowing_to_full(self) -> None:
         clause = Incompatibility(
@@ -428,9 +438,11 @@ class TestFormatErrorNarrow:
         assert message == "so a 3 and not b [1, 9)"
 
     def test_raise_site_narrows_through_provider(self) -> None:
-        """The resolver passes ``narrow_for_display`` to ``format_error``:
-        the positive NO_VERSIONS term is narrowed, the negative dep side of
-        the DEPENDENCY clause still renders the requested range."""
+        """The resolver passes ``narrow_for_display`` to ``format_error``.
+
+        The availability line and the negative dependency side both render the
+        range they hold; only an originally-positive term elsewhere is narrowed.
+        """
         provider = _NarrowingProvider(
             {"root": {1: {"foo": Range.full()}}},
             target="foo",
@@ -440,8 +452,7 @@ class TestFormatErrorNarrow:
         with pytest.raises(ResolutionError) as exc_info:
             resolver.resolve({"root": Range.singleton(1)})
         message = str(exc_info.value)
-        assert "because no versions of foo [5, 7) are available" in message
-        # Pinned as a whole line: a narrowed dep side would print [5, 7).
+        assert "because no versions of foo are available" in message.splitlines()
         assert "because root 1 depends on foo" in message.splitlines()
         assert provider.narrow_calls
 
@@ -512,3 +523,74 @@ class TestConflictCreditTarget:
             cause=IncompatibilityCause.DEPENDENCY,
         )
         assert conflict_credit_target(self._derivation("child", self_dep)) == "child"
+
+
+_REJECTED_RUN = {
+    "a": {
+        1: {},
+        2: {"py": Range.at_least(10)},
+        3: {"py": Range.at_least(11)},
+        4: {"py": Range.at_least(12)},
+    },
+    "py": {9: {}},
+}
+
+
+class TestUnstatedVersions:
+    """A line that reaches past its causes states the listing it needs, once."""
+
+    def _message(
+        self, packages: dict[str, dict[int, dict[str, Range]]], root: dict[str, Range]
+    ) -> str:
+        with pytest.raises(ResolutionError) as exc_info:
+            Resolver(_SnappingProvider(packages)).resolve(root)
+        return str(exc_info.value)
+
+    def test_states_the_gaps_a_widened_run_leaves(self) -> None:
+        """Several lines reach past their causes; the listing is stated once."""
+        message = self._message(_REJECTED_RUN, {"a": Range.at_least(2)})
+        assert message.count("because no versions of a") == 1
+        assert "because no versions of a (2, 3) | (3, 4) | (4, +inf) are available" in (
+            message
+        )
+
+    def test_states_the_gap_a_resolved_requirement_leaves(self) -> None:
+        """The requirement runs past the exclusion that resolves it."""
+        packages = {"a": {1: {}, 2: {"py": Range.at_least(11)}, 3: {}}, "py": {9: {}}}
+        root = {"a": Range.greater_than(1) & Range.less_than(3)}
+        message = self._message(packages, root)
+        assert "because no versions of a (1, 2) | (2, 3) are available" in message
+
+    def test_states_nothing_when_narrowing_drops_no_version(self) -> None:
+        provider = _WideningProvider(_REJECTED_RUN)
+        with pytest.raises(ResolutionError) as exc_info:
+            Resolver(provider).resolve({"a": Range.at_least(2)})
+        incompatibility = exc_info.value.incompatibility
+        assert incompatibility is not None
+        assert format_error(
+            incompatibility, narrow=provider.narrow_for_display
+        ) == format_error(incompatibility)
+
+    def test_states_nothing_for_a_derivation_without_causes(self) -> None:
+        clause = Incompatibility(
+            [Term("a", Range.at_least(2), positive=True)],
+            cause=IncompatibilityCause.DERIVED,
+        )
+        message = format_error(
+            clause, narrow=lambda package, constraint: Range.singleton(3)
+        )
+        assert message == "so a 3"
+
+    def test_states_nothing_for_a_package_the_line_shows_negated(self) -> None:
+        cause = Incompatibility(
+            [Term("a", Range.singleton(2), positive=True)],
+            cause=IncompatibilityCause.NO_VERSIONS,
+        )
+        clause = Incompatibility(
+            [Term("a", Range.at_least(1), positive=False)],
+            cause=IncompatibilityCause.DERIVED,
+            cause_left=cause,
+            cause_right=cause,
+        )
+        message = format_error(clause, narrow=lambda package, constraint: constraint)
+        assert message == "because no versions of a 2 are available\nso not a [1, +inf)"


### PR DESCRIPTION
With `a` listing 1, 2 and 3, only 2 rejected, and `a>1,<3` required, the resolver printed:

```
because no versions of py [11, +inf) are available
because a 2 depends on py [11, +inf)
so a 2
because your project depends on a (1, 3)
so <root> 1
```

`so a 2` does not rule out the requirement below it, and nothing in the message says whether another version of `a` in (1, 3) would work, so the conclusion does not follow from what is printed.

A rejected version is recorded over the gap to its listed neighbors, so the clause really covers `a (1, 3)`, and `narrow_for_display` snaps it back onto the listing for the message. The gap it drops is the fact the step turns on, and it was printed nowhere. The renderer now states it, once per package, at the first line that needs it:

```
because no versions of py [11, +inf) are available
because a 2 depends on py [11, +inf)
so a 2
because your project depends on a (1, 3)
because no versions of a (1, 2) | (2, 3) are available
so <root> 1
```

The same snap was also shortening the availability line itself, so a line ruling out `[100.0, +inf)` could sit above a requirement of `[50, +inf)` without covering it. An availability line now renders the range it holds, and both read `[50, +inf)`.

Rendering stays per-version, so a run of rejections keeps naming the release and the Python floor it needs rather than a window between neighbors. A run of forty rejected versions grows the message by one line.

The gap line is a complement, so it can carry a term per interior gap and gets longer as the run does. Stating it as a bound instead would read better and is worth doing separately.

#448 edits the same lines of `report.py`, so whichever lands second needs a rebase.

