### PR TITLE
Make every config source replace, not append

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -138,10 +138,12 @@ A project option can be overridden for one run with a `--project-<key>`
 flag: `--project-resolution`, `--project-mode`, `--project-requires-python`,
 `--project-uploaded-prior-to`, `--project-dist-policy`,
 `--project-build-policy`, and the repeatable `--project-constraint` and
-`--project-default-group`. Each changes the resolved set, so passing one
-prints a reproducibility notice on stderr and records the override in the
-lockfile's `[tool.nab]` block, since the lock no longer derives from the
-committed files alone.
+`--project-default-group`. Every one of them replaces the file value
+outright; repeating `--project-constraint` builds up that run's whole
+constraint list rather than adding to the declared one. Each changes the
+resolved set, so passing one prints a reproducibility notice on stderr
+and records the override in the lockfile's `[tool.nab]` block, since the
+lock no longer derives from the committed files alone.
 
 `--locked` re-resolves and checks that the committed `pylock.toml` is
 already up to date, writing nothing. It exits non-zero if the lock would
@@ -206,11 +208,10 @@ actions:
 * `nab config list` prints every option with its value, scope, and
   the source it came from.
 * `nab config get <key>` prints one effective value.
-* `nab config explain <key>` prints the full source stack for one
-  key, the winning source marked with a `>`. Array options concatenate
-  every layer instead of one winning, so each source is shown as a
-  contribution and the merged effective value is printed on a trailing
-  `= effective:` line.
+* `nab config explain <key>` prints the full source stack for one key.
+  The winning row carries a `>` gutter and the status `winner`, and
+  every source it beats is `shadowed`. A shadowed source contributes
+  nothing to the value, whatever the key's type.
 
 `--include-rejected` is a flag on `nab config` itself, so every action
 takes it. Without it, a config file that sets an unknown key or a key

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -813,8 +813,11 @@ nab lock [PATH]
 A project option can be overridden for a single run with a
 `--project-<key>` flag (for example `--project-resolution`,
 `--project-dist-policy`, or the repeatable `--project-constraint`); the
-structured table options stay file-only. A `--project-*` override changes
-the resolved set, so it prints a notice and is recorded in the lockfile.
+structured table options stay file-only. The flag replaces the file
+value, list flags included: passing `--project-constraint` twice
+resolves against exactly those two constraints, whatever `constraints`
+the files declare. A `--project-*` override changes the resolved set, so
+it prints a notice and is recorded in the lockfile.
 `--project-dist-policy` takes a bare policy, so it replaces the whole
 `dist-policy` value and resets `trust-unverified-deps`; set the table form
 in a file to keep that flag.
@@ -851,11 +854,25 @@ Sources are consulted low to high; a higher source wins:
 3. user `nab.toml` (`$XDG_CONFIG_HOME/nab/nab.toml`, else
    `~/.config/nab/nab.toml`)
 4. `pyproject.toml` `[tool.nab]` and the project-directory `nab.toml`
-   (same precedence; setting one key to conflicting values across the two
-   files is a hard error, identical values are fine, and array options
-   from both files concatenate)
+   (same precedence; setting one key in both files is covered below)
 5. `NAB_*` environment variables
 6. the CLI flag
+
+Winning is all-or-nothing. Whatever the key's type, the highest source
+that sets it supplies the whole value and nothing from a lower source
+survives: a `constraints` list on the CLI is the entire constraint set
+for that run, and an `[environment]` table in a file is the entire
+environment. No source adds to the one beneath it, so the value the
+resolve uses is the one you can read in a single place. To extend a
+list, edit the file that declares it.
+
+Rung 4 is two files at one precedence, so neither can win. Setting one
+key in both is allowed only if the two values are identical; different
+values are a hard error naming both files. That applies to every key:
+two `constraints` lists, two `[[indexes]]` arrays, and `python` under
+`[tool.nab.environment]` against `platform` under `[environment]` in the
+project `nab.toml` are all the same conflict, one key set twice. Set the
+key in one of the two files.
 
 The standalone `nab.toml` files use the same key names as
 `[tool.nab]`, but at the top level (no `[tool.nab]` table):

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -1824,12 +1824,7 @@ def _parse_indexes(value: object) -> tuple[IndexConfig, ...]:
 
 
 def _check_index_name_uniqueness(indexes: Sequence[IndexConfig]) -> None:
-    """Reject two indexes declared with the same name.
-
-    Shared by the single-file parse and the registry's across-file merge
-    re-validation (config_sources): a name may appear at most once, whether
-    the duplicate is in one file or split across the two project files.
-    """
+    """Reject two indexes declared with the same name."""
     seen: set[str] = set()
     for index in indexes:
         if index.name in seen:
@@ -2805,13 +2800,7 @@ def _parse_conflicts(value: object) -> tuple[ConflictSet, ...]:
 
 
 def _check_conflict_member_uniqueness(sets: Sequence[ConflictSet]) -> None:
-    """Reject a member declared in more than one conflict set.
-
-    Shared by the single-file parse and the registry's across-file merge
-    re-validation (config_sources): a member may belong to at most one
-    conflict set, whether the duplicate is in one file or split across the
-    two project files.
-    """
+    """Reject a member declared in more than one conflict set."""
     seen: set[ConflictMember] = set()
     for conflict_set in sets:
         for member in conflict_set.members:

--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -13,8 +13,9 @@ Everything else is derived by iterating :data:`OPTIONS`:
   not allowed in that source kind (the category gate).
 * :func:`read_env_layer` reads ``NAB_*`` for the rows that declare an
   env var, and warns on any ``NAB_*`` name it does not recognize.
-* :func:`resolve_config` merges the discovered layers low-to-high and
-  attaches ``(scope, origin)`` provenance to each effective value.
+* :func:`resolve_config` ranks the discovered layers low-to-high, takes
+  each option's whole value from the highest source that bound it, and
+  attaches ``(scope, origin)`` provenance to it.
 * :func:`render_list` / :func:`render_get` / :func:`render_explain`
   back ``nab config``.
 
@@ -266,27 +267,6 @@ class OptionSpec:
     cli_param: str | None
     parse: Callable[[Any, str], Any]
     render: Callable[[Any], str]
