### PR TITLE
fix RecursionError on a cyclic sdist PKG-INFO symlink

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -583,6 +583,9 @@ def _extract_sdist_files(data: bytes) -> tuple[str | None, str | None]:
         KeyError,
         EOFError,
         zlib.error,
+        # tarfile resolves a link member by recursing on its target, so a
+        # cycle of links only ends at the recursion limit.
+        RecursionError,
     ):
         return (None, None)
 

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -1799,3 +1799,27 @@ class TestExtractSdistFiles:
             link.linkname = "pkg-1.0/absent"
             tar.addfile(link)
         assert _extract_sdist_files(buf.getvalue()) == (None, None)
+
+    @pytest.mark.parametrize(
+        "links",
+        [
+            [("pkg-1.0/PKG-INFO", "PKG-INFO")],
+            [("pkg-1.0/PKG-INFO", "other"), ("pkg-1.0/other", "PKG-INFO")],
+        ],
+        ids=["self", "two-member-cycle"],
+    )
+    def test_returns_none_when_pkg_info_symlinks_form_a_cycle(
+        self, links: list[tuple[str, str]]
+    ) -> None:
+        """A PKG-INFO symlink cycle never resolves, so it is treated as absent."""
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            directory = tarfile.TarInfo("pkg-1.0")
+            directory.type = tarfile.DIRTYPE
+            tar.addfile(directory)
+            for name, linkname in links:
+                link = tarfile.TarInfo(name)
+                link.type = tarfile.SYMTYPE
+                link.linkname = linkname
+                tar.addfile(link)
+        assert _extract_sdist_files(buf.getvalue()) == (None, None)


### PR DESCRIPTION
An sdist whose PKG-INFO is a symlink pointing at itself, or at another symlink that points back to it, crashes `nab lock` with a raw RecursionError traceback instead of being skipped.

`_extract_sdist_files` is documented to return `(None, None)` when the archive cannot be read, and it already catches the errors a malformed archive raises. tarfile resolves a link member by recursing on its target, so a cycle of links only ends at the recursion limit, and RecursionError is not a TarError, so it escapes that handler. Adding it to the tuple sends a cyclic link down the same unreadable path.
