### PR TITLE
pin the Simple-API serialization per index

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -35,7 +35,9 @@ requires-python = ">=3.10"
 # Reproducibility cutoff.  Distributions uploaded after this timestamp
 # are ignored.  Accepts ISO 8601 strings, native TOML datetimes, or a
 # "P<n>D" duration relative to the resolve anchor.  Artifacts from a
-# local file:// index carry no upload time and are always kept.
+# local file:// index carry no upload time and are always kept.  An
+# HTML listing rarely carries one, and a file without an upload time
+# is excluded; see "Serialization" below.
 uploaded-prior-to = "2026-05-01T00:00:00Z"
 
 # Version selection within an allowed range.  Mirrors uv's --resolution.
@@ -148,10 +150,47 @@ url  = "https://pypi.org/simple/"
 [[tool.nab.indexes]]
 name = "torch-cpu"
 url  = "https://download.pytorch.org/whl/cpu"
+
+[[tool.nab.indexes]]
+name = "internal"
+url  = "https://artifactory.example.com/api/pypi/pypi/simple/"
+# Which Simple-API serialization to ask this index for.
+serialization = "html"   # "negotiate" (default) | "json" | "html"
 ```
 
 When `[[tool.nab.indexes]]` is omitted entirely, nab defaults to a
 single PyPI entry.
+
+### Serialization
+
+By default nab negotiates: it advertises the PEP 691 JSON listing, the
+PEP 691 HTML listing and PEP 503 `text/html`, and decodes whichever one
+the index serves.  `serialization` pins a single choice, for an index
+that does not answer both reliably.
+
+The pin covers the `Accept` header and the decoder together.  A pinned
+index that answers in the other serialization is an error: a pin nab
+quietly read past would leave the divergence it was set to stop.  An
+index that holds only the other serialization and negotiates strictly
+answers 406, which fails the same way.  Either error ends the resolve
+rather than falling through to the next index in the list.
+
+Listings fetched under one setting are not reused under another: a
+pinned index keeps its own listing cache.
+
+`serialization` is not settable on a `file://` index, `"negotiate"`
+included.  A local index is read from disk with no `Accept`
+negotiation, so the key is rejected rather than accepted and ignored.
+
+Pinning `html` costs the data PEP 700 defines for the JSON listing
+only, and two of the losses bite:
+
+* A PEP 503 page carries no upload time.  Unless the index emits the
+  non-standard `data-upload-time` attribute, every file it serves is
+  excluded once `uploaded-prior-to` applies.
+* A page carries at most one hash, in the URL fragment.  A file whose
+  only fragment digest is md5 gives `nab lock` nothing to record, and
+  the PEP 751 and requirements writers then fail on the missing hash.
 
 ## Overrides
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -36,8 +36,8 @@ requires-python = ">=3.10"
 # are ignored.  Accepts ISO 8601 strings, native TOML datetimes, or a
 # "P<n>D" duration relative to the resolve anchor.  Artifacts from a
 # local file:// index carry no upload time and are always kept.  An
-# HTML listing rarely carries one, and a file without an upload time
-# is excluded; see "Serialization" below.
+# HTML listing rarely carries one either, and those files are then
+# excluded; see "Serialization" below.
 uploaded-prior-to = "2026-05-01T00:00:00Z"
 
 # Version selection within an allowed range.  Mirrors uv's --resolution.
@@ -169,11 +169,11 @@ the index serves.  `serialization` pins a single choice, for an index
 that does not answer both reliably.
 
 The pin covers the `Accept` header and the decoder together.  A pinned
-index that answers in the other serialization is an error: a pin nab
-quietly read past would leave the divergence it was set to stop.  An
-index that holds only the other serialization and negotiates strictly
-answers 406, which fails the same way.  Either error ends the resolve
-rather than falling through to the next index in the list.
+index that answers in the other serialization is an error: reading it
+anyway would hide the behaviour the pin was set to stop.  An index that
+holds only the other serialization and negotiates strictly answers 406,
+which fails the same way.  Either error ends the resolve rather than
+falling through to the next index in the list.
 
 Listings fetched under one setting are not reused under another: a
 pinned index keeps its own listing cache.
@@ -182,8 +182,8 @@ pinned index keeps its own listing cache.
 included.  A local index is read from disk with no `Accept`
 negotiation, so the key is rejected rather than accepted and ignored.
 
-Pinning `html` costs the data PEP 700 defines for the JSON listing
-only, and two of the losses bite:
+Pinning `html` gives up the extra data PEP 700 defines for the JSON
+listing.  Two of those losses matter:
 
 * A PEP 503 page carries no upload time.  Unless the index emits the
   non-standard `data-upload-time` attribute, every file it serves is

--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -7,11 +7,15 @@ before any HTTP transport call.
 
 Layout under ``root``:
 
-    simple-v1/<index>/<package>.json       <- PEP 691 JSON body
-    simple-v1/<index>/<package>.policy     <- {fetched_at, max_age, etag}
-    simple-neg-v0/<index>/<package>.neg    <- {fetched_at, max_age, etag}
+    simple-v1/<index>[-<serialization>]/<package>.json    <- PEP 691 JSON body
+    simple-v1/<index>[-<serialization>]/<package>.policy  <- {fetched_at, max_age, etag}
+    simple-neg-v0/<index>[-<serialization>]/<package>.neg <- {fetched_at, max_age, etag}
     metadata-v1/<index>/<package>/<url digest>.metadata
     sdist-v1/<index>/<package>/<version>.json  <- {pkg_info, pyproject}
+
+An index pinned to one serialization gets its own listings directory,
+because a body fetched under one serialization is not an answer to a
+request for the other.
 
 A versioned bucket name (``simple-v1``) gives zero-cost schema
 migration: when the on-disk format changes, bump the suffix and the
@@ -42,6 +46,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 
 from .atomic import atomic_write
+from .serialization import SimpleSerialization
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -165,12 +170,23 @@ def _make_removable(root: Path) -> None:
 class OnDiskCache:
     """File-per-key cache for Simple API and wheel metadata."""
 
-    def __init__(self, root: Path, index_url: str) -> None:
+    def __init__(
+        self,
+        root: Path,
+        index_url: str,
+        *,
+        serialization: SimpleSerialization = SimpleSerialization.NEGOTIATE,
+    ) -> None:
         """Create a cache rooted at ``root`` for ``index_url``."""
         self._root = root
         self._index = _index_dirname(index_url)
-        self._simple_dir = root / f"simple-{CACHE_VERSION_SIMPLE}" / self._index
-        self._neg_dir = root / f"simple-neg-{CACHE_VERSION_SIMPLE_NEG}" / self._index
+        simple_index = (
+            self._index
+            if serialization is SimpleSerialization.NEGOTIATE
+            else f"{self._index}-{serialization.value}"
+        )
+        self._simple_dir = root / f"simple-{CACHE_VERSION_SIMPLE}" / simple_index
+        self._neg_dir = root / f"simple-neg-{CACHE_VERSION_SIMPLE_NEG}" / simple_index
         self._metadata_dir = root / f"metadata-{CACHE_VERSION_METADATA}" / self._index
         self._sdist_dir = root / f"sdist-{CACHE_VERSION_SDIST}" / self._index
 

--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -14,8 +14,7 @@ Layout under ``root``:
     sdist-v1/<index>/<package>/<version>.json  <- {pkg_info, pyproject}
 
 An index pinned to one serialization gets its own listings directory,
-because a body fetched under one serialization is not an answer to a
-request for the other.
+since a stored body records nothing about which serialization it came from.
 
 A versioned bucket name (``simple-v1``) gives zero-cost schema
 migration: when the on-disk format changes, bump the suffix and the

--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -91,8 +91,8 @@ class CachedAsyncSimpleClient:
         it. A fresh memo is built when none is passed, so a stand-alone client
         still learns each host's range behaviour within its own lifetime.
 
