### PR TITLE
use the default resolver iteration limit in benchmarks

### DIFF
--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -64,7 +64,7 @@ from nab_python.provider import (
     VcsPolicy,
     split_extra,
 )
-from nab_resolver.resolver import Resolver
+from nab_resolver.resolver import DEFAULT_MAX_ITERATIONS, Resolver
 
 BENCHMARKS_DIR = Path(__file__).parent
 SCENARIOS_DIR = BENCHMARKS_DIR / "scenarios"
@@ -115,7 +115,6 @@ class CanaryPreparation(NamedTuple):
 
 
 WALL_TIMEOUT_S = 60
-MAX_ITERATIONS = 50_000
 # Preserve contract v2 for comparisons with existing canary results.
 CANARY_CONTRACT_VERSION = 2
 
@@ -360,7 +359,6 @@ def run_one(  # noqa: PLR0913 - one wrapper per scenario knob
             provider,
             range_type=VersionRange,
             root_version="0",
-            max_iterations=MAX_ITERATIONS,
         )
 
         start = time.monotonic()
@@ -386,7 +384,7 @@ def run_one(  # noqa: PLR0913 - one wrapper per scenario knob
                 "dist_policy": DistPolicy.WHEEL_OR_SDIST.value,
                 "build_policy": BuildPolicy.NEVER.value,
                 "trust_unverified_sdist_deps": trust_unverified_sdist_deps,
-                "max_iterations": MAX_ITERATIONS,
+                "max_iterations": DEFAULT_MAX_ITERATIONS,
                 "wall_timeout_seconds": host.wall_timeout_seconds,
                 "runtime": _runtime_manifest(host),
                 "direct_packages": sorted(direct_packages),

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -64,7 +64,7 @@ from nab_python.provider import (
     VcsPolicy,
     split_extra,
 )
-from nab_resolver.resolver import Resolver
+from nab_resolver.resolver import DEFAULT_MAX_ITERATIONS, Resolver
 
 BENCHMARKS_DIR = Path(__file__).parent
 SCENARIOS_DIR = BENCHMARKS_DIR / "scenarios"
@@ -844,7 +844,6 @@ def parse_datetime(value: str) -> datetime:
 
 
 SCENARIO_WALL_TIMEOUT_SECONDS = 120
-MAX_ITERATIONS = 50_000
 
 
 CACHE_DIR = BENCHMARKS_DIR / "cache"
@@ -884,7 +883,7 @@ def standard_benchmark_settings(host: BenchmarkHost) -> dict[str, object]:
         "dist_policy": DistPolicy.WHEEL_OR_SDIST.value,
         "build_policy": BuildPolicy.NEVER.value,
         "trust_unverified_sdist_deps_default": True,
-        "max_iterations": MAX_ITERATIONS,
+        "max_iterations": DEFAULT_MAX_ITERATIONS,
         "wall_timeout_seconds": host.wall_timeout_seconds,
         "host": host.identity(),
     }
@@ -1347,7 +1346,6 @@ def resolve_scenario(  # noqa: PLR0913 - one wrapper per scenario knob
             provider,
             range_type=VersionRange,
             root_version="0",
-            max_iterations=MAX_ITERATIONS,
         )
 
         start = time.monotonic()

--- a/nab-python/tests/test_benchmark_canary.py
+++ b/nab-python/tests/test_benchmark_canary.py
@@ -435,6 +435,7 @@ def test_canary_configures_lowest_direct_roots(
 ) -> None:
     module = _harness()
     seen: dict[str, object] = {}
+    resolver_kwargs: dict[str, object] = {}
 
     class FakeCoordinator:
         def __init__(self, *_args: object, **_kwargs: object) -> None:
@@ -456,7 +457,8 @@ def test_canary_configures_lowest_direct_roots(
             )
 
     class FakeResolver:
