### PR TITLE
resolve local index hrefs as URLs, not filesystem paths

### DIFF
--- a/nab-index/src/nab_index/_pep503.py
+++ b/nab-index/src/nab_index/_pep503.py
@@ -27,6 +27,9 @@ _LEGACY_METADATA_ATTR = "data-dist-info-metadata"
 _UPLOAD_TIME_ATTR = "data-upload-time"
 _REPOSITORY_VERSION_META = "pypi:repository-version"
 
+# HTML's ASCII whitespace set: a URL attribute's value may be surrounded by it.
+_HTML_WHITESPACE = "\t\n\f\r "
+
 
 @dataclass(frozen=True, slots=True)
 class Anchor:
@@ -77,7 +80,9 @@ def _anchor(attrs: list[tuple[str, str | None]]) -> Anchor | None:
         return None
 
     metadata = core_metadata if core_metadata is not None else legacy_metadata
-    return Anchor(href, requires_python, metadata, yanked, upload_time)
+    return Anchor(
+        href.strip(_HTML_WHITESPACE), requires_python, metadata, yanked, upload_time
+    )
 
 
 class _ProjectPageParser(HTMLParser):

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -97,7 +97,9 @@ def parse_file_url(url: str) -> Path:
     paths (``file:///C:/...``) and percent-encoded characters round-trip
     cleanly across platforms. An empty or ``localhost`` authority (RFC
     8089) means the local machine; any other host becomes a UNC share on
-    Windows and is rejected elsewhere.
+    Windows and is rejected elsewhere.  :mod:`pathlib` accepts a decoded
+    null character, which names no file on any platform, so it raises
+    :class:`ValueError` here instead.
     """
     parsed = urlparse(url)
     if parsed.scheme != "file":
@@ -113,7 +115,12 @@ def parse_file_url(url: str) -> Path:
         msg = f"non-local file:// URL is not supported on this platform: {url!r}"
         raise ValueError(msg)
 
-    return Path(url2pathname(netloc + parsed.path))
+    path = url2pathname(netloc + parsed.path)
+    if "\x00" in path:
+        msg = f"file:// URL decodes to a path containing a null character: {url!r}"
+        raise ValueError(msg)
+
+    return Path(path)
 
 
 def _resolve_served_path(url: str) -> Path:
@@ -163,14 +170,14 @@ def _scan_pep503_directory(
         raise MalformedLocalListingError(msg) from exc
 
     anchors, base_href = read_page(text)
-    base_url: str | None = None
+    base_url = (package_dir.resolve() / "index.html").as_uri()
     if base_href is not None:
         # A base href every relative anchor resolves against, so one that
         # cannot be parsed leaves the whole page's targets unknown. Fail
-        # loudly rather than fall back to the package directory, which
-        # would resolve each link to a different file than the page names.
+        # loudly rather than fall back to the page URL, which would resolve
+        # each link to a different file than the page names.
         try:
-            base_url = urljoin(index_html.as_uri(), base_href)
+            base_url = urljoin(base_url, base_href)
         except ValueError as exc:
             msg = f"{index_html} has an unparseable <base href>: {exc}"
             raise MalformedLocalListingError(msg) from exc
@@ -182,7 +189,7 @@ def _scan_pep503_directory(
             continue
 
         filename, file_url, local_path, hashes = _resolve_local_link(
-            anchor.href, package_dir, base_url
+            anchor.href, base_url
         )
         if filename is None:
             continue
@@ -202,14 +209,15 @@ def _scan_pep503_directory(
 
 def _resolve_local_link(
     href: str,
-    package_dir: Path,
-    base_url: str | None,
+    base_url: str,
 ) -> tuple[str | None, str, Path | None, tuple[tuple[str, str], ...]]:
     """Resolve an anchor href to ``(filename, url, local_path, hashes)``.
 
-    ``base_url`` is the page's ``<base href>`` when it carries one, else
-    ``None``.  A relative href joins against it; an absolute href ignores
-    it per RFC 3986.
+    ``base_url`` is the page's ``<base href>`` when it carries one, else the
+    ``index.html`` URL.  An href is a URL reference, so only its path
+    component names the artefact, and the target may sit outside the package
+    directory: the standard mirror layout links to a shared
+    ``../../packages/`` tree.
 
     The href's hash fragment is surfaced as the file record's ``hashes``
     tuple so the lockfile writer has something to round-trip.
@@ -225,29 +233,22 @@ def _resolve_local_link(
     # these raise, so the drop guard has to start here rather than at the
     # path resolution below.
     try:
-        if base_url is not None:
-            href_no_frag = urljoin(base_url, href_no_frag)
-        parsed = urlparse(href_no_frag)
+        url = urljoin(base_url, href_no_frag)
+        parsed = urlparse(url)
     except ValueError:
         return (None, href_no_frag, None, hashes)
 
     if parsed.scheme in {"http", "https"}:
         filename = unquote(parsed.path.rsplit("/", 1)[-1]) or None
-        return (filename, href_no_frag, None, hashes)
+        return (filename, url, None, hashes)
 
-    # Drop an anchor we cannot turn into a path (non-local file:// authority,
-    # or a percent-encoded null byte) rather than fail the whole listing.
+    # Drop an anchor naming no local file rather than fail the whole listing.
     try:
-        if parsed.scheme == "file":
-            path = parse_file_url(href_no_frag)
-            return (path.name, href_no_frag, path, hashes)
-        # Without a base href a relative link resolves against the package page;
-        # the standard mirror layout links to a shared ../../packages/ tree, so
-        # the target legitimately sits outside the package directory.
-        target = (package_dir.resolve() / unquote(href_no_frag)).resolve()
+        path = parse_file_url(url)
     except ValueError:
-        return (None, href_no_frag, None, hashes)
-    return (target.name, target.as_uri(), target, hashes)
+        return (None, url, None, hashes)
+
+    return (path.name, url, path, hashes)
 
 
 def _scan_flat_wheelhouse(

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -1356,6 +1356,13 @@ class TestHtmlListing:
         files, _ = self._fetch(_make_cache(tmp_path), page, "text/html")
         assert [f.filename for f in files] == ["torch-2.7.0-py3-none-any.whl"]
 
+    def test_href_wrapped_in_whitespace_is_read(self, tmp_path: Path) -> None:
+        # HTML allows a URL attribute's value to be surrounded by whitespace.
+        page = b'<a href="\n      torch-2.7.0-py3-none-any.whl\n    ">torch</a>'
+        files, _ = self._fetch(_make_cache(tmp_path), page, "text/html")
+        assert [f.filename for f in files] == ["torch-2.7.0-py3-none-any.whl"]
+        assert files[0].url == f"{self._INDEX}torch/torch-2.7.0-py3-none-any.whl"
+
     def test_malformed_base_href_fails_the_listing(self, tmp_path: Path) -> None:
         # Every relative anchor resolves against <base href>, so one that
         # cannot be parsed leaves the page's targets unknown.

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -258,6 +258,10 @@ class TestParseFileUrl:
         with pytest.raises(ValueError, match="expected file:// URL"):
             parse_file_url("https://example.com/")
 
+    def test_rejects_null_character(self) -> None:
+        with pytest.raises(ValueError, match="null character"):
+            parse_file_url("file:///srv/sub%00dir/foo-1.0-py3-none-any.whl")
+
     def test_localhost_authority_is_local(self, tmp_path: Path) -> None:
         # RFC 8089: a "localhost" authority resolves like an empty one.
         with_host = tmp_path.as_uri().replace("file://", "file://localhost", 1)
@@ -568,6 +572,35 @@ class TestPep503Directory:
         assert len(result) == 1
         assert result[0].local_path == wheel_path.resolve()
 
+    def test_relative_href_with_query_names_the_artifact(self, tmp_path: Path) -> None:
+        # RFC 3986 puts the query outside the path, so a cache-busting query
+        # on a relative link is not part of the filename.
+        digest = "b" * 64
+        body = f'<a href="foo-1.0-py3-none-any.whl?rev=7#sha256={digest}">foo</a>'
+        package_dir = self._make_index(tmp_path, body)
+        wheel_path = package_dir / "foo-1.0-py3-none-any.whl"
+        wheel_path.write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        (record,) = run(client.get_files("foo"))
+        assert record.filename == "foo-1.0-py3-none-any.whl"
+        assert record.version == "1.0"
+        assert record.local_path == wheel_path.resolve()
+        assert parse_file_url(record.url) == wheel_path.resolve()
+        assert record.hashes == (("sha256", digest),)
+
+    def test_relative_href_wrapped_in_whitespace_names_the_artifact(
+        self, tmp_path: Path
+    ) -> None:
+        # HTML allows a URL attribute's value to be surrounded by whitespace.
+        body = '<a href="\n      foo-1.0-py3-none-any.whl\n    ">foo</a>'
+        package_dir = self._make_index(tmp_path, body)
+        wheel_path = package_dir / "foo-1.0-py3-none-any.whl"
+        wheel_path.write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        (record,) = run(client.get_files("foo"))
+        assert record.filename == "foo-1.0-py3-none-any.whl"
+        assert record.local_path == wheel_path.resolve()
+
     def test_base_href_redirects_relative_anchor(self, tmp_path: Path) -> None:
         # An absolute <base href> moves the resolution base off the page
         # directory; the relative anchor must land on the real wheel there.
@@ -717,9 +750,22 @@ class TestPep503Directory:
         result = run(client.get_files("foo"))
         assert [r.version for r in result] == ["2.0"]
 
+    def test_pep503_null_byte_directory_href_dropped(self, tmp_path: Path) -> None:
+        # The null byte need not sit in the filename: the guard covers the
+        # whole path, not just its last segment.
+        body = (
+            '<a href="sub%00dir/foo-1.0-py3-none-any.whl">foo-bad</a>'
+            '<a href="foo-2.0-py3-none-any.whl">foo-2.0</a>'
+        )
+        package_dir = self._make_index(tmp_path, body)
+        (package_dir / "foo-2.0-py3-none-any.whl").write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        result = run(client.get_files("foo"))
+        assert [r.version for r in result] == ["2.0"]
+
     def test_pep503_malformed_ipv6_href_dropped(self, tmp_path: Path) -> None:
-        # An unterminated IPv6 bracket makes urlparse raise ValueError before
-        # the scheme is even known; drop that anchor and keep the sibling.
+        # An unterminated IPv6 bracket makes the href join raise ValueError
+        # before the scheme is known; drop that anchor and keep the sibling.
         body = (
             '<a href="http://[bad">foo-bad</a>'
             '<a href="foo-2.0-py3-none-any.whl">foo-2.0</a>'
@@ -733,9 +779,8 @@ class TestPep503Directory:
     def test_pep503_malformed_ipv6_href_under_valid_base_dropped(
         self, tmp_path: Path
     ) -> None:
-        # Under a usable <base href> the join is what raises, one call earlier
-        # than urlparse. Both sit under the same guard, so the anchor is dropped
-        # and its good sibling is kept.
+        # A usable <base href> does not turn one unparseable anchor into a
+        # page failure: the anchor is dropped and its sibling kept.
         body = (
             '<base href="https://mirror.example/simple/foo/">'
             '<a href="http://[bad">foo-bad</a>'


### PR DESCRIPTION
On a `file://` PEP 503 index the anchor href was joined onto the package directory as a filesystem path, so anything in the URL reference that is not part of its path ended up in the filename. A relative link like `foo-1.0-py3-none-any.whl?rev=7` named a file with the query still in it, so the wheel dropped out of the listing. An href wrapped in whitespace, which HTML allows around a URL attribute value, was lost the same way.

Every href now joins against the page's own URL, and only the path component names the file, the way the http and absolute `file:` branches already worked. The anchor parser strips HTML's ASCII whitespace set, so a wrapped href also reads correctly on remote HTML listings. `parse_file_url` rejects a decoded null character, so a `%00` in the path drops that one anchor rather than failing the listing.
