### PR TITLE
reject a NUL in a local-source or workspace path instead of crashing

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -49,6 +49,7 @@ from .config_sources import (
     resolve_config,
 )
 from .fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL, IndexRoute
+from .paths import resolve_path
 from .provider import (
     ArchiveSource,
     BuildPolicy,
@@ -2457,57 +2458,67 @@ def _parse_vcs(value: object) -> VcsConfig:
 _LOCAL_SOURCE_KEYS = frozenset({"name", "path", "editable", "subdirectory"})
 
 
+def _parse_local_source(entry: object, i: int, *, pyproject_dir: Path) -> LocalSource:
+    if not isinstance(entry, dict):
+        msg = f"local-sources[{i}] must be a table, got {type(entry).__name__}"
+        raise ConfigError(msg)
+
+    unknown = sorted(set(entry) - _LOCAL_SOURCE_KEYS)
+    if unknown:
+        msg = (
+            f"unknown local-sources[{i}] keys: {unknown!r};"
+            f" expected {sorted(_LOCAL_SOURCE_KEYS)!r}"
+        )
+        raise ConfigError(msg)
+
+    try:
+        name = entry["name"]
+        path_value = entry["path"]
+    except KeyError as missing:
+        msg = f"local-sources[{i}] missing required key {missing!s}"
+        raise ConfigError(msg) from None
+    if not isinstance(name, str) or not isinstance(path_value, str):
+        msg = f"local-sources[{i}] name and path must be strings"
+        raise ConfigError(msg)
+
+    editable = entry.get("editable", False)
+    if not isinstance(editable, bool):
+        msg = f"local-sources[{i}] editable must be a boolean"
+        raise ConfigError(msg)
+
+    subdirectory = entry.get("subdirectory")
+    if subdirectory is not None and not isinstance(subdirectory, str):
+        msg = f"local-sources[{i}] subdirectory must be a string"
+        raise ConfigError(msg)
+    if subdirectory is not None and subdirectory_escapes(subdirectory):
+        msg = (
+            f"local-sources[{i}] subdirectory {subdirectory!r} escapes the source tree"
+        )
+        raise ConfigError(msg)
+
+    resolved = resolve_path(pyproject_dir, path_value)
+    if resolved is None:
+        msg = f"local-sources[{i}] path {path_value!r} is not a usable filesystem path"
+        raise ConfigError(msg)
+
+    return LocalSource(
+        name=name,
+        path=str(resolved),
+        editable=editable,
+        subdirectory=subdirectory,
+    )
+
+
 def _parse_local_sources(
     value: object, *, pyproject_dir: Path
 ) -> tuple[LocalSource, ...]:
     if not isinstance(value, list):
         msg = f"local-sources must be an array of tables, got {type(value).__name__}"
         raise ConfigError(msg)
-    out: list[LocalSource] = []
-    for i, entry in enumerate(value):
-        if not isinstance(entry, dict):
-            msg = f"local-sources[{i}] must be a table, got {type(entry).__name__}"
-            raise ConfigError(msg)
-        unknown = sorted(set(entry) - _LOCAL_SOURCE_KEYS)
-        if unknown:
-            msg = (
-                f"unknown local-sources[{i}] keys: {unknown!r};"
-                f" expected {sorted(_LOCAL_SOURCE_KEYS)!r}"
-            )
-            raise ConfigError(msg)
-        try:
-            name = entry["name"]
-            path_value = entry["path"]
-        except KeyError as missing:
-            msg = f"local-sources[{i}] missing required key {missing!s}"
-            raise ConfigError(msg) from None
-        if not isinstance(name, str) or not isinstance(path_value, str):
-            msg = f"local-sources[{i}] name and path must be strings"
-            raise ConfigError(msg)
-        editable = entry.get("editable", False)
-        if not isinstance(editable, bool):
-            msg = f"local-sources[{i}] editable must be a boolean"
-            raise ConfigError(msg)
-        subdirectory = entry.get("subdirectory")
-        if subdirectory is not None and not isinstance(subdirectory, str):
-            msg = f"local-sources[{i}] subdirectory must be a string"
-            raise ConfigError(msg)
-        if subdirectory is not None and subdirectory_escapes(subdirectory):
-            msg = (
-                f"local-sources[{i}] subdirectory {subdirectory!r}"
-                " escapes the source tree"
-            )
-            raise ConfigError(msg)
-        resolved = str((pyproject_dir / path_value).resolve())
-        out.append(
-            LocalSource(
-                name=name,
-                path=resolved,
-                editable=editable,
-                subdirectory=subdirectory,
-            )
-        )
-    return tuple(out)
+    return tuple(
+        _parse_local_source(entry, i, pyproject_dir=pyproject_dir)
+        for i, entry in enumerate(value)
+    )
 
 
 _VCS_SOURCE_KEYS = frozenset({"name", "url"})

--- a/nab-python/src/nab_python/paths.py
+++ b/nab-python/src/nab_python/paths.py
@@ -1,4 +1,4 @@
-"""Presence checks that keep an absent path apart from an unreadable one."""
+"""Path resolution, plus presence checks that tell absent from unreadable."""
 
 from __future__ import annotations
 
@@ -14,6 +14,7 @@ __all__ = [
     "PathState",
     "is_absent_error",
     "path_state",
+    "resolve_path",
 ]
 
 _ABSENT_ERRNOS = frozenset({errno.ENOENT, errno.ENOTDIR})
@@ -74,3 +75,18 @@ def path_state(path: Path) -> PathState:
     if stat.S_ISDIR(st.st_mode):
         return PathState.DIRECTORY
     return PathState.OTHER
+
+
+def resolve_path(base: Path, entry: str) -> Path | None:
+    """Resolve ``entry`` against ``base``, or ``None`` for an unusable name.
+
+    An embedded NUL is checked up front because Windows keeps it in the
+    resolved path instead of raising; other unencodable names raise from
+    the resolve itself.
+    """
+    if "\x00" in entry:
+        return None
+    try:
+        return (base / entry).resolve()
+    except ValueError:
+        return None

--- a/nab-python/src/nab_python/workspace.py
+++ b/nab-python/src/nab_python/workspace.py
@@ -27,7 +27,7 @@ import tomli
 
 from ._toml import tool_nab_section
 from ._vendor.packaging.utils import canonicalize_name
-from .paths import path_state
+from .paths import path_state, resolve_path
 from .provider import LocalSource
 
 if TYPE_CHECKING:
@@ -164,7 +164,14 @@ def workspace_local_sources(
             )
             raise WorkspaceDiscoveryError(msg)
 
-        member_dir = (root_dir / entry).resolve()
+        member_dir = resolve_path(root_dir, entry)
+        if member_dir is None:
+            msg = (
+                f"{declared_in}: workspace member {entry!r}"
+                " is not a usable filesystem path"
+            )
+            raise WorkspaceDiscoveryError(msg)
+
         member_pyproject = member_dir / "pyproject.toml"
         if not path_state(member_pyproject).should_read:
             msg = (

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -2309,6 +2309,15 @@ class TestLocalSources:
         with pytest.raises(ConfigError, match="unknown local-sources"):
             read_pyproject_config(path)
 
+    def test_path_with_nul_rejected(self, tmp_path: Path) -> None:
+        # An embedded NUL is valid TOML, so the parser hands it through.
+        path = write(
+            tmp_path,
+            '[[tool.nab.local-sources]]\nname = "x"\npath = "../\\u0000x"\n',
+        )
+        with pytest.raises(ConfigError, match="is not a usable filesystem path"):
+            read_pyproject_config(path)
+
     def test_duplicate_canonical_name_rejected(self, tmp_path: Path) -> None:
         path = write(
             tmp_path,

--- a/nab-python/tests/test_paths.py
+++ b/nab-python/tests/test_paths.py
@@ -8,7 +8,7 @@ import stat
 from pathlib import Path
 from unittest.mock import patch
 
-from nab_python.paths import PathState, path_state
+from nab_python.paths import PathState, path_state, resolve_path
 
 
 def _fake_stat(mode: int) -> os.stat_result:
@@ -56,3 +56,20 @@ class TestPathState:
             state = path_state(path)
         assert state is PathState.UNREADABLE
         assert state.should_read
+
+
+class TestResolvePath:
+    def test_normalises_against_base(self, tmp_path: Path) -> None:
+        base = tmp_path.resolve()
+        (base / "pkg").mkdir()
+        assert resolve_path(base / "pkg", "../lib") == base / "lib"
+
+    def test_nul_in_name(self, tmp_path: Path) -> None:
+        assert resolve_path(tmp_path, "pk\x00g") is None
+
+    def test_unencodable_name(self, tmp_path: Path) -> None:
+        # A lone surrogate only fails the encode on POSIX, so the resolve is
+        # mocked to reach the arm on every platform.
+        broken = UnicodeEncodeError("utf-8", "\ud800", 0, 1, "surrogates not allowed")
+        with patch.object(Path, "resolve", side_effect=broken):
+            assert resolve_path(tmp_path, "pkg") is None

--- a/nab-python/tests/test_workspace.py
+++ b/nab-python/tests/test_workspace.py
@@ -298,6 +298,19 @@ class TestReadWorkspaceMembers:
         with pytest.raises(WorkspaceDiscoveryError, match="globs in"):
             read_workspace_members(root)
 
+    def test_member_with_nul_raises(self, tmp_path: Path) -> None:
+        # An embedded NUL is valid TOML, so the parser hands it through.
+        root = _write(
+            tmp_path / "pyproject.toml",
+            '[project]\nname = "ws"\nversion = "0"\n'
+            "[tool.nab.workspace]\n"
+            'members = ["pk\\u0000g"]\n',
+        )
+        with pytest.raises(
+            WorkspaceDiscoveryError, match="is not a usable filesystem path"
+        ):
+            read_workspace_members(root)
+
     def test_member_without_pyproject_raises(self, tmp_path: Path) -> None:
         root = _write(
             tmp_path / "pyproject.toml",


### PR DESCRIPTION
A NUL byte in a filesystem path read from user config (`path` under `[[tool.nab.local-sources]]`, or an entry in `[tool.nab.workspace].members`) came out as a raw `ValueError` traceback instead of the `ConfigError` or `WorkspaceDiscoveryError` those readers raise for bad input. TOML accepts the `` escape, so the string reaches `Path.resolve()`, where `os.lstat` raises `ValueError` for an embedded NUL rather than `OSError`.

Both call sites now go through `resolve_path` in `nab_python.paths`, which returns `None` for a name the filesystem cannot take, and each reader turns that into its own error naming the offending value. The NUL check runs before the resolve because Windows keeps it in the resolved path instead of raising. The per-entry local-sources parsing moved into its own function along the way.
