### PR TITLE
refuse percent-encoded dot segments in vcs.allowed-repos

### DIFF
--- a/nab-python/src/nab_python/_vcs_admission.py
+++ b/nab-python/src/nab_python/_vcs_admission.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import enum
 import posixpath
 from dataclasses import dataclass
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import unquote, urlsplit, urlunsplit
 
 from nab_index.vcs import FULL_GIT_SHA_RE
 
@@ -142,7 +142,7 @@ _REPO_BOUNDARY_CHARS: frozenset[str] = frozenset({"/", "@", "#"})
 
 
 def _repo_prefix_matches(inner_url: str, prefix: str) -> bool:
-    """Return True if ``inner_url`` names a repo under ``prefix``.
+    r"""Return True if ``inner_url`` names a repo under ``prefix``.
 
     A bare :meth:`str.startswith` would admit a sibling repo whose URL
     merely begins with an allowed entry (``.../airflow.git`` would admit
@@ -157,9 +157,17 @@ def _repo_prefix_matches(inner_url: str, prefix: str) -> bool:
 
     A path git would rewrite is refused first: git applies RFC 3986
     dot-segment removal at fetch time, so a raw ``..`` path could pass the
-    string match while git fetches a repo outside the prefix.
+    string match while git fetches a repo outside the prefix.  That check
+    reads the whole post-authority remainder, query included since
+    :meth:`nab_index.vcs.VcsRequest.parse` keeps it, decoded once so an
+    encoded ``%2e%2e`` cannot slip past, and with ``\`` folded to ``/``
+    because Windows resolves it as a separator.  The prefix comparison
+    below is on the raw URL.
     """
-    path = urlsplit(inner_url).path
+    parts = urlsplit(inner_url)
+    remainder = f"{parts.path}?{parts.query}" if parts.query else parts.path
+    path = unquote(remainder).replace("\\", "/")
+
     if path and posixpath.normpath(path) != path:
         return False
 

--- a/nab-python/tests/property_python/test_vcs_admission.py
+++ b/nab-python/tests/property_python/test_vcs_admission.py
@@ -19,13 +19,16 @@ Invariants:
 * admission/clone agreement: a URL admitted under
   ``require_pin=True`` must parse (``VcsRequest.parse``) to a ref
   that IS a full commit sha, i.e. the admission layer's "pinned"
-  promise holds at clone time.
+  promise holds at clone time;
+* containment: a path that normalises above where it is written is
+  refused however permissive the allowlists are, whether written raw,
+  percent-encoded, or with backslashes.
 """
 
 from __future__ import annotations
 
 import posixpath
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import unquote, urlsplit, urlunsplit
 
 import pytest
 from hypothesis import given
@@ -94,7 +97,20 @@ def structured_urls(draw: st.DrawFn) -> str:
     host = draw(st.sampled_from(["github.com", "example.org", "h"]))
     segments = draw(
         st.lists(
-            st.sampled_from(["org", "orgx", "repo.git", "repo.gitx", "repo", "a"]),
+            st.sampled_from(
+                [
+                    "org",
+                    "orgx",
+                    "repo.git",
+                    "repo.gitx",
+                    "repo",
+                    "a",
+                    "..",
+                    "%2e%2e",
+                    "..%2f..",
+                    "..\\..",
+                ]
+            ),
             max_size=3,
         )
     )
@@ -122,6 +138,16 @@ def structured_urls(draw: st.DrawFn) -> str:
     return f"{scheme}://{user}{host}{path}{ref}{frag}"
 
 
+@st.composite
+def escaping_urls(draw: st.DrawFn) -> str:
+    """A pinned URL whose path resolves one level above where it is written."""
+    scheme = draw(st.sampled_from(VALID_SCHEMES))
+    host = draw(st.sampled_from(["github.com", "h"]))
+    escape = draw(st.sampled_from(["..", "%2e%2e", "%2E%2E", "..%2f..", "..\\.."]))
+    tail = draw(st.sampled_from(["other", "other/repo", "repo"]))
+    return f"{scheme}://{host}/org/repo/{escape}/{tail}@{SHA}"
+
+
 def _decision(url: str, config: VcsConfig) -> tuple[str, str]:
     try:
         return ("admit", admit_vcs_url(url, config))
@@ -138,17 +164,21 @@ def _drop_login(url: str) -> str:
 
 
 def _prefix_under_repo(inner: str, prefix: str) -> bool:
-    """Boundary-aware repo-prefix check, transcribed from the documented policy.
+    r"""Boundary-aware repo-prefix check, transcribed from the documented policy.
 
     A candidate is under an allowed prefix only when the prefix ends at a
     path-segment boundary, so a sibling repo whose URL merely begins with
     the prefix (``.../airflow.git`` vs ``.../airflow.git.other``) is refused.
     Git's optional ``.git`` suffix is stripped from the prefix and skipped
     once on the candidate so an exact-repo prefix and the ``.git`` clone URL
-    match either way round.  A candidate whose path git would rewrite (its
-    dot-segment-normalised form differs from the raw path) is refused first.
+    match either way round.  A candidate whose path git would rewrite is
+    refused first: the whole post-authority remainder, decoded once and with
+    ``\`` folded to ``/``, must equal its dot-segment-normalised form.
     """
-    path = urlsplit(inner).path
+    parts = urlsplit(inner)
+    remainder = f"{parts.path}?{parts.query}" if parts.query else parts.path
+    path = unquote(remainder).replace("\\", "/")
+
     if path and posixpath.normpath(path) != path:
         return False
 
@@ -205,6 +235,22 @@ def test_total_partition_and_determinism_arbitrary_text(
 @given(url=structured_urls(), config=configs)
 def test_matches_documented_oracle(url: str, config: VcsConfig) -> None:
     assert _decision(url, config)[0] == _oracle(url, config)
+
+
+@PROPERTY_SETTINGS
+@given(url=escaping_urls())
+def test_escaping_path_refused_under_allow_all(url: str) -> None:
+    """An allow-all config still refuses a path that resolves above itself.
+
+    ``""`` is a prefix of every URL, so only the containment check can
+    refuse these.
+    """
+    config = VcsConfig(
+        policy=VcsPolicy.ALLOW,
+        allowed_schemes=frozenset(VALID_SCHEMES),
+        allowed_repos=("",),
+    )
+    assert _decision(url, config)[0] == "refuse"
 
 
 @PROPERTY_SETTINGS

--- a/nab-python/tests/test_vcs_admission.py
+++ b/nab-python/tests/test_vcs_admission.py
@@ -396,6 +396,103 @@ class TestAdmitVcsUrlRepo:
                 config,
             )
 
+    @pytest.mark.parametrize(
+        "escape",
+        [
+            "/%2e%2e/%2e%2e/other/repo",
+            "/%2E%2E/%2E%2E/other/repo",
+            "/..%2f..%2fother/repo",
+            "/..\\..\\other/repo",
+            "/..%5c..%5cother/repo",
+            "/%2e%2e\\%2e%2e/other/repo",
+        ],
+    )
+    def test_encoded_dot_segment_escape_refused(self, escape: str) -> None:
+        r"""An encoded escape is refused like the raw ``../`` form.
+
+        A percent-encoded ``..`` decodes at fetch time, and Windows
+        resolves ``\`` as a separator.
+        """
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+file"}),
+            allowed_repos=("file:///srv/repos/trusted/repo",),
+        )
+        with pytest.raises(UnsupportedVcsError, match="not in vcs.allowed-repos"):
+            admit_vcs_url(
+                f"git+file:///srv/repos/trusted/repo{escape}@{_FORTY}",
+                config,
+            )
+
+    def test_backslash_escape_over_ssh_refused(self) -> None:
+        r"""The ``\`` escape is refused on a remote scheme too."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+ssh"}),
+            allowed_repos=("ssh://host/srv/trusted/repo",),
+        )
+        with pytest.raises(UnsupportedVcsError, match="not in vcs.allowed-repos"):
+            admit_vcs_url(
+                f"git+ssh://host/srv/trusted/repo/..\\..\\other@{_FORTY}",
+                config,
+            )
+
+    def test_query_dot_segment_escape_refused(self) -> None:
+        """A ``?query`` carrying the escape is refused.
+
+        ``VcsRequest.parse`` keeps the query in the URL it hands git, so the
+        rewrite check covers the whole post-authority remainder.
+        """
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+file"}),
+            allowed_repos=("file:///srv/repos/trusted/",),
+        )
+        with pytest.raises(UnsupportedVcsError, match="not in vcs.allowed-repos"):
+            admit_vcs_url(
+                f"git+file:///srv/repos/trusted/repo?/../../other/repo@{_FORTY}",
+                config,
+            )
+
+    def test_percent_encoded_repo_name_still_admits(self) -> None:
+        """Encoding that decodes to no dot-segment leaves the repo admitted."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+file"}),
+            allowed_repos=("file:///srv/repos/trusted",),
+        )
+        scheme = admit_vcs_url(
+            f"git+file:///srv/repos/trusted/my%20repo@{_FORTY}",
+            config,
+        )
+        assert scheme == "git+file"
+
+    def test_double_encoded_dot_segment_still_admits(self) -> None:
+        """Decoding runs once, so ``%252e%252e`` stays the directory ``%2e%2e``."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+file"}),
+            allowed_repos=("file:///srv/repos/trusted",),
+        )
+        scheme = admit_vcs_url(
+            f"git+file:///srv/repos/trusted/repo/%252e%252e/other@{_FORTY}",
+            config,
+        )
+        assert scheme == "git+file"
+
+    def test_literal_backslash_in_repo_name_still_admits(self) -> None:
+        r"""A ``\`` that is not a dot-segment escape leaves the repo admitted."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+file"}),
+            allowed_repos=("file:///srv/repos/trusted",),
+        )
+        scheme = admit_vcs_url(
+            f"git+file:///srv/repos/trusted/my\\repo@{_FORTY}",
+            config,
+        )
+        assert scheme == "git+file"
+
     def test_plain_repo_under_same_prefix_still_admits(self) -> None:
         """A plain in-repo URL under that prefix still admits."""
         config = VcsConfig(


### PR DESCRIPTION
The `vcs.allowed-repos` guard refuses a repo URL whose path git would rewrite at fetch time, but it ran that check on the still-encoded path. `git+file:///srv/repos/trusted/repo/%2e%2e/%2e%2e/other/repo` passed the match, git decoded the `%2e%2e` before fetching, and the clone landed outside the allowed prefix. A backslash slipped through the same way on Windows, where git resolves `\` as a separator. So did an escape carried in a `?query`, since `VcsRequest.parse` keeps the query in the URL it hands git.

The check now reads the whole post-authority remainder, decoded once and with `\` folded to `/`, and compares it against its dot-segment-normalized form. Decoding once means `%252e%252e` stays a literal directory name. The prefix comparison itself is still on the raw URL.
