### PR TITLE
fix the `nab lock` traceback on an oversized version in source metadata

### DIFF
--- a/nab-python/src/nab_python/_build/runner.py
+++ b/nab-python/src/nab_python/_build/runner.py
@@ -41,7 +41,7 @@ from nab_resolver.resolver import ResolutionError
 from .._vendor.packaging.requirements import InvalidRequirement, Requirement
 from .._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from .._vendor.packaging.utils import canonicalize_name
-from .._vendor.packaging.version import InvalidVersion, Version
+from .._vendor.packaging.version import Version
 from ..metadata import WheelMetadata
 from .env import BuildEnvError, NabBuildEnv
 from .errors import BuildBackendError
@@ -297,7 +297,8 @@ def _parse_metadata(metadata_path: Path) -> WheelMetadata:
         raise BuildBackendError(msg)
     try:
         version = Version(version_raw)
-    except InvalidVersion as exc:
+    except ValueError as exc:
+        # InvalidVersion, or int() refusing a digit run past CPython's limit.
         msg = f"backend METADATA has invalid Version {version_raw!r}: {exc}"
         raise BuildBackendError(msg) from exc
 

--- a/nab-python/src/nab_python/_build/runner.py
+++ b/nab-python/src/nab_python/_build/runner.py
@@ -38,11 +38,11 @@ import tomli
 
 from nab_resolver.resolver import ResolutionError
 
-from .._vendor.packaging.requirements import InvalidRequirement, Requirement
-from .._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
+from .._vendor.packaging.requirements import Requirement
+from .._vendor.packaging.specifiers import SpecifierSet
 from .._vendor.packaging.utils import canonicalize_name
 from .._vendor.packaging.version import Version
-from ..metadata import WheelMetadata
+from ..metadata import WheelMetadata, validate_specifier_versions
 from .env import BuildEnvError, NabBuildEnv
 from .errors import BuildBackendError
 
@@ -303,24 +303,27 @@ def _parse_metadata(metadata_path: Path) -> WheelMetadata:
         raise BuildBackendError(msg) from exc
 
     requires_python_raw = msg_obj.get("Requires-Python")
-    try:
-        requires_python = (
-            SpecifierSet(requires_python_raw) if requires_python_raw else None
-        )
-    except InvalidSpecifier as exc:
-        msg = (
-            f"backend METADATA has invalid Requires-Python "
-            f"{requires_python_raw!r}: {exc}"
-        )
-        raise BuildBackendError(msg) from exc
+    requires_python = None
+    if requires_python_raw:
+        try:
+            requires_python = SpecifierSet(requires_python_raw)
+            validate_specifier_versions(requires_python)
+        except ValueError as exc:
+            msg = (
+                f"backend METADATA has invalid Requires-Python "
+                f"{requires_python_raw!r}: {exc}"
+            )
+            raise BuildBackendError(msg) from exc
 
