### PR TITLE
Make benchmark host matching explicit

### DIFF
--- a/nab-python/benchmarks/README.md
+++ b/nab-python/benchmarks/README.md
@@ -42,7 +42,7 @@ python nab-python/benchmarks/_profile_runner.py \
 
 `strategy_sweep.py` is a compatibility alias for `scenarios.py --strategy-matrix`; it does not implement another resolver or result format. Retired selections such as `--toml pip-lowest` fail with the canonical replacement command.
 
-Each run initializes `_standard_manifest.json` as incomplete before resolving anything. It becomes complete only after every applicable execution has an exact, valid result; every unsupported or host-inapplicable scenario is accounted for; no result is missing or extra; and the source tree is clean. The manifest records the source identity at both run boundaries, corpus hash, execution settings, physical host identity, strategies, selected files, and terminal key sets. Reusing a result label requires the same mode, corpus, selection, and host. Use a new label or `--force` when any of those inputs changes. `--force` replaces the standard JSON results for the label while preserving universal results and top-level provenance.
+Each run initializes `_standard_manifest.json` as incomplete before resolving anything. It becomes complete only after every applicable execution has an exact, valid result; every unsupported or host-inapplicable scenario is accounted for; no result is missing or extra; and the source tree is clean. The manifest records the source identity at both run boundaries, corpus hash, execution settings, physical host identity, strategies, selected files, scenarios that require a matching host, and terminal key sets. Reusing a result label requires the same mode, corpus, selection, and host. Use a new label or `--force` when any of those inputs changes. `--force` replaces the standard JSON results for the label while preserving universal results and top-level provenance.
 
 ### Canary subset
 
@@ -76,7 +76,7 @@ Benchmark outputs are local run artifacts rather than repository baselines. Gene
 
 Each single-environment scenario is a top-level TOML table keyed by name, with at least `requirements` and a fixed `datetime` (used as the `uploaded-prior-to` cutoff). Optional single-environment knobs include constraints, marker overlays, distribution policy, and build policy.
 
-Marker overrides on the wheel-tag axes also declare which physical hosts may run a scenario. A Windows marker scenario is inapplicable on Linux rather than resolving with Windows markers and Linux wheel tags. A top-level `platform_system` restricts the OS family. An exact target sets `platform_system`, `sys_platform`, `os_name`, `platform_machine`, `implementation_name`, and `platform_python_implementation` together.
+`marker_environment` and the `platform_system` shorthand define the resolver target without restricting the host. Set `requires_matching_host = true` when the physical host must match those values so its wheel tags remain faithful. `platform_system` alone admits any machine in that OS family; machine and implementation markers narrow the match. A nonmatching host records the scenario as inapplicable.
 
 Universal scenarios require `python`, `platforms`, and `requirements`. They may also set constraints, a cutoff, Python ordering, alignment, resolution strategy, an explanatory reason, and expected-failure handling.
 

--- a/nab-python/benchmarks/_profile_runner.py
+++ b/nab-python/benchmarks/_profile_runner.py
@@ -80,8 +80,17 @@ def build_inputs(
         marker_environment,
         build_policy_overrides,
     )
+    requires_matching_host = sc.parse_requires_matching_host(
+        name,
+        scenario,
+        marker_environment,
+    )
     effective_host = host or sc.BenchmarkHost.current(sc.SCENARIO_WALL_TIMEOUT_SECONDS)
-    admission = effective_host.target_for(python_version, marker_environment)
+    admission = effective_host.target_for(
+        python_version,
+        marker_environment,
+        requires_matching_host=requires_matching_host,
+    )
     if admission.target is None:
         msg = f"{name}: benchmark is inapplicable: {admission.inapplicable_reason}"
         raise SystemExit(msg)

--- a/nab-python/benchmarks/benchmark_host.py
+++ b/nab-python/benchmarks/benchmark_host.py
@@ -19,6 +19,12 @@ if TYPE_CHECKING:
 HOST_TAG_MISMATCH_REASON = (
     "marker environment requires wheel tags from a different host"
 )
+_HOST_MATCH_MARKERS = frozenset(
+    key
+    for candidates in (PLATFORM_MARKERS, IMPLEMENTATION_MARKERS)
+    for candidate in candidates.values()
+    for key in candidate
+)
 
 
 class BenchmarkTimeout(BaseException):
@@ -43,7 +49,7 @@ def validate_target_marker_environment(
     scenario_name: str,
     marker_environment: Mapping[str, str],
 ) -> None:
-    """Reject host restrictions that cannot describe a supported target."""
+    """Reject marker values that cannot describe a supported target."""
     if not _marker_family_matches(marker_environment, PLATFORM_MARKERS):
         msg = f"{scenario_name}: marker_environment describes no supported platform"
         raise ValueError(msg)
