### PR TITLE
reject unsafe canary benchmark selections

### DIFF
--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -456,6 +456,115 @@ def run_one(  # noqa: PLR0913 - one wrapper per scenario knob
         }
 
 
+_PORTABLE_COMPONENT_START = frozenset(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_"
+)
+_PORTABLE_COMPONENT_CHARS = _PORTABLE_COMPONENT_START | frozenset(".-")
+_MAX_PORTABLE_COMPONENT_LENGTH = 128
+_WINDOWS_RESERVED_COMPONENTS = frozenset(
+    {
+        "aux",
+        "con",
+        "nul",
+        "prn",
+        *(f"com{number}" for number in range(1, 10)),
+        *(f"lpt{number}" for number in range(1, 10)),
+    }
+)
+
+
+class _SelectionError(ValueError):
+    """Raised when benchmark inputs select an unsafe or missing path."""
+
+
+def _is_portable_path_component(value: str) -> bool:
+    """Return whether *value* fits the portable ASCII filename grammar."""
+    if (
+        not value
+        or len(value) > _MAX_PORTABLE_COMPONENT_LENGTH
+        or value[0] not in _PORTABLE_COMPONENT_START
+        or value.endswith(".")
+        or any(char not in _PORTABLE_COMPONENT_CHARS for char in value)
+    ):
+        return False
+    windows_basename = value.partition(".")[0].casefold()
+    return windows_basename not in _WINDOWS_RESERVED_COMPONENTS
+
+
+def _result_directory_label(value: str) -> str:
+    """Validate a user-provided results-directory label."""
+    if not _is_portable_path_component(value):
+        msg = f"commit label must use a portable ASCII filename, got {value!r}"
+        raise argparse.ArgumentTypeError(msg)
+    return value
+
+
+def _result_directory(label: str) -> Path:
+    """Return a direct, non-symlinked child of the configured results directory."""
+    results_dir = RESULTS_DIR.resolve()
+    candidate = RESULTS_DIR / label
+    if candidate.is_symlink() or candidate.resolve().parent != results_dir:
+        msg = f"results directory for {label!r} must be a direct child of RESULTS_DIR"
+        raise _SelectionError(msg)
+    return candidate
+
+
+def _scenario_file(toml_stem: str) -> Path:
+    """Return a top-level TOML path contained by the scenarios directory."""
+    if not _is_portable_path_component(toml_stem):
+        msg = (
+            f"scenario file stem must use a portable ASCII filename, got {toml_stem!r}"
+        )
+        raise _SelectionError(msg)
+    scenarios_dir = SCENARIOS_DIR.resolve()
+    toml_path = (scenarios_dir / f"{toml_stem}.toml").resolve()
+    if not toml_path.is_relative_to(scenarios_dir):
+        msg = f"scenario file {toml_stem!r} resolves outside SCENARIOS_DIR"
+        raise _SelectionError(msg)
+    return toml_path
+
+
+def select_scenarios(specs: list[str]) -> list[str]:
+    """Validate every selection before a benchmark run or result write."""
+    if not specs:
+        msg = "at least one scenario must be selected"
+        raise _SelectionError(msg)
+    missing = [spec for spec in specs if find_scenario(spec) is None]
+    if missing:
+        label = "scenario" if len(missing) == 1 else "scenarios"
+        msg = f"{label} not found: {', '.join(repr(spec) for spec in missing)}"
+        raise _SelectionError(msg)
+    return specs
+
+
+def _parse_scenario_selection(
+    parser: argparse.ArgumentParser,
+    specs: list[str],
+) -> list[str]:
+    try:
+        return select_scenarios(specs)
+    except _SelectionError as exc:
+        parser.error(str(exc))
+
+
+def _check_result_directory(
+    parser: argparse.ArgumentParser,
+    label: str,
+) -> None:
+    try:
+        _result_directory(label)
+    except _SelectionError as exc:
+        parser.error(str(exc))
+
+
+def _summary_path(parser: argparse.ArgumentParser, label: str) -> Path:
+    try:
+        out_dir = _result_directory(label)
+    except _SelectionError as exc:
+        parser.error(str(exc))
+    return out_dir / f"canary_{int(time.time())}.json"
+
+
 def find_scenario(spec: str) -> dict | None:
     """Locate a scenario by name, or by ``stem:name`` to pin a specific TOML file.
 
@@ -466,15 +575,24 @@ def find_scenario(spec: str) -> dict | None:
     can pin the variant with ``stem:name``.
     """
     if ":" in spec:
