### PR TITLE
Drop nab-resolver's typing_extensions dependency

### DIFF
--- a/nab-resolver/README.md
+++ b/nab-resolver/README.md
@@ -6,6 +6,8 @@ package is a SAT-style solver core.  The Python provider lives in
 [`nab-python`](https://pypi.org/project/nab-python/) and the
 user-facing CLI in [`nab`](https://pypi.org/project/nab/).
 
+It has no runtime dependencies: the standard library is all it needs.
+
 ## When to use it
 
 Use `nab-resolver` when you are building some kind of package

--- a/nab-resolver/pyproject.toml
+++ b/nab-resolver/pyproject.toml
@@ -19,9 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
-dependencies = [
-    "typing_extensions>=4.10",
-]
+dependencies = []
 
 [project.urls]
 Homepage = "https://github.com/notatallshaw/nab"

--- a/nab-resolver/src/nab_resolver/_compat.py
+++ b/nab-resolver/src/nab_resolver/_compat.py
@@ -1,0 +1,22 @@
+"""Runtime fallback for typing helpers, so nab-resolver needs no third-party install.
+
+``override`` runs at class-body time, so unlike the annotation-only helpers it
+cannot hide under ``TYPE_CHECKING``.  It is looked up by name rather than by
+interpreter version, which keeps this free of a version-gated branch.  Before
+3.12 the fallback is the identity and so does not set ``__override__``, which
+nothing here reads.
+"""
+
+from __future__ import annotations
+
+import typing
+from typing import TYPE_CHECKING
+
+__all__ = [
+    "override",
+]
+
+if TYPE_CHECKING:
+    from typing_extensions import override
+else:
+    override = getattr(typing, "override", lambda method: method)

--- a/nab-resolver/src/nab_resolver/ranges.py
+++ b/nab-resolver/src/nab_resolver/ranges.py
@@ -14,8 +14,7 @@ from __future__ import annotations
 
 from typing import Any, Generic, TypeAlias
 
-from typing_extensions import override
-
+from ._compat import override
 from .types import RangeRelation, VersionType
 
 # Bound once so the hot return paths load a module global instead of a class

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -23,9 +23,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Generic, Protocol
-
-from typing_extensions import TypeIs
+from typing import TYPE_CHECKING, Any, Generic, Protocol
 
 from . import conflict, decide, incompat_index, propagate
 from .errors import ResolutionError
@@ -44,6 +42,9 @@ from .types import (
     Term,
     VersionType,
 )
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeIs
 
 __all__ = [
     "Incompatibility",
@@ -278,17 +279,20 @@ class ResolverObserver(Generic[PackageType, VersionType]):
         """Handle one iteration of the conflict resolution loop."""
 
 
-def _is_range_mapping(
+def _is_root_sequence(
     requirements: Mapping[PackageType, RangeProtocol[VersionType]]
     | Sequence[RootRequirement[PackageType, VersionType]],
-) -> TypeIs[Mapping[PackageType, RangeProtocol[VersionType]]]:
-    """Return whether the caller passed the one-range-per-package form.
+) -> TypeIs[Sequence[RootRequirement[PackageType, VersionType]]]:
+    """Return whether the caller passed the one-clause-per-requirement form.
 
     A ``TypeIs`` rather than a bare ``isinstance``: one type can satisfy both
     members of the union, so plain narrowing can leave an intersection that
-    has lost the mapping's value type.
+    has lost the mapping's value type.  ty needs the sequence rather than the
+    mapping as the narrowed side to keep those parameters, while the test
+    itself stays on ``Mapping`` so every non-mapping iterable is still taken
+    as the sequence form.
     """
-    return isinstance(requirements, Mapping)
+    return not isinstance(requirements, Mapping)
 
 
 def _as_root_requirements(
@@ -296,7 +300,7 @@ def _as_root_requirements(
     | Sequence[RootRequirement[PackageType, VersionType]],
 ) -> Sequence[RootRequirement[PackageType, VersionType]]:
     """Accept either shape ``Resolver.resolve`` takes and return the sequence."""
-    if not _is_range_mapping(requirements):
+    if _is_root_sequence(requirements):
         return requirements
     # The parameters are spelled out because ``constraint`` is a contravariant
     # protocol, which gives the version parameter no inference site.

--- a/nab-resolver/src/nab_resolver/root.py
+++ b/nab-resolver/src/nab_resolver/root.py
@@ -7,7 +7,7 @@ time (which would create a cycle).
 
 from __future__ import annotations
 
-from typing_extensions import override
+from ._compat import override
 
 __all__ = [
     "ROOT",

--- a/nab-resolver/src/nab_resolver/types.py
+++ b/nab-resolver/src/nab_resolver/types.py
@@ -12,9 +12,13 @@ Reference: https://github.com/dart-lang/pub/blob/master/doc/solver.md#definition
 from __future__ import annotations
 
 import enum
-from typing import Any, Generic, Protocol, TypeVar
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
 
-from typing_extensions import NamedTuple, Self, override
+from ._compat import override
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 __all__ = [
     "Incompatibility",
@@ -237,7 +241,11 @@ class RelationProtocol(Protocol):
         ...
 
 
-class RootRequirement(NamedTuple, Generic[PackageType, VersionType]):
+# No ``slots=True``: on 3.10 a frozen slotted dataclass raises TypeError when
+# ``typing._GenericAlias.__call__`` sets ``__orig_class__``, which the
+# subscripted construction in ``resolver._as_root_requirements`` triggers.
+@dataclass(frozen=True)
+class RootRequirement(Generic[PackageType, VersionType]):
     """One requirement as the caller wrote it, kept as its own clause.
 
     A caller that passes a mapping has to intersect its requirements on a

--- a/nab-resolver/tests/test_stdlib_only.py
+++ b/nab-resolver/tests/test_stdlib_only.py
@@ -1,0 +1,26 @@
+"""nab_resolver must import without typing_extensions, the dependency it used to declare."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+_PROBE = """
+import importlib
+import pkgutil
+import sys
+
+sys.modules["typing_extensions"] = None
+
+import nab_resolver
+
+names = sorted(module.name for module in pkgutil.iter_modules(nab_resolver.__path__))
+assert names, "found no nab_resolver submodules to import"
+for name in names:
+    importlib.import_module(f"nab_resolver.{name}")
+"""
+
+
+def test_imports_without_typing_extensions() -> None:
+    """Every submodule imports with typing_extensions blocked."""
+    subprocess.run([sys.executable, "-c", _PROBE], check=True)  # noqa: S603

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ types = [
     "pyright>=1.1.400",
     "ty>=0.0.20",
     "pyrefly>=0.50",
+    "typing_extensions>=4.10",
     "zuban>=0.6",
 ]
 pre-commit = [


### PR DESCRIPTION
nab-resolver declared typing_extensions purely for typing helpers. `Self`, `TypeIs` and the `NamedTuple` base are only needed by type checkers, and `override` comes from `typing` on 3.12 and later with a one-line fallback below that, so the package now ships with no runtime dependencies at all.

The obstacle was `RootRequirement`, a generic `NamedTuple`, which 3.10 rejects outright with "Multiple inheritance with NamedTuple is not supported" against nab's 3.10 floor. It becomes a frozen dataclass, which is generic on every supported version; nothing in the workspace uses its tuple behaviour and it has not been in a release. Verified on a clean 3.10 environment with only nab-resolver installed and typing_extensions absent.
