### PR TITLE
fix lock dropping a package shared by a conflict extra

### DIFF
--- a/docs/explanation/conflicts.md
+++ b/docs/explanation/conflicts.md
@@ -130,6 +130,10 @@ member of two or more engaged sets at once, its marker is the
 conjunction across those sets; this stays correct for one set, the
 common case.
 
+A dependency a member shares with a selection outside the set names
+both in its marker (`"cpu" in extras or "docs" in extras`), so
+selecting the member on its own still installs it.
+
 The lockfile stays within PEP 751: the membership markers use the
 standard `extras` and `dependency_groups` variables, and each fork's
 marker negates the co-members of every conflict set it draws from

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -683,12 +683,16 @@ def _build_marker(
     A package a selected extra or group reaches while the project's own
     dependencies do not carries that selection's gate (see
     :attr:`~nab_python.lockfile.TargetLock.package_gates`), which is
-    joined by ``and`` onto each contribution.  An env collapses only when
-    its forks agree on the gate, since one entry cannot carry two.  When the
-    package covers every target, every env collapsed, and every target
-    gates it the same way, the env clauses are dropped and the gate
-    stands alone: a selection is a property of the install context, not
-    of the platform, so ``"cli" in extras`` is the whole marker.
+    joined by ``and`` onto each contribution.  A fork whose gate names
+    its own selection needs no gate: its marker already asserts that
+    member.  An env collapses only when its forks agree on the rest of
+    the gate, and the collapsed entry carries their union, so a package
+    one fork reaches through its own member and another through a
+    non-conflicting extra installs for either.  When the package covers
+    every target, every env collapsed, and every env gates it the same
+    way, the env clauses are dropped and the gate stands alone: a
+    selection is a property of the install context, not of the platform,
+    so ``"cli" in extras`` is the whole marker.
     """
     by_env: defaultdict[tuple[tuple[str, str], ...], list[str]] = defaultdict(list)
     for label in labels:
@@ -701,6 +705,7 @@ def _build_marker(
     # dep present in all forks of an env keeps the membership OR, so it
     # is not unconditional even at full coverage.
     contributions: list[Marker] = []
+    collapsed_gates: set[tuple[tuple[str, str], ...]] = set()
     unconditional = len(labels) >= len(targets)
     for signature, env_labels in by_env.items():
         base_names = env_base_names.get(signature)
@@ -714,15 +719,26 @@ def _build_marker(
             if base_names is not None
             else (env_fork_counts[signature] == 1)
         )
-        agreed_gate = len({gates[label] for label in env_labels}) == 1
+        agreed_gate = (
+            len({_shared_gate(targets[label], gates[label]) for label in env_labels})
+            == 1
+        )
+
         if len(env_labels) >= env_fork_counts[signature] and is_base and agreed_gate:
             head = targets[env_labels[0]].target
+            merged = _merge_gates(gates[label] for label in env_labels)
+            collapsed_gates.add(merged)
             contributions.append(
-                Marker(_with_gate(head.environment_marker_string, gates[env_labels[0]]))
+                Marker(_with_gate(head.environment_marker_string, merged))
             )
         else:
             contributions.extend(
-                Marker(_with_gate(selection_markers[label], gates[label]))
+                Marker(
+                    _with_gate(
+                        selection_markers[label],
+                        _fork_gate(targets[label], gates[label]),
+                    )
+                )
                 for label in env_labels
             )
             unconditional = False
@@ -732,13 +748,54 @@ def _build_marker(
 
     # Every env collapsed at full coverage: the environment is not what
     # selects this package, so only the gate can, and only when every
-    # target agrees on it.
-    common = set(gates.values())
-    if common == {()}:
+    # env agrees on it.
+    if collapsed_gates == {()}:
         return None
-    if len(common) == 1:
-        return Marker(_gate_clause(next(iter(common))))
+    if len(collapsed_gates) == 1:
+        return Marker(_gate_clause(next(iter(collapsed_gates))))
     return _or_markers(contributions)
+
+
+def _shared_gate(
+    lock: TargetLock, gate: tuple[tuple[str, str], ...]
+) -> tuple[tuple[str, str], ...]:
+    """Return the part of a gate the fork's own selection does not supply.
+
+    Two forks of one environment gate a package the same way when these
+    agree; each fork's own member necessarily differs, and
+    :func:`_merge_gates` folds it back in.
+    """
+    return tuple(sorted(set(gate) - set(lock.target.selection)))
+
+
+def _fork_gate(
+    lock: TargetLock, gate: tuple[tuple[str, str], ...]
+) -> tuple[tuple[str, str], ...]:
+    """Return the gate to conjoin onto one fork's own membership marker.
+
+    A gate that names a member of the fork's selection is already
+    satisfied there, so it drops whole rather than narrowing the fork's
+    marker to the gate's other selections.
+    """
+    if set(gate) & set(lock.target.selection):
+        return ()
+    return gate
+
+
+def _merge_gates(
+    gates: Iterable[tuple[tuple[str, str], ...]],
+) -> tuple[tuple[str, str], ...]:
+    """OR the per-fork gates of one collapsing environment into one gate.
+
+    A fork with an empty gate installs the package whenever its own
+    member is selected, so the merged gate is empty too.
+    """
+    merged: set[tuple[str, str]] = set()
+    for gate in gates:
+        if not gate:
+            return ()
+        merged |= set(gate)
+    return tuple(sorted(merged))
 
 
 def _selection_marker(

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -372,7 +372,8 @@ class TargetLock:
 
     ``package_gates`` maps a package this target locked to the selected
     extras and groups that reach it while the project's own dependencies
-    do not, as ``(kind, name)`` members.  The writer emits each one as a
+    do not, as ``(kind, name)`` members, including the conflict fork's
+    own selection.  The writer emits each one as a
     ``'name' in extras`` / ``'name' in dependency_groups`` clause on that
     package's marker, so a default install (no extras, the default
     groups) leaves it out.  A package the project's dependencies reach is

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -165,8 +165,9 @@ class InstallContexts:
     it (see :attr:`~nab_python.lockfile.TargetLock.package_gates`) and a
     default install leaves it out.
 
-    A member of the fork's own ``selection`` is not a selector here: its
-    clause is already on every pin of the fork.
+    The fork's own ``selection`` is one of those selectors, so a package
+    it shares with another active selection names both members and
+    installs for either.
     """
 
     project: tuple[Requirement, ...] = ()
