### PR TITLE
stop `--locked` blaming the lockfile for an undeclared group or extra

### DIFF
--- a/nab-python/src/nab_python/_lockfile/validate.py
+++ b/nab-python/src/nab_python/_lockfile/validate.py
@@ -312,11 +312,11 @@ def check_locked(  # noqa: PLR0913 - the envelope fields and the validity inputs
     """Disqualify the committed lock at ``lockfile``, or return ``None``.
 
     Runs the envelope checks, then the validity checks over the active
-    direct requirements and constraints. ``roots`` of ``None`` (the caller
-    could not read them) runs the envelope checks alone. ``exclude`` holds
-    canonical names to skip, for the workspace members ``--no-emit-workspace``
-    drops from both sides. Constraints arrive as text; the config loader has
-    already rejected any that do not parse.
+    direct requirements and constraints. ``roots`` of ``None`` runs the
+    envelope checks alone. ``exclude`` holds canonical names to skip, for
+    the workspace members ``--no-emit-workspace`` drops from both sides.
+    Constraints arrive as text; the config loader has already rejected any
+    that do not parse.
 
     Raises the errors :func:`read_committed_pylock` raises.
     """

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -324,15 +324,34 @@ def _fast_fail_locked(
     non-zero; otherwise it returns and the full resolve runs.
     """
     target = _locked_target_path(output)
+
     # A stat that failed is not an absent lock.
     if path_state(target) is PathState.ABSENT:
         _cli.printer().error(
             f"--locked: no lockfile at {target} to check; run `nab lock` first."
         )
         sys.exit(1)
-    roots, marker_env = _locked_check_inputs(
-        path, config, python=python, extras=extras, groups=groups
-    )
+
+    # A run whose own requirements cannot be read or evaluated is not the
+    # lock's fault, so leave the error to the resolve rather than reporting a
+    # stale lock.
+    try:
+        roots = _active_root_requirements(
+            path,
+            extras=extras,
+            groups=groups,
+            default_groups=config.default_groups,
+        )
+    except (
+        InvalidProjectTableError,
+        InvalidProjectRequirementError,
+        LookupError,
+        UnevaluableMarkerError,
+    ):
+        return
+
+    marker_env = _locked_marker_env(config, python=python)
+
     try:
         disqualification = check_locked(
             target,
@@ -369,35 +388,18 @@ def _fast_fail_locked(
     sys.exit(1)
 
 
-def _locked_check_inputs(
-    path: Path,
-    config: NabProjectConfig,
-    *,
-    python: str | None,
-    extras: tuple[str, ...],
-    groups: tuple[str, ...],
-) -> tuple[list[RootRequirement] | None, Mapping[str, str] | None]:
-    """Collect the validity-check inputs, or ``(None, None)`` to skip them.
+def _locked_marker_env(
+    config: NabProjectConfig, *, python: str | None
+) -> Mapping[str, str] | None:
+    """Return the environment the validity checks evaluate markers against.
 
-    A target the declaration excludes and a project whose requirements cannot
-    be read or evaluated both skip the validity checks, left for the full
-    resolve.  The envelope checks still run.
+    ``None`` when the declaration excludes this run's target, which leaves
+    the validity checks to the full resolve.  The envelope checks still run.
     """
     try:
-        target = plan_targets(with_python_override(config, python))[0]
+        return plan_targets(with_python_override(config, python))[0].marker_env
     except ConfigError:
-        return None, None
-    try:
-        roots = _active_root_requirements(path, extras=extras, groups=groups)
-    except (
-        KeyError,
-        InvalidProjectTableError,
-        InvalidProjectRequirementError,
-        LookupError,
-        UnevaluableMarkerError,
-    ):
-        return None, None
-    return roots, target.marker_env
+        return None
 
 
 def _active_root_requirements(
@@ -405,17 +407,20 @@ def _active_root_requirements(
     *,
     extras: tuple[str, ...],
     groups: tuple[str, ...],
+    default_groups: tuple[str, ...],
 ) -> list[RootRequirement]:
     """Collect this run's active direct requirements with their source clause.
 
     Covers ``[project].dependencies`` plus the requirements each selected extra
     and group contributes, each carrying the clause it came from so a
-    disqualification can name it.  Default groups are left to the full resolve.
+    disqualification can name it.  A default group is expanded only so an
+    undeclared name raises here too; its requirements are left to the resolve.
     """
     roots = [
         RootRequirement(requirement=req, source="[project].dependencies")
         for req in read_pyproject_dependencies(path)
     ]
+
     if extras:
         optional = read_pyproject_optional_dependencies(path)
         project_name = read_pyproject_name(path)
@@ -424,15 +429,21 @@ def _active_root_requirements(
                 RootRequirement(requirement=req, source=f"the {extra!r} extra")
                 for req in expand_extra_requirements(optional, project_name, [extra])
             )
-    if groups:
+
+    effective_groups = dict.fromkeys((*groups, *default_groups))
+    if effective_groups:
         table = read_pyproject_groups(path)
-        for group in groups:
+        for group in effective_groups:
+            requirements = resolve_groups_to_requirements(table, [group])
+            if group not in groups:
+                continue
             roots.extend(
                 RootRequirement(
                     requirement=req, source=f"the {group!r} dependency group"
                 )
-                for req in resolve_groups_to_requirements(table, [group])
+                for req in requirements
             )
+
     return roots
 
 

--- a/tests/test_lock_locked.py
+++ b/tests/test_lock_locked.py
@@ -1,8 +1,10 @@
 """Flow tests for the fast-fail tier in ``nab lock --locked``.
 
-Each case drives the real CLI with ``nab.cli.resolve_for_targets`` mocked
-and a committed pylock on disk.  Whether the resolver was called shows
+Each case drives the real CLI against a committed pylock on disk.  Most mock
+``nab.cli.resolve_for_targets``, so whether the resolver was called shows
 whether the tier fired: a disqualifier never calls it, a fall-through does.
+The invalid-invocation cases keep the real resolve, to pin the error it
+reports when the tier defers.
 """
 
 from __future__ import annotations
@@ -93,6 +95,28 @@ def _run_locked(pyproject: Path, out: Path, mock: MagicMock, *extra: str) -> Non
         )
 
 
+def _run_locked_unmocked(pyproject: Path, out: Path, *extra: str) -> None:
+    """Drive ``--locked`` against the real resolve, to pin what it reports.
+
+    Runs offline with the cache off: these cases fail while reading the
+    project, before the resolve would reach an index.
+    """
+    app.cli(
+        args=[
+            "lock",
+            str(pyproject),
+            "--output",
+            str(out),
+            "--locked",
+            "--offline",
+            "True",
+            "--no-cache",
+            *extra,
+        ],
+        prog="nab",
+    )
+
+
 # --- fire cases: the resolver is never called ---
 
 
@@ -139,6 +163,33 @@ def test_tightened_constraint_fires_without_resolving(
         "the constraint foo<3 is violated by the pinned foo 3.1"
         in capsys.readouterr().err
     )
+    mock.assert_not_called()
+
+
+def test_added_declared_default_group_fires_without_resolving(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    body = (
+        '[project]\nname = "proj"\nversion = "0"\ndependencies = ["foo"]\n'
+        "[dependency-groups]\n"
+        'test = ["bb"]\n'
+    )
+    pyproject = _write_pyproject(tmp_path, body)
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}))
+    capsys.readouterr()
+    pyproject.write_text(
+        f'{body}[tool.nab]\ndefault-groups = ["test"]\n', encoding="utf-8"
+    )
+
+    mock = _locked_mock()
+    with pytest.raises(SystemExit) as exc:
+        _run_locked(pyproject, out, mock)
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "built with default-groups {} but this run selects {test}" in err
+    assert "is out of date" in err
     mock.assert_not_called()
 
 
