### PR TITLE
honour --offline in artefact downloads and build environments

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -191,6 +191,10 @@ wheel shared across tuples is fetched once.
 lock` uses, so a `NAB_*` variable or a system/user/project `nab.toml` is
 read for `nab download` as for `nab lock`.
 
+Offline covers the artefacts too: an artefact that is neither already in
+the output directory with a matching digest nor readable from a local
+`file://` path fails the run instead of being fetched.
+
 A summary of how many files were written and how many were
 already present is printed to stderr.
 
@@ -247,6 +251,9 @@ Both subcommands accept the same runtime knobs:
 
 A name absent from the index is remembered for a short window, so a
 repeated lookup is answered from cache, offline included.
+
+Offline refuses rather than fetches. A PEP 517 build environment with
+`[build-system].requires` to install fails the run.
 
 `urllib3` is the only backend pulled in by the base install. The
 others surface a helpful `ImportError` if selected without the

--- a/nab-python/src/nab_python/_build/env.py
+++ b/nab-python/src/nab_python/_build/env.py
@@ -146,6 +146,10 @@ class NabBuildEnv:
     marker overlay) before the inner resolve so the build env is
     computed against PyPI alone.
 
+    ``offline`` refuses to populate the env at all, since every build
+    requirement would have to come off the network.  An empty
+    ``requires`` needs nothing fetched and is still served.
+
     The venv is created from the host interpreter and the PEP 517
     hooks run in it, so the build requirements resolve for the host
     and not for any ``--python`` retarget: a wheel for another
@@ -160,11 +164,13 @@ class NabBuildEnv:
         requires: list[str],
         *,
         config: NabProjectConfig,
+        offline: bool = False,
         transport_factory: Callable[[], AsyncHttpTransport] = Urllib3AsyncTransport,
     ) -> None:
         """Capture inputs; the venv and inner resolve happen in __enter__."""
         self._requires = list(requires)
         self._config = config
+        self._offline = offline
         self._transport_factory = transport_factory
 
         self._tmpdir: tempfile.TemporaryDirectory[str] | None = None
@@ -330,6 +336,11 @@ class NabBuildEnv:
         requires = list(self._requires)
         if extra:
             requires.extend(extra)
+
+        if self._offline:
+            joined = ", ".join(requires)
+            msg = f"build requirements unavailable in offline mode: {joined}"
+            raise BuildEnvError(msg)
 
         synthetic_dir = wheel_dir.parent / "_inner_project"
         synthetic_dir.mkdir(parents=True, exist_ok=True)

--- a/nab-python/src/nab_python/_build/runner.py
+++ b/nab-python/src/nab_python/_build/runner.py
@@ -65,6 +65,7 @@ def run_build_backend(
     source_dir: Path,
     *,
     config: NabProjectConfig,
+    offline: bool = False,
 ) -> WheelMetadata:
     """Extract wheel metadata for ``source_dir`` via the build backend.
 
@@ -72,7 +73,8 @@ def run_build_backend(
     the ``METADATA`` file the backend produces.  Raises
     :class:`BuildBackendError` on any failure: backend import
     error, hook crash, malformed METADATA, an unreadable built
-    wheel, or sdist-only build deps.
+    wheel, sdist-only build deps, or build requirements ``offline``
+    bars from being fetched.
 
     The build runs in an isolated venv driven by
     :class:`NabBuildEnv`; nothing in the user's main environment is
@@ -100,7 +102,9 @@ def run_build_backend(
     skip_prepare = _should_skip_prepare(backend, data)
 
     try:
-        with NabBuildEnv(requires=list(requires), config=config) as env:
+        with NabBuildEnv(
+            requires=list(requires), config=config, offline=offline
+        ) as env:
             project = build.ProjectBuilder.from_isolated_env(
                 env,
                 source_dir=str(source_dir),

--- a/nab-python/src/nab_python/_provider/build_remote.py
+++ b/nab-python/src/nab_python/_provider/build_remote.py
@@ -93,6 +93,7 @@ def build_remote_sdist(
             built = build_backend.extract_metadata(
                 source_dir,
                 config=provider.build_config,
+                offline=provider.coordinator.offline,
             )
         except BuildBackendError as exc:
             msg = f"{package}=={version} build-remote backend failed: {exc}"

--- a/nab-python/src/nab_python/_provider/sources.py
+++ b/nab-python/src/nab_python/_provider/sources.py
@@ -118,7 +118,11 @@ def extract_source_metadata(
         )
         raise UnsupportedSdistError(msg)
     try:
-        return build_backend.extract_metadata(path, config=provider.build_config)
+        return build_backend.extract_metadata(
+            path,
+            config=provider.build_config,
+            offline=provider.coordinator.offline,
+        )
     except BuildBackendError as exc:
         msg = f"{descriptor}: {exc}"
         raise UnsupportedSdistError(msg) from exc

--- a/nab-python/src/nab_python/build_backend.py
+++ b/nab-python/src/nab_python/build_backend.py
@@ -202,6 +202,7 @@ def extract_metadata(
     source_dir: Path,
     *,
     config: NabProjectConfig | None = None,
+    offline: bool = False,
 ) -> WheelMetadata:
     """Extract metadata for a source directory.
 
