### PR TITLE
refuse conflicting extras co-selected above a micro boundary

### DIFF
--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -300,9 +300,7 @@ def self_extra_markers(
     """Return the markers gating the self-references ``selected`` reaches.
 
     The closure is walked without an environment, so the result holds every
-    clause :func:`expand_self_extras` could read under any of them.  A
-    caller deciding which environments to expand the closure under needs the
-    clauses before it has an environment to read them with.
+    clause :func:`expand_self_extras` could read under any environment.
     """
     if project_name is None:
         return []

--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -18,7 +18,7 @@ from ._vendor.packaging.requirements import InvalidRequirement, Requirement
 from ._vendor.packaging.utils import InvalidName, canonicalize_name
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterator, Sequence
     from pathlib import Path
 
     from ._vendor.packaging.ranges import VersionRange
@@ -35,6 +35,7 @@ __all__ = [
     "read_pyproject_name",
     "read_pyproject_optional_dependencies",
     "resolve_groups_to_requirements",
+    "self_extra_markers",
 ]
 
 
@@ -255,13 +256,7 @@ def expand_self_extras(
             continue
         seen.add(extra)
         out.append(extra)
-        for req_str in canonical_deps.get(extra, ()):
-            try:
-                req = Requirement(req_str)
-            except (ValueError, TypeError):
-                continue
-            if canonicalize_name(req.name) != canonical_project:
-                continue
+        for req in _self_references(canonical_deps, canonical_project, extra):
             if (
                 environment is not None
                 and req.marker is not None
@@ -276,6 +271,49 @@ def expand_self_extras(
                 if canonicalize_name(sub) not in seen
             )
     return out
+
+
+def _self_references(
+    canonical_deps: Mapping[str, Sequence[str]],
+    canonical_project: str,
+    extra: str,
+) -> Iterator[Requirement]:
+    """Yield the requirements of ``extra`` that name the project itself.
+
+    An unparseable requirement is skipped rather than raised on: this walk
+    only decides which extras are reachable.
+    """
+    for req_str in canonical_deps.get(extra, ()):
+        try:
+            req = Requirement(req_str)
+        except (ValueError, TypeError):
+            continue
+        if canonicalize_name(req.name) == canonical_project:
+            yield req
+
+
+def self_extra_markers(
+    optional_deps: Mapping[str, Sequence[str]],
+    project_name: str | None,
+    selected: Sequence[str],
+) -> list[Marker]:
+    """Return the markers gating the self-references ``selected`` reaches.
+
+    The closure is walked without an environment, so the result holds every
+    clause :func:`expand_self_extras` could read under any of them.  A
+    caller deciding which environments to expand the closure under needs the
+    clauses before it has an environment to read them with.
+    """
+    if project_name is None:
+        return []
+    canonical_project = canonicalize_name(project_name)
+    canonical_deps = _canonicalize_optional_deps(optional_deps)
+    return [
+        req.marker
+        for extra in expand_self_extras(optional_deps, project_name, selected)
+        for req in _self_references(canonical_deps, canonical_project, extra)
+        if req.marker is not None
+    ]
 
 
 def _and_markers(marker: Marker | None, gates: frozenset[str]) -> Marker:

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -78,6 +78,7 @@ from .requirements_file import (
     read_pyproject_name,
     read_pyproject_optional_dependencies,
     resolve_groups_to_requirements,
+    self_extra_markers,
 )
 from .target import (
     UNBOUNDABLE_MARKER_VARIABLES,
@@ -1224,21 +1225,46 @@ def _validate_conflict_members_exist(
         raise ConfigError(msg)
 
 
+def _conflict_check_targets(
+    tables: _ProjectTables,
+    selected_extras: Sequence[str],
+    targets: Sequence[ResolveTarget],
+) -> list[ResolveTarget]:
+    """Return ``targets`` split at the micros a self-ref marker cuts them at.
+
+    A bare-minor target's ``python_full_version`` is the synthesized
+    ``{minor}.0`` floor, so a self reference gated on ``python_full_version
+    >= "3.10.4"`` read there answers for the whole minor by how its floor
+    happens to read it.  The resolve does not work that way:
+    :func:`_resolve_with_micro_narrowing` splits the minor at that boundary
+    and runs the upper slice with both extras active, so the checks split it
+    the same way and read the closure once per slice.
+    """
+    markers = self_extra_markers(tables.optional, tables.project_name, selected_extras)
+    return [
+        sliced
+        for target in targets
+        for sliced in slices_from_points(target, micro_boundary_points(target, markers))
+    ]
+
+
 def _check_conflict_minimums(
     conflicts: Sequence[ConflictSet],
     tables: _ProjectTables,
     selected_extras: Sequence[str],
     active_groups: Sequence[str],
-    targets: Sequence[ResolveTarget],
+    planned: Sequence[ResolveTarget],
 ) -> None:
     """Run the require-one minimums check per target, marker-aware.
 
     A member reached only through a marker-gated self reference is active
     only on the targets whose environment satisfies that marker, so the
-    check expands the self-extra closure against each target's
-    environment.  A target on which no member is active fails the policy
-    even when another target satisfies it.
+    check expands the self-extra closure against each environment the
+    ``planned`` targets cover (see :func:`_conflict_check_targets`).  An
+    environment on which no member is active fails the policy even when
+    another one satisfies it.
     """
+    targets = _conflict_check_targets(tables, selected_extras, planned)
     for target in targets:
         active_extras = expand_self_extras(
             tables.optional, tables.project_name, selected_extras, target.marker_env
@@ -1254,15 +1280,15 @@ def _check_conflict_exclusions(
     tables: _ProjectTables,
     active_extras: Sequence[str],
     active_groups: Sequence[str],
-    targets: Sequence[ResolveTarget],
+    planned: Sequence[ResolveTarget],
 ) -> None:
     """Run the at-most-one exclusion check per target, marker-aware.
 
-    A self reference reaches its target only on the targets whose
-    environment satisfies its marker, so the self-extra closure is
-    expanded against each one.  Members reached under disjoint markers
-    never share a target and pass; two that co-activate on one target
-    fail.
+    A self reference reaches its extra only where its marker holds, so the
+    self-extra closure is expanded against each environment the ``planned``
+    targets cover (see :func:`_conflict_check_targets`).  Members reached
+    under disjoint markers never share an environment and pass; two that
+    co-activate on one fail.
 
     This runs once per fork, where each fork holds at most one member of
     an engaged set, so it only catches co-selection an umbrella extra or
@@ -1272,6 +1298,7 @@ def _check_conflict_exclusions(
     instead of raising here.
     """
     expanded_groups = expand_group_includes(tables.groups, active_groups)
+    targets = _conflict_check_targets(tables, active_extras, planned)
     for target in targets:
         expanded_extras = expand_self_extras(
             tables.optional, tables.project_name, active_extras, target.marker_env

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -24,7 +24,7 @@ import logging
 import tempfile
 import time
 from collections import defaultdict
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
@@ -82,6 +82,7 @@ from .requirements_file import (
 )
 from .target import (
     UNBOUNDABLE_MARKER_VARIABLES,
+    NonIntervalMarkerError,
     ResolveTarget,
     environment_declaration,
     marker_variables,
@@ -1234,18 +1235,31 @@ def _conflict_check_targets(
 
     A bare-minor target's ``python_full_version`` is the synthesized
     ``{minor}.0`` floor, so a self reference gated on ``python_full_version
-    >= "3.10.4"`` read there answers for the whole minor by how its floor
-    happens to read it.  The resolve does not work that way:
-    :func:`_resolve_with_micro_narrowing` splits the minor at that boundary
-    and runs the upper slice with both extras active, so the checks split it
-    the same way and read the closure once per slice.
+    >= "3.10.4"`` answers for the whole minor by how that floor reads it, and
+    a member reached only above the boundary is never seen.  One slice per
+    boundary reads the closure where each answer holds.
     """
     markers = self_extra_markers(tables.optional, tables.project_name, selected_extras)
     return [
         sliced
         for target in targets
-        for sliced in slices_from_points(target, micro_boundary_points(target, markers))
+        for sliced in slices_from_points(target, _tileable_points(target, markers))
     ]
+
+
+def _tileable_points(target: ResolveTarget, markers: Sequence[Marker]) -> list[Version]:
+    """Return the boundaries the tileable ``markers`` cut ``target``'s minor at.
+
+    The self-extra closure is walked without an environment, so it carries
+    markers from branches this target never reaches; one of those that cannot
+    tile the minor is skipped rather than raised on.  A marker a resolve does
+    consult still raises, in :func:`_resolve_with_micro_narrowing`.
+    """
+    points: set[Version] = set()
+    for marker in markers:
+        with suppress(NonIntervalMarkerError):
+            points.update(micro_boundary_points(target, [marker]))
+    return sorted(points)
 
 
 def _check_conflict_minimums(

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -22,6 +22,7 @@ from nab_python.requirements_file import (
     read_pyproject_name,
     read_pyproject_optional_dependencies,
     resolve_groups_to_requirements,
+    self_extra_markers,
 )
 from nab_resolver.errors import ResolutionError
 
@@ -521,6 +522,42 @@ class TestExpandSelfExtras:
         }
         env = {"python_version": "3.11", "python_full_version": "3.11.0"}
         assert expand_self_extras(opt, "mypkg", ["gpu"], env) == ["gpu", "fast"]
+
+
+class TestSelfExtraMarkers:
+    def test_unknown_project_name_has_no_markers(self) -> None:
+        """Without a project name nothing is a self-reference."""
+        opt = {"all": ["mypkg[a]; python_version < '3.10'"], "a": ["depA"]}
+        assert self_extra_markers(opt, None, ["all"]) == []
+
+    def test_unmarked_self_reference_contributes_nothing(self) -> None:
+        opt = {"all": ["mypkg[a]", "plain; python_version < '3.10'"], "a": ["depA"]}
+        assert self_extra_markers(opt, "mypkg", ["all"]) == []
+
+    def test_marker_collected_from_reachable_extras(self) -> None:
+        """The walk follows the closure, so a nested gate is collected too."""
+        opt = {
+            "all": ["mypkg[mid]; python_full_version >= '3.10.4'"],
+            "mid": ["mypkg[leaf]; sys_platform == 'win32'"],
+            "leaf": ["depL"],
+        }
+        assert [str(m) for m in self_extra_markers(opt, "mypkg", ["all"])] == [
+            'python_full_version >= "3.10.4"',
+            'sys_platform == "win32"',
+        ]
+
+    def test_marker_collected_regardless_of_outer_gate(self) -> None:
+        """A gate behind a false-under-some-environment gate still counts:
+        the environments the caller has to check are not chosen yet."""
+        opt = {
+            "all": ["mypkg[mid]; python_version < '3.0'"],
+            "mid": ["mypkg[leaf]; python_full_version >= '3.10.4'"],
+            "leaf": ["depL"],
+        }
+        assert [str(m) for m in self_extra_markers(opt, "mypkg", ["all"])] == [
+            'python_version < "3.0"',
+            'python_full_version >= "3.10.4"',
+        ]
 
 
 class TestExpandExtraRequirements:

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -547,7 +547,7 @@ class TestSelfExtraMarkers:
         ]
 
     def test_marker_collected_regardless_of_outer_gate(self) -> None:
-        """A gate behind a false-under-some-environment gate still counts:
+        """A nested gate counts even where the gate above it reads false:
         the environments the caller has to check are not chosen yet."""
         opt = {
             "all": ["mypkg[mid]; python_version < '3.0'"],

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -1699,6 +1699,96 @@ class TestResolveUniversalPyproject:
             _resolved(pyproject, extras=["all"])
         mock_universal.assert_not_called()
 
+    def test_umbrella_extra_co_selecting_above_a_micro_boundary_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """A self-ref gated on a micro of the tuple's own minor still refuses.
+
+        ``all`` reaches cpu everywhere and gpu from 3.10.4 up, so every real
+        3.10.4+ interpreter activates both. The tuple's synthesized 3.10.0
+        answers the gate false, so the check has to split the minor the way the
+        resolve does before it reads the clause.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = ["base"]\n'
+            "[project.optional-dependencies]\n"
+            'cpu = ["foo==1.0"]\n'
+            'gpu = ["foo==2.0"]\n'
+            "all = [\n"
+            '    "x[cpu]",\n'
+            "    \"x[gpu]; python_full_version >= '3.10.4'\",\n"
+            "]\n"
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.10"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+        with (
+            patch("nab_python.resolve.resolve_with_coordinator") as mock_universal,
+            pytest.raises(ConflictSelectionError, match="cannot be selected together"),
+        ):
+            _resolved(pyproject, extras=["all"])
+        mock_universal.assert_not_called()
+
+    def test_require_one_member_lost_above_a_micro_boundary_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """An exactly-one member reachable only below a micro leaves the
+        slice above it with no member, so the resolve is refused."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = ["base"]\n'
+            "[project.optional-dependencies]\n"
+            'cpu = ["foo==1.0"]\n'
+            'gpu = ["foo==2.0"]\n'
+            "all = [\"x[cpu]; python_full_version < '3.10.4'\"]\n"
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'conflicts = [{ members = [{ extra = "cpu" },'
+            ' { extra = "gpu" }], policy = "exactly-one" }]\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.10"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+        with (
+            patch("nab_python.resolve.resolve_with_coordinator") as mock_universal,
+            pytest.raises(ConflictSelectionError, match="exactly one"),
+        ):
+            _resolved(pyproject, extras=["all"])
+        mock_universal.assert_not_called()
+
+    @patch("nab_python.resolve.resolve_with_coordinator")
+    def test_umbrella_extra_disjoint_micro_markers_resolve(
+        self, mock_engine: MagicMock, tmp_path: Path
+    ) -> None:
+        """Self-refs split at the same micro reach one member per slice.
+
+        cpu below 3.10.4 and gpu from 3.10.4 up never meet on one
+        interpreter, so splitting the minor must not turn into a refusal.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = ["base"]\n'
+            "[project.optional-dependencies]\n"
+            'cpu = ["foo==1.0"]\n'
+            'gpu = ["foo==2.0"]\n'
+            "all = [\n"
+            "    \"x[cpu]; python_full_version < '3.10.4'\",\n"
+            "    \"x[gpu]; python_full_version >= '3.10.4'\",\n"
+            "]\n"
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.10"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+        _resolved(pyproject, extras=["all"])
+        mock_engine.assert_called_once()
+
     @patch("nab_python.resolve.resolve_with_coordinator")
     def test_umbrella_extra_reaching_one_member_single_fork(
         self, mock_engine: MagicMock, tmp_path: Path

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -1706,8 +1706,8 @@ class TestResolveUniversalPyproject:
 
         ``all`` reaches cpu everywhere and gpu from 3.10.4 up, so every real
         3.10.4+ interpreter activates both. The tuple's synthesized 3.10.0
-        answers the gate false, so the check has to split the minor the way the
-        resolve does before it reads the clause.
+        answers the gate false, so the check has to split the minor before it
+        reads the clause.
         """
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text(
@@ -1788,6 +1788,70 @@ class TestResolveUniversalPyproject:
         )
         _resolved(pyproject, extras=["all"])
         mock_engine.assert_called_once()
+
+    @patch("nab_python.resolve.resolve_with_coordinator")
+    def test_untileable_self_ref_marker_off_the_matrix_resolves(
+        self, mock_engine: MagicMock, tmp_path: Path
+    ) -> None:
+        """A self-ref no tuple can reach does not have to tile a minor.
+
+        The closure is walked without an environment, so legacy's 3.7-only
+        membership marker is scanned on a 3.10 tuple that never reaches it.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = ["base"]\n'
+            "[project.optional-dependencies]\n"
+            'cpu = ["foo==1.0"]\n'
+            'gpu = ["foo==2.0"]\n'
+            "legacy = [\"x[gpu]; python_full_version in '3.7.1 3.7.2'\"]\n"
+            "all = [\n"
+            '    "x[cpu]",\n'
+            "    \"x[legacy]; python_version < '3.8'\",\n"
+            "]\n"
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.10"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+        _resolved(pyproject, extras=["all"])
+        mock_engine.assert_called_once()
+
+    def test_untileable_self_ref_marker_keeps_the_other_boundaries(
+        self, tmp_path: Path
+    ) -> None:
+        """Skipping an untileable marker leaves the cuts the rest make.
+
+        gpu is still reached from 3.10.4 up alongside cpu, so the refusal
+        stands with legacy's untileable marker in the same closure.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = ["base"]\n'
+            "[project.optional-dependencies]\n"
+            'cpu = ["foo==1.0"]\n'
+            'gpu = ["foo==2.0"]\n'
+            "legacy = [\"x[gpu]; python_full_version in '3.7.1 3.7.2'\"]\n"
+            "all = [\n"
+            '    "x[cpu]",\n'
+            "    \"x[legacy]; python_version < '3.8'\",\n"
+            "    \"x[gpu]; python_full_version >= '3.10.4'\",\n"
+            "]\n"
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.10"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+        with (
+            patch("nab_python.resolve.resolve_with_coordinator") as mock_universal,
+            pytest.raises(ConflictSelectionError, match="cannot be selected together"),
+        ):
+            _resolved(pyproject, extras=["all"])
+        mock_universal.assert_not_called()
 
     @patch("nab_python.resolve.resolve_with_coordinator")
     def test_umbrella_extra_reaching_one_member_single_fork(


### PR DESCRIPTION
In universal mode a matrix minor is a single target whose `python_full_version` is the synthesized `{minor}.0`, so the conflict checks read a self-reference gated on `python_full_version >= "3.10.4"` exactly once, at 3.10.0, where it answers false. An umbrella extra that reaches two members of an exclusive set only above that boundary was never refused, and the lock installed both. The same gap hid the other direction for `exactly-one`: a member reachable only below the boundary left every interpreter above it with no member at all.

The checks now split each target at the micro boundaries its self-reference markers cut in the minor, the way the resolve already does when it narrows, and expand the self-extra closure once per slice. That closure is walked without an environment, so it also picks up markers from branches a given target can never reach. A marker that cannot tile the minor is skipped rather than stopping the resolve, and the boundaries the remaining markers cut still apply.
