### PR TITLE
Stop conflict resolution stalling on an unconstrained requirement

### DIFF
--- a/nab-python/tests/test_resolver_packaging.py
+++ b/nab-python/tests/test_resolver_packaging.py
@@ -420,6 +420,76 @@ class TestConflictDetection:
             )
 
 
+class TestArbitraryAdmittingRootRange:
+    """A bare root requirement supplies the top that admits ``===`` strings.
+
+    A subtraction that removes versions drops the admission, so recording it
+    in a term would stall conflict resolution.
+    """
+
+    def test_bare_root_requirement_reports_the_conflict(self) -> None:
+        """``a`` needs a ``b`` that has no versions; say so."""
+        provider = PackagingProvider(
+            {
+                "a": {
+                    V("3.0"): {"b": SpecifierSet(">=1")},
+                    V("2.0"): {"b": SpecifierSet(">=1")},
+                    V("1.0"): {"b": SpecifierSet(">=1")},
+                },
+            },
+        )
+        with pytest.raises(ResolutionError) as exc_info:
+            Resolver(provider, range_type=VersionRange, root_version="0").resolve(
+                {"a": SpecifierSet("").to_range()}
+            )
+        message = str(exc_info.value)
+        assert "no versions of b" in message
+        assert "your project depends on a" in message
+        assert "resolver bug" not in message
+
+
+class _ArbitraryAdmittingProvider(PackagingProvider):
+    """A provider whose bare dependency edges keep the ``===`` admission.
+
+    :class:`PackagingProvider` opts out of it; a provider written against
+    :class:`~nab_resolver.types.RangeProtocol` alone need not.
+    """
+
+    def get_dependencies(
+        self, package: str, version: Version
+    ) -> dict[str, VersionRange]:
+        """Convert bare specifiers to the arbitrary-admitting full range."""
+        raw = self._packages.get(package, {}).get(version, {})
+        return {
+            dep: (spec.to_range() if spec else VersionRange.full())
+            for dep, spec in raw.items()
+        }
+
+
+class TestArbitraryAdmittingDependencyRange:
+    """A provider may hand back the admitting top on a bare dependency edge.
+
+    Here a stall would cost a solution rather than an explanation:
+    backtracking off ``a==3.0`` is what reaches the version that resolves.
+    """
+
+    def test_bare_dependency_edge_resolves(self) -> None:
+        """``a==3.0`` is unusable, so ``a==2.0`` is the answer."""
+        provider = _ArbitraryAdmittingProvider(
+            {
+                "a": {
+                    V("3.0"): {"c": SpecifierSet("")},
+                    V("2.0"): {},
+                },
+                "c": {V("1.0"): {"a": SpecifierSet(">=9.0")}},
+            },
+        )
+        result = Resolver(provider, range_type=VersionRange, root_version="0").resolve(
+            {"a": VersionRange.full(admit_arbitrary=False)}
+        )
+        assert result == {"a": V("2.0")}
+
+
 class TestMultiLevelConflict:
     """Verify the resolver handles conflicts requiring deep backtracking."""
 

--- a/nab-resolver/src/nab_resolver/decide.py
+++ b/nab-resolver/src/nab_resolver/decide.py
@@ -88,6 +88,22 @@ def choose_version(resolver: Resolver[Any, Any], package: Any) -> Any | None:
     return resolver.provider.choose_version(package, current_range)
 
 
+def _normalize_terms(
+    resolver: Resolver[Any, Any], incompatibility: Incompatibility[Any, Any]
+) -> None:
+    """Replace, in place, any term whose constraint is not a legal term range.
+
+    A provider builds a pending clause's terms itself, so they reach the
+    formula without the substitution a supplied range gets on the way in.
+    """
+    for index, term in enumerate(incompatibility.terms):
+        constraint = resolver.as_term_range(term.constraint)
+        if constraint is not term.constraint:
+            incompatibility.terms[index] = Term(
+                term.package, constraint, positive=term.is_positive()
+            )
+
+
 def absorb_pending_clauses(resolver: Resolver[Any, Any]) -> bool:
     """Drain provider-queued incompatibilities into the formula.
 
@@ -98,6 +114,7 @@ def absorb_pending_clauses(resolver: Resolver[Any, Any]) -> bool:
     """
     clauses = list(resolver.provider.consume_pending_clauses())
     for incompatibility in clauses:
