### PR TITLE
stop re-downloading a declared archive source on every resolve

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -576,7 +576,10 @@ dependencies works at any `build-policy`; dynamic dependencies require
 
 The URL is read by its own scheme, whatever the configured indexes use:
 a `file://` archive is read from disk, and any other archive is fetched
-over HTTP.
+over HTTP.  The extracted tree is cached alongside the hashes it was
+verified against, so a later resolve that declares those same hashes
+reuses it and downloads nothing, `--offline` included.  Declaring a hash
+the cached tree was not checked against downloads the archive again.
 
 ## Universal mode
 

--- a/nab-python/src/nab_python/_provider/sources.py
+++ b/nab-python/src/nab_python/_provider/sources.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from ..provider import ArchiveSource, LocalSource, Provider, VcsSource
 
 _EXTRACTED_MARKER = ".nab-extracted"
+_HASHES_MARKER = ".nab-hashes"
 
 
 def index_local_sources(
@@ -282,12 +283,49 @@ def index_archive_sources(
 def _fetch_archive_bytes(
     provider: Provider,
     source: ArchiveSource,
-) -> tuple[Path, ArchiveRequest, str, bytes]:
-    """Return ``(cache_dir, request, digest, data)`` for a verified archive.
+    request: ArchiveRequest,
+) -> bytes:
+    """Return the hash-verified bytes of ``source``'s archive.
 
-    Raises before returning if the cache dir is missing, the download failed,
-    or the bytes fail their hash.  The coordinator reads the declared URL
-    without verifying it, so every declared hash is checked here.
+    Raises before returning if the fetch recorded a failure, produced no
+    bytes, or the bytes fail their hash.  The coordinator reads the declared
+    URL without verifying it, so every declared hash is checked here.
+    """
+    from ..provider import UnsupportedSdistError
+
+    canonical = canonicalize_name(source.name)
+    digest = request.hashes[0][1]
+    index = provider.coordinator.index
+
+    event = provider.coordinator.request_direct_archive(canonical, digest, request.url)
+    event.wait()
+
+    failure = index.get_sdist_archive_error(canonical, digest)
+    if failure is not None:
+        msg = f"archive source {source.name!r}: {failure}"
+        raise UnsupportedSdistError(msg) from failure
+
+    data = index.get_sdist_archive(canonical, digest)
+    if data is None:
+        msg = f"archive source {source.name!r}: download from {request.url} failed"
+        raise UnsupportedSdistError(msg)
+
+    for pinned_hash in request.hashes:
+        verify_sdist_hash(data, pinned_hash)
+
+    return data
+
+
+def _prepare_archive_tree(
+    provider: Provider,
+    source: ArchiveSource,
+) -> tuple[Path, ArchiveRequest]:
+    """Return the extracted tree's root and the parsed request for ``source``.
+
+    The cached tree is used with no download, offline runs included, only when
+    the record left at extraction covers every hash this resolve declares.
+    Otherwise the archive is downloaded and checked against the whole
+    declaration, so adding a hash re-verifies rather than trusting the tree.
     """
     from ..provider import UnsupportedSdistError
 
@@ -300,49 +338,63 @@ def _fetch_archive_bytes(
         raise UnsupportedSdistError(msg)
 
     request = ArchiveRequest.parse(source.url)
-    canonical = canonicalize_name(source.name)
 
-    # The version is unknown until the tree is extracted, so key the download
-    # by the first declared digest: unique and known up-front.  The fragment
+    # The version is unknown until the tree is extracted, so key the cache by
+    # the first declared digest: unique and known up-front.  The fragment
     # only carries accepted algorithms, so every pair is verifiable.
     digest = request.hashes[0][1]
+    target = cache_dir / digest
 
-    event = provider.coordinator.request_direct_archive(canonical, digest, request.url)
-    event.wait()
-    data = provider.coordinator.index.get_sdist_archive(canonical, digest)
-    if data is None:
-        msg = f"archive source {source.name!r}: download from {request.url} failed"
-        raise UnsupportedSdistError(msg)
+    declared = set(request.hashes)
+    if (target / _EXTRACTED_MARKER).is_file() and declared <= _verified_hashes(target):
+        return _extracted_root(target), request
 
-    for pinned_hash in request.hashes:
-        verify_sdist_hash(data, pinned_hash)
-    return cache_dir, request, digest, data
+    data = _fetch_archive_bytes(provider, source, request)
+    return _extract_archive(cache_dir, digest, data, request.hashes), request
 
 
-# Extraction (this function and _extract_archive) is excluded from coverage: it
-# requires the PEP 706 tar data filter (Python 3.10.12+), but GitHub Actions
-# setup-python installs 3.10.11 on macOS-arm64 and Windows (python.org stopped
-# shipping 3.10 installers after 3.10.11, and actions/python-versions builds
-# those OSes from installers), so no 3.10.12+ artifact exists for them.  The
-# extraction tests skip there, leaving these lines unhit on those two runners.
-# The download-and-verify guards live in _fetch_archive_bytes above so they stay
-# gated on every runner.  Remove the pragmas when that 3.10 cell is dropped,
-# sourced from python-build-standalone, or 3.10 reaches EOL (2026-10).
+def _verified_hashes(target: Path) -> set[tuple[str, str]]:
+    """Return the hashes the tree at ``target`` was verified against.
+
+    The record is written with the completion marker, so a tree with no record
+    covers nothing and is refetched rather than trusted.
+    """
+    record = target / _HASHES_MARKER
+    if not record.is_file():
+        return set()
+
+    lines = record.read_text(encoding="utf-8").splitlines()
+    return {
+        (algorithm, hex_digest)
+        for algorithm, _, hex_digest in (line.partition("=") for line in lines)
+    }
+
+
+# Extraction (this function and _extract_archive) is excluded from coverage: a
+# cold archive requires the PEP 706 tar data filter (Python 3.10.12+), but
+# GitHub Actions setup-python installs 3.10.11 on macOS-arm64 and Windows
+# (python.org stopped shipping 3.10 installers after 3.10.11, and
+# actions/python-versions builds those OSes from installers), so no 3.10.12+
+# artifact exists for them.  The extraction tests skip there, leaving these
+# lines unhit on those two runners.  The cache-hit test and the
+# download-and-verify guards live in _prepare_archive_tree and
+# _fetch_archive_bytes above so they stay gated on every runner.  Remove the
+# pragmas when that 3.10 cell is dropped, sourced from python-build-standalone,
+# or 3.10 reaches EOL (2026-10).
 def materialize_archive_source(
     provider: Provider,
     normalized: str,
     source: ArchiveSource,
 ) -> list[tuple[Version, SdistFile]]:  # pragma: no cover (tar data filter)
-    """Download and hash-verify ``source``, extract it, then materialise it.
+    """Materialise ``source`` from its extracted tree, downloading if needed.
 
-    A declared archive is always verified against its required hash in
-    :func:`_fetch_archive_bytes`, so a tampered archive fails the resolve
+    Every hash ``source`` declares is checked: against the downloaded bytes in
+    :func:`_fetch_archive_bytes`, or against the record the extraction left when
+    the cached tree is reused.  A tampered archive therefore fails the resolve
     loudly rather than being used and pinned unverified.  The extracted tree
     then takes the same path as a LocalSource.
     """
-    # Download, hash-verify, and extract the archive into the cache.
-    cache_dir, request, digest, data = _fetch_archive_bytes(provider, source)
-    root = _extract_archive(cache_dir, digest, data)
+    root, request = _prepare_archive_tree(provider, source)
 
     # Read the extracted tree's metadata as a local source and seed one candidate.
     path = root / request.subdirectory if request.subdirectory else root
@@ -358,15 +410,22 @@ def materialize_archive_source(
 
 
 def _extract_archive(
-    cache_dir: Path, digest: str, data: bytes
+    cache_dir: Path,
+    digest: str,
+    data: bytes,
+    verified: tuple[tuple[str, str], ...],
 ) -> Path:  # pragma: no cover (tar data filter; see materialize_archive_source)
     """Extract ``data`` under ``cache_dir`` keyed by ``digest``; return the root.
 
-    Idempotent, like :func:`prepare_clone`: a digest already extracted in a
-    prior resolve is reused rather than re-extracted, since the tree is
-    content-addressed by its verified hash.  A fresh extraction lands in a
-    temporary sibling and is renamed into place once its completion marker is
-    written, so the cache path never holds a partial tree.
+    ``verified`` names the hashes the caller checked ``data`` against, recorded
+    beside the completion marker so a later resolve reuses the tree only for a
+    declaration those hashes cover.
+
+    Idempotent, like :func:`prepare_clone`: a tree another run published
+    between the caller's cache check and this call is reused rather than
+    re-extracted.  A fresh extraction lands in a temporary sibling and is
+    renamed into place once its completion marker is written, so the cache
+    path never holds a partial tree.
     """
     from ..provider import UnsupportedSdistError
 
@@ -388,6 +447,11 @@ def _extract_archive(
             # resolved temp dir, since extract_sdist_archive resolves symlinks
             # and relative cache dirs.
             root_name = root.name if root != tmp.resolve() else ""
+
+            record = "\n".join(
+                f"{algorithm}={hex_digest}" for algorithm, hex_digest in verified
+            )
+            (tmp / _HASHES_MARKER).write_text(record, encoding="utf-8")
             (tmp / _EXTRACTED_MARKER).write_text(root_name, encoding="utf-8")
 
             try:
@@ -408,7 +472,15 @@ def _extract_archive(
             # interrupt included, would leak the temp tree.
             shutil.rmtree(tmp, ignore_errors=True)
 
-    root_name = marker.read_text(encoding="utf-8").strip()
+    return _extracted_root(target)
+
+
+def _extracted_root(target: Path) -> Path:
+    """Return the source root inside the extracted tree at ``target``.
+
+    An empty marker records a flat archive, whose root is the tree itself.
+    """
+    root_name = (target / _EXTRACTED_MARKER).read_text(encoding="utf-8").strip()
 
     # Resolve so the file URI works even for a relative cache dir.
     base = target / root_name if root_name else target

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -1210,6 +1210,10 @@ class FetchCoordinator:
         absent so the resolver works with what the cache holds.  Any other
         failure is recorded as an error, because a file the listing advertised
         and the index then failed to serve is not one that does not exist.
+
+        A declared archive is the exception: it is the package's only
+        candidate, so there is nothing to degrade to and an offline miss is
+        recorded as an error.
         """
         assert req.version is not None
         if req.kind is FetchKind.METADATA:
@@ -1231,7 +1235,7 @@ class FetchCoordinator:
                 self.index.store_sdist_metadata(req.package, req.version, None)
             else:
                 self.index.store_sdist_metadata_error(req.package, req.version, exc)
-        elif offline:
+        elif offline and req.kind is FetchKind.SDIST_ARCHIVE:
             self.index.store_sdist_archive(req.package, req.version, None)
         else:
             self.index.store_sdist_archive_error(req.package, req.version, exc)

--- a/nab-python/tests/test_archive.py
+++ b/nab-python/tests/test_archive.py
@@ -28,6 +28,7 @@ from nab_index.client import SdistHashMismatchError, extract_sdist_archive
 from nab_index.httpx_async_transport import HttpxAsyncTransport
 from nab_index.multi_index import IndexConfig
 from nab_index.subdir import subdirectory_escapes
+from nab_index.transport import HttpError
 from nab_python._provider import sources
 from nab_python._provider.sources import _fetch_archive_bytes
 from nab_python._vendor.packaging.utils import canonicalize_name
@@ -130,6 +131,26 @@ def _fetching_provider(
         archive_cache_dir=cache_dir,
         build_policy=BuildPolicy.NEVER,
     )
+
+
+def _fetch_bytes(provider: Provider, source: ArchiveSource) -> bytes:
+    """Fetch and verify ``source``'s archive the way materialisation does."""
+    return _fetch_archive_bytes(provider, source, ArchiveRequest.parse(source.url))
+
+
+def _warm_extracted_tree(cache: Path, digest: str, root: str) -> None:
+    """Write the extracted tree a prior resolve of ``digest`` leaves behind.
+
+    ``root`` is the archive's single root directory, or ``""`` for a flat
+    archive, as the completion marker records it.  The hash record names the
+    one sha256 that resolve verified.
+    """
+    target = cache / digest
+    source_dir = target / root if root else target
+    source_dir.mkdir(parents=True)
+    (source_dir / "pyproject.toml").write_text(_PYPROJECT, encoding="utf-8")
+    (target / ".nab-hashes").write_text(f"sha256={digest}", encoding="utf-8")
+    (target / ".nab-extracted").write_text(root, encoding="utf-8")
 
 
 def _lock_input(pins: Mapping[str, PinShape]) -> LockInput:
@@ -421,6 +442,31 @@ class TestArchiveMaterialize:
         assert sentinel.exists()
 
     @requires_data_filter
+    def test_every_verified_hash_is_recorded_for_reuse(self, tmp_path: Path) -> None:
+        # A warm resolve tests its declaration against the record, so the
+        # record has to name every hash the download was checked against.
+        data = _make_sdist("foo", "1.0.0", _PYPROJECT)
+        digest = hashlib.sha256(data).hexdigest()
+        sha512 = hashlib.sha512(data).hexdigest()
+        source = ArchiveSource(
+            name="foo",
+            url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}&sha512={sha512}",
+        )
+        cache = tmp_path / "arch"
+        first = _provider([source], cache)
+        first.coordinator.index.store_sdist_archive("foo", digest, data)
+        first.fetch_versions("foo")
+
+        record = (cache / digest / ".nab-hashes").read_text(encoding="utf-8")
+        assert record.splitlines() == [f"sha256={digest}", f"sha512={sha512}"]
+
+        second = _provider([source], cache)
+        versions = second.fetch_versions("foo")
+
+        assert str(versions[0][0]) == "1.0.0"
+        second.coordinator.request_direct_archive.assert_not_called()
+
+    @requires_data_filter
     def test_partial_tree_never_visible_at_cache_path(
         self,
         tmp_path: Path,
@@ -510,7 +556,7 @@ class TestArchiveMaterialize:
         monkeypatch.setattr(sources, "extract_sdist_archive", interrupted_extract)
 
         with pytest.raises(KeyboardInterrupt):
-            sources._extract_archive(cache, digest, data)
+            sources._extract_archive(cache, digest, data, (("sha256", digest),))
 
         assert list(cache.iterdir()) == []
 
@@ -555,6 +601,108 @@ class TestArchiveMaterialize:
         assert str(versions[0][0]) == "1.0.0"
 
 
+class TestWarmArchiveCache:
+    """A digest already extracted is served from the cache, with no download."""
+
+    def test_warm_tree_is_served_without_a_fetch(self, tmp_path: Path) -> None:
+        digest = "b" * 64
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
+        )
+        cache = tmp_path / "arch"
+        _warm_extracted_tree(cache, digest, "foo-1.0.0")
+        provider = _provider([source], cache)
+
+        versions = provider.fetch_versions("foo")
+
+        assert str(versions[0][0]) == "1.0.0"
+        provider.coordinator.request_direct_archive.assert_not_called()
+
+    def test_warm_flat_tree_is_served_without_a_fetch(self, tmp_path: Path) -> None:
+        # An empty marker records a flat archive, whose root is the tree itself.
+        digest = "c" * 64
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
+        )
+        cache = tmp_path / "arch"
+        _warm_extracted_tree(cache, digest, "")
+        provider = _provider([source], cache)
+
+        versions = provider.fetch_versions("foo")
+
+        assert str(versions[0][0]) == "1.0.0"
+        provider.coordinator.request_direct_archive.assert_not_called()
+
+    def test_partial_tree_without_marker_is_not_served(self, tmp_path: Path) -> None:
+        # Without the completion marker the tree is a crashed run's leftover,
+        # so the archive is fetched rather than read out of a half-written tree.
+        digest = "d" * 64
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
+        )
+        cache = tmp_path / "arch"
+        partial = cache / digest / "foo-1.0.0"
+        partial.mkdir(parents=True)
+        (partial / "pyproject.toml").write_text(_PYPROJECT, encoding="utf-8")
+        provider = _provider([source], cache)
+
+        with pytest.raises(UnsupportedSdistError, match="download.*failed"):
+            provider.fetch_versions("foo")
+
+    def test_added_hash_is_checked_against_the_bytes(self, tmp_path: Path) -> None:
+        # The tree records only the sha256 it is keyed on, so adding a hash
+        # refetches and checks the bytes against it.
+        data = _make_sdist("foo", "1.0.0", _PYPROJECT)
+        digest = hashlib.sha256(data).hexdigest()
+        source = ArchiveSource(
+            name="foo",
+            url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}&sha512={'f' * 128}",
+        )
+        cache = tmp_path / "arch"
+        _warm_extracted_tree(cache, digest, "foo-1.0.0")
+        provider = _provider([source], cache)
+        provider.coordinator.index.store_sdist_archive("foo", digest, data)
+
+        with pytest.raises(SdistHashMismatchError):
+            provider.fetch_versions("foo")
+
+    def test_tree_without_hash_record_is_not_served(self, tmp_path: Path) -> None:
+        # A tree extracted before the record was written says nothing about
+        # which hashes were checked, so it is refetched rather than trusted.
+        digest = "e" * 64
+        source = ArchiveSource(
+            name="foo", url=f"https://ex.com/foo-1.0.0.tar.gz#sha256={digest}"
+        )
+        cache = tmp_path / "arch"
+        _warm_extracted_tree(cache, digest, "foo-1.0.0")
+        (cache / digest / ".nab-hashes").unlink()
+        provider = _provider([source], cache)
+
+        with pytest.raises(UnsupportedSdistError, match="download.*failed"):
+            provider.fetch_versions("foo")
+
+    @respx.mock
+    def test_offline_resolve_reads_the_warm_tree(self, tmp_path: Path) -> None:
+        # --offline never reaches the network, so the tree an earlier resolve
+        # extracted is all there is to resolve from.
+        data = _make_sdist("foo", "1.0.0", _PYPROJECT)
+        digest = hashlib.sha256(data).hexdigest()
+        url = "https://ex.invalid/foo-1.0.0.tar.gz"
+        route = respx.get(url).mock(return_value=httpx.Response(200, content=data))
+        source = ArchiveSource(name="foo", url=f"{url}#sha256={digest}")
+        cache = tmp_path / "arch"
+        _warm_extracted_tree(cache, digest, "foo-1.0.0")
+
+        with FetchCoordinator(
+            transport=HttpxAsyncTransport(), offline=True
+        ) as coordinator:
+            provider = _fetching_provider(coordinator, source, cache)
+            versions = provider.fetch_versions("foo")
+
+        assert str(versions[0][0]) == "1.0.0"
+        assert not route.called
+
+
 class TestArchiveFetch:
     """An archive URL is read by its own scheme, whatever the index speaks."""
 
@@ -569,9 +717,8 @@ class TestArchiveFetch:
 
         with FetchCoordinator(transport=HttpxAsyncTransport()) as coordinator:
             provider = _fetching_provider(coordinator, source, tmp_path / "arch")
-            _, _, key, fetched = _fetch_archive_bytes(provider, source)
+            fetched = _fetch_bytes(provider, source)
 
-        assert key == digest
         assert fetched == data
 
     @respx.mock
@@ -591,12 +738,16 @@ class TestArchiveFetch:
             indexes=[IndexConfig("local", wheelhouse.as_uri())],
         ) as coordinator:
             provider = _fetching_provider(coordinator, source, tmp_path / "arch")
