### PR TITLE
Run platform-specific benchmarks only on matching hosts

### DIFF
--- a/nab-python/benchmarks/README.md
+++ b/nab-python/benchmarks/README.md
@@ -42,7 +42,7 @@ python nab-python/benchmarks/_profile_runner.py \
 
 `strategy_sweep.py` is a compatibility alias for `scenarios.py --strategy-matrix`; it does not implement another resolver or result format. Retired selections such as `--toml pip-lowest` fail with the canonical replacement command.
 
-Each run initializes `_standard_manifest.json` as incomplete before resolving anything. It becomes complete only after every selected supported execution has an exact, valid result; every selected unsupported scenario is declared; no result is missing or extra; and the source tree is clean. The manifest records the full source identity at both run boundaries, corpus hash, execution settings, strategies, selected files, and exact available, selected, completed, and unsupported logical and execution key sets. A missing, malformed, dirty, source-changing, or incomplete manifest does not describe a valid run. Reusing a result label resumes only when that manifest describes the same mode, strategy set, corpus, and selection. Use a new label or `--force` when any of those inputs changes. `--force` replaces the standard JSON results for the label while preserving universal results and top-level provenance.
+Each run initializes `_standard_manifest.json` as incomplete before resolving anything. It becomes complete only after every applicable execution has an exact, valid result; every unsupported or host-inapplicable scenario is accounted for; no result is missing or extra; and the source tree is clean. The manifest records the source identity at both run boundaries, corpus hash, execution settings, physical host identity, strategies, selected files, and terminal key sets. Reusing a result label requires the same mode, corpus, selection, and host. Use a new label or `--force` when any of those inputs changes. `--force` replaces the standard JSON results for the label while preserving universal results and top-level provenance.
 
 ### Canary subset
 
@@ -75,6 +75,8 @@ Benchmark outputs are local run artifacts rather than repository baselines. Gene
 ## Scenario shape
 
 Each single-environment scenario is a top-level TOML table keyed by name, with at least `requirements` and a fixed `datetime` (used as the `uploaded-prior-to` cutoff). Optional single-environment knobs include constraints, marker overlays, distribution policy, and build policy.
+
+Marker overrides on the wheel-tag axes also declare which physical hosts may run a scenario. A Windows marker scenario is inapplicable on Linux rather than resolving with Windows markers and Linux wheel tags. A top-level `platform_system` restricts the OS family. An exact target sets `platform_system`, `sys_platform`, `os_name`, `platform_machine`, `implementation_name`, and `platform_python_implementation` together.
 
 Universal scenarios require `python`, `platforms`, and `requirements`. They may also set constraints, a cutoff, Python ordering, alignment, resolution strategy, an explanatory reason, and expected-failure handling.
 

--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -68,6 +68,7 @@ def build_inputs(
     name: str,
     scenario: dict,
     resolution_override: sc.ResolutionStrategy | None = None,
+    host: sc.BenchmarkHost | None = None,
 ) -> dict:
     python_version = scenario["python_version"]
     requirement_strings = list(scenario["requirements"])
@@ -79,6 +80,12 @@ def build_inputs(
         marker_environment,
         build_policy_overrides,
     )
