### PR TITLE
stop an untagged wheel winning over a timestamp-numbered rebuild

### DIFF
--- a/nab-python/src/nab_python/tags.py
+++ b/nab-python/src/nab_python/tags.py
@@ -73,11 +73,9 @@ _MIN_WHEEL_FILENAME_PARTS = 5
 _MAX_WHEEL_TAGS = 4096
 
 # PEP 427: a build tag adds a sixth dash-separated segment at index 2, and
-# starts with a digit (captured here for ordering).  The digit run is bounded
-# because the index names it and int() raises above 4300 digits, so an absurd
-# one is malformed and sorts lowest, like any other unreadable build tag.
+# starts with a digit (captured here for ordering).
 _WHEEL_PARTS_WITH_BUILD = 6
-_BUILD_TAG_RE = re.compile(r"(\d{1,9})(\D.*)?$", re.ASCII)
+_BUILD_TAG_RE = re.compile(r"(\d+)(.*)", re.ASCII)
 
 # runs-on-libc (or runs-on-macos) names a system the lock must run on.  A
 # wheel is a member iff it runs there: the target accepts every
@@ -498,7 +496,14 @@ def _build_tag_sort_key(filename: str) -> tuple[int, str]:
     match = _BUILD_TAG_RE.match(parts[2])
     if match is None:
         return (-1, "")
-    return (int(match.group(1)), match.group(2) or "")
+
+    # int() refuses a digit run past CPython's conversion limit.
+    try:
+        build_number = int(match.group(1))
+    except ValueError:
+        return (-1, "")
+
+    return (build_number, match.group(2))
 
 
 def _cpython_abi(py_version: tuple[int, int], *, free_threaded: bool) -> str:

--- a/nab-python/tests/property_python/test_tags_differential.py
+++ b/nab-python/tests/property_python/test_tags_differential.py
@@ -15,8 +15,11 @@ distribution as the oracle and requires agreement:
    ``parse_wheel_filename`` on every spec-valid filename.
 5. ``TagSet.pick`` must choose a wheel whose best upstream rank is
    the minimum over all candidate wheels.
+6. Among wheels of equal rank, ``TagSet.pick`` must choose the one
+   with the highest upstream `PEP 427`_ build tag.
 
 .. _PEP 425: https://peps.python.org/pep-0425/
+.. _PEP 427: https://peps.python.org/pep-0427/
 """
 
 from __future__ import annotations
@@ -26,7 +29,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 from packaging import tags as upstream_tags
 from packaging import utils as upstream_utils
-from packaging.utils import InvalidWheelFilename
+from packaging.utils import BuildTag, InvalidWheelFilename
 from packaging.version import InvalidVersion
 
 from nab_index.client import WheelFile
@@ -364,6 +367,55 @@ class TestSelectWheelMinimizesUpstreamRank:
             f"chose {chosen.filename} rank {best_rank(chosen)}; "
             f"best available {min(oracle_ranks)}"
         )
+
+
+BUILD_TAGS = (
+    "0",
+    "1",
+    "5",
+    "42",
+    "999999999",
+    "1000000000",
+    "1753900000",
+    "1753900001",
+    "20260730123456",
+    "3post1",
+)
+
+
+class TestBuildTagOrderMatchesUpstream:
+    """`PEP 427`_ orders same-tag wheels by build number, an absent tag
+    lowest.  Upstream ``parse_wheel_filename`` reads the whole leading
+    digit run, so ``TagSet.pick`` must choose a wheel whose upstream
+    build tag is the maximum over all candidate wheels.
+
+    .. _PEP 427: https://peps.python.org/pep-0427/#file-name-convention
+    """
+
+    @given(
+        builds=st.lists(
+            st.sampled_from(BUILD_TAGS), min_size=1, max_size=4, unique=True
+        ),
+        untagged=st.booleans(),
+        python_version=st.sampled_from(PY_VERSIONS),
+    )
+    @PROPERTY_SETTINGS
+    def test_pick_prefers_the_highest_upstream_build_tag(
+        self, builds: list[str], untagged: bool, python_version: str
+    ) -> None:
+        """The picked wheel carries the highest upstream build tag."""
+        wheels = [_wheel(f"pkg-1.0-{build}-py3-none-any.whl") for build in builds]
+        if untagged:
+            wheels.append(_wheel("pkg-1.0-py3-none-any.whl"))
+
+        def oracle_build(w: WheelFile) -> BuildTag:
+            return upstream_utils.parse_wheel_filename(w.filename)[2]
+
+        chosen = TagSet.for_spec(
+            python_version=python_version, spec=PlatformSpec("linux_x86_64")
+        ).pick(wheels)
+        assert chosen is not None
+        assert oracle_build(chosen) == max(oracle_build(w) for w in wheels)
 
 
 class TestAcceptedSpecNamesAPlatform:

--- a/nab-python/tests/test_tags.py
+++ b/nab-python/tests/test_tags.py
@@ -920,6 +920,25 @@ class TestSelectWheel:
         )
         assert chosen is build3
 
+    def test_timestamp_build_tag_beats_untagged(self) -> None:
+        """A rebuild numbered with a timestamp sorts above an absent tag."""
+        spec = PlatformSpec("linux_x86_64", runs_on_libc=(2, 28))
+        untagged = _wheel("pkg-1.0-py3-none-any.whl")
+        rebuild = _wheel("pkg-1.0-1753900000-py3-none-any.whl")
+        chosen = TagSet.for_spec(python_version="3.12", spec=spec).pick(
+            [untagged, rebuild]
+        )
+        assert chosen is rebuild
+
+    def test_higher_timestamp_build_tag_wins_either_order(self) -> None:
+        """Two timestamp rebuilds order by build number, not by listing order."""
+        spec = PlatformSpec("linux_x86_64", runs_on_libc=(2, 28))
+        older = _wheel("pkg-1.0-1753900000-py3-none-any.whl")
+        newer = _wheel("pkg-1.0-1753900001-py3-none-any.whl")
+        tags = TagSet.for_spec(python_version="3.12", spec=spec)
+        assert tags.pick([older, newer]) is newer
+        assert tags.pick([newer, older]) is newer
+
     def test_an_absurd_build_number_is_malformed(self) -> None:
         """The index names the build tag, and int() raises above 4300 digits."""
         spec = PlatformSpec("linux_x86_64")
@@ -985,6 +1004,15 @@ class TestWheelRank:
         assert build5 is not None
         assert untagged[0] == build5[0]
         assert untagged[1] < build5[1]
+
+    def test_timestamp_build_tags_do_not_tie(self) -> None:
+        """Timestamp-numbered rebuilds rank apart, so they never tie."""
+        tags = TagSet.for_spec(python_version="3.12", spec=PlatformSpec("linux_x86_64"))
+        first = tags.wheel_rank("pkg-1.0-20260730123456-py3-none-any.whl")
+        second = tags.wheel_rank("pkg-1.0-20260730123457-py3-none-any.whl")
+        assert first is not None
+        assert second is not None
+        assert first < second
 
 
 class TestUnknownPlatformKindGuard:


### PR DESCRIPTION
A PEP 427 build tag of ten or more digits, which is what epoch and timestamp rebuilds use, was read as no build tag at all. `pkg-1.0-1753900000-py3-none-any.whl` therefore tied with `pkg-1.0-py3-none-any.whl`, and two such rebuilds tied with each other, so which one `TagSet.pick` returned came down to the order the index listed them in.

The build-tag regex capped the leading digit run at nine digits. It now matches the whole run, the way packaging's `parse_wheel_filename` does. A digit run that `int()` refuses to convert is still treated as malformed and sorts below every real build number.
