### PR TITLE
fail the tests when the provider stops forwarding sdist hashes

### DIFF
--- a/nab-python/src/nab_python/_testing/coordinator_fake.py
+++ b/nab-python/src/nab_python/_testing/coordinator_fake.py
@@ -5,6 +5,9 @@ around a real :class:`~nab_python.fetch.InMemoryIndex`.  The mock's
 request methods write to the index and return an already-set
 :class:`threading.Event`, so the synchronous provider code under test
 sees fetches resolve immediately.
+
+Unlike the real coordinator, the request methods take the published hashes
+as required arguments, so a caller that stops forwarding them fails.
 """
 
 from __future__ import annotations
@@ -100,7 +103,7 @@ def _wire_metadata_side_effects(
         index.store_metadata(pkg, ver, text, url)
 
     def _request_metadata(
-        pkg: str, ver: str, url: str, _hash: tuple[str, str] | None = None
+        pkg: str, ver: str, url: str, _hash: tuple[str, str] | None
     ) -> threading.Event:
         _fetch_metadata(pkg, ver, url)
         return _done_event()
@@ -127,12 +130,7 @@ def _wire_sdist_side_effects(
     sdist_pkg_info_by_version: Mapping[str, str | None] | None,
     sdist_pyproject_toml: str | None,
 ) -> None:
-    """Attach the ``request_sdist`` side effect.
-
-    The published hashes have no default here: the real fetcher verifies the
-    archive against them, so a call site that stops forwarding them fails
-    loudly instead of quietly resolving from an unverified sdist.
-    """
+    """Attach the ``request_sdist`` side effect."""
 
     def _request_sdist(
         pkg: str,

--- a/nab-python/src/nab_python/_testing/coordinator_fake.py
+++ b/nab-python/src/nab_python/_testing/coordinator_fake.py
@@ -127,13 +127,18 @@ def _wire_sdist_side_effects(
     sdist_pkg_info_by_version: Mapping[str, str | None] | None,
     sdist_pyproject_toml: str | None,
 ) -> None:
-    """Attach the ``request_sdist`` side effect."""
+    """Attach the ``request_sdist`` side effect.
+
+    The published hashes have no default here: the real fetcher verifies the
+    archive against them, so a call site that stops forwarding them fails
+    loudly instead of quietly resolving from an unverified sdist.
+    """
 
     def _request_sdist(
         pkg: str,
         ver: str,
         _url: str,
-        _hashes: tuple[tuple[str, str], ...] = (),
+        _hashes: tuple[tuple[str, str], ...],
     ) -> threading.Event:
         pkg_info = (
             sdist_pkg_info

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -7622,7 +7622,7 @@ class TestPrefetchWalkAhead:
         # An empty fetch (no sidecar served) still marks the slot fetched.
         two = make_wheel("2.0")
         assert two.metadata_url is not None
-        coordinator.request_metadata("foo", "2.0", two.metadata_url)
+        coordinator.request_metadata("foo", "2.0", two.metadata_url, None)
         coordinator.reset_mock()
         provider.prefetch_walk_ahead("foo")
         items = coordinator.request_metadata_batch.call_args[0][0]
@@ -9369,16 +9369,17 @@ class TestBuildRemoteFailureModes:
             build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
 
     @respx.mock
-    def test_listing_hashes_are_checked_against_the_served_archive(self) -> None:
-        """The listing's digests decide whether the served bytes reach a build.
+    def test_archive_hash_checked_over_real_fetch(self) -> None:
+        """A tampered archive is refused against the listing's published sha256.
 
-        Runs the fetch for real, so the archive is only refused if the
-        listing's hashes travel with the request.
+        Fetches for real, so the refusal only happens if the provider
+        forwards the listing's hashes.
         """
         sdist = make_sdist("1.0", hashes=(("sha256", "0" * 64),))
         respx.get(sdist.url).mock(
             return_value=httpx.Response(200, content=b"tampered bytes")
         )
