### PR TITLE
reject oversized specifier versions in the root project's own deps

### DIFF
--- a/nab-python/src/nab_python/metadata.py
+++ b/nab-python/src/nab_python/metadata.py
@@ -10,6 +10,7 @@ LRU cache so repeated dep strings parse once.
 from __future__ import annotations
 
 import email.parser
+from contextlib import suppress
 from dataclasses import dataclass, field
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any
@@ -18,7 +19,7 @@ import tomli
 
 from ._vendor.packaging.requirements import Requirement
 from ._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
-from ._vendor.packaging.version import Version
+from ._vendor.packaging.version import InvalidVersion, Version
 
 if TYPE_CHECKING:
     from ._vendor.packaging.markers import Marker
@@ -70,12 +71,15 @@ def validate_specifier_versions(specifier_set: SpecifierSet) -> None:
     A :class:`SpecifierSet` keeps its clause versions as strings and
     converts them only when something compares against it, so a digit run
     past CPython's int-from-string limit is accepted here and raises a
-    bare ``ValueError`` from the comparison much later.  Arbitrary
-    equality (``===``) compares as a string, so its version is never
-    converted.
+    bare ``ValueError`` from the comparison much later.  An arbitrary
+    equality (``===``) literal need not be a PEP 440 version, so only a
+    failure other than :class:`InvalidVersion` rejects one.
     """
     for clause in specifier_set:
-        if clause.operator != "===":
+        if clause.operator == "===":
+            with suppress(InvalidVersion):
+                Version(clause.version)
+        else:
             Version(clause.version.removesuffix(".*"))
 
 

--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -14,7 +14,7 @@ from ._vendor.packaging.dependency_groups import resolve_dependency_groups
 from ._vendor.packaging.errors import ExceptionGroup
 from ._vendor.packaging.markers import Marker
 from ._vendor.packaging.markersets import MarkerSet
-from ._vendor.packaging.requirements import InvalidRequirement, Requirement
+from ._vendor.packaging.requirements import Requirement
 from ._vendor.packaging.utils import canonicalize_name
 from .metadata import validate_specifier_versions
 
@@ -52,15 +52,6 @@ class InvalidProjectTableError(TypeError):
     specifically so an unrelated internal ``TypeError`` is not mislabelled
     as a user-file error.
     """
-
-
-def _parse_requirements(strings: Sequence[str], source: str) -> list[Requirement]:
-    """Parse PEP 508 strings, naming ``source`` if one is malformed."""
-    try:
-        return [Requirement(s) for s in strings]
-    except InvalidRequirement as exc:
-        msg = f"invalid requirement in {source}: {exc}"
-        raise InvalidProjectRequirementError(msg) from exc
 
 
 def _add_extra_marker(dep_str: str, extra_name: str) -> str:
@@ -106,6 +97,11 @@ def _parse_project_requirement(
         msg = f"invalid requirement in {source}: {exc}"
         raise InvalidProjectRequirementError(msg) from exc
     return req
+
+
+def _parse_requirements(strings: Sequence[str], source: str) -> list[Requirement]:
+    """Parse PEP 508 strings, naming ``source`` if one is malformed."""
+    return [_parse_project_requirement(s, source) for s in strings]
 
 
 def _require_string_list(value: object, source: str) -> list[str]:
@@ -510,7 +506,7 @@ def resolve_groups_to_requirements(
             raise LookupError(detail) from group
         msg = f"invalid [dependency-groups]: {detail}"
         raise InvalidProjectRequirementError(msg) from group
-    return [Requirement(s) for s in resolved]
+    return _parse_requirements(resolved, "[dependency-groups]")
 
 
 def raise_for_unsatisfiable(

--- a/nab-python/tests/test_metadata.py
+++ b/nab-python/tests/test_metadata.py
@@ -214,6 +214,8 @@ class TestValidateSpecifierVersions:
             "!=2.*",
             "~=1.4.2",
             "===lolwat",
+            "===1.0-bananas",
+            "===1.0",
             "==1.0+abc",
             "<4,>=3.9",
             ">1!2.0",
@@ -235,8 +237,10 @@ class TestValidateSpecifierVersions:
             pytest.param(f">=1.0.dev{_OVERSIZED}", id="dev"),
             pytest.param(f"==1.0+{_OVERSIZED}", id="local"),
             pytest.param(f"=={_OVERSIZED}.*", id="wildcard"),
+            pytest.param(f"==={_OVERSIZED}", id="arbitrary"),
         ],
     )
     def test_rejects_oversized_digit_run(self, spec: str) -> None:
+        """``===`` is included: ``to_range`` converts its literal too."""
         with pytest.raises(ValueError, match="Exceeds the limit"):
             validate_specifier_versions(SpecifierSet(spec))

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -25,6 +26,9 @@ from nab_python.requirements_file import (
     self_extra_markers,
 )
 from nab_resolver.errors import ResolutionError
+
+_AT_LIMIT = "1" * sys.get_int_max_str_digits()
+_OVERSIZED = _AT_LIMIT + "1"
 
 
 class TestAddExtraMarker:
@@ -180,6 +184,25 @@ class TestReadPyprojectDependencies:
         ):
             read_pyproject_dependencies(p)
 
