### PR TITLE
fail the build when pyproject.toml is not a regular file

### DIFF
--- a/nab-python/src/nab_python/_build/runner.py
+++ b/nab-python/src/nab_python/_build/runner.py
@@ -44,7 +44,7 @@ from .._vendor.packaging.specifiers import SpecifierSet
 from .._vendor.packaging.utils import canonicalize_name, parse_wheel_filename
 from .._vendor.packaging.version import Version
 from ..metadata import WheelMetadata, validate_specifier_versions
-from ..paths import path_state
+from ..paths import PathState, path_state
 from .env import BuildEnvError, NabBuildEnv
 from .errors import BuildBackendError
 
@@ -84,12 +84,18 @@ def run_build_backend(
     :class:`NabBuildEnv` for why) so callers do not pass one in.
     """
     pyproject = source_dir / "pyproject.toml"
-    if path_state(pyproject).should_read:
+    state = path_state(pyproject)
+
+    if state.should_read:
         try:
             data = tomli.loads(pyproject.read_text(encoding="utf-8"))
         except (OSError, UnicodeDecodeError, tomli.TOMLDecodeError) as exc:
             msg = f"could not read pyproject.toml at {source_dir}: {exc}"
             raise BuildBackendError(msg) from exc
+    elif state is not PathState.ABSENT:
+        # The file is there, so the tree is not the legacy setup.py case.
+        msg = f"{pyproject} exists but is not a regular file"
+        raise BuildBackendError(msg)
     elif path_state(source_dir / "setup.py").should_read:
         # PEP 517 fallback for legacy setup.py projects: treat the
         # missing ``[build-system]`` as the documented default

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -275,6 +275,24 @@ class TestRunBuildBackend:
         ):
             run_build_backend(tmp_path, config=config)
 
+    def test_directory_pyproject_reports_not_a_regular_file(
+        self, tmp_path: Path, config: NabProjectConfig
+    ) -> None:
+        (tmp_path / "pyproject.toml").mkdir()
+
+        # setup.py is here so a fall-through would take the legacy branch.
+        (tmp_path / "setup.py").write_text("from setuptools import setup\n")
+
+        env = MagicMock()
+        env.__enter__ = MagicMock(return_value=env)
+        env.__exit__ = MagicMock(return_value=None)
+
+        with (
+            patch("nab_python._build.runner.NabBuildEnv", return_value=env),
+            pytest.raises(BuildBackendError, match="not a regular file"),
+        ):
+            run_build_backend(tmp_path, config=config)
+
     def test_unsearchable_setup_py_takes_the_legacy_branch(
         self,
         tmp_path: Path,


### PR DESCRIPTION
A source tree with a `pyproject.toml` directory sitting next to a `setup.py` crashed `nab lock` with a raw `IsADirectoryError` traceback instead of dropping the source with a build error.

`run_build_backend` dispatched on whether the path could be read, so a path that exists but is not a regular file counted as absent and took the legacy `setup.py` branch. That branch hands the tree to `build.ProjectBuilder`, which opens `pyproject.toml` itself, and the `OSError` it raises is not one of the exceptions the runner translates.

The runner now checks for that case at the dispatch and raises `BuildBackendError`, as config layer discovery and the CLI `--path` check already do.
