### PR TITLE
Document --include-rejected on every nab config action

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -210,8 +210,29 @@ actions:
   key, the winning source marked with a `>`. Array options concatenate
   every layer instead of one winning, so each source is shown as a
   contribution and the merged effective value is printed on a trailing
-  `= effective:` line. Add `--include-rejected` to also list sources
-  that tried to set the key but were rejected by the category gate.
+  `= effective:` line.
+
+`--include-rejected` is a flag on `nab config` itself, so every action
+takes it. Without it, a config file that sets an unknown key or a key
+its scope does not allow is a config error: the inspector writes the
+message to stderr, prints no configuration, and exits 1. With the flag
+the run succeeds, and each action shows the refused sources differently:
+
+* `nab config list --include-rejected` prints the option table, then a
+  `rejected:` section with one line per refused source: a key set
+  outside its scope, an unknown key, and a `NAB_*` variable that is
+  unknown or names a project-scope option. Without the flag those
+  variables are stderr warnings instead.
+* `nab config explain <key> --include-rejected` adds a `rejected` row
+  for every source that tried to set that key and was not allowed. A
+  refusal that names no option (an unknown key, or an unrecognised
+  `NAB_*` variable) belongs under no key, so only `nab config list`
+  shows it: on `explain` such a variable loses its stderr warning and
+  gains no row.
+* `nab config get <key> --include-rejected` prints the value and nothing
+  else. `get` renders no refusal at all, so the flag only decides
+  whether the command runs, and takes those `NAB_*` warnings off stderr
+  without printing anything in their place.
 
 The same per-option override flags the run commands accept (the
 `--project-*` overrides and the user knobs `--offline`, `--cache-dir`,

--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -1229,12 +1229,12 @@ class Layer:
 
 @dataclass(frozen=True, slots=True)
 class RejectedLayer:
-    """A source that tried to set a key it is not allowed to set.
+    """A source refused by the registry: a key outside its scope, or unknown.
 
-    Captured (not raised) by :func:`discover_layers` only when the caller
-    asks to collect rejections for ``nab config explain
-    --include-rejected``.  The normal load path raises a
-    :class:`SourceConfigError` instead.
+    Captured (not raised) by :func:`discover_layers` for the TOML sources and
+    :func:`read_env_layer` for the ``NAB_*`` ones, only when the caller asks
+    to collect rejections for ``nab config --include-rejected``.  The normal
+    load path raises :class:`SourceConfigError` for TOML and warns for env.
     """
 
     origin: Origin
@@ -1288,8 +1288,8 @@ def _load_toml_layer(
     ``[tool.nab]``; the standalone ``nab.toml`` sources read top-level
     keys.  Every registry key is parsed by its row.  A key that names an
     option not allowed in ``kind`` (the category gate) raises
-    :class:`SourceConfigError`, unless ``rejections`` is supplied, in
-    which case it is appended there and skipped (for explain).
+    :class:`SourceConfigError`, unless ``rejections`` is supplied, in which
+    case it is appended there and skipped (for ``--include-rejected``).
     """
     raw = _read_raw_table(path, kind)
     origin = Origin(kind, str(path))
@@ -1378,8 +1378,8 @@ def read_env_layer(
     ``reserved_env`` names the ``NAB_*`` vars other layers own (nab's
     output layer consumes ``NAB_VERBOSITY`` and ``NAB_NO_PROGRESS``), so
     the guard skips them silently.  When ``rejections`` is supplied
-    (``nab config explain --include-rejected``) those env casualties are
-    recorded there instead of warned, mirroring the TOML loader.
+    (``nab config --include-rejected``) those env casualties are recorded
+    there instead of warned, mirroring the TOML loader.
     """
     _warn_renamed_env(environ, rejections=rejections)
     _warn_unknown_env(environ, reserved_env=reserved_env, rejections=rejections)

--- a/src/nab/_config_cmd.py
+++ b/src/nab/_config_cmd.py
@@ -69,8 +69,13 @@ def config_command(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag
 
     ``nab config list`` lists every option with value/scope/origin.
     ``nab config get <key>`` prints one effective value.  ``nab config
-    explain <key>`` prints the full shadowed source stack;
-    ``--include-rejected`` also lists category-rejected sources.
+    explain <key>`` prints the full shadowed source stack.
+
+    ``--include-rejected`` sits on the command, so every action takes it.
+    It turns a refused source (a key set outside its scope, an unknown key,
+    an unknown or renamed ``NAB_*`` var) from a fatal config error into a
+    collected rejection, which ``list`` prints as a trailing section and
+    ``explain`` as a ``rejected`` row under the key it names.
 
     The same per-option flags the run commands accept (the USER
     ``--offline`` / ``--cache-dir`` / ``--http-backend`` /

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -1016,3 +1016,123 @@ class TestDownloadLadder:
         with pytest.raises(SystemExit):
             download(hermetic_roots / "pyproject.toml", output=hermetic_roots / "out")
         assert "config error" in capsys.readouterr().err
+
+
+_CLI_REFERENCE = Path(__file__).resolve().parents[1] / "docs" / "reference" / "cli.md"
+
+_FLAG = "--include-rejected"
+
+
+def _config_reference_section() -> str:
+    text = _CLI_REFERENCE.read_text(encoding="utf-8")
+    return text.partition("\n## `nab config`\n")[2].partition("\n## ")[0]
+
+
+def _prose_chunks(section: str) -> list[str]:
+    """Split a reference section into one string per paragraph and bullet."""
+    chunks: list[str] = []
+    current: list[str] = []
+    for raw in section.splitlines():
+        line = raw.strip()
+        if current and (not line or raw.startswith("* ")):
+            chunks.append(" ".join(current))
+            current = []
+        if line:
+            current.append(line)
+
+    if current:
+        chunks.append(" ".join(current))
+    return chunks
+
+
+def _include_rejected_chunks() -> list[str]:
+    return [c for c in _prose_chunks(_config_reference_section()) if _FLAG in c]
+
+
+def _action_bullet(action: str) -> str:
+    """The ``--include-rejected`` bullet for one ``nab config`` action."""
+    prefix = f"* `nab config {action}"
+    return next(c for c in _include_rejected_chunks() if c.startswith(prefix))
+
+
+class TestCliReferenceDocumentsIncludeRejected:
+    """The CLI reference describes ``--include-rejected`` as it behaves.
+
+    The flag sits on ``nab config`` itself: it decides whether a refused
+    source is fatal, and ``list`` is the only action that shows a refusal
+    naming no option.
+    """
+
+    def test_list_shows_a_rejection_explain_cannot_reach(
+        self,
+        hermetic_roots: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        _project(hermetic_roots)
+        monkeypatch.setenv("NAB_OFLINE", "1")
+        path = str(hermetic_roots / "pyproject.toml")
+
+        listed = _run_config(["list", _FLAG, "--path", path])
+        with caplog.at_level(logging.WARNING, logger="nab_python"):
+            _run_config(["explain", "offline", "--path", path])
+            warned = caplog.text
+            caplog.clear()
+            explained = _run_config(["explain", "offline", _FLAG, "--path", path])
+            silenced = caplog.text
+
+        assert "NAB_OFLINE" in listed
+        assert "NAB_OFLINE" not in explained
+        assert "NAB_OFLINE" in warned
+        assert "NAB_OFLINE" not in silenced
+        assert "stderr" in _action_bullet("explain")
+
+    def test_rejected_section_is_documented(
+        self, hermetic_roots: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _project(hermetic_roots)
+        monkeypatch.setenv("NAB_OFLINE", "1")
+        out = _run_config(
+            ["list", _FLAG, "--path", str(hermetic_roots / "pyproject.toml")]
+        )
+
+        label = "rejected:"
+        assert any(line.strip() == label for line in out.splitlines())
+        assert f"`{label}`" in _config_reference_section()
+
+    def test_exit_without_the_flag_is_documented(self, hermetic_roots: Path) -> None:
+        _project(hermetic_roots)
+        _write(hermetic_roots / "nab.toml", 'resolutionn = "lowest"\n')
+        path = str(hermetic_roots / "pyproject.toml")
+
+        out, err = io.StringIO(), io.StringIO()
+        with (
+            redirect_stdout(out),
+            redirect_stderr(err),
+            pytest.raises(SystemExit) as exc,
+        ):
+            app.cli(args=["config", "list", "--path", path], prog="nab")
+
+        assert out.getvalue() == ""
+        assert "config error" in err.getvalue()
+        assert "resolutionn" in _run_config(["list", _FLAG, "--path", path])
+        assert f"exits {exc.value.code}" in _config_reference_section()
+
+    def test_get_renders_no_rejection(
+        self,
+        hermetic_roots: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        _project(hermetic_roots)
+        _write(hermetic_roots / "nab.toml", 'resolutionn = "lowest"\n')
+        monkeypatch.setenv("NAB_OFLINE", "1")
+        path = str(hermetic_roots / "pyproject.toml")
+
+        with caplog.at_level(logging.WARNING, logger="nab_python"):
+            out = _run_config(["get", "resolution", _FLAG, "--path", path])
+
+        assert out == "highest\n"
+        # The flag silences the NAB_* warning and prints nothing in its place.
+        assert "NAB_OFLINE" not in caplog.text
+        assert "stderr" in _action_bullet("get")


### PR DESCRIPTION
The CLI reference described `--include-rejected` as extra rows on `nab config explain`. It is a flag on `nab config` itself, so all three actions take it, and two of its effects were undocumented.

`nab config list --include-rejected` is the only place a refusal that names no option shows up, so a typo'd key or an unknown `NAB_*` variable appears there and nowhere else. The flag also decides whether the inspector runs: a config file carrying an unknown or scope-gated key is a config error that prints no configuration and exits 1, and the flag turns that into a successful run with the refused sources listed.

This rewrites the `nab config` section to cover what each action does with the flag, and corrects the same explain-only wording in the `RejectedLayer` and `read_env_layer` docstrings. The added tests run each action and compare its output against the reference text.
