### PR TITLE
fix walk-ahead prefetch fetching newest versions under lowest

### DIFF
--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -697,9 +697,17 @@ def prefetch_walk_ahead(
         return
     picked = wheel_by_version(provider, normalized, versions_list)
     coordinator_index = provider.coordinator.index
+
+    # Reverse out of place: ``versions_list`` is the shared cached listing.
+    ordered = (
+        list(reversed(versions_list))
+        if provider.wants_lowest(normalized)
+        else versions_list
+    )
+
     items: list[tuple[str, str, str, tuple[str, str] | None]] = []
     seen_versions: set[Version] = set()
-    for version, _ in versions_list:
+    for version, _ in ordered:
         if version in seen_versions:
             continue
         seen_versions.add(version)

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -7634,7 +7634,7 @@ class TestPrefetchWalkAhead:
     """``prefetch_walk_ahead`` covers the abort-skip walk after the scan.
 
     Fired from ``_scan_candidates_pipelined``; submits up to
-    ``DEEP_PREFETCH_COUNT`` wheel metadata requests for the front of
+    ``DEEP_PREFETCH_COUNT`` wheel metadata requests in scan order over
     ``versions_cache[normalized]``.  Fire-and-forget; correctness only
     depends on it being a superset of what the resolver later asks for.
     """
@@ -7658,6 +7658,30 @@ class TestPrefetchWalkAhead:
         # fetch_versions already prefetched the newest version; it fills a
         # window slot but is skipped as already-held.
         assert len(items) == provider.DEEP_PREFETCH_COUNT - 1
+
+    @pytest.mark.parametrize(
+        "strategy",
+        [ResolutionStrategy.LOWEST, ResolutionStrategy.LOWEST_DIRECT],
+    )
+    def test_walk_ahead_is_oldest_first_under_lowest(
+        self, strategy: ResolutionStrategy
+    ) -> None:
+        """Under a lowest strategy the batch follows the scan: oldest first."""
+        wheels = [make_wheel(f"{i}.0") for i in range(100, 0, -1)]
+        coordinator = make_coordinator(wheels, package="foo")
+        provider = Provider(
+            coordinator,
+            resolution_strategy=strategy,
+            direct_packages=frozenset({"foo"}),
+        )
+        provider.fetch_versions("foo")
+        coordinator.reset_mock()
+        provider.prefetch_walk_ahead("foo")
+        items = coordinator.request_metadata_batch.call_args[0][0]
+        versions = [ver for _, ver, _, _ in items]
+        assert versions == [
+            f"{i}.0" for i in range(1, provider.DEEP_PREFETCH_COUNT + 1)
+        ]
 
     def test_skips_versions_with_cached_deps(self) -> None:
         """Versions already in ``deps_cache`` are excluded from the batch."""


### PR DESCRIPTION
Under `--resolution lowest` (and `lowest-direct` for a direct package) `choose_version` walks candidates oldest to newest, but `prefetch_walk_ahead` always submitted the newest 64 versions of the listing. The batch warmed the end of the listing the scan never reaches, so the walk paid one metadata fetch per version while every request in the batch went to versions the resolver would never try.

This is the same defect #418 fixed in `prefetch_root_batch`, with the same fix: walk a reversed copy of the shared listing when the strategy wants the lowest version, so the batch follows the scan.
