### PR TITLE
stop an inherited GIT_DIR from pointing a clone at the caller's repo

### DIFF
--- a/nab-index/src/nab_index/vcs.py
+++ b/nab-index/src/nab_index/vcs.py
@@ -63,6 +63,19 @@ _LS_REMOTE_TIMEOUT_SECONDS = 120
 # builds a large repo's pack.
 _FETCH_TIMEOUT_SECONDS = 1800
 
+# git reads these to pick which repository, and which of its refs, a command
+# acts on, and they outrank ``cwd``.  git sets them itself around hooks, so an
+# inherited one is not always deliberate.
+_REPO_SELECTION_VARS = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_NAMESPACE",
+)
+
 
 class VcsCloneError(Exception):
     """Raised when a clone or ref resolution fails."""
@@ -328,30 +341,32 @@ def _shallow_clone(repo_url: str, sha: str, dest: Path) -> None:
     :func:`tempfile.mkdtemp`, so it already exists.
     """
     dest.mkdir(parents=True, exist_ok=True)
+    env = _git_env()
+
     init_args = ["git", "init", "--quiet"]
     fetch_args = ["git", "fetch", "--quiet", "--depth", "1", repo_url, sha]
     checkout_args = ["git", "checkout", "--quiet", "FETCH_HEAD"]
+
     try:
         subprocess.run(  # noqa: S603 - git is a runtime dep
             init_args,
             check=True,
             cwd=dest,
-            env=_git_env(),
+            env=env,
         )
         subprocess.run(  # noqa: S603 - URL admission upstream
             fetch_args,
             check=True,
             cwd=dest,
-            env=_git_env(),
+            env=env,
             timeout=_FETCH_TIMEOUT_SECONDS,
         )
         subprocess.run(  # noqa: S603 - git is a runtime dep
             checkout_args,
             check=True,
             cwd=dest,
-            env=_git_env(),
+            env=env,
         )
-        (dest / ".git" / _COMPLETE_MARKER).touch()
     except (
         FileNotFoundError,
         subprocess.CalledProcessError,
@@ -362,15 +377,26 @@ def _shallow_clone(repo_url: str, sha: str, dest: Path) -> None:
         msg = f"failed to clone {repo_url} @ {sha}: {exc}"
         raise VcsCloneError(msg) from exc
 
+    try:
+        (dest / ".git" / _COMPLETE_MARKER).touch()
+    except OSError as exc:
+        shutil.rmtree(dest, ignore_errors=True)
+        msg = f"clone of {repo_url} @ {sha} could not be marked complete: {exc}"
+        raise VcsCloneError(msg) from exc
+
 
 def _git_env() -> dict[str, str]:
     """Return an environment for git subprocesses.
 
