### PR TITLE
fix raw TypeError from a non-string matrix.python-order

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -3076,7 +3076,9 @@ def _parse_matrix(value: object) -> MatrixConfig | None:
     # marker, which has no libc or free-threading variable, so two targets
     # sharing an id would render the same marker.
     _reject_duplicates("matrix.platforms", tuple(p.platform_id for p in platforms))
-    python_order = value.get("python-order", "asc")
+    python_order = _parse_string_value(
+        "matrix.python-order", value.get("python-order", "asc")
+    )
     if python_order not in {"asc", "desc"}:
         msg = f"matrix.python-order must be 'asc' or 'desc', got {python_order!r}"
         raise ConfigError(msg)

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -3938,6 +3938,28 @@ class TestMatrix:
         with pytest.raises(ConfigError, match="python-order must be 'asc' or 'desc'"):
             read_pyproject_config(path)
 
+    @pytest.mark.parametrize(
+        ("literal", "type_name"),
+        [('["desc"]', "list"), ("[]", "list"), ("{}", "dict")],
+    )
+    def test_non_string_python_order(
+        self, tmp_path: Path, literal: str, type_name: str
+    ) -> None:
+        """An unhashable value is rejected before the membership test."""
+        path = write(
+            tmp_path,
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            "[tool.nab.matrix]\n"
+            'python = ">=3.11"\n'
+            'platforms = ["linux_x86_64"]\n'
+            f"python-order = {literal}\n",
+        )
+        with pytest.raises(
+            ConfigError, match=f"matrix.python-order must be a string, got {type_name}"
+        ):
+            read_pyproject_config(path)
+
     def test_unknown_platform_rejected(self, tmp_path: Path) -> None:
         body = self._matrix_body()
         body = body.replace('["linux_x86_64", "macos_arm64"]', '["frobnicate"]')

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -2463,6 +2463,16 @@ class TestCrossFieldProjectOptions:
         ):
             _resolve(SourceRoots(project_dir=tmp_path))
 
+    def test_matrix_python_order_bad_type_keeps_message(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        _write(
+            tmp_path / "nab.toml", _MATRIX_PROJECT_TOML + 'python-order = ["desc"]\n'
+        )
+        with pytest.raises(
+            SourceConfigError, match="matrix.python-order must be a string, got list"
+        ):
+            _resolve(SourceRoots(project_dir=tmp_path))
+
     def test_matrix_cross_file_conflict(self, tmp_path: Path) -> None:
         _project(tmp_path, _MATRIX_PYPROJECT)
         _write(


### PR DESCRIPTION
Setting `matrix.python-order` to a TOML array or inline table crashes `nab lock`, `nab download` and `nab config` with a raw `TypeError: unhashable type` instead of a config error.

The value went straight into a `not in {"asc", "desc"}` membership test, which raises on an unhashable value before the validation message is reached. It now goes through the same string check the other matrix keys use, so the failure reports `matrix.python-order must be a string, got list`.