@@ -1081,28 +1082,27 @@ def _plan_forks(
 def _selector_requirements(
     path: Path, tables: _ProjectTables, fork: ConflictFork
 ) -> dict[tuple[str, str], tuple[Requirement, ...]]:
-    """Split a fork's selection into one requirement list per member.
+    """Split a fork's active extras and groups into one requirement list each.
 
     The lock writer walks the resolved graph from each of them to gate
     the packages only that extra or group reaches.  A member of the
-    fork's own ``selection`` is left out: every pin of the fork already
-    carries its clause, so gating it again would only repeat it.
+    fork's own ``selection`` is a selector like any other: a package it
+    shares with another active selection has to name both, or the lock
+    carries only the other one's clause and an install that selects the
+    member alone misses the package.
 
     A group named in ``default-groups`` is here like any other: PEP 751
     seeds ``dependency_groups`` from ``default-groups`` when the
     installer selects none, so the gate still holds for a default
     install.
     """
-    chosen = set(fork.selection)
     selectors: dict[tuple[str, str], tuple[Requirement, ...]] = {}
     for extra in fork.active_extras:
         member = (ConflictKind.EXTRA.value, str(canonicalize_name(extra)))
-        if member not in chosen:
-            selectors[member] = tuple(_extra_requirements(tables, [extra], path))
+        selectors[member] = tuple(_extra_requirements(tables, [extra], path))
     for group in fork.active_groups:
         member = (ConflictKind.GROUP.value, str(canonicalize_name(group)))
-        if member not in chosen:
-            selectors[member] = tuple(_group_requirements(tables.groups, [group], path))
+        selectors[member] = tuple(_group_requirements(tables.groups, [group], path))
     return selectors
 
 

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -854,6 +854,64 @@ class TestConflictForkBaseDepMarkers:
         assert universal.marker is None
 
 
+class TestConflictForkGateMerge:
+    """Forks of one environment merge their gates on a collapsing entry.
+
+    A base dep present in every fork drops its membership clause, so
+    only the selections that reach it still gate the entry, and those
+    differ per fork: a fork reaches it through its own member as well as
+    through the non-conflicting selections every fork shares.
+    """
+
+    _LINUX: ClassVar[ResolveTarget] = _target()
+    _CPU: ClassVar[tuple[tuple[str, str], ...]] = (("extra", "cpu"),)
+    _GPU: ClassVar[tuple[tuple[str, str], ...]] = (("extra", "gpu"),)
+
+    def _marker(
+        self,
+        cpu_gate: tuple[tuple[str, str], ...],
+        gpu_gate: tuple[tuple[str, str], ...],
+    ) -> Marker | None:
+        pins: dict[str, PinShape] = {"shared": _index_pin(name="shared", version="1.0")}
+        cpu = self._LINUX.with_selection(self._CPU)
+        gpu = self._LINUX.with_selection(self._GPU)
+        lock_input = LockInput(
+            targets={
+                cpu.label: TargetLock(
+                    target=cpu, pins=dict(pins), package_gates={"shared": cpu_gate}
+                ),
+                gpu.label: TargetLock(
+                    target=gpu, pins=dict(pins), package_gates={"shared": gpu_gate}
+                ),
+            },
+            env_base_names={_env_signature(self._LINUX): frozenset({"shared"})},
+            extras=("cpu", "gpu", "docs"),
+            conflicts=(
+                ConflictSet(
+                    members=(
+                        ConflictMember(ConflictKind.EXTRA, "cpu"),
+                        ConflictMember(ConflictKind.EXTRA, "gpu"),
+                    ),
+                    policy=ConflictPolicy.AT_MOST_ONE,
+                ),
+            ),
+        )
+        pylock = build_pylock(lock_input)
+        shared = next(p for p in pylock.packages if str(p.name) == "shared")
+        return shared.marker
+
+    def test_own_member_disjoins_with_the_shared_selection(self) -> None:
+        """cpu and docs both reach it; either one on its own installs it."""
+        marker = self._marker(
+            (("extra", "cpu"), ("extra", "docs")), (("extra", "docs"),)
+        )
+        assert str(marker) == '"cpu" in extras or "docs" in extras'
+
+    def test_an_ungated_fork_leaves_the_entry_unconditional(self) -> None:
+        """The cpu fork's own dependencies reach it, so no gate holds."""
+        assert self._marker((), (("extra", "gpu"),)) is None
+
+
 class TestConflictForkBaseDepDivergence:
     """A base dep pinned differently across the conflict forks of one
     environment cannot drop the membership clause on any entry, so no

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -1353,6 +1353,43 @@ class TestResolveUniversalPyproject:
             "torch==2.0+gpu",
         ]
 
+    @patch("nab_python.resolve.resolve_with_coordinator")
+    def test_fork_selects_on_its_own_member_too(
+        self, mock_engine: MagicMock, tmp_path: Path
+    ) -> None:
+        """A fork's own member is one of the selections its lock gates on.
+
+        ``shared`` is required by the conflicting ``cpu`` extra and by the
+        non-conflicting ``docs`` extra, so the cpu fork has to attribute it
+        to both or the lock names only ``docs``.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = ["base"]\n'
+            "[project.optional-dependencies]\n"
+            'cpu = ["shared", "cpu-only"]\n'
+            'gpu = ["gpu-only"]\n'
+            'docs = ["shared", "sphinx"]\n'
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.11"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+        _resolved(pyproject, extras=["cpu", "gpu", "docs"])
+        forks = mock_engine.call_args.kwargs["forks"]
+        cpu = next(f for f in forks if f.selection == (("extra", "cpu"),))
+        assert cpu.contexts is not None
+        selectors = {
+            member: [str(r) for r in reqs]
+            for member, reqs in cpu.contexts.selectors.items()
+        }
+        assert selectors == {
+            ("extra", "cpu"): ["shared", "cpu-only"],
+            ("extra", "docs"): ["shared", "sphinx"],
+        }
+
     def test_exactly_one_with_no_member_raises(self, tmp_path: Path) -> None:
         """A universal exactly-one set with no active member raises."""
         pyproject = tmp_path / "pyproject.toml"
@@ -3895,6 +3932,72 @@ class TestExtraAndGroupMembershipMarkers:
             "mytool": '"cli" in extras',
             "subtool": '"cli" in extras',
         }