+        if (
+            len(spec) >= 3
+            and spec[0].isalpha()
+            and spec[1] == ":"
+            and spec[2] in {"/", "\\"}
+        ):
+            msg = f"scenario file stem must use a portable ASCII filename, got {spec!r}"
+            raise _SelectionError(msg)
         toml_stem, name = spec.split(":", 1)
-        toml_path = SCENARIOS_DIR / f"{toml_stem}.toml"
+        toml_path = _scenario_file(toml_stem)
         if not toml_path.is_file():
             return None
         with toml_path.open("rb") as f:
             return tomllib.load(f).get(name)
 
     matches: list[tuple[str, dict]] = []
-    for toml_file in sorted(SCENARIOS_DIR.glob("*.toml")):
+    for entry in sorted(SCENARIOS_DIR.glob("*.toml")):
+        toml_file = _scenario_file(entry.stem)
         with toml_file.open("rb") as f:
             data = tomllib.load(f)
         if spec in data:
@@ -633,7 +751,7 @@ def median_run(
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run canary benchmark")
-    parser.add_argument("--commit", default=None)
+    parser.add_argument("--commit", type=_result_directory_label, default=None)
     parser.add_argument("--runs", type=int, default=3)
     parser.add_argument("--scenario", action="append", help="Run only named scenarios")
     parser.add_argument("--scenarios-list", help="File with one scenario per line")
@@ -645,11 +763,14 @@ def main() -> None:
     scenarios_to_run: list[str]
     if args.scenarios_list:
         with Path(args.scenarios_list).open(encoding="utf-8") as f:
-            scenarios_to_run = [line.strip() for line in f if line.strip()]
+            scenarios_to_run = _parse_scenario_selection(
+                parser,
+                [line.strip() for line in f if line.strip()],
+            )
     elif args.scenario:
-        scenarios_to_run = args.scenario
+        scenarios_to_run = _parse_scenario_selection(parser, args.scenario)
     else:
-        scenarios_to_run = list(CANARY_SCENARIOS)
+        scenarios_to_run = _parse_scenario_selection(parser, list(CANARY_SCENARIOS))
 
     labels = [name.split(":", 1)[-1] for name in scenarios_to_run]
     duplicate_labels = sorted({label for label in labels if labels.count(label) > 1})
@@ -673,6 +794,7 @@ def main() -> None:
         f"{'max_dec':>8}"
     )
     print("-" * 110)
+    _check_result_directory(parser, commit)
 
     summary_all: dict[str, dict] = {}
     for name, label in zip(scenarios_to_run, labels, strict=True):
@@ -716,8 +838,9 @@ def main() -> None:
             f"{summary['max_decisions']:>8}"
         )
 
-    out_file = out_dir / f"canary_{int(time.time())}.json"
-    out_file.write_text(json.dumps(summary_all, indent=2) + "\n")
+    out_file = _summary_path(parser, commit)
+    with out_file.open("x", encoding="utf-8") as f:
+        f.write(json.dumps(summary_all, indent=2) + "\n")
     print(f"\nResults: {out_file}")
 
 

