### PR TITLE
Evaluate Requires-Python at the language level on every target

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -410,12 +410,15 @@ it both widens and narrows:
   older Pythons reject it.
 
 The override goes through the same comparison a declared
-`Requires-Python` value takes (the full target Python version against
-the specifier), so it admits or rejects a version exactly as a declared
-value would.  An empty string (`requires-python = ""`) removes
-the Python requirement entirely (admits every target).  For an index pin
-the lock records the overridden specifier, so a widened pin stays
-installable by a conforming PEP 751 installer.  A local-path or VCS pin
+`Requires-Python` value takes, so it admits or rejects a version exactly
+as a declared value would.  That comparison is made at the language
+version: a micro segment neither admits a target nor excludes one, so
+`>=3.13.2`, `==3.13.4` and `==3.13.*` all admit a 3.13 target, while
+`!=3.13` excludes every 3.13 interpreter.  An empty string
+(`requires-python = ""`) removes the Python requirement entirely (admits
+every target).  For an index pin the lock records the overridden
+specifier, so a widened pin stays installable by a conforming PEP 751
+installer, which enforces it in full.  A local-path or VCS pin
 has no `requires-python` field, but the override is still what its Python
 check enforces.
 
@@ -844,8 +847,13 @@ error.  See [Build policy](build-policy.md).
 * `[tool.nab].requires-python` (or `[project].requires-python`): the
   range the project supports.  A declaration.  It is recorded as the
   lockfile's top-level `requires-python` and checked against the resolve
-  target; it does not choose that target.  A declaration that excludes
-  the target is a config error naming the knob that moves it:
+  target; it does not choose that target.  The check reads the
+  declaration at the language version, the same way a candidate's
+  `Requires-Python` is read, so `==3.13` and `>=3.13.2` both admit a
+  3.13 target however precisely that target names its interpreter, and
+  `!=3.13` excludes one however it is named.  A
+  declaration that excludes the target is a config error naming the knob
+  that moves it:
   `[tool.nab.environment] python` for a single-environment resolve,
   `[tool.nab.matrix].python` and `[tool.nab.matrix.python-patches]` for a
   matrix target, since neither `--python` nor `[tool.nab.environment]` is

--- a/nab-python/src/nab_python/_provider/build_remote.py
+++ b/nab-python/src/nab_python/_provider/build_remote.py
@@ -112,7 +112,7 @@ def build_remote_sdist(
     ):
         msg = (
             f"{package}=={version} built sdist requires Python {spec} but the"
-            f" resolve targets Python {target.python_full_version}"
+            f" resolve targets Python {target.python_version}"
         )
         raise UnsupportedSdistError(msg)
     if canonicalize_name(built.name) != canonical or built.version != version:

