### PR TITLE
stop reading a content-encoded index error as ranges unsupported

### DIFF
--- a/nab-index/src/nab_index/lazy_wheel.py
+++ b/nab-index/src/nab_index/lazy_wheel.py
@@ -331,17 +331,16 @@ async def _absolute_attempt(
     A probe that is refused, or that reports no usable total, steps down to
     the plain GET: neither answer says the file is unserveable, so only the
     plain GET is authoritative for whether the wheel can be served at all.
+    Any other 4xx/5xx raises through, whatever its Content-Encoding.
     """
     probe = await _range_get(transport, url, "bytes=0-0")
     if probe.status_code in _RANGE_REJECT_STATUSES:
         return await _fallback_full_body(
             transport, url, latch=probe.status_code != _HTTP_RANGE_NOT_SATISFIABLE
         )
-    if _non_identity(probe):
-        return _UNSUPPORTED_NONE
-    if probe.status_code == _HTTP_OK:
+    if probe.status_code == _HTTP_OK and not _non_identity(probe):
         return (RangeCapability.FULL_BODY_ONLY, _AcqKind.FULL_BODY, probe.content)
-    if probe.status_code != _HTTP_PARTIAL:
+    if probe.status_code != _HTTP_PARTIAL or _non_identity(probe):
         probe.raise_for_status()
         return _UNSUPPORTED_NONE
     parsed = _parse_content_range(probe.headers.get("content-range"))
@@ -360,6 +359,7 @@ async def _absolute_tail(
 
     A tail refused after an honoured probe still steps down to the plain GET,
     since a shrunk file or a flaky proxy can 416 a range the probe implied.
+    Any other 4xx/5xx raises through, whatever its Content-Encoding.
     """
     low = max(0, total - tail_size)
     tail = await _range_get(transport, url, f"bytes={low}-{total - 1}")
@@ -367,11 +367,9 @@ async def _absolute_tail(
         return await _fallback_full_body(
             transport, url, latch=tail.status_code != _HTTP_RANGE_NOT_SATISFIABLE
         )
-    if _non_identity(tail):
-        return _UNSUPPORTED_NONE
-    if tail.status_code == _HTTP_OK:
+    if tail.status_code == _HTTP_OK and not _non_identity(tail):
         return (RangeCapability.FULL_BODY_ONLY, _AcqKind.FULL_BODY, tail.content)
-    if tail.status_code != _HTTP_PARTIAL:
+    if tail.status_code != _HTTP_PARTIAL or _non_identity(tail):
         tail.raise_for_status()
         return _UNSUPPORTED_NONE
     sparse = _SparseFile(total)

--- a/nab-index/tests/test_lazy_wheel.py
+++ b/nab-index/tests/test_lazy_wheel.py
@@ -568,14 +568,23 @@ def test_absolute_probe_206_without_total_falls_back_to_plain_get(
     assert result.text == _META.decode("utf-8")
 
 
-def test_absolute_probe_error_raises() -> None:
+@pytest.mark.parametrize(
+    "error_headers",
+    [{}, {"content-encoding": "gzip"}],
+    ids=["identity", "encoded"],
+)
+def test_absolute_probe_error_raises(error_headers: dict[str, str]) -> None:
+    """A content-encoded error body is still an error, not a refused range."""
+
     def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
         if kind == "suffix":
             return _FakeResponse(501, {}, b"")
-        return _FakeResponse(404, {}, b"")
+        return _FakeResponse(404, error_headers, b"")
 
+    memo = RangeCapabilityMemo()
     with pytest.raises(HttpError):
-        _run_scripted(script)
+        _run_scripted(script, memo=memo)
+    assert memo.capability("files.example.org") is RangeCapability.UNKNOWN
 
 
 def test_range_rejected_plain_get_error_raises() -> None:
@@ -680,16 +689,23 @@ def test_absolute_tail_206_gzip_is_unsupported() -> None:
     assert result.outcome is RangeOutcome.UNSUPPORTED
 
 
-def test_absolute_tail_error_raises() -> None:
+@pytest.mark.parametrize(
+    "error_headers",
+    [{}, {"content-encoding": "gzip"}],
+    ids=["identity", "encoded"],
+)
+def test_absolute_tail_error_raises(error_headers: dict[str, str]) -> None:
     def script(t: _ScriptedTransport, kind: str, a: int, b: int) -> _FakeResponse:
         if kind == "suffix":
             return _FakeResponse(501, {}, b"")
         if a == 0 and b == 0:
             return t.partial(0, 0)
-        return _FakeResponse(500, {}, b"")
+        return _FakeResponse(500, error_headers, b"")
 
+    memo = RangeCapabilityMemo()
     with pytest.raises(HttpError):
-        _run_scripted(script)
+        _run_scripted(script, memo=memo)
+    assert memo.capability("files.example.org") is RangeCapability.UNKNOWN
 
 
 def test_growth_200_full_body_recovers() -> None:


### PR DESCRIPTION
The lazy wheel's absolute range probe and its tail read checked Content-Encoding before the status, so a 404, 429, or 503 whose error body arrived gzipped never reached raise_for_status. The response was read as a host that cannot serve ranges: the index error came back as an empty metadata result, and the netloc was latched UNSUPPORTED for the rest of the run, taking every later wheel from that host off ranges.

Both paths now check the status first. A 200 or 206 counts only when the body is identity-encoded, and any other status raises through whatever encoding it carries.
