### PR TITLE
fix lock markers that demand a member of every conflict set

### DIFF
--- a/docs/explanation/conflicts.md
+++ b/docs/explanation/conflicts.md
@@ -125,10 +125,16 @@ selection, which is how the writer tells the two apart. When the
 forks of one environment pin a base dependency at different versions,
 no single entry can serve the no-member context; the writer raises a
 `DivergentBaseDependencyError` rather than emit a lock that silently
-skips the dependency. When a single dependency is required by every
-member of two or more engaged sets at once, its marker is the
-conjunction across those sets; this stays correct for one set, the
-common case.
+skips the dependency.
+
+With two or more sets engaged, each entry names only the sets its
+package varies over. A dependency one member of one set pulls in at the
+same version in every fork of the other sets contributes no clause for
+them, so selecting that member on its own installs it, and a dependency
+a member of each of two sets reaches is selected by either alone. A
+package whose version does depend on the combination keeps the
+conjunction, and so does anything that requires it: an entry never
+fires where one of its own dependencies would not.
 
 A dependency a member shares with a selection outside the set names
 both in its marker (`"cpu" in extras or "docs" in extras`), so

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -12,9 +12,11 @@ from __future__ import annotations
 
 import os
 from collections import Counter, defaultdict
+from dataclasses import dataclass
 from functools import reduce
+from itertools import product
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import tomli_w
 
@@ -63,6 +65,64 @@ __all__ = [
     "build_pylock",
     "write_lock",
 ]
+
+# A hashable environment (see _env_signatures), a set of (kind, name)
+# selection members, and the key a fork is indexed under.
+_EnvSignature: TypeAlias = "tuple[tuple[str, str], ...]"
+_Members: TypeAlias = "frozenset[tuple[str, str]]"
+_ForkKey: TypeAlias = "tuple[_EnvSignature, _Members]"
+
+_NO_MEMBERS: _Members = frozenset()
+
+
+@dataclass(frozen=True, slots=True)
+class _ForkAxes:
+    """The declared conflict sets a lock's forks vary along.
+
+    ``exclusion_groups`` are the ``(kind, name)`` member sets an install
+    context may activate at most one member of.  ``forks`` indexes every
+    target by its environment and its selection, which is how
+    :func:`_project_fork` walks one set's members with the other sets
+    held fixed.  ``markers`` is each fork's unprojected selection marker,
+    which does not vary by package, and ``gates`` each fork's
+    :attr:`~nab_python.lockfile.TargetLock.package_gates` as sets.
+    """
+
+    exclusion_groups: tuple[AbstractSet[tuple[str, str]], ...]
+    forks: Mapping[_ForkKey, str]
+    targets: Mapping[str, TargetLock]
+    env_signatures: Mapping[str, _EnvSignature]
+    markers: Mapping[str, str]
+    gates: Mapping[tuple[str, str], _Members]
+
+
+@dataclass(frozen=True, slots=True)
+class _Projection:
+    """One package's marker shape at one fork.
+
+    ``dropped`` are the selection members whose clauses fall away, and
+    ``gate`` is the membership gate that stands in for the fork's own
+    once they do (:func:`_merged_fork_gate`).
+    """
+
+    dropped: _Members
+    gate: _Members
+
+
+def _fork_index(
+    targets: Mapping[str, TargetLock],
+    env_signatures: Mapping[str, _EnvSignature],
+) -> dict[_ForkKey, str]:
+    """Index every target by its environment and its selection.
+
+    A conflict-forked environment holds one target per point of the
+    cartesian product across the engaged sets, so this is the lookup that
+    answers "which fork agrees with this one everywhere but here".
+    """
+    return {
+        (env_signatures[label], frozenset(lock.target.selection)): label
+        for label, lock in targets.items()
+    }
 
 
 class UnsoundSimplificationError(ValueError):