--- a/nab-python/src/nab_python/_provider/listing.py
+++ b/nab-python/src/nab_python/_provider/listing.py
@@ -610,10 +610,9 @@ def excluded_by_python(
     A per-package ``requires-python`` override substitutes for
     ``dist.requires_python`` and goes through the same cached comparison,
     keyed by the specifier string; the verdict depends only on that string
-    and the fixed ``provider.target``.  A minor-interval target admits the
-    candidate when the specifier overlaps the whole minor; a whole target
-    when its single release satisfies it (see
-    :meth:`~nab_python.target.ResolveTarget.admits_requires_python`).
+    and the fixed ``provider.target``.  The specifier is read at the language
+    minor, so a micro segment never excludes a target
+    (see :meth:`~nab_python.target.ResolveTarget.admits_requires_python`).
     """
     override_rp = provider.effective_requires_python(normalized, version)
     effective = override_rp if override_rp is not None else dist.requires_python

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -754,7 +754,7 @@ def _reject_incompatible_python(
 
     msg = (
         f"{package} {version} requires Python {spec} but the"
-        f" {target.label} resolve targets Python {target.python_full_version}"
+        f" {target.label} resolve targets Python {target.python_version}"
     )
     raise IncompatiblePythonError(msg)
 

--- a/nab-python/src/nab_python/config.py
+++ b/nab-python/src/nab_python/config.py
@@ -1255,26 +1255,22 @@ def _check_requires_python_admits_target(
     does not support would produce a lock the project's own metadata
     rejects, so it fails loud and names the knob that moves the target.
 
-    A minor-interval target is admitted when ``requires-python`` overlaps its
-    whole minor, so a micro floor like ``>= "3.11.4"`` admits the 3.11 minor
-    rather than excluding it at the synthetic ``.0`` floor.  Which knob the
-    error names depends on the target.  A matrix declares the python axis of
-    every target it expands, and both ``--python`` and ``[tool.nab.environment]``
-    are themselves errors alongside one, so a matrix target is moved by
-    ``matrix.python`` instead.
+    The declaration goes through
+    :meth:`~nab_python.target.ResolveTarget.admits_requires_python`, the
+    comparison every candidate's ``Requires-Python`` takes, so it is read at
+    the language minor and a micro floor like ``>= "3.11.4"`` admits a 3.11
+    target.  Which knob the error names depends on the target.  A matrix
+    declares the python axis of every target it expands, and both
+    ``--python`` and ``[tool.nab.environment]`` are themselves errors
+    alongside one, so a matrix target is moved by ``matrix.python`` instead.
     """
     if requires_python is None:
         return
-    # A minor-interval target is admitted when the specifier overlaps the whole
-    # minor; a whole target when its single release satisfies it.  A specifier
-    # admits no prerelease unless it names one, so ">=3.14" has to admit a 3.14
-    # candidate host.  This is the comparison every candidate's Requires-Python
-    # takes too (see ResolveTarget.admits_requires_python).
     if target.admits_requires_python(SpecifierSet(requires_python)):
         return
     excludes = (
         f"{source} = {requires_python!r} excludes the resolve target"
-        f" Python {target.python_full_version} ({target.label})."
+        f" Python {target.python_version} ({target.label})."
     )
     if matrix:
         msg = (
@@ -1405,7 +1401,7 @@ def _parse_requires_python(value: object) -> str | None:
     can pass it straight to :class:`SpecifierSet`.  Raises
     :class:`ConfigError` for invalid specifiers and for well-meaning bare
     versions like ``"3.13"``; those are not valid specifiers and must be
-    written ``"==3.13"`` or ``">=3.13,<3.14"``.
+    written ``"==3.13"`` or ``">=3.13"``.
     """
     raw = _parse_string_value("requires-python", value)
     try:
@@ -1414,7 +1410,7 @@ def _parse_requires_python(value: object) -> str | None:
     except ValueError as exc:
         msg = (
             f"requires-python must be a PEP 440 specifier, got {raw!r}."
-            f"  Did you mean ==X.Y or >=X.Y,<X.{{Y+1}}?"
+            "  Did you mean ==X.Y or >=X.Y?"
         )
         raise ConfigError(msg) from exc
     return raw

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -1967,7 +1967,7 @@ def _raise_for_source_python(
         if spec is not None and not target.admits_requires_python(spec):
             msg = (
                 f"{normalized} {version} requires Python {spec} but the"
-                f" {target.label} resolve targets Python {target.python_full_version}"
+                f" {target.label} resolve targets Python {target.python_version}"
             )
             raise ResolutionError(msg)
 

--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -32,7 +32,7 @@ from ._conflict_kind import (
 from ._vendor.packaging import tags as ptags
 from ._vendor.packaging.markers import Marker, default_environment
 from ._vendor.packaging.markersets import variable_names
-from ._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
+from ._vendor.packaging.specifiers import InvalidSpecifier, Specifier, SpecifierSet
 from ._vendor.packaging.version import InvalidVersion, Version
 from .tags import (
     FREE_THREADED_MIN_PYTHON,
@@ -42,7 +42,6 @@ from .tags import (
 )
 
 if TYPE_CHECKING:
-    from ._vendor.packaging.ranges import VersionRange
     from .tags import TagsSource
 
 
@@ -704,6 +703,134 @@ def apply_python_axis_overlay(
     environment.update(axis)
 
 
+def _language_minor(version: Version) -> str:
+    """Return ``version`` as an epoch-preserving ``major.minor`` string.
+
+    ``3.13.7`` and ``3.13rc1`` both give ``3.13``; a version written with
+    only a major (``3``) gives ``3.0``.  The epoch survives because
+    ``1!3.13`` and ``3.13`` name different languages.
+    """
+    release = version.release
+    minor = release[1] if len(release) >= _PYTHON_VERSION_PARTS else 0
+    epoch = f"{version.epoch}!" if version.epoch else ""
+    return f"{epoch}{release[0]}.{minor}"
+
+
+def _names_a_micro(version: Version) -> bool:
+    """Whether ``version`` names a point inside a minor rather than the minor.
+
+    ``3.13.7`` and ``3.13.0`` name one micro, ``3.13rc1`` one prerelease of
+    one; ``3.13`` and ``3`` name the minor itself.
+    """
+    return (
+        len(version.release) > _PYTHON_VERSION_PARTS
+        or version.pre is not None
+        or version.post is not None
+        or version.dev is not None
+        or version.local is not None
+    )
+
+
+def _arbitrary_at_the_minor(raw: str) -> str:
+    """Rewrite a ``===`` version, which names one interpreter build.
+
+    A version PEP 440 cannot parse is kept as written.  ``===`` compares by
+    string, so it goes on matching nothing.
+    """
+    try:
+        named = Version(raw)
+    except InvalidVersion:
+        return f"==={raw}"
+    return f"=={_language_minor(named)}"
+
+
+def _prefix_at_the_minor(operator: str, raw: str) -> str | None:
+    """Rewrite an ``==``/``!=`` prefix match to the minor its prefix names.
+
+    ``== "3.*"`` carries no minor of its own and already matches whole
+    major.minor values, so it is kept as written.  A prefix reaching past
+    the minor names micros of it, so it reads like the point clause of the
+    same operator: ``== "3.13.4.*"`` still admits 3.13, while
+    ``!= "3.13.0.*"`` leaves the rest of the minor and drops.
+    """
+    prefix = Version(raw.removesuffix(".*"))
+    if len(prefix.release) < _PYTHON_VERSION_PARTS:
+        return f"{operator}{raw}"
+    if operator == "!=" and _names_a_micro(prefix):
+        return None
+    return f"{operator}{_language_minor(prefix)}"
+
+
+def _bound_at_the_minor(operator: str, version: Version, minor: str) -> str:
+    """Rewrite an ordered clause to bound whole minors.
+
+    A bound anywhere inside a minor still leaves micros of that minor on its
+    admitted side, so ``> "3.13.9"`` becomes ``>= "3.13"``.  Only an upper
+    bound at or below the minor's ``.0`` floor excludes the minor outright.
+    """
+    if operator in {">", ">="}:
+        return f">={minor}"
+    floor = Version(minor)
+    admits_a_micro = version > floor if operator == "<" else version >= floor
+    return f"<={minor}" if admits_a_micro else f"<{minor}"
+
+
+def _language_level_clause(clause: Specifier) -> str | None:
+    """Rewrite one ``Requires-Python`` clause to name language versions.
+
+    Returns ``None`` for a clause that constrains only micros, which says
+    nothing about any minor and so drops out of the set.
+    """
+    operator, raw = clause.operator, clause.version
+    if operator == "===":
+        return _arbitrary_at_the_minor(raw)
+    if raw.endswith(".*"):
+        return _prefix_at_the_minor(operator, raw)
+
+    version = Version(raw)
+    minor = _language_minor(version)
+    if operator in {">", ">=", "<", "<="}:
+        return _bound_at_the_minor(operator, version, minor)
+    if operator == "!=":
+        return None if _names_a_micro(version) else f"!={minor}"
+
+    # ~= "3.13.4" is >= "3.13.4", == "3.13.*": exactly the 3.13 minor.
+    if operator == "~=" and len(version.release) > _PYTHON_VERSION_PARTS:
+        return f"=={minor}"
+
+    # ~= "3.13" and == "3.13" already say what they mean about the minor.
+    return f"{operator}{minor}"
+
+
+def _language_level(spec: SpecifierSet) -> SpecifierSet:
+    """Reduce a ``Requires-Python`` specifier to language (major.minor) level.
+
+    ``Requires-Python`` states which Python language a distribution runs on,
+    so nab reads it at that granularity: ``>= "3.13.2"`` supports the 3.13
+    language, and a micro segment neither adds a version nor takes one away.
+    The result is compared against a target's ``python_version``, which is
+    itself a bare ``major.minor``.
+
+    A version no ``int()`` can hold raises :class:`ValueError` here, as
+    comparing against the raw specifier does.
+    """
+    clauses = (_language_level_clause(clause) for clause in spec)
+    return SpecifierSet(",".join(clause for clause in clauses if clause is not None))
+
+
+def _check_comparable(label: str, name: str, value: str) -> None:
+    """Reject a target python value no version comparison can read.
+
+    ``label`` and ``name`` identify the target and the marker variable, so
+    the failure says which value to fix.
+    """
+    try:
+        Version(value)
+    except InvalidVersion as exc:
+        msg = f"target {label!r} names {name} {value!r}, which is not a PEP 440 version"
+        raise ValueError(msg) from exc
+
+
 @dataclass(frozen=True)
 class ResolveTarget:
     """One environment a resolve runs against: markers, wheel tags, a name.
@@ -757,18 +884,14 @@ class ResolveTarget:
     def __post_init__(self) -> None:
         """Reject a python the resolve cannot compare Requires-Python against.
 
-        Every candidate's ``Requires-Python`` is tested against this target,
-        so an unparseable version has to fail here, naming itself, rather than
-        as an ``InvalidVersion`` raised per candidate deep in the listing.
+        Every candidate's ``Requires-Python`` is tested against
+        ``python_version`` and every version marker against
+        ``python_full_version``, so an unparseable value has to fail here,
+        naming itself, rather than as an ``InvalidVersion`` raised per
+        candidate deep in the listing.
         """
-        try:
-            Version(self.python_full_version)
-        except InvalidVersion as exc:
-            msg = (
-                f"target {self.label!r} names python_full_version"
-                f" {self.python_full_version!r}, which is not a PEP 440 version"
-            )
-            raise ValueError(msg) from exc
+        _check_comparable(self.label, "python_version", self.python_version)
+        _check_comparable(self.label, "python_full_version", self.python_full_version)
 
     @property
     def python_version(self) -> str:
@@ -781,29 +904,16 @@ class ResolveTarget:
         return self.marker_env["python_full_version"]
 
     @property
-    def python_release(self) -> Version:
-        """The release a ``Requires-Python`` specifier is compared against.
-
-        ``python_full_version`` is the PEP 508 marker value, so on a release
-        candidate it carries the ``rc``.  A specifier admits no prerelease
-        unless it names one, so comparing that value directly would exclude
-        every distribution requiring the very release the interpreter is a
-        candidate for.  pip compares ``sys.version_info``, and so does this.
-        """
-        return Version(Version(self.python_full_version).base_version)
-
-    @property
     def is_minor_interval(self) -> bool:
         """Whether this target is a bare minor resolved as a micro interval.
 
         A host reports a real interpreter and a python-patches pin names a
         concrete micro; both are whole and resolve at one point.  A bare minor
         synthesizes ``{minor}.0`` and stands for every real micro of the minor,
-        so the micro line can be split on it and Requires-Python is answered
-        against the whole minor, not the synthetic floor.  A slice off that
-        minor carries ``micro_clauses`` and still stands for every interpreter
-        its bounds admit, so it too is an interval answering Requires-Python at
-        the same whole minor.
+        so the micro line can be split on it and the emitted markers leave the
+        micro open.  A slice off that minor carries ``micro_clauses`` and still
+        stands for every interpreter its bounds admit, so it too is an
+        interval.
 
         A pinned ``X.Y.0`` reads as the synthetic floor by string alone, so the
         concrete-micro flag, not the value, decides: a python-patches pin is
@@ -815,26 +925,16 @@ class ResolveTarget:
             return True
         return self.python_full_version == f"{self.python_version}.0"
 
-    @property
-    def minor_range(self) -> VersionRange:
-        """The ``[X.Y.0, X.(Y+1).0)`` range this target's minor covers."""
-        release = Version(self.python_version).release
-        major, minor = release[0], release[1]
-        return SpecifierSet(f">={major}.{minor}.0,<{major}.{minor + 1}.0").to_range()
-
     def admits_requires_python(self, spec: SpecifierSet) -> bool:
         """Whether a candidate's ``Requires-Python`` admits this target.
 
-        A whole target (host or a concrete micro) is admitted when its single
-        release satisfies ``spec``.  A minor interval is admitted when ``spec``
-        overlaps the whole minor, so a micro floor like ``>= "3.13.2"`` admits
-        the 3.13 minor instead of excluding it at the synthetic ``.0`` floor.
-        The test is range overlap, not a scalar ``in``: ``>= "3.13.2"`` would
-        exclude both ``3.13`` and ``3.13.0``.
+        Both sides are read at the language minor: ``spec`` through
+        :func:`_language_level` and the target through its
+        ``python_version``.  Every kind of target answers the same way, so a
+        micro floor like ``>= "3.13.2"`` admits 3.13 whether the target is a
+        bare minor, a patch-level pin, or the running host.
         """
-        if self.is_minor_interval:
-            return not spec.to_range().intersection(self.minor_range).is_empty
-        return self.python_release in spec
+        return _language_level(spec).contains(self.python_version)
 
     @property
     def implementation(self) -> str:

--- a/nab-python/tests/test_config.py
+++ b/nab-python/tests/test_config.py
@@ -60,7 +60,7 @@ from nab_python.provider import (
     VcsSource,
 )
 from nab_python.tags import PlatformSpec
-from nab_python.target import ResolveTarget, host_environment
+from nab_python.target import ResolveTarget, declared_range_marker, host_environment
 from nab_python.workspace import WorkspaceConfig
 
 
@@ -1168,7 +1168,7 @@ class TestRequiresPython:
                 "python_full_version": "3.14.0rc1",
             },
         )
