### PR TITLE
count the response Age header toward Simple listing freshness

### DIFF
--- a/nab-index/src/nab_index/cache.py
+++ b/nab-index/src/nab_index/cache.py
@@ -92,7 +92,11 @@ class OfflineError(Exception):
 
 @dataclass(frozen=True, slots=True)
 class CachePolicy:
-    """RFC 9111-style freshness policy for one Simple API entry."""
+    """RFC 9111-style freshness policy for one Simple API entry.
+
+    ``fetched_at`` is the start of the freshness window: when nab received the
+    response, less any Age a relaying shared cache reported.
+    """
 
     fetched_at: int
     max_age: int

--- a/nab-index/src/nab_index/cached_client.py
+++ b/nab-index/src/nab_index/cached_client.py
@@ -56,6 +56,23 @@ logger = logging.getLogger(__name__)
 _DEFAULT_MAX_AGE = 600
 _HTTP_NOT_MODIFIED = 304
 _MAX_AGE_RE = re.compile(r"max-age\s*=\s*(\d+)")
+_AGE_RE = re.compile(r"\A\s*(\d+)\s*\Z")
+_SECONDS_CEILING = 2**31
+_SECONDS_CEILING_DIGITS = len(str(_SECONDS_CEILING))
+
+
+def _parse_seconds(digits: str) -> int:
+    """Return a ``delta-seconds`` digit run as an int.
+
+    RFC 9110 5.6.7 allows leading zeros, sets no length limit on the run, and
+    caps a value too large to represent at 2**31. ``int`` refuses a string past
+    4300 digits, so the padding is stripped before the run is measured.
+    """
+    trimmed = digits.lstrip("0")
+
+    if len(trimmed) > _SECONDS_CEILING_DIGITS:
+        return _SECONDS_CEILING
+    return min(int(trimmed or "0"), _SECONDS_CEILING)
 
 
 def _parse_max_age(cache_control: str | None) -> int:
@@ -64,7 +81,31 @@ def _parse_max_age(cache_control: str | None) -> int:
     match = _MAX_AGE_RE.search(cache_control)
     if match is None:
         return _DEFAULT_MAX_AGE
-    return int(match.group(1))
+    return _parse_seconds(match.group(1))
+
+
+def _parse_age(age: str | None) -> int:
+    """Return the seconds a response spent in caches before nab received it.
+
+    An absent header, or one that is not a bare run of digits, reads as 0.
+    """
+    if age is None:
+        return 0
+    match = _AGE_RE.match(age)
+    if match is None:
+        return 0
+    return _parse_seconds(match.group(1))
+
+
+def _freshness_start(response: HttpResponse) -> int:
+    """Return when ``response`` opened its freshness window.
+
+    A shared cache reports as Age how long ago the origin generated the
+    representation, so a relayed response arrives that far into its window.
+    Only the Age term of RFC 9111 4.2.3 is applied; the apparent age computed
+    from the Date header is not.
+    """
+    return int(time.time()) - _parse_age(_header(response, "age"))
 
 
 class CachedAsyncSimpleClient:
@@ -163,7 +204,9 @@ class CachedAsyncSimpleClient:
         max_age = min(
             _parse_max_age(_header(response, "cache-control")), _DEFAULT_MAX_AGE
         )
