### PR TITLE
Import nab_resolver names from promised paths

### DIFF
--- a/nab-python/benchmarks/deterministic_smoke.py
+++ b/nab-python/benchmarks/deterministic_smoke.py
@@ -52,7 +52,7 @@ from nab_python.provider import ResolutionStrategy
 from nab_python.resolve import ResolveResult, build_lock_input, resolve_with_coordinator
 from nab_python.tags import PlatformSpec
 from nab_python.target import Matrix, ResolveTarget, environment_declaration
-from nab_resolver.resolver import ResolutionError
+from nab_resolver.errors import ResolutionError
 
 BENCHMARKS_DIR = Path(__file__).parent
 SMOKE_DIR = BENCHMARKS_DIR / "smoke"

--- a/nab-python/src/nab_python/_build/runner.py
+++ b/nab-python/src/nab_python/_build/runner.py
@@ -39,7 +39,7 @@ import pyproject_hooks
 import tomli
 
 from nab_index.local_index import UnsupportedWheelError, wheel_metadata_member
-from nab_resolver.resolver import ResolutionError
+from nab_resolver.errors import ResolutionError
 
 from .._vendor.packaging.requirements import Requirement
 from .._vendor.packaging.specifiers import SpecifierSet

--- a/nab-python/src/nab_python/resolve.py
+++ b/nab-python/src/nab_python/resolve.py
@@ -31,12 +31,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple, Protocol
 
 from nab_index.cache import ARCHIVE_BUCKET, VCS_BUCKET
