### PR TITLE
drop the duplicate accepted-hash list in the metadata sidecar path

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -629,30 +629,22 @@ def _has_metadata(file_info: dict) -> bool:
     return value is True or isinstance(value, dict)
 
 
-_ACCEPTED_METADATA_HASHES: tuple[str, ...] = ("sha256", "sha384", "sha512")
-
-
 def _metadata_hash(file_info: dict) -> tuple[str, str] | None:
     """Return the sidecar's published ``(algo, hex)`` to verify, or None.
 
-    Prefers sha256, then sha384, then sha512, so a sidecar published with
-    only a stronger digest is still verified. Algorithm names match
-    case-insensitively. A bare ``true`` (sidecar exists, no hash), an empty
-    digest, or a table with no accepted algorithm yields None, so no check runs.
+    A bare ``true`` (sidecar exists, no hash), an empty digest, or a table with
+    no accepted algorithm yields None, so no check runs.
     """
     value = _metadata_value(file_info)
     if not isinstance(value, dict):
         return None
-    published = {
-        algo.lower(): digest
+
+    published = tuple(
+        (algo, digest)
         for algo, digest in value.items()
         if isinstance(algo, str) and isinstance(digest, str)
-    }
-    for algo in _ACCEPTED_METADATA_HASHES:
-        digest = published.get(algo)
-        if digest:
-            return (algo, digest.lower())
-    return None
+    )
+    return _select_artifact_hash(published)
 
 
 def _verify_metadata_hash(content: bytes, metadata_hash: tuple[str, str]) -> None:


### PR DESCRIPTION
`nab_index/client.py` declared the accepted hash algorithms twice and walked them with two near-identical selectors, one for artifact hashes and one for PEP 658 metadata sidecars, so the preference order had to be kept in sync by hand.

`_metadata_hash` now collects the published `(algo, digest)` pairs and passes them to `_select_artifact_hash`, leaving one accepted-algorithm list and one selector. Selection is unchanged: sha256, then sha384, then sha512, case-insensitive on the algorithm name, and None when nothing qualifies.
