### PR TITLE
fix raw ImportError from the httpx backend when h2 is missing

### DIFF
--- a/docs/how-to/install.md
+++ b/docs/how-to/install.md
@@ -38,8 +38,9 @@ is `uv` on recent pipx; the `pip` backend works equivalently.
 uv tool install 'nab[httpx]'
 ```
 
-Pick it at run-time with `--http-backend httpx`. Selecting a backend
-that was not installed surfaces a helpful `ImportError`.
+Pick it at run-time with `--http-backend httpx`. The extra installs
+httpx along with the `h2` package the backend needs. If either is
+missing, selecting the backend exits with an install hint.
 
 Both backends send the same `User-Agent`, `nab-index/<version>`.
 

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -172,7 +172,16 @@ def _make_transport(backend: HttpBackend) -> AsyncHttpTransport:
         except ImportError:
             printer().error("httpx is not installed; run `pip install nab[httpx]`")
             sys.exit(1)
-        return HttpxAsyncTransport()
+
+        # httpx raises ImportError from its client constructor when h2 is missing.
+        try:
+            return HttpxAsyncTransport()
+        except ImportError:
+            printer().error(
+                "httpx is installed without HTTP/2 support; "
+                "run `pip install nab[httpx]`"
+            )
+            sys.exit(1)
 
     return Urllib3AsyncTransport()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4587,6 +4587,26 @@ class TestMakeTransport:
         assert info.value.code == 1
         assert "nab[httpx]" in capsys.readouterr().err
 
+    def test_httpx_without_h2_exits_with_hint(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """When httpx is installed without ``h2``, the CLI exits with a hint."""
+        original_import = builtins.__import__
+
+        def fake_import(name: str, *args: object, **kwargs: object) -> object:
+            if name == "h2":
+                raise ImportError(name)
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        with pytest.raises(SystemExit) as info:
+            _make_transport("httpx")
+        assert info.value.code == 1
+        err = capsys.readouterr().err
+        assert "nab[httpx]" in err
+        assert "HTTP/2" in err
+        assert "httpx is not installed" not in err
+
 
 class TestDownloadCommand:
     """Tests for the download subcommand."""


### PR DESCRIPTION
Running `nab lock` or `nab download` with `--http-backend httpx` in an environment that has httpx but not h2 crashes with a raw ImportError traceback instead of the install hint. The transport is built up front, so even a run that issues no requests fails.

The guard only wrapped the `nab_index.httpx_async_transport` import, and that import succeeds. httpx defers its h2 check to the client constructor, so the ImportError comes out of `httpx.AsyncClient(http2=True)`. The guard now covers the construction as well and exits with the same `pip install nab[httpx]` hint.

The install page said that selecting an uninstalled backend surfaces an ImportError. It now says the extra installs h2 as well.
