### PR TITLE
stop reporting a .zip-only project page as a missing package

### DIFF
--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -29,6 +29,7 @@ from .client import (
     _parse_files,
     _select_artifact_hash,
     _verify_metadata_hash,
+    holds_unreadable_format,
     verify_sdist_hash,
 )
 from .lazy_wheel import (
@@ -93,6 +94,7 @@ class CachedAsyncSimpleClient:
         self._cache = cache
         self._index_url = index_url.rstrip("/") + "/"
         self._offline = offline
+        self._unreadable_only: set[str] = set()
         self._range_memo = (
             range_memo if range_memo is not None else RangeCapabilityMemo()
         )
@@ -137,7 +139,7 @@ class CachedAsyncSimpleClient:
             data = self._decode_cached_listing(body, package)
             if data is not None:
                 if policy.is_fresh() or self._offline:
-                    return _parse_files(data, self._index_url, package)
+                    return self._parse_body(data, package)
                 return await self._revalidate_simple(package, body, policy)
             corrupt_positive = True
 
@@ -193,7 +195,18 @@ class CachedAsyncSimpleClient:
                 f"{package!r}: body is not valid JSON"
             )
             raise MalformedSimpleResponseError(msg) from exc
-        return _parse_files(data, self._index_url, package)
+        return self._parse_body(data, package)
+
+    def _parse_body(self, data: object, package: str) -> list[WheelFile | SdistFile]:
+        """Parse a decoded listing body, marking one with no readable file."""
+        files = _parse_files(data, self._index_url, package)
+        if not files and holds_unreadable_format(data):
+            self._unreadable_only.add(package)
+        return files
+
+    def served_unreadable_only(self, package: str) -> bool:
+        """Whether a listing for ``package`` held only files nab cannot read."""
+        return package in self._unreadable_only
 
     async def _revalidate_simple(
         self, package: str, body: bytes, policy: CachePolicy

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -48,6 +48,8 @@ __all__ = [
     "WheelFile",
     "WheelHashMismatchError",
     "extract_sdist_archive",
+    "holds_unreadable_format",
+    "is_readable_filename",
     "verify_sdist_hash",
 ]
 
@@ -174,6 +176,36 @@ def _parse_sdist_filename(filename: str) -> tuple[NormalizedName, str] | None:
     except InvalidSdistFilename:
         return None
     return (name, str(version))
+
+
+def holds_unreadable_format(data: object) -> bool:
+    """Whether a Simple-API body offers a file nab cannot read.
+
+    nab reads wheels and ``.tar.gz`` sdists, so a page of ``.zip`` sdists
+    or ``.exe`` installers parses to no files at all.  A body that is not
+    a list of file entries answers ``False``.
+    """
+    if not isinstance(data, dict):
+        return False
+    raw_files = data.get("files")
+    if not isinstance(raw_files, list):
+        return False
+
+    for file_info in raw_files:
+        if not isinstance(file_info, dict) or file_info.get("yanked"):
+            continue
+        filename = file_info.get("filename")
+        if isinstance(filename, str) and not is_readable_filename(filename):
+            return True
+    return False
+
+
+def is_readable_filename(filename: str) -> bool:
+    """Whether ``filename`` names a wheel or a ``.tar.gz`` sdist."""
+    return (
+        _parse_wheel_filename(filename) is not None
+        or _parse_sdist_filename(filename) is not None
+    )
 
 
 # PEP 691: advertise every serialization we can read, because an index that

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -31,6 +31,8 @@ from typing import TYPE_CHECKING
 from urllib.parse import unquote, urljoin, urlparse
 from urllib.request import url2pathname
 
+from packaging.utils import InvalidSdistFilename, parse_sdist_filename
+
 from ._naming import canonical as _canonical
 from ._pep503 import hash_fragment, metadata_declaration, read_page
 from .client import (
@@ -39,6 +41,7 @@ from .client import (
     _extract_sdist_files,
     _parse_sdist_filename,
     _parse_wheel_filename,
+    is_readable_filename,
 )
 from .transport import HttpError
 
@@ -150,11 +153,15 @@ _FLAT_EXTS = re.compile(r"\.(whl|tar\.gz)$", re.IGNORECASE)
 def _scan_pep503_directory(
     package_dir: Path,
     canonical: str,
-) -> list[WheelFile | SdistFile]:
-    """Parse ``<package>/index.html`` and return file records."""
+) -> tuple[list[WheelFile | SdistFile], bool]:
+    """Parse ``<package>/index.html`` and return file records.
+
+    The second element says the page linked a file in a format nab does
+    not read, which tells a page of ``.zip`` sdists from an empty one.
+    """
     index_html = package_dir / "index.html"
     if not index_html.exists():
-        return []
+        return [], False
 
     try:
         text = index_html.read_text(encoding="utf-8")
@@ -176,6 +183,8 @@ def _scan_pep503_directory(
             raise MalformedLocalListingError(msg) from exc
 
     files: list[WheelFile | SdistFile] = []
+    unreadable = False
+
     for anchor in anchors:
         # PEP 592: a yanked link never reaches the listing.
         if anchor.yanked:
@@ -186,6 +195,10 @@ def _scan_pep503_directory(
         )
         if filename is None:
             continue
+        if not is_readable_filename(filename):
+            unreadable = True
+            continue
+
         record = _make_record(
             filename,
             file_url,
@@ -197,7 +210,7 @@ def _scan_pep503_directory(
         )
         if record is not None:
             files.append(record)
-    return files
+    return files, unreadable
 
 
 def _resolve_local_link(
@@ -253,18 +266,25 @@ def _resolve_local_link(
 def _scan_flat_wheelhouse(
     root: Path,
     package: str,
-) -> list[WheelFile | SdistFile]:
+) -> tuple[list[WheelFile | SdistFile], bool]:
     """Find all dists for ``package`` in a flat directory of files.
 
     Entries are sorted because the listing order breaks ties between dists at
     one version, and ``iterdir`` order comes from the filesystem.
+
+    The second element says the directory holds a ``.zip`` sdist for
+    ``package``, a format nab does not read.  One directory serves every
+    package, so a file that does not name ``package`` says nothing about it.
     """
     canonical = _canonical(package)
     files: list[WheelFile | SdistFile] = []
+    unreadable = False
+
     for entry in sorted(root.iterdir()):
         if not entry.is_file():
             continue
         if _FLAT_EXTS.search(entry.name) is None:
+            unreadable = unreadable or _is_zip_sdist(entry.name, canonical)
             continue
         requires_python = _flat_requires_python(entry, canonical)
         record = _make_record(
@@ -278,7 +298,18 @@ def _scan_flat_wheelhouse(
         )
         if record is not None:
             files.append(record)
-    return files
+    return files, unreadable
+
+
+def _is_zip_sdist(filename: str, canonical: str) -> bool:
+    """Whether ``filename`` is a ``.zip`` sdist belonging to ``canonical``."""
+    if not filename.endswith(".zip"):
+        return False
+    try:
+        name, _ = parse_sdist_filename(filename)
+    except InvalidSdistFilename:
+        return False
+    return name == canonical
 
 
 def _flat_requires_python(entry: Path, canonical: str) -> str | None:
@@ -467,6 +498,7 @@ class LocalIndexClient:
     def __init__(self, index_url: str) -> None:
         """Hold the resolved root path for ``index_url``."""
         self._root = parse_file_url(index_url)
+        self._unreadable_only: set[str] = set()
 
     async def aclose(self) -> None:
         """No-op; nothing to release."""
@@ -482,12 +514,21 @@ class LocalIndexClient:
         """Return all distribution files known for ``package``."""
         canonical = _canonical(package)
         package_dir = self._root / canonical
-        if (package_dir / "index.html").is_file():
-            return _scan_pep503_directory(package_dir, canonical)
 
-        if not self._root.is_dir():
-            return []
-        return _scan_flat_wheelhouse(self._root, package)
+        if (package_dir / "index.html").is_file():
+            files, unreadable = _scan_pep503_directory(package_dir, canonical)
+        elif not self._root.is_dir():
+            files, unreadable = [], False
+        else:
+            files, unreadable = _scan_flat_wheelhouse(self._root, package)
+
+        if not files and unreadable:
+            self._unreadable_only.add(package)
+        return files
+
+    def served_unreadable_only(self, package: str) -> bool:
+        """Whether a listing for ``package`` held only files nab cannot read."""
+        return package in self._unreadable_only
 
     async def get_metadata_text(
         self,

--- a/nab-index/src/nab_index/multi_index.py
+++ b/nab-index/src/nab_index/multi_index.py
@@ -58,6 +58,10 @@ class IndexClient(Protocol):
         """Return the listing for ``package``."""
         ...
 
+    def served_unreadable_only(self, package: str) -> bool:
+        """Whether a listing for ``package`` held only files nab cannot read."""
+        ...
+
     async def get_metadata_text(
         self,
         package: str,
@@ -232,6 +236,17 @@ class MultiIndexClient:
         if skipped_offline is not None:
             raise skipped_offline
         return []
+
+    def served_unreadable_only(self, package: str) -> bool:
+        """Whether any walked index listed ``package`` in unreadable formats.
+
+        An empty walk routes ``package`` to the first index, which need not
+        be the one that served the unreadable page, so every client is asked
+        rather than the routed one.
+        """
+        return any(
+            client.served_unreadable_only(package) for client in self._clients.values()
+        )
 
     async def get_metadata_text(
         self,

--- a/nab-index/tests/test_index_client.py
+++ b/nab-index/tests/test_index_client.py
@@ -4,7 +4,54 @@ from __future__ import annotations
 
 import pytest
 
-from nab_index.client import _sdist_member_top_level
+from nab_index.client import (
+    _sdist_member_top_level,
+    holds_unreadable_format,
+    is_readable_filename,
+)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["foo-1.0-py3-none-any.whl", "foo-1.0.tar.gz"],
+)
+def test_readable_filenames(filename: str) -> None:
+    assert is_readable_filename(filename)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["foo-1.0.zip", "foo-1.5.win32.exe", "foo-1.0.tar.bz2", "foo.egg"],
+)
+def test_unreadable_filenames(filename: str) -> None:
+    assert not is_readable_filename(filename)
+
+
+def test_holds_unreadable_format_finds_zip_sdist() -> None:
+    data = {"files": [{"filename": "foo-1.0.zip", "url": "https://e.example/f"}]}
+    assert holds_unreadable_format(data)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param(["files"], id="body-not-an-object"),
+        pytest.param({"files": "nope"}, id="files-not-a-list"),
+        pytest.param({"files": []}, id="no-entries"),
+        pytest.param({"files": ["foo-1.0.zip"]}, id="entry-not-an-object"),
+        pytest.param({"files": [{"filename": 3}]}, id="filename-not-a-string"),
+        pytest.param(
+            {"files": [{"filename": "foo-1.0.zip", "yanked": True}]},
+            id="yanked-entry",
+        ),
+        pytest.param(
+            {"files": [{"filename": "foo-1.0-py3-none-any.whl"}]},
+            id="readable-entry",
+        ),
+    ],
+)
+def test_holds_unreadable_format_false(data: object) -> None:
+    assert not holds_unreadable_format(data)
 
 
 def test_sdist_member_top_level_normal() -> None:

--- a/nab-index/tests/test_index_local.py
+++ b/nab-index/tests/test_index_local.py
@@ -56,7 +56,7 @@ def test_scan_directory_without_index_html_returns_empty(tmp_path: Path) -> None
     # exercised directly here.
     package_dir = tmp_path / "foo"
     package_dir.mkdir()
-    assert _scan_pep503_directory(package_dir, "foo") == []
+    assert _scan_pep503_directory(package_dir, "foo") == ([], False)
 
 
 def test_get_sdist_archive_returns_file_bytes(tmp_path: Path) -> None:

--- a/nab-index/tests/test_index_multi.py
+++ b/nab-index/tests/test_index_multi.py
@@ -42,6 +42,9 @@ class _RecordingClient:
     async def get_files(self, package: str) -> list[WheelFile]:
         return list(self._listing.get(canonical(package), []))
 
+    def served_unreadable_only(self, package: str) -> bool:
+        return False
+
     async def get_sdist_archive(
         self,
         package: str,

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -150,6 +150,8 @@ class InMemoryIndex:
         self._listing_indexes: dict[str, str] = {}
         # Packages whose empty listing stands for an index skipped offline.
         self._offline_listing_misses: set[str] = set()
+        # Packages whose empty listing stands for a page of formats nab cannot read.
+        self._unreadable_only_listings: set[str] = set()
         # Metadata text is keyed by the artifact it came from: the sidecar URL
         # for a wheel's METADATA, or None for text that stands for the version
         # itself (sdist PKG-INFO, an injected override).  Two wheels of one
@@ -196,6 +198,7 @@ class InMemoryIndex:
         data: Sequence[WheelFile | SdistFile],
         *,
         offline_miss: bool = False,
+        unreadable_only: bool = False,
     ) -> None:
         """Cache the listing for ``package`` and unblock any waiter.
 
@@ -204,7 +207,8 @@ class InMemoryIndex:
         internal ``list[WheelFile | SdistFile]`` cache.
 
         ``offline_miss`` marks the empty listing as an index skipped offline
-        rather than one that served no files.
+        rather than one that served no files.  ``unreadable_only`` marks it
+        as a page whose every file is in a format nab does not read.
         """
         key = f"listing:{package}"
         materialised = list(data)
@@ -212,6 +216,8 @@ class InMemoryIndex:
             self._listings[package] = materialised
             if offline_miss:
                 self._offline_listing_misses.add(package)
+            if unreadable_only:
+                self._unreadable_only_listings.add(package)
             pending = self._pending.get(key)
         if pending is not None:
             pending.result = materialised
@@ -222,11 +228,16 @@ class InMemoryIndex:
         with self._lock:
             return package in self._offline_listing_misses
 
+    def is_unreadable_only_listing(self, package: str) -> bool:
+        """Whether ``package``'s empty listing held only unreadable formats."""
+        with self._lock:
+            return package in self._unreadable_only_listings
+
     def store_listing_error(self, package: str, error: BaseException) -> None:
         """Record a failed listing fetch and unblock any waiter.
 
         Distinct from ``store_listing([])``: an empty listing means the
-        index served no files (a 404), while an error means the fetch
+        index served nothing nab could read, while an error means the fetch
         itself failed. ``fetch_versions`` re-raises the error instead of
         reporting the package as having no candidates.
         """
@@ -1249,7 +1260,11 @@ class FetchCoordinator:
         # further synchronisation to apply per-index policy to the listing
         # filter (mirrors the sdist pyproject store-before-fire ordering).
         self._record_serving_index(client, req.package)
-        self.index.store_listing(req.package, files)
+        self.index.store_listing(
+            req.package,
+            files,
+            unreadable_only=client.served_unreadable_only(req.package),
+        )
         logger.debug("fetched listing: %s (%d files)", req.package, len(files))
         if self._on_fetch is not None:
             self._on_fetch()

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -1679,9 +1679,11 @@ class Provider:
         ``all_versions`` is post-filter, so an empty one means either the
         index served no files or every file it served was dropped by the
         wheel-tag filter, requires-python, dist-policy, or the upload-time
-        cutoff.  The raw listing tells absence from incompatibility apart,
-        except that an index skipped offline also stores an empty listing,
-        so that case is reported as offline rather than absence.
+        cutoff.  The stored listing tells absence from incompatibility
+        apart, except that it is also empty for an index skipped offline
+        and for a page of formats nab does not read (``.zip`` sdists,
+        ``.exe`` installers).  Both are marked when stored so the reason
+        names them instead of absence.
         The wheel-tag case (a Windows-only package on a Linux target) is
         named only when the base pass dropped nothing, or when the file
         it dropped was an sdist: there the reason names both the rejected
@@ -1701,6 +1703,11 @@ class Provider:
             if not raw_listing:
                 if self.coordinator.index.is_offline_listing_miss(normalized):
                     reason = "offline mode skipped an index with no cached listing"
+                elif self.coordinator.index.is_unreadable_only_listing(normalized):
+                    reason = (
+                        "found on index but no file is a wheel or a .tar.gz sdist"
+                        " (the formats nab reads)"
+                    )
                 else:
                     reason = "package not found on any configured index"
             elif tag_excluded and normalized not in self.base_filtered_packages:

--- a/nab-python/tests/property_python/test_fetch_coordinator.py
+++ b/nab-python/tests/property_python/test_fetch_coordinator.py
@@ -112,6 +112,9 @@ class FakeClient:
         files.append(_sdist(package, VERSIONS[0]))
         return files
 
+    def served_unreadable_only(self, package: str) -> bool:
+        return False
+
     async def get_metadata_text(
         self,
         package: str,

--- a/nab-python/tests/property_python/test_multi_index_contract.py
+++ b/nab-python/tests/property_python/test_multi_index_contract.py
@@ -66,6 +66,9 @@ class Stub:
             return [_wheel(canonical(package), self.idx_name)]
         return []
 
+    def served_unreadable_only(self, package: str) -> bool:
+        return False
+
     async def get_metadata_text(
         self,
         package: str,

--- a/nab-python/tests/property_python/test_multi_index_pep503.py
+++ b/nab-python/tests/property_python/test_multi_index_pep503.py
@@ -72,6 +72,9 @@ class _Stub:
             return [_wheel(norm)]
         return []
 
+    def served_unreadable_only(self, package: str) -> bool:
+        return False
+
     async def get_metadata_text(
         self,
         package: str,

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -1359,10 +1359,20 @@ class TestFetchCoordinator:
 
         class RecordingIndex(InMemoryIndex):
             def store_listing(
-                self, package: str, data: Sequence[WheelFile | SdistFile]
+                self,
+                package: str,
+                data: Sequence[WheelFile | SdistFile],
+                *,
+                offline_miss: bool = False,
+                unreadable_only: bool = False,
             ) -> None:
                 serving_at_event.append(self.get_listing_index(package))
-                super().store_listing(package, data)
+                super().store_listing(
+                    package,
+                    data,
+                    offline_miss=offline_miss,
+                    unreadable_only=unreadable_only,
+                )
 
         with _coord() as coord:
             coord.index = RecordingIndex()

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -304,6 +304,33 @@ class TestFlatWheelhouse:
         (tmp_path / "foo-1.0.zip").write_bytes(b"")
         client = LocalIndexClient(tmp_path.as_uri())
         assert run(client.get_files("foo")) == []
+        assert client.served_unreadable_only("foo")
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            pytest.param("bar-1.0.zip", id="another-package"),
+            pytest.param("foo-notaversion.zip", id="unparseable-version"),
+            pytest.param("foo-1.5.win32.exe", id="installer-names-no-package"),
+        ],
+    )
+    def test_unmatched_file_is_not_an_unreadable_listing(
+        self, tmp_path: Path, filename: str
+    ) -> None:
+        """A wheelhouse serves every package, so only a named dist counts."""
+        (tmp_path / filename).write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        assert run(client.get_files("foo")) == []
+        assert not client.served_unreadable_only("foo")
+
+    def test_zip_beside_readable_wheel_is_not_unreadable_only(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "foo-1.0.zip").write_bytes(b"")
+        (tmp_path / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        assert len(run(client.get_files("foo"))) == 1
+        assert not client.served_unreadable_only("foo")
 
     def test_filters_other_packages(self, tmp_path: Path) -> None:
         (tmp_path / "foo-1.0-py3-none-any.whl").write_bytes(b"")
@@ -542,6 +569,24 @@ class TestPep503Directory:
         assert v1.requires_python == ">=3.10"
         v2 = next(r for r in result if r.version == "2.0")
         assert v2.requires_python is None
+
+    def test_page_of_zip_sdists_is_an_unreadable_listing(self, tmp_path: Path) -> None:
+        body = '<a href="foo-1.0.zip">foo-1.0</a><a href="foo-2.0.zip">foo-2.0</a>'
+        self._make_index(tmp_path, body)
+        client = LocalIndexClient(tmp_path.as_uri())
+        assert run(client.get_files("foo")) == []
+        assert client.served_unreadable_only("foo")
+
+    def test_page_of_other_names_is_not_an_unreadable_listing(
+        self, tmp_path: Path
+    ) -> None:
+        """A page listing another project's wheel is a mismatch, not a format."""
+        body = '<a href="bar-1.0-py3-none-any.whl">bar-1.0</a>'
+        package_dir = self._make_index(tmp_path, body)
+        (package_dir / "bar-1.0-py3-none-any.whl").write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        assert run(client.get_files("foo")) == []
+        assert not client.served_unreadable_only("foo")
 
     def test_relative_href_resolves_against_dir(self, tmp_path: Path) -> None:
         body = '<a href="foo-1.0-py3-none-any.whl">foo</a>'

--- a/nab-python/tests/test_multi_index.py
+++ b/nab-python/tests/test_multi_index.py
@@ -44,6 +44,7 @@ class FakeClient:
 
     def __init__(self, listing: dict[str, list[WheelFile | SdistFile]]) -> None:
         self.listing = listing
+        self.unreadable: set[str] = set()
         self.get_files_calls: list[str] = []
         self.metadata_calls: list[tuple[str, str, str]] = []
         self.sdist_calls: list[tuple[str, str, str]] = []
@@ -57,6 +58,9 @@ class FakeClient:
     async def get_files(self, package: str) -> list[WheelFile | SdistFile]:
         self.get_files_calls.append(package)
         return list(self.listing.get(_normalise_name(package), []))
+
+    def served_unreadable_only(self, package: str) -> bool:
+        return package in self.unreadable
 
     async def get_metadata_text(
         self,
@@ -172,6 +176,20 @@ class TestPresenceBased:
             {},
         )
         assert run(client.get_files("foo")) == []
+
+    def test_unreadable_only_reported_from_any_walked_index(self) -> None:
+        """An empty walk routes to the first index, so every client is asked."""
+        first = FakeClient({})
+        second = FakeClient({})
+        second.unreadable.add("foo")
+        client = MultiIndexClient(
+            {"a": first, "b": second},
+            ["a", "b"],
+            {},
+        )
+        assert run(client.get_files("foo")) == []
+        assert client.served_unreadable_only("foo")
+        assert not client.served_unreadable_only("bar")
 
     def test_route_cache_subsequent_calls(self) -> None:
         first = FakeClient({})

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import io
+import json
 import tarfile
 import threading
 import zipfile
@@ -1145,6 +1146,120 @@ class TestNoVersionsReasons:
         assert (
             provider.get_no_versions_reason("foo")
             == "package not found on any configured index"
+        )
+
+    def test_unreadable_formats_only_reports_format_not_absence(
+        self, tmp_path: Path
+    ) -> None:
+        """A page of formats nab does not read is not reported as absence."""
+        body = json.dumps(
+            {
+                "files": [
+                    {
+                        "filename": "foo-1.0.zip",
+                        "url": "https://pypi.example/foo-1.0.zip",
+                    },
+                    {
+                        "filename": "foo-1.0.win32.exe",
+                        "url": "https://pypi.example/foo-1.0.win32.exe",
+                    },
+                ]
+            }
+        ).encode()
+        OnDiskCache(tmp_path, DEFAULT_INDEX_URL).put_simple(
+            "foo", body, CachePolicy(fetched_at=0, max_age=1, etag=None)
+        )
+        with FetchCoordinator(
+            transport=Urllib3AsyncTransport(),
+            cache_dir=tmp_path,
+            offline=True,
+        ) as coordinator:
+            provider = Provider(coordinator)
+            provider.choose_version("foo", SpecifierSet("").to_range())
+        assert provider.get_no_versions_reason("foo") == (
+            "found on index but no file is a wheel or a .tar.gz sdist"
+            " (the formats nab reads)"
+        )
+
+    def test_unreadable_formats_on_second_index_reports_format(
+        self, tmp_path: Path
+    ) -> None:
+        """The router names the format when any walked index served one."""
+        body = json.dumps(
+            {"files": [{"filename": "foo-1.0.zip", "url": "https://e.example/f.zip"}]}
+        ).encode()
+        stale = CachePolicy(fetched_at=0, max_age=1, etag=None)
+        OnDiskCache(tmp_path, DEFAULT_INDEX_URL).put_negative("foo", stale)
+        OnDiskCache(tmp_path, "https://extra.example/simple/").put_simple(
+            "foo", body, stale
+        )
+        with FetchCoordinator(
+            transport=Urllib3AsyncTransport(),
+            cache_dir=tmp_path,
+            offline=True,
+            indexes=[
+                IndexConfig("pypi", DEFAULT_INDEX_URL),
+                IndexConfig("extra", "https://extra.example/simple/"),
+            ],
+        ) as coordinator:
+            provider = Provider(coordinator)
+            provider.choose_version("foo", SpecifierSet("").to_range())
+        assert provider.get_no_versions_reason("foo") == (
+            "found on index but no file is a wheel or a .tar.gz sdist"
+            " (the formats nab reads)"
+        )
+
+    def test_local_wheelhouse_zip_only_reports_format_not_absence(
+        self, tmp_path: Path
+    ) -> None:
+        """A find-links directory holding only a ``.zip`` sdist names the format."""
+        (tmp_path / "foo-1.0.zip").write_bytes(b"")
+        with FetchCoordinator(
+            transport=Urllib3AsyncTransport(),
+            indexes=[IndexConfig("local", tmp_path.as_uri())],
+        ) as coordinator:
+            provider = Provider(coordinator)
+            provider.choose_version("foo", SpecifierSet("").to_range())
+        assert provider.get_no_versions_reason("foo") == (
+            "found on index but no file is a wheel or a .tar.gz sdist"
+            " (the formats nab reads)"
+        )
+
+    def test_local_wheelhouse_other_package_zip_still_reports_absence(
+        self, tmp_path: Path
+    ) -> None:
+        """Another package's ``.zip`` in the directory does not name the format."""
+        (tmp_path / "bar-1.0.zip").write_bytes(b"")
+        with FetchCoordinator(
+            transport=Urllib3AsyncTransport(),
+            indexes=[IndexConfig("local", tmp_path.as_uri())],
+        ) as coordinator:
+            provider = Provider(coordinator)
+            provider.choose_version("foo", SpecifierSet("").to_range())
+        assert (
+            provider.get_no_versions_reason("foo")
+            == "package not found on any configured index"
+        )
+
+    def test_local_pep503_page_zip_only_reports_format_not_absence(
+        self, tmp_path: Path
+    ) -> None:
+        """A local PEP 503 page listing only a ``.zip`` names the format."""
+        package_dir = tmp_path / "foo"
+        package_dir.mkdir()
+        (package_dir / "index.html").write_text(
+            '<a href="foo-1.0.zip">foo-1.0.zip</a>', encoding="utf-8"
+        )
+        (package_dir / "foo-1.0.zip").write_bytes(b"")
+        with FetchCoordinator(
+            transport=Urllib3AsyncTransport(),
+            indexes=[IndexConfig("local", tmp_path.as_uri())],
+        ) as coordinator:
+            provider = Provider(coordinator)
+            provider.choose_version("foo", SpecifierSet("").to_range())
+        assert provider.get_no_versions_reason("foo") == (
+            "found on index but no file is a wheel or a .tar.gz sdist"
+            " (the formats nab reads)"
         )
 
     def test_no_match_in_range_records_no_match_reason(self) -> None:


### PR DESCRIPTION
A project page that lists only files nab does not read (.zip sdists, .exe installers) parses to zero files. An empty listing already meant a 404, so nab reported "package not found on any configured index". That sends you looking for a typo in the name when the project is on the index, just in a format nab skips.

The index clients now flag a listing where every file was dropped at parse, and the message names the formats nab reads instead of saying the package does not exist. This covers remote Simple-API pages, a local PEP 503 page, and a find-links directory holding only a .zip for that project. Another package's .zip in the same flat directory still reports absence, since that directory holds files for every package.
