### PR TITLE
keep a conditional dependency inside its package fork

### DIFF
--- a/nab-python/tests/universal/test_external_scenarios.py
+++ b/nab-python/tests/universal/test_external_scenarios.py
@@ -181,3 +181,96 @@ def test_transitive_prerelease_admission_stays_in_its_fork() -> None:
         ]
         assert len(matching_c) == 1
         assert str(matching_c[0].version) == expected_c[target.platform_id]
+
+
+def test_conditional_dependency_stays_in_its_package_fork() -> None:
+    a_old = _wheel("a", "1.0.0")
+    a_new = _wheel("a", "2.0.0")
+    b = _wheel("b", "1.0.0")
+    assert a_old.metadata_url is not None
+    assert a_new.metadata_url is not None
+    assert b.metadata_url is not None
+    metadata = {
+        a_old.metadata_url: (
+            "Metadata-Version: 2.1\n"
+            "Name: a\n"
+            "Version: 1.0.0\n"
+            "Requires-Dist: b ; sys_platform == 'linux'\n\n"
+        ),
+        a_new.metadata_url: (
+            "Metadata-Version: 2.1\n"
+            "Name: a\n"
+            "Version: 2.0.0\n"
+            "Requires-Dist: b ; sys_platform == 'linux'\n\n"
+        ),
+        b.metadata_url: "Metadata-Version: 2.1\nName: b\nVersion: 1.0.0\n\n",
+    }
+    coordinator = make_coordinator(
+        listings={"a": [a_old, a_new], "b": [b]},
+        metadata_by_url=metadata,
+    )
+    project_python = ">=3.12"
+    witness_python = ">=3.12,<3.13"
+    targets = Matrix(
+        python=witness_python,
+        platforms=(
+            PlatformSpec("linux_x86_64"),
+            PlatformSpec("macos_arm64"),
+        ),
+    ).expand()
+    config = NabProjectConfig(requires_python=project_python)
+
+    result = resolve_with_coordinator(
+        coordinator,
+        targets,
+        [
+            Requirement("a>=2 ; sys_platform == 'linux'"),
+            Requirement("a<2 ; sys_platform == 'darwin'"),
+        ],
+        config=config,
+    )
+
+    assert result.success
+    assert {
+        target_result.target.label: target_result.pins
+        for target_result in result.target_results
+    } == {
+        "py312-linux_x86_64": {
+            "a": Version("2.0.0"),
+            "b": Version("1.0.0"),
+        },
+        "py312-macos_arm64": {"a": Version("1.0.0")},
+    }
+
+    pylock = build_pylock(build_lock_input(result, config=config))
+    pylock.validate()
+    assert len(pylock.environments) == len(targets) == 2
+    for target in targets:
+        assert (
+            sum(marker.evaluate(target.marker_env) for marker in pylock.environments)
+            == 1
+        )
+
+    a_packages = [package for package in pylock.packages if str(package.name) == "a"]
+    assert len(a_packages) == 2
+    assert {str(package.version) for package in a_packages} == {"1.0.0", "2.0.0"}
+    a_by_version = {str(package.version): package for package in a_packages}
+    assert list(a_by_version["1.0.0"].dependencies or ()) == []
+    assert list(a_by_version["2.0.0"].dependencies or ()) == [{"name": "b"}]
+
+    b_packages = [package for package in pylock.packages if str(package.name) == "b"]
+    assert len(b_packages) == 1
+    assert str(b_packages[0].version) == "1.0.0"
+    assert b_packages[0].marker is not None
+
+    expected_packages = {
+        "linux_x86_64": [("a", "2.0.0"), ("b", "1.0.0")],
+        "macos_arm64": [("a", "1.0.0")],
+    }
+    for target in targets:
+        matching_packages = sorted(
+            (str(package.name), str(package.version))
+            for package in pylock.packages
+            if package.marker is None or package.marker.evaluate(target.marker_env)
+        )
+        assert matching_packages == expected_packages[target.platform_id]


### PR DESCRIPTION
For CPython 3.12, Linux selects `a==2.0.0` with its Linux-only `b==1.0.0` dependency, while macOS selects `a==1.0.0` without `b`. This adds a universal-lock case that checks the package markers and keeps the `a==2.0.0` to `b` edge inside the Linux fork.
