### PR TITLE
record universal benchmark pins and failures

### DIFF
--- a/nab-python/benchmarks/README.md
+++ b/nab-python/benchmarks/README.md
@@ -23,15 +23,21 @@ metrics, and writes a JSON summary under
 `nab-python/benchmarks/universal_scenarios.py` runs
 universal-resolution scenarios sourced from public uv/poetry/pex
 slowness reports.  The cases stress cross-tuple alignment, marker
-divergence, and pre-release handling.
+divergence, and broad target matrices.
 
 ```bash
 python nab-python/benchmarks/universal_scenarios.py
+python nab-python/benchmarks/universal_scenarios.py --scenario marker-heavy
 python nab-python/benchmarks/universal_summary.py
 ```
 
-`universal_summary.py` walks the latest results directory and
-prints a markdown table.
+`universal_summary.py` walks the latest results directory and prints a markdown table.
+
+Each result retains its per-target solutions and merged target-label pin projection. The runner exits nonzero after an unexpected resolution, timeout, lock-emission failure, or projection failure.
+
+The result schema and source identity invalidate stale caches.
+
+A full run writes `_manifest.json` with the current scenario set; the summary follows that set, ignores removed result files, and accepts only complete runs from a clean source tree. Selected diagnostics are isolated under `universal-selected/` and are never treated as a full-suite baseline.
 
 Benchmark outputs are local run artifacts rather than repository baselines.
 Generate both sides of a comparison on the same machine, with the same initial
@@ -42,10 +48,9 @@ provenance, timeouts, and iteration limits needed to interpret it.
 
 ## Scenario shape
 
-Each scenario is a top-level TOML table keyed by name, with at least
-`requirements` and a fixed `datetime` (used as the
-`uploaded-prior-to` cutoff).  Optional knobs include constraints,
-marker overlay, dist policy, and build policy.
+Each single-environment scenario is a top-level TOML table keyed by name, with at least `requirements` and a fixed `datetime` (used as the `uploaded-prior-to` cutoff). Optional single-environment knobs include constraints, marker overlays, distribution policy, and build policy.
+
+Universal scenarios require `python`, `platforms`, and `requirements`. They may also set constraints, a cutoff, Python ordering, alignment, resolution strategy, an explanatory reason, and expected-failure handling.
 
 ## What the suites cover
 
@@ -55,6 +60,4 @@ marker overlay, dist policy, and build policy.
 * Universal-mode fork-explosion cases (xinference, vllm,
   ultralytics, copick).
 
-The suites are diagnostic harnesses that flag regressions on pull
-requests.  Walltime is noisy; decision count and round count are
-the load-bearing numbers.
+The suites are opt-in diagnostic harnesses. Wall time is noisy, so prefer decision and round counts when comparing resolver search.

--- a/nab-python/benchmarks/scenarios/universal.toml
+++ b/nab-python/benchmarks/scenarios/universal.toml
@@ -2,10 +2,10 @@
 #
 # Each entry exercises the matrix-based universal resolver in
 # ``examples/universal/``.  Scenarios are sourced from real-world
-# reports of slow / problematic universal locks in uv, poetry, pex,
-# and pip-tools.
+# reports of slow or problematic universal locks in uv, Poetry, and PEX,
+# plus a few explicitly labeled real-world stress cases.
 #
-# Schema (all optional except python and platforms):
+# Schema (all optional except python, platforms, and requirements):
 #
 #   python = ">=3.11, <3.13"             # PEP 440 specifier set
 #   platforms = ["linux_x86_64", ...]    # known platform ids
@@ -13,11 +13,8 @@
 #   requirements = ["pkg>=1.0", ...]
 #   constraints = ["pkg<2.0", ...]       # optional
 #   datetime = "2025-06-01 14:00:00"     # exclude-newer-style cap
-#   align_across_tuples = true           # fork-strategy=fewest semantics
-#   resolution_strategy = "highest"      # uv --resolution
-#   parallel = false                     # ThreadPoolExecutor over tuples
-#   second_pass = false                  # cross-tuple max-version preference promotion
-#   second_pass_as_constraints = false   # promote unified preferences to == constraints
+#   align_across_tuples = false          # disable cross-target alignment
+#   resolution_strategy = "lowest"       # uv --resolution
 #   reason = "uv issue #1560"            # reference for the case
 #   skip_on_fail = false                 # if true, treat resolution failure as expected
 
@@ -32,7 +29,6 @@ python = ">=3.10, <3.13"
 platforms = ["linux_x86_64"]
 requirements = ["apache-airflow"]
 datetime = "2024-08-08 00:00:00"
-align_across_tuples = true
 
 # ---------------------------------------------------------------------------
 # Sourced from uv issue #8157 (numba / numpy / llvmlite):
@@ -45,7 +41,6 @@ python = ">=3.11, <3.13"
 platforms = ["linux_x86_64", "macos_arm64"]
 requirements = ["numpy>=2.1,<2.2", "numba<=0.60,>0.1"]
 datetime = "2025-06-01 00:00:00"
-align_across_tuples = true
 
 # ---------------------------------------------------------------------------
 # Sourced from uv issue #8157 (sentry/python-rapidjson/sentry-kafka-schemas):
@@ -60,7 +55,6 @@ requirements = [
     "sentry-kafka-schemas<=0.1.113,>=0.1.50",
 ]
 datetime = "2025-01-01 00:00:00"
-align_across_tuples = true
 
 # ---------------------------------------------------------------------------
 # Sourced from uv issue #1398:
@@ -80,7 +74,6 @@ requirements = [
     "selenium",
 ]
 datetime = "2023-10-01 00:00:00"
-align_across_tuples = true
 
 # ---------------------------------------------------------------------------
 # Sourced from uv issue #8157 (starlette/fastapi):
@@ -96,7 +89,6 @@ requirements = [
     "fastapi<=0.115.2",
 ]
 datetime = "2024-12-01 00:00:00"
-align_across_tuples = true
 
 # ---------------------------------------------------------------------------
 # Sourced from uv issue #1560:
@@ -112,7 +104,6 @@ requirements = [
     "apache-beam<=2.49.0",
 ]
 datetime = "2024-08-08 00:00:00"
-align_across_tuples = true
 
 # ---------------------------------------------------------------------------
 # Sourced from poetry #4924, mirosval.sk blog post on poetry slowness:
@@ -131,7 +122,6 @@ requirements = [
     "isort",
 ]
 datetime = "2024-01-01 00:00:00"
-align_across_tuples = true
 
 # ---------------------------------------------------------------------------
 # Real-world scenario: PyTorch CPU-only + transformers across 3 Pythons.
@@ -149,7 +139,6 @@ requirements = [
     "datasets",
 ]
 datetime = "2025-06-01 00:00:00"
-align_across_tuples = true
 
 # ---------------------------------------------------------------------------
 # Real-world scenario: scientific Python stack across 4 Pythons.
@@ -167,16 +156,14 @@ requirements = [
     "scikit-learn",
 ]
 datetime = "2025-06-01 00:00:00"
-align_across_tuples = true
 
 # ---------------------------------------------------------------------------
-# Sourced from PEX #2036 (top-88 PyPI packages):
-# 88-dep set used to demonstrate sequential pip download slowness in
-# pex.  Different bottleneck for nab (we share metadata fetches), but
-# good stress test for parallel/serial trade-off.
+# Legacy local 36-root workload historically attributed to PEX #2036.
+# It differs from that issue's pinned 88-item requirements file, so this is
+# a wide-fanout stress case rather than an issue reproduction.
 # ---------------------------------------------------------------------------
