### PR TITLE
fix contributing.md's broken coverage command

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -28,7 +28,16 @@ under `nab_resolver`, `nab_python`, `nab_index`, and `nab`:
 
 ```bash
 .venv/bin/python -m pytest                # default selection (no markers)
-.venv/bin/python -m pytest --cov          # with branch coverage
+```
+
+Branch coverage runs through the `coverage` CLI. Each process writes its
+own data file, so combine before reporting:
+
+```bash
+.venv/bin/python -m coverage erase
+.venv/bin/python -m coverage run -m pytest
+.venv/bin/python -m coverage combine
+.venv/bin/python -m coverage report       # fails below 100 percent
 ```
 
 CI gates each workspace's coverage on its own tests through nox (see
@@ -79,11 +88,11 @@ the floor.
 The `pyproject.toml` `[tool.coverage.report] fail_under = 100`
 setting requires 100 percent branch coverage on every workspace
 package: `nab_resolver`, `nab_python`, `nab_index`, and `nab`. The
-full local suite (`pytest --cov`) checks all four together; nox splits
-them per workspace in CI so each workspace's tests cover only its own
-package, with `nab_index` gated alongside `nab_python`, whose tests
-exercise it. When code is genuinely unreachable from the default
-suite, prefer:
+full local suite under `coverage run -m pytest` checks all four
+together; nox splits them per workspace in CI so each workspace's
+tests cover only its own package, with `nab_index` gated alongside
+`nab_python`, whose tests exercise it. When code is genuinely
+unreachable from the default suite, prefer:
 
 * `# pragma: no cover` for a platform-specific or defensively
   unreachable line.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ only-include = ["src/nab", "tests", "conftest.py"]
 exclude = [
     "tests/test_build_dists.py",
     "tests/test_classifiers.py",
+    "tests/test_contributing_docs.py",
     "tests/test_release.py",
 ]
 

--- a/tests/test_contributing_docs.py
+++ b/tests/test_contributing_docs.py
@@ -1,0 +1,141 @@
+"""Check the contributing page's commands against this check-out.
+
+A contributor pastes these into a shell, so a documented pytest flag has to be
+one the installed pytest accepts, and the documented coverage recipe has to run
+the steps CI's gate runs.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+CONTRIBUTING = REPO_ROOT / "docs" / "contributing.md"
+NOXFILE = REPO_ROOT / "noxfile.py"
+
+_FENCE = re.compile(r"^```.*?^```", re.DOTALL | re.MULTILINE)
+_INLINE = re.compile(r"`([^`\n]+)`")
+
+
+def _documented_commands() -> list[str]:
+    """Every command the page prints, fenced or inline."""
+    text = CONTRIBUTING.read_text(encoding="utf-8")
+    commands = [
+        line for block in _FENCE.findall(text) for line in block.splitlines()[1:-1]
+    ]
+    commands.extend(_INLINE.findall(_FENCE.sub("", text)))
+    return commands
+
+
+def _invocation(command: str) -> tuple[str, tuple[str, ...]] | None:
+    """Split a command into the tool it runs and that tool's arguments."""
+    try:
+        tokens = shlex.split(command, comments=True)
+    except ValueError:
+        return None
+
+    if tokens[1:2] == ["-m"] and PurePosixPath(tokens[0]).name.startswith("python"):
+        tokens = tokens[2:]
+    if not tokens:
+        return None
+
+    return PurePosixPath(tokens[0]).name, tuple(tokens[1:])
+
+
+def _documented_pytest_arguments() -> set[tuple[str, ...]]:
+    """Argument lists the page passes to pytest."""
+    found = set()
+    for command in _documented_commands():
+        invocation = _invocation(command)
+        if invocation is None:
+            continue
+        tool, args = invocation
+        if tool == "pytest":
+            found.add(args)
+        elif tool == "coverage" and args[:3] == ("run", "-m", "pytest"):
+            found.add(args[3:])
+    return found
+
+
+def _documented_coverage_steps() -> set[str]:
+    """Coverage subcommands the page documents."""
+    steps = set()
+    for command in _documented_commands():
+        invocation = _invocation(command)
+        if invocation is not None and invocation[0] == "coverage" and invocation[1]:
+            steps.add(invocation[1][0])
+    return steps
+
+
+def _ci_coverage_steps() -> set[str]:
+    """Coverage subcommands the nox tests session runs."""
+    tree = ast.parse(NOXFILE.read_text(encoding="utf-8"))
+    session = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "tests"
+    )
+
+    steps = set()
+    for call in ast.walk(session):
+        if not isinstance(call, ast.Call):
+            continue
+        literals = [
+            arg.value
+            for arg in call.args
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str)
+        ]
+        if literals[:1] == ["coverage"] and len(literals) > 1:
+            steps.add(literals[1])
+    return steps
+
+
+def test_documented_pytest_arguments_are_accepted() -> None:
+    """Each documented pytest command must parse and name paths that exist."""
+    documented = _documented_pytest_arguments()
+    assert documented, "contributing.md documents no pytest command"
+
+    # The probe sees only the flags the page prints, and writes no coverage data.
+    env = dict(os.environ)
+    env.pop("PYTEST_ADDOPTS", None)
+    env.pop("COVERAGE_PROCESS_START", None)
+
+    for args in sorted(documented):
+        result = subprocess.run(  # noqa: S603 - arguments come from the page
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                *args,
+                "--collect-only",
+                "-q",
+                # Parse the arguments and resolve their paths, collect no test.
+                "--ignore-glob=*",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+            env=env,
+            check=False,
+        )
+        assert result.returncode != pytest.ExitCode.USAGE_ERROR, (
+            f"contributing.md documents `pytest {shlex.join(args)}`, which the "
+            f"installed pytest will not run:\n{result.stdout}{result.stderr}"
+        )
+
+
+def test_documented_coverage_recipe_matches_ci() -> None:
+    """The documented coverage recipe must run every step CI runs."""
+    missing = _ci_coverage_steps() - _documented_coverage_steps()
+    assert not missing, (
+        f"contributing.md omits the coverage step(s) CI runs: {sorted(missing)}"
+    )


### PR DESCRIPTION
docs/contributing.md tells contributors to measure branch coverage with `.venv/bin/python -m pytest --cov`, but pytest-cov is not declared anywhere in the repo, so pytest exits 4 on the unrecognized argument without running a test. The tests dependency-group pins `coverage` instead, and noxfile.py drives its CLI directly.

The page now documents that recipe (coverage erase, coverage run -m pytest, combine, report), which is what the nox tests session runs, and the coverage policy section further down no longer points at the dead flag. tests/test_contributing_docs.py parses every pytest command the page prints with pytest's own argument parser and checks the documented coverage steps against noxfile.py, so the page and the noxfile stay in step.