-    try:
-        requires_dist: list[Requirement] = [
-            Requirement(raw) for raw in msg_obj.get_all("Requires-Dist") or ()
-        ]
-    except InvalidRequirement as exc:
-        msg = f"backend METADATA has an invalid Requires-Dist: {exc}"
-        raise BuildBackendError(msg) from exc
+    requires_dist: list[Requirement] = []
+    for raw in msg_obj.get_all("Requires-Dist") or ():
+        try:
+            req = Requirement(raw)
+            validate_specifier_versions(req.specifier)
+        except ValueError as exc:
+            msg = f"backend METADATA has an invalid Requires-Dist: {exc}"
+            raise BuildBackendError(msg) from exc
+        requires_dist.append(req)
 
     provides_extra: list[str] = sorted(
         {

--- a/nab-python/src/nab_python/build_backend.py
+++ b/nab-python/src/nab_python/build_backend.py
@@ -17,7 +17,7 @@ from ._build.errors import (
 )
 from ._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from ._vendor.packaging.utils import canonicalize_name
-from ._vendor.packaging.version import InvalidVersion, Version
+from ._vendor.packaging.version import Version
 from .metadata import WheelMetadata, load_static_project
 from .requirements_file import (
     InvalidProjectRequirementError,
@@ -53,7 +53,7 @@ def extract_static_metadata(source_dir: Path) -> WheelMetadata | None:
     Raises :class:`InvalidProjectRequirementError` when a present,
     non-dynamic field is corrupt: a structurally wrong ``dependencies`` /
     ``optional-dependencies`` (not an array of strings / not a table), a
-    ``version`` string that is not valid :pep:`440`, or a
+    ``version`` string that does not parse as :pep:`440`, or a
     ``requires-python`` that is not a string or not a valid specifier.  A
     corrupt static value is not something the build backend can compute,
     so it raises rather than deferring to a build of the same broken file.
@@ -106,7 +106,8 @@ def _project_to_metadata(project: dict) -> WheelMetadata | None:
     # raises instead of returning None.
     try:
         version = Version(version_raw)
-    except InvalidVersion as exc:
+    except ValueError as exc:
+        # InvalidVersion, or int() refusing a digit run past CPython's limit.
         msg = f"invalid [project].version {version_raw!r}: {exc}"
         raise InvalidProjectRequirementError(msg) from exc
 

--- a/nab-python/src/nab_python/build_backend.py
+++ b/nab-python/src/nab_python/build_backend.py
@@ -15,10 +15,10 @@ from typing import TYPE_CHECKING
 from ._build.errors import (
     BuildBackendError as BuildBackendError,  # noqa: PLC0414  (public re-export)
 )
-from ._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
+from ._vendor.packaging.specifiers import SpecifierSet
 from ._vendor.packaging.utils import canonicalize_name
 from ._vendor.packaging.version import Version
-from .metadata import WheelMetadata, load_static_project
+from .metadata import WheelMetadata, load_static_project, validate_specifier_versions
 from .requirements_file import (
     InvalidProjectRequirementError,
     _parse_project_requirement,
@@ -54,9 +54,10 @@ def extract_static_metadata(source_dir: Path) -> WheelMetadata | None:
     non-dynamic field is corrupt: a structurally wrong ``dependencies`` /
     ``optional-dependencies`` (not an array of strings / not a table), a
     ``version`` string that does not parse as :pep:`440`, or a
-    ``requires-python`` that is not a string or not a valid specifier.  A
-    corrupt static value is not something the build backend can compute,
-    so it raises rather than deferring to a build of the same broken file.
+    ``requires-python`` that is not a string or does not parse as a
+    specifier.  A corrupt static value is not something the build backend
+    can compute, so it raises rather than deferring to a build of the same
+    broken file.
 
     The returned ``provides_extra`` includes both the lower-cased
     keys of ``project.optional-dependencies`` and any extras declared
@@ -135,10 +136,12 @@ def _static_requires_python(raw: object) -> SpecifierSet | None:
         msg = f"[project].requires-python must be a string, got {type(raw).__name__}"
         raise InvalidProjectRequirementError(msg)
     try:
-        return SpecifierSet(raw)
-    except InvalidSpecifier as exc:
+        specifier_set = SpecifierSet(raw)
+        validate_specifier_versions(specifier_set)
+    except ValueError as exc:
         msg = f"invalid [project].requires-python {raw!r}: {exc}"
         raise InvalidProjectRequirementError(msg) from exc
+    return specifier_set
 
 
 def _collect_requires_dist(project: dict) -> list[Requirement]:

--- a/nab-python/src/nab_python/metadata.py
+++ b/nab-python/src/nab_python/metadata.py
@@ -30,6 +30,7 @@ __all__ = [
     "load_static_project",
     "metadata_deps_are_static",
     "parse_metadata",
+    "validate_specifier_versions",
 ]
 
 
@@ -61,6 +62,21 @@ def load_static_project(text: str) -> dict[str, Any] | None:
         if _DYNAMIC_FIELD_BLOCKERS & dynamic_set:
             return None
     return project
+
+
+def validate_specifier_versions(specifier_set: SpecifierSet) -> None:
+    """Convert every clause's version, raising when one will not parse.
+
+    A :class:`SpecifierSet` keeps its clause versions as strings and
+    converts them only when something compares against it, so a digit run
+    past CPython's int-from-string limit is accepted here and raises a
+    bare ``ValueError`` from the comparison much later.  Arbitrary
+    equality (``===``) compares as a string, so its version is never
+    converted.
+    """
+    for clause in specifier_set:
+        if clause.operator != "===":
+            Version(clause.version.removesuffix(".*"))
 
 
 # PEP 643 dependency-affecting METADATA fields, lowercased.

--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -15,7 +15,8 @@ from ._vendor.packaging.errors import ExceptionGroup
 from ._vendor.packaging.markers import Marker
 from ._vendor.packaging.markersets import MarkerSet
 from ._vendor.packaging.requirements import InvalidRequirement, Requirement
-from ._vendor.packaging.utils import InvalidName, canonicalize_name
+from ._vendor.packaging.utils import canonicalize_name
+from .metadata import validate_specifier_versions
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -92,16 +93,19 @@ def _parse_project_requirement(
     """Parse one PEP 508 dependency string, raising if it is malformed.
 
     An ``extra`` name is folded in as an ``extra == "name"`` marker. A string
-    that is not valid PEP 508 raises :class:`InvalidProjectRequirementError`,
-    so a candidate declaring one malformed dependency is rejected whole rather
+    that is not valid PEP 508, or one whose specifier carries a version that
+    will not convert, raises :class:`InvalidProjectRequirementError`, so a
+    candidate declaring one malformed dependency is rejected whole rather
     than resolved with the dependency silently dropped.
     """
     try:
         text = _add_extra_marker(dep_str, extra) if extra is not None else dep_str
-        return Requirement(text)
-    except (InvalidRequirement, InvalidName) as exc:
+        req = Requirement(text)
+        validate_specifier_versions(req.specifier)
+    except ValueError as exc:
         msg = f"invalid requirement in {source}: {exc}"
         raise InvalidProjectRequirementError(msg) from exc
+    return req
 
 
 def _require_string_list(value: object, source: str) -> list[str]:

--- a/nab-python/tests/test_build_backend.py
+++ b/nab-python/tests/test_build_backend.py
@@ -8,6 +8,7 @@ dynamic dispatch in ``extract_metadata``, including the
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -173,6 +174,18 @@ class TestExtractStaticMetadata:
         with pytest.raises(
             InvalidProjectRequirementError,
             match=r"invalid \[project\]\.version 'not.a.version!'",
+        ):
+            extract_static_metadata(tmp_path)
+
+    def test_oversized_version_raises(self, tmp_path: Path) -> None:
+        """A release segment past the int-from-string limit is corrupt too."""
+        oversized = "1" * (sys.get_int_max_str_digits() + 1)
+        _write_pyproject(
+            tmp_path, f'[project]\nname = "foo"\nversion = "{oversized}"\n'
+        )
+        with pytest.raises(
+            InvalidProjectRequirementError,
+            match=r"invalid \[project\]\.version",
         ):
             extract_static_metadata(tmp_path)
 

--- a/nab-python/tests/test_build_backend.py
+++ b/nab-python/tests/test_build_backend.py
@@ -189,6 +189,31 @@ class TestExtractStaticMetadata:
         ):
             extract_static_metadata(tmp_path)
 
+    def test_oversized_requires_python_raises(self, tmp_path: Path) -> None:
+        """A specifier parses fine and only fails when something compares it."""
+        oversized = "1" * (sys.get_int_max_str_digits() + 1)
+        _write_pyproject(
+            tmp_path,
+            f'[project]\nname = "foo"\nversion = "1.0"\n'
+            f'requires-python = ">={oversized}"\n',
+        )
+        with pytest.raises(
+            InvalidProjectRequirementError,
+            match=r"invalid \[project\]\.requires-python",
+        ):
+            extract_static_metadata(tmp_path)
+
+    def test_oversized_dependency_version_raises(self, tmp_path: Path) -> None:
+        """The same deferred conversion applies to a dependency's specifier."""
+        oversized = "1" * (sys.get_int_max_str_digits() + 1)
+        _write_pyproject(
+            tmp_path,
+            f'[project]\nname = "foo"\nversion = "1.0"\n'
+            f'dependencies = ["bar>={oversized}"]\n',
+        )
+        with pytest.raises(InvalidProjectRequirementError, match="invalid requirement"):
+            extract_static_metadata(tmp_path)
+
     def test_invalid_requires_python_raises(self, tmp_path: Path) -> None:
         """A bare "3.11" has no operator, so it is not a valid specifier; raise."""
         _write_pyproject(

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -680,6 +680,34 @@ class TestParseMetadata:
         with pytest.raises(BuildBackendError, match="invalid Requires-Dist"):
             _parse_metadata(path)
 
+    def test_oversized_requires_python_raises(self, tmp_path: Path) -> None:
+        """A specifier parses fine and only fails when something compares it."""
+        from nab_python._build.runner import _parse_metadata
+
+        oversized = "1" * (sys.get_int_max_str_digits() + 1)
+        path = tmp_path / "METADATA"
+        path.write_text(
+            f"Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n"
+            f"Requires-Python: >={oversized}\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(BuildBackendError, match="invalid Requires-Python"):
+            _parse_metadata(path)
+
+    def test_oversized_requires_dist_version_raises(self, tmp_path: Path) -> None:
+        """The same deferred conversion applies to a Requires-Dist specifier."""
+        from nab_python._build.runner import _parse_metadata
+
+        oversized = "1" * (sys.get_int_max_str_digits() + 1)
+        path = tmp_path / "METADATA"
+        path.write_text(
+            f"Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n"
+            f"Requires-Dist: click>={oversized}\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(BuildBackendError, match="invalid Requires-Dist"):
+            _parse_metadata(path)
+
     def test_provides_extra_whitespace_stripped(self, tmp_path: Path) -> None:
         """Surrounding whitespace on a Provides-Extra value is insignificant
         per RFC 822; canonicalize_name does not strip it, so strip first."""

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -641,6 +641,19 @@ class TestParseMetadata:
         with pytest.raises(BuildBackendError, match="invalid Version"):
             _parse_metadata(path)
 
+    def test_oversized_version_raises(self, tmp_path: Path) -> None:
+        """A release segment past the int-from-string limit is corrupt too."""
+        from nab_python._build.runner import _parse_metadata
+
+        oversized = "1" * (sys.get_int_max_str_digits() + 1)
+        path = tmp_path / "METADATA"
+        path.write_text(
+            f"Metadata-Version: 2.1\nName: foo\nVersion: {oversized}\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(BuildBackendError, match="invalid Version"):
+            _parse_metadata(path)
+
     def test_invalid_requires_python_raises(self, tmp_path: Path) -> None:
         from nab_python._build.runner import _parse_metadata
 

--- a/nab-python/tests/test_metadata.py
+++ b/nab-python/tests/test_metadata.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.version import Version
-from nab_python.metadata import metadata_deps_are_static, parse_metadata
+from nab_python.metadata import (
+    metadata_deps_are_static,
+    parse_metadata,
+    validate_specifier_versions,
+)
 
 
 def test_parses_minimal_metadata() -> None:
@@ -191,3 +197,46 @@ class TestMetadataDepsAreStatic:
     def test_unparseable_metadata_version_is_not_static(self) -> None:
         md = parse_metadata("Metadata-Version: 2.x\nName: foo\nVersion: 1.0\n")
         assert metadata_deps_are_static(md) is False
+
+
+_AT_LIMIT = "1" * sys.get_int_max_str_digits()
+_OVERSIZED = _AT_LIMIT + "1"
+
+
+class TestValidateSpecifierVersions:
+    """A clause ``SpecifierSet`` accepts can still fail to convert later."""
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            ">=3.8",
+            "==1.0.*",
+            "!=2.*",
+            "~=1.4.2",
+            "===lolwat",
+            "==1.0+abc",
+            "<4,>=3.9",
+            ">1!2.0",
+            "==1.0.0.dev1",
+            f"=={_AT_LIMIT}",
+        ],
+    )
+    def test_accepts_every_legal_clause(self, spec: str) -> None:
+        """Including a run of exactly the limit, which int() still converts."""
+        assert validate_specifier_versions(SpecifierSet(spec)) is None
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            pytest.param(f">={_OVERSIZED}", id="release"),
+            pytest.param(f">={_OVERSIZED}!1.0", id="epoch"),
+            pytest.param(f">=1.0rc{_OVERSIZED}", id="pre"),
+            pytest.param(f">=1.0.post{_OVERSIZED}", id="post"),
+            pytest.param(f">=1.0.dev{_OVERSIZED}", id="dev"),
+            pytest.param(f"==1.0+{_OVERSIZED}", id="local"),
+            pytest.param(f"=={_OVERSIZED}.*", id="wildcard"),
+        ],
+    )
+    def test_rejects_oversized_digit_run(self, spec: str) -> None:
+        with pytest.raises(ValueError, match="Exceeds the limit"):
+            validate_specifier_versions(SpecifierSet(spec))


### PR DESCRIPTION
A release segment past CPython's int-from-string limit raises a plain `ValueError` rather than an `InvalidVersion`, and both the static `[project].version` reader and the build runner's METADATA parse only caught `InvalidVersion`. A local, VCS, or archive source declaring one crashed `nab lock` with a raw traceback instead of being reported as corrupt metadata.

Both readers now catch `ValueError`. The same trap sits one level down: a `SpecifierSet` keeps its clause versions as strings and converts them only when something compares against it, so an oversized version in `requires-python` or in a dependency parsed cleanly and then raised from inside `admits_requires_python`. The new `validate_specifier_versions` converts the clauses up front, skipping `===` because arbitrary equality compares as a string.