-        return CachePolicy(fetched_at=int(time.time()), max_age=max_age, etag=None)
+        return CachePolicy(
+            fetched_at=_freshness_start(response), max_age=max_age, etag=None
+        )
 
     def _decode_cached_listing(self, body: bytes, package: str) -> object | None:
         """Return the parsed JSON of a cached Simple body, or ``None``.
@@ -225,7 +268,7 @@ class CachedAsyncSimpleClient:
             # A 304 without cache-control keeps the stored max-age.
             cache_control = _header(response, "cache-control")
             new_policy = CachePolicy(
-                fetched_at=int(time.time()),
+                fetched_at=_freshness_start(response),
                 max_age=(
                     _parse_max_age(cache_control)
                     if cache_control is not None
@@ -248,7 +291,7 @@ class CachedAsyncSimpleClient:
         files = self._parse_listing(new_body, package)
 
         new_policy = CachePolicy(
-            fetched_at=int(time.time()),
+            fetched_at=_freshness_start(response),
             max_age=_parse_max_age(_header(response, "cache-control")),
             etag=_header(response, "etag"),
         )
@@ -269,7 +312,7 @@ class CachedAsyncSimpleClient:
         files = self._parse_listing(body, package)
 
         policy = CachePolicy(
-            fetched_at=int(time.time()),
+            fetched_at=_freshness_start(response),
             max_age=_parse_max_age(_header(response, "cache-control")),
             etag=_header(response, "etag"),
         )

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -26,6 +26,7 @@ from nab_index.cache import CachePolicy, NullCache, OfflineError, OnDiskCache
 from nab_index.cached_client import (
     CachedAsyncSimpleClient,
     _header,
+    _parse_age,
     _parse_max_age,
 )
 from nab_index.client import (
@@ -733,6 +734,47 @@ class TestParseMaxAge:
     def test_extracts_value_with_spaces(self) -> None:
         assert _parse_max_age("public, max-age = 1200") == 1200
 
+    def test_leading_zeros_ignored(self) -> None:
+        assert _parse_max_age("max-age=00000000900") == 900
+
+    def test_above_ceiling_clamped(self) -> None:
+        assert _parse_max_age("max-age=9999999999") == 2**31
+
+    def test_digit_run_too_long_to_convert_clamped(self) -> None:
+        assert _parse_max_age("max-age=" + "9" * 9000) == 2**31
+
+
+class TestParseAge:
+    def test_absent_is_zero(self) -> None:
+        assert _parse_age(None) == 0
+
+    def test_extracts_value(self) -> None:
+        assert _parse_age("472") == 472
+
+    def test_surrounding_space_tolerated(self) -> None:
+        assert _parse_age(" 472 ") == 472
+
+    def test_non_numeric_is_zero(self) -> None:
+        assert _parse_age("a while") == 0
+
+    def test_negative_is_zero(self) -> None:
+        assert _parse_age("-5") == 0
+
+    def test_above_ceiling_clamped(self) -> None:
+        assert _parse_age("9999999999") == 2**31
+
+    def test_digit_run_too_long_to_convert_clamped(self) -> None:
+        assert _parse_age("9" * 9000) == 2**31
+
+    def test_leading_zeros_ignored(self) -> None:
+        assert _parse_age("00000000472") == 472
+
+    def test_all_zeros_is_zero(self) -> None:
+        assert _parse_age("0" * 9000) == 0
+
+    def test_padded_value_above_ceiling_clamped(self) -> None:
+        assert _parse_age("0" * 9000 + "9" * 20) == 2**31
+
 
 class TestHeader:
     def test_lowercase_lookup(self) -> None:
@@ -1146,6 +1188,198 @@ class TestGetFiles:
 
         files = asyncio.run(go())
         assert len(files) == 1
+
+
+class TestResponseAge:
+    """An Age header counts toward the entry's age (RFC 9111 4.2.3).
+
+    A shared cache in front of the index reports how long ago the origin
+    generated the representation, so the window opened before nab's receipt.
+    """
+
+    def test_cold_fetch_opens_window_at_origin_generation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(time, "time", lambda: 1000.0)
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport(
+            [
+                _FakeResponse(
+                    LISTING_BYTES,
+                    headers={
+                        "etag": "v1",
+                        "cache-control": "max-age=600, must-revalidate",
+                        "age": "472",
+                    },
+                )
+            ]
+        )
+
+        assert len(_run_get_files(transport, cache, "pkg")) == 1
+
+        cached = cache.get_simple("pkg")
+        assert cached is not None
+        _, policy = cached
+        assert policy.fetched_at == 528
+        assert policy.is_fresh(now=1127) is True
+        assert policy.is_fresh(now=1128) is False
+
+    def test_relayed_entry_revalidates_before_receipt_window_ends(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cache = _make_cache(tmp_path)
+        monkeypatch.setattr(time, "time", lambda: 1000.0)
+        cold = _FakeTransport(
+            [
+                _FakeResponse(
+                    LISTING_BYTES,
+                    headers={
+                        "etag": "v1",
+                        "cache-control": "max-age=600",
+                        "age": "472",
+                    },
+                )
+            ]
+        )
+        assert len(_run_get_files(cold, cache, "pkg")) == 1
+
+        monkeypatch.setattr(time, "time", lambda: 1300.0)
+        warm = _FakeTransport([_FakeResponse(b"", status=304, headers={"etag": "v1"})])
+        assert len(_run_get_files(warm, cache, "pkg")) == 1
+
+        assert len(warm.calls) == 1
+        sent_headers = warm.calls[0][1]
+        assert sent_headers is not None
+        assert sent_headers.get("If-None-Match") == "v1"
+
+    def test_no_age_header_opens_window_at_receipt(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(time, "time", lambda: 1000.0)
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport(
+            [
+                _FakeResponse(
+                    LISTING_BYTES,
+                    headers={"etag": "v1", "cache-control": "max-age=600"},
+                )
+            ]
+        )
+
+        assert len(_run_get_files(transport, cache, "pkg")) == 1
+
+        cached = cache.get_simple("pkg")
+        assert cached is not None
+        _, policy = cached
+        assert policy.fetched_at == 1000
+
+    def test_304_refresh_backdates_by_age(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(time, "time", lambda: 5000.0)
+        cache = _make_cache(tmp_path)
+        cache.put_simple(
+            "pkg",
+            LISTING_BYTES,
+            CachePolicy(fetched_at=0, max_age=60, etag="v1"),
+        )
+        transport = _FakeTransport(
+            [_FakeResponse(b"", status=304, headers={"etag": "v1", "age": "30"})]
+        )
+
+        assert len(_run_get_files(transport, cache, "pkg")) == 1
+
+        cached = cache.get_simple("pkg")
+        assert cached is not None
+        _, policy = cached
+        assert policy.fetched_at == 4970
+        assert policy.max_age == 60
+
+    def test_revalidated_200_backdates_by_age(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(time, "time", lambda: 5000.0)
+        cache = _make_cache(tmp_path)
+        cache.put_simple(
+            "pkg",
+            LISTING_BYTES,
+            CachePolicy(fetched_at=0, max_age=60, etag="v1"),
+        )
+        transport = _FakeTransport(
+            [
+                _FakeResponse(
+                    LISTING_BYTES,
+                    headers={
+                        "etag": "v2",
+                        "cache-control": "max-age=600",
+                        "age": "90",
+                    },
+                )
+            ]
+        )
+
+        assert len(_run_get_files(transport, cache, "pkg")) == 1
+
+        cached = cache.get_simple("pkg")
+        assert cached is not None
+        _, policy = cached
+        assert policy.fetched_at == 4910
+        assert policy.etag == "v2"
+
+    def test_404_sentinel_backdates_by_age(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(time, "time", lambda: 1000.0)
+        cache = _make_cache(tmp_path)
+        transport = _FakeTransport(
+            [
+                _FakeResponse(
+                    b"",
+                    status=404,
+                    headers={"cache-control": "max-age=600", "age": "500"},
+                )
+            ]
+        )
+
+        assert _run_get_files(transport, cache, "absent") == []
+
+        neg = cache.get_negative("absent")
+        assert neg is not None
+        assert neg.fetched_at == 500
+        assert neg.is_fresh(now=1099) is True
+        assert neg.is_fresh(now=1100) is False
+
+    def test_age_at_max_age_is_stale_on_arrival(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(time, "time", lambda: 1000.0)
+        cache = _make_cache(tmp_path)
+        cold = _FakeTransport(
+            [
+                _FakeResponse(
+                    LISTING_BYTES,
+                    headers={
+                        "etag": "v1",
+                        "cache-control": "max-age=600",
+                        "age": "600",
+                    },
+                )
+            ]
+        )
+        assert len(_run_get_files(cold, cache, "pkg")) == 1
+
+        cached = cache.get_simple("pkg")
+        assert cached is not None
+        _, policy = cached
+        assert policy.is_fresh(now=1000) is False
+
+        warm = _FakeTransport([_FakeResponse(b"", status=304, headers={"etag": "v1"})])
+        assert len(_run_get_files(warm, cache, "pkg")) == 1
+
+        assert len(warm.calls) == 1
+        sent_headers = warm.calls[0][1]
+        assert sent_headers is not None
+        assert sent_headers.get("If-None-Match") == "v1"
 
 
 class TestNonJsonListingBody:


### PR DESCRIPTION
nab starts a Simple listing's freshness window when the response arrives and ignores the Age header, so a listing relayed by a CDN or any other shared cache gets a full max-age of reuse on top of the time it already spent in that cache. With a max-age of 600 and an Age of 472, the entry is reused for 1072 seconds rather than the 600 the origin allowed, and nothing revalidates it in between, so a new release stays unseen past the point the index said to recheck.

The four places that build a CachePolicy now start the window at the response's arrival time minus its Age, which is when the origin generated the representation. Age is read as an RFC 9110 delta-seconds: absent or non-numeric counts as 0, and a value too large to represent clamps to 2**31. Leading zeros are stripped before that length check, so a zero-padded value reads as itself. max-age is parsed the same way, since it had the same overflow.