-        def __init__(self, *_args: object, **_kwargs: object) -> None:
+        def __init__(self, *_args: object, **kwargs: object) -> None:
+            resolver_kwargs.update(kwargs)
             self.stats = SimpleNamespace(
                 decisions=0,
                 conflicts=0,
@@ -493,7 +495,7 @@ def test_canary_configures_lowest_direct_roots(
     assert settings["dist_policy"] == "wheel-or-sdist"
     assert settings["build_policy"] == "never"
     assert settings["trust_unverified_sdist_deps"] is False
-    assert settings["max_iterations"] == module.MAX_ITERATIONS
+    assert settings["max_iterations"] == module.DEFAULT_MAX_ITERATIONS
     assert settings["wall_timeout_seconds"] is None
     assert settings["runtime"]["python"] == sys.version
     assert settings["runtime"]["implementation"] == sys.implementation.name
@@ -506,6 +508,10 @@ def test_canary_configures_lowest_direct_roots(
     assert seen["resolution_strategy"] is module.ResolutionStrategy.LOWEST_DIRECT
     assert seen["direct_packages"] == frozenset({"root", "other"})
     assert seen["target"] is admission.target
+    assert resolver_kwargs == {
+        "range_type": module.VersionRange,
+        "root_version": "0",
+    }
 
 
 def test_canary_main_records_v2_contract(

--- a/nab-python/tests/test_benchmark_compare.py
+++ b/nab-python/tests/test_benchmark_compare.py
@@ -44,7 +44,7 @@ def _settings() -> dict[str, object]:
         "dist_policy": "wheel-or-sdist",
         "build_policy": "never",
         "trust_unverified_sdist_deps_default": True,
-        "max_iterations": 50_000,
+        "max_iterations": 200_000,
         "wall_timeout_seconds": 120,
         "host": {
             "python": "3.12.1 (benchmark fixture)",
@@ -384,7 +384,7 @@ def test_comparison_rejects_manifest_identity_differences(tmp_path: Path) -> Non
     second_dir = _write_run(module, tmp_path, "second", source_commit="b" * 40)
     _rewrite_json(
         second_dir / module.MANIFEST_FILENAME,
-        lambda data: data["settings"].update(wall_timeout_seconds=None),
+        lambda data: data["settings"].update(max_iterations=100_000),
     )
     manifest = json.loads((second_dir / module.MANIFEST_FILENAME).read_text())
     for key in manifest["completed_execution_keys"]:

--- a/nab-python/tests/test_benchmark_strategy_matrix.py
+++ b/nab-python/tests/test_benchmark_strategy_matrix.py
@@ -957,7 +957,8 @@ def test_resolve_scenario_uses_the_supplied_target_and_host(
             self.stats = _empty_provider_stats()
 
     class FakeResolver:
-        def __init__(self, *_args: object, **_kwargs: object) -> None:
+        def __init__(self, *_args: object, **kwargs: object) -> None:
+            seen["resolver_kwargs"] = kwargs
             self.stats = _empty_resolver_stats()
 
         def resolve(self, *_args: object, **_kwargs: object) -> dict:
@@ -982,7 +983,14 @@ def test_resolve_scenario_uses_the_supplied_target_and_host(
     )
 
     assert result["result"] == {"success": True, "error": None}
-    assert seen == {"target": target, "timeout": host}
+    assert seen == {
+        "target": target,
+        "resolver_kwargs": {
+            "range_type": module.VersionRange,
+            "root_version": "0",
+        },
+        "timeout": host,
+    }
 
 
 def test_marker_build_scenarios_are_explicitly_unsupported() -> None:
@@ -1654,6 +1662,7 @@ def test_main_writes_exact_complete_default_and_matrix_manifests(
 
     assert manifest["mode"] == ("strategy-matrix" if matrix else "default")
     assert manifest["strategies"] == expected_strategies
+    assert manifest["settings"]["max_iterations"] == module.DEFAULT_MAX_ITERATIONS
     assert manifest["settings"]["host"]["wheel_tags_count"] > 0
     assert len(manifest["settings"]["host"]["wheel_tags_hash"]) == 64
 

--- a/nab-resolver/README.md
+++ b/nab-resolver/README.md
@@ -22,7 +22,8 @@ internal and may be renamed or relocated in any release.
 ```text
 nab_resolver.errors     ResolutionError
 nab_resolver.ranges     Range
-nab_resolver.resolver   BaseProvider, Resolver, ResolverObserver, ResolverProvider
+nab_resolver.resolver   BaseProvider, DEFAULT_MAX_ITERATIONS, Resolver,
+                        ResolverObserver, ResolverProvider
 nab_resolver.root       ROOT
 nab_resolver.types      Incompatibility, IncompatibilityCause,
                         RangeProtocol, RootRequirement, Term

--- a/nab-resolver/src/nab_resolver/__init__.py
+++ b/nab-resolver/src/nab_resolver/__init__.py
@@ -6,7 +6,8 @@ renamed or relocated in any release.
 
     nab_resolver.errors     ResolutionError
     nab_resolver.ranges     Range
-    nab_resolver.resolver   BaseProvider, Resolver, ResolverObserver, ResolverProvider
+    nab_resolver.resolver   BaseProvider, DEFAULT_MAX_ITERATIONS, Resolver,
+                            ResolverObserver, ResolverProvider
     nab_resolver.root       ROOT
     nab_resolver.types      Incompatibility, IncompatibilityCause,
                             RangeProtocol, RootRequirement, Term

--- a/nab-resolver/src/nab_resolver/resolver.py
+++ b/nab-resolver/src/nab_resolver/resolver.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     from typing_extensions import TypeIs
 
 __all__ = [
+    "DEFAULT_MAX_ITERATIONS",
     "BaseProvider",
     "Incompatibility",
     "IncompatibilityCause",
@@ -60,6 +61,8 @@ __all__ = [
     "SetRelation",
     "Term",
 ]
+
+DEFAULT_MAX_ITERATIONS = 200_000
 
 
 class ResolverProvider(Protocol[PackageType, VersionType]):
@@ -390,7 +393,7 @@ class Resolver(Generic[PackageType, VersionType]):
         self,
         provider: ResolverProvider[PackageType, VersionType],
         observer: ResolverObserver[PackageType, VersionType] | None = None,
-        max_iterations: int = 200_000,
+        max_iterations: int = DEFAULT_MAX_ITERATIONS,
         range_type: type[RangeProtocol[Any]] = Range,
         root_version: Any = 1,
     ) -> None:

--- a/nab-resolver/tests/test_resolver.py
+++ b/nab-resolver/tests/test_resolver.py
@@ -35,6 +35,7 @@ from nab_resolver.report import (
     union_terms,
 )
 from nab_resolver.resolver import (
+    DEFAULT_MAX_ITERATIONS,
     ResolutionError,
     Resolver,
     ResolverObserver,
@@ -602,6 +603,12 @@ class TestPreference:
 
 
 class TestMaxIterations:
+    def test_default_is_public(self) -> None:
+        resolver = Resolver(DictProvider({}))
+
+        assert DEFAULT_MAX_ITERATIONS == 200_000
+        assert resolver.max_iterations == DEFAULT_MAX_ITERATIONS
+
     def test_exceeds_max_iterations(self) -> None:
         """Resolver raises when max_iterations is exceeded."""
         provider = DictProvider(


### PR DESCRIPTION
The pip:apache-airflow-311-full scenario reached the benchmark-only 50,000-iteration limit with the lowest strategy, while Resolver defaults to 200,000. The standard and canary runners now omit the override and record the public default in their result identities.
