### PR TITLE
fix UndefinedComparison crash on a valid `~= "3"` marker

### DIFF
--- a/nab-python/src/nab_python/_conflict_kind.py
+++ b/nab-python/src/nab_python/_conflict_kind.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
+from ._vendor.packaging.markers import UndefinedComparison
 from ._vendor.packaging.markersets import MarkerSet
 
 if TYPE_CHECKING:
@@ -57,6 +58,38 @@ def membership_set_in_marker(marker_text: str) -> str | None:
     return match.group(1) if match else None
 
 
+class UnevaluableMarkerError(ValueError):
+    """A dependency marker parses but no comparison decides it.
+
+    PEP 508 accepts any operator between a variable and a literal, and PEP 440
+    gives the compatible-release operator a meaning only over a release with
+    at least two components.  So ``python_full_version ~= "3"`` is a valid
+    marker with nothing to evaluate, and ``sys_platform ~= "linux"`` is one on
+    a variable that holds no version at all.
+
+    A requirement the project declares is neither activated nor dropped by
+    such a marker, and either guess changes what gets locked, so the run stops
+    and names it.  A candidate's own metadata takes the other route:
+    ``Provider.get_dependencies`` already turns metadata it cannot read into a
+    candidate skip.
+    """
+
+
+def marker_set(marker: Marker) -> MarkerSet:
+    """Return the algebra form of ``marker``.
+
+    Each clause is checked against its operator while the set is built, so
+    this is the one place a marker with no meaning can be caught.  Raises
+    :class:`UnevaluableMarkerError` naming the whole marker, since the failing
+    clause alone does not say which dependency to edit.
+    """
+    try:
+        return MarkerSet.from_marker(marker)
+    except UndefinedComparison as exc:
+        msg = f"marker {marker} cannot be evaluated: {exc}"
+        raise UnevaluableMarkerError(msg) from exc
+
+
 def dependency_marker_holds(
     marker: Marker, environment: Mapping[str, str | AbstractSet[str]]
 ) -> bool:
