### PR TITLE
stop a find-links wheel reading another target's sdist PKG-INFO

### DIFF
--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -75,17 +75,14 @@ def resolve_metadata(
 
     # Sibling wheels of one version can declare different dependencies, so the
     # read is keyed by the artifact this target would install.  ``versions`` is
-    # the target's own tag-filtered listing, so the pick is per-target.  A
-    # sidecar wheel keys on its sidecar URL; a bare remote wheel (rung 4) keys
-    # on its own wheel URL, so its range-recovered text stays independent of a
-    # sibling wheel's.
+    # the target's own tag-filtered listing, so the pick is per-target.
     dist = pick_dist_for_metadata(
         versions, version, provider.wheel_tags, provider.target
     )
-    if _is_bare_remote_wheel(dist):
-        metadata_url = dist.url
-    elif isinstance(dist, WheelFile):
-        metadata_url = dist.metadata_url
+
+    # A wheel keys on its sidecar URL, or on its own URL when it publishes none.
+    if isinstance(dist, WheelFile):
+        metadata_url = dist.metadata_url or dist.url
     else:
         metadata_url = None
 

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -258,11 +258,11 @@ class InMemoryIndex:
         """Return the text answering for ``metadata_url`` and its origin.
 
         Caller holds the lock.  The artifact's own slot wins, then the
-        version-level one.  An sdist's PKG-INFO answers for an artifact with
-        no text of its own, but not for a sidecar nobody has fetched yet:
+        version-level one.  An sdist's PKG-INFO answers for an artifact whose
+        own read returned nothing, but not for one nobody has read yet:
         lending it there would give a wheel that declares its own dependencies
         the sdist's.  An injected override has no artifact behind it and
-        answers for any.  A wheel with no sidecar asks with ``None``.
+        answers for any.
         """
         if metadata_url is not None:
             slot = (package, version, metadata_url)
@@ -388,9 +388,7 @@ class InMemoryIndex:
     ) -> BaseException | None:
         """Return a recorded metadata fetch error, or ``None``.
 
-        The artifact's own error wins; a version-level error (a tampered
-        sdist archive) answers for any artifact, as the version-level text
-        does.
+        The artifact's own error wins, then a version-level one.
         """
         with self._lock:
             if metadata_url is not None:
@@ -405,11 +403,11 @@ class InMemoryIndex:
         """Store sdist-derived PKG-INFO in the version-level metadata slot.
 
         PKG-INFO is core-metadata-equivalent, so it stands for the version
-        rather than for one artifact and answers for a wheel with no sidecar
-        of its own.  The pending key differs from a wheel's so an sdist
-        request can run in parallel with (or after) a failed wheel metadata
-        request.  :meth:`metadata_from_sdist` reports which kind the
-        version-level slot holds.
+        rather than for one artifact and answers a read that names no
+        artifact.  The pending key differs from a wheel's so an sdist request
+        can run in parallel with (or after) a failed wheel metadata request.
+        :meth:`metadata_from_sdist` reports which kind the version-level slot
+        holds.
         """
         key = f"sdist:{package}:{version}"
         with self._lock:

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -7535,6 +7535,46 @@ PKG_INFO_DYNAMIC_PROVIDES_EXTRA = (
 )
 
 
