### PR TITLE
Export nab-resolver's public API from the package

### DIFF
--- a/nab-resolver/README.md
+++ b/nab-resolver/README.md
@@ -11,6 +11,8 @@ user-facing CLI in [`nab`](https://pypi.org/project/nab/).
 Use `nab-resolver` when you are building some kind of package
 resolver, Python or otherwise.
 
-The public API is the `Resolver` class plus the
-`ResolverProvider` protocol, the `Range` and `Term` types, and the
-`ResolutionError` exception.  Everything else is internal.
+The public API is what the `nab_resolver` package exports: the
+`Resolver` class, the `ResolverProvider` and `RangeProtocol`
+protocols, the `Range`, `Term` and `Incompatibility` types, the
+`ResolutionError` exception, and the `ROOT` sentinel.  Import them
+from `nab_resolver` itself; its submodules are internal.

--- a/nab-resolver/src/nab_resolver/__init__.py
+++ b/nab-resolver/src/nab_resolver/__init__.py
@@ -1,1 +1,24 @@
-"""PubGrub dependency resolver."""
+"""PubGrub dependency resolver.
+
+The names re-exported here are the supported API. The submodules they come
+from are internal and can be renamed or moved without notice, so import from
+``nab_resolver`` rather than from ``nab_resolver.resolver`` or
+``nab_resolver.types``.
+"""
+
+from .errors import ResolutionError
+from .ranges import Range
+from .resolver import Resolver, ResolverProvider
+from .root import ROOT
+from .types import Incompatibility, RangeProtocol, Term
+
+__all__ = [
+    "ROOT",
+    "Incompatibility",
+    "Range",
+    "RangeProtocol",
+    "ResolutionError",
+    "Resolver",
+    "ResolverProvider",
+    "Term",
+]

--- a/nab-resolver/tests/test_public_api.py
+++ b/nab-resolver/tests/test_public_api.py
@@ -1,0 +1,47 @@
+"""Keep the package's exports, its imports, and its README in step.
+
+Embedders are told to import from ``nab_resolver`` rather than from its
+submodules, which only works if every advertised name is really bound there.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from types import ModuleType
+
+import nab_resolver
+
+README = Path(__file__).resolve().parents[1] / "README.md"
+
+_CLAIM_OPENING = "The public API is"
+_BACKTICKED = re.compile(r"`([^`\n]+)`")
+
+
+def _readme_api_names() -> set[str]:
+    """Names the README's public-API paragraph claims the package exports."""
+    paragraphs = README.read_text(encoding="utf-8").split("\n\n")
+    claims = [p for p in paragraphs if p.startswith(_CLAIM_OPENING)]
+    assert len(claims) == 1, f"expected one paragraph opening {_CLAIM_OPENING!r}"
+
+    # The paragraph also names the package it is describing.
+    return set(_BACKTICKED.findall(claims[0])) - {nab_resolver.__name__}
+
+
+def test_every_exported_name_resolves() -> None:
+    missing = [name for name in nab_resolver.__all__ if not hasattr(nab_resolver, name)]
+    assert missing == []
+
+
+def test_no_public_name_escapes_all() -> None:
+    """Anything bound on the package root without an underscore is declared."""
+    bound = {
+        name
+        for name, value in vars(nab_resolver).items()
+        if not name.startswith("_") and not isinstance(value, ModuleType)
+    }
+    assert bound == set(nab_resolver.__all__)
+
+
+def test_readme_lists_the_exported_names() -> None:
+    assert _readme_api_names() == set(nab_resolver.__all__)


### PR DESCRIPTION
`nab_resolver/__init__.py` was a single docstring, so anything embedding the solver imported from `nab_resolver.resolver`, `nab_resolver.types`, `nab_resolver.errors` and `nab_resolver.root`. That pins the embedder to four module paths rather than to a package API, and it makes every internal reshuffle of the solver a breaking change for them. Sketching a pip resolver backend against this package is what made it concrete: four import lines, four module paths, and no package API to depend on.

The package root now exports `Resolver`, `ResolverProvider`, `RangeProtocol`, `Range`, `Term`, `Incompatibility`, `ResolutionError` and `ROOT`, and the module docstring says those are the supported names while the submodules are not. The README already claimed a public API, so it now names the same set. This is additive: nothing moved and no behaviour changed.
