### PR TITLE
fix InvalidMarker crash on a quote in an extra name

### DIFF
--- a/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
+++ b/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
@@ -30,6 +30,10 @@ plus at most one checked-in patch, and nothing else.
   - `markersets.py` and `_markersets.py`: the marker-algebra module and the
     private engine behind it, both new files, plus the `Marker.to_set`
     accessor they need on `markers.py`.
+  - `_parser.py`: `Value.serialize` from pypa/packaging#1213, which merged
+    after the pin. A value containing a double quote is emitted single-quoted,
+    so `str(Marker)` stays parseable. Drop this hunk once the pin moves past
+    `5b583e3`.
 
   Upstream PRs are planned for the bound ordering, the direct subset and
   disjoint walks, `filter`'s `assume_sorted` fast path, and

--- a/nab-python/src/nab_python/_vendor/packaging/_parser.py
+++ b/nab-python/src/nab_python/_vendor/packaging/_parser.py
@@ -68,7 +68,14 @@ class Value(Node):
     __slots__ = ()
 
     def serialize(self) -> str:
-        return f'"{self}"'
+        value = str(self)
+        if '"' not in value:
+            return f'"{value}"'
+        if "'" not in value:
+            return f"'{value}'"
+        raise ValueError(
+            "Cannot serialize marker value containing both quote characters"
+        )
 
 
 class Op(Node):

--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -250,9 +250,11 @@ _BY_CONSTRAINT = ("python_full_version", "implementation_version")
 
 # One ``lhs op rhs`` comparison of a marker, matched against the string form
 # :func:`Marker.__str__` normalises to: an operand is either a quoted literal
-# or a bare variable token, which is what tells the two apart.  Ordered so
-# the two-character operators win over their prefixes.
-_MARKER_OPERAND = r'"[^"]*"|[A-Za-z_][A-Za-z0-9_]*'
+# or a bare variable token, which is what tells the two apart.  Both quote
+# styles are matched, since packaging emits a value holding a double quote
+# single-quoted.  Ordered so the two-character operators win over their
+# prefixes.
+_MARKER_OPERAND = r'"[^"]*"|\'[^\']*\'|[A-Za-z_][A-Za-z0-9_]*'
 _MARKER_CLAUSE_RE = re.compile(
     rf"(?P<lhs>{_MARKER_OPERAND})\s*"
     r"(?P<op>===|==|!=|<=|>=|~=|<|>|not\s+in|in)\s*"

--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -1816,6 +1816,48 @@ class TestBuildLockInput:
         versions = {lock.pins["pkg"].version for lock in merged.targets.values()}
         assert versions == {"1.0", "2.0"}
 
+    def test_a_double_quote_in_a_consulted_marker_value_still_locks(self) -> None:
+        """A marker value carrying a double quote still locks.
+
+        urllib3 1.11 gates a dependency on
+        ``extra == 'secure;python_version>"2.7"'``, and the lock's
+        ``environments`` come from re-parsing the markers the resolve read,
+        so the value has to survive that round trip.
+        """
+        metadata = (
+            "Metadata-Version: 2.1\n"
+            "Name: foo\n"
+            "Version: 1.0\n"
+            'Provides-Extra: secure;python_version>"2.7"\n'
+            "Requires-Dist: mid ; extra == 'secure;python_version>\"2.7\"'\n"
+        )
+
+        coordinator = make_coordinator(
+            listings={
+                "foo": [_make_wheel("1.0", package="foo")],
+                "mid": [_make_wheel("2.0", package="mid")],
+            },
+            metadata_by_version={
+                "1.0": metadata,
+                "2.0": "Metadata-Version: 2.1\nName: mid\nVersion: 2.0\n",
+            },
+        )
+        result = resolve_with_coordinator(
+            coordinator, [_linux_311()], _reqs("foo"), config=_no_build()
+        )
+
+        assert result.success
+        assert set(result.target_results[0].pins) == {"foo"}
+
+        merged = build_lock_input(result, config=_no_build())
+        assert set(merged.targets) == {"py311-linux_x86_64"}
+        assert [str(row) for row in merged.environments] == [
+            (
+                'python_version == "3.11" and sys_platform == "linux"'
+                ' and platform_machine == "x86_64"'
+            )
+        ]
+
 
 class TestResolveWithCoordinator:
     """End-to-end orchestration via the testable injected-coordinator entry."""
@@ -2462,6 +2504,42 @@ class TestMicroBoundaryNarrowing:
         assert result.success
         assert len(result.target_results) == 1
         assert spy.call_count == 1
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            'x;python_full_version>="3.10.4"',
+            'a python_full_version in "3.10.4"',
+        ],
+    )
+    def test_a_quote_in_a_marker_value_does_not_cut_the_minor(self, value: str) -> None:
+        """A single-quoted value is consumed whole by the micro scanner, so
+        the clause inside it neither splits 3.10 at a boundary no dependency
+        gates on nor trips the splitter on an operator it cannot tile."""
+        coordinator = self._coordinator(
+            {
+                "1.0": self._meta("foo", "1.0", f"mid ; platform_release == '{value}'"),
+                "2.0": self._meta("mid", "2.0"),
+            }
+        )
+        targets = Matrix(
+            python="==3.10", platforms=(PlatformSpec("linux_x86_64"),)
+        ).expand()
+
+        result = resolve_with_coordinator(
+            coordinator, targets, _reqs("foo"), config=_no_build()
+        )
+
+        assert result.success
+        assert self._pins_by_label(result) == {"py310-linux_x86_64": {"foo"}}
+
+        merged = build_lock_input(result, config=_no_build())
+        assert [str(row) for row in merged.environments] == [
+            (
+                'python_version == "3.10" and sys_platform == "linux"'
+                ' and platform_machine == "x86_64"'
+            )
+        ]
 
     @staticmethod
     def _linux_host_env() -> dict[str, str]:

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -1712,6 +1712,26 @@ index 0000000..054dd73
 +        _clause_formula(sorted(clause, key=_atom_key)) for clause in residual
 +    )
 +    return make_and([*lead, inner])
