### PR TITLE
backjump instead of aborting when a root extra loses its provider

### DIFF
--- a/nab-python/src/nab_python/_provider/extras.py
+++ b/nab-python/src/nab_python/_provider/extras.py
@@ -64,6 +64,11 @@ def choose_extra_version(
         candidates = list(reversed(candidates))
 
     chosen = _pick_in_mode(provider, base, extra, candidates)
+    if chosen is not None and (normalized, extra) in provider.root_extras:
+        chosen = _pick_for_user_extra(
+            provider, base, extra, chosen, candidates, all_versions
+        )
+
     # Enumerate pre-releases too: default filtering buffers a pre-release
     # behind any matching final and would drop one that the base's bounds
     # exclude, so it would never be recorded and the proxy would keep a
@@ -125,6 +130,46 @@ def _pick_in_mode(
         if metadata is None or extra in provided:
             return version
     return None
+
+
+def _pick_for_user_extra(
+    provider: Provider,
+    base: str,
+    extra: str,
+    chosen: Version,
+    candidates: list[Version],
+    all_versions: list[Version],
+) -> Version | None:
+    """Keep or drop ``chosen`` when the root asked for ``extra``.
+
+    A root extra pins the first in-range version even when that version
+    lacks the extra, so the miss is reported against it rather than
+    against an older version that declares it.  The exception is a range
+    the search narrowed off every version declaring the extra: reporting
+    no version there leaves a clause the search can backjump on.  The
+    check runs against the root requirement's range, so the answer
+    follows the index rather than the metadata fetched so far.
+    """
+    # Late import: ``provider`` imports this module at module load.
+    from ..provider import ExtrasMode
+
+    if provider.extras_mode == ExtrasMode.WARN:
+        return chosen
+
+    _, _, normalized = provider.split_and_normalize(base)
+    root_range = provider.root_requirements.get(normalized, VersionRange.full())
+    outside = [v for v in root_range.filter(all_versions) if v not in candidates]
+    if not outside:
+        return chosen
+
+    if any(version_provides_extra(provider, base, extra, v) for v in candidates):
+        return chosen
+
+    # Declared outside the narrowed range but not inside it: the
+    # narrowing is what lost the extra, so let it be backjumped away.
+    if any(version_provides_extra(provider, base, extra, v) for v in outside):
+        return None
+    return chosen
 
 
 def version_provides_extra(

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -6258,6 +6258,80 @@ class TestExtras:
         version = provider.choose_version("foo[security]", spec.to_range())
         assert version == V("2.0")
 
+    @staticmethod
+    def _user_extra_provider(
+        extras_mode: ExtrasMode,
+        root_spec: str = "",
+        extra: str = "security",
+    ) -> Provider:
+        """A provider whose ``foo`` declares ``security`` only at 2.0.
+
+        ``root_spec`` is the specifier the root requirement put on ``foo``.
+        """
+        wheels = [make_wheel(v) for v in ("3.0", "2.1", "2.0", "1.0")]
+        coordinator = make_coordinator(
+            wheels,
+            package="foo",
+            metadata_by_version={
+                "3.0": make_metadata("foo", "3.0"),
+                "2.1": make_metadata("foo", "2.1"),
+                "2.0": make_metadata("foo", "2.0") + "Provides-Extra: security\n",
+                "1.0": make_metadata("foo", "1.0"),
+            },
+        )
+        return Provider(
+            coordinator,
+            extras_mode=extras_mode,
+            root_extras={("foo", extra)},
+            root_requirements={"foo": SpecifierSet(root_spec).to_range()},
+        )
+
+    @pytest.mark.parametrize(
+        "extras_mode", [ExtrasMode.ERROR_USER, ExtrasMode.BACKTRACK]
+    )
+    def test_user_extra_reports_no_version_when_range_drops_the_provider(
+        self, extras_mode: ExtrasMode
+    ) -> None:
+        """A narrowed range holding no provider of a user extra has no version.
+
+        Pinning one would commit the resolver to a version the extra
+        cannot be expanded from, aborting the resolve instead of
+        backjumping off whatever narrowed the range.
+        """
+        provider = self._user_extra_provider(extras_mode)
+        spec = SpecifierSet(">=2.1")
+        assert provider.choose_version("foo[security]", spec.to_range()) is None
+
+    def test_user_extra_keeps_the_first_version_over_an_older_provider(self) -> None:
+        """A user extra pins the first in-range version, not an older provider."""
+        provider = self._user_extra_provider(ExtrasMode.ERROR_USER)
+        spec = SpecifierSet(">=2.0")
+        assert provider.choose_version("foo[security]", spec.to_range()) == V("3.0")
+
+    def test_user_extra_keeps_the_first_version_when_the_root_excludes_it(self) -> None:
+        """A root range with no provider of its own stays the user's error.
+
+        Pinning the first version reports the miss against it, rather
+        than reporting no version and losing the error naming the extra.
+        """
+        provider = self._user_extra_provider(ExtrasMode.ERROR_USER, root_spec=">=2.1")
+        spec = SpecifierSet(">=2.1")
+        assert provider.choose_version("foo[security]", spec.to_range()) == V("3.0")
+
+    def test_user_extra_keeps_the_first_version_when_no_version_declares_it(
+        self,
+    ) -> None:
+        """An extra no version of the package declares stays the user's error."""
+        provider = self._user_extra_provider(ExtrasMode.ERROR_USER, extra="nonexistent")
+        spec = SpecifierSet(">=2.1")
+        assert provider.choose_version("foo[nonexistent]", spec.to_range()) == V("3.0")
+
+    def test_warn_mode_user_extra_keeps_the_first_version(self) -> None:
+        """WARN mode pins the first in-range version whatever the range."""
+        provider = self._user_extra_provider(ExtrasMode.WARN)
+        spec = SpecifierSet(">=2.1")
+        assert provider.choose_version("foo[security]", spec.to_range()) == V("3.0")
+
     def test_extra_dep_with_arbitrary_equality_is_literal_range(self) -> None:
         """Extra deps using ``===`` round-trip as a literal-only range."""
         metadata = (

--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -1596,6 +1596,101 @@ class TestResolveWithCoordinator:
         with pytest.raises(MissingExtraError):
             resolve_with_coordinator(coordinator, _one_target(), _reqs("pkg[missing]"))
 
+    @staticmethod
+    def _extra_backtrack_coordinator() -> MagicMock:
+        """An index where only ``aa==3.0`` provides the ``y`` extra.
+
+        ``aa[y]`` pulls in ``cc<3.0``, so a resolve that decides ``cc``
+        at 3.0 first has to backjump off that decision to keep the extra.
+        """
+        aa_wheels = [_make_wheel(v, package="aa") for v in ("1.0", "2.0", "2.1", "3.0")]
+        coordinator = make_coordinator(
+            listings={
+                "aa": aa_wheels,
+                "cc": [_make_wheel(v, package="cc") for v in ("1.1", "2.1", "3.0")],
+            },
+            auto_metadata=True,
+        )
+        coordinator.index.store_metadata(
+            "aa",
+            "3.0",
+            "Metadata-Version: 2.1\nName: aa\nVersion: 3.0\n"
+            "Provides-Extra: y\n"
+            'Requires-Dist: cc<3.0; extra == "y"\n\n',
+            aa_wheels[-1].metadata_url,
+        )
+        return coordinator
+
+    @pytest.mark.parametrize(
+        "texts",
+        [("aa[y]>=2.0", "cc>1.0"), ("cc>1.0", "aa[y]>=2.0")],
+    )
+    def test_root_extra_resolves_under_either_root_order(
+        self, texts: tuple[str, str]
+    ) -> None:
+        """A root extra resolves the same however the roots are ordered.
+
+        Root order seeds the decision tiebreak, so deciding ``cc`` first
+        narrows ``aa[y]`` onto versions that do not declare ``y``; the
+        proxy has to report no version there rather than pin one and
+        error out.
+        """
+        result = resolve_with_coordinator(
+            self._extra_backtrack_coordinator(), _one_target(), _reqs(*texts)
+        )
+        assert result.success
+        assert result.target_results[0].pins == {
+            "aa": Version("3.0"),
+            "cc": Version("2.1"),
+        }
+
+    @staticmethod
+    def _narrowed_base_coordinator() -> MagicMock:
+        """An index where only ``aa==3.0`` provides the ``y`` extra.
+
+        ``bb==2.0`` requires ``aa<3.0``, so a resolve that takes it
+        narrows ``aa`` off the extra's only provider before ``aa[y]``
+        is ever asked for a version.
+        """
+        aa_wheels = [_make_wheel(v, package="aa") for v in ("1.0", "2.0", "2.1", "3.0")]
+        bb_wheels = [_make_wheel(v, package="bb") for v in ("1.0", "2.0")]
+        coordinator = make_coordinator(
+            listings={"aa": aa_wheels, "bb": bb_wheels},
+            auto_metadata=True,
+        )
+        coordinator.index.store_metadata(
+            "aa",
+            "3.0",
+            "Metadata-Version: 2.1\nName: aa\nVersion: 3.0\nProvides-Extra: y\n\n",
+            aa_wheels[-1].metadata_url,
+        )
+        coordinator.index.store_metadata(
+            "bb",
+            "2.0",
+            "Metadata-Version: 2.1\nName: bb\nVersion: 2.0\nRequires-Dist: aa<3.0\n\n",
+            bb_wheels[-1].metadata_url,
+        )
+        return coordinator
+
+    @pytest.mark.parametrize("texts", [("bb", "aa[y]"), ("aa[y]", "bb")])
+    def test_root_extra_resolves_when_its_base_is_narrowed_first(
+        self, texts: tuple[str, str]
+    ) -> None:
+        """A root extra survives its base being decided before it is asked.
+
+        Whichever root order runs, ``aa`` is narrowed to ``<3.0`` before
+        ``aa[y]`` picks a version, so the proxy only sees versions that
+        lack ``y`` and has to report none, dropping ``bb==2.0``.
+        """
+        result = resolve_with_coordinator(
+            self._narrowed_base_coordinator(), _one_target(), _reqs(*texts)
+        )
+        assert result.success
+        assert result.target_results[0].pins == {
+            "aa": Version("3.0"),
+            "bb": Version("1.0"),
+        }
+
     def test_constraints_passed_through(self) -> None:
         """The config's constraints reach the resolver."""
         coordinator = _make_coordinator(


### PR DESCRIPTION
A resolvable requirement set can fail with MissingExtraError when a root requirement asks for an extra, and whether it fails flips with the order the roots are declared in.

For a root-requested extra the extras proxy pinned the first version in its current range without checking Provides-Extra. Once the search had narrowed that range onto versions that all lack the extra, the resolver decided one of them and the error aborted the resolve instead of backjumping off whatever caused the narrowing. The proxy now reports no version in that case, leaving a clause the search can backjump on.

Whether the extra is missing at all is checked against the root requirement's own range, so the answer follows the index rather than the metadata the search happened to fetch. The error still fires when no version the root allows declares the extra, and the first in-range version is still pinned when one does.