-        ``serialization`` pins the Simple-API serialization this index is
-        asked for and the one nab will decode from it.
+        ``serialization`` pins which Simple-API serialization this index is
+        asked for and read as.
         """
         self._transport = transport
         self._cache = cache

--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -18,7 +18,6 @@ from typing import TYPE_CHECKING
 from .cache import CacheBackend, CachePolicy, OfflineError
 from .client import (
     _HTTP_NOT_FOUND,
-    _SIMPLE_ACCEPT,
     DEFAULT_INDEX,
     MalformedSimpleResponseError,
     SdistFile,
@@ -38,6 +37,7 @@ from .lazy_wheel import (
     RangeOutcome,
     read_wheel_metadata_over_range,
 )
+from .serialization import SimpleSerialization, simple_accept_header
 from .transport import IDENTITY_HEADERS, raise_unless_ok
 
 if TYPE_CHECKING:
@@ -82,6 +82,7 @@ class CachedAsyncSimpleClient:
         *,
         offline: bool = False,
         range_memo: RangeCapabilityMemo | None = None,
+        serialization: SimpleSerialization = SimpleSerialization.NEGOTIATE,
     ) -> None:
         """Create a cached client wrapping ``transport``.
 
@@ -89,11 +90,15 @@ class CachedAsyncSimpleClient:
         indexes' clients; the coordinator owns the shared instance and injects
         it. A fresh memo is built when none is passed, so a stand-alone client
         still learns each host's range behaviour within its own lifetime.
+
+        ``serialization`` pins the Simple-API serialization this index is
+        asked for and the one nab will decode from it.
         """
         self._transport = transport
         self._cache = cache
         self._index_url = index_url.rstrip("/") + "/"
         self._offline = offline
+        self._serialization = serialization
         self._unreadable_only: set[str] = set()
         self._range_memo = (
             range_memo if range_memo is not None else RangeCapabilityMemo()
@@ -212,7 +217,7 @@ class CachedAsyncSimpleClient:
         self, package: str, body: bytes, policy: CachePolicy
     ) -> list[WheelFile | SdistFile]:
         url = f"{self._index_url}{package}/"
-        headers = {"Accept": _SIMPLE_ACCEPT}
+        headers = {"Accept": simple_accept_header(self._serialization)}
         if policy.etag is not None:
             headers["If-None-Match"] = policy.etag
         response = await self._transport.get(url, headers=headers)
@@ -235,7 +240,9 @@ class CachedAsyncSimpleClient:
             self._cache.put_negative(package, self._negative_policy(response))
             return []
         raise_unless_ok(response, url)
-        new_body = _listing_body(response, self._index_url, package)
+        new_body = _listing_body(
+            response, self._index_url, package, self._serialization
+        )
 
         # Parse before caching so a bad body never poisons the cache.
         files = self._parse_listing(new_body, package)
@@ -250,12 +257,13 @@ class CachedAsyncSimpleClient:
 
     async def _fetch_simple(self, package: str) -> list[WheelFile | SdistFile]:
         url = f"{self._index_url}{package}/"
-        response = await self._transport.get(url, headers={"Accept": _SIMPLE_ACCEPT})
+        accept = simple_accept_header(self._serialization)
+        response = await self._transport.get(url, headers={"Accept": accept})
         if response.status_code == _HTTP_NOT_FOUND:
             self._cache.put_negative(package, self._negative_policy(response))
             return []
         raise_unless_ok(response, url)
-        body = _listing_body(response, self._index_url, package)
+        body = _listing_body(response, self._index_url, package, self._serialization)
 
         # Parse before caching so a bad body never poisons the cache.
         files = self._parse_listing(body, package)

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -268,7 +268,6 @@ def _listing_body(
             if content_type is not None
             else "no Content-Type"
         )
-        # Only an HTML answer names a serialization the user could pin instead.
         instead = (
             f" set serialization = {SimpleSerialization.HTML.value!r},"
             if is_html

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -28,6 +28,7 @@ from packaging.utils import (
 from packaging.version import InvalidVersion, Version
 
 from ._pep503 import json_listing
+from .serialization import SimpleSerialization, simple_accept_header
 from .transport import IDENTITY_HEADERS, HttpError, raise_unless_ok
 
 if TYPE_CHECKING:
@@ -208,13 +209,6 @@ def is_readable_filename(filename: str) -> bool:
     )
 
 
-# PEP 691: advertise every serialization we can read, because an index that
-# cannot honour the header may answer with a type we did not ask for.
-_SIMPLE_ACCEPT = (
-    "application/vnd.pypi.simple.v1+json, "
-    "application/vnd.pypi.simple.v1+html;q=0.2, "
-    "text/html;q=0.01"
-)
 _HTTP_NOT_FOUND = 404
 
 DEFAULT_INDEX = "https://pypi.org/simple/"
@@ -248,15 +242,46 @@ def _is_html_listing(content_type: str | None) -> bool:
     return media_type == "text/html" or media_type.endswith("+html")
 
 
-def _listing_body(response: HttpResponse, index_url: str, package: str) -> bytes:
+def _listing_body(
+    response: HttpResponse,
+    index_url: str,
+    package: str,
+    serialization: SimpleSerialization,
+) -> bytes:
     """Return a listing response's body as PEP 691 JSON bytes.
 
     The served Content-Type picks the decoder. An HTML page is re-serialized
     so the parser and the cache only ever see one shape; any other body is
     passed through untouched.
+
+    Under a pin, nab accepts exactly what it advertised, so a body in the
+    other serialization raises rather than being read anyway.
     """
     body = response.content
-    if not _is_html_listing(_header(response, "content-type")):
+    content_type = _header(response, "content-type")
+    is_html = _is_html_listing(content_type)
+    if serialization is not SimpleSerialization.NEGOTIATE and is_html != (
+        serialization is SimpleSerialization.HTML
+    ):
+        served = (
+            f"Content-Type {content_type!r}"
+            if content_type is not None
+            else "no Content-Type"
+        )
+        # Only an HTML answer names a serialization the user could pin instead.
+        instead = (
+            f" set serialization = {SimpleSerialization.HTML.value!r},"
+            if is_html
+            else ""
+        )
+        msg = (
+            f"{index_url} served {package!r} with {served}, but this index is"
+            f" pinned to serialization = {serialization.value!r}."
+            f"  Drop the pin,{instead} or set url to an endpoint that serves"
+            f" {serialization.value}."
+        )
+        raise MalformedSimpleResponseError(msg)
+    if not is_html:
         return body
 
     try:
@@ -370,11 +395,14 @@ class AsyncSimpleClient:
     async def get_files(self, package: str) -> list[WheelFile | SdistFile]:
         """Fetch all distribution files for a package."""
         url = f"{self._index_url}{package}/"
-        response = await self._transport.get(url, headers={"Accept": _SIMPLE_ACCEPT})
+        accept = simple_accept_header(SimpleSerialization.NEGOTIATE)
+        response = await self._transport.get(url, headers={"Accept": accept})
         if response.status_code == _HTTP_NOT_FOUND:
             return []
         raise_unless_ok(response, url)
-        body = _listing_body(response, self._index_url, package)
+        body = _listing_body(
+            response, self._index_url, package, SimpleSerialization.NEGOTIATE
+        )
         return _parse_files(json.loads(body), self._index_url, package)
 
     async def get_metadata_text(self, metadata_url: str) -> str:

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -252,14 +252,13 @@ def _listing_body(
 
     The served Content-Type picks the decoder. An HTML page is re-serialized
     so the parser and the cache only ever see one shape; any other body is
-    passed through untouched.
-
-    Under a pin, nab accepts exactly what it advertised, so a body in the
-    other serialization raises rather than being read anyway.
+    passed through untouched. A pinned index that answers in the other
+    serialization raises instead.
     """
     body = response.content
     content_type = _header(response, "content-type")
     is_html = _is_html_listing(content_type)
+
     if serialization is not SimpleSerialization.NEGOTIATE and is_html != (
         serialization is SimpleSerialization.HTML
     ):