-[top88-pypi-stress]
-reason = "PEX #2036: top-88 PyPI packages stress test"
+[legacy-36-root-stress]
+reason = "legacy local 36-root workload historically attributed to PEX #2036"
 python = ">=3.11, <3.12"
 platforms = ["linux_x86_64", "macos_arm64", "windows_amd64"]
 requirements = [
@@ -218,7 +205,6 @@ requirements = [
     "wheel",
 ]
 datetime = "2024-09-01 00:00:00"
-align_across_tuples = true
 
 # ---------------------------------------------------------------------------
 # Marker-heavy scenario: lots of platform-conditional deps that exercise
@@ -238,7 +224,6 @@ requirements = [
     'lxml',
 ]
 datetime = "2025-06-01 00:00:00"
-align_across_tuples = true
 
 # ---------------------------------------------------------------------------
 # Maximalist case: 5 Pythons * 5 platforms = 25 tuples on a non-trivial
@@ -256,7 +241,6 @@ platforms = [
 ]
 requirements = ["dask"]
 datetime = "2025-06-01 00:00:00"
-align_across_tuples = true
 
 # ---------------------------------------------------------------------------
 # Comparison: same airflow scenario without cross-tuple alignment.
@@ -272,12 +256,11 @@ datetime = "2024-08-08 00:00:00"
 align_across_tuples = false
 
 # ---------------------------------------------------------------------------
-# Comparison: top88 with parallel=true to see if threads help on a
-# medium graph.  Threads are not expected to help materially per the
-# section 12.3 finding; this records the empirical gap.
+# Comparison: the legacy local 36-root workload without cross-tuple
+# alignment, with every other input unchanged.
 # ---------------------------------------------------------------------------
-[top88-parallel]
-reason = "top88 with parallel=true to measure thread impact"
+[legacy-36-root-noalign]
+reason = "legacy local 36-root workload without cross-tuple alignment"
 python = ">=3.11, <3.12"
 platforms = ["linux_x86_64", "macos_arm64", "windows_amd64"]
 requirements = [
@@ -292,21 +275,6 @@ requirements = [
 ]
 datetime = "2024-09-01 00:00:00"
 align_across_tuples = false
-parallel = true
-
-# ---------------------------------------------------------------------------
-# Comparison: airflow with second_pass + constraint mode to see if
-# the more aggressive alignment changes wall time.
-# ---------------------------------------------------------------------------
-[apache-airflow-second-pass]
-reason = "airflow with second-pass constraint promotion"
-python = ">=3.10, <3.13"
-platforms = ["linux_x86_64"]
-requirements = ["apache-airflow"]
-datetime = "2024-08-08 00:00:00"
-align_across_tuples = false
-second_pass = true
-second_pass_as_constraints = true
 
 # ---------------------------------------------------------------------------
 # Sourced from poetry's history: --resolution=lowest tests work
@@ -320,7 +288,6 @@ platforms = ["linux_x86_64"]
 requirements = ["numpy>=1.24", "scipy>=1.10", "pandas>=2"]
 datetime = "2025-01-01 00:00:00"
 resolution_strategy = "lowest"
-align_across_tuples = false
 
 # ---------------------------------------------------------------------------
 # Sourced from poetry #5962 (numpy + airflow-providers-amazon):
@@ -332,7 +299,6 @@ python = ">=3.11, <3.12"
 platforms = ["linux_x86_64"]
 requirements = ["apache-airflow-providers-amazon", "numpy"]
 datetime = "2024-09-01 00:00:00"
-align_across_tuples = true
 
 [numpy-wide-python-diverge]
 reason = "py-minor version-floor divergence; tests matrix divergence path"
@@ -348,4 +314,3 @@ python = ">=3.9, <3.14"
 platforms = ["linux_x86_64"]
 requirements = ["numpy", "scipy", "pandas"]
 datetime = "2025-06-01 00:00:00"
-align_across_tuples = true

--- a/nab-python/benchmarks/universal_result.py
+++ b/nab-python/benchmarks/universal_result.py
@@ -1,0 +1,429 @@
+"""Shared contract for persisted universal benchmark results."""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime
+
+RESULT_SCHEMA_VERSION = 3
+MANIFEST_FILENAME = "_manifest.json"
+
+_TOP_LEVEL_FIELDS = frozenset(
+    {"input", "reason", "result", "merged_pins", "stats", "per_tuple"}
+)
+_REQUIRED_INPUT_FIELDS = frozenset(
+    {
+        "align_across_tuples",
+        "benchmark_schema",
+        "build_policy",
+        "commit",
+        "dist_policy",
+        "platforms",
+        "python",
+        "python_order",
+        "reason",
+        "requirements",
+        "resolution_strategy",
+        "scenario",
+        "skip_on_fail",
+        "source",
+        "trust_unverified_sdist_deps",
+    }
+)
+_OPTIONAL_INPUT_FIELDS = frozenset({"constraints", "datetime"})
+_SOURCE_FIELDS = frozenset({"commit", "diff_hash", "dirty"})
+_RESOLUTION_STRATEGIES = frozenset({"highest", "lowest", "lowest-direct"})
+_DIST_POLICIES = frozenset(
+    {"prefer-wheel", "sdist-install", "sdist-only", "wheel-only", "wheel-or-sdist"}
+)
+_BUILD_POLICIES = frozenset({"build-local", "build-remote", "never"})
+_RESULT_FIELDS = frozenset(
+    {
+        "error",
+        "expected_failure",
+        "lock_consistent",
+        "lock_inconsistencies",
+        "resolution_success",
+        "skip_on_fail",
+        "success",
+        "timed_out",
+    }
+)
+_STATS_FIELDS = frozenset(
+    {
+        "backjumps_total",
+        "conflicts_total",
+        "decisions_total",
+        "distributions_seen_total",
+        "diverging_packages",
+        "merged_packages",
+        "metadata_fetched_total",
+        "rounds_total",
+        "tuples_fail",
+        "tuples_ok",
+        "tuples_recorded",
+        "tuples_total",
+    }
+)
+_TUPLE_COUNTER_FIELDS = frozenset(
+    {
+        "backjumps",
+        "conflicts",
+        "decisions",
+        "distributions_seen",
+        "metadata_fetched",
+        "package_count",
+        "rounds",
+    }
+)
+_TUPLE_FIELDS = _TUPLE_COUNTER_FIELDS | {
+    "error",
+    "label",
+    "pins",
+    "platform_id",
+    "python_version",
+    "success",
+    "wall_time_seconds",
+}
+_TUPLE_TOTALS = {
+    "backjumps_total": "backjumps",
+    "conflicts_total": "conflicts",
+    "decisions_total": "decisions",
+    "distributions_seen_total": "distributions_seen",
+    "metadata_fetched_total": "metadata_fetched",
+    "rounds_total": "rounds",
+}
+
+
+def _is_optional_bool(value: object) -> bool:
+    return value is None or type(value) is bool
+
+
+def _is_nonnegative_number(value: object) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+        and value >= 0
+    )
+
+
+def _is_hex_digest(value: object, lengths: set[int]) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) in lengths
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _valid_source(value: object) -> bool:
+    if not isinstance(value, dict) or set(value) != _SOURCE_FIELDS:
+        return False
+    commit = value["commit"]
+    diff_hash = value["diff_hash"]
+    dirty = value["dirty"]
+    if type(dirty) is not bool:
+        return False
+    if commit is not None and not _is_hex_digest(commit, {40, 64}):
+        return False
+    if diff_hash is not None and not _is_hex_digest(diff_hash, {64}):
+        return False
+    return dirty is True or (commit is not None and diff_hash is None)
+
+
+def _valid_string_list(value: object, *, unique: bool = False) -> bool:
+    return (
+        isinstance(value, list)
+        and bool(value)
+        and all(isinstance(item, str) and bool(item) for item in value)
+        and (not unique or len(set(value)) == len(value))
+    )
+
+
+def _valid_datetime(value: object) -> bool:
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        datetime.fromisoformat(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _valid_input(value: object, reason: object) -> bool:
+    if not isinstance(value, dict):
+        return False
+    fields = set(value)
+    if not fields >= _REQUIRED_INPUT_FIELDS or not fields <= (
+        _REQUIRED_INPUT_FIELDS | _OPTIONAL_INPUT_FIELDS
+    ):
+        return False
+    return (
+        value["benchmark_schema"] == RESULT_SCHEMA_VERSION
+        and isinstance(value["scenario"], str)
+        and bool(value["scenario"])
+        and isinstance(value["commit"], str)
+        and bool(value["commit"])
+        and _valid_source(value["source"])
+        and isinstance(value["python"], str)
+        and bool(value["python"])
+        and _valid_string_list(value["platforms"], unique=True)
+        and isinstance(value["python_order"], str)
+        and value["python_order"] in {"asc", "desc"}
+        and _valid_string_list(value["requirements"])
+        and type(value["align_across_tuples"]) is bool
+        and isinstance(value["resolution_strategy"], str)
+        and value["resolution_strategy"] in _RESOLUTION_STRATEGIES
+        and isinstance(value["dist_policy"], str)
+        and value["dist_policy"] in _DIST_POLICIES
+        and isinstance(value["build_policy"], str)
+        and value["build_policy"] in _BUILD_POLICIES
+        and type(value["trust_unverified_sdist_deps"]) is bool
+        and type(value["skip_on_fail"]) is bool
+        and isinstance(value["reason"], str)
+        and reason == value["reason"]
+        and ("constraints" not in value or _valid_string_list(value["constraints"]))
+        and ("datetime" not in value or _valid_datetime(value["datetime"]))
+    )
+
+
+def _valid_result(value: object, input_data: dict) -> bool:
+    if not isinstance(value, dict) or set(value) != _RESULT_FIELDS:
+        return False
+    inconsistencies = value["lock_inconsistencies"]
+    error = value["error"]
+    return (
+        type(value["success"]) is bool
+        and _is_optional_bool(value["resolution_success"])
+        and type(value["expected_failure"]) is bool
+        and type(value["skip_on_fail"]) is bool
+        and value["skip_on_fail"] is input_data["skip_on_fail"]
+        and type(value["timed_out"]) is bool
+        and _is_optional_bool(value["lock_consistent"])
+        and (error is None or (isinstance(error, str) and bool(error)))
+        and isinstance(inconsistencies, list)
+        and all(isinstance(item, str) and bool(item) for item in inconsistencies)
+    )
+
+
+def _valid_stats(value: object) -> bool:
+    if not isinstance(value, dict) or set(value) != _STATS_FIELDS | {
+        "wall_time_seconds"
+    }:
+        return False
+    return (
+        all(type(value[field]) is int and value[field] >= 0 for field in _STATS_FIELDS)
+        and value["tuples_total"] > 0
+        and _is_nonnegative_number(value["wall_time_seconds"])
+    )
+
+
+def _valid_tuple(value: object) -> bool:
+    if not isinstance(value, dict) or set(value) != _TUPLE_FIELDS:
+        return False
+    if not all(
+        isinstance(value[field], str) and bool(value[field])
+        for field in ("label", "platform_id", "python_version")
+    ):
+        return False
+    pins = value["pins"]
+    error = value["error"]
+    return (
+        type(value["success"]) is bool
+        and all(
+            type(value[field]) is int and value[field] >= 0
+            for field in _TUPLE_COUNTER_FIELDS
+        )
+        and (
+            (value["success"] is True and error is None)
+            or (value["success"] is False and isinstance(error, str) and bool(error))
+        )
+        and _is_nonnegative_number(value["wall_time_seconds"])
+        and isinstance(pins, dict)
+        and all(
+            isinstance(name, str)
+            and bool(name)
+            and isinstance(version, str)
+            and bool(version)
+            for name, version in pins.items()
+        )
+        and value["package_count"] == len(pins)
+        and (value["success"] is True or not pins)
+    )
+
+
+def _valid_per_tuple(value: object, stats: dict, input_data: dict) -> bool:
+    if not isinstance(value, list):
+        return False
+    if not all(_valid_tuple(item) for item in value):
+        return False
+    labels = [item["label"] for item in value]
+    cells = {(item["python_version"], item["platform_id"]) for item in value}
+    platforms = set(input_data["platforms"])
+    python_versions = {item["python_version"] for item in value}
+    return (
+        len(value) == stats["tuples_recorded"]
+        and stats["tuples_ok"] + stats["tuples_fail"] == len(value)
+        and sum(item["success"] is True for item in value) == stats["tuples_ok"]
+        and len(set(labels)) == len(labels)
+        and all(item["platform_id"] in platforms for item in value)
+        and (
+            not value
+            or (
+                cells
+                == {
+                    (python, platform)
+                    for python in python_versions
+                    for platform in platforms
+                }
+                and len(cells) == stats["tuples_total"]
+            )
+        )
+        and all(
+            stats[total] == sum(item[field] for item in value)
+            for total, field in _TUPLE_TOTALS.items()
+        )
+    )
+
+
+def _valid_merged_pins(value: object, stats: dict, per_tuple: list[dict]) -> bool:
+    if not isinstance(value, dict) or len(value) != stats["merged_packages"]:
+        return False
+    expected: dict[str, set[tuple[str, str]]] = {}
+    for item in per_tuple:
+        if item["success"]:
+            for name, version in item["pins"].items():
+                expected.setdefault(name, set()).add((version, item["label"]))
+    labels = {item["label"] for item in per_tuple}
+    actual: dict[str, set[tuple[str, str]]] = {}
+    for name, pins in value.items():
+        if (
+            not isinstance(name, str)
+            or not name
+            or not isinstance(pins, list)
+            or not pins
+            or not all(
+                isinstance(pin, dict)
+                and set(pin) == {"version", "target"}
+                and isinstance(pin["version"], str)
+                and bool(pin["version"])
+                and isinstance(pin["target"], str)
+                and pin["target"] in labels
+                for pin in pins
+            )
+        ):
+            return False
+        pairs = {(pin["version"], pin["target"]) for pin in pins}
+        if len(pairs) != len(pins):
+            return False
+        actual[name] = pairs
+    diverging = sum(
+        1 for pins in value.values() if len({pin["version"] for pin in pins}) > 1
+    )
+    return actual == expected and stats["diverging_packages"] == diverging
+
+
+def _valid_outcome(
+    result: dict, stats: dict, per_tuple: list, merged_pins: dict
+) -> bool:
+    resolution_success = result["resolution_success"]
+    if resolution_success is None:
+        zero_fields = _STATS_FIELDS - {"tuples_total"}
+        return (
+            result["success"] is False
+            and result["expected_failure"] is False
+            and result["lock_consistent"] is None
+            and not result["lock_inconsistencies"]
+            and isinstance(result["error"], str)
+            and all(stats[field] == 0 for field in zero_fields)
+            and not per_tuple
+            and not merged_pins
+        )
+    if (
+        stats["tuples_recorded"] < stats["tuples_total"]
+        or result["timed_out"] is True
+        or result["success"]
+        is not (resolution_success is True and result["lock_consistent"] is True)
+        or result["expected_failure"]
+        is not (result["skip_on_fail"] is True and resolution_success is False)
+    ):
+        return False
+    if resolution_success is False:
+        return (
+            stats["tuples_fail"] > 0
+            and result["lock_consistent"] is None
+            and not result["lock_inconsistencies"]
+            and result["error"] is None
+        )
+    return _valid_successful_resolution_outcome(result, stats)
+
+
+def _valid_successful_resolution_outcome(result: dict, stats: dict) -> bool:
+    if (
+        stats["tuples_fail"] != 0
+        or stats["tuples_ok"] != stats["tuples_recorded"]
+        or result["expected_failure"] is True
+    ):
+        return False
+    if result["error"] is not None:
+        return (
+            result["success"] is False
+            and result["lock_consistent"] is None
+            and not result["lock_inconsistencies"]
+        )
+    if result["lock_consistent"] is True:
+        return result["success"] is True and not result["lock_inconsistencies"]
+    return (
+        result["lock_consistent"] is False
+        and result["success"] is False
+        and bool(result["lock_inconsistencies"])
+    )
+
+
+def _result_outcome_is_accepted(result: dict) -> bool:
+    successful_lock = (
+        result["success"] is True
+        and result["resolution_success"] is True
+        and result["expected_failure"] is False
+        and result["lock_consistent"] is True
+        and result["timed_out"] is False
+        and result["error"] is None
+    )
+    expected_resolution_failure = (
+        result["success"] is False
+        and result["resolution_success"] is False
+        and result["expected_failure"] is True
+        and result["skip_on_fail"] is True
+        and result["lock_consistent"] is None
+        and result["timed_out"] is False
+        and result["error"] is None
+    )
+    return successful_lock or expected_resolution_failure
+
+
+def result_is_well_formed(data: object) -> bool:
+    """Whether a persisted result could have been emitted by the runner."""
+    if not isinstance(data, dict) or set(data) != _TOP_LEVEL_FIELDS:
+        return False
+    input_data = data["input"]
+    result = data["result"]
+    stats = data["stats"]
+    per_tuple = data["per_tuple"]
+    merged_pins = data["merged_pins"]
+    return (
+        _valid_input(input_data, data["reason"])
+        and _valid_result(result, input_data)
+        and _valid_stats(stats)
+        and _valid_per_tuple(per_tuple, stats, input_data)
+        and _valid_merged_pins(merged_pins, stats, per_tuple)
+        and _valid_outcome(result, stats, per_tuple, merged_pins)
+    )
+
+
+def result_is_accepted(data: object) -> bool:
+    """Whether a persisted scenario result satisfies the benchmark contract."""
+    return (
+        result_is_well_formed(data)
+        and isinstance(data, dict)
+        and _result_outcome_is_accepted(data["result"])
+    )

--- a/nab-python/benchmarks/universal_scenarios.py
+++ b/nab-python/benchmarks/universal_scenarios.py
@@ -9,6 +9,7 @@ divergence between tuples is visible.
 
 Usage:
     python nab-python/benchmarks/universal_scenarios.py [--commit LABEL] [--force]
+        [--scenario NAME]
 
 The runner is opt-in: it lives outside the standard scenario flow so
 existing benchmarks are not affected.
@@ -17,13 +18,21 @@ existing benchmarks are not affected.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import os
 import signal
 import subprocess
 import sys
 import time
+from contextlib import contextmanager
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -31,12 +40,19 @@ else:
     # nab pins py>=3.10 but the import fallback matches scenarios.py
     import tomli as tomllib  # type: ignore[no-redef] # pragma: no cover
 
+from universal_result import (
+    MANIFEST_FILENAME,
+    RESULT_SCHEMA_VERSION,
+    result_is_accepted,
+    result_is_well_formed,
+)
+
 from nab_index.urllib3_async_transport import Urllib3AsyncTransport
-from nab_python._lockfile.pylock import build_pylock
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.utils import canonicalize_name
-from nab_python.config import NabProjectConfig
+from nab_python.config import NabProjectConfig, enforce_build_policy_for_targets
 from nab_python.fetch import FetchCoordinator
+from nab_python.lockfile import build_pylock, render_lock
 from nab_python.provider import ResolutionStrategy
 from nab_python.resolve import (
     ResolveResult,
@@ -54,6 +70,20 @@ CACHE_DIR = BENCHMARKS_DIR / "cache"
 # Per-scenario wall-time cap.  Universal resolves are bounded by
 # matrix size * single-tuple cost, so we give them a generous budget.
 SCENARIO_WALL_TIMEOUT_SECONDS = 300
+UNIVERSAL_SCENARIO_KEYS = frozenset(
+    {
+        "align_across_tuples",
+        "constraints",
+        "datetime",
+        "platforms",
+        "python",
+        "python_order",
+        "reason",
+        "requirements",
+        "resolution_strategy",
+        "skip_on_fail",
+    }
+)
 
 
 class _ScenarioTimeoutError(BaseException):
@@ -69,19 +99,92 @@ def _alarm_handler(_signum: int, _frame: object) -> None:
     raise _ScenarioTimeoutError(msg)
 
 
+@contextmanager
+def _scenario_wall_timeout() -> Iterator[None]:
+    """Install the POSIX wall timer when the platform provides one."""
+    sigalrm = getattr(signal, "SIGALRM", None)
+    alarm = getattr(signal, "alarm", None)
+    if sigalrm is None or alarm is None:
+        yield
+        return
+
+    previous_handler = signal.signal(sigalrm, _alarm_handler)
+    alarm(SCENARIO_WALL_TIMEOUT_SECONDS)
+    try:
+        yield
+    finally:
+        alarm(0)
+        signal.signal(sigalrm, previous_handler)
+
+
 def get_git_commit() -> str:
-    """Return a short git SHA for the working tree, or 'no-git'."""
+    """Return the Git SHA for the working tree, or 'no-git'."""
     try:
         out = subprocess.run(
-            ["git", "rev-parse", "--short", "HEAD"],
+            ["git", "rev-parse", "HEAD"],
             check=True,
             capture_output=True,
             text=True,
-            cwd=Path(__file__).parent,
+            cwd=BENCHMARKS_DIR,
         )
     except (subprocess.CalledProcessError, FileNotFoundError):
         return "no-git"
     return out.stdout.strip()
+
+
+def get_git_source_state() -> dict[str, str | bool | None]:
+    """Record source identity separately from the result-directory label."""
+    commit = get_git_commit()
+    if commit == "no-git":
+        return {"commit": None, "dirty": True, "diff_hash": None}
+    try:
+        root = Path(
+            subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                capture_output=True,
+                check=True,
+                text=True,
+                cwd=BENCHMARKS_DIR,
+            ).stdout.strip()
+        )
+        status = subprocess.run(
+            ["git", "status", "--porcelain=v1", "-z", "--untracked-files=all"],
+            capture_output=True,
+            check=True,
+            cwd=root,
+        ).stdout
+        diff = subprocess.run(
+            ["git", "diff", "--binary", "HEAD", "--"],
+            capture_output=True,
+            check=True,
+            cwd=root,
+        ).stdout
+        untracked = subprocess.run(
+            ["git", "ls-files", "--others", "--exclude-standard", "-z"],
+            capture_output=True,
+            check=True,
+            cwd=root,
+        ).stdout
+        untracked_hashes = bytearray()
+        for raw_path in untracked.split(b"\0"):
+            if not raw_path:
+                continue
+            object_hash = subprocess.run(  # noqa: S603 - path is one arg after --
+                ["git", "hash-object", "--", os.fsdecode(raw_path)],
+                capture_output=True,
+                check=True,
+                cwd=root,
+            ).stdout
+            untracked_hashes.extend(raw_path + b"\0" + object_hash)
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return {"commit": commit, "dirty": True, "diff_hash": None}
+    dirty = bool(status)
+    diff_hash = (
+        hashlib.sha256(status + b"\0" + diff + b"\0" + untracked_hashes).hexdigest()
+        if dirty
+        else None
+    )
+    return {"commit": commit, "dirty": dirty, "diff_hash": diff_hash}
 
 
 def parse_datetime(value: str) -> datetime:
@@ -107,9 +210,10 @@ def check_lock_consistency(result: ResolveResult) -> tuple[bool, list[str]]:
     """
     lock_input = build_lock_input(result)
     try:
+        render_lock(lock_input)
         pylock = build_pylock(lock_input)
     except Exception as exc:
-        return False, [f"build_pylock raised {type(exc).__name__}: {exc}"[:200]]
+        return False, [f"lock emission raised {type(exc).__name__}: {exc}"[:200]]
 
     problems: list[str] = []
     for tr in result.target_results:
@@ -139,14 +243,85 @@ def check_lock_consistency(result: ResolveResult) -> tuple[bool, list[str]]:
     return not problems, problems
 
 
+def validate_scenario(scenario_name: str, scenario: dict) -> None:
+    """Reject settings the universal runner would otherwise silently ignore."""
+    unknown = sorted(set(scenario) - UNIVERSAL_SCENARIO_KEYS)
+    if unknown:
+        msg = f"{scenario_name}: unknown scenario setting(s): {', '.join(unknown)}"
+        raise ValueError(msg)
+    for key in ("python", "platforms", "requirements"):
+        if key not in scenario:
+            msg = f"{scenario_name}: missing required setting {key!r}"
+            raise ValueError(msg)
+    if not isinstance(scenario["python"], str) or not scenario["python"]:
+        msg = f"{scenario_name}: python must be a non-empty string"
+        raise TypeError(msg)
+    for key in ("platforms", "requirements", "constraints"):
+        value = scenario.get(key, [])
+        if not isinstance(value, list) or not all(
+            isinstance(item, str) and item for item in value
+        ):
+            msg = f"{scenario_name}: {key} must be a list of strings"
+            raise TypeError(msg)
+    if not scenario["platforms"] or not scenario["requirements"]:
+        msg = f"{scenario_name}: platforms and requirements cannot be empty"
+        raise ValueError(msg)
+    for key in ("align_across_tuples", "skip_on_fail"):
+        if key in scenario and type(scenario[key]) is not bool:
+            msg = f"{scenario_name}: {key} must be a boolean"
+            raise TypeError(msg)
+    for key in ("datetime", "reason"):
+        if key in scenario and not isinstance(scenario[key], str):
+            msg = f"{scenario_name}: {key} must be a string"
+            raise TypeError(msg)
+    python_order = scenario.get("python_order", "asc")
+    if python_order not in {"asc", "desc"}:
+        msg = f"{scenario_name}: python_order must be 'asc' or 'desc'"
+        raise ValueError(msg)
+    resolution = scenario.get("resolution_strategy", "highest")
+    try:
+        ResolutionStrategy(resolution)
+    except (TypeError, ValueError) as exc:
+        msg = f"{scenario_name}: unknown resolution_strategy {resolution!r}"
+        raise ValueError(msg) from exc
+
+
+def write_manifest(
+    path: Path,
+    *,
+    commit: str,
+    source: dict[str, str | bool | None],
+    run_kind: str,
+    available_scenarios: list[str],
+    selected_scenarios: list[str],
+    completed_scenarios: list[str],
+    complete: bool,
+) -> None:
+    """Write the scenario-set contract consumed by benchmark summaries."""
+    data = {
+        "benchmark_schema": RESULT_SCHEMA_VERSION,
+        "commit": commit,
+        "source": source,
+        "run_kind": run_kind,
+        "available_scenarios": sorted(available_scenarios),
+        "selected_scenarios": sorted(selected_scenarios),
+        "completed_scenarios": sorted(completed_scenarios),
+        "complete": complete,
+    }
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
 def process_scenario(
     scenario_name: str,
     scenario: dict,
     commit: str,
     *,
     force: bool,
-) -> None:
+    output_dir: Path | None = None,
+    source: dict[str, str | bool | None] | None = None,
+) -> bool:
     """Resolve one universal scenario and save results."""
+    validate_scenario(scenario_name, scenario)
     python_spec: str = scenario["python"]
     platforms: tuple[str, ...] = tuple(scenario["platforms"])
     python_order: str = scenario.get("python_order", "asc")
@@ -159,59 +334,102 @@ def process_scenario(
     skip_on_fail: bool = scenario.get("skip_on_fail", False)
 
     uploaded_prior_to = parse_datetime(datetime_str) if datetime_str else None
+    matrix = Matrix(
+        python=python_spec,
+        platforms=tuple(PlatformSpec(p) for p in platforms),
+        python_order=python_order,
+    )
+    targets = matrix.expand()
+    config = NabProjectConfig(
+        constraints=tuple(constraint_strings),
+        uploaded_prior_to=uploaded_prior_to,
+    )
+    build_policy = enforce_build_policy_for_targets(
+        targets=targets,
+        build_policy=config.build_policy,
+        build_policy_set=False,
+        package_overrides=config.package_overrides,
+        index_overrides=config.index_overrides,
+    )
+    config = replace(config, build_policy=build_policy)
 
-    output_dir = RESULTS_DIR / commit / "universal"
+    output_dir = output_dir or RESULTS_DIR / commit / "universal"
     output_path = output_dir / f"{scenario_name}.json"
 
     expected_input = {
+        "benchmark_schema": RESULT_SCHEMA_VERSION,
+        "scenario": scenario_name,
         "commit": commit,
+        "source": source if source is not None else get_git_source_state(),
         "python": python_spec,
         "platforms": list(platforms),
         "python_order": python_order,
         "requirements": requirement_strings,
         "align_across_tuples": align,
         "resolution_strategy": resolution_strategy,
+        "dist_policy": config.dist_policy.value,
+        "build_policy": config.build_policy.value,
+        "trust_unverified_sdist_deps": config.trust_unverified_sdist_deps,
+        "skip_on_fail": skip_on_fail,
+        "reason": reason,
     }
     if constraint_strings:
         expected_input["constraints"] = constraint_strings
     if datetime_str:
         expected_input["datetime"] = datetime_str
 
-    if output_path.exists() and not force:
-        existing = json.loads(output_path.read_text())
-        if existing.get("input") == expected_input:
-            return
+    source_state = expected_input["source"]
+    source_is_cacheable = isinstance(source_state, dict) and (
+        source_state.get("dirty") is False
+        or isinstance(source_state.get("diff_hash"), str)
+    )
+    if output_path.exists() and not force and source_is_cacheable:
+        try:
+            existing = json.loads(output_path.read_text())
+        except (OSError, ValueError):
+            existing = None
+        if isinstance(existing, dict) and existing.get("input") == expected_input:
+            if result_is_well_formed(existing):
+                accepted = result_is_accepted(existing)
+                status = "cached, accepted" if accepted else "CACHED FAILURE"
+                print(f"  {scenario_name} {status}")
+                return accepted
+            print(f"  {scenario_name} invalid cache; rerunning")
+        elif existing is None:
+            print(f"  {scenario_name} unreadable cache; rerunning")
+    elif output_path.exists() and not force:
+        print(f"  {scenario_name} source identity unavailable; rerunning")
 
     print(f"  {scenario_name} ", end="", flush=True)
-    matrix = Matrix(
-        python=python_spec,
-        platforms=tuple(PlatformSpec(p) for p in platforms),
-        python_order=python_order,
-    )
-
-    previous_handler = signal.signal(signal.SIGALRM, _alarm_handler)
-    signal.alarm(SCENARIO_WALL_TIMEOUT_SECONDS)
     start = time.monotonic()
     timed_out = False
+    completed = False
+    harness_error: str | None = None
+    resolution_success: bool | None = None
+    per_tuple: list[dict] = []
+    merged: dict = {}
+    diverging_packages = 0
+    lock_consistent: bool | None = None
+    lock_inconsistencies: list[str] = []
     try:
-        config = NabProjectConfig(
-            constraints=tuple(constraint_strings),
-            uploaded_prior_to=uploaded_prior_to,
-        )
-        with FetchCoordinator(
-            Urllib3AsyncTransport(),
-            indexes=list(config.indexes),
-            cache_dir=CACHE_DIR,
-        ) as coordinator:
+        with (
+            _scenario_wall_timeout(),
+            FetchCoordinator(
+                Urllib3AsyncTransport(),
+                indexes=list(config.indexes),
+                cache_dir=CACHE_DIR,
+            ) as coordinator,
+        ):
             result = resolve_with_coordinator(
                 coordinator,
-                matrix.expand(),
+                targets,
                 [Requirement(text) for text in requirement_strings],
                 config=config,
                 cache_dir=CACHE_DIR,
                 resolution_strategy=ResolutionStrategy(resolution_strategy),
                 align_across_targets=align,
             )
+        resolution_success = result.success
         elapsed = time.monotonic() - start
         per_tuple = [
             {
@@ -228,6 +446,10 @@ def process_scenario(
                 "distributions_seen": tr.distributions_seen,
                 "wall_time_seconds": round(tr.wall_time, 3),
                 "package_count": len(tr.pins),
+                "pins": {
+                    canonicalize_name(name): str(version)
+                    for name, version in sorted(tr.pins.items())
+                },
             }
             for tr in result.target_results
         ]
@@ -235,59 +457,45 @@ def process_scenario(
         diverging_packages = sum(
             1 for pins in merged.values() if len({version for version, _ in pins}) > 1
         )
-        success = result.success
-        if success:
+        if resolution_success:
             lock_consistent, lock_inconsistencies = check_lock_consistency(result)
         else:
             lock_consistent, lock_inconsistencies = None, []
-    except _ScenarioTimeoutError:
+        completed = True
+    except _ScenarioTimeoutError as exc:
         elapsed = time.monotonic() - start
         timed_out = True
-        per_tuple = []
-        merged = {}
-        diverging_packages = 0
-        success = False
-        lock_consistent, lock_inconsistencies = None, []
+        harness_error = str(exc)
     except Exception as exc:
         elapsed = time.monotonic() - start
-        per_tuple = [
-            {
-                "label": "n/a",
-                "python_version": "n/a",
-                "platform_id": "n/a",
-                "success": False,
-                "error": f"{type(exc).__name__}: {exc}"[:200],
-                "decisions": 0,
-                "rounds": 0,
-                "conflicts": 0,
-                "backjumps": 0,
-                "metadata_fetched": 0,
-                "distributions_seen": 0,
-                "wall_time_seconds": 0.0,
-                "package_count": 0,
-            }
-        ]
-        merged = {}
-        diverging_packages = 0
-        success = False
-        lock_consistent, lock_inconsistencies = None, []
-    finally:
-        signal.alarm(0)
-        signal.signal(signal.SIGALRM, previous_handler)
+        harness_error = f"{type(exc).__name__}: {exc}"[:200]
 
+    scenario_success = resolution_success is True and lock_consistent is True
+    expected_failure = skip_on_fail and completed and resolution_success is False
     data = {
         "input": expected_input,
         "reason": reason,
         "result": {
-            "success": success,
+            "success": scenario_success,
+            "resolution_success": resolution_success,
+            "expected_failure": expected_failure,
             "timed_out": timed_out,
             "skip_on_fail": skip_on_fail,
             "lock_consistent": lock_consistent,
             "lock_inconsistencies": lock_inconsistencies,
+            "error": harness_error,
+        },
+        "merged_pins": {
+            canonicalize_name(name): [
+                {"version": str(version), "target": target}
+                for version, target in target_pins
+            ]
+            for name, target_pins in sorted(merged.items())
         },
         "stats": {
             "wall_time_seconds": round(elapsed, 3),
-            "tuples_total": len(per_tuple),
+            "tuples_total": len(targets),
+            "tuples_recorded": len(per_tuple),
             "tuples_ok": sum(1 for t in per_tuple if t["success"]),
             "tuples_fail": sum(1 for t in per_tuple if not t["success"]),
             "merged_packages": len(merged),
@@ -308,32 +516,44 @@ def process_scenario(
     stats = data["stats"]
     if timed_out:
         print(f"TIMEOUT after {elapsed:.1f}s ({stats['tuples_total']} tuples)")
-    elif success:
-        lock_note = "" if lock_consistent else " LOCK-INCONSISTENT"
+    elif scenario_success:
         print(
             f"ok ({stats['tuples_total']} tuples, "
             f"{stats['merged_packages']} pkgs, "
             f"{stats['diverging_packages']} diverging, "
             f"{stats['decisions_total']} decisions, "
-            f"{stats['wall_time_seconds']}s){lock_note}"
+            f"{stats['wall_time_seconds']}s)"
+        )
+    elif harness_error:
+        print(f"FAILED ({harness_error})")
+    elif resolution_success is True:
+        print(
+            "FAILED (resolved, but the emitted lock does not reproduce every tuple; "
+            f"{len(lock_inconsistencies)} inconsistency report(s))"
         )
     else:
         failures = [t for t in per_tuple if not t["success"]]
-        label = "skipped (expected to fail)" if skip_on_fail else "FAILED"
-        first_fail = failures[0]["error"] if failures else "?"
+        label = "skipped (expected to fail)" if expected_failure else "FAILED"
+        first_fail = failures[0]["error"] if failures else harness_error or "?"
         print(
             f"{label} ({stats['tuples_fail']}/{stats['tuples_total']} tuples; "
             f"first error: {first_fail[:80]})"
         )
+    return result_is_accepted(data)
 
 
 def main() -> None:
-    """Run all universal scenarios."""
+    """Run the selected universal scenarios."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--commit",
         default=None,
         help="Override the commit label used for the results directory",
+    )
+    parser.add_argument(
+        "--scenario",
+        action="append",
+        help="Run only the named scenario; may be repeated",
     )
     parser.add_argument(
         "--force",
@@ -342,13 +562,79 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    commit = args.commit or get_git_commit()
+    source = get_git_source_state()
+    commit = args.commit or str(source["commit"] or "no-git")
     toml_path = SCENARIOS_DIR / "universal.toml"
     print(f"Running universal scenarios from {toml_path}")
-    print(f"Results -> {RESULTS_DIR / commit / 'universal'}\n")
     scenarios = tomllib.loads(toml_path.read_text())
-    for scenario_name, scenario in scenarios.items():
-        process_scenario(scenario_name, scenario, commit, force=args.force)
+    if args.scenario:
+        duplicates = sorted(
+            {name for name in args.scenario if args.scenario.count(name) > 1}
+        )
+        if duplicates:
+            parser.error(f"duplicate scenario(s): {', '.join(duplicates)}")
+        missing = sorted(set(args.scenario) - scenarios.keys())
+        if missing:
+            parser.error(f"unknown scenario(s): {', '.join(missing)}")
+        selected = [(name, scenarios[name]) for name in args.scenario]
+    else:
+        selected = list(scenarios.items())
+
+    result_kind = "universal-selected" if args.scenario else "universal"
+    output_dir = RESULTS_DIR / commit / result_kind
+    output_dir.mkdir(parents=True, exist_ok=True)
+    print(f"Results -> {output_dir}\n")
+    manifest_path = output_dir / MANIFEST_FILENAME
+    available_names = list(scenarios)
+    selected_names = [name for name, _scenario in selected]
+    run_kind = "selected" if args.scenario else "full"
+    completed_names: list[str] = []
+    accepted: list[bool] = []
+    write_manifest(
+        manifest_path,
+        commit=commit,
+        source=source,
+        run_kind=run_kind,
+        available_scenarios=available_names,
+        selected_scenarios=selected_names,
+        completed_scenarios=completed_names,
+        complete=False,
+    )
+    for name, scenario in selected:
+        accepted.append(
+            process_scenario(
+                name,
+                scenario,
+                commit,
+                force=args.force,
+                output_dir=output_dir,
+                source=source,
+            )
+        )
+        if (output_dir / f"{name}.json").is_file():
+            completed_names.append(name)
+        write_manifest(
+            manifest_path,
+            commit=commit,
+            source=source,
+            run_kind=run_kind,
+            available_scenarios=available_names,
+            selected_scenarios=selected_names,
+            completed_scenarios=completed_names,
+            complete=False,
+        )
+    write_manifest(
+        manifest_path,
+        commit=commit,
+        source=source,
+        run_kind=run_kind,
+        available_scenarios=available_names,
+        selected_scenarios=selected_names,
+        completed_scenarios=completed_names,
+        complete=len(completed_names) == len(selected_names),
+    )
+    if not all(accepted):
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/nab-python/benchmarks/universal_summary.py
+++ b/nab-python/benchmarks/universal_summary.py
@@ -5,8 +5,86 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+from typing import cast
+
+from universal_result import (
+    MANIFEST_FILENAME,
+    RESULT_SCHEMA_VERSION,
+    result_is_accepted,
+    result_is_well_formed,
+)
 
 RESULTS_DIR = Path(__file__).parent / "results"
+
+
+def _valid_scenario_names(value: object) -> bool:
+    if not isinstance(value, list) or not value:
+        return False
+    if not all(isinstance(name, str) and name for name in value):
+        return False
+    names: list[str] = value
+    return all(Path(name).name == name for name in names) and len(set(names)) == len(
+        names
+    )
+
+
+def _valid_clean_source(value: object) -> bool:
+    if not isinstance(value, dict):
+        return False
+    commit = value.get("commit")
+    return (
+        isinstance(commit, str)
+        and len(commit) in {40, 64}
+        and all(character in "0123456789abcdef" for character in commit)
+        and value.get("dirty") is False
+        and value.get("diff_hash") is None
+    )
+
+
+def authoritative_result_paths(
+    target_dir: Path,
+) -> tuple[list[Path], str, dict] | None:
+    """Return the complete full-run scenario set declared by its manifest."""
+    manifest_path = target_dir / MANIFEST_FILENAME
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (OSError, ValueError):
+        return None
+    if (
+        not isinstance(manifest, dict)
+        or manifest.get("benchmark_schema") != RESULT_SCHEMA_VERSION
+        or manifest.get("run_kind") != "full"
+        or manifest.get("complete") is not True
+    ):
+        return None
+    commit = manifest.get("commit")
+    source = manifest.get("source")
+    available = manifest.get("available_scenarios")
+    selected = manifest.get("selected_scenarios")
+    completed = manifest.get("completed_scenarios")
+    if (
+        not isinstance(commit, str)
+        or not commit
+        or commit != target_dir.parent.name
+        or not _valid_clean_source(source)
+        or not all(
+            _valid_scenario_names(names) for names in (available, selected, completed)
+        )
+    ):
+        return None
+    available_names = cast("list[str]", available)
+    selected_names = cast("list[str]", selected)
+    completed_names = cast("list[str]", completed)
+    if sorted(available_names) != sorted(selected_names) or sorted(
+        available_names
+    ) != sorted(completed_names):
+        return None
+    paths = [target_dir / f"{name}.json" for name in sorted(available_names)]
+    return (
+        (paths, commit, cast("dict", source))
+        if all(path.is_file() for path in paths)
+        else None
+    )
 
 
 def main() -> int:
@@ -22,6 +100,31 @@ def main() -> int:
             print("No universal/ result directory found.", file=sys.stderr)
             return 1
         target_dir = candidates[-1]
+    authoritative = authoritative_result_paths(target_dir)
+    if authoritative is None:
+        print(f"No complete universal run found in {target_dir}.", file=sys.stderr)
+        return 1
+    paths, manifest_commit, manifest_source = authoritative
+    records: list[tuple[Path, dict]] = []
+    for path in paths:
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, ValueError):
+            print(f"Invalid universal result: {path}", file=sys.stderr)
+            return 1
+        if not isinstance(data, dict) or not result_is_well_formed(data):
+            print(f"Invalid universal result: {path}", file=sys.stderr)
+            return 1
+        input_data = data["input"]
+        if (
+            input_data.get("scenario") != path.stem
+            or input_data.get("commit") != manifest_commit
+            or input_data.get("source") != manifest_source
+        ):
+            print(f"Universal result provenance mismatch: {path}", file=sys.stderr)
+            return 1
+        records.append((path, data))
+
     print(f"Results from {target_dir.relative_to(RESULTS_DIR.parent)}\n")
     print(
         "| Scenario | Tuples | OK | Pkgs | Diverge | Lock"
@@ -30,14 +133,26 @@ def main() -> int:
     print("|---|---:|---:|---:|---:|:---:|---:|---:|---|")
     checked = 0
     inconsistent = 0
-    for path in sorted(target_dir.glob("*.json")):
-        data = json.loads(path.read_text())
+    unexpected_failures = 0
+    for path, data in records:
         s = data["stats"]
         reason = data.get("reason", "")
-        timed_out = data["result"].get("timed_out", False)
-        success = data["result"]["success"]
-        suffix = " (TIMEOUT)" if timed_out else "" if success else " (FAIL)"
-        lock_consistent = data["result"].get("lock_consistent")
+        result = data.get("result") or {}
+        timed_out = result.get("timed_out", False)
+        success = result.get("success") is True
+        accepted = result_is_accepted(data)
+        expected_failure = accepted and result.get("expected_failure") is True
+        if timed_out:
+            suffix = " (TIMEOUT)"
+        elif expected_failure:
+            suffix = " (EXPECTED FAIL)"
+        elif accepted and success:
+            suffix = ""
+        else:
+            suffix = " (FAIL)"
+        if not accepted:
+            unexpected_failures += 1
+        lock_consistent = result.get("lock_consistent")
         if lock_consistent is None:
             lock_cell = "-"
         elif lock_consistent:
@@ -62,7 +177,7 @@ def main() -> int:
         f"\nlock consistency: {checked - inconsistent}/{checked} successful locks "
         f"reproduce every tuple's solution"
     )
