### PR TITLE
report the same untileable marker clause on every run

### DIFF
--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -471,6 +471,9 @@ def micro_boundary_points(
     :class:`NonIntervalMarkerError` (see there); with the whole-minor pin gone,
     an untileable marker stops the resolve loudly.  A whole target (a host, or
     a python-patches pin) is not an interval and is never cut.
+
+    Markers are scanned in text order, so the clause a crash names is the same
+    every run even when ``consulted`` is unordered.
     """
     if not target.is_minor_interval:
         return []
@@ -479,7 +482,7 @@ def micro_boundary_points(
     scanned = _scanned_version_variables(target)
 
     points: set[Version] = set()
-    for marker in consulted:
+    for marker in sorted(consulted, key=str):
         for atom in _MARKER_CLAUSE_RE.finditer(str(marker)):
             points.update(
                 _clause_boundary_points(

--- a/nab-python/tests/test_target.py
+++ b/nab-python/tests/test_target.py
@@ -1123,6 +1123,25 @@ class TestMicroBoundarySplitting:
         with pytest.raises(NonIntervalMarkerError):
             micro_boundary_points(self._target(), [Marker(marker)])
 
+    def test_the_crash_names_the_same_clause_in_either_order(self) -> None:
+        """Two untileable markers name the same clause in either order.
+
+        The caller passes an unordered set, so the scan order varies per run.
+        """
+        markers = [
+            Marker('python_full_version in "3.12.1"'),
+            Marker('python_full_version === "3.12.4"'),
+        ]
+
+        messages: set[str] = set()
+        for ordering in (markers, list(reversed(markers))):
+            with pytest.raises(NonIntervalMarkerError) as caught:
+                micro_boundary_points(self._target(), ordering)
+            messages.add(str(caught.value))
+
+        assert len(messages) == 1
+        assert 'clause python_full_version === "3.12.4" cannot tile' in messages.pop()
+
     def test_a_non_version_clause_is_ignored(self) -> None:
         """Only the python_full_version clause of a marker is a boundary."""
         found = micro_boundary_points(


### PR DESCRIPTION
A project with two untileable `python_full_version` clauses got a different error out of `nab lock` on each run, because the message names whichever clause the scan reached first.

The consulted markers arrive as a `set[Marker]`, so their iteration order is hash-seeded, and `micro_boundary_points` raises on the first clause it finds that cannot tile the minor. Scanning them in text order makes the reported clause stable across runs on identical inputs.
