### PR TITLE
keep the package listing when a version is oversized

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -20,12 +20,8 @@ from functools import lru_cache
 from typing import TYPE_CHECKING
 from urllib.parse import urljoin, urlsplit, urlunsplit
 
-from packaging.utils import (
-    InvalidSdistFilename,
-    canonicalize_name,
-    parse_sdist_filename,
-)
-from packaging.version import InvalidVersion, Version
+from packaging.utils import canonicalize_name, parse_sdist_filename
+from packaging.version import Version
 
 from ._pep503 import json_listing
 from .serialization import SimpleSerialization, simple_accept_header
@@ -143,7 +139,8 @@ def _parse_wheel_filename(filename: str) -> tuple[NormalizedName, str] | None:
 
     try:
         version = _canonical_version(parts[1])
-    except InvalidVersion:
+    except ValueError:
+        # InvalidVersion, and int() refusing a digit run past CPython's limit.
         return None
 
     bad_build = (
@@ -174,7 +171,8 @@ def _parse_sdist_filename(filename: str) -> tuple[NormalizedName, str] | None:
 
     try:
         name, version = parse_sdist_filename(filename)
-    except InvalidSdistFilename:
+    except ValueError:
+        # InvalidSdistFilename, and int() refusing a digit run past CPython's limit.
         return None
     return (name, str(version))
 

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -112,7 +112,9 @@ def _parse_wheel_filename(filename: str) -> tuple[NormalizedName, str] | None:
     """Parse a wheel filename per PEP 427.
 
     Returns ``(canonical_name, version_string)`` or ``None`` for any
-    filename packaging rejects (wrong extension, malformed, etc.).
+    filename packaging rejects (wrong extension, malformed, etc.) and
+    for a version digit run past CPython's int-from-string limit.
+    Never raises.
     The version string is the canonical form produced by
     :class:`packaging.version.Version`, so trailing-zero handling
     matches what packaging records on the file; e.g. a wheel
@@ -140,7 +142,7 @@ def _parse_wheel_filename(filename: str) -> tuple[NormalizedName, str] | None:
     try:
         version = _canonical_version(parts[1])
     except ValueError:
-        # InvalidVersion, and int() refusing a digit run past CPython's limit.
+        # InvalidVersion, or int() refusing a digit run past CPython's limit.
         return None
 
     bad_build = (
@@ -157,9 +159,10 @@ def _parse_wheel_filename(filename: str) -> tuple[NormalizedName, str] | None:
 def _parse_sdist_filename(filename: str) -> tuple[NormalizedName, str] | None:
     """Parse a ``.tar.gz`` sdist filename to ``(canonical_name, version)``.
 
-    Returns ``None`` for anything packaging rejects and for ``.zip``
-    sdists, which nab does not support (gzip-tar only, and not part of
-    the PEP 625 standard).
+    Returns ``None`` for anything packaging rejects, for a version digit
+    run past CPython's int-from-string limit, and for ``.zip`` sdists,
+    which nab does not support (gzip-tar only, and not part of the PEP 625
+    standard).  Never raises.
 
     Legacy filenames with embedded build tags (e.g. ``cffi-1.0.2-2.tar.gz``)
     parse to a surprising ``(name="cffi-1-0-2", version="2")``, so callers
@@ -172,7 +175,7 @@ def _parse_sdist_filename(filename: str) -> tuple[NormalizedName, str] | None:
     try:
         name, version = parse_sdist_filename(filename)
     except ValueError:
-        # InvalidSdistFilename, and int() refusing a digit run past CPython's limit.
+        # InvalidSdistFilename, or int() refusing a digit run past CPython's limit.
         return None
     return (name, str(version))
 

--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -31,7 +31,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import unquote, urljoin, urlparse, urlsplit
 from urllib.request import url2pathname
 
-from packaging.utils import InvalidSdistFilename, parse_sdist_filename
+from packaging.utils import parse_sdist_filename
 
 from ._naming import canonical as _canonical
 from ._pep503 import hash_fragment, metadata_declaration, read_page
@@ -321,7 +321,8 @@ def _is_zip_sdist(filename: str, canonical: str) -> bool:
         return False
     try:
         name, _ = parse_sdist_filename(filename)
-    except InvalidSdistFilename:
+    except ValueError:
+        # InvalidSdistFilename, or int() refusing a digit run past CPython's limit.
         return False
     return name == canonical
 

--- a/nab-index/tests/test_index_client.py
+++ b/nab-index/tests/test_index_client.py
@@ -12,7 +12,7 @@ from nab_index.client import (
     is_readable_filename,
 )
 
-# A version digit run past the int-from-string limit, which int() refuses.
+# A version digit run past CPython's int-from-string limit.
 OVERSIZED = "1" * (sys.get_int_max_str_digits() + 1)
 
 

--- a/nab-index/tests/test_index_client.py
+++ b/nab-index/tests/test_index_client.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from nab_index.client import (
@@ -9,6 +11,9 @@ from nab_index.client import (
     holds_unreadable_format,
     is_readable_filename,
 )
+
+# A version digit run past the int-from-string limit, which int() refuses.
+OVERSIZED = "1" * (sys.get_int_max_str_digits() + 1)
 
 
 @pytest.mark.parametrize(
@@ -27,8 +32,27 @@ def test_unreadable_filenames(filename: str) -> None:
     assert not is_readable_filename(filename)
 
 
+@pytest.mark.parametrize(
+    "filename",
+    [
+        pytest.param(f"foo-{OVERSIZED}-py3-none-any.whl", id="wheel"),
+        pytest.param(f"foo-{OVERSIZED}.tar.gz", id="sdist"),
+        pytest.param(f"foo-{OVERSIZED}!1.0-py3-none-any.whl", id="epoch"),
+        pytest.param(f"foo-1.0.dev{OVERSIZED}-py3-none-any.whl", id="dev"),
+    ],
+)
+def test_oversized_version_is_unreadable(filename: str) -> None:
+    assert not is_readable_filename(filename)
+
+
 def test_holds_unreadable_format_finds_zip_sdist() -> None:
     data = {"files": [{"filename": "foo-1.0.zip", "url": "https://e.example/f"}]}
+    assert holds_unreadable_format(data)
+
+
+def test_holds_unreadable_format_finds_oversized_version() -> None:
+    filename = f"foo-{OVERSIZED}-py3-none-any.whl"
+    data = {"files": [{"filename": filename, "url": "https://e.example/f"}]}
     assert holds_unreadable_format(data)
 
 

--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -585,10 +585,10 @@ def excluded_by_python(
         try:
             spec = SpecifierSet(effective)
             cached = not provider.target.admits_requires_python(spec)
-        except InvalidSpecifier:
-            # Malformed Requires-Python on the dist: treat as
-            # not-excluded, let downstream logic decide.  Our own
-            # python_version is validated at Provider construction.
+        except ValueError:
+            # Malformed Requires-Python on the dist, or a digit run int()
+            # refuses: treat as not-excluded, let downstream logic decide.
+            # Our own python_version is validated at Provider construction.
             cached = False
         provider.requires_python_cache[effective] = cached
     if cached:

--- a/nab-python/tests/property_python/test_filename_differential.py
+++ b/nab-python/tests/property_python/test_filename_differential.py
@@ -11,9 +11,10 @@ Upstream packaging is the oracle for both.
 from __future__ import annotations
 
 import string
+import sys
 
 import pytest
-from hypothesis import given
+from hypothesis import example, given
 from hypothesis import strategies as st
 from packaging.utils import (
     InvalidSdistFilename,
@@ -84,6 +85,8 @@ extensions = st.sampled_from(
     [".whl", ".WHL", ".tar.gz", ".zip", "", ".whl ", ".whl.whl"]
 )
 
+OVERSIZED_VERSION = "1" * (sys.get_int_max_str_digits() + 1)
+
 
 @st.composite
 def wheelish_filenames(draw: st.DrawFn) -> str:
@@ -150,10 +153,15 @@ def test_wheel_parse_matches_upstream_fuzz(filename: str) -> None:
         assert result == oracle_wheel(filename + ".whl")
 
 
+@example(filename=f"foo-{OVERSIZED_VERSION}-py3-none-any.whl")
 @given(filename=st.text(min_size=0, max_size=40))
 @DEEP_SETTINGS
 def test_wheel_parse_never_crashes(filename: str) -> None:
-    """Malformed input is rejected with ``None``, never an exception."""
+    """Malformed input is rejected with ``None``, never an exception.
+
+    The drawn text is far shorter than the int-from-string limit, so the
+    version int() refuses comes in as an explicit example.
+    """
     result = _parse_wheel_filename(filename)
     assert result is None or isinstance(result, tuple)
 

--- a/nab-python/tests/property_python/test_filename_differential.py
+++ b/nab-python/tests/property_python/test_filename_differential.py
@@ -159,8 +159,8 @@ def test_wheel_parse_matches_upstream_fuzz(filename: str) -> None:
 def test_wheel_parse_never_crashes(filename: str) -> None:
     """Malformed input is rejected with ``None``, never an exception.
 
-    The drawn text is far shorter than the int-from-string limit, so the
-    version int() refuses comes in as an explicit example.
+    Hypothesis draws text far shorter than the int-from-string limit, so an
+    oversized version comes in as an explicit example.
     """
     result = _parse_wheel_filename(filename)
     assert result is None or isinstance(result, tuple)
@@ -189,3 +189,16 @@ def test_sdist_parse_matches_upstream_fuzz(filename: str) -> None:
     """Arbitrary text with a ``.tar.gz`` suffix parses exactly like upstream."""
     fn = filename + ".tar.gz"
     assert _parse_sdist_filename(fn) == oracle_sdist(fn)
+
+
+@example(filename=f"foo-{OVERSIZED_VERSION}.tar.gz")
+@given(filename=st.text(min_size=0, max_size=40))
+@DEEP_SETTINGS
+def test_sdist_parse_never_crashes(filename: str) -> None:
+    """Malformed input is rejected with ``None``, never an exception.
+
+    Hypothesis draws text far shorter than the int-from-string limit, so an
+    oversized version comes in as an explicit example.
+    """
+    result = _parse_sdist_filename(filename)
+    assert result is None or isinstance(result, tuple)

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -19,6 +19,7 @@ from nab_index.local_index import (
     LocalIndexClient,
     MalformedLocalListingError,
     UnsupportedWheelError,
+    _is_zip_sdist,
     _make_record,
     _read_sdist_requires_python,
     parse_file_url,
@@ -326,6 +327,15 @@ class TestFlatWheelhouse:
         client = LocalIndexClient(tmp_path.as_uri())
         assert run(client.get_files("foo")) == []
         assert not client.served_unreadable_only("foo")
+
+    def test_zip_sdist_check_rejects_oversized_version(self) -> None:
+        """An oversized version answers False instead of raising.
+
+        Called directly because the filename is longer than any filesystem
+        allows, so it cannot arrive from a directory scan.
+        """
+        oversized = "1" * (sys.get_int_max_str_digits() + 1)
+        assert not _is_zip_sdist(f"foo-{oversized}.zip", "foo")
 
     def test_zip_beside_readable_wheel_is_not_unreadable_only(
         self, tmp_path: Path

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -6,6 +6,7 @@ import asyncio
 import io
 import json
 import logging
+import sys
 import tarfile
 import threading
 import zipfile
@@ -498,6 +499,39 @@ class TestFetchVersions:
         assert files[0].requires_python is None
         coordinator = make_coordinator(files, package="foo")
         provider = Provider(coordinator, target=_PY312)
+        assert len(provider.fetch_versions("foo")) == 1
+
+    @pytest.mark.parametrize(
+        "target",
+        [
+            pytest.param(_PY312, id="minor-interval"),
+            pytest.param(ResolveTarget.for_host_python("3.12.4"), id="whole-target"),
+        ],
+    )
+    def test_oversized_requires_python_admitted_without_crash(
+        self, target: ResolveTarget
+    ) -> None:
+        """An oversized requires-python admits the wheel instead of crashing.
+
+        The entry is a string, so it passes the parser's isinstance guard and
+        SpecifierSet accepts it; the ValueError only lands when the target
+        compares against it, on either branch of admits_requires_python.
+        """
+        oversized = ">=" + "1" * (sys.get_int_max_str_digits() + 1)
+        data = {
+            "files": [
+                {
+                    "filename": "foo-1.0-py3-none-any.whl",
+                    "url": "https://example.com/foo/foo-1.0-py3-none-any.whl",
+                    "requires-python": oversized,
+                }
+            ]
+        }
+
+        files = _parse_files(data, "https://example.com/", "foo")
+        coordinator = make_coordinator(files, package="foo")
+        provider = Provider(coordinator, target=target)
+
         assert len(provider.fetch_versions("foo")) == 1
 
     def test_requires_python_cache_hit_exercises_cached_branch(self) -> None:

--- a/nab-python/tests/test_simple_client_filenames.py
+++ b/nab-python/tests/test_simple_client_filenames.py
@@ -5,8 +5,8 @@ while skipping the discarded tag-set parse and interning the version, its
 canonical string, and the canonical name. These tests assert it
 accepts/rejects exactly what packaging does and that the interners return
 byte-identical results to the uncached functions, so the optimization stays
-output-invariant even if packaging is re-vendored. Both parsers are total:
-a filename they cannot read comes back as ``None``.
+output-invariant even if packaging is re-vendored. Neither parser raises: a
+filename it cannot read comes back as ``None``.
 """
 
 from __future__ import annotations
@@ -29,7 +29,7 @@ from nab_index.client import (
     _parse_wheel_filename,
 )
 
-# Version digit runs at and just past the int-from-string limit int() enforces.
+# Version digit runs at and just past CPython's int-from-string limit.
 AT_LIMIT = "1" * sys.get_int_max_str_digits()
 OVERSIZED = AT_LIMIT + "1"
 

--- a/nab-python/tests/test_simple_client_filenames.py
+++ b/nab-python/tests/test_simple_client_filenames.py
@@ -1,14 +1,17 @@
-"""Differential tests for nab_index's wheel-filename parser.
+"""Differential tests for nab_index's filename parsers.
 
 ``_parse_wheel_filename`` reproduces packaging's name/version validation
 while skipping the discarded tag-set parse and interning the version, its
 canonical string, and the canonical name. These tests assert it
 accepts/rejects exactly what packaging does and that the interners return
 byte-identical results to the uncached functions, so the optimization stays
-output-invariant even if packaging is re-vendored.
+output-invariant even if packaging is re-vendored. Both parsers are total:
+a filename they cannot read comes back as ``None``.
 """
 
 from __future__ import annotations
+
+import sys
 
 import pytest
 from packaging.utils import (
@@ -22,8 +25,13 @@ from nab_index.client import (
     _canonical_version,
     _intern_name,
     _intern_version,
+    _parse_sdist_filename,
     _parse_wheel_filename,
 )
+
+# Version digit runs at and just past the int-from-string limit int() enforces.
+AT_LIMIT = "1" * sys.get_int_max_str_digits()
+OVERSIZED = AT_LIMIT + "1"
 
 CORPUS = [
     # valid, no build tag
@@ -79,6 +87,31 @@ EMPTY_TAG_COMPONENT = [
 @pytest.mark.parametrize("filename", EMPTY_TAG_COMPONENT)
 def test_rejects_empty_tag_component(filename: str) -> None:
     assert _parse_wheel_filename(filename) is None
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        pytest.param(f"foo-{OVERSIZED}-py3-none-any.whl", id="release"),
+        pytest.param(f"foo-{OVERSIZED}!1.0-py3-none-any.whl", id="epoch"),
+        pytest.param(f"foo-1.0.dev{OVERSIZED}-py3-none-any.whl", id="dev"),
+        pytest.param(f"foo-1.0.post{OVERSIZED}-py3-none-any.whl", id="post"),
+        pytest.param(f"foo-{OVERSIZED}-1-py3-none-any.whl", id="build-tag"),
+    ],
+)
+def test_rejects_oversized_wheel_version(filename: str) -> None:
+    assert _parse_wheel_filename(filename) is None
+
+
+def test_rejects_oversized_sdist_version() -> None:
+    assert _parse_sdist_filename(f"foo-{OVERSIZED}.tar.gz") is None
+
+
+def test_accepts_version_at_int_limit() -> None:
+    assert _parse_wheel_filename(f"foo-{AT_LIMIT}-py3-none-any.whl") == (
+        canonicalize_name("foo"),
+        AT_LIMIT,
+    )
 
 
 def test_canonical_form_and_trailing_zeros() -> None:

--- a/nab-python/tests/test_simple_client_malformed.py
+++ b/nab-python/tests/test_simple_client_malformed.py
@@ -8,6 +8,8 @@ result means "package absent" to the multi-index router.  A malformed
 
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from nab_index.client import (
@@ -18,6 +20,9 @@ from nab_index.client import (
 from nab_index.transport import HttpError
 
 _INDEX = "https://example.com/"
+
+# A version digit run past the int-from-string limit, which int() refuses.
+_OVERSIZED = "1" * (sys.get_int_max_str_digits() + 1)
 
 
 def _good_file() -> dict[str, object]:
@@ -101,6 +106,19 @@ def test_bad_entry_dropped_good_entry_kept(bad_entry: object) -> None:
     files = _parse_files(data, _INDEX, "foo")
     assert len(files) == 1
     assert files[0].filename == "foo-1.0-py3-none-any.whl"
+
+
+@pytest.mark.parametrize(
+    "bad_filename",
+    [
+        pytest.param(f"foo-{_OVERSIZED}-py3-none-any.whl", id="wheel"),
+        pytest.param(f"foo-{_OVERSIZED}.tar.gz", id="sdist"),
+    ],
+)
+def test_entry_with_oversized_version_is_skipped(bad_filename: str) -> None:
+    entry = {"filename": bad_filename, "url": f"{_INDEX}foo/{bad_filename}"}
+    files = _parse_files({"files": [entry, _good_file()]}, _INDEX, "foo")
+    assert [f.filename for f in files] == ["foo-1.0-py3-none-any.whl"]
 
 
 @pytest.mark.parametrize(

--- a/nab-python/tests/test_simple_client_malformed.py
+++ b/nab-python/tests/test_simple_client_malformed.py
@@ -21,7 +21,7 @@ from nab_index.transport import HttpError
 
 _INDEX = "https://example.com/"
 
-# A version digit run past the int-from-string limit, which int() refuses.
+# A version digit run past CPython's int-from-string limit.
 _OVERSIZED = "1" * (sys.get_int_max_str_digits() + 1)
 
 


### PR DESCRIPTION
A listing entry whose version segment has more than 4300 digits raised a ValueError out of nab-index's filename parsers, so the whole package listing failed instead of that one entry being skipped.

packaging's InvalidVersion and InvalidSdistFilename are both ValueError subclasses, but a digit run past CPython's int-from-string limit raises a plain ValueError, which the narrower excepts missed. The wheel and sdist parsers now catch ValueError and return None, the existing unreadable-filename path, so the bad file is dropped and the rest of the listing is kept. The same widening covers the local-index zip-sdist check and a Requires-Python with an oversized digit run, where the file is now admitted instead of crashing the resolve.