-            _, _, _, fetched = _fetch_archive_bytes(provider, source)
+            fetched = _fetch_bytes(provider, source)
 
         assert fetched == data
 
     @respx.mock
-    def test_offline_https_archive_is_not_fetched(self, tmp_path: Path) -> None:
+    def test_offline_cold_archive_reports_offline_not_download_failure(
+        self, tmp_path: Path
+    ) -> None:
+        # Nothing was downloaded, so "download failed" would name the wrong
+        # cause: the run was told not to reach the network.
         data = _make_sdist("foo", "1.0.0", _PYPROJECT)
         digest = hashlib.sha256(data).hexdigest()
         url = "https://ex.invalid/foo-1.0.0.tar.gz"
@@ -607,10 +758,24 @@ class TestArchiveFetch:
             transport=HttpxAsyncTransport(), offline=True
         ) as coordinator:
             provider = _fetching_provider(coordinator, source, tmp_path / "arch")
-            with pytest.raises(UnsupportedSdistError, match="download.*failed"):
-                _fetch_archive_bytes(provider, source)
+            with pytest.raises(UnsupportedSdistError, match="offline mode") as excinfo:
+                _fetch_bytes(provider, source)
 
+        assert url in str(excinfo.value)
         assert not route.called
+
+    @respx.mock
+    def test_http_error_is_reported_with_its_status(self, tmp_path: Path) -> None:
+        url = "https://ex.invalid/foo-1.0.0.tar.gz"
+        respx.get(url).mock(return_value=httpx.Response(404))
+        source = ArchiveSource(name="foo", url=f"{url}#sha256={'a' * 64}")
+
+        with FetchCoordinator(transport=HttpxAsyncTransport()) as coordinator:
+            provider = _fetching_provider(coordinator, source, tmp_path / "arch")
+            with pytest.raises(UnsupportedSdistError, match="404") as excinfo:
+                _fetch_bytes(provider, source)
+
+        assert isinstance(excinfo.value.__cause__, HttpError)
 
     def test_missing_file_archive_fails_the_resolve(self, tmp_path: Path) -> None:
         absent = tmp_path / "absent-1.0.0.tar.gz"
