### PR TITLE
drop the never-hit Version cache in the wheel filename parser

### DIFF
--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -91,15 +91,9 @@ _WHEEL_DASHES_WITH_BUILD = 5
 
 
 @lru_cache(maxsize=65536)
-def _intern_version(version: str) -> Version:
-    """Construct a cached :class:`Version`."""
-    return Version(version)
-
-
-@lru_cache(maxsize=65536)
 def _canonical_version(version: str) -> str:
     """Return a cached canonical version string."""
-    return str(_intern_version(version))
+    return str(Version(version))
 
 
 @lru_cache(maxsize=65536)

--- a/nab-python/tests/test_simple_client_filenames.py
+++ b/nab-python/tests/test_simple_client_filenames.py
@@ -1,8 +1,8 @@
 """Differential tests for nab_index's filename parsers.
 
 ``_parse_wheel_filename`` reproduces packaging's name/version validation
-while skipping the discarded tag-set parse and interning the version, its
-canonical string, and the canonical name. These tests assert it
+while skipping the discarded tag-set parse and interning the canonical
+version string and the canonical name. These tests assert it
 accepts/rejects exactly what packaging does and that the interners return
 byte-identical results to the uncached functions, so the optimization stays
 output-invariant even if packaging is re-vendored. Neither parser raises: a
@@ -19,12 +19,11 @@ from packaging.utils import (
     canonicalize_name,
     parse_wheel_filename,
 )
-from packaging.version import InvalidVersion
+from packaging.version import InvalidVersion, Version
 
 from nab_index.client import (
     _canonical_version,
     _intern_name,
-    _intern_version,
     _parse_sdist_filename,
     _parse_wheel_filename,
 )
@@ -121,15 +120,9 @@ def test_canonical_form_and_trailing_zeros() -> None:
     )
 
 
-def test_intern_reuses_version_object() -> None:
-    first = _intern_version("9.99.123")
-    second = _intern_version("9.99.123")
-    assert first is second
-
-
 @pytest.mark.parametrize("raw", ["1.26.4", "2.0.0", "1.0", "10!2.3.4rc1.post2"])
 def test_canonical_version_matches_str_version(raw: str) -> None:
-    assert _canonical_version(raw) == str(_intern_version(raw))
+    assert _canonical_version(raw) == str(Version(raw))
 
 
 def test_canonical_version_reuses_string() -> None:


### PR DESCRIPTION
`nab_index.client` stacked two caches on the same key. `_canonical_version` is memoized on the version string, and it was the only caller of `_intern_version`, which is memoized on that same string. So the inner cache never saw a repeat: everything that reached it was already an outer miss. It bought nothing and held a second table of up to 65536 `Version` objects alive alongside the first.

`_canonical_version` now builds the `Version` itself. `_intern_version` goes, along with the test that pinned its object identity. Parser output is unchanged. The similarly named `intern_version` in `nab_python.metadata` is a different function and is untouched.