@@ -56,7 +62,7 @@ def parse_target_marker_environment(
     scenario_name: str,
     scenario: Mapping[str, object],
 ) -> dict[str, str]:
-    """Read and validate one scenario's physical-target marker overrides."""
+    """Read and validate one scenario's target marker overrides."""
     raw = scenario.get("marker_environment", {})
     if not isinstance(raw, dict) or any(
         type(key) is not str or type(value) is not str for key, value in raw.items()
@@ -80,9 +86,30 @@ def parse_target_marker_environment(
     return marker_environment
 
 
+def parse_requires_matching_host(
+    scenario_name: str,
+    scenario: Mapping[str, object],
+    marker_environment: Mapping[str, str],
+) -> bool:
+    """Read whether a scenario requires physical-host wheel tags."""
+    requires_matching_host = scenario.get("requires_matching_host", False)
+    if type(requires_matching_host) is not bool:
+        msg = f"{scenario_name}: requires_matching_host must be a boolean"
+        raise TypeError(msg)
+    if requires_matching_host and not _HOST_MATCH_MARKERS.intersection(
+        marker_environment
+    ):
+        msg = (
+            f"{scenario_name}: requires_matching_host needs a platform "
+            "or interpreter marker"
+        )
+        raise ValueError(msg)
+    return requires_matching_host
+
+
 @dataclass(frozen=True, slots=True)
 class TargetAdmission:
-    """A faithful resolve target, or the reason this host cannot provide one."""
+    """A resolve target, or why its required matching host is unavailable."""
 
     target: ResolveTarget | None
     inapplicable_reason: str | None
@@ -113,8 +140,10 @@ class BenchmarkHost:
         self,
         python_version: str,
         marker_environment: Mapping[str, str],
+        *,
+        requires_matching_host: bool,
     ) -> TargetAdmission:
-        """Build a scenario target when this host can supply faithful tags."""
+        """Build a target, enforcing faithful tags when the host must match."""
         host_markers = self.target.marker_env
         host_tags = self.target.tags.ordered
         target = ResolveTarget.for_host_python(
@@ -123,7 +152,7 @@ class BenchmarkHost:
             tags_source=lambda: iter(host_tags),
         ).with_marker_overrides(marker_environment)
 
-        if not target.tags_faithful:
+        if requires_matching_host and not target.tags_faithful:
             return TargetAdmission(None, HOST_TAG_MISMATCH_REASON)
         if any(
             target.marker_env.get(key) != value

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -37,6 +37,7 @@ else:
 from benchmark_host import (
     BenchmarkHost,
     BenchmarkTimeout,
+    parse_requires_matching_host,
     parse_target_marker_environment,
 )
 
@@ -780,7 +781,16 @@ def _prepare_canary_execution(
     indexes = _canary_indexes(scenario)
     index_routes = _canary_index_routes(scenario)
 
-    admission = host.target_for(python_version, marker_environment)
+    requires_matching_host = parse_requires_matching_host(
+        scenario_name,
+        scenario,
+        marker_environment,
+    )
+    admission = host.target_for(
+        python_version,
+        marker_environment,
+        requires_matching_host=requires_matching_host,
+    )
     if admission.target is None:
         return CanaryPreparation(None, admission.inapplicable_reason)
     target = admission.target

--- a/nab-python/benchmarks/compare.py
+++ b/nab-python/benchmarks/compare.py
@@ -16,7 +16,7 @@ from typing import NamedTuple, NoReturn
 
 RESULTS_DIR = Path(__file__).parent / "results"
 MANIFEST_FILENAME = "_standard_manifest.json"
-MANIFEST_SCHEMA = 2
+MANIFEST_SCHEMA = 3
 _RESERVED_DIRECTORIES = frozenset({"universal", "universal-selected"})
 _MANIFEST_FIELDS = frozenset(
     {
@@ -34,6 +34,7 @@ _MANIFEST_FIELDS = frozenset(
         "selected_logical_keys",
         "completed_logical_keys",
         "unsupported_logical_keys",
+        "requires_matching_host_logical_keys",
         "inapplicable_logical_keys",
         "available_execution_keys",
         "selected_execution_keys",
@@ -285,11 +286,15 @@ def _validate_manifest_partitions(
     selected = lists["selected_logical_keys"]
     completed = lists["completed_logical_keys"]
     unsupported = lists["unsupported_logical_keys"]
+    requires_matching_host = lists["requires_matching_host_logical_keys"]
     inapplicable = lists["inapplicable_logical_keys"]
     available_keys = lists["available_execution_keys"]
     selected_keys = lists["selected_execution_keys"]
-    if not set(selected) <= set(available) or not _exact_partition(
-        selected, completed, unsupported, inapplicable
+    if (
+        not set(selected) <= set(available)
+        or not set(requires_matching_host) <= set(selected)
+        or not set(inapplicable) <= set(requires_matching_host)
+        or not _exact_partition(selected, completed, unsupported, inapplicable)
     ):
         _fail(f"invalid logical benchmark partition: {run_dir}")
     available_map = _execution_map(available, strategies)

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -36,6 +36,7 @@ from benchmark_host import (
     HOST_TAG_MISMATCH_REASON,
     BenchmarkHost,
     BenchmarkTimeout,
+    parse_requires_matching_host,
     parse_target_marker_environment,
     settings_hash,
 )
@@ -70,7 +71,7 @@ SCENARIOS_DIR = BENCHMARKS_DIR / "scenarios"
 RESULTS_DIR = BENCHMARKS_DIR / "results"
 _LEGACY_STRATEGY_SUFFIXES = ("-lowest", "-lowest-direct")
 STANDARD_MANIFEST_FILENAME = "_standard_manifest.json"
-STANDARD_MANIFEST_SCHEMA = 2
+STANDARD_MANIFEST_SCHEMA = 3
 _INAPPLICABLE_KEY_PREVIEW = 8
 _STANDARD_METADATA_FILENAMES = frozenset(
     {STANDARD_MANIFEST_FILENAME, "_provenance.json"}
@@ -117,6 +118,7 @@ _STANDARD_MANIFEST_FIELDS = frozenset(
         "selected_logical_keys",
         "completed_logical_keys",
         "unsupported_logical_keys",
+        "requires_matching_host_logical_keys",
         "inapplicable_logical_keys",
         "available_execution_keys",
         "selected_execution_keys",
@@ -574,6 +576,7 @@ def load_standard_corpus(files: list[Path]) -> list[StandardScenario]:
         )
     for row in rows:
         marker_environment = parse_marker_environment(row.name, row.definition)
+        parse_requires_matching_host(row.name, row.definition, marker_environment)
         build_policy_overrides = parse_build_packages(row.name, row.definition)
         if "unsupported_reason" in row.definition:
             continue
@@ -600,16 +603,22 @@ def standard_run_plan(
     strategies: tuple[ResolutionStrategy, ...],
     host: BenchmarkHost,
 ) -> StandardRunPlan:
-    """Admit each scenario once, then expand faithful targets by strategy."""
+    """Plan each scenario once, then expand admitted targets by strategy."""
     targets: dict[str, ResolveTarget] = {}
     inapplicable: list[str] = []
     for row in rows:
         if "unsupported_reason" in row.definition:
             continue
         marker_environment = parse_marker_environment(row.name, row.definition)
+        requires_matching_host = parse_requires_matching_host(
+            row.name,
+            row.definition,
+            marker_environment,
+        )
         admission = host.target_for(
             row.definition["python_version"],
             marker_environment,
+            requires_matching_host=requires_matching_host,
         )
         if admission.target is None:
             inapplicable.append(row.logical_key)
@@ -650,6 +659,20 @@ def standard_execution_keys(
         for strategy in strategies
         for row in rows
     )
+
+
+def _requires_matching_host_logical_keys(rows: list[StandardScenario]) -> list[str]:
+    """Return scenarios whose target must match the physical host."""
+    required: list[str] = []
+    for row in rows:
+        marker_environment = parse_marker_environment(row.name, row.definition)
+        if parse_requires_matching_host(
+            row.name,
+            row.definition,
+            marker_environment,
+        ):
+            required.append(row.logical_key)
+    return sorted(required)
 
 
 def get_git_commit() -> str:
@@ -998,6 +1021,9 @@ def standard_manifest_contract(  # noqa: PLR0913 - explicit contract fields
         "available_logical_keys": sorted(row.logical_key for row in all_rows),
         "selected_logical_keys": sorted(row.logical_key for row in selected_rows),
         "unsupported_logical_keys": sorted(row.logical_key for row in unsupported_rows),
+        "requires_matching_host_logical_keys": (
+            _requires_matching_host_logical_keys(selected_rows)
+        ),
         "inapplicable_logical_keys": plan.inapplicable_logical_keys,
         "available_execution_keys": standard_execution_keys(all_rows, strategies),
         "selected_execution_keys": standard_execution_keys(selected_rows, strategies),

--- a/nab-python/benchmarks/scenarios/uv.toml
+++ b/nab-python/benchmarks/scenarios/uv.toml
@@ -1522,6 +1522,7 @@ requirements = ["llvmlite==0.44.0"]
 python_version = "3.10.17"
 datetime = "2025-05-21 09:12:43"
 requirements = ["protobuf", "retina-face"]
+requires_matching_host = true
 [uv-tensorflow-macos.marker_environment]
 platform_system = "Darwin"
 sys_platform = "darwin"
@@ -1549,6 +1550,7 @@ datetime = "2025-02-20 12:19:21"
 requirements = [
     "pywin32; sys_platform == 'win32'",
 ]
+requires_matching_host = true
 [pywin32-windows-amd64-real-index.marker_environment]
 platform_system = "Windows"
 sys_platform = "win32"

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -14,6 +14,8 @@ from types import ModuleType, SimpleNamespace
 import pytest
 from typing_extensions import Self
 
+from nab_python.target import ResolveTarget
+
 _CANARY = Path(__file__).resolve().parents[1] / "benchmarks" / "canary.py"
 
 
@@ -194,7 +196,40 @@ def test_canary_rejects_supported_marker_build_policy(
         module.median_run(scenario, 1, scenario_name="example", host=host)
 
 
-def test_canary_skips_a_platform_overlay_with_unfaithful_host_tags(
+@pytest.mark.parametrize("nested", [False, True])
+def test_canary_runs_a_platform_overlay_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    nested: bool,
+) -> None:
+    module = _harness()
+    host = module.BenchmarkHost.current(module.WALL_TIMEOUT_S)
+    current_system = host.target.marker_env["platform_system"]
+    required_system = "Windows" if current_system != "Windows" else "Linux"
+
+    targets: list[ResolveTarget] = []
+
+    def fake_run_one(*_args: object, **kwargs: object) -> dict[str, object]:
+        target = kwargs["target"]
+        assert isinstance(target, ResolveTarget)
+        targets.append(target)
+        return _run_result()
+
+    monkeypatch.setattr(module, "run_one", fake_run_one)
+    scenario: dict[str, object] = {"python_version": "3.11", "requirements": []}
+    if nested:
+        scenario["marker_environment"] = {"platform_system": required_system}
+    else:
+        scenario["platform_system"] = required_system
+    runs, _summary = module.median_run(scenario, 1, host=host)
+
+    assert runs == [_run_result()]
+    assert len(targets) == 1
+    target = targets[0]
+    assert target.marker_env["platform_system"] == required_system
+    assert target.tags_faithful is False
+
+
+def test_canary_skips_an_explicit_host_requirement_with_unfaithful_tags(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     module = _harness()
@@ -202,15 +237,16 @@ def test_canary_skips_a_platform_overlay_with_unfaithful_host_tags(
     current_system = host.target.marker_env["platform_system"]
     required_system = "Windows" if current_system != "Windows" else "Linux"
 
-    def unexpected_run(*_args: object, **_kwargs: object) -> dict:
-        pytest.fail("inapplicable scenario reached the resolver")
+    def unexpected_run(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("host admission must happen before resolution")
 
     monkeypatch.setattr(module, "run_one", unexpected_run)
     runs, summary = module.median_run(
         {
             "python_version": "3.11",
             "requirements": [],
-            "platform_system": required_system,
+            "marker_environment": {"platform_system": required_system},
+            "requires_matching_host": True,
         },
         1,
         host=host,
@@ -222,7 +258,7 @@ def test_canary_skips_a_platform_overlay_with_unfaithful_host_tags(
     }
 
 
-def test_canary_rejects_an_invalid_host_restriction(
+def test_canary_rejects_an_invalid_target_marker_declaration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     module = _harness()
@@ -440,7 +476,7 @@ def test_canary_configures_lowest_direct_roots(
     requirements = module.parse_requirements(["Root[feature]", "Other==1"])
     captured = module.BenchmarkHost.current(module.WALL_TIMEOUT_S)
     host = module.BenchmarkHost(captured.target, captured.python_runtime, None)
-    admission = host.target_for("3.11", {})
+    admission = host.target_for("3.11", {}, requires_matching_host=False)
     assert admission.target is not None
     result = module.run_one(
         requirements,

--- a/nab-python/tests/test_benchmark_compare.py
+++ b/nab-python/tests/test_benchmark_compare.py
@@ -15,6 +15,7 @@ _STRATEGIES = ("highest", "lowest", "lowest-direct")
 _COMPLETED_LOGICAL = ("cases:done",)
 _UNSUPPORTED_LOGICAL = ("cases:nope",)
 _INAPPLICABLE_LOGICAL = ("cases:host",)
+_REQUIRES_MATCHING_HOST_LOGICAL = ("cases:host",)
 
 
 def _harness() -> ModuleType:
@@ -90,6 +91,7 @@ def _manifest(
         "selected_logical_keys": list(available_logical),
         "completed_logical_keys": list(_COMPLETED_LOGICAL),
         "unsupported_logical_keys": list(_UNSUPPORTED_LOGICAL),
+        "requires_matching_host_logical_keys": list(_REQUIRES_MATCHING_HOST_LOGICAL),
         "inapplicable_logical_keys": list(_INAPPLICABLE_LOGICAL),
         "available_execution_keys": _execution_keys(available_logical),
         "selected_execution_keys": _execution_keys(available_logical),
@@ -217,6 +219,16 @@ def test_comparison_uses_the_manifest_and_keeps_scenario_inputs(
         pytest.param(
             lambda data: data["completed_logical_keys"].append("cases:host"),
             id="overlapping-partition",
+        ),
+        pytest.param(
+            lambda data: data["requires_matching_host_logical_keys"].clear(),
+            id="inapplicable-without-host-requirement",
+        ),
+        pytest.param(
+            lambda data: data["requires_matching_host_logical_keys"].append(
+                "cases:other"
+            ),
+            id="unselected-host-requirement",
         ),
     ],
 )
@@ -388,12 +400,34 @@ def test_comparison_rejects_manifest_identity_differences(tmp_path: Path) -> Non
         module.require_comparable(first, changed_identity)
 
 
+def test_comparison_rejects_different_host_requirements(tmp_path: Path) -> None:
+    module = _harness()
+    first = module.load_run(
+        _write_run(module, tmp_path, "first", source_commit="a" * 40)
+    )
+    second_dir = _write_run(module, tmp_path, "second", source_commit="b" * 40)
+    _rewrite_json(
+        second_dir / module.MANIFEST_FILENAME,
+        lambda data: data.update(
+            requires_matching_host_logical_keys=["cases:done", "cases:host"]
+        ),
+    )
+    second = module.load_run(second_dir)
+
+    with pytest.raises(module.ComparisonError, match="different identities"):
+        module.require_comparable(first, second)
+
+
 def test_comparison_rejects_runs_without_completed_executions(tmp_path: Path) -> None:
     module = _harness()
 
     def make_all_inapplicable(run_dir: Path) -> None:
         def rewrite_manifest(data: dict) -> None:
             data["completed_logical_keys"] = []
+            data["requires_matching_host_logical_keys"] = [
+                "cases:done",
+                "cases:host",
+            ]
             data["inapplicable_logical_keys"] = ["cases:done", "cases:host"]
             data["completed_execution_keys"] = []
             data["file_execution_keys"] = []

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -33,7 +33,7 @@ _MARKER_BUILD_SCENARIOS = {
     "pip:pip-9572-textract-pypdf2",
     "uv:uv-issue-13321-axolotl-stack",
 }
-_EXACT_HOST_MARKERS = {
+_MATCHING_HOST_MARKERS = {
     "uv:uv-tensorflow-macos": {
         "implementation_name": "cpython",
         "os_name": "posix",
@@ -67,6 +67,7 @@ _MANIFEST_FIELDS = {
     "selected_logical_keys",
     "completed_logical_keys",
     "unsupported_logical_keys",
+    "requires_matching_host_logical_keys",
     "inapplicable_logical_keys",
     "available_execution_keys",
     "selected_execution_keys",
@@ -225,10 +226,12 @@ def _harness(name: str) -> ModuleType:
     return module
 
 
-def _exact_host_rows(module: ModuleType) -> dict[str, object]:
+def _matching_host_rows(module: ModuleType) -> dict[str, object]:
     rows = module.load_standard_corpus(module.standard_scenario_files())
     return {
-        row.logical_key: row for row in rows if "marker_environment" in row.definition
+        row.logical_key: row
+        for row in rows
+        if row.definition.get("requires_matching_host") is True
     }
 
 
@@ -254,6 +257,7 @@ unsupported_reason = "requires a native system dependency"
 python_version = "3.11"
 requirements = []
 platform_system = "Windows"
+requires_matching_host = true
 """.lstrip(),
         encoding="utf-8",
     )
@@ -432,7 +436,7 @@ def test_standard_execution_census() -> None:
                 "os_name": "posix",
                 "platform_tag": "manylinux_2_17_x86_64",
             },
-            {"linux", "neutral"},
+            {"linux", "windows", "neutral", "simulated-windows"},
         ),
         (
             {
@@ -442,7 +446,7 @@ def test_standard_execution_census() -> None:
                 "os_name": "nt",
                 "platform_tag": "win_amd64",
             },
-            {"windows", "windows-amd64", "neutral"},
+            {"linux", "windows", "windows-amd64", "neutral", "simulated-windows"},
         ),
         (
             {
@@ -452,7 +456,7 @@ def test_standard_execution_census() -> None:
                 "os_name": "nt",
                 "platform_tag": "win_arm64",
             },
-            {"windows", "neutral"},
+            {"linux", "windows", "neutral", "simulated-windows"},
         ),
         (
             {
@@ -462,7 +466,7 @@ def test_standard_execution_census() -> None:
                 "os_name": "posix",
                 "platform_tag": "macosx_14_0_arm64",
             },
-            {"mac-arm", "neutral"},
+            {"linux", "windows", "mac-arm", "neutral", "simulated-windows"},
         ),
         (
             {
@@ -472,7 +476,7 @@ def test_standard_execution_census() -> None:
                 "os_name": "posix",
                 "platform_tag": "macosx_14_0_x86_64",
             },
-            {"neutral"},
+            {"linux", "windows", "neutral", "simulated-windows"},
         ),
         (
             {
@@ -483,11 +487,11 @@ def test_standard_execution_census() -> None:
                 "platform_tag": "macosx_14_0_arm64",
                 "implementation": "pypy",
             },
-            {"neutral"},
+            {"linux", "windows", "neutral", "simulated-windows"},
         ),
     ],
 )
-def test_standard_plan_admits_only_targets_with_host_wheel_tags(
+def test_standard_plan_applies_explicit_host_requirements(
     host_kwargs: dict[str, str],
     expected: set[str],
 ) -> None:
@@ -496,12 +500,18 @@ def test_standard_plan_admits_only_targets_with_host_wheel_tags(
         module.StandardScenario(
             "test",
             "linux",
-            {"python_version": "3.11", "platform_system": "Linux"},
+            {
+                "python_version": "3.11",
+                "platform_system": "Linux",
+            },
         ),
         module.StandardScenario(
             "test",
             "windows",
-            {"python_version": "3.11", "platform_system": "Windows"},
+            {
+                "python_version": "3.11",
+                "platform_system": "Windows",
+            },
         ),
         module.StandardScenario(
             "test",
@@ -516,6 +526,7 @@ def test_standard_plan_admits_only_targets_with_host_wheel_tags(
                     "platform_system": "Windows",
                     "sys_platform": "win32",
                 },
+                "requires_matching_host": True,
             },
         ),
         module.StandardScenario(
@@ -531,6 +542,15 @@ def test_standard_plan_admits_only_targets_with_host_wheel_tags(
                     "platform_system": "Darwin",
                     "sys_platform": "darwin",
                 },
+                "requires_matching_host": True,
+            },
+        ),
+        module.StandardScenario(
+            "test",
+            "simulated-windows",
+            {
+                "python_version": "3.11",
+                "marker_environment": {"platform_system": "Windows"},
             },
         ),
         module.StandardScenario("test", "neutral", {"python_version": "3.11"}),
@@ -543,8 +563,120 @@ def test_standard_plan_admits_only_targets_with_host_wheel_tags(
     )
 
     assert {execution.scenario.name for execution in plan.executions} == expected
-    assert all(target.tags_faithful for target in plan.targets_by_logical_key.values())
+    assert all(
+        plan.targets_by_logical_key[execution.scenario.logical_key].tags_faithful
+        for execution in plan.executions
+        if execution.scenario.definition.get("requires_matching_host")
+    )
+    simulated_target = plan.targets_by_logical_key["test:simulated-windows"]
+    assert simulated_target.tags_faithful is (host_kwargs["system"] == "Windows")
     assert len(plan.inapplicable_logical_keys) == len(rows) - len(expected)
+
+
+def test_manifest_matching_host_census_is_explicit() -> None:
+    module = _harness("scenarios")
+    rows = [
+        module.StandardScenario(
+            "test",
+            "shorthand",
+            {"python_version": "3.11", "platform_system": "Windows"},
+        ),
+        module.StandardScenario(
+            "test",
+            "nested",
+            {
+                "python_version": "3.11",
+                "marker_environment": {"platform_system": "Windows"},
+            },
+        ),
+        module.StandardScenario(
+            "test",
+            "explicit-false",
+            {
+                "python_version": "3.11",
+                "platform_system": "Windows",
+                "requires_matching_host": False,
+            },
+        ),
+        module.StandardScenario(
+            "test",
+            "explicit-true",
+            {
+                "python_version": "3.11",
+                "platform_system": "Windows",
+                "requires_matching_host": True,
+            },
+        ),
+    ]
+    host = _host(
+        module,
+        system="Linux",
+        sys_platform="linux",
+        machine="x86_64",
+        os_name="posix",
+        platform_tag="manylinux_2_17_x86_64",
+    )
+    strategies = (module.ResolutionStrategy.HIGHEST,)
+    plan = module.standard_run_plan(rows, strategies, host)
+    manifest = module.standard_manifest_contract(
+        commit="run",
+        mode="default",
+        all_rows=rows,
+        selected_rows=rows,
+        corpus_files=["test.toml"],
+        selected_files=["test.toml"],
+        strategies=strategies,
+        corpus_hash="a" * 64,
+        plan=plan,
+        settings=module.standard_benchmark_settings(host),
+    )
+
+    assert manifest["requires_matching_host_logical_keys"] == ["test:explicit-true"]
+    assert manifest["inapplicable_logical_keys"] == ["test:explicit-true"]
+
+
+@pytest.mark.parametrize(
+    ("implementation", "runs"),
+    [("cpython", False), ("pypy", True)],
+)
+def test_matching_host_requirement_accepts_an_interpreter_only_selector(
+    implementation: str,
+    runs: bool,
+) -> None:
+    module = _harness("scenarios")
+    row = module.StandardScenario(
+        "test",
+        "pypy",
+        {
+            "python_version": "3.11",
+            "marker_environment": {"implementation_name": "pypy"},
+            "requires_matching_host": True,
+        },
+    )
+    host = _host(
+        module,
+        system="Linux",
+        sys_platform="linux",
+        machine="x86_64",
+        os_name="posix",
+        platform_tag="manylinux_2_17_x86_64",
+        implementation=implementation,
+    )
+
+    plan = module.standard_run_plan(
+        [row],
+        (module.ResolutionStrategy.HIGHEST,),
+        host,
+    )
+
+    if runs:
+        assert len(plan.executions) == 1
+        assert plan.inapplicable_logical_keys == []
+        assert plan.targets_by_logical_key[row.logical_key].tags_faithful
+    else:
+        assert plan.executions == []
+        assert plan.targets_by_logical_key == {}
+        assert plan.inapplicable_logical_keys == [row.logical_key]
 
 
 @pytest.mark.parametrize(
@@ -578,7 +710,7 @@ def test_standard_plan_admits_only_targets_with_host_wheel_tags(
         ),
     ],
 )
-def test_invalid_host_restrictions_are_rejected(
+def test_invalid_target_marker_declarations_are_rejected(
     definition: dict[str, object],
     message: str,
 ) -> None:
@@ -595,13 +727,75 @@ def test_invalid_host_restrictions_are_rejected(
         {"marker_environment": {"platform_system": 1}},
     ],
 )
-def test_host_restrictions_require_string_values(
+def test_target_marker_declarations_require_string_values(
     definition: dict[str, object],
 ) -> None:
     module = _harness("scenarios")
 
     with pytest.raises(TypeError, match="must be .*string"):
         module.parse_marker_environment("invalid", definition)
+
+
+@pytest.mark.parametrize(
+    ("definition", "expected"),
+    [
+        ({}, False),
+        ({"platform_system": "Linux"}, False),
+        ({"marker_environment": {"platform_system": "Linux"}}, False),
+        (
+            {
+                "marker_environment": {"platform_system": "Linux"},
+                "requires_matching_host": True,
+            },
+            True,
+        ),
+        (
+            {
+                "marker_environment": {"platform_system": "Linux"},
+                "requires_matching_host": False,
+            },
+            False,
+        ),
+        (
+            {
+                "platform_system": "Linux",
+                "requires_matching_host": False,
+            },
+            False,
+        ),
+    ],
+)
+def test_matching_host_requirement_is_explicit(
+    definition: dict[str, object],
+    expected: bool,
+) -> None:
+    module = _harness("scenarios")
+    markers = module.parse_marker_environment("example", definition)
+
+    assert (
+        module.parse_requires_matching_host("example", definition, markers) is expected
+    )
+
+
+@pytest.mark.parametrize("value", [1, "true", [], {}])
+def test_matching_host_requirement_must_be_boolean(value: object) -> None:
+    module = _harness("scenarios")
+    definition = {
+        "marker_environment": {"platform_system": "Linux"},
+        "requires_matching_host": value,
+    }
+    markers = module.parse_marker_environment("invalid", definition)
+
+    with pytest.raises(TypeError, match="requires_matching_host must be a boolean"):
+        module.parse_requires_matching_host("invalid", definition, markers)
+
+
+def test_matching_host_requirement_needs_target_identity() -> None:
+    module = _harness("scenarios")
+    definition = {"requires_matching_host": True}
+
+    with pytest.raises(ValueError, match="needs a platform or interpreter marker"):
+        module.parse_requires_matching_host("invalid", definition, {})
 
 
 def test_standard_plan_reuses_one_admitted_target_across_strategies() -> None:
@@ -748,7 +942,7 @@ def test_resolve_scenario_uses_the_supplied_target_and_host(
         os_name="posix",
         platform_tag="manylinux_2_17_x86_64",
     )
-    admission = host.target_for("3.11", {})
+    admission = host.target_for("3.11", {}, requires_matching_host=False)
     assert admission.target is not None
     target = admission.target
     seen: dict[str, object] = {}
@@ -807,18 +1001,18 @@ def test_marker_build_scenarios_are_explicitly_unsupported() -> None:
     )
 
 
-def test_exact_host_scenarios_define_complete_marker_environments() -> None:
+def test_matching_host_scenario_census_has_complete_marker_environments() -> None:
     module = _harness("scenarios")
-    rows = _exact_host_rows(module)
+    rows = _matching_host_rows(module)
 
     assert {
         key: row.definition["marker_environment"] for key, row in rows.items()
-    } == _EXACT_HOST_MARKERS
+    } == _MATCHING_HOST_MARKERS
 
 
-def test_exact_host_scenarios_retain_their_reviewed_inputs() -> None:
+def test_matching_host_scenarios_retain_their_reviewed_inputs() -> None:
     module = _harness("scenarios")
-    rows = _exact_host_rows(module)
+    rows = _matching_host_rows(module)
 
     tensorflow = rows["uv:uv-tensorflow-macos"].definition
     assert tensorflow["python_version"] == "3.10.17"
@@ -855,12 +1049,12 @@ def test_exact_host_scenarios_retain_their_reviewed_inputs() -> None:
         ),
     ],
 )
-def test_exact_host_scenarios_run_on_matching_hosts(
+def test_matching_host_scenarios_run_on_matching_hosts(
     logical_key: str,
     host_kwargs: dict[str, str],
 ) -> None:
     module = _harness("scenarios")
-    row = _exact_host_rows(module)[logical_key]
+    row = _matching_host_rows(module)[logical_key]
     host = _host(module, **host_kwargs)
 
     plan = module.standard_run_plan(
@@ -870,6 +1064,7 @@ def test_exact_host_scenarios_run_on_matching_hosts(
     )
 
     assert len(plan.executions) == 1
+    assert plan.inapplicable_logical_keys == []
     assert plan.targets_by_logical_key[logical_key].tags_faithful
 
 
@@ -896,6 +1091,26 @@ requirements = ["demo"]
             "with a marker environment overlay"
         ),
     ):
+        module.load_standard_corpus([path])
+
+
+def test_standard_corpus_validates_host_requirement_on_unsupported_rows(
+    tmp_path: Path,
+) -> None:
+    module = _harness("scenarios")
+    path = tmp_path / "quick.toml"
+    path.write_text(
+        """
+[unsupported]
+python_version = "3.11"
+requirements = []
+unsupported_reason = "not runnable"
+requires_matching_host = "yes"
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(TypeError, match="requires_matching_host must be a boolean"):
         module.load_standard_corpus([path])
 
 
@@ -1458,6 +1673,7 @@ def test_main_writes_exact_complete_default_and_matrix_manifests(
 
     assert manifest["completed_logical_keys"] == ["quick:example"]
     assert manifest["unsupported_logical_keys"] == ["quick:unsupported"]
+    assert manifest["requires_matching_host_logical_keys"] == ["quick:foreign-host"]
     assert manifest["inapplicable_logical_keys"] == ["quick:foreign-host"]
 
     assert manifest["completed_execution_keys"] == expected_completed
@@ -1805,7 +2021,11 @@ def test_profile_runner_uses_the_admitted_target_for_roots_and_resolution() -> N
         os_name="posix",
         platform_tag="manylinux_2_17_x86_64",
     )
-    admission = physical_host.target_for("3.11", {})
+    admission = physical_host.target_for(
+        "3.11",
+        {},
+        requires_matching_host=False,
+    )
     assert admission.target is not None
 
     class PlannedHost:
@@ -1815,9 +2035,12 @@ def test_profile_runner_uses_the_admitted_target_for_roots_and_resolution() -> N
             self,
             python_version: str,
             marker_environment: dict[str, str],
+            *,
+            requires_matching_host: bool,
         ) -> object:
             assert python_version == "3.11"
             assert marker_environment == {}
+            assert requires_matching_host is False
             return admission
 
     host = PlannedHost()
@@ -1862,7 +2085,8 @@ def test_profile_runner_rejects_an_inapplicable_host_before_resolution() -> None
     scenario = {
         "python_version": "3.11",
         "requirements": [],
-        "platform_system": "Windows",
+        "marker_environment": {"platform_system": "Windows"},
+        "requires_matching_host": True,
     }
     host = _host(
         module.sc,
@@ -1875,3 +2099,28 @@ def test_profile_runner_rejects_an_inapplicable_host_before_resolution() -> None
 
     with pytest.raises(SystemExit, match="benchmark is inapplicable"):
         module.build_inputs("example", scenario, host=host)
+
+
+def test_profile_runner_allows_target_only_foreign_overlay() -> None:
+    module = _harness("_profile_runner")
+    host = _host(
+        module.sc,
+        system="Linux",
+        sys_platform="linux",
+        machine="x86_64",
+        os_name="posix",
+        platform_tag="manylinux_2_17_x86_64",
+    )
+    inputs = module.build_inputs(
+        "example",
+        {
+            "python_version": "3.11",
+            "requirements": [],
+            "marker_environment": {"platform_system": "Windows"},
+        },
+        host=host,
+    )
+
+    target = inputs["target"]
+    assert target.marker_env["platform_system"] == "Windows"
+    assert target.tags_faithful is False


### PR DESCRIPTION
`uv-tensorflow-macos` needs macOS arm64 wheel tags, while `pywin32-windows-amd64-real-index` needs Windows AMD64 tags. Both now set `requires_matching_host = true` and are recorded as inapplicable when the current host cannot supply faithful tags. Marker overlays without that setting remain runnable on any host. The standard manifest records declared host requirements alongside the applicability set, so comparisons cannot mix runs with different coverage.
