### PR TITLE
report the original sdist failure on a repeat lookup

### DIFF
--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -711,8 +711,10 @@ class Provider:
             tuple[str, Version], dict[str, list[tuple[Requirement, str]]]
         ] = {}
 
-        # Memoised sdist-rejections so re-tries do not re-parse PKG-INFO.
-        self._unsupported_sdists: set[tuple[str, Version]] = set()
+        # Memoised sdist-rejections so re-tries do not re-parse PKG-INFO or
+        # rebuild.  Value is the cached error message so a re-ask raises the
+        # same rejection.
+        self._unsupported_sdists: dict[tuple[str, Version], str] = {}
 
         # Memoised metadata-parse failures (malformed Requires-Dist, etc.)
         # keyed by (canonical_name, Version).  Value is the cached error
@@ -2063,15 +2065,9 @@ class Provider:
         cache_key = (normalized, version)
         if cache_key in self.deps_cache:
             return self.deps_cache[cache_key]
-        if cache_key in self._unsupported_sdists:
-            effective = self.effective_build_policy(
-                normalized, version, self.serving_index(normalized)
-            )
-            msg = (
-                f"{normalized}=={version} sdist metadata could not be extracted"
-                f" under BuildPolicy.{effective.name} (cached prior failure)"
-            )
-            raise UnsupportedSdistError(msg)
+        cached_unsupported = self._unsupported_sdists.get(cache_key)
+        if cached_unsupported is not None:
+            raise UnsupportedSdistError(cached_unsupported)
         cached_invalid = self._invalid_metadata.get(cache_key)
         if cached_invalid is not None:
             raise MetadataError(cached_invalid)
@@ -2127,8 +2123,8 @@ class Provider:
             self.parse_and_cache_metadata(
                 cache_key, metadata_text, from_sdist=from_sdist
             )
-        except UnsupportedSdistError:
-            self._unsupported_sdists.add(cache_key)
+        except UnsupportedSdistError as exc:
+            self._unsupported_sdists[cache_key] = str(exc)
             raise
         except (ForeignMetadataError, IncompatiblePythonError) as exc:
             self._invalid_metadata[cache_key] = str(exc)

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -9698,6 +9698,53 @@ class TestBuildRemoteFailureModes:
         with pytest.raises(UnsupportedSdistError, match="does not match"):
             build_remote.build_remote_sdist(provider, "pkg", V("1.0"))
 
+    def test_cached_rejection_repeats_original_message(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        coordinator = make_coordinator(
+            [make_sdist("1.0")],
+            sdist_pkg_info=PKG_INFO_DYNAMIC_DEPS,
+        )
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            dist_policy=DistPolicy.WHEEL_OR_SDIST,
+            build_policy=BuildPolicy.BUILD_REMOTE,
+        )
+
+        def _ok_fetch(
+            pkg: str,
+            ver: str,
+            _url: str,
+            _hashes: tuple[tuple[str, str], ...],
+        ) -> threading.Event:
+            coordinator.index.store_sdist_archive(pkg, ver, b"data")
+            return _done_event()
+
+        coordinator.request_sdist_archive.side_effect = _ok_fetch
+        monkeypatch.setattr(
+            build_remote, "extract_sdist_archive", lambda _d, target: target
+        )
+
+        built = WheelMetadata(
+            name="pkg",
+            version=V("1.0"),
+            requires_python=SpecifierSet(">=3.13"),
+            requires_dist=[Requirement("dep-a>=1")],
+            provides_extra=[],
+        )
+        monkeypatch.setattr(
+            "nab_python.build_backend.extract_metadata", lambda *_a, **_k: built
+        )
+
+        with pytest.raises(UnsupportedSdistError) as first:
+            provider.get_dependencies("pkg", V("1.0"))
+        with pytest.raises(UnsupportedSdistError) as second:
+            provider.get_dependencies("pkg", V("1.0"))
+
+        assert "built sdist requires Python >=3.13" in str(first.value)
+        assert str(second.value) == str(first.value)
+
 
 class TestPublicAccessors:
     """Public read accessors used by lockfile / download tooling."""


### PR DESCRIPTION
An sdist candidate that fails metadata extraction is cached so a re-ask does not refetch or rebuild it. That cache was a set, so the failure message was dropped and every later lookup of the same candidate raised a generic line instead: `pkg==1.0 sdist metadata could not be extracted under BuildPolicy.BUILD_REMOTE (cached prior failure)`. The real reason (the built sdist needs a Python the resolve does not target, or declares a name and version that do not match the candidate) was only visible on the first attempt.

The no-versions diagnostic records whatever message the failure raises at the time, and those records are cleared on each look-ahead flush. So a package rejected once and asked for again reports the generic line, and the cause never reaches the user.

Make the cache a dict and re-raise the original message, matching the `_invalid_metadata` cache next to it.