@@ -499,18 +559,33 @@ def _build_packages(
     base_names = _close_base_names(
         targets, env_signatures, env_fork_counts, lock_input.env_base_names
     )
-    # One selection marker per label; it does not vary by package.
-    selection_markers = {
-        label: _selection_marker(lock.target, exclusion_groups)
-        for label, lock in targets.items()
+    pin_groups = {
+        canonical_name: _group_pins_by_pin(per_target)
+        for canonical_name, per_target in by_name.items()
     }
     shortened: dict[str, Marker | None] = {}
+    axes = _ForkAxes(
+        exclusion_groups=tuple(exclusion_groups),
+        forks=_fork_index(targets, env_signatures),
+        targets=targets,
+        env_signatures=env_signatures,
+        # One selection marker per label; it does not vary by package.
+        markers={
+            label: _selection_marker(lock.target, exclusion_groups)
+            for label, lock in targets.items()
+        },
+        gates={
+            (name, label): frozenset(gate)
+            for label, lock in targets.items()
+            for name, gate in lock.package_gates.items()
+        },
+    )
+    projections = _fork_projections(axes, pin_groups, env_fork_counts, base_names)
 
-    for canonical_name, per_target in by_name.items():
-        groups = _group_pins_by_pin(per_target)
+    for canonical_name, groups in pin_groups.items():
         _check_base_fork_agreement(
             canonical_name,
-            per_target,
+            by_name[canonical_name],
             groups,
             env_signatures,
             env_fork_counts,
@@ -521,11 +596,10 @@ def _build_packages(
             marker = _build_marker(
                 canonical_name,
                 labels,
-                targets,
-                env_signatures,
                 env_fork_counts,
                 base_names,
-                selection_markers,
+                axes,
+                projections,
             )
             marker = _finalize_cached(marker, universe, canonical_name, shortened)
             out.append(
@@ -765,11 +839,10 @@ def _check_base_fork_agreement(
 def _build_marker(
     name: str,
     labels: Sequence[str],
-    targets: Mapping[str, TargetLock],
-    env_signatures: Mapping[str, tuple[tuple[str, str], ...]],
     env_fork_counts: Mapping[tuple[tuple[str, str], ...], int],
     env_base_names: Mapping[tuple[tuple[str, str], ...], frozenset[str]],
-    selection_markers: Mapping[str, str],
+    axes: _ForkAxes,
+    projections: Mapping[tuple[str, str], _Projection],
 ) -> Marker | None:
     """Return the marker selecting ``labels``, or ``None`` if unconditional.
 
@@ -795,6 +868,13 @@ def _build_marker(
     reads ``[tool.nab].conflicts`` still installs at most one fork.  See
     :func:`_selection_marker`.
 
+    The selection is projected per package first: a conflict set the
+    package does not vary over contributes no clause, so with two sets
+    engaged a dep reached through one of them names only that one and
+    still installs for a selection that leaves the other set empty.  See
+    :func:`_fork_projections`.  The projection makes several forks render
+    the same contribution, which is emitted once.
+
     A package a selected extra or group reaches while the project's own
     dependencies do not carries that selection's gate (see
     :attr:`~nab_python.lockfile.TargetLock.package_gates`), which is
@@ -809,9 +889,10 @@ def _build_marker(
     selection is a property of the install context, not of the platform,
     so ``"cli" in extras`` is the whole marker.
     """
+    targets = axes.targets
     by_env: defaultdict[tuple[tuple[str, str], ...], list[str]] = defaultdict(list)
     for label in labels:
-        by_env[env_signatures[label]].append(label)
+        by_env[axes.env_signatures[label]].append(label)
 
     gates = {label: targets[label].package_gates.get(name, ()) for label in labels}
 
@@ -823,17 +904,7 @@ def _build_marker(
     collapsed_gates: set[tuple[tuple[str, str], ...]] = set()
     unconditional = len(labels) >= len(targets)
     for signature, env_labels in by_env.items():
-        base_names = env_base_names.get(signature)
-
-        # When no base pass ran for an env (``base_names is None``),
-        # treat the dep as base only if no fork ran either; with forks
-        # but no base attribution, base status is unknowable and the
-        # safe answer is to keep the membership OR.
-        is_base = (
-            (name in base_names)
-            if base_names is not None
-            else (env_fork_counts[signature] == 1)
-        )
+        is_base = _is_base(name, signature, env_fork_counts, env_base_names)
         agreed_gate = (
             len({_shared_gate(targets[label], gates[label]) for label in env_labels})
             == 1
@@ -848,13 +919,8 @@ def _build_marker(
             )
         else:
             contributions.extend(
-                Marker(
-                    _with_gate(
-                        selection_markers[label],
-                        _fork_gate(targets[label], gates[label]),
-                    )
-                )
-                for label in env_labels
+                Marker(text)
+                for text in _fork_contributions(axes, projections, name, env_labels)
             )
             unconditional = False
 
@@ -871,6 +937,221 @@ def _build_marker(
     return _or_markers(contributions)
 
 
+def _fork_contributions(
+    axes: _ForkAxes,
+    projections: Mapping[tuple[str, str], _Projection],
+    name: str,
+    env_labels: Sequence[str],
+) -> list[str]:
+    """Render one environment's per-fork markers, projected and deduped.
+
+    Each fork drops the clauses of the conflict sets the package does not
+    vary over (:func:`_fork_projections`), which leaves the forks of a
+    dropped set rendering the same text; the duplicates are folded into
+    one contribution, in first-seen order.
+    """
+    seen: dict[str, None] = {}
+    for label in env_labels:
+        target = axes.targets[label].target
+        projection = projections[name, label]
+        text = (
+            axes.markers[label]
+            if not projection.dropped
+            else _selection_marker(target, axes.exclusion_groups, projection.dropped)
+        )
+        kept = frozenset(target.selection) - projection.dropped
+        seen[_with_gate(text, _fork_gate(kept, projection.gate))] = None
+    return list(seen)
+
+
+def _fork_projections(
+    axes: _ForkAxes,
+    pin_groups: Mapping[str, Sequence[tuple[list[PinShape], list[str]]]],
+    env_fork_counts: Mapping[_EnvSignature, int],
+    env_base_names: Mapping[_EnvSignature, frozenset[str]],
+) -> dict[tuple[str, str], _Projection]:
+    """Return, per (package, fork), the selection clauses its marker can drop.
+
+    Every fork starts free to drop its whole selection and
+    :func:`_project_fork` keeps only what the fork space justifies.  The
+    dependency edges then narrow it: an entry that fires where one of its
+    own dependencies does not is a lock that cannot be installed, so a
+    package keeps every member its dependencies at that fork keep.  The
+    allowances only shrink, so the loop settles.
+    """
+    same_pin: dict[tuple[str, str], frozenset[str]] = {}
+    edges: dict[tuple[str, str], frozenset[str]] = {}
+    for name, groups in pin_groups.items():
+        for _, labels in groups:
+            group = frozenset(labels)
+            declared = frozenset(
+                dep
+                for peer in labels
+                for dep in axes.targets[peer].dependencies.get(name, ())
+            )
+            for label in labels:
+                same_pin[name, label] = group
+                edges[name, label] = declared
+
+    limits = {key: frozenset(axes.targets[key[1]].target.selection) for key in same_pin}
+    projections: dict[tuple[str, str], _Projection] = {}
+    stale = set(same_pin)
+    while stale:
+        for name, label in stale:
+            projections[name, label] = _project_fork(
+                axes,
+                name,
+                label,
+                limits[name, label],
+                same_pin[name, label],
+                is_base=_is_base(
+                    name, axes.env_signatures[label], env_fork_counts, env_base_names
+                ),
+            )
+        narrowed = {
+            (name, label): limit
+            & _dependency_drops(axes, projections, label, edges[name, label])
+            for (name, label), limit in limits.items()
+        }
+        stale = {key for key, limit in narrowed.items() if limit != limits[key]}
+        limits = narrowed
+    return projections
+
+
+def _dependency_drops(
+    axes: _ForkAxes,
+    projections: Mapping[tuple[str, str], _Projection],
+    label: str,
+    declared: AbstractSet[str],
+) -> _Members:
+    """Return the members every dependency an entry declares drops at one fork.
+
+    :func:`_dependency_entries` unions the edges over the entry's forks,
+    so an edge only one fork has still rides on the whole entry; a fork
+    that does not carry that dependency at all can drop nothing.
+    """
+    shared = frozenset(axes.targets[label].target.selection)
+    for dep in declared:
+        projection = projections.get((dep, label))
+        shared &= projection.dropped if projection is not None else _NO_MEMBERS
+    return shared
+
+
+def _project_fork(
+    axes: _ForkAxes,
+    name: str,
+    label: str,
+    limit: _Members,
+    same_pin: AbstractSet[str],
+    *,
+    is_base: bool,
+) -> _Projection:
+    """Return the clauses one fork's entry for ``name`` can drop.
+
+    A declared conflict set is irrelevant to a package when swapping the
+    fork's member of that set for any other member, every other set held
+    fixed, leaves the package at the same pin reached the same way.
+    Conjoining such a set's clauses narrows the entry to the forks that
+    vary something the package does not depend on, so a selection naming
+    a member of one set alone matches no entry and the package silently
+    does not install.
+
+    Sets are folded in one at a time and each candidate is checked over
+    the whole sub-cube of the sets folded in so far rather than one axis
+    at a time.  Two axes that are each flat through this fork can still
+    meet at a fork with a different pin; dropping both would leave two
+    entries of one package overlapping, and the forks have to stay
+    mutually exclusive in the marker itself.
+    """
+    own_gate = axes.gates.get((name, label), _NO_MEMBERS)
+    selection = frozenset(axes.targets[label].target.selection)
+    signature = axes.env_signatures[label]
+
+    dropped: _Members = frozenset()
+    gate = own_gate
+    varying: list[AbstractSet[tuple[str, str]]] = []
+    for group in axes.exclusion_groups:
+        member = group & selection & limit
+        if len(member) != 1:
+            continue
+
+        candidate = [*varying, group]
+        erased = _NO_MEMBERS.union(*candidate)
+        held = selection - erased
+        keys = [
+            (signature, held | frozenset(swap))
+            for swap in product(*(sorted(members) for members in candidate))
+        ]
+        peers = [axes.forks[key] for key in keys if key in axes.forks]
+        if len(peers) != len(keys) or not same_pin.issuperset(peers):
+            continue
+
+        merged = _merged_fork_gate(axes, name, peers, erased)
+        if merged is None:
+            continue
+        varying = candidate
+        dropped |= member
+        gate = merged
+
+    # A member-only package with nothing left to name would fire in the
+    # no-member install context, where a dep the base does not require
+    # must not install.
+    if not is_base and not gate and not selection - dropped:
+        return _Projection(frozenset(), own_gate)
+    return _Projection(dropped, gate)
+
+
+def _merged_fork_gate(
+    axes: _ForkAxes,
+    name: str,
+    peers: Sequence[str],
+    erased: _Members,
+) -> _Members | None:
+    """Return the gate the sub-cube's forks share, or ``None`` when they do not.
+
+    Dropping a set replaces the fork's own gate with one that holds at
+    every point of the sub-cube: the part naming nothing in the dropped
+    sets, plus every dropped member that reaches the package in the forks
+    that select it.  The forks share such a gate only when each one's is
+    exactly that, so a member that reaches the package under one fork of
+    the other dropped sets but not another refuses the drop rather than
+    guessing which way the projected entry should fire.
+    """
+    gates = {peer: axes.gates.get((name, peer), _NO_MEMBERS) for peer in peers}
+
+    # An empty gate means that fork installs the package whichever of its
+    # members are selected (:func:`_merge_gates`), which no clause stands
+    # in for, so a sub-cube mixing the two does not project.
+    if len({bool(gate) for gate in gates.values()}) != 1:
+        return None
+
+    residual = gates[peers[0]] - erased
+    carried = frozenset(member for gate in gates.values() for member in gate & erased)
+    for peer, gate in gates.items():
+        if gate != residual | (carried & set(axes.targets[peer].target.selection)):
+            return None
+    return residual | carried
+
+
+def _is_base(
+    name: str,
+    signature: _EnvSignature,
+    env_fork_counts: Mapping[_EnvSignature, int],
+    env_base_names: Mapping[_EnvSignature, frozenset[str]],
+) -> bool:
+    """Say whether an environment's base pass reached ``name``.
+
+    When no base pass ran for the env (the signature is missing), treat
+    the dep as base only if no fork ran either; with forks but no base
+    attribution, base status is unknowable and the safe answer is to keep
+    the membership OR.
+    """
+    base_names = env_base_names.get(signature)
+    if base_names is None:
+        return env_fork_counts[signature] == 1
+    return name in base_names
+
+
 def _shared_gate(
     lock: TargetLock, gate: tuple[tuple[str, str], ...]
 ) -> tuple[tuple[str, str], ...]:
@@ -884,17 +1165,18 @@ def _shared_gate(
 
 
 def _fork_gate(
-    lock: TargetLock, gate: tuple[tuple[str, str], ...]
+    kept: AbstractSet[tuple[str, str]], gate: AbstractSet[tuple[str, str]]
 ) -> tuple[tuple[str, str], ...]:
     """Return the gate to conjoin onto one fork's own membership marker.
 
-    A gate that names a member of the fork's selection is already
+    A gate that names a member the fork's marker still asserts is already
     satisfied there, so it drops whole rather than narrowing the fork's
-    marker to the gate's other selections.
+    marker to the gate's other selections.  A member whose clause the
+    projection dropped asserts nothing, so it does not count.
     """
-    if set(gate) & set(lock.target.selection):
+    if gate & kept:
         return ()
-    return gate
+    return tuple(sorted(gate))
 
 
 def _merge_gates(
@@ -916,24 +1198,35 @@ def _merge_gates(
 def _selection_marker(
     target: ResolveTarget,
     exclusion_groups: Sequence[AbstractSet[tuple[str, str]]],
+    dropped: AbstractSet[tuple[str, str]] = frozenset(),
 ) -> str:
     """Return the fork's per-package marker with its co-members negated.
 
-    Starts from the target's
-    :attr:`~nab_python.target.ResolveTarget.marker_string` and conjoins
-    ``'name' not in <variable>`` for every other member of every conflict
-    set the selection draws from, so at most one fork installs.  A
-    selection drawing from no exclusion group returns ``marker_string``
-    unchanged.
+    Conjoins ``'name' in <variable>`` for every member of the selection
+    onto the target's environment marker, then ``'name' not in
+    <variable>`` for every other member of every conflict set the
+    selection draws from, so at most one fork installs.  With no
+    ``dropped`` members this is the target's
+    :attr:`~nab_python.target.ResolveTarget.marker_string` plus the
+    negations, and a selection drawing from no exclusion group is
+    ``marker_string`` unchanged.
+
+    ``dropped`` are the members of conflict sets the package does not
+    vary over (:func:`_project_fork`); both their positive clause and
+    their set's negations fall away, since a set nothing is kept from is
+    no longer drawn from.
     """
-    selected = set(target.selection)
+    selected = set(target.selection) - set(dropped)
 
     co_members: set[tuple[str, str]] = set()
     for group in exclusion_groups:
         if group & selected:
             co_members |= group - selected
 
-    marker = target.marker_string
+    marker = target.environment_marker_string
+    for kind, name in sorted(selected):
+        variable = MARKER_VARIABLE_FOR_KIND[kind]
+        marker += f' and "{name}" in {variable}'
     for kind, name in sorted(co_members):
         variable = MARKER_VARIABLE_FOR_KIND[kind]
         marker += f' and "{name}" not in {variable}'

--- a/nab-python/src/nab_python/lockfile.py
+++ b/nab-python/src/nab_python/lockfile.py
@@ -366,9 +366,10 @@ class TargetLock:
     conflict environment's no-member base-name set over these edges only.
 
     ``target`` is the environment the pins hold for.  The writer reads
-    its markers (see :attr:`~nab_python.target.ResolveTarget.marker_string`)
-    rather than being handed a projection of them, so a lock entry and
-    the environment it was resolved for cannot drift apart.
+    its markers and its
+    :attr:`~nab_python.target.ResolveTarget.selection` rather than being
+    handed a projection of them, so a lock entry and the environment it
+    was resolved for cannot drift apart.
 
     ``package_gates`` maps a package this target locked to the selected
     extras and groups that reach it while the project's own dependencies

--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -663,9 +663,9 @@ class ResolveTarget:
     ``(kind, name)`` members (``kind`` is ``"extra"`` or ``"group"``)
     active in this fork's resolve, empty for an unforked one.  When set,
     it adds a ``'name' in extras`` / ``'name' in dependency_groups``
-    clause to :attr:`marker_string`; the lockfile emitter derives the
-    per-package marker, which also negates the co-members of the conflict
-    sets that forbid co-selection, from it.
+    clause to :attr:`marker_string`; the lockfile emitter builds the
+    per-package marker from the members themselves, keeping only the sets
+    the package varies over and negating their co-members.
 
     ``platform_spec`` is set on a declared (matrix) target and names the
     tag knobs it was expanded from; a host target has none.

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -5370,3 +5370,306 @@ class TestConflictForkNegatedEmission:
 
         assert torch_markers["2.5.0"] == raw_marker(("a0", "b0", "c0"))
         assert torch_markers["2.6.0"] == raw_marker(("a1", "b1", "c1"))
+
+
+class TestConflictSetCrossGating:
+    """Two engaged conflict sets gate a package only along the set it varies over.
+
+    ``--all-groups`` over two declared sets forks into their cartesian
+    product.  A package one member of one set pulls in is the same in
+    every fork of the other set, so its marker names only its own set;
+    conjoining a member of both leaves a selection naming a member of one
+    set alone matching no entry, which under-installs silently.  The
+    projection stops wherever a dependency cannot follow it.
+
+    The fixture mirrors what a resolve produces for a project with
+    ``a1 = [six==1.16.0]``, ``a2 = [six==1.15.0]``,
+    ``b1/b2/b3 = [idna==3.7/3.6/3.4]``, a base dependency on
+    ``packaging``, and ``conflicts = [[a1, a2], [b1, b2, b3]]``.
+    """
+
+    _BASE: ClassVar[ResolveTarget] = _target(python_version="3.12")
+    _ENV: ClassVar[dict[str, str]] = dict(_target(python_version="3.12").marker_env)
+    _A: ClassVar[dict[str, str]] = {"a1": "1.16.0", "a2": "1.15.0"}
+    _B: ClassVar[dict[str, str]] = {"b1": "3.7", "b2": "3.6", "b3": "3.4"}
+
+    @property
+    def _conflicts(self) -> tuple[ConflictSet, ...]:
+        return tuple(
+            ConflictSet(
+                members=tuple(ConflictMember(ConflictKind.GROUP, m) for m in members),
+                policy=ConflictPolicy.AT_MOST_ONE,
+            )
+            for members in (self._A, self._B)
+        )
+
+    def _forked_lock(
+        self,
+        contribution: Callable[
+            [str, str],
+            tuple[dict[str, PinShape], dict[str, tuple[tuple[str, str], ...]]],
+        ],
+        base_names: frozenset[str] = frozenset(),
+        edges: Callable[[str, str], dict[str, tuple[str, ...]]] | None = None,
+    ) -> Pylock:
+        """Emit the 2x3 product of the a and b sets, one fork per point."""
+        targets: dict[str, TargetLock] = {}
+        for a, b in itertools.product(self._A, self._B):
+            fork = self._BASE.with_selection((("group", a), ("group", b)))
+            pins, gates = contribution(a, b)
+            targets[fork.label] = TargetLock(
+                target=fork,
+                pins=pins,
+                dependencies=edges(a, b) if edges is not None else {},
+                package_gates=gates,
+            )
+        text = write_lock(
+            LockInput(
+                targets=targets,
+                env_base_names={_env_signature(self._BASE): base_names},
+                dependency_groups=(*self._A, *self._B),
+                conflicts=self._conflicts,
+            )
+        )
+        return Pylock.from_dict(tomllib.loads(text))
+
+    def _lock(self) -> Pylock:
+        def contribution(
+            a: str, b: str
+        ) -> tuple[dict[str, PinShape], dict[str, tuple[tuple[str, str], ...]]]:
+            return (
+                {
+                    "packaging": _selection_pin("packaging", "24.0"),
+                    "six": _selection_pin("six", self._A[a]),
+                    "idna": _selection_pin("idna", self._B[b]),
+                },
+                # What ``_membership_gates`` derives: the group whose
+                # requirements reach the package, and nothing for the
+                # package the project requires itself.
+                {"six": (("group", a),), "idna": (("group", b),)},
+            )
+
+        return self._forked_lock(contribution, base_names=frozenset({"packaging"}))
+
+    def _select(self, pylock: Pylock, groups: Sequence[str]) -> set[str]:
+        return {
+            f"{pkg.name} {pkg.version}"
+            for pkg, _ in pylock.select(
+                environment=self._ENV,  # type: ignore[arg-type]
+                extras=(),
+                dependency_groups=groups,
+            )
+        }
+
+    def _dangling(self, pylock: Pylock) -> list[tuple[tuple[str, ...], str, list[str]]]:
+        """Selections where a selected entry declares a dep the selection misses."""
+        out = []
+        for a, b in itertools.product([None, *self._A], [None, *self._B]):
+            groups = tuple(name for name in (a, b) if name is not None)
+            chosen = [
+                pkg
+                for pkg, _ in pylock.select(
+                    environment=self._ENV,  # type: ignore[arg-type]
+                    extras=(),
+                    dependency_groups=groups,
+                )
+            ]
+            names = {str(pkg.name) for pkg in chosen}
+            for pkg in chosen:
+                missing = sorted(
+                    {str(dep["name"]) for dep in (pkg.dependencies or ())} - names
+                )
+                if missing:
+                    out.append((groups, str(pkg.name), missing))
+        return out
+
+    def test_marker_names_only_the_set_the_package_varies_over(self) -> None:
+        by_key = {
+            (str(p.name), str(p.version)): str(p.marker) for p in self._lock().packages
+        }
+
+        six = by_key["six", "1.16.0"]
+        assert '"a1" in dependency_groups' in six
+        assert '"a2" not in dependency_groups' in six
+        assert not any(member in six for member in self._B)
+
+        idna = by_key["idna", "3.7"]
+        assert '"b1" in dependency_groups' in idna
+        assert '"b2" not in dependency_groups' in idna
+        assert '"b3" not in dependency_groups' in idna
+        assert not any(member in idna for member in self._A)
+
+    def test_base_dependency_keeps_its_unconditional_entry(self) -> None:
+        packaging = next(p for p in self._lock().packages if str(p.name) == "packaging")
+        assert packaging.marker is None
+
+    @pytest.mark.parametrize("a", [None, "a1", "a2"])
+    @pytest.mark.parametrize("b", [None, "b1", "b2", "b3"])
+    def test_every_legal_selection_installs_what_it_asked_for(
+        self, a: str | None, b: str | None
+    ) -> None:
+        # at-most-one permits selecting none of a set, so the legal
+        # selections are the product of each set plus its empty case.
+        groups = [name for name in (a, b) if name is not None]
+        expected = {"packaging 24.0"}
+        if a is not None:
+            expected.add(f"six {self._A[a]}")
+        if b is not None:
+            expected.add(f"idna {self._B[b]}")
+        assert self._select(self._lock(), groups) == expected
+
+    def test_entries_of_one_name_stay_disjoint(self) -> None:
+        # The forks stay mutually exclusive in the markers alone, with no
+        # conflict-declaration universe to lean on.
+        pylock = self._lock()
+        for name in ("six", "idna"):
+            markers = [
+                MarkerSet.from_marker(str(p.marker))
+                for p in pylock.packages
+                if str(p.name) == name
+            ]
+            for left, right in itertools.combinations(markers, 2):
+                assert left.is_disjoint(right)
+
+    def test_disjointness_gate_accepts_the_projected_markers(self) -> None:
+        validate_marker_disjointness(
+            self._lock().packages,
+            environments={"env": self._ENV},
+            extras=(),
+            groups=(*self._A, *self._B),
+            exclusive_groups=conflict_exclusion_groups(self._conflicts),
+        )
+
+    def test_a_package_varying_over_both_sets_keeps_both(self) -> None:
+        # attrs is pinned by the a-member and the b-member together, so
+        # neither set is flat and the marker keeps the full conjunction.
+        pylock = self._forked_lock(
+            lambda a, b: (
+                {"attrs": _selection_pin("attrs", f"{a[-1]}.{b[-1]}")},
+                {"attrs": (("group", a), ("group", b))},
+            )
+        )
+        marker = next(str(p.marker) for p in pylock.packages if str(p.version) == "1.1")
+        assert '"a1" in dependency_groups' in marker
+        assert '"b1" in dependency_groups' in marker
+        assert '"a2" not in dependency_groups' in marker
+        assert '"b2" not in dependency_groups' in marker
+        assert '"b3" not in dependency_groups' in marker
+
+    def test_member_only_package_flat_everywhere_keeps_the_set_that_reaches_it(
+        self,
+    ) -> None:
+        # attrs is the same in all six forks, and its gate says the
+        # a-members are what reach it, so the b-set drops and the a-set
+        # stays: a1 alone installs it, no member at all does not.
+        pylock = self._forked_lock(
+            lambda a, _b: (
+                {"attrs": _selection_pin("attrs", "24.0")},
+                {"attrs": (("group", a),)},
+            )
+        )
+        assert self._select(pylock, ["a1"]) == {"attrs 24.0"}
+        assert self._select(pylock, ["b1"]) == set()
+        assert self._select(pylock, []) == set()
+
+    def test_a_dependency_either_set_reaches_installs_for_either_alone(self) -> None:
+        # attrs is the same in every fork and a member of each set
+        # requires it, so neither set is what selects it and the gate
+        # stands alone.
+        pylock = self._forked_lock(
+            lambda a, b: (
+                {"attrs": _selection_pin("attrs", "24.0")},
+                {"attrs": (("group", a), ("group", b))},
+            )
+        )
+        marker = next(str(p.marker) for p in pylock.packages)
+        assert "not in dependency_groups" not in marker
+        for member in (*self._A, *self._B):
+            assert self._select(pylock, [member]) == {"attrs 24.0"}
+        assert self._select(pylock, []) == set()
+
+    def test_a_dependency_two_members_share_installs_for_either_alone(self) -> None:
+        # a1 and b1 both name attrs, so the forks that select neither do
+        # not carry it at all; a1 alone and b1 alone still install it.
+        def contribution(
+            a: str, b: str
+        ) -> tuple[dict[str, PinShape], dict[str, tuple[tuple[str, str], ...]]]:
+            named = tuple(("group", m) for m in (a, b) if m in {"a1", "b1"})
+            if not named:
+                return ({}, {})
+            return ({"attrs": _selection_pin("attrs", "24.0")}, {"attrs": named})
+
+        pylock = self._forked_lock(contribution)
+        assert self._select(pylock, ["a1"]) == {"attrs 24.0"}
+        assert self._select(pylock, ["b1"]) == {"attrs 24.0"}
+        assert self._select(pylock, ["a2", "b2"]) == set()
+        assert self._select(pylock, []) == set()
+
+    def test_a_drop_a_dependency_cannot_follow_is_refused(self) -> None:
+        # attrs is the same in every fork of the b-set but the idna it
+        # requires is not, so attrs keeps the b-clauses rather than
+        # installing into a selection idna cannot reach.
+        pylock = self._forked_lock(
+            lambda a, b: (
+                {
+                    "attrs": _selection_pin("attrs", "24.0"),
+                    "idna": _selection_pin("idna", self._B[b]),
+                },
+                {"attrs": (("group", a),), "idna": (("group", a),)},
+            ),
+            edges=lambda _a, _b: {"attrs": ("idna",)},
+        )
+        assert self._dangling(pylock) == []
+        assert self._select(pylock, ["a1"]) == set()
+        assert self._select(pylock, ["a1", "b1"]) == {"attrs 24.0", "idna 3.7"}
+
+    def test_an_edge_only_one_fork_carries_holds_the_whole_entry(self) -> None:
+        # The entry's edges are the union over its forks, so the idna
+        # only the b1 forks require rides on attrs everywhere; a fork
+        # that does not carry idna at all projects nothing.
+        def contribution(
+            a: str, b: str
+        ) -> tuple[dict[str, PinShape], dict[str, tuple[tuple[str, str], ...]]]:
+            pins: dict[str, PinShape] = {"attrs": _selection_pin("attrs", "24.0")}
+            gates = {"attrs": (("group", a),)}
+            if b == "b1":
+                pins["idna"] = _selection_pin("idna", "3.7")
+                gates["idna"] = (("group", a),)
+            return (pins, gates)
+
+        pylock = self._forked_lock(
+            contribution,
+            edges=lambda _a, b: {"attrs": ("idna",)} if b == "b1" else {},
+        )
+        assert self._select(pylock, ["a1", "b1"]) == {"attrs 24.0", "idna 3.7"}
+        assert self._select(pylock, ["a1"]) == set()
+
+    def test_a_fork_the_base_reaches_blocks_the_drop(self) -> None:
+        # attrs is ungated in the b1 forks, so those install it whichever
+        # a-member is selected while the others need their own; no one
+        # set of clauses covers both, and the b-set stays named.
+        pylock = self._forked_lock(
+            lambda _a, b: (
+                {"attrs": _selection_pin("attrs", "24.0")},
+                {} if b == "b1" else {"attrs": (("group", b),)},
+            )
+        )
+        assert self._select(pylock, ["b1"]) == {"attrs 24.0"}
+        assert self._select(pylock, ["b2"]) == {"attrs 24.0"}
+        assert self._select(pylock, ["a1"]) == set()
+        assert self._select(pylock, []) == set()
+
+    def test_reach_that_differs_across_the_dropped_set_blocks_the_drop(self) -> None:
+        # attrs is reached through the a-member in the b1 forks and
+        # through the b-member elsewhere, so the b-set is not something
+        # attrs is indifferent to and its clauses stay.
+        pylock = self._forked_lock(
+            lambda a, b: (
+                {"attrs": _selection_pin("attrs", "24.0")},
+                {"attrs": ((("group", a),) if b == "b1" else (("group", b),))},
+            )
+        )
+        assert self._select(pylock, ["b2"]) == {"attrs 24.0"}
+        assert self._select(pylock, ["a1", "b1"]) == {"attrs 24.0"}
+        assert self._select(pylock, ["b1"]) == set()
+        assert self._select(pylock, ["a1"]) == set()


### PR DESCRIPTION
With two conflict sets declared, `nab lock --all-groups` forks into their product and every entry carried the conjunction of both sets' clauses. A project with groups `a1/a2` and `b1/b2/b3` locked six tuples, but `--groups a1` installed only the base dependencies: the `six` that `a1` asks for also named `b1`, `b2` and `b3`, and the install selected none of those.

Each fork's selection is now projected per package. A conflict set the package does not vary over contributes no clause, so a dependency reached through one set names only that set, and a dependency a member of each set reaches is selected by either alone. The projection stops wherever a dependency cannot follow it, so an entry never fires in a context that would leave one of its own dependencies uninstalled.