-from nab_resolver.resolver import (
+from nab_resolver.errors import ResolutionError
+from nab_resolver.resolver import Resolver, ResolverObserver
+from nab_resolver.types import (
     Incompatibility,
     IncompatibilityCause,
-    ResolutionError,
-    Resolver,
-    ResolverObserver,
     RootRequirement,
 )
 

--- a/nab-python/tests/property_python/test_prerelease_admission.py
+++ b/nab-python/tests/property_python/test_prerelease_admission.py
@@ -24,7 +24,8 @@ from nab_python._packaging_provider import PackagingProvider
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.version import Version
-from nab_resolver.resolver import ResolutionError, Resolver
+from nab_resolver.errors import ResolutionError
+from nab_resolver.resolver import Resolver
 
 from .strategies import PROPERTY_SETTINGS
 

--- a/nab-python/tests/property_python/test_resolver_pep440.py
+++ b/nab-python/tests/property_python/test_resolver_pep440.py
@@ -25,7 +25,8 @@ from nab_python._packaging_provider import PackagingProvider
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.version import Version
-from nab_resolver.resolver import ResolutionError, Resolver
+from nab_resolver.errors import ResolutionError
+from nab_resolver.resolver import Resolver
 
 from .strategies import (
     BRUTE_FORCE_SETTINGS,

--- a/nab-python/tests/test_build_runner.py
+++ b/nab-python/tests/test_build_runner.py
@@ -70,7 +70,7 @@ from nab_python.provider import BuildPolicy, DistPolicy, MissingExtraError
 from nab_python.resolve import ResolveResult, TargetResult
 from nab_python.tags import PlatformSpec, TagSet
 from nab_python.target import ResolveTarget
-from nab_resolver.resolver import ResolutionError
+from nab_resolver.errors import ResolutionError
 
 
 def _unpack_fixture_sdist(data: bytes, target_dir: Path) -> Path:

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -94,7 +94,8 @@ from nab_python.resolve import (
 )
 from nab_python.tags import PlatformSpec
 from nab_python.target import ResolveTarget
-from nab_resolver.resolver import ResolutionError, Resolver
+from nab_resolver.errors import ResolutionError
+from nab_resolver.resolver import Resolver
 from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
 
 V = Version

--- a/nab-python/tests/test_resolve.py
+++ b/nab-python/tests/test_resolve.py
@@ -62,13 +62,9 @@ from nab_python.resolve import (
 )
 from nab_python.tags import PlatformSpec
 from nab_python.target import ResolveTarget
+from nab_resolver.errors import ResolutionError
 from nab_resolver.ranges import Range
-from nab_resolver.resolver import (
-    Incompatibility,
-    IncompatibilityCause,
-    ResolutionError,
-    Term,
-)
+from nab_resolver.types import Incompatibility, IncompatibilityCause, Term
 
 V = Version
 

--- a/nab-python/tests/test_resolver_packaging.py
+++ b/nab-python/tests/test_resolver_packaging.py
@@ -13,8 +13,9 @@ from nab_python._packaging_provider import PackagingProvider
 from nab_python._vendor.packaging.ranges import VersionRange
 from nab_python._vendor.packaging.specifiers import SpecifierSet
 from nab_python._vendor.packaging.version import Version
+from nab_resolver.errors import ResolutionError
 from nab_resolver.report import union_terms
-from nab_resolver.resolver import ResolutionError, Resolver
+from nab_resolver.resolver import Resolver
 from nab_resolver.types import Term
 
 V = Version

--- a/nab-python/tests/test_widen_decision.py
+++ b/nab-python/tests/test_widen_decision.py
@@ -33,7 +33,8 @@ from nab_python.provider import (
     VcsSource,
 )
 from nab_python.target import ResolveTarget
-from nab_resolver.resolver import ResolutionError, Resolver
+from nab_resolver.errors import ResolutionError
+from nab_resolver.resolver import Resolver
 from nab_resolver.root import ROOT
 
 if TYPE_CHECKING:

--- a/src/nab/cli.py
+++ b/src/nab/cli.py
@@ -86,7 +86,7 @@ from nab_python.resolve import (
 )
 from nab_python.target import NonIntervalMarkerError, UnevaluableMarkerError
 from nab_python.workspace import WorkspaceDiscoveryError
-from nab_resolver.resolver import ResolutionError
+from nab_resolver.errors import ResolutionError
 
 from .output import (
     OUTPUT_ENV_VARS,

--- a/tasks/check_boundaries.py
+++ b/tasks/check_boundaries.py
@@ -1,6 +1,6 @@
 """Check the workspace import boundaries the four nab packages are built on.
 
-Two rules, both over shipped source only:
+Four rules, all over shipped source only:
 
 ``declared``
     A package may import a sibling only when it depends on it. The allowed
@@ -11,6 +11,13 @@ Two rules, both over shipped source only:
     A package may not import an underscore-prefixed name from a sibling.
     Reaching past the underscore couples a caller to something the owning
     package can rename without notice.
+
+``supported``
+    Where a sibling publishes a supported-path table in its package
+    docstring, a name in that table must be imported from the path the
+    table gives it. Another module may happen to re-export the same name,
+    but only the table's path is held still across releases, so an import
+    that goes the other way works today and breaks on a reshuffle.
 
 ``vendored``
     ``_vendor`` is stricter still: it is off limits to every other package
@@ -30,6 +37,7 @@ Run directly::
 from __future__ import annotations
 
 import ast
+import re
 import sys
 from pathlib import Path
 
@@ -42,6 +50,11 @@ REMEDY = (
     "drop the underscore, add it to that module's __all__, and update its "
     "existing callers."
 )
+
+# Packages whose docstring publishes a supported-path table. Listed here so a
+# table that stops parsing fails the run rather than quietly dropping the
+# ``supported`` rule for the package it covers.
+PUBLISHES_SUPPORTED_PATHS = ("nab_resolver",)
 
 
 class Package:
@@ -57,6 +70,11 @@ class Package:
         self.requires: frozenset[str] = frozenset(
             _requirement_module(text) for text in project.get("dependencies", [])
         )
+        self.supported: dict[str, str] = (
+            _supported_paths(self.source, self.module)
+            if self.module in PUBLISHES_SUPPORTED_PATHS
+            else {}
+        )
 
 
 def _requirement_module(text: str) -> str:
@@ -64,6 +82,36 @@ def _requirement_module(text: str) -> str:
     for separator in ("[", "=", ">", "<", "!", "~", ";", " "):
         text = text.split(separator, 1)[0]
     return text.strip().replace("-", "_")
+
+
+def _supported_paths(source: Path, module: str) -> dict[str, str]:
+    """Map each name in ``module``'s supported-path table to its module path.
+
+    The table sits in the package docstring as indented ``<module path>  <names>``
+    rows. A row whose name list ends in a comma continues on the next indented
+    line, which is how a long row wraps.
+    """
+    init = source / "__init__.py"
+    docstring = ast.get_docstring(ast.parse(init.read_text("utf-8"), str(init))) or ""
+    row = re.compile(rf"^\s+({re.escape(module)}\.\w+)\s+(\S.*)$")
+
+    supported: dict[str, str] = {}
+    module_path = ""
+    wrapped = False
+    for line in docstring.splitlines():
+        match = row.match(line)
+        if match:
+            module_path, names = match.group(1), match.group(2).rstrip()
+        elif wrapped and line.startswith(" ") and line.strip():
+            names = line.strip()
+        else:
+            wrapped = False
+            continue
+        supported.update(
+            (name.strip(), module_path) for name in names.split(",") if name.strip()
+        )
+        wrapped = names.endswith(",")
+    return supported
 
 
 def packages() -> list[Package]:
@@ -122,12 +170,32 @@ def violations(package: Package, modules: dict[str, Package]) -> list[str]:
             )
             if private is not None:
                 found.append(f"{location}:{lineno}: {dotted} is private ({private})")
+
+            module_path, _, name = dotted.rpartition(".")
+            promised = modules[head].supported.get(name)
+            if promised is not None and promised != module_path:
+                found.append(
+                    f"{location}:{lineno}: {modules[head].dist_name} supports "
+                    f"{name} at {promised}, not through {module_path}"
+                )
     return found
 
 
 def main() -> int:
     """Report every violation and return the process exit status."""
     known = {package.module: package for package in packages()}
+    unread = [
+        module
+        for module in PUBLISHES_SUPPORTED_PATHS
+        if module not in known or not known[module].supported
+    ]
+    if unread:
+        print(
+            f"Could not read a supported-path table from: {', '.join(unread)}",
+            file=sys.stderr,
+        )
+        return 1
+
     found = [
         message for package in known.values() for message in violations(package, known)
     ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,7 +81,7 @@ from nab_python.requirements_file import InvalidProjectRequirementError
 from nab_python.resolve import ResolveResult, TargetResult, env_signature
 from nab_python.tags import PlatformSpec
 from nab_python.target import ResolveTarget, host_environment
-from nab_resolver.resolver import ResolutionError
+from nab_resolver.errors import ResolutionError
 
 V = Version
 


### PR DESCRIPTION
`nab_resolver`'s package docstring names the five module paths its supported names live at and says everything else is internal and free to move. nab's own packages were not following it. `nab_python.resolve` pulled `Incompatibility`, `IncompatibilityCause` and `RootRequirement` out of `nab_resolver.resolver`, which only re-exports them from `nab_resolver.types`, and `ResolutionError` came through the same re-export in `_build/runner.py` and `nab/cli.py`. Those imports work today entirely because `resolver.py` re-exports, and the re-exports are the part the promise leaves free to move.

This points every `nab_resolver` import in nab-python and the nab CLI at the path the docstring names, splitting the combined statements where a name now comes from a different module.

The wrong import is invisible at runtime, so `tasks/check_boundaries.py` gains a fourth rule to stop it drifting back: where a package publishes a supported-path table in its docstring, shipped code must import those names from the paths the table gives them. It reads the table out of `nab_resolver/__init__.py` instead of keeping a second copy of the names.
