### PR TITLE
promote the pyproject requirement helpers out of requirements_file's privates

### DIFF
--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -29,9 +29,9 @@ from ..metadata import (
 )
 from ..requirements_file import (
     InvalidProjectRequirementError,
-    _parse_project_requirement,
-    _parse_requirements,
-    _require_string_list,
+    parse_project_requirement,
+    parse_requirements,
+    require_string_list,
 )
 from ..tags import python_axis_accepts
 
@@ -403,7 +403,7 @@ def augment_from_pyproject(
     if project is None:
         return None
 
-    deps = _require_string_list(
+    deps = require_string_list(
         project.get("dependencies", []), "[project].dependencies"
     )
     optional = project.get("optional-dependencies", {})
@@ -438,8 +438,8 @@ def extend_with_extras(requires_dist: list[Requirement], optional: dict) -> list
         source = f"[project].optional-dependencies extra {extra_name!r}"
         provides_extra.append(extra_name)
         requires_dist.extend(
-            _parse_project_requirement(dep_str, source, extra=extra_name)
-            for dep_str in _require_string_list(extra_deps, source)
+            parse_project_requirement(dep_str, source, extra=extra_name)
+            for dep_str in require_string_list(extra_deps, source)
         )
     return provides_extra
 
@@ -447,12 +447,12 @@ def extend_with_extras(requires_dist: list[Requirement], optional: dict) -> list
 def parse_pyproject_deps(deps: list) -> list[Requirement]:
     """Parse a ``project.dependencies`` list, raising on a malformed entry.
 
-    Entries are already validated as strings by :func:`_require_string_list`;
+    Entries are already validated as strings by :func:`require_string_list`;
     a string that is not valid PEP 508 raises
     :class:`InvalidProjectRequirementError`, so the whole version is rejected
     rather than resolved with the dependency dropped.
     """
-    return _parse_requirements(deps, "[project].dependencies")
+    return parse_requirements(deps, "[project].dependencies")
 
 
 def find_sdist(

--- a/nab-python/src/nab_python/build_backend.py
+++ b/nab-python/src/nab_python/build_backend.py
@@ -22,8 +22,8 @@ from .metadata import WheelMetadata, load_static_project, validate_specifier_ver
 from .paths import is_absent_error, path_state
 from .requirements_file import (
     InvalidProjectRequirementError,
-    _parse_project_requirement,
-    _require_string_list,
+    parse_project_requirement,
+    require_string_list,
 )
 
 if TYPE_CHECKING:
@@ -188,8 +188,8 @@ def _extend_with_dep_strings(
     extra: str | None = None,
 ) -> None:
     out.extend(
-        _parse_project_requirement(dep, source, extra=extra)
-        for dep in _require_string_list(raw, source)
+        parse_project_requirement(dep, source, extra=extra)
+        for dep in require_string_list(raw, source)
     )
 
 

--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -30,11 +30,14 @@ __all__ = [
     "expand_extra_requirements",
     "expand_group_includes",
     "expand_self_extras",
+    "parse_project_requirement",
+    "parse_requirements",
     "raise_for_unsatisfiable",
     "read_pyproject_dependencies",
     "read_pyproject_groups",
     "read_pyproject_name",
     "read_pyproject_optional_dependencies",
+    "require_string_list",
     "resolve_groups_to_requirements",
     "self_extra_markers",
 ]
@@ -78,7 +81,7 @@ def _add_extra_marker(dep_str: str, extra_name: str) -> str:
     return f"{req} ; {marker}"
 
 
-def _parse_project_requirement(
+def parse_project_requirement(
     dep_str: str, source: str, *, extra: str | None = None
 ) -> Requirement:
     """Parse one PEP 508 dependency string, raising if it is malformed.
@@ -99,12 +102,12 @@ def _parse_project_requirement(
     return req
 
 
-def _parse_requirements(strings: Sequence[str], source: str) -> list[Requirement]:
+def parse_requirements(strings: Sequence[str], source: str) -> list[Requirement]:
     """Parse PEP 508 strings, naming ``source`` if one is malformed."""
-    return [_parse_project_requirement(s, source) for s in strings]
+    return [parse_project_requirement(s, source) for s in strings]
 
 
-def _require_string_list(value: object, source: str) -> list[str]:
+def require_string_list(value: object, source: str) -> list[str]:
     """Validate that a PEP 621 dependency value is an array of strings.
 
     A bare string passes the type checker as ``Sequence[str]`` but
@@ -164,8 +167,8 @@ def read_pyproject_dependencies(path: Path) -> list[Requirement]:
                 " path does not support"
             )
             raise InvalidProjectRequirementError(msg)
-    dep_strings = _require_string_list(project.get("dependencies", []), source)
-    return _parse_requirements(dep_strings, source)
+    dep_strings = require_string_list(project.get("dependencies", []), source)
+    return parse_requirements(dep_strings, source)
 
 
 def read_pyproject_name(path: Path) -> str | None:
@@ -205,7 +208,7 @@ def _canonicalize_optional_deps(
     for name, reqs in optional_deps.items():
         source = f"[project.optional-dependencies] extra {name!r}"
         canonical.setdefault(canonicalize_name(name), []).extend(
-            _require_string_list(reqs, source)
+            require_string_list(reqs, source)
         )
     return canonical
 
@@ -390,7 +393,7 @@ def expand_extra_requirements(
                 f" [project.optional-dependencies]; defined: {sorted(canonical_deps)!r}"
             )
             raise LookupError(msg)
-        for req in _parse_requirements(
+        for req in parse_requirements(
             canonical_deps[extra],
             f"[project.optional-dependencies] extra {extra!r}",
         ):
@@ -506,7 +509,7 @@ def resolve_groups_to_requirements(
             raise LookupError(detail) from group
         msg = f"invalid [dependency-groups]: {detail}"
         raise InvalidProjectRequirementError(msg) from group
-    return _parse_requirements(resolved, "[dependency-groups]")
+    return parse_requirements(resolved, "[dependency-groups]")
 
 
 def raise_for_unsatisfiable(

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -13,10 +13,10 @@ from nab_python._vendor.packaging.utils import InvalidName
 from nab_python.requirements_file import (
     InvalidProjectRequirementError,
     _add_extra_marker,
-    _parse_project_requirement,
     expand_extra_requirements,
     expand_group_includes,
     expand_self_extras,
+    parse_project_requirement,
     raise_for_unsatisfiable,
     read_pyproject_dependencies,
     read_pyproject_groups,
@@ -93,7 +93,7 @@ class TestAddExtraMarker:
         """An invalid extra name is rejected by the synthesis path, not
         folded into a dependency with a marker that is always true."""
         with pytest.raises(InvalidProjectRequirementError):
-            _parse_project_requirement(
+            parse_project_requirement(
                 "pkg",
                 "[project.optional-dependencies] extra 'x'",
                 extra='a" or os_name != "x',


### PR DESCRIPTION
`_provider/metadata_resolver.py` and `build_backend.py` both import `_parse_project_requirement`, `_parse_requirements` and `_require_string_list` from `requirements_file`, so all three are already part of that module's surface and only look internal. Reaching past the underscore couples those callers to names `requirements_file` is free to rename, which is the coupling the workspace import rules exist to prevent.

This drops the underscore, adds the three to `requirements_file.__all__`, and updates every caller. Behaviour is unchanged.

`tasks/check_boundaries.py` does not flag this today because its `public` rule only compares distributions, and all three importers live inside nab-python. Whether that rule should also apply within a distribution is a separate question and is not settled here.