### PR TITLE
Keep transitive prerelease admission local to a universal fork

### DIFF
--- a/nab-python/tests/universal/test_external_scenarios.py
+++ b/nab-python/tests/universal/test_external_scenarios.py
@@ -13,12 +13,17 @@ from nab_python.tags import PlatformSpec
 from nab_python.target import Matrix
 
 
-def _wheel(version: str) -> WheelFile:
+def _wheel(
+    package: str,
+    version: str,
+    *,
+    requires_python: str | None = None,
+) -> WheelFile:
     return WheelFile(
-        filename=f"a-{version}-py3-none-any.whl",
-        url=f"https://example.invalid/a-{version}.whl",
+        filename=f"{package}-{version}-py3-none-any.whl",
+        url=f"https://example.invalid/{package}-{version}.whl",
         version=version,
-        requires_python=">=3.12",
+        requires_python=requires_python,
         has_metadata=True,
         upload_time=None,
         hashes=(("sha256", "a" * 64),),
@@ -34,7 +39,11 @@ def test_overlapping_root_markers_cover_each_python_partition() -> None:
     """
     versions = ("1.0.0", "1.1.0", "1.2.0")
     coordinator = make_coordinator(
-        listings={"a": [_wheel(version) for version in versions]},
+        listings={
+            "a": [
+                _wheel("a", version, requires_python=">=3.12") for version in versions
+            ]
+        },
         auto_metadata=True,
     )
     python = ">=3.12,<3.15"
@@ -85,3 +94,90 @@ def test_overlapping_root_markers_cover_each_python_partition() -> None:
     ] == [
         ("a", "1.2.0", ">=3.12", None),
     ]
+
+
+def test_transitive_prerelease_admission_stays_in_its_fork() -> None:
+    """Keep explicit prerelease admission local to the matching target."""
+    a = _wheel("a", "1.0.0")
+    c_stable = _wheel("c", "1.0.0")
+    c_beta = _wheel("c", "2.0.0b1")
+    assert a.metadata_url is not None
+    assert c_stable.metadata_url is not None
+    assert c_beta.metadata_url is not None
+    metadata = {
+        a.metadata_url: (
+            "Metadata-Version: 2.1\n"
+            "Name: a\n"
+            "Version: 1.0.0\n"
+            "Requires-Dist: c>=2.0.0b1 ; sys_platform == 'linux'\n"
+            "Requires-Dist: c==1.0.0 ; sys_platform != 'linux'\n\n"
+        ),
+        c_stable.metadata_url: ("Metadata-Version: 2.1\nName: c\nVersion: 1.0.0\n\n"),
+        c_beta.metadata_url: ("Metadata-Version: 2.1\nName: c\nVersion: 2.0.0b1\n\n"),
+    }
+    coordinator = make_coordinator(
+        listings={"a": [a], "c": [c_stable, c_beta]},
+        metadata_by_url=metadata,
+    )
+    project_python = ">=3.12"
+    witness_python = ">=3.12,<3.13"
+    targets = Matrix(
+        python=witness_python,
+        platforms=(
+            PlatformSpec("linux_x86_64"),
+            PlatformSpec("windows_amd64"),
+        ),
+    ).expand()
+    config = NabProjectConfig(requires_python=project_python)
+
+    result = resolve_with_coordinator(
+        coordinator,
+        targets,
+        [Requirement("a")],
+        config=config,
+    )
+
+    assert result.success
+    assert {
+        target_result.target.label: target_result.pins
+        for target_result in result.target_results
+    } == {
+        "py312-linux_x86_64": {
+            "a": Version("1.0.0"),
+            "c": Version("2.0.0b1"),
+        },
+        "py312-windows_amd64": {
+            "a": Version("1.0.0"),
+            "c": Version("1.0.0"),
+        },
+    }
+
+    pylock = build_pylock(build_lock_input(result, config=config))
+    pylock.validate()
+    assert len(pylock.environments) == len(targets) == 2
+    for target in targets:
+        assert (
+            sum(marker.evaluate(target.marker_env) for marker in pylock.environments)
+            == 1
+        )
+
+    a_packages = [package for package in pylock.packages if str(package.name) == "a"]
+    assert [(str(package.version), package.marker) for package in a_packages] == [
+        ("1.0.0", None)
+    ]
+    assert list(a_packages[0].dependencies or ()) == [{"name": "c"}]
+    c_packages = [package for package in pylock.packages if str(package.name) == "c"]
+    assert len(c_packages) == 2
+    assert {str(package.version) for package in c_packages} == {"1.0.0", "2.0.0b1"}
+    expected_c = {
+        "linux_x86_64": "2.0.0b1",
+        "windows_amd64": "1.0.0",
+    }
+    for target in targets:
+        matching_c = [
+            package
+            for package in c_packages
+            if package.marker is None or package.marker.evaluate(target.marker_env)
+        ]
+        assert len(matching_c) == 1
+        assert str(matching_c[0].version) == expected_c[target.platform_id]


### PR DESCRIPTION
For Python 3.12, the Linux fork's transitive `c>=2.0.0b1` requirement selects `c==2.0.0b1`, while the Windows fork keeps `c==1.0.0`. This adds a universal-lock regression test for that behavior under the default policy.
