### PR TITLE
fix lock markers when a conflict set member is never selected

### DIFF
--- a/docs/explanation/conflicts.md
+++ b/docs/explanation/conflicts.md
@@ -154,13 +154,18 @@ package whose version does depend on the combination keeps the
 conjunction, and so does anything that requires it: an entry never
 fires where one of its own dependencies would not.
 
+A set forks only over the members the selection activates. The rest of
+its declared members are absent from the lock's `extras` and
+`dependency-groups` arrays and from every marker, so a set with an
+unselected member gates an entry exactly as one without it would.
+
 A dependency a member shares with a selection outside the set names
 both in its marker (`"cpu" in extras or "docs" in extras`), so
 selecting the member on its own still installs it.
 
 The lockfile stays within PEP 751: the membership markers use the
 standard `extras` and `dependency_groups` variables, and each fork's
-marker negates the co-members of every conflict set it draws from
+marker negates the other members it was forked against
 (`"cpu" in extras and "gpu" not in extras`), so the forks are mutually
 exclusive in the markers themselves. A PEP 751 consumer that never
 reads `[tool.nab].conflicts` still installs at most one fork; the two

--- a/nab-python/src/nab_python/_lockfile/pylock.py
+++ b/nab-python/src/nab_python/_lockfile/pylock.py
@@ -80,8 +80,9 @@ class _ForkAxes:
     """The declared conflict sets a lock's forks vary along.
 
     ``exclusion_groups`` are the ``(kind, name)`` member sets an install
-    context may activate at most one member of.  ``forks`` indexes every
-    target by its environment and its selection, which is how
+    context may activate at most one member of, restricted to the members
+    the resolve forked over (:func:`_forked_exclusion_groups`).  ``forks``
+    indexes every target by its environment and its selection, which is how
     :func:`_project_fork` walks one set's members with the other sets
     held fixed.  ``markers`` is each fork's unprojected selection marker,
     which does not vary by package, and ``gates`` each fork's
@@ -123,6 +124,23 @@ def _fork_index(
         (env_signatures[label], frozenset(lock.target.selection)): label
         for label, lock in targets.items()
     }
+
+
+def _forked_exclusion_groups(
+    exclusion_groups: Sequence[AbstractSet[tuple[str, str]]],
+    targets: Mapping[str, TargetLock],
+) -> tuple[AbstractSet[tuple[str, str]], ...]:
+    """Restrict each declared conflict set to the members a fork selects.
+
+    A set forks only over the members the run selected, so a declared
+    member the selection omits has no fork for :func:`_project_fork` to
+    swap in and no place in the lock's ``extras`` or ``dependency-groups``
+    arrays for an install context to activate.
+    """
+    forked = frozenset(
+        member for lock in targets.values() for member in lock.target.selection
+    )
+    return tuple(group & forked for group in exclusion_groups)
 
 
 class UnsoundSimplificationError(ValueError):
@@ -564,14 +582,15 @@ def _build_packages(
         for canonical_name, per_target in by_name.items()
     }
     shortened: dict[str, Marker | None] = {}
+    forked_groups = _forked_exclusion_groups(exclusion_groups, targets)
     axes = _ForkAxes(
-        exclusion_groups=tuple(exclusion_groups),
+        exclusion_groups=forked_groups,
         forks=_fork_index(targets, env_signatures),
         targets=targets,
         env_signatures=env_signatures,
         # One selection marker per label; it does not vary by package.
         markers={
-            label: _selection_marker(lock.target, exclusion_groups)
+            label: _selection_marker(lock.target, forked_groups)
             for label, lock in targets.items()
         },
         gates={
@@ -1048,9 +1067,9 @@ def _project_fork(
 ) -> _Projection:
     """Return the clauses one fork's entry for ``name`` can drop.
 
-    A declared conflict set is irrelevant to a package when swapping the
-    fork's member of that set for any other member, every other set held
-    fixed, leaves the package at the same pin reached the same way.
+    A conflict set is irrelevant to a package when swapping the fork's
+    member of that set for any other member, every other set held fixed,
+    leaves the package at the same pin reached the same way.
     Conjoining such a set's clauses narrows the entry to the forks that
     vary something the package does not depend on, so a selection naming
     a member of one set alone matches no entry and the package silently

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -5357,28 +5357,24 @@ class TestConflictForkNegatedEmission:
         assert self._select(pylock, ["cpu", "mkl"]) == {"onnxruntime"}
 
     def test_three_large_sets_write_lock_within_budget(self) -> None:
-        # Three declared 5-member at-most-one sets, each fork drawing one
-        # member per set, so every per-package marker negates 12
-        # co-members.  The disjointness gate binds them through the
-        # selection instead of the full membership powerset, so the lock
-        # is written rather than raising IntractableMarkerSet.
+        # Three declared 5-member at-most-one sets, one fork per member
+        # index, so every per-package marker negates 12 co-members.  The
+        # disjointness gate binds them through the selection instead of
+        # the full membership powerset, so the lock is written rather
+        # than raising IntractableMarkerSet.
         sets = [tuple(f"{letter}{i}" for i in range(5)) for letter in ("a", "b", "c")]
         all_names = tuple(name for members in sets for name in members)
