### PR TITLE
fix raw traceback when a project TOML cannot be read

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -883,6 +883,9 @@ def _reject_unknown_pyproject_keys(path: Path) -> None:
     except (UnicodeDecodeError, tomli.TOMLDecodeError) as exc:
         msg = f"{path} is not valid TOML: {exc}"
         raise ConfigError(msg) from exc
+    except OSError as exc:
+        msg = f"cannot read {path}: {exc}"
+        raise ConfigError(msg) from exc
     raw = tool_nab_section(data)
     if not isinstance(raw, dict):
         msg = f"[tool.nab] must be a table, got {type(raw).__name__}"

--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -1342,6 +1342,9 @@ def _read_raw_table(path: Path, kind: SourceKind) -> Mapping[str, Any]:
     except (UnicodeDecodeError, tomli.TOMLDecodeError) as exc:
         msg = f"{path} is not valid TOML: {exc}"
         raise SourceConfigError(msg) from exc
+    except OSError as exc:
+        msg = f"cannot read {path}: {exc}"
+        raise SourceConfigError(msg) from exc
     if kind is SourceKind.PYPROJECT:
         section = tool_nab_section(data)
         # A non-table [tool.nab] is malformed, not an empty config.

--- a/nab-python/src/nab_python/workspace.py
+++ b/nab-python/src/nab_python/workspace.py
@@ -55,17 +55,20 @@ _PROJECT_TOML = "nab.toml"
 
 
 def _load_member_toml(pyproject: Path) -> dict[str, Any]:
-    """Parse ``pyproject``, raising :class:`WorkspaceDiscoveryError` on bad TOML.
+    """Parse ``pyproject``, raising :class:`WorkspaceDiscoveryError` on a bad read.
 
-    :func:`discover_workspace_root` swallows parse errors while walking,
-    but a chosen root and its declared members must parse, so malformed
-    TOML here is a hard error.
+    :func:`discover_workspace_root` swallows read and parse errors while
+    walking, but a chosen root and its declared members must parse, so an
+    unreadable or malformed file here is a hard error.
     """
     try:
         with pyproject.open("rb") as f:
             return tomli.load(f)
     except (UnicodeDecodeError, tomli.TOMLDecodeError) as exc:
         msg = f"{pyproject} is not valid TOML: {exc}"
+        raise WorkspaceDiscoveryError(msg) from exc
+    except OSError as exc:
+        msg = f"cannot read {pyproject}: {exc}"
         raise WorkspaceDiscoveryError(msg) from exc
 
 

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import errno
 import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -250,6 +252,15 @@ class TestTopLevelKeys:
         path = tmp_path / "pyproject.toml"
         path.write_bytes(b'[project]\nname = "demo"\ndescription = "\xe9"\n')
         with pytest.raises(ConfigError, match="not valid TOML"):
+            read_pyproject_config(path)
+
+    def test_unreadable_rejected(self, tmp_path: Path) -> None:
+        path = write(tmp_path, '[project]\nname = "demo"\n')
+        denied = PermissionError(errno.EACCES, "Permission denied", str(path))
+        with (
+            patch.object(Path, "open", side_effect=denied),
+            pytest.raises(ConfigError, match="cannot read .*Permission denied"),
+        ):
             read_pyproject_config(path)
 
     @pytest.mark.parametrize("user_key", ["offline = true", 'cache-dir = "x"'])

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -11,8 +11,10 @@ renderers.  Search roots are injected so nothing reads the real
 
 from __future__ import annotations
 
+import errno
 import logging
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -572,6 +574,15 @@ class TestLoadTomlLayerDirect:
         path.write_bytes(b'[project]\ndescription = "\xe9"\n')
         with pytest.raises(SourceConfigError, match="not valid TOML"):
             _load_toml_layer(path, SourceKind.PYPROJECT)
+
+    def test_unreadable_file_errors(self, tmp_path: Path) -> None:
+        path = _write(tmp_path / "nab.toml", 'resolution = "lowest"\n')
+        denied = PermissionError(errno.EACCES, "Permission denied", str(path))
+        with (
+            patch.object(Path, "open", side_effect=denied),
+            pytest.raises(SourceConfigError, match="cannot read .*Permission denied"),
+        ):
+            _load_toml_layer(path, SourceKind.USER_TOML)
 
     def test_pyproject_without_tool_nab_is_empty(self, tmp_path: Path) -> None:
         path = _write(tmp_path / "pyproject.toml", '[project]\nname = "x"\n')

--- a/nab-python/tests/test_workspace.py
+++ b/nab-python/tests/test_workspace.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import errno
 import logging
 import re
+from contextlib import AbstractContextManager
 from pathlib import Path
+from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -21,6 +25,18 @@ def _write(path: Path, body: str) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(body)
     return path
+
+
+def _deny_open(target: Path) -> AbstractContextManager[Any]:
+    """Patch ``Path.open`` to refuse ``target`` and pass everything else through."""
+    real = Path.open
+
+    def opener(self: Path, *args: Any, **kwargs: Any) -> Any:
+        if self == target:
+            raise PermissionError(errno.EACCES, "Permission denied", str(target))
+        return real(self, *args, **kwargs)
+
+    return patch.object(Path, "open", opener)
 
 
 class TestDiscoverWorkspaceRoot:
@@ -364,6 +380,26 @@ class TestReadWorkspaceMembers:
         with pytest.raises(
             WorkspaceDiscoveryError,
             match=rf"{re.escape(str(member))} is not valid TOML",
+        ):
+            read_workspace_members(root)
+
+    def test_member_unreadable_raises(self, tmp_path: Path) -> None:
+        root = _write(
+            tmp_path / "pyproject.toml",
+            '[project]\nname = "ws"\nversion = "0"\n'
+            "[tool.nab.workspace]\n"
+            'members = ["pkg"]\n',
+        )
+        member = _write(
+            tmp_path / "pkg" / "pyproject.toml",
+            '[project]\nname = "pkg"\nversion = "0"\n',
+        )
+        with (
+            _deny_open(member),
+            pytest.raises(
+                WorkspaceDiscoveryError,
+                match=rf"cannot read {re.escape(str(member))}.*Permission denied",
+            ),
         ):
             read_workspace_members(root)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1038,6 +1038,26 @@ class TestLockCommandSpecific:
             lock(pyproject, output=Path("-"))
         assert "is not valid TOML" in capsys.readouterr().err
 
+    def test_unreadable_toml_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An unreadable pyproject reports a clean message, not a traceback."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "demo"\ndependencies = []\n')
+        denied = PermissionError(errno.EACCES, "Permission denied", str(pyproject))
+        with (
+            patch.object(Path, "open", side_effect=denied),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            lock(pyproject, output=Path("-"))
+        err = capsys.readouterr().err
+        # OSError renders its filename with repr, which doubles the
+        # backslashes of a Windows path.
+        assert err.splitlines() == [
+            f"error: in [tool.nab]: cannot read {pyproject}:"
+            f" [Errno {errno.EACCES}] Permission denied: {str(pyproject)!r}"
+        ]
+
     def test_pylock_passed_as_the_project_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
A project pyproject.toml or nab.toml that exists but cannot be read (no read permission, an I/O error part way through) made nab lock, nab download and nab config exit with a raw PermissionError traceback instead of the usual error line.

The two config-layer readers and the workspace member reader only caught decode and parse errors, so an OSError from the open escaped to the top. They now report it the same way the other TOML readers already do, as `cannot read <path>: <reason>`, which the CLI prints as a single error line before exiting 1.