--- a/nab-python/tests/test_benchmark_canary_selection.py
+++ b/nab-python/tests/test_benchmark_canary_selection.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_CANARY = Path(__file__).resolve().parents[1] / "benchmarks" / "canary.py"
+_EXPECTED_CANARY_CASES = 19
+
+
+def _harness() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "_benchmark_canary_selection", _CANARY
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_scenario(path: Path, name: str = "example") -> dict[str, object]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f'[{name}]\npython_version = "3.11"\nrequirements = ["demo"]\n',
+        encoding="utf-8",
+    )
+    return {"python_version": "3.11", "requirements": ["demo"]}
+
+
+def _resolve_path_as(
+    monkeypatch: pytest.MonkeyPatch,
+    path: Path,
+    target: Path,
+) -> None:
+    original_resolve = Path.resolve
+    resolved_target = target.resolve()
+
+    def resolve(candidate: Path, strict: bool = False) -> Path:
+        if candidate == path:
+            return resolved_target
+        return original_resolve(candidate, strict=strict)
+
+    monkeypatch.setattr(Path, "resolve", resolve)
+
+
+def test_default_canary_selection_remains_19_cases() -> None:
+    module = _harness()
+
+    selected = module.select_scenarios(list(module.CANARY_SCENARIOS))
+
+    assert len(selected) == _EXPECTED_CANARY_CASES
+    assert selected == module.CANARY_SCENARIOS
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        "6110d2d3",
+        "verify-base-6110d2d3",
+        "verify-branch-7669d712",
+        "benchmark_1",
+        "a" * 128,
+    ],
+)
+def test_result_directory_label_accepts_one_component(label: str) -> None:
+    module = _harness()
+
+    assert module._result_directory_label(label) == label
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        "",
+        ".",
+        "..",
+        "../escape",
+        "/absolute",
+        "nested/path",
+        "nested\\path",
+        "..\\escape",
+        "C:\\absolute",
+        "C:/absolute",
+        "C:drive-relative",
+        "\\rooted",
+        "\\\\server\\share",
+        "a" * 129,
+    ],
+)
+def test_result_directory_label_rejects_escaping_or_nested_paths(label: str) -> None:
+    module = _harness()
+
+    with pytest.raises(
+        argparse.ArgumentTypeError,
+        match="commit label must use a portable ASCII filename",
+    ):
+        module._result_directory_label(label)
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        "CON",
+        "con.txt",
+        "PRN",
+        "AUX.log",
+        "NUL",
+        "COM1",
+        "com9.json",
+        "LPT1",
+        "lpt9.txt",
+        "label.",
+        "label ",
+        "space label",
+        ".hidden",
+        "-leading-hyphen",
+        "label<",
+        "label>",
+        'label"',
+        "label|",
+        "label?",
+        "label*",
+        "résumé",
+    ],
+)
+def test_result_directory_label_rejects_nonportable_windows_names(
+    label: str,
+) -> None:
+    module = _harness()
+
+    with pytest.raises(argparse.ArgumentTypeError):
+        module._result_directory_label(label)
+
+
+def test_invalid_commit_label_exits_before_creating_results(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _harness()
+    results_dir = tmp_path / "results"
+    monkeypatch.setattr(module, "RESULTS_DIR", results_dir)
+    monkeypatch.setattr(sys, "argv", ["canary.py", "--commit", "../escape"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main()
+
+    assert exc_info.value.code == 2
+    assert "commit label must use a portable ASCII filename" in capsys.readouterr().err
+    assert not results_dir.exists()
+
+
+def test_result_directory_rejects_symlinked_child(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+    link = results_dir / "safe"
+    original_is_symlink = Path.is_symlink
+
+    def is_symlink(path: Path) -> bool:
+        return path == link or original_is_symlink(path)
+
+    monkeypatch.setattr(Path, "is_symlink", is_symlink)
+    monkeypatch.setattr(module, "RESULTS_DIR", results_dir)
+
+    with pytest.raises(ValueError, match="must be a direct child of RESULTS_DIR"):
+        module._result_directory("safe")
+
+
+def test_existing_summary_is_not_overwritten(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    scenarios_dir = tmp_path / "scenarios"
+    scenarios_dir.mkdir()
+    (scenarios_dir / "inside.toml").write_text(
+        '[skipped]\nunsupported_reason = "test fixture"\n',
+        encoding="utf-8",
+    )
+    results_dir = tmp_path / "results"
+    out_dir = results_dir / "safe"
+    out_dir.mkdir(parents=True)
+    existing = out_dir / "canary_123.json"
+    existing.write_text("sentinel\n", encoding="utf-8")
+    monkeypatch.setattr(module, "SCENARIOS_DIR", scenarios_dir)
+    monkeypatch.setattr(module, "RESULTS_DIR", results_dir)
+    monkeypatch.setattr(module.time, "time", lambda: 123)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["canary.py", "--commit", "safe", "--scenario", "inside:skipped"],
+    )
+
+    with pytest.raises(FileExistsError):
+        module.main()
+
+    assert existing.read_text(encoding="utf-8") == "sentinel\n"
+
+
+def test_find_scenario_reads_a_real_toml_inside_scenarios_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    scenarios_dir = tmp_path / "scenarios"
+    expected = _write_scenario(scenarios_dir / "inside.toml")
+    monkeypatch.setattr(module, "SCENARIOS_DIR", scenarios_dir)
+
+    assert module.find_scenario("inside:example") == expected
+
+
+def test_find_scenario_rejects_parent_traversal_to_a_real_toml(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    scenarios_dir = tmp_path / "scenarios"
+    scenarios_dir.mkdir()
+    _write_scenario(tmp_path / "outside.toml")
+    monkeypatch.setattr(module, "SCENARIOS_DIR", scenarios_dir)
+
+    with pytest.raises(ValueError, match="scenario file stem must use a portable"):
+        module.find_scenario("../outside:example")
+
+
+def test_find_scenario_rejects_absolute_path_to_a_real_toml(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    scenarios_dir = tmp_path / "scenarios"
+    scenarios_dir.mkdir()
+    outside = tmp_path / "outside.toml"
+    _write_scenario(outside)
+    monkeypatch.setattr(module, "SCENARIOS_DIR", scenarios_dir)
+
+    with pytest.raises(ValueError, match="scenario file stem must use a portable"):
+        module.find_scenario(f"{outside.with_suffix('')}:example")
+
+
+def test_find_scenario_rejects_windows_parent_traversal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    scenarios_dir = tmp_path / "scenarios"
+    scenarios_dir.mkdir()
+    monkeypatch.setattr(module, "SCENARIOS_DIR", scenarios_dir)
+
+    with pytest.raises(ValueError, match="scenario file stem must use a portable"):
+        module.find_scenario("..\\outside:example")
+
+
+def test_find_scenario_rejects_symlink_outside_scenarios_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    scenarios_dir = tmp_path / "scenarios"
+    scenarios_dir.mkdir()
+    outside = tmp_path / "outside.toml"
+    _write_scenario(outside)
+    link = scenarios_dir / "linked.toml"
+    _write_scenario(link)
+    _resolve_path_as(monkeypatch, link, outside)
+    monkeypatch.setattr(module, "SCENARIOS_DIR", scenarios_dir)
+
+    with pytest.raises(ValueError, match="resolves outside SCENARIOS_DIR"):
+        module.find_scenario("linked:example")
+
+
+def test_bare_scenario_rejects_symlink_outside_scenarios_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    scenarios_dir = tmp_path / "scenarios"
+    scenarios_dir.mkdir()
+    outside = tmp_path / "outside.toml"
+    _write_scenario(outside)
+    link = scenarios_dir / "linked.toml"
+    _write_scenario(link)
+    _resolve_path_as(monkeypatch, link, outside)
+    monkeypatch.setattr(module, "SCENARIOS_DIR", scenarios_dir)
+
+    with pytest.raises(ValueError, match="resolves outside SCENARIOS_DIR"):
+        module.find_scenario("example")
+
+
+def test_missing_scenario_exits_before_creating_results(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _harness()
+    scenarios_dir = tmp_path / "scenarios"
+    scenarios_dir.mkdir()
+    (scenarios_dir / "inside.toml").write_text(
+        '[known]\nunsupported_reason = "test fixture"\n',
+        encoding="utf-8",
+    )
+    results_dir = tmp_path / "results"
+    monkeypatch.setattr(module, "SCENARIOS_DIR", scenarios_dir)
+    monkeypatch.setattr(module, "RESULTS_DIR", results_dir)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "canary.py",
+            "--commit",
+            "safe",
+            "--scenario",
+            "inside:known",
+            "--scenario",
+            "missing:example",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main()
+
+    assert exc_info.value.code == 2
+    assert "scenario not found: 'missing:example'" in capsys.readouterr().err
+    assert not results_dir.exists()
+
+
+def test_empty_scenarios_list_exits_before_creating_results(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _harness()
+    scenarios_list = tmp_path / "empty.txt"
+    scenarios_list.write_text("\n  \n", encoding="utf-8")
+    results_dir = tmp_path / "results"
+    monkeypatch.setattr(module, "RESULTS_DIR", results_dir)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "canary.py",
+            "--commit",
+            "safe",
+            "--scenarios-list",
+            str(scenarios_list),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main()
+
+    assert exc_info.value.code == 2
+    assert "at least one scenario must be selected" in capsys.readouterr().err
+    assert not results_dir.exists()


### PR DESCRIPTION
Canary result labels and pinned scenario selectors currently become filesystem paths without validation. Path-like labels can place output outside the benchmark results tree, pinned selectors can load TOML outside the scenario corpus, and missing or empty selections can still produce successful empty results.

Require bounded ASCII filename labels, reject Windows device names, confine selected TOMLs and result directories to their configured roots, and validate the complete nonempty selection before any benchmark begins. Result files are created exclusively so existing artifacts are not overwritten.
