### PR TITLE
clear the live progress line before mid-resolve diagnostics

### DIFF
--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -767,9 +767,7 @@ def main() -> None:
     _printer = Printer(
         verbosity=options.verbosity, color=options.color, progress=options.progress
     )
-    install_log_handler(
-        options.verbosity, stream=sys.stderr, color_enabled=_printer.color_enabled
-    )
+    install_log_handler(_printer)
 
     try:
         app.cli(prog="nab", args=_normalize_layered_bool_flags(rest))

--- a/src/nab/output.py
+++ b/src/nab/output.py
@@ -118,6 +118,10 @@ _SGR = {
 }
 _RESET = "\033[0m"
 
+# Carriage return plus "erase to end of line": repaints the progress line in
+# place and wipes it before any other stderr write.
+_CLEAR_LINE = "\r\033[K"
+
 
 _LOG_LEVELS: dict[Verbosity, int] = {
     Verbosity.SILENT: logging.ERROR,
@@ -175,6 +179,8 @@ class Printer:
             and verbosity is Verbosity.NORMAL
             and _isatty(self._err)
         )
+        self._err_lock = threading.Lock()
+        self._progress_drawn = False
 
     @property
     def stderr(self) -> IO[str]:
@@ -191,7 +197,7 @@ class Printer:
         """Write ``token message`` to stderr when the level allows it."""
         if self.verbosity < threshold:
             return
-        self._err.write(f"{self._paint(token, color)} {message}\n")
+        self.stderr_write(f"{self._paint(token, color)} {message}\n")
 
     def data(self, text: str) -> None:
         """Write requested output to stdout verbatim (the pipeable channel)."""
@@ -218,7 +224,7 @@ class Printer:
         if self.verbosity < Verbosity.NORMAL:
             return
         head, sep, tail = message.partition(" ")
-        self._err.write(f"{self._paint(head, 'green')}{sep}{tail}\n")
+        self.stderr_write(f"{self._paint(head, 'green')}{sep}{tail}\n")
 
     def stderr_line(self, message: str) -> None:
         """Write a raw normal-level line to stderr with no token or colour.
@@ -227,7 +233,34 @@ class Printer:
         matrix report), where the leading-token shape does not fit.
         """
         if self.verbosity >= Verbosity.NORMAL:
-            self._err.write(message)
+            self.stderr_write(message)
+
+    def stderr_write(self, text: str) -> None:
+        """Write ``text`` to stderr, wiping any live progress line first.
+
+        Takes the same lock as the progress repaints, so a diagnostic never
+        interleaves with one.
+        """
+        with self._err_lock:
+            if self._progress_drawn:
+                self._err.write(_CLEAR_LINE)
+                self._progress_drawn = False
+            self._err.write(text)
+
+    def progress_line(self, line: str) -> None:
+        """Repaint the live progress line in place, without a newline."""
+        with self._err_lock:
+            self._err.write(_CLEAR_LINE + line)
+            self._err.flush()
+            self._progress_drawn = True
+
+    def clear_progress(self) -> None:
+        """Wipe the progress line so the next stderr write starts clean."""
+        with self._err_lock:
+            if self._progress_drawn:
+                self._err.write(_CLEAR_LINE)
+                self._err.flush()
+                self._progress_drawn = False
 
 
 # The engine logs through ``logging.getLogger(__name__)``; these are the
@@ -242,8 +275,24 @@ _LEVEL_TOKENS: dict[int, tuple[str, str]] = {
 }
 
 
+class _PrinterStream:
+    """File-like wrapper so the log handler writes via :meth:`Printer.stderr_write`."""
+
+    def __init__(self, printer: Printer) -> None:
+        self._printer = printer
+
+    def write(self, text: str) -> None:
+        self._printer.stderr_write(text)
+
+    def flush(self) -> None:
+        self._printer.stderr.flush()
+
+
 class _NabLogHandler(logging.StreamHandler):  # type: ignore[type-arg]
     """Marker subclass so a re-install can find and drop nab's own handler."""
+
+    def __init__(self, printer: Printer) -> None:
+        super().__init__(_PrinterStream(printer))
 
 
 class _LevelFormatter(logging.Formatter):
@@ -277,22 +326,23 @@ def _remove_nab_handlers(logger: logging.Logger) -> None:
     logger.handlers = [h for h in logger.handlers if not isinstance(h, _NabLogHandler)]
 
 
-def install_log_handler(
-    verbosity: Verbosity, *, stream: IO[str], color_enabled: bool
-) -> None:
-    """Route the engine's ``logging`` records to ``stream`` at the run's level.
+def install_log_handler(printer: Printer) -> None:
+    """Route the engine's ``logging`` records through ``printer``'s stderr.
 
     One handler is shared across the nab top-level loggers, so engine records
