### PR TITLE
fix relative cache-dir crashing a resolve with a VCS source

### DIFF
--- a/nab-python/src/nab_python/_provider/sources.py
+++ b/nab-python/src/nab_python/_provider/sources.py
@@ -248,7 +248,10 @@ def materialize_vcs_source(
         msg = f"vcs source {source.name!r}: {exc}"
         raise UnsupportedSdistError(msg) from exc
     provider.vcs_pins[canonicalize_name(source.name)] = clone.commit_sha
-    path = clone.path / clone.subdirectory if clone.subdirectory else clone.path
+
+    # The cache dir can be relative, and a file URI needs an absolute path.
+    root = clone.path.resolve()
+    path = root / clone.subdirectory if clone.subdirectory else root
     descriptor = f"vcs source {source.name!r}"
     metadata = extract_source_metadata(
         provider,

--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -1488,6 +1488,38 @@ class TestVcsConfigPlumbing:
         assert len(roots) == 1
         assert not roots[0].exists()
 
+    def test_vcs_source_resolves_under_a_relative_cache_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``nab lock --cache-dir relcache`` materialises a declared VCS source.
+
+        ``cache-dir`` is cwd-relative, so the clone root can be relative.
+        """
+
+        def fake_run(cmd: list[str], **kwargs: object) -> object:
+            cwd = Path(str(kwargs["cwd"]))
+            if cmd[:2] == ["git", "init"]:
+                (cwd / ".git").mkdir(exist_ok=True)
+            if cmd[:2] == ["git", "checkout"]:
+                (cwd / "pyproject.toml").write_text(
+                    '[project]\nname = "pkg"\nversion = "1.0"\n', encoding="utf-8"
+                )
+            return type("P", (), {"returncode": 0})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.chdir(tmp_path)
+
+        result = resolve_with_coordinator(
+            _make_coordinator({}),
+            _one_target(),
+            _reqs("pkg"),
+            config=_no_build(vcs=self._allow(), vcs_sources=(self._source(),)),
+            cache_dir=Path("relcache"),
+        )
+
+        assert result.success
+        assert result.target_results[0].pins == {"pkg": Version("1.0")}
+
 
 class TestRunPassSerial:
     """``_run_pass`` resolves each target in turn, covering the alignment chain."""

--- a/nab-python/tests/test_vcs.py
+++ b/nab-python/tests/test_vcs.py
@@ -790,6 +790,44 @@ class TestProviderVcsIntegration:
         # Unknown package returns None.
         assert provider.vcs_pin_for("missing") is None
 
+    def test_relative_cache_dir_yields_an_absolute_clone_uri(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A cwd-relative cache dir still yields an absolute ``file:`` URI.
+
+        ``cache-dir`` is cwd-relative, so the provider can be handed a
+        relative clone root.
+        """
+        sha = "a" * 40
+        monkeypatch.chdir(tmp_path)
+        clone_dir = tmp_path / "cache" / "vcs" / "k" / sha
+        _mark_complete(clone_dir)
+        (clone_dir / "pyproject.toml").write_text(
+            '[project]\nname = "foo"\nversion = "1.0.0"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("nab_index.vcs._repo_key", lambda _url: "k")
+
+        provider = Provider(
+            self.coordinator(),
+            vcs_config=VcsConfig(
+                policy=VcsPolicy.ALLOW,
+                allowed_schemes=frozenset({"git+https"}),
+                allowed_repos=("https://example.com/",),
+                require_pin=True,
+            ),
+            vcs_sources=[
+                VcsSource(name="foo", url=f"git+https://example.com/foo.git@{sha}"),
+            ],
+            vcs_cache_dir=Path("cache"),
+            build_policy=BuildPolicy.NEVER,
+        )
+        versions = provider.fetch_versions("foo")
+        assert len(versions) == 1
+        assert versions[0][1].url == clone_dir.resolve().as_uri()
+
     def test_floating_ref_lock_records_resolved_sha(
         self,
         tmp_path: Path,


### PR DESCRIPTION
Point nab at a relative cache dir (`--cache-dir .nab-cache`, or the same key in `nab.toml`) and any resolve with a declared VCS source dies with a bare `ValueError: relative path can't be expressed as a file URI` traceback.

The clone root is the cache dir joined with the repo key and commit, so a relative cache dir gives a relative clone path, and the synthetic sdist listing built from that clone calls `Path.as_uri()` on it. Resolve the clone path before the listing is built, so the URL is absolute whatever was passed in.