+_MATRIX_ORDERS = [
+    ("windows_amd64", "linux_x86_64"),
+    ("linux_x86_64", "windows_amd64"),
+]
+
+
+def _declared_target(platform: str) -> ResolveTarget:
+    """A declared 3.12 target for one platform."""
+    return ResolveTarget.for_declared(
+        python_version="3.12", spec=PlatformSpec(platform)
+    )
+
+
+def _wheelhouse_wheel(
+    directory: Path, *reqs: str, dist_info: str = "pkg-1.0"
+) -> WheelFile:
+    """Write a linux-only 1.0 wheel to disk, listed as a flat wheelhouse would.
+
+    A flat wheelhouse serves no PEP 658 sidecar, so ``has_metadata`` is false
+    and the METADATA lives only inside the ``.whl``.  A ``dist_info`` naming
+    another distribution makes that METADATA unreadable.
+    """
+    filename = "pkg-1.0-py3-none-manylinux_2_17_x86_64.whl"
+    path = directory / filename
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr(
+            f"{dist_info}.dist-info/METADATA", make_metadata("pkg", "1.0", *reqs)
+        )
+
+    return WheelFile(
+        filename=filename,
+        url=path.as_uri(),
+        version="1.0",
+        requires_python=None,
+        has_metadata=False,
+        upload_time=None,
+        local_path=path,
+    )
+
+
 class TestSharedSlotProvenance:
     def test_pkg_info_stays_gated_for_provider_with_wheel_in_view(self) -> None:
         """PKG-INFO stored by one provider stays sdist-gated for another.
@@ -7584,6 +7624,86 @@ class TestSharedSlotProvenance:
         second = Provider(coordinator, target=_PY312)
         second.versions_cache["pkg"] = [(V("1.0"), make_sdist("1.0"))]
         assert "dep-b" in second.get_dependencies("pkg", V("1.0"))
+
+    @pytest.mark.parametrize("order", _MATRIX_ORDERS)
+    def test_a_wheelhouse_wheel_reads_its_own_metadata(
+        self, tmp_path: Path, order: tuple[str, str]
+    ) -> None:
+        """A find-links wheel is not served a sibling target's PKG-INFO.
+
+        A flat wheelhouse publishes no sidecar, and the windows target, whose
+        only artifact is the sdist, fills the version-level slot the matrix
+        shares.  Either order leaves linux its own wheel's dependencies.
+        """
+        wheel = _wheelhouse_wheel(tmp_path, "wheel-dep")
+        pkg_info = (
+            "Metadata-Version: 2.2\nName: pkg\nVersion: 1.0\nRequires-Dist: sdist-dep\n"
+        )
+        coordinator = make_coordinator(
+            [wheel, make_sdist("1.0")], sdist_pkg_info=pkg_info
+        )
+
+        deps = {
+            platform: Provider(
+                coordinator, target=_declared_target(platform)
+            ).get_dependencies("pkg", V("1.0"))
+            for platform in order
+        }
+
+        assert "sdist-dep" in deps["windows_amd64"]
+        assert "wheel-dep" in deps["linux_x86_64"]
+        assert "sdist-dep" not in deps["linux_x86_64"]
+
+    @pytest.mark.parametrize("order", _MATRIX_ORDERS)
+    def test_an_unreadable_wheelhouse_wheel_falls_back_to_pkg_info(
+        self, tmp_path: Path, order: tuple[str, str]
+    ) -> None:
+        """A wheel with no usable METADATA of its own still reads the sdist's.
+
+        Its ``.dist-info`` names another distribution, so nothing answers for
+        the wheel and the version-level PKG-INFO stands for the version.
+        """
+        wheel = _wheelhouse_wheel(tmp_path, "wheel-dep", dist_info="other-9.9")
+        pkg_info = (
+            "Metadata-Version: 2.2\nName: pkg\nVersion: 1.0\nRequires-Dist: sdist-dep\n"
+        )
+        coordinator = make_coordinator(
+            [wheel, make_sdist("1.0")], sdist_pkg_info=pkg_info
+        )
+
+        deps = {
+            platform: Provider(
+                coordinator, target=_declared_target(platform)
+            ).get_dependencies("pkg", V("1.0"))
+            for platform in order
+        }
+
+        assert "sdist-dep" in deps["linux_x86_64"]
+        assert "wheel-dep" not in deps["linux_x86_64"]
+
+    @pytest.mark.parametrize("order", _MATRIX_ORDERS)
+    def test_a_wheelhouse_wheel_survives_an_unbuildable_sdist(
+        self, tmp_path: Path, order: tuple[str, str]
+    ) -> None:
+        """A target holding an installable wheel is not refused with the sdist.
+
+        The sdist's pre-PEP-643 PKG-INFO has to go through the dynamic-deps
+        path, which the default build policy refuses.  That refusal belongs to
+        the target with no wheel; the target that installs the wheelhouse wheel
+        reads its METADATA off disk and keeps the version.
+        """
+        wheel = _wheelhouse_wheel(tmp_path, "wheel-dep")
+        coordinator = make_coordinator(
+            [wheel, make_sdist("1.0")], sdist_pkg_info=PKG_INFO_PRE_PEP643_DEPS
+        )
+
+        for platform in order:
+            provider = Provider(coordinator, target=_declared_target(platform))
+            if platform == "windows_amd64":
+                with pytest.raises(UnsupportedSdistError):
+                    provider.get_dependencies("pkg", V("1.0"))
+            else:
+                assert "wheel-dep" in provider.get_dependencies("pkg", V("1.0"))
 
 
 class TestPickDistForMetadata:


### PR DESCRIPTION
A universal lock could lose a version that has an installable wheel in a flat wheelhouse, and whether it did depended on the order the matrix targets resolved in. A target whose only artifact was the sdist filled the version-level metadata slot with that sdist's PKG-INFO, and a target holding the wheel then read that text rather than the wheel's own METADATA. It got the sdist's dependencies, and when the PKG-INFO predates PEP 643 the default build policy refused it and the version dropped out.

The read was keyed on the artifact the target would install, but a wheel that publishes no PEP 658 sidecar had no key of its own, so it fell through to the shared slot. It now keys on its own URL, and the sdist's PKG-INFO answers only a read that names no artifact.