-    # How bindings from different sources combine.  The default is scalar
-    # last-wins: the highest-precedence source's value is the effective one,
-    # and the same key set to different values in the two project files is a
-    # conflict error.
-    #
-    # ``is_array`` concatenates every binding's items low-to-high into one
-    # value, so the two project files contribute additively rather than
-    # conflicting; the concatenated whole is then re-validated (see
-    # ``merge_check``).
-    is_array: bool = False
-    # ``is_mapping`` is a name-keyed table (``index``, ``marker-environment``)
-    # whose sub-keys merge across sources, folded low-to-high, so the two
-    # project files contribute disjoint sub-keys additively and only the same
-    # sub-key set differently is a conflict.  Mutually exclusive with
-    # ``is_array``.
-    is_mapping: bool = False
-    # For an ``is_array`` row whose items are already-built objects (not
-    # plain strings), the check to run over the concatenated whole; it
-    # returns the validated tuple.  A plain-string array leaves this ``None``
-    # and is re-validated by re-running ``parse`` over the concatenation.
-    merge_check: Callable[[Sequence[Any]], tuple[Any, ...]] | None = None
 
     def allowed_in_toml(self, kind: SourceKind) -> bool:
         """Whether a TOML source of ``kind`` may set this option.
@@ -525,10 +505,7 @@ def _parse_workspace(value: Any, where: str) -> Any:
 def _parse_constraints(value: Any, where: str) -> tuple[str, ...]:
     # Array of PEP 508 strings.  Delegates to config._parse_constraints so
     # the list-of-strings shape check and the per-item PEP 508 validation
-    # (and their messages) are identical to the pyproject parse path.  Runs
-    # both per-layer (each file's own list) and again over the concatenated
-    # whole (the array merge re-validates the result), which is why the
-    # delegate must accept any tuple as well as a list.
+    # (and their messages) are identical to the pyproject parse path.
     del where
     from .config import (  # noqa: PLC0415 (config import cycle)
         _parse_constraints as _impl,
@@ -552,35 +529,19 @@ def _parse_default_groups(value: Any, where: str) -> tuple[str, ...]:
 
 
 def _parse_indexes(value: Any, where: str) -> tuple[IndexConfig, ...]:
-    # One file's array-of-tables: config._parse_indexes validates
-    # shape, keys, and the within-file same-name check into IndexConfig
-    # entries.  The across-file same-name check runs over the concatenation
-    # via merge_check (_revalidate_index_names).
+    # One file's array-of-tables: config._parse_indexes validates shape,
+    # keys, and the same-name check into IndexConfig entries.
     del where
     from .config import _parse_indexes as _impl  # noqa: PLC0415 (config import cycle)
 
     return _delegate(lambda: _impl(value))
 
 
-def _revalidate_index_names(indexes: Sequence[Any]) -> tuple[IndexConfig, ...]:
-    # Re-run the same-name check over the concatenated indexes, re-typing the
-    # error so its message matches the single-file path.
-    from .config import (  # noqa: PLC0415 (config import cycle)
-        _check_index_name_uniqueness as _impl,
-    )
-
-    merged = tuple(indexes)
-    _delegate(lambda: _impl(merged))
-    return merged
-
-
 def _parse_local_sources(value: Any, where: str) -> tuple[LocalSource, ...]:
     # One file's array-of-tables (name, path, editable, subdirectory).  Paths
     # resolve relative to the declaring file's directory (both legal sources
-    # share the project dir).  There is no within-key duplicate check (the
-    # cross-source local/vcs/archive name check is a whole-config pass on the
-    # resolve path), so the concatenation passes through unchanged
-    # (merge_check=tuple).
+    # share the project dir).  The cross-source local/vcs/archive name check
+    # is a whole-config pass on the resolve path.
     del where
     from .config import (  # noqa: PLC0415 (config import cycle)
         _parse_local_sources as _impl,
@@ -602,9 +563,7 @@ def _declaring_dir() -> Path:
 
 
 def _parse_vcs_sources(value: Any, where: str) -> tuple[VcsSource, ...]:
-    # One file's array-of-tables (name, url).  Like local-sources there is no
-    # within-key duplicate check, so the concatenation passes through
-    # (merge_check=tuple).
+    # One file's array-of-tables (name, url); same shape as local-sources.
     del where
     from .config import (  # noqa: PLC0415 (config import cycle)
         _parse_vcs_sources as _impl,
@@ -614,8 +573,7 @@ def _parse_vcs_sources(value: Any, where: str) -> tuple[VcsSource, ...]:
 
 
 def _parse_archive_sources(value: Any, where: str) -> tuple[ArchiveSource, ...]:
-    # One file's array-of-tables (name, url); same passthrough shape as
-    # vcs-sources (merge_check=tuple).
+    # One file's array-of-tables (name, url); same shape as vcs-sources.
     del where
     from .config import (  # noqa: PLC0415 (config import cycle)
         _parse_archive_sources as _impl,
@@ -645,18 +603,18 @@ def _override_anchor() -> datetime:
 # ``packages`` (name-keyed sugar) and ``package-rules`` (array-of-tables) are
 # two rows that both desugar into one PackageOverride tuple, so each parses
 # only its own surface and config validates the body and the within-surface
-# same-field overlap.  The across-file overlap runs over the concatenation
-# via merge_check (_revalidate_override_overlap).  The cross-surface
-# packages-vs-package-rules overlap and the route-names-a-declared-index
-# check both need the merged whole, so they run on the resolve path in
-# config._config_from_effective, not here.
+# same-field overlap.  The cross-surface packages-vs-package-rules overlap
+# and the route-names-a-declared-index check both need the merged whole, so
+# they run on the resolve path in config._config_from_effective, not here.
 def _parse_packages(value: Any, where: str) -> tuple[Any, ...]:
     del where
     from .config import (  # noqa: PLC0415 (config import cycle)
         _parse_packages_sugar as _impl,
     )
 
-    return _delegate(lambda: tuple(_impl(value, anchor=_override_anchor())))
+    return _delegate(
+        lambda: _checked_overrides(_impl(value, anchor=_override_anchor()))
+    )
 
 
 def _parse_package_rules(value: Any, where: str) -> tuple[Any, ...]:
@@ -665,28 +623,32 @@ def _parse_package_rules(value: Any, where: str) -> tuple[Any, ...]:
         _parse_package_rules as _impl,
     )
 
-    return _delegate(lambda: tuple(_impl(value, anchor=_override_anchor())))
-
-
-def _revalidate_override_overlap(overrides: Sequence[Any]) -> tuple[Any, ...]:
-    # Re-run the per-package same-field overlap check over the concatenation,
-    # re-typing the error to the registry's SourceConfigError.
-    from .config import (  # noqa: PLC0415 (config import cycle)
-        _check_package_override_overlap as _impl,
+    return _delegate(
+        lambda: _checked_overrides(_impl(value, anchor=_override_anchor()))
     )
 
-    merged = tuple(overrides)
-    _delegate(lambda: _impl(merged))
-    return merged
+
+def _checked_overrides(overrides: Iterable[Any]) -> tuple[Any, ...]:
+    """Reject a same-field overlap among one surface's desugared overrides.
+
+    The cross-surface packages-vs-package-rules overlap needs both rows
+    merged, so it runs on the resolve path; this is the within-surface half,
+    run here so ``nab config`` refuses the same file the resolve refuses.
+    """
+    from .config import (  # noqa: PLC0415 (config import cycle)
+        _check_package_override_overlap as _check,
+    )
+
+    built = tuple(overrides)
+    _check(built)
+    return built
 
 
 def _parse_index_overrides(value: Any, where: str) -> Mapping[str, Any]:
     # Name-keyed table (``[tool.nab.index.<name>]``).  The body (policy
     # fields) is validated as on the pyproject path; the
     # key-names-a-declared-index check needs the merged indexes and so runs on
-    # the resolve path.  As a mapping row the two project files contribute
-    # disjoint index names additively, and only the same index name set
-    # differently across them is a conflict.
+    # the resolve path.
     del where
     from .config import (  # noqa: PLC0415 (config import cycle)
         _parse_index_overrides as _impl,
@@ -697,9 +659,7 @@ def _parse_index_overrides(value: Any, where: str) -> Mapping[str, Any]:
 
 def _parse_conflicts(value: Any, where: str) -> tuple[Any, ...]:
     # One file's array-of-tables (member list/table + policy): config validates
-    # shape, members, and policy and runs the within-file member-uniqueness
-    # check.  The across-file member-uniqueness check runs over the
-    # concatenation via merge_check (_revalidate_conflict_members).  The
+    # shape, members, and policy and runs the member-uniqueness check.  The
     # default-groups-vs-conflicts check needs both merged values, so it runs
     # on the resolve path.
     del where
@@ -708,25 +668,12 @@ def _parse_conflicts(value: Any, where: str) -> tuple[Any, ...]:
     return _delegate(lambda: _impl(value))
 
 
-def _revalidate_conflict_members(conflicts: Sequence[Any]) -> tuple[Any, ...]:
-    # Re-run the member-uniqueness check over the concatenation, re-typing the
-    # error so its message matches the single-file path.
-    from .config import (  # noqa: PLC0415 (config import cycle)
-        _check_conflict_member_uniqueness as _impl,
-    )
-
-    merged = tuple(conflicts)
-    _delegate(lambda: _impl(merged))
-    return merged
-
-
 def _parse_matrix(value: Any, where: str) -> Any:
     # Nested table (python, platforms, python-order, python-patches,
-    # implementations).  Scalar last-wins, compared by value (a frozen
-    # MatrixConfig or None).  Delegates to config._parse_matrix so axis
-    # validation and eager expansion are identical to the pyproject path.
-    # The mode/matrix mutual-requirement check needs both merged values, so
-    # it runs over the merged config rather than in this row.
+    # implementations).  Delegates to config._parse_matrix so axis validation
+    # and eager expansion are identical to the pyproject path.  The
+    # mode/matrix mutual-requirement check needs both merged values, so it
+    # runs over the merged config rather than in this row.
     del where
     from .config import _parse_matrix as _impl  # noqa: PLC0415 (config import cycle)
 
@@ -882,7 +829,6 @@ OPTIONS: tuple[OptionSpec, ...] = (
         cli_param="project_constraint",
         parse=_parse_constraints,
         render=_render_string_tuple,
-        is_array=True,
     ),
     OptionSpec(
         key="default-groups",
@@ -894,7 +840,6 @@ OPTIONS: tuple[OptionSpec, ...] = (
         cli_param="project_default_group",
         parse=_parse_default_groups,
         render=_render_string_tuple,
-        is_array=True,
     ),
     OptionSpec(
         key="requires-python",
@@ -950,7 +895,6 @@ OPTIONS: tuple[OptionSpec, ...] = (
         cli_param=None,
         parse=_parse_environment,
         render=_render_environment,
-        is_mapping=True,
     ),
     OptionSpec(
         key="marker-environment",
@@ -962,7 +906,6 @@ OPTIONS: tuple[OptionSpec, ...] = (
         cli_param=None,
         parse=_parse_marker_environment,
         render=_render_marker_environment,
-        is_mapping=True,
     ),
     OptionSpec(
         key="vcs",
@@ -996,8 +939,6 @@ OPTIONS: tuple[OptionSpec, ...] = (
         cli_param=None,
         parse=_parse_indexes,
         render=_render_index_list,
-        is_array=True,
-        merge_check=_revalidate_index_names,
     ),
     OptionSpec(
         key="local-sources",
@@ -1009,8 +950,6 @@ OPTIONS: tuple[OptionSpec, ...] = (
         cli_param=None,
         parse=_parse_local_sources,
         render=_render_local_sources,
-        is_array=True,
-        merge_check=tuple,
     ),
     OptionSpec(
         key="vcs-sources",
@@ -1022,8 +961,6 @@ OPTIONS: tuple[OptionSpec, ...] = (
         cli_param=None,
         parse=_parse_vcs_sources,
         render=_render_vcs_sources,
-        is_array=True,
-        merge_check=tuple,
     ),
     OptionSpec(
         key="archive-sources",
@@ -1035,8 +972,6 @@ OPTIONS: tuple[OptionSpec, ...] = (
         cli_param=None,
         parse=_parse_archive_sources,
         render=_render_archive_sources,
-        is_array=True,
-        merge_check=tuple,
     ),
     OptionSpec(
         key="packages",
@@ -1048,8 +983,6 @@ OPTIONS: tuple[OptionSpec, ...] = (
         cli_param=None,
         parse=_parse_packages,
         render=_render_package_overrides,
-        is_array=True,
-        merge_check=_revalidate_override_overlap,
     ),
     OptionSpec(
         key="package-rules",
@@ -1061,8 +994,6 @@ OPTIONS: tuple[OptionSpec, ...] = (
         cli_param=None,
         parse=_parse_package_rules,
         render=_render_package_overrides,
-        is_array=True,
-        merge_check=_revalidate_override_overlap,
     ),
     OptionSpec(
         key="index",
@@ -1074,7 +1005,6 @@ OPTIONS: tuple[OptionSpec, ...] = (
         cli_param=None,
         parse=_parse_index_overrides,
         render=_render_index_overrides,
-        is_mapping=True,
     ),
     OptionSpec(
         key="conflicts",
@@ -1086,8 +1016,6 @@ OPTIONS: tuple[OptionSpec, ...] = (
         cli_param=None,
         parse=_parse_conflicts,
         render=_render_conflicts,
-        is_array=True,
-        merge_check=_revalidate_conflict_members,
     ),
     OptionSpec(
         key="matrix",
@@ -1549,20 +1477,20 @@ def resolve_config(
     every registry row, each carrying its winner ``(scope, origin)`` and
     the full shadowed stack.  ``rejected`` (category-gate casualties) is
     attached per key for ``explain --include-rejected``.
+
+    Whatever the row's type, the highest source that binds the key
+    supplies the whole value: a list or table from a higher source
+    replaces the one below rather than adding to it.
     """
     all_layers = [*layers, env_layer, cli_layer]
     out: dict[str, EffectiveValue] = {}
     for spec in OPTIONS:
         stack = _stack_for(spec, all_layers)
         rejected_for_key = tuple(r for r in rejected if r.key == spec.key)
