### PR TITLE
name each requirement the user wrote in a resolution failure

### DIFF
--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -28,7 +28,7 @@ from collections import defaultdict
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, NamedTuple, Protocol
 
 from nab_index.cache import ARCHIVE_BUCKET, VCS_BUCKET
 from nab_resolver.resolver import (
@@ -37,6 +37,7 @@ from nab_resolver.resolver import (
     ResolutionError,
     Resolver,
     ResolverObserver,
+    RootRequirement,
 )
 
 from ._conflict_kind import dependency_marker_holds, membership_set_in_marker
@@ -838,19 +839,19 @@ def _resolve_one_target(
     config = settings.config
     environment = target.marker_env
     try:
-        resolver_requirements, root_extras = _build_resolver_inputs(
+        root_requirements, resolver_requirements, root_extras = _build_resolver_inputs(
             requirements,
             config,
             environment=environment,
             warned=settings.warned_root_markers,
         )
-        resolver_constraints, _ = _build_resolver_inputs(
+        resolver_constraints = _build_resolver_inputs(
             constraints,
             config,
             environment=environment,
             kind="constraint",
             warned=settings.warned_root_markers,
-        )
+        ).ranges
     except ResolutionError as exc:
         return TargetResult(target=target, success=False, error=exc)
 
@@ -893,7 +894,7 @@ def _resolve_one_target(
     _logger.debug("resolving %s", target.label)
     start = time.monotonic()
     try:
-        raw = resolver.resolve(resolver_requirements, constraints=resolver_constraints)
+        raw = resolver.resolve(root_requirements, constraints=resolver_constraints)
         pins = {k: v for k, v in raw.items() if split_extra(k)[1] is None}
         _raise_for_source_python(provider, target, pins)
     except ResolutionError as exc:
@@ -1546,6 +1547,14 @@ def _warn_dropped_root_marker(req: Requirement, warned: set[str]) -> None:
     )
 
 
+class _ResolverInputs(NamedTuple):
+    """What one set of root requirements gives the resolver and the provider."""
+
+    roots: list[RootRequirement[str, VersionRange]]
+    ranges: dict[str, VersionRange]
+    extras: set[tuple[str, str]]
+
+
 def _build_resolver_inputs(
     requirements: Sequence[Requirement],
     config: NabProjectConfig,
@@ -1553,26 +1562,31 @@ def _build_resolver_inputs(
     environment: Mapping[str, str],
     kind: str = "requirement",
     warned: set[str] | None = None,
-) -> tuple[dict[str, VersionRange], set[tuple[str, str]]]:
+) -> _ResolverInputs:
     """Convert PEP 508 requirements to the resolver's input shape.
 
     Requirements whose PEP 508 marker evaluates to ``False`` under
     ``environment`` are skipped, matching pip/uv's root-requirement
-    handling.  Repeated package names are intersected into one range;
-    an empty intersection raises :class:`ResolutionError`.  A direct-URL
-    or VCS requirement is refused by :func:`admit_vcs_url`; resolving one
-    is not implemented.
+    handling.  A direct-URL or VCS requirement is refused by
+    :func:`admit_vcs_url`; resolving one is not implemented.
 
-    ``kind`` is ``"requirement"`` or ``"constraint"``.  A constraint may
-    not carry extras, and shapes the error wording; the returned extras
-    set is empty for one.
+    Each surviving requirement becomes its own
+    :class:`~nab_resolver.types.RootRequirement`, tagged with the string the
+    user wrote, so a failure names the requirements rather than their
+    intersection.  ``ranges`` folds the same requirements per package for the
+    provider, which asks about one package at a time.
+
+    ``kind`` is ``"requirement"`` or ``"constraint"``.  A constraint may not
+    carry extras, and the returned extras set is empty for one.  Constraints
+    do not become root clauses, so an empty constraint intersection is still
+    caught here by :func:`raise_for_unsatisfiable` rather than by the solver.
 
     ``warned`` is the run's set of already-reported extra/group root
     markers (see :func:`_warn_dropped_root_marker`); a caller that does
     not share one gets a fresh set, so it warns per call.
     """
+    roots: list[RootRequirement[str, VersionRange]] = []
     resolver_requirements: dict[str, VersionRange] = {}
-    sources: defaultdict[str, list[str]] = defaultdict(list)
     root_extras: set[tuple[str, str]] = set()
     already_warned = set() if warned is None else warned
     for req in requirements:
@@ -1599,15 +1613,24 @@ def _build_resolver_inputs(
             else VersionRange.full(admit_arbitrary=False)
         )
         resolver_requirements[name] = previous & term
-        sources[name].append(str(req))
+        roots.append(RootRequirement(name, term, str(req)))
         for extra in sorted(req.extras):
             extra_key = join_extra(name, extra)
-            resolver_requirements[extra_key] = VersionRange.full(admit_arbitrary=False)
+            # A proxy key carries no version, so a second mention of the same
+            # extra would only repeat a line in the failure report.
+            if extra_key not in resolver_requirements:
+                proxy = VersionRange.full(admit_arbitrary=False)
+                resolver_requirements[extra_key] = proxy
+                roots.append(RootRequirement(extra_key, proxy, str(req)))
             _, normalized_extra = split_extra(extra_key)
             assert normalized_extra is not None  # join_extra always sets one
             root_extras.add((name, normalized_extra))
-    raise_for_unsatisfiable(resolver_requirements, sources, kind=kind)
-    return resolver_requirements, root_extras
+    if kind == "constraint":
+        sources: defaultdict[str, list[str]] = defaultdict(list)
+        for root in roots:
+            sources[root.package].append(root.origin)
+        raise_for_unsatisfiable(resolver_requirements, sources, kind=kind)
+    return _ResolverInputs(roots, resolver_requirements, root_extras)
 
 
 def _extend_constraints_to_proxies(

--- a/nab-python/tests/property_python/test_alignment.py
+++ b/nab-python/tests/property_python/test_alignment.py
@@ -87,11 +87,11 @@ class TestQuoteCanonicalDirectNames:
         self, names: list[str]
     ) -> None:
         """Variations of the same name canonicalise to a single canonical form."""
-        out, _ = _build_resolver_inputs(
+        out = _build_resolver_inputs(
             [Requirement(name) for name in names],
             NabProjectConfig(),
             environment=_fake_target().marker_env,
-        )
+        ).ranges
         assert all(n == n.lower() for n in out)
         if names:
             assert set(out) == {"my-pkg"}
@@ -147,11 +147,11 @@ class TestMarkerFiltering:
         excluded = seen - applies
 
         try:
-            out, _ = _build_resolver_inputs(
+            out = _build_resolver_inputs(
                 parsed,
                 NabProjectConfig(),
                 environment=linux_env,
-            )
+            ).ranges
         except ResolutionError:
             # Self-contradictory draws (e.g. ``pkg<0.0``) are rejected
             # by the function; this property tests marker filtering only.

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -7044,7 +7044,7 @@ class TestExtrasPrereleaseAdmission:
         return make_coordinator(listings=listings, metadata_by_version=metadata)
 
     def _resolve(self, requirements: list[str]) -> dict[str, Version]:
-        root_reqs, root_extras = _build_resolver_inputs(
+        _, root_reqs, root_extras = _build_resolver_inputs(
             [Requirement(r) for r in requirements],
             NabProjectConfig(),
             environment={},

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -19,6 +19,7 @@ from nab_index.transport import HttpError
 from nab_python._testing.coordinator_fake import make_coordinator
 from nab_python._vendor.packaging.markers import Marker, default_environment
 from nab_python._vendor.packaging.pylock import Pylock
+from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.version import Version
 from nab_python.config import (
@@ -104,6 +105,15 @@ def _pins(result: ResolveResult) -> dict[str, Version]:
     return result.target_results[0].pins
 
 
+def _root_ranges(mock_resolver: MagicMock) -> dict[str, VersionRange]:
+    """The root requirements the resolver was called with, folded per package."""
+    folded: dict[str, VersionRange] = {}
+    for root in mock_resolver.resolve.call_args.args[0]:
+        previous = folded.get(root.package, VersionRange.full())
+        folded[root.package] = previous & root.constraint
+    return folded
+
+
 def _locked(lock_input: LockInput) -> dict[str, PinShape]:
     """The pins a single-environment lock carries."""
     (lock,) = lock_input.targets.values()
@@ -128,13 +138,12 @@ def _build_constraints(
     The parser is shared with the requirement side; ``kind`` is what
     tells the two apart.
     """
-    ranges, _ = _build_resolver_inputs(
+    return _build_resolver_inputs(
         [Requirement(text) for text in config.constraints],
         config,
         environment=environment,
         kind="constraint",
-    )
-    return ranges
+    ).ranges
 
 
 def _malformed_group_pyproject(tmp_path: Path) -> Path:
@@ -806,7 +815,7 @@ class TestResolvePyproject:
             }
             _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
 
-        forwarded = mock_resolver.resolve.call_args.args[0]
+        forwarded = _root_ranges(mock_resolver)
         assert "foo" in forwarded
         assert "bar" in forwarded
         assert "custom" in forwarded["foo"]
@@ -887,8 +896,7 @@ class TestResolvePyproject:
 
         _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
 
-        call_args = mock_resolver.resolve.call_args
-        requirements = call_args.args[0]
+        requirements = _root_ranges(mock_resolver)
         assert "requests" in requirements
         assert "requests[security]" in requirements
         # root_extras passed to provider
@@ -922,7 +930,7 @@ class TestResolvePyproject:
 
         _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
 
-        requirements = mock_resolver_cls.return_value.resolve.call_args.args[0]
+        requirements = _root_ranges(mock_resolver_cls.return_value)
         assert "foo" in requirements
         assert "windows-only" not in requirements
 
@@ -963,7 +971,7 @@ class TestResolvePyproject:
 
         _resolved(pyproject, _FAKE_TRANSPORT)
 
-        requirements = mock_resolver_cls.return_value.resolve.call_args.args[0]
+        requirements = _root_ranges(mock_resolver_cls.return_value)
         assert "foo" in requirements
         assert "legacy" in requirements
 
@@ -997,7 +1005,7 @@ class TestResolvePyproject:
 
         _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
 
-        requirements = mock_resolver_cls.return_value.resolve.call_args.args[0]
+        requirements = _root_ranges(mock_resolver_cls.return_value)
         assert "linux-only" in requirements
 
     @patch("nab_python.resolve.build_target_lock")
@@ -1023,7 +1031,7 @@ class TestResolvePyproject:
 
         _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.10.0")
 
-        requirements = mock_resolver_cls.return_value.resolve.call_args.args[0]
+        requirements = _root_ranges(mock_resolver_cls.return_value)
         assert "newer" not in requirements
 
     def test_unparseable_python_version_raises(self, tmp_path: Path) -> None:
@@ -2367,11 +2375,11 @@ class TestLoadExtraRequirements:
         assert req.name == "some-dep"
         assert str(req.marker) == 'python_version < "3.10"'
 
-        excluded, _ = _build_resolver_inputs(
+        excluded = _build_resolver_inputs(
             [req],
             NabProjectConfig(),
             environment={"python_version": "3.12", "python_full_version": "3.12.0"},
-        )
+        ).ranges
         assert "some-dep" not in excluded
 
 
@@ -2381,27 +2389,37 @@ class TestBuildResolverInputs:
     def test_duplicate_name_intersects(self) -> None:
         """Two requirements for one package combine to their overlap."""
         reqs = [Requirement("foo>=2.0"), Requirement("foo<3.0")]
-        resolver_requirements, _ = _build_resolver_inputs(
+        resolver_requirements = _build_resolver_inputs(
             reqs, NabProjectConfig(), environment={}
-        )
+        ).ranges
         foo = resolver_requirements["foo"]
         assert V("2.5") in foo
         assert V("1.0") not in foo
         assert V("5.0") not in foo
 
-    def test_conflicting_names_raise(self) -> None:
-        """Pinned-but-different requirements for one package raise."""
+    def test_conflicting_names_stay_separate_roots(self) -> None:
+        """Contradictory requirements reach the solver as their own clauses."""
         reqs = [Requirement("foo==1.0"), Requirement("foo==2.0")]
-        with pytest.raises(ResolutionError, match="foo==1.0"):
-            _build_resolver_inputs(reqs, NabProjectConfig(), environment={})
+        inputs = _build_resolver_inputs(reqs, NabProjectConfig(), environment={})
+        assert [(root.package, root.origin) for root in inputs.roots] == [
+            ("foo", "foo==1.0"),
+            ("foo", "foo==2.0"),
+        ]
+        assert inputs.ranges["foo"].is_empty
+
+    def test_a_repeated_extra_gets_one_proxy_root(self) -> None:
+        """A second mention of the same extra adds no second proxy clause."""
+        reqs = [Requirement("foo[dev]>1"), Requirement("foo[dev]<9")]
+        inputs = _build_resolver_inputs(reqs, NabProjectConfig(), environment={})
+        assert [root.package for root in inputs.roots] == ["foo", "foo[dev]", "foo"]
 
     def test_root_extra_marker_warns(self, caplog: pytest.LogCaptureFixture) -> None:
         """A root requirement gated on ``extra ==`` is dropped with a warning."""
         reqs = [Requirement('foo ; extra == "test"')]
         with caplog.at_level("WARNING", logger="nab_python.resolve"):
-            resolver_requirements, _ = _build_resolver_inputs(
+            resolver_requirements = _build_resolver_inputs(
                 reqs, NabProjectConfig(), environment={}
-            )
+            ).ranges
         assert "foo" not in resolver_requirements
         assert any("membership marker" in rec.message for rec in caplog.records)
 
@@ -2411,9 +2429,9 @@ class TestBuildResolverInputs:
         """A root ``"x" in extras`` marker is dropped with a warning, not a crash."""
         reqs = [Requirement('foo ; "x" in extras')]
         with caplog.at_level("WARNING", logger="nab_python.resolve"):
-            resolver_requirements, _ = _build_resolver_inputs(
+            resolver_requirements = _build_resolver_inputs(
                 reqs, NabProjectConfig(), environment={}
-            )
+            ).ranges
         assert "foo" not in resolver_requirements
         assert any("membership marker" in rec.message for rec in caplog.records)
 
@@ -2423,9 +2441,9 @@ class TestBuildResolverInputs:
         """A root ``in dependency_groups`` marker is dropped with a warning."""
         reqs = [Requirement('foo ; "dev" in dependency_groups')]
         with caplog.at_level("WARNING", logger="nab_python.resolve"):
-            resolver_requirements, _ = _build_resolver_inputs(
+            resolver_requirements = _build_resolver_inputs(
                 reqs, NabProjectConfig(), environment={}
-            )
+            ).ranges
         assert "foo" not in resolver_requirements
         assert any("membership marker" in rec.message for rec in caplog.records)
 
@@ -2444,9 +2462,9 @@ class TestBuildResolverInputs:
         """``pkg[redis]`` is the syntax the warning points at; it must not warn."""
         reqs = [Requirement("foo[redis]")]
         with caplog.at_level("WARNING", logger="nab_python.resolve"):
-            resolver_requirements, _ = _build_resolver_inputs(
+            resolver_requirements = _build_resolver_inputs(
                 reqs, NabProjectConfig(), environment={}
-            )
+            ).ranges
         assert "foo" in resolver_requirements
         assert not caplog.records
 
@@ -2455,9 +2473,9 @@ class TestBuildResolverInputs:
         reqs = [Requirement('foo ; python_version < "3.0"')]
         env = {"python_version": "3.11", "python_full_version": "3.11.2"}
         with caplog.at_level("WARNING", logger="nab_python.resolve"):
-            resolver_requirements, _ = _build_resolver_inputs(
+            resolver_requirements = _build_resolver_inputs(
                 reqs, NabProjectConfig(), environment=env
-            )
+            ).ranges
         assert "foo" not in resolver_requirements
         assert not caplog.records
 
@@ -2473,9 +2491,9 @@ class TestBuildResolverInputs:
         """
         req = Requirement("demo[x,y,z]")
         monkeypatch.setattr(req, "extras", ["z", "y", "x"])
-        resolver_requirements, _ = _build_resolver_inputs(
+        resolver_requirements = _build_resolver_inputs(
             [req], NabProjectConfig(), environment={}
-        )
+        ).ranges
         proxy_keys = [k for k in resolver_requirements if k.startswith("demo[")]
         assert proxy_keys == ["demo[x]", "demo[y]", "demo[z]"]
 
@@ -3324,6 +3342,58 @@ class TestAugmentResolutionError:
             in diagnostics
         )
         assert "foo: no version matches the requirement" not in diagnostics
+
+
+class TestConflictingRootRequirements:
+    def test_both_requirements_are_named(self, tmp_path: Path) -> None:
+        """Two requirements on one package each get their own line."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\ndependencies = ["foo>1.0", "foo==1.0"]\n',
+            encoding="utf-8",
+        )
+        coordinator = make_coordinator(
+            listings={"foo": _index_wheels("foo", "1.0", "2.0")},
+            metadata_by_version={
+                "1.0": _metadata("foo", "1.0"),
+                "2.0": _metadata("foo", "2.0"),
+            },
+        )
+
+        with patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda _self: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            with pytest.raises(ResolutionError) as info:
+                _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
+
+        lines = str(info.value).splitlines()
+        named = [line for line in lines if "your project depends on foo" in line]
+        assert len(named) == 2
+        assert not any("empty" in line for line in lines)
+
+    def test_conflicting_constraints_still_fail_before_the_solve(
+        self, tmp_path: Path
+    ) -> None:
+        """Constraints are not root clauses, so their fold stays pre-checked."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "proj"\ndependencies = ["foo"]\n'
+            '[tool.nab]\nconstraints = ["foo<1.0", "foo>2.0"]\n',
+            encoding="utf-8",
+        )
+        coordinator = make_coordinator(
+            listings={"foo": _index_wheels("foo", "1.0", "2.0")},
+            metadata_by_version={
+                "1.0": _metadata("foo", "1.0"),
+                "2.0": _metadata("foo", "2.0"),
+            },
+        )
+
+        with patch("nab_python.resolve.FetchCoordinator") as mock_coord_cls:
+            mock_coord_cls.return_value.__enter__ = lambda _self: coordinator
+            mock_coord_cls.return_value.__exit__ = MagicMock(return_value=False)
+            with pytest.raises(ResolutionError, match="conflicting constraints"):
+                _resolved(pyproject, _FAKE_TRANSPORT, python_version="3.12.0")
 
 
 def _tuple_for_python(python_version: str) -> ResolveTarget:

--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -1016,33 +1016,33 @@ class TestBuildResolverInputs:
     def test_marker_true_keeps_requirement(self) -> None:
         """A requirement whose marker matches the env is kept."""
         env = _linux_311().marker_env
-        out, _ = _build_resolver_inputs(
+        out = _build_resolver_inputs(
             _reqs('pkg; sys_platform == "linux"'), NabProjectConfig(), environment=env
-        )
+        ).ranges
         assert "pkg" in out
 
     def test_marker_false_drops_requirement(self) -> None:
         """A requirement whose marker excludes the env is dropped."""
         env = _linux_311().marker_env
-        out, _ = _build_resolver_inputs(
+        out = _build_resolver_inputs(
             _reqs('pkg; sys_platform == "win32"'), NabProjectConfig(), environment=env
-        )
+        ).ranges
         assert out == {}
 
     def test_set_marker_drops_without_crash(self) -> None:
         """A lockfile-only set marker is empty at resolve time, so the dep drops."""
         env = _linux_311().marker_env
-        out, _ = _build_resolver_inputs(
+        out = _build_resolver_inputs(
             _reqs('pkg ; "x" in extras'), NabProjectConfig(), environment=env
-        )
+        ).ranges
         assert out == {}
 
     def test_extras_get_separate_entries(self) -> None:
         """Extras become ``name[extra]`` entries with any-version range."""
         env = _linux_311().marker_env
-        out, _ = _build_resolver_inputs(
+        out = _build_resolver_inputs(
             _reqs("pkg[foo,bar]"), NabProjectConfig(), environment=env
-        )
+        ).ranges
         assert "pkg" in out
         assert "pkg[foo]" in out
         assert "pkg[bar]" in out
@@ -1059,24 +1059,24 @@ class TestBuildResolverInputs:
         env = _linux_311().marker_env
         req = Requirement("pkg[a,b,c]")
         monkeypatch.setattr(req, "extras", sorted(req.extras, reverse=True))
-        out, _ = _build_resolver_inputs([req], NabProjectConfig(), environment=env)
+        out = _build_resolver_inputs([req], NabProjectConfig(), environment=env).ranges
         proxy_keys = [k for k in out if k.startswith("pkg[")]
         assert proxy_keys == ["pkg[a]", "pkg[b]", "pkg[c]"]
 
     def test_no_specifier_yields_any(self) -> None:
         """An unconstrained requirement gets the any() range."""
         env = _linux_311().marker_env
-        out, _ = _build_resolver_inputs(
+        out = _build_resolver_inputs(
             _reqs("pkg"), NabProjectConfig(), environment=env
-        )
+        ).ranges
         assert out["pkg"] == VersionRange.full(admit_arbitrary=False)
 
     def test_specifier_yields_intervals(self) -> None:
         """A bounded specifier produces the corresponding interval."""
         env = _linux_311().marker_env
-        out, _ = _build_resolver_inputs(
+        out = _build_resolver_inputs(
             _reqs("pkg>=1.0,<2.0"), NabProjectConfig(), environment=env
-        )
+        ).ranges
         # The specifier should be stricter than unbounded; we check
         # by confirming a known-out-of-range version is excluded.
         assert Version("0.5") not in out["pkg"]
@@ -1090,9 +1090,9 @@ class TestBuildResolverInputs:
         Declared extras still flow through.
         """
         env = _linux_311().marker_env
-        out, _ = _build_resolver_inputs(
+        out = _build_resolver_inputs(
             _reqs("pkg[ext]===1.0.special"), NabProjectConfig(), environment=env
-        )
+        ).ranges
         assert "pkg" in out
         assert "1.0.special" in out["pkg"]
         assert Version("1.0") not in out["pkg"]
@@ -1101,20 +1101,21 @@ class TestBuildResolverInputs:
     def test_duplicate_name_intersects(self) -> None:
         """Two requirements for one package combine to their overlap."""
         env = _linux_311().marker_env
-        out, _ = _build_resolver_inputs(
+        out = _build_resolver_inputs(
             _reqs("pkg>=2.0", "pkg<3.0"), NabProjectConfig(), environment=env
-        )
+        ).ranges
         assert Version("2.5") in out["pkg"]
         assert Version("1.0") not in out["pkg"]
         assert Version("5.0") not in out["pkg"]
 
-    def test_conflicting_names_raise(self) -> None:
-        """Contradictory pins for one package raise ResolutionError."""
+    def test_conflicting_names_stay_separate_roots(self) -> None:
+        """Contradictory pins reach the solver as their own clauses."""
         env = _linux_311().marker_env
-        with pytest.raises(ResolutionError, match="pkg==1.0"):
-            _build_resolver_inputs(
-                _reqs("pkg==1.0", "pkg==2.0"), NabProjectConfig(), environment=env
-            )
+        inputs = _build_resolver_inputs(
+            _reqs("pkg==1.0", "pkg==2.0"), NabProjectConfig(), environment=env
+        )
+        assert [root.origin for root in inputs.roots] == ["pkg==1.0", "pkg==2.0"]
+        assert inputs.ranges["pkg"].is_empty
 
     def test_constraint_extras_rejected(self) -> None:
         """A constraint carrying extras is rejected, matching pip."""
@@ -1135,32 +1136,32 @@ class TestBuildResolverInputs:
         path once enforced such constraints unconditionally (issue #38).
         """
         env = _linux_311().marker_env
-        out, _ = _build_resolver_inputs(
+        out = _build_resolver_inputs(
             _reqs('pkg<2.0 ; sys_platform == "win32"'),
             NabProjectConfig(),
             environment=env,
             kind="constraint",
-        )
+        ).ranges
         assert out == {}
 
     def test_marker_true_keeps_constraint(self) -> None:
         """A constraint whose marker matches the env binds its range."""
         env = _linux_311().marker_env
-        out, _ = _build_resolver_inputs(
+        out = _build_resolver_inputs(
             _reqs('pkg<2.0 ; sys_platform == "linux"'),
             NabProjectConfig(),
             environment=env,
             kind="constraint",
-        )
+        ).ranges
         assert Version("1.0") in out["pkg"]
         assert Version("2.0") not in out["pkg"]
 
     def test_extra_proxy_key_normalized(self) -> None:
         """The proxy key is PEP 685 normalized."""
         env = _linux_311().marker_env
-        out, _ = _build_resolver_inputs(
+        out = _build_resolver_inputs(
             _reqs("pkg[My_Extra]"), NabProjectConfig(), environment=env
-        )
+        ).ranges
         assert "pkg[my-extra]" in out
 
     def test_plain_url_requirement_refused(self) -> None:
@@ -1232,18 +1233,18 @@ class TestSelfRefMarker:
                 ["all"],
             )
         )
-        excluded, _ = _build_resolver_inputs(
+        excluded = _build_resolver_inputs(
             reqs, NabProjectConfig(), environment=_linux_311().marker_env
-        )
+        ).ranges
         assert "some-dep" not in excluded
         included_env = {
             **_linux_311().marker_env,
             "python_version": "3.9",
             "python_full_version": "3.9.0",
         }
-        included, _ = _build_resolver_inputs(
+        included = _build_resolver_inputs(
             reqs, NabProjectConfig(), environment=included_env
-        )
+        ).ranges
         assert "some-dep" in included
 
 
@@ -1252,16 +1253,16 @@ class TestRootExtras:
 
     def test_recovers_and_normalizes_extras(self) -> None:
         env = _linux_311().marker_env
-        _, root_extras = _build_resolver_inputs(
+        root_extras = _build_resolver_inputs(
             _reqs("pkg[My_Extra]", "other"), NabProjectConfig(), environment=env
-        )
+        ).extras
         assert root_extras == {("pkg", "my-extra")}
 
     def test_no_extras_yields_empty(self) -> None:
         env = _linux_311().marker_env
-        _, root_extras = _build_resolver_inputs(
+        root_extras = _build_resolver_inputs(
             _reqs("pkg"), NabProjectConfig(), environment=env
-        )
+        ).extras
         assert root_extras == set()
 
 


### PR DESCRIPTION
Stacked on #741, which gives the solver a root-requirement sequence.

A project declaring `dependencies = ["foo>1.0", "foo==1.0"]` had both lines folded into one range before the solve, so the failure report named the empty intersection instead of the two requirements, and `_build_resolver_inputs` carried a `raise_for_unsatisfiable` pre-check to catch the worst of it. The pre-check only ever saw the empty case, so two requirements that intersect to a live range and only conflict after a transitive narrowing were still reported against the fold.

The engine now hands the solver one root requirement per line as written, tagged with the requirement string, and the requirement-side pre-check goes away. The provider still gets the folded range per package, because it asks about one package at a time. Constraints keep the pre-check: they never become root clauses, so dropping it there would silently stop reporting a constraint pair that leaves a package nothing.
