### PR TITLE
read a built wheel's own dist-info

### DIFF
--- a/nab-python/src/nab_python/_build/runner.py
+++ b/nab-python/src/nab_python/_build/runner.py
@@ -36,11 +36,12 @@ import build
 import pyproject_hooks
 import tomli
 
+from nab_index.local_index import UnsupportedWheelError, wheel_metadata_member
 from nab_resolver.resolver import ResolutionError
 
 from .._vendor.packaging.requirements import Requirement
 from .._vendor.packaging.specifiers import SpecifierSet
-from .._vendor.packaging.utils import canonicalize_name
+from .._vendor.packaging.utils import canonicalize_name, parse_wheel_filename
 from .._vendor.packaging.version import Version
 from ..metadata import WheelMetadata, validate_specifier_versions
 from ..paths import path_state
@@ -220,9 +221,9 @@ def _extract_metadata_dir(
         if skip_prepare:
             return _build_wheel_and_extract(project, output_dir)
         return Path(project.metadata_path(output_dir))
-    # build raises a bare ValueError for a wheel whose name will not parse; a
-    # member zipfile cannot decompress surfaces as zlib.error, lzma.LZMAError,
-    # or NotImplementedError (a RuntimeError subclass).
+    # A wheel whose name will not parse raises a bare ValueError on either
+    # branch; a member zipfile cannot decompress surfaces as zlib.error,
+    # lzma.LZMAError, or NotImplementedError (a RuntimeError subclass).
     except (
         zipfile.BadZipFile,
         ValueError,
@@ -246,35 +247,37 @@ def _extract_metadata_dir(
 def _build_wheel_and_extract(
     project: build.ProjectBuilder, output_directory: Path
 ) -> Path:
-    """Build a wheel and extract its dist-info directory.
+    """Build a wheel and extract its own dist-info directory.
 
-    The built wheel ends up in ``output_directory``; this helper
-    pulls out its ``*.dist-info/`` and returns the path so the
-    caller can read ``METADATA``.  Mirrors what
-    :meth:`build.ProjectBuilder.metadata_path` does internally
-    when the prepare hook is missing; we just call it
-    unconditionally for the hatchling+dynamic-deps case.
+    The built wheel ends up in ``output_directory``; this helper pulls
+    out the ``*.dist-info/`` for the distribution the wheel's filename
+    names and returns the path so the caller can read ``METADATA``.
+    Selection goes through
+    :func:`nab_index.local_index.wheel_metadata_member` so a built wheel
+    and an indexed one agree on what a wheel's own metadata is.
     """
     wheel = project.build("wheel", str(output_directory))
     wheel_path = Path(wheel)
+    expected = parse_wheel_filename(wheel_path.name)[0]
+
     with zipfile.ZipFile(wheel_path) as zf:
-        dist_info_members = [
-            n
-            for n in zf.namelist()
-            if "/" in n and n.split("/")[0].endswith(".dist-info")
-        ]
-        if not dist_info_members:
-            msg = f"built wheel {wheel_path.name} has no .dist-info directory"
+        names = zf.namelist()
+
+        try:
+            member = wheel_metadata_member(names, expected)
+        except UnsupportedWheelError as exc:
+            msg = f"built wheel {wheel_path.name} is unusable: {exc}"
+            raise BuildBackendError(msg) from exc
+        if member is None:
+            msg = f"built wheel {wheel_path.name} has no .dist-info/METADATA"
             raise BuildBackendError(msg)
-        distinfo_dir = dist_info_members[0].split("/")[0]
+
+        distinfo_dir = member.partition("/")[0]
         zf.extractall(
             output_directory,
-            (
-                m
-                for m in zf.namelist()
-                if m == distinfo_dir or m.startswith(distinfo_dir + "/")
-            ),
+            (m for m in names if m.startswith(distinfo_dir + "/")),
         )
+
     return output_directory / distinfo_dir
 
 

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -43,7 +43,11 @@ from nab_python._build.env import (
     _picked_wheel_pin,
     _venv_scheme_paths,
 )
-from nab_python._build.runner import BuildBackendError, run_build_backend
+from nab_python._build.runner import (
+    BuildBackendError,
+    _build_wheel_and_extract,
+    run_build_backend,
+)
 from nab_python._provider.metadata_resolver import pick_dist
 from nab_python._vendor.packaging.version import Version
 from nab_python.config import NabProjectConfig
@@ -113,7 +117,8 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
 
     name = "fake-dyn"
     version = "9.9.9"
-    distinfo = f"{name}-{version}.dist-info"
+    escaped = name.replace("-", "_")
+    distinfo = f"{escaped}-{version}.dist-info"
     metadata = (
         "Metadata-Version: 2.1\\n"
         f"Name: {name}\\n"
@@ -121,7 +126,7 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
         "Requires-Python: >=3.10\\n"
         "Requires-Dist: click>=8\\n"
     )
-    wheel_name = f"{name}-{version}-py3-none-any.whl"
+    wheel_name = f"{escaped}-{version}-py3-none-any.whl"
     target = os.path.join(wheel_directory, wheel_name)
     with zipfile.ZipFile(target, "w") as zf:
         zf.writestr(f"{distinfo}/METADATA", metadata)
@@ -760,26 +765,83 @@ class TestParseMetadata:
 
 
 class TestBuildWheelExtraction:
-    """``_build_wheel_and_extract`` raises when the built wheel has
-    no .dist-info directory.  The happy path is exercised end-to-end
-    through the hatchling-quirk-skip test in ``TestRunBuildBackend``.
+    """``_build_wheel_and_extract`` reads the dist-info directory the built
+    wheel's own filename names, and refuses one that does not match.
     """
 
-    def test_wheel_without_dist_info_raises(self, tmp_path: Path) -> None:
-        import zipfile
-
-        from nab_python._build.runner import _build_wheel_and_extract
-
-        wheel_path = tmp_path / "fake-1.0-py3-none-any.whl"
-        with zipfile.ZipFile(wheel_path, "w") as zf:
-            zf.writestr("loose-file.txt", "hi")
-
+    def _builder(self, wheel_path: Path) -> build.ProjectBuilder:
         class _Builder:
             def build(self, _kind: str, _outdir: str) -> str:
                 return str(wheel_path)
 
+        return _Builder()  # type: ignore[return-value]
+
+    def _metadata(self, name: str, version: str, requires: str) -> str:
+        return (
+            "Metadata-Version: 2.1\n"
+            f"Name: {name}\n"
+            f"Version: {version}\n"
+            f"Requires-Dist: {requires}\n"
+        )
+
+    def test_wheel_without_dist_info_raises(self, tmp_path: Path) -> None:
+        wheel_path = tmp_path / "fake-1.0-py3-none-any.whl"
+        with zipfile.ZipFile(wheel_path, "w") as zf:
+            zf.writestr("loose-file.txt", "hi")
+
         with pytest.raises(BuildBackendError, match="no .dist-info"):
-            _build_wheel_and_extract(_Builder(), tmp_path)  # type: ignore[arg-type]
+            _build_wheel_and_extract(self._builder(wheel_path), tmp_path)
+
+    def test_leftover_dist_info_from_another_release_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """A stale ``<name>-<oldver>.dist-info/`` left in the source tree can
+        get swept into the built wheel alongside the real one.
+        """
+        wheel_path = tmp_path / "bar-2.0-py3-none-any.whl"
+        with zipfile.ZipFile(wheel_path, "w") as zf:
+            zf.writestr(
+                "bar-1.9.dist-info/METADATA", self._metadata("bar", "1.9", "old-dep==1")
+            )
+            zf.writestr(
+                "bar-2.0.dist-info/METADATA", self._metadata("bar", "2.0", "new-dep>=2")
+            )
+            zf.writestr("bar/__init__.py", "")
+
+        with pytest.raises(BuildBackendError, match="multiple .dist-info"):
+            _build_wheel_and_extract(self._builder(wheel_path), tmp_path)
+
+    def test_dist_info_for_another_distribution_raises(self, tmp_path: Path) -> None:
+        wheel_path = tmp_path / "bar-2.0-py3-none-any.whl"
+        with zipfile.ZipFile(wheel_path, "w") as zf:
+            zf.writestr(
+                "aaa-1.0.dist-info/METADATA", self._metadata("aaa", "1.0", "old-dep==1")
+            )
+            zf.writestr("bar/__init__.py", "")
+
+        with pytest.raises(BuildBackendError, match="different distribution"):
+            _build_wheel_and_extract(self._builder(wheel_path), tmp_path)
+
+    def test_extracts_dist_info_named_by_filename(self, tmp_path: Path) -> None:
+        """Members ahead of the dist-info do not hide it, and an escaped name
+        (``zope.interface`` as ``zope_interface``) still matches.
+        """
+        wheel_path = tmp_path / "zope_interface-5.0-py3-none-any.whl"
+        with zipfile.ZipFile(wheel_path, "w") as zf:
+            zf.writestr("zope/interface/__init__.py", "")
+            zf.writestr(
+                "zope_interface-5.0.dist-info/METADATA",
+                self._metadata("zope.interface", "5.0", "new-dep>=2"),
+            )
+            zf.writestr("zope_interface-5.0.dist-info/WHEEL", "Wheel-Version: 1.0\n")
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        result = _build_wheel_and_extract(self._builder(wheel_path), out_dir)
+
+        assert result == out_dir / "zope_interface-5.0.dist-info"
+        assert (result / "WHEEL").is_file()
+        assert "Version: 5.0" in (result / "METADATA").read_text(encoding="utf-8")
 
 
 _UNREADABLE_DIST_INFO = "foo-1.0.dist-info"
@@ -932,6 +994,25 @@ class TestRunBuildBackendCorruptBuiltWheel:
         monkeypatch.setattr(runner_mod, "_should_skip_prepare", lambda *_a: True)
         self._run(
             tmp_path, config, self._corrupt_building_project("foo-1.0-py3-none-any.whl")
+        )
+
+    def test_skip_prepare_invalid_wheel_name_wrapped(
+        self,
+        tmp_path: Path,
+        config: NabProjectConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The skip-prepare path parses the wheel filename too, so a readable
+        zip under a name that does not parse is refused there as well.
+        """
+        self._pyproject(tmp_path)
+        monkeypatch.setattr(runner_mod, "_should_skip_prepare", lambda *_a: True)
+        self._run(
+            tmp_path,
+            config,
+            self._corrupt_building_project(
+                "garbage.whl", _wheel_zip(zipfile.ZIP_DEFLATED)
+            ),
         )
 
     @pytest.mark.parametrize("skip_prepare", [False, True])


### PR DESCRIPTION
When nab builds a wheel to read its metadata, the runner took whichever `.dist-info/` came first in the zip's namelist. A source tree still holding a `<name>-<oldversion>.dist-info/` from an earlier build can get it packed into the new wheel, and nab then reads the old release's METADATA and resolves that project's dependencies from the wrong version.

Selection now goes through `wheel_metadata_member`, the helper the local wheel reader and the HTTP range reader already share, using the distribution name from the built wheel's own filename. A wheel with more than one top-level dist-info, or with one that belongs to a different distribution, is now a build error.
