### PR TITLE
report an offline metadata miss instead of blaming the sdist

### DIFF
--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -8,6 +8,7 @@ each ``Requires-Dist`` entry into base deps vs per-extra deps.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, TypeGuard
 from urllib.parse import urlsplit
 
@@ -50,6 +51,10 @@ TargetDepSignature = tuple[
     dict[str, dict[str, VersionRange]],
     dict[str | None, set[tuple[str, frozenset[str], str]]],
 ]
+
+logger = logging.getLogger(__name__)
+
+_OFFLINE_METADATA_MISS = "offline mode skipped a metadata fetch with no cached metadata"
 
 
 def resolve_metadata(
@@ -120,15 +125,35 @@ def resolve_metadata(
     if metadata_text is not None:
         return (metadata_text, from_sdist)
 
-    # A fetched sdist with no PKG-INFO is a distinct failure from no sdist at all.
-    reason = (
-        "the sdist has no readable PKG-INFO"
-        if sdist is not None
-        else "no sdist available"
-    )
+    # Only the rung the ladder gave up on can name the reason: an earlier rung
+    # skipped offline says nothing about what this one read.
+    last_url = sdist.url if sdist is not None else metadata_url
 
-    msg = f"No metadata for {package}=={version}: no PEP 658 metadata and {reason}"
+    if index.is_offline_metadata_miss(normalized, ver_str, last_url):
+        reason = _OFFLINE_METADATA_MISS
+        _report_offline_skip(index, normalized, package, version)
+    elif sdist is not None:
+        # A fetched sdist with no PKG-INFO is distinct from no sdist at all.
+        reason = "no PEP 658 metadata and the sdist has no readable PKG-INFO"
+    else:
+        reason = "no PEP 658 metadata and no sdist available"
+
+    msg = f"No metadata for {package}=={version}: {reason}"
     raise MetadataError(msg)
+
+
+def _report_offline_skip(
+    index: InMemoryIndex, normalized: str, package: str, version: Version
+) -> None:
+    """Report a release skipped for want of cached metadata.
+
+    The resolver drops the version and can still succeed on an older one, so
+    the drop has to be visible.  A cold cache drops as many releases as the
+    listing holds, hence one warning per package and an info line per release.
+    """
+    if index.claim_offline_metadata_warning(normalized):
+        logger.warning("Skipping releases of %s: %s", package, _OFFLINE_METADATA_MISS)
+    logger.info("Skipping %s==%s: %s", package, version, _OFFLINE_METADATA_MISS)
 
 
 def _read_direct_wheel_metadata(

--- a/nab-python/src/nab_python/fetch.py
+++ b/nab-python/src/nab_python/fetch.py
@@ -160,6 +160,11 @@ class InMemoryIndex:
         # artifact its own target would install.
         self._metadata: dict[tuple[str, str, str | None], str | None] = {}
         self._metadata_errors: dict[tuple[str, str, str | None], BaseException] = {}
+        # Empty metadata slots that stand for a rung skipped offline, keyed by
+        # that rung's URL.
+        self._offline_metadata_misses: set[tuple[str, str, str]] = set()
+        # Packages whose offline skips have already been warned about.
+        self._offline_metadata_warned: set[str] = set()
         # Versions whose version-level slot was written from an sdist PKG-INFO;
         # readers need the origin because only sdist deps go through the
         # PEP 643 gate.
@@ -408,6 +413,38 @@ class InMemoryIndex:
                 if error is not None:
                     return error
             return self._metadata_errors.get((package, version, None))
+
+    def record_offline_metadata_miss(
+        self, package: str, version: str, url: str
+    ) -> None:
+        """Mark the metadata fetch at ``url`` as one offline mode skipped.
+
+        The skip writes the same empty slot a metadata-less artifact writes, so
+        without the mark the two read alike.  ``url`` keys it to one rung of the
+        ladder: a rung skipped is no claim about an artifact a later rung read.
+        """
+        with self._lock:
+            self._offline_metadata_misses.add((package, version, url))
+
+    def is_offline_metadata_miss(
+        self, package: str, version: str, url: str | None
+    ) -> bool:
+        """Whether the metadata fetch at ``url`` was skipped offline."""
+        with self._lock:
+            return (package, version, url) in self._offline_metadata_misses
+
+    def claim_offline_metadata_warning(self, package: str) -> bool:
+        """Whether the caller owns ``package``'s one offline-skip warning.
+
+        True for the first caller only.  The targets of a run share this index
+        but each builds its own :class:`~nab_python.provider.Provider`, so the
+        state lives here to hold the report to one per package.
+        """
+        with self._lock:
+            if package in self._offline_metadata_warned:
+                return False
+            self._offline_metadata_warned.add(package)
+            return True
 
     def store_sdist_metadata(
         self, package: str, version: str, data: str | None
@@ -1249,10 +1286,17 @@ class FetchCoordinator:
         A declared archive is the exception: it is the package's only
         candidate, so there is nothing to degrade to and an offline miss is
         recorded as an error.
+
+        A metadata rung marks the skip before it stores, so a waiter released
+        by the store reads the mark and not a bare empty slot.
         """
         assert req.version is not None
         if req.kind is FetchKind.METADATA:
             if offline:
+                assert req.url is not None
+                self.index.record_offline_metadata_miss(
+                    req.package, req.version, req.url
+                )
                 self.index.store_metadata(req.package, req.version, None, req.url)
             else:
                 self.index.store_metadata_error(req.package, req.version, exc, req.url)
@@ -1260,6 +1304,9 @@ class FetchCoordinator:
             assert req.url is not None
             if offline:
                 # A cold offline miss is a rung miss: fall through to the sdist.
+                self.index.record_offline_metadata_miss(
+                    req.package, req.version, req.url
+                )
                 self.index.store_range_absent(req.package, req.version, req.url)
             else:
                 # A malformed blob or an unserveable advertised wheel fails
@@ -1267,6 +1314,10 @@ class FetchCoordinator:
                 self.index.store_range_error(req.package, req.version, req.url, exc)
         elif req.kind is FetchKind.SDIST:
             if offline:
+                assert req.url is not None
+                self.index.record_offline_metadata_miss(
+                    req.package, req.version, req.url
+                )
                 self.index.store_sdist_metadata(req.package, req.version, None)
             else:
                 self.index.store_sdist_metadata_error(req.package, req.version, exc)

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -107,6 +107,36 @@ class TestInMemoryIndex:
         idx.store_metadata("foo", "1.0", None)
         assert idx.has_metadata("foo", "1.0")
 
+    def test_offline_metadata_miss_roundtrip(self) -> None:
+        idx = InMemoryIndex()
+        url = "https://files.example.com/foo-1.0.whl"
+        assert not idx.is_offline_metadata_miss("foo", "1.0", url)
+        idx.record_offline_metadata_miss("foo", "1.0", url)
+        assert idx.is_offline_metadata_miss("foo", "1.0", url)
+        assert not idx.is_offline_metadata_miss("foo", "2.0", url)
+
+    def test_an_offline_miss_is_keyed_to_the_rung_that_skipped(self) -> None:
+        idx = InMemoryIndex()
+        idx.record_offline_metadata_miss(
+            "foo", "1.0", "https://files.example.com/foo-1.0.whl"
+        )
+        assert not idx.is_offline_metadata_miss(
+            "foo", "1.0", "https://files.example.com/foo-1.0.tar.gz"
+        )
+        assert not idx.is_offline_metadata_miss("foo", "1.0", None)
+
+    def test_empty_metadata_slot_is_not_an_offline_miss(self) -> None:
+        idx = InMemoryIndex()
+        idx.store_metadata("foo", "1.0", None)
+        idx.store_sdist_metadata("foo", "1.0", None)
+        assert not idx.is_offline_metadata_miss("foo", "1.0", None)
+
+    def test_only_the_first_caller_claims_the_offline_warning(self) -> None:
+        idx = InMemoryIndex()
+        assert idx.claim_offline_metadata_warning("foo")
+        assert not idx.claim_offline_metadata_warning("foo")
+        assert idx.claim_offline_metadata_warning("bar")
+
     def test_metadata_error_roundtrip(self) -> None:
         idx = InMemoryIndex()
         assert idx.get_metadata_error("foo", "1.0") is None
@@ -1770,7 +1800,8 @@ class TestFetchCoordinatorCache:
         """Offline with a cache miss records the artifact absent, not as an error.
 
         Offline is the one failure the resolver works around: it resolves from
-        what the cache holds, so an uncached artifact is skipped.
+        what the cache holds, so an uncached artifact is skipped.  Each
+        metadata rung marks the skip alongside the empty slot.
         """
         with FetchCoordinator(
             transport=HttpxAsyncTransport(),
@@ -1796,6 +1827,12 @@ class TestFetchCoordinatorCache:
             assert coord.index.get_metadata_error("pkg", "2.0") is None
             assert coord.index.get_sdist_archive("pkg", "3.0") is None
             assert coord.index.get_sdist_archive_error("pkg", "3.0") is None
+            assert coord.index.is_offline_metadata_miss(
+                "pkg", "1.0", "https://files.example.com/pkg-1.0.whl.metadata"
+            )
+            assert coord.index.is_offline_metadata_miss(
+                "pkg", "2.0", "https://files.example.com/pkg-2.0.tar.gz"
+            )
         assert not coord._crashed
 
     @respx.mock

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import io
 import json
+import logging
 import tarfile
 import threading
 import zipfile
@@ -1640,6 +1641,196 @@ class TestNoVersionsReasons:
             f"requires bar in {dep_range} but solution has it in {pos_range}" in reason
         )
         assert "disjoint with current solution range" not in reason
+
+
+def _sdist_entry(version: str) -> dict[str, object]:
+    """A Simple-API file record for ``foo``'s sdist at ``version``."""
+    return {
+        "filename": f"foo-{version}.tar.gz",
+        "url": f"https://pypi.example/foo-{version}.tar.gz",
+    }
+
+
+def _wheel_entry(version: str, *, sidecar: bool) -> dict[str, object]:
+    """A Simple-API file record for ``foo``'s wheel at ``version``."""
+    return {
+        "filename": f"foo-{version}-py3-none-any.whl",
+        "url": f"https://pypi.example/foo-{version}-py3-none-any.whl",
+        "core-metadata": sidecar,
+    }
+
+
+def _skipped_release_messages(caplog: pytest.LogCaptureFixture) -> list[str]:
+    """The per-release offline-skip lines logged for ``foo``."""
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelno == logging.INFO and r.getMessage().startswith("Skipping foo==")
+    ]
+
+
+def _seed_listing(cache_dir: Path, files: list[dict[str, object]]) -> OnDiskCache:
+    """Write a cached Simple listing for ``foo`` and return the cache."""
+    cache = OnDiskCache(cache_dir, DEFAULT_INDEX_URL)
+    cache.put_simple(
+        "foo",
+        json.dumps({"files": files}).encode(),
+        CachePolicy(fetched_at=0, max_age=1, etag=None),
+    )
+    return cache
+
+
+class TestOfflineMetadataMiss:
+    """A version whose metadata is uncached is named as an offline miss.
+
+    Offline still degrades by skipping the version, but what the user is told
+    must not name an artifact nab never requested.
+    """
+
+    _PKG_INFO = "Metadata-Version: 2.2\nName: foo\nVersion: {ver}\n\n"
+
+    @pytest.mark.parametrize(
+        "files",
+        [
+            pytest.param([_sdist_entry("1.0")], id="sdist-only"),
+            pytest.param(
+                [_wheel_entry("1.0", sidecar=True), _sdist_entry("1.0")],
+                id="sidecar-and-sdist",
+            ),
+            pytest.param([_wheel_entry("1.0", sidecar=False)], id="bare-wheel"),
+        ],
+    )
+    def test_cold_metadata_names_offline_not_the_artifact(
+        self, tmp_path: Path, files: list[dict[str, object]]
+    ) -> None:
+        """Each metadata rung reports the offline miss it actually hit."""
+        _seed_listing(tmp_path, files)
+        with FetchCoordinator(
+            transport=Urllib3AsyncTransport(),
+            cache_dir=tmp_path,
+            offline=True,
+        ) as coordinator:
+            provider = Provider(coordinator, target=_PY312)
+            with pytest.raises(MetadataError) as excinfo:
+                provider.get_dependencies("foo", V("1.0"))
+
+        message = str(excinfo.value)
+        assert "offline mode" in message
+        assert "no cached metadata" in message
+        assert "PKG-INFO" not in message
+        assert "no sdist available" not in message
+        assert "no PEP 658 metadata" not in message
+
+    def test_a_read_sdist_is_not_reported_as_an_offline_miss(
+        self, tmp_path: Path
+    ) -> None:
+        """An earlier rung skipped does not speak for the sdist nab did read."""
+        cache = _seed_listing(
+            tmp_path, [_wheel_entry("1.0", sidecar=False), _sdist_entry("1.0")]
+        )
+        cache.put_sdist_files("foo", "1.0", None, None)
+        with FetchCoordinator(
+            transport=Urllib3AsyncTransport(),
+            cache_dir=tmp_path,
+            offline=True,
+        ) as coordinator:
+            provider = Provider(coordinator, target=_PY312)
+            with pytest.raises(MetadataError) as excinfo:
+                provider.get_dependencies("foo", V("1.0"))
+
+        assert "the sdist has no readable PKG-INFO" in str(excinfo.value)
+        assert "offline mode" not in str(excinfo.value)
+
+    def test_one_warning_covers_the_package_across_targets(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """One warning covers a package's skipped releases across every target.
+
+        A cold cache skips as many releases as the listing holds, and each
+        target rescans them with its own provider, so a warning per release
+        would bury the one fact worth reading.
+        """
+        versions = ("1.0", "2.0", "3.0")
+        _seed_listing(tmp_path, [_sdist_entry(v) for v in versions])
+        with (
+            caplog.at_level(logging.INFO),
+            FetchCoordinator(
+                transport=Urllib3AsyncTransport(),
+                cache_dir=tmp_path,
+                offline=True,
+            ) as coordinator,
+        ):
+            for target in (_PY312, _LINUX311):
+                provider = Provider(coordinator, target=target)
+                for version in versions:
+                    with pytest.raises(MetadataError):
+                        provider.get_dependencies("foo", V(version))
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert "Skipping releases of foo" in warnings[0].getMessage()
+
+        skipped = _skipped_release_messages(caplog)
+        assert len(skipped) == len(versions) * 2
+        assert {m.split(":")[0] for m in skipped} == {
+            f"Skipping foo=={v}" for v in versions
+        }
+
+    def test_a_dropped_version_is_reported_when_an_older_one_pins(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A newer version dropped for a cold slot is not dropped in silence."""
+        cache = _seed_listing(tmp_path, [_sdist_entry("1.0"), _sdist_entry("2.0")])
+        cache.put_sdist_files("foo", "1.0", self._PKG_INFO.format(ver="1.0"), None)
+        root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
+        with (
+            caplog.at_level(logging.INFO),
+            FetchCoordinator(
+                transport=Urllib3AsyncTransport(),
+                cache_dir=tmp_path,
+                offline=True,
+            ) as coordinator,
+        ):
+            provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
+            resolver = Resolver(provider, range_type=VersionRange, root_version="0")
+            pins = resolver.resolve(root_reqs)
+
+        assert pins["foo"] == V("1.0")
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert "Skipping releases of foo" in warnings[0].getMessage()
+        assert "offline mode" in warnings[0].getMessage()
+
+        skipped = _skipped_release_messages(caplog)
+        assert len(skipped) == 1
+        assert "foo==2.0" in skipped[0]
+
+    def test_warm_metadata_offline_pins_the_newest_and_stays_quiet(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The control: with both slots warm, offline pins 2.0 and logs nothing."""
+        cache = _seed_listing(tmp_path, [_sdist_entry("1.0"), _sdist_entry("2.0")])
+        for version in ("1.0", "2.0"):
+            cache.put_sdist_files(
+                "foo", version, self._PKG_INFO.format(ver=version), None
+            )
+        root_reqs = {"foo": VersionRange.full(admit_arbitrary=False)}
+        with (
+            caplog.at_level(logging.INFO),
+            FetchCoordinator(
+                transport=Urllib3AsyncTransport(),
+                cache_dir=tmp_path,
+                offline=True,
+            ) as coordinator,
+        ):
+            provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
+            resolver = Resolver(provider, range_type=VersionRange, root_version="0")
+            pins = resolver.resolve(root_reqs)
+
+        assert pins["foo"] == V("2.0")
+        assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+        assert _skipped_release_messages(caplog) == []
 
 
 class TestMetadataBlockerCount:


### PR DESCRIPTION
Under `nab lock --offline` with a cold cache, a release whose metadata was not cached failed with "no PEP 658 metadata and the sdist has no readable PKG-INFO", an artifact nab never requested. An offline skip writes the same empty metadata slot an artifact with no metadata writes, so the ladder could not tell the two apart and named whichever rung it had reached last.

Each rung now marks its skip alongside the empty slot, keyed by the URL it skipped, and the failure reads back the mark of the rung the ladder gave up on. When nab did read the sdist and it had no PKG-INFO, the message still says so.

The same miss was silent when the resolve could survive it: if an older release had warm metadata, the resolve exited 0 on the older pin and said nothing about dropping the newer one. Dropped releases now log at info, with one warning per package for the run.