@@ -280,6 +279,7 @@ def _listing_body(
             f" {serialization.value}."
         )
         raise MalformedSimpleResponseError(msg)
+
     if not is_html:
         return body
 

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -28,7 +28,7 @@ import zlib
 from email.parser import BytesParser, Parser
 from pathlib import Path
 from typing import TYPE_CHECKING
-from urllib.parse import unquote, urljoin, urlparse
+from urllib.parse import unquote, urljoin, urlparse, urlsplit
 from urllib.request import url2pathname
 
 from packaging.utils import InvalidSdistFilename, parse_sdist_filename
@@ -56,6 +56,7 @@ __all__ = [
     "MalformedLocalListingError",
     "NonLocalArtifactError",
     "UnsupportedWheelError",
+    "is_file_url",
     "parse_file_url",
     "read_wheel_metadata",
     "wheel_metadata_member",
@@ -91,6 +92,18 @@ class NonLocalArtifactError(HttpError):
     the fetch fails through the same path as a remote index error rather than a
     raw :class:`ValueError` from :func:`parse_file_url`.
     """
+
+
+def is_file_url(url: str) -> bool:
+    """Whether ``url`` names a local index in either RFC 8089 spelling.
+
+    An authority :func:`urlsplit` cannot parse, such as an unterminated
+    IPv6 bracket, is not a ``file:`` URL.
+    """
+    try:
+        return urlsplit(url).scheme == "file"
+    except ValueError:
+        return False
 
 
 def parse_file_url(url: str) -> Path:

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -95,10 +95,10 @@ class NonLocalArtifactError(HttpError):
 
 
 def is_file_url(url: str) -> bool:
-    """Whether ``url`` names a local index in either RFC 8089 spelling.
+    """Return True when ``url`` is a ``file:`` URL in either RFC 8089 spelling.
 
-    An authority :func:`urlsplit` cannot parse, such as an unterminated
-    IPv6 bracket, is not a ``file:`` URL.
+    An authority :func:`urlsplit` cannot parse, such as an unterminated IPv6
+    bracket, is not one.
     """
     try:
         return urlsplit(url).scheme == "file"

--- a/nab-index/src/nab_index/multi_index.py
+++ b/nab-index/src/nab_index/multi_index.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Protocol
 
 from ._naming import canonical as _normalise_name
 from .cache import OfflineError
+from .serialization import SimpleSerialization
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -115,11 +116,13 @@ class IndexConfig:
     ``name`` is the index identifier used by overrides and lockfile
     output.  ``url`` is the Simple API root (HTTPS or ``file://``).
     Order is significant: callers walk the list left-to-right and
-    presence-based first-index applies.
+    presence-based first-index applies.  ``serialization`` pins the
+    Simple-API serialization this index is asked for and decoded from.
     """
 
     name: str
     url: str
+    serialization: SimpleSerialization = SimpleSerialization.NEGOTIATE
 
 
 class MultiIndexClient:

--- a/nab-index/src/nab_index/multi_index.py
+++ b/nab-index/src/nab_index/multi_index.py
@@ -116,8 +116,8 @@ class IndexConfig:
     ``name`` is the index identifier used by overrides and lockfile
     output.  ``url`` is the Simple API root (HTTPS or ``file://``).
     Order is significant: callers walk the list left-to-right and
-    presence-based first-index applies.  ``serialization`` pins the
-    Simple-API serialization this index is asked for and decoded from.
+    presence-based first-index applies.  ``serialization`` pins which
+    Simple-API serialization this index is asked for and read as.
     """
 
     name: str

--- a/nab-index/src/nab_index/serialization.py
+++ b/nab-index/src/nab_index/serialization.py
@@ -1,7 +1,8 @@
 """Simple-API serialization vocabulary for nab-index.
 
-A leaf module: the enum and the ``Accept`` header each of its members asks
-for, importable from the client, the cache and the config layer alike.
+The enum and the ``Accept`` header each of its members asks for.  Kept free
+of nab-index imports so the client, the cache, and the config layer can all
+reach it.
 """
 
 from __future__ import annotations
@@ -22,10 +23,10 @@ class SimpleSerialization(enum.Enum):
     HTML = "html"
 
 
-# PEP 691: advertise every serialization we can read, because an index that
-# cannot honour the header may answer with a type we did not ask for.  The
-# HTML entry names text/html as well because PEP 691 makes it an alias for
-# the pre-691 spelling, not a second format.
+# PEP 691: negotiation advertises every serialization we can read, because an
+# index that cannot honour the header may answer with a type we did not ask
+# for.  The HTML pin names text/html too, which PEP 691 treats as an alias for
+# the pre-691 spelling rather than a second format.
 _ACCEPT: dict[SimpleSerialization, str] = {
     SimpleSerialization.NEGOTIATE: (
         "application/vnd.pypi.simple.v1+json, "

--- a/nab-index/src/nab_index/serialization.py
+++ b/nab-index/src/nab_index/serialization.py
@@ -1,0 +1,42 @@
+"""Simple-API serialization vocabulary for nab-index.
+
+A leaf module: the enum and the ``Accept`` header each of its members asks
+for, importable from the client, the cache and the config layer alike.
+"""
+
+from __future__ import annotations
+
+import enum
+
+__all__ = [
+    "SimpleSerialization",
+    "simple_accept_header",
+]
+
+
+class SimpleSerialization(enum.Enum):
+    """Which Simple-API serialization nab asks an index for."""
+
+    NEGOTIATE = "negotiate"
+    JSON = "json"
+    HTML = "html"
+
+
+# PEP 691: advertise every serialization we can read, because an index that
+# cannot honour the header may answer with a type we did not ask for.  The
+# HTML entry names text/html as well because PEP 691 makes it an alias for
+# the pre-691 spelling, not a second format.
+_ACCEPT: dict[SimpleSerialization, str] = {
+    SimpleSerialization.NEGOTIATE: (
+        "application/vnd.pypi.simple.v1+json, "
+        "application/vnd.pypi.simple.v1+html;q=0.2, "
+        "text/html;q=0.01"
+    ),
+    SimpleSerialization.JSON: "application/vnd.pypi.simple.v1+json",
+    SimpleSerialization.HTML: "application/vnd.pypi.simple.v1+html, text/html;q=0.01",
+}
+
+
+def simple_accept_header(serialization: SimpleSerialization) -> str:
+    """Return the ``Accept`` header for a listing request under ``serialization``."""
+    return _ACCEPT[serialization]

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -22,7 +22,9 @@ import tomli
 from typing_extensions import override
 
 from nab_index.archive import ArchiveRequest, ArchiveRequestError
+from nab_index.local_index import is_file_url
 from nab_index.multi_index import IndexConfig
+from nab_index.serialization import SimpleSerialization
 from nab_index.subdir import subdirectory_escapes
 
 from ._conflict_kind import KIND_EXTRA, KIND_GROUP
@@ -1725,7 +1727,7 @@ def _environment_from_effective(
     return environment
 
 
-_INDEX_KEYS = frozenset({"name", "url"})
+_INDEX_KEYS = frozenset({"name", "url", "serialization"})
 
 
 def _parse_indexes(value: object) -> tuple[IndexConfig, ...]:
@@ -1758,7 +1760,20 @@ def _parse_indexes(value: object) -> tuple[IndexConfig, ...]:
         if not isinstance(name, str) or not isinstance(url, str):
             msg = f"indexes[{i}] name and url must be strings"
             raise ConfigError(msg)
-        out.append(IndexConfig(name=name, url=url))
+        if "serialization" in entry and is_file_url(url):
+            msg = (
+                f"indexes[{i}].serialization is not settable on a file:// index:"
+                " a local index is read from disk with no Accept negotiation,"
+                f" so the pin would do nothing.  Drop it from index {name!r}."
+            )
+            raise ConfigError(msg)
+        serialization = _parse_enum(
+            f"indexes[{i}].serialization",
+            entry.get("serialization"),
+            SimpleSerialization,
+            SimpleSerialization.NEGOTIATE,
+        )
+        out.append(IndexConfig(name=name, url=url, serialization=serialization))
     _check_index_name_uniqueness(out)
     return tuple(out)
 

--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -39,6 +39,7 @@ from typing import TYPE_CHECKING, Any
 import tomli
 
 from nab_index.multi_index import IndexConfig
+from nab_index.serialization import SimpleSerialization
 
 from ._toml import tool_nab_section
 from .fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL
@@ -547,7 +548,7 @@ def _parse_default_groups(value: Any, where: str) -> tuple[str, ...]:
 
 
 def _parse_indexes(value: Any, where: str) -> tuple[IndexConfig, ...]:
-    # One file's array-of-tables (name, url): config._parse_indexes validates
+    # One file's array-of-tables: config._parse_indexes validates
     # shape, keys, and the within-file same-name check into IndexConfig
     # entries.  The across-file same-name check runs over the concatenation
     # via merge_check (_revalidate_index_names).
@@ -756,7 +757,13 @@ def _render_index_overrides(value: Mapping[str, Any]) -> str:
 def _render_index_list(value: Sequence[IndexConfig]) -> str:
     if not value:
         return "<none>"
-    return ", ".join(f"{i.name}={i.url}" for i in value)
+    return ", ".join(f"{i.name}={i.url}{_render_index_pin(i)}" for i in value)
+
+
+def _render_index_pin(index: IndexConfig) -> str:
+    if index.serialization is SimpleSerialization.NEGOTIATE:
+        return ""
+    return f" serialization={index.serialization.value}"
 
 
 def _render_local_sources(value: Sequence[LocalSource]) -> str:
@@ -978,7 +985,7 @@ OPTIONS: tuple[OptionSpec, ...] = (
     OptionSpec(
         key="indexes",
         scope=Scope.PROJECT,
-        type_label="array-of-tables(name,url)",
+        type_label="array-of-tables(name,url,serialization)",
         default=(IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL),),
         env_var=None,
         cli_flag=None,

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -27,6 +27,7 @@ from nab_index.client import SdistFile, WheelFile
 from nab_index.lazy_wheel import RangeCapabilityMemo, RangeOutcome
 from nab_index.local_index import LocalIndexClient, is_file_url, parse_file_url
 from nab_index.multi_index import IndexConfig, MultiIndexClient
+from nab_index.serialization import SimpleSerialization
 from nab_index.transport import IDENTITY_HEADERS, raise_unless_ok
 
 from ._vendor.packaging.utils import canonicalize_name
@@ -691,10 +692,8 @@ class FetchCoordinator:
         otherwise ``cache_dir`` enables a per-index :class:`OnDiskCache`
         and ``None`` falls back to a :class:`NullCache`.  Passing an
         explicit ``cache_backend`` together with more than one entry in
-        ``indexes`` is rejected: each index needs its own cache.  An
-        explicit backend is used as passed, so a caller that pins an
-        index's ``serialization`` is responsible for building the
-        backend with the same pin.
+        ``indexes``, or with an index that pins its ``serialization``, is
+        rejected: each of those needs its own cache.
         """
         if indexes is None:
             indexes = [IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL)]
@@ -714,6 +713,15 @@ class FetchCoordinator:
             msg = (
                 "explicit cache_backend is incompatible with more than one"
                 " index: pass cache_dir so each index gets its own cache."
+            )
+            raise ValueError(msg)
+        if cache_backend is not None and any(
+            idx.serialization is not SimpleSerialization.NEGOTIATE for idx in indexes
+        ):
+            msg = (
+                "explicit cache_backend is incompatible with a pinned"
+                " serialization: pass cache_dir so the pinned index gets a"
+                " cache of its own."
             )
             raise ValueError(msg)
         if cache_backend is not None:

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -25,7 +25,7 @@ from nab_index.cache import CacheBackend, NullCache, OfflineError, OnDiskCache
 from nab_index.cached_client import CachedAsyncSimpleClient
 from nab_index.client import SdistFile, WheelFile
 from nab_index.lazy_wheel import RangeCapabilityMemo, RangeOutcome
-from nab_index.local_index import LocalIndexClient, parse_file_url
+from nab_index.local_index import LocalIndexClient, is_file_url, parse_file_url
 from nab_index.multi_index import IndexConfig, MultiIndexClient
 from nab_index.transport import IDENTITY_HEADERS, raise_unless_ok
 
@@ -691,7 +691,10 @@ class FetchCoordinator:
         otherwise ``cache_dir`` enables a per-index :class:`OnDiskCache`
         and ``None`` falls back to a :class:`NullCache`.  Passing an
         explicit ``cache_backend`` together with more than one entry in
-        ``indexes`` is rejected: each index needs its own cache.
+        ``indexes`` is rejected: each index needs its own cache.  An
+        explicit backend is used as passed, so a caller that pins an
+        index's ``serialization`` is responsible for building the
+        backend with the same pin.
         """
         if indexes is None:
             indexes = [IndexConfig(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL)]
@@ -1043,11 +1046,10 @@ class FetchCoordinator:
         """
         override_map = _resolve_routes(self._index_routes)
         if len(self.indexes) == 1 and not override_map:
-            cfg = self.indexes[0]
-            return self._build_index_client(cfg.url)
+            return self._build_index_client(self.indexes[0])
         clients_by_name: dict[str, CachedAsyncSimpleClient | LocalIndexClient] = {}
         for cfg in self.indexes:
-            clients_by_name[cfg.name] = self._build_index_client(cfg.url)
+            clients_by_name[cfg.name] = self._build_index_client(cfg)
         order = [cfg.name for cfg in self.indexes]
         return MultiIndexClient(
             clients_by_name,
@@ -1057,36 +1059,32 @@ class FetchCoordinator:
 
     def _build_index_client(
         self,
-        url: str,
+        cfg: IndexConfig,
     ) -> CachedAsyncSimpleClient | LocalIndexClient:
-        """Build a single index client for ``url``.
+        """Build a single index client for ``cfg``.
 
         A ``file:`` URL in either RFC 8089 spelling goes to
         :class:`LocalIndexClient` (no caching; the filesystem is the
         cache).  Everything else goes to :class:`CachedAsyncSimpleClient`
         with a per-URL :class:`OnDiskCache` when ``cache_dir`` is set.
         """
-        # urlsplit raises on an authority it cannot parse, such as an
-        # unterminated IPv6 bracket.
-        try:
-            is_file = urlsplit(url).scheme == "file"
-        except ValueError:
-            is_file = False
-
-        if is_file:
-            return LocalIndexClient(url)
+        if is_file_url(cfg.url):
+            return LocalIndexClient(cfg.url)
 
         backend: CacheBackend
         if self._cache_dir is not None:
-            backend = OnDiskCache(self._cache_dir, url)
+            backend = OnDiskCache(
+                self._cache_dir, cfg.url, serialization=cfg.serialization
+            )
         else:
             backend = self._cache
         return CachedAsyncSimpleClient(
             self._transport,
             backend,
-            url,
+            cfg.url,
             offline=self._offline,
             range_memo=self._range_memo,
+            serialization=cfg.serialization,
         )
 
     async def _async_fetcher(self) -> None:

--- a/nab-python/tests/test_cache.py
+++ b/nab-python/tests/test_cache.py
@@ -14,7 +14,10 @@ import pytest
 
 from nab_index.atomic import atomic_write_text
 from nab_index.cache import (
+    CACHE_VERSION_METADATA,
+    CACHE_VERSION_SDIST,
     CACHE_VERSION_SIMPLE,
+    CACHE_VERSION_SIMPLE_NEG,
     VCS_BUCKET,
     CachePolicy,
     NullCache,
@@ -25,10 +28,14 @@ from nab_index.cache import (
     _encode_policy,
     _index_dirname,
 )
+from nab_index.serialization import SimpleSerialization
 from nab_index.vcs import VcsRequest, prepare_clone
 
 # Derived so a bucket-version bump does not need every path updated.
 SIMPLE_BUCKET = f"simple-{CACHE_VERSION_SIMPLE}"
+NEG_BUCKET = f"simple-neg-{CACHE_VERSION_SIMPLE_NEG}"
+METADATA_BUCKET = f"metadata-{CACHE_VERSION_METADATA}"
+SDIST_BUCKET = f"sdist-{CACHE_VERSION_SDIST}"
 
 # Two wheels of one version, each with its own PEP 658 sidecar.
 METADATA_URLS = (
@@ -792,6 +799,54 @@ class TestAddOwnerMode:
         monkeypatch.setattr(Path, "is_symlink", lambda _self: True)
         _add_owner_mode(target, stat.S_IWUSR)
         assert not target.stat().st_mode & stat.S_IWUSR
+
+
+class TestSerializationPartition:
+    """A pinned index gets its own Simple buckets, sharing the rest."""
+
+    _URL = "https://pypi.org/simple/"
+
+    def test_unpinned_layout_is_unchanged(self, tmp_path: Path) -> None:
+        # The warm caches every existing user already has on disk.
+        cache = OnDiskCache(tmp_path, self._URL)
+        cache.put_simple("foo", b"{}", _FRESH)
+        cache.put_negative("bar", _FRESH)
+        assert (tmp_path / SIMPLE_BUCKET / "pypi" / "foo.json").exists()
+        assert (tmp_path / SIMPLE_BUCKET / "pypi" / "foo.policy").exists()
+        assert (tmp_path / NEG_BUCKET / "pypi" / "bar.neg").exists()
+
+    @pytest.mark.parametrize(
+        ("serialization", "dirname"),
+        [
+            (SimpleSerialization.JSON, "pypi-json"),
+            (SimpleSerialization.HTML, "pypi-html"),
+        ],
+    )
+    def test_pin_gets_its_own_listing_directory(
+        self, tmp_path: Path, serialization: SimpleSerialization, dirname: str
+    ) -> None:
+        cache = OnDiskCache(tmp_path, self._URL, serialization=serialization)
+        cache.put_simple("foo", b"{}", _FRESH)
+        cache.put_negative("bar", _FRESH)
+        assert (tmp_path / SIMPLE_BUCKET / dirname / "foo.json").exists()
+        assert (tmp_path / NEG_BUCKET / dirname / "bar.neg").exists()
+        assert not (tmp_path / SIMPLE_BUCKET / "pypi").exists()
+
+    def test_metadata_and_sdist_records_are_shared(self, tmp_path: Path) -> None:
+        # The same bytes at the same URL however the listing that named
+        # them was serialized, so a flip must not re-download them.
+        unpinned = OnDiskCache(tmp_path, self._URL)
+        unpinned.put_metadata("foo", METADATA_URLS[0], "Name: foo\n")
+        unpinned.put_sdist_files("foo", "1.0", "Name: foo\n", None)
+
+        pinned = OnDiskCache(
+            tmp_path, self._URL, serialization=SimpleSerialization.HTML
+        )
+        pinned.put_metadata("foo", METADATA_URLS[1], "Name: foo\n")
+        assert pinned.get_metadata("foo", METADATA_URLS[0]) == "Name: foo\n"
+        assert pinned.get_sdist_files("foo", "1.0") == ("Name: foo\n", None)
+        assert [p.name for p in (tmp_path / METADATA_BUCKET).iterdir()] == ["pypi"]
+        assert [p.name for p in (tmp_path / SDIST_BUCKET).iterdir()] == ["pypi"]
 
 
 class TestNullCacheEnumeration:

--- a/nab-python/tests/test_cache.py
+++ b/nab-python/tests/test_cache.py
@@ -807,7 +807,6 @@ class TestSerializationPartition:
     _URL = "https://pypi.org/simple/"
 
     def test_unpinned_layout_is_unchanged(self, tmp_path: Path) -> None:
-        # The warm caches every existing user already has on disk.
         cache = OnDiskCache(tmp_path, self._URL)
         cache.put_simple("foo", b"{}", _FRESH)
         cache.put_negative("bar", _FRESH)
@@ -833,8 +832,7 @@ class TestSerializationPartition:
         assert not (tmp_path / SIMPLE_BUCKET / "pypi").exists()
 
     def test_metadata_and_sdist_records_are_shared(self, tmp_path: Path) -> None:
-        # The same bytes at the same URL however the listing that named
-        # them was serialized, so a flip must not re-download them.
+        # Same bytes at the same URL either way, so a flip must not refetch.
         unpinned = OnDiskCache(tmp_path, self._URL)
         unpinned.put_metadata("foo", METADATA_URLS[0], "Name: foo\n")
         unpinned.put_sdist_files("foo", "1.0", "Name: foo\n", None)

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -1656,6 +1656,115 @@ class TestSerializationPin:
             )
 
 
+class TestSerializationCacheFlip:
+    """A body fetched under one pin never answers a request under the other."""
+
+    _INDEX = "https://pypi.org/simple/"
+    _PAGE = b'<a href="pkg-1.0-py3-none-any.whl#sha256=' + b"d" * 64 + b'">pkg</a>'
+    _JSON_BYTES = json.dumps(
+        {
+            "meta": {"api-version": "1.0"},
+            "name": "pkg",
+            "files": [
+                {
+                    "filename": "pkg-1.0-py3-none-any.whl",
+                    "url": "https://files.example.com/pkg-1.0-py3-none-any.whl",
+                    "hashes": {"sha256": "e" * 64},
+                    "size": 4321,
+                    "upload-time": "2026-01-02T03:04:05Z",
+                }
+            ],
+        }
+    ).encode()
+
+    def _cache(self, tmp_path: Path, serialization: SimpleSerialization) -> OnDiskCache:
+        return OnDiskCache(tmp_path, self._INDEX, serialization=serialization)
+
+    def _get(
+        self,
+        tmp_path: Path,
+        serialization: SimpleSerialization,
+        transport: _FakeTransport,
+    ) -> list:
+        cache = self._cache(tmp_path, serialization)
+
+        async def go() -> list:
+            client = CachedAsyncSimpleClient(
+                transport, cache, self._INDEX, serialization=serialization
+            )
+            try:
+                return await client.get_files("pkg")
+            finally:
+                await client.aclose()
+
+        return asyncio.run(go())
+
+    def _warm_html(self, tmp_path: Path, cache_control: str | None = None) -> None:
+        headers = {"content-type": "text/html"}
+        if cache_control is not None:
+            headers["cache-control"] = cache_control
+        self._get(
+            tmp_path,
+            SimpleSerialization.HTML,
+            _FakeTransport([_FakeResponse(self._PAGE, headers=headers)]),
+        )
+
+    def _json_transport(self) -> _FakeTransport:
+        return _FakeTransport(
+            [
+                _FakeResponse(
+                    self._JSON_BYTES,
+                    headers={"content-type": "application/vnd.pypi.simple.v1+json"},
+                )
+            ]
+        )
+
+    def test_fresh_entry_from_the_other_pin_is_refetched(self, tmp_path: Path) -> None:
+        self._warm_html(tmp_path, cache_control="max-age=86400")
+        transport = self._json_transport()
+        files = self._get(tmp_path, SimpleSerialization.JSON, transport)
+        assert len(transport.calls) == 1
+        sent = transport.calls[0][1]
+        assert sent is not None
+        assert "If-None-Match" not in sent
+        (wheel,) = files
+        assert wheel.hashes == (("sha256", "e" * 64),)
+        assert wheel.size == 4321
+        assert wheel.upload_time == "2026-01-02T03:04:05Z"
+
+    def test_stale_entry_from_the_other_pin_is_not_revalidated(
+        self, tmp_path: Path
+    ) -> None:
+        self._warm_html(tmp_path)
+        html_cache = self._cache(tmp_path, SimpleSerialization.HTML)
+        cached = html_cache.get_simple("pkg")
+        assert cached is not None
+        html_cache.put_simple(
+            "pkg", cached[0], CachePolicy(fetched_at=0, max_age=1, etag="html-etag")
+        )
+
+        transport = self._json_transport()
+        files = self._get(tmp_path, SimpleSerialization.JSON, transport)
+        sent = transport.calls[0][1]
+        assert sent is not None
+        assert "If-None-Match" not in sent
+        (wheel,) = files
+        assert wheel.hashes == (("sha256", "e" * 64),)
+
+    def test_negative_sentinel_from_the_other_pin_is_not_served(
+        self, tmp_path: Path
+    ) -> None:
+        self._cache(tmp_path, SimpleSerialization.JSON).put_negative(
+            "pkg", CachePolicy(fetched_at=int(time.time()), max_age=600, etag=None)
+        )
+        transport = _FakeTransport(
+            [_FakeResponse(self._PAGE, headers={"content-type": "text/html"})]
+        )
+        files = self._get(tmp_path, SimpleSerialization.HTML, transport)
+        assert len(transport.calls) == 1
+        assert [f.filename for f in files] == ["pkg-1.0-py3-none-any.whl"]
+
+
 class TestGetMetadataText:
     def test_cold_cache_fetches_and_stores(self, tmp_path: Path) -> None:
         cache = _make_cache(tmp_path)

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -1536,7 +1536,7 @@ class TestHtmlListing:
 
 
 class TestSerializationPin:
-    """A pin fixes the Accept header and the decoder nab will accept."""
+    """A pin fixes both the Accept header and the decoder."""
 
     _INDEX = "https://pypi.org/simple/"
     _PAGE = b'<a href="pkg-1.0-py3-none-any.whl">pkg</a>'

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -40,6 +40,7 @@ from nab_index.client import (
     _select_artifact_hash,
 )
 from nab_index.lazy_wheel import RangeMetadataResult, RangeOutcome
+from nab_index.serialization import SimpleSerialization
 from nab_index.transport import HttpError
 from nab_python.metadata import parse_metadata
 
@@ -1532,6 +1533,127 @@ class TestHtmlListing:
             self._fetch(_make_cache(tmp_path), page, "text/html")
         assert isinstance(caught.value, HttpError)
         assert _make_cache(tmp_path).get_simple("torch") is None
+
+
+class TestSerializationPin:
+    """A pin fixes the Accept header and the decoder nab will accept."""
+
+    _INDEX = "https://pypi.org/simple/"
+    _PAGE = b'<a href="pkg-1.0-py3-none-any.whl">pkg</a>'
+    _JSON_TYPE = "application/vnd.pypi.simple.v1+json"
+
+    def _fetch(
+        self,
+        cache: OnDiskCache,
+        serialization: SimpleSerialization,
+        body: bytes = LISTING_BYTES,
+        content_type: str | None = _JSON_TYPE,
+    ) -> tuple[list, _FakeTransport]:
+        headers = {} if content_type is None else {"content-type": content_type}
+        transport = _FakeTransport([_FakeResponse(body, headers=headers)])
+
+        async def go() -> list:
+            client = CachedAsyncSimpleClient(
+                transport, cache, self._INDEX, serialization=serialization
+            )
+            try:
+                return await client.get_files("pkg")
+            finally:
+                await client.aclose()
+
+        return (asyncio.run(go()), transport)
+
+    def test_json_pin_asks_for_json_only(self, tmp_path: Path) -> None:
+        _, transport = self._fetch(_make_cache(tmp_path), SimpleSerialization.JSON)
+        sent = transport.calls[0][1]
+        assert sent is not None
+        assert sent["Accept"] == "application/vnd.pypi.simple.v1+json"
+
+    def test_html_pin_asks_for_both_html_spellings(self, tmp_path: Path) -> None:
+        _, transport = self._fetch(
+            _make_cache(tmp_path),
+            SimpleSerialization.HTML,
+            self._PAGE,
+            "text/html",
+        )
+        sent = transport.calls[0][1]
+        assert sent is not None
+        assert sent["Accept"] == (
+            "application/vnd.pypi.simple.v1+html, text/html;q=0.01"
+        )
+
+    def test_revalidation_sends_the_pinned_accept_with_the_etag(
+        self, tmp_path: Path
+    ) -> None:
+        cache = _make_cache(tmp_path)
+        cache.put_simple(
+            "pkg",
+            LISTING_BYTES,
+            CachePolicy(fetched_at=0, max_age=1, etag="old-etag"),
+        )
+        _, transport = self._fetch(cache, SimpleSerialization.JSON)
+        sent = transport.calls[0][1]
+        assert sent is not None
+        assert sent["Accept"] == "application/vnd.pypi.simple.v1+json"
+        assert sent["If-None-Match"] == "old-etag"
+
+    def test_json_pin_rejects_an_html_body(self, tmp_path: Path) -> None:
+        with pytest.raises(MalformedSimpleResponseError) as caught:
+            self._fetch(
+                _make_cache(tmp_path),
+                SimpleSerialization.JSON,
+                self._PAGE,
+                "text/html",
+            )
+        message = str(caught.value)
+        assert "Content-Type 'text/html'" in message
+        assert "pinned to serialization = 'json'" in message
+        assert "set serialization = 'html'" in message
+
+    def test_html_pin_rejects_a_json_body(self, tmp_path: Path) -> None:
+        with pytest.raises(MalformedSimpleResponseError) as caught:
+            self._fetch(_make_cache(tmp_path), SimpleSerialization.HTML)
+        message = str(caught.value)
+        assert f"Content-Type {self._JSON_TYPE!r}" in message
+        assert "pinned to serialization = 'html'" in message
+
+    def test_json_pin_decodes_a_json_body(self, tmp_path: Path) -> None:
+        files, _ = self._fetch(_make_cache(tmp_path), SimpleSerialization.JSON)
+        assert [f.filename for f in files] == ["pkg-1.0-py3-none-any.whl"]
+
+    @pytest.mark.parametrize(
+        "content_type",
+        ["text/html", "application/vnd.pypi.simple.v1+html"],
+    )
+    def test_html_pin_decodes_both_html_content_types(
+        self, tmp_path: Path, content_type: str
+    ) -> None:
+        files, _ = self._fetch(
+            _make_cache(tmp_path),
+            SimpleSerialization.HTML,
+            self._PAGE,
+            content_type,
+        )
+        assert [f.filename for f in files] == ["pkg-1.0-py3-none-any.whl"]
+
+    def test_missing_content_type_reads_as_json_under_a_json_pin(
+        self, tmp_path: Path
+    ) -> None:
+        files, _ = self._fetch(
+            _make_cache(tmp_path), SimpleSerialization.JSON, content_type=None
+        )
+        assert [f.filename for f in files] == ["pkg-1.0-py3-none-any.whl"]
+
+    def test_missing_content_type_is_rejected_under_an_html_pin(
+        self, tmp_path: Path
+    ) -> None:
+        with pytest.raises(MalformedSimpleResponseError, match="no Content-Type"):
+            self._fetch(
+                _make_cache(tmp_path),
+                SimpleSerialization.HTML,
+                self._PAGE,
+                content_type=None,
+            )
 
 
 class TestGetMetadataText:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -93,8 +93,7 @@ def universal_mode_section() -> str:
 def indexes_doc_example() -> str:
     """Return the first fenced TOML block of the config reference's Indexes section.
 
-    ``first_tool_nab_example`` only returns blocks that open with
-    ``[tool.nab]``, so the indexes example needs its own reader.
+    ``first_tool_nab_example`` only returns blocks that open with ``[tool.nab]``.
     """
     text = DOCS_CONFIGURATION.read_text()
     section = re.search(r"^## Indexes.*?(?=^## )", text, flags=re.DOTALL | re.MULTILINE)

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -90,6 +90,22 @@ def universal_mode_section() -> str:
     return match.group(0)
 
 
+def indexes_doc_example() -> str:
+    """Return the first fenced TOML block of the config reference's Indexes section.
+
+    ``first_tool_nab_example`` only returns blocks that open with
+    ``[tool.nab]``, so the indexes example needs its own reader.
+    """
+    text = DOCS_CONFIGURATION.read_text()
+    section = re.search(r"^## Indexes.*?(?=^## )", text, flags=re.DOTALL | re.MULTILINE)
+    if section is None:
+        raise AssertionError("no indexes section in configuration.md")
+    blocks = re.findall(r"```toml\n(.*?)```", section.group(0), re.DOTALL)
+    if not blocks:
+        raise AssertionError("no TOML example in configuration.md's indexes section")
+    return blocks[0]
+
+
 def default_groups_doc_comment() -> str:
     """Return the comment above ``default-groups`` in the config reference."""
     lines = first_tool_nab_example().splitlines()
@@ -2086,6 +2102,12 @@ class TestIndexSerialization:
         assert positional == keyword
         assert hash(positional) == hash(keyword)
         assert positional.serialization is SimpleSerialization.NEGOTIATE
+
+    def test_reference_example_parses(self, tmp_path: Path) -> None:
+        path = write(tmp_path, indexes_doc_example())
+        pins = {i.name: i.serialization for i in read_pyproject_config(path).indexes}
+        assert pins["pypi"] is SimpleSerialization.NEGOTIATE
+        assert pins["internal"] is SimpleSerialization.HTML
 
 
 class TestVcs:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+from nab_index.multi_index import IndexConfig
+from nab_index.serialization import SimpleSerialization
 from nab_python._vendor.packaging.markers import default_environment
 from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.version import Version
@@ -159,6 +161,7 @@ class TestDefaults:
         # Default index is PyPI
         assert config.indexes[0].name == DEFAULT_INDEX_NAME
         assert config.indexes[0].url == DEFAULT_INDEX_URL
+        assert config.indexes[0].serialization is SimpleSerialization.NEGOTIATE
         assert config.mode is ResolveMode.SPECIFIC
         assert config.dist_policy is DistPolicy.WHEEL_OR_SDIST
         assert config.build_policy is BuildPolicy.BUILD_LOCAL
@@ -1980,8 +1983,109 @@ class TestIndexes:
             tmp_path,
             '[[tool.nab.indexes]]\nname = "x"\nurl = "https://a/"\nbogus = 1\n',
         )
-        with pytest.raises(ConfigError, match="unknown indexes"):
+        with pytest.raises(
+            ConfigError,
+            match=re.escape("expected ['name', 'serialization', 'url']"),
+        ):
             read_pyproject_config(path)
+
+
+class TestIndexSerialization:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("negotiate", SimpleSerialization.NEGOTIATE),
+            ("json", SimpleSerialization.JSON),
+            ("html", SimpleSerialization.HTML),
+        ],
+    )
+    def test_each_value_parses(
+        self, tmp_path: Path, value: str, expected: SimpleSerialization
+    ) -> None:
+        path = write(
+            tmp_path,
+            "[[tool.nab.indexes]]\n"
+            'name = "x"\n'
+            'url = "https://a/simple/"\n'
+            f'serialization = "{value}"\n',
+        )
+        assert read_pyproject_config(path).indexes[0].serialization is expected
+
+    def test_omitted_key_negotiates(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[[tool.nab.indexes]]\nname = "x"\nurl = "https://a/simple/"\n',
+        )
+        idx = read_pyproject_config(path).indexes[0]
+        assert idx.serialization is SimpleSerialization.NEGOTIATE
+
+    def test_unknown_value_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[[tool.nab.indexes]]\n"
+            'name = "x"\n'
+            'url = "https://a/simple/"\n'
+            'serialization = "xml"\n',
+        )
+        with pytest.raises(
+            ConfigError, match=r"indexes\[0\]\.serialization must be one of"
+        ):
+            read_pyproject_config(path)
+
+    def test_non_string_rejected(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[[tool.nab.indexes]]\n"
+            'name = "x"\n'
+            'url = "https://a/simple/"\n'
+            "serialization = 1\n",
+        )
+        with pytest.raises(ConfigError, match="must be a string, got int"):
+            read_pyproject_config(path)
+
+    @pytest.mark.parametrize("url", ["file:/x", "file://localhost/x", "file:///x"])
+    def test_rejected_on_a_file_index(self, tmp_path: Path, url: str) -> None:
+        path = write(
+            tmp_path,
+            "[[tool.nab.indexes]]\n"
+            'name = "local"\n'
+            f'url = "{url}"\n'
+            'serialization = "html"\n',
+        )
+        with pytest.raises(
+            ConfigError, match="not settable on a file:// index"
+        ) as caught:
+            read_pyproject_config(path)
+        assert "index 'local'" in str(caught.value)
+
+    def test_rejected_on_a_file_index_even_when_default(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[[tool.nab.indexes]]\n"
+            'name = "local"\n'
+            'url = "file:///x"\n'
+            'serialization = "negotiate"\n',
+        )
+        with pytest.raises(ConfigError, match="not settable on a file:// index"):
+            read_pyproject_config(path)
+
+    def test_accepted_on_an_unparseable_authority(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[[tool.nab.indexes]]\n"
+            'name = "bad"\n'
+            'url = "https://[::1/simple/"\n'
+            'serialization = "json"\n',
+        )
+        idx = read_pyproject_config(path).indexes[0]
+        assert idx.serialization is SimpleSerialization.JSON
+
+    def test_positional_construction_still_defaults(self) -> None:
+        positional = IndexConfig("pypi", "https://pypi.org/simple/")
+        keyword = IndexConfig(name="pypi", url="https://pypi.org/simple/")
+        assert positional == keyword
+        assert hash(positional) == hash(keyword)
+        assert positional.serialization is SimpleSerialization.NEGOTIATE
 
 
 class TestVcs:

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -1722,6 +1722,7 @@ class TestArrayOfTablesSources:
 
     def test_indexes_type_label_lists_every_accepted_key(self) -> None:
         spec = next(s for s in OPTIONS if s.key == "indexes")
+        assert spec.type_label == "array-of-tables(name,url,serialization)"
         listed = spec.type_label.partition("(")[2].rstrip(")").split(",")
         assert set(listed) == _INDEX_KEYS
 

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -16,7 +16,10 @@ from pathlib import Path
 
 import pytest
 
+from nab_index.multi_index import IndexConfig
+from nab_index.serialization import SimpleSerialization
 from nab_python.config import (
+    _INDEX_KEYS,
     ConflictKind,
     ConflictMember,
     ConflictPolicy,
@@ -1701,6 +1704,75 @@ class TestArrayOfTablesSources:
         assert spec.render(()) == "<none>"
         rendered = spec.render(spec.default)
         assert rendered == "pypi=https://pypi.org/simple/"
+
+    def test_indexes_render_shows_a_pin(self) -> None:
+        spec = next(s for s in OPTIONS if s.key == "indexes")
+        value = (
+            IndexConfig("pypi", "https://pypi.org/simple/"),
+            IndexConfig(
+                "internal",
+                "https://internal/simple/",
+                serialization=SimpleSerialization.JSON,
+            ),
+        )
+        assert spec.render(value) == (
+            "pypi=https://pypi.org/simple/,"
+            " internal=https://internal/simple/ serialization=json"
+        )
+
+    def test_indexes_type_label_lists_every_accepted_key(self) -> None:
+        spec = next(s for s in OPTIONS if s.key == "indexes")
+        listed = spec.type_label.partition("(")[2].rstrip(")").split(",")
+        assert set(listed) == _INDEX_KEYS
+
+    def test_indexes_bad_serialization_keeps_message(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        _write(
+            tmp_path / "nab.toml",
+            '[[indexes]]\nname = "x"\nurl = "https://a/"\nserialization = "xml"\n',
+        )
+        with pytest.raises(SourceConfigError, match="must be one of"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_indexes_file_url_pin_keeps_message(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        _write(
+            tmp_path / "nab.toml",
+            '[[indexes]]\nname = "local"\nurl = "file:///x"\nserialization = "html"\n',
+        )
+        with pytest.raises(SourceConfigError, match="not settable on a file:// index"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_indexes_pin_survives_the_across_file_concat(self, tmp_path: Path) -> None:
+        _project(
+            tmp_path,
+            '[[tool.nab.indexes]]\nname = "pypi"\nurl = "https://pypi.org/simple/"\n',
+        )
+        _write(
+            tmp_path / "nab.toml",
+            '[[indexes]]\nname = "extra"\nurl = "https://extra/simple/"\n'
+            'serialization = "html"\n',
+        )
+        value = _resolve(SourceRoots(project_dir=tmp_path))["indexes"].value
+        assert [i.name for i in value] == ["pypi", "extra"]
+        assert value[0].serialization is SimpleSerialization.NEGOTIATE
+        assert value[1].serialization is SimpleSerialization.HTML
+
+    def test_indexes_pin_cannot_be_added_to_an_index_declared_elsewhere(
+        self, tmp_path: Path
+    ) -> None:
+        # A same-name entry is a duplicate, not an amendment.
+        _project(
+            tmp_path,
+            '[[tool.nab.indexes]]\nname = "pypi"\nurl = "https://pypi.org/simple/"\n',
+        )
+        _write(
+            tmp_path / "nab.toml",
+            '[[indexes]]\nname = "pypi"\nurl = "https://pypi.org/simple/"\n'
+            'serialization = "json"\n',
+        )
+        with pytest.raises(SourceConfigError, match="duplicate index name"):
+            _resolve(SourceRoots(project_dir=tmp_path))
 
     def test_local_sources_from_pyproject(self, tmp_path: Path) -> None:
         _project(

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -1762,7 +1762,6 @@ class TestArrayOfTablesSources:
     def test_indexes_pin_cannot_be_added_to_an_index_declared_elsewhere(
         self, tmp_path: Path
     ) -> None:
-        # A same-name entry is a duplicate, not an amendment.
         _project(
             tmp_path,
             '[[tool.nab.indexes]]\nname = "pypi"\nurl = "https://pypi.org/simple/"\n',

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -21,7 +21,7 @@ import httpx
 import pytest
 import respx
 
-from nab_index.cache import NullCache, OfflineError
+from nab_index.cache import NullCache, OfflineError, OnDiskCache
 from nab_index.cached_client import CachedAsyncSimpleClient
 from nab_index.client import (
     MalformedSimpleResponseError,
@@ -34,6 +34,7 @@ from nab_index.httpx_async_transport import HttpxAsyncTransport
 from nab_index.lazy_wheel import RangeOutcome
 from nab_index.local_index import LocalIndexClient
 from nab_index.multi_index import IndexConfig, MultiIndexClient
+from nab_index.serialization import SimpleSerialization
 from nab_index.transport import HttpError
 from nab_python.fetch import (
     FetchCoordinator,
@@ -2184,6 +2185,57 @@ class TestMultiIndexCoordinator:
         try:
             client = coord._build_client()
             assert isinstance(client, CachedAsyncSimpleClient)
+        finally:
+            coord.shutdown()
+
+    def test_pin_reaches_the_client_and_its_cache(self, tmp_path: Path) -> None:
+        coord = FetchCoordinator(
+            transport=HttpxAsyncTransport(),
+            cache_dir=tmp_path,
+            indexes=[
+                IndexConfig(
+                    "custom",
+                    "https://custom.example/",
+                    serialization=SimpleSerialization.JSON,
+                )
+            ],
+        )
+        try:
+            client = coord._build_client()
+            assert isinstance(client, CachedAsyncSimpleClient)
+            assert client._serialization is SimpleSerialization.JSON
+            backend = client._cache
+            assert isinstance(backend, OnDiskCache)
+            assert backend._simple_dir.name.endswith("-json")
+        finally:
+            coord.shutdown()
+
+    def test_each_index_keeps_its_own_pin(self, tmp_path: Path) -> None:
+        coord = FetchCoordinator(
+            transport=HttpxAsyncTransport(),
+            cache_dir=tmp_path,
+            indexes=[
+                IndexConfig(
+                    "a", "https://a.example/", serialization=SimpleSerialization.JSON
+                ),
+                IndexConfig(
+                    "b", "https://b.example/", serialization=SimpleSerialization.HTML
+                ),
+            ],
+        )
+        try:
+            client = coord._build_client()
+            assert isinstance(client, MultiIndexClient)
+            first, second = client._clients["a"], client._clients["b"]
+            assert isinstance(first, CachedAsyncSimpleClient)
+            assert isinstance(second, CachedAsyncSimpleClient)
+            assert first._serialization is SimpleSerialization.JSON
+            assert second._serialization is SimpleSerialization.HTML
+            first_cache, second_cache = first._cache, second._cache
+            assert isinstance(first_cache, OnDiskCache)
+            assert isinstance(second_cache, OnDiskCache)
+            assert first_cache._simple_dir.name.endswith("-json")
+            assert second_cache._simple_dir.name.endswith("-html")
         finally:
             coord.shutdown()
 

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -2069,6 +2069,21 @@ class TestMultiIndexCoordinator:
                 ],
             )
 
+    def test_explicit_cache_backend_with_a_pin_raises(self) -> None:
+        """cache_backend + a pinned serialization is a config error."""
+        with pytest.raises(ValueError, match="pinned serialization"):
+            FetchCoordinator(
+                transport=HttpxAsyncTransport(),
+                cache_backend=NullCache(),
+                indexes=[
+                    IndexConfig(
+                        "art",
+                        "https://art.example/",
+                        serialization=SimpleSerialization.JSON,
+                    )
+                ],
+            )
+
     def test_default_indexes_is_pypi(self) -> None:
         """Without explicit indexes, the coordinator defaults to PyPI."""
         coord = FetchCoordinator(transport=HttpxAsyncTransport())

--- a/nab-python/tests/test_index_serialization.py
+++ b/nab-python/tests/test_index_serialization.py
@@ -1,0 +1,30 @@
+"""Tests for nab_index.serialization."""
+
+from __future__ import annotations
+
+from nab_index.serialization import SimpleSerialization, simple_accept_header
+
+
+class TestAcceptHeader:
+    def test_negotiate_advertises_every_supported_type(self) -> None:
+        assert simple_accept_header(SimpleSerialization.NEGOTIATE) == (
+            "application/vnd.pypi.simple.v1+json, "
+            "application/vnd.pypi.simple.v1+html;q=0.2, "
+            "text/html;q=0.01"
+        )
+
+    def test_json_asks_for_one_type_without_a_quality_value(self) -> None:
+        assert (
+            simple_accept_header(SimpleSerialization.JSON)
+            == "application/vnd.pypi.simple.v1+json"
+        )
+
+    def test_html_also_advertises_the_pep503_spelling(self) -> None:
+        assert simple_accept_header(SimpleSerialization.HTML) == (
+            "application/vnd.pypi.simple.v1+html, text/html;q=0.01"
+        )
+
+
+class TestVocabulary:
+    def test_values_are_the_config_vocabulary(self) -> None:
+        assert [m.value for m in SimpleSerialization] == ["negotiate", "json", "html"]


### PR DESCRIPTION
Follow-up to #542. Negotiation is a good default, but it does not help an index that answers inconsistently: the Artifactory instance raised in that thread serves JSON for internal packages and 404s for anything proxied from PyPI, and there was no way to tell nab to stop asking it for JSON.

`[[tool.nab.indexes]]` entries now take `serialization`, one of `"negotiate"` (the default, today's behaviour), `"json"`, or `"html"`. The pin covers the `Accept` header and the decoder together: a pinned index that answers in the other serialization raises, since reading it anyway would hide the behaviour the pin was set to stop.

The reference page spells out what pinning `html` costs: a PEP 503 page carries no upload time and at most one hash, so `uploaded-prior-to` can exclude every file it serves and `nab lock` can fail on a missing hash.

No CLI flag and no env var, matching how indexes are declared today.
