### PR TITLE
Retry an index GET that returns 408

### DIFF
--- a/nab-index/src/nab_index/retry.py
+++ b/nab-index/src/nab_index/retry.py
@@ -1,7 +1,7 @@
 """Retry policy for index GETs, shared by the async transports.
 
-An index GET is idempotent, and a 5xx, a 429, or a dropped connection is
-usually a blip rather than the index's answer.
+An index GET is idempotent, and a 5xx, a 429, a 408, or a dropped connection
+is usually a blip rather than the index's answer.
 
 urllib3's default retries a connection error but retries a 413, 429, or 503
 only when the response carries ``Retry-After``; httpx retries nothing. Both
@@ -30,8 +30,9 @@ the transports' own retry loops count them across all failures."""
 MAX_REDIRECTS = 20
 """Redirects followed per GET, matching httpx's default."""
 
+# A 408 says the server gave up waiting for the request (RFC 9110 15.5.9).
 # 520-524 and 527 are Cloudflare's transient origin errors, not the index's answer.
-RETRY_STATUSES = frozenset({429, 500, 502, 503, 504, 520, 521, 522, 523, 524, 527})
+RETRY_STATUSES = frozenset({408, 429, 500, 502, 503, 504, 520, 521, 522, 523, 524, 527})
 """Statuses that are retried; any other status is served to the caller."""
 
 _BACKOFF_FACTOR = 0.25

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -283,6 +283,12 @@ class TestRetryPolicy:
         assert not GET_RETRY.is_retry("GET", 404, has_retry_after=False)
         assert not GET_RETRY.is_retry("GET", 403, has_retry_after=False)
 
+    def test_request_timeout_is_retried(self) -> None:
+        """A 408 says the server gave up waiting, so the client may repeat the GET."""
+        assert 408 in RETRY_STATUSES
+        assert GET_RETRY.is_retry("GET", 408, has_retry_after=False)
+        assert GET_RETRY.is_retry("GET", 408, has_retry_after=True)
+
     def test_cloudflare_transient_5xx_is_retried(self) -> None:
         """Cloudflare's 520-524 and 527 origin errors are blips, so they retry."""
         for status in (520, 521, 522, 523, 524, 527):
@@ -648,6 +654,26 @@ class TestHttpxAsyncTransport:
         """A Cloudflare 52x origin error is a blip, so ask again before believing it."""
         route = respx.get("https://example.com/pkg").mock(
             side_effect=[httpx.Response(status), httpx.Response(200, json={"ok": True})]
+        )
+
+        async def go() -> _HttpxResponse:
+            transport = HttpxAsyncTransport(http2=False)
+            try:
+                return await transport.get("https://example.com/pkg")
+            finally:
+                await transport.aclose()
+
+        resp = asyncio.run(go())
+        resp.raise_for_status()
+        assert resp.status_code == 200
+        assert route.call_count == 2
+        assert slept == [0.0]
+
+    @respx.mock
+    def test_get_retries_a_request_timeout(self, slept: list[float]) -> None:
+        """A 408 is a blip, so ask again before believing it."""
+        route = respx.get("https://example.com/pkg").mock(
+            side_effect=[httpx.Response(408), httpx.Response(200, json={"ok": True})]
         )
 
         async def go() -> _HttpxResponse:
@@ -1156,6 +1182,23 @@ class TestUrllib3AsyncTransport:
         """One Cloudflare 52x origin error with no Retry-After must not end the fetch."""
         with _stub_index([status]) as index:
             url = f"http://127.0.0.1:{index.server_port}/pkg/pkg-1.0.whl.metadata"
+
+            async def go() -> _Urllib3Response:
+                transport = Urllib3AsyncTransport()
+                try:
+                    return await transport.get(url)
+                finally:
+                    await transport.aclose()
+
+            resp = asyncio.run(go())
+            resp.raise_for_status()
+            assert resp.status_code == 200
+            assert len(index.seen) == 2
+
+    def test_get_retries_a_request_timeout(self) -> None:
+        """One 408 must not end the fetch."""
+        with _stub_index([408]) as index:
+            url = f"http://127.0.0.1:{index.server_port}/pkg/"
 
             async def go() -> _Urllib3Response:
                 transport = Urllib3AsyncTransport()


### PR DESCRIPTION
A 408 from an index went straight back to the caller, so one keep-alive timeout on an idempotent GET could fail a resolve. The same timeout reported as a 503 was retried and absorbed.

408 means the server gave up waiting for the request rather than answering it (RFC 9110 15.5.9), so repeating the GET is safe, the way the other transient statuses in RETRY_STATUSES already are. 408 was missing from that set. Adding it covers both the httpx and urllib3 backends, since both take their retry policy from nab_index.retry.