@@ -70,9 +103,11 @@ def dependency_marker_holds(
     ``UndefinedEnvironmentName``; callers pass a complete
     ``ResolveTarget.marker_env``.  The lockfile-only set variables are seeded
     empty, so a marker that tests one evaluates to False rather than raising.
+
+    A clause no comparison decides raises :class:`UnevaluableMarkerError`.
     """
     env: dict[str, str | AbstractSet[str]] = {"extra": frozenset()}
     env.update(environment)
     env.update(EMPTY_MEMBERSHIP_SETS)
 
-    return MarkerSet.from_marker(marker).evaluate(env)
+    return marker_set(marker).evaluate(env)

--- a/nab-python/src/nab_python/_lockfile/validate.py
+++ b/nab-python/src/nab_python/_lockfile/validate.py
@@ -30,11 +30,8 @@ from typing import TYPE_CHECKING
 
 import tomli
 
-from .._conflict_kind import dependency_marker_holds
-from .._vendor.packaging.markers import (
-    UndefinedComparison,
-    UndefinedEnvironmentName,
-)
+from .._conflict_kind import UnevaluableMarkerError, dependency_marker_holds
+from .._vendor.packaging.markers import UndefinedEnvironmentName
 from .._vendor.packaging.pylock import Pylock, PylockValidationError
 from .._vendor.packaging.requirements import Requirement
 from .._vendor.packaging.specifiers import SpecifierSet
@@ -261,7 +258,7 @@ def _marker_skips(marker: Marker | None, marker_env: Mapping[str, str]) -> bool:
         return False
     try:
         active = dependency_marker_holds(marker, marker_env)
-    except (UndefinedComparison, UndefinedEnvironmentName):
+    except (UnevaluableMarkerError, UndefinedEnvironmentName):
         return True
     return not active
 

--- a/nab-python/src/nab_python/requirements_file.py
+++ b/nab-python/src/nab_python/requirements_file.py
@@ -9,11 +9,10 @@ import tomli
 
 from nab_resolver.errors import ResolutionError
 
-from ._conflict_kind import dependency_marker_holds
+from ._conflict_kind import dependency_marker_holds, marker_set
 from ._vendor.packaging.dependency_groups import resolve_dependency_groups
 from ._vendor.packaging.errors import ExceptionGroup
 from ._vendor.packaging.markers import Marker
-from ._vendor.packaging.markersets import MarkerSet
 from ._vendor.packaging.requirements import Requirement
 from ._vendor.packaging.utils import canonicalize_name
 from .metadata import validate_specifier_versions
@@ -341,7 +340,7 @@ def _environment_residual(marker: Marker, extra: str) -> str | bool:
     extra``) is kept as a residual atom over the target's own value rather
     than decided against the machine running nab.
     """
-    residual = MarkerSet.from_marker(marker).restrict(
+    residual = marker_set(marker).restrict(
         {"extra": frozenset({extra})}, on_unknown_variable="residual"
     )
 

--- a/nab-python/src/nab_python/target.py
+++ b/nab-python/src/nab_python/target.py
@@ -24,7 +24,11 @@ from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING
 
-from ._conflict_kind import EMPTY_MEMBERSHIP_SETS, MARKER_VARIABLE_FOR_KIND
+from ._conflict_kind import (
+    EMPTY_MEMBERSHIP_SETS,
+    MARKER_VARIABLE_FOR_KIND,
+    UnevaluableMarkerError,
+)
 from ._vendor.packaging import tags as ptags
 from ._vendor.packaging.markers import Marker, default_environment
 from ._vendor.packaging.markersets import variable_names
@@ -52,6 +56,7 @@ __all__ = [
     "Matrix",
     "NonIntervalMarkerError",
     "ResolveTarget",
+    "UnevaluableMarkerError",
     "apply_python_axis_overlay",
     "check_free_threaded",
     "declared_environment",

--- a/nab-python/tests/test_conflict_kind.py
+++ b/nab-python/tests/test_conflict_kind.py
@@ -11,7 +11,10 @@ from collections.abc import Set as AbstractSet
 
 import pytest
 
-from nab_python._conflict_kind import dependency_marker_holds
+from nab_python._conflict_kind import (
+    UnevaluableMarkerError,
+    dependency_marker_holds,
+)
 from nab_python._vendor.packaging.markers import Marker
 
 _ENV: dict[str, str] = {
@@ -95,4 +98,37 @@ class TestDependencyMarkerHoldsScalarExtra:
         self, marker_text: str, want: bool
     ) -> None:
         """A marker naming no extra evaluates against the environment alone."""
+        assert dependency_marker_holds(Marker(marker_text), _ENV) is want
+
+
+class TestDependencyMarkerHoldsUnevaluableClause:
+    """A clause PEP 508 parses and no comparison decides."""
+
+    @pytest.mark.parametrize(
+        "marker_text",
+        [
+            'python_full_version ~= "3"',
+            'python_version ~= "3"',
+            'sys_platform ~= "linux"',
+            'platform_release ~= "5"',
+        ],
+    )
+    def test_unevaluable_clause_names_the_marker(self, marker_text: str) -> None:
+        """The error quotes the whole marker, not just the failing operand."""
+        with pytest.raises(UnevaluableMarkerError) as excinfo:
+            dependency_marker_holds(Marker(marker_text), _ENV)
+        assert marker_text in str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        ("marker_text", "want"),
+        [
+            ('python_full_version ~= "3.11"', True),
+            ('python_full_version ~= "3.12"', False),
+            ('python_version ~= "3.11"', True),
+        ],
+    )
+    def test_two_component_compatible_release_still_evaluates(
+        self, marker_text: str, want: bool
+    ) -> None:
+        """``~=`` stays supported wherever PEP 440 gives it a meaning."""
         assert dependency_marker_holds(Marker(marker_text), _ENV) is want

--- a/nab-python/tests/test_requirements_file.py
+++ b/nab-python/tests/test_requirements_file.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from nab_python._conflict_kind import UnevaluableMarkerError
 from nab_python._vendor.packaging.requirements import Requirement
 from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.utils import InvalidName
@@ -561,6 +562,18 @@ class TestExpandSelfExtras:
         }
         env = {"python_version": "3.11", "python_full_version": "3.11.0"}
         assert expand_self_extras(opt, "mypkg", ["gpu"], env) == ["gpu", "fast"]
+
+
+class TestSelfReferenceUnevaluableMarker:
+    def test_self_reference_gate_no_comparison_decides(self) -> None:
+        """A self-ref gate is reduced against the walked extra, which is the
+        second place a marker with no meaning is read."""
+        opt = {
+            "all": ["mypkg[fast]; python_full_version ~= '3'"],
+            "fast": ["some-dep"],
+        }
+        with pytest.raises(UnevaluableMarkerError, match='python_full_version ~= "3"'):
+            expand_extra_requirements(opt, "mypkg", ["all"])
 
 
 class TestSelfExtraMarkers:

--- a/src/nab/_lock.py
+++ b/src/nab/_lock.py
@@ -62,6 +62,7 @@ from nab_python.requirements_file import (
     read_pyproject_optional_dependencies,
     resolve_groups_to_requirements,
 )
+from nab_python.target import UnevaluableMarkerError
 
 from . import cli as _cli
 from .cli import (
@@ -370,8 +371,8 @@ def _locked_check_inputs(
     """Collect the validity-check inputs, or ``(None, None)`` to skip them.
 
     A target the declaration excludes and a project whose requirements cannot
-    be read both skip the validity checks, left for the full resolve.  The
-    envelope checks still run.
+    be read or evaluated both skip the validity checks, left for the full
+    resolve.  The envelope checks still run.
     """
     try:
         target = plan_targets(with_python_override(config, python))[0]
@@ -384,6 +385,7 @@ def _locked_check_inputs(
         InvalidProjectTableError,
         InvalidProjectRequirementError,
         LookupError,
+        UnevaluableMarkerError,
     ):
         return None, None
     return roots, target.marker_env

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -83,7 +83,7 @@ from nab_python.resolve import (
     build_lock_input,  # noqa: F401 - referenced as _cli.build_lock_input in _lock
     resolve_for_targets,
 )
-from nab_python.target import NonIntervalMarkerError
+from nab_python.target import NonIntervalMarkerError, UnevaluableMarkerError
 from nab_python.workspace import WorkspaceDiscoveryError
 from nab_resolver.resolver import ResolutionError
 
@@ -604,6 +604,7 @@ def _resolve(  # noqa: PLR0913, PLR0912, C901 - one wrapper per resolve_for_targ
         SiblingMetadataDivergenceError,
         SourceNameMismatchError,
         NonIntervalMarkerError,
+        UnevaluableMarkerError,
     ) as e:
         printer().error(f"{failure_prefix}: {e}")
         sys.exit(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -906,6 +906,28 @@ class TestLockCommandSpecific:
         assert "does not provide extra 'nonexistent'" in err
         assert "Traceback" not in err
 
+    def test_unevaluable_root_marker_exits_cleanly(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """``~= "3"`` is a valid marker no comparison decides.
+
+        PEP 440 gives the compatible-release operator no meaning over a
+        single-component release, so PEP 508 accepts the clause and nothing
+        evaluates it. It needs no matrix and no ``--python``.
+        """
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\nname = "probe"\nversion = "0.1.0"\n'
+            "dependencies = [\"somepkg; python_full_version ~= '3'\"]\n",
+        )
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, output=Path("-"), offline=True)
+
+        err = capsys.readouterr().err
+        assert 'cannot lock: marker python_full_version ~= "3"' in err
+        assert "cannot be evaluated" in err
+        assert "Traceback" not in err
+
     def test_sibling_metadata_divergence_exits(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -3542,6 +3564,35 @@ class TestLockedFlag:
                 ],
                 prog="nab",
             )
+
+    def test_unevaluable_root_marker_leaves_the_error_to_the_resolve(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The pre-resolve validity check reads the root requirements too.
+
+        A self-referencing extra gated on a marker no comparison decides is a
+        project nab cannot read, not a stale lock, so the checks are skipped
+        and the resolve reports it.
+        """
+        pyproject = _make_pyproject(
+            tmp_path,
+            '[project]\nname = "probe"\nversion = "0.1.0"\ndependencies = []\n'
+            "[project.optional-dependencies]\n"
+            'fast = ["somepkg"]\n'
+            "all = [\"probe[fast]; python_full_version ~= '3'\"]\n",
+        )
+        out = tmp_path / "pylock.toml"
+        out.write_text(
+            'lock-version = "1.0"\ncreated-by = "nab"\n'
+            'extras = ["all"]\npackages = []\n'
+        )
+        with pytest.raises(SystemExit, match="1"):
+            lock(pyproject, output=out, locked=True, offline=True, extras=("all",))
+
+        err = capsys.readouterr().err
+        assert 'cannot lock: marker python_full_version ~= "3"' in err
+        assert "--locked" not in err
+        assert "Traceback" not in err
 
     def test_up_to_date_exits_zero_without_writing(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
`python_full_version ~= "3"` is a valid PEP 508 marker, and PEP 440 gives the compatible-release operator no meaning over a single-component release, so nothing evaluates the clause. A pyproject with `dependencies = ["somepkg; python_full_version ~= '3'"]` and `nab lock --offline` crashed with an uncaught `UndefinedComparison` traceback out of the vendored marker algebra. It needs no matrix and no `--python`, and `sys_platform ~= "linux"` reaches the same place on a variable that carries no version at all.

Marker sets are built in three places that read the project's own requirements: the resolve-time filter, the self-referencing-extra walk, and the pre-resolve `--locked` check. Routing all three through one helper turns the vendored exception into an error naming the whole marker, which the CLI prints as a plain error, and lets the `--locked` fast path defer to the resolve the way it does for a project whose requirements it cannot read. A candidate's own metadata keeps its route: `get_dependencies` turns an unreadable marker into a candidate skip.
