### PR TITLE
stop a raw ValueError escaping on oversized index integers

### DIFF
--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -218,7 +218,7 @@ class CachedAsyncSimpleClient:
         """
         try:
             return json.loads(body)
-        except (json.JSONDecodeError, UnicodeDecodeError):
+        except ValueError:
             logger.warning(
                 "Corrupt cached Simple-API body for %r from %s: not valid JSON; "
                 "treating as a miss and re-fetching",
@@ -232,13 +232,13 @@ class CachedAsyncSimpleClient:
 
         A body that is not valid JSON raises the same
         :class:`MalformedSimpleResponseError` as a valid-JSON body of the
-        wrong shape, not a raw decode error. ``json.loads`` on non-UTF-8
-        bytes raises :class:`UnicodeDecodeError`, not
-        :class:`json.JSONDecodeError`, so both are caught.
+        wrong shape, not a raw decode error. ``json.loads`` raises a
+        :class:`ValueError` for every body it rejects, including non-UTF-8
+        bytes and an integer literal past CPython's conversion limit.
         """
         try:
             data = json.loads(body)
-        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        except ValueError as exc:
             msg = (
                 f"{self._index_url} served a malformed Simple-API response for "
                 f"{package!r}: body is not valid JSON"

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -393,7 +393,11 @@ class AsyncSimpleClient:
         await self.aclose()
 
     async def get_files(self, package: str) -> list[WheelFile | SdistFile]:
-        """Fetch all distribution files for a package."""
+        """Fetch all distribution files for a package.
+
+        A body ``json.loads`` rejects becomes a
+        :class:`MalformedSimpleResponseError`, not a raw decode error.
+        """
         url = f"{self._index_url}{package}/"
         accept = simple_accept_header(SimpleSerialization.NEGOTIATE)
         response = await self._transport.get(url, headers={"Accept": accept})
@@ -403,7 +407,16 @@ class AsyncSimpleClient:
         body = _listing_body(
             response, self._index_url, package, SimpleSerialization.NEGOTIATE
         )
-        return _parse_files(json.loads(body), self._index_url, package)
+
+        try:
+            data = json.loads(body)
+        except ValueError as exc:
+            msg = (
+                f"{self._index_url} served a malformed Simple-API response for "
+                f"{package!r}: body is not valid JSON"
+            )
+            raise MalformedSimpleResponseError(msg) from exc
+        return _parse_files(data, self._index_url, package)
 
     async def get_metadata_text(self, metadata_url: str) -> str:
         """Fetch metadata text from a known PEP 658/714 metadata URL."""

--- a/nab-index/src/nab_index/lazy_wheel.py
+++ b/nab-index/src/nab_index/lazy_wheel.py
@@ -277,16 +277,17 @@ def _non_identity(response: HttpResponse) -> bool:
 
 
 def _parse_content_range(value: str | None) -> tuple[int, int, int] | None:
-    """Parse ``bytes start-end/total`` into a tuple, or ``None``. Never raises."""
+    """Parse ``bytes start-end/total`` into a tuple, or ``None``."""
     if value is None:
         return None
     match = _CONTENT_RANGE_RE.match(value.strip())
     if match is None:
         return None
+
     try:
         return (int(match[1]), int(match[2]), int(match[3]))
     except ValueError:
-        # int() refuses a digit run past CPython's conversion limit.
+        # \d+ still matches a run past CPython's int-from-string limit.
         return None
 
 

--- a/nab-index/src/nab_index/lazy_wheel.py
+++ b/nab-index/src/nab_index/lazy_wheel.py
@@ -277,13 +277,17 @@ def _non_identity(response: HttpResponse) -> bool:
 
 
 def _parse_content_range(value: str | None) -> tuple[int, int, int] | None:
-    """Parse ``bytes start-end/total`` into a tuple, or ``None``."""
+    """Parse ``bytes start-end/total`` into a tuple, or ``None``. Never raises."""
     if value is None:
         return None
     match = _CONTENT_RANGE_RE.match(value.strip())
     if match is None:
         return None
-    return (int(match[1]), int(match[2]), int(match[3]))
+    try:
+        return (int(match[1]), int(match[2]), int(match[3]))
+    except ValueError:
+        # int() refuses a digit run past CPython's conversion limit.
+        return None
 
 
 async def _range_get(

--- a/nab-index/tests/test_lazy_wheel.py
+++ b/nab-index/tests/test_lazy_wheel.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import io
+import sys
 import zipfile
 from typing import TYPE_CHECKING
 
@@ -17,6 +18,7 @@ from nab_index.lazy_wheel import (
     RangeCapabilityMemo,
     RangeMetadataResult,
     RangeOutcome,
+    _parse_content_range,
     _SparseFile,
     read_wheel_metadata_over_range,
 )
@@ -27,6 +29,10 @@ if TYPE_CHECKING:
 
 _META = b"Metadata-Version: 2.1\nName: widget\nVersion: 1.0\n\nBody text.\n"
 _URL = "https://files.example.org/packages/widget-1.0-py3-none-any.whl"
+
+# Byte-count digit runs at and just past CPython's int-from-string limit.
+_AT_LIMIT_DIGITS = "9" * sys.get_int_max_str_digits()
+_OVERSIZED_DIGITS = _AT_LIMIT_DIGITS + "9"
 
 
 def build_wheel(
@@ -544,8 +550,12 @@ def test_absolute_probe_200_gzip_is_unsupported() -> None:
 
 @pytest.mark.parametrize(
     "probe_headers",
-    [{}, {"content-range": "bytes 0-0/*"}],
-    ids=["absent", "unknown-length"],
+    [
+        {},
+        {"content-range": "bytes 0-0/*"},
+        {"content-range": f"bytes 0-0/{_OVERSIZED_DIGITS}"},
+    ],
+    ids=["absent", "unknown-length", "oversized-length"],
 )
 def test_absolute_probe_206_without_total_falls_back_to_plain_get(
     probe_headers: dict[str, str],
@@ -903,6 +913,41 @@ def test_suffix_206_unparseable_content_range_downgrades() -> None:
     result = _run_scripted(script)
     assert result.outcome is RangeOutcome.PARTIAL
     assert result.text == _META.decode("utf-8")
+
+
+def test_suffix_206_oversized_total_downgrades() -> None:
+    """A complete-length too long to convert reads as no length at all."""
+
+    def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
+        if kind == "suffix":
+            start = max(0, t.total - a)
+            headers = {
+                "content-range": f"bytes {start}-{t.total - 1}/{_OVERSIZED_DIGITS}"
+            }
+            return _FakeResponse(206, headers, t.wheel[start:])
+        return t.partial(a, b)
+
+    result = _run_scripted(script, wheel=build_wheel_member_front())
+    assert result.outcome is RangeOutcome.PARTIAL
+    assert result.text == _META.decode("utf-8")
+
+
+def test_parse_content_range_at_int_limit() -> None:
+    parsed = _parse_content_range(f"bytes 0-0/{_AT_LIMIT_DIGITS}")
+    assert parsed == (0, 0, int(_AT_LIMIT_DIGITS))
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        f"bytes 0-0/{_OVERSIZED_DIGITS}",
+        f"bytes 0-{_OVERSIZED_DIGITS}/{_OVERSIZED_DIGITS}",
+        f"bytes {_OVERSIZED_DIGITS}-{_OVERSIZED_DIGITS}/{_OVERSIZED_DIGITS}",
+    ],
+    ids=["total", "end", "start"],
+)
+def test_parse_content_range_past_int_limit(value: str) -> None:
+    assert _parse_content_range(value) is None
 
 
 def test_memo_suffix_ok_no_reprobe() -> None:

--- a/nab-index/tests/test_lazy_wheel.py
+++ b/nab-index/tests/test_lazy_wheel.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 _META = b"Metadata-Version: 2.1\nName: widget\nVersion: 1.0\n\nBody text.\n"
 _URL = "https://files.example.org/packages/widget-1.0-py3-none-any.whl"
 
-# Byte-count digit runs at and just past CPython's int-from-string limit.
+# Digit runs at and just past CPython's int-from-string limit.
 _AT_LIMIT_DIGITS = "9" * sys.get_int_max_str_digits()
 _OVERSIZED_DIGITS = _AT_LIMIT_DIGITS + "9"
 
@@ -560,10 +560,11 @@ def test_absolute_probe_200_gzip_is_unsupported() -> None:
 def test_absolute_probe_206_without_total_falls_back_to_plain_get(
     probe_headers: dict[str, str],
 ) -> None:
-    """An honoured probe that reports no length steps down to the plain GET.
+    """An honoured probe that reports no usable length steps down to the plain GET.
 
-    RFC 9110 section 14.4 allows ``*`` as the complete-length. It leaves
-    nothing to range against, and says nothing about fetching the wheel whole.
+    RFC 9110 section 14.4 allows ``*`` as the complete-length, and a digit run
+    too long to convert reads the same way. Either leaves nothing to range
+    against, and says nothing about fetching the wheel whole.
     """
 
     def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -9,6 +9,7 @@ import io
 import itertools
 import json
 import ssl
+import sys
 import tarfile
 import threading
 from collections.abc import Callable, Iterator, Mapping, Sequence
@@ -26,7 +27,11 @@ import urllib3
 
 from nab_index.cache import NullCache
 from nab_index.cached_client import CachedAsyncSimpleClient
-from nab_index.client import AsyncSimpleClient, _extract_sdist_files
+from nab_index.client import (
+    AsyncSimpleClient,
+    MalformedSimpleResponseError,
+    _extract_sdist_files,
+)
 from nab_index.httpx_async_transport import HttpxAsyncTransport, _HttpxResponse
 from nab_index.retry import (
     GET_RETRY,
@@ -1607,6 +1612,35 @@ class TestAsyncSimpleClient:
         assert [f.url for f in files] == [
             "https://pypi.org/simple/pkg/pkg-1.0-py3-none-any.whl"
         ]
+
+    def test_get_files_oversized_int_raises_clean(self) -> None:
+        """A ``size`` too long to convert must not escape as a raw ValueError."""
+        oversized = "9" * (sys.get_int_max_str_digits() + 1)
+        listing = {
+            "meta": {"api-version": "1.1"},
+            "name": "pkg",
+            "files": [
+                {
+                    "filename": "pkg-1.0-py3-none-any.whl",
+                    "url": "https://files.example.com/pkg-1.0-py3-none-any.whl",
+                    "size": "PLACEHOLDER",
+                },
+            ],
+        }
+
+        # json.dumps hits the same limit writing the int out, so splice it in.
+        body = json.dumps(listing).replace('"PLACEHOLDER"', oversized).encode()
+        transport = self._FakeTransport(body)
+
+        async def go() -> list:
+            async with AsyncSimpleClient(transport, "https://pypi.org/simple/") as c:
+                return await c.get_files("pkg")
+
+        with pytest.raises(
+            MalformedSimpleResponseError, match="malformed Simple-API"
+        ) as caught:
+            asyncio.run(go())
+        assert isinstance(caught.value, HttpError)
 
     def test_get_files_404_returns_empty(self) -> None:
         transport = self._FakeTransport(b"not found", status=404)

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -9,6 +9,7 @@ import io
 import json
 import logging
 import re
+import sys
 import tarfile
 import time
 import zipfile
@@ -57,6 +58,9 @@ LISTING = {
     ],
 }
 LISTING_BYTES = json.dumps(LISTING).encode()
+
+# A digit run just past CPython's int-from-string limit.
+OVERSIZED_DIGITS = "9" * (sys.get_int_max_str_digits() + 1)
 
 
 class _FakeResponse:
@@ -3299,6 +3303,64 @@ class TestCorruptCachedListing:
                 json.loads(self._WRONG_SHAPE), "https://pypi.org/simple/", "pkg"
             )
         assert str(caught.value) == str(wire.value)
+
+
+class TestOversizedListingInt:
+    """A listing integer too long to convert reads as an undecodable body.
+
+    ``json.loads`` builds a JSON integer with ``int()``, so a numeric literal
+    past CPython's conversion limit raises a bare :class:`ValueError` rather
+    than a :class:`json.JSONDecodeError`. PEP 700 makes ``size`` a required
+    field, so every api-version 1.1 listing carries one.
+    """
+
+    # json.dumps hits the same limit writing the int out, so splice it in.
+    _BODY = (
+        json.dumps(
+            {
+                "meta": {"api-version": "1.1"},
+                "name": "pkg",
+                "files": [
+                    {
+                        "filename": "pkg-1.0-py3-none-any.whl",
+                        "url": "https://files.example.com/pkg-1.0-py3-none-any.whl",
+                        "size": "PLACEHOLDER",
+                    },
+                ],
+            }
+        )
+        .replace('"PLACEHOLDER"', OVERSIZED_DIGITS)
+        .encode()
+    )
+
+    def test_wire_body_raises_clean_and_skips_cache(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport([_FakeResponse(self._BODY, status=200)])
+
+        with pytest.raises(
+            MalformedSimpleResponseError, match="malformed Simple-API"
+        ) as caught:
+            _run_get_files(transport, cache, "pkg")
+
+        assert isinstance(caught.value, HttpError)
+        assert cache.get_simple("pkg") is None
+
+    def test_cached_body_self_heals_online(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cache = _make_cache(tmp_path)
+        cache.put_simple("pkg", self._BODY, _fresh_policy())
+        transport = _FakeTransport([_FakeResponse(LISTING_BYTES, status=200)])
+
+        with caplog.at_level(logging.WARNING, logger="nab_index.cached_client"):
+            files = _run_get_files(transport, cache, "pkg")
+
+        assert len(files) == 1
+        assert len(transport.calls) == 1
+        healed = cache.get_simple("pkg")
+        assert healed is not None
+        assert healed[0] == LISTING_BYTES
+        assert len(_cached_warnings(caplog)) == 1
 
 
 class TestModuleDocstring:


### PR DESCRIPTION
An index serving a digit run longer than CPython's int-from-string limit (4300 digits by default) crashed `nab lock` with a raw `ValueError` from inside nab-index. Two parse sites passed unvalidated digits to `int()`: the three numbers in `Content-Range`, and the `size` field of a Simple-API listing, which `json.loads` converts with `int()` as well.

Each site now falls back the way it already does for a value it cannot use. An unreadable `Content-Range` reads as no usable length and steps down to the plain GET. A listing body that `json.loads` rejects raises `MalformedSimpleResponseError` like any other malformed body. The cached-listing paths catch `ValueError` rather than the two decode subclasses, so a cache entry holding an oversized integer counts as a miss and is refetched.

The `Cache-Control` max-age site this originally covered is now handled on main: #667's `_parse_seconds` measures the digit run and clamps to 2\*\*31 before calling `int()`, and #683 routes `_parse_max_age` through it. That arm is dropped.