### PR TITLE
reuse axis partitions across marker-set decisions

### DIFF
--- a/nab-python/src/nab_python/_vendor/packaging/_markersets.py
+++ b/nab-python/src/nab_python/_vendor/packaging/_markersets.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import re
 import sys
 import threading
+from collections import OrderedDict
 from itertools import pairwise, product
 from typing import TYPE_CHECKING, NamedTuple, cast
 
@@ -165,10 +166,10 @@ def _oversized_numeric(text: str) -> bool:
 # ---------------------------------------------------------------------------- atoms
 
 
-# A value atom's denotation is memoised per atom, so the cache lives and dies
-# with the atom's tree. The bound stops a long-lived atom evaluated against
-# ever-new points from accumulating them. The oversized-value guards run
-# uncached before any ``holds`` call, so a warm cache never bypasses them.
+# A value atom's denotation is memoised per atom. The bound stops a long-lived
+# atom evaluated against ever-new points from accumulating them. The
+# oversized-value guards run uncached before any ``holds`` call, so a warm cache
+# never bypasses them.
 _HOLDS_CACHE_LIMIT = 1024
 
 
@@ -1000,10 +1001,14 @@ def _partition_axis(axis: tuple, atoms: Sequence[Atom], max_cells: int) -> list[
     return partition_boolean_axis(atoms, max_cells)
 
 
-# One simplify re-partitions the same axes with the same atoms over and over.
-# The cache lives only for that span and is thread-local, so a concurrent
-# simplify never shares a store.
+# A partition is a pure function of its key, so one store serves every decision.
+# Thread-local, so a concurrent decision never shares a store and the entry
+# ordering needs no lock.
 _partition_cache = threading.local()
+
+# The store outlives the decision that filled it, so the bound stops a
+# long-lived process accumulating axes it will not partition again.
+_PARTITION_CACHE_LIMIT = 4096
 
 # ``max_cells`` bounds one decision, and the greedy fixpoint issues one per
 # clause and per atom per universe row, so the meter is what bounds the run:
@@ -1024,16 +1029,33 @@ def charge_work(units: int) -> None:
         raise IntractableMarkerSet(msg)
 
 
+def _partition_store() -> OrderedDict[tuple, list[Cell]]:
+    """Return this thread's partition store, created on first use."""
+    store: OrderedDict[tuple, list[Cell]] | None = getattr(
+        _partition_cache, "store", None
+    )
+    if store is None:
+        store = _partition_cache.store = OrderedDict()
+    return store
+
+
 def partition_axis(axis: tuple, atoms: Sequence[Atom], max_cells: int) -> list[Cell]:
     """Partition one axis's domain into cells on which every atom is constant."""
-    store: dict | None = getattr(_partition_cache, "store", None)
-    if store is None:
-        return _partition_axis(axis, atoms, max_cells)
-    key = (axis, tuple(atoms), max_cells)
+    store = _partition_store()
+
+    # The digit limit gates ``reject_oversized_version_literals`` inside the
+    # partition, so an entry built under a different limit would skip it.
+    key = (axis, tuple(atoms), max_cells, sys.get_int_max_str_digits())
+
     cached = store.get(key)
-    if cached is None:
-        cached = _partition_axis(axis, atoms, max_cells)
-        store[key] = cached
+    if cached is not None:
+        store.move_to_end(key)
+        return cached
+
+    cached = _partition_axis(axis, atoms, max_cells)
+    store[key] = cached
+    if len(store) > _PARTITION_CACHE_LIMIT:
+        store.popitem(last=False)
     return cached
 
 
@@ -1682,9 +1704,7 @@ def simplify_within(
     original = _disjunction(clauses)
     rows = _decompose_rows(universe)
     original_by_row = [restrict_tree(original, row.pins) for row in rows]
-    previous_store = getattr(_partition_cache, "store", None)
     previous_work = getattr(_work_meter, "remaining", None)
-    _partition_cache.store = {}
     _work_meter.remaining = max_work
     try:
         while True:
@@ -1694,7 +1714,6 @@ def simplify_within(
             if _canonical(clauses) == before:
                 break
     finally:
-        _partition_cache.store = previous_store
         _work_meter.remaining = previous_work
     if not clauses:
         return FALSE

--- a/nab-python/tests/test_markersets.py
+++ b/nab-python/tests/test_markersets.py
@@ -9,9 +9,11 @@ an independent brute-force oracle.
 from __future__ import annotations
 
 import importlib.util
+import sys
 from collections import defaultdict
 from functools import reduce
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 from packaging.markers import Marker
@@ -22,6 +24,11 @@ from nab_python._vendor.packaging.markersets import (
     IntractableMarkerSet,
     MarkerSet,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator, Sequence
+
+    from nab_python._vendor.packaging._markersets import Atom, Cell
 
 _spec = importlib.util.spec_from_file_location(
     "simplify_corpus_fixtures",
@@ -490,4 +497,150 @@ def test_work_meter_is_unset_outside_a_simplify() -> None:
     within = _narrow_universe()
     ms(_narrow_linux_span()).simplify(within=within)
     assert getattr(engine._work_meter, "remaining", None) is None
-    assert getattr(engine._partition_cache, "store", None) is None
+
+
+@pytest.fixture
+def no_partition_store() -> Iterator[None]:
+    """Run a test with no partition store at all, and leave none behind it.
+
+    Removing the attribute rather than emptying the store is what lets a test
+    tell a store built on demand from one that was already there.
+    """
+
+    def discard() -> None:
+        if hasattr(engine._partition_cache, "store"):
+            del engine._partition_cache.store
+
+    discard()
+    yield
+    discard()
+
+
+def _count_rebuilds(monkeypatch: pytest.MonkeyPatch) -> Callable[[], int]:
+    """Start counting axis partitions, and return a reader for the count.
+
+    Counts calls that reach :func:`_partition_axis`, so a decision served from
+    the store adds nothing.
+    """
+    calls = 0
+    real = engine._partition_axis
+
+    def counting(axis: tuple, atoms: Sequence[Atom], max_cells: int) -> list[Cell]:
+        nonlocal calls
+        calls += 1
+        return real(axis, atoms, max_cells)
+
+    monkeypatch.setattr(engine, "_partition_axis", counting)
+    return lambda: calls
+
+
+def _two_axis_pair() -> tuple[MarkerSet, MarkerSet]:
+    """Return two sets whose disjointness spans a python and a platform axis."""
+    return (
+        ms('python_version < "3.11" and sys_platform == "linux"'),
+        ms('python_version >= "3.12" and sys_platform == "linux"'),
+    )
+
+
+def test_partition_store_serves_a_later_decision(
+    no_partition_store: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An identical later decision partitions no axis again.
+
+    Nothing installs a store here, so this pins that an ordinary decision both
+    builds one on demand and is served from it. The repeat parses its markers
+    afresh, so a future memo on :class:`MarkerSet` itself could not satisfy it.
+    """
+    narrow, wide = _two_axis_pair()
+    assert narrow.is_disjoint(wide)
+
+    rebuilds = _count_rebuilds(monkeypatch)
+    again_narrow, again_wide = _two_axis_pair()
+
+    assert again_narrow.is_disjoint(again_wide)
+    assert rebuilds() == 0
+
+
+def test_partition_store_outlives_a_simplify(
+    no_partition_store: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A repeated simplify reuses the partitions the first one built.
+
+    ``simplify_within`` no longer installs a store of its own, so what it learns
+    is still there for the next caller. Nothing memoises simplify itself, so the
+    repeat really does decide again.
+    """
+    within = _narrow_universe()
+    ms(_narrow_linux_span()).simplify(within=within)
+
+    rebuilds = _count_rebuilds(monkeypatch)
+
+    assert ms(_narrow_linux_span()).simplify(within=within).to_marker_string() == (
+        'platform_machine == "x86_64" and sys_platform == "linux"'
+    )
+    assert rebuilds() == 0
+
+
+def test_partition_store_is_keyed_on_the_int_digit_limit(
+    no_partition_store: None,
+) -> None:
+    """Lowering the interpreter's digit limit invalidates a warm partition.
+
+    The limit gates ``reject_oversized_version_literals`` inside the partition,
+    so serving an entry built under a wider limit would skip the guard and decide
+    a literal the interpreter can no longer parse. Deciding twice under the lower
+    limit also pins that the raising partition cached nothing.
+
+    The literal's digit run has to exceed the lowered limit and sit under the
+    default one, and the interpreter refuses any limit below
+    ``sys.int_info.str_digits_check_threshold``.
+    """
+    limit = sys.int_info.str_digits_check_threshold + 1
+    marker = ms('python_full_version >= "1.' + "9" * (limit + 359) + '"')
+    original = sys.get_int_max_str_digits()
+
+    assert marker.is_empty() is False
+
+    sys.set_int_max_str_digits(limit)
+    try:
+        for _ in range(2):
+            with pytest.raises(
+                IntractableMarkerSet, match=f"exceeds the {limit}-digit parse limit"
+            ):
+                marker.is_empty()
+    finally:
+        sys.set_int_max_str_digits(original)
+
+
+def test_partition_store_is_keyed_on_atom_order(no_partition_store: None) -> None:
+    """Two decisions over one axis's atoms in different order do not share a cell list.
+
+    ``Cell.vector`` is positionally aligned with the atom list its partition was
+    built for, so keying on an unordered atom set would read one decision's truth
+    values off the other's cells. The store reaching past a single simplify is
+    what makes that worth pinning here.
+    """
+    narrow, narrower = ms('python_version < "3.11"'), ms('python_version < "3.10"')
+
+    assert (narrow & ~narrower).is_empty() is False
+    assert (narrower & ~narrow).is_empty() is True
+
+
+def test_partition_store_evicts_the_least_recently_used(
+    no_partition_store: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Past the bound the store drops the coldest axis, not the one just used."""
+    monkeypatch.setattr(engine, "_PARTITION_CACHE_LIMIT", 4)
+
+    for release in range(4):
+        assert ms(f'platform_release == "{release}"').is_empty() is False
+    store = engine._partition_cache.store
+    coldest, next_coldest = list(store)[:2]
+
+    # Touching the coldest entry should move the eviction onto its neighbour.
+    assert ms('platform_release == "0"').is_empty() is False
+    assert ms('platform_release == "4"').is_empty() is False
+
+    assert len(store) == 4
+    assert coldest in store
+    assert next_coldest not in store

--- a/tasks/vendoring/packaging.patch
+++ b/tasks/vendoring/packaging.patch
@@ -1,9 +1,9 @@
 diff --git a/nab-python/src/nab_python/_vendor/packaging/_markersets.py b/nab-python/src/nab_python/_vendor/packaging/_markersets.py
 new file mode 100644
-index 0000000..054dd73
+index 0000000..96ef396
 --- /dev/null
 +++ b/nab-python/src/nab_python/_vendor/packaging/_markersets.py
-@@ -0,0 +1,1708 @@
+@@ -0,0 +1,1727 @@
 +"""Marker algebra engine: reason about PEP 508 markers as sets of environments.
 +
 +The private engine behind :class:`~packaging.markersets.MarkerSet`. Parses a
@@ -23,6 +23,7 @@ index 0000000..054dd73
 +import re
 +import sys
 +import threading
++from collections import OrderedDict
 +from itertools import pairwise, product
 +from typing import TYPE_CHECKING, NamedTuple, cast
 +
@@ -171,10 +172,10 @@ index 0000000..054dd73
 +# ---------------------------------------------------------------------------- atoms
 +
 +
-+# A value atom's denotation is memoised per atom, so the cache lives and dies
-+# with the atom's tree. The bound stops a long-lived atom evaluated against
-+# ever-new points from accumulating them. The oversized-value guards run
-+# uncached before any ``holds`` call, so a warm cache never bypasses them.
++# A value atom's denotation is memoised per atom. The bound stops a long-lived
++# atom evaluated against ever-new points from accumulating them. The
++# oversized-value guards run uncached before any ``holds`` call, so a warm cache
++# never bypasses them.
 +_HOLDS_CACHE_LIMIT = 1024
 +
 +
@@ -1006,10 +1007,14 @@ index 0000000..054dd73
 +    return partition_boolean_axis(atoms, max_cells)
 +
 +
-+# One simplify re-partitions the same axes with the same atoms over and over.
-+# The cache lives only for that span and is thread-local, so a concurrent
-+# simplify never shares a store.
++# A partition is a pure function of its key, so one store serves every decision.
++# Thread-local, so a concurrent decision never shares a store and the entry
++# ordering needs no lock.
 +_partition_cache = threading.local()
++
++# The store outlives the decision that filled it, so the bound stops a
++# long-lived process accumulating axes it will not partition again.
++_PARTITION_CACHE_LIMIT = 4096
 +
 +# ``max_cells`` bounds one decision, and the greedy fixpoint issues one per
 +# clause and per atom per universe row, so the meter is what bounds the run:
@@ -1030,16 +1035,33 @@ index 0000000..054dd73
 +        raise IntractableMarkerSet(msg)
 +
 +
++def _partition_store() -> OrderedDict[tuple, list[Cell]]:
++    """Return this thread's partition store, created on first use."""
++    store: OrderedDict[tuple, list[Cell]] | None = getattr(
++        _partition_cache, "store", None
++    )
++    if store is None:
++        store = _partition_cache.store = OrderedDict()
++    return store
++
++
 +def partition_axis(axis: tuple, atoms: Sequence[Atom], max_cells: int) -> list[Cell]:
 +    """Partition one axis's domain into cells on which every atom is constant."""
-+    store: dict | None = getattr(_partition_cache, "store", None)
-+    if store is None:
-+        return _partition_axis(axis, atoms, max_cells)
-+    key = (axis, tuple(atoms), max_cells)
++    store = _partition_store()
++
++    # The digit limit gates ``reject_oversized_version_literals`` inside the
++    # partition, so an entry built under a different limit would skip it.
++    key = (axis, tuple(atoms), max_cells, sys.get_int_max_str_digits())
++
 +    cached = store.get(key)
-+    if cached is None:
-+        cached = _partition_axis(axis, atoms, max_cells)
-+        store[key] = cached
++    if cached is not None:
++        store.move_to_end(key)
++        return cached
++
++    cached = _partition_axis(axis, atoms, max_cells)
++    store[key] = cached
++    if len(store) > _PARTITION_CACHE_LIMIT:
++        store.popitem(last=False)
 +    return cached
 +
 +
@@ -1688,9 +1710,7 @@ index 0000000..054dd73
 +    original = _disjunction(clauses)
 +    rows = _decompose_rows(universe)
 +    original_by_row = [restrict_tree(original, row.pins) for row in rows]
-+    previous_store = getattr(_partition_cache, "store", None)
 +    previous_work = getattr(_work_meter, "remaining", None)
-+    _partition_cache.store = {}
 +    _work_meter.remaining = max_work
 +    try:
 +        while True:
@@ -1700,7 +1720,6 @@ index 0000000..054dd73
 +            if _canonical(clauses) == before:
 +                break
 +    finally:
-+        _partition_cache.store = previous_store
 +        _work_meter.remaining = previous_work
 +    if not clauses:
 +        return FALSE


### PR DESCRIPTION
Every MarkerSet decision partitions each referenced variable's domain into cells before enumerating the cell product, and `partition_axis` already memoised that work. The memo only existed while `simplify_within` had installed a store, and nothing else ever installed one, so every decision outside a simplify rebuilt each partition from scratch. The store is now built on demand and bounded, so a partition outlives the decision that built it.

Simplifying 600 per-package markers within a 12-minor by 8-platform universe goes from 1.65s to 0.58s. That is marker work rather than a `nab lock` end to end, and it lands on emission rather than resolution, so a wide matrix's lockfile write is where it shows.

The cache key carries `sys.get_int_max_str_digits()` because that limit gates the oversized-literal check inside the partition, so an entry built under a wider limit would skip it.