-    return 1 if inconsistent else 0
+    return 1 if inconsistent or unexpected_failures else 0
 
 
 if __name__ == "__main__":

--- a/nab-python/tests/test_universal_benchmark.py
+++ b/nab-python/tests/test_universal_benchmark.py
@@ -1,0 +1,963 @@
+"""Regression tests for universal benchmark result contracts."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from typing_extensions import Self
+
+from nab_python._vendor.packaging.version import Version
+from nab_python.lockfile import IndexPin, TargetLock, WheelArtifact
+from nab_python.resolve import ResolveResult, TargetResult
+from nab_python.tags import PlatformSpec
+from nab_python.target import ResolveTarget
+
+_BENCHMARK = (
+    Path(__file__).resolve().parents[1] / "benchmarks" / "universal_scenarios.py"
+)
+if str(_BENCHMARK.parent) not in sys.path:
+    sys.path.insert(0, str(_BENCHMARK.parent))
+_CLEAN_SOURCE = {"commit": "a" * 40, "dirty": False, "diff_hash": None}
+
+
+class _FakeCoordinator:
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        pass
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        pass
+
+
+def _successful_result() -> tuple[ResolveTarget, ResolveResult]:
+    target = ResolveTarget.for_declared(
+        python_version="3.11",
+        spec=PlatformSpec("linux_x86_64"),
+    )
+    target_result = TargetResult(
+        target=target,
+        success=True,
+        error=None,
+        decisions=2,
+        rounds=3,
+        conflicts=0,
+        backjumps=0,
+        metadata_fetched=1,
+        distributions_seen=4,
+        wall_time=0.1,
+        pins={"Foo": Version("1.0")},
+    )
+    result = ResolveResult(
+        targets=(target,),
+        target_results=[target_result],
+    )
+    return target, result
+
+
+def _result_data(result: dict, *, schema: int = 3) -> dict:
+    complete_result = {
+        "success": False,
+        "resolution_success": None,
+        "expected_failure": False,
+        "skip_on_fail": False,
+        "lock_consistent": None,
+        "lock_inconsistencies": [],
+        "timed_out": False,
+        "error": None,
+        **result,
+    }
+    if complete_result["lock_consistent"] is False:
+        complete_result["lock_inconsistencies"] = ["projection mismatch"]
+    resolution_success = complete_result["resolution_success"]
+    if resolution_success is True:
+        per_tuple = [
+            {
+                "label": "cp311-linux_x86_64",
+                "python_version": "3.11",
+                "platform_id": "linux_x86_64",
+                "success": True,
+                "error": None,
+                "decisions": 2,
+                "rounds": 3,
+                "conflicts": 0,
+                "backjumps": 0,
+                "metadata_fetched": 1,
+                "distributions_seen": 4,
+                "wall_time_seconds": 0.1,
+                "package_count": 1,
+                "pins": {"foo": "1.0"},
+            }
+        ]
+        merged_pins = {"foo": [{"version": "1.0", "target": "cp311-linux_x86_64"}]}
+    elif resolution_success is False:
+        per_tuple = [
+            {
+                "label": "cp311-linux_x86_64",
+                "python_version": "3.11",
+                "platform_id": "linux_x86_64",
+                "success": False,
+                "error": "resolution failed",
+                "decisions": 0,
+                "rounds": 0,
+                "conflicts": 0,
+                "backjumps": 0,
+                "metadata_fetched": 0,
+                "distributions_seen": 0,
+                "wall_time_seconds": 0.0,
+                "package_count": 0,
+                "pins": {},
+            }
+        ]
+        merged_pins = {}
+    else:
+        per_tuple = []
+        merged_pins = {}
+    tuples_ok = sum(item["success"] is True for item in per_tuple)
+    tuples_fail = len(per_tuple) - tuples_ok
+    return {
+        "input": {
+            "benchmark_schema": schema,
+            "scenario": "example",
+            "commit": "run",
+            "source": _CLEAN_SOURCE,
+            "python": ">=3.11,<3.12",
+            "platforms": ["linux_x86_64"],
+            "python_order": "asc",
+            "requirements": ["foo"],
+            "align_across_tuples": True,
+            "resolution_strategy": "highest",
+            "dist_policy": "wheel-or-sdist",
+            "build_policy": "never",
+            "trust_unverified_sdist_deps": False,
+            "skip_on_fail": complete_result["skip_on_fail"],
+            "reason": "",
+        },
+        "reason": "",
+        "result": complete_result,
+        "merged_pins": merged_pins,
+        "stats": {
+            "wall_time_seconds": 0.0,
+            "tuples_total": 1,
+            "tuples_recorded": len(per_tuple),
+            "tuples_ok": tuples_ok,
+            "tuples_fail": tuples_fail,
+            "merged_packages": len(merged_pins),
+            "diverging_packages": 0,
+            "decisions_total": sum(item["decisions"] for item in per_tuple),
+            "rounds_total": sum(item["rounds"] for item in per_tuple),
+            "conflicts_total": 0,
+            "backjumps_total": 0,
+            "metadata_fetched_total": sum(
+                item["metadata_fetched"] for item in per_tuple
+            ),
+            "distributions_seen_total": sum(
+                item["distributions_seen"] for item in per_tuple
+            ),
+        },
+        "per_tuple": per_tuple,
+    }
+
+
+def _harness() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("_universal_benchmark", _BENCHMARK)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _summary_harness() -> ModuleType:
+    path = _BENCHMARK.with_name("universal_summary.py")
+    spec = importlib.util.spec_from_file_location("_universal_summary", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_wall_timeout_noops_without_posix_alarm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    monkeypatch.delattr(module.signal, "SIGALRM", raising=False)
+    monkeypatch.delattr(module.signal, "alarm", raising=False)
+
+    with module._scenario_wall_timeout():
+        pass
+
+
+def test_wall_timeout_installs_and_restores_alarm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    previous_handler = object()
+    handlers: list[tuple[int, object]] = []
+    alarms: list[int] = []
+
+    def fake_signal(signum: int, handler: object) -> object:
+        handlers.append((signum, handler))
+        return previous_handler
+
+    def fake_alarm(seconds: int) -> None:
+        alarms.append(seconds)
+
+    monkeypatch.setattr(module.signal, "SIGALRM", 14, raising=False)
+    monkeypatch.setattr(module.signal, "signal", fake_signal)
+    monkeypatch.setattr(module.signal, "alarm", fake_alarm, raising=False)
+
+    with module._scenario_wall_timeout():
+        assert alarms == [module.SCENARIO_WALL_TIMEOUT_SECONDS]
+
+    assert alarms == [module.SCENARIO_WALL_TIMEOUT_SECONDS, 0]
+    assert handlers == [
+        (14, module._alarm_handler),
+        (14, previous_handler),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("data", "accepted"),
+    [
+        (
+            _result_data(
+                {
+                    "success": True,
+                    "resolution_success": True,
+                    "lock_consistent": True,
+                    "timed_out": False,
+                }
+            ),
+            True,
+        ),
+        (
+            _result_data(
+                {
+                    "success": True,
+                    "resolution_success": True,
+                    "lock_consistent": False,
+                    "timed_out": False,
+                }
+            ),
+            False,
+        ),
+        (
+            _result_data(
+                {
+                    "success": False,
+                    "resolution_success": False,
+                    "expected_failure": True,
+                    "skip_on_fail": True,
+                    "timed_out": False,
+                }
+            ),
+            True,
+        ),
+        (
+            _result_data(
+                {
+                    "success": False,
+                    "resolution_success": False,
+                    "expected_failure": True,
+                    "skip_on_fail": True,
+                    "timed_out": True,
+                }
+            ),
+            False,
+        ),
+        (
+            _result_data(
+                {
+                    "success": False,
+                    "resolution_success": False,
+                    "expected_failure": True,
+                    "timed_out": False,
+                }
+            ),
+            False,
+        ),
+        (_result_data({"success": True}, schema=1), False),
+        ({}, False),
+    ],
+)
+def test_result_is_accepted(data: dict, accepted: bool) -> None:
+    assert _harness().result_is_accepted(data) is accepted
+    assert _summary_harness().result_is_accepted(data) is accepted
+
+
+def test_result_contract_rejects_contradictory_aggregates() -> None:
+    module = _harness()
+    result = {
+        "success": True,
+        "resolution_success": True,
+        "lock_consistent": True,
+    }
+
+    wrong_total = _result_data(result)
+    wrong_total["stats"]["decisions_total"] += 1
+    assert module.result_is_well_formed(wrong_total) is False
+
+    wrong_pin = _result_data(result)
+    wrong_pin["merged_pins"]["foo"][0]["version"] = "2.0"
+    assert module.result_is_well_formed(wrong_pin) is False
+
+    vacuous = _result_data(result)
+    vacuous["per_tuple"] = []
+    vacuous["merged_pins"] = {}
+    for field in (
+        "backjumps_total",
+        "conflicts_total",
+        "decisions_total",
+        "distributions_seen_total",
+        "diverging_packages",
+        "merged_packages",
+        "metadata_fetched_total",
+        "rounds_total",
+        "tuples_fail",
+        "tuples_ok",
+        "tuples_recorded",
+    ):
+        vacuous["stats"][field] = 0
+    assert module.result_is_well_formed(vacuous) is False
+
+
+def test_result_contract_requires_the_complete_input_shape() -> None:
+    module = _harness()
+    result = _result_data(
+        {
+            "success": True,
+            "resolution_success": True,
+            "lock_consistent": True,
+        }
+    )
+
+    for field in tuple(result["input"]):
+        missing = json.loads(json.dumps(result))
+        missing["input"].pop(field)
+        assert module.result_is_well_formed(missing) is False, field
+
+    unexpected = json.loads(json.dumps(result))
+    unexpected["input"]["unused"] = True
+    assert module.result_is_well_formed(unexpected) is False
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("source", {"commit": "a" * 40, "dirty": False}),
+        ("python_order", "newest-first"),
+        ("requirements", []),
+        ("platforms", ["linux_x86_64", "linux_x86_64"]),
+        ("align_across_tuples", "true"),
+        ("resolution_strategy", "newest"),
+        ("resolution_strategy", []),
+        ("dist_policy", "anything"),
+        ("build_policy", "always"),
+        ("trust_unverified_sdist_deps", "false"),
+        ("skip_on_fail", "false"),
+    ],
+)
+def test_result_contract_validates_input_fields(field: str, value: object) -> None:
+    module = _harness()
+    data = _result_data(
+        {
+            "success": True,
+            "resolution_success": True,
+            "lock_consistent": True,
+        }
+    )
+    data["input"][field] = value
+
+    assert module.result_is_well_formed(data) is False
+
+
+def test_result_contract_validates_optional_input_fields() -> None:
+    module = _harness()
+    data = _result_data(
+        {
+            "success": True,
+            "resolution_success": True,
+            "lock_consistent": True,
+        }
+    )
+    data["input"].update({"constraints": ["foo<2"], "datetime": "2025-06-01 00:00:00"})
+    assert module.result_is_well_formed(data) is True
+
+    for field, value in (("constraints", []), ("datetime", "not-a-date")):
+        invalid = json.loads(json.dumps(data))
+        invalid["input"][field] = value
+        assert module.result_is_well_formed(invalid) is False
+
+
+def test_result_contract_allows_multiple_slices_per_declared_cell() -> None:
+    module = _harness()
+    data = _result_data(
+        {
+            "success": True,
+            "resolution_success": True,
+            "lock_consistent": True,
+        }
+    )
+    second = json.loads(json.dumps(data["per_tuple"][0]))
+    second["label"] = "cp311-linux_x86_64-slice-2"
+    second["pins"]["foo"] = "2.0"
+    data["per_tuple"].append(second)
+    data["merged_pins"]["foo"].append({"version": "2.0", "target": second["label"]})
+    data["stats"].update(
+        {
+            "tuples_recorded": 2,
+            "tuples_ok": 2,
+            "decisions_total": 4,
+            "rounds_total": 6,
+            "metadata_fetched_total": 2,
+            "distributions_seen_total": 8,
+            "diverging_packages": 1,
+        }
+    )
+
+    assert module.result_is_well_formed(data) is True
+    assert module.result_is_accepted(data) is True
+
+
+def test_git_source_state_hashes_untracked_contents(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    git = shutil.which("git")
+    assert git is not None
+
+    def run_git(*args: str) -> None:
+        subprocess.run([git, *args], cwd=tmp_path, check=True)  # noqa: S603
+
+    run_git("init", "-q")
+    benchmarks_dir = tmp_path / "nab-python" / "benchmarks"
+    benchmarks_dir.mkdir(parents=True)
+    (benchmarks_dir / "tracked").write_text("tracked\n")
+    run_git("add", "nab-python/benchmarks/tracked")
+    run_git(
+        "-c",
+        "user.name=Benchmark Test",
+        "-c",
+        "user.email=benchmark@example.invalid",
+        "commit",
+        "-qm",
+        "initial",
+    )
+    untracked = tmp_path / "nab-python" / "src" / "source.py"
+    untracked.parent.mkdir(parents=True)
+    untracked.write_text("first\n")
+    module = _harness()
+    monkeypatch.setattr(module, "BENCHMARKS_DIR", benchmarks_dir)
+
+    first = module.get_git_source_state()
+    untracked.write_text("second\n")
+    second = module.get_git_source_state()
+
+    assert first["commit"] == second["commit"]
+    assert first["dirty"] is second["dirty"] is True
+    assert first["diff_hash"] != second["diff_hash"]
+
+
+def test_lock_consistency_requires_a_valid_emitted_pylock() -> None:
+    module = _harness()
+    target = ResolveTarget.for_declared(
+        python_version="3.11",
+        spec=PlatformSpec("linux_x86_64"),
+    )
+    wheel = WheelArtifact(
+        filename="foo-2.0-py3-none-any.whl",
+        url="https://example.test/foo-2.0-py3-none-any.whl",
+        hashes=(("sha256", "a" * 64),),
+    )
+    pin = IndexPin(
+        name="foo",
+        version="1.0",
+        index="https://pypi.org/simple",
+        wheels=(wheel,),
+    )
+    target_result = TargetResult(
+        target=target,
+        success=True,
+        pins={"foo": Version("1.0")},
+        lock=TargetLock(target=target, pins={"foo": pin}),
+    )
+    result = ResolveResult(
+        targets=(target,),
+        target_results=[target_result],
+    )
+
+    consistent, problems = module.check_lock_consistency(result)
+
+    assert consistent is False
+    assert len(problems) == 1
+    assert "foo-2.0" in problems[0]
+    assert "package version '1.0'" in problems[0]
+
+
+def test_lock_inconsistency_fails_and_pins_are_retained(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _harness()
+    target, resolve_result = _successful_result()
+
+    monkeypatch.setattr(module, "RESULTS_DIR", tmp_path)
+    monkeypatch.setattr(module, "CACHE_DIR", tmp_path / "cache")
+    monkeypatch.setattr(module, "Urllib3AsyncTransport", object)
+    monkeypatch.setattr(module, "FetchCoordinator", _FakeCoordinator)
+    monkeypatch.setattr(
+        module,
+        "resolve_with_coordinator",
+        lambda *_args, **_kwargs: resolve_result,
+    )
+    monkeypatch.setattr(
+        module,
+        "check_lock_consistency",
+        lambda _result: (False, ["projection mismatch"]),
+    )
+
+    accepted = module.process_scenario(
+        "example",
+        {
+            "python": ">=3.11,<3.12",
+            "platforms": ["linux_x86_64"],
+            "requirements": ["foo"],
+        },
+        "commit",
+        force=True,
+        source=_CLEAN_SOURCE,
+    )
+
+    data = json.loads((tmp_path / "commit" / "universal" / "example.json").read_text())
+    assert accepted is False
+    assert data["input"]["benchmark_schema"] == module.RESULT_SCHEMA_VERSION
+    assert data["input"]["scenario"] == "example"
+    assert data["input"]["source"] == _CLEAN_SOURCE
+    assert data["input"]["build_policy"] == "never"
+    assert data["input"]["dist_policy"] == "wheel-or-sdist"
+    assert data["input"]["trust_unverified_sdist_deps"] is False
+    assert data["input"]["skip_on_fail"] is False
+    assert data["input"]["reason"] == ""
+    assert data["result"]["resolution_success"] is True
+    assert data["result"]["success"] is False
+    assert data["per_tuple"][0]["pins"] == {"foo": "1.0"}
+    assert data["merged_pins"] == {"foo": [{"version": "1.0", "target": target.label}]}
+
+    capsys.readouterr()
+    assert (
+        module.process_scenario(
+            "example",
+            {
+                "python": ">=3.11,<3.12",
+                "platforms": ["linux_x86_64"],
+                "requirements": ["foo"],
+            },
+            "commit",
+            force=False,
+            source=_CLEAN_SOURCE,
+        )
+        is False
+    )
+    assert "example CACHED FAILURE" in capsys.readouterr().out
+
+
+def test_skip_on_fail_does_not_accept_post_resolution_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    target, resolve_result = _successful_result()
+    monkeypatch.setattr(module, "RESULTS_DIR", tmp_path)
+    monkeypatch.setattr(module, "CACHE_DIR", tmp_path / "cache")
+    monkeypatch.setattr(module, "Urllib3AsyncTransport", object)
+    monkeypatch.setattr(module, "FetchCoordinator", _FakeCoordinator)
+    monkeypatch.setattr(
+        module,
+        "resolve_with_coordinator",
+        lambda *_args, **_kwargs: resolve_result,
+    )
+
+    def fail_lock_check(_result: object) -> tuple[bool, list[str]]:
+        raise RuntimeError("projection crashed")
+
+    monkeypatch.setattr(module, "check_lock_consistency", fail_lock_check)
+
+    accepted = module.process_scenario(
+        "example",
+        {
+            "python": ">=3.11,<3.12",
+            "platforms": ["linux_x86_64"],
+            "requirements": ["foo"],
+            "skip_on_fail": True,
+        },
+        "commit",
+        force=True,
+        source=_CLEAN_SOURCE,
+    )
+
+    data = json.loads((tmp_path / "commit" / "universal" / "example.json").read_text())
+    assert accepted is False
+    assert data["result"]["resolution_success"] is True
+    assert data["result"]["expected_failure"] is False
+    assert data["result"]["timed_out"] is False
+    assert data["result"]["error"] == "RuntimeError: projection crashed"
+    assert data["stats"]["tuples_total"] == 1
+    assert data["stats"]["tuples_recorded"] == 1
+    assert data["per_tuple"][0]["pins"] == {"foo": "1.0"}
+    assert data["merged_pins"] == {"foo": [{"version": "1.0", "target": target.label}]}
+
+
+def test_cached_result_must_match_the_shape_and_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    _target, resolve_result = _successful_result()
+    calls = 0
+
+    def resolve(*_args: object, **_kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        return resolve_result
+
+    monkeypatch.setattr(module, "RESULTS_DIR", tmp_path)
+    monkeypatch.setattr(module, "CACHE_DIR", tmp_path / "cache")
+    monkeypatch.setattr(module, "Urllib3AsyncTransport", object)
+    monkeypatch.setattr(module, "FetchCoordinator", _FakeCoordinator)
+    monkeypatch.setattr(module, "resolve_with_coordinator", resolve)
+    monkeypatch.setattr(module, "check_lock_consistency", lambda _result: (True, []))
+    scenario = {
+        "python": ">=3.11,<3.12",
+        "platforms": ["linux_x86_64"],
+        "requirements": ["foo"],
+    }
+
+    assert module.process_scenario(
+        "example", scenario, "label", force=True, source=_CLEAN_SOURCE
+    )
+    result_path = tmp_path / "label" / "universal" / "example.json"
+    malformed = json.loads(result_path.read_text())
+    malformed.pop("stats")
+    result_path.write_text(json.dumps(malformed))
+    assert module.process_scenario(
+        "example", scenario, "label", force=False, source=_CLEAN_SOURCE
+    )
+    other_source = {"commit": "b" * 40, "dirty": False, "diff_hash": None}
+    assert module.process_scenario(
+        "example", scenario, "label", force=False, source=other_source
+    )
+    unknown_source = {"commit": "c" * 40, "dirty": True, "diff_hash": None}
+    assert module.process_scenario(
+        "example", scenario, "label", force=False, source=unknown_source
+    )
+    assert module.process_scenario(
+        "example", scenario, "label", force=False, source=unknown_source
+    )
+
+    assert calls == 5
+    data = json.loads(result_path.read_text())
+    assert data["input"]["source"] == unknown_source
+
+
+def test_unknown_universal_setting_is_rejected() -> None:
+    module = _harness()
+    with pytest.raises(
+        ValueError,
+        match=r"example: unknown scenario setting\(s\): parallel",
+    ):
+        module.validate_scenario("example", {"parallel": True})
+
+
+def test_universal_boolean_settings_do_not_coerce_strings() -> None:
+    module = _harness()
+    with pytest.raises(
+        TypeError,
+        match="example: align_across_tuples must be a boolean",
+    ):
+        module.validate_scenario(
+            "example",
+            {
+                "python": ">=3.11,<3.12",
+                "platforms": ["linux_x86_64"],
+                "requirements": ["foo"],
+                "align_across_tuples": "false",
+            },
+        )
+
+
+def test_main_exits_nonzero_for_unexpected_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    monkeypatch.setattr(module, "RESULTS_DIR", tmp_path)
+    monkeypatch.setattr(module, "get_git_source_state", lambda: _CLEAN_SOURCE)
+    full_dir = tmp_path / "label" / "universal"
+    full_dir.mkdir(parents=True)
+    full_manifest = full_dir / "_manifest.json"
+    full_manifest.write_text('{"existing": true}')
+
+    def fake_process(
+        name: str,
+        _scenario: dict,
+        _commit: str,
+        *,
+        force: bool,
+        output_dir: Path,
+        source: dict,
+    ) -> bool:
+        assert force is False
+        assert source == _CLEAN_SOURCE
+        (output_dir / f"{name}.json").write_text("{}")
+        return False
+
+    monkeypatch.setattr(module, "process_scenario", fake_process)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [str(_BENCHMARK), "--commit", "label", "--scenario", "marker-heavy"],
+    )
+
+    with pytest.raises(SystemExit, match="1"):
+        module.main()
+
+    manifest = json.loads(
+        (tmp_path / "label" / "universal-selected" / "_manifest.json").read_text()
+    )
+    assert manifest["run_kind"] == "selected"
+    assert manifest["complete"] is True
+    assert manifest["completed_scenarios"] == ["marker-heavy"]
+    assert full_manifest.read_text() == '{"existing": true}'
+
+
+def test_main_records_the_complete_full_scenario_set(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    monkeypatch.setattr(module, "RESULTS_DIR", tmp_path)
+    monkeypatch.setattr(module, "get_git_source_state", lambda: _CLEAN_SOURCE)
+
+    def fake_process(
+        name: str,
+        _scenario: dict,
+        commit: str,
+        *,
+        force: bool,
+        output_dir: Path,
+        source: dict,
+    ) -> bool:
+        assert force is False
+        assert source == _CLEAN_SOURCE
+        assert output_dir == tmp_path / commit / "universal"
+        (output_dir / f"{name}.json").write_text("{}")
+        return True
+
+    monkeypatch.setattr(module, "process_scenario", fake_process)
+    monkeypatch.setattr(sys, "argv", [str(_BENCHMARK)])
+
+    module.main()
+
+    manifest = json.loads(
+        (
+            tmp_path / _CLEAN_SOURCE["commit"] / "universal" / "_manifest.json"
+        ).read_text()
+    )
+    assert manifest["run_kind"] == "full"
+    assert manifest["complete"] is True
+    assert manifest["available_scenarios"] == manifest["selected_scenarios"]
+    assert manifest["available_scenarios"] == manifest["completed_scenarios"]
+    assert manifest["source"] == _CLEAN_SOURCE
+    assert len(manifest["available_scenarios"]) == 18
+
+
+def test_universal_scenarios_only_override_alignment_for_noalign_cases() -> None:
+    module = _harness()
+    scenarios = module.tomllib.loads(
+        (module.SCENARIOS_DIR / "universal.toml").read_text()
+    )
+
+    assert {
+        name
+        for name, scenario in scenarios.items()
+        if scenario.get("align_across_tuples") is False
+    } == {
+        "apache-airflow-universal-noalign",
+        "legacy-36-root-noalign",
+        "numpy-wide-python-diverge",
+    }
+    assert not any(
+        scenario.get("align_across_tuples") is True for scenario in scenarios.values()
+    )
+
+
+@pytest.mark.parametrize(
+    ("result", "schema", "exit_code"),
+    [
+        (
+            {
+                "success": False,
+                "resolution_success": None,
+                "expected_failure": False,
+                "skip_on_fail": False,
+                "timed_out": True,
+                "lock_consistent": None,
+                "error": "scenario exceeded wall-clock budget",
+            },
+            3,
+            1,
+        ),
+        (
+            {
+                "success": False,
+                "resolution_success": False,
+                "expected_failure": True,
+                "skip_on_fail": True,
+                "timed_out": False,
+                "lock_consistent": None,
+            },
+            3,
+            0,
+        ),
+        (
+            {
+                "success": False,
+                "resolution_success": False,
+                "expected_failure": True,
+                "skip_on_fail": False,
+                "timed_out": False,
+                "lock_consistent": None,
+            },
+            3,
+            1,
+        ),
+        (
+            {
+                "success": True,
+                "resolution_success": True,
+                "expected_failure": False,
+                "skip_on_fail": False,
+                "timed_out": False,
+                "lock_consistent": True,
+            },
+            2,
+            1,
+        ),
+    ],
+)
+def test_summary_exit_status(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    result: dict,
+    schema: int,
+    exit_code: int,
+) -> None:
+    module = _summary_harness()
+    result_dir = tmp_path / "run" / "universal"
+    result_dir.mkdir(parents=True)
+    data = _result_data(result, schema=schema)
+    data["input"].update(
+        {"scenario": "example", "commit": "run", "source": _CLEAN_SOURCE}
+    )
+    (result_dir / "example.json").write_text(json.dumps(data))
+    (result_dir / "_manifest.json").write_text(
+        json.dumps(
+            {
+                "benchmark_schema": 3,
+                "commit": "run",
+                "source": _CLEAN_SOURCE,
+                "run_kind": "full",
+                "available_scenarios": ["example"],
+                "selected_scenarios": ["example"],
+                "completed_scenarios": ["example"],
+                "complete": True,
+            }
+        )
+    )
+    (result_dir / "removed.json").write_text(
+        json.dumps(
+            {
+                "input": {"benchmark_schema": 2, "commit": "run"},
+                "result": {"success": True},
+                "stats": {"decisions_total": 999},
+            }
+        )
+    )
+    monkeypatch.setattr(module, "RESULTS_DIR", tmp_path)
+    monkeypatch.setattr(sys, "argv", ["universal_summary.py", "run"])
+
+    assert module.main() == exit_code
+
+
+def test_summary_exits_nonzero_without_results(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _summary_harness()
+    monkeypatch.setattr(module, "RESULTS_DIR", tmp_path)
+    monkeypatch.setattr(sys, "argv", ["universal_summary.py", "missing"])
+
+    assert module.main() == 1
+
+
+def test_summary_rejects_a_selected_run_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _summary_harness()
+    result_dir = tmp_path / "run" / "universal"
+    result_dir.mkdir(parents=True)
+    (result_dir / "_manifest.json").write_text(
+        json.dumps(
+            {
+                "benchmark_schema": 3,
+                "commit": "run",
+                "source": _CLEAN_SOURCE,
+                "run_kind": "selected",
+                "available_scenarios": ["a", "b"],
+                "selected_scenarios": ["a"],
+                "completed_scenarios": ["a"],
+                "complete": True,
+            }
+        )
+    )
+    monkeypatch.setattr(module, "RESULTS_DIR", tmp_path)
+    monkeypatch.setattr(sys, "argv", ["universal_summary.py", "run"])
+
+    assert module.main() == 1
+
+
+def test_summary_rejects_a_dirty_full_run(
+    tmp_path: Path,
+) -> None:
+    module = _summary_harness()
+    result_dir = tmp_path / "run" / "universal"
+    result_dir.mkdir(parents=True)
+    dirty_source = {"commit": "a" * 40, "dirty": True, "diff_hash": "b" * 64}
+    (result_dir / "_manifest.json").write_text(
+        json.dumps(
+            {
+                "benchmark_schema": 3,
+                "commit": "run",
+                "source": dirty_source,
+                "run_kind": "full",
+                "available_scenarios": ["example"],
+                "selected_scenarios": ["example"],
+                "completed_scenarios": ["example"],
+                "complete": True,
+            }
+        )
+    )
+
+    assert module.authoritative_result_paths(result_dir) is None


### PR DESCRIPTION
Universal benchmark runs could exit successfully after a timeout, resolution failure, or invalid emitted lock. Their JSON also omitted the pins needed to inspect the outcome.

Record per-target and merged pins, validate the rendered lock, and return a failure status for unexpected outcomes. A versioned manifest prevents incomplete full runs from being summarized, while single-scenario diagnostics use a separate result directory. The runner now applies the product's declared-target build policy, and the catalog no longer advertises settings it never supported.