### PR TITLE
add the missing Python 3.14 classifier to all four packages

### DIFF
--- a/nab-index/pyproject.toml
+++ b/nab-index/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
 dependencies = [

--- a/nab-python/pyproject.toml
+++ b/nab-python/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
 dependencies = [

--- a/nab-resolver/pyproject.toml
+++ b/nab-resolver/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
 dependencies = [
@@ -48,10 +49,14 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.sdist]
 only-include = ["src/nab", "tests", "conftest.py"]
 
-# test_build_dists.py and test_release.py cover the repo-level release tooling
-# in tasks/, not the shipped CLI, so they stay out of the package sdist.
-# (hatchling always ships pyproject.toml, hatch.toml, and .gitignore itself.)
-exclude = ["tests/test_build_dists.py", "tests/test_release.py"]
+# These cover repo-level tooling and manifests, not the shipped CLI, and they
+# read files the sdist does not carry, so they stay out of it. (hatchling
+# always ships pyproject.toml, hatch.toml, and .gitignore itself.)
+exclude = [
+    "tests/test_build_dists.py",
+    "tests/test_classifiers.py",
+    "tests/test_release.py",
+]
 
 # Dependency groups feed `nab lock` for CI lockfiles; regenerate via
 # tasks/refresh-locks.sh. Local dev uses hatch envs from hatch.toml.

--- a/tests/test_classifiers.py
+++ b/tests/test_classifiers.py
@@ -1,0 +1,64 @@
+"""Check the published Python classifiers against the tested CI matrix.
+
+PyPI metadata is immutable per release, so a stale classifier list cannot be
+corrected without cutting another one.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import tomli
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+PYPROJECT_PATHS = (
+    REPO_ROOT / "pyproject.toml",
+    REPO_ROOT / "nab-resolver" / "pyproject.toml",
+    REPO_ROOT / "nab-python" / "pyproject.toml",
+    REPO_ROOT / "nab-index" / "pyproject.toml",
+)
+
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "test.yml"
+
+PREFIX = "Programming Language :: Python :: "
+
+# Only the test matrix gives python-version a list; the standalone jobs pin a
+# scalar. A YAML flow sequence of quoted strings is also valid JSON.
+_MATRIX = re.compile(r"^\s*python-version:\s*(\[[^\]]*\])\s*$", re.MULTILINE)
+
+# A matrix entry may carry an implementation or build tag (pypy3.11, 3.14t);
+# only the language version reaches a classifier.
+_LANGUAGE_VERSION = re.compile(r"\d+\.\d+")
+
+
+def _tested_versions() -> set[str]:
+    lists = _MATRIX.findall(WORKFLOW.read_text(encoding="utf-8"))
+    assert len(lists) == 1, f"expected one python-version list, found {lists}"
+    versions = set()
+    for entry in json.loads(lists[0]):
+        found = _LANGUAGE_VERSION.search(entry)
+        assert found is not None, f"no Python version in matrix entry {entry!r}"
+        versions.add(found.group())
+    return versions
+
+
+def _claims_version(classifier: str) -> bool:
+    if not classifier.startswith(PREFIX):
+        return False
+    # Siblings such as "3 :: Only" and "Implementation :: CPython" share the
+    # prefix but name no version.
+    return all(part.isdigit() for part in classifier[len(PREFIX) :].split("."))
+
+
+def _version_classifiers(path: Path) -> set[str]:
+    project = tomli.loads(path.read_text(encoding="utf-8"))["project"]
+    return {entry for entry in project["classifiers"] if _claims_version(entry)}
+
+
+def test_classifiers_cover_every_tested_python_version() -> None:
+    expected = {PREFIX + version for version in {"3", *_tested_versions()}}
+    for path in PYPROJECT_PATHS:
+        assert _version_classifiers(path) == expected, path


### PR DESCRIPTION
CI has run the full suite on 3.14 since the matrix gained it, but the published classifiers on all four packages stop at 3.13, so PyPI and anything else reading the metadata still says 3.14 is unsupported. Nothing updated the manifests when the matrix moved.

This adds `Programming Language :: Python :: 3.14` to the umbrella, nab-resolver, nab-python and nab-index manifests, plus a test that compares each manifest's Python classifiers against the `python-version` matrix in `.github/workflows/test.yml` so the two cannot drift apart again. Release metadata is immutable once uploaded, so drift here can only be corrected by cutting another release.
