### PR TITLE
fix traceback on an unsearchable parent directory

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -15,8 +15,8 @@ The property suite under ``nab-*/tests/property*/`` uses explicit
 ``PROPERTY_SETTINGS``/``DEEP_SETTINGS``/``BRUTE_FORCE_SETTINGS``
 decorators so its example budget is independent of the profile.
 
-``cap_writes`` is here rather than in one suite's conftest because both the
-``nab-python`` suite and the CLI suite use it.
+``cap_writes`` and ``deny_access`` are here rather than in one suite's
+conftest because both the ``nab-python`` suite and the CLI suite use them.
 """
 
 from __future__ import annotations
@@ -25,7 +25,9 @@ import errno
 import io
 import os
 from contextlib import contextmanager
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
 
 import pytest
 from hypothesis import HealthCheck, settings
@@ -107,6 +109,38 @@ def _cap_writes(budget: int) -> Iterator[None]:
         yield
     finally:
         io.open = real_open  # type: ignore[assignment]
+
+
+@contextmanager
+def _deny_access(target: Path) -> Iterator[None]:
+    real_stat, real_open = Path.stat, Path.open
+
+    def refuse(self: Path, real: Any, *args: Any, **kwargs: Any) -> Any:
+        if self == target:
+            raise PermissionError(errno.EACCES, "Permission denied", str(target))
+        return real(self, *args, **kwargs)
+
+    with (
+        patch.object(
+            Path, "stat", lambda self, *a, **k: refuse(self, real_stat, *a, **k)
+        ),
+        patch.object(
+            Path, "open", lambda self, *a, **k: refuse(self, real_open, *a, **k)
+        ),
+    ):
+        yield
+
+
+@pytest.fixture
+def deny_access() -> Callable[[Path], AbstractContextManager[None]]:
+    """Simulate a directory the running user cannot search.
+
+    Inside ``deny_access(p)`` every stat and open of ``p`` raises ``EACCES``,
+    which is what a parent directory without the search bit does to both
+    halves of a read.  chmod cannot express that on Windows, so the state is
+    simulated rather than created.
+    """
+    return _deny_access
 
 
 @pytest.fixture

--- a/conftest.py
+++ b/conftest.py
@@ -113,20 +113,24 @@ def _cap_writes(budget: int) -> Iterator[None]:
 
 @contextmanager
 def _deny_access(target: Path) -> Iterator[None]:
-    real_stat, real_open = Path.stat, Path.open
+    real_stat, real_open = os.stat, Path.open
+    denied = os.fspath(target)
 
-    def refuse(self: Path, real: Any, *args: Any, **kwargs: Any) -> Any:
-        if self == target:
-            raise PermissionError(errno.EACCES, "Permission denied", str(target))
-        return real(self, *args, **kwargs)
+    def refuse(candidate: Any) -> None:
+        if isinstance(candidate, (str, os.PathLike)) and os.fspath(candidate) == denied:
+            raise PermissionError(errno.EACCES, "Permission denied", denied)
+
+    def denying_stat(path: Any, *args: Any, **kwargs: Any) -> Any:
+        refuse(path)
+        return real_stat(path, *args, **kwargs)
+
+    def denying_open(self: Path, *args: Any, **kwargs: Any) -> Any:
+        refuse(self)
+        return real_open(self, *args, **kwargs)
 
     with (
-        patch.object(
-            Path, "stat", lambda self, *a, **k: refuse(self, real_stat, *a, **k)
-        ),
-        patch.object(
-            Path, "open", lambda self, *a, **k: refuse(self, real_open, *a, **k)
-        ),
+        patch.object(os, "stat", denying_stat),
+        patch.object(Path, "open", denying_open),
     ):
         yield
 
@@ -137,8 +141,10 @@ def deny_access() -> Callable[[Path], AbstractContextManager[None]]:
 
     Inside ``deny_access(p)`` every stat and open of ``p`` raises ``EACCES``,
     which is what a parent directory without the search bit does to both
-    halves of a read.  chmod cannot express that on Windows, so the state is
-    simulated rather than created.
+    halves of a read. chmod cannot express that on Windows, so the state is
+    simulated rather than created. ``os.stat`` is the patch point rather than
+    ``Path.stat`` because every presence check ends up there, whether it went
+    through ``pathlib`` or ``os.path``.
     """
     return _deny_access
 

--- a/nab-python/src/nab_python/_build/runner.py
+++ b/nab-python/src/nab_python/_build/runner.py
@@ -43,6 +43,7 @@ from .._vendor.packaging.specifiers import SpecifierSet
 from .._vendor.packaging.utils import canonicalize_name
 from .._vendor.packaging.version import Version
 from ..metadata import WheelMetadata, validate_specifier_versions
+from ..paths import path_state
 from .env import BuildEnvError, NabBuildEnv
 from .errors import BuildBackendError
 
@@ -82,13 +83,13 @@ def run_build_backend(
     :class:`NabBuildEnv` for why) so callers do not pass one in.
     """
     pyproject = source_dir / "pyproject.toml"
-    if pyproject.is_file():
+    if path_state(pyproject).should_read:
         try:
             data = tomli.loads(pyproject.read_text(encoding="utf-8"))
         except (OSError, UnicodeDecodeError, tomli.TOMLDecodeError) as exc:
             msg = f"could not read pyproject.toml at {source_dir}: {exc}"
             raise BuildBackendError(msg) from exc
-    elif (source_dir / "setup.py").is_file():
+    elif path_state(source_dir / "setup.py").should_read:
         # PEP 517 fallback for legacy setup.py projects: treat the
         # missing ``[build-system]`` as the documented default
         # (setuptools.build_meta:__legacy__).

--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -179,9 +179,9 @@ def read_lockfile_anchor(path: Path) -> datetime | None:
     re-locks: the anchor used for the previous resolve is read back
     and reused unless the user passes ``--upgrade``.
 
-    Returns ``None`` when ``path`` does not exist, is not valid TOML,
-    is not a PEP 751-shaped pylock, or is missing the ``[tool.nab]``
-    block.  Naive timestamps (no timezone offset) are coerced to UTC
+    Returns ``None`` when ``path`` does not exist, cannot be read, is
+    not valid TOML, is not a PEP 751-shaped pylock, or is missing the
+    ``[tool.nab]`` block.  Naive timestamps (no offset) are coerced to UTC
     for symmetry with the writer; this is informational provenance, so
     a missing offset is recoverable rather than fatal.
     """
