### PR TITLE
check the free-threaded floor after --python moves the target

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -917,9 +917,10 @@ def plan_targets(config: NabProjectConfig) -> tuple[ResolveTarget, ...]:
     project that declares neither resolves against the running interpreter,
     like pip.
 
-    The ``requires-python`` declaration is checked here rather than at parse
-    time because ``--python`` moves the target after the config is read, and
-    it is the flag that rescues a project whose declaration excludes the host.
+    The ``requires-python`` declaration and the free-threaded floor are
+    checked here rather than at parse time because ``--python`` moves the
+    target after the config is read, and it is the flag that rescues a
+    project whose declaration excludes the host.
 
     Every target is checked, matrix included: the lock records the
     declaration at top level and the targets in ``environments``, so a
@@ -927,6 +928,12 @@ def plan_targets(config: NabProjectConfig) -> tuple[ResolveTarget, ...]:
     and that a PEP 751 installer refuses.
     """
     targets = _plan_targets(config.matrix, config.environment)
+
+    if config.environment is not None:
+        _check_free_threaded_environment(
+            config.environment, (targets[0].python_version,)
+        )
+
     for target in targets:
         _check_requires_python_admits_target(
             config.requires_python,
@@ -970,21 +977,40 @@ def _declared_target(environment: EnvironmentConfig) -> ResolveTarget:
     python = environment.python or host_environment()["python_full_version"]
     axis = python_axis_environment(python)
     implementation = environment.implementation or "cpython"
-    try:
-        check_free_threaded(
-            platforms=(environment.platform,),
-            implementations=(implementation,),
-            python_versions=(axis["python_version"],),
-        )
-    except ValueError as exc:
-        msg = f"invalid [tool.nab.environment]: {exc}"
-        raise ConfigError(msg) from exc
+
+    _check_free_threaded_environment(
+        environment, (axis["python_version"],) if environment.python else ()
+    )
+
     return ResolveTarget.for_declared(
         python_version=axis["python_version"],
         spec=environment.platform,
         implementation=implementation,
         python_full_version=axis["python_full_version"],
     )
+
+
+def _check_free_threaded_environment(
+    environment: EnvironmentConfig, python_versions: Sequence[str]
+) -> None:
+    """Hold ``[tool.nab.environment]`` to the free-threaded interpreter floor.
+
+    ``python_versions`` is empty for a table that names no python, since
+    ``--python`` can still move that axis after the parse.  The parse then
+    checks only the implementation, and :func:`plan_targets` checks the
+    python the target ended up on.
+    """
+    if environment.platform is None:
+        return
+    try:
+        check_free_threaded(
+            platforms=(environment.platform,),
+            implementations=(environment.implementation or "cpython",),
+            python_versions=python_versions,
+        )
+    except ValueError as exc:
+        msg = f"invalid [tool.nab.environment]: {exc}"
+        raise ConfigError(msg) from exc
 
 
 def matrix_from_config(matrix: MatrixConfig) -> Matrix:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -58,7 +58,7 @@ from nab_python.provider import (
     VcsSource,
 )
 from nab_python.tags import PlatformSpec
-from nab_python.target import ResolveTarget
+from nab_python.target import ResolveTarget, host_environment
 from nab_python.workspace import WorkspaceConfig
 
 
@@ -1480,6 +1480,19 @@ class TestResolution:
             read_pyproject_config(path)
 
 
+_FREE_THREADED_NO_PYTHON = (
+    "[tool.nab.environment]\n"
+    'platform = { id = "linux_x86_64", free-threaded = true }\n'
+    '[tool.nab]\nbuild-policy = "never"\n'
+)
+
+
+def _host_python(monkeypatch: pytest.MonkeyPatch, full_version: str) -> None:
+    """Report ``full_version`` as the running interpreter to the planner."""
+    env = {**host_environment(), "python_full_version": full_version}
+    monkeypatch.setattr("nab_python.config.host_environment", lambda: env)
+
+
 class TestEnvironment:
     """``[tool.nab.environment]``: the one environment to resolve for."""
 
@@ -1710,6 +1723,52 @@ class TestEnvironment:
         )
         with pytest.raises(ConfigError, match="needs CPython, not"):
             read_pyproject_config(path)
+
+    def test_free_threaded_rejects_pypy_without_a_python_axis(
+        self, tmp_path: Path
+    ) -> None:
+        """No flag moves the implementation axis, so the parse still checks it."""
+        path = write(
+            tmp_path,
+            "[tool.nab.environment]\n"
+            'implementation = "pypy"\n'
+            'platform = { id = "linux_x86_64", free-threaded = true }\n'
+            '[tool.nab]\nbuild-policy = "never"\n',
+        )
+        with pytest.raises(ConfigError, match="needs CPython, not"):
+            read_pyproject_config(path)
+
+    def test_free_threaded_without_python_accepts_a_newer_override(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The floor is checked against the python ``--python`` picked."""
+        _host_python(monkeypatch, "3.12.11")
+        path = write(tmp_path, _FREE_THREADED_NO_PYTHON)
+        config = read_pyproject_config(path)
+        (target,) = plan_targets(with_python_override(config, "3.14"))
+
+        assert target.python_version == "3.14"
+        assert target.tags.accepts("somepkg-1.0-cp314-cp314t-manylinux_2_28_x86_64.whl")
+
+    def test_free_threaded_without_python_still_rejects_an_old_host(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With no ``--python`` the host is the target, and 3.12 is too old."""
+        _host_python(monkeypatch, "3.12.11")
+        path = write(tmp_path, _FREE_THREADED_NO_PYTHON)
+        config = read_pyproject_config(path)
+        with pytest.raises(ConfigError, match="needs CPython 3.13 or newer"):
+            plan_targets(config)
+
+    def test_free_threaded_rejects_an_old_python_override(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--python`` is held to the same floor a declared python is."""
+        _host_python(monkeypatch, "3.14.0")
+        path = write(tmp_path, _FREE_THREADED_NO_PYTHON)
+        config = read_pyproject_config(path)
+        with pytest.raises(ConfigError, match="needs CPython 3.13 or newer"):
+            with_python_override(config, "3.12")
 
     def test_must_be_table(self, tmp_path: Path) -> None:
         path = write(tmp_path, '[tool.nab]\nenvironment = "no"\n')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,7 +79,7 @@ from nab_python.provider import (
 from nab_python.requirements_file import InvalidProjectRequirementError
 from nab_python.resolve import ResolveResult, TargetResult, env_signature
 from nab_python.tags import PlatformSpec
-from nab_python.target import ResolveTarget
+from nab_python.target import ResolveTarget, host_environment
 from nab_resolver.resolver import ResolutionError
 
 V = Version
@@ -1446,6 +1446,31 @@ class TestPythonFlag:
             download(pyproject, output=out, python="3.11")
         config = mock_resolve.call_args.kwargs["config"]
         assert config.environment.python == "3.11"
+
+    def test_retargets_a_free_threaded_platform_onto_a_new_python(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--python`` lands before the free-threaded floor is checked.
+
+        Checked against the 3.12 host instead, the floor would reject the
+        run the flag retargets onto 3.14.
+        """
+        env = {**host_environment(), "python_full_version": "3.12.11"}
+        monkeypatch.setattr("nab_python.config.host_environment", lambda: env)
+
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\ndependencies = ["foo"]\n'
+            '[tool.nab]\nbuild-policy = "never"\n'
+            "[tool.nab.environment]\n"
+            'platform = { id = "linux_x86_64", free-threaded = true }\n',
+        )
+        out = tmp_path / "pylock.toml"
+        with patch(
+            "nab.cli.resolve_for_targets", return_value=_stub_resolve_result()
+        ) as mock_resolve:
+            lock(pyproject, output=out, python="3.14")
+        assert mock_resolve.call_args.kwargs["config"].environment.python == "3.14"
 
     def test_download_rejects_it_in_universal_mode(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
On a 3.12 host, `nab lock --python 3.14` fails with "a free-threaded platform needs CPython 3.13 or newer, not ['3.12']" when `[tool.nab.environment]` declares a free-threaded platform and no `python`. Writing `python = "3.14"` into the same table is accepted, so the flag and the key disagree about a config both should accept.

The floor was checked during the config parse, where an environment with no declared python falls back to the host interpreter, and `--python` only lands afterwards. The parse now checks only the implementation axis, which no flag can move. The python side of the floor runs in `plan_targets`, over the target that was actually planned, so it covers the host default and a `--python` override. `--python 3.12` on a free-threaded platform still fails.