-    Disables interactive prompts and any auto-detected user config
-    so the clone fails fast on unauthenticated repos rather than
-    hanging.
+    Disables interactive prompts and any auto-detected user config so
+    the clone fails fast on unauthenticated repos rather than hanging,
+    and drops the inherited repo-selection variables so every call acts
+    on the directory nab passes as ``cwd``.
     """
     env = dict(os.environ)
+    for name in _REPO_SELECTION_VARS:
+        env.pop(name, None)
+
     env["GIT_TERMINAL_PROMPT"] = "0"
     env.setdefault("GIT_CONFIG_GLOBAL", "/dev/null")
     env.setdefault("GIT_CONFIG_SYSTEM", "/dev/null")

--- a/nab-python/tests/test_vcs.py
+++ b/nab-python/tests/test_vcs.py
@@ -16,6 +16,7 @@ from nab_index.client import SdistFile, WheelFile  # noqa: F401 - re-exported by
 from nab_index.httpx_async_transport import HttpxAsyncTransport
 from nab_index.vcs import (
     _COMPLETE_MARKER,
+    _REPO_SELECTION_VARS,
     VcsCloneError,
     VcsRequest,
     _clone_complete,
@@ -603,6 +604,88 @@ class TestPrepareClone:
         clone = prepare_clone(tmp_path, req, require_pin=True)
         assert clone.path == dest
         assert payload.read_text() == "kept"
+
+
+class TestAmbientGitEnvironment:
+    """git's repo-selection variables must not reach nab's git calls."""
+
+    def _set_ambient_vars(self, monkeypatch: pytest.MonkeyPatch, home: Path) -> None:
+        for name in _REPO_SELECTION_VARS:
+            monkeypatch.setenv(name, str(home / name.lower()))
+        monkeypatch.setenv("GIT_SSH_COMMAND", "ssh -i /keys/id_ed25519")
+
+    def _assert_scrubbed(self, names: list[str]) -> None:
+        assert [name for name in _REPO_SELECTION_VARS if name in names] == []
+        # The scrub stays narrow: git+ssh reaches credentials through this one.
+        assert "GIT_SSH_COMMAND" in names
+
+    def test_clone_drops_inherited_repo_selection_vars(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._set_ambient_vars(monkeypatch, tmp_path / "elsewhere")
+        sha = "a" * 40
+        seen: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> object:
+            env = kwargs["env"]
+            assert isinstance(env, dict)
+            seen.append([name for name in env if name.startswith("GIT_")])
+            cwd = Path(str(kwargs["cwd"]))
+            if cmd[:2] == ["git", "init"]:
+                (cwd / ".git").mkdir(exist_ok=True)
+            return type("P", (), {"returncode": 0})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        req = VcsRequest("git", "https://example/repo.git", sha, "")
+        prepare_clone(tmp_path, req, require_pin=True)
+
+        assert len(seen) == 3
+        for names in seen:
+            self._assert_scrubbed(names)
+            assert "GIT_TERMINAL_PROMPT" in names
+
+    def test_ls_remote_drops_inherited_repo_selection_vars(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._set_ambient_vars(monkeypatch, tmp_path / "elsewhere")
+        sha = "b" * 40
+        seen: list[str] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> object:
+            env = kwargs["env"]
+            assert isinstance(env, dict)
+            seen.extend(name for name in env if name.startswith("GIT_"))
+            return type("P", (), {"stdout": f"{sha}\trefs/heads/main\n"})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        req = VcsRequest("git", "https://example/repo.git", "main", "")
+        assert _resolve_sha(req, require_pin=False) == sha
+        self._assert_scrubbed(seen)
+
+    def test_marker_write_failure_does_not_blame_the_remote(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A marker write that fails is local state, not an unreachable remote."""
+        sha = "c" * 40
+
+        def fake_run(cmd: list[str], **_kwargs: object) -> object:
+            return type("P", (), {"returncode": 0})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        req = VcsRequest("git", "https://example/repo.git", sha, "")
+        with pytest.raises(VcsCloneError) as caught:
+            prepare_clone(tmp_path, req, require_pin=True)
+
+        message = str(caught.value)
+        assert "could not be marked complete" in message
+        assert "failed to clone" not in message
+        assert list((tmp_path / "vcs").rglob("*.tmp")) == []
 
 
 class TestOfflineClone:


### PR DESCRIPTION
nab builds its git environment from os.environ, so a GIT_DIR exported by the caller, or set by git itself around a hook, took precedence over the cwd nab passes. The init, fetch, and checkout for a VCS dependency then ran against the caller's own repository: the fetch landed there and the checkout moved its HEAD. An inherited GIT_NAMESPACE was a quieter version of the same thing: it hid every ref from ls-remote, so a floating ref looked like it did not exist.

The git environment now drops GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE, GIT_OBJECT_DIRECTORY, GIT_ALTERNATE_OBJECT_DIRECTORIES, GIT_COMMON_DIR, and GIT_NAMESPACE. Everything else is left alone, including GIT_SSH_COMMAND, which git+ssh needs to reach credentials.

The completion marker is now written outside the clone's try block. Path.touch raises FileNotFoundError when .git is missing, and the except tuple caught that and reported "failed to clone <url> @ <sha>" for what was a local failure.
