### PR TITLE
let a released packaging VersionRange drive the resolver

### DIFF
--- a/nab-resolver/src/nab_resolver/propagate.py
+++ b/nab-resolver/src/nab_resolver/propagate.py
@@ -16,12 +16,15 @@ from typing import TYPE_CHECKING, Any
 from .types import IncompatibilityState, SetRelation, Term
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from .resolver import Resolver
-    from .types import Incompatibility
+    from .types import Incompatibility, RangeProtocol, RelationProtocol
 
 __all__ = [
     "classify_relation",
     "evaluate_incompatibility",
+    "relation_flags",
     "term_relation",
     "unit_propagation",
 ]
@@ -127,10 +130,8 @@ def term_relation(resolver: Resolver[Any, Any], term: Term[Any, Any]) -> SetRela
     key = (positive, assignment, term.constraint)
     result = cache.get(key)
     if result is None:
-        relation = assignment.relation(term.constraint)
-        result = classify_relation(
-            term, subset=relation.is_subset, disjoint=relation.is_disjoint
-        )
+        subset, disjoint = relation_flags(assignment, term.constraint)
+        result = classify_relation(term, subset=subset, disjoint=disjoint)
         if len(cache) >= RELATION_CACHE_MAX:
             cache.clear()
         cache[key] = result
@@ -144,6 +145,25 @@ def term_relation(resolver: Resolver[Any, Any], term: Term[Any, Any]) -> SetRela
     return result
 
 