+
         with FetchCoordinator(transport=HttpxAsyncTransport()) as coordinator:
             provider = Provider(
                 coordinator,

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -16,7 +16,9 @@ from pathlib import Path
 from typing import ClassVar, cast
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
+import respx
 
 from nab_index.cache import CachePolicy, OnDiskCache
 from nab_index.client import (
@@ -27,6 +29,7 @@ from nab_index.client import (
     WheelFile,
     _parse_files,
 )
+from nab_index.httpx_async_transport import HttpxAsyncTransport
 from nab_index.lazy_wheel import RangeMetadataResult, RangeOutcome
 from nab_index.local_index import LocalIndexClient
 from nab_index.multi_index import IndexConfig
@@ -151,6 +154,7 @@ def make_sdist(
     requires_python: str | None = None,
     upload_time: str | None = None,
     local_path: Path | None = None,
+    hashes: tuple[tuple[str, str], ...] = (),
 ) -> SdistFile:
     """Build a SdistFile for testing."""
     return SdistFile(
@@ -160,6 +164,7 @@ def make_sdist(
         requires_python=requires_python,
         upload_time=upload_time,
         local_path=local_path,
+        hashes=hashes,
     )
 
 
@@ -2122,7 +2127,7 @@ class TestGetDependencies:
             pkg: str,
             ver: str,
             _url: str,
-            _hashes: tuple[tuple[str, str], ...] = (),
+            _hashes: tuple[tuple[str, str], ...],
         ) -> threading.Event:
             coordinator.index.store_sdist_metadata_error(
                 pkg, ver, SdistHashMismatchError("sdist sha256 mismatch")
@@ -8643,7 +8648,7 @@ class TestEffectiveBuildPolicy:
             pkg: str,
             ver: str,
             _url: str,
-            _hashes: tuple[tuple[str, str], ...] = (),
+            _hashes: tuple[tuple[str, str], ...],
         ) -> threading.Event:
             coordinator.index.store_sdist_archive(pkg, ver, archive_bytes)
             return _done_event()
@@ -9103,7 +9108,7 @@ class TestStaticSdistMetadata:
             pkg: str,
             ver: str,
             _url: str,
-            _hashes: tuple[tuple[str, str], ...] = (),
+            _hashes: tuple[tuple[str, str], ...],
         ) -> threading.Event:
             coordinator.index.store_sdist_archive(pkg, ver, archive_bytes)
             return _done_event()
@@ -9147,7 +9152,7 @@ class TestStaticSdistMetadata:
             pkg: str,
             ver: str,
             _url: str,
-            _hashes: tuple[tuple[str, str], ...] = (),
+            _hashes: tuple[tuple[str, str], ...],
         ) -> threading.Event:
             coordinator.index.store_sdist_archive_error(
                 pkg, ver, SdistHashMismatchError("sdist sha256 mismatch")
@@ -9180,7 +9185,7 @@ class TestStaticSdistMetadata:
             pkg: str,
             ver: str,
             _url: str,
-            _hashes: tuple[tuple[str, str], ...] = (),
+            _hashes: tuple[tuple[str, str], ...],
         ) -> threading.Event:
             coordinator.index.store_sdist_archive_error(
                 pkg, ver, HttpError("503 Server Error fetching sdist archive")
@@ -9214,7 +9219,7 @@ class TestStaticSdistMetadata:
             pkg: str,
             ver: str,
             _url: str,
-            _hashes: tuple[tuple[str, str], ...] = (),
+            _hashes: tuple[tuple[str, str], ...],
         ) -> threading.Event:
             coordinator.index.store_sdist_archive(pkg, ver, b"sdist-archive-bytes")
             return _done_event()
@@ -9263,7 +9268,7 @@ class TestStaticSdistMetadata:
             pkg: str,
             ver: str,
             url: str,
