### PR TITLE
report a malformed archive-sources url as a config error

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -2544,12 +2544,14 @@ def _parse_archive_sources(value: object) -> tuple[ArchiveSource, ...]:
 
 
 def _validate_archive_url(index: int, url: str) -> None:
-    """Reject an archive URL with no hash or an unsupported format.
+    """Reject an archive URL that is malformed, has no hash, or is not a .tar.gz.
 
     PEP 751 ``packages.archive.hashes`` is required, so nab requires the
     hash in the URL fragment and verifies the download against it.  Only
     ``.tar.gz`` source archives are supported today; wheels and zips are
-    refused loudly rather than mis-handled.
+    refused loudly rather than mis-handled.  :func:`urlsplit` raises
+    ValueError on an authority it cannot parse, such as an unterminated
+    IPv6 bracket, so that surfaces as a ConfigError here too.
     """
     try:
         request = ArchiveRequest.parse(url)
@@ -2564,7 +2566,13 @@ def _validate_archive_url(index: int, url: str) -> None:
         )
         raise ConfigError(msg)
 
-    if not urlsplit(request.url).path.endswith(".tar.gz"):
+    try:
+        path = urlsplit(request.url).path
+    except ValueError as exc:
+        msg = f"archive-sources[{index}] url {url!r} does not parse: {exc}"
+        raise ConfigError(msg) from exc
+
+    if not path.endswith(".tar.gz"):
         msg = (
             f"archive-sources[{index}] url {url!r} is not a .tar.gz archive;"
             " only .tar.gz source archives are supported"

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -2465,6 +2465,34 @@ class TestArchiveSources:
         with pytest.raises(ConfigError, match="unknown archive URL fragment"):
             read_pyproject_config(path)
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://[::1/foo-1.0.tar.gz",
+            "https://ex.com]/foo-1.0.tar.gz",
+            "https://exa\N{ACCOUNT OF}mple.com/foo-1.0.tar.gz",
+        ],
+    )
+    def test_malformed_authority_rejected(self, tmp_path: Path, url: str) -> None:
+        path = write(
+            tmp_path,
+            '[[tool.nab.archive-sources]]\nname = "x"\n'
+            f'url = "{url}#sha256=' + "e" * 64 + '"\n',
+        )
+        with pytest.raises(
+            ConfigError, match=r"archive-sources\[0\] url .* does not parse"
+        ):
+            read_pyproject_config(path)
+
+    def test_bracketed_ipv6_authority_accepted(self, tmp_path: Path) -> None:
+        url = "https://[2001:db8::1]/foo-1.0.tar.gz#sha256=" + "e" * 64
+        path = write(
+            tmp_path,
+            f'[[tool.nab.archive-sources]]\nname = "x"\nurl = "{url}"\n',
+        )
+        (source,) = read_pyproject_config(path).archive_sources
+        assert source.url == url
+
     def test_duplicate_collides_with_vcs_source(self, tmp_path: Path) -> None:
         path = write(
             tmp_path,

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -63,7 +63,9 @@ from nab_python.workspace import WorkspaceConfig
 
 def write(tmp_path: Path, body: str) -> Path:
     p = tmp_path / "pyproject.toml"
-    p.write_text(body)
+    # TOML is UTF-8 by spec and nab reads the file in binary, so the fixture
+    # must not pick up the platform default (cp1252 on Windows).
+    p.write_text(body, encoding="utf-8")
     return p
 
 


### PR DESCRIPTION
A malformed authority in an `[[tool.nab.archive-sources]]` url, such as an unterminated IPv6 bracket, escaped as a raw `ValueError` traceback from `urllib` instead of a config error. Anything that reads `pyproject.toml` hit it, including `nab lock` and `nab download`.

`_validate_archive_url` called `urlsplit` unguarded on its way to the `.tar.gz` suffix check. It now catches the `ValueError` and raises a `ConfigError` naming the entry index and the url, matching the hash and suffix checks next to it. A well-formed bracketed IPv6 host is still accepted.
