### PR TITLE
fix conflicts page missing the default-groups refusal

### DIFF
--- a/docs/explanation/conflicts.md
+++ b/docs/explanation/conflicts.md
@@ -66,8 +66,11 @@ reject it: it forks the resolve. For example `nab lock --extras cpu gpu`,
 or `nab lock --all-groups` over the `black*` groups above, resolves each
 member separately and writes every result into one lockfile. This is the
 same in specific and universal mode; the resolve mode does not change how
-a conflict is handled. Each fork's pins carry a marker selecting that
-member:
+a conflict is handled. Two cases are refused rather than forked, both
+covered below: a selection that reaches both members through one
+umbrella, and a `default-groups` that activates two members on its own.
+
+Each fork's pins carry a marker selecting that member:
 
 ```toml
 [[packages]]
@@ -102,12 +105,12 @@ error: in [tool.nab]: extra 'cpu', extra 'gpu' cannot be selected together: decl
 
 This happens when an umbrella extra self-references both members
 (`all = ["proj[cpu]", "proj[gpu]"]`) or an umbrella group includes both
-member groups. Co-selecting the members directly still forks; only the
-all-in-one umbrella, which cannot resolve disjointly, is rejected.
+member groups. Co-selecting the members directly still forks. The
+all-in-one umbrella cannot resolve disjointly, so it is rejected.
 
 The require-one policies still raise. Declaring `exactly-one` or
 `at-least-one` and selecting none of its members is rejected before the
-resolve, regardless of mode; only the co-selection case forks.
+resolve, regardless of mode; co-selection forks instead.
 
 Groups named in `[tool.nab].default-groups` count as part of the
 selection for every conflict check. A project with
@@ -116,6 +119,21 @@ groups `a` and `b`
 satisfies the minimum without passing `--groups`, and a `--groups b`
 on top of that default activates two members of an exclusive set,
 which then forks into two.
+
+Defaults have one restriction of their own. Naming two members of the
+same `at-most-one` or `exactly-one` set as defaults is refused when the
+config is read, before any command-line selection applies:
+
+```console
+$ nab lock
+error: in [tool.nab]: default-groups activates 'black22', 'black23', which are declared mutually exclusive in [tool.nab].conflicts
+```
+
+A default install activates every default group at once. The emit-time
+disjointness check prunes any context that activates two members of an
+exclusive set, so that install is never checked against the declared
+conflict. `at-least-one` permits co-selection, so all of its members
+may be defaults.
 
 A dependency required by every member of a set but not by the base
 keeps its membership marker, so it does not install when no member is

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -23,7 +23,9 @@ constraints = ["urllib3<2"]
 # PEP 735 dependency groups activated on every resolve, unioned
 # with any --groups selection: their dependencies are resolved
 # and pinned into the lock.  The names are also recorded in the
-# lockfile's default-groups array.
+# lockfile's default-groups array.  Two members of the same
+# at-most-one or exactly-one set in [tool.nab].conflicts cannot
+# both be defaults.
 default-groups = ["dev"]
 
 # The Python range this project supports.  A declaration: it is

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2931,14 +2931,19 @@ _CONFLICTS_DOC = (
 )
 
 
-def _console_block(text: str) -> list[str]:
-    lines = text.splitlines()
-    start = lines.index("```console")
-    return lines[start + 1 : lines.index("```", start + 1)]
+def _console_block(text: str, command: str) -> list[str]:
+    """The output lines of the ``console`` block whose first line is ``command``."""
+    for body in re.findall(r"```console\n(.*?)\n```", text, re.DOTALL):
+        lines = body.splitlines()
+        if lines[0] == command:
+            return lines[1:]
+
+    msg = f"no console block for {command!r}"
+    raise AssertionError(msg)
 
 
 class TestConflictsDocTranscript:
-    """The conflicts page quotes the refusal line the CLI prints."""
+    """The conflicts page quotes the refusal lines the CLI prints."""
 
     _UMBRELLA = (
         '[project]\nname = "proj"\nversion = "0.1.0"\ndependencies = []\n'
@@ -2950,6 +2955,16 @@ class TestConflictsDocTranscript:
         'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
     )
 
+    _DEFAULT_GROUPS = (
+        '[project]\nname = "proj"\nversion = "0.1.0"\ndependencies = []\n'
+        "[dependency-groups]\n"
+        'black22 = ["black==22.1.0"]\n'
+        'black23 = ["black==23.12.0"]\n'
+        "[tool.nab]\n"
+        'default-groups = ["black22", "black23"]\n'
+        'conflicts = [[{ group = "black22" }, { group = "black23" }]]\n'
+    )
+
     def test_umbrella_refusal_matches_documented_transcript(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -2959,9 +2974,20 @@ class TestConflictsDocTranscript:
             lock(pyproject, cache_dir=tmp_path / "cache", extras=("all",))
         printed = capsys.readouterr().err.strip()
 
-        block = _console_block(_CONFLICTS_DOC.read_text(encoding="utf-8"))
-        assert block[0] == "$ nab lock --extras all"
-        assert printed in block[1:]
+        doc = _CONFLICTS_DOC.read_text(encoding="utf-8")
+        assert printed in _console_block(doc, "$ nab lock --extras all")
+
+    def test_default_groups_refusal_matches_documented_transcript(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Two default groups in one exclusive set print the page's line."""
+        pyproject = _make_pyproject(tmp_path, self._DEFAULT_GROUPS)
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, cache_dir=tmp_path / "cache")
+        printed = capsys.readouterr().err.strip()
+
+        doc = _CONFLICTS_DOC.read_text(encoding="utf-8")
+        assert printed in _console_block(doc, "$ nab lock")
 
 
 _CLI_REFERENCE_DOC = (


### PR DESCRIPTION
The conflicts explanation says that activating two members of a set forks the resolve rather than rejecting it, and that the all-in-one umbrella is the only case refused. It misses one: naming two members of the same at-most-one or exactly-one set in `[tool.nab].default-groups` is refused when the config is read, before any command-line selection applies. Anyone reading the page would take that error for a bug.

The page now covers the default-groups case with the line the CLI prints, and says why it is caught at parse time: a default install activates every default group at once, and the emit-time disjointness check prunes that context, so the declared conflict is never checked against it. The configuration reference gets the restriction next to `default-groups`, and the transcript test that pins the umbrella line now pins this one too, so the helper picks its console block by command instead of taking the first one on the page.
