### PR TITLE
reject a NUL in cache-dir as a config error instead of crashing

### DIFF
--- a/nab-python/src/nab_python/config_sources.py
+++ b/nab-python/src/nab_python/config_sources.py
@@ -43,7 +43,7 @@ from nab_index.serialization import SimpleSerialization
 
 from ._toml import tool_nab_section
 from .fetch import DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL
-from .paths import PathState, path_state
+from .paths import PathState, is_usable_path_name, path_state
 from .provider import (
     ArchiveSource,
     BuildPolicy,
@@ -329,6 +329,9 @@ def _parse_path(value: Any, where: str) -> Path:
         # An empty NAB_CACHE_DIR would resolve Path("") to the cwd; reject
         # it instead.
         msg = f"{where} must be a non-empty path"
+        raise SourceConfigError(msg)
+    if not is_usable_path_name(value):
+        msg = f"{where} {value!r} is not a usable filesystem path"
         raise SourceConfigError(msg)
     return Path(value)
 

--- a/nab-python/src/nab_python/paths.py
+++ b/nab-python/src/nab_python/paths.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 __all__ = [
     "PathState",
     "is_absent_error",
+    "is_usable_path_name",
     "path_state",
     "resolve_path",
 ]
@@ -77,14 +78,22 @@ def path_state(path: Path) -> PathState:
     return PathState.OTHER
 
 
+def is_usable_path_name(entry: str) -> bool:
+    """Whether the filesystem can carry ``entry`` as a name.
+
+    An embedded NUL has to be tested for rather than caught: building a
+    ``Path`` never raises on one, and a non-strict resolve keeps it in
+    the path on Windows.
+    """
+    return "\x00" not in entry
+
+
 def resolve_path(base: Path, entry: str) -> Path | None:
     """Resolve ``entry`` against ``base``, or ``None`` for an unusable name.
 
-    An embedded NUL is checked up front because Windows keeps it in the
-    resolved path instead of raising; other unencodable names raise from
-    the resolve itself.
+    Unencodable names other than a NUL raise from the resolve itself.
     """
-    if "\x00" in entry:
+    if not is_usable_path_name(entry):
         return None
     try:
         return (base / entry).resolve()

--- a/nab-python/tests/test_config_sources.py
+++ b/nab-python/tests/test_config_sources.py
@@ -318,6 +318,15 @@ class TestCacheDirLadder:
                 environ={"NAB_CACHE_DIR": ""},
             )
 
+    def test_cache_dir_with_nul_errors(self, tmp_path: Path) -> None:
+        # An embedded NUL is valid TOML, so the parser hands it through.
+        _project(tmp_path)
+        user = _write(
+            tmp_path / "usr" / "nab" / "nab.toml", 'cache-dir = "/c/\\u0000x"\n'
+        )
+        with pytest.raises(SourceConfigError, match="is not a usable filesystem path"):
+            _resolve(SourceRoots(user_toml=user, project_dir=tmp_path))
+
 
 class TestHttpBackendLadder:
     def test_default(self, tmp_path: Path) -> None:

--- a/tests/test_cache_cmd.py
+++ b/tests/test_cache_cmd.py
@@ -205,6 +205,15 @@ class TestLayeredCacheDir:
         assert exc.value.code == 1
         assert "config error" in capsys.readouterr().err
 
+    def test_nul_layer_value_exits_one(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _write_toml(tmp_path / _PROJECT_TOML, 'cache-dir = "/c/\\u0000x"\n')
+        with pytest.raises(SystemExit) as exc:
+            _run_cache(["verify"])
+        assert exc.value.code == 1
+        assert "is not a usable filesystem path" in capsys.readouterr().err
+
     def test_discovery_anchored_at_working_dir(
         self, config_anchors: list[Path], capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
A cache-dir with an embedded NUL, set in nab.toml or through NAB_CACHE_DIR, was turned into a Path with no check. Path accepts the NUL, so nothing failed until the cache directory was touched, and the failure surfaced as a raw `ValueError: embedded null byte` traceback out of `nab lock`, `nab download`, `nab cache verify` and `nab cache clear` instead of the config error that every other bad value for that key produces.

The config path parser now rejects a name the filesystem cannot carry, so it reports the key and the offending value like any other config error. The NUL check `resolve_path` already had moves into a shared helper in `paths.py`.
