### PR TITLE
mark incompatible build-policy scenarios unsupported

### DIFF
--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -74,10 +74,11 @@ def build_inputs(
     constraint_strings = scenario.get("constraints", [])
     marker_environment = sc.parse_marker_environment(name, scenario)
     build_policy_overrides = sc.parse_build_packages(name, scenario)
-
-    # BUILD_REMOTE + marker_environment overlay is unsupported; drop overrides.
-    if marker_environment and build_policy_overrides:
-        build_policy_overrides = {}
+    sc.validate_scenario_build_policy(
+        name,
+        marker_environment,
+        build_policy_overrides,
+    )
 
     declared_resolution = sc.ResolutionStrategy(
         scenario.get("resolution", sc.ResolutionStrategy.HIGHEST.value)

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -818,16 +818,11 @@ def median_run(
         str(name): BuildPolicy.BUILD_REMOTE for name in raw_build_packages
     }
     if marker_environment and build_policy_overrides:
-        # See ``scenarios.py``: marker_environment + BUILD_REMOTE override
-        # is rejected to preserve metadata soundness.  Drop the overrides;
-        # a resolution that now fails was relying on the previous silent
-        # passthrough and needs an audit.
-        print(
-            f"  [audit] dropping {len(build_policy_overrides)} build_packages"
-            " override(s) because of marker_environment overlay.",
-            flush=True,
+        msg = (
+            f"{scenario_name}: build_packages cannot be combined "
+            "with a marker environment overlay"
         )
-        build_policy_overrides = {}
+        raise ValueError(msg)
     requirement_marker_env = _scenario_marker_env(python_version, marker_environment)
     requirements = parse_requirements(
         requirement_strings,

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -499,7 +499,6 @@ class PreparedStandardExecution(NamedTuple):
     vcs_config: VcsConfig
     trust_unverified_sdist_deps: bool
     expected_input: dict[str, object]
-    dropped_build_packages: int
 
 
 def load_standard_corpus(files: list[Path]) -> list[StandardScenario]:
@@ -555,6 +554,16 @@ def load_standard_corpus(files: list[Path]) -> list[StandardScenario]:
         rows.extend(
             StandardScenario(path.stem, name, definition)
             for name, definition in scenarios.items()
+        )
+    for row in rows:
+        marker_environment = parse_marker_environment(row.name, row.definition)
+        build_policy_overrides = parse_build_packages(row.name, row.definition)
+        if "unsupported_reason" in row.definition:
+            continue
+        validate_scenario_build_policy(
+            row.name,
+            marker_environment,
+            build_policy_overrides,
         )
     return rows
 
@@ -1467,6 +1476,20 @@ def parse_build_packages(
     return overrides
 
 
+def validate_scenario_build_policy(
+    scenario_name: str,
+    marker_environment: Mapping[str, str],
+    build_policy_overrides: Mapping[str, BuildPolicy],
+) -> None:
+    """Reject build policy paired with a marker environment overlay."""
+    if marker_environment and build_policy_overrides:
+        msg = (
+            f"{scenario_name}: build_packages cannot be combined "
+            "with a marker environment overlay"
+        )
+        raise ValueError(msg)
+
+
 def prepare_standard_execution(
     execution: StandardExecution,
     *,
@@ -1484,10 +1507,12 @@ def prepare_standard_execution(
     indexes = parse_indexes(scenario_name, scenario)
     index_routes = parse_index_routes(scenario_name, scenario)
     build_policy_overrides = dict(parse_build_packages(scenario_name, scenario))
-    dropped_build_packages = 0
-    if marker_environment and build_policy_overrides:
-        dropped_build_packages = len(build_policy_overrides)
-        build_policy_overrides = {}
+    if "unsupported_reason" not in scenario:
+        validate_scenario_build_policy(
+            scenario_name,
+            marker_environment,
+            build_policy_overrides,
+        )
     datetime_str: str | None = scenario.get("datetime")
     project_name: str | None = scenario.get("project_name")
     project_extras: list[str] = scenario.get("project_extras", [])
@@ -1547,7 +1572,6 @@ def prepare_standard_execution(
         vcs_config=vcs_config,
         trust_unverified_sdist_deps=trust_unverified_sdist_deps,
         expected_input=expected_input,
-        dropped_build_packages=dropped_build_packages,
     )
 
 
@@ -1570,13 +1594,6 @@ def process_scenario(
         source=source,
         corpus_hash=corpus_hash,
     )
-    if prepared.dropped_build_packages:
-        print(
-            f"\n  [audit] {scenario_name}: dropping {prepared.dropped_build_packages}"
-            " build_packages override(s) because host-built metadata cannot"
-            " reflect a marker_environment overlay.",
-            flush=True,
-        )
 
     run_dir = _result_directory(commit)
     output_path = _standard_result_path(run_dir, execution)

--- a/nab-python/benchmarks/scenarios/ai-stack.toml
+++ b/nab-python/benchmarks/scenarios/ai-stack.toml
@@ -11,10 +11,8 @@
 python_version = "3.11"
 platform_system = "Linux"
 datetime = "2025-05-29 08:33:51"
-# deepspeed at this version is sdist-only; uv builds it.  nab needs
-# a native CUDA toolchain to build it locally and benchmarks may
-# fail at build time on a stripped-down CI host -- the override
-# documents the requirement.
+unsupported_reason = "build policy cannot represent a marker-only target"
+# deepspeed at this version is sdist-only and needs a native CUDA toolchain.
 build_packages = ["deepspeed"]
 requirements = [
     "accelerate==1.4.0",
@@ -468,6 +466,7 @@ requirements = [
 python_version = "3.11"
 platform_system = "Linux"
 datetime = "2025-08-09 08:17:20"
+unsupported_reason = "build policy cannot represent a marker-only target"
 # Pure-Python sdists (newspaper3k transitive chain) with no wheel
 # under the exclude-newer date.
 build_packages = [

--- a/nab-python/benchmarks/scenarios/forums.toml
+++ b/nab-python/benchmarks/scenarios/forums.toml
@@ -731,6 +731,7 @@ requirements = [
 python_version = "3.8"
 platform_system = "Linux"
 datetime = "2021-07-20 14:00:00"
+unsupported_reason = "build policy cannot represent a marker-only target"
 # Pure-Python sdists with no wheel under the exclude-newer date.
 build_packages = ["future", "pymeeus"]
 requirements = [

--- a/nab-python/benchmarks/scenarios/pip.toml
+++ b/nab-python/benchmarks/scenarios/pip.toml
@@ -1169,6 +1169,7 @@ requirements = [
 python_version = "3.7"
 platform_system = "Linux"
 datetime = "2023-01-29 06:46:46"
+unsupported_reason = "build policy cannot represent a marker-only target"
 # Sdist-only at the listed pins.  shapely needs libgeos to build;
 # the rest are pure Python.
 build_packages = [
@@ -1206,8 +1207,8 @@ requirements = [
 python_version = "3.7"
 platform_system = "Linux"
 datetime = "2023-01-29 20:33:23"
-# Pure-Python sdists with no wheel under the exclude-newer date.  Building
-# them is cheap enough to run inside the benchmark host.
+unsupported_reason = "build policy cannot represent a marker-only target"
+# Pure-Python sdists with no wheel under the exclude-newer date.
 build_packages = ["antlr4-python3-runtime", "future"]
 requirements = [
     "einops==0.3",
@@ -1370,6 +1371,7 @@ requirements = [
 python_version = "3.8"
 platform_system = "Linux"
 datetime = "2021-02-09 09:53:34"
+unsupported_reason = "build policy cannot represent a marker-only target"
 # Pure-Python sdists with no wheel under the exclude-newer date.
 # olefile is built indirectly via extract-msg's pin chain (older
 # pins reference olefile==0.43 / 0.46, both sdist-only).

--- a/nab-python/benchmarks/scenarios/uv.toml
+++ b/nab-python/benchmarks/scenarios/uv.toml
@@ -614,6 +614,7 @@ requirements = [
 python_version = "3.13"
 platform_system = "Linux"
 datetime = "2025-05-06 22:13:25"
+unsupported_reason = "build policy cannot represent a marker-only target"
 # Sdist-only deps along the resolved path.  outlines-core (Rust),
 # sentencepiece (C++), and xformers (CUDA) need native toolchains;
 # the rest are pure Python.

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -133,6 +133,32 @@ def test_canary_rejects_unknown_resolution() -> None:
         )
 
 
+def test_canary_rejects_supported_marker_build_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+
+    def unexpected_run(*_args: object, **_kwargs: object) -> dict:
+        pytest.fail("scenario reached the resolver")
+
+    monkeypatch.setattr(module, "run_one", unexpected_run)
+    scenario = {
+        "python_version": "3.11",
+        "requirements": ["demo"],
+        "platform_system": "Linux",
+        "build_packages": ["demo"],
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "example: build_packages cannot be combined "
+            "with a marker environment overlay"
+        ),
+    ):
+        module.median_run(scenario, 1, scenario_name="example")
+
+
 def test_canary_explicit_resolution_overrides_declared_strategy(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -17,7 +17,19 @@ import pytest
 _BENCHMARKS = Path(__file__).resolve().parents[1] / "benchmarks"
 _STANDARD_FILES = 14
 _STANDARD_SCENARIOS = 558
-_RUNNABLE_SCENARIOS = 543
+_RUNNABLE_SCENARIOS = 536
+_UNSUPPORTED_SCENARIOS = 22
+_TOTAL_EXECUTION_IDENTITIES = 1_674
+_RUNNABLE_STRATEGY_EXECUTIONS = 1_608
+_MARKER_BUILD_SCENARIOS = {
+    "ai-stack:llama-index-experimental-gpt5",
+    "ai-stack:open-r1",
+    "forums:so-gluonts-mxnet-pin-68451898",
+    "pip:pip-11760-torchgeo-min",
+    "pip:pip-11760-torchgeo-nbconvert-pin",
+    "pip:pip-9572-textract-pypdf2",
+    "uv:uv-issue-13321-axolotl-stack",
+}
 _CLEAN_SOURCE = {"commit": "a" * 40, "dirty": False, "diff_hash": None}
 _MANIFEST_FIELDS = {
     "benchmark_schema",
@@ -256,10 +268,62 @@ def test_standard_corpus_is_one_canonical_definition_per_scenario() -> None:
     assert len(files) == _STANDARD_FILES
     assert len(rows) == _STANDARD_SCENARIOS
     assert len({row.logical_key for row in rows}) == _STANDARD_SCENARIOS
-    assert sum("unsupported_reason" not in row.definition for row in rows) == (
-        _RUNNABLE_SCENARIOS
-    )
+    runnable = sum("unsupported_reason" not in row.definition for row in rows)
+    assert runnable == _RUNNABLE_SCENARIOS
+    assert len(rows) - runnable == _UNSUPPORTED_SCENARIOS
     assert all("resolution" not in row.definition for row in rows)
+
+
+def test_standard_execution_census() -> None:
+    module = _harness("scenarios")
+    rows = module.load_standard_corpus(module.standard_scenario_files())
+    executions = module.standard_execution_plan(rows, module.STANDARD_STRATEGIES)
+    execution_keys = module.standard_execution_keys(rows, module.STANDARD_STRATEGIES)
+
+    assert len(executions) == _RUNNABLE_STRATEGY_EXECUTIONS
+    assert len(execution_keys) == _TOTAL_EXECUTION_IDENTITIES
+
+
+def test_marker_build_scenarios_are_explicitly_unsupported() -> None:
+    module = _harness("scenarios")
+    rows = module.load_standard_corpus(module.standard_scenario_files())
+    marker_build_rows = {
+        row.logical_key: row
+        for row in rows
+        if module.parse_marker_environment(row.name, row.definition)
+        and module.parse_build_packages(row.name, row.definition)
+    }
+
+    assert set(marker_build_rows) == _MARKER_BUILD_SCENARIOS
+    assert all(
+        row.definition.get("unsupported_reason") for row in marker_build_rows.values()
+    )
+
+
+def test_standard_corpus_rejects_supported_marker_build_policy(
+    tmp_path: Path,
+) -> None:
+    module = _harness("scenarios")
+    path = tmp_path / "quick.toml"
+    path.write_text(
+        """
+[example]
+python_version = "3.11"
+platform_system = "Linux"
+build_packages = ["demo"]
+requirements = ["demo"]
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "example: build_packages cannot be combined "
+            "with a marker environment overlay"
+        ),
+    ):
+        module.load_standard_corpus([path])
 
 
 def test_standard_corpus_rejects_a_strategy_clone(
@@ -1042,3 +1106,22 @@ def test_profile_runner_accepts_an_explicit_strategy() -> None:
 
     assert default["resolution_strategy"] is module.sc.ResolutionStrategy.HIGHEST
     assert lowest["resolution_strategy"] is module.sc.ResolutionStrategy.LOWEST
+
+
+def test_profile_runner_rejects_supported_marker_build_policy() -> None:
+    module = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": ["demo"],
+        "platform_system": "Linux",
+        "build_packages": ["demo"],
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "example: build_packages cannot be combined "
+            "with a marker environment overlay"
+        ),
+    ):
+        module.build_inputs("example", scenario)


### PR DESCRIPTION
Seven standard scenarios, including `ai-stack:open-r1`, combine per-package build declarations with a marker-only platform target. Nab's PEP 517 backend runs on the host, so the harness cannot guarantee target-faithful metadata for those scenarios. The runners dropped the build declarations and resolved a different contract. The scenarios are now explicitly unsupported, and the standard, canary, and profile paths reject any future runnable scenario with the same combination.

The scenario IDs, source context, build declarations, and result identities remain in the corpus. The runnable corpus falls from 543 to 536 logical cases, reducing the three-strategy execution plan from 1,629 to 1,608 executions.
