### PR TITLE
reject unparseable vcs.allowed-repos entries at config read

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -2443,6 +2443,8 @@ def _parse_vcs(value: object) -> VcsConfig:
     allowed_repos = _parse_string_list(
         "vcs.allowed-repos", value.get("allowed-repos", [])
     )
+    for repo in allowed_repos:
+        _validate_allowed_repo(repo)
     require_pin_raw = value.get("require-pin", True)
     if not isinstance(require_pin_raw, bool):
         msg = f"vcs.require-pin must be a boolean, got {type(require_pin_raw).__name__}"
@@ -2453,6 +2455,19 @@ def _parse_vcs(value: object) -> VcsConfig:
         allowed_repos=tuple(allowed_repos),
         require_pin=require_pin_raw,
     )
+
+
+def _validate_allowed_repo(repo: str) -> None:
+    """Reject an ``allowed-repos`` entry whose authority does not parse.
+
+    :func:`urlsplit` raises ValueError on an authority it cannot parse,
+    such as an unterminated IPv6 bracket.
+    """
+    try:
+        urlsplit(repo)
+    except ValueError as exc:
+        msg = f"vcs.allowed-repos entry {repo!r} does not parse: {exc}"
+        raise ConfigError(msg) from exc
 
 
 _LOCAL_SOURCE_KEYS = frozenset({"name", "path", "editable", "subdirectory"})

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -2221,6 +2221,31 @@ class TestVcs:
         ):
             read_pyproject_config(path)
 
+    def test_unparseable_allowed_repo_rejected(self, tmp_path: Path) -> None:
+        """A malformed entry fails the read even behind a well-formed one."""
+        path = write(
+            tmp_path,
+            "[tool.nab.vcs]\n"
+            'policy = "allow"\n'
+            'allowed-schemes = ["git+https"]\n'
+            'allowed-repos = ["https://github.com/org/repo",'
+            ' "https://[2001:db8::1:7999/org/repo"]\n',
+        )
+        with pytest.raises(
+            ConfigError,
+            match=r"vcs\.allowed-repos entry"
+            r" 'https://\[2001:db8::1:7999/org/repo' does not parse",
+        ):
+            read_pyproject_config(path)
+
+    def test_bracketed_ipv6_allowed_repo_accepted(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            '[tool.nab.vcs]\nallowed-repos = ["https://[2001:db8::1]:7999/org/repo"]\n',
+        )
+        vcs = read_pyproject_config(path).vcs
+        assert vcs.allowed_repos == ("https://[2001:db8::1]:7999/org/repo",)
+
 
 class TestLocalSources:
     def test_relative_path_resolved_against_pyproject(self, tmp_path: Path) -> None:


### PR DESCRIPTION
An allowed-repos entry whose authority does not parse, like an unterminated IPv6 bracket, raised during the allowlist match instead of at config read. The resulting error refused the VCS URL being checked and called that URL malformed, and since the match short-circuits it only fired when the bad entry sat before a matching one, so the same config could accept or refuse a URL depending on list order.

Each entry now goes through urlsplit while the config is read, so a bad entry fails the read with a ConfigError that names the entry.
