### PR TITLE
seed micro slices from the targets before them in the matrix

### DIFF
--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -483,9 +483,6 @@ def _resolve_with_micro_narrowing(
     result = _resolve_passes(
         targets, fork_list, constraints, settings, preferences, base_requirements
     )
-    seed = _threaded_preferences(
-        dict(preferences or {}), result.target_results, align=settings.align
-    )
     points: list[list[Version]] = [[] for _ in targets]
     combined = result
     for _ in range(_MAX_MICRO_SPLIT_PASSES):
@@ -498,14 +495,15 @@ def _resolve_with_micro_narrowing(
             for target, target_points in zip(targets, points, strict=True)
             if target_points
         }
-        slices = [
-            sliced
-            for target, target_points in zip(targets, points, strict=True)
-            if target_points
-            for sliced in slices_from_points(target, target_points)
-        ]
-        slice_result = _resolve_passes(
-            slices, fork_list, constraints, settings, seed, base_requirements
+        slice_result = _resolve_slices(
+            targets,
+            points,
+            fork_list,
+            constraints,
+            settings,
+            preferences,
+            base_requirements,
+            result,
         )
         combined = _merge_micro_results(targets, result, slice_result, split_sigs)
     msg = (
@@ -513,6 +511,73 @@ def _resolve_with_micro_narrowing(
         f" {_MAX_MICRO_SPLIT_PASSES} passes"
     )
     raise ResolutionError(msg)
+
+
+def _resolve_slices(
+    targets: Sequence[ResolveTarget],
+    points: Sequence[Sequence[Version]],
+    fork_list: Sequence[ResolveFork],
+    constraints: Sequence[Requirement],
+    settings: _EngineSettings,
+    preferences: Mapping[str, Version] | None,
+    base_requirements: Sequence[Requirement] | None,
+    first_pass: ResolveResult,
+) -> ResolveResult:
+    """Resolve every split target's slices, one pass per fork.
+
+    A fork's pass walks the whole matrix in order: a split target has its
+    slices resolved, and an unsplit target folds its first-pass pins in where
+    it sits rather than resolving a second time.  Alignment therefore threads
+    through the slices in matrix order, as it does in the first pass.
+    """
+    sliced = [
+        slices_from_points(target, target_points) if target_points else []
+        for target, target_points in zip(targets, points, strict=True)
+    ]
+
+    accumulated = dict(preferences or {})
+    results: list[TargetResult] = []
+    for index, fork in enumerate(fork_list):
+        # first_pass holds one contiguous run of results per fork, in order.
+        fork_first = first_pass.target_results[
+            index * len(targets) : (index + 1) * len(targets)
+        ]
+
+        for target_slices, first_result in zip(sliced, fork_first, strict=True):
+            if not target_slices:
+                accumulated = _threaded_preferences(
+                    accumulated, [first_result], align=settings.align
+                )
+                continue
+
+            fork_slices = [
+                t.with_selection(fork.selection) if fork.selection else t
+                for t in target_slices
+            ]
+            pass_results = _run_pass(
+                fork_slices,
+                fork.requirements,
+                constraints,
+                settings,
+                accumulated,
+                fork.contexts,
+            )
+
+            results.extend(pass_results)
+            accumulated = _threaded_preferences(
+                accumulated, pass_results, align=settings.align
+            )
+
+    all_slices = [t for group in sliced for t in group]
+    base_results, env_base_names = _base_pass(
+        all_slices, base_requirements, constraints, settings, preferences or {}
+    )
+    return ResolveResult(
+        targets=tuple(all_slices),
+        target_results=results,
+        base_results=base_results,
+        env_base_names=env_base_names,
+    )
 
 
 def _grow_micro_points(
@@ -608,33 +673,50 @@ def _resolve_passes(
             accumulated, pass_results, align=settings.align
         )
 
-    # A base (no-member) pass names the deps that install regardless of
-    # which member is chosen, so the writer keeps the membership clause
-    # on a dep required only by members.
-    base_results: list[TargetResult] = []
-    env_base_names: dict[EnvSignature, frozenset[str]] = {}
-    if base_requirements is not None:
-        base_results = _run_pass(
-            list(targets), base_requirements, constraints, settings, preferences or {}
-        )
-        for tr in base_results:
-            if tr.success:
-                env_base_names[env_signature(tr.target)] = frozenset(
-                    canonicalize_name(name) for name in tr.pins
-                )
-            else:
-                _logger.warning(
-                    "Base attribution skipped for tuple %s: %s",
-                    tr.target.label,
-                    tr.error,
-                )
-
+    base_results, env_base_names = _base_pass(
+        targets, base_requirements, constraints, settings, preferences or {}
+    )
     return ResolveResult(
         targets=tuple(targets),
         target_results=results,
         base_results=base_results,
         env_base_names=env_base_names,
     )
+
+
+def _base_pass(
+    targets: Sequence[ResolveTarget],
+    base_requirements: Sequence[Requirement] | None,
+    constraints: Sequence[Requirement],
+    settings: _EngineSettings,
+    preferences: Mapping[str, Version],
+) -> tuple[list[TargetResult], dict[EnvSignature, frozenset[str]]]:
+    """Resolve the no-member requirements per target, if there are any.
+
+    The pass names the deps that install regardless of which member is chosen,
+    so the writer keeps the membership clause on a dep required only by members.
+    """
+    if base_requirements is None:
+        return [], {}
+
+    results = _run_pass(
+        list(targets), base_requirements, constraints, settings, preferences
+    )
+
+    env_base_names: dict[EnvSignature, frozenset[str]] = {}
+    for tr in results:
+        if tr.success:
+            env_base_names[env_signature(tr.target)] = frozenset(
+                canonicalize_name(name) for name in tr.pins
+            )
+        else:
+            _logger.warning(
+                "Base attribution skipped for tuple %s: %s",
+                tr.target.label,
+                tr.error,
+            )
+
+    return results, env_base_names
 
 
 def build_lock_input(

--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -2684,3 +2684,153 @@ class TestMicroBoundaryNarrowing:
                 "implementation_name": "cpython",
             }
             assert sum(row.evaluate(env) for row in rows) == 1
+
+
+class TestMicroSliceAlignmentDirection:
+    """Splitting a minor does not turn cross-target alignment around.
+
+    Within a fork's pass alignment threads forward: a target's slices start
+    from what the targets before it settled on, and a target that resolves
+    later leaves them alone.
+    """
+
+    @staticmethod
+    def _meta(name: str, version: str, *requires: str) -> str:
+        head = f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n"
+        return head + "".join(f"Requires-Dist: {req}\n" for req in requires)
+
+    @classmethod
+    def _coordinator(cls, *split_markers: str) -> MagicMock:
+        """A graph whose ``foo`` splits every minor ``split_markers`` cuts.
+
+        ``bar`` is the package under test: nothing in the split concerns it,
+        and both its versions resolve everywhere, so whichever one a slice
+        pins came from that slice's preferences.
+        """
+        requires = {"foo": [f"mid ; {marker}" for marker in split_markers]}
+        listings = {
+            "foo": [_make_wheel("1.0", package="foo")],
+            "mid": [_make_wheel("1.0", package="mid")],
+            "bar": [
+                _make_wheel("1.0", package="bar"),
+                _make_wheel("2.0", package="bar"),
+            ],
+        }
+        metadata: dict[str, str | None] = {}
+        for name, wheels in listings.items():
+            for wheel in wheels:
+                assert wheel.metadata_url is not None
+                metadata[wheel.metadata_url] = cls._meta(
+                    name, wheel.version, *requires.get(name, ())
+                )
+        return make_coordinator(listings=listings, metadata_by_url=metadata)
+
+    @staticmethod
+    def _bar_versions(result: ResolveResult) -> dict[str, str]:
+        return {tr.target.label: str(tr.pins["bar"]) for tr in result.target_results}
+
+    def test_a_later_target_does_not_seed_the_slices_before_it(self) -> None:
+        """Windows resolves after linux and caps ``bar`` at 1.0, so the linux
+        slices keep 2.0."""
+        targets = Matrix(
+            python="==3.11",
+            platforms=(PlatformSpec("linux_x86_64"), PlatformSpec("windows_amd64")),
+        ).expand()
+
+        result = resolve_with_coordinator(
+            self._coordinator('python_full_version >= "3.11.4"'),
+            targets,
+            _reqs("foo", "bar", 'bar<2.0 ; sys_platform == "win32"'),
+            config=_no_build(),
+        )
+
+        assert result.success
+        assert self._bar_versions(result) == {
+            "py311-linux_x86_64-pf3110": "2.0",
+            "py311-linux_x86_64-pf3114": "2.0",
+            "py311-windows_amd64-pf3110": "1.0",
+            "py311-windows_amd64-pf3114": "1.0",
+        }
+
+    def test_a_desc_matrix_keeps_the_newest_python_pin_on_its_slices(self) -> None:
+        """``python_order = "desc"`` resolves 3.12 first, so 3.11's narrower
+        answer must not propagate back onto the 3.12 slices."""
+        targets = Matrix(
+            python=">=3.11,<3.13",
+            platforms=(PlatformSpec("linux_x86_64"),),
+            python_order="desc",
+        ).expand()
+
+        result = resolve_with_coordinator(
+            self._coordinator(
+                'python_full_version >= "3.11.4"', 'python_full_version >= "3.12.3"'
+            ),
+            targets,
+            _reqs("foo", "bar", 'bar<2.0 ; python_version == "3.11"'),
+            config=_no_build(),
+        )
+
+        assert result.success
+        assert self._bar_versions(result) == {
+            "py312-linux_x86_64-pf3120": "2.0",
+            "py312-linux_x86_64-pf3123": "2.0",
+            "py311-linux_x86_64-pf3110": "1.0",
+            "py311-linux_x86_64-pf3114": "1.0",
+        }
+
+    def test_an_earlier_unsplit_target_still_seeds_a_later_split_one(self) -> None:
+        """3.10 does not split and caps ``bar`` at 1.0.  It resolves first, so
+        the 3.11 slices still align onto it rather than jumping to 2.0."""
+        targets = Matrix(
+            python=">=3.10,<3.12", platforms=(PlatformSpec("linux_x86_64"),)
+        ).expand()
+
+        result = resolve_with_coordinator(
+            self._coordinator('python_full_version >= "3.11.4"'),
+            targets,
+            _reqs("foo", "bar", 'bar<2.0 ; python_version == "3.10"'),
+            config=_no_build(),
+        )
+
+        assert result.success
+        assert self._bar_versions(result) == {
+            "py310-linux_x86_64": "1.0",
+            "py311-linux_x86_64-pf3110": "1.0",
+            "py311-linux_x86_64-pf3114": "1.0",
+        }
+
+    def test_slices_align_within_their_own_fork(self) -> None:
+        """Only group ``b`` caps ``bar``, and only on 3.11.  Group ``a``'s
+        slices walk the matrix under its own answers, so they keep 2.0
+        throughout."""
+        targets = Matrix(
+            python=">=3.11,<3.13", platforms=(PlatformSpec("linux_x86_64"),)
+        ).expand()
+        forks = [
+            ResolveFork((("group", "a"),), tuple(_reqs("foo", "bar"))),
+            ResolveFork(
+                (("group", "b"),),
+                tuple(_reqs("foo", "bar", 'bar<2.0 ; python_version == "3.11"')),
+            ),
+        ]
+
+        result = resolve_with_coordinator(
+            self._coordinator(
+                'python_full_version >= "3.11.4"', 'python_full_version >= "3.12.3"'
+            ),
+            targets,
+            forks=forks,
+            config=_no_build(),
+        )
+
+        assert result.success
+        assert self._bar_versions(result) == {
+            "py311-linux_x86_64-pf3110-group-a": "2.0",
+            "py311-linux_x86_64-pf3114-group-a": "2.0",
+            "py312-linux_x86_64-pf3120-group-a": "2.0",
+            "py312-linux_x86_64-pf3123-group-a": "2.0",
+            "py311-linux_x86_64-pf3110-group-b": "1.0",
+            "py311-linux_x86_64-pf3114-group-b": "1.0",
+            "py312-linux_x86_64-pf3120-group-b": "1.0",
+            "py312-linux_x86_64-pf3123-group-b": "1.0",
+        }


### PR DESCRIPTION
Resolving a matrix hands each target's pins to the targets after it as preferences, so the matrix settles on shared versions where it can. That only flows one way. A target is aligned onto the targets before it and never onto the ones that come later.

Splitting a minor broke the direction. A marker on `python_full_version` splits a minor into slices that are resolved a second time, and that second pass started from a flat merge of the pins of every target in the matrix, across every fork, rather than the ones ahead of the split. A target that resolved later could hand its pins to the slices of a target that resolved earlier.

With `python-order = "desc"` the matrix runs 3.12 before 3.11. Add `bar<2.0 ; python_version == "3.11"`, and 3.11 pins bar 1.0, which then landed on the 3.12 slices and locked bar 1.0 for 3.12 as well, where nothing asked for the cap. Platforms went the same way, with a Windows-only cap reaching the linux slices.

The second pass now walks the matrix in the order the first pass does, once per fork. A split target has its slices resolved where it sits, and an unsplit target folds its first-pass pins into the running preferences instead of resolving a second time.
