### PR TITLE
fix --locked failing on a marker inside the Python minor

### DIFF
--- a/nab-python/src/nab_python/_lockfile/validate.py
+++ b/nab-python/src/nab_python/_lockfile/validate.py
@@ -19,6 +19,12 @@ picks from the intersection of every requirement on a name, so a fresh
 resolve can land on a pre-release the requirement checked here does not opt
 into on its own.
 
+The validity checks read one marker environment. A target standing for a
+whole Python minor synthesizes ``{minor}.0`` as its ``python_full_version``
+while the resolve answers one micro slice at a time, so a marker cutting a
+boundary inside the minor is indeterminate here rather than decided at that
+floor.
+
 :func:`check_locked` is the entry point the CLI calls: it reads the committed
 lock and runs both stages, so a caller never handles a parsed lock itself.
 """
@@ -37,6 +43,7 @@ from .._vendor.packaging.requirements import Requirement
 from .._vendor.packaging.specifiers import SpecifierSet
 from .._vendor.packaging.utils import canonicalize_name
 from ..metadata import validate_specifier_versions
+from ..target import NonIntervalMarkerError, micro_boundary_points
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
@@ -45,6 +52,7 @@ if TYPE_CHECKING:
     from .._vendor.packaging.markers import Marker
     from .._vendor.packaging.pylock import Package
     from .._vendor.packaging.version import Version
+    from ..target import ResolveTarget
 
 
 class LockfileSyntaxError(Exception):
@@ -147,6 +155,7 @@ def check_direct_requirements(
     requirements: Iterable[RootRequirement],
     *,
     marker_env: Mapping[str, str],
+    resolve_target: ResolveTarget | None = None,
 ) -> LockDisqualification | None:
     """Check every active direct requirement against the committed lock.
 
