### PR TITLE
report a filtered version as filtered, not missing

### DIFF
--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -488,6 +488,45 @@ def excluded_by_wheel_tags(
     return True
 
 
+def _parsed_version(raw: str) -> Version | None:
+    """Return the interned version, or None when it is not a PEP 440 version."""
+    try:
+        return _intern_version(raw)
+    except InvalidVersion:
+        return None
+
+
+def has_filtered_in_range_release(
+    provider: Provider,
+    normalized: str,
+    version_range: VersionRange,
+    kept: Sequence[Version],
+) -> bool:
+    """Whether a filter dropped a release inside ``version_range``.
+
+    Callers ask only when no surviving version falls in the range, so a
+    dropped one that does is the release the requirement asked for.  A
+    dropped version equal to one in ``kept`` survived under another
+    spelling instead: :func:`filter_distributions` collapses equal
+    versions onto one representative, and ``===`` compares its string
+    form.  Filtering through ``version_range`` keeps the pre-release
+    semantics candidate selection uses.
+    """
+    files = provider.coordinator.index.get_listing(normalized)
+    if not files:
+        return False
+
+    surviving = set(kept)
+    dropped = (
+        version
+        for dist in files
+        if (version := _parsed_version(dist.version)) is not None
+        and version not in surviving
+    )
+
+    return any(version_range.filter(dropped))
+
+
 def _drop_sdist_install_wheel_only(
     result: list[tuple[Version, DistFile]],
     policy_by_version: Mapping[Version, DistPolicy],

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -1288,7 +1288,9 @@ class Provider:
         no_lookahead = not self.root_requirements and not self.solution_decisions
         if no_lookahead or not candidates:
             if not candidates:
-                self._record_no_versions_reason(package, all_versions)
+                self._record_no_versions_reason(
+                    package, all_versions, version_range=version_range
+                )
             return candidates[0] if candidates else None
 
         skip = self._try_abort_skip(normalized, candidates[0])
@@ -1661,6 +1663,7 @@ class Provider:
         all_versions: list[Version],
         *,
         blockers: list[str] | None = None,
+        version_range: VersionRange | None = None,
     ) -> None:
         """Record why ``choose_version`` returned ``None`` for ``package``.
 
@@ -1675,6 +1678,11 @@ class Provider:
         missing from the index when in fact it is the resolver's
         transitive constraints (or a too-strict build policy) that
         excluded every candidate.
+
+        ``version_range`` is passed only when no surviving version fell
+        inside it.  A version the listing filter dropped that does fall
+        inside it is the release the requirement asked for, so the reason
+        names the filter rather than reporting no match.
 
         ``all_versions`` is post-filter, so an empty one means either the
         index served no files or every file it served was dropped by the
@@ -1696,8 +1704,8 @@ class Provider:
         nothing falls in.  That second ask has no blockers of its own, so
         its no-match reason must not overwrite the one naming the blocker.
         """
+        _, _, normalized = self.split_and_normalize(package)
         if not all_versions:
-            _, _, normalized = self.split_and_normalize(package)
             raw_listing = self.coordinator.index.get_listing(normalized)
             tag_excluded = self.tag_excluded_wheels.get(normalized, 0)
             if not raw_listing:
@@ -1742,6 +1750,14 @@ class Provider:
         elif package in self._no_versions_reasons:
             # The weakest reason: keep whatever is already recorded.
             return
+        elif version_range is not None and _listing.has_filtered_in_range_release(
+            self, normalized, version_range, all_versions
+        ):
+            reason = (
+                "found on index but every version matching the requirement"
+                " was filtered (by requires-python, wheel tags, dist-policy,"
+                " or upload-time)"
+            )
         else:
             reason = "no version matches the requirement"
         self._no_versions_reasons[package] = reason

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -10,6 +10,7 @@ import sys
 import tarfile
 import threading
 import zipfile
+from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import ClassVar, cast
@@ -1302,6 +1303,124 @@ class TestNoVersionsReasons:
         coordinator = make_coordinator([make_wheel("1.0")], package="foo")
         provider = Provider(coordinator)
         provider.choose_version("foo", SpecifierSet(">=5.0").to_range())
+        assert (
+            provider.get_no_versions_reason("foo")
+            == "no version matches the requirement"
+        )
+
+    @pytest.mark.parametrize(
+        ("listing", "build"),
+        [
+            pytest.param(
+                [make_wheel("2.0", requires_python=">=3.13"), make_wheel("1.0")],
+                lambda coordinator: Provider(
+                    coordinator, target=ResolveTarget.for_host_python("3.9.0")
+                ),
+                id="requires-python",
+            ),
+            pytest.param(
+                [
+                    WheelFile(
+                        filename="pkg-2.0-cp311-cp311-win_amd64.whl",
+                        url="https://example.com/pkg-2.0-cp311-cp311-win_amd64.whl",
+                        version="2.0",
+                        requires_python=None,
+                        has_metadata=True,
+                        upload_time=None,
+                    ),
+                    make_wheel("1.0"),
+                ],
+                lambda coordinator: Provider(coordinator, target=_LINUX311),
+                id="wheel-tags",
+            ),
+            pytest.param(
+                [make_sdist("2.0"), make_wheel("1.0")],
+                lambda coordinator: Provider(
+                    coordinator, dist_policy=DistPolicy.WHEEL_ONLY
+                ),
+                id="dist-policy",
+            ),
+            pytest.param(
+                [
+                    make_wheel("2.0", upload_time="2024-06-01T00:00:00Z"),
+                    make_wheel("1.0", upload_time="2024-01-01T00:00:00Z"),
+                ],
+                lambda coordinator: Provider(
+                    coordinator,
+                    uploaded_prior_to=datetime(2024, 3, 1, tzinfo=timezone.utc),
+                ),
+                id="upload-time",
+            ),
+        ],
+    )
+    def test_filtered_in_range_release_reports_the_filter(
+        self,
+        listing: list[WheelFile | SdistFile],
+        build: Callable[[MagicMock], Provider],
+    ) -> None:
+        """An in-range release a filter dropped is not reported as no such version.
+
+        Each listing keeps an out-of-range 1.0, so the package still has a
+        surviving version and only the 2.0 the requirement asks for was
+        filtered away.
+        """
+        coordinator = make_coordinator(listing, package="foo")
+        provider = build(coordinator)
+        assert provider.choose_version("foo", SpecifierSet(">=2").to_range()) is None
+        assert provider.get_no_versions_reason("foo") == (
+            "found on index but every version matching the requirement was"
+            " filtered (by requires-python, wheel tags, dist-policy, or"
+            " upload-time)"
+        )
+
+    def test_unparseable_listing_version_is_not_read_as_a_filtered_match(self) -> None:
+        """A version nab cannot parse cannot be the in-range release."""
+        unparseable = WheelFile(
+            filename="pkg-not-a-version-py3-none-any.whl",
+            url="https://example.com/pkg-not-a-version-py3-none-any.whl",
+            version="not-a-version",
+            requires_python=None,
+            has_metadata=True,
+            upload_time=None,
+        )
+        coordinator = make_coordinator([unparseable, make_wheel("1.0")], package="foo")
+        provider = Provider(coordinator)
+        assert provider.choose_version("foo", SpecifierSet(">=2").to_range()) is None
+        assert (
+            provider.get_no_versions_reason("foo")
+            == "no version matches the requirement"
+        )
+
+    def test_another_spelling_of_a_kept_version_is_not_a_filtered_match(self) -> None:
+        """A release that survived under another spelling was not filtered.
+
+        The wheel's ``1.0`` and the sdist's ``1.0.0`` are one release, which
+        the listing collapses onto the ``1.0`` representative.  ``===``
+        compares the string, so ``1.0.0`` falls in range while the kept
+        representative does not, and no filter dropped anything.
+        """
+        coordinator = make_coordinator(
+            [make_wheel("1.0"), make_sdist("1.0.0")], package="foo"
+        )
+        provider = Provider(coordinator)
+        assert (
+            provider.choose_version("foo", SpecifierSet("===1.0.0").to_range()) is None
+        )
+        assert (
+            provider.get_no_versions_reason("foo")
+            == "no version matches the requirement"
+        )
+
+    def test_local_source_out_of_range_reports_no_match(self, tmp_path: Path) -> None:
+        """A local source has no index listing to have filtered anything."""
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "foo"\nversion = "1.2.3"\n', encoding="utf-8"
+        )
+        coordinator = make_coordinator([], package="foo")
+        provider = Provider(
+            coordinator, local_sources=[LocalSource("foo", str(tmp_path))]
+        )
+        assert provider.choose_version("foo", SpecifierSet(">=5").to_range()) is None
         assert (
             provider.get_no_versions_reason("foo")
             == "no version matches the requirement"

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -3052,6 +3052,51 @@ class TestAugmentResolutionError:
         assert "bar" in diagnostics
         assert "foo: no version matches the requirement" not in diagnostics
 
+    def test_filtered_release_is_not_reported_as_a_missing_version(
+        self, tmp_path: Path
+    ) -> None:
+        """A filtered release reads as filtered rather than as absent.
+
+        ``foo`` 2.0 matches ``foo>=2`` and only its ``Requires-Python``
+        keeps it off a 3.12 target.  Its 1.0 survives, so the package has a
+        version and the whole-listing wording does not fire.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\ndependencies = ["foo>=2"]\n',
+            encoding="utf-8",
+        )
+
+        newer = WheelFile(
+            filename="foo-2.0-py3-none-any.whl",
+            url="https://example.com/foo-2.0-py3-none-any.whl",
+            version="2.0",
+            requires_python=">=3.13",
+            has_metadata=True,
+            upload_time=None,
+        )
+        coordinator = make_coordinator(
+            listings={"foo": [newer, *_index_wheels("foo", "1.0")]},
+            metadata_by_version={
+                "2.0": _metadata("foo", "2.0"),
+                "1.0": _metadata("foo", "1.0"),
+            },
+        )
+
+        with patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda _self: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            with pytest.raises(ResolutionError) as info:
+                _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
+
+        diagnostics = str(info.value).split("Diagnostics:")[1]
+        assert (
+            "foo: found on index but every version matching the requirement was"
+            " filtered (by requires-python, wheel tags, dist-policy, or"
+            " upload-time)" in diagnostics
+        )
+        assert "no version matches the requirement" not in diagnostics
+
     def test_constraint_does_not_hide_the_transitive_blocker(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
When a package has a release that matches the requirement but a listing filter dropped it, the diagnostics said `foo: no version matches the requirement`, even though that version is sitting on the index. nab already had wording for the filtered case, but it only fired when every file for the package was dropped, so a package with other surviving versions fell through to the generic no-match line.

Now, when no surviving version falls inside the requested range, the stored listing is checked for a dropped release that does, and the reason names the filter instead. A dropped version equal to a surviving one does not count, since that version survived under another spelling.

With `foo>=2`, where foo 2.0 is `Requires-Python >=3.13` on a 3.12 target and foo 1.0 survives, the reason is now `found on index but every version matching the requirement was filtered (by requires-python, wheel tags, dist-policy, or upload-time)`.
