### PR TITLE
cover pre-release pins in the `nab lock --locked` checks

### DIFF
--- a/nab-python/src/nab_python/_lockfile/validate.py
+++ b/nab-python/src/nab_python/_lockfile/validate.py
@@ -13,7 +13,11 @@ writer computes straight from the inputs: ``requires-python``, ``extras``,
 ``dependency-groups`` and ``default-groups``. The validity checks
 (:func:`check_direct_requirements`, :func:`check_constraints`) cover what
 every successful resolve renders: each active direct requirement is present
-and its specifier met, and each pin satisfies every active constraint.
+and its specifier met, and each pin satisfies every active constraint. A
+pre-release pin is never disqualified for being a pre-release: the resolver
+picks from the intersection of every requirement on a name, so a fresh
+resolve can land on a pre-release the requirement checked here does not opt
+into on its own.
 
 :func:`check_locked` is the entry point the CLI calls: it reads the committed
 lock and runs both stages, so a caller never handles a parsed lock itself.

--- a/nab-python/tests/test_lockfile_validate.py
+++ b/nab-python/tests/test_lockfile_validate.py
@@ -310,6 +310,34 @@ def test_direct_marker_true_applies_and_fires() -> None:
     assert result.reason.startswith("[project].dependencies requires foo>=2.0")
 
 
+def test_direct_prerelease_pin_inside_specifier_does_not_fire() -> None:
+    """A pre-release pin is not on its own a reason to disqualify the lock."""
+    committed = pylock_of(index_pin("foo", "2.0b1"))
+    assert (
+        check_direct_requirements(committed, [root("foo>=2.0b1")], marker_env=LINUX_ENV)
+        is None
+    )
+
+
+def test_direct_prerelease_pin_under_bare_requirement_does_not_fire() -> None:
+    committed = pylock_of(index_pin("foo", "2.0b1"))
+    assert (
+        check_direct_requirements(committed, [root("foo")], marker_env=LINUX_ENV)
+        is None
+    )
+
+
+def test_direct_prerelease_pin_outside_specifier_fires() -> None:
+    committed = pylock_of(index_pin("foo", "1.0b1"))
+    result = check_direct_requirements(
+        committed, [root("foo>=2.0")], marker_env=LINUX_ENV
+    )
+    assert result is not None
+    assert result.reason == (
+        "[project].dependencies requires foo>=2.0 but the lock pins foo 1.0b1"
+    )
+
+
 def test_direct_versionless_pin_skipped() -> None:
     committed = pylock_of(directory_pin("foo"))
     assert (
@@ -414,6 +442,22 @@ def test_constraint_violated_fires() -> None:
     result = check_constraints(committed, [Requirement("baz<3")], marker_env=LINUX_ENV)
     assert result is not None
     assert result.reason == ("the constraint baz<3 is violated by the pinned baz 3.1")
+
+
+def test_constraint_satisfied_by_prerelease_pin_does_not_fire() -> None:
+    """A constraint bounds the version without excluding pre-releases."""
+    committed = pylock_of(index_pin("baz", "2.0b1"))
+    assert (
+        check_constraints(committed, [Requirement("baz<3")], marker_env=LINUX_ENV)
+        is None
+    )
+
+
+def test_constraint_violated_by_prerelease_pin_fires() -> None:
+    committed = pylock_of(index_pin("baz", "3.1b1"))
+    result = check_constraints(committed, [Requirement("baz<3")], marker_env=LINUX_ENV)
+    assert result is not None
+    assert result.reason == "the constraint baz<3 is violated by the pinned baz 3.1b1"
 
 
 def test_constraint_marker_false_skipped() -> None:

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -274,6 +274,26 @@ def test_non_sticky_stale_falls_through_out_of_date(
     mock.assert_called_once()
 
 
+def test_prerelease_pin_falls_through(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # The pin satisfies the direct specifier and the constraint, so neither fires.
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\ndependencies = ["foo>=2.0b1"]\n'
+        '[tool.nab]\nconstraints = ["foo<3"]\n',
+    )
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "2.0b1"}))
+    capsys.readouterr()
+
+    mock = _locked_mock(_result({"foo": "2.0b1"}))
+    _run_locked(pyproject, out, mock)
+
+    assert "is up to date" in capsys.readouterr().err
+    mock.assert_called_once()
+
+
 def test_marker_inactive_absent_requirement_falls_through(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
Nothing tested a pre-release pin against the `nab lock --locked` validity checks, so the `prereleases=True` on both specifier containment calls in `_lockfile/validate.py` could be dropped with the suite still green. Without it, `--locked` reports any lock holding a pre-release pin as out of date, even when the pin still satisfies the direct requirement and every constraint.

The new tests cover a pre-release pin inside and outside a direct specifier, a constraint the pin satisfies and one it violates, and a `--locked` run over a lock that pins a pre-release. The module docstring now records why such a pin is admitted: the resolver picks from the intersection of every requirement on a name, so a resolve can land on a pre-release that the requirement checked here does not opt into by itself.