@@ -158,12 +167,16 @@ def check_direct_requirements(
     marker, a URL requirement, a version-less or direct (URL, VCS, directory)
     pin, and a name carrying more than one versioned pin. Returns the first
     violation, or ``None``.
+
+    ``resolve_target`` is the target ``marker_env`` came from: a marker its
+    micro slices answer differently is indeterminate rather than read off the
+    environment.
     """
     package_names = {package.name for package in committed.packages}
     versioned = _versioned_pins(committed)
     for root in requirements:
         req = root.requirement
-        if _marker_skips(req.marker, marker_env):
+        if _marker_skips(req.marker, marker_env, resolve_target):
             continue
         name = canonicalize_name(req.name)
         if name not in package_names:
@@ -193,6 +206,7 @@ def check_constraints(
     constraints: Iterable[Requirement],
     *,
     marker_env: Mapping[str, str],
+    resolve_target: ResolveTarget | None = None,
 ) -> LockDisqualification | None:
     """Check every active constraint against the committed lock.
 
@@ -201,10 +215,14 @@ def check_constraints(
     inactive or indeterminate marker, and a name with no single versioned pin
     (absent, version-less, or multiple under a conflict fork), are skipped.
     Returns the first violation, or ``None``.
+
+    ``resolve_target`` is the target ``marker_env`` came from: a marker its
+    micro slices answer differently is indeterminate rather than read off the
+    environment.
     """
     versioned = _versioned_pins(committed)
     for constraint in constraints:
-        if _marker_skips(constraint.marker, marker_env):
+        if _marker_skips(constraint.marker, marker_env, resolve_target):
             continue
         version = versioned.get(canonicalize_name(constraint.name))
         if version is None:
@@ -248,19 +266,40 @@ def _is_direct_pin(package: Package) -> bool:
     )
 
 
-def _marker_skips(marker: Marker | None, marker_env: Mapping[str, str]) -> bool:
+def _marker_skips(
+    marker: Marker | None,
+    marker_env: Mapping[str, str],
+    target: ResolveTarget | None,
+) -> bool:
     """Return whether an item is inactive or indeterminate for ``marker_env``.
 
     A missing marker is active. A false marker is inactive. A marker that
-    cannot be evaluated is indeterminate. Both inactive and indeterminate skip.
+    cannot be evaluated, or that ``target``'s micro slices answer differently,
+    is indeterminate. Both inactive and indeterminate skip.
     """
     if marker is None:
         return False
+    if target is not None and _splits_micro_line(marker, target):
+        return True
     try:
         active = dependency_marker_holds(marker, marker_env)
     except (UnevaluableMarkerError, UndefinedEnvironmentName):
         return True
     return not active
+
+
+def _splits_micro_line(marker: Marker, target: ResolveTarget) -> bool:
+    """Whether ``marker`` reads differently across ``target``'s micro slices.
+
+    A minor target's ``marker_env`` answers the micro axis at the synthesized
+    ``{minor}.0`` floor, so a marker cutting a boundary inside the minor is
+    decided per slice by the resolve rather than here. A marker the split
+    cannot tile is undecided here too, and the full resolve reports it.
+    """
+    try:
+        return bool(micro_boundary_points(target, [marker]))
+    except NonIntervalMarkerError:
+        return True
 
 
 def _render_specifier(spec: SpecifierSet | None) -> str:
@@ -306,17 +345,17 @@ def check_locked(  # noqa: PLR0913 - the envelope fields and the validity inputs
     default_groups: tuple[str, ...],
     roots: Iterable[RootRequirement] | None = None,
     constraints: Iterable[str] = (),
-    marker_env: Mapping[str, str] | None = None,
+    resolve_target: ResolveTarget | None = None,
     exclude: frozenset[str] = frozenset(),
 ) -> LockDisqualification | None:
     """Disqualify the committed lock at ``lockfile``, or return ``None``.
 
     Runs the envelope checks, then the validity checks over the active
-    direct requirements and constraints. ``roots`` of ``None`` runs the
-    envelope checks alone. ``exclude`` holds canonical names to skip, for
-    the workspace members ``--no-emit-workspace`` drops from both sides.
-    Constraints arrive as text; the config loader has already rejected any
-    that do not parse.
+    direct requirements and constraints, reading ``resolve_target``'s marker
+    environment. ``roots`` or ``resolve_target`` of ``None`` runs the envelope
+    checks alone. ``exclude`` holds canonical names to skip, for the workspace
+    members ``--no-emit-workspace`` drops from both sides. Constraints arrive
+    as text; the config loader has already rejected any that do not parse.
 
     Raises the errors :func:`read_committed_pylock` raises.
     """
@@ -328,15 +367,25 @@ def check_locked(  # noqa: PLR0913 - the envelope fields and the validity inputs
         dependency_groups=dependency_groups,
         default_groups=default_groups,
     )
-    if disqualification is not None or roots is None or marker_env is None:
+    if disqualification is not None or roots is None or resolve_target is None:
         return disqualification
     active = [
         root
         for root in roots
         if canonicalize_name(root.requirement.name) not in exclude
     ]
-    direct = check_direct_requirements(committed, active, marker_env=marker_env)
+    direct = check_direct_requirements(
+        committed,
+        active,
+        marker_env=resolve_target.marker_env,
+        resolve_target=resolve_target,
+    )
     if direct is not None:
         return direct
     parsed = [Requirement(text) for text in constraints]
-    return check_constraints(committed, parsed, marker_env=marker_env)
+    return check_constraints(
+        committed,
+        parsed,
+        marker_env=resolve_target.marker_env,
+        resolve_target=resolve_target,
+    )

--- a/nab-python/tests/test_lockfile_locked.py
+++ b/nab-python/tests/test_lockfile_locked.py
@@ -30,15 +30,6 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
     from pathlib import Path
 
-LINUX_ENV = {
-    "python_version": "3.11",
-    "sys_platform": "linux",
-    "os_name": "posix",
-    "platform_machine": "x86_64",
-    "platform_system": "Linux",
-    "implementation_name": "cpython",
-}
-
 TARGET = ResolveTarget.for_declared(
     python_version="3.11", spec=PlatformSpec("linux_x86_64")
 )
@@ -198,7 +189,7 @@ class TestArtifactUrlFilenames:
                 dependency_groups=(),
                 default_groups=(),
                 roots=[RootRequirement(Requirement("torch"), "[project].dependencies")],
-                marker_env=LINUX_ENV,
+                resolve_target=TARGET,
             )
             is None
         )
@@ -223,7 +214,7 @@ class TestArtifactUrlFilenames:
                 dependency_groups=(),
                 default_groups=(),
                 roots=[RootRequirement(Requirement("spam"), "[project].dependencies")],
-                marker_env=LINUX_ENV,
+                resolve_target=TARGET,
             )
             is None
         )
@@ -275,7 +266,7 @@ class TestArtifactUrlFilenames:
                 dependency_groups=(),
                 default_groups=(),
                 roots=[RootRequirement(Requirement("torch"), "[project].dependencies")],
-                marker_env=LINUX_ENV,
+                resolve_target=TARGET,
             )
             is None
         )
@@ -309,7 +300,7 @@ class TestCheckLocked:
                 dependency_groups=(),
                 default_groups=(),
                 roots=[RootRequirement(Requirement("foo"), "[project].dependencies")],
-                marker_env=LINUX_ENV,
+                resolve_target=TARGET,
             )
             is None
         )
@@ -336,12 +327,12 @@ class TestCheckLocked:
                 dependency_groups=(),
                 default_groups=(),
                 roots=None,
-                marker_env=LINUX_ENV,
+                resolve_target=TARGET,
             )
             is None
         )
 
-    def test_marker_env_none_runs_envelope_only(self, tmp_path: Path) -> None:
+    def test_resolve_target_none_runs_envelope_only(self, tmp_path: Path) -> None:
         target = _write_lock(tmp_path / "pylock.toml", {"foo": _pin("foo", "1.0")})
         assert (
             check_locked(
@@ -351,7 +342,7 @@ class TestCheckLocked:
                 dependency_groups=(),
                 default_groups=(),
                 roots=[RootRequirement(Requirement("bar"), "[project].dependencies")],
-                marker_env=None,
+                resolve_target=None,
             )
             is None
         )
@@ -365,7 +356,7 @@ class TestCheckLocked:
             dependency_groups=(),
             default_groups=(),
             roots=[RootRequirement(Requirement("bar"), "[project].dependencies")],
-            marker_env=LINUX_ENV,
+            resolve_target=TARGET,
         )
         assert result is not None
         assert "no bar pin" in result.reason
@@ -380,7 +371,7 @@ class TestCheckLocked:
                 dependency_groups=(),
                 default_groups=(),
                 roots=[RootRequirement(Requirement("Bar"), "[project].dependencies")],
-                marker_env=LINUX_ENV,
+                resolve_target=TARGET,
                 exclude=frozenset({"bar"}),
             )
             is None
@@ -396,7 +387,7 @@ class TestCheckLocked:
             default_groups=(),
             roots=[],
             constraints=["foo>=2"],
-            marker_env=LINUX_ENV,
+            resolve_target=TARGET,
         )
         assert result is not None
         assert "constraint foo>=2" in result.reason

--- a/nab-python/tests/test_lockfile_validate.py
+++ b/nab-python/tests/test_lockfile_validate.py
@@ -18,6 +18,8 @@ from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.utils import canonicalize_name
 from nab_python._vendor.packaging.version import Version
 from nab_python.lockfile import LockDisqualification, RootRequirement
+from nab_python.tags import PlatformSpec
+from nab_python.target import ResolveTarget
 
 
 def make_pylock(
@@ -224,6 +226,13 @@ def test_lock_disqualification_is_frozen() -> None:
 
 LINUX_ENV = {"sys_platform": "linux"}
 
+# A target standing for the whole 3.11 minor, so its python_full_version is
+# the synthesized 3.11.0 floor.
+MINOR_TARGET = ResolveTarget.for_declared(
+    python_version="3.11", spec=PlatformSpec("linux_x86_64")
+)
+MINOR_ENV = MINOR_TARGET.marker_env
+
 
 def index_pin(name: str, version: str) -> Package:
     return Package(name=canonicalize_name(name), version=Version(version))
@@ -429,6 +438,49 @@ def test_direct_no_requirements_returns_none() -> None:
     assert check_direct_requirements(pylock_of(), [], marker_env=LINUX_ENV) is None
 
 
+def test_direct_marker_splitting_the_minor_skipped() -> None:
+    """A requirement gated at a micro boundary is undecided at the floor.
+
+    It holds in some of the minor's slices and not others. The skip covers
+    the presence check too, which is coarser than the proof needs: the lower
+    slice alone would settle a name the lock never pins.
+    """
+    committed = pylock_of()
+    assert (
+        check_direct_requirements(
+            committed,
+            [root('bar>=1; python_full_version < "3.11.4"')],
+            marker_env=MINOR_ENV,
+            resolve_target=MINOR_TARGET,
+        )
+        is None
+    )
+
+
+def test_direct_marker_not_splitting_the_minor_still_fires() -> None:
+    """A micro-axis marker that does not split the minor is decided at the floor."""
+    committed = pylock_of()
+    result = check_direct_requirements(
+        committed,
+        [root('bar>=1; python_full_version >= "3.9"')],
+        marker_env=MINOR_ENV,
+        resolve_target=MINOR_TARGET,
+    )
+    assert result is not None
+    assert result.reason.startswith("[project].dependencies requires bar")
+
+
+def test_direct_marker_on_a_micro_boundary_at_a_point_fires() -> None:
+    committed = pylock_of()
+    result = check_direct_requirements(
+        committed,
+        [root('bar>=1; python_full_version < "3.11.4"')],
+        marker_env=MINOR_ENV,
+    )
+    assert result is not None
+    assert result.reason.startswith("[project].dependencies requires bar")
+
+
 def test_constraint_satisfied_returns_none() -> None:
     committed = pylock_of(index_pin("baz", "2.0"))
     assert (
@@ -498,6 +550,61 @@ def test_constraint_versionless_pin_skipped() -> None:
         check_constraints(committed, [Requirement("baz<3")], marker_env=LINUX_ENV)
         is None
     )
+
+
+def test_constraint_marker_splitting_the_minor_skipped() -> None:
+    """A constraint gated below a micro boundary cannot judge a pin from above it."""
+    committed = pylock_of(marked_pin("baz", "3.1", 'python_full_version >= "3.11.4"'))
+    assert (
+        check_constraints(
+            committed,
+            [Requirement('baz<3; python_full_version < "3.11.4"')],
+            marker_env=MINOR_ENV,
+            resolve_target=MINOR_TARGET,
+        )
+        is None
+    )
+
+
+def test_constraint_marker_the_split_cannot_tile_skipped() -> None:
+    """A micro-axis clause the split cannot tile is undecided here too.
+
+    It holds at the floor, so without the skip the check would fire on it.
+    """
+    committed = pylock_of(index_pin("baz", "3.1"))
+    assert (
+        check_constraints(
+            committed,
+            [Requirement('baz<3; python_full_version not in "3.11.4"')],
+            marker_env=MINOR_ENV,
+            resolve_target=MINOR_TARGET,
+        )
+        is None
+    )
+
+
+def test_constraint_marker_on_a_micro_boundary_at_a_point_fires() -> None:
+    committed = pylock_of(index_pin("baz", "3.1"))
+    result = check_constraints(
+        committed,
+        [Requirement('baz<3; python_full_version < "3.11.4"')],
+        marker_env=MINOR_ENV,
+    )
+    assert result is not None
+    assert result.reason == "the constraint baz<3 is violated by the pinned baz 3.1"
+
+
+def test_constraint_marker_not_splitting_the_minor_still_fires() -> None:
+    """Only a marker the minor's slices answer differently is indeterminate."""
+    committed = pylock_of(index_pin("baz", "3.1"))
+    result = check_constraints(
+        committed,
+        [Requirement('baz<3; python_full_version >= "3.9"')],
+        marker_env=MINOR_ENV,
+        resolve_target=MINOR_TARGET,
+    )
+    assert result is not None
+    assert result.reason == "the constraint baz<3 is violated by the pinned baz 3.1"
 
 
 def test_constraint_duplicate_versioned_pins_skipped() -> None:

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -353,7 +353,7 @@ def _fast_fail_locked(
     ):
         return
 
-    marker_env = _locked_marker_env(config, python=python)
+    resolve_target = _locked_resolve_target(config, python=python)
 
     try:
         disqualification = check_locked(
@@ -364,7 +364,7 @@ def _fast_fail_locked(
             default_groups=config.default_groups,
             roots=roots,
             constraints=config.constraints,
-            marker_env=marker_env,
+            resolve_target=resolve_target,
             exclude=workspace_to_drop,
         )
     except OSError as e:
@@ -391,16 +391,18 @@ def _fast_fail_locked(
     sys.exit(1)
 
 
-def _locked_marker_env(
+def _locked_resolve_target(
     config: NabProjectConfig, *, python: str | None
-) -> Mapping[str, str] | None:
-    """Return the environment the validity checks evaluate markers against.
+) -> ResolveTarget | None:
+    """Return the target the validity checks evaluate markers against.
 
     ``None`` when the declaration excludes this run's target, which leaves
     the validity checks to the full resolve.  The envelope checks still run.
+    The checks read the target's marker environment; the target itself says
+    which markers its micro slices decide instead.
     """
     try:
-        return plan_targets(with_python_override(config, python))[0].marker_env
+        return plan_targets(with_python_override(config, python))[0]
     except ConfigError:
         return None
 

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -193,6 +193,39 @@ def test_added_declared_default_group_fires_without_resolving(
     mock.assert_not_called()
 
 
+def test_constraint_not_splitting_the_minor_fires_without_resolving(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # No boundary inside the minor, so the target's floor decides the marker.
+    pyproject = _write_pyproject(
+        tmp_path,
+        "[project]\n"
+        "dependencies = ['foo']\n"
+        "[tool.nab]\n"
+        "constraints = ['foo<1.0 ; python_full_version >= \"3.9\"']\n"
+        "[tool.nab.environment]\n"
+        'python = "3.11"\n',
+    )
+    out = tmp_path / "pylock.toml"
+    out.write_text(
+        'lock-version = "1.0"\n'
+        'created-by = "nab"\n\n'
+        + _foo_package("1.5", 'python_full_version >= \\"3.11\\"'),
+        encoding="utf-8",
+    )
+
+    mock = _locked_mock(_result({"foo": "1.5"}))
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock)
+
+    assert exc.value.code == 1
+    assert (
+        "the constraint foo<1.0 is violated by the pinned foo 1.5"
+        in capsys.readouterr().err
+    )
+    mock.assert_not_called()
+
+
 def test_changed_requires_python_fires_without_resolving(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -485,6 +518,37 @@ def test_conflict_fork_duplicate_pins_fall_through(
     assert exc.value.code == 1
     err = capsys.readouterr().err
     assert "the lock pins foo" not in err
+    mock.assert_called_once()
+
+
+def test_micro_gated_constraint_falls_through(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # A bare-minor target resolves once per micro slice, so a constraint gated
+    # below the boundary says nothing about the pin the slice above produced.
+    pyproject = _write_pyproject(
+        tmp_path,
+        "[project]\n"
+        "dependencies = ['foo ; python_full_version >= \"3.11.4\"']\n"
+        "[tool.nab]\n"
+        "constraints = ['foo<1.0 ; python_full_version < \"3.11.4\"']\n"
+        "[tool.nab.environment]\n"
+        'python = "3.11"\n',
+    )
+    out = tmp_path / "pylock.toml"
+    out.write_text(
+        'lock-version = "1.0"\n'
+        'created-by = "nab"\n\n'
+        + _foo_package("1.5", 'python_full_version >= \\"3.11.4.dev0\\"'),
+        encoding="utf-8",
+    )
+
+    mock = _locked_mock(_result({"foo": "1.5"}))
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock)
+
+    assert exc.value.code == 1
+    assert "the constraint foo<1.0" not in capsys.readouterr().err
     mock.assert_called_once()
 
 


### PR DESCRIPTION
With a bare-minor target such as `python = "3.11"`, an up-to-date lock is reported out of date and `nab lock --locked` exits before resolving.

The fast-fail check evaluates markers at the target's synthesized `3.11.0` full version, while the resolve answers one micro slice at a time. So a requirement or constraint gated on a `python_full_version` boundary inside the minor gets read at that floor, then judged against a pin only the other slice produced.

The checks now take the resolve target and treat a marker whose boundaries split that minor as indeterminate, leaving the full resolve to decide it. A marker the split cannot tile is skipped the same way.
