### PR TITLE
vcs.allowed-repos admits a `..` masked by the trailing `@<ref>`

### DIFF
--- a/nab-python/src/nab_python/_vcs_admission.py
+++ b/nab-python/src/nab_python/_vcs_admission.py
@@ -127,15 +127,34 @@ def _without_userinfo(url: str) -> str:
     return urlunsplit(parts._replace(netloc=host))
 
 
+def _drop_ref(remainder: str) -> str:
+    """Return ``remainder`` without a trailing ``@<ref>``, split on the last ``@``."""
+    return remainder.rpartition("@")[0] if "@" in remainder else remainder
+
+
 def _repo_path(inner_url: str) -> str:
     """Return the path of ``inner_url`` with any trailing ``@<ref>`` dropped.
 
-    The ref is whatever follows the last ``@`` of the path component, the
-    same split :class:`nab_index.vcs.VcsRequest` makes at clone time.  An
-    empty result means the URL names no repo.
+    An empty result means the URL names no repo.
     """
-    path = urlsplit(inner_url).path
-    return path.rpartition("@")[0] if "@" in path else path
+    return _drop_ref(urlsplit(inner_url).path)
+
+
+def _rewritten_by_git(path: str) -> bool:
+    r"""Return True if git would rewrite ``path`` before it fetches.
+
+    Git applies RFC 3986 dot-segment removal at fetch time.  ``path`` is
+    decoded once so an encoded ``%2e%2e`` cannot slip past, and ``\`` is
+    folded to ``/`` because Windows resolves it as a separator.  A trailing
+    ``/`` is put back: RFC 3986 keeps it and :func:`posixpath.normpath`
+    does not.
+    """
+    decoded = unquote(path).replace("\\", "/")
+    normalised = posixpath.normpath(decoded)
+    if decoded.endswith("/") and not normalised.endswith("/"):
+        normalised += "/"
+
+    return bool(decoded) and normalised != decoded
 
 
 _REPO_BOUNDARY_CHARS: frozenset[str] = frozenset({"/", "@", "#"})
@@ -155,20 +174,21 @@ def _repo_prefix_matches(inner_url: str, prefix: str) -> bool:
     Both URLs have their authority ``user[:pass]@`` / ``git@`` stripped
     by the caller.
 
-    A path git would rewrite is refused first: git applies RFC 3986
-    dot-segment removal at fetch time, so a raw ``..`` path could pass the
-    string match while git fetches a repo outside the prefix.  That check
-    reads the whole post-authority remainder, query included since
-    :meth:`nab_index.vcs.VcsRequest.parse` keeps it, decoded once so an
-    encoded ``%2e%2e`` cannot slip past, and with ``\`` folded to ``/``
-    because Windows resolves it as a separator.  The prefix comparison
-    below is on the raw URL.
+    A path git would rewrite is refused first, since a ``..`` could pass
+    the string match while git fetches a repo outside the prefix.  The ref
+    is dropped before that check, off the whole post-authority remainder
+    rather than the path alone, matching the split :mod:`nab_index.vcs`
+    makes at clone time; otherwise a ``..`` in the final segment hides as
+    the ordinary name ``..@<ref>``.  The prefix comparison below is on the
+    raw URL.
     """
     parts = urlsplit(inner_url)
     remainder = f"{parts.path}?{parts.query}" if parts.query else parts.path
-    path = unquote(remainder).replace("\\", "/")
+    repo = _drop_ref(remainder)
 
-    if path and posixpath.normpath(path) != path:
+    # An http URL ends its path at the "?"; a file URL keeps it as a path
+    # character, and either way the query reaches git.
+    if any(_rewritten_by_git(part) for part in (repo, repo.partition("?")[0])):
         return False
 
     prefix = prefix.removesuffix(".git")

--- a/nab-python/tests/property_python/test_vcs_admission.py
+++ b/nab-python/tests/property_python/test_vcs_admission.py
@@ -163,6 +163,20 @@ def _drop_login(url: str) -> str:
     return urlunsplit(parts._replace(netloc=parts.netloc.rsplit("@", 1)[1]))
 
 
+def _git_would_rewrite(path: str) -> bool:
+    r"""Dot-segment removal, transcribed from the documented policy.
+
+    Read off ``path`` decoded once and with ``\`` folded to ``/``.  A
+    trailing ``/`` survives RFC 3986, so it is put back after
+    :func:`posixpath.normpath` drops it.
+    """
+    decoded = unquote(path).replace("\\", "/")
+    normalised = posixpath.normpath(decoded)
+    if decoded.endswith("/") and not normalised.endswith("/"):
+        normalised += "/"
+    return bool(decoded) and normalised != decoded
+
+
 def _prefix_under_repo(inner: str, prefix: str) -> bool:
     r"""Boundary-aware repo-prefix check, transcribed from the documented policy.
 
@@ -172,14 +186,15 @@ def _prefix_under_repo(inner: str, prefix: str) -> bool:
     Git's optional ``.git`` suffix is stripped from the prefix and skipped
     once on the candidate so an exact-repo prefix and the ``.git`` clone URL
     match either way round.  A candidate whose path git would rewrite is