+def relation_flags(
+    assignment: RangeProtocol[Any], constraint: RangeProtocol[Any]
+) -> tuple[bool, bool]:
+    """Return ``(is_subset, is_disjoint)`` for assignment against constraint.
+
+    ``relation`` is optional on :class:`~nab_resolver.types.RangeProtocol`. A
+    range type that answers both in one walk offers it; released
+    :class:`packaging.ranges.VersionRange` does not, and is asked twice.
+    """
+    relate: Callable[[Any], RelationProtocol] | None = getattr(
+        assignment, "relation", None
+    )
+    if relate is None:
+        return assignment.is_subset(constraint), assignment.is_disjoint(constraint)
+
+    relation = relate(constraint)
+    return relation.is_subset, relation.is_disjoint
+
+
 def classify_relation(
     term: Term[Any, Any],
     *,
@@ -153,7 +173,7 @@ def classify_relation(
     """Classify a term from the assignment's relation to its constraint.
 
     ``subset`` and ``disjoint`` describe the assignment against
-    ``term.constraint``, as returned by ``RangeProtocol.relation``.
+    ``term.constraint``, as :func:`relation_flags` returns them.
 
     Positive term: satisfied when the assignment is a subset of the
     constraint; contradicted when the two are disjoint.

--- a/nab-resolver/src/nab_resolver/types.py
+++ b/nab-resolver/src/nab_resolver/types.py
@@ -46,9 +46,12 @@ VersionType_contra = TypeVar("VersionType_contra", contravariant=True)
 class RangeProtocol(Protocol[VersionType_contra]):
     """Contract for version range types used by the resolver.
 
-    Both :class:`nab_resolver.ranges.Range` and
-    :class:`packaging.ranges.VersionRange` satisfy this protocol.  Mixing
-    range types within a single resolution is unsupported.
+    :class:`nab_resolver.ranges.Range` satisfies it, and so does
+    :class:`packaging.ranges.VersionRange` from packaging 26.3, the first
+    release carrying that module.  A range type may also offer
+    ``relation(other)``, returning a :class:`RelationProtocol` with both flags
+    from one walk; unit propagation uses it when it is there.  Mixing range
+    types within a single resolution is unsupported.
     """
 
     @classmethod
@@ -101,13 +104,6 @@ class RangeProtocol(Protocol[VersionType_contra]):
 
     def is_disjoint(self, other: Self) -> bool:
         """Return whether self and other share no version."""
-        ...
-
-    def relation(self, other: Self) -> RelationProtocol:
-        """Return how self's members sit against other's.
-
-        Both flags hold at once only for an empty self.
-        """
         ...
 
     # __eq__ and __hash__ come from object; redeclaring them in the

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -2727,3 +2727,113 @@ class TestRelationCache:
 
         key = (True, resolver.solution.get("foo"), term.constraint)
         assert resolver.relation_cache == {key: result}
+
+
+class PlainRange:
+    """A range type that answers subset and disjoint separately.
+
+    ``packaging.ranges.VersionRange`` carries every member ``RangeProtocol``
+    requires; ``relation`` is added by nab's vendoring patch and is not in the
+    released module. Delegating to ``Range`` keeps the semantics while leaving
+    that member off.
+    """
+
+    __slots__ = ("_inner",)
+
+    def __init__(self, inner: Range[int]) -> None:
+        self._inner = inner
+
+    @classmethod
+    def empty(cls) -> PlainRange:
+        return cls(Range.empty())
+
+    @classmethod
+    def full(cls) -> PlainRange:
+        return cls(Range.full())
+
+    @classmethod
+    def singleton(cls, version: int) -> PlainRange:
+        return cls(Range.singleton(version))
+
+    @property
+    def is_empty(self) -> bool:
+        return self._inner.is_empty
+
+    def _peer(self, other: object) -> Range[int]:
+        assert isinstance(other, PlainRange)
+        return other._inner
+
+    def __contains__(self, version: object) -> bool:
+        """Test version membership."""
+        return version in self._inner
+
+    def __and__(self, other: object) -> PlainRange:
+        """Intersect two ranges."""
+        return PlainRange(self._inner & self._peer(other))
+
+    def __or__(self, other: object) -> PlainRange:
+        """Union two ranges."""
+        return PlainRange(self._inner | self._peer(other))
+
+    def __invert__(self) -> PlainRange:
+        """Complement the range."""
+        return PlainRange(~self._inner)
+
+    def __sub__(self, other: object) -> PlainRange:
+        """Take the versions in self but not in other."""
+        return PlainRange(self._inner - self._peer(other))
+
+    def is_subset(self, other: PlainRange) -> bool:
+        return self._inner.is_subset(other._inner)
+
+    def is_superset(self, other: PlainRange) -> bool:
+        return self._inner.is_superset(other._inner)
+
+    def is_disjoint(self, other: PlainRange) -> bool:
+        return self._inner.is_disjoint(other._inner)
+
+    def __eq__(self, other: object) -> bool:
+        """Compare the wrapped ranges."""
+        if not isinstance(other, PlainRange):
+            return NotImplemented
+        return self._inner == other._inner
+
+    def __hash__(self) -> int:
+        """Hash the wrapped range."""
+        return hash(self._inner)
+
+    def __repr__(self) -> str:
+        """Show the wrapped range."""
+        return repr(self._inner)
+
+
+def backtracking_packages(range_type: type[Any]) -> dict[str, Any]:
+    """root wants any foo; foo@2 wants a bar other than 1, and only bar@1 ships."""
+    return {
+        "root": {1: {"foo": range_type.full()}},
+        "foo": {2: {"bar": ~range_type.singleton(1)}, 1: {}},
+        "bar": {1: {}},
+    }
+
+
+class TestRangeTypeWithoutRelation:
+    def test_resolves_without_the_fused_relation(self) -> None:
+        assert not hasattr(PlainRange, "relation")
+
+        resolver: Resolver[str, int] = Resolver(
+            DictProvider(backtracking_packages(PlainRange)), range_type=PlainRange
+        )
+        result = resolver.resolve({"root": PlainRange.singleton(1)})
+
+        assert result == {"root": 1, "foo": 1}
+        assert resolver.relation_cache
+
+    def test_matches_the_fused_range_type(self) -> None:
+        plain: Resolver[str, int] = Resolver(
+            DictProvider(backtracking_packages(PlainRange)), range_type=PlainRange
+        )
+        fused: Resolver[str, int] = Resolver(DictProvider(backtracking_packages(Range)))
+
+        assert plain.resolve({"root": PlainRange.singleton(1)}) == fused.resolve(
+            {"root": Range.singleton(1)}
+        )


### PR DESCRIPTION
`nab_resolver.types.RangeProtocol` required a `relation` method, and unit propagation called it on every cache miss, so a range type without one raised `AttributeError` on the first propagation step. Only nab's vendored packaging fork carries that method. `packaging.ranges.VersionRange` as released in 26.3 has all twelve of the protocol's other members, so a host that vendors `nab-resolver` on its own and installs packaging from PyPI could not run a resolve.

`relation` is now optional. A range type that answers subset and disjoint in one walk keeps offering it, and unit propagation keeps taking that path; a type that does not is asked the two questions separately.

The protocol docstring claimed `VersionRange` satisfied the contract, which is the sentence that hid the gap.
