### PR TITLE
drop nab-resolver's last runtime dependency

### DIFF
--- a/nab-resolver/README.md
+++ b/nab-resolver/README.md
@@ -6,6 +6,8 @@ package is a SAT-style solver core.  The Python provider lives in
 [`nab-python`](https://pypi.org/project/nab-python/) and the
 user-facing CLI in [`nab`](https://pypi.org/project/nab/).
 
+It has no runtime dependencies: the standard library is all it needs.
+
 ## When to use it
 
 Use `nab-resolver` when you are building some kind of package

--- a/nab-resolver/pyproject.toml
+++ b/nab-resolver/pyproject.toml
@@ -19,9 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
-dependencies = [
-    "typing_extensions>=4.6",
-]
+dependencies = []
 
 [project.urls]
 Homepage = "https://github.com/notatallshaw/nab"

--- a/nab-resolver/src/nab_resolver/_compat.py
+++ b/nab-resolver/src/nab_resolver/_compat.py
@@ -1,0 +1,36 @@
+"""Runtime stand-ins for typing features newer than the 3.10 floor.
+
+Defined here rather than taken from a backport package, so the solver core
+keeps no runtime dependency.
+"""
+
+from __future__ import annotations
+
+import typing
+from typing import TYPE_CHECKING, Any, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+__all__ = [
+    "override",
+]
+
+_F = TypeVar("_F", bound="Callable[..., Any]")
+
+
+def _override(method: _F, /) -> _F:
+    """Stand in for :func:`typing.override` below 3.12, where it arrived.
+
+    Both are no-ops at run time; a type checker does the checking.
+    """
+    return method
+
+
+# A checker reads the typing_extensions spelling, so decorated methods keep
+# being checked against their base class. The interpreter's own is asked for by
+# name, not by version, so there is no branch only one version can take.
+if TYPE_CHECKING:
+    from typing_extensions import override
+else:
+    override = getattr(typing, "override", _override)

--- a/nab-resolver/src/nab_resolver/ranges.py
+++ b/nab-resolver/src/nab_resolver/ranges.py
@@ -14,8 +14,7 @@ from __future__ import annotations
 
 from typing import Any, Generic, TypeAlias
 
-from typing_extensions import override
-
+from ._compat import override
 from .types import RangeRelation, VersionType
 
 # Bound once so the hot return paths load a module global instead of a class

--- a/nab-resolver/src/nab_resolver/root.py
+++ b/nab-resolver/src/nab_resolver/root.py
@@ -7,7 +7,7 @@ time (which would create a cycle).
 
 from __future__ import annotations
 
-from typing_extensions import override
+from ._compat import override
 
 __all__ = [
     "ROOT",

--- a/nab-resolver/src/nab_resolver/types.py
+++ b/nab-resolver/src/nab_resolver/types.py
@@ -12,9 +12,12 @@ Reference: https://github.com/dart-lang/pub/blob/master/doc/solver.md#definition
 from __future__ import annotations
 
 import enum
-from typing import Generic, Protocol, TypeVar
+from typing import TYPE_CHECKING, Generic, Protocol, TypeVar
 
-from typing_extensions import Self, override
+from ._compat import override
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 __all__ = [
     "Incompatibility",

--- a/nab-resolver/tests/test_compat.py
+++ b/nab-resolver/tests/test_compat.py
@@ -1,0 +1,11 @@
+"""Tests for the typing stand-ins that keep nab-resolver dependency-free."""
+
+from __future__ import annotations
+
+from nab_resolver import _compat
+
+
+def test_override_stand_in_returns_the_decorated_object() -> None:
+    def sample() -> None: ...
+
+    assert _compat._override(sample) is sample

--- a/nab-resolver/tests/test_stdlib_only.py
+++ b/nab-resolver/tests/test_stdlib_only.py
@@ -1,0 +1,61 @@
+"""Hold nab-resolver to the standard library at run time."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import nab_resolver
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+SOURCE_ROOT = Path(nab_resolver.__file__).parent
+
+
+def _guards_type_checking(test: ast.expr) -> bool:
+    """Return whether ``test`` is the TYPE_CHECKING flag, however spelled."""
+    if isinstance(test, ast.Name):
+        return test.id == "TYPE_CHECKING"
+    return isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"
+
+
+def _runtime_imports(node: ast.AST) -> Iterator[str]:
+    """Yield the top-level module of every import under ``node`` that executes.
+
+    A ``TYPE_CHECKING`` block is what a checker reads and never runs, so only
+    the fallback arm of one is walked. Relative imports stay inside the package
+    and are not reported.
+    """
+    if isinstance(node, ast.Import):
+        for alias in node.names:
+            yield alias.name.partition(".")[0]
+        return
+
+    if isinstance(node, ast.ImportFrom):
+        if node.level == 0 and node.module is not None:
+            yield node.module.partition(".")[0]
+        return
+
+    if isinstance(node, ast.If) and _guards_type_checking(node.test):
+        for fallback in node.orelse:
+            yield from _runtime_imports(fallback)
+        return
+
+    for child in ast.iter_child_nodes(node):
+        yield from _runtime_imports(child)
+
+
+def test_every_shipped_module_imports_only_the_standard_library() -> None:
+    modules = sorted(SOURCE_ROOT.rglob("*.py"))
+    assert modules
+
+    outside = {
+        (path.name, imported)
+        for path in modules
+        for imported in _runtime_imports(ast.parse(path.read_text(encoding="utf-8")))
+        if imported != "nab_resolver" and imported not in sys.stdlib_module_names
+    }
+    assert outside == set()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,9 @@ types = [
     "ty>=0.0.20",
     "pyrefly>=0.50",
     "zuban>=0.6",
+    # nab-resolver reads it under TYPE_CHECKING but takes no runtime
+    # dependency on it, so the checkers need it declared here.
+    "typing_extensions>=4.6",
 ]
 pre-commit = [
     "pre-commit>=4",


### PR DESCRIPTION
nab-resolver is a generic solver core that already refuses to import packaging, and it declared a single runtime dependency: typing_extensions, for `override` in three modules and `Self` in the range protocol's annotations. Neither needs a package. `Self` is annotation-only in a module that already has `from __future__ import annotations`, so it moves under `TYPE_CHECKING`, which is how the rest of the tree already spells it. `override` runs, so it gets a three-line stand-in in a new `_compat` module, with the typing_extensions spelling kept for the type checkers so mypy's `explicit-override` error code stays on.

What this buys is embedding. Anyone vendoring the solver core into an application can take it on its own now, rather than also shipping and tracking a package they need for nothing else.
