### PR TITLE
reject committed lock requires-python past the int digit limit

### DIFF
--- a/nab-python/src/nab_python/_lockfile/validate.py
+++ b/nab-python/src/nab_python/_lockfile/validate.py
@@ -39,6 +39,7 @@ from .._vendor.packaging.pylock import Pylock, PylockValidationError
 from .._vendor.packaging.requirements import Requirement
 from .._vendor.packaging.specifiers import SpecifierSet
 from .._vendor.packaging.utils import canonicalize_name
+from ..metadata import validate_specifier_versions
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
@@ -278,16 +279,25 @@ def read_committed_pylock(path: Path) -> Pylock:
 
     Raises :class:`OSError` when the file cannot be read,
     :class:`LockfileSyntaxError` when it is not TOML, and
-    :class:`InvalidLockfileError` when it is TOML but not a PEP 751 lock.
+    :class:`InvalidLockfileError` when it is TOML but not a usable
+    PEP 751 lock.
     """
     try:
         data = tomli.loads(path.read_text(encoding="utf-8"))
     except (UnicodeDecodeError, tomli.TOMLDecodeError) as e:
         raise LockfileSyntaxError(str(e)) from e
     try:
-        return Pylock.from_dict(data)
+        pylock = Pylock.from_dict(data)
     except PylockValidationError as e:
         raise InvalidLockfileError(str(e)) from e
+
+    if pylock.requires_python is not None:
+        try:
+            validate_specifier_versions(pylock.requires_python)
+        except ValueError as e:
+            msg = f"{e} in 'requires-python'"
+            raise InvalidLockfileError(msg) from e
+    return pylock
 
 
 def check_locked(  # noqa: PLR0913 - the envelope fields and the validity inputs are each a separate check

--- a/nab-python/tests/test_lockfile_locked.py
+++ b/nab-python/tests/test_lockfile_locked.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -93,8 +94,23 @@ def _write_foreign_lock(path: Path, packages: str) -> Path:
     return path
 
 
+_AT_LIMIT = "9" * sys.get_int_max_str_digits()
+_OVERSIZED = _AT_LIMIT + "9"
+
+
+def _write_requires_python_lock(path: Path, requires_python: str) -> Path:
+    path.write_text(
+        "lock-version = '1.0'\n"
+        "created-by = 'other-tool'\n"
+        f"requires-python = '{requires_python}'\n"
+        "packages = []\n",
+        encoding="utf-8",
+    )
+    return path
+
+
 class TestReadErrors:
-    """A committed lock that cannot be parsed raises a typed error."""
+    """A committed lock that cannot be parsed or used raises a typed error."""
 
     def test_not_toml_raises_syntax_error(self, tmp_path: Path) -> None:
         target = tmp_path / "pylock.toml"
@@ -130,6 +146,32 @@ class TestReadErrors:
                 dependency_groups=(),
                 default_groups=(),
             )
+
+    def test_oversized_requires_python_raises_invalid(self, tmp_path: Path) -> None:
+        """A digit run past int()'s limit parses as a specifier but never converts."""
+        target = _write_requires_python_lock(
+            tmp_path / "pylock.toml", f">={_OVERSIZED}"
+        )
+        with pytest.raises(InvalidLockfileError, match="requires-python"):
+            check_locked(
+                target,
+                requires_python=">=3.10",
+                extras=(),
+                dependency_groups=(),
+                default_groups=(),
+            )
+
+    def test_at_limit_requires_python_is_compared(self, tmp_path: Path) -> None:
+        target = _write_requires_python_lock(tmp_path / "pylock.toml", f">={_AT_LIMIT}")
+        result = check_locked(
+            target,
+            requires_python=">=3.10",
+            extras=(),
+            dependency_groups=(),
+            default_groups=(),
+        )
+        assert result is not None
+        assert "requires-python" in result.reason
 
 
 class TestArtifactUrlFilenames:

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -7,6 +7,7 @@ whether the tier fired: a disqualifier never calls it, a fall-through does.
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Callable
 from contextlib import AbstractContextManager
 from pathlib import Path
@@ -483,6 +484,35 @@ def test_non_pep751_precondition(
 
     assert exc.value.code == 1
     assert "not a valid PEP 751 lockfile" in capsys.readouterr().err
+    mock.assert_not_called()
+
+
+def test_oversized_requires_python_precondition(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # PEP 440 puts no cap on release digits; int() refuses them only at compare time.
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\ndependencies = ["foo"]\n[tool.nab]\nrequires-python = ">=3.10"\n',
+    )
+    out = tmp_path / "pylock.toml"
+    oversized = "9" * (sys.get_int_max_str_digits() + 1)
+    out.write_text(
+        'lock-version = "1.0"\n'
+        f'requires-python = ">={oversized}"\n'
+        'created-by = "nab"\n'
+        "packages = []\n",
+        encoding="utf-8",
+    )
+
+    mock = _locked_mock()
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock)
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "not a valid PEP 751 lockfile" in err
+    assert "requires-python" in err
     mock.assert_not_called()
 
 


### PR DESCRIPTION
`nab lock --locked` crashes with a raw ValueError traceback when the committed pylock's top-level `requires-python` has a release segment longer than CPython's int-from-string limit. `SpecifierSet` keeps clause versions as strings and only converts them when compared, so the bad value survives parsing and blows up later inside `SpecifierSet.__eq__` during the requires-python check.

`read_committed_pylock` now runs `validate_specifier_versions` over the field, the same check metadata parsing already uses, and raises `InvalidLockfileError`, so the command reports an invalid lockfile and exits 1 instead of tracebacking. A digit run at the limit still parses and compares as before.
