### PR TITLE
end failure reports with a conclusion, not the root sentinel

### DIFF
--- a/nab-python/tests/test_widen_decision.py
+++ b/nab-python/tests/test_widen_decision.py
@@ -631,7 +631,7 @@ class TestNarrowForDisplay:
         assert str(exc_info.value).splitlines() == [
             "because no versions of a are available",
             f"because your project depends on a {root_reqs['a']}",
-            "so <root> <VersionRange '[0, 0]'>",
+            "so your project's requirements cannot be satisfied",
         ]
 
     def test_promoted_parent_reads_as_all_versions(self) -> None:

--- a/nab-resolver/src/nab_resolver/report.py
+++ b/nab-resolver/src/nab_resolver/report.py
@@ -11,10 +11,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, TypeAlias
 
+from .root import ROOT
 from .types import IncompatibilityCause, PackageType, Term, VersionType
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
 
     from .types import Incompatibility
 
@@ -276,6 +277,19 @@ def _render_line(
             f"{term.package} {incompatibility.constraint_range}"
         )
 
+    return _render_prefix_line(cause, terms)
+
+
+def _render_prefix_line(
+    cause: IncompatibilityCause, terms: Sequence[Term[Any, Any]]
+) -> str:
+    """Render a clause that has no attribution form as a prefix and a body."""
+    # The virtual root is always selected, so naming it says nothing; a line
+    # holding nothing else is the conclusion.
+    stated = [term for term in terms if term.package is not ROOT]
+    if not stated:
+        return "so your project's requirements cannot be satisfied"
+
     prefix = {
         IncompatibilityCause.ROOT: "because root requires",
         IncompatibilityCause.DEPENDENCY: "because",
@@ -283,7 +297,7 @@ def _render_line(
         IncompatibilityCause.DERIVED: "so",
     }.get(cause, "")
     render = _format_requirement if cause in _REQUIREMENT_PREFIX_CAUSES else format_term
-    body = " and ".join(render(term) for term in terms)
+    body = " and ".join(render(term) for term in stated)
 
     if cause is IncompatibilityCause.NO_VERSIONS:
         return f"{prefix} {body} are available"

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -2006,6 +2006,41 @@ class TestErrorMessages:
             "so qux [5, +inf)",
         ]
 
+    def test_clause_holding_only_the_root_states_the_conclusion(self) -> None:
+        """A clause left with the virtual root alone has no package to name."""
+        # Term[Any, int] sidesteps the invariant PackageType TypeVar so
+        # ROOT and str entries can share a list.
+        root_term: Term[Any, int] = Term(ROOT, Range.singleton(0), positive=True)
+        absent_baz: Term[Any, int] = Term("baz", Range.full(), positive=False)
+        project = Incompatibility(
+            [root_term, absent_baz],
+            cause=IncompatibilityCause.ROOT,
+        )
+        terminal = Incompatibility(
+            [root_term],
+            cause=IncompatibilityCause.DERIVED,
+            cause_left=project,
+        )
+        assert format_error(terminal).splitlines() == [
+            "because your project depends on baz",
+            "so your project's requirements cannot be satisfied",
+        ]
+
+    def test_report_never_names_the_root_sentinel(self) -> None:
+        """A derived line that absorbed a project requirement drops the root term."""
+        provider = DictProvider({"a": {2: {"b": Range.at_least(2)}}, "b": {1: {}}})
+        with pytest.raises(ResolutionError) as exc_info:
+            Resolver(provider).resolve(
+                {"a": Range.singleton(2), "b": Range.between(1, 2)}
+            )
+        assert str(exc_info.value).splitlines() == [
+            "because a 2 depends on b [2, +inf)",
+            "because your project depends on b [1, 2)",
+            "so a 2",
+            "because your project depends on a 2",
+            "so your project's requirements cannot be satisfied",
+        ]
+
     def test_format_term_marks_negation(self) -> None:
         """format_term prefixes a negated term with `not` and leaves positives bare."""
         positive = format_term(Term("a", Range.at_least(1), positive=True))

--- a/nab-resolver/tests/test_widen_hook.py
+++ b/nab-resolver/tests/test_widen_hook.py
@@ -468,7 +468,7 @@ class TestFormatErrorNarrow:
             "because root 1 depends on foo\n"
             "so root 1\n"
             "because your project depends on root 1\n"
-            "so <root> 1"
+            "so your project's requirements cannot be satisfied"
         )
 
 


### PR DESCRIPTION
Failure reports ended on the internal root sentinel. The last line read `so <root> [0, 0]` rather than saying the requirements cannot be satisfied, and derived lines in the middle of a report named it too.

The virtual root sits in those clauses and the generic line renderer had no case for it, so it printed the sentinel's repr and the version the resolver had assigned it.

Report lines now drop root terms, and a line with nothing else left reads `so your project's requirements cannot be satisfied`.