+    @pytest.mark.parametrize("operator", ["==", "==="])
+    def test_oversized_specifier_version_raises(
+        self, tmp_path: object, operator: str
+    ) -> None:
+        """An oversized version converts only on comparison; parsing forces it."""
+        p = Path(str(tmp_path)) / "pyproject.toml"
+        p.write_text(f'[project]\ndependencies = ["foo{operator}{_OVERSIZED}"]\n')
+        with pytest.raises(
+            InvalidProjectRequirementError,
+            match=r"\[project\].dependencies: Exceeds the limit",
+        ):
+            read_pyproject_dependencies(p)
+
+    def test_at_limit_specifier_version_is_read(self, tmp_path: object) -> None:
+        """A run of exactly the limit converts, so it stays a legal dependency."""
+        p = Path(str(tmp_path)) / "pyproject.toml"
+        p.write_text(f'[project]\ndependencies = ["foo=={_AT_LIMIT}"]\n')
+        assert [d.name for d in read_pyproject_dependencies(p)] == ["foo"]
+
     def test_string_dependencies_value_raises(self, tmp_path: object) -> None:
         """A bare string is rejected, not iterated character by character."""
         p = Path(str(tmp_path)) / "pyproject.toml"
@@ -283,6 +306,22 @@ class TestResolveGroupsToRequirements:
             InvalidProjectRequirementError, match=r"\[dependency-groups\]"
         ):
             resolve_groups_to_requirements({"dev": ["pytest >= bad junk"]}, ("dev",))
+
+    @pytest.mark.parametrize("operator", ["==", "==="])
+    def test_oversized_specifier_version_raises(self, operator: str) -> None:
+        """An oversized version converts only on comparison; parsing forces it."""
+        with pytest.raises(
+            InvalidProjectRequirementError,
+            match=r"\[dependency-groups\]: Exceeds the limit",
+        ):
+            resolve_groups_to_requirements(
+                {"dev": [f"foo{operator}{_OVERSIZED}"]}, ("dev",)
+            )
+
+    def test_at_limit_specifier_version_resolves(self) -> None:
+        """A run of exactly the limit converts, so it stays a legal requirement."""
+        reqs = resolve_groups_to_requirements({"dev": [f"foo=={_AT_LIMIT}"]}, ("dev",))
+        assert [r.name for r in reqs] == ["foo"]
 
 
 class TestReadPyprojectOptionalDependencies:
@@ -570,6 +609,22 @@ class TestExpandExtraRequirements:
         opt = {"all": ["mypkg[fast]", "plain"], "fast": ["some-dep"]}
         out = expand_extra_requirements(opt, None, ["all"])
         assert sorted(r.name for r in out) == ["mypkg", "plain"]
+
+    @pytest.mark.parametrize("operator", ["==", "==="])
+    def test_oversized_specifier_version_raises(self, operator: str) -> None:
+        """An oversized version converts only on comparison; parsing forces it."""
+        with pytest.raises(
+            InvalidProjectRequirementError,
+            match=r"\[project.optional-dependencies\] extra 'x': Exceeds the limit",
+        ):
+            expand_extra_requirements(
+                {"x": [f"foo{operator}{_OVERSIZED}"]}, "mypkg", ["x"]
+            )
+
+    def test_at_limit_specifier_version_expands(self) -> None:
+        """A run of exactly the limit converts, so it stays a legal requirement."""
+        out = expand_extra_requirements({"x": [f"foo=={_AT_LIMIT}"]}, "mypkg", ["x"])
+        assert [r.name for r in out] == ["foo"]
 
     def test_plain_extra_requirements_keep_their_markers(self) -> None:
         opt = {"cpu": ["torch", "numpy; python_version < '3.10'"]}


### PR DESCRIPTION
`nab lock` and `nab download` still crash with a bare `ValueError` when the root project's own pyproject declares a dependency whose specifier holds more digits than CPython's int-from-string limit allows, such as `foo==<4301 digits>`. A `SpecifierSet` keeps each clause's version as a string and converts it only when something compares against it, so the requirement builds cleanly and the failure surfaces out of `to_range()` much later.

#654 added a check for this to `_parse_project_requirement`, but the three root-project readers never reached it. `[project].dependencies` and `[project.optional-dependencies]` went through `_parse_requirements`, which caught only `InvalidRequirement`, and `[dependency-groups]` built its `Requirement`s with no check at all. All three now route through `_parse_project_requirement` and raise `InvalidProjectRequirementError` naming the offending table.

`validate_specifier_versions` also skipped `===` clauses on the grounds that arbitrary equality compares as a string, but `to_range()` coerces that literal too. Those clauses are converted now, with only `InvalidVersion` suppressed so a non-PEP-440 literal like `===1.0-bananas` stays legal.