+
+
+class TestConflictMemberMembershipMarkers:
+    """A conflict fork's own extra gates the packages only it reaches.
+
+    End to end from ``pyproject.toml`` to the emitted lock, for
+    ``nab lock --extra cpu --extra gpu --extra docs`` over an
+    ``at-most-one`` cpu/gpu set.  ``shared-lib`` is a direct requirement
+    of both ``cpu`` and ``docs``, so its ``packages.marker`` has to name
+    both selections.
+    """
+
+    _NAMES: ClassVar[tuple[str, ...]] = (
+        "core",
+        "shared-lib",
+        "cpu-only",
+        "gpu-only",
+        "sphinx",
+    )
+
+    _MEMBERS: ClassVar[dict[str, str]] = {
+        name: f'[project]\nname = "{name}"\nversion = "1.0"\n' for name in _NAMES
+    }
+
+    _ROOT: ClassVar[str] = (
+        '[project]\nname = "app"\nversion = "1.0"\ndependencies = ["core"]\n'
+        "[project.optional-dependencies]\n"
+        'cpu = ["shared-lib", "cpu-only"]\n'
+        'gpu = ["gpu-only"]\n'
+        'docs = ["shared-lib", "sphinx"]\n'
+        "[tool.nab]\n"
+        'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+        + "".join(
+            f'[[tool.nab.local-sources]]\nname = "{name}"\npath = "{name}"\n'
+            for name in _NAMES
+        )
+    )
+
+    def _lock(self, tmp_path: Path) -> Pylock:
+        return TestExtraAndGroupMembershipMarkers._lock(
+            tmp_path,
+            extras=("cpu", "gpu", "docs"),
+            root=self._ROOT,
+            members=self._MEMBERS,
+        )
+
+    def test_shared_package_names_both_selections_that_reach_it(
+        self, tmp_path: Path
+    ) -> None:
+        markers = TestExtraAndGroupMembershipMarkers._markers(self._lock(tmp_path))
+
+        assert markers["shared-lib"] == '"cpu" in extras or "docs" in extras'
+        assert markers["sphinx"] == '"docs" in extras'
+        assert markers["core"] is None
+
+    def test_selecting_the_member_alone_installs_what_it_requires(
+        self, tmp_path: Path
+    ) -> None:
+        """``shared-lib`` is a direct requirement of the ``cpu`` extra."""
+        pylock = self._lock(tmp_path)
+        selected = TestExtraAndGroupMembershipMarkers._selected
+
+        assert selected(pylock, extras=["cpu"]) == {"core", "cpu-only", "shared-lib"}
+        assert selected(pylock, extras=["gpu"]) == {"core", "gpu-only"}
+        assert selected(pylock, extras=["docs"]) == {"core", "shared-lib", "sphinx"}
+        assert selected(pylock) == {"core"}
 
 
 class TestSidecarFetchFailure:


### PR DESCRIPTION
When a package is reached by both a member of a conflict set and a non-conflicting extra, the lock put only the other selection's clause on its marker. Locking an at-most-one `cpu`/`gpu` project with `--extra cpu --extra gpu --extra docs` gave a package required directly by `cpu` the marker `"docs" in extras`, so an install that selects `cpu` alone skipped it.

A fork's own selection was left out of the install-context selectors, so anything it reached was attributed to whichever other selection also reached it. It is now a selector like the rest. A gate that a fork's own marker already satisfies is dropped rather than narrowed, and the per-fork gates merge when an environment collapses, so the shared package comes out as `"cpu" in extras or "docs" in extras` and installs for either.
