### PR TITLE
report a self-contradictory dependency group on its own

### DIFF
--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -1369,6 +1369,15 @@ def _group_package_ranges(
 
 
 @dataclass(frozen=True, slots=True)
+class _SelfEmptyGroup:
+    """One group whose own requirements on a package leave no version."""
+
+    group: str
+    package: str
+    reqs: str
+
+
+@dataclass(frozen=True, slots=True)
 class _GroupConflict:
     """One direct group-vs-group conflict on a single package.
 
@@ -1382,6 +1391,29 @@ class _GroupConflict:
     right_req: str
 
 
+def _find_self_empty_groups(
+    per_group: Mapping[str, list[Requirement]],
+    environment: Mapping[str, str],
+) -> list[_SelfEmptyGroup]:
+    """Return the groups whose own requirements on a package leave no version.
+
+    The result is sorted by ``(group, package)``.
+    """
+    self_empty: list[_SelfEmptyGroup] = []
+    for group in sorted(per_group):
+        ranges, sources = _group_package_ranges(per_group[group], environment)
+        self_empty.extend(
+            _SelfEmptyGroup(
+                group=group,
+                package=package,
+                reqs=", ".join(sources[package]),
+            )
+            for package in sorted(ranges)
+            if ranges[package].is_empty
+        )
+    return self_empty
+
+
 def _find_group_conflicts(
     per_group: Mapping[str, list[Requirement]],
     environment: Mapping[str, str],
@@ -1389,11 +1421,11 @@ def _find_group_conflicts(
     """Return the direct group-vs-group conflicts under ``environment``.
 
     Only direct conflicts are caught; one that emerges through a shared
-    transitive dependency falls through to the resolver.  A group whose
-    own requirements on a package already leave no version is left out
-    of the pairing, since nothing another group requires can be the
-    cause; :func:`raise_for_unsatisfiable` names those requirements.
-    The result is sorted by ``(left_group, right_group, package)``.
+    transitive dependency falls through to the resolver.  A group that
+    already leaves no version on a package is left out of the pairing,
+    since no other group can be the cause; it is reported by name from
+    :func:`_find_self_empty_groups` instead.  The result is sorted by
+    ``(left_group, right_group, package)``.
     """
     # Invert to: package -> the groups that name it directly, each with
     # its folded range and the requirement strings behind it. Visiting
@@ -1432,38 +1464,55 @@ def _find_group_conflicts(
     return conflicts
 
 
+def _tuple_scope(labels: set[str], targets: Sequence[ResolveTarget]) -> str:
+    """Name the tuples a finding holds on, when there is more than one."""
+    if len(targets) == 1:
+        return ""
+    return f" for tuple(s) {', '.join(sorted(labels))}"
+
+
 def _check_group_disjointness(
     per_group: Mapping[str, list[Requirement]],
     targets: Sequence[ResolveTarget],
 ) -> None:
-    """Raise on a direct conflict between two selected groups, naming them.
+    """Raise on a group that cannot hold on its own, or on a conflicting pair.
 
-    A conflict is reported when it holds on any target; the offending
-    tuples are named when there is more than one to name.  A no-op below
-    two groups.
+    A finding is reported when it holds on any target; the offending
+    tuples are named when there is more than one to name.  A group that
+    leaves no version on its own is named alone, since no other group
+    can be the cause.
     """
+    self_empty: dict[_SelfEmptyGroup, set[str]] = defaultdict(set)
     affected: dict[_GroupConflict, set[str]] = defaultdict(set)
     for target in targets:
+        for empty in _find_self_empty_groups(per_group, target.marker_env):
+            self_empty[empty].add(target.label)
         for conflict in _find_group_conflicts(per_group, target.marker_env):
             affected[conflict].add(target.label)
-    if not affected:
+
+    if not self_empty and not affected:
         return
+
     clauses: list[str] = []
+    for empty in sorted(self_empty, key=lambda e: (e.group, e.package)):
+        where = _tuple_scope(self_empty[empty], targets)
+        clauses.append(
+            f"Dependency group {empty.group!r} has conflicting requirements on"
+            f" {empty.package!r}{where}: {empty.reqs}."
+        )
+
     for conflict in sorted(
         affected,
         key=lambda c: (c.left_group, c.right_group, c.package),
     ):
-        where = (
-            f" for tuple(s) {', '.join(sorted(affected[conflict]))}"
-            if len(targets) > 1
-            else ""
-        )
+        where = _tuple_scope(affected[conflict], targets)
         clauses.append(
             f"Dependency groups {conflict.left_group!r} and"
             f" {conflict.right_group!r} conflict on {conflict.package!r}{where}:"
             f" group {conflict.left_group!r} requires {conflict.left_req} but group"
             f" {conflict.right_group!r} requires {conflict.right_req}."
         )
+
     raise ResolutionError("; ".join(clauses))
 
 

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -1389,8 +1389,11 @@ def _find_group_conflicts(
     """Return the direct group-vs-group conflicts under ``environment``.
 
     Only direct conflicts are caught; one that emerges through a shared
-    transitive dependency falls through to the resolver. The result is
-    sorted by ``(left_group, right_group, package)``.
+    transitive dependency falls through to the resolver.  A group whose
+    own requirements on a package already leave no version is left out
+    of the pairing, since nothing another group requires can be the
+    cause; :func:`raise_for_unsatisfiable` names those requirements.
+    The result is sorted by ``(left_group, right_group, package)``.
     """
     # Invert to: package -> the groups that name it directly, each with
     # its folded range and the requirement strings behind it. Visiting
@@ -1401,6 +1404,8 @@ def _find_group_conflicts(
     for group in sorted(per_group):
         ranges, sources = _group_package_ranges(per_group[group], environment)
         for package, package_range in ranges.items():
+            if package_range.is_empty:
+                continue
             requirers[package].append((group, package_range, sources[package]))
 
     # Two groups conflict on a package when their ranges cannot both

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -2662,6 +2662,45 @@ class TestCheckGroupDisjointness:
         }
         _check_group_disjointness(per_group, [_target({})])
 
+    def test_self_empty_group_does_not_blame_an_unversioned_group(self) -> None:
+        """A group that cannot hold alone is not a conflict with anyone.
+
+        ``beta`` pins nothing, so no range it could carry would clash;
+        ``alpha`` folds to empty on its own.
+        """
+        per_group = {
+            "alpha": [Requirement("sphinx>=7"), Requirement("sphinx<6")],
+            "beta": [Requirement("sphinx")],
+        }
+        _check_group_disjointness(per_group, [_target({})])
+
+    def test_self_empty_group_does_not_blame_an_overlapping_group(self) -> None:
+        """Every other group naming the package stays unaccused."""
+        per_group = {
+            "alpha": [Requirement("sphinx>=7"), Requirement("sphinx<6")],
+            "beta": [Requirement("sphinx")],
+            "gamma": [Requirement("sphinx>=2")],
+        }
+        _check_group_disjointness(per_group, [_target({})])
+
+    def test_umbrella_group_is_not_blamed_for_the_pair_it_includes(self) -> None:
+        """An umbrella group only reports the pair underneath it.
+
+        ``dev`` is ``lint`` plus ``test`` expanded, so its own fold is
+        empty; the one real conflict is ``lint`` against ``test``.
+        """
+        per_group = {
+            "dev": [Requirement("sphinx<6"), Requirement("sphinx>=7")],
+            "lint": [Requirement("sphinx>=7")],
+            "test": [Requirement("sphinx<6")],
+        }
+        with pytest.raises(ResolutionError) as info:
+            _check_group_disjointness(per_group, [_target({})])
+        assert str(info.value) == (
+            "Dependency groups 'lint' and 'test' conflict on 'sphinx':"
+            " group 'lint' requires sphinx>=7 but group 'test' requires sphinx<6."
+        )
+
 
 class TestFindGroupConflictsManyGroups:
     """``_find_group_conflicts`` only compares groups sharing a package.
@@ -2704,6 +2743,15 @@ class TestFindGroupConflictsManyGroups:
         per_group[self._RIGHT].append(Requirement("shared<5"))
         assert _find_group_conflicts(per_group, environment={}) == []
 
+    def test_self_empty_group_pairs_with_nobody(self) -> None:
+        """One group's own contradiction stays out of the pairwise walk."""
+        per_group = self._disjoint_groups()
+        per_group[self._LEFT].extend(
+            [Requirement("shared>=2"), Requirement("shared<1")]
+        )
+        per_group[self._RIGHT].append(Requirement("shared>=1"))
+        assert _find_group_conflicts(per_group, environment={}) == []
+
 
 class TestResolvePyprojectGroupConflict:
     """End-to-end: a two-group direct conflict names the groups."""
@@ -2731,6 +2779,32 @@ class TestResolvePyprojectGroupConflict:
         assert "'docs'" in message
         assert "'test'" in message
         assert "sphinx" in message
+
+    def test_self_empty_group_reports_its_own_requirements(
+        self, tmp_path: Path
+    ) -> None:
+        """A group that cannot hold alone is reported as unsatisfiable."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = []\n'
+            "[dependency-groups]\n"
+            'alpha = ["sphinx>=7", "sphinx<6"]\n'
+            'beta = ["sphinx"]\n'
+        )
+        with (
+            patch("nab_python.resolve.FetchCoordinator"),
+            pytest.raises(ResolutionError) as info,
+        ):
+            _resolved(
+                pyproject,
+                _FAKE_TRANSPORT,
+                python_version="3.12.0",
+                groups=["alpha", "beta"],
+            )
+        message = str(info.value)
+        assert "Dependency groups" not in message
+        assert "conflicting requirements leave no satisfiable version" in message
+        assert "sphinx>=7, sphinx<6" in message
 
     @patch("nab_python.resolve.build_target_lock")
     @patch("nab_python.resolve.Resolver")

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -2603,9 +2603,19 @@ class TestCheckGroupDisjointness:
         }
         _check_group_disjointness(per_group, [_target({})])
 
-    def test_single_group_is_noop(self) -> None:
-        per_group = {"docs": [Requirement("sphinx<7"), Requirement("sphinx>=7")]}
+    def test_single_group_pairs_with_nobody(self) -> None:
+        per_group = {"docs": [Requirement("sphinx<7")]}
         _check_group_disjointness(per_group, [_target({})])
+
+    def test_single_group_that_cannot_hold_is_named(self) -> None:
+        """One group contradicting itself is reported without a partner."""
+        per_group = {"docs": [Requirement("sphinx<7"), Requirement("sphinx>=7")]}
+        with pytest.raises(ResolutionError) as info:
+            _check_group_disjointness(per_group, [_target({})])
+        assert str(info.value) == (
+            "Dependency group 'docs' has conflicting requirements on 'sphinx':"
+            " sphinx<7, sphinx>=7."
+        )
 
     def test_empty_mapping_is_noop(self) -> None:
         _check_group_disjointness({}, [_target({})])
@@ -2663,31 +2673,51 @@ class TestCheckGroupDisjointness:
         _check_group_disjointness(per_group, [_target({})])
 
     def test_self_empty_group_does_not_blame_an_unversioned_group(self) -> None:
-        """A group that cannot hold alone is not a conflict with anyone.
-
-        ``beta`` pins nothing, so no range it could carry would clash;
-        ``alpha`` folds to empty on its own.
-        """
+        """A group that cannot hold alone is named, and nobody else is."""
         per_group = {
             "alpha": [Requirement("sphinx>=7"), Requirement("sphinx<6")],
             "beta": [Requirement("sphinx")],
         }
-        _check_group_disjointness(per_group, [_target({})])
+        with pytest.raises(ResolutionError) as info:
+            _check_group_disjointness(per_group, [_target({})])
+        assert str(info.value) == (
+            "Dependency group 'alpha' has conflicting requirements on 'sphinx':"
+            " sphinx>=7, sphinx<6."
+        )
 
     def test_self_empty_group_does_not_blame_an_overlapping_group(self) -> None:
-        """Every other group naming the package stays unaccused."""
+        """The other groups naming the package are not reported."""
         per_group = {
             "alpha": [Requirement("sphinx>=7"), Requirement("sphinx<6")],
             "beta": [Requirement("sphinx")],
             "gamma": [Requirement("sphinx>=2")],
         }
-        _check_group_disjointness(per_group, [_target({})])
+        with pytest.raises(ResolutionError) as info:
+            _check_group_disjointness(per_group, [_target({})])
+        message = str(info.value)
+        assert "'alpha'" in message
+        assert "'beta'" not in message
+        assert "'gamma'" not in message
+
+    def test_self_empty_group_on_one_package_still_pairs_on_another(self) -> None:
+        """The self-empty skip is per package, not per group."""
+        per_group = {
+            "a": [Requirement("x>=2"), Requirement("x<1"), Requirement("y<3")],
+            "b": [Requirement("y>=4")],
+        }
+        with pytest.raises(ResolutionError) as info:
+            _check_group_disjointness(per_group, [_target({})])
+        assert str(info.value) == (
+            "Dependency group 'a' has conflicting requirements on 'x':"
+            " x>=2, x<1.;"
+            " Dependency groups 'a' and 'b' conflict on 'y':"
+            " group 'a' requires y<3 but group 'b' requires y>=4."
+        )
 
     def test_umbrella_group_is_not_blamed_for_the_pair_it_includes(self) -> None:
-        """An umbrella group only reports the pair underneath it.
+        """An umbrella group is named alone, not paired with its members.
 
-        ``dev`` is ``lint`` plus ``test`` expanded, so its own fold is
-        empty; the one real conflict is ``lint`` against ``test``.
+        ``dev`` here is ``lint`` plus ``test`` expanded.
         """
         per_group = {
             "dev": [Requirement("sphinx<6"), Requirement("sphinx>=7")],
@@ -2697,7 +2727,33 @@ class TestCheckGroupDisjointness:
         with pytest.raises(ResolutionError) as info:
             _check_group_disjointness(per_group, [_target({})])
         assert str(info.value) == (
-            "Dependency groups 'lint' and 'test' conflict on 'sphinx':"
+            "Dependency group 'dev' has conflicting requirements on 'sphinx':"
+            " sphinx<6, sphinx>=7.;"
+            " Dependency groups 'lint' and 'test' conflict on 'sphinx':"
+            " group 'lint' requires sphinx>=7 but group 'test' requires sphinx<6."
+        )
+
+    def test_umbrella_group_through_include_group_is_named_alone(
+        self, tmp_path: Path
+    ) -> None:
+        """The same shape read through a real ``include-group`` table."""
+        path = tmp_path / "pyproject.toml"
+        path.write_text(
+            "[project]\nname = 'x'\n"
+            "[dependency-groups]\n"
+            "dev = [{ include-group = 'lint' }, { include-group = 'test' }]\n"
+            "lint = ['sphinx>=7']\n"
+            "test = ['sphinx<6']\n"
+        )
+        per_group = _group_requirements_by_group(
+            read_pyproject_groups(path), ["dev", "lint", "test"], path
+        )
+        with pytest.raises(ResolutionError) as info:
+            _check_group_disjointness(per_group, [_target({})])
+        assert str(info.value) == (
+            "Dependency group 'dev' has conflicting requirements on 'sphinx':"
+            " sphinx>=7, sphinx<6.;"
+            " Dependency groups 'lint' and 'test' conflict on 'sphinx':"
             " group 'lint' requires sphinx>=7 but group 'test' requires sphinx<6."
         )
 
@@ -2780,10 +2836,8 @@ class TestResolvePyprojectGroupConflict:
         assert "'test'" in message
         assert "sphinx" in message
 
-    def test_self_empty_group_reports_its_own_requirements(
-        self, tmp_path: Path
-    ) -> None:
-        """A group that cannot hold alone is reported as unsatisfiable."""
+    def test_self_empty_group_names_only_itself(self, tmp_path: Path) -> None:
+        """A group that cannot hold alone is named without its neighbour."""
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text(
             '[project]\nname = "x"\ndependencies = []\n'
@@ -2795,16 +2849,16 @@ class TestResolvePyprojectGroupConflict:
             patch("nab_python.resolve.FetchCoordinator"),
             pytest.raises(ResolutionError) as info,
         ):
-            _resolved(
+            resolve_for_targets(
                 pyproject,
                 _FAKE_TRANSPORT,
                 python_version="3.12.0",
                 groups=["alpha", "beta"],
             )
-        message = str(info.value)
-        assert "Dependency groups" not in message
-        assert "conflicting requirements leave no satisfiable version" in message
-        assert "sphinx>=7, sphinx<6" in message
+        assert str(info.value) == (
+            "Dependency group 'alpha' has conflicting requirements on 'sphinx':"
+            " sphinx>=7, sphinx<6."
+        )
 
     @patch("nab_python.resolve.build_target_lock")
     @patch("nab_python.resolve.Resolver")
@@ -3236,10 +3290,17 @@ class TestCheckGroupDisjointnessAcrossTuples:
         tuples = [_tuple_for_python("3.10"), _tuple_for_python("3.12")]
         _check_group_disjointness(per_group, tuples)
 
-    def test_single_group_is_noop(self) -> None:
+    def test_single_group_that_cannot_hold_names_its_tuples(self) -> None:
+        """A self-contradictory group is named per tuple, like a pair."""
         per_group = {"a": [Requirement("foo<2"), Requirement("foo>=2")]}
         tuples = [_tuple_for_python("3.10"), _tuple_for_python("3.12")]
-        _check_group_disjointness(per_group, tuples)
+        with pytest.raises(ResolutionError) as info:
+            _check_group_disjointness(per_group, tuples)
+        assert str(info.value) == (
+            "Dependency group 'a' has conflicting requirements on 'foo'"
+            " for tuple(s) py310-linux_x86_64, py312-linux_x86_64:"
+            " foo<2, foo>=2."
+        )
 
     def test_empty_mapping_is_noop(self) -> None:
         tuples = [_tuple_for_python("3.12")]


### PR DESCRIPTION
If one selected dependency group's own requirements on a package leave no version, the group conflict check folded that group down to an empty range. An empty range is disjoint from every other range, so the check paired the group with whichever other group also named the package and reported the two as conflicting, even when the other group asked for nothing more than the bare package name. When the self-contradictory group was the only one selected there was no partner to pair it with, so nothing was reported.

Each group is now checked on its own first. A group whose own requirements on a package cannot all hold is named alone and kept out of the pairwise comparison, so no other group is blamed for it. A `dev` group that pulls in a `lint` and a `test` that disagree is now named itself, with `lint` and `test` still reported as the pair behind it.
