### PR TITLE
cross-check the deterministic smoke suite with uv

### DIFF
--- a/nab-python/benchmarks/README.md
+++ b/nab-python/benchmarks/README.md
@@ -17,6 +17,22 @@ The scenarios use Nab's default highest resolution strategy and default cross-ta
 
 Each resolve gets a fresh coordinator against the same prebuilt offline fixture. Warmups happen before measurement, and each recorded inner interval covers only the resolver call; fixture generation, coordinator lifecycle, semantic validation, and lock emission stay outside it. Timing samples are local diagnostics, not a reusable baseline or comparative result, and should be collected sequentially under controlled conditions.
 
+## uv semantic oracle
+
+`deterministic_smoke_uv.py` accepts an explicitly supplied uv binary and resolves all eleven frozen scenarios against the same local wheel corpus. Nine single-target mappings use `uv pip compile --format pylock.toml`; the two universal mappings use a temporary copy of the checked-in uv project so `uv.lock` never enters the worktree.
+
+```bash
+python nab-python/benchmarks/deterministic_smoke_uv.py --uv /path/to/uv
+```
+
+Both universal cases run as one user-facing `uv lock` operation. Default resolution arguments stay omitted. `universal-independent` uses uv's default `requires-python` fork strategy without an override, while `universal-aligned` explicitly requests the non-default `fewest` strategy for the complete four-target project.
+
+The adapter disables configuration discovery, downloads, caching, and builds. Every uv subprocess has a fixed timeout, explicit UTF-8 decoding, an isolated working directory, and a declared environment allowlist which excludes ambient `UV_*` policy.
+
+It checks exact target projections, fixture-local wheel paths and SHA-256 hashes, and the universal lock's target domain, package sources, and dependency edges. Relative artifact and registry values are resolved from the directory containing the emitted pylock or `uv.lock`, independent of the caller's working directory. The semantic report records each command's exit classification and the identities of its executable, source inputs, fixture, and subprocess policy. Those identities are checked again after the run. The report contains no wall time or reusable timing baseline.
+
+uv remains an external oracle and is not added to Nab's development or release dependencies.
+
 ## Single-environment scenarios
 
 `nab-python/benchmarks/scenarios.py` runs scenarios drawn from

--- a/nab-python/benchmarks/deterministic_smoke.py
+++ b/nab-python/benchmarks/deterministic_smoke.py
@@ -104,6 +104,8 @@ _SCENARIO_KEYS = frozenset(
         "platforms",
         "resolution",
         "align-across-targets",
+        "uv-mapping",
+        "uv-fork-strategy",
         "expected",
     }
 )
@@ -233,6 +235,8 @@ class Scenario:
     platforms: tuple[str, ...]
     resolution: ResolutionStrategy | None
     align_across_targets: bool | None
+    uv_mapping: str | None
+    uv_fork_strategy: str | None
     expected: tuple[ExpectedTarget, ...]
 
 
@@ -538,6 +542,32 @@ def _parse_expected_targets(
     return tuple(expected)
 
 
+def _parse_uv_mapping(
+    raw: Mapping[str, object], label: str, mode: str
+) -> tuple[str | None, str | None]:
+    mapping = raw.get("uv-mapping")
+    if mapping is not None and not isinstance(mapping, str):
+        _fail(f"{label}.uv-mapping must be a string")
+    if mapping not in {None, "pip-compile", "lock"}:
+        _fail(f"{label}.uv-mapping is invalid")
+
+    fork_strategy = raw.get("uv-fork-strategy")
+    if fork_strategy is not None and not isinstance(fork_strategy, str):
+        _fail(f"{label}.uv-fork-strategy must be a string")
+    if mapping == "lock" and fork_strategy not in {"fewest", "requires-python"}:
+        _fail(
+            f"{label}.uv-fork-strategy must be fewest or requires-python"
+            " for a lock mapping"
+        )
+    if mapping != "lock" and fork_strategy is not None:
+        _fail(f"{label}.uv-fork-strategy is only valid for a lock mapping")
+    if mapping == "pip-compile" and mode != "specific":
+        _fail(f"{label}.pip-compile mapping requires specific mode")
+    if mapping == "lock" and mode != "universal":
+        _fail(f"{label}.lock mapping requires universal mode")
+    return mapping, fork_strategy
+
+
 def _parse_scenario(raw: Mapping[str, object], index: int) -> Scenario:
     """Parse one `[[scenario]]` table into its declared resolver inputs."""
     label = f"scenario[{index}]"
@@ -559,6 +589,8 @@ def _parse_scenario(raw: Mapping[str, object], index: int) -> Scenario:
     mode = str(raw["mode"])
     if mode not in {"specific", "universal"}:
         _fail(f"{label}.mode must be specific or universal")
+    uv_mapping, uv_fork_strategy = _parse_uv_mapping(raw, label, mode)
+
     # Absent means "leave the product default alone", which prepare_scenario and
     # _resolve_once each honour by not passing the argument at all.
     alignment = raw.get("align-across-targets")
@@ -595,6 +627,8 @@ def _parse_scenario(raw: Mapping[str, object], index: int) -> Scenario:
         platforms=platforms,
         resolution=resolution,
         align_across_targets=alignment,
+        uv_mapping=uv_mapping,
+        uv_fork_strategy=uv_fork_strategy,
         expected=expected,
     )
 