-    refused first: the whole post-authority remainder, decoded once and with
-    ``\`` folded to ``/``, must equal its dot-segment-normalised form.
+    refused first: the post-authority remainder, minus the trailing ``@<ref>``
+    the clone splits off, must equal its dot-segment-normalised form both
+    whole and cut at the first ``?``.
     """
     parts = urlsplit(inner)
     remainder = f"{parts.path}?{parts.query}" if parts.query else parts.path
-    path = unquote(remainder).replace("\\", "/")
+    repo = remainder.rpartition("@")[0] if "@" in remainder else remainder
 
-    if path and posixpath.normpath(path) != path:
+    if any(_git_would_rewrite(part) for part in (repo, repo.partition("?")[0])):
         return False
 
     prefix = prefix.removesuffix(".git")

--- a/nab-python/tests/test_vcs_admission.py
+++ b/nab-python/tests/test_vcs_admission.py
@@ -454,6 +454,84 @@ class TestAdmitVcsUrlRepo:
                 config,
             )
 
+    @pytest.mark.parametrize(
+        ("prefix", "url"),
+        [
+            (
+                "file:///srv/work/lib.git",
+                f"git+file:///srv/work/lib.git/..@{_FORTY}",
+            ),
+            (
+                "https://github.com/myorg/",
+                f"git+https://github.com/myorg/lib.git/..@{_FORTY}",
+            ),
+            (
+                "https://github.com/myorg/lib.git",
+                f"git+https://github.com/myorg/lib.git/%2e%2e@{_FORTY}",
+            ),
+            (
+                "ssh://host/srv/trusted/repo",
+                f"git+ssh://host/srv/trusted/repo/..@{_FORTY}",
+            ),
+        ],
+    )
+    def test_dot_segment_in_final_segment_refused(self, prefix: str, url: str) -> None:
+        """The clone splits the ref off, so ``lib.git/..@<ref>`` fetches the parent."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+file", "git+https", "git+ssh"}),
+            allowed_repos=(prefix,),
+        )
+        with pytest.raises(UnsupportedVcsError, match="not in vcs.allowed-repos"):
+            admit_vcs_url(url, config)
+
+    def test_query_after_final_dot_segment_refused(self) -> None:
+        """A ``?`` following the ``..`` ends the path an http fetch sends."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com/myorg/lib.git",),
+        )
+        with pytest.raises(UnsupportedVcsError, match="not in vcs.allowed-repos"):
+            admit_vcs_url(
+                f"git+https://github.com/myorg/lib.git/..?x=1@{_FORTY}",
+                config,
+            )
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            f"git+https://github.com/myorg/lib@x/..?y@{_FORTY}",
+            f"git+https://github.com/myorg/lib.git@x/..?y@{_FORTY}",
+        ],
+    )
+    def test_at_in_query_does_not_hide_the_escape(self, url: str) -> None:
+        """The ref splits off the whole remainder, not the path alone.
+
+        Cutting the path at its own last ``@`` lands inside ``lib@x``, taking
+        the ``..`` with it.
+        """
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com/myorg/lib",),
+        )
+        with pytest.raises(UnsupportedVcsError, match="not in vcs.allowed-repos"):
+            admit_vcs_url(url, config)
+
+    def test_trailing_slash_repo_still_admits(self) -> None:
+        """A trailing ``/`` is not a rewrite: git clones the same repo."""
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com/myorg/lib.git",),
+        )
+        scheme = admit_vcs_url(
+            f"git+https://github.com/myorg/lib.git/@{_FORTY}",
+            config,
+        )
+        assert scheme == "git+https"
+
     def test_percent_encoded_repo_name_still_admits(self) -> None:
         """Encoding that decodes to no dot-segment leaves the repo admitted."""
         config = VcsConfig(
@@ -688,6 +766,38 @@ class TestPinAppendMonotonicity:
         if not self._admits(url, self._config(require_pin=False)):
             return
         assert self._admits(f"{url}@{_FORTY}", self._config(require_pin=True))
+
+
+class TestRefAppendMonotonicity:
+    """Appending a ref must never turn a refuse into an admit."""
+
+    URLS = (
+        "git+https://github.com/trusted/repo/..",
+        "git+https://github.com/trusted/repo/../..",
+        "git+https://github.com/trusted/repo/%2e%2e",
+        "git+https://github.com/trusted/repo/..?x=1",
+        "git+https://github.com/trusted/repo/../../other/repo",
+        "git+https://github.com/other/repo",
+    )
+
+    def _admits(self, url: str) -> bool:
+        config = VcsConfig(
+            policy=VcsPolicy.ALLOW,
+            allowed_schemes=frozenset({"git+https"}),
+            allowed_repos=("https://github.com/trusted/repo",),
+            require_pin=False,
+        )
+        try:
+            admit_vcs_url(url, config)
+        except UnsupportedVcsError:
+            return False
+        return True
+
+    @pytest.mark.parametrize("url", URLS)
+    def test_ref_append_never_turns_refuse_into_admit(self, url: str) -> None:
+        assert not self._admits(url)
+        assert not self._admits(f"{url}@{_FORTY}")
+        assert not self._admits(f"{url}@main")
 
 
 class TestAdmitVcsUrlUserinfoPosition:


### PR DESCRIPTION
`vcs.allowed-repos` could admit a URL that clones a repo one level above the allowed one. The dot-segment guard read the path with the trailing `@<ref>` still attached, so a `..` in the final segment looked like an ordinary repo named `..@<sha>` instead of something git would rewrite. The clone splits the ref off, leaving git a bare `..`:

```
allowed-repos = ["https://github.com/myorg/lib.git"]
git+https://github.com/myorg/lib.git/..@<sha>    # git fetches github.com/myorg
```

The guard now drops the ref the way the clone does, off the whole post-authority remainder rather than the path alone, so an `@` in the query cannot shift the split point. The remainder is checked both whole and cut at the first `?`, since the http and file transports disagree about where a `?` ends the path. Dropping the ref exposes a trailing `/` to the check, so it is put back after `normpath` strips it: git clones `lib.git/` as the same repo as `lib.git`.
