### PR TITLE
return the dependency graph alongside the pins

### DIFF
--- a/nab-resolver/README.md
+++ b/nab-resolver/README.md
@@ -23,7 +23,7 @@ internal and may be renamed or relocated in any release.
 nab_resolver.errors     ResolutionError
 nab_resolver.ranges     Range
 nab_resolver.resolver   BaseProvider, DEFAULT_MAX_ITERATIONS, Resolver,
-                        ResolverObserver, ResolverProvider
+                        ResolverObserver, ResolverProvider, Solution
 nab_resolver.root       ROOT
 nab_resolver.types      Incompatibility, IncompatibilityCause,
                         RangeProtocol, RootRequirement, Term

--- a/nab-resolver/src/nab_resolver/__init__.py
+++ b/nab-resolver/src/nab_resolver/__init__.py
@@ -7,7 +7,7 @@ renamed or relocated in any release.
     nab_resolver.errors     ResolutionError
     nab_resolver.ranges     Range
     nab_resolver.resolver   BaseProvider, DEFAULT_MAX_ITERATIONS, Resolver,
-                            ResolverObserver, ResolverProvider
+                            ResolverObserver, ResolverProvider, Solution
     nab_resolver.root       ROOT
     nab_resolver.types      Incompatibility, IncompatibilityCause,
                             RangeProtocol, RootRequirement, Term

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -29,7 +29,7 @@ from . import conflict, decide, incompat_index, propagate
 from .errors import ResolutionError
 from .partial_solution import PartialSolution
 from .ranges import Range
-from .result import Solution, build_solution
+from .result import build_solution_data
 from .root import ROOT
 from .types import (
     Incompatibility,
@@ -64,6 +64,22 @@ __all__ = [
 ]
 
 DEFAULT_MAX_ITERATIONS = 200_000
+
+
+@dataclass(frozen=True)
+class Solution(Generic[PackageType, VersionType]):
+    """Pins and dependency relationships from a finished resolution.
+
+    ``pins`` maps every transitively reachable package to its decided
+    version.  ``edges`` are distinct ``(parent, child)`` pairs in
+    breadth-first order from ``roots``.  Both endpoints of each edge are
+    keys of ``pins``.  ``roots`` are the packages the caller required
+    directly, in requirement order.
+    """
+
+    pins: dict[PackageType, VersionType]
+    edges: tuple[tuple[PackageType, PackageType], ...]
+    roots: tuple[PackageType, ...]
 
 
 class ResolverProvider(Protocol[PackageType, VersionType]):
@@ -601,12 +617,13 @@ class Resolver(Generic[PackageType, VersionType]):
         Per the PubGrub spec, the solution must not contain extra packages:
         "all selected packages are transitively reachable from the root."
         """
-        return build_solution(
+        pins, edges, roots = build_solution_data(
             self.solution.decisions(),
             self.incompatibilities,
             self.provider.get_dependencies,
             root_sentinel=ROOT,
         )
+        return Solution(pins=pins, edges=edges, roots=roots)
 
     def _reset(
         self,

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -10,8 +10,8 @@ The phase functions live in :mod:`nab_resolver.propagate`,
 :mod:`nab_resolver.incompat_index`.  ``Resolver`` is a thin coordinator that
 holds shared state and delegates to those modules.  State attributes are
 named without leading underscores so the phase modules can read and mutate
-them directly; the supported public API is ``__init__``, ``resolve``, and
-``stats``.
+them directly; the supported public API is ``__init__``, ``resolve``,
+``solve``, and ``stats``.
 
 Specification: https://github.com/dart-lang/pub/blob/master/doc/solver.md
 Original blog post: https://nex3.medium.com/pubgrub-2fb6470504f
@@ -29,7 +29,7 @@ from . import conflict, decide, incompat_index, propagate
 from .errors import ResolutionError
 from .partial_solution import PartialSolution
 from .ranges import Range
-from .result import build_reachable_decisions
+from .result import Solution, build_solution
 from .root import ROOT
 from .types import (
     Incompatibility,
@@ -59,6 +59,7 @@ __all__ = [
     "ResolverStats",
     "RootRequirement",
     "SetRelation",
+    "Solution",
     "Term",
 ]
 
@@ -449,6 +450,19 @@ class Resolver(Generic[PackageType, VersionType]):
     ) -> dict[PackageType, VersionType]:
         """Resolve requirements and return ``{package: version}``.
 
+        The pins of :meth:`solve`, for a caller that has no use for the
+        dependency graph.
+        """
+        return self.solve(requirements, constraints).pins
+
+    def solve(
+        self,
+        requirements: Mapping[PackageType, RangeProtocol[VersionType]]
+        | Sequence[RootRequirement[PackageType, VersionType]],
+        constraints: Mapping[PackageType, RangeProtocol[VersionType]] | None = None,
+    ) -> Solution[PackageType, VersionType]:
+        """Resolve requirements and return the pins, roots, and edges.
+
         ``requirements`` is either one range per package, or a sequence of
         :class:`~nab_resolver.types.RootRequirement` when the caller has more
         than one requirement on a package and wants each named as written in
@@ -581,13 +595,13 @@ class Resolver(Generic[PackageType, VersionType]):
                 )
         return next_package
 