+        drawn = [tuple(members[i] for members in sets) for i in range(5)]
 
-        fork_one = self._BASE.with_selection(
-            (("extra", "a0"), ("extra", "b0"), ("extra", "c0"))
-        )
-        fork_two = self._BASE.with_selection(
-            (("extra", "a1"), ("extra", "b1"), ("extra", "c1"))
-        )
-
+        forks = [
+            self._BASE.with_selection(tuple(("extra", name) for name in names))
+            for names in drawn
+        ]
         targets = {
-            fork_one.label: TargetLock(
-                target=fork_one, pins={"torch": _selection_pin("torch", "2.5.0")}
-            ),
-            fork_two.label: TargetLock(
-                target=fork_two, pins={"torch": _selection_pin("torch", "2.6.0")}
-            ),
+            fork.label: TargetLock(
+                target=fork, pins={"torch": _selection_pin("torch", f"2.{5 + i}.0")}
+            )
+            for i, fork in enumerate(forks)
         }
 
         conflicts = tuple(
@@ -5394,7 +5390,7 @@ class TestConflictForkNegatedEmission:
         text = write_lock(
             LockInput(
                 targets=targets,
-                env_base_names={_env_signature(fork_one): frozenset()},
+                env_base_names={_env_signature(forks[0]): frozenset()},
                 extras=all_names,
                 conflicts=conflicts,
             )
@@ -5406,7 +5402,7 @@ class TestConflictForkNegatedEmission:
             for p in pylock.packages
             if str(p.name) == "torch"
         }
-        assert set(torch_markers) == {"2.5.0", "2.6.0"}
+        assert set(torch_markers) == {f"2.{5 + i}.0" for i in range(len(drawn))}
 
         # simplify overruns the cell budget on this fork, so the emitter
         # passes the raw marker through unchanged: base env, the fork's three
@@ -5417,18 +5413,18 @@ class TestConflictForkNegatedEmission:
             ' and platform_machine == "x86_64"'
         )
 
-        def raw_marker(drawn: tuple[str, str, str]) -> str:
-            positives = " and ".join(f'"{name}" in extras' for name in drawn)
+        def raw_marker(names: tuple[str, ...]) -> str:
+            positives = " and ".join(f'"{name}" in extras' for name in names)
             negatives = " and ".join(
                 f'"{name}" not in extras'
                 for members in sets
                 for name in members
-                if name not in drawn
+                if name not in names
             )
             return f"{base} and {positives} and {negatives}"
 
-        assert torch_markers["2.5.0"] == raw_marker(("a0", "b0", "c0"))
-        assert torch_markers["2.6.0"] == raw_marker(("a1", "b1", "c1"))
+        for i, names in enumerate(drawn):
+            assert torch_markers[f"2.{5 + i}.0"] == raw_marker(names)
 
 
 class TestConflictSetCrossGating:
@@ -5732,3 +5728,95 @@ class TestConflictSetCrossGating:
         assert self._select(pylock, ["a1", "b1"]) == {"attrs 24.0"}
         assert self._select(pylock, ["b1"]) == set()
         assert self._select(pylock, ["a1"]) == set()