-            hashes: tuple[tuple[str, str], ...] = (),
+            hashes: tuple[tuple[str, str], ...],
         ) -> threading.Event:
             coordinator.index.store_sdist_metadata(
                 pkg,
@@ -9326,7 +9331,7 @@ class TestBuildRemoteFailureModes:
             pkg: str,
             ver: str,
             _url: str,
-            _hashes: tuple[tuple[str, str], ...] = (),
+            _hashes: tuple[tuple[str, str], ...],
         ) -> threading.Event:
             provider.coordinator.index.store_sdist_archive(pkg, ver, None)
             return _done_event()
@@ -9350,7 +9355,7 @@ class TestBuildRemoteFailureModes:
             pkg: str,
             ver: str,
             _url: str,
-            _hashes: tuple[tuple[str, str], ...] = (),
+            _hashes: tuple[tuple[str, str], ...],
         ) -> threading.Event:
             provider.coordinator.index.store_sdist_archive_error(
                 pkg, ver, SdistHashMismatchError("sdist sha256 mismatch")
@@ -9362,6 +9367,28 @@ class TestBuildRemoteFailureModes:
         ).request_sdist_archive.side_effect = _tampered_fetch
         with pytest.raises(SdistHashMismatchError):
             build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
+
+    @respx.mock
+    def test_listing_hashes_are_checked_against_the_served_archive(self) -> None:
+        """The listing's digests decide whether the served bytes reach a build.
+
+        Runs the fetch for real, so the archive is only refused if the
+        listing's hashes travel with the request.
+        """
+        sdist = make_sdist("1.0", hashes=(("sha256", "0" * 64),))
+        respx.get(sdist.url).mock(
+            return_value=httpx.Response(200, content=b"tampered bytes")
+        )
+        with FetchCoordinator(transport=HttpxAsyncTransport()) as coordinator:
+            provider = Provider(
+                coordinator,
+                target=_PY312,
+                dist_policy=DistPolicy.WHEEL_OR_SDIST,
+                build_policy=BuildPolicy.BUILD_REMOTE,
+            )
+            provider.versions_cache["pkg"] = [(V("1.0"), sdist)]
+            with pytest.raises(SdistHashMismatchError, match="0" * 64):
+                build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
 
     @pytest.mark.parametrize(
         "data",
@@ -9381,7 +9408,7 @@ class TestBuildRemoteFailureModes:
             pkg: str,
             ver: str,
             _url: str,
-            _hashes: tuple[tuple[str, str], ...] = (),
+            _hashes: tuple[tuple[str, str], ...],
         ) -> threading.Event:
             provider.coordinator.index.store_sdist_archive(pkg, ver, data)
             return _done_event()
@@ -9404,7 +9431,7 @@ class TestBuildRemoteFailureModes:
             pkg: str,
             ver: str,
             _url: str,
-            _hashes: tuple[tuple[str, str], ...] = (),
+            _hashes: tuple[tuple[str, str], ...],
         ) -> threading.Event:
             provider.coordinator.index.store_sdist_archive(pkg, ver, b"data")
             return _done_event()
@@ -9435,7 +9462,7 @@ class TestBuildRemoteFailureModes:
             pkg: str,
             ver: str,
             _url: str,
-            _hashes: tuple[tuple[str, str], ...] = (),
+            _hashes: tuple[tuple[str, str], ...],
         ) -> threading.Event:
             provider.coordinator.index.store_sdist_archive(pkg, ver, b"data")
             return _done_event()
@@ -9462,7 +9489,7 @@ class TestBuildRemoteFailureModes:
             pkg: str,
             ver: str,
             _url: str,
-            _hashes: tuple[tuple[str, str], ...] = (),
+            _hashes: tuple[tuple[str, str], ...],
         ) -> threading.Event:
             provider.coordinator.index.store_sdist_archive(pkg, ver, b"data")
             return _done_event()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@ import re
 import runpy
 import stat
 import sys
+import tarfile
 import zipfile
 from collections.abc import Callable
 from contextlib import AbstractContextManager
@@ -46,7 +47,6 @@ from nab.cli import (
     main,
 )
 from nab.output import Printer, Verbosity
-from nab_index.client import SdistHashMismatchError
 from nab_index.httpx_async_transport import HttpxAsyncTransport
 from nab_index.transport import HttpError
 from nab_index.urllib3_async_transport import Urllib3AsyncTransport