@@ -618,8 +783,8 @@ class TestArchiveFetch:
 
         with FetchCoordinator(transport=HttpxAsyncTransport()) as coordinator:
             provider = _fetching_provider(coordinator, source, tmp_path / "arch")
-            with pytest.raises(UnsupportedSdistError, match="download.*failed"):
-                _fetch_archive_bytes(provider, source)
+            with pytest.raises(UnsupportedSdistError, match="absent-1.0.0"):
+                _fetch_bytes(provider, source)
 
 
 class TestArchiveDownload:

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -19,7 +19,7 @@ import httpx
 import pytest
 import respx
 
-from nab_index.cache import NullCache
+from nab_index.cache import NullCache, OfflineError
 from nab_index.cached_client import CachedAsyncSimpleClient
 from nab_index.client import (
     MalformedSimpleResponseError,
@@ -1479,6 +1479,22 @@ class TestFetchCoordinator:
 
             assert event is pending.event
             assert coord.index.get_sdist_archive("pkg", "digest") is None
+
+    def test_offline_direct_archive_records_the_offline_error(self) -> None:
+        """An offline miss on a declared archive is recorded as an error.
+
+        An index artifact recorded absent lets the resolver skip that version;
+        a declared archive is the package's only candidate, so there is no
+        version to skip to.
+        """
+        with _coord(offline=True) as coord:
+            event = coord.request_direct_archive(
+                "pkg", "digest", "https://files.example.com/pkg-1.0.tar.gz"
+            )
+            event.wait(timeout=5)
+            assert coord.index.get_sdist_archive("pkg", "digest") is None
+            error = coord.index.get_sdist_archive_error("pkg", "digest")
+            assert isinstance(error, OfflineError)
 
     def test_file_index_still_closes_the_transport(self, tmp_path: Path) -> None:
         """A file:// index client owns no transport; a direct archive fetch may."""


### PR DESCRIPTION
A `[[tool.nab.archive-sources]]` entry was downloaded and extracted again on every resolve, even when the same digest was already extracted in the archive cache. Extraction recorded only that it had finished, not which hashes the bytes were verified against, so a later declaration had nothing to check and the archive was refetched every time. Under `nab lock --offline` that failed the resolve outright, reported as `download ... failed` even though nothing had been downloaded.

Extraction now writes the verified hashes next to the completion marker. A resolve whose declared hashes are all covered by that record reads the tree from the cache without fetching, including under `--offline`. Declaring a hash the tree was not checked against downloads the archive again and verifies it against the whole declaration. An offline miss on a declared archive is now recorded as the offline error rather than as an absent artifact.