-    follow the same verbosity as the printer instead of Python's uncontrolled
-    ``lastResort`` fallback.  Idempotent: a prior nab handler is dropped first,
-    so calling this again (as the test suite does) does not stack handlers.
+    follow the printer's verbosity instead of Python's uncontrolled
+    ``lastResort`` fallback, and reach stderr through the printer so they
+    never land on the live progress line.  Idempotent: a prior nab handler is
+    dropped first, so calling this again (as the test suite does) does not
+    stack handlers.
     """
-    level = logging_level_for(verbosity)
-    handler = _NabLogHandler(stream)
+    level = logging_level_for(printer.verbosity)
+    handler = _NabLogHandler(printer)
     handler.setLevel(level)
     handler.setFormatter(
         _LevelFormatter(
-            verbose=verbosity >= Verbosity.VERBOSE, color_enabled=color_enabled
+            verbose=printer.verbosity >= Verbosity.VERBOSE,
+            color_enabled=printer.color_enabled,
         )
     )
     for name in _NAB_LOGGERS:
@@ -311,9 +361,6 @@ def reset_log_handlers() -> None:
 
 
 _SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
-# Carriage return plus "erase to end of line": repaints the progress line in
-# place and, on its own, wipes it before the run summary.
-_CLEAR_LINE = "\r\033[K"
 _PROGRESS_MIN_INTERVAL = 0.05
 
 
@@ -326,7 +373,9 @@ class ProgressReporter:
     terminal, progress not switched off), throttled to keep off the hot path,
     and guarded by a lock since the two callers run on different threads.
     When it is not allowed every method is a cheap no-op, so a piped, quiet,
-    or verbose run pays nothing and stdout stays clean.
+    or verbose run pays nothing and stdout stays clean.  The line is painted
+    through :meth:`Printer.progress_line`, so a mid-resolve diagnostic wipes
+    it instead of landing on it.
     """
 
     def __init__(
@@ -338,7 +387,7 @@ class ProgressReporter:
     ) -> None:
         """Build a reporter that renders through ``printer``'s stderr."""
         self._enabled = printer.progress_allowed
-        self._stream = printer.stderr
+        self._printer = printer
         self._color = printer.color_enabled
         self._clock = clock
         self._min_interval = min_interval
@@ -347,7 +396,7 @@ class ProgressReporter:
         self._pinned = 0
         self._frame = 0
         self._last = 0.0
-        self._drawn = False
+        self._painted = False
 
     def on_fetch(self) -> None:
         """Record one more package listing fetched, then repaint."""
@@ -368,7 +417,7 @@ class ProgressReporter:
     def _render(self) -> None:
         """Repaint the line, unless the throttle window has not elapsed."""
         now = self._clock()
-        if self._drawn and now - self._last < self._min_interval:
+        if self._painted and now - self._last < self._min_interval:
             return
         self._last = now
         frame = _SPINNER[self._frame % len(_SPINNER)]
@@ -376,19 +425,13 @@ class ProgressReporter:
         line = f"{frame} Resolving... {self._fetched} fetched, {self._pinned} pinned"
         if self._color:
             line = f"\033[2m{line}\033[0m"
-        self._stream.write(_CLEAR_LINE + line)
-        self._stream.flush()
-        self._drawn = True
+        self._printer.progress_line(line)
+        self._painted = True
 
     def clear(self) -> None:
         """Wipe the progress line so the next stderr write starts clean."""
-        if not self._enabled:
-            return
-        with self._lock:
-            if self._drawn:
-                self._stream.write(_CLEAR_LINE)
-                self._stream.flush()
-                self._drawn = False
+        if self._enabled:
+            self._printer.clear_progress()
 
 
 class OutputOptionError(ValueError):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -299,10 +299,20 @@ def _emit_record(name: str, level: int, message: str) -> None:
     logging.getLogger(name).log(level, message)
 
 
-def test_log_handler_normal_prefixes_warning() -> None:
+def _handler_printer(
+    verbosity: Verbosity = Verbosity.NORMAL,
+    *,
+    color: ColorChoice = ColorChoice.NEVER,
+) -> tuple[Printer, io.StringIO]:
     stream = io.StringIO()
+    printer = Printer(verbosity=verbosity, color=color, stderr=stream, env={})
+    return printer, stream
+
+
+def test_log_handler_normal_prefixes_warning() -> None:
+    printer, stream = _handler_printer()
     try:
-        install_log_handler(Verbosity.NORMAL, stream=stream, color_enabled=False)
+        install_log_handler(printer)
         _emit_record("nab_python.demo", logging.WARNING, "dropped marker")
         _emit_record("nab_python.demo", logging.INFO, "hidden at normal")
     finally:
@@ -311,9 +321,9 @@ def test_log_handler_normal_prefixes_warning() -> None:
 
 
 def test_log_handler_colours_token() -> None:
-    stream = io.StringIO()
+    printer, stream = _handler_printer(color=ColorChoice.ALWAYS)
     try:
