### PR TITLE
fix EACCES escaping the --locked lockfile presence check

### DIFF
--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -51,6 +51,7 @@ from nab_python.lockfile import (
     read_lockfile_packages,
     summarize_lock,
 )
+from nab_python.paths import PathState, path_state
 from nab_python.requirements_file import (
     InvalidProjectRequirementError,
     InvalidProjectTableError,
@@ -313,7 +314,8 @@ def _fast_fail_locked(
     non-zero; otherwise it returns and the full resolve runs.
     """
     target = _locked_target_path(output)
-    if not target.exists():
+    # A stat that failed is not an absent lock.
+    if path_state(target) is PathState.ABSENT:
         _cli.printer().error(
             f"--locked: no lockfile at {target} to check; run `nab lock` first."
         )

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -7,6 +7,8 @@ whether the tier fired: a disqualifier never calls it, a fall-through does.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from contextlib import AbstractContextManager
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -498,4 +500,27 @@ def test_unreadable_lock_precondition(
 
     assert exc.value.code == 1
     assert "cannot read lockfile" in capsys.readouterr().err
+    mock.assert_not_called()
+
+
+def test_unsearchable_parent_precondition(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    deny_access: Callable[[Path], AbstractContextManager[None]],
+) -> None:
+    # EACCES lands on the presence check's stat, before any open.
+    pyproject = _write_pyproject(tmp_path, '[project]\ndependencies = ["foo"]\n')
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}))
+    capsys.readouterr()
+
+    mock = _locked_mock()
+    with deny_access(out), pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock)
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "no lockfile" not in err
+    assert "cannot read lockfile" in err
+    assert "Permission denied" in err
     mock.assert_not_called()


### PR DESCRIPTION
`nab lock --locked` checks the committed lockfile is present before reading it, and that check was a boolean `Path.exists()`. If a parent directory is unsearchable the stat behind it fails with EACCES, which `Path.exists` re-raises on Python 3.13 and below and reports as absent on 3.14. So the command either printed a traceback or said there was no lockfile and to run `nab lock` first, for a file that is present.

The presence check now goes through `nab_python.paths`, which distinguishes an absent path from one whose stat failed. A path that could not be stat'd falls through to the read below, which reports the OS error and exits 1 with `--locked: cannot read lockfile ...`.
