### PR TITLE
fix hash corrupted or dropped by a multi-part PEP 503 fragment

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -190,9 +190,9 @@ listing.  Two of those losses matter:
 * A PEP 503 page carries no upload time.  Unless the index emits the
   non-standard `data-upload-time` attribute, every file it serves is
   excluded once `uploaded-prior-to` applies.
-* A page carries at most one hash, in the URL fragment.  A file whose
-  only fragment digest is md5 gives `nab lock` nothing to record, and
-  the PEP 751 and requirements writers then fail on the missing hash.
+* A page publishes its hashes in the URL fragment.  A file whose only
+  fragment digest is md5 gives `nab lock` nothing to record, and the
+  PEP 751 and requirements writers then fail on the missing hash.
 
 ## Overrides
 

--- a/nab-index/src/nab_index/_pep503.py
+++ b/nab-index/src/nab_index/_pep503.py
@@ -7,6 +7,7 @@ client both have to read the same anchor-tag shape.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass
 from html.parser import HTMLParser
@@ -155,17 +156,26 @@ def metadata_declaration(value: str | None) -> bool | dict[str, str] | None:
 
 
 def hash_fragment(fragment: str) -> tuple[tuple[str, str], ...]:
-    """Parse one ``algo=digest`` URL fragment into the ``hashes`` tuple shape.
+    """Read a URL fragment's hash declarations into the ``hashes`` tuple shape.
 
     :pep:`503` carries the artefact's hash in the URL fragment; it is the only
     place the hash appears when the index has not opted into :pep:`691` JSON.
+    The fragment is a ``&``-separated list of ``key=value`` parts, so a hash
+    can sit beside ``egg`` or ``subdirectory`` in any order.  A part keyed by
+    a ``hashlib`` algorithm and carrying a digest is a hash; anything else is
+    not.
     """
-    if not fragment:
-        return ()
-    algo, sep, digest = fragment.partition("=")
-    if not sep or not algo or not digest:
-        return ()
-    return ((algo.lower(), digest.lower()),)
+    hashes: list[tuple[str, str]] = []
+
+    for part in fragment.split("&"):
+        algo, sep, digest = part.partition("=")
+        if not sep or not digest:
+            continue
+        algo = algo.lower()
+        if algo in hashlib.algorithms_guaranteed:
+            hashes.append((algo, digest.lower()))
+
+    return tuple(hashes)
 
 
 def _file_entry(anchor: Anchor, base_url: str) -> dict[str, object] | None:

--- a/nab-python/tests/test_cached_client.py
+++ b/nab-python/tests/test_cached_client.py
@@ -1610,6 +1610,31 @@ class TestHtmlListing:
         assert wheel.hashes == (("sha256", self._DIGEST),)
         assert wheel.upload_time == self._UPLOAD_TIME
 
+    def test_hash_fragment_before_an_egg_part(self, tmp_path: Path) -> None:
+        page = (
+            f'<a href="torch-2.7.0-py3-none-any.whl#sha256={self._DIGEST}'
+            '&amp;egg=torch-2.7.0">torch</a>'
+        ).encode()
+        files, _ = self._fetch(_make_cache(tmp_path), page, "text/html")
+        assert files[0].hashes == (("sha256", self._DIGEST),)
+
+    def test_hash_fragment_after_an_egg_part(self, tmp_path: Path) -> None:
+        page = (
+            '<a href="torch-2.7.0-py3-none-any.whl#egg=torch-2.7.0'
+            f'&amp;sha256={self._DIGEST}">torch</a>'
+        ).encode()
+        files, _ = self._fetch(_make_cache(tmp_path), page, "text/html")
+        assert files[0].hashes == (("sha256", self._DIGEST),)
+
+    def test_every_fragment_hash_is_read(self, tmp_path: Path) -> None:
+        sha512 = "f" * 128
+        page = (
+            f'<a href="torch-2.7.0-py3-none-any.whl#sha256={self._DIGEST}'
+            f'&amp;sha512={sha512}">torch</a>'
+        ).encode()
+        files, _ = self._fetch(_make_cache(tmp_path), page, "text/html")
+        assert files[0].hashes == (("sha256", self._DIGEST), ("sha512", sha512))
+
     def test_malformed_ipv6_href_is_dropped(self, tmp_path: Path) -> None:
         # An unterminated IPv6 bracket makes the href join and split raise;
         # that anchor is dropped and its good sibling still resolves.

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -957,6 +957,46 @@ class TestPep503Directory:
         result = run(client.get_files("foo"))
         assert result[0].hashes == ()
 
+    def test_pep503_hash_fragment_beside_subdirectory(self, tmp_path: Path) -> None:
+        digest = "e" * 64
+        body = (
+            f'<a href="foo-1.0-py3-none-any.whl#sha256={digest}'
+            '&amp;subdirectory=pkg">foo</a>'
+        )
+        package_dir = self._make_index(tmp_path, body)
+        (package_dir / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        result = run(client.get_files("foo"))
+        assert result[0].hashes == (("sha256", digest),)
+
+    def test_pep503_fragment_keeps_every_hash_part(self, tmp_path: Path) -> None:
+        sha256, sha512 = "e" * 64, "f" * 128
+        body = (
+            f'<a href="foo-1.0-py3-none-any.whl#sha256={sha256}'
+            f'&amp;sha512={sha512}">foo</a>'
+        )
+        package_dir = self._make_index(tmp_path, body)
+        (package_dir / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        result = run(client.get_files("foo"))
+        assert result[0].hashes == (("sha256", sha256), ("sha512", sha512))
+
+    def test_pep503_egg_fragment_yields_no_hashes(self, tmp_path: Path) -> None:
+        body = '<a href="foo-1.0-py3-none-any.whl#egg=foo-1.0">foo</a>'
+        package_dir = self._make_index(tmp_path, body)
+        (package_dir / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        result = run(client.get_files("foo"))
+        assert result[0].hashes == ()
+
+    def test_pep503_empty_digest_yields_no_hashes(self, tmp_path: Path) -> None:
+        body = '<a href="foo-1.0-py3-none-any.whl#sha256=&amp;egg=foo-1.0">foo</a>'
+        package_dir = self._make_index(tmp_path, body)
+        (package_dir / "foo-1.0-py3-none-any.whl").write_bytes(b"")
+        client = LocalIndexClient(tmp_path.as_uri())
+        result = run(client.get_files("foo"))
+        assert result[0].hashes == ()
+
     def test_pep503_sdist_hash_fragment(self, tmp_path: Path) -> None:
         digest = "d" * 64
         body = f'<a href="foo-1.0.tar.gz#sha256={digest}">foo</a>'


### PR DESCRIPTION
`hash_fragment` read the whole URL fragment as a single `algo=digest` pair, which only works when the hash is the only thing in it. An index serving `#sha256=<digest>&egg=name` gave back a digest with `&egg=name` on the end, and the resolve aborted on a hash mismatch for a file that was fine. With the parts the other way round, `#egg=name&sha256=<digest>`, no hash came back at all, so the artefact went unverified and `nab lock` failed on the missing hash.

A fragment is a `&`-separated list of `key=value` parts, so every part keyed by a hashlib algorithm is now read as a hash, in any order.