+diff --git a/nab-python/src/nab_python/_vendor/packaging/_parser.py b/nab-python/src/nab_python/_vendor/packaging/_parser.py
+index b4ea978..9331b4b 100644
+--- a/nab-python/src/nab_python/_vendor/packaging/_parser.py
++++ b/nab-python/src/nab_python/_vendor/packaging/_parser.py
+@@ -68,7 +68,14 @@ class Value(Node):
+     __slots__ = ()
+ 
+     def serialize(self) -> str:
+-        return f'"{self}"'
++        value = str(self)
++        if '"' not in value:
++            return f'"{value}"'
++        if "'" not in value:
++            return f"'{value}'"
++        raise ValueError(
++            "Cannot serialize marker value containing both quote characters"
++        )
+ 
+ 
+ class Op(Node):
 diff --git a/nab-python/src/nab_python/_vendor/packaging/_ranges.py b/nab-python/src/nab_python/_vendor/packaging/_ranges.py
 index 5370ec8..b305068 100644
 --- a/nab-python/src/nab_python/_vendor/packaging/_ranges.py


### PR DESCRIPTION
urllib3 1.11 and 1.12 declare `Provides-Extra: secure;python_version>"2.7"`. Resolving against them succeeds, and then `nab lock` and `nab download` fail with a raw InvalidMarker traceback while building the lock. pip and uv both handle the same input.

The vendored packaging always emits marker values in double quotes, so this one serializes back out as `extra == "secure;python_version>"2.7""`, which no longer parses. The lock's `environments` rows come from re-parsing the markers the resolve consulted, which is where it breaks.

This backports the upstream fix, pypa/packaging#1213, into the vendored tree: a value holding a double quote is emitted single-quoted instead. The patch hunk drops out once the vendoring pin moves past that commit.

The micro-boundary scanner matches marker clauses against that same serialized text, so its operand pattern accepts the single-quoted form too. Otherwise the scan runs on into the literal and reads the clause inside it as a `python_full_version` comparison, splitting a minor at a boundary no dependency gates on.
