### PR TITLE
fix crash when a build hook returns a non-string path

### DIFF
--- a/nab-python/src/nab_python/_build/runner.py
+++ b/nab-python/src/nab_python/_build/runner.py
@@ -122,27 +122,12 @@ def run_build_backend(
                 env.install(extra)
 
             with tempfile.TemporaryDirectory(prefix="nab-build-meta-") as out_str:
-                output_dir = Path(out_str)
-                try:
-                    if skip_prepare:
-                        metadata_dir = _build_wheel_and_extract(project, output_dir)
-                    else:
-                        metadata_dir = Path(project.metadata_path(output_dir))
-                # build raises a bare ValueError for a wheel whose name will not
-                # parse; a member zipfile cannot decompress surfaces as zlib.error,
-                # lzma.LZMAError, or NotImplementedError (a RuntimeError subclass).
-                except (
-                    zipfile.BadZipFile,
-                    ValueError,
-                    OSError,
-                    zlib.error,
-                    lzma.LZMAError,
-                    RuntimeError,
-                ) as exc:
-                    msg = (
-                        f"build backend {backend!r} produced an unreadable wheel: {exc}"
-                    )
-                    raise BuildBackendError(msg) from exc
+                metadata_dir = _extract_metadata_dir(
+                    project,
+                    Path(out_str),
+                    backend=backend,
+                    skip_prepare=skip_prepare,
+                )
                 return _parse_metadata(metadata_dir / "METADATA")
     except (
         build.BuildException,
@@ -209,6 +194,46 @@ def _should_skip_prepare(backend: str, data: dict) -> bool:
         return False
     dyn = {d for d in dynamic if isinstance(d, str)}
     return bool(dyn & {"dependencies", "optional-dependencies"})
+
+
+def _extract_metadata_dir(
+    project: build.ProjectBuilder,
+    output_dir: Path,
+    *,
+    backend: str,
+    skip_prepare: bool,
+) -> Path:
+    """Return the dist-info directory the backend produced.
+
+    ``build`` lets two faults through raw, outside its own hook-error
+    wrapper: reading back a wheel it just built, and joining a
+    path-returning hook's result onto ``output_dir``.
+    """
+    try:
+        if skip_prepare:
+            return _build_wheel_and_extract(project, output_dir)
+        return Path(project.metadata_path(output_dir))
+    # build raises a bare ValueError for a wheel whose name will not parse; a
+    # member zipfile cannot decompress surfaces as zlib.error, lzma.LZMAError,
+    # or NotImplementedError (a RuntimeError subclass).
+    except (
+        zipfile.BadZipFile,
+        ValueError,
+        OSError,
+        zlib.error,
+        lzma.LZMAError,
+        RuntimeError,
+    ) as exc:
+        msg = f"build backend {backend!r} produced an unreadable wheel: {exc}"
+        raise BuildBackendError(msg) from exc
+    # PEP 517's path-returning hooks must return a basename string, so a
+    # non-string reaches os.path.join as-is.
+    except TypeError as exc:
+        msg = (
+            f"build backend {backend!r} returned a non-string path"
+            f" from a build hook: {exc}"
+        )
+        raise BuildBackendError(msg) from exc
 
 
 def _build_wheel_and_extract(

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import build
+import pyproject_hooks
 import pytest
 from installer.utils import SCHEME_NAMES, Scheme
 
@@ -871,6 +872,108 @@ class TestRunBuildBackendCorruptBuiltWheel:
                 "foo-1.0-py3-none-any.whl", _unreadable_metadata_wheel(kind)
             ),
         )
+
+
+_HOOK_MISSING = object()
+
+
+class TestRunBuildBackendNonStringHookPath:
+    """PEP 517's path-returning hooks return the basename of what they wrote.
+    ``build`` joins that onto the output directory outside its own hook-error
+    wrapper, so a non-string basename arrives as a bare ``TypeError`` from
+    ``os.path.join`` rather than a ``BuildBackendException``.
+    """
+
+    def _pyproject(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            "[build-system]\n"
+            "requires = []\n"
+            'build-backend = "nab_test_backend"\n'
+            'backend-path = ["."]\n',
+            encoding="utf-8",
+        )
+
+    def _stub_hooks(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        prepare: object = _HOOK_MISSING,
+        build_wheel: object = "foo-1.0-py3-none-any.whl",
+    ) -> None:
+        """Answer the wheel hooks in-process, so no backend subprocess runs.
+
+        A ``prepare`` of ``_HOOK_MISSING`` raises ``HookMissing``, which is what
+        sends ``build.ProjectBuilder.metadata_path`` down its ``build_wheel``
+        fallback.
+        """
+
+        def _prepare(*_a: object, **_k: object) -> object:
+            if prepare is _HOOK_MISSING:
+                raise pyproject_hooks.HookMissing("prepare_metadata_for_build_wheel")
+            return prepare
+
+        monkeypatch.setattr(
+            pyproject_hooks.BuildBackendHookCaller,
+            "get_requires_for_build_wheel",
+            lambda *_a, **_k: [],
+        )
+        monkeypatch.setattr(
+            pyproject_hooks.BuildBackendHookCaller,
+            "prepare_metadata_for_build_wheel",
+            _prepare,
+        )
+        monkeypatch.setattr(
+            pyproject_hooks.BuildBackendHookCaller,
+            "build_wheel",
+            lambda *_a, **_k: build_wheel,
+        )
+
+    def _run(self, tmp_path: Path, config: NabProjectConfig) -> None:
+        env = MagicMock()
+        env.__enter__ = MagicMock(return_value=env)
+        env.__exit__ = MagicMock(return_value=None)
+        with (
+            patch("nab_python._build.runner.NabBuildEnv", return_value=env),
+            pytest.raises(BuildBackendError, match="non-string path"),
+        ):
+            run_build_backend(tmp_path, config=config)
+
+    @pytest.mark.parametrize("value", [None, 1, ["foo-1.0.dist-info"]])
+    def test_prepare_hook_non_string_wrapped(
+        self,
+        tmp_path: Path,
+        config: NabProjectConfig,
+        monkeypatch: pytest.MonkeyPatch,
+        value: object,
+    ) -> None:
+        self._pyproject(tmp_path)
+        self._stub_hooks(monkeypatch, prepare=value)
+        self._run(tmp_path, config)
+
+    def test_build_wheel_fallback_non_string_wrapped(
+        self,
+        tmp_path: Path,
+        config: NabProjectConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """With no prepare hook, ``build.metadata_path`` falls back to
+        ``build_wheel``, whose return hits the same join.
+        """
+        self._pyproject(tmp_path)
+        self._stub_hooks(monkeypatch, build_wheel=1)
+        self._run(tmp_path, config)
+
+    def test_skip_prepare_non_string_wrapped(
+        self,
+        tmp_path: Path,
+        config: NabProjectConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The skip-prepare path calls ``build_wheel`` from the runner itself."""
+        self._pyproject(tmp_path)
+        monkeypatch.setattr(runner_mod, "_should_skip_prepare", lambda *_a: True)
+        self._stub_hooks(monkeypatch, build_wheel=None)
+        self._run(tmp_path, config)
 
 
 class TestRunBuildBackendDefaults:


### PR DESCRIPTION
`run_build_backend` should raise `BuildBackendError` for any backend failure, but a backend whose `prepare_metadata_for_build_wheel` or `build_wheel` returns something other than a string basename slips through. `build` joins the hook's return value onto the output directory outside its own hook-error wrapper, so `os.path.join` raises a bare `TypeError` and `nab lock` exits with an unhandled traceback.

Move the metadata-directory lookup into a helper and catch `TypeError` there alongside the existing unreadable-wheel cases, so the `BuildBackendError` names the backend and reports that the hook returned a non-string path.
