### PR TITLE
fix InvalidSpecifier crash on a valid `< "3.12.*"` marker

### DIFF
--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -28,7 +28,7 @@ from ._conflict_kind import EMPTY_MEMBERSHIP_SETS, MARKER_VARIABLE_FOR_KIND
 from ._vendor.packaging import tags as ptags
 from ._vendor.packaging.markers import Marker, default_environment
 from ._vendor.packaging.markersets import variable_names
-from ._vendor.packaging.specifiers import SpecifierSet
+from ._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from ._vendor.packaging.version import InvalidVersion, Version
 from .tags import (
     FREE_THREADED_MIN_PYTHON,
@@ -393,9 +393,10 @@ class NonIntervalMarkerError(ValueError):
     comparison has to partition that interval so every real interpreter reads
     it the same way its slice does.  A membership (``in``/``not in``), a
     verbatim ``===``, a non-version string comparison, a comparison against
-    another variable, or a prerelease-version literal that would carve a slice
-    off a real micro cannot be tiled, so the resolve stops loudly rather than
-    pin the whole minor to one synthetic answer.
+    another variable, a prerelease-version literal that would carve a slice
+    off a real micro, or a literal PEP 440 refuses under the operator it is
+    written with (``< "3.12.*"``, ``~= "3"``) cannot be tiled, so the resolve
+    stops loudly rather than pin the whole minor to one synthetic answer.
     """
 
 
@@ -406,9 +407,10 @@ def _non_interval(
     lhs, op, rhs = parts
     return NonIntervalMarkerError(
         f"consulted marker clause {lhs} {op} {rhs} cannot tile the"
-        f" {target.label} minor interval: a python_full_version membership,"
-        " verbatim ===, non-version, variable, or prerelease comparison names"
-        " no micro boundary the lock can render"
+        f" {target.label} minor interval: no micro boundary the lock can"
+        " render comes from a python_full_version membership, a verbatim ===,"
+        " a comparison against a variable, a prerelease comparison, or a"
+        " literal the operator cannot spell as a version bound"
     )
 
 
@@ -536,7 +538,7 @@ def _clause_boundary_points(
     parsed = _clause_interval_literal(parts, scanned, target)
     if parsed is None:
         return set()
-    op, raw, version = parsed
+    op, specifier, version = parsed
 
     if version.is_prerelease and op in _AT_LITERAL_OPERATORS:
         # The boundary lands at the prerelease itself; only a strictly interior
@@ -547,11 +549,7 @@ def _clause_boundary_points(
             raise _non_interval(parts, target)
         return set()
 
-    intervals = (
-        SpecifierSet(f"{op}{raw}")
-        .to_range()
-        .release_intervals(_PYTHON_FULL_VERSION_PARTS)
-    )
+    intervals = specifier.to_range().release_intervals(_PYTHON_FULL_VERSION_PARTS)
     return {
         edge
         for lower, upper in intervals
@@ -576,14 +574,21 @@ def _in_minor(point: Version, minor_release: tuple[int, ...], floor: Version) ->
 
 def _clause_interval_literal(
     parts: tuple[str, str, str], scanned: frozenset[str], target: ResolveTarget
-) -> tuple[str, str, Version] | None:
-    """Return ``(op, literal, version)`` for a version-boundary clause.
+) -> tuple[str, SpecifierSet, Version] | None:
+    """Return ``(op, specifier, version)`` for a version-boundary clause.
 
     ``None`` when the clause names no scanned version variable.  Raises
     :class:`NonIntervalMarkerError` when it names one but cannot tile an
     interval.  A literal-first clause has an ordered or symmetric operator
     mirrored back to variable-on-left form; ``~=``/``===`` and the membership
     operators cannot be mirrored, so a literal-first one of those is untileable.
+
+    The specifier is built here rather than by the caller because PEP 508
+    accepts literals PEP 440 refuses under the operator they are written with.
+    A ``.*`` suffix is a specifier only under ``==``/``!=``, and ``~=`` needs
+    two release components, so ``< "3.12.*"`` and ``~= "3"`` are valid markers
+    with no specifier form; building it is what tells them from the clauses
+    that have one.
     """
     lhs, op, rhs = parts
     if lhs in scanned:
