### PR TITLE
ban only the versions look-ahead rejected

### DIFF
--- a/nab-python/src/nab_python/_provider/lookahead.py
+++ b/nab-python/src/nab_python/_provider/lookahead.py
@@ -1,17 +1,19 @@
 """Decision-aware look-ahead for :class:`nab_python.provider.Provider`.
 
-Owns ``_look_ahead_ok`` and the pending-block tables that record
-"this candidate is incompatible with this decision/positive range"
-rejections.  Each rejection becomes a grouped binary
-incompatibility (``{candidate range, blocker range}``) when
-``flush_pending_blocks`` runs at the end of ``choose_version``.
-Version-derived terms are widened onto the listing's gaps, which
-leaves the selectable versions they name unchanged.  The blocker term
-widens further when every rejection in the group recorded a dependency
-range: each fired because the blocker sat outside that range, so every
-blocker version outside their union repeats the same rejections.
-Groups queued without ranges, such as the extras block path, keep the
-narrower term.
+Owns ``_look_ahead_ok`` and the pending-block tables that record why a
+candidate was rejected.  ``flush_pending_blocks`` turns those into
+incompatibilities at the end of ``choose_version``.  A decision or
+positive-range rejection becomes a grouped binary incompatibility
+(``{candidate range, blocker range}``).  Version-derived terms are
+widened onto the listing's gaps, which leaves the selectable versions
+they name unchanged.  The blocker term widens further when every
+rejection in the group recorded a dependency range: each fired because
+the blocker sat outside that range, so every blocker version outside
+their union repeats the same rejections.  Groups queued without ranges,
+such as the extras block path, keep the narrower term.
+
+A root-requirement or metadata rejection has no blocker to name: nothing
+later in the resolve undoes it, so its versions are banned outright.
 """
 
 from __future__ import annotations
@@ -25,6 +27,8 @@ from .._vendor.packaging.ranges import VersionRange
 from .._vendor.packaging.utils import canonicalize_name
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from .._vendor.packaging.version import Version
     from ..provider import Provider
 
