### PR TITLE
apply a base package's constraint to its extras proxy

### DIFF
--- a/nab-python/src/nab_python/_provider/extras.py
+++ b/nab-python/src/nab_python/_provider/extras.py
@@ -147,8 +147,9 @@ def _pick_for_user_extra(
     against an older version that declares it.  The exception is a range
     the search narrowed off every version declaring the extra: reporting
     no version there leaves a clause the search can backjump on.  The
-    check runs against the root requirement's range, so the answer
-    follows the index rather than the metadata fetched so far.
+    check runs against the root requirement's range intersected with the
+    user's constraint, so the answer follows the index rather than the
+    metadata fetched so far.
     """
     # Late import: ``provider`` imports this module at module load.
     from ..provider import ExtrasMode
@@ -158,6 +159,10 @@ def _pick_for_user_extra(
 
     _, _, normalized = provider.split_and_normalize(base)
     root_range = provider.root_requirements.get(normalized, VersionRange.full())
+    constraint = provider.constraints.get(normalized)
+    if constraint is not None:
+        root_range = root_range & constraint
+
     outside = [v for v in root_range.filter(all_versions) if v not in candidates]
     if not outside:
         return chosen

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -485,6 +485,11 @@ class Provider:
     and neither filter runs, since nothing has said which machine the
     resolve targets.
 
+    ``constraints`` are the user's version bounds, keyed as the resolver
+    keys packages, so an extras proxy carries its base's bound under its
+    own ``name[extra]`` key.  The provider reads them when deciding
+    whether a missing root extra is worth reporting.
+
     ``preferences`` are versions another resolve already decided, tried
     first when they are usable here.  A multi-target resolve passes the
     pins of an already-resolved target, which aligns the matrix on one
@@ -573,6 +578,7 @@ class Provider:
         preferences: Mapping[str, Version] | None = None,
         listing_filter_cache: ListingFilterCache | None = None,
         *,
+        constraints: Mapping[str, VersionRange] | None = None,
         trust_unverified_sdist_deps: bool = False,
     ) -> None:
         """Construct the provider; see the class docstring for parameters."""
@@ -687,6 +693,7 @@ class Provider:
         self.base_filtered_packages: set[str] = set()
 
         self.root_requirements = root_requirements or {}
+        self.constraints: Mapping[str, VersionRange] = constraints or {}
         self.versions_cache: dict[str, list[tuple[Version, DistFile]]] = {}
         self.deps_cache: dict[tuple[str, Version], dict[str, VersionRange]] = {}
         # Unbounded by design and never evicted mid-resolve: it keeps every

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -851,11 +851,14 @@ def _resolve_one_target(
     except ResolutionError as exc:
         return TargetResult(target=target, success=False, error=exc)
 
+    _extend_constraints_to_proxies(resolver_constraints, root_extras)
+
     source_root = settings.source_root
     provider = Provider(
         settings.coordinator,
         target=target,
         root_requirements=resolver_requirements,
+        constraints=resolver_constraints,
         root_extras=root_extras,
         uploaded_prior_to=config.uploaded_prior_to,
         dist_policy=config.dist_policy,
@@ -1548,6 +1551,24 @@ def _build_resolver_inputs(
             root_extras.add((name, normalized_extra))
     raise_for_unsatisfiable(resolver_requirements, sources, kind=kind)
     return resolver_requirements, root_extras
+
+
+def _extend_constraints_to_proxies(
+    constraints: dict[str, VersionRange],
+    root_extras: set[tuple[str, str]],
+) -> None:
+    """Copy each base package's constraint onto its extras proxies.
+
+    The resolver keys constraints by the package it is deciding, and an
+    extras proxy decides under its own ``name[extra]`` key, so the base's
+    constraint does not otherwise reach it.  Sharing the key also keeps
+    the proxy on the constraint-attribution path, so a constraint that
+    leaves it nothing is named in the failure.
+    """
+    for name, extra in root_extras:
+        constraint = constraints.get(name)
+        if constraint is not None:
+            constraints[join_extra(name, extra)] = constraint
 
 
 def _raise_for_source_python(

--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -1824,6 +1824,82 @@ class TestResolveWithCoordinator:
         assert result.success
         assert result.target_results[0].pins == {"pkg": Version("1.0")}
 
+    @staticmethod
+    def _dropped_extra_coordinator() -> MagicMock:
+        """An index whose newest ``aaa`` no longer declares the ``x`` extra.
+
+        1.0 and 2.0 declare ``x`` and pull ``bbb`` through it; 3.0
+        provides no extras at all.
+        """
+        aaa_wheels = [_make_wheel(v, package="aaa") for v in ("1.0", "2.0", "3.0")]
+        coordinator = make_coordinator(
+            listings={"aaa": aaa_wheels, "bbb": [_make_wheel("1.0", package="bbb")]},
+            auto_metadata=True,
+        )
+        for wheel in aaa_wheels[:-1]:
+            coordinator.index.store_metadata(
+                "aaa",
+                wheel.version,
+                f"Metadata-Version: 2.1\nName: aaa\nVersion: {wheel.version}\n"
+                "Provides-Extra: x\n"
+                'Requires-Dist: bbb; extra == "x"\n\n',
+                wheel.metadata_url,
+            )
+        return coordinator
+
+    @pytest.mark.parametrize(
+        "constraint", ["aaa==2.0", "aaa<=2.0", "aaa<3.0", "aaa!=3.0"]
+    )
+    def test_constraint_bounds_an_extras_proxy(self, constraint: str) -> None:
+        """A constraint on the base bounds ``aaa[x]`` as well.
+
+        The proxy decides before its base, so a constraint it cannot see
+        lets it pin ``aaa==3.0`` and abort on the extra 3.0 dropped.
+        """
+        result = resolve_with_coordinator(
+            self._dropped_extra_coordinator(),
+            _one_target(),
+            _reqs("aaa[x]"),
+            config=NabProjectConfig(constraints=(constraint,)),
+        )
+        assert result.success
+        assert result.target_results[0].pins == {
+            "aaa": Version("2.0"),
+            "bbb": Version("1.0"),
+        }
+
+    def test_constraint_that_empties_an_extras_proxy_is_blamed(self) -> None:
+        """A constraint that leaves the proxy nothing is named in the failure.
+
+        Three versions of ``aaa`` exist, so blaming the proxy's own
+        listing would be wrong.
+        """
+        result = resolve_with_coordinator(
+            self._dropped_extra_coordinator(),
+            _one_target(),
+            _reqs("aaa[x]"),
+            config=NabProjectConfig(constraints=("aaa<0.5",)),
+        )
+        assert not result.success
+        message = str(result.target_results[0].error)
+        assert "the user constrained aaa[x]" in message
+        assert "0.5" in message
+        assert "no versions of aaa[x]" not in message
+
+    def test_constraint_off_the_extra_still_reports_the_miss(self) -> None:
+        """A constraint pinning a version without the extra reports it.
+
+        The constraint leaves ``aaa==3.0`` the only candidate, so the
+        proxy pins it and the miss is reported against it.
+        """
+        with pytest.raises(MissingExtraError, match="aaa==3.0"):
+            resolve_with_coordinator(
+                self._dropped_extra_coordinator(),
+                _one_target(),
+                _reqs("aaa[x]"),
+                config=NabProjectConfig(constraints=("aaa==3.0",)),
+            )
+
     def test_resolution_strategy_overrides_the_config(self) -> None:
         """An explicit strategy wins over the config's ``resolution``."""
         coordinator = _make_coordinator(


### PR DESCRIPTION
With `constraints = ["aaa<3.0"]` under `[tool.nab]`, `nab lock aaa[x]` still pinned the newest `aaa` in the index and aborted with `aaa==3.0 does not provide extra 'x'`, even though 2.0 is inside the constraint and declares the extra.

The resolver keys a constraint by the package it is deciding, and the `aaa[x]` proxy decides under its own key, so the bound written on `aaa` never reached it. A root-requested extra now carries its base's constraint under the proxy key. That narrows the proxy's range and puts it on the constraint-attribution path, so a constraint that leaves the proxy nothing is named in the failure instead of surfacing as no versions of `aaa[x]`. The provider intersects the same bound when it decides whether a missing root extra is the user's own error, so a constraint pinning a version that genuinely lacks the extra still reports that version.