-        if not stack:
-            origin, value = Origin(SourceKind.DEFAULT, "builtin-default"), spec.default
-        elif spec.is_array:
-            origin, value = stack[-1][0], _merge_array(spec, stack)
-        elif spec.is_mapping:
-            origin, value = stack[-1][0], _merge_mapping(stack)
-        else:
+        if stack:
             origin, value = stack[-1]
+        else:
+            origin, value = Origin(SourceKind.DEFAULT, "builtin-default"), spec.default
         out[spec.key] = EffectiveValue(
             spec=spec,
             value=value,
@@ -1600,45 +1528,6 @@ def _stack_for(
     return found
 
 
-def _merge_array(
-    spec: OptionSpec, stack: Sequence[tuple[Origin, Any]]
-) -> tuple[Any, ...]:
-    """Concatenate an array option's bindings low-to-high, then re-validate.
-
-    Bindings concatenate in precedence order, so the two project files
-    contribute additively and a higher source appends rather than replaces.
-    A row whose items are already-built objects re-validates the whole
-    through ``merge_check`` (the index-name, override-overlap, and
-    conflict-member checks); a plain-string row re-runs ``parse`` over the
-    concatenation, so ``constraints`` is re-checked as PEP 508 as a whole.
-    """
-    merged: list[Any] = []
-    for _origin, value in stack:
-        merged.extend(value)
-    if spec.merge_check is not None:
-        return spec.merge_check(merged)
-    return spec.parse(merged, f"config {spec.key!r}")
-
-
-def _merge_mapping(stack: Sequence[tuple[Origin, Any]]) -> Mapping[str, Any]:
-    """Fold a name-keyed table's bindings sub-key by sub-key, low-to-high.
-
-    Each layer in ``stack`` already holds a per-layer-validated mapping (its
-    own file's ``[tool.nab.index.<name>]`` / ``[marker-environment]`` table
-    parsed by the row).  The two project files contribute disjoint sub-keys
-    additively; a sub-key present in more than one layer takes the
-    highest-precedence binding (and across the two same-rung project files a
-    differing sub-key is already an error, caught by
-    :func:`_check_project_file_conflict`).  Returned as a plain dict; the
-    per-entry body is already validated, and the check that an index name is
-    declared runs over the merged config.
-    """
-    merged: dict[str, Any] = {}
-    for _origin, value in stack:
-        merged.update(value)
-    return merged
-
-
 def _check_project_file_conflict(
     spec: OptionSpec, found: Sequence[tuple[Origin, Any]]
 ) -> None:
@@ -1649,26 +1538,15 @@ def _check_project_file_conflict(
     :class:`SourceConfigError`, not a silent last-wins.  Identical values
     are fine.
 
-    An array option (``is_array``) is exempt: its two project-file
-    bindings concatenate additively, so differing lists are a merge, not a
-    conflict.  The concat is order-stable (pyproject before project-dir
-    nab.toml) so the result is deterministic.
-
-    A name-keyed table (``is_mapping``) merges sub-key by sub-key, so the
-    two project files contribute disjoint sub-keys additively; only the
-    same sub-key set to different values across them is a conflict
-    (handled below), mirroring the additive array exemption.
+    Every row is compared as one whole value, lists and tables included,
+    so two project files declaring different constraints or different
+    sub-keys of one table conflict rather than combining.
     """
-    if spec.is_array:
-        return
     by_kind = {origin.kind: value for origin, value in found}
     if SourceKind.PYPROJECT not in by_kind or SourceKind.PROJECT_TOML not in by_kind:
         return
     pyproject_value = by_kind[SourceKind.PYPROJECT]
     project_value = by_kind[SourceKind.PROJECT_TOML]
-    if spec.is_mapping:
-        _check_mapping_subkey_conflict(spec, pyproject_value, project_value)
-        return
     if pyproject_value == project_value:
         return
     msg = (
@@ -1679,28 +1557,6 @@ def _check_project_file_conflict(
         " same value."
     )
     raise SourceConfigError(msg)
-
-
-def _check_mapping_subkey_conflict(
-    spec: OptionSpec,
-    pyproject_value: Mapping[str, Any],
-    project_value: Mapping[str, Any],
-) -> None:
-    """For a name-keyed table, only a shared sub-key set differently errors.
-
-    Disjoint sub-keys across the two project files merge (additive, like an
-    array row); a sub-key present in both with a differing value is the hard
-    conflict.  Sorted so the message is deterministic.
-    """
-    for sub_key in sorted(set(pyproject_value) & set(project_value)):
-        if pyproject_value[sub_key] != project_value[sub_key]:
-            msg = (
-                f"config {spec.key!r}.{sub_key} is set to conflicting values in"
-                " pyproject [tool.nab] and project-dir nab.toml.  Both files sit"
-                " at the same precedence level; set the sub-key in only one, or"
-                " set them to the same value."
-            )
-            raise SourceConfigError(msg)
 
 
 # ----- nab config renderers (all derived from the effective map) -----
@@ -1784,32 +1640,22 @@ def render_explain(
 ) -> str:
     """Render the full shadowed stack for ``key``.
 
-    The winner is marked with a ``>`` gutter, every other source is
-    ``shadowed``.  With ``include_rejected`` the category-rejected
-    sources (a source that tried to set ``key`` but was not allowed) are
-    listed too, labelled ``rejected``.
+    The highest source is the ``winner`` and carries a ``>`` gutter;
+    every source it beats is ``shadowed``.  With ``include_rejected`` the
+    category-rejected sources (a source that tried to set ``key`` but was
+    not allowed) are listed too, labelled ``rejected``.
     """
     ev = _require_key(effective, key)
     lines = [f"{key} ({ev.spec.scope.value}, {ev.spec.type_label})"]
     winner_index = len(ev.stack) - 1
-    merged = ev.spec.is_array or ev.spec.is_mapping
     for i, (origin, value) in enumerate(ev.stack):
-        # Array / name-keyed-table options merge every layer low-to-high
-        # (concat for arrays, sub-key union for mappings), so no single
-        # layer's binding is the effective value; the per-layer rows are
-        # contributions and the merged value is rendered separately below.
-        if merged:
-            gutter, status = " ", "contributes"
-        else:
-            gutter = ">" if i == winner_index else " "
-            status = "winner" if i == winner_index else "shadowed"
+        gutter = ">" if i == winner_index else " "
+        status = "winner" if i == winner_index else "shadowed"
         rendered = ev.spec.render(value)
         lines.append(
             f"{gutter} {origin.scope:<{_LIST_SCOPE_W}} {rendered:<{_LIST_VALUE_W}}"
             f" {status:<{_EXPLAIN_STATUS_W}} {origin.label}"
         )
-    if merged:
-        lines.append(f"= effective: {ev.spec.render(ev.value)}")
     if include_rejected:
         lines.extend(
             f"  {rej.origin.scope:<{_LIST_SCOPE_W}} {'-':<{_LIST_VALUE_W}}"
@@ -1833,8 +1679,8 @@ def build_cli_overrides(locals_by_param: Mapping[str, Any]) -> dict[str, Any]:
 
     Iterates :data:`OPTIONS`, reads each row's ``cli_param`` out of
     ``locals_by_param``, and keeps only the keys the user actually set.
-    An unset scalar flag is ``None`` and an unset array flag is an empty
-    tuple (the append-action default); both are omitted so they do not
+    An unset scalar flag is ``None`` and an unset repeatable flag is an
+    empty tuple (the append-action default); both are omitted so they do not
     shadow the file ladder.  A file-only row (``cli_param`` is ``None``)
     has no CLI flag, so it is skipped entirely.  Both the run subcommands
     and ``nab config`` build their override dict through this single
@@ -1862,9 +1708,9 @@ def build_cli_layer(values: Mapping[str, Any]) -> Layer:
     parsed: dict[str, Any] = {}
     for key, value in values.items():
         spec = _BY_KEY[key]
-        # An array flag arrives as a tuple from tyro's append action; the
+        # A repeatable flag arrives as a tuple from tyro's append action; the
         # parse hooks expect a TOML list, so normalise it here.
-        raw = list(value) if spec.is_array and isinstance(value, tuple) else value
+        raw = list(value) if isinstance(value, tuple) else value
         parsed[key] = spec.parse(raw, f"cli:{spec.cli_flag}")
     return Layer(Origin(SourceKind.CLI, "cli"), parsed)
 

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -160,12 +160,12 @@ class TestCliOverridesFold:
         )
         assert plain == explicit_none
 
-    def test_cli_array_appends_after_files(self, tmp_path: Path) -> None:
+    def test_cli_list_replaces_the_file_list(self, tmp_path: Path) -> None:
         path = write(tmp_path, '[tool.nab]\nconstraints = ["a<1"]\n')
         config = read_pyproject_config(
             path, discover_workspace=False, cli_overrides={"constraints": ["b<2"]}
         )
-        assert config.constraints == ("a<1", "b<2")
+        assert config.constraints == ("b<2",)
 
     def test_cli_mode_universal_requires_matrix(self, tmp_path: Path) -> None:
         path = write(tmp_path, '[project]\nname = "x"\nversion = "0"\n')
@@ -4889,19 +4889,6 @@ class TestProjectNabTomlConfiguresResolve:
         assert config.constraints == ("foo<2",)
         assert _inspect(path, "constraints") == "foo<2"
 
-    def test_list_constraints_concat_across_files(self, tmp_path: Path) -> None:
-        # Array concat: a pyproject list and a project-nab.toml list merge
-        # additively, they do not conflict.
-        path = self._write(
-            tmp_path,
-            '[project]\nname = "x"\nversion = "0"\n'
-            '[tool.nab]\nconstraints = ["foo<2"]\n',
-            'constraints = ["bar<3"]\n',
-        )
-        config = read_pyproject_config(path, discover_workspace=False)
-        assert config.constraints == ("foo<2", "bar<3")
-        assert _inspect(path, "constraints") == "foo<2, bar<3"
-
     def test_array_of_tables_indexes(self, tmp_path: Path) -> None:
         path = self._write(
             tmp_path,
@@ -5021,19 +5008,27 @@ class TestProjectNabTomlGateAndConflict:
         with pytest.raises(SourceConfigError, match="conflicting values"):
             read_pyproject_config(path, discover_workspace=False)
 
-    def test_override_overlap_across_project_files_rejected(
-        self, tmp_path: Path
-    ) -> None:
-        # The per-package same-field overlap composes with the cross-file
-        # rule: an override in pyproject and an overlapping one in the project
-        # nab.toml is the hard overlap error, not a silent last-win.
+    def test_list_conflict_across_project_files_rejected(self, tmp_path: Path) -> None:
+        # A list is compared whole like a scalar, so two project files
+        # declaring different constraints is the same hard error.
         path = tmp_path / "pyproject.toml"
         path.write_text(
             '[project]\nname = "x"\nversion = "0"\n'
-            '[tool.nab.packages.numpy]\nbuild-policy = "never"\n'
+            '[tool.nab]\nconstraints = ["foo<2"]\n'
         )
-        (tmp_path / "nab.toml").write_text(
-            '[packages.numpy]\nbuild-policy = "build-local"\n'
+        (tmp_path / "nab.toml").write_text('constraints = ["bar<3"]\n')
+        with pytest.raises(SourceConfigError, match="conflicting values"):
+            read_pyproject_config(path, discover_workspace=False)
+
+    def test_table_conflict_across_project_files_rejected(self, tmp_path: Path) -> None:
+        # A table is compared whole too, so disjoint sub-keys across the two
+        # files conflict rather than folding into an environment neither
+        # file declares.
+        path = tmp_path / "pyproject.toml"
+        path.write_text(
+            '[project]\nname = "x"\nversion = "0"\n'
+            '[tool.nab.environment]\npython = "3.12"\n'
         )
-        with pytest.raises(SourceConfigError, match="overlapping versions"):
+        (tmp_path / "nab.toml").write_text('[environment]\nplatform = "linux_x86_64"\n')
+        with pytest.raises(SourceConfigError, match="conflicting values"):
             read_pyproject_config(path, discover_workspace=False)

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -786,6 +786,24 @@ class TestRenderers:
         assert "rejected" in out
         assert "project-scope" in out
 
+    def test_render_explain_docstring_names_every_status(self, tmp_path: Path) -> None:
+        # One source per status: the user file is rejected (project-scope
+        # key), the pyproject binding is shadowed, and the CLI wins.
+        _project(tmp_path, 'resolution = "lowest"\n')
+        user = _write(tmp_path / "usr" / "nab.toml", 'resolution = "highest"\n')
+
+        eff = _resolve(
+            SourceRoots(user_toml=user, project_dir=tmp_path),
+            cli={"resolution": "highest"},
+            collect_rejected=True,
+        )
+        printed = render_explain(eff, "resolution", include_rejected=True)
+
+        doc = render_explain.__doc__ or ""
+        for status in ("winner", "shadowed", "rejected"):
+            assert status in printed, status
+            assert f"``{status}``" in doc, status
+
 
 class TestReproducibilityNotice:
     """A CLI PROJECT override is never silent; the lock can be reproduced."""
@@ -1267,9 +1285,10 @@ class TestTableProjectOptions:
         assert eff["marker-environment"].value == {"platform_system": "Linux"}
         assert eff["marker-environment"].origin.kind is SourceKind.PROJECT_TOML
 
-    def test_marker_environment_disjoint_vars_merge(self, tmp_path: Path) -> None:
-        # Different sub-keys merge: disjoint marker vars across the two
-        # project files merge instead of raising a spurious conflict.
+    def test_marker_environment_disjoint_vars_conflict(self, tmp_path: Path) -> None:
+        # The table is compared whole, so two project files setting
+        # different marker vars conflict rather than folding into one
+        # environment neither file declares.
         _project(
             tmp_path,
             '[tool.nab.marker-environment]\nplatform_system = "Linux"\n',
@@ -1278,25 +1297,8 @@ class TestTableProjectOptions:
             tmp_path / "nab.toml",
             '[marker-environment]\nsys_platform = "linux"\n',
         )
-        eff = _resolve(SourceRoots(project_dir=tmp_path))
-        assert eff["marker-environment"].value == {
-            "platform_system": "Linux",
-            "sys_platform": "linux",
-        }
-
-    def test_marker_environment_explain_shows_merged(self, tmp_path: Path) -> None:
-        _project(
-            tmp_path,
-            '[tool.nab.marker-environment]\nplatform_system = "Linux"\n',
-        )
-        _write(
-            tmp_path / "nab.toml",
-            '[marker-environment]\nsys_platform = "linux"\n',
-        )
-        eff = _resolve(SourceRoots(project_dir=tmp_path))
-        explained = render_explain(eff, "marker-environment")
-        assert "contributes" in explained
-        assert "= effective: platform_system=Linux, sys_platform=linux" in explained
+        with pytest.raises(SourceConfigError, match="conflicting values"):
+            _resolve(SourceRoots(project_dir=tmp_path))
 
     def test_marker_environment_default_render(self, tmp_path: Path) -> None:
         _project(tmp_path)
@@ -1350,6 +1352,16 @@ class TestTableProjectOptions:
     def test_vcs_cross_file_conflict(self, tmp_path: Path) -> None:
         _project(tmp_path, '[tool.nab.vcs]\npolicy = "allow"\n')
         _write(tmp_path / "nab.toml", '[vcs]\npolicy = "block"\n')
+        with pytest.raises(SourceConfigError, match="conflicting values"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_vcs_cross_file_disjoint_sub_keys_still_conflict(
+        self, tmp_path: Path
+    ) -> None:
+        # vcs is compared as one value, not folded sub-key by sub-key, so
+        # disjoint sub-keys across the two project files still conflict.
+        _project(tmp_path, '[tool.nab.vcs]\npolicy = "allow"\n')
+        _write(tmp_path / "nab.toml", "[vcs]\nrequire-pin = true\n")
         with pytest.raises(SourceConfigError, match="conflicting values"):
             _resolve(SourceRoots(project_dir=tmp_path))
 
@@ -1467,9 +1479,9 @@ class TestArrayProjectOptions:
     """The PROJECT array options: constraints, default-groups.
 
     Each reuses the single-environment list parser, is gated PROJECT-only,
-    is visible in ``nab config``, and (unlike the scalar/table rows)
-    concatenates additively across the ladder, so the two project files
-    merge rather than conflict.
+    and is visible in ``nab config``.  A list is one value like any other
+    row, so the highest source supplies the whole of it and the two
+    project files setting it differently is a conflict.
     """
 
     def test_constraints_from_pyproject(self, tmp_path: Path) -> None:
@@ -1520,29 +1532,19 @@ class TestArrayProjectOptions:
         with pytest.raises(SourceConfigError, match="must be a list of strings"):
             _resolve(SourceRoots(project_dir=tmp_path))
 
-    def test_constraints_concat_across_project_files(self, tmp_path: Path) -> None:
-        # Arrays are exempt from the conflict check: the two same-rung project
-        # files contribute additively, so differing lists merge (pyproject
-        # first, then the project-dir nab.toml) rather than raise a conflict.
+    def test_constraints_cross_file_conflict(self, tmp_path: Path) -> None:
+        # A list at the same rung raises the hard error a scalar does.
         _project(tmp_path, 'constraints = ["urllib3<2"]\n')
         _write(tmp_path / "nab.toml", 'constraints = ["certifi>=2024"]\n')
-        eff = _resolve(SourceRoots(project_dir=tmp_path))
-        assert eff["constraints"].value == ("urllib3<2", "certifi>=2024")
-        assert eff["constraints"].origin.kind is SourceKind.PROJECT_TOML
-
-    def test_constraints_concat_revalidates_whole(self, tmp_path: Path) -> None:
-        # The concatenated whole is re-validated as PEP 508: a per-file
-        # list can be individually fine yet the merge re-runs the check.
-        _project(tmp_path, 'constraints = ["urllib3<2"]\n')
-        _write(tmp_path / "nab.toml", 'constraints = ["bad !! req"]\n')
-        with pytest.raises(SourceConfigError, match="is not a valid requirement"):
+        with pytest.raises(SourceConfigError, match="conflicting values"):
             _resolve(SourceRoots(project_dir=tmp_path))
 
-    def test_constraints_identical_lists_concat(self, tmp_path: Path) -> None:
+    def test_constraints_identical_lists_across_files_ok(self, tmp_path: Path) -> None:
         _project(tmp_path, 'constraints = ["urllib3<2"]\n')
         _write(tmp_path / "nab.toml", 'constraints = ["urllib3<2"]\n')
         eff = _resolve(SourceRoots(project_dir=tmp_path))
-        assert eff["constraints"].value == ("urllib3<2", "urllib3<2")
+        assert eff["constraints"].value == ("urllib3<2",)
+        assert eff["constraints"].origin.kind is SourceKind.PROJECT_TOML
 
     def test_default_groups_from_pyproject(self, tmp_path: Path) -> None:
         _project(tmp_path, 'default-groups = ["dev"]\n')
@@ -1581,11 +1583,11 @@ class TestArrayProjectOptions:
         with pytest.raises(SourceConfigError, match="must be a string"):
             _resolve(SourceRoots(project_dir=tmp_path))
 
-    def test_default_groups_concat_across_project_files(self, tmp_path: Path) -> None:
+    def test_default_groups_cross_file_conflict(self, tmp_path: Path) -> None:
         _project(tmp_path, 'default-groups = ["dev"]\n')
         _write(tmp_path / "nab.toml", 'default-groups = ["docs"]\n')
-        eff = _resolve(SourceRoots(project_dir=tmp_path))
-        assert eff["default-groups"].value == ("dev", "docs")
+        with pytest.raises(SourceConfigError, match="conflicting values"):
+            _resolve(SourceRoots(project_dir=tmp_path))
 
     def test_array_defaults_empty(self, tmp_path: Path) -> None:
         _project(tmp_path)
@@ -1613,47 +1615,45 @@ class TestArrayProjectOptions:
         assert "dev" in explained
 
     def test_array_explain_shows_both_project_files(self, tmp_path: Path) -> None:
-        # Both project-file bindings show in the explain stack (the array
-        # merge keeps the full shadowed stack, ordered low -> high).
+        # Both project-file bindings show in the explain stack, ordered
+        # low -> high, even though only the higher one is the value.
         _project(tmp_path, 'constraints = ["urllib3<2"]\n')
-        _write(tmp_path / "nab.toml", 'constraints = ["certifi>=2024"]\n')
+        _write(tmp_path / "nab.toml", 'constraints = ["urllib3<2"]\n')
         eff = _resolve(SourceRoots(project_dir=tmp_path))
         stack_kinds = [origin.kind for origin, _ in eff["constraints"].stack]
         assert stack_kinds == [SourceKind.PYPROJECT, SourceKind.PROJECT_TOML]
 
-    def test_array_explain_shows_merged_effective(self, tmp_path: Path) -> None:
-        # An array option has no single winning layer: every layer
-        # "contributes" and the concatenated effective value is rendered on
-        # its own line, so explain and get cannot diverge on the effective
-        # value.
+    def test_array_cli_flag_replaces_the_file_list(self, tmp_path: Path) -> None:
+        # The CLI is the highest rung, so its list is the whole value; the
+        # file's list is shadowed rather than appended to.
         _project(tmp_path, 'constraints = ["urllib3<2"]\n')
-        _write(tmp_path / "nab.toml", 'constraints = ["certifi>=2024"]\n')
-        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        eff = _resolve(
+            SourceRoots(project_dir=tmp_path), cli={"constraints": ("certifi>=2024",)}
+        )
+        assert eff["constraints"].value == ("certifi>=2024",)
+        assert eff["constraints"].origin.kind is SourceKind.CLI
         explained = render_explain(eff, "constraints")
-        assert "winner" not in explained
-        assert explained.count("contributes") == 2
-        merged = render_get(eff, "constraints").strip()
-        assert f"= effective: {merged}" in explained
+        assert "urllib3<2" in explained
+        assert "shadowed" in explained
+        assert render_get(eff, "constraints").strip() == "certifi>=2024"
 
-    def test_array_project_rows_have_append_cli_flags(self) -> None:
+    def test_array_project_rows_have_repeatable_cli_flags(self) -> None:
         for key, flag in (
             ("constraints", "--project-constraint"),
             ("default-groups", "--project-default-group"),
         ):
             spec = next(s for s in OPTIONS if s.key == key)
             assert spec.cli_flag == flag
-            assert spec.is_array is True
 
 
 class TestArrayOfTablesSources:
     """The array-of-tables PROJECT sources: indexes, local-sources,
     vcs-sources.  Each reuses the single-environment parser per layer
     (shape/key/dup messages match the pyproject path), is gated
-    PROJECT-only and file-only, concatenates additively across the two
-    project files, and is visible in ``nab config``.  indexes re-runs its
-    same-name dup check over the merged whole; local/vcs-sources carry no
-    intra-key dup check (the cross-key local/vcs check stays on the resolve
-    path), so their merge is a plain concat.
+    PROJECT-only and file-only, and is visible in ``nab config``.  The
+    declaring file owns the whole list, so the same-name dup check is a
+    within-file check and the two project files declaring different lists
+    is a conflict.
     """
 
     def test_indexes_from_pyproject(self, tmp_path: Path) -> None:
@@ -1725,7 +1725,9 @@ class TestArrayOfTablesSources:
         with pytest.raises(SourceConfigError, match="unknown indexes"):
             _resolve(SourceRoots(project_dir=tmp_path))
 
-    def test_indexes_concat_across_project_files(self, tmp_path: Path) -> None:
+    def test_indexes_cross_file_conflict(self, tmp_path: Path) -> None:
+        # A second index is added by editing the file that declares them,
+        # not by declaring a rival list in the other project file.
         _project(
             tmp_path,
             '[[tool.nab.indexes]]\nname = "pypi"\nurl = "https://pypi.org/simple/"\n',
@@ -1734,23 +1736,7 @@ class TestArrayOfTablesSources:
             tmp_path / "nab.toml",
             '[[indexes]]\nname = "extra"\nurl = "https://extra/simple/"\n',
         )
-        eff = _resolve(SourceRoots(project_dir=tmp_path))
-        assert [i.name for i in eff["indexes"].value] == ["pypi", "extra"]
-        assert eff["indexes"].origin.kind is SourceKind.PROJECT_TOML
-
-    def test_indexes_merge_rejects_duplicate_name(self, tmp_path: Path) -> None:
-        # The merged-whole re-check: the same index name in both project
-        # files conflicts, with the same message the single-file dup check
-        # raises.
-        _project(
-            tmp_path,
-            '[[tool.nab.indexes]]\nname = "pypi"\nurl = "https://pypi.org/simple/"\n',
-        )
-        _write(
-            tmp_path / "nab.toml",
-            '[[indexes]]\nname = "pypi"\nurl = "https://other/simple/"\n',
-        )
-        with pytest.raises(SourceConfigError, match="duplicate index name"):
+        with pytest.raises(SourceConfigError, match="conflicting values"):
             _resolve(SourceRoots(project_dir=tmp_path))
 
     def test_indexes_per_file_duplicate_name(self, tmp_path: Path) -> None:
@@ -1807,13 +1793,11 @@ class TestArrayOfTablesSources:
         with pytest.raises(SourceConfigError, match="not settable on a file:// index"):
             _resolve(SourceRoots(project_dir=tmp_path))
 
-    def test_indexes_pin_survives_the_across_file_concat(self, tmp_path: Path) -> None:
-        _project(
-            tmp_path,
-            '[[tool.nab.indexes]]\nname = "pypi"\nurl = "https://pypi.org/simple/"\n',
-        )
+    def test_indexes_pin_is_per_entry(self, tmp_path: Path) -> None:
+        _project(tmp_path)
         _write(
             tmp_path / "nab.toml",
+            '[[indexes]]\nname = "pypi"\nurl = "https://pypi.org/simple/"\n'
             '[[indexes]]\nname = "extra"\nurl = "https://extra/simple/"\n'
             'serialization = "html"\n',
         )
@@ -1821,21 +1805,6 @@ class TestArrayOfTablesSources:
         assert [i.name for i in value] == ["pypi", "extra"]
         assert value[0].serialization is SimpleSerialization.NEGOTIATE
         assert value[1].serialization is SimpleSerialization.HTML
-
-    def test_indexes_pin_cannot_be_added_to_an_index_declared_elsewhere(
-        self, tmp_path: Path
-    ) -> None:
-        _project(
-            tmp_path,
-            '[[tool.nab.indexes]]\nname = "pypi"\nurl = "https://pypi.org/simple/"\n',
-        )
-        _write(
-            tmp_path / "nab.toml",
-            '[[indexes]]\nname = "pypi"\nurl = "https://pypi.org/simple/"\n'
-            'serialization = "json"\n',
-        )
-        with pytest.raises(SourceConfigError, match="duplicate index name"):
-            _resolve(SourceRoots(project_dir=tmp_path))
 
     def test_local_sources_from_pyproject(self, tmp_path: Path) -> None:
         _project(
@@ -1887,7 +1856,7 @@ class TestArrayOfTablesSources:
         with pytest.raises(SourceConfigError, match="must be an array of tables"):
             _resolve(SourceRoots(project_dir=tmp_path))
 
-    def test_local_sources_concat_across_project_files(self, tmp_path: Path) -> None:
+    def test_local_sources_cross_file_conflict(self, tmp_path: Path) -> None:
         _project(
             tmp_path,
             '[[tool.nab.local-sources]]\nname = "a"\npath = "./a"\n',
@@ -1896,8 +1865,8 @@ class TestArrayOfTablesSources:
             tmp_path / "nab.toml",
             '[[local-sources]]\nname = "b"\npath = "./b"\n',
         )
-        eff = _resolve(SourceRoots(project_dir=tmp_path))
-        assert [s.name for s in eff["local-sources"].value] == ["a", "b"]
+        with pytest.raises(SourceConfigError, match="conflicting values"):
+            _resolve(SourceRoots(project_dir=tmp_path))
 
     def test_local_sources_render(self, tmp_path: Path) -> None:
         spec = next(s for s in OPTIONS if s.key == "local-sources")
@@ -1957,7 +1926,7 @@ class TestArrayOfTablesSources:
         with pytest.raises(SourceConfigError, match="must be an array of tables"):
             _resolve(SourceRoots(project_dir=tmp_path))
 
-    def test_vcs_sources_concat_across_project_files(self, tmp_path: Path) -> None:
+    def test_vcs_sources_cross_file_conflict(self, tmp_path: Path) -> None:
         _project(
             tmp_path,
             '[[tool.nab.vcs-sources]]\nname = "a"\nurl = "git+https://e/a.git@1"\n',
@@ -1966,8 +1935,8 @@ class TestArrayOfTablesSources:
             tmp_path / "nab.toml",
             '[[vcs-sources]]\nname = "b"\nurl = "git+https://e/b.git@2"\n',
         )
-        eff = _resolve(SourceRoots(project_dir=tmp_path))
-        assert [s.name for s in eff["vcs-sources"].value] == ["a", "b"]
+        with pytest.raises(SourceConfigError, match="conflicting values"):
+            _resolve(SourceRoots(project_dir=tmp_path))
 
     def test_vcs_sources_render(self) -> None:
         spec = next(s for s in OPTIONS if s.key == "vcs-sources")
@@ -1982,12 +1951,11 @@ class TestArrayOfTablesSources:
         rendered = spec.render((ArchiveSource(name="pkg", url=url),))
         assert rendered == f"pkg@{url}"
 
-    def test_array_of_tables_rows_are_file_only_arrays(self) -> None:
+    def test_array_of_tables_rows_are_file_only(self) -> None:
         for key in ("indexes", "local-sources", "vcs-sources"):
             spec = next(s for s in OPTIONS if s.key == key)
             assert spec.cli_flag is None
             assert spec.cli_param is None
-            assert spec.is_array is True
 
     def test_array_of_tables_keys_visible_in_config(self, tmp_path: Path) -> None:
         _project(
@@ -2007,13 +1975,12 @@ class TestOverrideTables:
 
     ``packages`` (name-keyed sugar) and ``package-rules`` (array of tables)
     both desugar into the same ``PackageOverride`` tuple; each is its own
-    file-only PROJECT array row, concatenating additively across the two
-    project files and re-running the same-field overlap check over the
-    merged whole.  ``index`` is a name-keyed table that merges sub-key by
-    sub-key like marker-environment.  Each reuses the single-environment
-    parser per layer so shape/key/body/overlap messages match the pyproject
-    path; the cross-key checks (packages-vs-package-rules overlap, route or
-    key names a declared index) run over the merged config instead.
+    file-only PROJECT row that carries the same-field overlap check over
+    its own surface.  ``index`` is a name-keyed table.  Each reuses the
+    single-environment parser per layer so shape/key/body/overlap messages
+    match the pyproject path; the cross-key checks (packages-vs-package-rules
+    overlap, route or key names a declared index) run over the merged config
+    instead.
     """
 
     def test_packages_from_pyproject(self, tmp_path: Path) -> None:
@@ -2067,48 +2034,32 @@ class TestOverrideTables:
         with pytest.raises(SourceConfigError, match="overlapping versions"):
             _resolve(SourceRoots(project_dir=tmp_path))
 
-    def test_packages_concat_across_project_files(self, tmp_path: Path) -> None:
+    def test_packages_cross_file_conflict(self, tmp_path: Path) -> None:
         _project(tmp_path, '[tool.nab.packages.lxml]\ndist-policy = "sdist-only"\n')
         _write(
             tmp_path / "nab.toml",
             '[packages.numpy]\ndist-policy = "wheel-only"\n',
         )
-        eff = _resolve(SourceRoots(project_dir=tmp_path))
-        assert sorted(o.name for o in eff["packages"].value) == ["lxml", "numpy"]
-        assert eff["packages"].origin.kind is SourceKind.PROJECT_TOML
-
-    def test_packages_merge_overlap_across_project_files(self, tmp_path: Path) -> None:
-        # The same field for one package over overlapping ranges in both
-        # project files raises the same-field overlap error over the merged
-        # whole, not a silent last-win.
-        _project(tmp_path, '[tool.nab.packages.lxml]\ndist-policy = "sdist-only"\n')
-        _write(
-            tmp_path / "nab.toml",
-            '[packages.lxml]\ndist-policy = "wheel-only"\n',
-        )
-        with pytest.raises(SourceConfigError, match="overlapping versions"):
+        with pytest.raises(SourceConfigError, match="conflicting values"):
             _resolve(SourceRoots(project_dir=tmp_path))
 
-    def test_packages_identical_overlap_still_errors(self, tmp_path: Path) -> None:
-        # Two entries setting one field for one package always overlap, so
-        # even identical bodies in the two project files conflict: arrays
-        # skip the cross-file equality check (they concat) and the overlap
-        # check then fires over the merged tuple, as it would within one file.
+    def test_packages_identical_across_files_ok(self, tmp_path: Path) -> None:
+        # One file's table is the whole value, so the two entries never
+        # land in the same overlap check.
         _project(tmp_path, '[tool.nab.packages.lxml]\ndist-policy = "sdist-only"\n')
         _write(
             tmp_path / "nab.toml",
             '[packages.lxml]\ndist-policy = "sdist-only"\n',
         )
-        with pytest.raises(SourceConfigError, match="overlapping versions"):
-            _resolve(SourceRoots(project_dir=tmp_path))
+        eff = _resolve(SourceRoots(project_dir=tmp_path))
+        assert [o.name for o in eff["packages"].value] == ["lxml"]
+        assert eff["packages"].origin.kind is SourceKind.PROJECT_TOML
 
-    def test_packages_disjoint_ranges_across_files_ok(self, tmp_path: Path) -> None:
+    def test_packages_disjoint_ranges_in_one_file_ok(self, tmp_path: Path) -> None:
         _project(
-            tmp_path, '[tool.nab.packages."lxml <= 2"]\ndist-policy = "sdist-only"\n'
-        )
-        _write(
-            tmp_path / "nab.toml",
-            '[packages."lxml > 2"]\ndist-policy = "wheel-only"\n',
+            tmp_path,
+            '[tool.nab.packages."lxml <= 2"]\ndist-policy = "sdist-only"\n'
+            '[tool.nab.packages."lxml > 2"]\ndist-policy = "wheel-only"\n',
         )
         eff = _resolve(SourceRoots(project_dir=tmp_path))
         assert [o.name for o in eff["packages"].value] == ["lxml", "lxml"]
@@ -2170,7 +2121,7 @@ class TestOverrideTables:
         with pytest.raises(SourceConfigError, match=r"package-rules\[0\] must be"):
             _resolve(SourceRoots(project_dir=tmp_path))
 
-    def test_package_rules_concat_across_project_files(self, tmp_path: Path) -> None:
+    def test_package_rules_cross_file_conflict(self, tmp_path: Path) -> None:
         _project(
             tmp_path,
             '[[tool.nab.package-rules]]\nmatch = ["a"]\ndist-policy = "sdist-only"\n',
@@ -2179,8 +2130,19 @@ class TestOverrideTables:
             tmp_path / "nab.toml",
             '[[package-rules]]\nmatch = ["b"]\ndist-policy = "wheel-only"\n',
         )
-        eff = _resolve(SourceRoots(project_dir=tmp_path))
-        assert [o.name for o in eff["package-rules"].value] == ["a", "b"]
+        with pytest.raises(SourceConfigError, match="conflicting values"):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
+    def test_package_rules_intra_file_overlap_keeps_message(
+        self, tmp_path: Path
+    ) -> None:
+        _project(
+            tmp_path,
+            '[[tool.nab.package-rules]]\nmatch = ["a"]\ndist-policy = "sdist-only"\n'
+            '[[tool.nab.package-rules]]\nmatch = ["a"]\ndist-policy = "wheel-only"\n',
+        )
+        with pytest.raises(SourceConfigError, match="overlapping versions"):
+            _resolve(SourceRoots(project_dir=tmp_path))
 
     def test_index_from_pyproject(self, tmp_path: Path) -> None:
         _project(
@@ -2251,24 +2213,22 @@ class TestOverrideTables:
         eff = _resolve(SourceRoots(project_dir=tmp_path))
         assert set(eff["index"].value) == {"pypi"}
 
-    def test_index_disjoint_names_merge(self, tmp_path: Path) -> None:
-        # Different sub-keys merge: disjoint index names across the two
-        # project files merge by sub-key rather than tripping a conflict.
+    def test_index_disjoint_names_conflict(self, tmp_path: Path) -> None:
+        # The table is one value, so each project file naming a different
+        # index is a conflict.
         _project(tmp_path, '[tool.nab.index.pypi]\ndist-policy = "wheel-only"\n')
         _write(
             tmp_path / "nab.toml",
             '[index.internal]\ndist-policy = "sdist-only"\n',
         )
-        eff = _resolve(SourceRoots(project_dir=tmp_path))
-        assert set(eff["index"].value) == {"pypi", "internal"}
+        with pytest.raises(SourceConfigError, match="conflicting values"):
+            _resolve(SourceRoots(project_dir=tmp_path))
 
-    def test_index_assume_fresh_seconds_merges(self, tmp_path: Path) -> None:
-        _project(
-            tmp_path,
-            "[tool.nab.index.pypi]\nassume-fresh-seconds = 3600\n",
-        )
+    def test_index_assume_fresh_seconds_is_per_index(self, tmp_path: Path) -> None:
+        _project(tmp_path)
         _write(
             tmp_path / "nab.toml",
+            "[index.pypi]\nassume-fresh-seconds = 3600\n"
             "[index.internal]\nassume-fresh-seconds = 30\n",
         )
         eff = _resolve(SourceRoots(project_dir=tmp_path))
@@ -2299,12 +2259,11 @@ class TestOverrideTables:
         )
         _write(
             tmp_path / "nab.toml",
-            '[packages.numpy]\nuploaded-prior-to = "P4D"\n',
+            '[packages.lxml]\nuploaded-prior-to = "P4D"\n',
         )
         with inspector_anchor():
             eff = _resolve(SourceRoots(project_dir=tmp_path))
-        names = {str(o.requirement) for o in eff["packages"].value}
-        assert names == {"lxml", "numpy"}
+        assert {str(o.requirement) for o in eff["packages"].value} == {"lxml"}
 
     def test_override_defaults_empty(self, tmp_path: Path) -> None:
         _project(tmp_path)
@@ -2337,15 +2296,10 @@ class TestOverrideTables:
         assert render_get(eff, "index").strip() == "a, b"
 
     def test_override_rows_shape(self) -> None:
-        for key in ("packages", "package-rules"):
+        for key in ("packages", "package-rules", "index"):
             spec = next(s for s in OPTIONS if s.key == key)
             assert spec.cli_flag is None
             assert spec.cli_param is None
-            assert spec.is_array is True
-        index = next(s for s in OPTIONS if s.key == "index")
-        assert index.cli_flag is None
-        assert index.cli_param is None
-        assert index.is_array is False
 
     def test_override_keys_visible_in_config(self, tmp_path: Path) -> None:
         _project(
@@ -2435,28 +2389,13 @@ class TestCrossFieldProjectOptions:
         ):
             _resolve(SourceRoots(project_dir=tmp_path))
 
-    def test_conflicts_concat_across_project_files(self, tmp_path: Path) -> None:
-        # Arrays skip the conflict check: the two same-rung project files
-        # contribute additively.
+    def test_conflicts_cross_file_conflict(self, tmp_path: Path) -> None:
         _project(tmp_path, _CONFLICTS_PYPROJECT)
         _write(
             tmp_path / "nab.toml",
             'conflicts = [[{ group = "test" }, { group = "docs" }]]\n',
         )
-        eff = _resolve(SourceRoots(project_dir=tmp_path))
-        assert len(eff["conflicts"].value) == 2
-        assert eff["conflicts"].origin.kind is SourceKind.PROJECT_TOML
-
-    def test_conflicts_merge_rejects_duplicate_member(self, tmp_path: Path) -> None:
-        # The merged-whole re-check: a member declared in both project files
-        # is the existing hard error, the same message the single-file
-        # uniqueness check raises.
-        _project(tmp_path, _CONFLICTS_PYPROJECT)
-        _write(
-            tmp_path / "nab.toml",
-            'conflicts = [[{ extra = "cpu" }, { extra = "tpu" }]]\n',
-        )
-        with pytest.raises(SourceConfigError, match="in more than one set"):
+        with pytest.raises(SourceConfigError, match="conflicting values"):
             _resolve(SourceRoots(project_dir=tmp_path))
 
     def test_conflicts_per_file_duplicate_member(self, tmp_path: Path) -> None:
@@ -2574,14 +2513,10 @@ class TestCrossFieldProjectOptions:
         assert rendered == "python=>=3.11, platforms=['linux_x86_64', 'macos_arm64']"
 
     def test_cross_field_rows_shape(self) -> None:
-        conflicts = next(s for s in OPTIONS if s.key == "conflicts")
-        assert conflicts.cli_flag is None
-        assert conflicts.cli_param is None
-        assert conflicts.is_array is True
-        matrix = next(s for s in OPTIONS if s.key == "matrix")
-        assert matrix.cli_flag is None
-        assert matrix.cli_param is None
-        assert matrix.is_array is False
+        for key in ("conflicts", "matrix"):
+            spec = next(s for s in OPTIONS if s.key == key)
+            assert spec.cli_flag is None
+            assert spec.cli_param is None
 
     def test_cross_field_keys_visible_in_config(self, tmp_path: Path) -> None:
         _project(tmp_path, _CONFLICTS_PYPROJECT + _MATRIX_PYPROJECT)

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -125,6 +125,21 @@ def _run_config(args: list[str]) -> str:
     return buf.getvalue()
 
 
+_CLI_REFERENCE = Path(__file__).resolve().parents[1] / "docs" / "reference" / "cli.md"
+
+
+def _config_reference_section() -> str:
+    """Return the ``nab config`` section of the CLI reference."""
+    text = _CLI_REFERENCE.read_text(encoding="utf-8")
+    return text.partition("\n## `nab config`\n")[2].partition("\n## ")[0]
+
+
+def _lock_reference_section() -> str:
+    """Return the ``nab lock`` section of the CLI reference."""
+    text = _CLI_REFERENCE.read_text(encoding="utf-8")
+    return text.partition("\n## `nab lock`\n")[2].partition("\n## ")[0]
+
+
 def test_config_search_roots_uses_symlink_dir_not_target(tmp_path: Path) -> None:
     # A symlinked pyproject keeps the symlink's own directory as the
     # local-sources base, matching the resolve path (not the target's dir).
@@ -361,6 +376,54 @@ class TestConfigExplain:
         with pytest.raises(SystemExit):
             config_command("explain", "bogus", path=hermetic_roots / "pyproject.toml")
         assert "unknown config key" in capsys.readouterr().err
+
+
+class TestConfigExplainReferenceDocs:
+    """The CLI reference names every status ``explain`` prints."""
+
+    def test_reference_names_every_status(
+        self, hermetic_roots: Path, tmp_path: Path
+    ) -> None:
+        # One source per status: the user file is rejected (project-scope
+        # key), the pyproject binding is shadowed, and the CLI wins.
+        _write(
+            hermetic_roots / "pyproject.toml",
+            '[project]\nname = "x"\nversion = "0"\ndependencies = []\n'
+            '[tool.nab]\nresolution = "lowest"\n',
+        )
+        _write(tmp_path / "usr" / "nab.toml", 'resolution = "highest"\n')
+
+        printed = _run_config(
+            [
+                "explain",
+                "resolution",
+                "--project-resolution",
+                "highest",
+                "--include-rejected",
+                "--path",
+                str(hermetic_roots / "pyproject.toml"),
+            ]
+        )
+
+        section = _config_reference_section()
+        for status in ("winner", "shadowed", "rejected"):
+            assert status in printed, status
+            assert f"`{status}`" in section, status
+
+
+class TestLockReferenceDocumentsProjectOverrides:
+    """The CLI reference lists every ``--project-*`` flag and how it combines."""
+
+    def test_every_project_flag_is_documented_as_replacing(self) -> None:
+        prefix = "--project-"
+        prose = "\n\n".join(
+            para for para in _lock_reference_section().split("\n\n") if prefix in para
+        )
+        for spec in OPTIONS:
+            if spec.cli_flag is not None and spec.cli_flag.startswith(prefix):
+                assert f"`{spec.cli_flag}`" in prose, spec.cli_flag
+        assert "replaces the file value" in prose
+        assert "append" not in prose
 
 
 class TestConfigErrors:
@@ -892,16 +955,18 @@ class TestProjectCliOverrides:
         assert config.dist_policy is DistPolicy.SDIST_ONLY
         assert config.trust_unverified_sdist_deps is False
 
-    def test_project_constraint_appends_across_repeats(
+    def test_project_constraint_repeats_replace_the_file_list(
         self, hermetic_roots: Path
     ) -> None:
+        # Repeats accumulate into the flag's own value, which then replaces
+        # the declared list rather than extending it.
         proj = _project(hermetic_roots, 'constraints = ["a<1"]\n')
         config, _ = self._lock_config(
             proj,
             hermetic_roots / "pylock.toml",
             ["--project-constraint", "b<2", "--project-constraint", "c<3"],
         )
-        assert config.constraints == ("a<1", "b<2", "c<3")
+        assert config.constraints == ("b<2", "c<3")
 
     def test_append_flag_does_not_swallow_positional_path(
         self, hermetic_roots: Path
@@ -1061,14 +1126,7 @@ class TestDownloadLadder:
         assert "config error" in capsys.readouterr().err
 
 
-_CLI_REFERENCE = Path(__file__).resolve().parents[1] / "docs" / "reference" / "cli.md"
-
 _FLAG = "--include-rejected"
-
-
-def _config_reference_section() -> str:
-    text = _CLI_REFERENCE.read_text(encoding="utf-8")
-    return text.partition("\n## `nab config`\n")[2].partition("\n## ")[0]
 
 
 def _prose_chunks(section: str) -> list[str]:


### PR DESCRIPTION
`--project-constraint` appended to the constraints a project declares, so no run could lock against only the constraint you passed. Arrays concatenated across the two project files as well, and `environment`, `marker-environment` and `index` folded a sub-key at a time.

Every source now supplies the whole value of the key it sets, whatever the type, and the two project files setting one key differently is the hard error it already was for a scalar.