+
+
+class TestConflictSetDeclaredMemberWithNoFork:
+    """A declared member the selection omits has no fork to swap it for.
+
+    ``conflicts`` names ``b1``/``b2``/``b3`` while the lock ran with only
+    ``b1`` and ``b2`` selected, so nothing forked over ``b3`` and the
+    lock's ``dependency-groups`` array does not offer it.  The b-set is
+    still flat through ``six``, so ``six`` names the a-set alone and
+    selecting ``a1`` on its own installs it.
+    """
+
+    _BASE: ClassVar[ResolveTarget] = _target(python_version="3.12")
+    _ENV: ClassVar[dict[str, str]] = dict(_target(python_version="3.12").marker_env)
+    _A: ClassVar[dict[str, str]] = {"a1": "1.16.0", "a2": "1.15.0"}
+    _B: ClassVar[dict[str, str]] = {"b1": "3.7", "b2": "3.6"}
+    _UNSELECTED: ClassVar[str] = "b3"
+
+    def _lock(self) -> Pylock:
+        """Emit the 2x2 product of the selected members, with b3 declared only."""
+        targets: dict[str, TargetLock] = {}
+        for a, b in itertools.product(self._A, self._B):
+            fork = self._BASE.with_selection((("group", a), ("group", b)))
+            targets[fork.label] = TargetLock(
+                target=fork,
+                pins={
+                    "packaging": _selection_pin("packaging", "24.0"),
+                    "six": _selection_pin("six", self._A[a]),
+                    "idna": _selection_pin("idna", self._B[b]),
+                },
+                package_gates={"six": (("group", a),), "idna": (("group", b),)},
+            )
+        conflicts = tuple(
+            ConflictSet(
+                members=tuple(ConflictMember(ConflictKind.GROUP, m) for m in members),
+                policy=ConflictPolicy.AT_MOST_ONE,
+            )
+            for members in (tuple(self._A), (*self._B, self._UNSELECTED))
+        )
+        text = write_lock(
+            LockInput(
+                targets=targets,
+                env_base_names={_env_signature(self._BASE): frozenset({"packaging"})},
+                dependency_groups=(*self._A, *self._B),
+                conflicts=conflicts,
+            )
+        )
+        return Pylock.from_dict(tomllib.loads(text))
+
+    def _select(self, pylock: Pylock, groups: Sequence[str]) -> set[str]:
+        return {
+            f"{pkg.name} {pkg.version}"
+            for pkg, _ in pylock.select(
+                environment=self._ENV,  # type: ignore[arg-type]
+                extras=(),
+                dependency_groups=groups,
+            )
+        }
+
+    def test_marker_names_only_the_set_the_package_varies_over(self) -> None:
+        six = next(
+            str(p.marker)
+            for p in self._lock().packages
+            if str(p.name) == "six" and str(p.version) == "1.16.0"
+        )
+        assert '"a1" in dependency_groups' in six
+        assert '"a2" not in dependency_groups' in six
+        for member in (*self._B, self._UNSELECTED):
+            assert member not in six
+
+    def test_marker_does_not_name_a_member_the_lock_cannot_offer(self) -> None:
+        idna = next(
+            str(p.marker)
+            for p in self._lock().packages
+            if str(p.name) == "idna" and str(p.version) == "3.7"
+        )
+        assert '"b1" in dependency_groups' in idna
+        assert '"b2" not in dependency_groups' in idna
+        assert self._UNSELECTED not in idna
+
+    @pytest.mark.parametrize("a", [None, "a1", "a2"])
+    @pytest.mark.parametrize("b", [None, "b1", "b2"])
+    def test_every_legal_selection_installs_what_it_asked_for(
+        self, a: str | None, b: str | None
+    ) -> None:
+        groups = [name for name in (a, b) if name is not None]
+        expected = {"packaging 24.0"}
+        if a is not None:
+            expected.add(f"six {self._A[a]}")
+        if b is not None:
+            expected.add(f"idna {self._B[b]}")
+        assert self._select(self._lock(), groups) == expected

--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -691,8 +691,14 @@ class TestTwoConflictSetsPartialInstall:
             for first, second in itertools.product(("a1", "a2"), ("b1", "b2"))
         ]
 
-    def _installed(self, extras: list[str]) -> set[str]:
-        """Lock all four extras, then select ``extras`` from the emitted lock."""
+    def _installed(
+        self, extras: list[str], *, b_members: tuple[str, ...] = ("b1", "b2")
+    ) -> set[str]:
+        """Lock all four extras, then select ``extras`` from the emitted lock.
+
+        ``b_members`` is what the b-set declares; only b1 and b2 are ever
+        selected, so a longer tuple names a member no fork carries.
+        """
         result = resolve_with_coordinator(
             self._coordinator(),
             _one_target(),
@@ -706,7 +712,7 @@ class TestTwoConflictSetsPartialInstall:
             build_lock_input(
                 result,
                 config=_no_build(
-                    conflicts=(_extra_set("a1", "a2"), _extra_set("b1", "b2"))
+                    conflicts=(_extra_set("a1", "a2"), _extra_set(*b_members))
                 ),
                 extras=("a1", "a2", "b1", "b2"),
             )
@@ -741,6 +747,16 @@ class TestTwoConflictSetsPartialInstall:
 
     def test_no_extras_installs_the_base_alone(self) -> None:
         assert self._installed([]) == {"base==1.0"}
+
+    def test_a_declared_member_no_fork_carries_gates_nothing(self) -> None:
+        # b3 is declared conflicting but never selected, so the resolve
+        # never forked over it and the lock does not offer it; the a1
+        # packages install for a1 alone just as they do without it.
+        assert self._installed(["a1"], b_members=("b1", "b2", "b3")) == {
+            "base==1.0",
+            "pkga1==1.0",
+            "shared==1.0",
+        }
 
 
 class TestDroppedRootMarkerWarnedOnce:


### PR DESCRIPTION
A conflict set can declare a member the resolve never selects, which leaves that member with no fork. The per-package projection from #643 asked for a fork at every declared member, so one missing member blocked the drop for that set and for every set folded in after it, and the entries kept naming both sets at once.

A project with groups `a1/a2` and `b1/b2/b3` that only forked over `b1` and `b2` locked fine, but `--groups a1` installed the base alone: the `six` entry `a1` asks for also named `b1` and `b2`, and the install selected neither.

The projection now runs over the members the forks select. A declared member that no fork carries has nothing to swap in and no place in the lock's `extras` or `dependency-groups` arrays for an install to activate, so it no longer blocks a drop or shows up in a marker.
