### PR TITLE
send a nab-index User-Agent instead of the HTTP library's default

### DIFF
--- a/docs/how-to/install.md
+++ b/docs/how-to/install.md
@@ -41,6 +41,8 @@ uv tool install 'nab[httpx]'
 Pick it at run-time with `--http-backend httpx`. Selecting a backend
 that was not installed surfaces a helpful `ImportError`.
 
+Both backends send the same `User-Agent`, `nab-index/<version>`.
+
 ## Throw-away invocations
 
 ```bash

--- a/nab-index/src/nab_index/httpx_async_transport.py
+++ b/nab-index/src/nab_index/httpx_async_transport.py
@@ -12,6 +12,7 @@ import truststore
 
 from .retry import MAX_REDIRECTS, MAX_RETRIES, RETRY_STATUSES, next_delay
 from .transport import (
+    DEFAULT_HEADERS,
     ContentDecodingError,
     HttpError,
     accepts_gzip,
@@ -92,12 +93,12 @@ class HttpxAsyncTransport:
         httpx has no retry machinery beyond reconnecting, so the shared policy
         runs in this loop rather than in the client. The body is read raw and
         decoded with ``decode_body``, so a truncated gzip stream is retried
-        instead of returned as if complete. Only gzip is advertised, and a
-        caller can override that with
+        instead of returned as if complete. ``headers`` overrides entries of
+        :data:`~nab_index.transport.DEFAULT_HEADERS`, so a caller can pass
         :data:`~nab_index.transport.IDENTITY_HEADERS` to get the body
         undecoded.
         """
-        request_headers = {"Accept-Encoding": "gzip"}
+        request_headers = dict(DEFAULT_HEADERS)
         if headers is not None:
             request_headers.update(headers)
 

--- a/nab-index/src/nab_index/transport.py
+++ b/nab-index/src/nab_index/transport.py
@@ -9,13 +9,16 @@ from __future__ import annotations
 
 import gzip
 import zlib
+from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING, Any, Final, Protocol
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
 __all__ = [
+    "DEFAULT_HEADERS",
     "IDENTITY_HEADERS",
+    "USER_AGENT",
     "AsyncHttpTransport",
     "ContentDecodingError",
     "HttpError",
@@ -25,6 +28,23 @@ __all__ = [
     "raise_for_error_status",
     "raise_unless_ok",
 ]
+
+
+def _user_agent() -> str:
+    """Return the ``nab-index/<version>`` name PyPI's API guidelines ask for."""
+    try:
+        return f"nab-index/{version('nab-index')}"
+    except PackageNotFoundError:
+        return "nab-index/0.0.0+unknown"
+
+
+USER_AGENT: Final[str] = _user_agent()
+
+# Sent on every request unless the caller overrides an entry.
+DEFAULT_HEADERS: Final[dict[str, str]] = {
+    "Accept-Encoding": "gzip",
+    "User-Agent": USER_AGENT,
+}
 
 # For a caller that needs the body exactly as stored, undecoded.
 IDENTITY_HEADERS: Final[dict[str, str]] = {"Accept-Encoding": "identity"}

--- a/nab-index/src/nab_index/urllib3_async_transport.py
+++ b/nab-index/src/nab_index/urllib3_async_transport.py
@@ -20,6 +20,7 @@ import urllib3
 
 from .retry import GET_RETRY, MAX_RETRIES, next_delay
 from .transport import (
+    DEFAULT_HEADERS,
     ContentDecodingError,
     HttpError,
     accepts_gzip,
@@ -183,12 +184,15 @@ class Urllib3AsyncTransport:
     ) -> _Urllib3Response:
         """Send a GET request, off-loaded to a worker thread.
 
-        Requests gzip; without it urllib3's stdlib base sends
-        ``Accept-Encoding: identity``, which disables compression. A caller
-        can override that with :data:`~nab_index.transport.IDENTITY_HEADERS`
-        to get the body undecoded.
+        ``headers`` overrides entries of
+        :data:`~nab_index.transport.DEFAULT_HEADERS`, so a caller can pass
+        :data:`~nab_index.transport.IDENTITY_HEADERS` to get the body
+        undecoded. Requesting gzip matters here: without it urllib3's stdlib
+        base sends ``Accept-Encoding: identity``, which disables compression.
+        The defaults go on the request rather than on the pool because urllib3
+        replaces the pool's headers with a request's own instead of merging.
         """
-        request_headers = {"Accept-Encoding": "gzip"}
+        request_headers = dict(DEFAULT_HEADERS)
         if headers is not None:
             request_headers.update(headers)
         try:

--- a/nab-index/tests/test_index_transport.py
+++ b/nab-index/tests/test_index_transport.py
@@ -1,7 +1,12 @@
-"""Tests for nab_index.urllib3_async_transport pooling."""
+"""Tests for urllib3 transport pooling and the default request headers."""
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, version
+
+import pytest
+
+from nab_index.transport import DEFAULT_HEADERS, USER_AGENT, _user_agent
 from nab_index.urllib3_async_transport import Urllib3AsyncTransport
 
 
@@ -12,3 +17,21 @@ def test_pool_reused_within_thread() -> None:
     first = transport._pool()
     second = transport._pool()
     assert first is second
+
+
+def test_user_agent_names_nab_index_and_its_version() -> None:
+    assert f"nab-index/{version('nab-index')}" == USER_AGENT
+
+
+def test_user_agent_falls_back_without_installed_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def missing(name: str) -> str:
+        raise PackageNotFoundError(name)
+
+    monkeypatch.setattr("nab_index.transport.version", missing)
+    assert _user_agent() == "nab-index/0.0.0+unknown"
+
+
+def test_default_headers_ask_for_gzip_and_name_nab_index() -> None:
+    assert DEFAULT_HEADERS == {"Accept-Encoding": "gzip", "User-Agent": USER_AGENT}

--- a/nab-python/tests/test_async_transports.py
+++ b/nab-python/tests/test_async_transports.py
@@ -36,6 +36,9 @@ from nab_index.retry import (
     next_delay,
 )
 from nab_index.transport import (
+    DEFAULT_HEADERS,
+    IDENTITY_HEADERS,
+    USER_AGENT,
     AsyncHttpTransport,
     ContentDecodingError,
     HttpError,
@@ -203,6 +206,41 @@ def _artifact_stub_index(body: bytes) -> Iterator[_ArtifactStubIndex]:
     server = _ArtifactStubIndex(("127.0.0.1", 0), _ArtifactStubIndexHandler)
     server.body = body
     server.accept_encoding = []
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+class _UserAgentStubIndex(ThreadingHTTPServer):
+    """Loopback index that records each request's User-Agent."""
+
+    user_agents: list[str | None]
+
+
+class _UserAgentStubIndexHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        assert isinstance(self.server, _UserAgentStubIndex)
+        self.server.user_agents.append(self.headers.get("User-Agent"))
+
+        body = b"ok"
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        """Drop the handler's stderr access log."""
+
+
+@contextmanager
+def _user_agent_stub_index() -> Iterator[_UserAgentStubIndex]:
+    server = _UserAgentStubIndex(("127.0.0.1", 0), _UserAgentStubIndexHandler)
+    server.user_agents = []
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
@@ -1007,7 +1045,7 @@ class TestUrllib3AsyncTransport:
         pool.request.assert_called_once_with(
             "GET",
             "https://example.com/",
-            headers={"Accept-Encoding": "gzip", "k": "v"},
+            headers={**DEFAULT_HEADERS, "k": "v"},
             timeout=5.0,
             retries=GET_RETRY,
             decode_content=False,
@@ -1087,7 +1125,7 @@ class TestUrllib3AsyncTransport:
         pool.request.assert_called_once_with(
             "GET",
             "https://example.com/",
-            headers={"Accept-Encoding": "gzip"},
+            headers=DEFAULT_HEADERS,
             timeout=5.0,
             retries=GET_RETRY,
             decode_content=False,
@@ -1116,7 +1154,7 @@ class TestUrllib3AsyncTransport:
         pool.request.assert_called_once_with(
             "GET",
             "https://example.com/",
-            headers={"Accept-Encoding": "identity"},
+            headers={**DEFAULT_HEADERS, **IDENTITY_HEADERS},
             timeout=5.0,
             retries=GET_RETRY,
             decode_content=False,
@@ -1739,6 +1777,46 @@ class TestUnfollowedRedirectAcrossBackends:
 
             with pytest.raises(HttpError, match="300"):
                 asyncio.run(go())
+
+
+class TestUserAgentAcrossBackends:
+    """Both backends send the same User-Agent."""
+
+    @pytest.mark.parametrize("make_transport", TRANSPORTS)
+    def test_get_sends_the_user_agent(
+        self, make_transport: Callable[[], AsyncHttpTransport]
+    ) -> None:
+        with _user_agent_stub_index() as index:
+            url = f"http://127.0.0.1:{index.server_port}/simple/pkg/"
+
+            async def go() -> None:
+                transport = make_transport()
+                try:
+                    await transport.get(url)
+                finally:
+                    await transport.aclose()
+
+            asyncio.run(go())
+
+        assert index.user_agents == [USER_AGENT]
+
+    @pytest.mark.parametrize("make_transport", TRANSPORTS)
+    def test_accept_encoding_override_keeps_the_user_agent(
+        self, make_transport: Callable[[], AsyncHttpTransport]
+    ) -> None:
+        with _user_agent_stub_index() as index:
+            url = f"http://127.0.0.1:{index.server_port}/files/pkg-1.0.whl"
+
+            async def go() -> None:
+                transport = make_transport()
+                try:
+                    await transport.get(url, headers=IDENTITY_HEADERS)
+                finally:
+                    await transport.aclose()
+
+            asyncio.run(go())
+
+        assert index.user_agents == [USER_AGENT]
 
 
 class TestExtractSdistFiles:


### PR DESCRIPTION
nab never set a User-Agent of its own, so every index request went out as `python-urllib3/2.7.0`, or as `python-httpx/0.28.1` under `--http-backend httpx`. An index sees no sign the traffic is nab, and the identity it does see changes with whichever backend is installed.

Both transports now build their request headers from a shared `DEFAULT_HEADERS` in `nab_index.transport`. It holds the existing `Accept-Encoding: gzip` plus `User-Agent: nab-index/<version>`, the name PyPI's API guidelines ask for. Caller headers still override individual entries, so passing `IDENTITY_HEADERS` for an undecoded body keeps the User-Agent. The version comes from installed metadata; when nab-index is not installed as a distribution the header is `nab-index/0.0.0+unknown`.