@@ -200,6 +200,20 @@ def _hashless_resolve_result() -> ResolveResult:
             )
         ],
     )
+
+
+def _sdist_archive(name: str = "foo", version: str = "1.0") -> bytes:
+    """Build sdist bytes whose PKG-INFO declares one dependency."""
+    pkg_info = (
+        f"Metadata-Version: 2.2\nName: {name}\nVersion: {version}\n"
+        "Requires-Dist: tampered-dep\n"
+    ).encode()
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        info = tarfile.TarInfo(f"{name}-{version}/PKG-INFO")
+        info.size = len(pkg_info)
+        tar.addfile(info, io.BytesIO(pkg_info))
+    return buf.getvalue()
 
 
 def _sidecarless_wheel(name: str = "foo", version: str = "1.0") -> bytes:
@@ -948,24 +962,50 @@ class TestLockCommandSpecific:
         assert "Traceback" not in err
 
     def test_sdist_hash_mismatch_exits(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """An sdist archive failing its published hash exits 1, not a traceback."""
+        """An sdist failing its published hash exits 1, not a traceback.
+
+        Drives a real resolve against a fake index whose only file for ``foo``
+        is an sdist published with a sha256 the served archive does not match,
+        so the archive's PKG-INFO never reaches the resolve.
+        """
+        monkeypatch.setattr(
+            "nab.cli._config_search_roots",
+            lambda p: SourceRoots(project_dir=p.parent, pyproject=p),
+        )
         pyproject = _make_pyproject(tmp_path)
+
+        sdist_url = "https://files.example.com/foo-1.0.tar.gz"
+        listing = {
+            "files": [
+                {
+                    "filename": "foo-1.0.tar.gz",
+                    "url": sdist_url,
+                    "hashes": {"sha256": "0" * 64},
+                }
+            ]
+        }
+        transport = _SidecarTransport(
+            {
+                "https://pypi.org/simple/foo/": json.dumps(listing).encode(),
+                sdist_url: _sdist_archive(),
+            }
+        )
+
         with (
-            patch(
-                "nab.cli.resolve_for_targets",
-                side_effect=SdistHashMismatchError(
-                    f"sdist sha256 mismatch: expected {'0' * 64}, got abc123"
-                ),
-            ),
+            patch("nab.cli._make_transport", return_value=transport),
             pytest.raises(SystemExit, match="1"),
         ):
-            lock(pyproject)
+            lock(pyproject, output=tmp_path / "pylock.toml", cache=False)
 
         err = capsys.readouterr().err
         assert "cannot lock" in err
         assert "sdist sha256 mismatch" in err
+        assert "0" * 64 in err
         assert "Traceback" not in err
 
     def test_dynamic_local_source_forbidden_build_exits(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -970,8 +970,7 @@ class TestLockCommandSpecific:
         """An sdist failing its published hash exits 1, not a traceback.
 
         Drives a real resolve against a fake index whose only file for ``foo``
-        is an sdist published with a sha256 the served archive does not match,
-        so the archive's PKG-INFO never reaches the resolve.
+        is an sdist published with a sha256 the served archive does not match.
         """
         monkeypatch.setattr(
             "nab.cli._config_search_roots",


### PR DESCRIPTION
The provider passes each sdist's published hashes to `request_sdist` and `request_sdist_archive`, and the PEP 658 sidecar hash to `request_metadata`. The fetcher checks the download against them before anything reads it. Nothing in the suite noticed when that argument went away: the shared coordinator fake declared the hashes with a default, so dropping the forwarding at every call site left the suite green with integrity checking off.

The fake now takes the hashes as required arguments, so a caller that stops passing them fails on the signature.

Two tests also stop stubbing the coordinator, so the refusal comes from the code that does the checking. The lock CLI test drives a real resolve against a listing whose only file for `foo` is an sdist published with a sha256 the served archive does not match. The build-remote test fetches through the real path, so a tampered archive is refused against the listing's digest.
