### PR TITLE
Report disjointness and divergent-pin refusals on nab lock --locked

### DIFF
--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -432,11 +432,9 @@ def _check_locked(lock_input: LockInput, *, output: Path | None) -> None:
     lock is never read back into the resolve.
     """
     target = _locked_target_path(output)
-    try:
-        new_text = _cli.render_lock(lock_input, lock_dir=target.parent)
-    except _cli.MissingHashError as e:
-        _cli.printer().error(f"cannot lock: {e}")
-        sys.exit(1)
+    new_text = _render_or_exit(
+        lambda: _cli.render_lock(lock_input, lock_dir=target.parent)
+    )
     committed = _packages_only(target.read_text(encoding="utf-8"))
     if _packages_only(new_text) == committed:
         _cli.printer().done(f"Lockfile {target} is up to date.")
@@ -450,7 +448,7 @@ def _check_locked(lock_input: LockInput, *, output: Path | None) -> None:
 def _emit_pylock(lock_input: LockInput, *, output: Path | None) -> None:
     """Write the PEP 751 lock to a file, or print it."""
     if _cli.is_stdout(output):
-        sys.stdout.write(_render_lock_or_exit(lock_input, target=None))
+        sys.stdout.write(_write_lock_or_exit(lock_input, target=None))
         return
 
     target = output if output is not None else Path(_cli._DEFAULT_OUTPUT["pylock"])  # noqa: SLF001
@@ -458,14 +456,19 @@ def _emit_pylock(lock_input: LockInput, *, output: Path | None) -> None:
     prior = read_lockfile_packages(target)
     # Pass the target so wheel/sdist/directory paths are written relative
     # to the lockfile's own directory, not the cwd.
-    _render_lock_or_exit(lock_input, target=target)
+    _write_lock_or_exit(lock_input, target=target)
     _cli.printer().done(f"Wrote {target} ({summarize_lock(lock_input, prior)})")
 
 
-def _render_lock_or_exit(lock_input: LockInput, *, target: Path | None) -> str:
-    """Render the lock, mapping every emit-time refusal to a clean exit."""
+def _write_lock_or_exit(lock_input: LockInput, *, target: Path | None) -> str:
+    """Write the lock, mapping every render-time refusal to a clean exit."""
+    return _render_or_exit(lambda: _cli.write_lock(lock_input, output_path=target))
+
+
+def _render_or_exit(render: Callable[[], str]) -> str:
+    """Run a lock render, mapping every refusal it raises to a clean exit."""
     try:
-        return _cli.write_lock(lock_input, output_path=target)
+        return render()
     except _cli.MissingHashError as e:
         _cli.printer().error(f"cannot lock: {e}")
         sys.exit(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,7 +74,7 @@ from nab_python.provider import (
     UnsupportedVcsError,
 )
 from nab_python.requirements_file import InvalidProjectRequirementError
-from nab_python.resolve import ResolveResult, TargetResult
+from nab_python.resolve import ResolveResult, TargetResult, env_signature
 from nab_python.tags import PlatformSpec
 from nab_python.target import ResolveTarget
 from nab_resolver.resolver import ResolutionError
@@ -3277,17 +3277,70 @@ def _hashed_resolve_result(*, sha: str) -> ResolveResult:
     )
 
 
+_CONFLICT_PROJECT = (
+    '[project]\nname = "demo"\nversion = "0.1.0"\ndependencies = ["shared"]\n'
+    "[project.optional-dependencies]\n"
+    "cpu = []\n"
+    "gpu = []\n"
+    "[tool.nab]\n"
+    'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+)
+
+
+def _conflict_fork_result(*, shared: tuple[str, str]) -> ResolveResult:
+    """Two conflict forks of the host environment, each pinning ``shared``.
+
+    ``shared`` is a base dependency of both forks, so equal pins collapse to
+    one entry and divergent pins are a refusal.
+    """
+    host = ResolveTarget.for_host()
+    forks = tuple(
+        host.with_selection((("extra", member),)) for member in ("cpu", "gpu")
+    )
+
+    return ResolveResult(
+        targets=forks,
+        target_results=[
+            _resolved(fork, {"shared": V(version)})
+            for fork, version in zip(forks, shared, strict=True)
+        ],
+        env_base_names={env_signature(forks[0]): frozenset({"shared"})},
+    )
+
+
 class TestLockedFlag:
     """``nab lock --locked`` re-resolves and verifies the committed pylock."""
 
-    def _write_lock(self, pyproject: Path, out: Path, result: ResolveResult) -> None:
-        with patch("nab.cli.resolve_for_targets", return_value=result):
-            app.cli(args=["lock", str(pyproject), "--output", str(out)], prog="nab")
-
-    def _run_locked(self, pyproject: Path, out: Path, result: ResolveResult) -> None:
+    def _write_lock(
+        self,
+        pyproject: Path,
+        out: Path,
+        result: ResolveResult,
+        *extra_args: str,
+    ) -> None:
         with patch("nab.cli.resolve_for_targets", return_value=result):
             app.cli(
-                args=["lock", str(pyproject), "--output", str(out), "--locked"],
+                args=["lock", str(pyproject), "--output", str(out), *extra_args],
+                prog="nab",
+            )
+
+    def _run_locked(
+        self,
+        pyproject: Path,
+        out: Path,
+        result: ResolveResult,
+        *extra_args: str,
+    ) -> None:
+        with patch("nab.cli.resolve_for_targets", return_value=result):
+            app.cli(
+                args=[
+                    "lock",
+                    str(pyproject),
+                    "--output",
+                    str(out),
+                    "--locked",
+                    *extra_args,
+                ],
                 prog="nab",
             )
 
@@ -3369,6 +3422,54 @@ class TestLockedFlag:
             )
         assert exc.value.code == 1
         assert "cannot lock" in capsys.readouterr().err
+        assert out.read_bytes() == before
+
+    def test_divergent_base_dep_during_render_exits_one(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # The forks agreed when the lock was committed and now pin the shared
+        # base dependency differently.
+        pyproject = _make_pyproject(tmp_path, _CONFLICT_PROJECT)
+        out = tmp_path / "pylock.toml"
+        agreed = _conflict_fork_result(shared=("1.0", "1.0"))
+        self._write_lock(pyproject, out, agreed, "--extras", "cpu", "gpu")
+        capsys.readouterr()
+        before = out.read_bytes()
+
+        diverged = _conflict_fork_result(shared=("1.0", "2.0"))
+        with pytest.raises(SystemExit) as exc:
+            self._run_locked(pyproject, out, diverged, "--extras", "cpu", "gpu")
+
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "error: shared: the conflict forks of one environment pin" in err
+        assert out.read_bytes() == before
+
+    def test_disjointness_during_render_exits_one(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        self._write_lock(pyproject, out, _stub_resolve_result(pins={"foo": V("1.0")}))
+        capsys.readouterr()
+        before = out.read_bytes()
+
+        hint = "foo: 2 entries fire under env='py311-linux_x86_64'"
+        with (
+            patch(
+                "nab.cli.resolve_for_targets",
+                return_value=_stub_resolve_result(pins={"foo": V("1.0")}),
+            ),
+            patch("nab.cli.render_lock", side_effect=DisjointnessError(hint)),
+            pytest.raises(SystemExit) as exc,
+        ):
+            app.cli(
+                args=["lock", str(pyproject), "--output", str(out), "--locked"],
+                prog="nab",
+            )
+
+        assert exc.value.code == 1
+        assert f"error: {hint}\n" in capsys.readouterr().err
         assert out.read_bytes() == before
 
     def test_malformed_committed_lock_exits_one(


### PR DESCRIPTION
`nab lock --locked` crashed with a raw traceback when the re-resolve hit a disjointness collision or a divergent base-dependency pin across conflict forks. Plain `nab lock` reports both and exits 1, so the check path and the write path disagreed on the same input.

The `--locked` path guarded its `render_lock` call with only `except MissingHashError`, so the other two refusals escaped. Both paths now share one helper that maps all three to an error line and exit 1, leaving the committed lockfile untouched.