-        assert target.python_release in SpecifierSet(">=3.14")
+        assert target.admits_requires_python(SpecifierSet(">=3.14"))
         _check_requires_python_admits_target(
             config.requires_python,
             target,
@@ -1228,7 +1228,7 @@ class TestRequiresPython:
         with pytest.raises(ConfigError) as exc:
             plan_targets(config)
         message = str(exc.value)
-        assert "excludes the resolve target Python 3.11.0" in message
+        assert "excludes the resolve target Python 3.11" in message
         assert "matrix.python" in message
         assert "python-patches" not in message
         assert "--python" not in message
@@ -1237,9 +1237,9 @@ class TestRequiresPython:
     def test_a_micro_floor_admits_the_whole_matrix_minor(self, tmp_path: Path) -> None:
         """A micro Requires-Python floor admits the language minor it names.
 
-        ``>= "3.11.4"`` overlaps the whole 3.11 minor, so the 3.11 target the
+        ``>= "3.11.4"`` declares the 3.11 language, so the 3.11 target the
         matrix expands is admitted rather than excluded at its synthetic ``.0``
-        floor.  The scalar probe the old code used was a no-op trap.
+        floor.
         """
         path = write(
             tmp_path,
@@ -1249,6 +1249,20 @@ class TestRequiresPython:
         )
         (target,) = plan_targets(read_pyproject_config(path))
         assert target.python_version == "3.11"
+
+    def test_a_pinned_minor_admits_a_micro_environment(self, tmp_path: Path) -> None:
+        """``==3.12`` names the 3.12 language, which a 3.12.13 target speaks.
+
+        Read as a version instead, it would zero-pad to ``3.12.0`` and reject
+        every environment naming the micro it actually runs.
+        """
+        path = write(
+            tmp_path,
+            '[tool.nab]\nrequires-python = "==3.12"\n'
+            '[tool.nab.environment]\npython = "3.12.13"\n',
+        )
+        (target,) = plan_targets(read_pyproject_config(path))
+        assert target.python_full_version == "3.12.13"
 
     def test_python_patches_pins_the_matrix_target(self, tmp_path: Path) -> None:
         """python-patches pins the minor to one concrete deployment micro."""
@@ -1738,7 +1752,7 @@ class TestEnvironment:
         )
         (target,) = plan_targets(read_pyproject_config(path))
         assert not target.is_minor_interval
