### PR TITLE
Add BaseProvider for the protocol's defaults

### DIFF
--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -46,6 +46,7 @@ from .types import (
 )
 
 __all__ = [
+    "BaseProvider",
     "Incompatibility",
     "IncompatibilityCause",
     "IncompatibilityState",
@@ -203,6 +204,60 @@ class ResolverProvider(Protocol[PackageType, VersionType]):
         holding no version, so dropping one that exists states a falsehood.
         """
         ...
+
+
+class BaseProvider(Generic[PackageType, VersionType]):
+    """Defaults for the six provider methods a synchronous provider does not need.
+
+    Supplies ``begin_decision_scan``, ``is_ready``,
+    ``receive_partial_solution_hint``, ``consume_pending_clauses``,
+    ``consume_force_backtrack_targets`` and ``narrow_for_display``, the six
+    :class:`ResolverProvider` methods with nothing to do when there is no async
+    layer, no queued clauses and no widening.  A subclass still owes
+    ``choose_version``, ``has_satisfying_version``, ``get_dependencies``,
+    ``prioritize`` and ``widen_decision``.
+
+    Subclassing is optional; the resolver accepts anything that satisfies the
+    protocol.  Nothing re-exports this, so import it as
+    ``from nab_resolver.resolver import BaseProvider``.
+    """
+
+    def begin_decision_scan(self) -> None:
+        """Freeze nothing: no state moves between scans."""
+
+    def is_ready(self, package: PackageType) -> bool:
+        """Report every package ready, since answers do not wait on a fetch."""
+        del package
+        return True
+
+    def receive_partial_solution_hint(
+        self,
+        positive_ranges: Mapping[PackageType, RangeProtocol[VersionType]],
+        decisions: Mapping[PackageType, VersionType],
+    ) -> None:
+        """Drop the snapshot: nothing here forward-checks against it."""
+        del positive_ranges, decisions
+
+    def consume_pending_clauses(
+        self,
+    ) -> list[Incompatibility[PackageType, VersionType]]:
+        """Return no clauses: ``choose_version`` queues none."""
+        return []
+
+    def consume_force_backtrack_targets(self) -> list[PackageType]:
+        """Return no targets: there is no force-backtrack signal to give."""
+        return []
+
+    def narrow_for_display(
+        self, package: PackageType, constraint: RangeProtocol[VersionType]
+    ) -> RangeProtocol[VersionType]:
+        """Return the constraint unchanged, as a provider that never widens does.
+
+        A subclass whose ``widen_decision`` widens overrides this as well, or
+        its error text carries widened ranges instead of known versions.
+        """
+        del package
+        return constraint
 
 
 @dataclass

--- a/nab-resolver/tests/test_base_provider.py
+++ b/nab-resolver/tests/test_base_provider.py
@@ -1,0 +1,170 @@
+"""Tests for BaseProvider, the defaults a synchronous provider inherits.
+
+The class turns an eleven-method protocol into a five-method one, so these pin
+both halves of that split and then drive a subclass through a real resolve and
+a real failure.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pytest
+
+from nab_resolver.ranges import Range
+from nab_resolver.resolver import (
+    BaseProvider,
+    ResolutionError,
+    Resolver,
+    ResolverProvider,
+)
+from nab_resolver.types import RangeProtocol
+
+# The split BaseProvider's docstring promises, spelled out so a protocol
+# method that lands in neither half fails a test rather than a review.
+SUPPLIED = frozenset(
+    {
+        "begin_decision_scan",
+        "consume_force_backtrack_targets",
+        "consume_pending_clauses",
+        "is_ready",
+        "narrow_for_display",
+        "receive_partial_solution_hint",
+    }
+)
+
+OWED = frozenset(
+    {
+        "choose_version",
+        "get_dependencies",
+        "has_satisfying_version",
+        "prioritize",
+        "widen_decision",
+    }
+)
+
+Graph = dict[str, dict[int, dict[str, Range[int]]]]
+
+
+class NewestFirstProvider(BaseProvider[str, int]):
+    """The five owed methods over an in-memory graph, newest version wins."""
+
+    def __init__(self, graph: Graph) -> None:
+        self._graph = graph
+
+    def _versions(self, package: str) -> list[int]:
+        """Versions of ``package``, newest first."""
+        return sorted(self._graph.get(package, {}), reverse=True)
+
+    def choose_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> int | None:
+        return next((v for v in self._versions(package) if v in version_range), None)
+
+    def has_satisfying_version(
+        self, package: str, version_range: RangeProtocol[int]
+    ) -> bool:
+        return any(v in version_range for v in self._versions(package))
+
+    def get_dependencies(self, package: str, version: int) -> Mapping[str, Range[int]]:
+        return self._graph.get(package, {}).get(version, {})
+
+    def prioritize(
+        self,
+        package: str,
+        version_range: RangeProtocol[int],
+        conflict_counts: Mapping[str, int],
+        culprit_counts: Mapping[str, int] | None = None,
+    ) -> int:
+        return sum(1 for v in self._versions(package) if v in version_range)
+
+    def widen_decision(self, package: str, version: int) -> RangeProtocol[int] | None:
+        return None
+
+
+class TestTheSplit:
+    def test_supplies_exactly_the_documented_defaults(self) -> None:
+        defined = {name for name in vars(BaseProvider) if not name.startswith("_")}
+        assert defined == SUPPLIED
+
+    def test_leaves_the_owed_methods_to_the_subclass(self) -> None:
+        assert OWED.isdisjoint(dir(BaseProvider))
+
+    def test_the_two_halves_cover_the_protocol(self) -> None:
+        """A method added to the protocol has to be sorted into one half."""
+        declared = {
+            name
+            for name, value in vars(ResolverProvider).items()
+            if not name.startswith("_") and callable(value)
+        }
+        assert declared == SUPPLIED | OWED
+
+
+class TestDefaults:
+    def test_beginning_a_scan_freezes_nothing(self) -> None:
+        assert BaseProvider[str, int]().begin_decision_scan() is None
+
+    def test_every_package_is_ready(self) -> None:
+        assert BaseProvider[str, int]().is_ready("anything") is True
+
+    def test_the_partial_solution_hint_is_dropped(self) -> None:
+        hint = BaseProvider[str, int]().receive_partial_solution_hint(
+            {"foo": Range.at_least(1)}, {"foo": 1}
+        )
+        assert hint is None
+
+    def test_no_clauses_are_queued(self) -> None:
+        assert BaseProvider[str, int]().consume_pending_clauses() == []
+
+    def test_no_backtrack_targets_are_forced(self) -> None:
+        assert BaseProvider[str, int]().consume_force_backtrack_targets() == []
+
+    def test_each_drain_hands_back_its_own_list(self) -> None:
+        """The resolver mutates what it drains, so a shared list would leak."""
+        provider = BaseProvider[str, int]()
+
+        clauses = provider.consume_pending_clauses()
+        assert clauses is not provider.consume_pending_clauses()
+
+        targets = provider.consume_force_backtrack_targets()
+        assert targets is not provider.consume_force_backtrack_targets()
+
+    def test_display_narrowing_is_the_identity(self) -> None:
+        constraint = Range.at_least(2)
+        narrowed = BaseProvider[str, int]().narrow_for_display("foo", constraint)
+        assert narrowed is constraint
+
+
+class TestSubclassDrivesARealResolve:
+    def test_five_methods_are_enough_to_resolve(self) -> None:
+        provider = NewestFirstProvider(
+            {
+                "root": {1: {"foo": Range.at_least(1)}},
+                "foo": {2: {"bar": Range.at_least(1)}, 1: {}},
+                "bar": {2: {}, 1: {}},
+            }
+        )
+        resolver = Resolver(provider)
+
+        assert resolver.resolve({"root": Range.singleton(1)}) == {
+            "root": 1,
+            "foo": 2,
+            "bar": 2,
+        }
+
+    def test_five_methods_are_enough_to_report_a_conflict(self) -> None:
+        """The failure path renders through the inherited ``narrow_for_display``."""
+        provider = NewestFirstProvider(
+            {
+                "root": {1: {"foo": Range.full(), "bar": Range.full()}},
+                "foo": {1: {"baz": Range.at_least(2)}},
+                "bar": {1: {"baz": Range.less_than(2)}},
+                "baz": {2: {}, 1: {}},
+            }
+        )
+        resolver = Resolver(provider)
+
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"root": Range.singleton(1)})
+
+        assert "baz" in str(excinfo.value)


### PR DESCRIPTION
`ResolverProvider` declares eleven methods and gives none of them a default, but six of them have nothing to do in a provider that answers synchronously, and the protocol's own docstrings already say so: "for providers with no such state this is a no-op", "Providers without an async layer should return True", "Providers without a force-backtrack signal return an empty list", "Default is a no-op". Every provider writes those bodies out by hand anyway. nab-resolver's own tests carry ten copies of them, one of which is a `_BaseProvider` class in `test_widen_hook.py` written for exactly this reason.

`BaseProvider` sits beside the protocol and supplies the six, so a synchronous provider subclasses it and writes `choose_version`, `has_satisfying_version`, `get_dependencies`, `prioritize` and `widen_decision`. The protocol is untouched and is still what the resolver type-checks against, so subclassing stays optional and nothing about resolution changes. There is no package-root re-export; import it as `from nab_resolver.resolver import BaseProvider`.