@@ -91,8 +95,6 @@ def look_ahead_ok(
     for dep_name, dep_range in deps.items():
         dep_normalized = canonicalize_name(dep_name)
 
-        # Root-requirement disagreement: diagnostic-only (the resolver
-        # already has the clause via its root_requirements input).
         if dep_normalized in provider.root_requirements:
             root_range = provider.root_requirements[dep_normalized]
             if dep_range.is_disjoint(root_range):
@@ -144,6 +146,16 @@ def _widen_or_singleton(
     return VersionRange.singleton(version) if widened is None else widened
 
 
+def _candidate_union(
+    provider: Provider, package: str, versions: Iterable[Version]
+) -> VersionRange:
+    """Return the widened union of one group's rejected candidate versions."""
+    union = VersionRange.empty()
+    for version in versions:
+        union = union | _widen_or_singleton(provider, package, version)
+    return union
+
+
 def _membership_widened(
     accumulated: DepRangeUnion, rejections: int
 ) -> VersionRange | None:
@@ -165,7 +177,7 @@ def _membership_widened(
 
 
 def flush_pending_blocks(provider: Provider) -> None:
-    """Convert queued rejections into grouped binary incompatibilities.
+    """Convert queued rejections into incompatibilities.
 
     For each ``(candidate_pkg, blocker_pkg, blocker_key)`` group we add
     ``{candidate_pkg in {v1,v2,...}, blocker_pkg in R}``, with each candidate
@@ -175,9 +187,15 @@ def flush_pending_blocks(provider: Provider) -> None:
     when the group recorded a range for every rejection and that widening still
     covers the blocker, otherwise the decided version's gap for decision-keyed
     groups and the captured positive range for range-keyed ones.  Sound across
-    backjumps
-    because the blocker term goes UNDETERMINED when the supporting decision is
-    reverted, so the candidate range can be reconsidered.
+    backjumps because the blocker term goes UNDETERMINED when the supporting
+    decision is reverted, so the candidate range can be reconsidered.
+
+    Root-requirement and metadata rejections have no such blocker: neither a
+    root requirement nor unreadable metadata changes over the resolve, so each
+    package's rejected versions go out as one single-term ``NO_VERSIONS``
+    clause naming just those versions.  The resolver's own fallback bans the
+    whole asked range, including the pre-releases the PEP 440 buffer kept out
+    of the scan.
     """
     # Decision-keyed rejections: the blocker term covers the decided version.
     for (
@@ -185,9 +203,7 @@ def flush_pending_blocks(provider: Provider) -> None:
         blocker_pkg,
         blocker_version,
     ), versions in provider.pending_blocks.items():
-        range_union = VersionRange.empty()
-        for v in versions:
-            range_union = range_union | _widen_or_singleton(provider, candidate_pkg, v)
+        range_union = _candidate_union(provider, candidate_pkg, versions)
         # The decided version lies outside every recorded dependency range, so
         # the widening contains it; the check fences a group whose ranges
         # disagree with its blocker.  Asked as a subset test rather than ``in``
@@ -223,9 +239,7 @@ def flush_pending_blocks(provider: Provider) -> None:
         blocker_pkg,
         blocker_range,
     ), versions in provider.pending_range_blocks.items():
-        range_union = VersionRange.empty()
-        for v in versions:
-            range_union = range_union | _widen_or_singleton(provider, candidate_pkg, v)
+        range_union = _candidate_union(provider, candidate_pkg, versions)
         # Every recorded dependency range was disjoint from the positive range,
         # so the widening covers it; the check fences a group whose ranges
         # disagree with its blocker.
@@ -252,7 +266,23 @@ def flush_pending_blocks(provider: Provider) -> None:
     provider.pending_range_blocks = defaultdict(list)
     provider.pending_range_dep_ranges = defaultdict(DepRangeUnion.zero)
 
-    # Root- and metadata-blocks are diagnostic-only; drop them without
-    # emitting clauses.
+    # Permanent rejections: a root requirement is fixed for the whole resolve,
+    # and a version whose metadata will not read is unusable in every state.
+    unusable: defaultdict[str, VersionRange] = defaultdict(VersionRange.empty)
+
+    for (candidate_pkg, *_), versions in provider.pending_root_blocks.items():
+        unusable[candidate_pkg] |= _candidate_union(provider, candidate_pkg, versions)
+
+    for candidate_pkg, versions in provider.pending_metadata_blocks.items():
+        unusable[candidate_pkg] |= _candidate_union(provider, candidate_pkg, versions)
+
+    for candidate_pkg, rejected in unusable.items():
+        provider.pending_clauses.append(
+            Incompatibility(
+                [Term(candidate_pkg, rejected, positive=True)],
+                cause=IncompatibilityCause.NO_VERSIONS,
+            )
+        )
+
     provider.pending_root_blocks = defaultdict(list)
     provider.pending_metadata_blocks = defaultdict(dict)

--- a/nab-python/src/nab_python/provider.py
+++ b/nab-python/src/nab_python/provider.py
@@ -792,16 +792,15 @@ class Provider:
             tuple[str, str, RangeProtocol[Version]], _lookahead.DepRangeUnion
         ] = defaultdict(_lookahead.DepRangeUnion.zero)
 
-        # Diagnostic-only: root_requirements feed PubGrub directly, so these
-        # blockers never need flushing as incompatibilities; they exist purely
-        # so the failure message can name the excluding root requirement.
+        # Root-requirement rejections, keyed by (candidate, blocker, the
+        # candidate's dependency range, the blocker's root range).
         self.pending_root_blocks: defaultdict[
             tuple[str, str, RangeProtocol[Version], RangeProtocol[Version]],
             list[Version],
         ] = defaultdict(list)
 
-        # Diagnostic-only: metadata-error rejections so the failure message
-        # can name the real cause (sdist build needed, malformed PKG-INFO, etc).
+        # Metadata-error rejections, carrying the message so the failure can
+        # name the real cause (sdist build needed, malformed PKG-INFO, etc).
         # Keyed by version so a re-checked candidate is counted once.
         self.pending_metadata_blocks: defaultdict[str, dict[Version, str]] = (
             defaultdict(dict)

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -3523,6 +3523,61 @@ class TestLookAhead:
         spec = SpecifierSet("")
         assert provider.choose_version("foo", spec.to_range()) is None
 
+    def test_root_rejection_queues_its_own_clause(self) -> None:
+        """A root-requirement rejection bans just the versions it rejected.
+
+        Look-ahead rejects the candidate before it is decided, so the
+        dependency clause that would explain the rejection is never added.
+        """
+        coordinator = make_coordinator(
+            [make_wheel("2.0"), make_wheel("1.0")],
+            metadata_by_version={
+                "2.0": (
+                    "Metadata-Version: 2.1\nName: foo\nVersion: 2.0\n"
+                    "Requires-Dist: bar>=5.0\n"
+                ),
+                "1.0": "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n",
+            },
+            package="foo",
+        )
+        root_range = SpecifierSet("<2.0").to_range()
+        provider = Provider(
+            coordinator, target=_PY312, root_requirements={"bar": root_range}
+        )
+        assert provider.choose_version("foo", SpecifierSet("").to_range()) == V("1.0")
+
+        (clause,) = provider.consume_pending_clauses()
+        assert clause.cause is IncompatibilityCause.NO_VERSIONS
+        (term,) = clause.terms
+        assert term.package == "foo"
+        assert term.is_positive()
+        assert V("2.0") in term.constraint
+        assert V("1.0") not in term.constraint
+
+    def test_metadata_rejection_queues_its_own_clause(self) -> None:
+        """A version whose metadata will not read is banned the same way."""
+        coordinator = make_coordinator(
+            [make_wheel("2.0"), make_wheel("1.0")],
+            metadata_by_version={
+                "2.0": "Metadata-Version: 2.1\nName: foo\nVersion: nope\n",
+                "1.0": "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n",
+            },
+            package="foo",
+        )
+        provider = Provider(
+            coordinator,
+            target=_PY312,
+            root_requirements={"foo": VersionRange.full(admit_arbitrary=False)},
+        )
+        assert provider.choose_version("foo", SpecifierSet("").to_range()) == V("1.0")
+
+        (clause,) = provider.consume_pending_clauses()
+        assert clause.cause is IncompatibilityCause.NO_VERSIONS
+        (term,) = clause.terms
+        assert term.package == "foo"
+        assert V("2.0") in term.constraint
+        assert V("1.0") not in term.constraint
+
     def test_cached_deps_used_for_look_ahead(self) -> None:
         """Look-ahead uses cached deps without re-fetching."""
         coordinator = make_coordinator(

--- a/nab-python/tests/test_widen_decision.py
+++ b/nab-python/tests/test_widen_decision.py
@@ -57,12 +57,18 @@ def _wheel(package: str, version: str) -> WheelFile:
     )
 
 
-def _graph_coordinator(graph: dict[str, dict[str, list[str]]]) -> MagicMock:
+def _graph_coordinator(
+    graph: dict[str, dict[str, list[str]]],
+    unreadable: set[tuple[str, str]] | None = None,
+) -> MagicMock:
     """Coordinator for ``{package: {version: [Requires-Dist lines]}}``.
 
     Metadata is pre-stored per ``(package, version)`` so packages may
-    share version strings.
+    share version strings.  ``unreadable`` names the pairs whose stored
+    metadata carries an unparsable version, so look-ahead rejects them as
+    metadata errors.
     """
+    unreadable = unreadable or set()
     listings = {
         package: [_wheel(package, version) for version in versions]
         for package, versions in graph.items()
@@ -70,7 +76,8 @@ def _graph_coordinator(graph: dict[str, dict[str, list[str]]]) -> MagicMock:
     coordinator = make_coordinator(listings=listings)
     for package, versions in graph.items():
         for version, requires in versions.items():
-            text = _METADATA.format(name=package, version=version)
+            stored = "not-a-version" if (package, version) in unreadable else version
+            text = _METADATA.format(name=package, version=stored)
             for requirement in requires:
                 text += f"Requires-Dist: {requirement}\n"
             coordinator.index.store_metadata(package, version, text + "\n")
@@ -564,7 +571,43 @@ class TestNarrowForDisplay:
         assert provider.narrow_for_display("empty", constraint) == constraint
 
     def test_availability_line_keeps_its_range(self) -> None:
-        """``a`` is rejected only against pinned ``c``, so the line keeps its range."""
+        """``a`` is rejected only against pinned ``c``, so the line keeps its range.
+
+        The two rejected versions ban their gaps and ``10.0`` sits outside the
+        requested range, so display narrowing would understate the ban.
+        """
+        coordinator = _graph_coordinator(
+            {
+                "a": {"10.0": [], "2.0": ["c==1.0"], "1.0": ["c==1.0"]},
+                "c": {"5.0": [], "1.0": []},
+            }
+        )
+        root_reqs = {
+            "a": SpecifierSet(">=1,<9").to_range(),
+            "c": SpecifierSet("==5.0").to_range(),
+        }
+        provider = Provider(
+            coordinator,
+            target=ResolveTarget.for_host_python("3.12.0"),
+            root_requirements=root_reqs,
+        )
+        resolver = Resolver(provider, range_type=VersionRange, root_version="0")
+        with pytest.raises(ResolutionError) as exc_info:
+            resolver.resolve(dict(root_reqs))
+
+        low = provider.widen_decision_gap("a", V("1.0"))
+        high = provider.widen_decision_gap("a", V("2.0"))
+        assert low is not None
+        assert high is not None
+        banned = low | high
+
+        assert provider.narrow_for_display("a", banned) != banned
+
+        expected = f"because no versions of a {banned} are available"
+        assert expected in str(exc_info.value).splitlines()
+
+    def test_whole_listing_rejected_drops_the_range(self) -> None:
+        """With every version of ``a`` rejected the line names no range."""
         coordinator = _graph_coordinator(
             {
                 "a": {"2.0": ["c==1.0"], "1.0": ["c==1.0"]},
@@ -584,8 +627,11 @@ class TestNarrowForDisplay:
         with pytest.raises(ResolutionError) as exc_info:
             resolver.resolve(dict(root_reqs))
 
-        expected = f"because no versions of a {root_reqs['a']} are available"
-        assert expected in str(exc_info.value).splitlines()
+        assert str(exc_info.value).splitlines() == [
+            "because no versions of a are available",
+            f"because your project depends on a {root_reqs['a']}",
+            "so <root> <VersionRange '[0, 0]'>",
+        ]
 
     def test_promoted_parent_reads_as_all_versions(self) -> None:
         """A promoted depending side takes the plural prose and verb."""
@@ -642,8 +688,9 @@ class TestWideningRegressionGraphs:
     def _resolve(
         graph: dict[str, dict[str, list[str]]],
         root_reqs: dict[str, VersionRange],
+        unreadable: set[tuple[str, str]] | None = None,
     ) -> dict[str, Version]:
-        coordinator = _graph_coordinator(graph)
+        coordinator = _graph_coordinator(graph, unreadable)
         provider = Provider(
             coordinator,
             target=ResolveTarget.for_host_python("3.12.0"),
@@ -686,6 +733,45 @@ class TestWideningRegressionGraphs:
         )
         assert pins["a"] == V("1.0")
         assert pins["c"] == V("1.5a1")
+
+    def test_root_blocked_final_leaves_the_prerelease_reachable(self) -> None:
+        """A final rejected against a root requirement must not ban its whole
+        range: the pre-release the PEP 440 buffer held back stays selectable."""
+        pins = self._resolve(
+            {
+                "a": {"2.0a1": ["b==1.*", "c==1.*"]},
+                "b": {"1.0.post1": ["c==1.0a1"], "1.1": ["d==1.0.*"]},
+                "c": {"1.0.post1": ["d==2.*"], "1.0a1": []},
+                "d": {"1.0a1": []},
+            },
+            {
+                "d": SpecifierSet("<1.0rc1").to_range(),
+                "a": SpecifierSet("==2.0a1").to_range(),
+            },
+        )
+        assert pins["a"] == V("2.0a1")
+        assert pins["c"] == V("1.0a1")
+        assert pins["d"] == V("1.0a1")
+
+    def test_unreadable_final_leaves_the_prerelease_reachable(self) -> None:
+        """The same graph with the final rejected for unreadable metadata
+        instead: an unusable version bans itself, not the range around it."""
+        pins = self._resolve(
+            {
+                "a": {"2.0a1": ["b==1.*", "c==1.*"]},
+                "b": {"1.0.post1": ["c==1.0a1"], "1.1": ["d==1.0.*"]},
+                "c": {"1.0.post1": [], "1.0a1": []},
+                "d": {"1.0a1": []},
+            },
+            {
+                "d": SpecifierSet("<1.0rc1").to_range(),
+                "a": SpecifierSet("==2.0a1").to_range(),
+            },
+            {("c", "1.0.post1")},
+        )
+        assert pins["a"] == V("2.0a1")
+        assert pins["c"] == V("1.0a1")
+        assert pins["d"] == V("1.0a1")
 
     def test_capped_prerelease_clip_does_not_leak(self) -> None:
         """The capped-prerelease clip graph: a failed parent's capped opt-in


### PR DESCRIPTION
When look-ahead rejects every candidate of a package because of a root requirement or unreadable metadata, nothing queues a clause, so the resolver falls back to banning the package's whole requested range. That range is wider than what was scanned: `choose_version` only offers the versions PEP 440 admits, so a pre-release held back by the default buffering gets banned without ever being looked at. A sibling requirement that later opts in to that pre-release finds it already foreclosed, and nab fails a resolve pip completes. The smallest case I hit: `c==1.*` offers only `1.0.post1`, whose `d==2.*` is disjoint from the root `d<1.0rc1`, and the ban takes `c 1.0a1` with it before `b` can ask for it.

Root-requirement and metadata rejections now queue their own single-term clause naming just the versions they rejected, widened onto the listing's gaps the way the grouped look-ahead clauses are. Both rejections are permanent: a root requirement is fixed for the whole resolve, and a version whose metadata will not parse is unusable in every state. So there is no blocker term to backjump against, and a single-term ban is sound.

The error text changes with it. A `no versions of X are available` line now names the versions look-ahead rejected rather than the range that was asked for, and drops the range entirely when every version in the listing was rejected.
