### PR TITLE
cli.md: an offline build refusal need not end the run

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -273,8 +273,12 @@ Both subcommands accept the same runtime knobs:
 A name absent from the index is remembered for a short window, so a
 repeated lookup is answered from cache, offline included.
 
-Offline refuses rather than fetches. A PEP 517 build environment with
-`[build-system].requires` to install fails the run.
+Offline refuses rather than fetches, so a PEP 517 build environment
+that has anything to install cannot be created and the build fails.
+At `build-remote` that rejects only the sdist version, and the
+resolve tries the next candidate. A declared local, VCS, or archive
+source, or a workspace member, is the only candidate for its name, so
+the same refusal ends the run. See [Build policy](build-policy.md).
 
 `urllib3` is the only backend pulled in by the base install. The
 others surface a helpful `ImportError` if selected without the


### PR DESCRIPTION
The CLI reference said that under `--offline` a PEP 517 build that needs to install `[build-system].requires` fails the run. That only holds when the sdist is the only candidate for its name. On the `build-remote` path the refusal rejects that one version and the resolve tries the next candidate, so the run can still succeed.

The wording now splits the two cases: a declared local, VCS, or archive source, or a workspace member is the only candidate for its name, so there the same refusal does end the run. It also links to the build policy reference.