-        install_log_handler(Verbosity.NORMAL, stream=stream, color_enabled=True)
+        install_log_handler(printer)
         _emit_record("nab_index.demo", logging.ERROR, "boom")
     finally:
         reset_log_handlers()
@@ -321,9 +331,9 @@ def test_log_handler_colours_token() -> None:
 
 
 def test_log_handler_verbose_shows_info_with_source() -> None:
-    stream = io.StringIO()
+    printer, stream = _handler_printer(Verbosity.VERBOSE)
     try:
-        install_log_handler(Verbosity.VERBOSE, stream=stream, color_enabled=False)
+        install_log_handler(printer)
         _emit_record("nab_python.demo", logging.INFO, "fetching")
     finally:
         reset_log_handlers()
@@ -331,10 +341,10 @@ def test_log_handler_verbose_shows_info_with_source() -> None:
 
 
 def test_log_handler_reinstall_does_not_stack() -> None:
-    stream = io.StringIO()
+    printer, stream = _handler_printer()
     try:
-        install_log_handler(Verbosity.NORMAL, stream=stream, color_enabled=False)
-        install_log_handler(Verbosity.NORMAL, stream=stream, color_enabled=False)
+        install_log_handler(printer)
+        install_log_handler(printer)
         _emit_record("nab_resolver.demo", logging.WARNING, "once")
     finally:
         reset_log_handlers()
@@ -342,9 +352,9 @@ def test_log_handler_reinstall_does_not_stack() -> None:
 
 
 def test_log_handler_untokened_level_is_bare() -> None:
-    stream = io.StringIO()
+    printer, stream = _handler_printer()
     try:
-        install_log_handler(Verbosity.NORMAL, stream=stream, color_enabled=False)
+        install_log_handler(printer)
         _emit_record("nab_python.demo", logging.WARNING + 5, "custom level")
     finally:
         reset_log_handlers()
@@ -352,8 +362,8 @@ def test_log_handler_untokened_level_is_bare() -> None:
 
 
 def test_reset_log_handlers_detaches() -> None:
-    stream = io.StringIO()
-    install_log_handler(Verbosity.NORMAL, stream=stream, color_enabled=False)
+    printer, stream = _handler_printer()
+    install_log_handler(printer)
     reset_log_handlers()
     _emit_record("nab_python.demo", logging.WARNING, "after reset")
     assert stream.getvalue() == ""
@@ -426,6 +436,46 @@ def test_progress_clear_wipes_then_is_noop() -> None:
     err.seek(0)
     reporter.clear()
     assert err.getvalue() == ""
+
+
+def _live_progress_printer() -> tuple[Printer, _TTY]:
+    err = _TTY(tty=True)
+    printer = Printer(
+        stderr=err, verbosity=Verbosity.NORMAL, color=ColorChoice.NEVER, env={}
+    )
+    return printer, err
+
+
+def test_printer_message_wipes_live_progress_line() -> None:
+    printer, err = _live_progress_printer()
+    reporter = ProgressReporter(printer, clock=lambda: 0.0)
+    reporter.on_fetch()
+    printer.warning("metadata cannot be parsed")
+    assert "pinnedwarning:" not in err.getvalue()
+    assert err.getvalue().endswith("\r\033[Kwarning: metadata cannot be parsed\n")
+
+
+def test_log_record_wipes_live_progress_line() -> None:
+    printer, err = _live_progress_printer()
+    reporter = ProgressReporter(printer, clock=lambda: 0.0)
+    try:
+        install_log_handler(printer)
+        reporter.on_fetch()
+        _emit_record("nab_python.demo", logging.WARNING, "offline skip")
+    finally:
+        reset_log_handlers()
+    assert "pinnedwarning:" not in err.getvalue()
+    assert err.getvalue().endswith("\r\033[Kwarning: offline skip\n")
+
+
+def test_progress_repaints_after_diagnostic() -> None:
+    times = iter([0.0, 10.0])
+    printer, err = _live_progress_printer()
+    reporter = ProgressReporter(printer, clock=lambda: next(times), min_interval=1.0)
+    reporter.on_fetch()
+    printer.warning("careful")
+    reporter.on_pin(1)
+    assert err.getvalue().endswith("\r\033[K⠙ Resolving... 1 fetched, 1 pinned")
 
 
 _CLI_REFERENCE = Path(__file__).resolve().parents[1] / "docs" / "reference" / "cli.md"


### PR DESCRIPTION
With the spinner running, a warning emitted during the resolve (from the printer or an engine log record) wrote straight to stderr while the progress line was still drawn, so the two ran together on one line, e.g. `⠙ Resolving... 3 fetched, 1 pinnedwarning: dropped marker`.

The printer now owns the progress line. Spinner repaints and every other stderr write go through it under one lock, and any write wipes a drawn progress line first. The engine log handler is rerouted through the printer as well, so log records get the same treatment, and the spinner repaints on its next tick after a diagnostic.
