### PR TITLE
reject an absolute or out-of-tree backend-path instead of crashing

### DIFF
--- a/nab-python/src/nab_python/_build/runner.py
+++ b/nab-python/src/nab_python/_build/runner.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import logging
 import lzma
+import os
 import tempfile
 import zipfile
 import zlib
@@ -74,9 +75,9 @@ def run_build_backend(
     Returns a :class:`~nab_python.metadata.WheelMetadata` parsed from
     the ``METADATA`` file the backend produces.  Raises
     :class:`BuildBackendError` on any failure: backend import
-    error, hook crash, malformed METADATA, an unreadable built
-    wheel, sdist-only build deps, or build requirements ``offline``
-    bars from being fetched.
+    error, a rejected ``backend-path``, hook crash, malformed
+    METADATA, an unreadable built wheel, sdist-only build deps, or
+    build requirements ``offline`` bars from being fetched.
 
     The build runs in an isolated venv driven by
     :class:`NabBuildEnv`; nothing in the user's main environment is
@@ -105,7 +106,8 @@ def run_build_backend(
         msg = f"no pyproject.toml or setup.py at {source_dir}"
         raise BuildBackendError(msg)
 
-    backend, requires, _backend_path = _read_build_system(data)
+    backend, requires, backend_path = _read_build_system(data)
+    _validate_backend_path(source_dir, backend_path)
 
     skip_prepare = _should_skip_prepare(backend, data)
 
@@ -188,6 +190,36 @@ def _read_build_system(
     if isinstance(raw_path, list) and all(isinstance(p, str) for p in raw_path):
         backend_path = tuple(raw_path)
     return backend, requires, backend_path
+
+
+def _validate_backend_path(
+    source_dir: Path, backend_path: tuple[str, ...] | None
+) -> None:
+    """Reject a ``backend-path`` a PEP 517 frontend would refuse.
+
+    pyproject_hooks raises a bare ``ValueError`` for an absolute entry
+    or one that leaves the source tree.
+    """
+    root = os.path.abspath(source_dir)
+    norm_root = os.path.normcase(root)
+
+    for entry in backend_path or ():
+        if os.path.isabs(entry):
+            msg = (
+                f"backend-path entry {entry!r} in pyproject.toml must be"
+                " relative to the project root"
+            )
+            raise BuildBackendError(msg)
+
+        # pyproject_hooks compares the two paths as strings, so match that
+        # rather than a stricter containment check.
+        resolved = os.path.normcase(os.path.normpath(os.path.join(root, entry)))
+        if not resolved.startswith(norm_root):
+            msg = (
+                f"backend-path entry {entry!r} in pyproject.toml is outside"
+                " the source tree"
+            )
+            raise BuildBackendError(msg)
 
 
 def _should_skip_prepare(backend: str, data: dict) -> bool:

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -47,6 +47,7 @@ from nab_python._build.env import (
 from nab_python._build.runner import (
     BuildBackendError,
     _build_wheel_and_extract,
+    _validate_backend_path,
     run_build_backend,
 )
 from nab_python._provider.metadata_resolver import pick_dist
@@ -493,6 +494,52 @@ class TestRunBuildBackend:
         )
         with pytest.raises(BuildBackendError, match="must be a table"):
             run_build_backend(tmp_path, config=config)
+
+    def test_backend_path_outside_source_tree_rejected(
+        self, tmp_path: Path, config: NabProjectConfig
+    ) -> None:
+        """A backend-path that leaves the source tree fails the build."""
+        source = tmp_path / "member"
+        source.mkdir()
+        (source / "pyproject.toml").write_text(
+            "[build-system]\n"
+            "requires = []\n"
+            'build-backend = "shared_backend"\n'
+            'backend-path = ["../shared"]\n',
+            encoding="utf-8",
+        )
+        with pytest.raises(BuildBackendError, match="outside the source tree"):
+            run_build_backend(source, config=config)
+
+    def test_absolute_backend_path_rejected(
+        self, tmp_path: Path, config: NabProjectConfig
+    ) -> None:
+        """backend-path entries are relative to the project root."""
+        source = tmp_path / "member"
+        source.mkdir()
+        (source / "pyproject.toml").write_text(
+            "[build-system]\n"
+            "requires = []\n"
+            'build-backend = "shared_backend"\n'
+            f'backend-path = ["{tmp_path.as_posix()}"]\n',
+            encoding="utf-8",
+        )
+        with pytest.raises(BuildBackendError, match="must be relative"):
+            run_build_backend(source, config=config)
+
+    def test_backend_path_to_sibling_sharing_a_prefix_accepted(
+        self, tmp_path: Path
+    ) -> None:
+        """A sibling whose name starts with the source directory's is allowed.
+
+        pyproject_hooks compares the two paths as strings and accepts
+        this entry, so rejecting it here would refuse a tree other
+        frontends build.
+        """
+        (tmp_path / "member-shared").mkdir()
+        source = tmp_path / "member"
+        source.mkdir()
+        _validate_backend_path(source, ("../member-shared",))
 
     def test_venv_creation_oserror_wrapped(
         self,


### PR DESCRIPTION
`nab lock` on a local source whose `[build-system].backend-path` is absolute, or points outside the source tree, fails with a raw `ValueError` traceback from pyproject_hooks. The rejection happens in `ProjectBuilder.from_isolated_env`, before any build hook runs, so `run_build_backend` never gets the chance to turn it into a `BuildBackendError` the way it does for every other build failure.

The runner now checks the entries itself before the build and names the offending one in a `BuildBackendError`. It compares the joined path as a string prefix, the same comparison pyproject_hooks makes, so a sibling directory whose name starts with the source directory's name is still accepted; a stricter containment check would reject it.
