### PR TITLE
fix crash on a relative file: index URL over a flat wheelhouse

### DIFF
--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -511,8 +511,11 @@ class LocalIndexClient:
     """
 
     def __init__(self, index_url: str) -> None:
-        """Hold the resolved root path for ``index_url``."""
-        self._root = parse_file_url(index_url)
+        """Hold the resolved root path for ``index_url``.
+
+        A ``file:`` URL may be cwd-relative; artefact URLs have to be absolute.
+        """
+        self._root = parse_file_url(index_url).resolve()
         self._unreadable_only: set[str] = set()
 
     async def aclose(self) -> None:

--- a/nab-python/tests/test_fetch.py
+++ b/nab-python/tests/test_fetch.py
@@ -2208,6 +2208,23 @@ class TestMultiIndexCoordinator:
             assert listing is not None
             assert [f.filename for f in listing] == ["foo-1.0-py3-none-any.whl"]
 
+    def test_local_index_with_relative_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A relative ``file:`` index URL lists a flat wheelhouse."""
+        wheelhouse = tmp_path / "wheelhouse"
+        wheelhouse.mkdir()
+        wheel = wheelhouse / "foo-1.0-py3-none-any.whl"
+        wheel.write_bytes(b"")
+        monkeypatch.chdir(tmp_path)
+
+        with _coord(indexes=[IndexConfig("local", "file:wheelhouse")]) as coord:
+            coord.request_listing("foo").wait(timeout=5)
+            listing = coord.index.get_listing("foo")
+            assert coord.index.get_listing_error("foo") is None
+            assert listing is not None
+            assert [f.url for f in listing] == [wheel.as_uri()]
+
     def test_unparseable_index_url_is_not_local(self, tmp_path: Path) -> None:
         """An index URL urlsplit cannot parse falls through to the remote client."""
         wheelhouse = tmp_path / "wheelhouse"

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -381,6 +381,33 @@ class TestFlatWheelhouse:
         client = LocalIndexClient(missing.as_uri())
         assert run(client.get_files("foo")) == []
 
+    def test_relative_root_lists_both_layouts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A cwd-relative ``file:`` root names artefacts by absolute URI."""
+        root = tmp_path / "idx"
+        (root / "foo").mkdir(parents=True)
+        (root / "foo" / "index.html").write_text(
+            '<a href="foo-1.0-py3-none-any.whl">foo-1.0-py3-none-any.whl</a>',
+            encoding="utf-8",
+        )
+        listed = root / "foo" / "foo-1.0-py3-none-any.whl"
+        listed.write_bytes(b"")
+
+        flat = root / "bar-2.0-py3-none-any.whl"
+        flat.write_bytes(b"")
+
+        monkeypatch.chdir(tmp_path)
+        client = LocalIndexClient("file:idx")
+
+        pep503 = run(client.get_files("foo"))
+        assert [f.url for f in pep503] == [listed.as_uri()]
+        assert [f.local_path for f in pep503] == [listed]
+
+        wheelhouse = run(client.get_files("bar"))
+        assert [f.url for f in wheelhouse] == [flat.as_uri()]
+        assert [f.local_path for f in wheelhouse] == [flat]
+
     def test_listing_order_independent_of_readdir_order(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
Pointing an index at a cwd-relative `file:` URL such as `file:wheelhouse` crashes `nab lock` and `nab download` with a raw ValueError traceback when the directory is a flat wheelhouse of files. The same URL works against a PEP 503 layout, which is why it looks like a wheelhouse problem rather than a URL one.

`LocalIndexClient` kept the root exactly as parsed, and the flat scan names each file with `Path.as_uri()`, which only accepts an absolute path. The PEP 503 layout never hit that because it resolves the package directory before building the base URL. The root is now resolved when the client is constructed, so both layouts name their files by absolute URI.