+    effective_host = host or sc.BenchmarkHost.current(sc.SCENARIO_WALL_TIMEOUT_SECONDS)
+    admission = effective_host.target_for(python_version, marker_environment)
+    if admission.target is None:
+        msg = f"{name}: benchmark is inapplicable: {admission.inapplicable_reason}"
+        raise SystemExit(msg)
+    target = admission.target
 
     declared_resolution = sc.ResolutionStrategy(
         scenario.get("resolution", sc.ResolutionStrategy.HIGHEST.value)
@@ -98,7 +105,7 @@ def build_inputs(
             scenario.get("optional_dependencies", {}),
         )
 
-    marker_env = sc.scenario_marker_env(python_version, marker_environment)
+    marker_env = dict(target.marker_env)
     requirements = sc.parse_requirements(
         requirement_strings, vcs_config=vcs_config, marker_environment=marker_env
     )
@@ -113,14 +120,14 @@ def build_inputs(
     datetime_str = scenario.get("datetime")
     return {
         "requirements": requirements,
-        "python_version": python_version,
         "uploaded_prior_to": sc.parse_datetime(datetime_str) if datetime_str else None,
         "constraints": constraints,
-        "marker_environment": marker_environment or None,
         "indexes": sc.parse_indexes(name, scenario),
         "index_routes": sc.parse_index_routes(name, scenario) or None,
         "build_policy_overrides": build_policy_overrides or None,
         "resolution_strategy": resolution_strategy,
+        "target": target,
+        "host": effective_host,
     }
 
 
@@ -154,7 +161,8 @@ def main() -> None:
     resolution_override = (
         sc.ResolutionStrategy(args.resolution) if args.resolution is not None else None
     )
-    inputs = build_inputs(name, scenario, resolution_override)
+    host = sc.BenchmarkHost.current(sc.SCENARIO_WALL_TIMEOUT_SECONDS)
+    inputs = build_inputs(name, scenario, resolution_override, host)
 
     if not args.cprofile:
         report(name, sc.resolve_scenario(**inputs))

--- a/nab-python/benchmarks/benchmark_host.py
+++ b/nab-python/benchmarks/benchmark_host.py
@@ -1,0 +1,172 @@
+"""Physical-host admission shared by the benchmark runners."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import signal
+import sys
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from nab_python.target import IMPLEMENTATION_MARKERS, PLATFORM_MARKERS, ResolveTarget
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping
+
+
+HOST_TAG_MISMATCH_REASON = (
+    "marker environment requires wheel tags from a different host"
+)
+
+
+class BenchmarkTimeout(BaseException):
+    """Escape resolver exception handlers when a benchmark exceeds its limit."""
+
+
+def _marker_family_matches(
+    marker_environment: Mapping[str, str],
+    candidates: Mapping[str, Mapping[str, str]],
+) -> bool:
+    candidate_keys = {key for candidate in candidates.values() for key in candidate}
+    declared = {
+        key: value for key, value in marker_environment.items() if key in candidate_keys
+    }
+    return not declared or any(
+        all(candidate.get(key) == value for key, value in declared.items())
+        for candidate in candidates.values()
+    )
+
+
+def validate_target_marker_environment(
+    scenario_name: str,
+    marker_environment: Mapping[str, str],
+) -> None:
+    """Reject host restrictions that cannot describe a supported target."""
+    if not _marker_family_matches(marker_environment, PLATFORM_MARKERS):
+        msg = f"{scenario_name}: marker_environment describes no supported platform"
+        raise ValueError(msg)
+    if not _marker_family_matches(marker_environment, IMPLEMENTATION_MARKERS):
+        msg = f"{scenario_name}: marker_environment describes no supported interpreter"
+        raise ValueError(msg)
+
+
+def parse_target_marker_environment(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+) -> dict[str, str]:
+    """Read and validate one scenario's physical-target marker overrides."""
+    raw = scenario.get("marker_environment", {})
+    if not isinstance(raw, dict) or any(
+        type(key) is not str or type(value) is not str for key, value in raw.items()
+    ):
+        msg = f"{scenario_name}: marker_environment must be a table of strings"
+        raise TypeError(msg)
+
+    marker_environment = dict(raw)
+    platform_system = scenario.get("platform_system")
+    if platform_system is not None:
+        if type(platform_system) is not str or not platform_system:
+            msg = f"{scenario_name}: platform_system must be a non-empty string"
+            raise TypeError(msg)
+        declared_system = marker_environment.get("platform_system")
+        if declared_system is not None and declared_system != platform_system:
+            msg = f"{scenario_name}: platform_system conflicts with marker_environment"
+            raise ValueError(msg)
+        marker_environment["platform_system"] = platform_system
+
+    validate_target_marker_environment(scenario_name, marker_environment)
+    return marker_environment
+
+
+@dataclass(frozen=True, slots=True)
+class TargetAdmission:
+    """A faithful resolve target, or the reason this host cannot provide one."""
+
+    target: ResolveTarget | None
+    inapplicable_reason: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkHost:
+    """One captured interpreter, marker environment, and wheel-tag set."""
+
+    target: ResolveTarget
+    python_runtime: str
+    wall_timeout_seconds: int | None
+
+    @classmethod
+    def current(cls, wall_timeout_seconds: int) -> BenchmarkHost:
+        """Capture the current host and its available timeout mechanism."""
+        timeout_available = (
+            getattr(signal, "SIGALRM", None) is not None
+            and getattr(signal, "alarm", None) is not None
+        )
+        return cls(
+            target=ResolveTarget.for_host(),
+            python_runtime=sys.version,
+            wall_timeout_seconds=wall_timeout_seconds if timeout_available else None,
+        )
+
+    def target_for(
+        self,
+        python_version: str,
+        marker_environment: Mapping[str, str],
+    ) -> TargetAdmission:
+        """Build a scenario target when this host can supply faithful tags."""
+        host_markers = self.target.marker_env
+        host_tags = self.target.tags.ordered
+        target = ResolveTarget.for_host_python(
+            python_version,
+            env_source=lambda: host_markers,
+            tags_source=lambda: iter(host_tags),
+        ).with_marker_overrides(marker_environment)
+
+        if not target.tags_faithful:
+            return TargetAdmission(None, HOST_TAG_MISMATCH_REASON)
+        if any(
+            target.marker_env.get(key) != value
+            for key, value in marker_environment.items()
+        ):
+            msg = "resolve target did not retain the scenario marker environment"
+            raise ValueError(msg)
+        return TargetAdmission(target, None)
+
+    def identity(self) -> dict[str, object]:
+        """Return the host fields that determine benchmark execution."""
+        tags = [str(tag) for tag in self.target.tags.ordered]
+        return {
+            "python": self.python_runtime,
+            "marker_environment": dict(sorted(self.target.marker_env.items())),
+            "wheel_tags_count": len(tags),
+            "wheel_tags_hash": hashlib.sha256("\n".join(tags).encode()).hexdigest(),
+        }
+
+    @contextmanager
+    def wall_timeout(self) -> Iterator[None]:
+        """Enforce the captured wall-time limit when this platform supports it."""
+        if self.wall_timeout_seconds is None:
+            yield
+            return
+
+        sigalrm = signal.SIGALRM
+        alarm = signal.alarm
+
+        def handle_timeout(_signum: int, _frame: object) -> None:
+            msg = f"scenario exceeded {self.wall_timeout_seconds}s wall-clock budget"
+            raise BenchmarkTimeout(msg)
+
+        previous_handler = signal.signal(sigalrm, handle_timeout)
+        alarm(self.wall_timeout_seconds)
+        try:
+            yield
+        finally:
+            alarm(0)
+            signal.signal(sigalrm, previous_handler)
+
+
+def settings_hash(settings: Mapping[str, object]) -> str:
+    """Hash the effective settings stored once in the run manifest."""
+    encoded = json.dumps(settings, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -16,24 +16,29 @@ import argparse
 import hashlib
 import json
 import os
-import platform
-import signal
 import statistics
 import subprocess
 import sys
 import time
-from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Mapping
+    from collections.abc import Mapping
+
+    from nab_python.target import ResolveTarget
 
 if sys.version_info >= (3, 11):
     import tomllib
 else:
     import tomli as tomllib  # type: ignore[no-redef]
+
+from benchmark_host import (
+    BenchmarkHost,
+    BenchmarkTimeout,
+    parse_target_marker_environment,
+)
 
 from nab_index.httpx_async_transport import HttpxAsyncTransport
 from nab_index.multi_index import IndexConfig
@@ -58,7 +63,6 @@ from nab_python.provider import (
     VcsPolicy,
     split_extra,
 )
-from nab_python.target import ResolveTarget
 from nab_resolver.resolver import Resolver
 
 BENCHMARKS_DIR = Path(__file__).parent
@@ -87,18 +91,32 @@ class CanaryV2Identity(NamedTuple):
     definition: dict
 
 
+class PreparedCanaryExecution(NamedTuple):
+    """Validated inputs for one or more runs of a canary scenario."""
+
+    requirements: dict[str, VersionRange]
+    uploaded_prior_to: datetime | None
+    constraints: dict[str, VersionRange] | None
+    indexes: list[IndexConfig]
+    index_routes: list[IndexRoute]
+    build_policy_overrides: dict[str, BuildPolicy]
+    resolution_strategy: ResolutionStrategy
+    trust_unverified_sdist_deps: bool
+    target: ResolveTarget
+    host: BenchmarkHost
+
+
+class CanaryPreparation(NamedTuple):
+    """A prepared canary execution, or its host-inapplicable reason."""
+
+    execution: PreparedCanaryExecution | None
+    inapplicable_reason: str | None
+
+
 WALL_TIMEOUT_S = 60
 MAX_ITERATIONS = 50_000
 # Preserve contract v2 for comparisons with existing canary results.
 CANARY_CONTRACT_VERSION = 2
-
-
-class _ScenarioTimeoutError(BaseException):
-    """Raised when a scenario exceeds the per-run wall-clock budget.
-
-    Subclasses BaseException so the resolver's internal ``except Exception``
-    handlers cannot swallow the alarm mid-resolve.
-    """
 
 
 def scenario_input_hash(scenario_name: str, scenario: dict) -> str:
@@ -181,6 +199,7 @@ def get_git_source_state() -> dict[str, str | bool | None]:
 
 
 def _target_manifest(target: ResolveTarget) -> dict[str, object]:
+    """Return the contract-v2 identity of an effective canary target."""
     tags = [str(tag) for tag in target.tags.ordered]
     return {
         "label": target.label,
@@ -193,37 +212,16 @@ def _target_manifest(target: ResolveTarget) -> dict[str, object]:
     }
 
 
-def _runtime_manifest() -> dict[str, str]:
+def _runtime_manifest(host: BenchmarkHost) -> dict[str, str]:
+    """Return the contract-v2 runtime fields from the captured host."""
+    marker_environment = host.target.marker_env
     return {
-        "python": sys.version,
-        "implementation": sys.implementation.name,
-        "system": platform.system(),
-        "release": platform.release(),
-        "machine": platform.machine(),
+        "python": host.python_runtime,
+        "implementation": marker_environment["implementation_name"],
+        "system": marker_environment["platform_system"],
+        "release": marker_environment["platform_release"],
+        "machine": marker_environment["platform_machine"],
     }
-
-
-def _alarm_handler(_signum: int, _frame: object) -> None:
-    msg = f"scenario exceeded {WALL_TIMEOUT_S}s wall-clock budget"
-    raise _ScenarioTimeoutError(msg)
-
-
-@contextmanager
-def _scenario_wall_timeout() -> Iterator[None]:
-    """Install the POSIX wall timer when the platform provides one."""
-    sigalrm = getattr(signal, "SIGALRM", None)
-    alarm = getattr(signal, "alarm", None)
-    if sigalrm is None or alarm is None:
-        yield
-        return
-
-    previous_handler = signal.signal(sigalrm, _alarm_handler)
-    alarm(WALL_TIMEOUT_S)
-    try:
-        yield
-    finally:
-        alarm(0)
-        signal.signal(sigalrm, previous_handler)
 
 
 def expand_project_extras(
@@ -295,33 +293,6 @@ def _full_marker_environment(
     return env
 
 
-_PYTHON_VERSION_PARTS = 2
-
-
-def _resolve_target(
-    python_version: str,
-    marker_environment: dict[str, str] | None,
-) -> ResolveTarget:
-    target = ResolveTarget.for_host_python(python_version)
-    return target.with_marker_overrides(marker_environment or {})
-
-
-def _scenario_marker_env(
-    python_version: str,
-    overlay: dict[str, str],
-) -> dict[str, str]:
-    env = dict(overlay)
-    env.setdefault("python_full_version", python_version)
-    if "python_version" not in env:
-        parts = python_version.split(".")
-        env["python_version"] = (
-            ".".join(parts[:_PYTHON_VERSION_PARTS])
-            if len(parts) >= _PYTHON_VERSION_PARTS
-            else python_version
-        )
-    return env
-
-
 def parse_datetime(value: str) -> datetime:
     dt = datetime.fromisoformat(value)
     if dt.tzinfo is None:
@@ -342,16 +313,16 @@ def get_git_commit() -> str:
 
 def run_one(  # noqa: PLR0913 - one wrapper per scenario knob
     requirements: dict[str, VersionRange],
-    python_version: str,
     uploaded_prior_to: datetime | None,
     constraints: dict[str, VersionRange] | None,
     *,
-    marker_environment: dict[str, str] | None = None,
     indexes: list[IndexConfig] | None = None,
     index_routes: list[IndexRoute] | None = None,
     build_policy_overrides: Mapping[str, BuildPolicy] | None = None,
     resolution_strategy: ResolutionStrategy = ResolutionStrategy.HIGHEST,
     trust_unverified_sdist_deps: bool = False,
+    target: ResolveTarget,
+    host: BenchmarkHost,
 ) -> dict:
     direct_packages = frozenset(
         name for name in requirements if split_extra(name)[1] is None
@@ -366,7 +337,6 @@ def run_one(  # noqa: PLR0913 - one wrapper per scenario knob
         )
         for name, policy in (build_policy_overrides or {}).items()
     )
-    target = _resolve_target(python_version, marker_environment)
     with FetchCoordinator(
         HttpxAsyncTransport(),
         indexes=effective_indexes,
@@ -394,14 +364,14 @@ def run_one(  # noqa: PLR0913 - one wrapper per scenario knob
 
         start = time.monotonic()
         try:
-            with _scenario_wall_timeout():
+            with host.wall_timeout():
                 raw = resolver.resolve(requirements, constraints=constraints)
             elapsed = time.monotonic() - start
             result = {k: v for k, v in raw.items() if split_extra(k)[1] is None}
             success = True
             error = None
             packages = len(result)
-        except (_ScenarioTimeoutError, Exception) as exc:
+        except (BenchmarkTimeout, Exception) as exc:
             elapsed = time.monotonic() - start
             success = False
             error = f"{type(exc).__name__}: {exc}"
@@ -416,8 +386,8 @@ def run_one(  # noqa: PLR0913 - one wrapper per scenario knob
                 "build_policy": BuildPolicy.NEVER.value,
                 "trust_unverified_sdist_deps": trust_unverified_sdist_deps,
                 "max_iterations": MAX_ITERATIONS,
-                "wall_timeout_seconds": WALL_TIMEOUT_S,
-                "runtime": _runtime_manifest(),
+                "wall_timeout_seconds": host.wall_timeout_seconds,
+                "runtime": _runtime_manifest(host),
                 "direct_packages": sorted(direct_packages),
                 "target": _target_manifest(target),
                 "indexes": [
@@ -757,62 +727,34 @@ def canary_v2_identity(
     return CanaryV2Identity(f"{stem}-{resolution.value}:{name}", definition)
 
 
-def median_run(
-    scenario: dict,
-    runs: int,
-    *,
-    scenario_name: str = "canary",
-    resolution_override: ResolutionStrategy | None = None,
-) -> tuple[list[dict], dict]:
-    if "unsupported_reason" in scenario:
-        return [], {"skipped": scenario["unsupported_reason"]}
-
-    python_version = scenario["python_version"]
-    requirement_strings = scenario["requirements"]
-    constraint_strings = scenario.get("constraints", [])
-    platform_system = scenario.get("platform_system")
-    marker_environment_raw = scenario.get("marker_environment", {})
-    if not isinstance(marker_environment_raw, dict):
-        msg = (
-            "marker_environment must be a TOML table of string -> string,"
-            f" got {type(marker_environment_raw).__name__}"
-        )
-        raise TypeError(msg)
-    marker_environment: dict[str, str] = {
-        str(k): str(v) for k, v in marker_environment_raw.items()
-    }
-    if platform_system and "platform_system" not in marker_environment:
-        marker_environment["platform_system"] = platform_system
-    datetime_str = scenario.get("datetime")
-    project_name = scenario.get("project_name")
-    project_extras = scenario.get("project_extras", [])
-    optional_dependencies = scenario.get("optional_dependencies", {})
-    vcs_config = VcsConfig(
-        policy=VcsPolicy(scenario.get("vcs_policy", "block")),
-        allowed_schemes=frozenset(scenario.get("vcs_allowed_schemes", [])),
-        allowed_repos=tuple(scenario.get("vcs_allowed_repos", [])),
-        require_pin=scenario.get("vcs_require_pin", True),
-    )
-
-    if project_name:
-        requirement_strings = [
-            *requirement_strings,
-            *expand_project_extras(project_name, project_extras, optional_dependencies),
-        ]
-
-    raw_indexes = scenario.get("indexes")
-    if raw_indexes is None:
-        indexes = list(DEFAULT_INDEXES)
-    else:
-        indexes = [
-            IndexConfig(name=str(entry["name"]), url=str(entry["url"]))
-            for entry in raw_indexes
-        ]
-    raw_routes = scenario.get("index_routes", [])
-    index_routes = [
-        IndexRoute(name=str(entry["name"]), index=str(entry["index"]))
-        for entry in raw_routes
+def _canary_indexes(scenario: dict) -> list[IndexConfig]:
+    raw = scenario.get("indexes")
+    if raw is None:
+        return list(DEFAULT_INDEXES)
+    return [
+        IndexConfig(name=str(entry["name"]), url=str(entry["url"])) for entry in raw
     ]
+
+
+def _canary_index_routes(scenario: dict) -> list[IndexRoute]:
+    return [
+        IndexRoute(name=str(entry["name"]), index=str(entry["index"]))
+        for entry in scenario.get("index_routes", [])
+    ]
+
+
+def _prepare_canary_execution(
+    scenario: dict,
+    *,
+    scenario_name: str,
+    resolution_override: ResolutionStrategy | None,
+    host: BenchmarkHost,
+) -> CanaryPreparation:
+    """Validate and prepare a supported canary scenario for this host."""
+    python_version = scenario["python_version"]
+    requirement_strings = list(scenario["requirements"])
+    constraint_strings = scenario.get("constraints", [])
+    marker_environment = parse_target_marker_environment(scenario_name, scenario)
     raw_build_packages = scenario.get("build_packages", []) or []
     build_policy_overrides = {
         str(name): BuildPolicy.BUILD_REMOTE for name in raw_build_packages
@@ -823,7 +765,37 @@ def median_run(
             "with a marker environment overlay"
         )
         raise ValueError(msg)
-    requirement_marker_env = _scenario_marker_env(python_version, marker_environment)
+
+    resolution_strategy = scenario_resolution(
+        scenario,
+        scenario_name=scenario_name,
+        override=resolution_override,
+    )
+    vcs_config = VcsConfig(
+        policy=VcsPolicy(scenario.get("vcs_policy", "block")),
+        allowed_schemes=frozenset(scenario.get("vcs_allowed_schemes", [])),
+        allowed_repos=tuple(scenario.get("vcs_allowed_repos", [])),
+        require_pin=scenario.get("vcs_require_pin", True),
+    )
+    indexes = _canary_indexes(scenario)
+    index_routes = _canary_index_routes(scenario)
+
+    admission = host.target_for(python_version, marker_environment)
+    if admission.target is None:
+        return CanaryPreparation(None, admission.inapplicable_reason)
+    target = admission.target
+
+    project_name = scenario.get("project_name")
+    if project_name:
+        requirement_strings.extend(
+            expand_project_extras(
+                project_name,
+                scenario.get("project_extras", []),
+                scenario.get("optional_dependencies", {}),
+            )
+        )
+
+    requirement_marker_env = dict(target.marker_env)
     requirements = parse_requirements(
         requirement_strings,
         vcs_config=vcs_config,
@@ -838,54 +810,92 @@ def median_run(
         if constraint_strings
         else None
     )
-    uploaded_prior_to = parse_datetime(datetime_str) if datetime_str else None
-    resolution_strategy = scenario_resolution(
-        scenario,
-        scenario_name=scenario_name,
-        override=resolution_override,
-    )
     # See scenarios.py: trust pre-2.2 sdist PKG-INFO deps by default so the
     # benchmark measures search, not strict PEP 643 sdist rejection.
     trust_unverified_sdist_deps = bool(
         scenario.get("trust_unverified_sdist_deps", True)
     )
-
-    runs_data: list[dict] = [
-        run_one(
-            requirements,
-            python_version,
-            uploaded_prior_to,
-            constraints,
-            marker_environment=marker_environment or None,
+    datetime_str = scenario.get("datetime")
+    return CanaryPreparation(
+        PreparedCanaryExecution(
+            requirements=requirements,
+            uploaded_prior_to=parse_datetime(datetime_str) if datetime_str else None,
+            constraints=constraints,
             indexes=indexes,
-            index_routes=index_routes or None,
-            build_policy_overrides=build_policy_overrides or None,
+            index_routes=index_routes,
+            build_policy_overrides=build_policy_overrides,
             resolution_strategy=resolution_strategy,
             trust_unverified_sdist_deps=trust_unverified_sdist_deps,
-        )
-        for _ in range(runs)
-    ]
+            target=target,
+            host=host,
+        ),
+        None,
+    )
 
-    def med(key: str) -> float:
-        vals = [r[key] for r in runs_data if isinstance(r.get(key), (int, float))]
-        return statistics.median(vals) if vals else 0
 
-    successes = sum(1 for r in runs_data if r["success"])
-    summary = {
+def _run_prepared_canary(execution: PreparedCanaryExecution) -> dict:
+    return run_one(
+        execution.requirements,
+        execution.uploaded_prior_to,
+        execution.constraints,
+        indexes=execution.indexes,
+        index_routes=execution.index_routes or None,
+        build_policy_overrides=execution.build_policy_overrides or None,
+        resolution_strategy=execution.resolution_strategy,
+        trust_unverified_sdist_deps=execution.trust_unverified_sdist_deps,
+        target=execution.target,
+        host=execution.host,
+    )
+
+
+def _summarize_runs(runs_data: list[dict]) -> dict[str, object]:
+    def median(key: str) -> float:
+        values = [
+            run[key] for run in runs_data if isinstance(run.get(key), (int, float))
+        ]
+        return statistics.median(values) if values else 0
+
+    successes = sum(1 for run in runs_data if run["success"])
+    return {
         "success_runs": f"{successes}/{len(runs_data)}",
-        "median_decisions": int(med("decisions")),
-        "median_distributions_seen": int(med("distributions_seen")),
-        "median_metadata_fetched": int(med("metadata_fetched")),
-        "median_packages": int(med("packages")),
-        "median_conflicts": int(med("conflicts")),
-        "median_backjumps": int(med("backjumps")),
-        "median_wall": round(med("wall_time_seconds"), 2),
-        "min_decisions": min(r["decisions"] for r in runs_data),
-        "max_decisions": max(r["decisions"] for r in runs_data),
-        "min_wall": round(min(r["wall_time_seconds"] for r in runs_data), 2),
-        "max_wall": round(max(r["wall_time_seconds"] for r in runs_data), 2),
+        "median_decisions": int(median("decisions")),
+        "median_distributions_seen": int(median("distributions_seen")),
+        "median_metadata_fetched": int(median("metadata_fetched")),
+        "median_packages": int(median("packages")),
+        "median_conflicts": int(median("conflicts")),
+        "median_backjumps": int(median("backjumps")),
+        "median_wall": round(median("wall_time_seconds"), 2),
+        "min_decisions": min(run["decisions"] for run in runs_data),
+        "max_decisions": max(run["decisions"] for run in runs_data),
+        "min_wall": round(min(run["wall_time_seconds"] for run in runs_data), 2),
+        "max_wall": round(max(run["wall_time_seconds"] for run in runs_data), 2),
     }
-    return runs_data, summary
+
+
+def median_run(
+    scenario: dict,
+    runs: int,
+    *,
+    scenario_name: str = "canary",
+    resolution_override: ResolutionStrategy | None = None,
+    host: BenchmarkHost | None = None,
+) -> tuple[list[dict], dict]:
+    if "unsupported_reason" in scenario:
+        return [], {"skipped": scenario["unsupported_reason"]}
+
+    effective_host = host or BenchmarkHost.current(WALL_TIMEOUT_S)
+    preparation = _prepare_canary_execution(
+        scenario,
+        scenario_name=scenario_name,
+        resolution_override=resolution_override,
+        host=effective_host,
+    )
+    if preparation.execution is None:
+        assert preparation.inapplicable_reason is not None
+        return [], {"skipped": preparation.inapplicable_reason}
+
+    runs_data = [_run_prepared_canary(preparation.execution) for _ in range(runs)]
+    return runs_data, _summarize_runs(runs_data)
 
 
 def main() -> None:
@@ -902,6 +912,7 @@ def main() -> None:
 
     source = get_git_source_state()
     commit = args.commit or str(source["commit"] or "no-git")
+    host = BenchmarkHost.current(WALL_TIMEOUT_S)
 
     cases_to_run: list[CanaryCase]
     if args.scenarios_list:
@@ -955,6 +966,7 @@ def main() -> None:
             args.runs,
             scenario_name=label,
             resolution_override=resolution,
+            host=host,
         )
         identity = canary_v2_identity(case, scenario, resolution)
         input_hash = scenario_input_hash(identity.scenario, identity.definition)

--- a/nab-python/benchmarks/compare.py
+++ b/nab-python/benchmarks/compare.py
@@ -1,17 +1,56 @@
-"""Compare benchmark results between two commits.
+"""Compare two complete standard benchmark runs.
 
 Usage:
-    python nab-python/benchmarks/compare.py <commit1> <commit2>
+    python nab-python/benchmarks/compare.py <baseline> <comparison>
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import math
 import sys
 from pathlib import Path
+from typing import NamedTuple, NoReturn
 
 RESULTS_DIR = Path(__file__).parent / "results"
+MANIFEST_FILENAME = "_standard_manifest.json"
+MANIFEST_SCHEMA = 2
+_RESERVED_DIRECTORIES = frozenset({"universal", "universal-selected"})
+_MANIFEST_FIELDS = frozenset(
+    {
+        "benchmark_schema",
+        "commit",
+        "source_start",
+        "source_end",
+        "mode",
+        "strategies",
+        "settings",
+        "corpus_hash",
+        "corpus_files",
+        "selected_files",
+        "available_logical_keys",
+        "selected_logical_keys",
+        "completed_logical_keys",
+        "unsupported_logical_keys",
+        "inapplicable_logical_keys",
+        "available_execution_keys",
+        "selected_execution_keys",
+        "completed_execution_keys",
+        "unsupported_execution_keys",
+        "file_execution_keys",
+        "complete",
+    }
+)
+_LIST_FIELDS = tuple(
+    sorted(
+        field
+        for field in _MANIFEST_FIELDS
+        if field.endswith("_keys")
+        or field in {"strategies", "corpus_files", "selected_files"}
+    )
+)
 
 STAT_LABELS = {
     "rounds": "Rounds",
@@ -38,34 +77,394 @@ STAT_LABELS = {
     "look_ahead_rejections": "Look-ahead rejections",
     "packages_resolved": "Packages resolved",
     "wall_time_seconds": "Wall time (s)",
-    "listing_requests": "Listing requests (legacy)",
-    "metadata_requests": "Metadata requests (legacy)",
 }
+_STANDARD_COUNTER_FIELDS = frozenset(STAT_LABELS) - {"wall_time_seconds"}
+_STANDARD_SETTINGS_FIELDS = frozenset(
+    {
+        "dist_policy",
+        "build_policy",
+        "trust_unverified_sdist_deps_default",
+        "max_iterations",
+        "wall_timeout_seconds",
+        "host",
+    }
+)
+_HOST_IDENTITY_FIELDS = frozenset(
+    {"python", "marker_environment", "wheel_tags_count", "wheel_tags_hash"}
+)
+_MODE_STRATEGIES = {
+    "default": ["highest"],
+    "strategy-matrix": ["highest", "lowest", "lowest-direct"],
+}
+
+
+class ComparisonError(ValueError):
+    """Raised when stored benchmark runs are not comparable."""
+
+
+class BenchmarkRun(NamedTuple):
+    """A validated manifest and its declared result payloads."""
+
+    manifest: dict[str, object]
+    results: dict[str, dict[str, object]]
+
+
+def _fail(message: str, cause: BaseException | None = None) -> NoReturn:
+    """Raise a comparison error, optionally chaining an underlying failure."""
+    raise ComparisonError(message) from cause
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+
+def _read_json(path: Path) -> object:
+    try:
+        return json.loads(
+            path.read_text(encoding="utf-8"),
+            parse_constant=lambda value: _fail(f"invalid JSON constant {value!r}"),
+        )
+    except (OSError, UnicodeError, ValueError) as exc:
+        _fail(f"unreadable benchmark JSON: {path}", exc)
+
+
+def _manifest_lists(data: dict[str, object]) -> dict[str, list[str]]:
+    lists: dict[str, list[str]] = {}
+    for field in _LIST_FIELDS:
+        value = data.get(field)
+        if (
+            not isinstance(value, list)
+            or any(type(item) is not str for item in value)
+            or value != sorted(set(value))
+        ):
+            _fail(f"manifest field {field!r} must be sorted and unique")
+        lists[field] = value
+    return lists
+
+
+def _clean_source(value: object) -> bool:
+    if not isinstance(value, dict) or set(value) != {"commit", "dirty", "diff_hash"}:
+        return False
+    commit = value.get("commit")
+    return (
+        isinstance(commit, str)
+        and len(commit) in {40, 64}
+        and all(character in "0123456789abcdef" for character in commit)
+        and value == {"commit": commit, "dirty": False, "diff_hash": None}
+    )
+
+
+def _is_sha256(value: object) -> bool:
+    return bool(
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _validate_settings(value: object, run_dir: Path) -> None:
+    if not isinstance(value, dict) or set(value) != _STANDARD_SETTINGS_FIELDS:
+        _fail(f"invalid standard benchmark settings: {run_dir}")
+    timeout = value["wall_timeout_seconds"]
+    if (
+        value["dist_policy"] != "wheel-or-sdist"
+        or value["build_policy"] != "never"
+        or value["trust_unverified_sdist_deps_default"] is not True
+        or type(value["max_iterations"]) is not int
+        or value["max_iterations"] <= 0
+        or (timeout is not None and (type(timeout) is not int or timeout <= 0))
+    ):
+        _fail(f"invalid standard benchmark settings: {run_dir}")
+
+    host = value["host"]
+    if not isinstance(host, dict) or set(host) != _HOST_IDENTITY_FIELDS:
+        _fail(f"invalid standard benchmark host identity: {run_dir}")
+    marker_environment = host["marker_environment"]
+    if (
+        not isinstance(host["python"], str)
+        or not host["python"]
+        or not isinstance(marker_environment, dict)
+        or not marker_environment
+        or any(
+            type(key) is not str or type(marker) is not str
+            for key, marker in marker_environment.items()
+        )
+        or type(host["wheel_tags_count"]) is not int
+        or host["wheel_tags_count"] <= 0
+        or not _is_sha256(host["wheel_tags_hash"])
+    ):
+        _fail(f"invalid standard benchmark host identity: {run_dir}")
+
+
+def _execution_map(logical_keys: list[str], strategies: list[str]) -> dict[str, str]:
+    executions: dict[str, str] = {}
+    for logical_key in logical_keys:
+        stem, separator, name = logical_key.partition(":")
+        if (
+            not separator
+            or not stem
+            or not name
+            or ":" in name
+            or any(character in stem + name for character in "/\\")
+        ):
+            _fail(f"invalid logical benchmark key: {logical_key!r}")
+        for strategy in strategies:
+            directory = stem if strategy == "highest" else f"{stem}-{strategy}"
+            execution_key = f"{directory}/{name}.json"
+            if execution_key in executions:
+                _fail(f"colliding benchmark key: {execution_key!r}")
+            executions[execution_key] = logical_key
+    return executions
+
+
+def _exact_partition(whole: list[str], *parts: list[str]) -> bool:
+    combined = [item for part in parts for item in part]
+    return len(combined) == len(set(combined)) and sorted(combined) == whole
+
+
+def _actual_result_keys(run_dir: Path) -> list[str]:
+    """List regular standard result JSON files below a run directory."""
+    keys: list[str] = []
+    try:
+        paths = run_dir.rglob("*")
+        for path in paths:
+            relative = path.relative_to(run_dir)
+            if relative.parts[0] in _RESERVED_DIRECTORIES:
+                if len(relative.parts) == 1 and (
+                    path.is_symlink() or not path.is_dir()
+                ):
+                    _fail(f"reserved result path is not a directory: {path}")
+                continue
+            if path.is_symlink():
+                _fail(f"benchmark result path is a symlink: {path}")
+            if path.suffix.casefold() != ".json":
+                continue
+            if not path.is_file():
+                _fail(f"benchmark result path is not regular: {path}")
+            key = relative.as_posix()
+            if key not in {MANIFEST_FILENAME, "_provenance.json"}:
+                keys.append(key)
+    except OSError as exc:
+        _fail(f"unreadable benchmark directory: {run_dir}", exc)
+    return sorted(keys)
+
+
+def _validate_manifest_identity(
+    data: dict[str, object],
+    run_dir: Path,
+) -> dict[str, list[str]]:
+    if data["benchmark_schema"] != MANIFEST_SCHEMA or data["complete"] is not True:
+        _fail(f"standard benchmark run is not complete: {run_dir}")
+    if data["commit"] != run_dir.name:
+        _fail(f"standard benchmark manifest does not own {run_dir}")
+    source = data["source_start"]
+    if not _clean_source(source) or source != data["source_end"]:
+        _fail(f"standard benchmark source is not clean and stable: {run_dir}")
+    if not _is_sha256(data["corpus_hash"]):
+        _fail(f"invalid standard benchmark identity: {run_dir}")
+    _validate_settings(data["settings"], run_dir)
+
+    lists = _manifest_lists(data)
+    strategies = lists["strategies"]
+    mode = data["mode"]
+    if (
+        not isinstance(mode, str)
+        or strategies != _MODE_STRATEGIES.get(mode)
+        or not set(lists["selected_files"]) <= set(lists["corpus_files"])
+    ):
+        _fail(f"invalid standard benchmark selection: {run_dir}")
+    return lists
+
+
+def _validate_manifest_partitions(
+    lists: dict[str, list[str]],
+    run_dir: Path,
+) -> None:
+    strategies = lists["strategies"]
+    available = lists["available_logical_keys"]
+    selected = lists["selected_logical_keys"]
+    completed = lists["completed_logical_keys"]
+    unsupported = lists["unsupported_logical_keys"]
+    inapplicable = lists["inapplicable_logical_keys"]
+    available_keys = lists["available_execution_keys"]
+    selected_keys = lists["selected_execution_keys"]
+    if not set(selected) <= set(available) or not _exact_partition(
+        selected, completed, unsupported, inapplicable
+    ):
+        _fail(f"invalid logical benchmark partition: {run_dir}")
+    available_map = _execution_map(available, strategies)
+    selected_map = _execution_map(selected, strategies)
+    completed_map = _execution_map(completed, strategies)
+    unsupported_map = _execution_map(unsupported, strategies)
+    inapplicable_map = _execution_map(inapplicable, strategies)
+    if available_keys != sorted(available_map) or selected_keys != sorted(selected_map):
+        _fail(f"invalid declared benchmark executions: {run_dir}")
+
+    completed_keys = lists["completed_execution_keys"]
+    unsupported_keys = lists["unsupported_execution_keys"]
+    if (
+        completed_keys != sorted(completed_map)
+        or unsupported_keys != sorted(unsupported_map)
+        or not _exact_partition(
+            selected_keys,
+            completed_keys,
+            unsupported_keys,
+            sorted(inapplicable_map),
+        )
+    ):
+        _fail(f"invalid execution benchmark partition: {run_dir}")
+    if (
+        lists["file_execution_keys"] != completed_keys
+        or _actual_result_keys(run_dir) != completed_keys
+    ):
+        _fail(f"result files do not match the benchmark manifest: {run_dir}")
+
+
+def _validate_manifest(run_dir: Path) -> dict[str, object]:
+    data = _read_json(run_dir / MANIFEST_FILENAME)
+    if not isinstance(data, dict) or set(data) != _MANIFEST_FIELDS:
+        _fail(f"invalid standard benchmark manifest: {run_dir}")
+    lists = _validate_manifest_identity(data, run_dir)
+    _validate_manifest_partitions(lists, run_dir)
+    return data
+
+
+def _settings_hash(settings: object) -> str:
+    return hashlib.sha256(_canonical_json(settings).encode()).hexdigest()
+
+
+def _validate_result_payload(data: dict[str, object], path: Path) -> None:
+    result = data.get("result")
+    if not isinstance(result, dict) or set(result) != {"success", "error"}:
+        _fail(f"invalid benchmark result payload: {path}")
+    success = result["success"]
+    error = result["error"]
+    if (
+        type(success) is not bool
+        or (success and error is not None)
+        or (not success and (not isinstance(error, str) or not error))
+    ):
+        _fail(f"invalid benchmark result payload: {path}")
+
+    stats = data.get("stats")
+    if not isinstance(stats, dict) or set(stats) != _STANDARD_COUNTER_FIELDS | {
+        "wall_time_seconds"
+    }:
+        _fail(f"invalid benchmark statistics: {path}")
+    if any(
+        type(stats[field]) is not int or stats[field] < 0
+        for field in _STANDARD_COUNTER_FIELDS
+    ):
+        _fail(f"invalid benchmark statistics: {path}")
+    wall_time = stats["wall_time_seconds"]
+    if (
+        not isinstance(wall_time, (int, float))
+        or isinstance(wall_time, bool)
+        or not math.isfinite(wall_time)
+        or wall_time < 0
+    ):
+        _fail(f"invalid benchmark statistics: {path}")
+
+
+def _validate_result(
+    path: Path,
+    execution_key: str,
+    logical_key: str,
+    manifest: dict[str, object],
+) -> dict[str, object]:
+    data = _read_json(path)
+    if not isinstance(data, dict) or set(data) != {"input", "result", "stats"}:
+        _fail(f"invalid benchmark result: {path}")
+    input_data = data.get("input")
+    if not isinstance(input_data, dict):
+        _fail(f"invalid benchmark input: {path}")
+    provenance = {
+        "benchmark_schema": manifest["benchmark_schema"],
+        "commit": manifest["commit"],
+        "source": manifest["source_start"],
+        "corpus_hash": manifest["corpus_hash"],
+        "logical_key": logical_key,
+        "execution_key": execution_key,
+        "settings_hash": _settings_hash(manifest["settings"]),
+    }
+    if any(
+        key not in input_data
+        or _canonical_json(input_data[key]) != _canonical_json(value)
+        for key, value in provenance.items()
+    ):
+        _fail(f"benchmark input does not match its manifest: {path}")
+
+    _validate_result_payload(data, path)
+    return data
+
+
+def load_run(run_dir: Path) -> BenchmarkRun:
+    """Load a complete run and validate every declared standard result."""
+    if run_dir.is_symlink() or not run_dir.is_dir():
+        _fail(f"no standard benchmark results in {run_dir}")
+    manifest = _validate_manifest(run_dir)
+    logical_by_execution = _execution_map(
+        manifest["completed_logical_keys"],  # type: ignore[arg-type]
+        manifest["strategies"],  # type: ignore[arg-type]
+    )
+    results = {
+        key: _validate_result(run_dir / key, key, logical_by_execution[key], manifest)
+        for key in manifest["completed_execution_keys"]  # type: ignore[union-attr]
+    }
+    return BenchmarkRun(manifest, results)
+
+
+def _without_provenance(data: dict[str, object]) -> dict[str, object]:
+    return {
+        key: value
+        for key, value in data.items()
+        if key not in {"commit", "source", "source_start", "source_end"}
+    }
+
+
+def require_comparable(first: BenchmarkRun, second: BenchmarkRun) -> None:
+    """Reject runs whose identities or normalized scenario inputs differ."""
+    if _canonical_json(_without_provenance(first.manifest)) != _canonical_json(
+        _without_provenance(second.manifest)
+    ):
+        _fail("standard benchmark manifests have different identities")
+    if not first.results:
+        _fail("standard benchmark runs have no completed executions")
+    for key in first.results:
+        first_input = first.results[key]["input"]
+        second_input = second.results[key]["input"]
+        assert isinstance(first_input, dict)
+        assert isinstance(second_input, dict)
+        if _canonical_json(_without_provenance(first_input)) != _canonical_json(
+            _without_provenance(second_input)
+        ):
+            _fail(f"benchmark inputs differ for {key}")
 
 
 def percent_change(old: float, new: float) -> str:
     if old == 0:
-        return "inf%" if new != 0 else "0%"
-    return f"{(new * 100) / old:.1f}%"
+        return "+inf%" if new != 0 else "0.0%"
+    return f"{((new - old) * 100) / old:+.1f}%"
 
 
-def compare_scenario(path1: Path, path2: Path, label: str) -> None:
-    """Compare two result JSONs and print differences."""
-    data1 = json.loads(path1.read_text())
-    data2 = json.loads(path2.read_text())
-
-    success1 = data1["result"]["success"]
-    success2 = data2["result"]["success"]
+def compare_scenario(
+    data1: dict[str, object], data2: dict[str, object], label: str
+) -> None:
+    """Print result and counter differences for one scenario execution."""
+    result1 = data1["result"]
+    result2 = data2["result"]
     stats1 = data1["stats"]
     stats2 = data2["stats"]
-
+    assert isinstance(result1, dict)
+    assert isinstance(result2, dict)
+    assert isinstance(stats1, dict)
+    assert isinstance(stats2, dict)
     messages: list[str] = []
 
-    if success1 != success2:
-        messages.append(f"Success: {success1} -> {success2}")
-
-    err1 = data1["result"]["error"]
-    err2 = data2["result"]["error"]
+    if result1["success"] != result2["success"]:
+        messages.append(f"Success: {result1['success']} -> {result2['success']}")
+    err1 = result1["error"]
+    err2 = result2["error"]
     if err1 != err2:
         if err1 and err2:
             messages.append(f"Error changed: {err1} -> {err2}")
@@ -73,58 +472,39 @@ def compare_scenario(path1: Path, path2: Path, label: str) -> None:
             messages.append(f"Error resolved: {err1}")
         else:
             messages.append(f"New error: {err2}")
-
     for key, label_text in STAT_LABELS.items():
-        v1 = stats1.get(key, 0)
-        v2 = stats2.get(key, 0)
-        if v1 != v2:
-            messages.append(f"{label_text}: {v1} -> {v2} ({percent_change(v1, v2)})")
-
+        value1 = stats1.get(key, 0)
+        value2 = stats2.get(key, 0)
+        if value1 != value2:
+            assert isinstance(value1, (int, float))
+            assert isinstance(value2, (int, float))
+            messages.append(
+                f"{label_text}: {value1} -> {value2} ({percent_change(value1, value2)})"
+            )
     if messages:
         print(f"{label}:")
-        for msg in messages:
-            print(f"\t{msg}")
+        for message in messages:
+            print(f"\t{message}")
         print()
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Compare nab benchmark results between commits"
+        description="Compare two complete nab benchmark result sets"
     )
-    parser.add_argument("commit1", help="First commit label (baseline)")
-    parser.add_argument("commit2", help="Second commit label (comparison)")
+    parser.add_argument("baseline", help="Baseline result label")
+    parser.add_argument("comparison", help="Comparison result label")
     args = parser.parse_args()
 
-    dir1 = RESULTS_DIR / args.commit1
-    dir2 = RESULTS_DIR / args.commit2
-
-    if not dir1.is_dir():
-        print(f"No results for commit {args.commit1}")
-        sys.exit(1)
-    if not dir2.is_dir():
-        print(f"No results for commit {args.commit2}")
-        sys.exit(1)
-
-    any_diff = False
-    for toml_dir in sorted(dir1.iterdir()):
-        if not toml_dir.is_dir():
-            continue
-        other_toml_dir = dir2 / toml_dir.name
-        if not other_toml_dir.is_dir():
-            continue
-
-        for result_file in sorted(toml_dir.glob("*.json")):
-            other_file = other_toml_dir / result_file.name
-            if not other_file.exists():
-                continue
-
-            scenario_name = result_file.stem
-            label = f"{toml_dir.name} / {scenario_name}"
-            compare_scenario(result_file, other_file, label)
-            any_diff = True
-
-    if not any_diff:
-        print("No matching scenarios found between the two commits.")
+    try:
+        first = load_run(RESULTS_DIR / args.baseline)
+        second = load_run(RESULTS_DIR / args.comparison)
+        require_comparable(first, second)
+    except ComparisonError as exc:
+        print(f"Cannot compare benchmark runs: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    for key in first.manifest["completed_execution_keys"]:  # type: ignore[union-attr]
+        compare_scenario(first.results[key], second.results[key], key)
 
 
 if __name__ == "__main__":

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -15,7 +15,6 @@ import hashlib
 import json
 import math
 import os
-import signal
 import subprocess
 import sys
 import time
@@ -26,10 +25,20 @@ from typing import TYPE_CHECKING, NamedTuple
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+    from nab_python.target import ResolveTarget
+
 if sys.version_info >= (3, 11):
     import tomllib
 else:
     import tomli as tomllib  # type: ignore[no-redef]
+
+from benchmark_host import (
+    HOST_TAG_MISMATCH_REASON,
+    BenchmarkHost,
+    BenchmarkTimeout,
+    parse_target_marker_environment,
+    settings_hash,
+)
 
 from nab_index.httpx_async_transport import HttpxAsyncTransport
 from nab_index.multi_index import IndexConfig
@@ -54,7 +63,6 @@ from nab_python.provider import (
     VcsPolicy,
     split_extra,
 )
-from nab_python.target import ResolveTarget
 from nab_resolver.resolver import Resolver
 
 BENCHMARKS_DIR = Path(__file__).parent
@@ -62,7 +70,8 @@ SCENARIOS_DIR = BENCHMARKS_DIR / "scenarios"
 RESULTS_DIR = BENCHMARKS_DIR / "results"
 _LEGACY_STRATEGY_SUFFIXES = ("-lowest", "-lowest-direct")
 STANDARD_MANIFEST_FILENAME = "_standard_manifest.json"
-STANDARD_MANIFEST_SCHEMA = 1
+STANDARD_MANIFEST_SCHEMA = 2
+_INAPPLICABLE_KEY_PREVIEW = 8
 _STANDARD_METADATA_FILENAMES = frozenset(
     {STANDARD_MANIFEST_FILENAME, "_provenance.json"}
 )
@@ -108,6 +117,7 @@ _STANDARD_MANIFEST_FIELDS = frozenset(
         "selected_logical_keys",
         "completed_logical_keys",
         "unsupported_logical_keys",
+        "inapplicable_logical_keys",
         "available_execution_keys",
         "selected_execution_keys",
         "completed_execution_keys",
@@ -139,7 +149,7 @@ def _is_portable_path_component(
 def _result_directory_label(value: str) -> str:
     """Validate a user-provided results-directory label."""
     if not _is_portable_path_component(value):
-        msg = f"commit label must use a portable ASCII filename, got {value!r}"
+        msg = f"result label must use a portable ASCII filename, got {value!r}"
         raise argparse.ArgumentTypeError(msg)
     return value
 
@@ -449,6 +459,14 @@ class StandardExecution(NamedTuple):
         return f"{self.result_stem}/{self.scenario.name}.json"
 
 
+class StandardRunPlan(NamedTuple):
+    """The admitted executions and host-inapplicable scenarios for one run."""
+
+    executions: list[StandardExecution]
+    targets_by_logical_key: dict[str, ResolveTarget]
+    inapplicable_logical_keys: list[str]
+
+
 def _standard_result_path(
     output_dir: Path,
     execution: StandardExecution,
@@ -488,16 +506,15 @@ def _standard_result_path(
 class PreparedStandardExecution(NamedTuple):
     """Validated inputs shared by cache validation and actual resolution."""
 
-    python_version: str
     requirement_strings: list[str]
     constraint_strings: list[str]
-    marker_environment: dict[str, str]
     indexes: list[IndexConfig]
     index_routes: list[IndexRoute]
     build_policy_overrides: dict[str, BuildPolicy]
     uploaded_prior_to: datetime | None
     vcs_config: VcsConfig
     trust_unverified_sdist_deps: bool
+    target: ResolveTarget
     expected_input: dict[str, object]
 
 
@@ -578,17 +595,49 @@ def standard_corpus_hash(rows: list[StandardScenario]) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
-def standard_execution_plan(
+def standard_run_plan(
     rows: list[StandardScenario],
     strategies: tuple[ResolutionStrategy, ...],
-) -> list[StandardExecution]:
-    """Expand supported canonical rows over the selected strategies."""
-    return [
+    host: BenchmarkHost,
+) -> StandardRunPlan:
+    """Admit each scenario once, then expand faithful targets by strategy."""
+    targets: dict[str, ResolveTarget] = {}
+    inapplicable: list[str] = []
+    for row in rows:
+        if "unsupported_reason" in row.definition:
+            continue
+        marker_environment = parse_marker_environment(row.name, row.definition)
+        admission = host.target_for(
+            row.definition["python_version"],
+            marker_environment,
+        )
+        if admission.target is None:
+            inapplicable.append(row.logical_key)
+            continue
+        targets[row.logical_key] = admission.target
+
+    executions = [
         StandardExecution(row, strategy)
         for strategy in strategies
         for row in rows
-        if "unsupported_reason" not in row.definition
+        if row.logical_key in targets
     ]
+    return StandardRunPlan(executions, targets, sorted(inapplicable))
+
+
+def _report_host_inapplicable(logical_keys: list[str]) -> None:
+    """Print a bounded summary of scenarios this host cannot run faithfully."""
+    if not logical_keys:
+        return
+    count = len(logical_keys)
+    noun = "scenario" if count == 1 else "scenarios"
+    print(f"Host-inapplicable: {count} {noun}; {HOST_TAG_MISMATCH_REASON}.")
+    print("  " + ", ".join(logical_keys[:_INAPPLICABLE_KEY_PREVIEW]))
+    remaining = count - _INAPPLICABLE_KEY_PREVIEW
+    if remaining > 0:
+        print(
+            f"  ... {remaining} more; exact keys are in {STANDARD_MANIFEST_FILENAME}."
+        )
 
 
 def standard_execution_keys(
@@ -763,40 +812,6 @@ def _full_marker_environment(
     return env
 
 
-_PYTHON_VERSION_PARTS = 2
-
-
-def scenario_marker_env(
-    python_version: str,
-    overlay: dict[str, str],
-) -> dict[str, str]:
-    """Build the marker environment that root-requirement markers use.
-
-    Folds ``python_version`` into the overlay just like ``Provider``
-    does internally so root-level markers see the scenario's Python
-    rather than the host's.
-    """
-    env = dict(overlay)
-    env.setdefault("python_full_version", python_version)
-    if "python_version" not in env:
-        parts = python_version.split(".")
-        env["python_version"] = (
-            ".".join(parts[:_PYTHON_VERSION_PARTS])
-            if len(parts) >= _PYTHON_VERSION_PARTS
-            else python_version
-        )
-    return env
-
-
-def resolve_target(
-    python_version: str,
-    marker_environment: dict[str, str] | None,
-) -> ResolveTarget:
-    """Build the scenario's resolve target: host machine, scenario Python."""
-    target = ResolveTarget.for_host_python(python_version)
-    return target.with_marker_overrides(marker_environment or {})
-
-
 def parse_datetime(value: str) -> datetime:
     """Parse an ISO 8601 datetime string to a timezone-aware datetime."""
     dt = datetime.fromisoformat(value)
@@ -807,19 +822,6 @@ def parse_datetime(value: str) -> datetime:
 
 SCENARIO_WALL_TIMEOUT_SECONDS = 120
 MAX_ITERATIONS = 50_000
-
-
-class _ScenarioTimeoutError(BaseException):
-    """Raised when a scenario exceeds the per-run wall-clock budget.
-
-    Subclasses BaseException so the resolver's internal ``except Exception``
-    handlers cannot swallow the alarm mid-resolve.
-    """
-
-
-def _alarm_handler(_signum: int, _frame: object) -> None:
-    msg = f"scenario exceeded {SCENARIO_WALL_TIMEOUT_SECONDS}s wall-clock budget"
-    raise _ScenarioTimeoutError(msg)
 
 
 CACHE_DIR = BENCHMARKS_DIR / "cache"
@@ -853,14 +855,15 @@ _STANDARD_COUNTER_FIELDS = frozenset(
 )
 
 
-def standard_benchmark_settings() -> dict[str, object]:
+def standard_benchmark_settings(host: BenchmarkHost) -> dict[str, object]:
     """Return the global settings shared by every standard result."""
     return {
         "dist_policy": DistPolicy.WHEEL_OR_SDIST.value,
         "build_policy": BuildPolicy.NEVER.value,
         "trust_unverified_sdist_deps_default": True,
         "max_iterations": MAX_ITERATIONS,
-        "wall_timeout_seconds": SCENARIO_WALL_TIMEOUT_SECONDS,
+        "wall_timeout_seconds": host.wall_timeout_seconds,
+        "host": host.identity(),
     }
 
 
@@ -922,6 +925,7 @@ def _result_input(
     commit: str,
     source: dict[str, str | bool | None],
     corpus_hash: str,
+    settings_digest: str,
 ) -> dict[str, object]:
     return {
         "benchmark_schema": STANDARD_MANIFEST_SCHEMA,
@@ -930,6 +934,7 @@ def _result_input(
         "corpus_hash": corpus_hash,
         "logical_key": execution.scenario.logical_key,
         "execution_key": execution.result_key,
+        "settings_hash": settings_digest,
     }
 
 
@@ -949,10 +954,7 @@ def _standard_result_files(output_dir: Path) -> list[str]:
 def _completed_standard_executions(
     output_dir: Path,
     executions: list[StandardExecution],
-    *,
-    commit: str,
-    source: dict[str, str | bool | None],
-    corpus_hash: str,
+    prepared_executions: Mapping[str, PreparedStandardExecution],
 ) -> list[str]:
     completed: list[str] = []
     for execution in executions:
@@ -961,18 +963,13 @@ def _completed_standard_executions(
             data = json.loads(path.read_text())
         except (OSError, ValueError):
             continue
-        prepared = prepare_standard_execution(
-            execution,
-            commit=commit,
-            source=source,
-            corpus_hash=corpus_hash,
-        )
+        prepared = prepared_executions[execution.result_key]
         if _standard_result_data_valid(data, prepared.expected_input):
             completed.append(execution.result_key)
     return sorted(completed)
 
 
-def standard_manifest_contract(
+def standard_manifest_contract(  # noqa: PLR0913 - explicit contract fields
     *,
     commit: str,
     mode: str,
@@ -982,6 +979,8 @@ def standard_manifest_contract(
     selected_files: list[str],
     strategies: tuple[ResolutionStrategy, ...],
     corpus_hash: str,
+    plan: StandardRunPlan,
+    settings: dict[str, object],
 ) -> dict[str, object]:
     """Return the immutable identity of one standard benchmark run."""
     unsupported_rows = [
@@ -992,13 +991,14 @@ def standard_manifest_contract(
         "commit": commit,
         "mode": mode,
         "strategies": [strategy.value for strategy in strategies],
-        "settings": standard_benchmark_settings(),
+        "settings": settings,
         "corpus_hash": corpus_hash,
         "corpus_files": sorted(corpus_files),
         "selected_files": sorted(selected_files),
         "available_logical_keys": sorted(row.logical_key for row in all_rows),
         "selected_logical_keys": sorted(row.logical_key for row in selected_rows),
         "unsupported_logical_keys": sorted(row.logical_key for row in unsupported_rows),
+        "inapplicable_logical_keys": plan.inapplicable_logical_keys,
         "available_execution_keys": standard_execution_keys(all_rows, strategies),
         "selected_execution_keys": standard_execution_keys(selected_rows, strategies),
         "unsupported_execution_keys": sorted(
@@ -1100,6 +1100,118 @@ def prepare_standard_result_namespace(
         raise ValueError(msg)
 
 
+def _is_exact_partition(whole: list[str], *parts: list[str]) -> bool:
+    """Return whether disjoint parts contain every member of whole."""
+    combined = [item for part in parts for item in part]
+    return len(combined) == len(set(combined)) and sorted(combined) == whole
+
+
+class StandardCompletionState(NamedTuple):
+    """Terminal logical keys, execution keys, and files for one standard run."""
+
+    completed_logical_keys: list[str]
+    unsupported_logical_keys: list[str]
+    completed_execution_keys: list[str]
+    unsupported_execution_keys: list[str]
+    inapplicable_execution_keys: list[str]
+    file_execution_keys: list[str]
+
+
+def _standard_completion_state(
+    output_dir: Path,
+    selected_rows: list[StandardScenario],
+    strategies: tuple[ResolutionStrategy, ...],
+    plan: StandardRunPlan,
+    prepared_executions: Mapping[str, PreparedStandardExecution],
+) -> StandardCompletionState:
+    """Derive each terminal partition from the selected rows and result files."""
+    completed_execution_keys = _completed_standard_executions(
+        output_dir,
+        plan.executions,
+        prepared_executions,
+    )
+    completed_set = set(completed_execution_keys)
+    supported_rows = [
+        row
+        for row in selected_rows
+        if "unsupported_reason" not in row.definition
+        and row.logical_key not in plan.inapplicable_logical_keys
+    ]
+    completed_logical_keys = sorted(
+        row.logical_key
+        for row in supported_rows
+        if all(
+            StandardExecution(row, strategy).result_key in completed_set
+            for strategy in strategies
+        )
+    )
+
+    unsupported_rows = [
+        row for row in selected_rows if "unsupported_reason" in row.definition
+    ]
+    unsupported_logical_keys = sorted(row.logical_key for row in unsupported_rows)
+    unsupported_execution_keys = sorted(
+        StandardExecution(row, strategy).result_key
+        for row in unsupported_rows
+        for strategy in strategies
+    )
+
+    inapplicable_rows = [
+        row
+        for row in selected_rows
+        if row.logical_key in plan.inapplicable_logical_keys
+    ]
+    inapplicable_execution_keys = sorted(
+        StandardExecution(row, strategy).result_key
+        for row in inapplicable_rows
+        for strategy in strategies
+    )
+    return StandardCompletionState(
+        completed_logical_keys=completed_logical_keys,
+        unsupported_logical_keys=unsupported_logical_keys,
+        completed_execution_keys=completed_execution_keys,
+        unsupported_execution_keys=unsupported_execution_keys,
+        inapplicable_execution_keys=inapplicable_execution_keys,
+        file_execution_keys=_standard_result_files(output_dir),
+    )
+
+
+def _standard_run_is_complete(
+    state: StandardCompletionState,
+    selected_rows: list[StandardScenario],
+    strategies: tuple[ResolutionStrategy, ...],
+    plan: StandardRunPlan,
+    source_start: dict[str, str | bool | None],
+    source_end: dict[str, str | bool | None] | None,
+    *,
+    finalize: bool,
+) -> bool:
+    """Return whether the terminal state satisfies the standard-run contract."""
+    selected_logical_keys = sorted(row.logical_key for row in selected_rows)
+    selected_execution_keys = standard_execution_keys(selected_rows, strategies)
+    expected_execution_keys = sorted(item.result_key for item in plan.executions)
+    return bool(
+        finalize
+        and _clean_source_identity(source_start)
+        and _clean_source_identity(source_end)
+        and source_end == source_start
+        and _is_exact_partition(
+            selected_logical_keys,
+            state.completed_logical_keys,
+            state.unsupported_logical_keys,
+            plan.inapplicable_logical_keys,
+        )
+        and _is_exact_partition(
+            selected_execution_keys,
+            state.completed_execution_keys,
+            state.unsupported_execution_keys,
+            state.inapplicable_execution_keys,
+        )
+        and state.completed_execution_keys == expected_execution_keys
+        and state.file_execution_keys == expected_execution_keys
+    )
+
+
 def write_standard_manifest(  # noqa: PLR0913 - explicit contract fields
     path: Path,
     *,
@@ -1113,6 +1225,9 @@ def write_standard_manifest(  # noqa: PLR0913 - explicit contract fields
     selected_files: list[str],
     strategies: tuple[ResolutionStrategy, ...],
     corpus_hash: str,
+    plan: StandardRunPlan,
+    settings: dict[str, object],
+    prepared_executions: Mapping[str, PreparedStandardExecution],
     finalize: bool,
 ) -> bool:
     """Write the strict standard-suite contract and return its completeness."""
@@ -1126,78 +1241,49 @@ def write_standard_manifest(  # noqa: PLR0913 - explicit contract fields
         selected_files=selected_files,
         strategies=strategies,
         corpus_hash=corpus_hash,
+        plan=plan,
+        settings=settings,
     )
-    selected_plan = standard_execution_plan(selected_rows, strategies)
-    expected_result_keys = sorted(item.result_key for item in selected_plan)
-    completed_execution_keys = _completed_standard_executions(
+    state = _standard_completion_state(
         output_dir,
-        selected_plan,
-        commit=commit,
-        source=source_start,
-        corpus_hash=corpus_hash,
+        selected_rows,
+        strategies,
+        plan,
+        prepared_executions,
     )
-    completed_set = set(completed_execution_keys)
-    supported_selected = [
-        row for row in selected_rows if "unsupported_reason" not in row.definition
-    ]
-    completed_logical_keys = sorted(
-        row.logical_key
-        for row in supported_selected
-        if all(
-            StandardExecution(row, strategy).result_key in completed_set
-            for strategy in strategies
-        )
-    )
-    unsupported_rows = [
-        row for row in selected_rows if "unsupported_reason" in row.definition
-    ]
-    unsupported_logical_keys = sorted(row.logical_key for row in unsupported_rows)
-    unsupported_execution_keys = sorted(
-        StandardExecution(row, strategy).result_key
-        for row in unsupported_rows
-        for strategy in strategies
-    )
-    selected_logical_keys = sorted(row.logical_key for row in selected_rows)
-    selected_execution_keys = standard_execution_keys(selected_rows, strategies)
-    file_execution_keys = _standard_result_files(output_dir)
-    complete = bool(
-        finalize
-        and _clean_source_identity(source_start)
-        and _clean_source_identity(source_end)
-        and source_end == source_start
-        and not (set(completed_logical_keys) & set(unsupported_logical_keys))
-        and sorted(completed_logical_keys + unsupported_logical_keys)
-        == selected_logical_keys
-        and not (set(completed_execution_keys) & set(unsupported_execution_keys))
-        and sorted(completed_execution_keys + unsupported_execution_keys)
-        == selected_execution_keys
-        and completed_execution_keys == expected_result_keys
-        and file_execution_keys == expected_result_keys
+    complete = _standard_run_is_complete(
+        state,
+        selected_rows,
+        strategies,
+        plan,
+        source_start,
+        source_end,
+        finalize=finalize,
     )
     data = {
         **contract,
         "source_start": source_start,
         "source_end": source_end,
-        "completed_logical_keys": completed_logical_keys,
-        "completed_execution_keys": completed_execution_keys,
-        "file_execution_keys": file_execution_keys,
+        "completed_logical_keys": state.completed_logical_keys,
+        "completed_execution_keys": state.completed_execution_keys,
+        "file_execution_keys": state.file_execution_keys,
         "complete": complete,
     }
     path.write_text(json.dumps(data, indent=2) + "\n")
     return complete
 
 
-def resolve_scenario(  # noqa: PLR0913, PLR0917 - one wrapper per scenario knob
+def resolve_scenario(  # noqa: PLR0913 - one wrapper per scenario knob
     requirements: dict[str, VersionRange],
-    python_version: str,
     uploaded_prior_to: datetime | None = None,
     constraints: dict[str, VersionRange] | None = None,
-    marker_environment: dict[str, str] | None = None,
     indexes: list[IndexConfig] | None = None,
     index_routes: list[IndexRoute] | None = None,
     build_policy_overrides: Mapping[str, BuildPolicy] | None = None,
     resolution_strategy: ResolutionStrategy = ResolutionStrategy.HIGHEST,
     *,
+    target: ResolveTarget,
+    host: BenchmarkHost,
     trust_unverified_sdist_deps: bool = False,
 ) -> dict:
     """Resolve requirements and return stats dict."""
@@ -1221,7 +1307,7 @@ def resolve_scenario(  # noqa: PLR0913, PLR0917 - one wrapper per scenario knob
     ) as coordinator:
         provider = Provider(
             coordinator,
-            target=resolve_target(python_version, marker_environment),
+            target=target,
             root_requirements=requirements,
             uploaded_prior_to=uploaded_prior_to,
             dist_policy=DistPolicy.WHEEL_OR_SDIST,
@@ -1238,24 +1324,20 @@ def resolve_scenario(  # noqa: PLR0913, PLR0917 - one wrapper per scenario knob
             max_iterations=MAX_ITERATIONS,
         )
 
-        previous_handler = signal.signal(signal.SIGALRM, _alarm_handler)
-        signal.alarm(SCENARIO_WALL_TIMEOUT_SECONDS)
         start = time.monotonic()
         try:
-            raw = resolver.resolve(requirements, constraints=constraints)
+            with host.wall_timeout():
+                raw = resolver.resolve(requirements, constraints=constraints)
             elapsed = time.monotonic() - start
             result = {k: v for k, v in raw.items() if split_extra(k)[1] is None}
             success = True
             error = None
             packages_resolved = len(result)
-        except (_ScenarioTimeoutError, Exception) as exc:
+        except (BenchmarkTimeout, Exception) as exc:
             elapsed = time.monotonic() - start
             success = False
             error = f"{type(exc).__name__}: {exc}"
             packages_resolved = 0
-        finally:
-            signal.alarm(0)
-            signal.signal(signal.SIGALRM, previous_handler)
 
         rstats = resolver.stats
         pstats = provider.stats
@@ -1425,18 +1507,7 @@ def parse_marker_environment(
     scenario: dict,
 ) -> dict[str, str]:
     """Read the ``marker_environment`` table + ``platform_system`` shorthand."""
-    raw = scenario.get("marker_environment", {})
-    if not isinstance(raw, dict):
-        msg = (
-            f"{scenario_name}: marker_environment must be a TOML table"
-            f" of string -> string, got {type(raw).__name__}"
-        )
-        raise TypeError(msg)
-    overlay: dict[str, str] = {str(k): str(v) for k, v in raw.items()}
-    platform_system = scenario.get("platform_system")
-    if platform_system and "platform_system" not in overlay:
-        overlay["platform_system"] = platform_system
-    return overlay
+    return parse_target_marker_environment(scenario_name, scenario)
 
 
 def parse_build_packages(
@@ -1492,10 +1563,12 @@ def validate_scenario_build_policy(
 
 def prepare_standard_execution(
     execution: StandardExecution,
+    target: ResolveTarget,
     *,
     commit: str,
     source: dict[str, str | bool | None],
     corpus_hash: str,
+    settings_digest: str,
 ) -> PreparedStandardExecution:
     """Prepare and identify one execution without performing network work."""
     scenario_name = execution.scenario.name
@@ -1558,19 +1631,19 @@ def prepare_standard_execution(
             commit=commit,
             source=source,
             corpus_hash=corpus_hash,
+            settings_digest=settings_digest,
         ),
     }
     return PreparedStandardExecution(
-        python_version=python_version,
         requirement_strings=requirement_strings,
         constraint_strings=constraint_strings,
-        marker_environment=marker_environment,
         indexes=indexes,
         index_routes=index_routes,
         build_policy_overrides=build_policy_overrides,
         uploaded_prior_to=parse_datetime(datetime_str) if datetime_str else None,
         vcs_config=vcs_config,
         trust_unverified_sdist_deps=trust_unverified_sdist_deps,
+        target=target,
         expected_input=expected_input,
     )
 
@@ -1580,20 +1653,11 @@ def process_scenario(
     commit: str,
     *,
     force: bool,
-    source: dict[str, str | bool | None],
-    corpus_hash: str,
-) -> bool:
+    prepared: PreparedStandardExecution,
+    host: BenchmarkHost,
+) -> None:
     """Resolve one scenario and save results."""
     scenario_name = execution.scenario.name
-    scenario = execution.scenario.definition
-    if "unsupported_reason" in scenario:
-        return False
-    prepared = prepare_standard_execution(
-        execution,
-        commit=commit,
-        source=source,
-        corpus_hash=corpus_hash,
-    )
 
     run_dir = _result_directory(commit)
     output_path = _standard_result_path(run_dir, execution)
@@ -1605,13 +1669,11 @@ def process_scenario(
         except (OSError, ValueError):
             existing = None
         if _standard_result_data_valid(existing, prepared.expected_input):
-            return True
+            return
 
     print(f"  {scenario_name} ", end="", flush=True)
 
-    requirement_marker_env = scenario_marker_env(
-        prepared.python_version, prepared.marker_environment
-    )
+    requirement_marker_env = dict(prepared.target.marker_env)
     requirements = parse_requirements(
         prepared.requirement_strings,
         vcs_config=prepared.vcs_config,
@@ -1628,14 +1690,14 @@ def process_scenario(
     )
     data = resolve_scenario(
         requirements,
-        prepared.python_version,
         prepared.uploaded_prior_to,
         constraints,
-        marker_environment=prepared.marker_environment or None,
         indexes=prepared.indexes,
         index_routes=prepared.index_routes or None,
         build_policy_overrides=prepared.build_policy_overrides or None,
         resolution_strategy=execution.strategy,
+        target=prepared.target,
+        host=host,
         trust_unverified_sdist_deps=prepared.trust_unverified_sdist_deps,
     )
     data["input"] = prepared.expected_input
@@ -1653,7 +1715,6 @@ def process_scenario(
         )
     else:
         print(f"FAILED: {data['result']['error']}")
-    return True
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -1688,6 +1749,7 @@ def main(argv: list[str] | None = None) -> None:
         except argparse.ArgumentTypeError as exc:
             parser.error(str(exc))
     source_start = get_git_source_state()
+    host = BenchmarkHost.current(SCENARIO_WALL_TIMEOUT_SECONDS)
 
     if not SCENARIOS_DIR.is_dir():
         print(f"Error: {SCENARIOS_DIR} does not exist")
@@ -1733,7 +1795,21 @@ def main(argv: list[str] | None = None) -> None:
     )
     mode = "strategy-matrix" if args.strategy_matrix else "default"
     corpus_hash = standard_corpus_hash(all_rows)
-    execution_plan = standard_execution_plan(selected_rows, strategies)
+    plan = standard_run_plan(selected_rows, strategies, host)
+    execution_plan = plan.executions
+    settings = standard_benchmark_settings(host)
+    settings_digest = settings_hash(settings)
+    prepared_executions = {
+        execution.result_key: prepare_standard_execution(
+            execution,
+            plan.targets_by_logical_key[execution.scenario.logical_key],
+            commit=commit,
+            source=source_start,
+            corpus_hash=corpus_hash,
+            settings_digest=settings_digest,
+        )
+        for execution in execution_plan
+    }
     contract = standard_manifest_contract(
         commit=commit,
         mode=mode,
@@ -1743,6 +1819,8 @@ def main(argv: list[str] | None = None) -> None:
         selected_files=[path.stem for path in selected_files],
         strategies=strategies,
         corpus_hash=corpus_hash,
+        plan=plan,
+        settings=settings,
     )
     try:
         output_dir = _result_directory(commit)
@@ -1766,6 +1844,9 @@ def main(argv: list[str] | None = None) -> None:
         "selected_files": [path.stem for path in selected_files],
         "strategies": strategies,
         "corpus_hash": corpus_hash,
+        "plan": plan,
+        "settings": settings,
+        "prepared_executions": prepared_executions,
     }
     write_standard_manifest(
         manifest_path,
@@ -1775,6 +1856,7 @@ def main(argv: list[str] | None = None) -> None:
     )
 
     print(f"Running scenarios for commit: {commit} ({mode})")
+    _report_host_inapplicable(plan.inapplicable_logical_keys)
     previous_stem: str | None = None
     for execution in execution_plan:
         if execution.result_stem != previous_stem:
@@ -1784,8 +1866,8 @@ def main(argv: list[str] | None = None) -> None:
             execution,
             commit,
             force=args.force,
-            source=source_start,
-            corpus_hash=corpus_hash,
+            prepared=prepared_executions[execution.result_key],
+            host=host,
         )
 
     complete = write_standard_manifest(

--- a/nab-python/benchmarks/scenarios/uv.toml
+++ b/nab-python/benchmarks/scenarios/uv.toml
@@ -1518,15 +1518,17 @@ requirements = ["llvmlite==0.44.0"]
 
 [uv-tensorflow-macos]
 # https://github.com/astral-sh/uv/issues/13568
-# Cross-platform resolution where tensorflow has different markers
-# on macOS vs Linux. Now resolvable via Phase A impersonation.
-python_version = "3.11"
-datetime = "2025-06-09 14:00:00"
-requirements = ["tensorflow"]
+# Exercises compatible-wheel selection for these roots on macOS arm64.
+python_version = "3.10.17"
+datetime = "2025-05-21 09:12:43"
+requirements = ["protobuf", "retina-face"]
 [uv-tensorflow-macos.marker_environment]
 platform_system = "Darwin"
 sys_platform = "darwin"
 platform_machine = "arm64"
+os_name = "posix"
+implementation_name = "cpython"
+platform_python_implementation = "CPython"
 
 [uv-issue-8601-jax-py-marker]
 # https://github.com/astral-sh/uv/issues/8601
@@ -1540,20 +1542,20 @@ requirements = [
     'jax>=0.4.33;python_version>="3.10"',
 ]
 
-[uv-issue-11664-pywin32-environments]
-# https://github.com/astral-sh/uv/issues/11664
-# pywin32 marker sys_platform == 'win32' is now exercised via Phase A
-# impersonation (a single-tuple Windows resolve from any host).
+[pywin32-windows-amd64-real-index]
+# Real-index diagnostic for an active Windows-only root marker.
 python_version = "3.12"
 datetime = "2025-02-20 12:19:21"
 requirements = [
     "pywin32; sys_platform == 'win32'",
 ]
-[uv-issue-11664-pywin32-environments.marker_environment]
+[pywin32-windows-amd64-real-index.marker_environment]
 platform_system = "Windows"
 sys_platform = "win32"
 os_name = "nt"
 platform_machine = "AMD64"
+implementation_name = "cpython"
+platform_python_implementation = "CPython"
 
 [uv-add-torch-pytorch-index]
 # https://github.com/astral-sh/uv/issues/12797

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -22,18 +22,53 @@ def _harness() -> ModuleType:
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    benchmark_dir = str(_CANARY.parent)
+    sys.path.insert(0, benchmark_dir)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.remove(benchmark_dir)
     return module
+
+
+def _run_result(
+    *,
+    success: bool = True,
+    decisions: int = 1,
+    distributions_seen: int = 0,
+    metadata_fetched: int = 0,
+    packages: int = 0,
+    conflicts: int = 0,
+    backjumps: int = 0,
+    wall_time_seconds: float = 0.0,
+) -> dict[str, object]:
+    return {
+        "success": success,
+        "error": None if success else "resolution failed",
+        "decisions": decisions,
+        "conflicts": conflicts,
+        "backjumps": backjumps,
+        "restarts": 0,
+        "incompatibilities_learned": 0,
+        "metadata_fetched": metadata_fetched,
+        "distributions_seen": distributions_seen,
+        "look_ahead_rejections": 0,
+        "packages": packages,
+        "wall_time_seconds": wall_time_seconds,
+    }
 
 
 def test_wall_timeout_noops_without_posix_alarm(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     module = _harness()
-    monkeypatch.delattr(module.signal, "SIGALRM", raising=False)
-    monkeypatch.delattr(module.signal, "alarm", raising=False)
+    host_module = sys.modules[module.BenchmarkHost.__module__]
+    monkeypatch.delattr(host_module.signal, "SIGALRM", raising=False)
+    monkeypatch.delattr(host_module.signal, "alarm", raising=False)
+    host = module.BenchmarkHost.current(module.WALL_TIMEOUT_S)
 
-    with module._scenario_wall_timeout():
+    assert host.wall_timeout_seconds is None
+    with host.wall_timeout():
         pass
 
 
@@ -41,6 +76,7 @@ def test_wall_timeout_installs_and_restores_alarm(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     module = _harness()
+    host_module = sys.modules[module.BenchmarkHost.__module__]
     previous_handler = object()
     handlers: list[tuple[int, object]] = []
     alarms: list[int] = []
@@ -52,18 +88,27 @@ def test_wall_timeout_installs_and_restores_alarm(
     def fake_alarm(seconds: int) -> None:
         alarms.append(seconds)
 
-    monkeypatch.setattr(module.signal, "SIGALRM", 14, raising=False)
-    monkeypatch.setattr(module.signal, "signal", fake_signal)
-    monkeypatch.setattr(module.signal, "alarm", fake_alarm, raising=False)
+    monkeypatch.setattr(host_module.signal, "SIGALRM", 14, raising=False)
+    monkeypatch.setattr(host_module.signal, "signal", fake_signal)
+    monkeypatch.setattr(host_module.signal, "alarm", fake_alarm, raising=False)
+    host = module.BenchmarkHost.current(module.WALL_TIMEOUT_S)
 
-    with module._scenario_wall_timeout():
-        assert alarms == [module.WALL_TIMEOUT_S]
+    def trigger_timeout() -> None:
+        with host.wall_timeout():
+            assert alarms == [module.WALL_TIMEOUT_S]
+            timeout_handler = handlers[0][1]
+            assert callable(timeout_handler)
+            timeout_handler(14, None)
+
+    assert issubclass(module.BenchmarkTimeout, BaseException)
+    assert not issubclass(module.BenchmarkTimeout, Exception)
+    with pytest.raises(module.BenchmarkTimeout, match="wall-clock budget"):
+        trigger_timeout()
 
     assert alarms == [module.WALL_TIMEOUT_S, 0]
-    assert handlers == [
-        (14, module._alarm_handler),
-        (14, previous_handler),
-    ]
+    assert len(handlers) == 2
+    assert handlers[0][0] == 14
+    assert handlers[1] == (14, previous_handler)
 
 
 @pytest.mark.parametrize(
@@ -85,20 +130,7 @@ def test_canary_uses_scenario_resolution(
 
     def fake_run_one(*_args: object, **kwargs: object) -> dict:
         seen.append(str(kwargs["resolution_strategy"].value))
-        return {
-            "success": True,
-            "error": None,
-            "decisions": 1,
-            "conflicts": 0,
-            "backjumps": 0,
-            "restarts": 0,
-            "incompatibilities_learned": 0,
-            "metadata_fetched": 0,
-            "distributions_seen": 0,
-            "look_ahead_rejections": 0,
-            "packages": 0,
-            "wall_time_seconds": 0.0,
-        }
+        return _run_result()
 
     monkeypatch.setattr(module, "run_one", fake_run_one)
     scenario = {
@@ -137,6 +169,9 @@ def test_canary_rejects_supported_marker_build_policy(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     module = _harness()
+    host = module.BenchmarkHost.current(module.WALL_TIMEOUT_S)
+    current_system = host.target.marker_env["platform_system"]
+    required_system = "Windows" if current_system != "Windows" else "Linux"
 
     def unexpected_run(*_args: object, **_kwargs: object) -> dict:
         pytest.fail("scenario reached the resolver")
@@ -145,7 +180,7 @@ def test_canary_rejects_supported_marker_build_policy(
     scenario = {
         "python_version": "3.11",
         "requirements": ["demo"],
-        "platform_system": "Linux",
+        "platform_system": required_system,
         "build_packages": ["demo"],
     }
 
@@ -156,7 +191,89 @@ def test_canary_rejects_supported_marker_build_policy(
             "with a marker environment overlay"
         ),
     ):
-        module.median_run(scenario, 1, scenario_name="example")
+        module.median_run(scenario, 1, scenario_name="example", host=host)
+
+
+def test_canary_skips_a_platform_overlay_with_unfaithful_host_tags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    host = module.BenchmarkHost.current(module.WALL_TIMEOUT_S)
+    current_system = host.target.marker_env["platform_system"]
+    required_system = "Windows" if current_system != "Windows" else "Linux"
+
+    def unexpected_run(*_args: object, **_kwargs: object) -> dict:
+        pytest.fail("inapplicable scenario reached the resolver")
+
+    monkeypatch.setattr(module, "run_one", unexpected_run)
+    runs, summary = module.median_run(
+        {
+            "python_version": "3.11",
+            "requirements": [],
+            "platform_system": required_system,
+        },
+        1,
+        host=host,
+    )
+
+    assert runs == []
+    assert summary == {
+        "skipped": "marker environment requires wheel tags from a different host"
+    }
+
+
+def test_canary_rejects_an_invalid_host_restriction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+
+    def unexpected_run(*_args: object, **_kwargs: object) -> dict:
+        pytest.fail("invalid scenario reached the resolver")
+
+    monkeypatch.setattr(module, "run_one", unexpected_run)
+
+    with pytest.raises(ValueError, match="no supported platform"):
+        module.median_run(
+            {
+                "python_version": "3.11",
+                "requirements": [],
+                "platform_system": "Linuz",
+            },
+            1,
+            scenario_name="example",
+        )
+
+
+def test_canary_filters_root_markers_with_the_admitted_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    host = module.BenchmarkHost.current(module.WALL_TIMEOUT_S)
+    host_python = host.target.marker_env["python_version"]
+    scenario_python = "3.10" if host_python != "3.10" else "3.11"
+    seen: dict[str, object] = {}
+
+    def fake_run_one(requirements: dict, *_args: object, **kwargs: object) -> dict:
+        seen["requirements"] = set(requirements)
+        seen["target_python"] = kwargs["target"].marker_env["python_version"]
+        return _run_result(packages=1)
+
+    monkeypatch.setattr(module, "run_one", fake_run_one)
+    module.median_run(
+        {
+            "python_version": scenario_python,
+            "requirements": [
+                f"selected; python_version == '{scenario_python}'",
+                f"excluded; python_version != '{scenario_python}'",
+            ],
+        },
+        1,
+        scenario_name="example",
+        host=host,
+    )
+
+    assert seen["target_python"] == scenario_python
+    assert seen["requirements"] == {"selected"}
 
 
 def test_canary_explicit_resolution_overrides_declared_strategy(
@@ -167,20 +284,7 @@ def test_canary_explicit_resolution_overrides_declared_strategy(
 
     def fake_run_one(*_args: object, **kwargs: object) -> dict:
         seen.append(kwargs["resolution_strategy"])
-        return {
-            "success": True,
-            "error": None,
-            "decisions": 1,
-            "conflicts": 0,
-            "backjumps": 0,
-            "restarts": 0,
-            "incompatibilities_learned": 0,
-            "metadata_fetched": 0,
-            "distributions_seen": 0,
-            "look_ahead_rejections": 0,
-            "packages": 0,
-            "wall_time_seconds": 0.0,
-        }
+        return _run_result()
 
     monkeypatch.setattr(module, "run_one", fake_run_one)
     module.median_run(
@@ -195,6 +299,99 @@ def test_canary_explicit_resolution_overrides_declared_strategy(
     )
 
     assert seen == [module.ResolutionStrategy.LOWEST]
+
+
+def test_canary_prepares_inputs_and_summarizes_repeated_runs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness()
+    host = module.BenchmarkHost.current(module.WALL_TIMEOUT_S)
+    returned_runs = [
+        _run_result(
+            decisions=1,
+            distributions_seen=9,
+            metadata_fetched=3,
+            packages=1,
+            conflicts=7,
+            backjumps=4,
+            wall_time_seconds=0.1,
+        ),
+        _run_result(
+            success=False,
+            decisions=9,
+            distributions_seen=3,
+            metadata_fetched=9,
+            packages=0,
+            conflicts=1,
+            backjumps=8,
+            wall_time_seconds=0.3,
+        ),
+        _run_result(
+            decisions=5,
+            distributions_seen=6,
+            metadata_fetched=6,
+            packages=3,
+            conflicts=4,
+            backjumps=2,
+            wall_time_seconds=0.2,
+        ),
+    ]
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def fake_run_one(*args: object, **kwargs: object) -> dict[str, object]:
+        calls.append((args, kwargs))
+        return returned_runs[len(calls) - 1]
+
+    monkeypatch.setattr(module, "run_one", fake_run_one)
+    runs, summary = module.median_run(
+        {
+            "python_version": "3.11",
+            "requirements": ["demo>=1"],
+            "constraints": ["support<3"],
+            "datetime": "2025-01-02 03:04:05",
+            "indexes": [{"name": "private", "url": "https://example.test/simple"}],
+            "index_routes": [{"name": "demo", "index": "private"}],
+            "build_packages": ["demo"],
+            "resolution": "lowest-direct",
+            "trust_unverified_sdist_deps": True,
+        },
+        3,
+        scenario_name="example",
+        host=host,
+    )
+
+    assert runs == returned_runs
+    assert summary == {
+        "success_runs": "2/3",
+        "median_decisions": 5,
+        "median_distributions_seen": 6,
+        "median_metadata_fetched": 6,
+        "median_packages": 1,
+        "median_conflicts": 4,
+        "median_backjumps": 4,
+        "median_wall": 0.2,
+        "min_decisions": 1,
+        "max_decisions": 9,
+        "min_wall": 0.1,
+        "max_wall": 0.3,
+    }
+
+    assert len(calls) == 3
+    assert calls[1:] == [calls[0], calls[0]]
+    args, kwargs = calls[0]
+    requirements, uploaded_prior_to, constraints = args
+    assert set(requirements) == {"demo"}
+    assert uploaded_prior_to == module.parse_datetime("2025-01-02 03:04:05")
+    assert set(constraints) == {"support"}
+    assert kwargs["indexes"] == [
+        module.IndexConfig("private", "https://example.test/simple")
+    ]
+    assert kwargs["index_routes"] == [module.IndexRoute("demo", "private")]
+    assert kwargs["build_policy_overrides"] == {"demo": module.BuildPolicy.BUILD_REMOTE}
+    assert kwargs["resolution_strategy"] is module.ResolutionStrategy.LOWEST_DIRECT
+    assert kwargs["trust_unverified_sdist_deps"] is True
+    assert kwargs["target"].marker_env["python_version"] == "3.11"
+    assert kwargs["host"] is host
 
 
 def test_canary_configures_lowest_direct_roots(
@@ -241,12 +438,17 @@ def test_canary_configures_lowest_direct_roots(
     monkeypatch.setattr(module, "Resolver", FakeResolver)
 
     requirements = module.parse_requirements(["Root[feature]", "Other==1"])
+    captured = module.BenchmarkHost.current(module.WALL_TIMEOUT_S)
+    host = module.BenchmarkHost(captured.target, captured.python_runtime, None)
+    admission = host.target_for("3.11", {})
+    assert admission.target is not None
     result = module.run_one(
         requirements,
-        "3.11",
         None,
         None,
         resolution_strategy=module.ResolutionStrategy.LOWEST_DIRECT,
+        target=admission.target,
+        host=host,
     )
 
     assert result["success"] is True
@@ -256,7 +458,7 @@ def test_canary_configures_lowest_direct_roots(
     assert settings["build_policy"] == "never"
     assert settings["trust_unverified_sdist_deps"] is False
     assert settings["max_iterations"] == module.MAX_ITERATIONS
-    assert settings["wall_timeout_seconds"] == module.WALL_TIMEOUT_S
+    assert settings["wall_timeout_seconds"] is None
     assert settings["runtime"]["python"] == sys.version
     assert settings["runtime"]["implementation"] == sys.implementation.name
     assert settings["direct_packages"] == ["other", "root"]
@@ -267,6 +469,7 @@ def test_canary_configures_lowest_direct_roots(
     assert settings["target"]["wheel_tags_count"] > 0
     assert seen["resolution_strategy"] is module.ResolutionStrategy.LOWEST_DIRECT
     assert seen["direct_packages"] == frozenset({"root", "other"})
+    assert seen["target"] is admission.target
 
 
 def test_canary_main_records_v2_contract(
@@ -352,7 +555,9 @@ def test_canary_main_preserves_v2_lowest_identity_and_effective_settings(
         *,
         scenario_name: str,
         resolution_override: object,
+        host: object,
     ) -> tuple[list[dict], dict]:
+        del host
         assert scenario_name == "example"
         assert resolution_override is module.ResolutionStrategy.LOWEST
         return [run], summary

--- a/nab-python/tests/test_benchmark_compare.py
+++ b/nab-python/tests/test_benchmark_compare.py
@@ -1,0 +1,413 @@
+"""Contracts for fail-closed standard benchmark comparisons."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from collections.abc import Callable
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_BENCHMARKS = Path(__file__).resolve().parents[1] / "benchmarks"
+_STRATEGIES = ("highest", "lowest", "lowest-direct")
+_COMPLETED_LOGICAL = ("cases:done",)
+_UNSUPPORTED_LOGICAL = ("cases:nope",)
+_INAPPLICABLE_LOGICAL = ("cases:host",)
+
+
+def _harness() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "_benchmark_compare", _BENCHMARKS / "compare.py"
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _execution_keys(logical_keys: tuple[str, ...]) -> list[str]:
+    keys: list[str] = []
+    for logical_key in logical_keys:
+        stem, name = logical_key.split(":")
+        for strategy in _STRATEGIES:
+            directory = stem if strategy == "highest" else f"{stem}-{strategy}"
+            keys.append(f"{directory}/{name}.json")
+    return sorted(keys)
+
+
+def _settings() -> dict[str, object]:
+    return {
+        "dist_policy": "wheel-or-sdist",
+        "build_policy": "never",
+        "trust_unverified_sdist_deps_default": True,
+        "max_iterations": 50_000,
+        "wall_timeout_seconds": 120,
+        "host": {
+            "python": "3.12.1 (benchmark fixture)",
+            "marker_environment": {
+                "implementation_name": "cpython",
+                "implementation_version": "3.12.1",
+                "os_name": "posix",
+                "platform_machine": "x86_64",
+                "platform_python_implementation": "CPython",
+                "platform_release": "fixture-release",
+                "platform_system": "Linux",
+                "platform_version": "fixture-version",
+                "python_full_version": "3.12.1",
+                "python_version": "3.12",
+                "sys_platform": "linux",
+            },
+            "wheel_tags_count": 2,
+            "wheel_tags_hash": "d" * 64,
+        },
+    }
+
+
+def _manifest(
+    module: ModuleType,
+    label: str,
+    source: dict[str, object],
+) -> dict[str, object]:
+    available_logical = tuple(
+        sorted(_COMPLETED_LOGICAL + _UNSUPPORTED_LOGICAL + _INAPPLICABLE_LOGICAL)
+    )
+    completed_execution = _execution_keys(_COMPLETED_LOGICAL)
+    return {
+        "benchmark_schema": module.MANIFEST_SCHEMA,
+        "commit": label,
+        "source_start": source,
+        "source_end": source,
+        "mode": "strategy-matrix",
+        "strategies": list(_STRATEGIES),
+        "settings": _settings(),
+        "corpus_hash": "c" * 64,
+        "corpus_files": ["cases"],
+        "selected_files": ["cases"],
+        "available_logical_keys": list(available_logical),
+        "selected_logical_keys": list(available_logical),
+        "completed_logical_keys": list(_COMPLETED_LOGICAL),
+        "unsupported_logical_keys": list(_UNSUPPORTED_LOGICAL),
+        "inapplicable_logical_keys": list(_INAPPLICABLE_LOGICAL),
+        "available_execution_keys": _execution_keys(available_logical),
+        "selected_execution_keys": _execution_keys(available_logical),
+        "completed_execution_keys": completed_execution,
+        "unsupported_execution_keys": _execution_keys(_UNSUPPORTED_LOGICAL),
+        "file_execution_keys": completed_execution,
+        "complete": True,
+    }
+
+
+def _execution_strategy(execution_key: str) -> str:
+    result_directory = execution_key.partition("/")[0]
+    for strategy in reversed(_STRATEGIES):
+        if result_directory.endswith(f"-{strategy}"):
+            return strategy
+    return "highest"
+
+
+def _result_payload(
+    module: ModuleType,
+    manifest: dict[str, object],
+    execution_key: str,
+    rounds: int,
+) -> dict[str, object]:
+    input_data = {
+        "benchmark_schema": module.MANIFEST_SCHEMA,
+        "commit": manifest["commit"],
+        "source": manifest["source_start"],
+        "corpus_hash": manifest["corpus_hash"],
+        "logical_key": "cases:done",
+        "execution_key": execution_key,
+        "settings_hash": module._settings_hash(manifest["settings"]),
+        "python_version": "3.12",
+        "requirements": ["demo>=1"],
+        "constraints": ["support<3"],
+    }
+    strategy = _execution_strategy(execution_key)
+    if strategy != "highest":
+        input_data["resolution"] = strategy
+
+    stats = dict.fromkeys(module._STANDARD_COUNTER_FIELDS, 0)
+    stats["rounds"] = rounds
+    stats["wall_time_seconds"] = 0.01
+    return {
+        "input": input_data,
+        "result": {"success": True, "error": None},
+        "stats": stats,
+    }
+
+
+def _write_run(
+    module: ModuleType,
+    root: Path,
+    label: str,
+    *,
+    source_commit: str,
+    rounds: int = 1,
+) -> Path:
+    """Write one complete strategy-matrix run with all terminal states."""
+    source = {"commit": source_commit, "dirty": False, "diff_hash": None}
+    manifest = _manifest(module, label, source)
+    run_dir = root / label
+    run_dir.mkdir()
+    (run_dir / module.MANIFEST_FILENAME).write_text(json.dumps(manifest))
+
+    for execution_key in _execution_keys(_COMPLETED_LOGICAL):
+        path = run_dir / execution_key
+        path.parent.mkdir(exist_ok=True)
+        path.write_text(
+            json.dumps(_result_payload(module, manifest, execution_key, rounds))
+        )
+    return run_dir
+
+
+def _rewrite_json(path: Path, mutate: Callable[[dict], None]) -> None:
+    data = json.loads(path.read_text())
+    mutate(data)
+    path.write_text(json.dumps(data))
+
+
+def _remove_completed_result(run_dir: Path) -> None:
+    (run_dir / "cases" / "done.json").unlink()
+
+
+def _add_extra_result(run_dir: Path) -> None:
+    (run_dir / "cases" / "extra.json").write_text("{}")
+
+
+def test_comparison_uses_the_manifest_and_keeps_scenario_inputs(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _harness()
+    first_dir = _write_run(module, tmp_path, "first", source_commit="a" * 40)
+    second_dir = _write_run(
+        module, tmp_path, "second", source_commit="b" * 40, rounds=2
+    )
+    (first_dir / "_provenance.json").write_text("{}")
+    (first_dir / "universal").mkdir()
+    (first_dir / "universal" / "result.json").write_text("{}")
+
+    first = module.load_run(first_dir)
+    second = module.load_run(second_dir)
+    module.require_comparable(first, second)
+    module.compare_scenario(
+        first.results["cases/done.json"],
+        second.results["cases/done.json"],
+        "cases/done.json",
+    )
+
+    assert first.results["cases/done.json"]["input"]["requirements"] == ["demo>=1"]
+    assert "Rounds: 1 -> 2 (+100.0%)" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(lambda data: data.update(complete=False), id="incomplete"),
+        pytest.param(
+            lambda data: data["source_start"].update(dirty=True),
+            id="dirty-source",
+        ),
+        pytest.param(lambda data: data.update(commit="other"), id="wrong-label"),
+        pytest.param(lambda data: data.update(mode="default"), id="wrong-mode"),
+        pytest.param(
+            lambda data: data["completed_logical_keys"].append("cases:host"),
+            id="overlapping-partition",
+        ),
+    ],
+)
+def test_load_run_rejects_an_invalid_manifest(
+    tmp_path: Path,
+    mutate: Callable[[dict], None],
+) -> None:
+    module = _harness()
+    run_dir = _write_run(module, tmp_path, "run", source_commit="a" * 40)
+    manifest_path = run_dir / module.MANIFEST_FILENAME
+    _rewrite_json(manifest_path, mutate)
+
+    with pytest.raises(module.ComparisonError):
+        module.load_run(run_dir)
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(lambda data: data["settings"].pop("host"), id="missing-host"),
+        pytest.param(
+            lambda data: data["settings"].update(wall_timeout_seconds=0),
+            id="zero-timeout",
+        ),
+        pytest.param(
+            lambda data: data["settings"]["host"].update(wheel_tags_count=True),
+            id="boolean-tag-count",
+        ),
+        pytest.param(
+            lambda data: data["settings"]["host"].update(wheel_tags_hash="not-a-hash"),
+            id="invalid-tag-hash",
+        ),
+    ],
+)
+def test_load_run_rejects_invalid_settings(
+    tmp_path: Path,
+    mutate: Callable[[dict], None],
+) -> None:
+    module = _harness()
+    run_dir = _write_run(module, tmp_path, "run", source_commit="a" * 40)
+    _rewrite_json(run_dir / module.MANIFEST_FILENAME, mutate)
+
+    with pytest.raises(module.ComparisonError):
+        module.load_run(run_dir)
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(_remove_completed_result, id="missing"),
+        pytest.param(_add_extra_result, id="extra"),
+    ],
+)
+def test_load_run_rejects_result_file_set_changes(
+    tmp_path: Path,
+    mutate: Callable[[Path], None],
+) -> None:
+    module = _harness()
+    run_dir = _write_run(module, tmp_path, "run", source_commit="a" * 40)
+    mutate(run_dir)
+
+    with pytest.raises(module.ComparisonError):
+        module.load_run(run_dir)
+
+
+@pytest.mark.parametrize(
+    ("old", "new", "expected"),
+    [
+        (100, 110, "+10.0%"),
+        (100, 90, "-10.0%"),
+        (0, 1, "+inf%"),
+        (0, 0, "0.0%"),
+    ],
+)
+def test_percent_change_is_relative_to_the_baseline(
+    old: float,
+    new: float,
+    expected: str,
+) -> None:
+    module = _harness()
+
+    assert module.percent_change(old, new) == expected
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(lambda data: data.update(result={}), id="result-shape"),
+        pytest.param(
+            lambda data: data["stats"].pop("rounds"),
+            id="stats-shape",
+        ),
+        pytest.param(
+            lambda data: data["stats"].update(rounds=-1),
+            id="negative-counter",
+        ),
+        pytest.param(
+            lambda data: data["stats"].update(wall_time_seconds="slow"),
+            id="wall-time-type",
+        ),
+    ],
+)
+def test_load_run_rejects_an_invalid_result_payload(
+    tmp_path: Path,
+    mutate: Callable[[dict], None],
+) -> None:
+    module = _harness()
+    run_dir = _write_run(module, tmp_path, "run", source_commit="a" * 40)
+    _rewrite_json(run_dir / "cases" / "done.json", mutate)
+
+    with pytest.raises(module.ComparisonError):
+        module.load_run(run_dir)
+
+
+@pytest.mark.parametrize("field", ["source", "settings_hash", "execution_key"])
+def test_load_run_rejects_result_provenance(
+    tmp_path: Path,
+    field: str,
+) -> None:
+    module = _harness()
+    run_dir = _write_run(module, tmp_path, "run", source_commit="a" * 40)
+    result_path = run_dir / "cases" / "done.json"
+    _rewrite_json(result_path, lambda data: data["input"].update({field: "wrong"}))
+
+    with pytest.raises(module.ComparisonError, match="does not match its manifest"):
+        module.load_run(run_dir)
+
+
+def test_comparison_rejects_scenario_input_differences(
+    tmp_path: Path,
+) -> None:
+    module = _harness()
+    first = module.load_run(
+        _write_run(module, tmp_path, "first", source_commit="a" * 40)
+    )
+    second_dir = _write_run(module, tmp_path, "second", source_commit="b" * 40)
+    result_path = second_dir / "cases" / "done.json"
+    _rewrite_json(
+        result_path,
+        lambda data: data["input"].update(requirements=["other"]),
+    )
+    second = module.load_run(second_dir)
+
+    with pytest.raises(module.ComparisonError, match="inputs differ"):
+        module.require_comparable(first, second)
+
+
+def test_comparison_rejects_manifest_identity_differences(tmp_path: Path) -> None:
+    module = _harness()
+    first = module.load_run(
+        _write_run(module, tmp_path, "first", source_commit="a" * 40)
+    )
+    second_dir = _write_run(module, tmp_path, "second", source_commit="b" * 40)
+    _rewrite_json(
+        second_dir / module.MANIFEST_FILENAME,
+        lambda data: data["settings"].update(wall_timeout_seconds=None),
+    )
+    manifest = json.loads((second_dir / module.MANIFEST_FILENAME).read_text())
+    for key in manifest["completed_execution_keys"]:
+        _rewrite_json(
+            second_dir / key,
+            lambda data: data["input"].update(
+                settings_hash=module._settings_hash(manifest["settings"])
+            ),
+        )
+    changed_identity = module.load_run(second_dir)
+
+    with pytest.raises(module.ComparisonError, match="different identities"):
+        module.require_comparable(first, changed_identity)
+
+
+def test_comparison_rejects_runs_without_completed_executions(tmp_path: Path) -> None:
+    module = _harness()
+
+    def make_all_inapplicable(run_dir: Path) -> None:
+        def rewrite_manifest(data: dict) -> None:
+            data["completed_logical_keys"] = []
+            data["inapplicable_logical_keys"] = ["cases:done", "cases:host"]
+            data["completed_execution_keys"] = []
+            data["file_execution_keys"] = []
+
+        _rewrite_json(run_dir / module.MANIFEST_FILENAME, rewrite_manifest)
+        for result_path in run_dir.glob("cases*/done.json"):
+            result_path.unlink()
+
+    first_dir = _write_run(module, tmp_path, "first", source_commit="a" * 40)
+    second_dir = _write_run(module, tmp_path, "second", source_commit="b" * 40)
+    make_all_inapplicable(first_dir)
+    make_all_inapplicable(second_dir)
+
+    first = module.load_run(first_dir)
+    second = module.load_run(second_dir)
+    with pytest.raises(module.ComparisonError, match="no completed executions"):
+        module.require_comparable(first, second)

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -5,14 +5,18 @@ from __future__ import annotations
 import importlib.util
 import json
 import re
+import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from typing import Literal
 
 import pytest
+
+from nab_python._vendor.packaging.tags import Tag
+from nab_python.target import ResolveTarget
 
 _BENCHMARKS = Path(__file__).resolve().parents[1] / "benchmarks"
 _STANDARD_FILES = 14
@@ -20,7 +24,6 @@ _STANDARD_SCENARIOS = 558
 _RUNNABLE_SCENARIOS = 536
 _UNSUPPORTED_SCENARIOS = 22
 _TOTAL_EXECUTION_IDENTITIES = 1_674
-_RUNNABLE_STRATEGY_EXECUTIONS = 1_608
 _MARKER_BUILD_SCENARIOS = {
     "ai-stack:llama-index-experimental-gpt5",
     "ai-stack:open-r1",
@@ -29,6 +32,24 @@ _MARKER_BUILD_SCENARIOS = {
     "pip:pip-11760-torchgeo-nbconvert-pin",
     "pip:pip-9572-textract-pypdf2",
     "uv:uv-issue-13321-axolotl-stack",
+}
+_EXACT_HOST_MARKERS = {
+    "uv:uv-tensorflow-macos": {
+        "implementation_name": "cpython",
+        "os_name": "posix",
+        "platform_machine": "arm64",
+        "platform_python_implementation": "CPython",
+        "platform_system": "Darwin",
+        "sys_platform": "darwin",
+    },
+    "uv:pywin32-windows-amd64-real-index": {
+        "implementation_name": "cpython",
+        "os_name": "nt",
+        "platform_machine": "AMD64",
+        "platform_python_implementation": "CPython",
+        "platform_system": "Windows",
+        "sys_platform": "win32",
+    },
 }
 _CLEAN_SOURCE = {"commit": "a" * 40, "dirty": False, "diff_hash": None}
 _MANIFEST_FIELDS = {
@@ -46,6 +67,7 @@ _MANIFEST_FIELDS = {
     "selected_logical_keys",
     "completed_logical_keys",
     "unsupported_logical_keys",
+    "inapplicable_logical_keys",
     "available_execution_keys",
     "selected_execution_keys",
     "completed_execution_keys",
@@ -53,6 +75,75 @@ _MANIFEST_FIELDS = {
     "file_execution_keys",
     "complete",
 }
+
+
+def _host(
+    module: ModuleType,
+    *,
+    system: str,
+    sys_platform: str,
+    machine: str,
+    os_name: str,
+    platform_tag: str,
+    implementation: str = "cpython",
+) -> object:
+    platform_implementation = "CPython" if implementation == "cpython" else "PyPy"
+    interpreter = "cp312" if implementation == "cpython" else "pp312"
+    abi = "cp312" if implementation == "cpython" else "pypy312_pp73"
+    environment = {
+        "implementation_name": implementation,
+        "implementation_version": "3.12.0",
+        "os_name": os_name,
+        "platform_machine": machine,
+        "platform_python_implementation": platform_implementation,
+        "platform_release": "test-release",
+        "platform_system": system,
+        "platform_version": "test-version",
+        "python_full_version": "3.12.0",
+        "python_version": "3.12",
+        "sys_platform": sys_platform,
+    }
+    target = ResolveTarget.for_host(
+        env_source=lambda: environment,
+        tags_source=lambda: iter(
+            (Tag(interpreter, abi, platform_tag), Tag("py3", "none", "any"))
+        ),
+    )
+    return module.BenchmarkHost(target, "test-runtime", 120)
+
+
+def _empty_provider_stats() -> SimpleNamespace:
+    fields = (
+        "listings_fetched",
+        "metadata_fetched",
+        "sdist_pkg_info_fetched",
+        "distributions_seen",
+        "wheels_seen",
+        "sdists_seen",
+        "excluded_by_python",
+        "excluded_by_time",
+        "excluded_by_dist_policy",
+        "excluded_by_build_policy",
+        "sdist_pyproject_fallbacks",
+        "get_dependencies_calls",
+        "choose_version_calls",
+        "prioritize_calls",
+        "look_ahead_rejections",
+    )
+    return SimpleNamespace(**dict.fromkeys(fields, 0))
+
+
+def _empty_resolver_stats() -> SimpleNamespace:
+    fields = (
+        "rounds",
+        "decisions",
+        "conflicts",
+        "derivations",
+        "backjumps",
+        "restarts",
+        "incompatibilities_learned",
+    )
+    return SimpleNamespace(**dict.fromkeys(fields, 0))
 
 
 @dataclass(frozen=True, order=True, slots=True)
@@ -126,8 +217,19 @@ def _harness(name: str) -> ModuleType:
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    sys.path.insert(0, str(_BENCHMARKS))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.remove(str(_BENCHMARKS))
     return module
+
+
+def _exact_host_rows(module: ModuleType) -> dict[str, object]:
+    rows = module.load_standard_corpus(module.standard_scenario_files())
+    return {
+        row.logical_key: row for row in rows if "marker_environment" in row.definition
+    }
 
 
 def _write_corpus(
@@ -147,6 +249,11 @@ requirements = ["{requirement}"]
 python_version = "3.11"
 requirements = ["native-only"]
 unsupported_reason = "requires a native system dependency"
+
+[foreign-host]
+python_version = "3.11"
+requirements = []
+platform_system = "Windows"
 """.lstrip(),
         encoding="utf-8",
     )
@@ -171,11 +278,19 @@ def _result_payload(
     source: dict[str, object],
     corpus_hash: str,
 ) -> dict[str, object]:
+    host = module.BenchmarkHost.current(module.SCENARIO_WALL_TIMEOUT_SECONDS)
+    plan = module.standard_run_plan(
+        [execution.scenario],
+        (execution.strategy,),
+        host,
+    )
     input_data = module.prepare_standard_execution(
         execution,
+        plan.targets_by_logical_key[execution.scenario.logical_key],
         commit=commit,
         source=source,
         corpus_hash=corpus_hash,
+        settings_digest="test-settings",
     ).expected_input
     stats = dict.fromkeys(module._STANDARD_COUNTER_FIELDS, 0)
     stats["packages_resolved"] = 1
@@ -215,20 +330,44 @@ def _run_fake(
     source_states = iter((effective_source, effective_end_source))
     monkeypatch.setattr(module, "get_git_source_state", lambda: next(source_states))
     seen: list[object] = []
+    captured_hosts: list[object] = []
+    captured_host = _host(
+        module,
+        system="Linux",
+        sys_platform="linux",
+        machine="x86_64",
+        os_name="posix",
+        platform_tag="manylinux_2_17_x86_64",
+    )
+
+    def current_host(_cls: type, timeout: int) -> object:
+        assert timeout == module.SCENARIO_WALL_TIMEOUT_SECONDS
+        captured_hosts.append(captured_host)
+        return captured_host
+
+    monkeypatch.setattr(module.BenchmarkHost, "current", classmethod(current_host))
 
     def process(
         execution: object,
         commit: str,
         *,
         force: bool,
-        source: dict[str, object],
-        corpus_hash: str,
-    ) -> bool:
+        prepared: object,
+        host: object,
+    ) -> None:
         del force
+        assert host is captured_hosts[0]
         seen.append(execution)
         if result_kind == "missing":
-            return True
-        payload = _result_payload(module, execution, commit, source, corpus_hash)
+            return
+        stats = dict.fromkeys(module._STANDARD_COUNTER_FIELDS, 0)
+        stats["packages_resolved"] = 1
+        stats["wall_time_seconds"] = 0.01
+        payload = {
+            "input": json.loads(json.dumps(prepared.expected_input)),
+            "result": {"success": True, "error": None},
+            "stats": stats,
+        }
         if result_kind == "malformed":
             payload["stats"] = {"wall_time_seconds": 0.01}
         if result_kind == "changed-input":
@@ -246,7 +385,6 @@ def _run_fake(
             nested = results_dir / commit / "nested" / module.STANDARD_MANIFEST_FILENAME
             nested.parent.mkdir()
             nested.write_text(json.dumps(payload) + "\n", encoding="utf-8")
-        return True
 
     monkeypatch.setattr(module, "process_scenario", process)
     argv = ["--commit", "run"]
@@ -257,6 +395,7 @@ def _run_fake(
     if force:
         argv.append("--force")
     module.main(argv)
+    assert len(captured_hosts) == 1
     return module, seen, results_dir / "run" / module.STANDARD_MANIFEST_FILENAME
 
 
@@ -277,11 +416,379 @@ def test_standard_corpus_is_one_canonical_definition_per_scenario() -> None:
 def test_standard_execution_census() -> None:
     module = _harness("scenarios")
     rows = module.load_standard_corpus(module.standard_scenario_files())
-    executions = module.standard_execution_plan(rows, module.STANDARD_STRATEGIES)
     execution_keys = module.standard_execution_keys(rows, module.STANDARD_STRATEGIES)
 
-    assert len(executions) == _RUNNABLE_STRATEGY_EXECUTIONS
     assert len(execution_keys) == _TOTAL_EXECUTION_IDENTITIES
+
+
+@pytest.mark.parametrize(
+    ("host_kwargs", "expected"),
+    [
+        (
+            {
+                "system": "Linux",
+                "sys_platform": "linux",
+                "machine": "x86_64",
+                "os_name": "posix",
+                "platform_tag": "manylinux_2_17_x86_64",
+            },
+            {"linux", "neutral"},
+        ),
+        (
+            {
+                "system": "Windows",
+                "sys_platform": "win32",
+                "machine": "AMD64",
+                "os_name": "nt",
+                "platform_tag": "win_amd64",
+            },
+            {"windows", "windows-amd64", "neutral"},
+        ),
+        (
+            {
+                "system": "Windows",
+                "sys_platform": "win32",
+                "machine": "ARM64",
+                "os_name": "nt",
+                "platform_tag": "win_arm64",
+            },
+            {"windows", "neutral"},
+        ),
+        (
+            {
+                "system": "Darwin",
+                "sys_platform": "darwin",
+                "machine": "arm64",
+                "os_name": "posix",
+                "platform_tag": "macosx_14_0_arm64",
+            },
+            {"mac-arm", "neutral"},
+        ),
+        (
+            {
+                "system": "Darwin",
+                "sys_platform": "darwin",
+                "machine": "x86_64",
+                "os_name": "posix",
+                "platform_tag": "macosx_14_0_x86_64",
+            },
+            {"neutral"},
+        ),
+        (
+            {
+                "system": "Darwin",
+                "sys_platform": "darwin",
+                "machine": "arm64",
+                "os_name": "posix",
+                "platform_tag": "macosx_14_0_arm64",
+                "implementation": "pypy",
+            },
+            {"neutral"},
+        ),
+    ],
+)
+def test_standard_plan_admits_only_targets_with_host_wheel_tags(
+    host_kwargs: dict[str, str],
+    expected: set[str],
+) -> None:
+    module = _harness("scenarios")
+    rows = [
+        module.StandardScenario(
+            "test",
+            "linux",
+            {"python_version": "3.11", "platform_system": "Linux"},
+        ),
+        module.StandardScenario(
+            "test",
+            "windows",
+            {"python_version": "3.11", "platform_system": "Windows"},
+        ),
+        module.StandardScenario(
+            "test",
+            "windows-amd64",
+            {
+                "python_version": "3.11",
+                "marker_environment": {
+                    "implementation_name": "cpython",
+                    "os_name": "nt",
+                    "platform_machine": "AMD64",
+                    "platform_python_implementation": "CPython",
+                    "platform_system": "Windows",
+                    "sys_platform": "win32",
+                },
+            },
+        ),
+        module.StandardScenario(
+            "test",
+            "mac-arm",
+            {
+                "python_version": "3.11",
+                "marker_environment": {
+                    "implementation_name": "cpython",
+                    "os_name": "posix",
+                    "platform_machine": "arm64",
+                    "platform_python_implementation": "CPython",
+                    "platform_system": "Darwin",
+                    "sys_platform": "darwin",
+                },
+            },
+        ),
+        module.StandardScenario("test", "neutral", {"python_version": "3.11"}),
+    ]
+
+    plan = module.standard_run_plan(
+        rows,
+        (module.ResolutionStrategy.HIGHEST,),
+        _host(module, **host_kwargs),
+    )
+
+    assert {execution.scenario.name for execution in plan.executions} == expected
+    assert all(target.tags_faithful for target in plan.targets_by_logical_key.values())
+    assert len(plan.inapplicable_logical_keys) == len(rows) - len(expected)
+
+
+@pytest.mark.parametrize(
+    ("definition", "message"),
+    [
+        ({"platform_system": "Linuz"}, "no supported platform"),
+        (
+            {
+                "marker_environment": {
+                    "platform_system": "Darwin",
+                    "sys_platform": "win32",
+                }
+            },
+            "no supported platform",
+        ),
+        (
+            {
+                "marker_environment": {
+                    "implementation_name": "cpython",
+                    "platform_python_implementation": "PyPy",
+                }
+            },
+            "no supported interpreter",
+        ),
+        (
+            {
+                "platform_system": "Linux",
+                "marker_environment": {"platform_system": "Windows"},
+            },
+            "platform_system conflicts",
+        ),
+    ],
+)
+def test_invalid_host_restrictions_are_rejected(
+    definition: dict[str, object],
+    message: str,
+) -> None:
+    module = _harness("scenarios")
+
+    with pytest.raises(ValueError, match=message):
+        module.parse_marker_environment("invalid", definition)
+
+
+@pytest.mark.parametrize(
+    "definition",
+    [
+        {"platform_system": 1},
+        {"marker_environment": {"platform_system": 1}},
+    ],
+)
+def test_host_restrictions_require_string_values(
+    definition: dict[str, object],
+) -> None:
+    module = _harness("scenarios")
+
+    with pytest.raises(TypeError, match="must be .*string"):
+        module.parse_marker_environment("invalid", definition)
+
+
+def test_standard_plan_reuses_one_admitted_target_across_strategies() -> None:
+    module = _harness("scenarios")
+    row = module.StandardScenario(
+        "test",
+        "neutral",
+        {"python_version": "3.11", "requirements": []},
+    )
+    plan = module.standard_run_plan(
+        [row],
+        module.STANDARD_STRATEGIES,
+        module.BenchmarkHost.current(120),
+    )
+
+    assert len(plan.targets_by_logical_key) == 1
+    target = plan.targets_by_logical_key[row.logical_key]
+    assert all(
+        plan.targets_by_logical_key[execution.scenario.logical_key] is target
+        for execution in plan.executions
+    )
+
+
+def test_host_identity_distinguishes_wheel_tag_sets() -> None:
+    module = _harness("scenarios")
+    environment = {
+        "implementation_name": "cpython",
+        "implementation_version": "3.12.0",
+        "os_name": "posix",
+        "platform_machine": "x86_64",
+        "platform_python_implementation": "CPython",
+        "platform_release": "test-release",
+        "platform_system": "Linux",
+        "platform_version": "test-version",
+        "python_full_version": "3.12.0",
+        "python_version": "3.12",
+        "sys_platform": "linux",
+    }
+    tags = (
+        Tag("cp312", "cp312", "manylinux_2_28_x86_64"),
+        Tag("cp312", "abi3", "manylinux_2_17_x86_64"),
+    )
+
+    def identity_for(ordered_tags: tuple[Tag, ...]) -> dict[str, object]:
+        target = ResolveTarget.for_host(
+            env_source=lambda: environment,
+            tags_source=lambda: iter(ordered_tags),
+        )
+        return module.BenchmarkHost(target, "test-runtime", 120).identity()
+
+    identity = identity_for(tags)
+    reversed_identity = identity_for(tuple(reversed(tags)))
+    wheel_tags_hash = identity["wheel_tags_hash"]
+
+    assert identity == {
+        "python": "test-runtime",
+        "marker_environment": dict(sorted(environment.items())),
+        "wheel_tags_count": 2,
+        "wheel_tags_hash": wheel_tags_hash,
+    }
+    assert isinstance(wheel_tags_hash, str)
+    assert len(wheel_tags_hash) == 64
+    assert wheel_tags_hash != reversed_identity["wheel_tags_hash"]
+
+
+def test_process_scenario_uses_the_planned_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness("scenarios")
+    host = _host(
+        module,
+        system="Linux",
+        sys_platform="linux",
+        machine="x86_64",
+        os_name="posix",
+        platform_tag="manylinux_2_17_x86_64",
+    )
+    row = module.StandardScenario(
+        "quick",
+        "markers",
+        {
+            "python_version": "3.11",
+            "requirements": [
+                "selected; platform_machine == 'x86_64'",
+                "excluded; platform_machine == 'arm64'",
+            ],
+        },
+    )
+    plan = module.standard_run_plan(
+        [row],
+        (module.ResolutionStrategy.HIGHEST,),
+        host,
+    )
+    execution = plan.executions[0]
+    target = plan.targets_by_logical_key[row.logical_key]
+    settings = module.standard_benchmark_settings(host)
+    prepared = module.prepare_standard_execution(
+        execution,
+        target,
+        commit="run",
+        source=dict(_CLEAN_SOURCE),
+        corpus_hash="f" * 64,
+        settings_digest=module.settings_hash(settings),
+    )
+    seen: dict[str, object] = {}
+
+    def resolve(requirements: dict, *_args: object, **kwargs: object) -> dict:
+        seen["requirements"] = requirements
+        seen.update(kwargs)
+        stats = dict.fromkeys(module._STANDARD_COUNTER_FIELDS, 0)
+        stats["wall_time_seconds"] = 0.01
+        return {
+            "result": {"success": True, "error": None},
+            "stats": stats,
+        }
+
+    monkeypatch.setattr(module, "RESULTS_DIR", tmp_path)
+    monkeypatch.setattr(module, "resolve_scenario", resolve)
+    module.process_scenario(
+        execution,
+        "run",
+        force=False,
+        prepared=prepared,
+        host=host,
+    )
+
+    requirements = seen["requirements"]
+    assert isinstance(requirements, dict)
+    assert set(requirements) == {"selected"}
+    assert seen["target"] is target
+    assert seen["host"] is host
+
+
+def test_resolve_scenario_uses_the_supplied_target_and_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harness("scenarios")
+    host = _host(
+        module,
+        system="Linux",
+        sys_platform="linux",
+        machine="x86_64",
+        os_name="posix",
+        platform_tag="manylinux_2_17_x86_64",
+    )
+    admission = host.target_for("3.11", {})
+    assert admission.target is not None
+    target = admission.target
+    seen: dict[str, object] = {}
+
+    @contextmanager
+    def fake_coordinator(*_args: object, **_kwargs: object) -> Iterator[object]:
+        yield object()
+
+    class FakeProvider:
+        def __init__(self, *_args: object, **kwargs: object) -> None:
+            seen["target"] = kwargs["target"]
+            self.stats = _empty_provider_stats()
+
+    class FakeResolver:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            self.stats = _empty_resolver_stats()
+
+        def resolve(self, *_args: object, **_kwargs: object) -> dict:
+            return {"demo": "1.0"}
+
+    @contextmanager
+    def wall_timeout(actual_host: object) -> Iterator[None]:
+        assert actual_host is host
+        seen["timeout"] = actual_host
+        yield
+
+    monkeypatch.setattr(module, "FetchCoordinator", fake_coordinator)
+    monkeypatch.setattr(module, "HttpxAsyncTransport", object)
+    monkeypatch.setattr(module, "Provider", FakeProvider)
+    monkeypatch.setattr(module, "Resolver", FakeResolver)
+    monkeypatch.setattr(module.BenchmarkHost, "wall_timeout", wall_timeout)
+
+    result = module.resolve_scenario(
+        module.parse_requirements(["demo"]),
+        target=target,
+        host=host,
+    )
+
+    assert result["result"] == {"success": True, "error": None}
+    assert seen == {"target": target, "timeout": host}
 
 
 def test_marker_build_scenarios_are_explicitly_unsupported() -> None:
@@ -298,6 +805,72 @@ def test_marker_build_scenarios_are_explicitly_unsupported() -> None:
     assert all(
         row.definition.get("unsupported_reason") for row in marker_build_rows.values()
     )
+
+
+def test_exact_host_scenarios_define_complete_marker_environments() -> None:
+    module = _harness("scenarios")
+    rows = _exact_host_rows(module)
+
+    assert {
+        key: row.definition["marker_environment"] for key, row in rows.items()
+    } == _EXACT_HOST_MARKERS
+
+
+def test_exact_host_scenarios_retain_their_reviewed_inputs() -> None:
+    module = _harness("scenarios")
+    rows = _exact_host_rows(module)
+
+    tensorflow = rows["uv:uv-tensorflow-macos"].definition
+    assert tensorflow["python_version"] == "3.10.17"
+    assert tensorflow["datetime"] == "2025-05-21 09:12:43"
+    assert tensorflow["requirements"] == ["protobuf", "retina-face"]
+
+    pywin32 = rows["uv:pywin32-windows-amd64-real-index"].definition
+    assert pywin32["requirements"] == ["pywin32; sys_platform == 'win32'"]
+    assert all("unsupported_reason" not in row.definition for row in rows.values())
+
+
+@pytest.mark.parametrize(
+    ("logical_key", "host_kwargs"),
+    [
+        (
+            "uv:uv-tensorflow-macos",
+            {
+                "system": "Darwin",
+                "sys_platform": "darwin",
+                "machine": "arm64",
+                "os_name": "posix",
+                "platform_tag": "macosx_14_0_arm64",
+            },
+        ),
+        (
+            "uv:pywin32-windows-amd64-real-index",
+            {
+                "system": "Windows",
+                "sys_platform": "win32",
+                "machine": "AMD64",
+                "os_name": "nt",
+                "platform_tag": "win_amd64",
+            },
+        ),
+    ],
+)
+def test_exact_host_scenarios_run_on_matching_hosts(
+    logical_key: str,
+    host_kwargs: dict[str, str],
+) -> None:
+    module = _harness("scenarios")
+    row = _exact_host_rows(module)[logical_key]
+    host = _host(module, **host_kwargs)
+
+    plan = module.standard_run_plan(
+        [row],
+        (module.ResolutionStrategy.HIGHEST,),
+        host,
+    )
+
+    assert len(plan.executions) == 1
+    assert plan.targets_by_logical_key[logical_key].tags_faithful
 
 
 def test_standard_corpus_rejects_supported_marker_build_policy(
@@ -715,16 +1288,20 @@ def test_canonical_scenario_names_cannot_collide_case_insensitively(
 
 def test_matrix_uses_historical_result_paths_and_partitions_unsupported() -> None:
     module = _harness("scenarios")
-    supported = module.StandardScenario("quick", "example", {})
+    supported = module.StandardScenario(
+        "quick", "example", {"python_version": "3.11", "requirements": []}
+    )
     unsupported = module.StandardScenario(
         "quick", "unsupported", {"unsupported_reason": "reviewed"}
     )
 
     assert [
         execution.result_key
-        for execution in module.standard_execution_plan(
-            [supported, unsupported], module.STANDARD_STRATEGIES
-        )
+        for execution in module.standard_run_plan(
+            [supported, unsupported],
+            module.STANDARD_STRATEGIES,
+            module.BenchmarkHost.current(120),
+        ).executions
     ] == [
         "quick/example.json",
         "quick-lowest/example.json",
@@ -771,7 +1348,7 @@ def test_result_validation_rejects_json_type_coercions(
         payload_source,
         "f" * 64,
     )
-    expected_input = payload["input"]
+    expected_input = json.loads(json.dumps(payload["input"]))
     assert isinstance(expected_input, dict)
     target = expected_input
     for key in field_path[:-1]:
@@ -780,16 +1357,52 @@ def test_result_validation_rejects_json_type_coercions(
         target = nested
     target[field_path[-1]] = forged_value
 
-    prepared = module.prepare_standard_execution(
+    assert not module._standard_result_data_valid(
+        payload,
+        expected_input,
+    )
+
+
+def test_result_cache_identity_includes_the_host_settings_hash() -> None:
+    module = _harness("scenarios")
+    row = module.StandardScenario(
+        "quick",
+        "example",
+        {"python_version": "3.11", "requirements": ["demo"]},
+    )
+    host = module.BenchmarkHost.current(module.SCENARIO_WALL_TIMEOUT_SECONDS)
+    plan = module.standard_run_plan(
+        [row],
+        (module.ResolutionStrategy.HIGHEST,),
+        host,
+    )
+    execution = plan.executions[0]
+    target = plan.targets_by_logical_key[row.logical_key]
+    first = module.prepare_standard_execution(
         execution,
+        target,
         commit="run",
         source=dict(_CLEAN_SOURCE),
         corpus_hash="f" * 64,
+        settings_digest="first-host",
     )
-    assert not module._standard_result_data_valid(
-        payload,
-        prepared.expected_input,
+    second = module.prepare_standard_execution(
+        execution,
+        target,
+        commit="run",
+        source=dict(_CLEAN_SOURCE),
+        corpus_hash="f" * 64,
+        settings_digest="second-host",
     )
+    stats = dict.fromkeys(module._STANDARD_COUNTER_FIELDS, 0)
+    stats["wall_time_seconds"] = 0.01
+    payload = {
+        "input": first.expected_input,
+        "result": {"success": True, "error": None},
+        "stats": stats,
+    }
+
+    assert not module._standard_result_data_valid(payload, second.expected_input)
 
 
 @pytest.mark.parametrize(
@@ -818,35 +1431,109 @@ def test_main_writes_exact_complete_default_and_matrix_manifests(
     manifest = json.loads(manifest_path.read_text())
 
     assert [execution.strategy.value for execution in seen] == expected_strategies
+
     assert set(manifest) == _MANIFEST_FIELDS
     assert manifest["benchmark_schema"] == module.STANDARD_MANIFEST_SCHEMA
     assert manifest["source_start"] == _CLEAN_SOURCE
     assert manifest["source_end"] == _CLEAN_SOURCE
+
     assert manifest["mode"] == ("strategy-matrix" if matrix else "default")
     assert manifest["strategies"] == expected_strategies
+    assert manifest["settings"]["host"]["wheel_tags_count"] > 0
+    assert len(manifest["settings"]["host"]["wheel_tags_hash"]) == 64
+
     assert manifest["corpus_files"] == ["other", "quick"]
     assert manifest["selected_files"] == ["quick"]
     assert manifest["available_logical_keys"] == [
         "other:other",
         "quick:example",
+        "quick:foreign-host",
         "quick:unsupported",
     ]
     assert manifest["selected_logical_keys"] == [
         "quick:example",
+        "quick:foreign-host",
         "quick:unsupported",
     ]
+
     assert manifest["completed_logical_keys"] == ["quick:example"]
     assert manifest["unsupported_logical_keys"] == ["quick:unsupported"]
+    assert manifest["inapplicable_logical_keys"] == ["quick:foreign-host"]
+
     assert manifest["completed_execution_keys"] == expected_completed
     assert manifest["file_execution_keys"] == expected_completed
+    inapplicable_execution_keys = [
+        key
+        for key in manifest["selected_execution_keys"]
+        if key.endswith("/foreign-host.json")
+    ]
     assert (
         sorted(
             manifest["completed_execution_keys"]
             + manifest["unsupported_execution_keys"]
+            + inapplicable_execution_keys
         )
         == manifest["selected_execution_keys"]
     )
+
     assert manifest["complete"] is True
+
+
+def test_main_reports_host_inapplicable_scenarios(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _run_fake(tmp_path, monkeypatch, matrix=False)
+
+    output = capsys.readouterr().out
+    assert (
+        "Host-inapplicable: 1 scenario; marker environment requires wheel tags "
+        "from a different host."
+    ) in output
+    assert "  quick:foreign-host" in output
+
+
+def test_host_inapplicable_report_is_bounded(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _harness("scenarios")
+    logical_keys = [
+        f"cases:case-{index}" for index in range(module._INAPPLICABLE_KEY_PREVIEW + 2)
+    ]
+
+    module._report_host_inapplicable(logical_keys)
+
+    assert capsys.readouterr().out.splitlines() == [
+        (
+            "Host-inapplicable: 10 scenarios; marker environment requires wheel "
+            "tags from a different host."
+        ),
+        "  " + ", ".join(logical_keys[:8]),
+        "  ... 2 more; exact keys are in _standard_manifest.json.",
+    ]
+
+
+def test_standard_runner_output_is_accepted_by_the_comparator(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scenarios, _, manifest_path = _run_fake(
+        tmp_path,
+        monkeypatch,
+        matrix=True,
+    )
+    comparator = _harness("compare")
+
+    run = comparator.load_run(manifest_path.parent)
+
+    assert comparator._STANDARD_COUNTER_FIELDS == scenarios._STANDARD_COUNTER_FIELDS
+    assert run.manifest == json.loads(manifest_path.read_text())
+    assert all(
+        result["input"]["settings_hash"]
+        == comparator._settings_hash(run.manifest["settings"])
+        for result in run.results.values()
+    )
 
 
 def test_reusing_a_label_rejects_default_after_strategy_matrix(
@@ -1108,6 +1795,49 @@ def test_profile_runner_accepts_an_explicit_strategy() -> None:
     assert lowest["resolution_strategy"] is module.sc.ResolutionStrategy.LOWEST
 
 
+def test_profile_runner_uses_the_admitted_target_for_roots_and_resolution() -> None:
+    module = _harness("_profile_runner")
+    physical_host = _host(
+        module.sc,
+        system="Linux",
+        sys_platform="linux",
+        machine="x86_64",
+        os_name="posix",
+        platform_tag="manylinux_2_17_x86_64",
+    )
+    admission = physical_host.target_for("3.11", {})
+    assert admission.target is not None
+
+    class PlannedHost:
+        target = physical_host.target
+
+        def target_for(
+            self,
+            python_version: str,
+            marker_environment: dict[str, str],
+        ) -> object:
+            assert python_version == "3.11"
+            assert marker_environment == {}
+            return admission
+
+    host = PlannedHost()
+    inputs = module.build_inputs(
+        "example",
+        {
+            "python_version": "3.11",
+            "requirements": [
+                "selected; python_version == '3.11'",
+                "excluded; python_version != '3.11'",
+            ],
+        },
+        host=host,
+    )
+
+    assert set(inputs["requirements"]) == {"selected"}
+    assert inputs["target"] is admission.target
+    assert inputs["host"] is host
+
+
 def test_profile_runner_rejects_supported_marker_build_policy() -> None:
     module = _harness("_profile_runner")
     scenario = {
@@ -1125,3 +1855,23 @@ def test_profile_runner_rejects_supported_marker_build_policy() -> None:
         ),
     ):
         module.build_inputs("example", scenario)
+
+
+def test_profile_runner_rejects_an_inapplicable_host_before_resolution() -> None:
+    module = _harness("_profile_runner")
+    scenario = {
+        "python_version": "3.11",
+        "requirements": [],
+        "platform_system": "Windows",
+    }
+    host = _host(
+        module.sc,
+        system="Linux",
+        sys_platform="linux",
+        machine="x86_64",
+        os_name="posix",
+        platform_tag="manylinux_2_17_x86_64",
+    )
+
+    with pytest.raises(SystemExit, match="benchmark is inapplicable"):
+        module.build_inputs("example", scenario, host=host)


### PR DESCRIPTION
`uv-tensorflow-macos` needs wheel tags from a macOS arm64 host, while `pywin32-windows-amd64-real-index` needs tags from a Windows AMD64 host. The standard runner records scenarios that do not match the current host as inapplicable, canary runs skip them, and the profiling runner exits before resolution. Manifests now capture host identity and the effective timeout, so comparisons reject runs from different hosts or with different applicable scenario sets.