-        assert not target.admits_requires_python(SpecifierSet(">=3.12.5"))
+        assert 'python_full_version == "3.12.0"' in declared_range_marker(target)
 
     def test_environment_bare_minor_is_an_interval(self, tmp_path: Path) -> None:
         """A ``python = "3.12"`` environment is a bare minor, resolved as a range."""
@@ -1750,7 +1764,7 @@ class TestEnvironment:
         )
         (target,) = plan_targets(read_pyproject_config(path))
         assert target.is_minor_interval
-        assert target.admits_requires_python(SpecifierSet(">=3.12.5"))
+        assert "python_full_version" not in declared_range_marker(target)
 
     def test_environment_no_platform_zero_micro_pins_whole(
         self, tmp_path: Path
@@ -1759,7 +1773,7 @@ class TestEnvironment:
         path = write(tmp_path, '[tool.nab.environment]\npython = "3.12.0"\n')
         (target,) = plan_targets(read_pyproject_config(path))
         assert not target.is_minor_interval
-        assert not target.admits_requires_python(SpecifierSet(">=3.12.5"))
+        assert 'python_full_version == "3.12.0"' in declared_range_marker(target)
 
     def test_environment_no_platform_bare_minor_is_an_interval(
         self, tmp_path: Path
@@ -1768,7 +1782,7 @@ class TestEnvironment:
         path = write(tmp_path, '[tool.nab.environment]\npython = "3.12"\n')
         (target,) = plan_targets(read_pyproject_config(path))
         assert target.is_minor_interval
-        assert target.admits_requires_python(SpecifierSet(">=3.12.5"))
+        assert "python_full_version" not in declared_range_marker(target)
 
     def test_windows_arm64_bare_id_declares_a_target(self, tmp_path: Path) -> None:
         path = write(

--- a/nab-python/tests/test_matrix.py
+++ b/nab-python/tests/test_matrix.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import pytest
 
 from nab_python._vendor.packaging.markers import Marker, default_environment
-from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python.tags import PlatformSpec
 from nab_python.target import (
     KNOWN_PYTHON_MINORS,
     Matrix,
     _pythons_in_range,
+    declared_range_marker,
 )
 
 
@@ -169,7 +169,11 @@ class TestMatrixExpand:
         assert tuples[0].marker_env["python_full_version"] == "3.11.0"
 
     def test_python_patches_zero_micro_pins_whole(self) -> None:
-        """A ``.0`` pin is a concrete micro resolved whole, not a bare minor."""
+        """A ``.0`` pin is a concrete micro resolved whole, not a bare minor.
+
+        The two read the same by string, so only the pin's markers tell them
+        apart: a whole target declares the micro it resolved at.
+        """
         matrix = Matrix(
             python="==3.13",
             platforms=(PlatformSpec("linux_x86_64"),),
@@ -177,7 +181,7 @@ class TestMatrixExpand:
         )
         target = matrix.expand()[0]
         assert not target.is_minor_interval
-        assert not target.admits_requires_python(SpecifierSet(">=3.13.5"))
+        assert 'python_full_version == "3.13.0"' in declared_range_marker(target)
 
     def test_python_patches_partial_mapping(self) -> None:
         """A partial mapping uses overrides for declared minors only."""

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -566,7 +566,7 @@ class TestFetchVersions:
 
         The entry is a string, so it passes the parser's isinstance guard and
         SpecifierSet accepts it; the ValueError only lands when the target
-        compares against it, on either branch of admits_requires_python.
+        compares against it, where the listing catches it and keeps the wheel.
         """
         oversized = ">=" + "1" * (sys.get_int_max_str_digits() + 1)
         data = {

--- a/nab-python/tests/test_provider_declared_target.py
+++ b/nab-python/tests/test_provider_declared_target.py
@@ -850,12 +850,11 @@ class TestUnsetKnobAcceptsAnyLevel:
 
 
 class TestRequiresPythonPatch:
-    """A whole target evaluates Requires-Python at its full patch version.
+    """Requires-Python is evaluated at the target's language minor.
 
-    A python-patches tuple names one concrete micro and is admitted when that
-    micro satisfies the specifier.  A bare minor is an interval and is admitted
-    when the specifier overlaps the whole minor, so a micro floor keeps the
-    dist rather than excluding it at the synthetic ``.0`` floor.
+    A python-patches tuple names one concrete micro and a bare minor stands
+    for all of them; both admit the same dists, so a micro floor keeps the
+    dist and only a disjoint minor drops it.
     """
 
     def test_dist_kept_when_patch_satisfies_requires_python(self) -> None:
@@ -871,10 +870,27 @@ class TestRequiresPythonPatch:
         result = provider.fetch_versions("pkg")
         assert [v for v, _ in result] == [Version("1.0")]
 
-    def test_whole_target_excludes_a_dist_its_patch_fails(self) -> None:
-        """A 3.13.1 python-patches tuple excludes a >=3.13.5 dist."""
+    def test_patch_pin_keeps_a_dist_its_own_micro_would_fail(self) -> None:
+        """A 3.13.1 python-patches tuple keeps a >=3.13.5 dist.
+
+        The dist declares the 3.13 language, which is what the tuple pins;
+        which micro of it the deployment runs is the installer's business.
+        """
         provider = Provider(
             _make_coordinator([_make_wheel("1.0", requires_python=">=3.13.5")]),
+            ResolveTarget.for_declared(
+                python_version="3.13",
+                spec=PlatformSpec("linux_x86_64"),
+                python_full_version="3.13.1",
+            ),
+        )
+        result = provider.fetch_versions("pkg")
+        assert [v for v, _ in result] == [Version("1.0")]
+
+    def test_patch_pin_excludes_a_disjoint_dist(self) -> None:
+        """A 3.13.1 python-patches tuple still excludes a >=3.14 dist."""
+        provider = Provider(
+            _make_coordinator([_make_wheel("1.0", requires_python=">=3.14")]),
             ResolveTarget.for_declared(
                 python_version="3.13",
                 spec=PlatformSpec("linux_x86_64"),
@@ -884,7 +900,7 @@ class TestRequiresPythonPatch:
         assert provider.fetch_versions("pkg") == []
 
     def test_minor_interval_keeps_a_dist_its_floor_would_fail(self) -> None:
-        """A bare 3.13 minor keeps a >=3.13.1 dist: the range overlaps 3.13."""
+        """A bare 3.13 minor keeps a >=3.13.1 dist: the floor is 3.13."""
         provider = Provider(
             _make_coordinator([_make_wheel("1.0", requires_python=">=3.13.1")]),
             ResolveTarget.for_declared(
@@ -895,7 +911,7 @@ class TestRequiresPythonPatch:
         assert [v for v, _ in result] == [Version("1.0")]
 
     def test_minor_interval_excludes_a_disjoint_dist(self) -> None:
-        """A bare 3.13 minor still excludes a >=3.14 dist: no overlap."""
+        """A bare 3.13 minor still excludes a >=3.14 dist: a later language."""
         provider = Provider(
             _make_coordinator([_make_wheel("1.0", requires_python=">=3.14")]),
             ResolveTarget.for_declared(

--- a/nab-python/tests/test_resolve_targets.py
+++ b/nab-python/tests/test_resolve_targets.py
@@ -2379,7 +2379,12 @@ class TestLocalVcsRequiresPython:
         assert result.success
         assert str(result.target_results[0].pins["foo"]) == "1.0"
 
-    def test_patch_below_local_requires_python_fails(self, tmp_path: Path) -> None:
+    def test_patch_below_local_requires_python_resolves(self, tmp_path: Path) -> None:
+        """A floor above the pinned patch is still the 3.13 language.
+
+        The pin says which micro the lock's markers describe, not which
+        micros the source supports, so the check runs at the minor.
+        """
         local = self._write(
             tmp_path,
             '[project]\nname = "foo"\nversion = "1.0"\nrequires-python = ">=3.13.5"\n',
@@ -2393,10 +2398,8 @@ class TestLocalVcsRequiresPython:
             ),
             local,
         )
-        assert not result.success
-        error = result.target_results[0].error
-        assert error is not None
-        assert "foo 1.0 requires Python" in str(error)
+        assert result.success
+        assert str(result.target_results[0].pins["foo"]) == "1.0"
 
 
 def _archive_bytes(name: str, version: str, pyproject: str) -> bytes:

--- a/nab-python/tests/test_target.py
+++ b/nab-python/tests/test_target.py
@@ -8,6 +8,7 @@ the one running the suite.  One smoke test uses the live sources.
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -109,37 +110,45 @@ class TestForHost:
         assert target.tags.ordered
 
 
-class TestPythonRelease:
-    """``Requires-Python`` names a release, so a prerelease host is one."""
+class TestPrereleaseHost:
+    """``Requires-Python`` names a language, so a prerelease host is one."""
 
-    def test_a_release_candidate_host_is_its_release(self) -> None:
+    def test_a_release_candidate_host_admits_its_release(self) -> None:
         """A 3.15 candidate satisfies ``>=3.15``, as it does under pip.
 
-        The PEP 508 marker value keeps the ``rc``, but a specifier admits no
+        The PEP 508 full version keeps the ``rc``, and a specifier admits no
         prerelease unless it names one, so comparing that value would drop
         every distribution requiring the release the host is a candidate for.
         """
         target = ResolveTarget.for_host(
-            env_source=lambda: {**_HOST_ENV, "python_full_version": "3.15.0rc1"},
+            env_source=lambda: {
+                **_HOST_ENV,
+                "python_full_version": "3.15.0rc1",
+                "python_version": "3.15",
+            },
             tags_source=_host_tags,
         )
         assert target.python_full_version == "3.15.0rc1"
-        assert target.python_release == Version("3.15.0")
-        assert target.python_release in SpecifierSet(">=3.15")
-
-    def test_a_final_release_is_itself(self) -> None:
-        target = ResolveTarget.for_host(env_source=_host_env, tags_source=_host_tags)
-        assert target.python_release == Version(_HOST_ENV["python_full_version"])
+        assert target.admits_requires_python(SpecifierSet(">=3.15"))
+        assert target.admits_requires_python(SpecifierSet("==3.15"))
 
 
 class TestTargetPythonIsComparable:
     """Every candidate's Requires-Python is tested against this target."""
 
-    def test_an_unparseable_python_names_itself(self) -> None:
+    def test_an_unparseable_full_version_names_itself(self) -> None:
         """A local-build version fails here, not once per candidate."""
-        with pytest.raises(ValueError, match="not a PEP 440 version"):
+        with pytest.raises(ValueError, match="python_full_version '3.11.2\\+'"):
             ResolveTarget.for_host(
                 env_source=lambda: {**_HOST_ENV, "python_full_version": "3.11.2+"},
+                tags_source=_host_tags,
+            )
+
+    def test_an_unparseable_minor_names_itself(self) -> None:
+        """Requires-Python is compared against the minor, so it is checked too."""
+        with pytest.raises(ValueError, match="python_version '3.11\\+'"):
+            ResolveTarget.for_host(
+                env_source=lambda: {**_HOST_ENV, "python_version": "3.11+"},
                 tags_source=_host_tags,
             )
 
@@ -219,7 +228,7 @@ class TestForHostPython:
             "3.13.0", env_source=_host_env, tags_source=_host_tags
         )
         assert not target.is_minor_interval
-        assert not target.admits_requires_python(SpecifierSet(">=3.13.5"))
+        assert 'python_full_version == "3.13.0"' in declared_range_marker(target)
 
     def test_bare_minor_is_an_interval(self) -> None:
         """A bare ``3.13`` target is a micro interval off its ``.0`` floor."""
@@ -288,74 +297,120 @@ class TestForDeclared:
         assert not any("manylinux" in t for t in tag_strs)
 
 
-class TestAdmitsRequiresPython:
-    """A minor interval admits a candidate whose Requires-Python overlaps it.
+def _a_bare_minor_target() -> ResolveTarget:
+    """A declared 3.13 target, standing for every micro of the minor."""
+    return ResolveTarget.for_declared(
+        python_version="3.13", spec=PlatformSpec("linux_x86_64")
+    )
 
-    Range overlap, not a scalar probe: truncating the compared scalar to
-    major.minor is a no-op, since ``3.13`` and ``3.13.0`` are both excluded by
-    ``>= "3.13.2"``.  The interval minor honours a micro floor at the language
-    minor it names; a whole target keeps the scalar test.
+
+def _a_patch_pinned_target() -> ResolveTarget:
+    """A matrix ``python-patches`` target pinned to one micro of 3.13."""
+    return ResolveTarget.for_declared(
+        python_version="3.13",
+        spec=PlatformSpec("linux_x86_64"),
+        python_full_version="3.13.4",
+    )
+
+
+def _a_host_target() -> ResolveTarget:
+    """The 3.13.2 host of ``_HOST_ENV``, reporting a real interpreter."""
+    return ResolveTarget.for_host(env_source=_host_env, tags_source=_host_tags)
+
+
+_EVERY_TARGET_KIND = pytest.mark.parametrize(
+    "make_target",
+    [
+        pytest.param(_a_bare_minor_target, id="bare-minor"),
+        pytest.param(_a_patch_pinned_target, id="patch-pin"),
+        pytest.param(_a_host_target, id="host"),
+    ],
+)
+
+# Requires-Python declarations and whether they admit the 3.13 language.
+_ADMITS_PYTHON_3_13 = [
+    ("", True),
+    ("==3.13", True),
+    ("==3.13.*", True),
+    ("==3.13.4.*", True),
+    ("==3.13.4", True),
+    ("==3.13.0", True),
+    ("==3.*", True),
+    ("==3", False),
+    ("==3.14", False),
+    ("!=3.13", False),
+    ("!=3.13.*", False),
+    ("!=3.13.0.*", True),
+    ("!=3.*", False),
+    ("!=3.13.7", True),
+    ("!=3.13.0", True),
+    ("!=3.13rc1", True),
+    ("!=3.13.post1", True),
+    ("!=3.13.dev1", True),
+    ("!=3.13+local", True),
+    (">=3.13", True),
+    (">=3.13.1", True),
+    (">=3.13.8", True),
+    (">=3.10a1", True),
+    (">=3.14", False),
+    (">=1!3.13", False),
+    (">3.13", True),
+    (">3.13.9", True),
+    ("<=3.13", True),
+    ("<=3.13.2", True),
+    ("<=3.13.0rc1", False),
+    ("<3.13.5", True),
+    ("<3.13", False),
+    ("<3.14", True),
+    ("<3.11", False),
+    ("~=3.13", True),
+    ("~=3.13.4", True),
+    ("~=3.14.0", False),
+    ("===3.13", True),
+    ("===3.13.7", True),
+    ("===not-a-version", False),
+    (">=3.7,!=3.9.7", True),
+]
+
+
+class TestAdmitsRequiresPython:
+    """Requires-Python names a language, so every target answers at its minor.
+
+    A micro segment says which patch releases a distribution was built and
+    tested against, not which Python it runs on, so it neither admits a minor
+    nor excludes one.  The three kinds of target differ in how precisely they
+    name their interpreter and agree on every declaration.
     """
 
-    @staticmethod
-    def _minor_target() -> ResolveTarget:
-        return ResolveTarget.for_declared(
-            python_version="3.13", spec=PlatformSpec("linux_x86_64")
-        )
+    @_EVERY_TARGET_KIND
+    @pytest.mark.parametrize(("spec", "admits"), _ADMITS_PYTHON_3_13)
+    def test_the_language_level_verdict(
+        self, make_target: Callable[[], ResolveTarget], spec: str, admits: bool
+    ) -> None:
+        assert make_target().admits_requires_python(SpecifierSet(spec)) is admits
 
-    def test_a_micro_floor_admits_the_whole_minor(self) -> None:
-        target = self._minor_target()
-        assert target.is_minor_interval
-        assert target.admits_requires_python(SpecifierSet(">=3.13.2"))
+    def test_a_declaration_that_names_only_micros_admits_everything(self) -> None:
+        """Every clause dropping leaves an empty set, which excludes nothing."""
+        target = _a_bare_minor_target()
+        assert target.admits_requires_python(SpecifierSet("!=3.13.7,!=3.9.2"))
 
-    def test_the_scalar_probe_is_a_no_op_trap(self) -> None:
-        target = self._minor_target()
-        assert target.python_release not in SpecifierSet(">=3.13.2")
-        assert Version("3.13") not in SpecifierSet(">=3.13.2")
-
-    def test_a_disjoint_floor_still_excludes(self) -> None:
-        target = self._minor_target()
-        assert not target.admits_requires_python(SpecifierSet(">=3.14"))
-        assert not target.admits_requires_python(SpecifierSet("<3.13"))
-
-    def test_a_whole_host_target_uses_the_scalar_test(self) -> None:
-        target = ResolveTarget.for_host(env_source=_host_env, tags_source=_host_tags)
-        assert not target.is_minor_interval
-        assert target.admits_requires_python(SpecifierSet(">=3.13.2"))
-        assert not target.admits_requires_python(SpecifierSet(">=3.13.3"))
-
-    def test_a_python_patches_micro_is_whole(self) -> None:
-        target = ResolveTarget.for_declared(
-            python_version="3.13",
-            spec=PlatformSpec("linux_x86_64"),
-            python_full_version="3.13.4",
-        )
-        assert not target.is_minor_interval
-        assert target.admits_requires_python(SpecifierSet(">=3.13.2"))
-        assert not target.admits_requires_python(SpecifierSet(">=3.13.5"))
-
-    def test_a_python_patches_zero_micro_is_whole(self) -> None:
-        """A ``.0`` pin is a concrete deployment micro, not a bare minor floor."""
-        target = ResolveTarget.for_declared(
-            python_version="3.13",
-            spec=PlatformSpec("linux_x86_64"),
-            python_full_version="3.13.0",
-        )
-        assert not target.is_minor_interval
-        assert target.admits_requires_python(SpecifierSet(">=3.13.0"))
-        assert not target.admits_requires_python(SpecifierSet(">=3.13.5"))
+    @_EVERY_TARGET_KIND
+    def test_an_uncomparable_version_raises(
+        self, make_target: Callable[[], ResolveTarget]
+    ) -> None:
+        """A version too large to compare raises instead of getting a verdict."""
+        oversized = SpecifierSet(">=3." + "9" * 5000)
+        with pytest.raises(ValueError, match="Exceeds the limit"):
+            make_target().admits_requires_python(oversized)
 
     def test_every_slice_of_a_split_minor_agrees(self) -> None:
         """A slice off a bare minor is an interval on every side of the split.
 
         A split moves the upper slice onto a real micro representative, but the
         row still stands for every interpreter above the boundary, so the whole
-        minor is the admission granularity.  Answering the upper slice at its
-        representative reverts to the synthetic-floor bug: a candidate whose
-        Requires-Python only its interpreters satisfy would be dropped on the
-        slice that can install it.
+        minor is the admission granularity.
         """
-        floor, upper = slices_from_points(self._minor_target(), [Version("3.13.4")])
+        floor, upper = slices_from_points(_a_bare_minor_target(), [Version("3.13.4")])
         assert floor.is_minor_interval
         assert upper.is_minor_interval
         spec = SpecifierSet(">=3.13.6")


### PR DESCRIPTION
The same `requires-python` string got opposite verdicts depending on how precisely the target named its interpreter. On a 3.12.13 host, `requires-python = "==3.12"` was reported as excluding the resolve target, and so was `>=3.12.14`; a bare `python = "3.12"` target admitted both. Nothing about the project changed between those two runs except the micro the target happened to carry.

Six decision sites go through `ResolveTarget.admits_requires_python`: the index listing filter, the project declaration check, the metadata-resolver rejection, the tied-sibling metadata reuse, the built-sdist check, and the local/VCS source pin. It took one of two paths, and they disagreed:

- a bare minor overlapped the specifier against the range `[3.12.0, 3.13.0)`
- a host or a `python-patches` pin tested its full release with `in`, so `==3.12` zero-padded to `3.12.0` and missed

`Requires-Python` says which Python language a distribution runs on, so nab now reads it there. Each clause is rewritten to name a `major.minor` and matched against the target's `python_version`, which every target has: one path, and the answer no longer depends on the target kind. The four error messages that quoted the target's full release now quote the minor they compared.

Verdicts for a 3.12 resolve:

| Requires-Python | before, bare 3.12 | before, 3.12.13 host or pin | after, all kinds |
|---|---|---|---|
| `==3.12` | admit | drop | admit |
| `>=3.12.14` | admit | drop | admit |
| `==3.12.4` | admit | drop | admit |
| `!=3.12.13` | admit | drop | admit |
| `!=3.12` | admit | admit | drop |
| `>=3.13` | drop | drop | drop |

### Behaviour change, for sign-off

A micro segment stops excluding anything. `>=3.12.14`, `==3.12.4` and `!=3.12.13` all admit a 3.12 target now, including the 3.12.13 host that `!=3.12.13` names, and `!=3.12.0.*` drops with them since its prefix reaches into the micros. A distribution that pinned a micro to fence off one bad patch release will be installed on it; a conforming PEP 751 installer still enforces the recorded specifier in full.

Bare `!=X.Y` gets stricter. `!=3.12` used to exclude only an exact `3.12` value, so every real 3.12 interpreter passed it; it now excludes the whole 3.12 minor. That is the one direction where a resolve that succeeded before can fail, and it is the judgment call in the change: `!=X.Y` is read as naming a language, not a version string no interpreter reports.

`requires-python = "3.13"` is still an error, and its hint now offers `==X.Y` or `>=X.Y`, both of which mean what a reader expects.
