### PR TITLE
stop a non-list dependency-group value crashing conflict planning

### DIFF
--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING
 
 import tomli
@@ -19,7 +19,7 @@ from ._vendor.packaging.utils import canonicalize_name
 from .metadata import validate_specifier_versions
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Sequence
+    from collections.abc import Iterator
     from pathlib import Path
 
     from ._vendor.packaging.ranges import VersionRange
@@ -439,10 +439,15 @@ def expand_group_includes(
 
     Unknown or cyclic includes are tolerated here;
     :func:`resolve_groups_to_requirements` raises on them when the
-    requirements themselves are loaded.
+    requirements themselves are loaded.  A group whose value is not a
+    list is skipped, and the loader reports it when that group is
+    selected.
     """
     canonical_groups: dict[str, list[str | Mapping[str, str]]] = {}
     for name, entries in groups.items():
+        # str is a Sequence, so a bare string would expand into characters.
+        if isinstance(entries, str) or not isinstance(entries, Sequence):
+            continue
         canonical_groups.setdefault(canonicalize_name(name), []).extend(entries)
 
     out: list[str] = []

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -1140,6 +1140,11 @@ class TestExpandGroupIncludes:
         groups = {"a": [{"include-group": 123}]}
         assert expand_group_includes(groups, ["a"]) == ["a"]
 
+    def test_non_sequence_group_value_tolerated(self) -> None:
+        """A group whose value is not a list is skipped, not crashed on."""
+        groups = {"a": [{"include-group": "b"}], "docs": 5}
+        assert expand_group_includes(groups, ["a", "docs"]) == ["a", "docs", "b"]
+
     def test_cycle_terminates(self) -> None:
         groups = {
             "a": [{"include-group": "b"}],

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -38,6 +38,7 @@ from nab_python.provider import (
     UnsupportedVcsError,
 )
 from nab_python.requirements_file import (
+    InvalidProjectRequirementError,
     read_pyproject_groups,
     read_pyproject_name,
     read_pyproject_optional_dependencies,
@@ -136,6 +137,24 @@ def _build_constraints(
     return ranges
 
 
+def _malformed_group_pyproject(tmp_path: Path) -> Path:
+    """A project with conflicting ``cpu`` and ``gpu`` extras, plus a
+    ``docs`` group whose value is an integer instead of a list."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[project]\nname = "x"\nversion = "0"\n'
+        "dependencies = []\n"
+        "[project.optional-dependencies]\n"
+        'cpu = ["foo==1.0"]\n'
+        'gpu = ["foo==2.0"]\n'
+        "[dependency-groups]\n"
+        "docs = 5\n"
+        "[tool.nab]\n"
+        'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+    )
+    return pyproject
+
+
 class TestSpecificModeConflictValidation:
     """Conflict handling in specific mode: direct co-selection forks, an
     umbrella that reaches two members without selecting either fails fast."""
@@ -202,6 +221,40 @@ class TestSpecificModeConflictValidation:
         assert V("1.0") in root_reqs["foo"]
         assert V("2.0") not in root_reqs["foo"]
         assert _pins(result) == {"foo": V("1.0")}
+
+    def test_unselected_malformed_group_still_resolves(self, tmp_path: Path) -> None:
+        """Conflict planning closes the group table over ``include-group``,
+        so it walks groups the resolve never selects."""
+        pyproject = _malformed_group_pyproject(tmp_path)
+        with (
+            patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls,
+            patch("nab_python.resolve.Provider") as mock_provider_cls,
+            patch("nab_python.resolve.build_target_lock"),
+        ):
+            mock_coord_cls.return_value.__enter__ = lambda s: s
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            mock_provider = mock_provider_cls.return_value
+            mock_provider.choose_version.return_value = V("1.0")
+            mock_provider.get_dependencies.return_value = {}
+            mock_provider.prioritize.return_value = 1
+            result = _resolved(
+                pyproject, _FAKE_TRANSPORT, extras=("cpu",), python_version="3.12.0"
+            )
+        assert _pins(result) == {"foo": V("1.0")}
+
+    def test_selected_malformed_group_reports_loader_error(
+        self, tmp_path: Path
+    ) -> None:
+        """Selecting the malformed group still fails, with the group
+        loader's message rather than a crash in the include walk."""
+        pyproject = _malformed_group_pyproject(tmp_path)
+        with pytest.raises(InvalidProjectRequirementError, match="not a sequence type"):
+            _resolved(
+                pyproject,
+                _FAKE_TRANSPORT,
+                groups=("docs",),
+                python_version="3.12.0",
+            )
 
     def test_direct_co_selection_forks_and_locks(self, tmp_path: Path) -> None:
         """A real specific-mode co-selection resolves to two forks, each


### PR DESCRIPTION
Declaring `[[tool.nab.conflicts]]` makes conflict planning walk the whole `[dependency-groups]` table so it can follow `include-group`, not just the selected groups. If any group's value is not a list, say `docs = 5`, that walk calls `list.extend` on it and nab exits with a raw `TypeError` traceback, even when the group is never selected. Remove the conflicts declaration from the same file and the resolve runs; select the bad group and the loader reports it properly.

`expand_group_includes` now skips a group whose value is not a list and leaves the report to the loader. A bare string is skipped on the same branch, since a string is a sequence and would otherwise expand into one entry per character.
