### PR TITLE
promote nab-index's accepted hash algorithms out of client's privates

### DIFF
--- a/nab-index/src/nab_index/archive.py
+++ b/nab-index/src/nab_index/archive.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .client import _ACCEPTED_HASH_ALGORITHMS
+from .client import ACCEPTED_HASH_ALGORITHMS
 from .subdir import subdirectory_escapes
 
 __all__ = [
@@ -54,7 +54,7 @@ class ArchiveRequest:
         """Split ``raw_url`` into its URL, hashes, and subdirectory.
 
         The fragment holds ``&``-separated ``key=value`` parts: a
-        recognised hash algorithm (see :data:`_ACCEPTED_HASH_ALGORITHMS`)
+        recognised hash algorithm (see :data:`ACCEPTED_HASH_ALGORITHMS`)
         or ``subdirectory``.  Any other key raises
         :class:`ArchiveRequestError`; requiring a hash is left to the
         config layer so the error names the offending source.
@@ -72,12 +72,12 @@ class ArchiveRequest:
                 raise ArchiveRequestError(msg)
             if key == "subdirectory":
                 subdirectory = value
-            elif key in _ACCEPTED_HASH_ALGORITHMS:
+            elif key in ACCEPTED_HASH_ALGORITHMS:
                 hashes.append((key, value.lower()))
             else:
                 msg = (
                     f"unknown archive URL fragment key {key!r} in {raw_url!r};"
-                    f" expected one of {', '.join(_ACCEPTED_HASH_ALGORITHMS)}"
+                    f" expected one of {', '.join(ACCEPTED_HASH_ALGORITHMS)}"
                     " or subdirectory"
                 )
                 raise ArchiveRequestError(msg)

--- a/nab-index/src/nab_index/client.py
+++ b/nab-index/src/nab_index/client.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     from .transport import AsyncHttpTransport, HttpResponse
 
 __all__ = [
+    "ACCEPTED_HASH_ALGORITHMS",
     "DEFAULT_INDEX",
     "AsyncSimpleClient",
     "MalformedSimpleResponseError",
@@ -51,7 +52,7 @@ __all__ = [
 ]
 
 # Verification order; sha256 is pip's hash-checking baseline.
-_ACCEPTED_HASH_ALGORITHMS = ("sha256", "sha384", "sha512")
+ACCEPTED_HASH_ALGORITHMS: tuple[str, ...] = ("sha256", "sha384", "sha512")
 
 # The tar ``data`` filter (PEP 706) landed in 3.12 and was backported to
 # 3.10.12 / 3.11.4; sdist extraction requires it (see extract_sdist_archive).
@@ -668,12 +669,12 @@ def _select_artifact_hash(
 ) -> tuple[str, str] | None:
     """Pick the preferred ``(algo, hex)`` to verify, or ``None`` if none qualify.
 
-    Walks :data:`_ACCEPTED_HASH_ALGORITHMS` in order, so sha256 is preferred,
+    Walks :data:`ACCEPTED_HASH_ALGORITHMS` in order, so sha256 is preferred,
     then sha384, then sha512. An empty set, an empty digest, or only unaccepted
     algorithms (md5) yields ``None``.
     """
     by_algo = {algo.lower(): digest.lower() for algo, digest in hashes}
-    for algo in _ACCEPTED_HASH_ALGORITHMS:
+    for algo in ACCEPTED_HASH_ALGORITHMS:
         digest = by_algo.get(algo)
         if digest:
             return (algo, digest)


### PR DESCRIPTION
`archive.py` imports `_ACCEPTED_HASH_ALGORITHMS` from `client` and reads it at three more places, deciding which `#sha256=...` fragment keys a direct-URL archive requirement may carry and naming the accepted set in the error when it carries something else. A constant another module parses user input against is part of `client`'s surface, not an internal.

This drops the underscore, adds it to `client.__all__`, and gives it the same `tuple[str, ...]` annotation the equivalent public constant in `nab_python.lockfile` already carries. Behaviour is unchanged.

`tasks/check_boundaries.py` does not flag this today because its `public` rule only compares distributions, and both modules live inside nab-index. Whether that rule should also apply within a distribution is a separate question and is not settled here.