--- a/nab-python/benchmarks/deterministic_smoke_uv.py
+++ b/nab-python/benchmarks/deterministic_smoke_uv.py
@@ -1,0 +1,1400 @@
+"""Execute uv semantic cross-checks against the deterministic smoke fixture."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, NoReturn
+from urllib.parse import urlparse
+from urllib.request import url2pathname
+
+import deterministic_smoke as smoke_core
+from deterministic_smoke import (
+    FIXTURE_PATH,
+    SCENARIOS_PATH,
+    Distribution,
+    PreparedScenario,
+    Scenario,
+    SmokeContractError,
+    file_sha256,
+    load_fixture,
+    load_scenarios,
+    materialize_fixture,
+    prepare_scenario,
+    validate_materialized_fixture,
+)
+
+from nab_python._vendor.packaging.markers import InvalidMarker, Marker
+from nab_python._vendor.packaging.requirements import Requirement
+from nab_python._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
+from nab_python._vendor.packaging.utils import (
+    InvalidName,
+    canonicalize_name,
+    parse_wheel_filename,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+ADAPTER_PATH = Path(__file__).resolve()
+CORE_PATH = Path(smoke_core.__file__).resolve()
+UV_PROJECT = ADAPTER_PATH.parent / "smoke" / "uv-lock" / "pyproject.toml"
+UV_SUBPROCESS_TIMEOUT_SECONDS = 120
+UV_NO_SOLUTION_EXIT_STATUS = 1
+_EXECUTION_ENVIRONMENT_ALLOWLIST = (
+    "SYSTEMROOT",
+    "WINDIR",
+)
+_CONTROLLED_TEMP_ENVIRONMENT = ("TEMP", "TMP", "TMPDIR")
+_UV_PLATFORM = {
+    ("linux", "x86_64"): "x86_64-unknown-linux-gnu",
+    ("win32", "AMD64"): "x86_64-pc-windows-msvc",
+}
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+class UvCrossCheckError(Exception):
+    """uv did not reproduce the declared deterministic semantic contract."""
+
+
+@dataclass(frozen=True, slots=True)
+class _UvIdentity:
+    """Resolved uv executable used throughout one verification."""
+
+    path: Path
+    sha256: str
+    version: str
+
+
+@dataclass(frozen=True, slots=True)
+class _LockDocument:
+    """Parsed lock data and the directory its relative paths use."""
+
+    data: Mapping[str, Any]
+    directory: Path
+
+
+@dataclass(frozen=True, slots=True)
+class _UvLockRun:
+    """One uv lock result retained while its project directory exists."""
+
+    document: _LockDocument
+    command: tuple[str, ...]
+    returncode: int
+
+
+@dataclass(frozen=True, slots=True)
+class _UvLockPackages:
+    """Project and external package rows from one uv lock."""
+
+    project: Mapping[str, Any]
+    external: tuple[Mapping[str, Any], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _SubprocessPolicy:
+    """Fixed subprocess inputs shared by every uv invocation."""
+
+    timeout_seconds: int
+    encoding: str
+    errors: str
+    cwd_policy: str
+    environment_allowlist: tuple[str, ...]
+    controlled_environment: tuple[str, ...]
+    environment: tuple[tuple[str, str], ...]
+    stripped_uv_variables: tuple[str, ...]
+
+    def environment_dict(self, cwd: Path) -> dict[str, str]:
+        """Return the minimal child environment for cwd."""
+        environment = dict(self.environment)
+        environment.update((name, str(cwd)) for name in self.controlled_environment)
+        return environment
+
+    def record(self) -> dict[str, object]:
+        """Return the report form of this subprocess policy."""
+        environment_sha256 = _canonical_sha256(dict(self.environment))
+        return {
+            "timeout_seconds": self.timeout_seconds,
+            "encoding": self.encoding,
+            "errors": self.errors,
+            "cwd": self.cwd_policy,
+            "environment_allowlist": list(self.environment_allowlist),
+            "inherited_environment": dict(self.environment),
+            "environment_sha256": environment_sha256,
+            "controlled_environment": dict.fromkeys(
+                self.controlled_environment, "<cwd>"
+            ),
+            "stripped_uv_variables": list(self.stripped_uv_variables),
+        }
+
+    def digest(self) -> str:
+        return _canonical_sha256(self.record())
+
+
+@dataclass(frozen=True, slots=True)
+class _ScenarioInputIdentity:
+    """Canonical digests for the selected scenario inputs."""
+
+    selected_sha256: str
+    scenarios: tuple[tuple[str, str], ...]
+
+    def record(self) -> dict[str, object]:
+        """Return the scenario identity fields used by a report."""
+        return {
+            "selected_scenarios_sha256": self.selected_sha256,
+            "scenario_sha256": dict(self.scenarios),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class _InputIdentity:
+    """Direct source and scenario inputs captured for one verification."""
+
+    adapter_sha256: str
+    core_sha256: str
+    scenario_manifest_sha256: str
+    fixture_manifest_sha256: str
+    fixture_input_sha256: str
+    uv_project_sha256: str
+    scenarios: _ScenarioInputIdentity
+
+    def record(self) -> dict[str, object]:
+        """Return the input identity fields used by a report."""
+        return {
+            "adapter_sha256": self.adapter_sha256,
+            "core_sha256": self.core_sha256,
+            "scenario_manifest_sha256": self.scenario_manifest_sha256,
+            "fixture_manifest_sha256": self.fixture_manifest_sha256,
+            "fixture_input_sha256": self.fixture_input_sha256,
+            "uv_project_sha256": self.uv_project_sha256,
+            **self.scenarios.record(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class _VerificationSnapshot:
+    """Inputs rechecked after all scenario commands finish."""
+
+    fixture_root: Path
+    fixture_sha256: str
+    fixture_mode: str
+    fixture_access: Mapping[str, object]
+    uv: _UvIdentity
+    policy: _SubprocessPolicy
+    policy_sha256: str
+    inputs: _InputIdentity
+    scenarios: tuple[Scenario, ...]
+    distributions: tuple[Distribution, ...]
+
+
+def _fail(message: str) -> NoReturn:
+    raise UvCrossCheckError(message)
+
+
+def _canonical_sha256(value: object) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _subprocess_policy() -> _SubprocessPolicy:
+    environment = tuple(
+        (name, os.environ[name])
+        for name in _EXECUTION_ENVIRONMENT_ALLOWLIST
+        if name in os.environ
+    )
+    stripped_uv_variables = tuple(
+        sorted(name for name in os.environ if name == "UV" or name.startswith("UV_"))
+    )
+    return _SubprocessPolicy(
+        timeout_seconds=UV_SUBPROCESS_TIMEOUT_SECONDS,
+        encoding="utf-8",
+        errors="strict",
+        cwd_policy="an explicit isolated temporary directory",
+        environment_allowlist=_EXECUTION_ENVIRONMENT_ALLOWLIST,
+        controlled_environment=_CONTROLLED_TEMP_ENVIRONMENT,
+        environment=environment,
+        stripped_uv_variables=stripped_uv_variables,
+    )
+
+
+def _run(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    policy: _SubprocessPolicy,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        resolved_cwd = cwd.resolve(strict=True)
+    except OSError as exc:
+        _fail(f"cannot use uv working directory {cwd}: {exc}")
+    if not resolved_cwd.is_dir():
+        _fail(f"uv working directory {resolved_cwd} is not a directory")
+    try:
+        return subprocess.run(  # noqa: S603 - argv only; no shell invocation
+            command,
+            capture_output=True,
+            check=False,
+            cwd=resolved_cwd,
+            env=policy.environment_dict(resolved_cwd),
+            timeout=policy.timeout_seconds,
+            encoding=policy.encoding,
+            errors=policy.errors,
+        )
+    except subprocess.TimeoutExpired:
+        _fail(f"{command[0]!r} timed out after {policy.timeout_seconds} seconds")
+    except UnicodeDecodeError as exc:
+        _fail(f"{command[0]!r} emitted non-UTF-8 output: {exc}")
+    except OSError as exc:
+        _fail(f"cannot execute {command[0]!r}: {exc}")
+
+
+def _run_uv_version(
+    path: Path, policy: _SubprocessPolicy
+) -> subprocess.CompletedProcess[str]:
+    with tempfile.TemporaryDirectory(prefix="nab-smoke-uv-version-") as temporary:
+        return _run((str(path), "--version"), cwd=Path(temporary), policy=policy)
+
+
+def _command_record(
+    command: Sequence[str], *, fixture_root: Path, work_root: Path
+) -> list[str]:
+    replacements = (
+        (fixture_root.resolve().as_uri(), "file://<fixture>"),
+        (str(fixture_root.resolve()), "<fixture>"),
+        (str(work_root.resolve()), "<work>"),
+    )
+    recorded: list[str] = []
+    for index, argument in enumerate(command):
+        if index == 0:
+            recorded.append("<uv>")
+            continue
+        recorded_argument = argument
+        has_redacted_root = False
+        for source, replacement in replacements:
+            if source not in recorded_argument:
+                continue
+            recorded_argument = recorded_argument.replace(source, replacement)
+            has_redacted_root = True
+        if has_redacted_root:
+            recorded_argument = recorded_argument.replace("\\", "/")
+        recorded.append(recorded_argument)
+    return recorded
+
+
+def _scenario_record(scenario: Scenario) -> dict[str, object]:
+    return {
+        "id": scenario.id,
+        "provenance": scenario.provenance,
+        "purpose": scenario.purpose,
+        "lane": scenario.lane,
+        "outcome": scenario.outcome,
+        "warmups": scenario.warmups,
+        "batch_size": scenario.batch_size,
+        "mode": scenario.mode,
+        "requirements": list(scenario.requirements),
+        "constraints": list(scenario.constraints),
+        "python": scenario.python,
+        "platforms": list(scenario.platforms),
+        "resolution": (
+            scenario.resolution.value if scenario.resolution is not None else None
+        ),
+        "align_across_targets": scenario.align_across_targets,
+        "uv_mapping": scenario.uv_mapping,
+        "uv_fork_strategy": scenario.uv_fork_strategy,
+        "expected": [
+            {
+                "target": expected.target,
+                "pins": dict(sorted(expected.pins.items())),
+            }
+            for expected in scenario.expected
+        ],
+    }
+
+
+def _scenario_input_identity(
+    scenarios: Sequence[Scenario],
+) -> _ScenarioInputIdentity:
+    records = [_scenario_record(scenario) for scenario in scenarios]
+    ids = [scenario.id for scenario in scenarios]
+    if len(ids) != len(set(ids)):
+        _fail("selected uv scenario ids must be unique")
+    return _ScenarioInputIdentity(
+        selected_sha256=_canonical_sha256(records),
+        scenarios=tuple(
+            (scenario.id, _canonical_sha256(record))
+            for scenario, record in zip(scenarios, records, strict=True)
+        ),
+    )
+
+
+def _fixture_input_digest(distributions: Sequence[Distribution]) -> str:
+    return _canonical_sha256(
+        [
+            {
+                "name": distribution.name,
+                "version": distribution.version,
+                "dependencies": list(distribution.dependencies),
+                "requires_python": distribution.requires_python,
+                "provides_extra": list(distribution.provides_extra),
+            }
+            for distribution in distributions
+        ]
+    )
+
+
+def _input_identity(
+    scenarios: Sequence[Scenario], distributions: Sequence[Distribution]
+) -> _InputIdentity:
+    try:
+        return _InputIdentity(
+            adapter_sha256=file_sha256(ADAPTER_PATH),
+            core_sha256=file_sha256(CORE_PATH),
+            scenario_manifest_sha256=file_sha256(SCENARIOS_PATH),
+            fixture_manifest_sha256=file_sha256(FIXTURE_PATH),
+            fixture_input_sha256=_fixture_input_digest(distributions),
+            uv_project_sha256=file_sha256(UV_PROJECT),
+            scenarios=_scenario_input_identity(scenarios),
+        )
+    except OSError as exc:
+        _fail(f"cannot identify uv comparison inputs: {exc}")
+
+
+def _uv_platform(environment: Mapping[str, str]) -> str:
+    platform = environment.get("sys_platform")
+    machine = environment.get("platform_machine")
+    if platform is None or machine is None:
+        _fail("uv platform mapping requires sys_platform and platform_machine")
+    key = (platform, machine)
+    try:
+        return _UV_PLATFORM[key]
+    except KeyError:
+        _fail(f"no exact uv platform mapping for {key}")
+
+
+def _fixture_inventory(fixture_root: Path) -> dict[tuple[str, str], tuple[Path, str]]:
+    inventory: dict[tuple[str, str], tuple[Path, str]] = {}
+    for wheel in sorted((fixture_root / "packages").glob("*.whl")):
+        try:
+            name, version, _build, _tags = parse_wheel_filename(wheel.name)
+        except ValueError as exc:
+            _fail(f"fixture contains an invalid wheel {wheel.name!r}: {exc}")
+        key = (str(canonicalize_name(name, validate=True)), str(version))
+        if key in inventory:
+            _fail(f"fixture contains duplicate wheel artifacts for {key}")
+        inventory[key] = (wheel.resolve(), file_sha256(wheel))
+    if not inventory:
+        _fail("fixture contains no wheels")
+    return inventory
+
+
+def _artifact_path(value: str, label: str, *, document_dir: Path) -> Path:
+    if not document_dir.is_absolute():
+        _fail(f"{label} document directory is not absolute")
+
+    try:
+        path = Path(value)
+        if path.is_absolute():
+            return path.resolve()
+
+        parsed = urlparse(value)
+        if parsed.scheme:
+            if parsed.scheme != "file" or parsed.netloc not in {"", "localhost"}:
+                _fail(f"{label} is not a local file URL")
+            path = Path(url2pathname(parsed.path))
+        if "\0" in os.fspath(path):
+            _fail(f"{label} has an invalid local path")
+        if not path.is_absolute():
+            path = document_dir / path
+        return path.resolve()
+    except (OSError, RuntimeError, ValueError):
+        _fail(f"{label} has an invalid local path")
+
+
+def _validate_artifact(
+    package: Mapping[str, Any],
+    *,
+    inventory: Mapping[tuple[str, str], tuple[Path, str]],
+    document_dir: Path,
+    pylock: bool,
+) -> tuple[str, str]:
+    name = package.get("name")
+    version = package.get("version")
+    if not isinstance(name, str) or not isinstance(version, str):
+        _fail("uv output contains an unversioned package")
+    key = (str(canonicalize_name(name, validate=True)), version)
+    expected = inventory.get(key)
+    if expected is None:
+        _fail(f"uv selected non-fixture package {key}")
+    if package.get("sdist") is not None:
+        _fail(f"uv selected an sdist for {key}")
+    wheels = package.get("wheels")
+    if not isinstance(wheels, list) or len(wheels) != 1:
+        _fail(f"uv did not retain exactly one fixture wheel for {key}")
+    wheel = wheels[0]
+    if not isinstance(wheel, dict):
+        _fail(f"uv emitted a malformed wheel for {key}")
+    location_key = "url" if pylock else "path"
+    location = wheel.get(location_key)
+    if not isinstance(location, str):
+        _fail(f"uv emitted no {location_key} for {key}")
+    path = _artifact_path(
+        location,
+        f"artifact for {key}",
+        document_dir=document_dir,
+    )
+    expected_path, expected_digest = expected
+    if path != expected_path or not path.is_file():
+        _fail(f"uv artifact for {key} is outside the frozen fixture")
+    if pylock:
+        hashes = wheel.get("hashes")
+        actual_digest = hashes.get("sha256") if isinstance(hashes, dict) else None
+    else:
+        raw_hash = wheel.get("hash")
+        actual_digest = (
+            raw_hash.removeprefix("sha256:")
+            if isinstance(raw_hash, str) and raw_hash.startswith("sha256:")
+            else None
+        )
+    if actual_digest != expected_digest or file_sha256(path) != expected_digest:
+        _fail(f"uv artifact hash for {key} does not match the frozen wheel")
+    return key
+
+
+def _pylock_pins(
+    document: _LockDocument,
+    inventory: Mapping[tuple[str, str], tuple[Path, str]],
+) -> dict[str, str]:
+    data = document.data
+    if data.get("lock-version") != "1.0" or data.get("created-by") != "uv":
+        _fail("uv emitted an unsupported pylock document")
+    packages = data.get("packages")
+    if not isinstance(packages, list):
+        _fail("uv pylock has no packages array")
+    pins: dict[str, str] = {}
+    for raw_package in packages:
+        if not isinstance(raw_package, dict):
+            _fail("uv pylock contains a malformed package")
+        name, version = _validate_artifact(
+            raw_package,
+            inventory=inventory,
+            document_dir=document.directory,
+            pylock=True,
+        )
+        if name in pins:
+            _fail(f"uv emitted {name!r} more than once")
+        pins[name] = version
+    return pins
+
+
+def _lock_projection(
+    document: Mapping[str, Any],
+    marker_environments: Mapping[str, Mapping[str, str]],
+) -> dict[str, dict[str, str]]:
+    packages = document.get("package")
+    if not isinstance(packages, list):
+        _fail("uv.lock has no package array")
+    projected = {target: {} for target in marker_environments}
+    for raw_package in packages:
+        if not isinstance(raw_package, dict):
+            _fail("uv.lock contains a malformed package")
+        if raw_package.get("source") == {"virtual": "."}:
+            continue
+        name = raw_package.get("name")
+        version = raw_package.get("version")
+        if not isinstance(name, str) or not isinstance(version, str):
+            _fail("uv.lock contains an unversioned non-project package")
+        canonical = str(canonicalize_name(name, validate=True))
+        raw_markers = raw_package.get("resolution-markers")
+        if raw_markers is None:
+            markers: tuple[Marker, ...] = ()
+        elif isinstance(raw_markers, list) and all(
+            isinstance(marker, str) for marker in raw_markers
+        ):
+            markers = tuple(Marker(marker) for marker in raw_markers)
+        else:
+            _fail(f"uv.lock has malformed resolution markers for {canonical}")
+        for target, environment in marker_environments.items():
+            if markers and not any(
+                marker.evaluate(environment=environment) for marker in markers
+            ):
+                continue
+            if canonical in projected[target]:
+                _fail(f"uv.lock selects {canonical!r} twice for {target}")
+            projected[target][canonical] = version
+    return projected
+
+
+def _marker_coverage(
+    raw_markers: object,
+    environments: Mapping[str, Mapping[str, str]],
+    label: str,
+) -> list[frozenset[str]]:
+    if (
+        not isinstance(raw_markers, list)
+        or not raw_markers
+        or not all(isinstance(marker, str) for marker in raw_markers)
+    ):
+        _fail(f"{label} must be a nonempty string array")
+    coverage: list[frozenset[str]] = []
+    for raw_marker in raw_markers:
+        marker = Marker(raw_marker)
+        selected = frozenset(
+            target
+            for target, environment in environments.items()
+            if marker.evaluate(environment=environment)
+        )
+        if not selected:
+            _fail(f"{label} contains a marker outside the declared target domain")
+        coverage.append(selected)
+    return coverage
+
+
+def _dependency_names(
+    dependencies: object,
+    environment: Mapping[str, str],
+    selected: Mapping[str, str],
+    *,
+    fixture_root: Path,
+    document_dir: Path,
+    label: str,
+) -> set[str]:
+    if dependencies is None:
+        return set()
+    if not isinstance(dependencies, list):
+        _fail(f"{label} dependencies must be an array")
+    names: set[str] = set()
+    for raw_dependency in dependencies:
+        if not isinstance(raw_dependency, dict):
+            _fail(f"{label} contains a malformed dependency")
+        raw_marker = raw_dependency.get("marker")
+        if raw_marker is not None:
+            if not isinstance(raw_marker, str):
+                _fail(f"{label} contains a malformed dependency marker")
+            if not Marker(raw_marker).evaluate(environment=environment):
+                continue
+        name = raw_dependency.get("name")
+        if not isinstance(name, str):
+            _fail(f"{label} contains an unnamed dependency")
+        canonical = str(canonicalize_name(name, validate=True))
+        if canonical not in selected:
+            _fail(f"{label} references unselected dependency {canonical!r}")
+        version = raw_dependency.get("version")
+        if version is not None and version != selected[canonical]:
+            _fail(f"{label} records the wrong version for {canonical!r}")
+        source = raw_dependency.get("source")
+        if source is not None:
+            if not isinstance(source, dict) or not isinstance(
+                source.get("registry"), str
+            ):
+                _fail(f"{label} contains a non-fixture dependency source")
+            if (
+                _artifact_path(
+                    source["registry"],
+                    label,
+                    document_dir=document_dir,
+                )
+                != fixture_root.resolve()
+            ):
+                _fail(f"{label} contains a non-fixture dependency source")
+        names.add(canonical)
+    return names
+
+
+def _validate_uv_lock_header(document: Mapping[str, Any], scenario: Scenario) -> None:
+    if document.get("version") != 1:
+        _fail(f"{scenario.id}: uv emitted an unsupported lock version")
+    requires_python = document.get("requires-python")
+    if not isinstance(requires_python, str) or SpecifierSet(
+        requires_python
+    ) != SpecifierSet(scenario.python):
+        _fail(f"{scenario.id}: uv lock changed the Python domain")
+    options = document.get("options")
+    if options is None:
+        effective_fork_strategy = "requires-python"
+    elif isinstance(options, dict):
+        effective_fork_strategy = options.get("fork-strategy", "requires-python")
+    else:
+        _fail(f"{scenario.id}: uv lock has malformed options")
+    if effective_fork_strategy != scenario.uv_fork_strategy:
+        _fail(f"{scenario.id}: uv lock did not retain the fork strategy")
+
+
+def _validate_uv_lock_marker_domain(
+    document: Mapping[str, Any],
+    scenario: Scenario,
+    prepared: PreparedScenario,
+) -> dict[str, Mapping[str, str]]:
+    environments = {target.label: target.marker_env for target in prepared.targets}
+    singleton_domain = {frozenset((target,)) for target in environments}
+    resolution_coverage = _marker_coverage(
+        document.get("resolution-markers"), environments, "resolution-markers"
+    )
+    if (
+        len(resolution_coverage) != len(environments)
+        or set(resolution_coverage) != singleton_domain
+    ):
+        _fail(f"{scenario.id}: uv lock does not cover each exact target cell once")
+    platform_groups: dict[tuple[str, str], set[str]] = {}
+    for target, environment in environments.items():
+        platform_groups.setdefault(
+            (environment["sys_platform"], environment["platform_machine"]), set()
+        ).add(target)
+    expected_platform_domain = {
+        frozenset(targets) for targets in platform_groups.values()
+    }
+    for key in ("supported-markers", "required-markers"):
+        coverage = _marker_coverage(document.get(key), environments, key)
+        if len(coverage) != len(expected_platform_domain) or set(coverage) != (
+            expected_platform_domain
+        ):
+            _fail(f"{scenario.id}: {key} differs from the exact platform domain")
+    return environments
+
+
+def _uv_lock_packages(
+    document: Mapping[str, Any], scenario: Scenario
+) -> _UvLockPackages:
+    packages = document.get("package")
+    if not isinstance(packages, list):
+        _fail("uv.lock has no package array")
+    project_packages = [
+        package
+        for package in packages
+        if isinstance(package, dict) and package.get("source") == {"virtual": "."}
+    ]
+    if len(project_packages) != 1 or project_packages[0].get("name") != (
+        "nab-smoke-uv-lock"
+    ):
+        _fail(f"{scenario.id}: uv lock has a missing or extra project package")
+    external_packages: list[Mapping[str, Any]] = []
+    for package in packages:
+        if package is project_packages[0]:
+            continue
+        if not isinstance(package, dict):
+            _fail("uv.lock contains a malformed package")
+        external_packages.append(package)
+    return _UvLockPackages(project_packages[0], tuple(external_packages))
+
+
+def _validate_uv_lock_package_records(
+    document: Mapping[str, Any],
+    scenario: Scenario,
+    prepared: PreparedScenario,
+    packages: _UvLockPackages,
+    *,
+    inventory: Mapping[tuple[str, str], tuple[Path, str]],
+    fixture_root: Path,
+    document_dir: Path,
+) -> None:
+    top_markers = set(document["resolution-markers"])
+    actual_records: set[tuple[str, str]] = set()
+    for package in packages.external:
+        raw_markers = package.get("resolution-markers", [])
+        if not isinstance(raw_markers, list) or not all(
+            isinstance(marker, str) and marker in top_markers for marker in raw_markers
+        ):
+            _fail(f"{scenario.id}: package markers escape the resolution domain")
+        source = package.get("source")
+        if not isinstance(source, dict) or not isinstance(source.get("registry"), str):
+            _fail(f"{scenario.id}: package has no fixture registry source")
+        if (
+            _artifact_path(
+                source["registry"],
+                "package source",
+                document_dir=document_dir,
+            )
+            != fixture_root.resolve()
+        ):
+            _fail(f"{scenario.id}: package source is outside the fixture")
+        record = _validate_artifact(
+            package,
+            inventory=inventory,
+            document_dir=document_dir,
+            pylock=False,
+        )
+        if record in actual_records:
+            _fail(f"{scenario.id}: uv lock emitted duplicate artifact records")
+        actual_records.add(record)
+    expected_records = {
+        (name, version)
+        for pins in prepared.expected.values()
+        for name, version in pins.items()
+    }
+    if actual_records != expected_records or len(packages.external) != len(
+        expected_records
+    ):
+        _fail(
+            f"{scenario.id}: uv lock package records differ:"
+            f" {actual_records} != {expected_records}"
+        )
+
+
+def _active_requirement_names(
+    requirements: Sequence[str], environment: Mapping[str, str]
+) -> set[str]:
+    names: set[str] = set()
+    for text in requirements:
+        requirement = Requirement(text)
+        if requirement.marker is None or requirement.marker.evaluate(
+            environment=environment
+        ):
+            names.add(str(canonicalize_name(requirement.name, validate=True)))
+    return names
+
+
+def _packages_for_target(
+    packages: Sequence[Mapping[str, Any]], selected: Mapping[str, str]
+) -> dict[str, Mapping[str, Any]]:
+    by_name: dict[str, Mapping[str, Any]] = {}
+    for package in packages:
+        canonical = str(canonicalize_name(str(package.get("name")), validate=True))
+        if canonical in selected and str(package.get("version")) == selected[canonical]:
+            by_name[canonical] = package
+    return by_name
+
+
+def _validate_uv_lock_target_edges(
+    scenario: Scenario,
+    target: str,
+    environment: Mapping[str, str],
+    selected: Mapping[str, str],
+    packages: _UvLockPackages,
+    distributions: Mapping[tuple[str, str], Distribution],
+    *,
+    fixture_root: Path,
+    document_dir: Path,
+) -> None:
+    actual_root = _dependency_names(
+        packages.project.get("dependencies"),
+        environment,
+        selected,
+        fixture_root=fixture_root,
+        document_dir=document_dir,
+        label=f"{scenario.id}:{target}:project",
+    )
+    expected_root = _active_requirement_names(scenario.requirements, environment)
+    if actual_root != expected_root:
+        _fail(f"{scenario.id}:{target}: root dependency edges differ")
+
+    by_name = _packages_for_target(packages.external, selected)
+    for parent, version in selected.items():
+        distribution = distributions.get((parent, version))
+        package = by_name.get(parent)
+        if distribution is None or package is None:
+            _fail(f"{scenario.id}:{target}: missing selected package {parent!r}")
+        expected_edges = _active_requirement_names(
+            distribution.dependencies, environment
+        )
+        actual_edges = _dependency_names(
+            package.get("dependencies"),
+            environment,
+            selected,
+            fixture_root=fixture_root,
+            document_dir=document_dir,
+            label=f"{scenario.id}:{target}:{parent}",
+        )
+        if actual_edges != expected_edges:
+            _fail(
+                f"{scenario.id}:{target}:{parent}: dependency edges differ:"
+                f" {actual_edges} != {expected_edges}"
+            )
+
+
+def _validate_uv_lock_edges(
+    scenario: Scenario,
+    distributions: Sequence[Distribution],
+    environments: Mapping[str, Mapping[str, str]],
+    packages: _UvLockPackages,
+    projected: Mapping[str, Mapping[str, str]],
+    *,
+    fixture_root: Path,
+    document_dir: Path,
+) -> None:
+    fixture_distributions = {
+        (str(canonicalize_name(dist.name, validate=True)), dist.version): dist
+        for dist in distributions
+    }
+    for target, environment in environments.items():
+        _validate_uv_lock_target_edges(
+            scenario,
+            target,
+            environment,
+            projected[target],
+            packages,
+            fixture_distributions,
+            fixture_root=fixture_root,
+            document_dir=document_dir,
+        )
+
+
+def _validate_uv_lock(
+    document: _LockDocument,
+    scenario: Scenario,
+    prepared: PreparedScenario,
+    distributions: Sequence[Distribution],
+    inventory: Mapping[tuple[str, str], tuple[Path, str]],
+    fixture_root: Path,
+) -> dict[str, dict[str, str]]:
+    data = document.data
+    _validate_uv_lock_header(data, scenario)
+    environments = _validate_uv_lock_marker_domain(data, scenario, prepared)
+    packages = _uv_lock_packages(data, scenario)
+    _validate_uv_lock_package_records(
+        data,
+        scenario,
+        prepared,
+        packages,
+        inventory=inventory,
+        fixture_root=fixture_root,
+        document_dir=document.directory,
+    )
+
+    projected = _lock_projection(data, environments)
+    if projected != prepared.expected:
+        _fail(f"{scenario.id}: uv lock differs: {projected} != {prepared.expected}")
+    _validate_uv_lock_edges(
+        scenario,
+        distributions,
+        environments,
+        packages,
+        projected,
+        fixture_root=fixture_root,
+        document_dir=document.directory,
+    )
+    return projected
+
+
+def _write_lines(path: Path, values: Sequence[str]) -> None:
+    path.write_text("\n".join(values) + "\n", encoding="utf-8", newline="\n")
+
+
+def _pip_compile_command(
+    scenario: Scenario,
+    prepared: PreparedScenario,
+    fixture_root: Path,
+    uv: str,
+    root: Path,
+) -> tuple[list[str], Path]:
+    target = prepared.targets[0]
+    requirements = root / "requirements.in"
+    _write_lines(requirements, scenario.requirements)
+    if not scenario.id or any(
+        character not in "abcdefghijklmnopqrstuvwxyz0123456789-"
+        for character in scenario.id
+    ):
+        _fail(f"{scenario.id!r} is not safe for an output artifact name")
+    output = root / f"pylock.{scenario.id}.toml"
+    command = [
+        uv,
+        "pip",
+        "compile",
+        str(requirements),
+        "--format",
+        "pylock.toml",
+        "--output-file",
+        str(output),
+        "--default-index",
+        fixture_root.resolve().as_uri(),
+        "--offline",
+        "--no-cache",
+        "--no-build",
+        "--no-config",
+        "--no-python-downloads",
+        "--python-version",
+        target.marker_env["python_version"],
+        "--python-platform",
+        _uv_platform(target.marker_env),
+        "--no-header",
+        "--no-annotate",
+    ]
+    if scenario.resolution is not None:
+        command.extend(("--resolution", scenario.resolution.value))
+    if scenario.constraints:
+        constraints = root / "constraints.txt"
+        _write_lines(constraints, scenario.constraints)
+        command.extend(("--constraints", str(constraints)))
+    return command, output
+
+
+def _read_lock_document(
+    path: Path,
+    scenario_id: str,
+    label: str,
+) -> _LockDocument:
+    """Read one lock document and bind relative paths to its directory."""
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+        directory = path.parent.resolve(strict=True)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        _fail(f"{scenario_id}: cannot read {label}: {exc}")
+    return _LockDocument(data, directory)
+
+
+def _read_optional_pylock(path: Path, scenario_id: str) -> _LockDocument | None:
+    if not path.is_file():
+        return None
+    return _read_lock_document(path, scenario_id, "uv pylock")
+
+
+def _validate_pip_compile_result(
+    scenario: Scenario,
+    prepared: PreparedScenario,
+    completed: subprocess.CompletedProcess[str],
+    document: _LockDocument | None,
+    inventory: Mapping[tuple[str, str], tuple[Path, str]],
+) -> tuple[dict[str, dict[str, str]], str]:
+    target = prepared.targets[0]
+    if scenario.outcome == "unsatisfiable":
+        diagnostics = completed.stdout + completed.stderr
+        if completed.returncode != UV_NO_SOLUTION_EXIT_STATUS:
+            _fail(
+                f"{scenario.id}: expected uv no-solution exit status"
+                f" {UV_NO_SOLUTION_EXIT_STATUS}, got {completed.returncode}:"
+                f" {diagnostics[-1000:]}"
+            )
+        if "No solution found" not in diagnostics or document is not None:
+            _fail(
+                f"{scenario.id}: uv did not report a resolution failure:"
+                f" {diagnostics[-1000:]}"
+            )
+        actual = {target.label: {}}
+        classification = "no-solution"
+    else:
+        if completed.returncode != 0:
+            _fail(f"{scenario.id}: uv failed: {completed.stderr[-1000:]}")
+        if document is None:
+            _fail(f"{scenario.id}: uv did not emit the requested pylock")
+        actual = {target.label: _pylock_pins(document, inventory)}
+        classification = "success"
+    if actual != prepared.expected:
+        _fail(f"{scenario.id}: uv pins differ: {actual} != {prepared.expected}")
+    return actual, classification
+
+
+def _verify_pip_compile(
+    scenario: Scenario,
+    fixture_root: Path,
+    uv: str,
+    inventory: Mapping[tuple[str, str], tuple[Path, str]],
+    policy: _SubprocessPolicy,
+) -> dict[str, object]:
+    prepared = prepare_scenario(scenario, fixture_root)
+    if scenario.uv_mapping != "pip-compile" or len(prepared.targets) != 1:
+        _fail(f"{scenario.id}: pip-compile mapping requires exactly one target")
+    with tempfile.TemporaryDirectory(prefix="nab-smoke-uv-pip-") as temporary:
+        root = Path(temporary)
+        command, output = _pip_compile_command(
+            scenario, prepared, fixture_root, uv, root
+        )
+        completed = _run(command, cwd=root, policy=policy)
+        command_record = _command_record(
+            command, fixture_root=fixture_root, work_root=root
+        )
+        document = _read_optional_pylock(output, scenario.id)
+        actual, classification = _validate_pip_compile_result(
+            scenario, prepared, completed, document, inventory
+        )
+    target = prepared.targets[0]
+    return {
+        "id": scenario.id,
+        "mapping": "pip-compile",
+        "outcome": scenario.outcome,
+        "resolution": prepared.config.resolution.value,
+        "targets": [target.label],
+        "pins_per_target": actual,
+        "command": command_record,
+        "return_status": {
+            "code": completed.returncode,
+            "classification": classification,
+        },
+    }
+
+
+def _uv_lock_command(
+    scenario: Scenario,
+    fixture_root: Path,
+    uv: str,
+    project: Path,
+) -> list[str]:
+    command = [
+        uv,
+        "lock",
+        "--project",
+        str(project),
+        "--default-index",
+        fixture_root.resolve().as_uri(),
+        "--offline",
+        "--no-cache",
+        "--no-build",
+        "--no-config",
+        "--no-python-downloads",
+    ]
+    if scenario.resolution is not None:
+        command.extend(("--resolution", scenario.resolution.value))
+    if scenario.uv_fork_strategy not in (None, "requires-python"):
+        command.extend(("--fork-strategy", str(scenario.uv_fork_strategy)))
+    return command
+
+
+def _run_uv_lock(
+    scenario: Scenario,
+    fixture_root: Path,
+    uv: str,
+    policy: _SubprocessPolicy,
+    *,
+    project: Path,
+) -> _UvLockRun:
+    shutil.copyfile(UV_PROJECT, project / "pyproject.toml")
+    command = _uv_lock_command(scenario, fixture_root, uv, project)
+    completed = _run(command, cwd=project, policy=policy)
+    if completed.returncode != 0:
+        _fail(f"{scenario.id}: uv lock failed: {completed.stderr[-1000:]}")
+    document = _read_lock_document(project / "uv.lock", scenario.id, "uv.lock")
+    command_record = _command_record(
+        command, fixture_root=fixture_root, work_root=project
+    )
+    return _UvLockRun(document, tuple(command_record), completed.returncode)
+
+
+def _verify_lock(
+    scenario: Scenario,
+    fixture_root: Path,
+    uv: str,
+    distributions: Sequence[Distribution],
+    inventory: Mapping[tuple[str, str], tuple[Path, str]],
+    policy: _SubprocessPolicy,
+) -> dict[str, object]:
+    prepared = prepare_scenario(scenario, fixture_root)
+    if scenario.uv_mapping != "lock" or scenario.uv_fork_strategy is None:
+        _fail(f"{scenario.id}: lock mapping requires a fork strategy")
+    with tempfile.TemporaryDirectory(prefix="nab-smoke-uv-lock-") as temporary:
+        run = _run_uv_lock(
+            scenario,
+            fixture_root,
+            uv,
+            policy,
+            project=Path(temporary),
+        )
+        actual = _validate_uv_lock(
+            run.document,
+            scenario,
+            prepared,
+            distributions,
+            inventory,
+            fixture_root,
+        )
+        return {
+            "id": scenario.id,
+            "mapping": "lock",
+            "fork_strategy": scenario.uv_fork_strategy,
+            "outcome": scenario.outcome,
+            "resolution": prepared.config.resolution.value,
+            "targets": sorted(prepared.expected),
+            "pins_per_target": actual,
+            "command": list(run.command),
+            "project_sha256": file_sha256(UV_PROJECT),
+            "return_status": {
+                "code": run.returncode,
+                "classification": "success",
+            },
+        }
+
+
+def _uv_binary(uv: str | Path, policy: _SubprocessPolicy) -> _UvIdentity:
+    requested = str(uv)
+    try:
+        path = Path(shutil.which(requested) or requested).resolve(strict=True)
+    except OSError as exc:
+        _fail(f"cannot identify the uv binary {requested!r}: {exc}")
+    if not path.is_file():
+        _fail(f"uv binary {path} is not a regular file")
+    try:
+        digest = file_sha256(path)
+    except OSError as exc:
+        _fail(f"cannot hash the uv binary {path}: {exc}")
+    completed = _run_uv_version(path, policy)
+    version = completed.stdout.strip()
+    if completed.returncode != 0 or not version.startswith("uv "):
+        _fail(f"cannot identify uv version: {completed.stderr.strip()}")
+    return _UvIdentity(path, digest, version)
+
+
+def _validate_fixture_inventory(
+    distributions: Sequence[Distribution],
+    inventory: Mapping[tuple[str, str], tuple[Path, str]],
+) -> None:
+    expected_records = {
+        (str(canonicalize_name(dist.name, validate=True)), dist.version)
+        for dist in distributions
+    }
+    if set(inventory) != expected_records:
+        _fail("materialized fixture artifacts differ from the fixture manifest")
+
+
+def _verify_scenario(
+    scenario: Scenario,
+    fixture_root: Path,
+    uv: _UvIdentity,
+    distributions: Sequence[Distribution],
+    inventory: Mapping[tuple[str, str], tuple[Path, str]],
+    policy: _SubprocessPolicy,
+) -> dict[str, object]:
+    if scenario.uv_mapping == "pip-compile":
+        return _verify_pip_compile(
+            scenario, fixture_root, str(uv.path), inventory, policy
+        )
+    if scenario.uv_mapping == "lock":
+        return _verify_lock(
+            scenario,
+            fixture_root,
+            str(uv.path),
+            distributions,
+            inventory,
+            policy,
+        )
+    _fail(f"{scenario.id}: no executable uv mapping")
+
+
+def _validate_uv_identity(uv: _UvIdentity, policy: _SubprocessPolicy) -> None:
+    try:
+        digest = file_sha256(uv.path)
+    except OSError as exc:
+        _fail(f"cannot revalidate the uv binary {uv.path}: {exc}")
+    if digest != uv.sha256:
+        _fail("uv binary changed during semantic verification")
+    completed = _run_uv_version(uv.path, policy)
+    if completed.returncode != 0 or completed.stdout.strip() != uv.version:
+        _fail("uv version identity changed during semantic verification")
+
+
+def _validate_input_identity(
+    before: _InputIdentity,
+    scenarios: Sequence[Scenario],
+    distributions: Sequence[Distribution],
+) -> None:
+    after = _input_identity(scenarios, distributions)
+    checks = (
+        (before.adapter_sha256, after.adapter_sha256, "uv adapter"),
+        (before.core_sha256, after.core_sha256, "deterministic smoke core"),
+        (
+            before.scenario_manifest_sha256,
+            after.scenario_manifest_sha256,
+            "scenario manifest",
+        ),
+        (
+            before.fixture_manifest_sha256,
+            after.fixture_manifest_sha256,
+            "fixture manifest",
+        ),
+        (
+            before.fixture_input_sha256,
+            after.fixture_input_sha256,
+            "fixture inputs",
+        ),
+        (before.uv_project_sha256, after.uv_project_sha256, "uv project"),
+        (
+            before.scenarios.selected_sha256,
+            after.scenarios.selected_sha256,
+            "selected scenario inputs",
+        ),
+        (before.scenarios.scenarios, after.scenarios.scenarios, "scenario inputs"),
+    )
+    for expected, actual, label in checks:
+        if actual != expected:
+            _fail(f"{label} changed during semantic verification")
+
+
+def _validate_end_identities(
+    snapshot: _VerificationSnapshot,
+) -> tuple[str, Mapping[str, object]]:
+    _resolved_after, fixture_sha256_after, fixture_access_after = (
+        validate_materialized_fixture(
+            snapshot.fixture_root,
+            snapshot.fixture_sha256,
+            mode=snapshot.fixture_mode,
+        )
+    )
+    if fixture_access_after != snapshot.fixture_access:
+        _fail("fixture storage changed during uv verification")
+    _validate_uv_identity(snapshot.uv, snapshot.policy)
+    _validate_input_identity(
+        snapshot.inputs, snapshot.scenarios, snapshot.distributions
+    )
+    if snapshot.policy.digest() != snapshot.policy_sha256:
+        _fail("subprocess policy changed during semantic verification")
+    return fixture_sha256_after, fixture_access_after
+
+
+def _verify_scenarios(
+    scenarios: Sequence[Scenario],
+    fixture_root: Path,
+    fixture_sha256: str,
+    uv: str | Path,
+    distributions: Sequence[Distribution],
+    *,
+    fixture_mode: str = "caller-materialized",
+) -> dict[str, Any]:
+    selected_scenarios = tuple(scenarios)
+    fixture_distributions = tuple(distributions)
+    if not selected_scenarios:
+        _fail("at least one uv scenario is required")
+    missing_mappings = [
+        scenario.id for scenario in selected_scenarios if scenario.uv_mapping is None
+    ]
+    if missing_mappings:
+        _fail(f"scenarios have no executable uv mapping: {missing_mappings}")
+    policy = _subprocess_policy()
+    policy_sha256 = policy.digest()
+    inputs = _input_identity(selected_scenarios, fixture_distributions)
+    fixture_root, fixture_sha256, fixture_access = validate_materialized_fixture(
+        fixture_root,
+        fixture_sha256,
+        mode=fixture_mode,
+    )
+    uv_identity = _uv_binary(uv, policy)
+    snapshot = _VerificationSnapshot(
+        fixture_root=fixture_root,
+        fixture_sha256=fixture_sha256,
+        fixture_mode=fixture_mode,
+        fixture_access=fixture_access,
+        uv=uv_identity,
+        policy=policy,
+        policy_sha256=policy_sha256,
+        inputs=inputs,
+        scenarios=selected_scenarios,
+        distributions=fixture_distributions,
+    )
+    inventory = _fixture_inventory(fixture_root)
+    _validate_fixture_inventory(fixture_distributions, inventory)
+    results = [
+        _verify_scenario(
+            scenario,
+            fixture_root,
+            uv_identity,
+            fixture_distributions,
+            inventory,
+            policy,
+        )
+        for scenario in selected_scenarios
+    ]
+    fixture_sha256_after, fixture_access_after = _validate_end_identities(snapshot)
+    return {
+        "schema": 2,
+        **inputs.record(),
+        "uv": uv_identity.version,
+        "uv_binary_path": str(uv_identity.path),
+        "uv_binary_sha256": uv_identity.sha256,
+        "fixture_sha256": fixture_sha256,
+        "fixture_sha256_after": fixture_sha256_after,
+        "fixture_mode": fixture_mode,
+        "fixture_access_before": fixture_access,
+        "fixture_access_after": fixture_access_after,
+        "subprocess_policy": policy.record(),
+        "subprocess_policy_sha256": policy_sha256,
+        "scenarios": results,
+    }
+
+
+def verify_scenarios(
+    scenarios: Sequence[Scenario],
+    fixture_root: Path,
+    fixture_sha256: str,
+    uv: str | Path,
+    distributions: Sequence[Distribution],
+    *,
+    fixture_mode: str = "caller-materialized",
+) -> dict[str, Any]:
+    """Run uv and translate malformed external data into the public error type."""
+    try:
+        return _verify_scenarios(
+            scenarios,
+            fixture_root,
+            fixture_sha256,
+            uv,
+            distributions,
+            fixture_mode=fixture_mode,
+        )
+    except (InvalidMarker, InvalidName, InvalidSpecifier, UnicodeDecodeError) as exc:
+        _fail(f"invalid uv comparison data ({type(exc).__name__}): {exc}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--uv", required=True, type=Path)
+    parser.add_argument("--scenario", action="append", default=[])
+    parser.add_argument("--fixture-dir", type=Path)
+    parser.add_argument("--json", type=Path)
+    args = parser.parse_args()
+    try:
+        scenarios = load_scenarios()
+        requested = set(args.scenario)
+        known = {scenario.id for scenario in scenarios}
+        if requested - known:
+            parser.error(f"unknown --scenario values: {sorted(requested - known)}")
+        selected = [
+            scenario
+            for scenario in scenarios
+            if not requested or scenario.id in requested
+        ]
+        distributions, expected_digest = load_fixture()
+        if args.fixture_dir is not None:
+            digest = materialize_fixture(
+                args.fixture_dir, distributions, expected_digest
+            )
+            report = verify_scenarios(
+                selected,
+                args.fixture_dir,
+                digest,
+                args.uv,
+                distributions,
+            )
+        else:
+            with tempfile.TemporaryDirectory(prefix="nab-smoke-uv-index-") as temporary:
+                fixture_root = Path(temporary)
+                digest = materialize_fixture(
+                    fixture_root, distributions, expected_digest
+                )
+                report = verify_scenarios(
+                    selected,
+                    fixture_root,
+                    digest,
+                    args.uv,
+                    distributions,
+                    fixture_mode="ephemeral-generated",
+                )
+    except (
+        InvalidMarker,
+        InvalidName,
+        InvalidSpecifier,
+        SmokeContractError,
+        UnicodeDecodeError,
+        UvCrossCheckError,
+    ) as exc:
+        parser.error(str(exc))
+    for result in report["scenarios"]:
+        print(f"{result['id']}: {result['outcome']} ({result['mapping']})")
+    if args.json is not None:
+        args.json.write_text(
+            json.dumps(report, indent=2) + "\n", encoding="utf-8", newline="\n"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/nab-python/benchmarks/smoke/scenarios.toml
+++ b/nab-python/benchmarks/smoke/scenarios.toml
@@ -8,6 +8,7 @@ purpose = "Straightforward graph, candidate ordering, metadata, and lock plumbin
 lane = "semantic"
 outcome = "satisfiable"
 mode = "specific"
+uv-mapping = "pip-compile"
 requirements = ["nab-smoke-basic"]
 python = "==3.11"
 platforms = ["linux_x86_64"]
@@ -25,6 +26,7 @@ outcome = "satisfiable"
 warmups = 2
 batch-size = 8
 mode = "specific"
+uv-mapping = "pip-compile"
 requirements = ["nab-smoke-pip-a"]
 python = "==3.11"
 platforms = ["linux_x86_64"]
@@ -42,6 +44,7 @@ outcome = "unsatisfiable"
 warmups = 2
 batch-size = 8
 mode = "specific"
+uv-mapping = "pip-compile"
 requirements = ["nab-smoke-pip-unsat-a"]
 python = "==3.11"
 platforms = ["linux_x86_64"]
@@ -59,6 +62,7 @@ outcome = "satisfiable"
 warmups = 2
 batch-size = 8
 mode = "specific"
+uv-mapping = "pip-compile"
 requirements = ["nab-smoke-backjump-pivot", "nab-smoke-backjump-link-1"]
 python = "==3.11"
 platforms = ["linux_x86_64"]
@@ -74,6 +78,7 @@ purpose = "A constraint narrows an otherwise higher direct candidate"
 lane = "semantic"
 outcome = "satisfiable"
 mode = "specific"
+uv-mapping = "pip-compile"
 requirements = ["nab-smoke-constrained>=1.0.0"]
 constraints = ["nab-smoke-constrained<3.0.0"]
 python = "==3.11"
@@ -90,6 +95,7 @@ purpose = "Requested extra activation and a transitive Python marker"
 lane = "semantic"
 outcome = "satisfiable"
 mode = "specific"
+uv-mapping = "pip-compile"
 requirements = ["nab-smoke-extra-app[speed]"]
 python = "==3.11"
 platforms = ["linux_x86_64"]
@@ -105,6 +111,7 @@ purpose = "Default highest policy selects newest direct and transitive candidate
 lane = "semantic"
 outcome = "satisfiable"
 mode = "specific"
+uv-mapping = "pip-compile"
 requirements = ["nab-smoke-strategy-app==1.0.0", "nab-smoke-strategy-direct>=1.0.0"]
 python = "==3.11"
 platforms = ["linux_x86_64"]
@@ -120,6 +127,7 @@ purpose = "Lowest policy selects oldest direct and transitive candidates"
 lane = "semantic"
 outcome = "satisfiable"
 mode = "specific"
+uv-mapping = "pip-compile"
 requirements = ["nab-smoke-strategy-app==1.0.0", "nab-smoke-strategy-direct>=1.0.0"]
 python = "==3.11"
 platforms = ["linux_x86_64"]
@@ -136,6 +144,7 @@ purpose = "Lowest-direct policy keeps transitives on their newest candidate"
 lane = "semantic"
 outcome = "satisfiable"
 mode = "specific"
+uv-mapping = "pip-compile"
 requirements = ["nab-smoke-strategy-app==1.0.0", "nab-smoke-strategy-direct>=1.0.0"]
 python = "==3.11"
 platforms = ["linux_x86_64"]
@@ -154,6 +163,8 @@ outcome = "satisfiable"
 warmups = 2
 batch-size = 192
 mode = "universal"
+uv-mapping = "lock"
+uv-fork-strategy = "fewest"
 requirements = ["nab-smoke-universal==1.0.0"]
 python = ">=3.11,<3.13"
 platforms = ["linux_x86_64", "windows_amd64"]
@@ -181,6 +192,8 @@ purpose = "The control run permits a compatible package to diverge across Python
 lane = "semantic"
 outcome = "satisfiable"
 mode = "universal"
+uv-mapping = "lock"
+uv-fork-strategy = "requires-python"
 requirements = ["nab-smoke-universal==1.0.0"]
 python = ">=3.11,<3.13"
 platforms = ["linux_x86_64", "windows_amd64"]

--- a/nab-python/benchmarks/smoke/uv-lock/pyproject.toml
+++ b/nab-python/benchmarks/smoke/uv-lock/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "nab-smoke-uv-lock"
+version = "0.0.0"
+requires-python = ">=3.11,<3.13"
+dependencies = ["nab-smoke-universal==1.0.0"]
+
+[tool.uv]
+environments = [
+    "python_version >= '3.11' and python_version < '3.13' and implementation_name == 'cpython' and sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "python_version >= '3.11' and python_version < '3.13' and implementation_name == 'cpython' and sys_platform == 'win32' and platform_machine == 'AMD64'",
+]
+required-environments = [
+    "sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "sys_platform == 'win32' and platform_machine == 'AMD64'",
+]

--- a/nab-python/tests/test_deterministic_smoke_uv.py
+++ b/nab-python/tests/test_deterministic_smoke_uv.py
@@ -1,0 +1,1546 @@
+"""Tests for the deterministic smoke suite's external uv semantic oracle."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, replace
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Protocol
+
+import pytest
+import tomli_w
+
+from nab_python._vendor.packaging.requirements import Requirement
+
+_BENCHMARKS = Path(__file__).resolve().parents[1] / "benchmarks"
+
+
+class _FixtureDistribution(Protocol):
+    """Distribution fields used to construct a synthetic uv lock."""
+
+    name: str
+    version: str
+    dependencies: Sequence[str]
+
+
+class _PreparedTarget(Protocol):
+    """Target fields used to construct uv resolution markers."""
+
+    label: str
+    marker_env: Mapping[str, str]
+
+
+class _PreparedSmokeScenario(Protocol):
+    """Prepared fields used to construct a synthetic uv lock."""
+
+    targets: Sequence[_PreparedTarget]
+    expected: Mapping[str, Mapping[str, str]]
+
+
+class _ExpectedTarget(Protocol):
+    """Expected target fields used by input-mutation tests."""
+
+    pins: Mapping[str, str]
+
+
+class _SmokeScenario(Protocol):
+    """Scenario fields used by the uv adapter tests."""
+
+    id: str
+    python: str
+    uv_fork_strategy: str | None
+    expected: Sequence[_ExpectedTarget]
+
+
+def _module(name: str, path: Path) -> ModuleType:
+    existing = sys.modules.get(name)
+    if existing is not None:
+        return existing
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        sys.modules.pop(name, None)
+        raise
+    return module
+
+
+def _core() -> ModuleType:
+    return _module("deterministic_smoke", _BENCHMARKS / "deterministic_smoke.py")
+
+
+def _adapter() -> ModuleType:
+    _core()
+    return _module(
+        "_nab_deterministic_smoke_uv",
+        _BENCHMARKS / "deterministic_smoke_uv.py",
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _FixtureCase:
+    """Materialized smoke fixture shared by the uv adapter tests."""
+
+    core: ModuleType
+    adapter: ModuleType
+    root: Path
+    distributions: tuple[_FixtureDistribution, ...]
+    digest: str
+    inventory: dict[tuple[str, str], tuple[Path, str]]
+
+    def scenario(self, scenario_id: str) -> _SmokeScenario:
+        """Return one declared scenario by identifier."""
+        return next(
+            scenario
+            for scenario in self.core.load_scenarios()
+            if scenario.id == scenario_id
+        )
+
+
+def _materialized_case(case: _FixtureCase, root: Path) -> _FixtureCase:
+    """Materialize the same fixture at root and return its bound test data."""
+    case.core.materialize_fixture(root, case.distributions, case.digest)
+    return _FixtureCase(
+        core=case.core,
+        adapter=case.adapter,
+        root=root,
+        distributions=case.distributions,
+        digest=case.digest,
+        inventory=case.adapter._fixture_inventory(root),
+    )
+
+
+@pytest.fixture(scope="module")
+def fixture_case(tmp_path_factory: pytest.TempPathFactory) -> _FixtureCase:
+    """Build the frozen wheel fixture once for this test module."""
+    core = _core()
+    adapter = _adapter()
+    distributions, digest = core.load_fixture()
+    root = tmp_path_factory.mktemp("deterministic-smoke-uv") / "index"
+    core.materialize_fixture(root, distributions, digest)
+    return _FixtureCase(
+        core=core,
+        adapter=adapter,
+        root=root,
+        distributions=tuple(distributions),
+        digest=digest,
+        inventory=adapter._fixture_inventory(root),
+    )
+
+
+def _pylock_document(case: _FixtureCase, pins: dict[str, str]) -> dict[str, object]:
+    """Build a pylock document for fixture-backed pins."""
+    packages: list[dict[str, object]] = []
+    for name, version in pins.items():
+        wheel, digest = case.inventory[(name, version)]
+        packages.append(
+            {
+                "name": name,
+                "version": version,
+                "wheels": [
+                    {
+                        "url": wheel.as_uri(),
+                        "hashes": {"sha256": digest},
+                    }
+                ],
+            }
+        )
+    return {"lock-version": "1.0", "created-by": "uv", "packages": packages}
+
+
+def _lock_document(
+    case: _FixtureCase,
+    data: Mapping[str, Any],
+    directory: Path,
+) -> Any:
+    """Bind parsed test data to the directory used by its relative paths."""
+    return case.adapter._LockDocument(data, directory.resolve())
+
+
+def _resolved_relative_path(path: Path, *, start: Path) -> str:
+    """Return a POSIX path relative to the resolved start directory."""
+    return Path(os.path.relpath(path.resolve(), start.resolve())).as_posix()
+
+
+def _write_pylock(
+    path: Path,
+    case: _FixtureCase,
+    pins: Mapping[str, str],
+    *,
+    artifact_location: str | None = None,
+    relative_artifacts: bool = False,
+) -> None:
+    """Write a minimal uv pylock, optionally overriding its artifact location."""
+    lines = ['lock-version = "1.0"', 'created-by = "uv"']
+    for name, version in pins.items():
+        wheel, digest = case.inventory[(name, version)]
+        location = artifact_location
+        if location is None:
+            location = (
+                _resolved_relative_path(wheel, start=path.parent)
+                if relative_artifacts
+                else wheel.as_uri()
+            )
+        lines.extend(
+            (
+                "",
+                "[[packages]]",
+                f"name = {json.dumps(name)}",
+                f"version = {json.dumps(version)}",
+                (
+                    "wheels = [{ url = "
+                    f"{json.dumps(location)}, hashes = {{ sha256 = {json.dumps(digest)} }} }}]"
+                ),
+            )
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
+
+
+def _target_markers(prepared: _PreparedSmokeScenario) -> dict[str, str]:
+    """Return uv resolution markers keyed by prepared target label."""
+    return {
+        target.label: (
+            f"python_version == '{target.marker_env['python_version']}' and "
+            f"sys_platform == '{target.marker_env['sys_platform']}'"
+        )
+        for target in prepared.targets
+    }
+
+
+def _translated_dependencies(
+    distribution: _FixtureDistribution,
+) -> list[dict[str, str]]:
+    """Translate fixture requirements into uv lock dependency records."""
+    dependencies: list[dict[str, str]] = []
+    for text in distribution.dependencies:
+        requirement = Requirement(text)
+        dependency = {"name": requirement.name}
+        if requirement.marker is not None:
+            dependency["marker"] = str(requirement.marker)
+        dependencies.append(dependency)
+    return dependencies
+
+
+def _fixture_package_record(
+    case: _FixtureCase,
+    distribution: _FixtureDistribution,
+    selected_targets: set[str],
+    target_markers: Mapping[str, str],
+) -> dict[str, object]:
+    """Build one uv lock package record from a fixture artifact."""
+    name = case.core.canonicalize_name(distribution.name)
+    wheel, digest = case.inventory[(name, distribution.version)]
+    package: dict[str, object] = {
+        "name": name,
+        "version": distribution.version,
+        "source": {"registry": case.root.resolve().as_uri()},
+        "wheels": [{"path": str(wheel), "hash": f"sha256:{digest}"}],
+    }
+    if selected_targets != set(target_markers):
+        package["resolution-markers"] = [
+            target_markers[target] for target in sorted(selected_targets)
+        ]
+
+    dependencies = _translated_dependencies(distribution)
+    if dependencies:
+        package["dependencies"] = dependencies
+    return package
+
+
+def _selected_fixture_packages(
+    case: _FixtureCase,
+    prepared: _PreparedSmokeScenario,
+    target_markers: Mapping[str, str],
+) -> list[dict[str, object]]:
+    """Build uv lock package records for every selected fixture version."""
+    distribution_by_key = {
+        (case.core.canonicalize_name(item.name), item.version): item
+        for item in case.distributions
+    }
+    records = {
+        (name, version)
+        for pins in prepared.expected.values()
+        for name, version in pins.items()
+    }
+    packages: list[dict[str, object]] = []
+    for name, version in sorted(records):
+        selected_targets = {
+            target
+            for target, pins in prepared.expected.items()
+            if pins.get(name) == version
+        }
+        packages.append(
+            _fixture_package_record(
+                case,
+                distribution_by_key[(name, version)],
+                selected_targets,
+                target_markers,
+            )
+        )
+    return packages
+
+
+def _uv_lock_document(
+    case: _FixtureCase,
+    scenario: _SmokeScenario,
+    prepared: _PreparedSmokeScenario,
+) -> dict[str, object]:
+    """Assemble a uv lock document for one prepared smoke scenario."""
+    target_markers = _target_markers(prepared)
+    packages = [
+        {
+            "name": "nab-smoke-uv-lock",
+            "version": "0.0.0",
+            "source": {"virtual": "."},
+            "dependencies": [{"name": "nab-smoke-universal"}],
+        }
+    ]
+    packages.extend(_selected_fixture_packages(case, prepared, target_markers))
+
+    platform_markers = [
+        "sys_platform == 'linux'",
+        "sys_platform == 'win32'",
+    ]
+    return {
+        "version": 1,
+        "requires-python": scenario.python,
+        "options": {"fork-strategy": scenario.uv_fork_strategy},
+        "resolution-markers": list(target_markers.values()),
+        "supported-markers": platform_markers,
+        "required-markers": platform_markers,
+        "package": packages,
+    }
+
+
+def _make_uv_lock_paths_relative(
+    document: dict[str, object],
+    case: _FixtureCase,
+    document_dir: Path,
+) -> None:
+    """Make fixture paths relative to the synthetic uv.lock directory."""
+    relative_registry = _resolved_relative_path(case.root, start=document_dir)
+    packages = document["package"]
+    assert isinstance(packages, list)
+    for package in packages:
+        assert isinstance(package, dict)
+        if package.get("source") != {"virtual": "."}:
+            package["source"] = {"registry": relative_registry}
+            wheels = package["wheels"]
+            assert isinstance(wheels, list)
+            wheel = wheels[0]
+            assert isinstance(wheel, dict)
+            wheel["path"] = _resolved_relative_path(
+                Path(str(wheel["path"])), start=document_dir
+            )
+        dependencies = package.get("dependencies", [])
+        assert isinstance(dependencies, list)
+        for dependency in dependencies:
+            assert isinstance(dependency, dict)
+            dependency["source"] = {"registry": relative_registry}
+
+
+def test_resolved_relative_path_uses_both_resolved_operands(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lexical_root = tmp_path / "var"
+    resolved_root = tmp_path / "private" / "var"
+    lexical_path = lexical_root / "fixture" / "wheel.whl"
+    lexical_start = lexical_root / "document"
+    resolutions = {
+        lexical_path: resolved_root / "fixture" / "wheel.whl",
+        lexical_start: resolved_root / "document",
+    }
+
+    def resolve_alias(path: Path, strict: bool = False) -> Path:
+        """Map a lexical path into the shared resolved test root."""
+        del strict
+        return resolutions[path]
+
+    monkeypatch.setattr(Path, "resolve", resolve_alias)
+
+    assert _resolved_relative_path(lexical_path, start=lexical_start) == (
+        "../fixture/wheel.whl"
+    )
+
+
+def test_manifest_declares_one_exact_uv_mapping_per_scenario() -> None:
+    scenarios = _core().load_scenarios()
+
+    assert [scenario.uv_mapping for scenario in scenarios].count("pip-compile") == 9
+    assert [scenario.uv_mapping for scenario in scenarios].count("lock") == 2
+    assert {
+        scenario.id: scenario.uv_fork_strategy
+        for scenario in scenarios
+        if scenario.uv_mapping == "lock"
+    } == {
+        "universal-aligned": "fewest",
+        "universal-independent": "requires-python",
+    }
+    assert all(
+        scenario.uv_fork_strategy is None
+        for scenario in scenarios
+        if scenario.uv_mapping == "pip-compile"
+    )
+
+
+@pytest.mark.parametrize(
+    ("raw", "mode", "message"),
+    [
+        ({"uv-mapping": "other"}, "specific", "uv-mapping is invalid"),
+        ({"uv-mapping": "lock"}, "universal", "fork-strategy"),
+        (
+            {"uv-mapping": "pip-compile", "uv-fork-strategy": "fewest"},
+            "specific",
+            "only valid for a lock",
+        ),
+        ({"uv-mapping": "pip-compile"}, "universal", "requires specific"),
+        (
+            {"uv-mapping": "lock", "uv-fork-strategy": "fewest"},
+            "specific",
+            "requires universal",
+        ),
+    ],
+)
+def test_uv_mapping_contract_rejects_inexact_adapters(
+    raw: dict[str, object], mode: str, message: str
+) -> None:
+    core = _core()
+
+    with pytest.raises(core.SmokeContractError, match=message):
+        core._parse_uv_mapping(raw, "scenario[0]", mode)
+
+
+def test_uv_project_declares_the_exact_universal_domain() -> None:
+    adapter = _adapter()
+    document = adapter.tomllib.loads(adapter.UV_PROJECT.read_text(encoding="utf-8"))
+
+    assert document["project"]["requires-python"] == ">=3.11,<3.13"
+    assert document["project"]["dependencies"] == ["nab-smoke-universal==1.0.0"]
+    assert document["tool"]["uv"]["environments"] == [
+        (
+            "python_version >= '3.11' and python_version < '3.13'"
+            " and implementation_name == 'cpython' and sys_platform == 'linux'"
+            " and platform_machine == 'x86_64'"
+        ),
+        (
+            "python_version >= '3.11' and python_version < '3.13'"
+            " and implementation_name == 'cpython' and sys_platform == 'win32'"
+            " and platform_machine == 'AMD64'"
+        ),
+    ]
+    assert document["tool"]["uv"]["required-environments"] == [
+        "sys_platform == 'linux' and platform_machine == 'x86_64'",
+        "sys_platform == 'win32' and platform_machine == 'AMD64'",
+    ]
+
+
+def test_artifact_paths_use_the_document_directory(tmp_path: Path) -> None:
+    adapter = _adapter()
+    fixture = (tmp_path / "fixture").resolve()
+    work = (tmp_path / "work").resolve()
+    artifact = (fixture / "wheel.whl").resolve()
+    fixture.mkdir()
+    work.mkdir()
+    artifact.write_bytes(b"wheel")
+
+    relative_artifact = Path(os.path.relpath(artifact, work)).as_posix()
+
+    assert adapter._artifact_path(str(artifact), "wheel", document_dir=work) == artifact
+    assert (
+        adapter._artifact_path(artifact.as_uri(), "wheel", document_dir=work)
+        == artifact
+    )
+    assert (
+        adapter._artifact_path(relative_artifact, "wheel", document_dir=work)
+        == artifact
+    )
+    assert (
+        adapter._artifact_path(
+            f"file:{relative_artifact}",
+            "wheel",
+            document_dir=work,
+        )
+        == artifact
+    )
+    with pytest.raises(adapter.UvCrossCheckError, match="local file URL"):
+        adapter._artifact_path(
+            "https://example.invalid/wheel.whl",
+            "wheel",
+            document_dir=work,
+        )
+    with pytest.raises(adapter.UvCrossCheckError, match="local file URL"):
+        adapter._artifact_path(
+            "file://remotehost/wheel.whl",
+            "wheel",
+            document_dir=work,
+        )
+    with pytest.raises(adapter.UvCrossCheckError, match="directory is not absolute"):
+        adapter._artifact_path(
+            "wheel.whl",
+            "wheel",
+            document_dir=Path("relative"),
+        )
+
+
+def test_artifact_path_normalizes_platform_resolution_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _adapter()
+
+    def fail_resolution(_path: Path, strict: bool = False) -> Path:
+        del strict
+        raise OSError("platform path failure")
+
+    monkeypatch.setattr(Path, "resolve", fail_resolution)
+
+    with pytest.raises(adapter.UvCrossCheckError, match="invalid local path"):
+        adapter._artifact_path(
+            "wheel.whl",
+            "wheel",
+            document_dir=tmp_path,
+        )
+
+
+def test_artifact_path_rejects_decoded_nul_before_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _adapter()
+
+    def accept_path(path: Path, strict: bool = False) -> Path:
+        """Model a Path.resolve implementation that accepts embedded NULs."""
+        del strict
+        return path
+
+    monkeypatch.setattr(Path, "resolve", accept_path)
+
+    with pytest.raises(adapter.UvCrossCheckError, match="invalid local path"):
+        adapter._artifact_path(
+            "file:%00wheel.whl",
+            "wheel",
+            document_dir=tmp_path,
+        )
+
+
+@pytest.mark.parametrize("separator", ["/", "\\"])
+def test_command_records_do_not_leak_temporary_roots(
+    tmp_path: Path, separator: str
+) -> None:
+    adapter = _adapter()
+    fixture = (tmp_path / "fixture").resolve()
+    work = (tmp_path / "work").resolve()
+
+    command = [
+        "/real/uv",
+        "--index",
+        fixture.as_uri(),
+        "--project",
+        f"{work}{separator}project",
+    ]
+    assert adapter._command_record(command, fixture_root=fixture, work_root=work) == [
+        "<uv>",
+        "--index",
+        "file://<fixture>",
+        "--project",
+        "<work>/project",
+    ]
+
+
+def test_pip_compile_command_carries_the_exact_offline_policy(
+    fixture_case: _FixtureCase, tmp_path: Path
+) -> None:
+    case = fixture_case
+    scenario = case.scenario("constraint-ceiling")
+    prepared = case.core.prepare_scenario(scenario, case.root)
+
+    command, output = case.adapter._pip_compile_command(
+        scenario, prepared, case.root, "/tool/uv", tmp_path
+    )
+
+    assert command[:3] == ["/tool/uv", "pip", "compile"]
+    assert output == tmp_path / "pylock.constraint-ceiling.toml"
+    assert (tmp_path / "requirements.in").read_text(encoding="utf-8") == (
+        "nab-smoke-constrained>=1.0.0\n"
+    )
+    assert (tmp_path / "constraints.txt").read_text(encoding="utf-8") == (
+        "nab-smoke-constrained<3.0.0\n"
+    )
+    for flag in (
+        "--offline",
+        "--no-cache",
+        "--no-build",
+        "--no-config",
+        "--no-python-downloads",
+    ):
+        assert flag in command
+    assert "--resolution" not in command
+    assert command[command.index("--python-version") + 1] == "3.11"
+    assert command[command.index("--python-platform") + 1] == (
+        "x86_64-unknown-linux-gnu"
+    )
+
+
+@pytest.mark.parametrize(
+    ("scenario_id", "resolution"),
+    [
+        ("strategy-lowest", "lowest"),
+        ("strategy-lowest-direct", "lowest-direct"),
+    ],
+)
+def test_pip_compile_command_retains_non_default_resolution(
+    fixture_case: _FixtureCase,
+    tmp_path: Path,
+    scenario_id: str,
+    resolution: str,
+) -> None:
+    case = fixture_case
+    scenario = case.scenario(scenario_id)
+    prepared = case.core.prepare_scenario(scenario, case.root)
+
+    command, _ = case.adapter._pip_compile_command(
+        scenario, prepared, case.root, "/tool/uv", tmp_path
+    )
+
+    assert command.count("--resolution") == 1
+    assert command[command.index("--resolution") + 1] == resolution
+
+
+@pytest.mark.parametrize(
+    ("scenario_id", "expected_fork_strategy_argument"),
+    [
+        ("universal-aligned", "fewest"),
+        ("universal-independent", None),
+    ],
+)
+def test_uv_lock_command_only_passes_non_default_policy(
+    fixture_case: _FixtureCase,
+    tmp_path: Path,
+    scenario_id: str,
+    expected_fork_strategy_argument: str | None,
+) -> None:
+    case = fixture_case
+    scenario = case.scenario(scenario_id)
+    prepared = case.core.prepare_scenario(scenario, case.root)
+
+    command = case.adapter._uv_lock_command(scenario, case.root, "/tool/uv", tmp_path)
+
+    assert len(prepared.targets) == 4
+    assert command[:2] == ["/tool/uv", "lock"]
+    assert command.count("--project") == 1
+    assert "--resolution" not in command
+    if expected_fork_strategy_argument is None:
+        assert "--fork-strategy" not in command
+    else:
+        assert command.count("--fork-strategy") == 1
+        assert (
+            command[command.index("--fork-strategy") + 1]
+            == expected_fork_strategy_argument
+        )
+    assert "--python-version" not in command
+    assert "--python-platform" not in command
+
+
+def test_uv_lock_command_retains_non_default_resolution(
+    fixture_case: _FixtureCase,
+    tmp_path: Path,
+) -> None:
+    case = fixture_case
+    scenario = replace(
+        case.scenario("universal-independent"),
+        resolution=case.core.ResolutionStrategy.LOWEST,
+    )
+
+    command = case.adapter._uv_lock_command(scenario, case.root, "/tool/uv", tmp_path)
+
+    assert command.count("--resolution") == 1
+    assert command[command.index("--resolution") + 1] == "lowest"
+    assert "--fork-strategy" not in command
+
+
+def test_pip_compile_result_accepts_fixture_pins(
+    fixture_case: _FixtureCase,
+) -> None:
+    case = fixture_case
+    scenario = case.scenario("basic-highest")
+    prepared = case.core.prepare_scenario(scenario, case.root)
+    expected = dict(next(iter(prepared.expected.values())))
+
+    assert case.adapter._validate_pip_compile_result(
+        scenario,
+        prepared,
+        subprocess.CompletedProcess(["uv"], 0, "", ""),
+        _lock_document(case, _pylock_document(case, expected), case.root),
+        case.inventory,
+    ) == (prepared.expected, "success")
+
+
+def test_pip_compile_validation_anchors_relative_artifacts_to_the_pylock(
+    fixture_case: _FixtureCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    case = fixture_case
+    scenario = case.scenario("basic-highest")
+    prepared = case.core.prepare_scenario(scenario, case.root)
+    expected = dict(next(iter(prepared.expected.values())))
+    binary = tmp_path / "uv"
+    binary.write_bytes(b"fake uv")
+    ambient = tmp_path / "ambient"
+    ambient.mkdir()
+    monkeypatch.chdir(ambient)
+
+    commands: list[tuple[str, ...]] = []
+
+    def run(
+        command: Sequence[str], *, cwd: Path, policy: object
+    ) -> subprocess.CompletedProcess[str]:
+        del cwd, policy
+        commands.append(tuple(command))
+        if list(command[1:]) == ["--version"]:
+            return subprocess.CompletedProcess(command, 0, "uv 1.2.3\n", "")
+        output = Path(command[command.index("--output-file") + 1])
+        _write_pylock(output, case, expected, relative_artifacts=True)
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(case.adapter, "_run", run)
+
+    report = case.adapter.verify_scenarios(
+        [scenario],
+        case.root,
+        case.digest,
+        binary,
+        case.distributions,
+    )
+
+    assert report["scenarios"][0]["pins_per_target"] == prepared.expected
+    assert len([command for command in commands if "compile" in command]) == 1
+
+
+def test_public_verification_rejects_invalid_artifact_paths(
+    fixture_case: _FixtureCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    case = fixture_case
+    scenario = case.scenario("basic-highest")
+    prepared = case.core.prepare_scenario(scenario, case.root)
+    expected = dict(next(iter(prepared.expected.values())))
+    binary = tmp_path / "uv"
+    binary.write_bytes(b"fake uv")
+    scenario_commands: list[tuple[str, ...]] = []
+
+    def run(
+        command: Sequence[str], *, cwd: Path, policy: object
+    ) -> subprocess.CompletedProcess[str]:
+        del cwd, policy
+        if list(command[1:]) == ["--version"]:
+            return subprocess.CompletedProcess(command, 0, "uv 1.2.3\n", "")
+
+        scenario_commands.append(tuple(command))
+        output = Path(command[command.index("--output-file") + 1])
+        _write_pylock(
+            output,
+            case,
+            expected,
+            artifact_location="file:%00wheel.whl",
+        )
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(case.adapter, "_run", run)
+
+    with pytest.raises(
+        case.adapter.UvCrossCheckError,
+        match=r"artifact for .* has an invalid local path",
+    ):
+        case.adapter.verify_scenarios(
+            [scenario],
+            case.root,
+            case.digest,
+            binary,
+            case.distributions,
+        )
+
+    assert len(scenario_commands) == 1
+
+
+def test_pip_compile_result_rejects_mismatched_artifact_hash(
+    fixture_case: _FixtureCase,
+) -> None:
+    case = fixture_case
+    scenario = case.scenario("basic-highest")
+    prepared = case.core.prepare_scenario(scenario, case.root)
+    expected = dict(next(iter(prepared.expected.values())))
+    document = _pylock_document(case, expected)
+    packages = document["packages"]
+    assert isinstance(packages, list)
+    package = packages[0]
+    assert isinstance(package, dict)
+    wheels = package["wheels"]
+    assert isinstance(wheels, list)
+    wheel = wheels[0]
+    assert isinstance(wheel, dict)
+    hashes = wheel["hashes"]
+    assert isinstance(hashes, dict)
+    hashes["sha256"] = "0" * 64
+
+    with pytest.raises(case.adapter.UvCrossCheckError, match="artifact hash"):
+        case.adapter._validate_pip_compile_result(
+            scenario,
+            prepared,
+            subprocess.CompletedProcess(["uv"], 0, "", ""),
+            _lock_document(case, document, case.root),
+            case.inventory,
+        )
+
+
+def test_pip_compile_result_accepts_expected_no_solution(
+    fixture_case: _FixtureCase,
+) -> None:
+    case = fixture_case
+    scenario = case.scenario("pip-deep-backtracking-unsatisfiable")
+    prepared = case.core.prepare_scenario(scenario, case.root)
+
+    assert case.adapter._validate_pip_compile_result(
+        scenario,
+        prepared,
+        subprocess.CompletedProcess(["uv"], 1, "", "No solution found"),
+        None,
+        case.inventory,
+    ) == (prepared.expected, "no-solution")
+
+
+def test_pip_compile_result_rejects_unrelated_failure_diagnostic(
+    fixture_case: _FixtureCase,
+) -> None:
+    case = fixture_case
+    scenario = case.scenario("pip-deep-backtracking-unsatisfiable")
+    prepared = case.core.prepare_scenario(scenario, case.root)
+
+    with pytest.raises(case.adapter.UvCrossCheckError, match="resolution failure"):
+        case.adapter._validate_pip_compile_result(
+            scenario,
+            prepared,
+            subprocess.CompletedProcess(["uv"], 1, "", "unrelated failure"),
+            None,
+            case.inventory,
+        )
+
+
+@pytest.mark.parametrize("returncode", [2, -9])
+def test_no_solution_requires_uv_exit_status_one(
+    fixture_case: _FixtureCase, returncode: int
+) -> None:
+    case = fixture_case
+    scenario = case.scenario("pip-deep-backtracking-unsatisfiable")
+    prepared = case.core.prepare_scenario(scenario, case.root)
+    completed = subprocess.CompletedProcess(["uv"], returncode, "", "No solution found")
+
+    with pytest.raises(
+        case.adapter.UvCrossCheckError,
+        match="expected uv no-solution exit status 1",
+    ):
+        case.adapter._validate_pip_compile_result(
+            scenario, prepared, completed, None, case.inventory
+        )
+
+
+def test_subprocess_runner_fixes_decoding_timeout_cwd_and_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    adapter = _adapter()
+    for name in adapter._EXECUTION_ENVIRONMENT_ALLOWLIST:
+        monkeypatch.delenv(name, raising=False)
+    for name in tuple(os.environ):
+        if name == "UV" or name.startswith("UV_"):
+            monkeypatch.delenv(name)
+    monkeypatch.setenv("PATH", "/ambient/bin")
+    monkeypatch.setenv("TMPDIR", "/ambient/tmp")
+    monkeypatch.setenv("UV_INDEX", "https://ambient.invalid/simple")
+    monkeypatch.setenv("UV_RESOLUTION", "lowest")
+    monkeypatch.setenv("UNRELATED_SECRET", "do-not-inherit")
+    policy = adapter._subprocess_policy()
+    captured: dict[str, object] = {}
+
+    def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(command, 0, "uv test\n", "")
+
+    monkeypatch.setattr(adapter.subprocess, "run", run)
+
+    completed = adapter._run(["/tool/uv", "--version"], cwd=tmp_path, policy=policy)
+
+    assert completed.stdout == "uv test\n"
+    assert captured == {
+        "capture_output": True,
+        "check": False,
+        "cwd": tmp_path.resolve(),
+        "env": {
+            "TEMP": str(tmp_path.resolve()),
+            "TMP": str(tmp_path.resolve()),
+            "TMPDIR": str(tmp_path.resolve()),
+        },
+        "timeout": adapter.UV_SUBPROCESS_TIMEOUT_SECONDS,
+        "encoding": "utf-8",
+        "errors": "strict",
+    }
+    assert policy.stripped_uv_variables == ("UV_INDEX", "UV_RESOLUTION")
+    effective_environment = policy.environment_dict(tmp_path.resolve())
+    assert "PATH" not in effective_environment
+    assert "UNRELATED_SECRET" not in effective_environment
+
+
+@pytest.mark.parametrize(
+    ("failure", "message"),
+    [
+        (
+            subprocess.TimeoutExpired(["uv"], 120),
+            "timed out after 120 seconds",
+        ),
+        (
+            UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte"),
+            "emitted non-UTF-8 output",
+        ),
+        (OSError("execution failed"), "cannot execute"),
+    ],
+    ids=("timeout", "decode", "os-error"),
+)
+def test_subprocess_failures_use_the_cross_check_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: BaseException,
+    message: str,
+) -> None:
+    adapter = _adapter()
+
+    def fail(*_args: object, **_kwargs: object) -> None:
+        raise failure
+
+    monkeypatch.setattr(adapter.subprocess, "run", fail)
+
+    with pytest.raises(adapter.UvCrossCheckError, match=message):
+        adapter._run(["/tool/uv"], cwd=tmp_path, policy=adapter._subprocess_policy())
+
+
+def test_uv_lock_validator_checks_domain_artifacts_projection_and_edges(
+    fixture_case: _FixtureCase,
+) -> None:
+    case = fixture_case
+    scenario = case.scenario("universal-aligned")
+    prepared = case.core.prepare_scenario(scenario, case.root)
+    document = _uv_lock_document(case, scenario, prepared)
+
+    assert (
+        case.adapter._validate_uv_lock(
+            _lock_document(case, document, case.root),
+            scenario,
+            prepared,
+            case.distributions,
+            case.inventory,
+            case.root,
+        )
+        == prepared.expected
+    )
+
+    bad_domain = copy.deepcopy(document)
+    resolution_markers = bad_domain["resolution-markers"]
+    assert isinstance(resolution_markers, list)
+    resolution_markers[0] = "sys_platform == 'darwin'"
+    with pytest.raises(case.adapter.UvCrossCheckError, match="declared target domain"):
+        case.adapter._validate_uv_lock(
+            _lock_document(case, bad_domain, case.root),
+            scenario,
+            prepared,
+            case.distributions,
+            case.inventory,
+            case.root,
+        )
+
+    bad_edges = copy.deepcopy(document)
+    packages = bad_edges["package"]
+    assert isinstance(packages, list)
+    project = packages[0]
+    assert isinstance(project, dict)
+    project["dependencies"] = []
+    with pytest.raises(case.adapter.UvCrossCheckError, match="root dependency edges"):
+        case.adapter._validate_uv_lock(
+            _lock_document(case, bad_edges, case.root),
+            scenario,
+            prepared,
+            case.distributions,
+            case.inventory,
+            case.root,
+        )
+
+
+def test_uv_lock_validation_anchors_relative_paths_to_the_lock(
+    fixture_case: _FixtureCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    case = fixture_case
+    scenario = case.scenario("universal-aligned")
+    prepared = case.core.prepare_scenario(scenario, case.root)
+    binary = tmp_path / "uv"
+    binary.write_bytes(b"fake uv")
+    ambient = tmp_path / "ambient"
+    ambient.mkdir()
+    commands: list[tuple[str, ...]] = []
+
+    def run(
+        command: Sequence[str], *, cwd: Path, policy: object
+    ) -> subprocess.CompletedProcess[str]:
+        del policy
+        commands.append(tuple(command))
+        if list(command[1:]) == ["--version"]:
+            return subprocess.CompletedProcess(command, 0, "uv 1.2.3\n", "")
+        document = _uv_lock_document(case, scenario, prepared)
+        _make_uv_lock_paths_relative(document, case, cwd)
+        (cwd / "uv.lock").write_text(
+            tomli_w.dumps(document),
+            encoding="utf-8",
+            newline="\n",
+        )
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(case.adapter, "_run", run)
+    monkeypatch.chdir(ambient)
+
+    report = case.adapter.verify_scenarios(
+        [scenario],
+        case.root,
+        case.digest,
+        binary,
+        case.distributions,
+    )
+
+    assert report["scenarios"][0]["pins_per_target"] == prepared.expected
+    assert len([command for command in commands if command[1:2] == ("lock",)]) == 1
+
+
+def test_uv_lock_runner_uses_a_temporary_project_and_redacts_it(
+    fixture_case: _FixtureCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    case = fixture_case
+    scenario = case.scenario("universal-independent")
+    invocations: list[list[str]] = []
+
+    def run(
+        command: list[str], *, cwd: Path, policy: object
+    ) -> subprocess.CompletedProcess[str]:
+        del policy
+        invocations.append(command)
+        project = Path(command[command.index("--project") + 1])
+        assert cwd == project.resolve()
+        (project / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(case.adapter, "_run", run)
+    lock_run = case.adapter._run_uv_lock(
+        scenario,
+        case.root,
+        "/tool/uv",
+        case.adapter._subprocess_policy(),
+        project=tmp_path,
+    )
+
+    assert lock_run.document.data == {"version": 1}
+    assert lock_run.document.directory == tmp_path.resolve()
+    assert len(invocations) == 1
+    command = invocations[0]
+    assert command[:2] == ["/tool/uv", "lock"]
+    assert "--fork-strategy" not in command
+    assert "--resolution" not in command
+    assert lock_run.command[0] == "<uv>"
+    assert lock_run.command[lock_run.command.index("--project") + 1] == "<work>"
+    assert lock_run.command[lock_run.command.index("--default-index") + 1] == (
+        "file://<fixture>"
+    )
+    assert lock_run.returncode == 0
+
+
+@pytest.mark.parametrize(
+    ("scenario_id", "message"),
+    [
+        ("basic-highest", "cannot read uv pylock"),
+        ("universal-independent", "cannot read uv.lock"),
+    ],
+)
+def test_public_verification_rejects_malformed_toml_output(
+    fixture_case: _FixtureCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    scenario_id: str,
+    message: str,
+) -> None:
+    case = fixture_case
+    scenario = case.scenario(scenario_id)
+    binary = tmp_path / f"uv-{scenario_id}"
+    binary.write_bytes(b"fake uv")
+    scenario_commands: list[tuple[str, ...]] = []
+
+    def run(
+        command: Sequence[str], *, cwd: Path, policy: object
+    ) -> subprocess.CompletedProcess[str]:
+        del policy
+        if list(command[1:]) == ["--version"]:
+            return subprocess.CompletedProcess(command, 0, "uv 1.2.3\n", "")
+        scenario_commands.append(tuple(command))
+        if "--output-file" in command:
+            output = Path(command[command.index("--output-file") + 1])
+        else:
+            output = cwd / "uv.lock"
+        output.write_text("[[malformed]\n", encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(case.adapter, "_run", run)
+
+    with pytest.raises(case.adapter.UvCrossCheckError, match=message):
+        case.adapter.verify_scenarios(
+            [scenario],
+            case.root,
+            case.digest,
+            binary,
+            case.distributions,
+        )
+
+    assert len(scenario_commands) == 1
+
+
+def test_uv_binary_identity_binds_resolved_path_hash_and_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    adapter = _adapter()
+    binary = tmp_path / "uv"
+    binary.write_bytes(b"fake uv")
+    monkeypatch.setattr(
+        adapter,
+        "_run",
+        lambda command, **_kwargs: subprocess.CompletedProcess(
+            command, 0, "uv 1.2.3\n", ""
+        ),
+    )
+
+    identity = adapter._uv_binary(binary, adapter._subprocess_policy())
+
+    assert identity.path == binary.resolve()
+    assert identity.sha256 == adapter.file_sha256(binary)
+    assert identity.version == "uv 1.2.3"
+
+
+def _assert_report_inputs(
+    case: _FixtureCase,
+    report: dict[str, Any],
+    scenario: _SmokeScenario,
+) -> None:
+    """Check the adapter, core, manifest, and scenario identities."""
+    scenario_record = case.adapter._scenario_record(scenario)
+
+    assert report["schema"] == 2
+    assert report["adapter_sha256"] == case.adapter.file_sha256(
+        case.adapter.ADAPTER_PATH
+    )
+    assert report["core_sha256"] == case.adapter.file_sha256(case.adapter.CORE_PATH)
+    assert report["scenario_manifest_sha256"] == case.adapter.file_sha256(
+        case.adapter.SCENARIOS_PATH
+    )
+    assert report["selected_scenarios_sha256"] == case.adapter._canonical_sha256(
+        [scenario_record]
+    )
+    assert report["scenario_sha256"] == {
+        scenario.id: case.adapter._canonical_sha256(scenario_record)
+    }
+
+
+def _assert_report_uv(
+    case: _FixtureCase,
+    report: dict[str, Any],
+    binary: Path,
+) -> None:
+    """Check the uv executable and project identities."""
+    assert report["uv"] == "uv 1.2.3"
+    assert report["uv_binary_path"] == str(binary.resolve())
+    assert report["uv_binary_sha256"] == case.adapter.file_sha256(binary)
+    assert report["uv_project_sha256"] == case.adapter.file_sha256(
+        case.adapter.UV_PROJECT
+    )
+
+
+def _assert_report_fixture(
+    case: _FixtureCase,
+    report: dict[str, Any],
+) -> None:
+    """Check the fixture inputs and before-and-after access identity."""
+    assert report["fixture_manifest_sha256"] == case.adapter.file_sha256(
+        case.adapter.FIXTURE_PATH
+    )
+    assert report["fixture_input_sha256"] == case.adapter._fixture_input_digest(
+        case.distributions
+    )
+    assert report["fixture_access_before"] == report["fixture_access_after"]
+    assert report["fixture_access_before"]["digest"] == case.digest
+
+
+def _assert_report_subprocess_policy(
+    case: _FixtureCase,
+    report: dict[str, Any],
+) -> None:
+    """Check the recorded subprocess policy and its digest."""
+    assert report["subprocess_policy_sha256"] == case.adapter._canonical_sha256(
+        report["subprocess_policy"]
+    )
+    assert report["subprocess_policy"]["timeout_seconds"] == 120
+
+
+def _assert_report_excludes_timing(report: dict[str, Any]) -> None:
+    """Check that semantic reports contain no timing sample."""
+    assert "elapsed" not in json.dumps(report)
+
+
+def test_report_binds_declared_inputs_and_execution_policy(
+    fixture_case: _FixtureCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    case = fixture_case
+    scenario = case.scenario("basic-highest")
+    binary = tmp_path / "uv"
+    binary.write_bytes(b"fake uv")
+
+    monkeypatch.setattr(
+        case.adapter,
+        "_run",
+        lambda command, **_kwargs: subprocess.CompletedProcess(
+            command, 0, "uv 1.2.3\n", ""
+        ),
+    )
+    monkeypatch.setattr(
+        case.adapter,
+        "_verify_scenario",
+        lambda *_args: {
+            "id": scenario.id,
+            "return_status": {"code": 0, "classification": "success"},
+        },
+    )
+
+    report = case.adapter.verify_scenarios(
+        [scenario],
+        case.root,
+        case.digest,
+        binary,
+        case.distributions,
+    )
+
+    _assert_report_inputs(case, report, scenario)
+    _assert_report_uv(case, report, binary)
+    _assert_report_fixture(case, report)
+    _assert_report_subprocess_policy(case, report)
+    _assert_report_excludes_timing(report)
+
+
+def test_verification_freezes_caller_scenario_and_fixture_sequences(
+    fixture_case: _FixtureCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    case = fixture_case
+    original = case.scenario("basic-highest")
+    replacement = case.scenario("constraint-ceiling")
+    selected = [original]
+    distributions = list(case.distributions)
+    expected_distribution_count = len(distributions)
+    binary = tmp_path / "uv"
+    binary.write_bytes(b"fake uv")
+    identity = case.adapter._UvIdentity(
+        binary.resolve(), case.adapter.file_sha256(binary), "uv test"
+    )
+    observed: list[str] = []
+
+    def identify(_uv: object, _policy: object) -> object:
+        selected[0] = replacement
+        distributions.clear()
+        return identity
+
+    def verify(
+        scenario: Any,
+        _fixture_root: object,
+        _uv: object,
+        frozen_distributions: tuple[Any, ...],
+        _inventory: object,
+        _policy: object,
+    ) -> dict[str, object]:
+        scenario_id = scenario.id
+        assert isinstance(scenario_id, str)
+        observed.append(scenario_id)
+        assert len(frozen_distributions) == expected_distribution_count
+        return {"id": scenario_id}
+
+    monkeypatch.setattr(case.adapter, "_uv_binary", identify)
+    monkeypatch.setattr(case.adapter, "_verify_scenario", verify)
+    monkeypatch.setattr(
+        case.adapter,
+        "_run",
+        lambda command, **_kwargs: subprocess.CompletedProcess(
+            command, 0, "uv test\n", ""
+        ),
+    )
+
+    report = case.adapter.verify_scenarios(
+        selected,
+        case.root,
+        case.digest,
+        binary,
+        distributions,
+    )
+
+    assert observed == [original.id]
+    assert report["scenario_sha256"] == {
+        original.id: case.adapter._canonical_sha256(
+            case.adapter._scenario_record(original)
+        )
+    }
+
+
+_MalformedBoundaryCase = Callable[
+    [_FixtureCase, _SmokeScenario, Mapping[str, str], Path], None
+]
+
+
+def _raise_invalid_name(
+    case: _FixtureCase,
+    _scenario: _SmokeScenario,
+    _environment: Mapping[str, str],
+    _malformed: Path,
+) -> None:
+    """Exercise invalid package-name parsing at the public boundary."""
+    case.adapter._validate_artifact(
+        {"name": "!!!", "version": "1"},
+        inventory=case.inventory,
+        document_dir=case.root.resolve(),
+        pylock=True,
+    )
+
+
+def _raise_invalid_marker(
+    case: _FixtureCase,
+    _scenario: _SmokeScenario,
+    environment: Mapping[str, str],
+    _malformed: Path,
+) -> None:
+    """Exercise invalid marker parsing at the public boundary."""
+    case.adapter._marker_coverage(
+        ["not a valid marker"],
+        {"target": environment},
+        "markers",
+    )
+
+
+def _raise_invalid_specifier(
+    case: _FixtureCase,
+    scenario: _SmokeScenario,
+    _environment: Mapping[str, str],
+    _malformed: Path,
+) -> None:
+    """Exercise invalid Python specifier parsing at the public boundary."""
+    case.adapter._validate_uv_lock_header(
+        {"version": 1, "requires-python": "not a specifier"},
+        scenario,
+    )
+
+
+def _raise_invalid_utf8(
+    case: _FixtureCase,
+    scenario: _SmokeScenario,
+    _environment: Mapping[str, str],
+    malformed: Path,
+) -> None:
+    """Exercise invalid pylock decoding at the public boundary."""
+    case.adapter._read_optional_pylock(malformed, scenario.id)
+
+
+@pytest.mark.parametrize(
+    ("malformed_case", "error_name"),
+    [
+        pytest.param(_raise_invalid_name, "InvalidName", id="name"),
+        pytest.param(_raise_invalid_marker, "InvalidMarker", id="marker"),
+        pytest.param(_raise_invalid_specifier, "InvalidSpecifier", id="specifier"),
+        pytest.param(_raise_invalid_utf8, "UnicodeDecodeError", id="utf8"),
+    ],
+)
+def test_public_boundary_wraps_malformed_external_data(
+    fixture_case: _FixtureCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    malformed_case: _MalformedBoundaryCase,
+    error_name: str,
+) -> None:
+    case = fixture_case
+    scenario = case.scenario("basic-highest")
+    binary = tmp_path / "uv"
+    binary.write_bytes(b"fake uv")
+    identity = case.adapter._UvIdentity(
+        binary.resolve(), case.adapter.file_sha256(binary), "uv test"
+    )
+    malformed = tmp_path / "malformed.toml"
+    malformed.write_bytes(b"\xff")
+    environment = case.core.prepare_scenario(scenario, case.root).targets[0].marker_env
+    monkeypatch.setattr(case.adapter, "_uv_binary", lambda _uv, _policy: identity)
+
+    def reject(*_args: object) -> dict[str, object]:
+        malformed_case(case, scenario, environment, malformed)
+        raise AssertionError("malformed input unexpectedly passed")
+
+    monkeypatch.setattr(case.adapter, "_verify_scenario", reject)
+
+    with pytest.raises(
+        case.adapter.UvCrossCheckError,
+        match=rf"invalid uv comparison data \({error_name}\)",
+    ):
+        case.adapter.verify_scenarios(
+            [scenario],
+            case.root,
+            case.digest,
+            binary,
+            case.distributions,
+        )
+
+
+def test_verification_rejects_a_uv_binary_that_changes_mid_run(
+    fixture_case: _FixtureCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    case = fixture_case
+    scenario = case.scenario("basic-highest")
+    binary = tmp_path / "uv"
+    binary.write_bytes(b"before")
+    identity = case.adapter._UvIdentity(
+        binary.resolve(), case.adapter.file_sha256(binary), "uv test"
+    )
+    monkeypatch.setattr(case.adapter, "_uv_binary", lambda _uv, _policy: identity)
+
+    def replace_binary(*_args: object) -> dict[str, object]:
+        binary.write_bytes(b"after")
+        return {"id": scenario.id}
+
+    monkeypatch.setattr(case.adapter, "_verify_scenario", replace_binary)
+
+    with pytest.raises(case.adapter.UvCrossCheckError, match="binary changed"):
+        case.adapter.verify_scenarios(
+            [scenario],
+            case.root,
+            case.digest,
+            binary,
+            case.distributions,
+        )
+
+
+def test_verification_rejects_post_run_fixture_replacement(
+    fixture_case: _FixtureCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shared = fixture_case
+    case = _materialized_case(shared, tmp_path / "fixture")
+    scenario = case.scenario("basic-highest")
+    prepared = case.core.prepare_scenario(scenario, case.root)
+    expected = dict(next(iter(prepared.expected.values())))
+    binary = tmp_path / "uv"
+    binary.write_bytes(b"fake uv")
+    replacement = tmp_path / "replacement"
+    original = tmp_path / "original"
+    verify_scenario = case.adapter._verify_scenario
+
+    def run(
+        command: Sequence[str], *, cwd: Path, policy: object
+    ) -> subprocess.CompletedProcess[str]:
+        del cwd, policy
+        if list(command[1:]) == ["--version"]:
+            return subprocess.CompletedProcess(command, 0, "uv 1.2.3\n", "")
+        output = Path(command[command.index("--output-file") + 1])
+        _write_pylock(output, case, expected)
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    def replace_after_verification(*args: object) -> dict[str, object]:
+        result = verify_scenario(*args)
+        case.core.materialize_fixture(
+            replacement,
+            case.distributions,
+            case.digest,
+        )
+        case.root.rename(original)
+        replacement.rename(case.root)
+        return result
+
+    monkeypatch.setattr(case.adapter, "_run", run)
+    monkeypatch.setattr(case.adapter, "_verify_scenario", replace_after_verification)
+
+    with pytest.raises(
+        case.adapter.UvCrossCheckError,
+        match="fixture storage changed during uv verification",
+    ):
+        case.adapter.verify_scenarios(
+            [scenario],
+            case.root,
+            case.digest,
+            binary,
+            case.distributions,
+        )
+
+    assert case.core.fixture_digest(case.root) == case.digest
+
+
+def test_verification_rejects_selected_scenario_input_changes(
+    fixture_case: _FixtureCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    case = fixture_case
+    scenario = case.scenario("basic-highest")
+    binary = tmp_path / "uv"
+    binary.write_bytes(b"fake uv")
+    identity = case.adapter._UvIdentity(
+        binary.resolve(), case.adapter.file_sha256(binary), "uv test"
+    )
+    monkeypatch.setattr(case.adapter, "_uv_binary", lambda _uv, _policy: identity)
+    monkeypatch.setattr(
+        case.adapter,
+        "_run",
+        lambda command, **_kwargs: subprocess.CompletedProcess(
+            command, 0, "uv test\n", ""
+        ),
+    )
+
+    def mutate(*_args: object) -> dict[str, object]:
+        pins = scenario.expected[0].pins
+        assert isinstance(pins, dict)
+        pins["nab-smoke-basic"] = "9.9.9"
+        return {"id": scenario.id}
+
+    monkeypatch.setattr(case.adapter, "_verify_scenario", mutate)
+
+    with pytest.raises(
+        case.adapter.UvCrossCheckError,
+        match="selected scenario inputs changed",
+    ):
+        case.adapter.verify_scenarios(
+            [scenario],
+            case.root,
+            case.digest,
+            binary,
+            case.distributions,
+        )


### PR DESCRIPTION
The deterministic smoke corpus currently trusts its own expected outcomes. This adds an offline uv cross-check for all eleven scenarios: nine run through `uv pip compile`, and the two universal scenarios each use one `uv lock` command over all four targets. The adapter checks expected outcomes and fixture artifacts in every case, including the six-level `deep-backjump` graph, and verifies target projections and dependency edges in the universal locks.

Reports bind the selected scenario inputs by SHA-256 and record source hashes, fixture identity, uv binary, and subprocess policy. They contain no timing data.
