### PR TITLE
keep each root requirement as its own clause

### DIFF
--- a/nab-resolver/pyproject.toml
+++ b/nab-resolver/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "typing_extensions>=4.6",
+    "typing_extensions>=4.10",
 ]
 
 [project.urls]

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -21,8 +21,11 @@ Rust implementation: https://github.com/pubgrub-rs/pubgrub
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Generic, Protocol
+from typing import Any, Generic, Protocol
+
+from typing_extensions import TypeIs
 
 from . import conflict, decide, incompat_index, propagate
 from .errors import ResolutionError
@@ -36,14 +39,11 @@ from .types import (
     IncompatibilityState,
     PackageType,
     RangeProtocol,
+    RootRequirement,
     SetRelation,
     Term,
     VersionType,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Mapping
-
 
 __all__ = [
     "Incompatibility",
@@ -54,6 +54,7 @@ __all__ = [
     "ResolverObserver",
     "ResolverProvider",
     "ResolverStats",
+    "RootRequirement",
     "SetRelation",
     "Term",
 ]
@@ -277,6 +278,34 @@ class ResolverObserver(Generic[PackageType, VersionType]):
         """Handle one iteration of the conflict resolution loop."""
 
 
+def _is_range_mapping(
+    requirements: Mapping[PackageType, RangeProtocol[VersionType]]
+    | Sequence[RootRequirement[PackageType, VersionType]],
+) -> TypeIs[Mapping[PackageType, RangeProtocol[VersionType]]]:
+    """Return whether the caller passed the one-range-per-package form.
+
+    A ``TypeIs`` rather than a bare ``isinstance``: one type can satisfy both
+    members of the union, so plain narrowing can leave an intersection that
+    has lost the mapping's value type.
+    """
+    return isinstance(requirements, Mapping)
+
+
+def _as_root_requirements(
+    requirements: Mapping[PackageType, RangeProtocol[VersionType]]
+    | Sequence[RootRequirement[PackageType, VersionType]],
+) -> Sequence[RootRequirement[PackageType, VersionType]]:
+    """Accept either shape ``Resolver.resolve`` takes and return the sequence."""
+    if not _is_range_mapping(requirements):
+        return requirements
+    # The parameters are spelled out because ``constraint`` is a contravariant
+    # protocol, which gives the version parameter no inference site.
+    return [
+        RootRequirement[PackageType, VersionType](package, required_range)
+        for package, required_range in requirements.items()
+    ]
+
+
 class Resolver(Generic[PackageType, VersionType]):
     """PubGrub dependency resolver.
 
@@ -352,10 +381,16 @@ class Resolver(Generic[PackageType, VersionType]):
 
     def resolve(
         self,
-        requirements: Mapping[PackageType, RangeProtocol[VersionType]],
+        requirements: Mapping[PackageType, RangeProtocol[VersionType]]
+        | Sequence[RootRequirement[PackageType, VersionType]],
         constraints: Mapping[PackageType, RangeProtocol[VersionType]] | None = None,
     ) -> dict[PackageType, VersionType]:
         """Resolve requirements and return ``{package: version}``.
+
+        ``requirements`` is either one range per package, or a sequence of
+        :class:`~nab_resolver.types.RootRequirement` when the caller has more
+        than one requirement on a package and wants each named as written in
+        the failure report.
 
         Constraints restrict a package's version range but do not cause
         it to be installed.  They are injected lazily: only when the
@@ -365,7 +400,7 @@ class Resolver(Generic[PackageType, VersionType]):
         Raises ``ResolutionError`` if no solution exists.
         """
         self._reset(constraints)
-        self._add_root_requirements(requirements)
+        self._add_root_requirements(_as_root_requirements(requirements))
 
         # Threshold doubles each restart (geometric schedule).
         restart_threshold = self._RESTART_THRESHOLD
@@ -515,20 +550,23 @@ class Resolver(Generic[PackageType, VersionType]):
         self.relation_cache.clear()
 
     def _add_root_requirements(
-        self, requirements: Mapping[PackageType, RangeProtocol[VersionType]]
+        self, requirements: Sequence[RootRequirement[PackageType, VersionType]]
     ) -> None:
-        """Create root incompatibilities and decide the root package."""
-        for idx, (package, required_range) in enumerate(requirements.items()):
+        """Create one root incompatibility per requirement, and decide root."""
+        for idx, root in enumerate(requirements):
             root_term: Term[Any, Any] = Term(
                 ROOT, self.range_type.singleton(self.root_version), positive=True
             )
             incompat_index.add_incompatibility(
                 self,
                 Incompatibility(
-                    [root_term, Term(package, required_range, positive=False)],
+                    [root_term, Term(root.package, root.constraint, positive=False)],
                     cause=IncompatibilityCause.ROOT,
+                    origin=root.origin,
                 ),
             )
-            self.root_package_order[package] = (0, idx, "")
+            # First mention fixes the tiebreak, so naming a package twice
+            # does not push its decision later.
+            self.root_package_order.setdefault(root.package, (0, idx, ""))
         self.solution.decide(ROOT, self.root_version)
         self.stats.decisions += 1

--- a/nab-resolver/src/nab_resolver/types.py
+++ b/nab-resolver/src/nab_resolver/types.py
@@ -12,9 +12,9 @@ Reference: https://github.com/dart-lang/pub/blob/master/doc/solver.md#definition
 from __future__ import annotations
 
 import enum
-from typing import Generic, Protocol, TypeVar
+from typing import Any, Generic, Protocol, TypeVar
 
-from typing_extensions import Self, override
+from typing_extensions import NamedTuple, Self, override
 
 __all__ = [
     "Incompatibility",
@@ -24,6 +24,7 @@ __all__ = [
     "RangeProtocol",
     "RangeRelation",
     "RelationProtocol",
+    "RootRequirement",
     "SetRelation",
     "Term",
     "VersionType",
@@ -236,6 +237,25 @@ class RelationProtocol(Protocol):
         ...
 
 
+class RootRequirement(NamedTuple, Generic[PackageType, VersionType]):
+    """One requirement as the caller wrote it, kept as its own clause.
+
+    A caller that passes a mapping has to intersect its requirements on a
+    package first, and the resolver then proves the failure against the
+    intersection, naming a range nobody wrote.  Passing a sequence of these
+    keeps each requirement separate all the way into the report.
+
+    ``origin`` is opaque to the resolver and travels onto the ROOT
+    incompatibility, so a caller's own error reporter can identify the
+    requirement behind a clause.  Two requirements on one package can share a
+    range, so the range alone cannot tell them apart.
+    """
+
+    package: PackageType
+    constraint: RangeProtocol[VersionType]
+    origin: Any = None
+
+
 class SetRelation(enum.Enum):
     """How the partial solution relates to a term.
 
@@ -294,10 +314,20 @@ class Incompatibility(Generic[PackageType, VersionType]):
     clause. The clause's term carries the requirement range that backtracking
     needs, so the user's constraint is kept here for the message.
 
+    ``origin`` holds the caller's :class:`RootRequirement` origin for a
+    ``ROOT`` clause, opaque to the resolver and never read by it.
+
     Reference: https://github.com/dart-lang/pub/blob/master/doc/solver.md#incompatibility
     """
 
-    __slots__ = ("cause", "cause_left", "cause_right", "constraint_range", "terms")
+    __slots__ = (
+        "cause",
+        "cause_left",
+        "cause_right",
+        "constraint_range",
+        "origin",
+        "terms",
+    )
 
     def __init__(
         self,
@@ -306,6 +336,7 @@ class Incompatibility(Generic[PackageType, VersionType]):
         cause_left: Incompatibility[PackageType, VersionType] | None = None,
         cause_right: Incompatibility[PackageType, VersionType] | None = None,
         constraint_range: RangeProtocol[VersionType] | None = None,
+        origin: Any = None,
     ) -> None:
         """Create an incompatibility with terms and a cause."""
         self.terms = terms
@@ -313,6 +344,7 @@ class Incompatibility(Generic[PackageType, VersionType]):
         self.cause_left = cause_left
         self.cause_right = cause_right
         self.constraint_range = constraint_range
+        self.origin = origin
 
     @override
     def __repr__(self) -> str:

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -44,6 +44,7 @@ from nab_resolver.types import (
     Incompatibility,
     IncompatibilityCause,
     RangeProtocol,
+    RootRequirement,
     SetRelation,
     Term,
 )
@@ -2138,6 +2139,95 @@ class TestFullRangeWording:
         assert lines[2] == "so p0 1"
         assert lines[-2] == f"because p{depth - 1} 1 depends on tail [1, +inf)"
         assert lines[-1] == f"so p{depth - 1} 1"
+
+
+class TestRootRequirements:
+    def test_disjoint_requirements_are_named_separately(self) -> None:
+        """Two roots on one package each get a line naming what was written."""
+        provider = DictProvider({"pkg": {2: {}, 1: {}}})
+        with pytest.raises(ResolutionError) as excinfo:
+            Resolver(provider).resolve(
+                [
+                    RootRequirement("pkg", Range.greater_than(1)),
+                    RootRequirement("pkg", Range.singleton(1)),
+                ]
+            )
+
+        lines = str(excinfo.value).splitlines()
+        assert "because your project depends on pkg (1, +inf)" in lines
+        assert "because your project depends on pkg 1" in lines
+        assert not any("empty" in line for line in lines)
+
+    def test_overlapping_requirements_survive_to_the_solution(self) -> None:
+        """Roots that intersect to a live range still resolve, once."""
+        provider = DictProvider({"pkg": {3: {}, 2: {}, 1: {}}})
+        result = Resolver(provider).resolve(
+            [
+                RootRequirement("pkg", Range.at_least(1)),
+                RootRequirement("pkg", Range.at_most(2)),
+            ]
+        )
+        assert result == {"pkg": 2}
+
+    def test_transitive_narrowing_names_the_written_requirement(self) -> None:
+        """A conflict past the intersection still quotes a root as written."""
+        provider = DictProvider(
+            {
+                "pkg": {2: {"dep": Range.singleton(9)}},
+                "dep": {1: {}},
+            }
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            Resolver(provider).resolve(
+                [
+                    RootRequirement("pkg", Range.at_least(1)),
+                    RootRequirement("pkg", Range.at_most(2)),
+                ]
+            )
+
+        lines = str(excinfo.value).splitlines()
+        assert "because your project depends on pkg [1, +inf)" in lines
+        assert "because your project depends on pkg (-inf, 2]" in lines
+
+    def test_repeated_package_keeps_its_first_mention_order(self) -> None:
+        """Naming a package twice must not push its decision later."""
+        provider = DictProvider({"pkg": {1: {}}, "other": {1: {}}})
+        resolver = Resolver(provider)
+        resolver.resolve(
+            [
+                RootRequirement("pkg", Range.full()),
+                RootRequirement("other", Range.full()),
+                RootRequirement("pkg", Range.at_least(1)),
+            ]
+        )
+        assert resolver.root_package_order["pkg"] == (0, 0, "")
+        assert resolver.root_package_order["other"] == (0, 1, "")
+
+    def test_origin_travels_onto_the_root_clause(self) -> None:
+        """The caller's opaque origin is readable off the clause it produced."""
+        provider = DictProvider({"pkg": {1: {}}})
+        resolver = Resolver(provider)
+        resolver.resolve([RootRequirement("pkg", Range.full(), "pkg>=1 (line 3)")])
+
+        origins = [
+            incompatibility.origin
+            for incompatibility in resolver.incompatibilities
+            if incompatibility.cause is IncompatibilityCause.ROOT
+        ]
+        assert origins == ["pkg>=1 (line 3)"]
+
+    def test_mapping_form_leaves_the_origin_unset(self) -> None:
+        """A mapping caller keeps working and sets no origin."""
+        provider = DictProvider({"pkg": {1: {}}})
+        resolver = Resolver(provider)
+        assert resolver.resolve({"pkg": Range.full()}) == {"pkg": 1}
+
+        roots = [
+            incompatibility
+            for incompatibility in resolver.incompatibilities
+            if incompatibility.cause is IncompatibilityCause.ROOT
+        ]
+        assert [incompatibility.origin for incompatibility in roots] == [None]
 
 
 class TestConstraints:


### PR DESCRIPTION
`Resolver.resolve` took one range per package, so a caller with two requirements on the same package had to intersect them before calling. Ask for `pkg>1` and `pkg==1.0` together and the solver proves the failure against the empty intersection, so the report reads `because your project depends on pkg <empty>` and names a range nobody wrote.

`resolve` now also accepts a sequence of `RootRequirement`, one entry per requirement as the caller wrote it, and adds a ROOT clause for each, so that case gets a line per requirement instead of one line about the fold. It also reaches the case the fold hides completely, where two requirements intersect to a live range and only conflict after a transitive narrowing. Each entry carries an opaque `origin` that travels onto its clause, which is how a host ties a clause back to the requirement behind it when two requirements share a range. Passing a mapping behaves exactly as before.
