### PR TITLE
fix raw traceback on config versions past CPython's int digit limit

### DIFF
--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -31,10 +31,10 @@ from ._conflict_kind import KIND_EXTRA, KIND_GROUP
 from ._iso8601 import parse_iso_datetime
 from ._toml import tool_nab_section
 from ._vcs_admission import known_vcs_schemes
-from ._vendor.packaging.requirements import InvalidRequirement, Requirement
+from ._vendor.packaging.requirements import Requirement
 from ._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from ._vendor.packaging.utils import InvalidName, canonicalize_name
-from ._vendor.packaging.version import InvalidVersion, Version
+from ._vendor.packaging.version import Version
 from .config_sources import (
     ConfigError,
     EffectiveValue,
@@ -1117,7 +1117,7 @@ def with_python_override(
 
     try:
         Version(python)
-    except InvalidVersion as exc:
+    except ValueError as exc:
         msg = f"--python must be a version like '3.12' or '3.12.4', got {python!r}"
         raise ConfigError(msg) from exc
 
@@ -1227,7 +1227,9 @@ def _require_constraint(key: str, item: str) -> None:
     """
     try:
         req = Requirement(item)
-    except InvalidRequirement as exc:
+        # a specifier defers parsing its versions; to_range() forces it
+        req.specifier.to_range()
+    except ValueError as exc:
         msg = f"{key} is not a valid requirement: {exc}"
         raise ConfigError(msg) from exc
 
@@ -1277,8 +1279,9 @@ def _parse_requires_python(value: object) -> str | None:
     """
     raw = _parse_string_value("requires-python", value)
     try:
-        SpecifierSet(raw)
-    except InvalidSpecifier as exc:
+        # a specifier defers parsing its versions; to_range() forces it
+        SpecifierSet(raw).to_range()
+    except ValueError as exc:
         msg = (
             f"requires-python must be a PEP 440 specifier, got {raw!r}."
             f"  Did you mean ==X.Y or >=X.Y,<X.{{Y+1}}?"
@@ -1470,7 +1473,7 @@ def _parse_marker_environment(value: object) -> dict[str, str]:
         if k in _VERSION_MARKER_VARIABLES:
             try:
                 Version(v)
-            except InvalidVersion as exc:
+            except ValueError as exc:
                 msg = f"marker-environment.{k} must be a PEP 440 version, got {v!r}"
                 raise ConfigError(msg) from exc
         out[k] = v
@@ -1536,7 +1539,7 @@ def _validate_environment_values(environment: Mapping[str, Any]) -> None:
     if python is not None:
         try:
             Version(python)
-        except InvalidVersion as exc:
+        except ValueError as exc:
             msg = (
                 "environment.python must be a version like '3.12' or"
                 f" '3.12.4', got {python!r}"
@@ -2039,7 +2042,9 @@ def _requirement_from_selector(raw: str, where: str) -> Requirement:
     """
     try:
         requirement = Requirement(raw)
-    except InvalidRequirement as exc:
+        # a specifier defers parsing its versions; to_range() forces it
+        requirement.specifier.to_range()
+    except ValueError as exc:
         msg = f"{where} entry {raw!r} is not a valid PEP 508 requirement"
         raise ConfigError(msg) from exc
     if requirement.extras or requirement.marker is not None or requirement.url:
@@ -2345,13 +2350,16 @@ def _parse_override_dependencies(
             )
             raise ConfigError(msg)
         try:
-            out.append(Requirement(item))
-        except InvalidRequirement as exc:
+            requirement = Requirement(item)
+            # a specifier defers parsing its versions; to_range() forces it
+            requirement.specifier.to_range()
+        except ValueError as exc:
             msg = (
                 f"{where}.dependencies[{i}] is not a valid PEP 508"
                 f" requirement: {item!r}"
             )
             raise ConfigError(msg) from exc
+        out.append(requirement)
     return tuple(out)
 
 
@@ -2709,7 +2717,7 @@ def _parse_python_patches(value: object) -> dict[str, str] | None:
         try:
             minor = Version(k)
             full = Version(v)
-        except InvalidVersion as exc:
+        except ValueError as exc:
             msg = f"matrix.python-patches expects version strings, got {k!r}: {v!r}"
             raise ConfigError(msg) from exc
 
@@ -2935,7 +2943,7 @@ def _validate_matrix_python(spec: str) -> None:
     for clause in specifier_set:
         try:
             version = Version(clause.version.removesuffix(".*"))
-        except InvalidVersion as exc:
+        except ValueError as exc:
             msg = f"matrix.python clause {clause} is not a valid version"
             raise ConfigError(msg) from exc
 
@@ -3089,7 +3097,7 @@ def _parse_major_minor(key: str, value: object) -> tuple[int, int] | None:
     text = _parse_string_value(key, value)
     try:
         version = Version(text)
-    except InvalidVersion as exc:
+    except ValueError as exc:
         msg = f"{key} must be a 'major.minor' version, got {text!r}"
         raise ConfigError(msg) from exc
     release = version.release

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -4267,6 +4267,154 @@ class TestMatrix:
             read_pyproject_config(path)
 
 
+# Longer than CPython's default 4300-digit limit on int-from-string conversion.
+_PAST_INT_LIMIT = "9" * 5000
+
+
+class TestDigitRunPastIntLimit:
+    """A version digit run past CPython's int limit is a config error.
+
+    ``Version()`` raises a bare ``ValueError`` for one (not
+    ``InvalidVersion``), and a specifier defers the conversion to its first
+    comparison, so each validator forces it and reports the key.
+    """
+
+    def test_environment_python(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path, f'[tool.nab.environment]\npython = "3.{_PAST_INT_LIMIT}"\n'
+        )
+        with pytest.raises(
+            ConfigError, match="environment.python must be a version like"
+        ):
+            read_pyproject_config(path)
+
+    def test_environment_platform_runs_on_macos(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab.environment]\nplatform ="
+            f' {{ id = "macos_arm64", runs-on-macos = "{_PAST_INT_LIMIT}.0" }}\n',
+        )
+        with pytest.raises(
+            ConfigError, match="runs-on-macos must be a 'major.minor' version"
+        ):
+            read_pyproject_config(path)
+
+    def test_marker_environment_version_variable(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab.marker-environment]\n"
+            f'python_full_version = "3.{_PAST_INT_LIMIT}"\n',
+        )
+        with pytest.raises(
+            ConfigError, match="python_full_version must be a PEP 440 version"
+        ):
+            read_pyproject_config(path)
+
+    def test_python_override(self, tmp_path: Path) -> None:
+        config = read_pyproject_config(write(tmp_path, "[tool.nab]\n"))
+        with pytest.raises(ConfigError, match="--python must be a version like"):
+            with_python_override(config, f"3.{_PAST_INT_LIMIT}")
+
+    def test_matrix_python_clause(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            "[tool.nab.matrix]\n"
+            f'python = ">=3.{_PAST_INT_LIMIT}"\n'
+            'platforms = ["linux_x86_64"]\n',
+        )
+        with pytest.raises(ConfigError, match="is not a valid version"):
+            read_pyproject_config(path)
+
+    def test_matrix_python_patches(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            "[tool.nab.matrix]\n"
+            'python = ">=3.11,<3.12"\n'
+            'platforms = ["linux_x86_64"]\n'
+            "[tool.nab.matrix.python-patches]\n"
+            f'"3.11" = "3.11.{_PAST_INT_LIMIT}"\n',
+        )
+        with pytest.raises(ConfigError, match="python-patches expects version"):
+            read_pyproject_config(path)
+
+    def test_matrix_platform_runs_on_libc(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            "[tool.nab.matrix]\n"
+            'python = ">=3.11,<3.12"\n'
+            "platforms ="
+            f' [{{ id = "linux_x86_64", runs-on-libc = "2.{_PAST_INT_LIMIT}" }}]\n',
+        )
+        with pytest.raises(
+            ConfigError, match="runs-on-libc must be a 'major.minor' version"
+        ):
+            read_pyproject_config(path)
+
+    def test_requires_python(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path, f'[tool.nab]\nrequires-python = ">=3.{_PAST_INT_LIMIT}"\n'
+        )
+        with pytest.raises(
+            ConfigError, match="requires-python must be a PEP 440 specifier"
+        ):
+            read_pyproject_config(path)
+
+    def test_constraints(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path, f'[tool.nab]\nconstraints = ["widget >= {_PAST_INT_LIMIT}"]\n'
+        )
+        with pytest.raises(
+            ConfigError, match=r"constraints\[0\] is not a valid requirement"
+        ):
+            read_pyproject_config(path)
+
+    def test_packages_selector(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            f'[tool.nab.packages."widget >= {_PAST_INT_LIMIT}"]\n'
+            'dist-policy = "sdist-only"\n',
+        )
+        with pytest.raises(ConfigError, match="is not a valid PEP 508 requirement"):
+            read_pyproject_config(path, discover_workspace=False)
+
+    def test_package_rules_match(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[[tool.nab.package-rules]]\n"
+            f'match = ["widget >= {_PAST_INT_LIMIT}"]\n'
+            'dist-policy = "sdist-only"\n',
+        )
+        with pytest.raises(ConfigError, match="is not a valid PEP 508 requirement"):
+            read_pyproject_config(path, discover_workspace=False)
+
+    def test_package_override_requires_python(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            f'[tool.nab.packages.widget]\nrequires-python = ">={_PAST_INT_LIMIT}"\n',
+        )
+        with pytest.raises(
+            ConfigError, match="requires-python must be a PEP 440 specifier"
+        ):
+            read_pyproject_config(path, discover_workspace=False)
+
+    def test_package_override_dependencies(self, tmp_path: Path) -> None:
+        path = write(
+            tmp_path,
+            "[tool.nab.packages.widget]\n"
+            f'dependencies = ["gadget >= {_PAST_INT_LIMIT}"]\n',
+        )
+        with pytest.raises(
+            ConfigError, match=r"dependencies\[0\] is not a valid PEP 508 requirement"
+        ):
+            read_pyproject_config(path, discover_workspace=False)
+
+
 class TestWorkspace:
     """``[tool.nab.workspace]`` parses into a typed :class:`WorkspaceConfig`."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1507,6 +1507,24 @@ class TestProjectFlagErrors:
         assert "[tool.nab]" not in err
         assert not out.exists()
 
+    def test_requires_python_digit_run_past_int_limit_names_the_flag(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Version() raises a bare ValueError for a digit run past CPython's
+        # int limit, so the flag parse must reject it like any bad value.
+        pyproject = _make_pyproject(tmp_path)
+        out = tmp_path / "pylock.toml"
+        with pytest.raises(SystemExit) as exc:
+            lock(pyproject, output=out, project_requires_python=">=3." + "9" * 5000)
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert (
+            "error: --project-requires-python: requires-python must be a"
+            " PEP 440 specifier" in err
+        )
+        assert "[tool.nab]" not in err
+        assert not out.exists()
+
     def test_download_requires_python_bad_value_names_the_flag(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -446,6 +446,17 @@ class TestConfigErrors:
         assert "[tool.nab] must be a table" in err
         assert type_name in err
 
+    def test_version_digit_run_past_int_limit_exits(
+        self, hermetic_roots: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # The read-only inspector hits the same validators as the resolve, so
+        # a digit run past CPython's int limit exits with the one-line error.
+        _project(hermetic_roots, 'environment = { python = "3.' + "9" * 5000 + '" }\n')
+        with pytest.raises(SystemExit) as exc:
+            config_command("list", path=hermetic_roots / "pyproject.toml")
+        assert exc.value.code == 1
+        assert "environment.python must be a version like" in capsys.readouterr().err
+
     def test_cli_offline_override_layer(self, hermetic_roots: Path) -> None:
         _project(hermetic_roots)
         buf = io.StringIO()
@@ -977,6 +988,16 @@ class TestProjectCliOverrides:
         # not a reusable absolute cutoff, so it pins no lock anchor.
         proj = _project(hermetic_roots)
         assert nab_cli.lock_anchor(proj, {"uploaded-prior-to": "P7D"}) is None
+
+    def test_lock_anchor_swallows_digit_run_past_int_limit(
+        self, hermetic_roots: Path
+    ) -> None:
+        # A digit run past CPython's int limit raises a bare ValueError;
+        # the best-effort anchor read swallows it like any config error.
+        proj = _project(
+            hermetic_roots, 'environment = { python = "3.' + "9" * 5000 + '" }\n'
+        )
+        assert nab_cli.lock_anchor(proj) is None
 
 
 class TestDownloadLadder:


### PR DESCRIPTION
A [tool.nab] version whose digit run exceeds CPython's 4300 digit int-from-string limit escaped config validation as a raw ValueError traceback instead of the usual one line config error. It hit nab lock, nab download, and even the read-only nab config list/get/explain.

The validators only caught InvalidVersion and InvalidSpecifier, but Version() raises a bare ValueError for these strings, and a specifier defers parsing its versions until the first comparison, so the guards never saw it. The validators now catch ValueError (the Invalid* exceptions are subclasses of it) and force the deferred parse with to_range(), so every such value is rejected with the message naming the offending key or flag.
