### PR TITLE
report a pylock as a lockfile on nab download --groups/--all-groups

### DIFF
--- a/src/nab/_config_cmd.py
+++ b/src/nab/_config_cmd.py
@@ -35,10 +35,10 @@ from .cli import (
     ResolutionFlag,
     _cli_overrides,
     _fail_config,
-    _require_pyproject_file,
     app,
     effective_config,
     printer,
+    require_pyproject_file,
 )
 
 ActionArg = Annotated[str, tyro.conf.Positional]
@@ -90,7 +90,7 @@ def config_command(  # noqa: PLR0913 - tyro maps each kwarg to a CLI flag
     # Validate the pyproject path the same way the run commands do: a
     # missing or directory --path is a hard error, not a silently-skipped
     # source that prints all-built-in defaults.
-    _require_pyproject_file(path)
+    require_pyproject_file(path)
 
     cli_overrides = _cli_overrides(
         cli_resolution=project_resolution,

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -51,7 +51,6 @@ from nab_python.lockfile import (
     read_lockfile_packages,
     summarize_lock,
 )
-from nab_python.paths import PathState, path_state
 from nab_python.requirements_file import (
     InvalidProjectRequirementError,
     InvalidProjectTableError,
@@ -822,17 +821,15 @@ def _read_selection_table_or_exit(
     """Read the table a selection flag expands over, exiting 1 on a bad file.
 
     ``nab download`` selects groups and extras before it loads the config, so
-    this read is the first to touch the pyproject and reports a bad file itself.
+    this read can be the first to touch the pyproject and runs the path guards
+    itself rather than relying on the config load having run.
     """
+    _cli.require_pyproject_file(path)
+
     try:
         return reader(path)
     except OSError as e:
-        if e.errno == errno.ENOENT:
-            _cli.printer().error(f"{path} not found")
-        elif path_state(path) is PathState.DIRECTORY:
-            _cli.printer().error(f"{path} is a directory")
-        else:
-            _cli.printer().error(f"cannot read {path}: {e}")
+        _cli.printer().error(f"cannot read {path}: {e}")
         sys.exit(1)
     except (UnicodeDecodeError, tomli.TOMLDecodeError) as e:
         _cli.printer().error(f"{path} is not valid TOML: {e}")

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -440,10 +440,10 @@ def _is_pylock(path: Path) -> bool:
     return "lock-version" in data and "project" not in data
 
 
-def _require_pyproject_file(path: Path) -> None:
+def require_pyproject_file(path: Path) -> None:
     """Exit 1 if ``path`` is not a readable pyproject file.
 
-    Shared by ``_load_config`` (the run path) and ``nab config`` so the
+    Shared by every command that takes a project path, so the
     not-found/directory wording lives in one place.  A missing or
     directory ``--path`` is a hard error, not a silently-skipped source.
     A path whose stat fails passes: the config read reports it, naming
@@ -492,7 +492,7 @@ def _load_config(
     anchor: datetime | None = None,
     cli_overrides: Mapping[str, object] | None = None,
 ) -> NabProjectConfig:
-    _require_pyproject_file(path)
+    require_pyproject_file(path)
 
     try:
         return read_pyproject_config(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -221,6 +221,20 @@ def _make_pyproject(tmp_path: Path, body: str = "") -> Path:
     return pyproject
 
 
+def _make_pylock_with_groups(tmp_path: Path) -> Path:
+    """Write a minimal PEP 751 lock.
+
+    Its ``dependency-groups`` is an array of names, a shape the PEP 735
+    table never has.
+    """
+    pylock = tmp_path / "pylock.toml"
+    pylock.write_text(
+        'lock-version = "1.0"\nrequires-python = ">=3.10"\n'
+        'dependency-groups = ["dev"]\ncreated-by = "nab"\npackages = []\n'
+    )
+    return pylock
+
+
 def _mismatched_local_source_project(tmp_path: Path) -> str:
     """Write a sibling tree named ``bar`` and declare it as local source ``foo``."""
     member = tmp_path / "bar"
@@ -3720,11 +3734,7 @@ class TestGroupAndExtraSelection:
     def test_all_groups_unreadable_file_surfaces_error(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """A regular file that still raises OSError reports the real error.
-
-        Neither ``not found`` nor ``is a directory`` applies, so the errno
-        must reach the message rather than default to ``not found``.
-        """
+        """A regular file that still raises OSError reports the real error."""
         pyproject = _make_pyproject(tmp_path)
         denied = PermissionError(errno.EACCES, "Permission denied", str(pyproject))
         with (
@@ -3757,11 +3767,10 @@ class TestGroupAndExtraSelection:
         capsys: pytest.CaptureFixture[str],
         deny_access: Callable[[Path], AbstractContextManager[None]],
     ) -> None:
-        """An unsearchable parent must not fail the is-a-directory check.
+        """An unsearchable parent must not fail the is-a-directory guard.
 
-        EACCES lands on the stat behind that check as well as on the read,
-        so classifying the path has to be raise-free or the handler raises
-        a second error out of itself.
+        EACCES lands on the stat behind that guard as well as on the read,
+        so classifying the path has to be raise-free.
         """
         pyproject = _make_pyproject(tmp_path)
         with deny_access(pyproject), pytest.raises(SystemExit, match="1"):
@@ -3769,6 +3778,24 @@ class TestGroupAndExtraSelection:
         err = capsys.readouterr().err
         assert "cannot read" in err
         assert "Permission denied" in err
+
+    def test_all_groups_on_a_pylock_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A lock passed as the project is named as one, not read for groups."""
+        pylock = _make_pylock_with_groups(tmp_path)
+        with pytest.raises(SystemExit, match="1"):
+            resolve_group_selection(pylock, groups=(), all_groups=True)
+        assert "is a PEP 751 lockfile" in capsys.readouterr().err
+
+    def test_all_extras_on_a_pylock_exits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Symmetric guard for ``--all-extras`` on a lock."""
+        pylock = _make_pylock_with_groups(tmp_path)
+        with pytest.raises(SystemExit, match="1"):
+            resolve_extra_selection(pylock, extras=(), all_extras=True)
+        assert "is a PEP 751 lockfile" in capsys.readouterr().err
 
     def test_all_groups_reads_defined_groups(self, tmp_path: Path) -> None:
         """Selection equals the keys of ``[dependency-groups]``.
@@ -4742,6 +4769,32 @@ class TestDownloadCommand:
         with pytest.raises(SystemExit, match="1"):
             download(tmp_path, **kwargs)
         assert "is a directory" in capsys.readouterr().err
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {},
+            {"all_groups": True},
+            {"all_extras": True},
+            {"groups": ("dev",)},
+            {"extras": ("e",)},
+        ],
+    )
+    def test_pylock_path_exits(
+        self,
+        kwargs: dict[str, object],
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``nab download`` names a lock as one under every selection flag.
+
+        Only the bare arm reaches the guard through the config load; the
+        selection flags read the path first and have to say the same thing.
+        """
+        pylock = _make_pylock_with_groups(tmp_path)
+        with pytest.raises(SystemExit, match="1"):
+            download(pylock, **kwargs)
+        assert "is a PEP 751 lockfile" in capsys.readouterr().err
 
     def test_extras_flag_forwarded_to_resolver(self, tmp_path: Path) -> None:
         # ``--extras`` is required for ``exactly_one`` / ``at_least_one``


### PR DESCRIPTION
`nab lock pylock.toml` says the file is a PEP 751 lockfile and points at the pyproject. `nab download pylock.toml --all-groups` (or `--groups dev`) instead prints `in pylock.toml: [dependency-groups] must be a table, got list`, which blames the file's shape rather than saying it is a lock. A lock written by nab carries `dependency-groups` as an array of names, so any nab lock passed by mistake lands here.

`nab download` resolves the group and extra selection before it loads the config, so that read is the first thing to touch the path. That read open-coded the not-found and is-a-directory checks but not the lockfile one, so the two commands disagreed on the same input.

The selection read now calls the shared path guard instead of open-coding part of it, and both the group and extra readers go through it. That meant dropping the leading underscore off `require_pyproject_file`, since `_lock` calls it across a module boundary.