+        _normalize_terms(resolver, incompatibility)
         add_incompatibility(resolver, incompatibility)
     return bool(clauses)
 
@@ -156,7 +173,7 @@ def record_no_versions(
     if had_pending:
         return
 
-    current_range = resolver.solution.get(package) or resolver.range_type.full()
+    current_range = resolver.solution.get(package) or resolver.term_top
     resolver.observer.on_no_versions(package, current_range)
 
     constraint = resolver.constraints.get(package)

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -449,6 +449,12 @@ class Resolver(Generic[PackageType, VersionType]):
         self.root_version = root_version
         self.format_range = format_range
 
+        # The widest value the type expresses is the identity a caller folds
+        # with, but a term needs a top its own difference agrees with, since
+        # conflict resolution relies on ``x.is_subset((x - y) | y)``.
+        self.fold_identity: RangeProtocol[Any] = range_type.full()
+        self.term_top: RangeProtocol[Any] = ~range_type.empty()
+
         self.incompatibilities: list[Incompatibility[Any, Any]] = []
         self.package_to_incompatibilities: defaultdict[Any, list[int]] = defaultdict(
             list
@@ -481,6 +487,16 @@ class Resolver(Generic[PackageType, VersionType]):
             tuple[bool, RangeProtocol[Any], RangeProtocol[Any]], SetRelation
         ] = {}
 
+    def as_term_range(self, range_: RangeProtocol[Any]) -> RangeProtocol[VersionType]:
+        """Return the term constraint to record for a supplied range.
+
+        Only a range equal to ``full()`` is substituted.  A range that breaks
+        the identity :class:`~nab_resolver.types.RangeProtocol` documents
+        without equalling ``full()``, such as ``full()`` minus an ``===``
+        literal, passes through and reaches conflict resolution's step budget.
+        """
+        return self.term_top if range_ == self.fold_identity else range_
+
     def resolve(
         self,
         requirements: Mapping[PackageType, RangeProtocol[VersionType]]
@@ -511,6 +527,10 @@ class Resolver(Generic[PackageType, VersionType]):
         it to be installed.  They are injected lazily: only when the
         resolver is about to decide a constrained package (meaning
         something already depends on it).
+
+        A supplied range equal to ``range_type.full()`` is recorded as
+        ``~range_type.empty()``, which may be strictly narrower; see
+        :class:`~nab_resolver.types.RangeProtocol`.
 
         Raises ``ResolutionError`` if no solution exists.
         """
@@ -606,8 +626,9 @@ class Resolver(Generic[PackageType, VersionType]):
             return next_package
         exact_range = self.range_type.singleton(chosen_version)
         widened = self.provider.widen_decision(next_package, chosen_version)
-        parent_range = exact_range if widened is None else widened
-        for dependency_package, dependency_range in dependencies.items():
+        parent_range = exact_range if widened is None else self.as_term_range(widened)
+        for dependency_package, supplied_range in dependencies.items():
+            dependency_range = self.as_term_range(supplied_range)
             cross_package = dependency_package != next_package
             if not cross_package:
                 # An incompatibility holds at most one term per package,
@@ -676,13 +697,14 @@ class Resolver(Generic[PackageType, VersionType]):
     ) -> None:
         """Create one root incompatibility per requirement, and decide root."""
         for idx, root in enumerate(requirements):
+            term_range = self.as_term_range(root.constraint)
             root_term: Term[Any, Any] = Term(
                 ROOT, self.range_type.singleton(self.root_version), positive=True
             )
             incompat_index.add_incompatibility(
                 self,
                 Incompatibility(
-                    [root_term, Term(root.package, root.constraint, positive=False)],
+                    [root_term, Term(root.package, term_range, positive=False)],
                     cause=IncompatibilityCause.ROOT,
                     origin=root.origin,
                 ),

--- a/nab-resolver/src/nab_resolver/types.py
+++ b/nab-resolver/src/nab_resolver/types.py
@@ -46,9 +46,23 @@ VersionType_contra = TypeVar("VersionType_contra", contravariant=True)
 class RangeProtocol(Protocol[VersionType_contra]):
     """Contract for version range types used by the resolver.
 
-    Both :class:`nab_resolver.ranges.Range` and
-    :class:`packaging.ranges.VersionRange` satisfy this protocol.  Mixing
-    range types within a single resolution is unsupported.
+    Beyond the signatures, conflict resolution only terminates while
+    ``x.is_subset((x - y) | y)`` holds for every term constraint ``x`` and
+    every ``y``; otherwise a clause resolves into itself and the loop spins.
+    :class:`nab_resolver.ranges.Range` holds it everywhere.  A type whose
+    widest value carries membership that ``-`` drops does not:
+    ``packaging.ranges.VersionRange.full()`` admits arbitrary ``===`` strings
+    and loses them to any ``y`` that removes versions.  The resolver therefore
+    records ``~empty()`` in place of any supplied range equal to :meth:`full`,
+    which may be strictly narrower.
+
+    That substitution covers the value equal to :meth:`full` and nothing else.
+    A range that keeps membership ``-`` drops without equalling it, such as
+    :meth:`full` minus an ``===`` literal, is the caller's to keep out of a
+    term; conflict resolution's step budget reports one as an internal error
+    rather than spinning on it.
+
+    Mixing range types within a single resolution is unsupported.
     """
 
     @classmethod
@@ -58,7 +72,11 @@ class RangeProtocol(Protocol[VersionType_contra]):
 
     @classmethod
     def full(cls) -> Self:
-        """Create a range containing all versions."""
+        """Create the widest range the type can express.
+
+        This is the identity for intersection folds, and may be wider than a
+        legal term constraint.
+        """
         ...
 
     @classmethod

--- a/nab-resolver/tests/test_range_contract.py
+++ b/nab-resolver/tests/test_range_contract.py
@@ -1,0 +1,381 @@
+"""The range-algebra contract conflict resolution depends on.
+
+Resolving a clause against its cause only shrinks the clause while
+``x.is_subset((x - y) | y)`` holds for the range type.  ``full()`` is where a
+range type breaks it: ``packaging.ranges.VersionRange.full()`` also admits
+arbitrary ``===`` strings and loses them to any ``y`` that removes versions,
+so the clause resolves into itself and the loop spins.
+
+``nab_resolver.ranges.Range`` carries no such flag, so these tests use the
+stub below.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar
+
+import pytest
+
+from nab_resolver.errors import ResolutionError
+from nab_resolver.ranges import Range
+from nab_resolver.resolver import Resolver
+from nab_resolver.types import (
+    Incompatibility,
+    IncompatibilityCause,
+    RangeRelation,
+    Term,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from nab_resolver.types import RangeProtocol
+
+
+class FlaggedRange:
+    """``Range[int]`` plus VersionRange's arbitrary-string admission flag.
+
+    ``full()`` sets the flag, ``empty()`` clears it, and the four operations
+    below carry it by VersionRange's rules.  As there, the flag admits strings
+    only at full bounds, so a full-bounded flagged range is a strict superset
+    of its unflagged twin and ``is_subset`` gates on that.  ``===`` literals
+    and pre-release regions are left out; the identity above turns on neither.
+    """
+
+    __slots__ = ("arbitrary", "base")
+
+    def __init__(self, base: Range[int], *, arbitrary: bool = False) -> None:
+        self.base = base
+        self.arbitrary = arbitrary
+
+    @classmethod
+    def empty(cls) -> FlaggedRange:
+        return cls(Range.empty())
+
+    @classmethod
+    def full(cls) -> FlaggedRange:
+        return cls(Range.full(), arbitrary=True)
+
+    @classmethod
+    def singleton(cls, version: int) -> FlaggedRange:
+        return cls(Range.singleton(version))
+
+    @property
+    def is_empty(self) -> bool:
+        return self.base.is_empty
+
+    def arbitrary_active(self) -> bool:
+        """Whether the flag actually admits strings, as VersionRange gates it."""
+        return self.arbitrary and self.base == Range.full()
+
+    def __contains__(self, version: int) -> bool:
+        """Test membership; the flag admits no integer."""
+        return version in self.base
+
+    def __and__(self, other: Any) -> FlaggedRange:
+        """Intersect; the flag needs both sides and a result with versions."""
+        new_base = self.base & other.base
+        return FlaggedRange(
+            new_base,
+            arbitrary=self.arbitrary and other.arbitrary and not new_base.is_empty,
+        )
+
+    def __or__(self, other: Any) -> FlaggedRange:
+        """Union; only an operand that has versions passes the flag on.
+
+        An empty operand carries the flag inertly, so ``~~full()`` is
+        ``full()`` again while re-widening bounds does not revive the
+        admission.
+        """
+        new_base = self.base | other.base
+        if new_base.is_empty:
+            arbitrary = self.arbitrary or other.arbitrary
+        else:
+            arbitrary = (self.arbitrary and not self.base.is_empty) or (
+                other.arbitrary and not other.base.is_empty
+            )
+        return FlaggedRange(new_base, arbitrary=arbitrary)
+
+    def __invert__(self) -> FlaggedRange:
+        """Complement, carrying the flag through."""
+        return FlaggedRange(~self.base, arbitrary=self.arbitrary)
+
+    def __sub__(self, other: Any) -> FlaggedRange:
+        """Difference, dropping the flag unless nothing was removed."""
+        new_base = self.base - other.base
+        return FlaggedRange(
+            new_base, arbitrary=self.arbitrary and new_base == self.base
+        )
+
+    def is_subset(self, other: FlaggedRange) -> bool:
+        """Subset on versions; a live admission needs another live one."""
+        if self.arbitrary_active() and not other.arbitrary_active():
+            return False
+        return self.base.is_subset(other.base)
+
+    def is_superset(self, other: FlaggedRange) -> bool:
+        return other.is_subset(self)
+
+    def is_disjoint(self, other: FlaggedRange) -> bool:
+        """Disjoint when the intersection holds no version and no admission."""
+        combined = self & other
+        return combined.base.is_empty and not combined.arbitrary_active()
+
+    def relation(self, other: FlaggedRange) -> RangeRelation:
+        """Classify against ``other``, so the flag reaches term classification."""
+        subset = self.is_subset(other)
+        disjoint = self.is_disjoint(other)
+        if subset:
+            return RangeRelation.EMPTY if disjoint else RangeRelation.SUBSET
+        return RangeRelation.DISJOINT if disjoint else RangeRelation.OVERLAPPING
+
+    def __eq__(self, other: object) -> bool:
+        """Equal when the interval sets and the flags both match."""
+        return (
+            isinstance(other, FlaggedRange)
+            and self.base == other.base
+            and self.arbitrary == other.arbitrary
+        )
+
+    def __hash__(self) -> int:
+        """Hash the interval set together with the flag."""
+        return hash((self.base, self.arbitrary))
+
+    def __repr__(self) -> str:
+        """Render the interval set, naming the flag when it is set."""
+        suffix = ", arbitrary" if self.arbitrary else ""
+        return f"FlaggedRange({self.base!r}{suffix})"
+
+
+DEPENDENCY = FlaggedRange(Range.singleton(9))
+GRAPH: dict[str, list[int]] = {"a": [3, 2, 1], "b": []}
+
+
+class FlaggedProvider:
+    """``a`` has three versions, each needing a ``b`` that does not exist."""
+
+    graph: ClassVar[dict[str, list[int]]] = GRAPH
+
+    def __init__(self, dependency: FlaggedRange = DEPENDENCY) -> None:
+        self.dependency = dependency
+
+    def choose_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> int | None:
+        for version in self.graph.get(package, []):
+            if version in version_range:
+                return version
+        return None
+
+    def has_satisfying_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> bool:
+        return any(v in version_range for v in self.graph.get(package, []))
+
+    def get_dependencies(self, package: str, version: int) -> dict[str, FlaggedRange]:
+        return {"b": self.dependency} if package == "a" else {}
+
+    def begin_decision_scan(self) -> None:
+        """No-op: nothing in this stub moves under a scan."""
+
+    def prioritize(
+        self,
+        package: str,
+        version_range: RangeProtocol[int],
+        conflict_counts: Mapping[str, int],
+        culprit_counts: Mapping[str, int] | None = None,
+    ) -> object:
+        return sum(1 for v in self.graph.get(package, []) if v in version_range)
+
+    def is_ready(self, package: str) -> bool:
+        """Everything is decidable immediately."""
+        return True
+
+    def receive_partial_solution_hint(
+        self,
+        positive_ranges: Mapping[str, RangeProtocol[int]],
+        decisions: Mapping[str, int],
+    ) -> None:
+        """No-op: this provider does not use partial solution state."""
+
+    def consume_pending_clauses(self) -> list[Incompatibility[str, int]]:
+        """No queued clauses."""
+        return []
+
+    def consume_force_backtrack_targets(self) -> list[str]:
+        """No force-backtrack signal."""
+        return []
+
+    def widen_decision(self, package: str, version: int) -> FlaggedRange | None:
+        """No widening."""
+        return None
+
+    def narrow_for_display(
+        self, package: str, constraint: RangeProtocol[int]
+    ) -> RangeProtocol[int]:
+        """Identity: constraints render as stored."""
+        return constraint
+
+
+class WideningProvider(FlaggedProvider):
+    """A provider that widens every decision to the admitting top."""
+
+    def widen_decision(self, package: str, version: int) -> FlaggedRange:
+        """Widen the decision to ``full()``, whatever was chosen."""
+        return FlaggedRange.full()
+
+
+class PendingClauseProvider(FlaggedProvider):
+    """A provider that queues ``a==3``'s edge as a clause it built itself.
+
+    Those terms reach the formula through ``consume_pending_clauses`` rather
+    than as ranges the resolver turns into terms.  ``c`` rules ``a==3`` out,
+    so the queued term has to shrink for ``a==2`` to be reached.
+    """
+
+    graph: ClassVar[dict[str, list[int]]] = {"a": [3, 2], "c": [1]}
+
+    def __init__(self, dependency: FlaggedRange) -> None:
+        """Queue ``a==3``'s edge on ``c`` as ``dependency``."""
+        super().__init__(dependency)
+        self.queued: list[Incompatibility[str, int]] = []
+
+    def choose_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> int | None:
+        """Pick as the base provider does, queueing ``a==3``'s edge on the way."""
+        chosen = super().choose_version(package, version_range)
+        if package == "a" and chosen == 3:
+            self.queued.append(
+                Incompatibility(
+                    [
+                        Term("a", FlaggedRange.singleton(chosen), positive=True),
+                        Term("c", self.dependency, positive=False),
+                    ],
+                    cause=IncompatibilityCause.DEPENDENCY,
+                )
+            )
+        return chosen
+
+    def get_dependencies(self, package: str, version: int) -> dict[str, FlaggedRange]:
+        """``c`` needs an ``a`` that does not exist; ``a``'s own edge is queued."""
+        return {"a": DEPENDENCY} if package == "c" else {}
+
+    def consume_pending_clauses(self) -> list[Incompatibility[str, int]]:
+        """Hand over whatever choosing a version queued."""
+        queued, self.queued = self.queued, []
+        return queued
+
+
+STALL_TIMEOUT_SECONDS = 60
+
+
+def build_resolver(provider: FlaggedProvider) -> Resolver[str, int]:
+    """Build a resolver over the provider's graph."""
+    return Resolver(
+        provider,
+        range_type=FlaggedRange,
+        root_version=0,
+        max_iterations=5000,
+    )
+
+
+def constraints_for(
+    resolver: Resolver[str, int],
+    package: str,
+    cause: IncompatibilityCause,
+    *,
+    positive: bool,
+) -> list[RangeProtocol[int]]:
+    """Collect the constraints ``package`` carries in clauses of ``cause``.
+
+    ``positive`` picks the side of the clause: a dependency edge holds the
+    depending package positively and the depended-on package negatively.
+    """
+    return [
+        term.constraint
+        for incompatibility in resolver.incompatibilities
+        if incompatibility.cause is cause
+        for term in incompatibility.terms
+        if term.package == package and term.is_positive() is positive
+    ]
+
+
+class TestFlaggedRangeFidelity:
+    """The stub carries the flag the way the range type it stands in for does."""
+
+    def test_flagged_top_breaks_the_subset_identity(self) -> None:
+        """``full()`` fails the identity; the term top holds it."""
+        flagged = FlaggedRange.full()
+        plain = ~FlaggedRange.empty()
+        assert not flagged.is_subset((flagged - DEPENDENCY) | DEPENDENCY)
+        assert plain.is_subset((plain - DEPENDENCY) | DEPENDENCY)
+        assert plain.is_subset(flagged)
+        assert not flagged.is_subset(plain)
+
+    def test_flag_survives_only_where_versionrange_keeps_it(self) -> None:
+        """A union cannot revive the admission, and an empty result drops it."""
+        flagged = FlaggedRange.full()
+        plain = ~FlaggedRange.empty()
+        assert not (~flagged | plain).arbitrary_active()
+        assert flagged & ~flagged == FlaggedRange.empty()
+
+
+class TestTermTopSubstitution:
+    """A supplied range equal to ``full()`` becomes the term top instead."""
+
+    @pytest.mark.timeout(STALL_TIMEOUT_SECONDS)
+    def test_root_range_equal_to_full_still_explains_the_conflict(self) -> None:
+        """A root seeded with ``full()`` reports why, rather than stalling."""
+        resolver = build_resolver(FlaggedProvider())
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"a": FlaggedRange.full()})
+        message = str(excinfo.value)
+        assert "no versions of b" in message
+        assert "your project depends on a" in message
+        assert "resolver bug" not in message
+
+    @pytest.mark.timeout(STALL_TIMEOUT_SECONDS)
+    def test_root_clause_records_the_term_top(self) -> None:
+        """The recorded root clause carries the term top, not ``full()``."""
+        resolver = build_resolver(FlaggedProvider())
+        with pytest.raises(ResolutionError):
+            resolver.resolve({"a": FlaggedRange.full()})
+        assert constraints_for(
+            resolver, "a", IncompatibilityCause.ROOT, positive=False
+        ) == [resolver.term_top]
+
+    @pytest.mark.timeout(STALL_TIMEOUT_SECONDS)
+    def test_dependency_clause_records_the_term_top(self) -> None:
+        """A provider handing back ``full()`` gets the same substitution."""
+        resolver = build_resolver(FlaggedProvider(FlaggedRange.full()))
+        with pytest.raises(ResolutionError):
+            resolver.resolve({"a": ~FlaggedRange.empty()})
+        recorded = constraints_for(
+            resolver, "b", IncompatibilityCause.DEPENDENCY, positive=False
+        )
+        assert recorded
+        assert all(constraint == resolver.term_top for constraint in recorded)
+
+    @pytest.mark.timeout(STALL_TIMEOUT_SECONDS)
+    def test_widened_decision_records_the_term_top(self) -> None:
+        """A decision widened to ``full()`` is substituted in the parent term."""
+        resolver = build_resolver(WideningProvider())
+        with pytest.raises(ResolutionError):
+            resolver.resolve({"a": ~FlaggedRange.empty()})
+        recorded = constraints_for(
+            resolver, "a", IncompatibilityCause.DEPENDENCY, positive=True
+        )
+        assert recorded
+        assert all(constraint == resolver.term_top for constraint in recorded)
+
+    @pytest.mark.timeout(STALL_TIMEOUT_SECONDS)
+    def test_pending_clause_records_the_term_top(self) -> None:
+        """A term the provider built itself is substituted as it is absorbed."""
+        resolver = build_resolver(PendingClauseProvider(FlaggedRange.full()))
+        assert resolver.resolve({"a": ~FlaggedRange.empty()}) == {"a": 2}
+        recorded = constraints_for(
+            resolver, "c", IncompatibilityCause.DEPENDENCY, positive=False
+        )
+        assert recorded
+        assert all(constraint == resolver.term_top for constraint in recorded)


### PR DESCRIPTION
A resolve can spin until its step budget runs out, then raise an internal error telling the caller they have found a resolver bug.

`nab_resolver` recorded a term's top as `range_type.full()`. For `VersionRange` that top also admits arbitrary `===` strings, and a subtraction that removes versions drops the admission, so `x.is_subset((x - y) | y)` is false for it against any such `y`. Conflict resolution depends on that identity: without it, resolving a clause against its cause hands back the same clause and the loop makes no progress.

Terms now record `~range_type.empty()`, at each point where a supplied range becomes one:

- root requirements
- dependency edges
- widened decisions
- clauses a provider queues through `consume_pending_clauses`

For `VersionRange` that is strictly narrower than the `full()` a caller passed in. `full()` keeps its other job as the identity for intersection folds, and `RangeProtocol` now says what the solver needs from a range type. The substitution covers a range equal to `full()` and nothing else: one that keeps membership `-` drops without equalling it, such as `full()` minus an `===` literal, still reaches the step budget.

nab's own entry points never reached this, because they already build bare terms with `full(admit_arbitrary=False)`. It is reachable through `nab_resolver`'s public API by a caller that passes `full()` as a root or dependency range, by a provider whose `widen_decision` returns it, or by one that queues a clause carrying it.