@@ -212,9 +212,9 @@ def read_lockfile_packages(path: Path) -> dict[str, Version] | None:
     Packages without a recorded version (direct-reference entries that
     omit it) are skipped.
 
-    Returns ``None`` when ``path`` does not exist, is not valid TOML,
-    or is not a spec-compliant PEP 751 lockfile; the caller falls back
-    to a no-diff summary line.
+    Returns ``None`` when ``path`` does not exist, cannot be read, is
+    not valid TOML, or is not a spec-compliant PEP 751 lockfile; the
+    caller falls back to a no-diff summary line.
     """
     if not path_state(path).should_read:
         return None

--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -25,6 +25,7 @@ from .._toml import tool_nab_section
 from .._vendor.packaging.pylock import Pylock, PylockValidationError
 from .._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from .._vendor.packaging.utils import canonicalize_name
+from ..paths import path_state
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
@@ -184,7 +185,7 @@ def read_lockfile_anchor(path: Path) -> datetime | None:
     for symmetry with the writer; this is informational provenance, so
     a missing offset is recoverable rather than fatal.
     """
-    if not path.is_file():
+    if not path_state(path).should_read:
         return None
     try:
         with path.open("rb") as f:
@@ -215,7 +216,7 @@ def read_lockfile_packages(path: Path) -> dict[str, Version] | None:
     or is not a spec-compliant PEP 751 lockfile; the caller falls back
     to a no-diff summary line.
     """
-    if not path.is_file():
+    if not path_state(path).should_read:
         return None
     try:
         with path.open("rb") as f:

--- a/nab-python/src/nab_python/_provider/sources.py
+++ b/nab-python/src/nab_python/_provider/sources.py
@@ -93,15 +93,25 @@ def extract_source_metadata(
     for :class:`VcsSource` clones and ``"archive"`` for extracted
     :class:`ArchiveSource` trees both build only at
     :attr:`BuildPolicy.BUILD_REMOTE`, like a remote sdist.
+
+    An unreadable ``pyproject.toml`` is reported as a read failure at
+    every policy level: the build path cannot read it either, so calling
+    it dynamic metadata would blame the policy for a permission error.
     """
     # Imported in-function so tests can patch the module attribute.
     from .. import build_backend
     from ..build_backend import BuildBackendError, extract_static_metadata
     from ..provider import BuildPolicy, UnsupportedSdistError
 
-    metadata = extract_static_metadata(path)
+    try:
+        metadata = extract_static_metadata(path)
+    except BuildBackendError as exc:
+        msg = f"{descriptor}: {exc}"
+        raise UnsupportedSdistError(msg) from exc
+
     if metadata is not None:
         return metadata
+
     effective = provider.effective_build_policy_for_source(package)
     if kind == "local":
         allowed = {BuildPolicy.BUILD_LOCAL, BuildPolicy.BUILD_REMOTE}

--- a/nab-python/src/nab_python/build_backend.py
+++ b/nab-python/src/nab_python/build_backend.py
@@ -19,7 +19,7 @@ from ._vendor.packaging.specifiers import SpecifierSet
 from ._vendor.packaging.utils import canonicalize_name
 from ._vendor.packaging.version import Version
 from .metadata import WheelMetadata, load_static_project, validate_specifier_versions