@@ -210,7 +211,8 @@ def extract_metadata(
     the project's PEP 517 backend is invoked in an isolated venv
     via :func:`nab_python._build.runner.run_build_backend`.  That
     needs a :class:`NabProjectConfig`; callers that cannot provide
-    one get a :class:`BuildBackendError` instead.
+    one get a :class:`BuildBackendError` instead.  ``offline`` bars
+    that path from fetching the backend's build requirements.
 
     The build env owns its own HTTP transport (see
     :class:`~nab_python._build.env.NabBuildEnv` for why); callers
@@ -231,4 +233,4 @@ def extract_metadata(
     # which we should not pay for in static-only callers.
     from ._build.runner import run_build_backend  # noqa: PLC0415
 
-    return run_build_backend(source_dir, config=config)
+    return run_build_backend(source_dir, config=config, offline=offline)

--- a/nab-python/src/nab_python/download.py
+++ b/nab-python/src/nab_python/download.py
@@ -184,6 +184,7 @@ def download_lock(
     output_dir: Path,
     *,
     max_concurrency: int = 8,
+    offline: bool = False,
 ) -> DownloadResult:
     """Download every artefact in ``lock_input`` into ``output_dir``.
 
@@ -192,12 +193,18 @@ def download_lock(
     Mismatched files are re-fetched and overwritten.  HTTP failures
     and post-download hash mismatches both raise
     :class:`DownloadError` after the fetcher has shut down.
+
+    ``offline`` refuses any artefact that would need an HTTP fetch;
+    already-present files and local ``file://`` artefacts are still
+    served.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
     artefacts = list(iter_artifacts(lock_input))
     _reject_colliding_targets(artefacts)
     return asyncio.run(
-        _run_downloads(artefacts, transport, output_dir, max_concurrency)
+        _run_downloads(
+            artefacts, transport, output_dir, max_concurrency, offline=offline
+        )
     )
 
 
@@ -206,6 +213,8 @@ async def _run_downloads(
     transport: AsyncHttpTransport,
     output_dir: Path,
     max_concurrency: int,
+    *,
+    offline: bool,
 ) -> DownloadResult:
     sem = asyncio.Semaphore(max_concurrency)
     client = AsyncSimpleClient(transport)
@@ -228,7 +237,7 @@ async def _run_downloads(
                 skipped.append(target)
                 logger.info("skip %s (%s matches)", entry.filename, entry.hash_algo)
                 return
-            data = await _fetch_bytes(entry, client)
+            data = await _fetch_bytes(entry, client, offline=offline)
             actual = hashlib.new(entry.hash_algo, data).hexdigest()
             if actual != entry.digest:
                 msg = (
@@ -255,8 +264,13 @@ async def _run_downloads(
     return DownloadResult(written=tuple(written), skipped=tuple(skipped))
 
 
-async def _fetch_bytes(entry: DownloadEntry, client: AsyncSimpleClient) -> bytes:
-    """Read a local artefact from disk, else fetch it over HTTP."""
+async def _fetch_bytes(
+    entry: DownloadEntry, client: AsyncSimpleClient, *, offline: bool
+) -> bytes:
+    """Read a local artefact from disk, else fetch it over HTTP.
+
+    ``offline`` refuses the HTTP half rather than fetching.
+    """
     if entry.local_path is not None:
         try:
             return entry.local_path.read_bytes()
@@ -266,6 +280,12 @@ async def _fetch_bytes(entry: DownloadEntry, client: AsyncSimpleClient) -> bytes
                 f" {entry.filename} from {entry.local_path}: {exc}"
             )
             raise DownloadError(msg) from exc
+    if offline:
+        msg = (
+            f"{entry.package}=={entry.version}: artefact fetch unavailable"
+            f" in offline mode ({entry.filename})"
+        )
+        raise DownloadError(msg)
     try:
         return await client.download(entry.url)
     except HttpError as exc:

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -1349,6 +1349,54 @@ class TestResolveAndDownload:
             env._resolve_and_download(wheel_dir)
 
 
+def _no_network(*_a: object, **_k: object) -> object:
+    """Stand in for anything an offline build env must not call."""
+    raise AssertionError("offline must not reach the network")
+
+
+class TestBuildEnvOffline:
+    """``offline`` bars the build env from fetching its requirements."""
+
+    @pytest.fixture(autouse=True)
+    def _offline(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("nab_python.resolve.resolve_for_targets", _no_network)
+        monkeypatch.setattr("nab_python._build.env.download_lock", _no_network)
+
+    def test_refuses_before_the_inner_resolve(self, tmp_path: Path) -> None:
+        env = NabBuildEnv(
+            requires=["foo"],
+            config=NabProjectConfig(),
+            offline=True,
+            transport_factory=_no_network,  # type: ignore[arg-type]
+        )
+        wheel_dir = tmp_path / "wheels"
+        wheel_dir.mkdir()
+        with pytest.raises(BuildEnvError, match=r"unavailable in offline mode: foo"):
+            env._resolve_and_download(wheel_dir)
+
+    def test_backend_with_build_requirements_is_refused(self, tmp_path: Path) -> None:
+        source = _write_fake_backend_project(tmp_path)
+        (source / "pyproject.toml").write_text(
+            "[build-system]\n"
+            'requires = ["hatchling"]\n'
+            'build-backend = "nab_test_backend"\n'
+            'backend-path = ["."]\n',
+            encoding="utf-8",
+        )
+        with pytest.raises(
+            BuildBackendError, match=r"unavailable in offline mode: hatchling"
+        ):
+            run_build_backend(source, config=NabProjectConfig(), offline=True)
+
+    def test_backend_with_no_build_requirements_still_builds(
+        self, tmp_path: Path, config: NabProjectConfig
+    ) -> None:
+        """Nothing to fetch, so the offline run is served."""
+        source = _write_fake_backend_project(tmp_path)
+        metadata = run_build_backend(source, config=config, offline=True)
+        assert metadata.name == "fake-pkg"
+
+
 class TestResolveAndDownloadSiblingWheels:
     """``_resolve_and_download`` narrows a pin to the one wheel PEP 425
     prefers, so the build venv never gets two wheels of a version.

--- a/nab-python/tests/test_download.py
+++ b/nab-python/tests/test_download.py
@@ -564,6 +564,68 @@ class TestLocalIndexArtefacts:
             )
 
 
+class TestOffline:
+    """``offline=True`` refuses every artefact that needs an HTTP fetch."""
+
+    def test_refuses_before_touching_the_transport(self, tmp_path: Path) -> None:
+        wheel_bytes = b"WHEELDATA"
+        pin = _index_pin(wheel_sha=hashlib.sha256(wheel_bytes).hexdigest())
+        transport = _FakeTransport({"https://example.com/foo-1.0.whl": wheel_bytes})
+        with pytest.raises(
+            DownloadError,
+            match=(
+                r"foo==1\.0: artefact fetch unavailable in offline mode"
+                r" \(foo-1\.0-py3-none-any\.whl\)"
+            ),
+        ):
+            download_lock(
+                LockInput(targets=_one({"foo": pin})),
+                transport,  # type: ignore[arg-type]
+                tmp_path,
+                offline=True,
+            )
+        assert transport.requested == []
+        assert list(tmp_path.iterdir()) == []
+
+    def test_already_present_file_still_succeeds(self, tmp_path: Path) -> None:
+        wheel_bytes = b"BYTES"
+        (tmp_path / "foo-1.0-py3-none-any.whl").write_bytes(wheel_bytes)
+        pin = _index_pin(wheel_sha=hashlib.sha256(wheel_bytes).hexdigest())
+        transport = _FakeTransport({})
+        result = download_lock(
+            LockInput(targets=_one({"foo": pin})),
+            transport,  # type: ignore[arg-type]
+            tmp_path,
+            offline=True,
+        )
+        assert len(result.skipped) == 1
+        assert result.written == ()
+        assert transport.requested == []
+
+    def test_local_path_artefact_still_succeeds(self, tmp_path: Path) -> None:
+        src = tmp_path / "wheelhouse"
+        src.mkdir()
+        out = tmp_path / "out"
+        wheel_bytes = b"WHEELDATA"
+        wheel_file = src / "foo-1.0-py3-none-any.whl"
+        wheel_file.write_bytes(wheel_bytes)
+        wheel = WheelArtifact(
+            filename="foo-1.0-py3-none-any.whl",
+            url=wheel_file.as_uri(),
+            hashes=(("sha256", hashlib.sha256(wheel_bytes).hexdigest()),),
+            local_path=wheel_file,
+        )
+        pin = IndexPin(name="foo", version="1.0", index="local", wheels=(wheel,))
+        result = download_lock(
+            LockInput(targets=_one({"foo": pin})),
+            _FakeTransport({}),  # type: ignore[arg-type]
+            out,
+            offline=True,
+        )
+        assert (out / "foo-1.0-py3-none-any.whl").read_bytes() == wheel_bytes
+        assert len(result.written) == 1
+
+
 def test_download_entry_is_a_dataclass() -> None:
     e = DownloadEntry(
         package="foo",

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -2863,7 +2863,43 @@ class TestLocalSources:
             build_policy=BuildPolicy.BUILD_LOCAL,
         )
         assert len(provider.fetch_versions("foo")) == 1
-        assert captured == {"config": provider.build_config}
+        assert captured == {"config": provider.build_config, "offline": False}
+
+    def test_local_source_build_refused_under_an_offline_coordinator(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The build env's own fetches obey ``--offline`` too."""
+        self._write_local(
+            tmp_path,
+            """
+            [project]
+            name = "foo"
+            version = "1.0"
+            dynamic = ["dependencies"]
+
+            [build-system]
+            requires = ["hatchling"]
+            build-backend = "hatchling.build"
+            """,
+        )
+
+        def _boom(*_args: object, **_kwargs: object) -> object:
+            raise AssertionError("offline must not reach the network")
+
+        monkeypatch.setattr("nab_python.resolve.resolve_for_targets", _boom)
+        coordinator = make_coordinator([], package="foo")
+        coordinator.offline = True
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            local_sources=[LocalSource("foo", str(tmp_path))],
+            build_policy=BuildPolicy.BUILD_LOCAL,
+            build_config=NabProjectConfig(),
+        )
+        with pytest.raises(UnsupportedSdistError, match="offline mode"):
+            provider.fetch_versions("foo")
 
     def test_priority_does_not_shadow_local_source_with_pypi_listing(
         self,
@@ -8306,7 +8342,10 @@ class TestEffectiveBuildPolicy:
         assert captured["bytes"] == archive_bytes
         # The backend runs on the host interpreter, so the resolve
         # target's Python must not reach the build env.
-        assert captured["kwargs"] == {"config": provider.build_config}
+        assert captured["kwargs"] == {
+            "config": provider.build_config,
+            "offline": False,
+        }
 
     def test_resolve_dynamic_sdist_reuses_cross_tuple_cache(self) -> None:
         """A second call for the same sdist returns the cached metadata.
@@ -8838,7 +8877,7 @@ class TestStaticSdistMetadata:
 
         coordinator.request_sdist_archive.side_effect = _request_archive
 
-        def _naive_build(_path: object, *, config: object) -> WheelMetadata:
+        def _naive_build(_path: object, **_kwargs: object) -> WheelMetadata:
             raise InvalidUploadTimeError(
                 "setuptools 68.0.0 has a timezone-naive upload time"
                 " '2025-06-01T00:00:00'; the Simple API requires"

--- a/src/nab/_download.py
+++ b/src/nab/_download.py
@@ -144,6 +144,7 @@ def download(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag so a config 
             download_transport,
             output,
             max_concurrency=settings.max_concurrency,
+            offline=settings.offline,
         )
     except DownloadError as e:
         _cli.printer().error(f"download failed: {e}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4344,6 +4344,21 @@ class TestDownloadCommand:
             download(pyproject, output=out)
         mock_dl.assert_called_once()
 
+    @pytest.mark.parametrize("offline", [True, False])
+    def test_threads_offline_into_the_artefact_fetch(
+        self, tmp_path: Path, offline: bool
+    ) -> None:
+        """``--offline`` must reach the download, not just the resolve."""
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "vendor"
+        download_result = MagicMock(written=(), skipped=())
+        with (
+            patch("nab.cli.resolve_for_targets", return_value=_stub_resolve_result()),
+            patch("nab.cli.download_lock", return_value=download_result) as mock_dl,
+        ):
+            download(pyproject, output=out, offline=offline)
+        assert mock_dl.call_args.kwargs["offline"] is offline
+
     def test_project_override_uses_download_wording(
         self,
         tmp_path: Path,


### PR DESCRIPTION
`--offline` says it never hits the network, but two paths still reached it. `nab download` fetched every artefact over HTTPS whenever the output directory was empty, and a project with dynamic metadata went back to PyPI through its PEP 517 build environment to install `[build-system].requires`, at the default build policy.

The setting now reaches the artefact download and the build environment, each refusing with an "unavailable in offline mode" error instead of fetching. What is already local still works: an artefact sitting in the output directory with a matching digest or behind a `file://` URL, and a build environment with nothing to install.
