### PR TITLE
fix stale two-subcommand wording in cli.py and docs

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -261,7 +261,7 @@ directory uses: `cache-dir` is read off the config source ladder, so a
 
 ## Runtime flags
 
-Both subcommands accept the same runtime knobs:
+`lock` and `download` accept the same runtime knobs:
 
 | Flag | Default | Effect |
 | ---- | ------- | ------ |

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -1,13 +1,14 @@
 """Entry point for the nab command.
 
-Holds the tyro :class:`SubcommandApp` registration plus the helpers
-shared between :mod:`nab._lock` and :mod:`nab._download`: HTTP
-transport selection, cache-directory defaults, config loading, and
-the resolver-error-to-exit-code translation.
+Holds the tyro :class:`SubcommandApp` registration plus the helpers the
+command modules share: config loading and cache-directory defaults,
+plus the HTTP transport selection and resolver-error-to-exit-code
+translation that only :mod:`nab._lock` and :mod:`nab._download` use.
 
-The two subcommands live in :mod:`nab._lock` and :mod:`nab._download`;
-this module imports them so their ``@app.command`` decorators run
-before :func:`main` calls ``app.cli()``.
+The subcommands live in :mod:`nab._lock`, :mod:`nab._download`,
+:mod:`nab._config_cmd`, and :mod:`nab._cache_cmd`; this module imports
+them so their ``@app.command`` decorators run before :func:`main` calls
+``app.cli()``.
 """
 
 from __future__ import annotations
@@ -739,8 +740,8 @@ def _normalize_layered_bool_flags(argv: list[str]) -> list[str]:
 
 
 # Side-effect imports: each module's @app.command decorators register the
-# subcommand.  Placed at the bottom so helpers above bind before
-# nab._lock / nab._download import back from this module.
+# subcommand.  Placed at the bottom so the helpers above bind before the
+# command modules import them back.
 from . import _cache_cmd as _cache_module  # noqa: E402, F401 - side-effect
 from . import _config_cmd as _config_module  # noqa: E402, F401 - side-effect
 from . import _download as _download_module  # noqa: E402, F401 - side-effect

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3182,6 +3182,28 @@ class TestCliReferenceFlagCoverage:
             assert _names_flag(scope, flag), f"{heading} omits {flag}"
 
 
+class TestCliDocstringCommandModules:
+    """``nab.cli``'s docstring names every module that registers a subcommand."""
+
+    def test_docstring_names_every_command_module(self) -> None:
+        # A command module only registers if cli.py imports it for the side
+        # effect, so cli's own module bindings are the registration set.
+        imported = {
+            module.__name__
+            for _, module in inspect.getmembers(cli, inspect.ismodule)
+            if module.__name__.startswith("nab._")
+        }
+        docstring = cli.__doc__
+        assert docstring is not None
+
+        named = set(re.findall(r"nab\._\w+", docstring))
+
+        assert named == imported, (
+            f"docstring misses {imported - named}, "
+            f"names unregistered {named - imported}"
+        )
+
+
 class TestDetermineLockAnchor:
     """``_determine_lock_anchor`` chooses between fresh and reused anchors."""
 


### PR DESCRIPTION
`nab.cli`'s module docstring still said the two subcommands live in `nab._lock` and `nab._download`, and the runtime-flags section of the CLI reference still opened with "Both subcommands". `config` and `cache` shipped after that text was written, so there are four.

The docstring now names all four command modules, and separates the helpers the command modules share from the transport selection and resolver-error-to-exit-code translation that only `lock` and `download` use. The reference line names `lock` and `download` instead of counting them.

A new test compares the module names in the docstring against the registered subcommands, so adding a command module without updating the docstring fails the test. It reads tyro's private `app._subcommands`, so a tyro upgrade could break the test rather than the code.
