### PR TITLE
land smoke listings before timing a resolve

### DIFF
--- a/nab-python/benchmarks/deterministic_smoke.py
+++ b/nab-python/benchmarks/deterministic_smoke.py
@@ -1375,7 +1375,29 @@ def prepare_scenario(scenario: Scenario, index_root: Path) -> PreparedScenario:
     )
 
 
-def _resolve_once(prepared: PreparedScenario) -> tuple[ResolveResult, int]:
+def _fixture_listing_packages(distributions: Sequence[Distribution]) -> tuple[str, ...]:
+    """Every canonical name in the fixture, in a stable order."""
+    return tuple(sorted({canonicalize_name(dist.name) for dist in distributions}))
+
+
+def _await_listings(coordinator: FetchCoordinator, packages: Sequence[str]) -> None:
+    """Land every fixture listing before the caller starts timing.
+
+    The priority scan sorts a package whose listing is still in flight behind
+    the ready ones, so a resolve racing its own fetches can decide in a
+    different order run to run and reach the same pins by a different path.
+    Requesting the whole fixture up front and waiting takes that race out of
+    the measurement; it does not change what the resolver does with a listing
+    once it holds one.  Every request goes out before the first wait so they
+    still overlap.
+    """
+    for event in [coordinator.request_listing(package) for package in packages]:
+        event.wait()
+
+
+def _resolve_once(
+    prepared: PreparedScenario, listing_packages: Sequence[str]
+) -> tuple[ResolveResult, int]:
     """Run one fresh-coordinator resolve and time only the resolver call."""
     with FetchCoordinator(
         Urllib3AsyncTransport(),
@@ -1387,6 +1409,7 @@ def _resolve_once(prepared: PreparedScenario) -> tuple[ResolveResult, int]:
             prepared.targets,
             prepared.requirements,
         )
+        _await_listings(coordinator, listing_packages)
         start = time.perf_counter_ns()
 
         # Omitting the argument entirely is the only way to measure the shipped
@@ -1488,9 +1511,10 @@ def _observe_scenario(
     prepared: PreparedScenario,
     distributions: Sequence[Distribution],
     index_root: Path,
+    listing_packages: Sequence[str],
 ) -> _ScenarioObservation:
     """Run and fully validate one resolve."""
-    result, elapsed = _resolve_once(prepared)
+    result, elapsed = _resolve_once(prepared, listing_packages)
     pins, lock_projection, failures = _validate_observation(
         prepared, result, distributions, index_root
     )
@@ -1652,6 +1676,7 @@ def run_scenario(scenario: Scenario, index_root: Path, runs: int) -> dict[str, A
     # index_root happens to hold; the digest check is what ties the two together.
     prepared = prepare_scenario(scenario, index_root)
     distributions, _fixture_manifest_digest = load_fixture()
+    listing_packages = _fixture_listing_packages(distributions)
 
     # A semantic case is validated once and never timed, so it collapses to a
     # single unmeasured batch of one.
@@ -1670,14 +1695,16 @@ def run_scenario(scenario: Scenario, index_root: Path, runs: int) -> dict[str, A
 
     for _ in range(scenario.warmups):
         observations.extend(
-            _observe_scenario(prepared, distributions, index_root)
+            _observe_scenario(prepared, distributions, index_root, listing_packages)
             for _ in range(batch_size)
         )
 
     for _ in range(measurement_batches):
         sample: list[int] = []
         for _ in range(batch_size):
-            observation = _observe_scenario(prepared, distributions, index_root)
+            observation = _observe_scenario(
+                prepared, distributions, index_root, listing_packages
+            )
             observations.append(observation)
             sample.append(observation.elapsed_ns)
             for label, seen, fetched in observation.fetch:

--- a/nab-python/tests/test_deterministic_smoke_core.py
+++ b/nab-python/tests/test_deterministic_smoke_core.py
@@ -401,8 +401,9 @@ def test_scenarios_use_product_defaults_except_declared_overrides(
     monkeypatch.setattr(harness, "Urllib3AsyncTransport", object)
     monkeypatch.setattr(harness, "resolve_with_coordinator", resolve)
 
-    harness._resolve_once(highest)
-    harness._resolve_once(independent)
+    # No listings to warm, so the stub coordinator is never asked for one.
+    harness._resolve_once(highest, ())
+    harness._resolve_once(independent, ())
 
     # A scenario that declares nothing must reach the resolver with the argument
     # absent, so the suite tracks the shipped default instead of restating it.
@@ -490,6 +491,39 @@ def test_basic_highest_local_coordinator_completes_bounded(smoke_index: Path) ->
 
     assert result["pins_per_target"] == expected
     assert result["lock_projection_per_target"] == expected
+
+
+def test_await_listings_dispatches_every_request_before_waiting() -> None:
+    """Every listing is requested first, then every one is awaited.
+
+    Waiting is what takes fetch timing out of the measurement, and dispatching
+    the whole set before the first wait is what keeps the reads overlapping.
+    Neither shows up in a resolve that happens to run on an idle machine, so
+    both are pinned here instead.
+    """
+    harness = _harness()
+    requested: list[str] = []
+
+    class _Event:
+        def __init__(self) -> None:
+            self.requests_at_wait: int | None = None
+
+        def wait(self) -> None:
+            self.requests_at_wait = len(requested)
+
+    events: list[_Event] = []
+
+    class _Coordinator:
+        def request_listing(self, package: str) -> _Event:
+            requested.append(package)
+            event = _Event()
+            events.append(event)
+            return event
+
+    harness._await_listings(_Coordinator(), ("beta", "alpha", "gamma"))
+
+    assert requested == ["beta", "alpha", "gamma"]
+    assert [event.requests_at_wait for event in events] == [3, 3, 3]
 
 
 def test_asyncio_wakeup_preflight_reports_restricted_execution() -> None:
@@ -607,9 +641,11 @@ def test_every_smoke_scenario_satisfies_its_contract(smoke_index: Path) -> None:
         "conflicts": 25,
         "backjumps": 24,
     }
+    # These hold only because _resolve_once lands every listing first; a
+    # resolve racing its own fetches walks this graph differently.
     assert results["deep-backjump"]["search"] == {
-        "decisions": 91,
-        "rounds": 111,
+        "decisions": 85,
+        "rounds": 105,
         "conflicts": 19,
         "backjumps": 19,
     }


### PR DESCRIPTION
The `deep-backjump` smoke scenario fails CI intermittently with `resolver search counters varied across repeated runs`, on main and on unrelated branches, mostly on Windows and macOS runners. The priority scan sorts a package whose listing is still in flight behind the ready ones, so a resolve that races its own fetches reaches the same pins by a different path and the repeat comparison rejects the run. It is the one scenario built with a competitor at every level, which is why it is the one that flakes.

Each timed resolve now requests every fixture listing and waits before the clock starts, so no listing can be in flight during the search. Under 2x CPU oversubscription the contract test went from 9 of 12 runs passing to 12 of 12. Deciding on a full listing view also settles `deep-backjump` at 85 decisions and 105 rounds instead of the 91/111 the race used to leave behind, so the pinned counters move with it.
