### PR TITLE
stop mirroring a literal-first marker clause when micro tiling

### DIFF
--- a/docs/explanation/universal.md
+++ b/docs/explanation/universal.md
@@ -201,7 +201,9 @@ operators (`<`, `<=`, `>`, `>=`) and the ones naming a region (`==`,
 into an interval is a loud error rather than a silent guess: a
 membership test (`in`, `not in`), a verbatim `===`, a non-version
 comparison, a comparison against another marker variable, or certain
-prerelease literals strictly inside the minor.
+prerelease literals strictly inside the minor. PEP 508 also allows the
+literal first (`"3.11.4rc1" < python_full_version`), and packaging reads
+that order differently, so nab tiles it from the order as written.
 
 To resolve a minor as one real release rather than split it, name the
 patch you deploy on:

--- a/docs/reference/lockfile.md
+++ b/docs/reference/lockfile.md
@@ -226,6 +226,17 @@ prerelease-version literal strictly inside the minor on an operator that
 fixes the boundary at the literal (`<`, `>=`, `==`, `!=`, `~=`). On `<=`
 or `>` a prerelease literal lands at the next release and tiles cleanly.
 
+Those literal rules are for the variable-on-left form. PEP 508 also
+allows `"3.11.4rc1" < python_full_version`, which packaging reads by
+building the specifier from the interpreter's version and testing the
+literal against it, so PEP 440's same-release exclusions land on the
+literal: that clause is False on 3.11.4 and cuts at 3.11.5. nab reads
+each order as written, and with the literal first a prerelease is never
+the obstacle, though `~=`, `===`, and the membership operators still
+are. A literal that is not a version, such as a `.*` wildcard, is the
+operand being tested there and never matches, so the clause is False on
+every micro and splits nothing.
+
 `platform_release` and `platform_version` are never declared: they
 name one machine's kernel build, so a lock carrying the resolving
 machine's value would refuse every other machine. A non-CPython target

--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -373,21 +373,9 @@ _NON_INTERVAL_OPERATORS = frozenset({"===", "in", "not in"})
 # release, so a prerelease there maps cleanly to that release.
 _AT_LITERAL_OPERATORS = frozenset({"<", ">=", "==", "!=", "~="})
 
-# PEP 508 lets either operand be the variable, and packaging preserves the
-# written order, so ``python_full_version < "3.10.2"`` and its literal-first
-# equivalent ``"3.10.2" > python_full_version`` both reach the scanner.  When
-# the literal is on the left, an ordered or symmetric operator is mirrored back
-# to the variable-on-left form; ``~=``/``===`` and the membership operators are
-# absent because they cannot be mirrored, so a literal-first one of those is not
-# tileable.
-_MIRRORED_OPERATOR: dict[str, str] = {
-    "<": ">",
-    ">": "<",
-    "<=": ">=",
-    ">=": "<=",
-    "==": "==",
-    "!=": "!=",
-}
+# The literal-first operators :func:`_literal_first_clause` rewrites.  ``~=`` is
+# not one of them, so a literal-first ``~=`` crashes.
+_LITERAL_FIRST_OPERATORS = frozenset({"<", ">", "<=", ">=", "==", "!="})
 
 
 class NonIntervalMarkerError(ValueError):
@@ -499,7 +487,10 @@ def micro_boundary_points(
     :meth:`~packaging.ranges.VersionRange.release_intervals`:
     ``<``/``>=`` at the literal, ``<=``/``>`` at the release just after it, and
     ``==``/``!=``/``~=``/``== V.*`` at each edge of the region they name.  A
-    boundary outside the minor or at its floor cuts nothing.
+    boundary outside the minor or at its floor cuts nothing.  PEP 508 also
+    allows the literal first, which packaging reads differently (see
+    :func:`_literal_first_clause`), so such a clause is rewritten to
+    variable-on-left form before its boundary is taken.
 
     An operator that cannot tile the interval raises
     :class:`NonIntervalMarkerError` (see there); with the whole-minor pin gone,
@@ -582,41 +573,88 @@ def _clause_interval_literal(
 ) -> tuple[str, SpecifierSet, Version] | None:
     """Return ``(op, specifier, version)`` for a version-boundary clause.
 
-    ``None`` when the clause names no scanned version variable.  Raises
-    :class:`NonIntervalMarkerError` when it names one but cannot tile an
-    interval.  A literal-first clause has an ordered or symmetric operator
-    mirrored back to variable-on-left form; ``~=``/``===`` and the membership
-    operators cannot be mirrored, so a literal-first one of those is untileable.
+    ``None`` when the clause names no scanned version variable, or when a
+    literal-first clause reads the same on every real micro.  Raises
+    :class:`NonIntervalMarkerError` when the clause names a scanned variable
+    but cannot tile an interval.
 
     The specifier is built here rather than by the caller because PEP 508
     accepts literals PEP 440 refuses under the operator they are written with.
     A ``.*`` suffix is a specifier only under ``==``/``!=``, and ``~=`` needs
     two release components, so ``< "3.12.*"`` and ``~= "3"`` are valid markers
     with no specifier form; building it is what tells them from the clauses
-    that have one.
+    that have one.  A literal-first clause is rewritten first, so its
+    specifier comes from the rewritten operator and release.
     """
     lhs, op, rhs = parts
     if lhs in scanned:
-        literal = rhs
+        literal, literal_first = rhs, False
     elif rhs in scanned:
-        literal = lhs
-        mirrored = _MIRRORED_OPERATOR.get(op)
-        if mirrored is None:
-            raise _non_interval(parts, target)
-        op = mirrored
+        literal, literal_first = lhs, True
     else:
         return None
 
     if op in _NON_INTERVAL_OPERATORS or not literal.startswith('"'):
         raise _non_interval(parts, target)
     raw = literal.strip('"')
-    base = raw.removesuffix(".*")
+
+    if not literal_first:
+        try:
+            version = Version(raw.removesuffix(".*"))
+            specifier = SpecifierSet(f"{op}{raw}")
+        except (InvalidVersion, InvalidSpecifier):
+            raise _non_interval(parts, target) from None
+        return op, specifier, version
+
     try:
-        version = Version(base)
-        specifier = SpecifierSet(f"{op}{raw}")
-    except (InvalidVersion, InvalidSpecifier):
-        raise _non_interval(parts, target) from None
-    return op, specifier, version
+        written = Version(raw)
+    except InvalidVersion:
+        # The literal is the tested operand here, so one packaging cannot parse
+        # matches nothing and the clause is False on every micro.
+        return None
+
+    if op not in _LITERAL_FIRST_OPERATORS:
+        raise _non_interval(parts, target)
+
+    rewritten = _literal_first_clause(op, written)
+    if rewritten is None:
+        return None
+    op, version = rewritten
+    return op, SpecifierSet(f"{op}{version}"), version
+
+
+def _literal_first_clause(op: str, literal: Version) -> tuple[str, Version] | None:
+    """Rewrite ``"<literal>" op python_full_version`` to variable-on-left form.
+
+    packaging builds the specifier from the right operand and tests the left
+    against it, so PEP 440's exclusive-comparison exclusions land on the
+    literal rather than on the interpreter's version.  On 3.13.4 the clause
+    ``"3.13.4rc1" < python_full_version`` is False where
+    ``python_full_version > "3.13.4rc1"`` is True, so reversing the operator
+    alone is sound only for a plain release literal.
+
+    A micro line is all plain releases, and over those the clause reads as a
+    comparison against the literal's own release, with the operator taken from
+    where the literal's public form sits relative to that release.  ``None``
+    when the public form is not that release, so an ``==``/``!=`` clause
+    matches no real micro and splits nothing.
+    """
+    release = Version(literal.base_version)
+    public = Version(literal.public)
+
+    if op == "<":
+        return ">", release
+    if op == ">":
+        return "<", release
+
+    if op == "<=":
+        return (">" if public > release else ">="), release
+    if op == ">=":
+        return ("<=" if public >= release else "<"), release
+
+    if public != release:
+        return None
+    return op, release
 
 
 def host_environment(

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -4223,6 +4223,47 @@ class TestLockDeclaresItsEnvironment:
         assert Marker(rows["above"]).evaluate(high)
         assert not Marker(rows["above"]).evaluate(low)
 
+    def test_a_literal_first_prerelease_marker_splits_above_the_floor(
+        self, tmp_path: Path
+    ) -> None:
+        """PEP 508 lets the literal come first, and the order changes the truth.
+
+        packaging builds the specifier from the right operand, so
+        ``"3.12.0rc1" < python_full_version`` is False on 3.12.0 (a ``<``
+        specifier excludes prereleases of its own release) and True on every
+        later micro.  Answering the whole minor at its 3.12.0 floor would drop
+        ``bar`` for every real 3.12, so the minor splits at 3.12.1.
+        """
+        coordinator = make_coordinator(
+            listings={
+                "foo": _index_wheels("foo", "1.0"),
+                "bar": _index_wheels("bar", "2.0"),
+            },
+            metadata_by_version={
+                "1.0": (
+                    "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n"
+                    'Requires-Dist: bar ; "3.12.0rc1" < python_full_version\n'
+                ),
+                "2.0": "Metadata-Version: 2.1\nName: bar\nVersion: 2.0\n",
+            },
+        )
+        lock_input = self._resolve(tmp_path, self._PYPROJECT, coordinator)
+
+        assert set(lock_input.targets["py312-linux_x86_64-pf3120"].pins) == {"foo"}
+        assert set(lock_input.targets["py312-linux_x86_64-pf3121"].pins) == {
+            "foo",
+            "bar",
+        }
+
+        above = next(
+            row
+            for row in lock_input.environments
+            if 'python_full_version >= "3.12.1.dev0"' in str(row)
+        )
+        assert Marker(str(above)).evaluate(
+            {**_PY312_ENV, "python_full_version": "3.12.1"}
+        )
+
 
 class TestExtraAndGroupMembershipMarkers:
     """A selected extra or group gates the packages only it reaches.

--- a/nab-python/tests/test_target.py
+++ b/nab-python/tests/test_target.py
@@ -1201,17 +1201,116 @@ class TestMicroBoundarySplitting:
             ('"3.12.4" != python_full_version', ["3.12.4", "3.12.5"]),
         ],
     )
-    def test_a_literal_on_the_left_mirrors_the_operator(
+    def test_a_plain_release_literal_reads_the_same_in_either_order(
         self, marker: str, points: list[str]
     ) -> None:
         """PEP 508 allows the literal first, and packaging keeps that order.
-        An ordered or symmetric operator is mirrored back to variable-on-left
-        form, so each literal-first clause cuts at the same release as its
-        variable-first equivalent: ``"3.12.4" > python_full_version`` reads
-        like ``< "3.12.4"``.
+        A plain release literal has no prerelease, post, or local part to
+        shift the comparison, so ``"3.12.4" > python_full_version`` cuts at
+        the same release as ``python_full_version < "3.12.4"``.
         """
         found = micro_boundary_points(self._target(), [Marker(marker)])
         assert [str(point) for point in found] == points
+
+    @pytest.mark.parametrize(
+        ("marker", "points"),
+        [
+            ('"3.12.0rc1" < python_full_version', ["3.12.1"]),
+            ('"3.12.4rc1" < python_full_version', ["3.12.5"]),
+            ('"3.12.4a1" < python_full_version', ["3.12.5"]),
+            ('"3.12.4.dev0" < python_full_version', ["3.12.5"]),
+            ('"3.12.4rc1" <= python_full_version', ["3.12.4"]),
+            ('"3.12.4rc1" > python_full_version', ["3.12.4"]),
+            ('"3.12.4rc1" >= python_full_version', ["3.12.4"]),
+            ('"3.12.4rc1" == python_full_version', []),
+            ('"3.12.4rc1" != python_full_version', []),
+            ('"3.12.4.post1" < python_full_version', ["3.12.5"]),
+            ('"3.12.4.post1" <= python_full_version', ["3.12.5"]),
+            ('"3.12.4.post1" > python_full_version', ["3.12.4"]),
+            ('"3.12.4.post1" >= python_full_version', ["3.12.5"]),
+            ('"3.12.4.post1" == python_full_version', []),
+            ('"3.12.0.post1" <= python_full_version', ["3.12.1"]),
+            ('"3.12.0.post1" > python_full_version', []),
+            ('"3.12.4+local" < python_full_version', ["3.12.5"]),
+            ('"3.12.4+local" <= python_full_version', ["3.12.4"]),
+            ('"3.12.4+local" > python_full_version', ["3.12.4"]),
+            ('"3.12.4+local" >= python_full_version', ["3.12.5"]),
+            ('"3.12.4+local" == python_full_version', ["3.12.4", "3.12.5"]),
+            ('"3.12.4+local" != python_full_version', ["3.12.4", "3.12.5"]),
+        ],
+    )
+    def test_a_literal_first_clause_cuts_where_the_evaluator_flips(
+        self, marker: str, points: list[str]
+    ) -> None:
+        """packaging builds the specifier from the right operand and tests the
+        left against it, so PEP 440's exclusive-comparison exclusions land on
+        the literal here, not on the interpreter's version.  Reversing the
+        operator is only sound for a plain release literal: on 3.12.4 the
+        clause ``"3.12.4rc1" < python_full_version`` is False, so it cuts at
+        3.12.5 where ``python_full_version > "3.12.4rc1"`` cuts at 3.12.4.
+        """
+        found = micro_boundary_points(self._target(), [Marker(marker)])
+        assert [str(point) for point in found] == points
+
+    @pytest.mark.parametrize(
+        "marker",
+        [
+            '"3.12.0rc1" < python_full_version',
+            '"3.12.4rc1" < python_full_version',
+            '"3.12.4.dev0" < python_full_version',
+            '"3.12.4rc1" <= python_full_version',
+            '"3.12.4rc1" > python_full_version',
+            '"3.12.4rc1" >= python_full_version',
+            '"3.12.4.post1" > python_full_version',
+            '"3.12.4.post1" >= python_full_version',
+            '"3.12.0.post1" <= python_full_version',
+            '"3.12.4+local" == python_full_version',
+            '"3.12.4+local" != python_full_version',
+            '"3.12.4+local" >= python_full_version',
+        ],
+    )
+    def test_every_real_micro_reads_a_literal_first_clause_like_its_slice(
+        self, marker: str
+    ) -> None:
+        """The tiling invariant: a slice resolves at its representative, so
+        every real micro its environment row admits has to read the consulted
+        clause the way that representative did.
+        """
+        parsed = Marker(marker)
+        target = self._target()
+        slices = slices_from_points(target, micro_boundary_points(target, [parsed]))
+        for sliced in slices:
+            row = Marker(environment_declaration(sliced, [parsed]))
+            answer = parsed.evaluate(self._probe(sliced.python_full_version))
+            covered = [
+                micro
+                for micro in (f"3.12.{n}" for n in range(8))
+                if row.evaluate(self._probe(micro))
+            ]
+            assert covered
+            assert all(
+                parsed.evaluate(self._probe(micro)) == answer for micro in covered
+            )
+
+    @pytest.mark.parametrize(
+        "marker",
+        [
+            '"3.12.4.*" == python_full_version',
+            '"3.12.4.*" != python_full_version',
+            '"3.12.4.*" < python_full_version',
+            '"3.12.4.*" ~= python_full_version',
+            '"wat" < python_full_version',
+        ],
+    )
+    def test_a_literal_first_non_version_splits_nothing(self, marker: str) -> None:
+        """The literal is the operand being tested here, and a standard
+        operator never matches an operand packaging cannot parse, so a
+        literal-first ``.*`` wildcard or non-version string reads False on
+        every micro and names no boundary.
+        """
+        parsed = Marker(marker)
+        assert micro_boundary_points(self._target(), [parsed]) == []
+        assert not any(parsed.evaluate(self._probe(f"3.12.{n}")) for n in range(8))
 
     @pytest.mark.parametrize(
         ("marker", "points"),
@@ -1343,7 +1442,8 @@ class TestMicroBoundarySplitting:
             'python_full_version == "3.12.4rc1"',
             'python_full_version ~= "3.12.4b1"',
             '"3.12.4" ~= python_full_version',
-            '"3.12.4rc1" == python_full_version',
+            '"3.12.4" === python_full_version',
+            "python_version < python_full_version",
         ],
     )
     def test_an_untileable_marker_crashes(self, marker: str) -> None:


### PR DESCRIPTION
A universal lock could drop a dependency from every real micro of a minor, and say nothing, when the marker was written with the literal on the left.

Splitting a minor read `"3.12.0rc1" < python_full_version` as the mirror of `python_full_version > "3.12.0rc1"`, but PEP 508 operand order is not symmetric. packaging builds the specifier out of the right operand and tests the left against it, so PEP 440's same-release exclusions land on the literal rather than on the interpreter's version. The clause is False on 3.12.0 and True from 3.12.1 up, so the split belongs at 3.12.1. The mirrored reading put it on the minor's 3.12.0 floor, where a split does nothing, and the whole minor was answered at 3.12.0 alone. Post-release and local literals moved the split by a micro the same way.

The scanner now rewrites a literal-first clause from where the literal's public form sits relative to its own release, so the split lands where the evaluator flips. The cases that fall out of that:

- A literal-first `==` or `!=` whose literal is not a plain release matches no real micro.
- A literal packaging cannot parse, a `.*` wildcard say, is the operand under test in that position, so it never matches either. Both read the same across the whole minor and name no split.
- `~=`, `===` and the membership operators stay untileable in either order.

`docs/reference/lockfile.md` and `docs/explanation/universal.md` cover the literal-first reading.