-    def _build_result(self) -> dict[PackageType, VersionType]:
+    def _build_result(self) -> Solution[PackageType, VersionType]:
         """Build the final result, including only reachable packages.
 
         Per the PubGrub spec, the solution must not contain extra packages:
         "all selected packages are transitively reachable from the root."
         """
-        return build_reachable_decisions(
+        return build_solution(
             self.solution.decisions(),
             self.incompatibilities,
             self.provider.get_dependencies,

--- a/nab-resolver/src/nab_resolver/result.py
+++ b/nab-resolver/src/nab_resolver/result.py
@@ -11,8 +11,7 @@ Reference: https://github.com/dart-lang/pub/blob/master/doc/solver.md#result
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Generic
+from typing import TYPE_CHECKING, Any
 
 from .types import IncompatibilityCause, PackageType, VersionType
 
@@ -21,38 +20,10 @@ if TYPE_CHECKING:
 
     from .types import Incompatibility, RangeProtocol
 
-__all__ = [
-    "Solution",
-    "build_solution",
-]
+__all__ = ["build_solution_data"]
 
 
-@dataclass(frozen=True)
-class Solution(Generic[PackageType, VersionType]):
-    """A finished resolution: what was chosen, and how it was reached.
-
-    ``pins`` maps every transitively reachable package to its decided
-    version.  ``roots`` are the packages the caller required directly, in
-    the order they were required.  ``edges`` are ``(parent, child)`` pairs,
-    one per dependency the reachability walk crossed, in breadth-first
-    order from ``roots``; a pair appears once, and both ends of every edge
-    are keys of ``pins``.
-
-    An edge records only that one pinned package depends on another, with
-    no version range and no requirement text, so reading the graph needs
-    nothing this package cannot express.  A caller that installs what it
-    resolves has to put a dependency on disk before its dependent, and
-    that ordering is a property of the graph rather than of the pins.  A
-    caller wanting one rooted graph joins ``roots`` to a root node of its
-    own.
-    """
-
-    pins: dict[PackageType, VersionType]
-    edges: tuple[tuple[PackageType, PackageType], ...]
-    roots: tuple[PackageType, ...]
-
-
-def build_solution(
+def build_solution_data(
     decisions: Mapping[PackageType, VersionType],
     incompatibilities: Iterable[Incompatibility[PackageType, VersionType]],
     get_dependencies: Callable[
@@ -60,22 +31,23 @@ def build_solution(
     ],
     *,
     root_sentinel: Any,
-) -> Solution[PackageType, VersionType]:
-    """Filter ``decisions`` to packages transitively reachable from root.
+) -> tuple[
+    dict[PackageType, VersionType],
+    tuple[tuple[PackageType, PackageType], ...],
+    tuple[PackageType, ...],
+]:
+    """Return pins, edges, and roots for decisions reachable from the root.
 
     ``incompatibilities`` is scanned for clauses with cause ``ROOT``
     to recover the user-specified root requirements.  ``get_dependencies``
     is the provider's ``get_dependencies(package, version)`` method,
     which is used to traverse the dependency graph.  Every dependency it
-    reports for a reachable package becomes an edge: the walk asks for
-    them to find the reachable set, so the graph costs nothing more.
+    reports for a reachable package becomes an edge.
     """
     all_decisions = dict(decisions)
     all_decisions.pop(root_sentinel, None)
 
-    # Recover the user-specified roots from ROOT-cause clauses.  Insertion
-    # ordered rather than a set, so the walk that starts here, and the edge
-    # order that comes out of it, do not move with the hash seed.
+    # Keep each root's first appearance so traversal follows the caller's order.
     root_required: dict[PackageType, None] = {}
     for incompatibility in incompatibilities:
         if incompatibility.cause != IncompatibilityCause.ROOT:
@@ -105,12 +77,12 @@ def build_solution(
             if dep_package not in reachable:
                 queue.append(dep_package)
 
-    return Solution(
-        pins={
+    return (
+        {
             package: version
             for package, version in all_decisions.items()
             if package in reachable
         },
-        edges=tuple(edges),
-        roots=tuple(root_required),
+        tuple(edges),
+        tuple(root_required),
     )

--- a/nab-resolver/src/nab_resolver/result.py
+++ b/nab-resolver/src/nab_resolver/result.py
@@ -2,16 +2,17 @@
 
 Per the PubGrub spec, a solution must not include packages that
 aren't transitively reachable from the root.  This module owns the
-BFS that walks the dependency graph from the root incompatibilities
-and filters the partial solution's decisions down to that reachable
-set.
+BFS that walks the dependency graph from the root incompatibilities,
+filters the partial solution's decisions down to that reachable set,
+and keeps the edges the walk crossed.
 
 Reference: https://github.com/dart-lang/pub/blob/master/doc/solver.md#result
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Generic
 
 from .types import IncompatibilityCause, PackageType, VersionType
 
@@ -21,11 +22,37 @@ if TYPE_CHECKING:
     from .types import Incompatibility, RangeProtocol
 
 __all__ = [
-    "build_reachable_decisions",
+    "Solution",
+    "build_solution",
 ]
 
 
-def build_reachable_decisions(
+@dataclass(frozen=True)
+class Solution(Generic[PackageType, VersionType]):
+    """A finished resolution: what was chosen, and how it was reached.
+
+    ``pins`` maps every transitively reachable package to its decided
+    version.  ``roots`` are the packages the caller required directly, in
+    the order they were required.  ``edges`` are ``(parent, child)`` pairs,
+    one per dependency the reachability walk crossed, in breadth-first
+    order from ``roots``; a pair appears once, and both ends of every edge
+    are keys of ``pins``.
+
+    An edge records only that one pinned package depends on another, with
+    no version range and no requirement text, so reading the graph needs
+    nothing this package cannot express.  A caller that installs what it
+    resolves has to put a dependency on disk before its dependent, and
+    that ordering is a property of the graph rather than of the pins.  A
+    caller wanting one rooted graph joins ``roots`` to a root node of its
+    own.
+    """
+
+    pins: dict[PackageType, VersionType]
+    edges: tuple[tuple[PackageType, PackageType], ...]
+    roots: tuple[PackageType, ...]
+
+
+def build_solution(
     decisions: Mapping[PackageType, VersionType],
     incompatibilities: Iterable[Incompatibility[PackageType, VersionType]],
     get_dependencies: Callable[
@@ -33,27 +60,33 @@ def build_reachable_decisions(
     ],
     *,
     root_sentinel: Any,
-) -> dict[PackageType, VersionType]:
+) -> Solution[PackageType, VersionType]:
     """Filter ``decisions`` to packages transitively reachable from root.
 
     ``incompatibilities`` is scanned for clauses with cause ``ROOT``
     to recover the user-specified root requirements.  ``get_dependencies``
     is the provider's ``get_dependencies(package, version)`` method,
-    which is used to traverse the dependency graph.
+    which is used to traverse the dependency graph.  Every dependency it
+    reports for a reachable package becomes an edge: the walk asks for
+    them to find the reachable set, so the graph costs nothing more.
     """
     all_decisions = dict(decisions)
     all_decisions.pop(root_sentinel, None)
 
-    # Recover the user-specified roots from ROOT-cause clauses.
-    root_required: set[PackageType] = set()
+    # Recover the user-specified roots from ROOT-cause clauses.  Insertion
+    # ordered rather than a set, so the walk that starts here, and the edge
+    # order that comes out of it, do not move with the hash seed.
+    root_required: dict[PackageType, None] = {}
     for incompatibility in incompatibilities:
         if incompatibility.cause != IncompatibilityCause.ROOT:
             continue
         for term in incompatibility.terms:
             if term.package is not root_sentinel:
-                root_required.add(term.package)
+                root_required[term.package] = None
 
-    # BFS through the decided graph to find transitively reachable packages.
+    # BFS through the decided graph to find transitively reachable packages,
+    # recording each dependency crossed on the way.
+    edges: list[tuple[PackageType, PackageType]] = []
     reachable: set[PackageType] = set()
     queue: list[PackageType] = list(root_required)
     while queue:
@@ -67,13 +100,17 @@ def build_reachable_decisions(
             unreachable = f"Bug: reachable package {package!r} has no decision"
             raise RuntimeError(unreachable)
 
-        dependencies = get_dependencies(package, version)
-        queue.extend(
-            dep_package for dep_package in dependencies if dep_package not in reachable
-        )
+        for dep_package in get_dependencies(package, version):
+            edges.append((package, dep_package))
+            if dep_package not in reachable:
+                queue.append(dep_package)
 
-    return {
-        package: version
-        for package, version in all_decisions.items()
-        if package in reachable
-    }
+    return Solution(
+        pins={
+            package: version
+            for package, version in all_decisions.items()
+            if package in reachable
+        },
+        edges=tuple(edges),
+        roots=tuple(root_required),
+    )

--- a/nab-resolver/tests/test_result.py
+++ b/nab-resolver/tests/test_result.py
@@ -2,15 +2,23 @@
 
 from __future__ import annotations
 
+import pickle
+from itertools import permutations
 from typing import Any
 
 import pytest
 
+import nab_resolver.result as result_module
 from nab_resolver.ranges import Range
 from nab_resolver.resolver import ResolutionError, Resolver, Solution
-from nab_resolver.result import build_solution
+from nab_resolver.result import build_solution_data
 from nab_resolver.root import ROOT
-from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
+from nab_resolver.types import (
+    Incompatibility,
+    IncompatibilityCause,
+    RootRequirement,
+    Term,
+)
 
 from .test_resolver import DictProvider
 
@@ -19,6 +27,11 @@ Packages = dict[str, dict[int, dict[str, Range]]]
 
 def solve(packages: Packages, **requirements: Range) -> Solution[str, int]:
     return Resolver(DictProvider(packages)).solve(dict(requirements))
+
+
+def _order_not_preserved_by_set(packages: tuple[str, ...]) -> tuple[str, ...]:
+    """Choose an order that this interpreter's set iteration changes."""
+    return next(order for order in permutations(packages) if tuple(set(order)) != order)
 
 
 class TestPins:
@@ -40,13 +53,30 @@ class TestPins:
             Resolver(DictProvider(packages)).solve({"foo": Range.full()})
 
 
+class TestPublicSolution:
+    def test_solution_uses_the_promised_module_and_pickle_path(self) -> None:
+        solution = solve({"a": {1: {}}}, a=Range.full())
+        serialized = pickle.dumps(solution, protocol=0)
+        restored = pickle.loads(serialized)  # noqa: S301
+
+        assert type(solution) is Solution
+        assert Solution.__module__ == "nab_resolver.resolver"
+        assert not hasattr(result_module, "Solution")
+        assert b"cnab_resolver.resolver\nSolution\n" in serialized
+        assert restored == solution
+
+
 class TestRoots:
     def test_roots_are_the_requirements_in_the_order_given(self) -> None:
         packages: Packages = {"a": {1: {}}, "b": {1: {}}, "c": {1: {}}}
+        root_order = _order_not_preserved_by_set(tuple(packages))
+        requirements = [
+            RootRequirement(package, Range.full()) for package in root_order
+        ]
 
-        solution = solve(packages, c=Range.full(), a=Range.full(), b=Range.full())
+        solution = Resolver(DictProvider(packages)).solve(requirements)
 
-        assert solution.roots == ("c", "a", "b")
+        assert solution.roots == root_order
 
     def test_a_root_that_is_also_a_dependency_is_still_a_root(self) -> None:
         packages: Packages = {"a": {1: {"b": Range.full()}}, "b": {1: {}}}
@@ -115,7 +145,7 @@ class TestEdges:
         )
 
 
-class TestBuildSolution:
+class TestBuildSolutionData:
     def test_the_root_sentinel_is_neither_pinned_nor_a_root(self) -> None:
         # Term[Any, int] sidesteps the invariant PackageType TypeVar so
         # ROOT and str entries can share a list.
@@ -125,15 +155,16 @@ class TestBuildSolution:
         ]
         root_clause = Incompatibility(terms, cause=IncompatibilityCause.ROOT)
 
-        solution = build_solution(
+        pins, edges, roots = build_solution_data(
             {ROOT: 1, "a": 3},
             [root_clause],
             lambda package, version: {},
             root_sentinel=ROOT,
         )
 
-        assert solution.pins == {"a": 3}
-        assert solution.roots == ("a",)
+        assert pins == {"a": 3}
+        assert edges == ()
+        assert roots == ("a",)
 
     def test_clauses_that_are_not_root_causes_contribute_no_roots(self) -> None:
         terms: list[Term[Any, int]] = [
@@ -144,13 +175,13 @@ class TestBuildSolution:
             terms, cause=IncompatibilityCause.DEPENDENCY
         )
 
-        solution = build_solution(
+        pins, edges, roots = build_solution_data(
             {"a": 1, "b": 1},
             [dependency_clause],
             lambda package, version: {},
             root_sentinel=ROOT,
         )
 
-        assert solution.pins == {}
-        assert solution.roots == ()
-        assert solution.edges == ()
+        assert pins == {}
+        assert edges == ()
+        assert roots == ()

--- a/nab-resolver/tests/test_result.py
+++ b/nab-resolver/tests/test_result.py
@@ -71,7 +71,7 @@ class TestRoots:
         packages: Packages = {"a": {1: {}}, "b": {1: {}}, "c": {1: {}}}
         root_order = _order_not_preserved_by_set(tuple(packages))
         requirements = [
-            RootRequirement(package, Range.full()) for package in root_order
+            RootRequirement[str, int](package, Range.full()) for package in root_order
         ]
 
         solution = Resolver(DictProvider(packages)).solve(requirements)

--- a/nab-resolver/tests/test_result.py
+++ b/nab-resolver/tests/test_result.py
@@ -1,0 +1,156 @@
+"""Tests for the solution a resolve returns: its pins, roots, and edges."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from nab_resolver.ranges import Range
+from nab_resolver.resolver import ResolutionError, Resolver, Solution
+from nab_resolver.result import build_solution
+from nab_resolver.root import ROOT
+from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
+
+from .test_resolver import DictProvider
+
+Packages = dict[str, dict[int, dict[str, Range]]]
+
+
+def solve(packages: Packages, **requirements: Range) -> Solution[str, int]:
+    return Resolver(DictProvider(packages)).solve(dict(requirements))
+
+
+class TestPins:
+    def test_resolve_returns_the_pins_of_solve(self) -> None:
+        packages: Packages = {
+            "root": {1: {"foo": Range.full()}},
+            "foo": {2: {"bar": Range.full()}, 1: {}},
+            "bar": {1: {}},
+        }
+        pins = Resolver(DictProvider(packages)).resolve({"root": Range.singleton(1)})
+
+        assert pins == solve(packages, root=Range.singleton(1)).pins
+        assert pins == {"root": 1, "foo": 2, "bar": 1}
+
+    def test_solve_raises_when_no_solution_exists(self) -> None:
+        packages: Packages = {"foo": {1: {"bar": Range.singleton(9)}}, "bar": {1: {}}}
+
+        with pytest.raises(ResolutionError):
+            Resolver(DictProvider(packages)).solve({"foo": Range.full()})
+
+
+class TestRoots:
+    def test_roots_are_the_requirements_in_the_order_given(self) -> None:
+        packages: Packages = {"a": {1: {}}, "b": {1: {}}, "c": {1: {}}}
+
+        solution = solve(packages, c=Range.full(), a=Range.full(), b=Range.full())
+
+        assert solution.roots == ("c", "a", "b")
+
+    def test_a_root_that_is_also_a_dependency_is_still_a_root(self) -> None:
+        packages: Packages = {"a": {1: {"b": Range.full()}}, "b": {1: {}}}
+
+        solution = solve(packages, a=Range.full(), b=Range.full())
+
+        assert solution.roots == ("a", "b")
+        assert solution.edges == (("a", "b"),)
+
+
+class TestEdges:
+    def test_edges_are_breadth_first_from_the_roots(self) -> None:
+        packages: Packages = {
+            "a": {1: {"b": Range.full(), "c": Range.full()}},
+            "b": {1: {"d": Range.full()}},
+            "c": {1: {"d": Range.full()}},
+            "d": {1: {}},
+        }
+
+        solution = solve(packages, a=Range.full())
+
+        assert solution.edges == (("a", "b"), ("a", "c"), ("b", "d"), ("c", "d"))
+
+    def test_a_shared_dependency_is_recorded_once_per_dependent(self) -> None:
+        packages: Packages = {
+            "a": {1: {"shared": Range.full()}},
+            "b": {1: {"shared": Range.full()}},
+            "shared": {1: {}},
+        }
+
+        solution = solve(packages, a=Range.full(), b=Range.full())
+
+        assert solution.edges == (("a", "shared"), ("b", "shared"))
+
+    def test_a_dependency_cycle_terminates(self) -> None:
+        packages: Packages = {
+            "a": {1: {"b": Range.full()}},
+            "b": {1: {"a": Range.full()}},
+        }
+
+        solution = solve(packages, a=Range.full())
+
+        assert solution.pins == {"a": 1, "b": 1}
+        assert solution.edges == (("a", "b"), ("b", "a"))
+
+    def test_a_leaf_resolve_has_no_edges(self) -> None:
+        solution = solve({"a": {1: {}}}, a=Range.full())
+
+        assert solution.pins == {"a": 1}
+        assert solution.edges == ()
+
+    def test_every_edge_endpoint_is_pinned(self) -> None:
+        packages: Packages = {
+            "a": {1: {"b": Range.full()}},
+            "b": {2: {"c": Range.full()}, 1: {}},
+            "c": {1: {}},
+            "unused": {1: {}},
+        }
+
+        solution = solve(packages, a=Range.full())
+
+        assert "unused" not in solution.pins
+        assert all(
+            parent in solution.pins and child in solution.pins
+            for parent, child in solution.edges
+        )
+
+
+class TestBuildSolution:
+    def test_the_root_sentinel_is_neither_pinned_nor_a_root(self) -> None:
+        # Term[Any, int] sidesteps the invariant PackageType TypeVar so
+        # ROOT and str entries can share a list.
+        terms: list[Term[Any, int]] = [
+            Term(ROOT, Range.singleton(1)),
+            Term("a", Range.full(), positive=False),
+        ]
+        root_clause = Incompatibility(terms, cause=IncompatibilityCause.ROOT)
+
+        solution = build_solution(
+            {ROOT: 1, "a": 3},
+            [root_clause],
+            lambda package, version: {},
+            root_sentinel=ROOT,
+        )
+
+        assert solution.pins == {"a": 3}
+        assert solution.roots == ("a",)
+
+    def test_clauses_that_are_not_root_causes_contribute_no_roots(self) -> None:
+        terms: list[Term[Any, int]] = [
+            Term("a", Range.singleton(1)),
+            Term("b", Range.full(), positive=False),
+        ]
+        dependency_clause = Incompatibility(
+            terms, cause=IncompatibilityCause.DEPENDENCY
+        )
+
+        solution = build_solution(
+            {"a": 1, "b": 1},
+            [dependency_clause],
+            lambda package, version: {},
+            root_sentinel=ROOT,
+        )
+
+        assert solution.pins == {}
+        assert solution.roots == ()
+        assert solution.edges == ()


### PR DESCRIPTION
pip's Nab adapter needs the resolved dependency graph for `get_installation_order`, which passes it to `get_topological_weights` to choose the install order. `Resolver.resolve` returns only `{package: version}`, leaving the adapter to ask the provider for dependencies a second time and rebuild the graph from that.

The reachability walk already visits each selected dependency. `Resolver.solve` now returns a documented `nab_resolver.resolver.Solution` carrying the pins, the ordered `(parent, child)` edges, and the directly required roots. Root recovery keeps requirement order rather than passing through a set, so traversal and edge order do not vary with the hash seed.

`Resolver.resolve` keeps its return contract and hands back `solve(...).pins` for callers that only want the selected versions.
