### PR TITLE
drop a lock pin's requires-python when its versions will not convert

### DIFF
--- a/nab-python/src/nab_python/_lockfile/builder.py
+++ b/nab-python/src/nab_python/_lockfile/builder.py
@@ -23,8 +23,9 @@ from nab_index.client import SdistFile, WheelFile
 from .._iso8601 import parse_iso_datetime
 from .._toml import tool_nab_section
 from .._vendor.packaging.pylock import Pylock, PylockValidationError
-from .._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
+from .._vendor.packaging.specifiers import SpecifierSet
 from .._vendor.packaging.utils import canonicalize_name
+from ..metadata import validate_specifier_versions
 from ..paths import path_state
 
 if TYPE_CHECKING:
@@ -656,19 +657,20 @@ def _common_requires_python(files: Iterable[WheelFile | SdistFile]) -> str | Non
     such artefact leaves the whole package unconstrained. Otherwise the
     value survives only when every artefact agrees.
 
-    A malformed value counts as unconstrained too, matching
-    ``excluded_by_python``, which admits a dist whose Requires-Python is
-    an unparseable specifier on any Python. So the lock writer always
-    parses a valid specifier or ``None``, and the pin is never
-    over-constrained by an artefact whose floor nab could not read.
+    A value nab cannot use counts as unconstrained too, matching
+    ``excluded_by_python``, which admits a dist on any Python when the
+    specifier will not parse or its versions will not convert. So the
+    lock writer always records a usable specifier or ``None``, and the
+    pin is never over-constrained by an artefact whose floor nab could
+    not read.
     """
     seen: set[str] = set()
     for f in files:
         if f.requires_python is None:
             return None
         try:
-            SpecifierSet(f.requires_python)
-        except InvalidSpecifier:
+            validate_specifier_versions(SpecifierSet(f.requires_python))
+        except ValueError:
             return None
         seen.add(f.requires_python)
     if len(seen) == 1:

--- a/nab-python/tests/test_lockfile.py
+++ b/nab-python/tests/test_lockfile.py
@@ -3016,6 +3016,43 @@ class TestBuildTargetLock:
         text = write_lock(_lock_from(lock))
         assert ">=3.6.*" not in text
 
+    def test_oversized_requires_python_dropped_and_emittable(self) -> None:
+        """A digit run past int()'s limit is dropped like a malformed value.
+
+        ``SpecifierSet`` converts a clause version only when something compares
+        against it, so this one constructs and ``excluded_by_python`` admits the
+        artefact on every Python.
+        """
+        oversized = ">=" + "9" * (sys.get_int_max_str_digits() + 1)
+        provider = _FakeProvider(
+            listings={"foo": [(Version("1.0"), _wheel_file(requires_python=oversized))]}
+        )
+
+        lock = build_target_lock(provider, _HOST, {"foo": Version("1.0")})
+        pin = lock.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.requires_python is None
+
+        text = write_lock(_lock_from(lock))
+        assert "999" not in text
+        package = Pylock.from_dict(tomllib.loads(text)).packages[0]
+        assert package.requires_python is None
+
+    def test_at_limit_requires_python_is_recorded(self) -> None:
+        """A digit run of exactly int()'s limit converts, so the pin keeps it.
+
+        The check is a conversion, not a length cap.
+        """
+        at_limit = ">=" + "9" * sys.get_int_max_str_digits()
+        provider = _FakeProvider(
+            listings={"foo": [(Version("1.0"), _wheel_file(requires_python=at_limit))]}
+        )
+
+        lock = build_target_lock(provider, _HOST, {"foo": Version("1.0")})
+        pin = lock.pins["foo"]
+        assert isinstance(pin, IndexPin)
+        assert pin.requires_python == at_limit
+
     def test_common_requires_python_malformed_with_valid_stays_unconstrained(
         self,
     ) -> None:


### PR DESCRIPTION
An index can serve a requires-python whose version carries a digit run past CPython's int-from-string limit. SpecifierSet accepts that string and only fails when something compares against it, so the listing filter admits the artefact on every Python.

The lock builder guarded only against SpecifierSet refusing to construct. It copied the value into the pin verbatim, and `nab lock` wrote a pylock.toml whose per-package requires-python raises a bare ValueError in `Pylock.select()`.

The builder now converts each clause version and records None when one fails, so a value nab cannot read leaves the pin unconstrained instead of landing in the file.