@@ -435,6 +486,133 @@ def test_conflict_fork_duplicate_pins_fall_through(
     err = capsys.readouterr().err
     assert "the lock pins foo" not in err
     mock.assert_called_once()
+
+
+# --- invalid invocation: the tier defers and the resolve reports why ---
+
+
+def test_undeclared_group_reports_the_group_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "proj"\nversion = "0"\ndependencies = ["foo"]\n'
+        "[dependency-groups]\n"
+        'test = ["bb"]\n',
+    )
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}))
+    capsys.readouterr()
+
+    with pytest.raises(SystemExit) as exc:
+        _run_locked_unmocked(pyproject, out, "--groups", "dev")
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "Dependency group 'dev' not found" in err
+    assert "is out of date" not in err
+    assert "re-run `nab lock`" not in err
+
+
+def test_undeclared_default_group_reports_the_group_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    body = (
+        '[project]\nname = "proj"\nversion = "0"\ndependencies = ["foo"]\n'
+        "[dependency-groups]\n"
+        'test = ["bb"]\n'
+    )
+    pyproject = _write_pyproject(tmp_path, body)
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}))
+    capsys.readouterr()
+    pyproject.write_text(
+        f'{body}[tool.nab]\ndefault-groups = ["dev"]\n', encoding="utf-8"
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        _run_locked_unmocked(pyproject, out)
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "Dependency group 'dev' not found" in err
+    assert "is out of date" not in err
+    assert "re-run `nab lock`" not in err
+
+
+def test_undeclared_project_default_group_reports_the_group_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "proj"\nversion = "0"\ndependencies = ["foo"]\n'
+        "[dependency-groups]\n"
+        'test = ["bb"]\n',
+    )
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}))
+    capsys.readouterr()
+
+    with pytest.raises(SystemExit) as exc:
+        _run_locked_unmocked(pyproject, out, "--project-default-group", "dev")
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "Dependency group 'dev' not found" in err
+    assert "is out of date" not in err
+    assert "re-run `nab lock`" not in err
+
+
+def test_undeclared_extra_reports_the_extra_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "proj"\nversion = "0"\ndependencies = ["foo"]\n'
+        "[project.optional-dependencies]\n"
+        'x = ["bb"]\n',
+    )
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}))
+    capsys.readouterr()
+
+    with pytest.raises(SystemExit) as exc:
+        _run_locked_unmocked(pyproject, out, "--extras", "typo")
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert (
+        "extra 'typo' is not declared in [project.optional-dependencies];"
+        " defined: ['x']" in err
+    )
+    assert "is out of date" not in err
+    assert "re-run `nab lock`" not in err
+
+
+def test_unreadable_requirement_with_changed_envelope_reports_the_parse_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pyproject = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "proj"\nversion = "0"\ndependencies = ["foo"]\n'
+        "[project.optional-dependencies]\n"
+        'x = ["bb"]\n',
+    )
+    out = tmp_path / "pylock.toml"
+    _write_lock(pyproject, out, _result({"foo": "1.0"}), "--extras", "x")
+    capsys.readouterr()
+    pyproject.write_text(
+        '[project]\nname = "proj"\nversion = "0"\ndependencies = ["foo (=="]\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        _run_locked_unmocked(pyproject, out)
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "[project].dependencies" in err
+    assert "is out of date" not in err
 
 
 # --- precondition cases: no resolve runs ---


### PR DESCRIPTION
`nab lock --locked --groups dev` on a project that declares no `dev` group said the lockfile was out of date and told you to re-run `nab lock`, and `nab lock` then failed with `Dependency group 'dev' not found`. Same for `--extras` with a name that is not in `[project.optional-dependencies]`, and for an undeclared `default-groups` entry.

The fast-fail tier reads the run's active direct requirements so it can check the lock against them. When that read failed on an unknown name it swallowed the error and ran the envelope checks anyway, which saw a group or extra the lock was not built with and called it stale.

A run whose own requirements cannot be read now skips the tier, so the resolve reports the real error.
