### PR TITLE
don't split a Python minor at an epoch-tagged marker literal

### DIFF
--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -561,8 +561,17 @@ def _clause_boundary_points(
 
 
 def _in_minor(point: Version, minor_release: tuple[int, ...], floor: Version) -> bool:
-    """Whether ``point`` is an interior micro of the minor above its floor."""
-    return point.release[:_PYTHON_VERSION_PARTS] == minor_release and point > floor
+    """Whether ``point`` is an interior micro of the minor above its floor.
+
+    An epoch sorts above every version of a lower one, so a boundary with a
+    different epoch is outside the minor whatever its release says:
+    ``1!3.12.4`` is not in ``[3.12.0, 3.13.0)``.
+    """
+    return (
+        point.epoch == floor.epoch
+        and point.release[:_PYTHON_VERSION_PARTS] == minor_release
+        and point > floor
+    )
 
 
 def _clause_interval_literal(

--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -2510,6 +2510,55 @@ class TestMicroBoundaryNarrowing:
         }
         assert any(row.evaluate(real_3119) for row in rows)
 
+    def test_an_epoch_tagged_marker_leaves_the_minor_whole(self) -> None:
+        """``>= "1!3.10.4"`` is False on every interpreter, since none reports
+        an epoch. Cutting the minor there would resolve a slice at
+        ``1!3.10.4`` and gate ``mid`` behind a row nothing matches.
+        """
+        coordinator = self._coordinator(
+            {
+                "1.0": self._meta(
+                    "foo", "1.0", 'mid ; python_full_version >= "1!3.10.4"'
+                ),
+                "2.0": self._meta("mid", "2.0"),
+            }
+        )
+        targets = Matrix(
+            python="==3.10", platforms=(PlatformSpec("linux_x86_64"),)
+        ).expand()
+
+        result = resolve_with_coordinator(
+            coordinator, targets, _reqs("foo"), config=_no_build()
+        )
+
+        assert result.success
+        assert self._pins_by_label(result) == {"py310-linux_x86_64": {"foo"}}
+        rows = build_lock_input(result, config=_no_build()).environments
+        assert len(rows) == 1
+
+    def test_an_epoch_tagged_marker_does_not_fail_the_resolve(self) -> None:
+        """A dep the index does not serve, gated on an epoch, is inactive on
+        every real 3.10, so the resolve succeeds rather than failing on a
+        slice no interpreter reaches.
+        """
+        coordinator = self._coordinator(
+            {
+                "1.0": self._meta(
+                    "foo", "1.0", 'absent ; python_full_version >= "1!3.10.4"'
+                )
+            }
+        )
+        targets = Matrix(
+            python="==3.10", platforms=(PlatformSpec("linux_x86_64"),)
+        ).expand()
+
+        result = resolve_with_coordinator(
+            coordinator, targets, _reqs("foo"), config=_no_build()
+        )
+
+        assert result.success
+        assert self._pins_by_label(result) == {"py310-linux_x86_64": {"foo"}}
+
     def _fixpoint_coordinator(self) -> MagicMock:
         return self._coordinator(
             {

--- a/nab-python/tests/test_target.py
+++ b/nab-python/tests/test_target.py
@@ -1264,6 +1264,38 @@ class TestMicroBoundarySplitting:
         ]
         assert micro_boundary_points(self._target(), markers) == []
 
+    @pytest.mark.parametrize(
+        "marker",
+        [
+            'python_full_version < "1!3.12.4"',
+            'python_full_version >= "1!3.12.4"',
+            'python_full_version <= "1!3.12.4"',
+            'python_full_version > "1!3.12.4"',
+            'python_full_version == "1!3.12.4"',
+            'python_full_version != "1!3.12.4"',
+            'python_full_version ~= "1!3.12.4"',
+            'python_full_version == "1!3.12.*"',
+            'python_full_version < "1!3.12.4rc1"',
+            '"1!3.12.4" > python_full_version',
+            'implementation_version >= "1!3.12.4"',
+        ],
+    )
+    def test_an_epoch_tagged_literal_does_not_split(self, marker: str) -> None:
+        """An epoch-tagged literal is outside ``[3.12.0, 3.13.0)`` whatever
+        its release says, and no interpreter reports an epoch, so the clause
+        is uniform across the real minor and splits nothing.
+        """
+        assert micro_boundary_points(self._target(), [Marker(marker)]) == []
+
+    def test_an_epoch_tagged_literal_reads_the_same_on_every_micro(self) -> None:
+        """The clause a split would have cut at reads the same on the slice
+        representative as on every real micro of the minor.
+        """
+        marker = Marker('python_full_version >= "1!3.12.4"')
+        assert not marker.evaluate(self._probe("3.12.0"))
+        assert not marker.evaluate(self._probe("3.12.4"))
+        assert not marker.evaluate(self._probe("3.12.19"))
+
     def test_a_prerelease_literal_below_the_floor_does_not_split(self) -> None:
         """``>= "3.12.0a1"`` names a prerelease of the floor, so it is uniform
         across the real minor under the rides-with-X convention and crashes


### PR DESCRIPTION
A dependency gated on `python_full_version >= "1!3.10.4"` made a 3.10 resolve split the micro line and solve one half at `1!3.10.4`. No interpreter reports an epoch, so that half is a slice nothing ever matches: the lock came out with an environments row no real Python selects, along with the packages that clause pulls in there. When the index has nothing to serve for the gated dependency, that half turns the whole resolve into a failure on a project every real 3.10 handles fine.

The in-minor test compared release parts only, and `Version("1!3.10.4").release` is `(3, 10, 4)` like any other 3.10.4, so the boundary looked interior. It now compares the epoch too, so a literal from another epoch sits outside the minor and leaves it whole.
