### PR TITLE
honor resolution strategies in canary benchmarks

### DIFF
--- a/nab-python/benchmarks/README.md
+++ b/nab-python/benchmarks/README.md
@@ -18,6 +18,13 @@ The runner records wall-clock, decision-count, and round-count
 metrics, and writes a JSON summary under
 `nab-python/benchmarks/results/<commit>/`.
 
+### Canary subset
+
+`canary.py` runs the small hard-case subset used by the local verification gate.
+It honors each selected scenario's `resolution` setting and records the complete TOML input, effective target and policy, source state, and content hashes.
+The local verifier compares success results only when their contract version and host-aware execution hashes match and both source trees are clean.
+Contract version 2 begins the strategy-aware series; older all-highest results are not its baseline.
+
 ## Universal-resolution scenarios
 
 `nab-python/benchmarks/universal_scenarios.py` runs

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -13,18 +13,22 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import os
+import platform
 import signal
 import statistics
 import subprocess
 import sys
 import time
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Iterator, Mapping
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -49,6 +53,7 @@ from nab_python.provider import (
     BuildPolicy,
     DistPolicy,
     Provider,
+    ResolutionStrategy,
     VcsConfig,
     VcsPolicy,
     split_extra,
@@ -92,6 +97,8 @@ CANARY_SCENARIOS = [
 
 WALL_TIMEOUT_S = 60
 MAX_ITERATIONS = 50_000
+# Version 2 separates strategy-aware results from the old all-highest series.
+CANARY_CONTRACT_VERSION = 2
 
 
 class _ScenarioTimeoutError(BaseException):
@@ -102,9 +109,129 @@ class _ScenarioTimeoutError(BaseException):
     """
 
 
+def scenario_input_hash(scenario_name: str, scenario: dict) -> str:
+    """Hash the selected source and its complete executable TOML definition."""
+    encoded = json.dumps(
+        {"scenario": scenario_name, "definition": scenario},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def scenario_execution_hash(
+    input_hash: str,
+    effective_settings: dict | None,
+) -> str:
+    """Hash the source input together with the effective host-dependent policy."""
+    encoded = json.dumps(
+        {"input_hash": input_hash, "effective_settings": effective_settings},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def get_git_source_state() -> dict[str, str | bool | None]:
+    """Describe the checked-out source without treating a label as identity."""
+    try:
+        commit = get_git_commit()
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return {"commit": None, "dirty": True, "diff_hash": None}
+    try:
+        root = Path(
+            subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                capture_output=True,
+                check=True,
+                text=True,
+                cwd=BENCHMARKS_DIR,
+            ).stdout.strip()
+        )
+        status = subprocess.run(
+            ["git", "status", "--porcelain=v1", "-z", "--untracked-files=all"],
+            capture_output=True,
+            check=True,
+            cwd=root,
+        ).stdout
+        diff = subprocess.run(
+            ["git", "diff", "--binary", "HEAD", "--"],
+            capture_output=True,
+            check=True,
+            cwd=root,
+        ).stdout
+        untracked = subprocess.run(
+            ["git", "ls-files", "--others", "--exclude-standard", "-z"],
+            capture_output=True,
+            check=True,
+            cwd=root,
+        ).stdout
+        untracked_hashes = bytearray()
+        for raw_path in untracked.split(b"\0"):
+            if not raw_path:
+                continue
+            object_hash = subprocess.run(  # noqa: S603 - path is one arg after --
+                ["git", "hash-object", "--", os.fsdecode(raw_path)],
+                capture_output=True,
+                check=True,
+                cwd=root,
+            ).stdout
+            untracked_hashes.extend(raw_path + b"\0" + object_hash)
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return {"commit": commit, "dirty": True, "diff_hash": None}
+    dirty = bool(status)
+    diff_hash = (
+        hashlib.sha256(status + b"\0" + diff + b"\0" + untracked_hashes).hexdigest()
+        if dirty
+        else None
+    )
+    return {"commit": commit, "dirty": dirty, "diff_hash": diff_hash}
+
+
+def _target_manifest(target: ResolveTarget) -> dict[str, object]:
+    tags = [str(tag) for tag in target.tags.ordered]
+    return {
+        "label": target.label,
+        "platform_id": target.platform_id,
+        "host_faithful": target.host_faithful,
+        "tags_faithful": target.tags_faithful,
+        "marker_environment": dict(sorted(target.marker_env.items())),
+        "wheel_tags_count": len(tags),
+        "wheel_tags_hash": hashlib.sha256("\n".join(tags).encode()).hexdigest(),
+    }
+
+
+def _runtime_manifest() -> dict[str, str]:
+    return {
+        "python": sys.version,
+        "implementation": sys.implementation.name,
+        "system": platform.system(),
+        "release": platform.release(),
+        "machine": platform.machine(),
+    }
+
+
 def _alarm_handler(_signum: int, _frame: object) -> None:
     msg = f"scenario exceeded {WALL_TIMEOUT_S}s wall-clock budget"
     raise _ScenarioTimeoutError(msg)
+
+
+@contextmanager
+def _scenario_wall_timeout() -> Iterator[None]:
+    """Install the POSIX wall timer when the platform provides one."""
+    sigalrm = getattr(signal, "SIGALRM", None)
+    alarm = getattr(signal, "alarm", None)
+    if sigalrm is None or alarm is None:
+        yield
+        return
+
+    previous_handler = signal.signal(sigalrm, _alarm_handler)
+    alarm(WALL_TIMEOUT_S)
+    try:
+        yield
+    finally:
+        alarm(0)
+        signal.signal(sigalrm, previous_handler)
 
 
 def expand_project_extras(
@@ -212,10 +339,11 @@ def parse_datetime(value: str) -> datetime:
 
 def get_git_commit() -> str:
     result = subprocess.run(
-        ["git", "rev-parse", "--short", "HEAD"],
+        ["git", "rev-parse", "HEAD"],
         capture_output=True,
         text=True,
         check=True,
+        cwd=BENCHMARKS_DIR,
     )
     return result.stdout.strip()
 
@@ -225,13 +353,18 @@ def run_one(  # noqa: PLR0913 - one wrapper per scenario knob
     python_version: str,
     uploaded_prior_to: datetime | None,
     constraints: dict[str, VersionRange] | None,
+    *,
     marker_environment: dict[str, str] | None = None,
     indexes: list[IndexConfig] | None = None,
     index_routes: list[IndexRoute] | None = None,
     build_policy_overrides: Mapping[str, BuildPolicy] | None = None,
-    *,
+    resolution_strategy: ResolutionStrategy = ResolutionStrategy.HIGHEST,
     trust_unverified_sdist_deps: bool = False,
 ) -> dict:
+    direct_packages = frozenset(
+        name for name in requirements if split_extra(name)[1] is None
+    )
+    effective_indexes = list(indexes) if indexes is not None else list(DEFAULT_INDEXES)
     package_overrides = tuple(
         PackageOverride(
             requirement=Requirement(name),
@@ -241,21 +374,24 @@ def run_one(  # noqa: PLR0913 - one wrapper per scenario knob
         )
         for name, policy in (build_policy_overrides or {}).items()
     )
+    target = _resolve_target(python_version, marker_environment)
     with FetchCoordinator(
         HttpxAsyncTransport(),
-        indexes=indexes,
+        indexes=effective_indexes,
         cache_dir=CACHE_DIR,
         index_routes=index_routes,
     ) as coordinator:
         provider = Provider(
             coordinator,
-            target=_resolve_target(python_version, marker_environment),
+            target=target,
             root_requirements=requirements,
             uploaded_prior_to=uploaded_prior_to,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
             build_policy=BuildPolicy.NEVER,
             package_overrides=package_overrides,
             trust_unverified_sdist_deps=trust_unverified_sdist_deps,
+            resolution_strategy=resolution_strategy,
+            direct_packages=direct_packages,
         )
         resolver = Resolver(
             provider,
@@ -264,11 +400,10 @@ def run_one(  # noqa: PLR0913 - one wrapper per scenario knob
             max_iterations=MAX_ITERATIONS,
         )
 
-        previous_handler = signal.signal(signal.SIGALRM, _alarm_handler)
-        signal.alarm(WALL_TIMEOUT_S)
         start = time.monotonic()
         try:
-            raw = resolver.resolve(requirements, constraints=constraints)
+            with _scenario_wall_timeout():
+                raw = resolver.resolve(requirements, constraints=constraints)
             elapsed = time.monotonic() - start
             result = {k: v for k, v in raw.items() if split_extra(k)[1] is None}
             success = True
@@ -279,13 +414,33 @@ def run_one(  # noqa: PLR0913 - one wrapper per scenario knob
             success = False
             error = f"{type(exc).__name__}: {exc}"
             packages = 0
-        finally:
-            signal.alarm(0)
-            signal.signal(signal.SIGALRM, previous_handler)
 
         rs = resolver.stats
         ps = provider.stats
         return {
+            "settings": {
+                "resolution": resolution_strategy.value,
+                "dist_policy": DistPolicy.WHEEL_OR_SDIST.value,
+                "build_policy": BuildPolicy.NEVER.value,
+                "trust_unverified_sdist_deps": trust_unverified_sdist_deps,
+                "max_iterations": MAX_ITERATIONS,
+                "wall_timeout_seconds": WALL_TIMEOUT_S,
+                "runtime": _runtime_manifest(),
+                "direct_packages": sorted(direct_packages),
+                "target": _target_manifest(target),
+                "indexes": [
+                    {"name": index.name, "url": index.url}
+                    for index in effective_indexes
+                ],
+                "index_routes": [
+                    {"name": route.name, "index": route.index}
+                    for route in (index_routes or [])
+                ],
+                "build_policy_overrides": {
+                    name: policy.value
+                    for name, policy in sorted((build_policy_overrides or {}).items())
+                },
+            },
             "success": success,
             "error": error,
             "decisions": rs.decisions,
@@ -336,7 +491,12 @@ def find_scenario(spec: str) -> dict | None:
     return matches[0][1]
 
 
-def median_run(scenario: dict, runs: int) -> tuple[list[dict], dict]:
+def median_run(
+    scenario: dict,
+    runs: int,
+    *,
+    scenario_name: str = "canary",
+) -> tuple[list[dict], dict]:
     if "unsupported_reason" in scenario:
         return [], {"skipped": scenario["unsupported_reason"]}
 
@@ -417,6 +577,16 @@ def median_run(scenario: dict, runs: int) -> tuple[list[dict], dict]:
         else None
     )
     uploaded_prior_to = parse_datetime(datetime_str) if datetime_str else None
+    resolution_raw = scenario.get("resolution", ResolutionStrategy.HIGHEST.value)
+    try:
+        resolution_strategy = ResolutionStrategy(resolution_raw)
+    except ValueError as exc:
+        valid = sorted(strategy.value for strategy in ResolutionStrategy)
+        msg = (
+            f"{scenario_name}: resolution must be one of {valid!r},"
+            f" got {resolution_raw!r}"
+        )
+        raise ValueError(msg) from exc
     # See scenarios.py: trust pre-2.2 sdist PKG-INFO deps by default so the
     # benchmark measures search, not strict PEP 643 sdist rejection.
     trust_unverified_sdist_deps = bool(
@@ -433,6 +603,7 @@ def median_run(scenario: dict, runs: int) -> tuple[list[dict], dict]:
             indexes=indexes,
             index_routes=index_routes or None,
             build_policy_overrides=build_policy_overrides or None,
+            resolution_strategy=resolution_strategy,
             trust_unverified_sdist_deps=trust_unverified_sdist_deps,
         )
         for _ in range(runs)
@@ -468,7 +639,8 @@ def main() -> None:
     parser.add_argument("--scenarios-list", help="File with one scenario per line")
     args = parser.parse_args()
 
-    commit = args.commit or get_git_commit()
+    source = get_git_source_state()
+    commit = args.commit or str(source["commit"] or "no-git")
 
     scenarios_to_run: list[str]
     if args.scenarios_list:
@@ -478,6 +650,14 @@ def main() -> None:
         scenarios_to_run = args.scenario
     else:
         scenarios_to_run = list(CANARY_SCENARIOS)
+
+    labels = [name.split(":", 1)[-1] for name in scenarios_to_run]
+    duplicate_labels = sorted({label for label in labels if labels.count(label) > 1})
+    if duplicate_labels:
+        parser.error(
+            "scenario names must be unique across selected files; duplicate(s): "
+            + ", ".join(duplicate_labels)
+        )
 
     out_dir = RESULTS_DIR / commit
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -495,14 +675,32 @@ def main() -> None:
     print("-" * 110)
 
     summary_all: dict[str, dict] = {}
-    for name in scenarios_to_run:
+    for name, label in zip(scenarios_to_run, labels, strict=True):
         scenario = find_scenario(name)
-        label = name.split(":", 1)[-1]
         if scenario is None:
             print(f"{label:<45} NOT FOUND")
             continue
-        runs_data, summary = median_run(scenario, args.runs)
-        summary_all[label] = {"runs": runs_data, "summary": summary}
+        runs_data, summary = median_run(
+            scenario,
+            args.runs,
+            scenario_name=label,
+        )
+        input_hash = scenario_input_hash(name, scenario)
+        effective_settings = runs_data[0]["settings"] if runs_data else None
+        summary_all[label] = {
+            "contract_version": CANARY_CONTRACT_VERSION,
+            "scenario": name,
+            "source": source,
+            "input_hash": input_hash,
+            "execution_hash": scenario_execution_hash(
+                input_hash,
+                effective_settings,
+            ),
+            "input": scenario,
+            "effective_settings": effective_settings,
+            "runs": runs_data,
+            "summary": summary,
+        }
 
         if "skipped" in summary:
             print(f"{label:<45} SKIPPED: {summary['skipped']}")

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -1,0 +1,406 @@
+"""Tests for the canary benchmark contract."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+from typing_extensions import Self
+
+_CANARY = Path(__file__).resolve().parents[1] / "benchmarks" / "canary.py"
+
+
+def _harness() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("_benchmark_canary", _CANARY)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_wall_timeout_noops_without_posix_alarm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    monkeypatch.delattr(module.signal, "SIGALRM", raising=False)
+    monkeypatch.delattr(module.signal, "alarm", raising=False)
+
+    with module._scenario_wall_timeout():
+        pass
+
+
+def test_wall_timeout_installs_and_restores_alarm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    previous_handler = object()
+    handlers: list[tuple[int, object]] = []
+    alarms: list[int] = []
+
+    def fake_signal(signum: int, handler: object) -> object:
+        handlers.append((signum, handler))
+        return previous_handler
+
+    def fake_alarm(seconds: int) -> None:
+        alarms.append(seconds)
+
+    monkeypatch.setattr(module.signal, "SIGALRM", 14, raising=False)
+    monkeypatch.setattr(module.signal, "signal", fake_signal)
+    monkeypatch.setattr(module.signal, "alarm", fake_alarm, raising=False)
+
+    with module._scenario_wall_timeout():
+        assert alarms == [module.WALL_TIMEOUT_S]
+
+    assert alarms == [module.WALL_TIMEOUT_S, 0]
+    assert handlers == [
+        (14, module._alarm_handler),
+        (14, previous_handler),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("resolution", "expected"),
+    [
+        (None, "highest"),
+        ("highest", "highest"),
+        ("lowest", "lowest"),
+        ("lowest-direct", "lowest-direct"),
+    ],
+)
+def test_canary_uses_scenario_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    resolution: str | None,
+    expected: str,
+) -> None:
+    module = _harness()
+    seen: list[str] = []
+
+    def fake_run_one(*_args: object, **kwargs: object) -> dict:
+        seen.append(str(kwargs["resolution_strategy"].value))
+        return {
+            "success": True,
+            "error": None,
+            "decisions": 1,
+            "conflicts": 0,
+            "backjumps": 0,
+            "restarts": 0,
+            "incompatibilities_learned": 0,
+            "metadata_fetched": 0,
+            "distributions_seen": 0,
+            "look_ahead_rejections": 0,
+            "packages": 0,
+            "wall_time_seconds": 0.0,
+        }
+
+    monkeypatch.setattr(module, "run_one", fake_run_one)
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+    }
+    if resolution is not None:
+        scenario["resolution"] = resolution
+    module.median_run(
+        scenario,
+        1,
+        scenario_name="example",
+    )
+
+    assert seen == [expected]
+
+
+def test_canary_rejects_unknown_resolution() -> None:
+    module = _harness()
+    with pytest.raises(
+        ValueError,
+        match="example: resolution must be one of.*got 'middle'",
+    ):
+        module.median_run(
+            {
+                "python_version": "3.11",
+                "requirements": [],
+                "resolution": "middle",
+            },
+            1,
+            scenario_name="example",
+        )
+
+
+def test_canary_configures_lowest_direct_roots(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    seen: dict[str, object] = {}
+
+    class FakeCoordinator:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            pass
+
+    class FakeProvider:
+        def __init__(self, *_args: object, **kwargs: object) -> None:
+            seen.update(kwargs)
+            self.stats = SimpleNamespace(
+                metadata_fetched=0,
+                distributions_seen=0,
+                look_ahead_rejections=0,
+            )
+
+    class FakeResolver:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            self.stats = SimpleNamespace(
+                decisions=0,
+                conflicts=0,
+                backjumps=0,
+                restarts=0,
+                incompatibilities_learned=0,
+            )
+
+        def resolve(self, *_args: object, **_kwargs: object) -> dict:
+            return {}
+
+    monkeypatch.setattr(module, "FetchCoordinator", FakeCoordinator)
+    monkeypatch.setattr(module, "HttpxAsyncTransport", object)
+    monkeypatch.setattr(module, "Provider", FakeProvider)
+    monkeypatch.setattr(module, "Resolver", FakeResolver)
+
+    requirements = module.parse_requirements(["Root[feature]", "Other==1"])
+    result = module.run_one(
+        requirements,
+        "3.11",
+        None,
+        None,
+        resolution_strategy=module.ResolutionStrategy.LOWEST_DIRECT,
+    )
+
+    assert result["success"] is True
+    settings = result["settings"]
+    assert settings["resolution"] == "lowest-direct"
+    assert settings["dist_policy"] == "wheel-or-sdist"
+    assert settings["build_policy"] == "never"
+    assert settings["trust_unverified_sdist_deps"] is False
+    assert settings["max_iterations"] == module.MAX_ITERATIONS
+    assert settings["wall_timeout_seconds"] == module.WALL_TIMEOUT_S
+    assert settings["runtime"]["python"] == sys.version
+    assert settings["runtime"]["implementation"] == sys.implementation.name
+    assert settings["direct_packages"] == ["other", "root"]
+    assert settings["indexes"] == [
+        {"name": module.DEFAULT_INDEX_NAME, "url": module.DEFAULT_INDEX_URL}
+    ]
+    assert settings["target"]["marker_environment"]["python_version"] == "3.11"
+    assert settings["target"]["wheel_tags_count"] > 0
+    assert seen["resolution_strategy"] is module.ResolutionStrategy.LOWEST_DIRECT
+    assert seen["direct_packages"] == frozenset({"root", "other"})
+
+
+def test_canary_main_records_v2_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    monkeypatch.setattr(module, "RESULTS_DIR", tmp_path)
+    source = {"commit": "source-sha", "dirty": False, "diff_hash": None}
+    monkeypatch.setattr(module, "get_git_source_state", lambda: source)
+    scenario = {"unsupported_reason": "test fixture"}
+    input_hash = module.scenario_input_hash("quick:requests", scenario)
+    monkeypatch.setattr(module, "find_scenario", lambda _name: scenario)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["canary.py", "--commit", "test", "--scenario", "quick:requests"],
+    )
+
+    module.main()
+
+    result_path = next((tmp_path / "test").glob("canary_*.json"))
+    data = json.loads(result_path.read_text())
+    assert data == {
+        "requests": {
+            "contract_version": module.CANARY_CONTRACT_VERSION,
+            "scenario": "quick:requests",
+            "source": source,
+            "input_hash": input_hash,
+            "execution_hash": module.scenario_execution_hash(input_hash, None),
+            "input": scenario,
+            "effective_settings": None,
+            "runs": [],
+            "summary": {"skipped": "test fixture"},
+        }
+    }
+
+
+def test_canary_input_hash_captures_executable_definition() -> None:
+    module = _harness()
+    scenario = {
+        "requirements": ["a", "b"],
+        "marker_environment": {"sys_platform": "linux", "os_name": "posix"},
+    }
+    reordered_mapping = {
+        "marker_environment": {"os_name": "posix", "sys_platform": "linux"},
+        "requirements": ["a", "b"],
+    }
+    digest = module.scenario_input_hash("quick:example", scenario)
+
+    assert digest == module.scenario_input_hash("quick:example", reordered_mapping)
+    assert digest != module.scenario_input_hash("other:example", scenario)
+    assert digest != module.scenario_input_hash(
+        "quick:example",
+        {**scenario, "requirements": ["b", "a"]},
+    )
+    assert digest != module.scenario_input_hash(
+        "quick:example",
+        {**scenario, "requirements": ["a", "c"]},
+    )
+    assert module.scenario_execution_hash(digest, {"target": "linux"}) != (
+        module.scenario_execution_hash(digest, {"target": "windows"})
+    )
+
+
+@pytest.mark.parametrize(
+    ("status", "diff", "dirty"),
+    [
+        (b"", b"", False),
+        (b" M canary.py\0", b"diff --git a/canary.py b/canary.py\n", True),
+    ],
+)
+def test_canary_source_state_marks_dirty_trees(
+    monkeypatch: pytest.MonkeyPatch,
+    status: bytes,
+    diff: bytes,
+    dirty: bool,
+) -> None:
+    module = _harness()
+    monkeypatch.setattr(module, "get_git_commit", lambda: "source-sha")
+
+    def run(command: list[str], **_kwargs: object) -> SimpleNamespace:
+        if command == ["git", "rev-parse", "--show-toplevel"]:
+            return SimpleNamespace(stdout="/repo")
+        if command[:2] == ["git", "status"]:
+            return SimpleNamespace(stdout=status)
+        if command[:2] == ["git", "diff"]:
+            return SimpleNamespace(stdout=diff)
+        if command[:2] == ["git", "ls-files"]:
+            return SimpleNamespace(stdout=b"")
+        raise AssertionError(command)
+
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        run,
+    )
+
+    state = module.get_git_source_state()
+
+    assert state["commit"] == "source-sha"
+    assert state["dirty"] is dirty
+    expected_hash = (
+        hashlib.sha256(status + b"\0" + diff + b"\0").hexdigest() if dirty else None
+    )
+    assert state["diff_hash"] == expected_hash
+
+
+def test_canary_source_state_hashes_sibling_untracked_contents(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    git = shutil.which("git")
+    assert git is not None
+
+    def run_git(*args: str) -> None:
+        subprocess.run([git, *args], cwd=tmp_path, check=True)  # noqa: S603
+
+    run_git("init", "-q")
+    benchmarks_dir = tmp_path / "nab-python" / "benchmarks"
+    benchmarks_dir.mkdir(parents=True)
+    (benchmarks_dir / "tracked").write_text("tracked\n")
+    run_git("add", "nab-python/benchmarks/tracked")
+    run_git(
+        "-c",
+        "user.name=Canary Test",
+        "-c",
+        "user.email=canary@example.invalid",
+        "commit",
+        "-qm",
+        "initial",
+    )
+    untracked = tmp_path / "nab-python" / "src" / "source.py"
+    untracked.parent.mkdir(parents=True)
+    untracked.write_text("first\n")
+    module = _harness()
+    monkeypatch.setattr(module, "BENCHMARKS_DIR", benchmarks_dir)
+
+    first = module.get_git_source_state()
+    untracked.write_text("second\n")
+    second = module.get_git_source_state()
+
+    assert first["commit"] == second["commit"]
+    assert first["dirty"] is second["dirty"] is True
+    assert first["diff_hash"] != second["diff_hash"]
+
+
+def test_canary_source_state_marks_a_source_export_dirty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+
+    def fail_commit() -> str:
+        raise module.subprocess.CalledProcessError(128, ["git", "rev-parse"])
+
+    monkeypatch.setattr(module, "get_git_commit", fail_commit)
+
+    assert module.get_git_source_state() == {
+        "commit": None,
+        "dirty": True,
+        "diff_hash": None,
+    }
+
+
+def test_canary_source_state_preserves_commit_when_hashing_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    commit = "a" * 40
+    monkeypatch.setattr(module, "get_git_commit", lambda: commit)
+
+    def fail_hashing(*_args: object, **_kwargs: object) -> object:
+        raise module.subprocess.CalledProcessError(128, ["git", "status"])
+
+    monkeypatch.setattr(module.subprocess, "run", fail_hashing)
+
+    assert module.get_git_source_state() == {
+        "commit": commit,
+        "dirty": True,
+        "diff_hash": None,
+    }
+
+
+def test_canary_main_rejects_duplicate_output_labels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "canary.py",
+            "--scenario",
+            "quick:requests",
+            "--scenario",
+            "quick-lowest:requests",
+        ],
+    )
+
+    with pytest.raises(SystemExit, match="2"):
+        module.main()


### PR DESCRIPTION
Canary entries selected from lowest and lowest-direct TOMLs were still resolved with the highest strategy because the harness did not forward the setting.

Forward each scenario's strategy and direct-root set to the provider, and version the recorded input and execution contract so corrected runs cannot be compared with the old all-highest series.