-from .paths import path_state
+from .paths import is_absent_error, path_state
 from .requirements_file import (
     InvalidProjectRequirementError,
     _parse_project_requirement,
@@ -51,6 +51,10 @@ def extract_static_metadata(source_dir: Path) -> WheelMetadata | None:
     authoritative, populating ``name``, ``version``,
     ``requires_python``, ``requires_dist``, and ``provides_extra``.
 
+    Raises :class:`BuildBackendError` when the file is there but cannot
+    be read.  Its contents are unknown, so it is neither "no static
+    metadata" nor a missing file; the message names the errno.
+
     Raises :class:`InvalidProjectRequirementError` when a present,
     non-dynamic field is corrupt: a structurally wrong ``dependencies`` /
     ``optional-dependencies`` (not an array of strings / not a table), a
@@ -76,9 +80,11 @@ def extract_static_metadata(source_dir: Path) -> WheelMetadata | None:
         return None
     try:
         text = pyproject.read_text(encoding="utf-8")
-    except OSError:
-        # The presence check is racy: the file may vanish or become
-        # unreadable before the read.  Treat it the same as missing.
+    except OSError as exc:
+        if not is_absent_error(exc):
+            msg = f"could not read pyproject.toml at {source_dir}: {exc}"
+            raise BuildBackendError(msg) from exc
+        # The presence check is racy: the file may vanish before the read.
         return None
     except UnicodeDecodeError:
         # TOML is UTF-8, so a file that will not decode has no static metadata.

--- a/nab-python/src/nab_python/build_backend.py
+++ b/nab-python/src/nab_python/build_backend.py
@@ -19,6 +19,7 @@ from ._vendor.packaging.specifiers import SpecifierSet
 from ._vendor.packaging.utils import canonicalize_name
 from ._vendor.packaging.version import Version
 from .metadata import WheelMetadata, load_static_project, validate_specifier_versions
+from .paths import path_state
 from .requirements_file import (
     InvalidProjectRequirementError,
     _parse_project_requirement,
@@ -71,13 +72,13 @@ def extract_static_metadata(source_dir: Path) -> WheelMetadata | None:
     as read-only.
     """
     pyproject = source_dir / "pyproject.toml"
-    if not pyproject.is_file():
+    if not path_state(pyproject).should_read:
         return None
     try:
         text = pyproject.read_text(encoding="utf-8")
     except OSError:
-        # ``is_file`` is racy: the file may vanish or become unreadable
-        # between the check and the read.  Treat it the same as missing.
+        # The presence check is racy: the file may vanish or become
+        # unreadable before the read.  Treat it the same as missing.
         return None
     except UnicodeDecodeError:
         # TOML is UTF-8, so a file that will not decode has no static metadata.

--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -43,6 +43,7 @@ from nab_index.serialization import SimpleSerialization
 
 from ._toml import tool_nab_section
 from .fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL
+from .paths import PathState, path_state
 from .provider import (
     ArchiveSource,
     BuildPolicy,
@@ -1513,13 +1514,16 @@ def discover_layers(
         ),
     ]
     for path, kind in plan:
-        if path is None or not path.exists():
+        if path is None:
             continue
-        if not path.is_file():
-            # A genuinely-absent file is skipped above; a path that exists
-            # but is not a regular file (e.g. an accidental `mkdir
-            # nab.toml`) would be silently ignored by an is_file() filter,
-            # so crash naming it rather than dropping the config source.
+        state = path_state(path)
+        if state is PathState.ABSENT:
+            continue
+        if not state.should_read:
+            # A path that exists but is not a regular file (e.g. an
+            # accidental `mkdir nab.toml`) would be silently ignored by an
+            # is_file() filter, so crash naming it rather than dropping the
+            # config source.
             msg = f"{path} exists but is not a regular file"
             raise SourceConfigError(msg)
         layers.append(_load_toml_layer(path, kind, rejections=rejections))

--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -1523,7 +1523,8 @@ def discover_layers(
             # A path that exists but is not a regular file (e.g. an
             # accidental `mkdir nab.toml`) would be silently ignored by an
             # is_file() filter, so crash naming it rather than dropping the
-            # config source.
+            # config source.  A failed stat goes to the read instead, which
+            # names the errno.
             msg = f"{path} exists but is not a regular file"
             raise SourceConfigError(msg)
         layers.append(_load_toml_layer(path, kind, rejections=rejections))

--- a/nab-python/src/nab_python/paths.py
+++ b/nab-python/src/nab_python/paths.py
@@ -12,12 +12,20 @@ if TYPE_CHECKING:
 
 __all__ = [
     "PathState",
+    "is_absent_error",
     "path_state",
 ]
 
-# ENOTDIR is a non-directory component part-way along the path, which leaves
-# nothing at the path just as surely as ENOENT does.
 _ABSENT_ERRNOS = frozenset({errno.ENOENT, errno.ENOTDIR})
+
+
+def is_absent_error(exc: OSError) -> bool:
+    """Whether ``exc`` from a stat or an open means nothing is at the path.
+
+    ``ENOTDIR`` is a non-directory component part-way along the path,
+    which leaves nothing at the path just as surely as ``ENOENT`` does.
+    """
+    return exc.errno in _ABSENT_ERRNOS
 
 
 class PathState(Enum):
@@ -33,8 +41,8 @@ class PathState(Enum):
     def should_read(self) -> bool:
         """Whether the caller should go on and open the path.
 
-        True for a regular file, and for one whose stat failed: opening
-        it is what turns that failure into a message naming the errno.
+        True for a regular file, and for one whose stat failed: what an
+        unreadable path means is the reader's call.
         """
         return self in (PathState.FILE, PathState.UNREADABLE)
 
@@ -42,20 +50,25 @@ class PathState(Enum):
 def path_state(path: Path) -> PathState:
     """Classify ``path`` without raising, keeping the stat failures apart.
 
-    ``Path.exists``/``is_file``/``is_dir`` answer with a bool, so the two
-    ways a stat can fail collapse into one.  When the parent directory is
-    not searchable the stat fails with ``EACCES``, which those methods
+    ``Path.exists``/``is_file``/``is_dir`` answer with a bool, so an absent
+    path and a stat that failed collapse into one answer.  An unsearchable
+    parent directory fails the stat with ``EACCES``, which those methods
     re-raise on Python 3.13 and below and report as absent on 3.14.
-    :data:`PathState.UNREADABLE` keeps that case its own, so a caller can
-    hand the path to the read that names the real errno instead of
-    calling a file that is there missing.
+    :data:`PathState.UNREADABLE` keeps that case separate, so the caller
+    can hand the path to the read that names the errno.
     """
     try:
         st = path.stat()
+    except ValueError:
+        # A name the OS cannot carry (an embedded NUL, an unencodable
+        # character) is nothing on disk, which is how pathlib's own
+        # predicates report it too.
+        return PathState.ABSENT
     except OSError as exc:
-        if exc.errno in _ABSENT_ERRNOS:
+        if is_absent_error(exc):
             return PathState.ABSENT
         return PathState.UNREADABLE
+
     if stat.S_ISREG(st.st_mode):
         return PathState.FILE
     if stat.S_ISDIR(st.st_mode):

--- a/nab-python/src/nab_python/paths.py
+++ b/nab-python/src/nab_python/paths.py
@@ -1,0 +1,63 @@
+"""Presence checks that keep an absent path apart from an unreadable one."""
+
+from __future__ import annotations
+
+import errno
+import stat
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+__all__ = [
+    "PathState",
+    "path_state",
+]
+
+# ENOTDIR is a non-directory component part-way along the path, which leaves
+# nothing at the path just as surely as ENOENT does.
+_ABSENT_ERRNOS = frozenset({errno.ENOENT, errno.ENOTDIR})
+
+
+class PathState(Enum):
+    """What a stat of a path found."""
+
+    ABSENT = "absent"
+    FILE = "file"
+    DIRECTORY = "directory"
+    OTHER = "other"
+    UNREADABLE = "unreadable"
+
+    @property
+    def should_read(self) -> bool:
+        """Whether the caller should go on and open the path.
+
+        True for a regular file, and for one whose stat failed: opening
+        it is what turns that failure into a message naming the errno.
+        """
+        return self in (PathState.FILE, PathState.UNREADABLE)
+
+
+def path_state(path: Path) -> PathState:
+    """Classify ``path`` without raising, keeping the stat failures apart.
+
+    ``Path.exists``/``is_file``/``is_dir`` answer with a bool, so the two
+    ways a stat can fail collapse into one.  When the parent directory is
+    not searchable the stat fails with ``EACCES``, which those methods
+    re-raise on Python 3.13 and below and report as absent on 3.14.
+    :data:`PathState.UNREADABLE` keeps that case its own, so a caller can
+    hand the path to the read that names the real errno instead of
+    calling a file that is there missing.
+    """
+    try:
+        st = path.stat()
+    except OSError as exc:
+        if exc.errno in _ABSENT_ERRNOS:
+            return PathState.ABSENT
+        return PathState.UNREADABLE
+    if stat.S_ISREG(st.st_mode):
+        return PathState.FILE
+    if stat.S_ISDIR(st.st_mode):
+        return PathState.DIRECTORY
+    return PathState.OTHER

--- a/nab-python/src/nab_python/workspace.py
+++ b/nab-python/src/nab_python/workspace.py
@@ -27,6 +27,7 @@ import tomli
 
 from ._toml import tool_nab_section
 from ._vendor.packaging.utils import canonicalize_name
+from .paths import path_state
 from .provider import LocalSource
 
 if TYPE_CHECKING:
@@ -165,7 +166,7 @@ def workspace_local_sources(
 
         member_dir = (root_dir / entry).resolve()
         member_pyproject = member_dir / "pyproject.toml"
-        if not member_pyproject.is_file():
+        if not path_state(member_pyproject).should_read:
             msg = (
                 f"{declared_in}: workspace member {entry!r} has no"
                 f" pyproject.toml at {member_pyproject}"

--- a/nab-python/tests/test_archive.py
+++ b/nab-python/tests/test_archive.py
@@ -51,7 +51,8 @@ from nab_python.provider import (
 from nab_python.target import ResolveTarget
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Callable, Mapping
+    from contextlib import AbstractContextManager
     from pathlib import Path
 
     from nab_python.lockfile import PinShape
@@ -1032,6 +1033,28 @@ class TestArchiveBuildPolicyLevels:
         metadata = self._extract(policy, tmp_path)
         assert metadata.name == "pkg"
         assert [str(r) for r in metadata.requires_dist] == ["requests>=2"]
+
+    @pytest.mark.parametrize("policy", [BuildPolicy.NEVER, BuildPolicy.BUILD_LOCAL])
+    def test_unreadable_pyproject_reports_the_errno(
+        self,
+        policy: BuildPolicy,
+        tmp_path: Path,
+        deny_access: Callable[[Path], AbstractContextManager[None]],
+    ) -> None:
+        """An unreadable pyproject is reported as a read failure.
+
+        Under a policy that bars the build, the fall-through would call the
+        source dynamic, which is a claim about a file nothing has read.
+        """
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "pkg"\nversion = "1.0.0"\n', encoding="utf-8"
+        )
+        with (
+            deny_access(tmp_path / "pyproject.toml"),
+            pytest.raises(UnsupportedSdistError, match="Permission denied") as caught,
+        ):
+            self._extract(policy, tmp_path)
+        assert "dynamic metadata" not in str(caught.value)
 
     @pytest.mark.parametrize("policy", [BuildPolicy.NEVER, BuildPolicy.BUILD_LOCAL])
     def test_dynamic_archive_raises_below_build_remote(

--- a/nab-python/tests/test_build_backend.py
+++ b/nab-python/tests/test_build_backend.py
@@ -9,6 +9,8 @@ dynamic dispatch in ``extract_metadata``, including the
 from __future__ import annotations
 
 import sys
+from collections.abc import Callable
+from contextlib import AbstractContextManager
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -81,6 +83,17 @@ class TestExtractStaticMetadata:
 
     def test_missing_pyproject_returns_none(self, tmp_path: Path) -> None:
         assert extract_static_metadata(tmp_path) is None
+
+    def test_unsearchable_parent_returns_none(
+        self,
+        tmp_path: Path,
+        deny_access: Callable[[Path], AbstractContextManager[None]],
+    ) -> None:
+        # EACCES on the presence check's stat means no static metadata,
+        # the same as an unreadable file, so the caller falls back to a build.
+        _write_pyproject(tmp_path, '[project]\nname = "foo"\nversion = "1.0"\n')
+        with deny_access(tmp_path / "pyproject.toml"):
+            assert extract_static_metadata(tmp_path) is None
 
     def test_malformed_toml_returns_none(self, tmp_path: Path) -> None:
         _write_pyproject(tmp_path, "this is not toml [")

--- a/nab-python/tests/test_build_backend.py
+++ b/nab-python/tests/test_build_backend.py
@@ -8,6 +8,7 @@ dynamic dispatch in ``extract_metadata``, including the
 
 from __future__ import annotations
 
+import errno
 import sys
 from collections.abc import Callable
 from contextlib import AbstractContextManager
@@ -84,16 +85,19 @@ class TestExtractStaticMetadata:
     def test_missing_pyproject_returns_none(self, tmp_path: Path) -> None:
         assert extract_static_metadata(tmp_path) is None
 
-    def test_unsearchable_parent_returns_none(
+    def test_unsearchable_parent_reports_the_errno(
         self,
         tmp_path: Path,
         deny_access: Callable[[Path], AbstractContextManager[None]],
     ) -> None:
-        # EACCES on the presence check's stat means no static metadata,
-        # the same as an unreadable file, so the caller falls back to a build.
+        # EACCES leaves the contents unknown, so it is neither "no static
+        # metadata" nor a missing file: the errno is reported.
         _write_pyproject(tmp_path, '[project]\nname = "foo"\nversion = "1.0"\n')
-        with deny_access(tmp_path / "pyproject.toml"):
-            assert extract_static_metadata(tmp_path) is None
+        with (
+            deny_access(tmp_path / "pyproject.toml"),
+            pytest.raises(BuildBackendError, match="could not read.*Permission denied"),
+        ):
+            extract_static_metadata(tmp_path)
 
     def test_malformed_toml_returns_none(self, tmp_path: Path) -> None:
         _write_pyproject(tmp_path, "this is not toml [")
@@ -365,20 +369,35 @@ class TestExtractStaticMetadata:
         ):
             extract_static_metadata(tmp_path)
 
-    def test_pyproject_unreadable_returns_none(self, tmp_path: Path) -> None:
-        # A directory in place of pyproject.toml: ``is_file`` is False so
+    def test_pyproject_is_a_directory_returns_none(self, tmp_path: Path) -> None:
+        # A directory in place of pyproject.toml is not a readable file, so
         # the static reader bails before the read.
         (tmp_path / "pyproject.toml").mkdir()
         assert extract_static_metadata(tmp_path) is None
 
-    def test_pyproject_read_oserror_returns_none(self, tmp_path: Path) -> None:
-        # An OSError raised between ``is_file`` and ``read_text`` (the
-        # races a regular file becoming unreadable mid-call) falls
-        # through to the same "treat as missing" branch.
+    def test_pyproject_vanishing_before_the_read_returns_none(
+        self, tmp_path: Path
+    ) -> None:
+        # The presence check is racy: a file deleted between the stat and
+        # the read is missing.
         _write_pyproject(tmp_path, '[project]\nname = "foo"\nversion = "1.0"\n')
+        gone = FileNotFoundError(errno.ENOENT, "No such file or directory")
         extract_static_metadata.cache_clear()
-        with patch.object(Path, "read_text", side_effect=PermissionError("locked")):
+        with patch.object(Path, "read_text", side_effect=gone):
             assert extract_static_metadata(tmp_path) is None
+        extract_static_metadata.cache_clear()
+
+    def test_pyproject_read_oserror_reports_the_errno(self, tmp_path: Path) -> None:
+        # Any other read failure leaves the contents unknown, so it is
+        # reported rather than reduced to "no static metadata".
+        _write_pyproject(tmp_path, '[project]\nname = "foo"\nversion = "1.0"\n')
+        broken = OSError(errno.EIO, "Input/output error")
+        extract_static_metadata.cache_clear()
+        with (
+            patch.object(Path, "read_text", side_effect=broken),
+            pytest.raises(BuildBackendError, match="could not read.*Input/output"),
+        ):
+            extract_static_metadata(tmp_path)
         extract_static_metadata.cache_clear()
 
     def test_extra_marker_combined_with_existing(self, tmp_path: Path) -> None:

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -22,6 +22,8 @@ import subprocess
 import sys
 import tarfile
 import zipfile
+from collections.abc import Callable
+from contextlib import AbstractContextManager
 from importlib.util import cache_from_source
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -250,6 +252,40 @@ class TestRunBuildBackend:
         self, tmp_path: Path, config: NabProjectConfig
     ) -> None:
         with pytest.raises(BuildBackendError, match="no pyproject.toml or setup.py"):
+            run_build_backend(tmp_path, config=config)
+
+    def test_unsearchable_pyproject_reports_the_errno(
+        self,
+        tmp_path: Path,
+        config: NabProjectConfig,
+        deny_access: Callable[[Path], AbstractContextManager[None]],
+    ) -> None:
+        # The presence check must not read EACCES as absence: the file is
+        # there, so the tree is not the no-pyproject.toml-or-setup.py case.
+        (tmp_path / "pyproject.toml").write_text("[build-system]\n", encoding="utf-8")
+        with (
+            deny_access(tmp_path / "pyproject.toml"),
+            pytest.raises(BuildBackendError, match="could not read.*Permission denied"),
+        ):
+            run_build_backend(tmp_path, config=config)
+
+    def test_unsearchable_setup_py_takes_the_legacy_branch(
+        self,
+        tmp_path: Path,
+        config: NabProjectConfig,
+        deny_access: Callable[[Path], AbstractContextManager[None]],
+    ) -> None:
+        # Same for the setup.py fallback: an unreadable one is a legacy
+        # project whose build fails, not a tree with no build inputs.
+        (tmp_path / "setup.py").write_text("from setuptools import setup\n")
+        with (
+            deny_access(tmp_path / "setup.py"),
+            patch(
+                "nab_python._build.runner.NabBuildEnv",
+                side_effect=BuildEnvError("no venv"),
+            ),
+            pytest.raises(BuildBackendError, match="build env setup"),
+        ):
             run_build_backend(tmp_path, config=config)
 
     def test_legacy_setup_py_uses_default_backend(

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -633,10 +633,10 @@ class TestDiscoverAndMissing:
         tmp_path: Path,
         deny_access: Callable[[Path], AbstractContextManager[None]],
     ) -> None:
-        # An unsearchable parent directory lands EACCES on the stat the
-        # presence check runs, before the read.  The source is present, so
-        # it must reach the read and be reported by name, neither skipped
-        # as absent nor escaping as a raw PermissionError.
+        # An unsearchable parent directory lands EACCES on the presence
+        # check's stat.  The source is present, so it must reach the read
+        # and be named there, neither skipped as absent nor escaping as a
+        # raw PermissionError.
         pyproject = _project(tmp_path)
         with (
             deny_access(pyproject),

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import errno
 import logging
+from collections.abc import Callable
+from contextlib import AbstractContextManager
 from pathlib import Path
 from unittest.mock import patch
 
@@ -624,6 +626,22 @@ class TestDiscoverAndMissing:
         _project(tmp_path)
         (tmp_path / "nab.toml").mkdir()
         with pytest.raises(SourceConfigError, match="not a regular file"):
+            discover_layers(SourceRoots(project_dir=tmp_path))
+
+    def test_unsearchable_parent_reports_the_errno(
+        self,
+        tmp_path: Path,
+        deny_access: Callable[[Path], AbstractContextManager[None]],
+    ) -> None:
+        # An unsearchable parent directory lands EACCES on the stat the
+        # presence check runs, before the read.  The source is present, so
+        # it must reach the read and be reported by name, neither skipped
+        # as absent nor escaping as a raw PermissionError.
+        pyproject = _project(tmp_path)
+        with (
+            deny_access(pyproject),
+            pytest.raises(SourceConfigError, match="cannot read .*Permission denied"),
+        ):
             discover_layers(SourceRoots(project_dir=tmp_path))
 
     def test_read_pyproject_false_keeps_project_nab_toml(self, tmp_path: Path) -> None:

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -1664,7 +1664,7 @@ class TestReadLockfileAnchor:
         assert read_lockfile_anchor(tmp_path / "missing.toml") is None
 
     def test_returns_none_when_file_is_directory(self, tmp_path: Path) -> None:
-        # ``is_file`` returns False for directories; the helper skips.
+        # A directory is not a readable file; the helper skips.
         assert read_lockfile_anchor(tmp_path) is None
 
     def test_returns_none_when_unsearchable_parent(

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -1667,6 +1667,18 @@ class TestReadLockfileAnchor:
         # ``is_file`` returns False for directories; the helper skips.
         assert read_lockfile_anchor(tmp_path) is None
 
+    def test_returns_none_when_unsearchable_parent(
+        self,
+        tmp_path: Path,
+        deny_access: Callable[[Path], AbstractContextManager[None]],
+    ) -> None:
+        # EACCES on the presence check's stat leaves the anchor unknown,
+        # which is a no-op for the caller, not a crash.
+        path = tmp_path / "pylock.toml"
+        path.write_text("[tool.nab]\ncreated-at = 2026-05-01T00:00:00+00:00\n")
+        with deny_access(path):
+            assert read_lockfile_anchor(path) is None
+
     def test_returns_none_when_toml_invalid(self, tmp_path: Path) -> None:
         path = tmp_path / "broken.toml"
         path.write_text("this is not [[[ valid TOML")
@@ -1752,6 +1764,18 @@ class TestReadLockfilePackages:
 
     def test_returns_none_when_file_is_directory(self, tmp_path: Path) -> None:
         assert read_lockfile_packages(tmp_path) is None
+
+    def test_returns_none_when_unsearchable_parent(
+        self,
+        tmp_path: Path,
+        deny_access: Callable[[Path], AbstractContextManager[None]],
+    ) -> None:
+        # EACCES on the presence check's stat leaves the prior pins
+        # unknown, so the caller falls back to a no-diff summary.
+        path = tmp_path / "pylock.toml"
+        path.write_text('lock-version = "1.0"\n')
+        with deny_access(path):
+            assert read_lockfile_packages(path) is None
 
     def test_returns_none_when_toml_invalid(self, tmp_path: Path) -> None:
         path = tmp_path / "pylock.toml"

--- a/nab-python/tests/test_paths.py
+++ b/nab-python/tests/test_paths.py
@@ -1,9 +1,4 @@
-"""Tests for the presence classifier (:mod:`nab_python.paths`).
-
-The classifier exists to keep an absent path apart from one whose stat
-fails for another reason, so the unreadable case is pinned here rather
-than left to whichever ``Path`` method a caller reached for.
-"""
+"""Tests for the presence classifier (:mod:`nab_python.paths`)."""
 
 from __future__ import annotations
 
@@ -25,12 +20,16 @@ class TestPathState:
         path = tmp_path / "pyproject.toml"
         path.write_text("")
         assert path_state(path) is PathState.FILE
+        assert path_state(path).should_read
 
     def test_directory(self, tmp_path: Path) -> None:
         assert path_state(tmp_path) is PathState.DIRECTORY
+        assert not path_state(tmp_path).should_read
 
     def test_missing(self, tmp_path: Path) -> None:
-        assert path_state(tmp_path / "missing.toml") is PathState.ABSENT
+        path = tmp_path / "missing.toml"
+        assert path_state(path) is PathState.ABSENT
+        assert not path_state(path).should_read
 
     def test_component_is_not_a_directory(self, tmp_path: Path) -> None:
         # ENOTDIR: a file part-way along the path leaves nothing at the end.
@@ -38,23 +37,22 @@ class TestPathState:
         blocker.write_text("")
         assert path_state(blocker / "pyproject.toml") is PathState.ABSENT
 
+    def test_name_the_os_cannot_carry(self, tmp_path: Path) -> None:
+        # An embedded NUL fails the stat with ValueError, not an errno.
+        assert path_state(tmp_path / "pyproject\x00.toml") is PathState.ABSENT
+
     def test_neither_file_nor_directory(self, tmp_path: Path) -> None:
         with patch.object(Path, "stat", return_value=_fake_stat(stat.S_IFIFO | 0o644)):
-            assert path_state(tmp_path / "fifo") is PathState.OTHER
+            state = path_state(tmp_path / "fifo")
+        assert state is PathState.OTHER
+        assert not state.should_read
 
     def test_stat_denied(self, tmp_path: Path) -> None:
-        # An unsearchable parent directory lands EACCES on the stat itself.
+        # An unsearchable parent directory lands EACCES on the stat itself,
+        # and the read decides what that means, so the path is still read.
         path = tmp_path / "pyproject.toml"
         denied = PermissionError(errno.EACCES, "Permission denied", str(path))
         with patch.object(Path, "stat", side_effect=denied):
-            assert path_state(path) is PathState.UNREADABLE
-
-
-class TestShouldRead:
-    def test_only_a_file_or_an_unreadable_path_is_read(self) -> None:
-        # An unreadable path is read so the open reports the errno; the
-        # other three have nothing worth opening.
-        assert [state for state in PathState if state.should_read] == [
-            PathState.FILE,
-            PathState.UNREADABLE,
-        ]
+            state = path_state(path)
+        assert state is PathState.UNREADABLE
+        assert state.should_read

--- a/nab-python/tests/test_paths.py
+++ b/nab-python/tests/test_paths.py
@@ -1,0 +1,60 @@
+"""Tests for the presence classifier (:mod:`nab_python.paths`).
+
+The classifier exists to keep an absent path apart from one whose stat
+fails for another reason, so the unreadable case is pinned here rather
+than left to whichever ``Path`` method a caller reached for.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import stat
+from pathlib import Path
+from unittest.mock import patch
+
+from nab_python.paths import PathState, path_state
+
+
+def _fake_stat(mode: int) -> os.stat_result:
+    return os.stat_result((mode, *([0] * 9)))
+
+
+class TestPathState:
+    def test_regular_file(self, tmp_path: Path) -> None:
+        path = tmp_path / "pyproject.toml"
+        path.write_text("")
+        assert path_state(path) is PathState.FILE
+
+    def test_directory(self, tmp_path: Path) -> None:
+        assert path_state(tmp_path) is PathState.DIRECTORY
+
+    def test_missing(self, tmp_path: Path) -> None:
+        assert path_state(tmp_path / "missing.toml") is PathState.ABSENT
+
+    def test_component_is_not_a_directory(self, tmp_path: Path) -> None:
+        # ENOTDIR: a file part-way along the path leaves nothing at the end.
+        blocker = tmp_path / "file"
+        blocker.write_text("")
+        assert path_state(blocker / "pyproject.toml") is PathState.ABSENT
+
+    def test_neither_file_nor_directory(self, tmp_path: Path) -> None:
+        with patch.object(Path, "stat", return_value=_fake_stat(stat.S_IFIFO | 0o644)):
+            assert path_state(tmp_path / "fifo") is PathState.OTHER
+
+    def test_stat_denied(self, tmp_path: Path) -> None:
+        # An unsearchable parent directory lands EACCES on the stat itself.
+        path = tmp_path / "pyproject.toml"
+        denied = PermissionError(errno.EACCES, "Permission denied", str(path))
+        with patch.object(Path, "stat", side_effect=denied):
+            assert path_state(path) is PathState.UNREADABLE
+
+
+class TestShouldRead:
+    def test_only_a_file_or_an_unreadable_path_is_read(self) -> None:
+        # An unreadable path is read so the open reports the errno; the
+        # other three have nothing worth opening.
+        assert [state for state in PathState if state.should_read] == [
+            PathState.FILE,
+            PathState.UNREADABLE,
+        ]

--- a/nab-python/tests/test_workspace.py
+++ b/nab-python/tests/test_workspace.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import errno
 import logging
 import re
+from collections.abc import Callable
 from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import Any
@@ -396,6 +397,32 @@ class TestReadWorkspaceMembers:
         )
         with (
             _deny_open(member),
+            pytest.raises(
+                WorkspaceDiscoveryError,
+                match=rf"cannot read {re.escape(str(member))}.*Permission denied",
+            ),
+        ):
+            read_workspace_members(root)
+
+    def test_member_in_unsearchable_directory_raises(
+        self,
+        tmp_path: Path,
+        deny_access: Callable[[Path], AbstractContextManager[None]],
+    ) -> None:
+        # EACCES on the presence check's stat must not escape raw, and the
+        # member is there, so it is not the has-no-pyproject.toml error.
+        root = _write(
+            tmp_path / "pyproject.toml",
+            '[project]\nname = "ws"\nversion = "0"\n'
+            "[tool.nab.workspace]\n"
+            'members = ["pkg"]\n',
+        )
+        member = _write(
+            tmp_path / "pkg" / "pyproject.toml",
+            '[project]\nname = "pkg"\nversion = "0"\n',
+        )
+        with (
+            deny_access(member),
             pytest.raises(
                 WorkspaceDiscoveryError,
                 match=rf"cannot read {re.escape(str(member))}.*Permission denied",

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -51,6 +51,7 @@ from nab_python.lockfile import (
     read_lockfile_packages,
     summarize_lock,
 )
+from nab_python.paths import PathState, path_state
 from nab_python.requirements_file import (
     InvalidProjectRequirementError,
     InvalidProjectTableError,
@@ -828,7 +829,7 @@ def _read_selection_table_or_exit(
     except OSError as e:
         if e.errno == errno.ENOENT:
             _cli.printer().error(f"{path} not found")
-        elif path.is_dir():
+        elif path_state(path) is PathState.DIRECTORY:
             _cli.printer().error(f"{path} is a directory")
         else:
             _cli.printer().error(f"cannot read {path}: {e}")

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -66,6 +66,7 @@ from nab_python.lockfile import (
     write_requirements_with_hashes,  # noqa: F401 - re-exported for tests
     write_requirements_without_hashes,  # noqa: F401 - re-exported for tests
 )
+from nab_python.paths import PathState, path_state
 from nab_python.provider import (
     InvalidUploadTimeError,
     MetadataError,
@@ -445,10 +446,15 @@ def _require_pyproject_file(path: Path) -> None:
     Shared by ``_load_config`` (the run path) and ``nab config`` so the
     not-found/directory wording lives in one place.  A missing or
     directory ``--path`` is a hard error, not a silently-skipped source.
+    A path that is there but cannot be stat'd passes: the config read
+    reports it, naming the errno.
     """
-    if not path.is_file():
-        reason = "is a directory" if path.is_dir() else "not found"
-        printer().error(f"{path} {reason}")
+    state = path_state(path)
+    if state is PathState.DIRECTORY:
+        printer().error(f"{path} is a directory")
+        sys.exit(1)
+    if not state.should_read:
+        printer().error(f"{path} not found")
         sys.exit(1)
     if _is_pylock(path):
         printer().error(

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -446,16 +446,19 @@ def _require_pyproject_file(path: Path) -> None:
     Shared by ``_load_config`` (the run path) and ``nab config`` so the
     not-found/directory wording lives in one place.  A missing or
     directory ``--path`` is a hard error, not a silently-skipped source.
-    A path that is there but cannot be stat'd passes: the config read
-    reports it, naming the errno.
+    A path whose stat fails passes: the config read reports it, naming
+    the errno.
     """
     state = path_state(path)
+
     if state is PathState.DIRECTORY:
         printer().error(f"{path} is a directory")
         sys.exit(1)
+
     if not state.should_read:
         printer().error(f"{path} not found")
         sys.exit(1)
+
     if _is_pylock(path):
         printer().error(
             f"{path} is a PEP 751 lockfile, not a pyproject.  nab resolves"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3727,7 +3727,7 @@ class TestGroupAndExtraSelection:
         """An unsearchable parent must not fail the is-a-directory check.
 
         EACCES lands on the stat behind that check as well as on the read,
-        so classifying the path has to be raise-free or the handler throws
+        so classifying the path has to be raise-free or the handler raises
         a second error out of itself.
         """
         pyproject = _make_pyproject(tmp_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3718,6 +3718,25 @@ class TestGroupAndExtraSelection:
         assert "not found" not in err
         assert "Permission denied" in err
 
+    def test_all_extras_unsearchable_parent_surfaces_error(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        deny_access: Callable[[Path], AbstractContextManager[None]],
+    ) -> None:
+        """An unsearchable parent must not fail the is-a-directory check.
+
+        EACCES lands on the stat behind that check as well as on the read,
+        so classifying the path has to be raise-free or the handler throws
+        a second error out of itself.
+        """
+        pyproject = _make_pyproject(tmp_path)
+        with deny_access(pyproject), pytest.raises(SystemExit, match="1"):
+            resolve_extra_selection(pyproject, extras=(), all_extras=True)
+        err = capsys.readouterr().err
+        assert "cannot read" in err
+        assert "Permission denied" in err
+
     def test_all_groups_reads_defined_groups(self, tmp_path: Path) -> None:
         """Selection equals the keys of ``[dependency-groups]``.
 

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -398,8 +398,8 @@ class TestConfigErrors:
         deny_access: Callable[[Path], AbstractContextManager[None]],
     ) -> None:
         # An unsearchable parent lands EACCES on the presence check's stat.
-        # The file is there, so the guard must neither raise nor call it
-        # missing: the read reports it, naming the errno.
+        # The file is there, so the guard must not call it missing: the
+        # read reports it, naming the errno.
         path = _project(hermetic_roots)
         with deny_access(path), pytest.raises(SystemExit):
             config_command("list", path=path)

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -15,8 +15,13 @@ from __future__ import annotations
 import inspect
 import io
 import logging
-from collections.abc import Mapping
-from contextlib import redirect_stderr, redirect_stdout, suppress
+from collections.abc import Callable, Mapping
+from contextlib import (
+    AbstractContextManager,
+    redirect_stderr,
+    redirect_stdout,
+    suppress,
+)
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -385,6 +390,23 @@ class TestConfigErrors:
             config_command("list", path=hermetic_roots)
         err = capsys.readouterr().err
         assert "is a directory" in err
+
+    def test_unsearchable_parent_reports_the_errno(
+        self,
+        hermetic_roots: Path,
+        capsys: pytest.CaptureFixture[str],
+        deny_access: Callable[[Path], AbstractContextManager[None]],
+    ) -> None:
+        # An unsearchable parent lands EACCES on the presence check's stat.
+        # The file is there, so the guard must neither raise nor call it
+        # missing: the read reports it, naming the errno.
+        path = _project(hermetic_roots)
+        with deny_access(path), pytest.raises(SystemExit):
+            config_command("list", path=path)
+        err = capsys.readouterr().err
+        assert "not found" not in err
+        assert "cannot read" in err
+        assert "Permission denied" in err
 
     def test_gate_error_exits(
         self, hermetic_roots: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
When a `pyproject.toml` sits in a directory without search permission, the `stat()` behind a presence check fails, not just the `open()` behind the read. `Path.exists()`, `is_file()` and `is_dir()` answer with a bool, so a failed stat and a missing file collapse into one answer. On 3.10 to 3.13 they re-raise the `PermissionError`, so `nab lock` and `nab config list` end in a raw traceback; on 3.14 they return False and nab treats a file that is there as missing. The code that reads it for `nab download`'s group and extra selection flags hits this from inside its own `except OSError` arm, where the `is_dir()` check raises a second error out of the handler.

The presence guards now go through a new `nab_python.paths`, which classifies a path as absent, file, directory, other, or unreadable without raising, so a failed stat stays separate from an absent path. An unreadable path is passed on to the read, which reports the errno, and `extract_static_metadata` raises instead of returning `None`, so a permission error is not read as a project with no static metadata.
