### PR TITLE
raise the installer floor to 1.0

### DIFF
--- a/nab-python/pyproject.toml
+++ b/nab-python/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "tomli>=2.0",
     "tomli_w>=1.2",
     "build>=1.2",
-    "installer>=0.7",
+    "installer>=1.0",
     "pyproject_hooks>=1.2",
     "typing_extensions>=4.6",
 ]

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -31,6 +31,7 @@ from unittest.mock import MagicMock, patch
 import build
 import pyproject_hooks
 import pytest
+import tomli
 from installer.utils import SCHEME_NAMES, Scheme
 
 from nab_index.client import SdistFile, WheelFile
@@ -49,6 +50,8 @@ from nab_python._build.runner import (
     run_build_backend,
 )
 from nab_python._provider.metadata_resolver import pick_dist
+from nab_python._vendor.packaging.requirements import Requirement
+from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python._vendor.packaging.version import Version
 from nab_python.config import NabProjectConfig
 from nab_python.download import DownloadError, DownloadResult, iter_artifacts
@@ -1271,6 +1274,29 @@ class TestFastSchemeDictionaryDestination:
         ) as parent:
             destination._compile_bytecode(Scheme("purelib"), MagicMock())
         parent.assert_called_once()
+
+
+class TestDeclaredInstallerFloor:
+    """``_install_wheels`` passes ``overwrite_existing``, added in installer 1.0."""
+
+    _LAST_RELEASE_WITHOUT_OVERWRITE_EXISTING = "0.7.0"
+
+    def test_floor_excludes_releases_without_overwrite_existing(self) -> None:
+        pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+        declared = tomli.loads(pyproject.read_text(encoding="utf-8"))["project"][
+            "dependencies"
+        ]
+
+        found = [
+            requirement
+            for requirement in map(Requirement, declared)
+            if canonicalize_name(requirement.name) == "installer"
+        ]
+        assert len(found) == 1, f"expected one installer requirement, got {found}"
+
+        assert not found[0].specifier.contains(
+            self._LAST_RELEASE_WITHOUT_OVERWRITE_EXISTING
+        )
 
 
 class TestNabBuildEnvOutsideContext:


### PR DESCRIPTION
nab-python declares installer>=0.7, but the isolated build environment installs each build dependency through a destination class that subclasses SchemeDictionaryDestination as a dataclass and passes overwrite_existing. Neither works before installer 1.0, so an environment that resolves installer 0.7.0 fails on the first wheel of every PEP 517 build.

Raise the floor to installer>=1.0 and add a test that keeps it tied to the API the build environment uses.
