### PR TITLE
drop the vendored subset and disjoint interval walks

### DIFF
--- a/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
+++ b/nab-python/src/nab_python/_vendor/packaging/PROVENANCE.md
@@ -16,11 +16,9 @@ plus at most one checked-in patch, and nothing else.
     `release_intervals`, and `relation` with its `RangeRelation` result type
     and the member aliases the return paths bind;
     an `assume_sorted` keyword on `filter` and the
-    `VersionRange._filter_sorted` it dispatches to; `is_subset` and
-    `is_disjoint` answered by a direct walk over the interval lists instead of
-    an intermediate range; the module-level helpers they need (`_relate_bounds`,
-    `_subset_bounds`, `_disjoint_bounds`, `_bisect_predicate`,
-    `_partition_indexes`, `_make_project`, `_check_order`, `_lattice_release`,
+    `VersionRange._filter_sorted` it dispatches to; the module-level helpers
+    they need (`_relate_bounds`, `_bisect_predicate`, `_partition_indexes`,
+    `_make_project`, `_check_order`, `_lattice_release`,
     `_release_boundary_point`); the `RangeRelation` and `SortedOrder` `__all__`
     entries; and the class-docstring lines naming them.
   - `_ranges.py`: an unbounded end canonicalizes its inclusivity, and
@@ -31,11 +29,10 @@ plus at most one checked-in patch, and nothing else.
     private engine behind it, both new files, plus the `Marker.to_set`
     accessor they need on `markers.py`.
 
-  Upstream PRs are planned for the bound ordering, the direct subset and
-  disjoint walks, `filter`'s `assume_sorted` fast path, and
-  `from_bounds`/`snap_bounds`/`release_intervals`.
-  `relation` is deliberately not proposed yet: most of its win is available
-  from the direct walks alone, and what is left depends on the interval shapes.
+  Upstream PRs are planned for the bound ordering, `filter`'s `assume_sorted`
+  fast path, and `from_bounds`/`snap_bounds`/`release_intervals`.
+  `relation` is deliberately not proposed yet: what it wins over asking the two
+  predicates separately depends on the interval shapes, and that is unmeasured.
 - `tasks/vendor-packaging.sh` fetches `pypa/packaging` at the pin, replaces this
   package with the pristine `src/packaging/` tree plus the repo-root license
   texts, and reapplies the patch. `--check` rebuilds into a temp location and

--- a/nab-python/src/nab_python/_vendor/packaging/ranges.py
+++ b/nab-python/src/nab_python/_vendor/packaging/ranges.py
@@ -219,53 +219,6 @@ def _relate_bounds(
     return _DISJOINT_REL if disjoint else _OVERLAPPING_REL
 
 
-def _subset_bounds(left: Sequence[Interval], right: Sequence[Interval]) -> bool:
-    """Return whether every version in ``left`` is also in ``right``.
-
-    The canonical lists let one two-pointer walk decide containment: skip the
-    right intervals that end too early, then check that the surviving one starts
-    early enough.
-    """
-    right_index = 0
-    right_len = len(right)
-    for left_lower, left_upper in left:
-        # A right interval ending below this one cannot cover it, and the left
-        # list ascends, so it cannot cover any later one either.
-        while right_index < right_len and right[right_index][1] < left_upper:
-            right_index += 1
-        if right_index == right_len:
-            return False
-        if right[right_index][0] > left_lower:
-            return False
-    return True
-
-
-def _disjoint_bounds(left: Sequence[Interval], right: Sequence[Interval]) -> bool:
-    """Return whether no version lies in both ``left`` and ``right``.
-
-    A two-pointer merge that stops at the first overlap.
-    """
-    left_index = right_index = 0
-    left_len = len(left)
-    right_len = len(right)
-    while left_index < left_len and right_index < right_len:
-        left_lower, left_upper = left[left_index]
-        right_lower, right_upper = right[right_index]
-
-        lower = max(left_lower, right_lower)
-        upper = min(left_upper, right_upper)
-        if not range_is_empty(lower, upper):
-            return False
-
-        # Advance whichever side has the smaller upper bound.
-        if left_upper < right_upper:
-            left_index += 1
-        else:
-            right_index += 1
-
-    return True
-
-
 def _complement_ranges(ranges: Sequence[Interval]) -> list[Interval]:
     """Complement a sorted, non-overlapping interval list.
 
@@ -1797,15 +1750,6 @@ class VersionRange:
         False
         >>> VersionRange.empty().is_subset(outer)
         True
-
-        A range with an exclusion is a subset of its span, but the span is not a
-        subset of it:
-
-        >>> punctured = SpecifierSet(">=1.0,<2.0,!=1.5").to_range()
-        >>> punctured.is_subset(outer)
-        True
-        >>> outer.is_subset(punctured)
-        False
         """
         self._check_policy_compat(other)
 
@@ -1816,7 +1760,7 @@ class VersionRange:
 
         # Plain ranges: subset reduces to bounds containment, no algebra needed.
         if self._is_plain() and other._is_plain():
-            return _subset_bounds(self._bounds, other._bounds)
+            return not intersect_ranges(self._bounds, _complement_ranges(other._bounds))
 
         # difference (unlike intersection with the one-way complement) resolves
         # ``===`` literals against both operands, so it stays correct for them.
@@ -1892,19 +1836,12 @@ class VersionRange:
         True
         >>> a.is_disjoint(SpecifierSet(">=1.5,<2.5").to_range())
         False
-
-        A range pinned to a version the other excludes is disjoint from it:
-
-        >>> SpecifierSet("==1.5").to_range().is_disjoint(
-        ...     SpecifierSet(">=1.0,<2.0,!=1.5").to_range()
-        ... )
-        True
         """
         self._check_policy_compat(other)
 
         # Plain ranges: disjointness is an empty bounds intersection.
         if self._is_plain() and other._is_plain():
-            return _disjoint_bounds(self._bounds, other._bounds)
+            return not intersect_ranges(self._bounds, other._bounds)
         return self.intersection(other).is_empty
 
     def _same_releases(self, other: VersionRange) -> bool:

--- a/nab-python/tests/test_vendor_bound_ordering.py
+++ b/nab-python/tests/test_vendor_bound_ordering.py
@@ -23,12 +23,9 @@ from nab_python._vendor.packaging._ranges import (
     BoundaryVersion,
     LowerBound,
     UpperBound,
+    intersect_ranges,
 )
-from nab_python._vendor.packaging.ranges import (
-    RangeRelation,
-    _relate_bounds,
-    _subset_bounds,
-)
+from nab_python._vendor.packaging.ranges import RangeRelation, _relate_bounds
 from nab_python._vendor.packaging.version import Version
 
 if TYPE_CHECKING:
@@ -188,16 +185,16 @@ class TestBoundOrdering:
                 assert pick(right, left) is right
 
     def test_the_interval_walks_see_one_unbounded_point(self) -> None:
-        # _relate_bounds reads coverage off the identity max() and min() hand
-        # back, and _subset_bounds compares the lower bounds outright, so an
-        # unbounded end spelled either way has to be the same point to both.
+        # _relate_bounds and intersect_ranges both read coverage off the identity
+        # max() and min() hand back, so an unbounded end spelled either way has
+        # to be the same point to both.
         left = [
             (LowerBound(None, inclusive=True), UpperBound(V("2.0"), inclusive=False))
         ]
         right = [(NEG_INF, POS_INF)]
         assert _relate_bounds(left, right) is RangeRelation.SUBSET
         assert _relate_bounds(right, left) is RangeRelation.OVERLAPPING
-        assert _subset_bounds(left, right)
+        assert intersect_ranges(left, right) == left
 
     @pytest.mark.parametrize("operator", ["__lt__", "__gt__", "__ge__", "__le__"])
     @pytest.mark.parametrize("cls", [LowerBound, UpperBound])

--- a/nab-python/tests/test_vendor_subset_disjoint.py
+++ b/nab-python/tests/test_vendor_subset_disjoint.py
@@ -1,11 +1,10 @@
-"""Tests for the vendored patch's bounds-only subset and disjointness walks.
+"""Tests for the vendored ``is_subset`` and ``is_disjoint`` predicates.
 
-``is_subset`` and ``is_disjoint`` take a two-pointer walk over the interval
-lists whenever both operands are plain, so every answer is checked against the
-set-algebra oracle it replaces (``(a - b).is_empty`` and ``(a & b).is_empty``)
-and against pointwise membership over a version pool. The population runs the
-algebra over specifier-built ranges first, which reaches interval shapes no
-specifier writes.
+Both take a bounds-only path whenever the operands are plain, so every answer is
+checked against the set-algebra oracle it stands in for (``(a - b).is_empty`` and
+``(a & b).is_empty``) and against pointwise membership over a version pool. The
+population runs the algebra over specifier-built ranges first, which reaches
+interval shapes no specifier writes.
 """
 
 from __future__ import annotations

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -2181,7 +2181,7 @@ index 0000000..74930e7
 +    def __repr__(self) -> str:
 +        return f"<{type(self).__name__} {_markersets.describe(self._tree)!r}>"
 diff --git a/nab-python/src/nab_python/_vendor/packaging/ranges.py b/nab-python/src/nab_python/_vendor/packaging/ranges.py
-index 8144a65..b94c447 100644
+index 8144a65..1e336ff 100644
 --- a/nab-python/src/nab_python/_vendor/packaging/ranges.py
 +++ b/nab-python/src/nab_python/_vendor/packaging/ranges.py
 @@ -24,6 +24,7 @@ import typing
@@ -2235,7 +2235,7 @@ index 8144a65..b94c447 100644
  
  #: The most ``!=`` exclusion fragments (``!=V`` points or ``!=P.*`` prefixes)
  #: that :meth:`VersionRange.to_specifier_set` will materialize to spell a
-@@ -144,6 +175,97 @@ def _union_ranges(
+@@ -144,6 +175,50 @@ def _union_ranges(
      return merged
  
  
@@ -2283,57 +2283,10 @@ index 8144a65..b94c447 100644
 +    return _DISJOINT_REL if disjoint else _OVERLAPPING_REL
 +
 +
-+def _subset_bounds(left: Sequence[Interval], right: Sequence[Interval]) -> bool:
-+    """Return whether every version in ``left`` is also in ``right``.
-+
-+    The canonical lists let one two-pointer walk decide containment: skip the
-+    right intervals that end too early, then check that the surviving one starts
-+    early enough.
-+    """
-+    right_index = 0
-+    right_len = len(right)
-+    for left_lower, left_upper in left:
-+        # A right interval ending below this one cannot cover it, and the left
-+        # list ascends, so it cannot cover any later one either.
-+        while right_index < right_len and right[right_index][1] < left_upper:
-+            right_index += 1
-+        if right_index == right_len:
-+            return False
-+        if right[right_index][0] > left_lower:
-+            return False
-+    return True
-+
-+
-+def _disjoint_bounds(left: Sequence[Interval], right: Sequence[Interval]) -> bool:
-+    """Return whether no version lies in both ``left`` and ``right``.
-+
-+    A two-pointer merge that stops at the first overlap.
-+    """
-+    left_index = right_index = 0
-+    left_len = len(left)
-+    right_len = len(right)
-+    while left_index < left_len and right_index < right_len:
-+        left_lower, left_upper = left[left_index]
-+        right_lower, right_upper = right[right_index]
-+
-+        lower = max(left_lower, right_lower)
-+        upper = min(left_upper, right_upper)
-+        if not range_is_empty(lower, upper):
-+            return False
-+
-+        # Advance whichever side has the smaller upper bound.
-+        if left_upper < right_upper:
-+            left_index += 1
-+        else:
-+            right_index += 1
-+
-+    return True
-+
-+
  def _complement_ranges(ranges: Sequence[Interval]) -> list[Interval]:
      """Complement a sorted, non-overlapping interval list.
  
-@@ -293,6 +415,142 @@ def _struct_admits(
+@@ -293,6 +368,142 @@ def _struct_admits(
      return matches_bounds_only(bounds, parsed)
  
  
@@ -2476,7 +2429,7 @@ index 8144a65..b94c447 100644
  # Repr helpers:
  
  
-@@ -905,7 +1163,8 @@ class VersionRange:
+@@ -905,7 +1116,8 @@ class VersionRange:
      :class:`~packaging.specifiers.SpecifierSet`.
  
      Construct via :meth:`~packaging.specifiers.SpecifierSet.to_range`, or with
@@ -2486,7 +2439,7 @@ index 8144a65..b94c447 100644
      Compose with :meth:`intersection`, :meth:`union`, :meth:`complement`, and
      :meth:`difference` (or the ``&`` / ``|`` / ``~`` / ``-`` operators). Test
      membership with ``in`` or :meth:`contains`, filter an iterable with
-@@ -920,9 +1179,9 @@ class VersionRange:
+@@ -920,9 +1132,9 @@ class VersionRange:
      that opt-in scoped to those versions, so unrelated pre-releases are not
      admitted wholesale.
  
@@ -2499,7 +2452,7 @@ index 8144a65..b94c447 100644
  
      >>> r = SpecifierSet(">=1.0,<2.0").to_range()
      >>> "1.5" in r
-@@ -998,7 +1257,8 @@ class VersionRange:
+@@ -998,7 +1210,8 @@ class VersionRange:
          raise TypeError(
              "cannot create 'VersionRange' instances directly; use "
              "SpecifierSet.to_range(), VersionRange.full(), "
@@ -2509,7 +2462,7 @@ index 8144a65..b94c447 100644
          )
  
      @classmethod
-@@ -1190,6 +1450,73 @@ class VersionRange:
+@@ -1190,6 +1403,73 @@ class VersionRange:
              prereleases_configured=prereleases,
          )
  
@@ -2583,30 +2536,7 @@ index 8144a65..b94c447 100644
      def intersection(self, other: VersionRange) -> VersionRange:
          """Range containing exactly the versions in both self and other.
  
-@@ -1470,6 +1797,15 @@ class VersionRange:
-         False
-         >>> VersionRange.empty().is_subset(outer)
-         True
-+
-+        A range with an exclusion is a subset of its span, but the span is not a
-+        subset of it:
-+
-+        >>> punctured = SpecifierSet(">=1.0,<2.0,!=1.5").to_range()
-+        >>> punctured.is_subset(outer)
-+        True
-+        >>> outer.is_subset(punctured)
-+        False
-         """
-         self._check_policy_compat(other)
- 
-@@ -1480,12 +1816,52 @@ class VersionRange:
- 
-         # Plain ranges: subset reduces to bounds containment, no algebra needed.
-         if self._is_plain() and other._is_plain():
--            return not intersect_ranges(self._bounds, _complement_ranges(other._bounds))
-+            return _subset_bounds(self._bounds, other._bounds)
- 
-         # difference (unlike intersection with the one-way complement) resolves
+@@ -1486,6 +1766,46 @@ class VersionRange:
          # ``===`` literals against both operands, so it stays correct for them.
          return self.difference(other).is_empty
  
@@ -2653,28 +2583,7 @@ index 8144a65..b94c447 100644
      def is_superset(self, other: VersionRange) -> bool:
          """Return whether every member of other is also a member of self.
  
-@@ -1516,12 +1892,19 @@ class VersionRange:
-         True
-         >>> a.is_disjoint(SpecifierSet(">=1.5,<2.5").to_range())
-         False
-+
-+        A range pinned to a version the other excludes is disjoint from it:
-+
-+        >>> SpecifierSet("==1.5").to_range().is_disjoint(
-+        ...     SpecifierSet(">=1.0,<2.0,!=1.5").to_range()
-+        ... )
-+        True
-         """
-         self._check_policy_compat(other)
- 
-         # Plain ranges: disjointness is an empty bounds intersection.
-         if self._is_plain() and other._is_plain():
--            return not intersect_ranges(self._bounds, other._bounds)
-+            return _disjoint_bounds(self._bounds, other._bounds)
-         return self.intersection(other).is_empty
- 
-     def _same_releases(self, other: VersionRange) -> bool:
-@@ -1540,6 +1923,8 @@ class VersionRange:
+@@ -1540,6 +1860,8 @@ class VersionRange:
          iterable: Iterable[UnparsedVersionVar],
          prereleases: bool | None = None,
          key: None = ...,
@@ -2683,7 +2592,7 @@ index 8144a65..b94c447 100644
      ) -> Iterator[UnparsedVersionVar]: ...
  
      @typing.overload
-@@ -1548,6 +1933,28 @@ class VersionRange:
+@@ -1548,6 +1870,28 @@ class VersionRange:
          iterable: Iterable[T],
          prereleases: bool | None = None,
          key: Callable[[T], UnparsedVersion] = ...,
@@ -2712,7 +2621,7 @@ index 8144a65..b94c447 100644
      ) -> Iterator[T]: ...
  
      def filter(
-@@ -1555,6 +1962,8 @@ class VersionRange:
+@@ -1555,6 +1899,8 @@ class VersionRange:
          iterable: Iterable[Any],
          prereleases: bool | None = None,
          key: Callable[[Any], Version | str] | None = None,
@@ -2721,7 +2630,7 @@ index 8144a65..b94c447 100644
      ) -> Iterator[Any]:
          """Yield items from iterable whose version falls inside the range.
  
-@@ -1565,13 +1974,56 @@ class VersionRange:
+@@ -1565,13 +1911,56 @@ class VersionRange:
          ``prereleases=True`` would yield it). A flushed buffer comes after
          every in-place yield, so the output is not version-sorted.
  
@@ -2779,7 +2688,7 @@ index 8144a65..b94c447 100644
          region: tuple[Interval, ...] = ()
          if prereleases is None:
              # The region applies only under the autodetect default; a configured
-@@ -1579,19 +2031,93 @@ class VersionRange:
+@@ -1579,19 +1968,93 @@ class VersionRange:
              prereleases = self._prereleases_configured
              region = self._pre_region
  
@@ -2878,7 +2787,7 @@ index 8144a65..b94c447 100644
      def _filter_with_admission(
          self,
          iterable: Iterable[Any],
-@@ -1679,6 +2205,123 @@ class VersionRange:
+@@ -1679,6 +2142,123 @@ class VersionRange:
          if not found_final:
              yield from all_nonfinal
  


### PR DESCRIPTION
nab's vendored packaging patch answers `VersionRange.is_subset` and `is_disjoint` with two-pointer walks over the interval lists. Released packaging already answers both from the same plain-range fast path and reaches the same answers, so the fork only changes how they are computed.

The speedup that justified the walks was measured against `difference().is_empty`, which is not what the pinned commit ships, so they have never been compared against the baseline they actually replace.

Counting the calls settles it:

- 3,794 across the nineteen canary scenarios.
- 8,636 across skypilot-dvc, langchain-gretel and two `apache-airflow[all]` resolves.
- 85 to 90 percent of those sit at a single interval on each side.

That is too few calls for any per-call difference to reach wall time, so both predicates go back to pristine and the patch loses 91 lines.