@@ -603,9 +608,10 @@ def _clause_interval_literal(
     base = raw.removesuffix(".*")
     try:
         version = Version(base)
-    except InvalidVersion:
+        specifier = SpecifierSet(f"{op}{raw}")
+    except (InvalidVersion, InvalidSpecifier):
         raise _non_interval(parts, target) from None
-    return op, raw, version
+    return op, specifier, version
 
 
 def host_environment(

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -1880,6 +1880,34 @@ class TestResolveUniversalPyproject:
         _resolved(pyproject, extras=["all"])
         mock_engine.assert_called_once()
 
+    @patch("nab_python.resolve.resolve_with_coordinator")
+    def test_wildcard_self_ref_marker_off_the_matrix_resolves(
+        self, mock_engine: MagicMock, tmp_path: Path
+    ) -> None:
+        """A ``.*`` literal under an ordering operator is skipped like any
+        other self-ref marker the closure carries but no tuple reaches.
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\ndependencies = ["base"]\n'
+            "[project.optional-dependencies]\n"
+            'cpu = ["foo==1.0"]\n'
+            'gpu = ["foo==2.0"]\n'
+            "legacy = [\"x[gpu]; python_full_version < '3.7.*'\"]\n"
+            "all = [\n"
+            '    "x[cpu]",\n'
+            "    \"x[legacy]; python_version < '3.8'\",\n"
+            "]\n"
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            'conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]\n'
+            "[tool.nab.matrix]\n"
+            'python = "==3.10"\n'
+            'platforms = ["linux_x86_64"]\n'
+        )
+        _resolved(pyproject, extras=["all"])
+        mock_engine.assert_called_once()
+
     def test_untileable_self_ref_marker_keeps_the_other_boundaries(
         self, tmp_path: Path
     ) -> None:

--- a/nab-python/tests/test_target.py
+++ b/nab-python/tests/test_target.py
@@ -1340,6 +1340,32 @@ class TestMicroBoundarySplitting:
         with pytest.raises(NonIntervalMarkerError):
             micro_boundary_points(self._target(), [Marker(marker)])
 
+    @pytest.mark.parametrize(
+        "marker",
+        [
+            'python_full_version < "3.12.*"',
+            'python_full_version <= "3.12.*"',
+            'python_full_version > "3.12.*"',
+            'python_full_version >= "3.12.*"',
+            'python_full_version < "3.13.*"',
+            'python_full_version < "3.11.0rc1.*"',
+            'python_full_version ~= "3"',
+            'python_full_version ~= "3.12.*"',
+            'implementation_version >= "3.12.*"',
+        ],
+    )
+    def test_a_literal_the_operator_rejects_crashes(self, marker: str) -> None:
+        """A ``.*`` suffix is a valid marker literal, but a valid specifier
+        only under ``==``/``!=``, and ``~=`` needs two release components.
+        The clause parses and the literal is a version either way, so the
+        mismatch shows up only when the specifier is built.
+
+        The literal names no interval under its operator whatever minor reads
+        it, so a literal outside the target's own minor is refused too.
+        """
+        with pytest.raises(NonIntervalMarkerError):
+            micro_boundary_points(self._target(), [Marker(marker)])
+
     def test_the_crash_names_the_same_clause_in_either_order(self) -> None:
         """Two untileable markers name the same clause in either order.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1699,6 +1699,32 @@ class TestLockCommandUniversal:
         assert "cannot tile the py312-linux_x86_64 minor interval" in err
         assert "Traceback" not in err
 
+    def test_wildcard_micro_marker_exits_cleanly(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """``< "3.12.*"`` is a valid marker whose specifier form is not.
+
+        PEP 508 accepts the literal and PEP 440 accepts a ``.*`` suffix only
+        under ``==``/``!=``, so the clause parses and the specifier does not.
+        """
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\nname = "probe"\nversion = "0.1.0"\n'
+            "dependencies = [\"somepkg; python_full_version < '3.12.*'\"]\n"
+            "[tool.nab]\n"
+            'mode = "universal"\n'
+            "[tool.nab.matrix]\n"
+            'python = ">=3.12,<3.13"\n'
+            'platforms = ["linux_x86_64"]\n',
+        )
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, output=Path("-"), offline=True)
+
+        err = capsys.readouterr().err
+        assert "cannot lock: consulted marker clause" in err
+        assert 'python_full_version < "3.12.*"' in err
+        assert "Traceback" not in err
+
     def test_pylock_writes_universal_lock(self, tmp_path: Path) -> None:
         """Universal + pylock format runs the real merge + write pipeline."""
         pyproject = _universal_pyproject(tmp_path)


### PR DESCRIPTION
`python_full_version < "3.12.*"` is a valid PEP 508 marker, and PEP 440 accepts a `.*` suffix only under `==` and `!=`, so the clause has no specifier form. Locking a project whose dependency carries one crashed with an uncaught `InvalidSpecifier` traceback out of `micro_boundary_points`. A pyproject with `dependencies = ["idna; python_full_version < '3.12.*'"]` and `nab lock --python 3.12 --offline` is enough to hit it. `~= "3"` reaches the same crash through a self-referencing extra, since `~=` needs two release components.

The literal was checked as a version but never against the operator it was written with, so the specifier constructor was the first thing to see the mismatch, and by then the clause had already passed validation. Building the specifier where the literal is validated turns the crash into the `NonIntervalMarkerError` that nab's other untileable clauses raise, which the CLI already prints as a plain error.
