### PR TITLE
stop giving up on a central directory larger than 1 MiB

### DIFF
--- a/nab-index/src/nab_index/lazy_wheel.py
+++ b/nab-index/src/nab_index/lazy_wheel.py
@@ -50,8 +50,6 @@ __all__ = [
 # Initial suffix window. pip and poetry read about 10 KiB; the growth loop
 # makes correctness independent of the exact value.
 _DEFAULT_TAIL = 10240
-# Hard ceiling on the window the growth loop will fetch before giving up.
-_MAX_TAIL = 1024 * 1024
 
 _HTTP_OK = 200
 _HTTP_PARTIAL = 206
@@ -502,9 +500,9 @@ async def _open_zip(
         if opened is not None:
             return opened
         have = total - tail_low
-        if have >= total or have >= _MAX_TAIL:
+        if have >= total:
             return None
-        new_size = min(have * 2, total, _MAX_TAIL)
+        new_size = min(have * 2, total)
         new_low = total - new_size
         response = await _range_get(transport, url, f"bytes={new_low}-{tail_low - 1}")
         low = _absorb_range(response, sparse, new_low, wheel_hash)
@@ -623,11 +621,12 @@ async def read_wheel_metadata_over_range(
 
     ``wheel_hash`` is the wheel's published ``(algorithm, hex_digest)`` from the
     Simple-API listing, or ``None`` when none was published.  Whenever the whole
-    wheel comes back, whether from a host that ignores or refuses ranges or from
-    a 200 volunteered while a partial read is growing its window, the bytes are
-    checked against ``wheel_hash`` before their METADATA is read, so bytes that
-    disagree with the published digest never drive the resolve.  A partial read
-    that holds only a slice of the wheel is left unverified.
+    wheel comes back as one body, whether from a host that ignores or refuses
+    ranges or from a 200 volunteered while a partial read is growing its window,
+    the bytes are checked against ``wheel_hash`` before their METADATA is read,
+    so bytes that disagree with the published digest never drive the resolve.  A
+    ranged read is left unverified, even one whose window grew to cover the
+    whole file.
 
     Raises :class:`~nab_index.client.WheelHashMismatchError` when a full-body
     wheel fails ``wheel_hash``, and

--- a/nab-index/tests/test_lazy_wheel.py
+++ b/nab-index/tests/test_lazy_wheel.py
@@ -72,6 +72,24 @@ def build_wheel_member_front(padding: int = 20000) -> bytes:
     return buf.getvalue()
 
 
+def build_wheel_big_directory() -> bytes:
+    """Build a wheel whose central directory alone tops a megabyte.
+
+    Thousands of long-named empty members inflate the directory while a
+    stored padding blob keeps it a small slice of the whole file, so the
+    directory can only be read by growing the tail window well past a
+    megabyte.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_STORED) as zf:
+        zf.writestr("widget-1.0.dist-info/METADATA", _META)
+        zf.writestr("widget-1.0.dist-info/WHEEL", b"Wheel-Version: 1.0\n")
+        zf.writestr("widget/_pad.bin", b"\x00" * 6_000_000)
+        for i in range(4400):
+            zf.writestr(f"widget/pad/{i:05d}_{'x' * 250}.py", b"")
+    return buf.getvalue()
+
+
 def build_wheel_member_last(metadata: bytes) -> bytes:
     """Build a wheel whose METADATA is the last member by offset.
 
@@ -93,6 +111,11 @@ def _parse_range(value: str) -> tuple[str, int, int]:
         return ("suffix", int(body[1:]), 0)
     start, _, end = body.partition("-")
     return ("absolute", int(start), int(end))
+
+
+def _range_span(rng: str, total: int) -> int:
+    kind, a, b = _parse_range(rng)
+    return min(a, total) if kind == "suffix" else b - a + 1
 
 
 class _FakeResponse:
@@ -341,12 +364,21 @@ def test_growth_loop_when_directory_beyond_tail() -> None:
     assert result.text == _META.decode("utf-8")
 
 
-def test_growth_cap_returns_missing(monkeypatch: pytest.MonkeyPatch) -> None:
-    import nab_index.lazy_wheel as lw
-
-    monkeypatch.setattr(lw, "_MAX_TAIL", 48)
-    wheel = build_wheel(padding=4000)
+def test_directory_over_a_megabyte_is_read_in_ranges() -> None:
+    # Real wheels carry directories this size (torch's tops 1.3 MB), so the
+    # growth loop must keep going rather than give up or fetch the body.
+    wheel = build_wheel_big_directory()
     transport = FakeRangeTransport("well_behaved", wheel)
+    result = _read(transport)
+    assert result.outcome is RangeOutcome.PARTIAL
+    assert result.text == _META.decode("utf-8")
+    assert all(rng is not None for rng, _ in transport.requests)
+    fetched = sum(_range_span(rng, len(wheel)) for rng, _ in transport.requests)
+    assert fetched < len(wheel) // 2
+
+
+def test_unreadable_bytes_exhaust_growth_and_return_missing() -> None:
+    transport = FakeRangeTransport("well_behaved", b"not a zip archive " * 300)
     result = _read(transport, tail_size=16)
     assert result.outcome is RangeOutcome.MISSING
     assert result.text is None


### PR DESCRIPTION
The lazy wheel's growth loop gave up once its window reached 1 MiB, so a wheel whose ZIP central directory is bigger never opened: on an index without PEP 658 sidecars the version lost its metadata and the resolve failed where pip succeeds (torch-2.5.1+cpu carries a 1.3 MB directory and download.pytorch.org publishes no sidecar for it). The cap is gone; the loop keeps doubling until the archive opens or the whole file is covered. Growth requests fetch only the missing slice, so a readable wheel still costs about twice its directory, and unreadable bytes cost no more than the full-body fallback already does.