### PR TITLE
fail on an unreadable local wheel instead of pinning an older release

### DIFF
--- a/nab-index/src/nab_index/local_index.py
+++ b/nab-index/src/nab_index/local_index.py
@@ -469,8 +469,10 @@ def read_wheel_metadata(wheel_path: Path) -> str | None:
     (taken from its filename); a wheel with several top-level ``.dist-info``
     directories, or one naming a different distribution, raises
     :class:`UnsupportedWheelError` rather than reading another package's
-    metadata.  Returns ``None`` when the file is not a readable zip, its name
-    is not a wheel filename, or it carries no METADATA member.
+    metadata.  Returns ``None`` when the archive cannot be parsed, its name is
+    not a wheel filename, or it carries no METADATA member.  A wheel that
+    cannot be opened raises :class:`UnreadableLocalIndexError` instead, so a
+    permission or mount fault is not read as a wheel that declares nothing.
     """
     parsed = _parse_wheel_filename(wheel_path.name)
     if parsed is None:
@@ -481,9 +483,11 @@ def read_wheel_metadata(wheel_path: Path) -> str | None:
             if member is None:
                 return None
             return zf.read(member).decode("utf-8")
+    except OSError as exc:
+        msg = f"cannot read local wheel {wheel_path}: {exc}"
+        raise UnreadableLocalIndexError(msg) from exc
     except (
         zipfile.BadZipFile,
-        OSError,
         UnicodeDecodeError,
         zlib.error,
         lzma.LZMAError,

--- a/nab-python/src/nab_python/_provider/metadata_resolver.py
+++ b/nab-python/src/nab_python/_provider/metadata_resolver.py
@@ -14,7 +14,11 @@ from urllib.parse import urlsplit
 
 from nab_index.client import SdistFile, WheelFile
 from nab_index.lazy_wheel import RangeOutcome
-from nab_index.local_index import UnsupportedWheelError, read_wheel_metadata
+from nab_index.local_index import (
+    UnreadableLocalIndexError,
+    UnsupportedWheelError,
+    read_wheel_metadata,
+)
 
 from .._conflict_kind import EMPTY_MEMBERSHIP_SETS
 from .._vcs_admission import admit_vcs_url
@@ -99,7 +103,7 @@ def resolve_metadata(
         msg = f"Version {version} of {package} not found in listing"
         raise MetadataError(msg)
 
-    metadata_text, from_sdist = _read_direct_wheel_metadata(
+    metadata_text, from_sdist, unreadable_wheel = _read_direct_wheel_metadata(
         provider, dist, normalized, ver_str
     )
 
@@ -125,6 +129,43 @@ def resolve_metadata(
     if metadata_text is not None:
         return (metadata_text, from_sdist)
 
+    raise _ladder_failure(
+        provider,
+        package,
+        normalized,
+        version,
+        sdist=sdist,
+        metadata_url=metadata_url,
+        unreadable_wheel=unreadable_wheel,
+    )
+
+
+def _ladder_failure(
+    provider: Provider,
+    package: str,
+    normalized: str,
+    version: Version,
+    *,
+    sdist: SdistFile | None,
+    metadata_url: str | None,
+    unreadable_wheel: UnreadableLocalIndexError | None,
+) -> Exception:
+    """Return the error for a version no rung of the ladder could answer.
+
+    An unreadable local wheel takes precedence, and is deliberately not a
+    :class:`~nab_python.provider.MetadataError`: look-ahead treats those as a
+    rejection, so the version would be dropped and an older release pinned
+    instead of the resolve failing.
+    """
+    # Late import: ``provider`` imports this module at module load.
+    from ..provider import MetadataError
+
+    if unreadable_wheel is not None:
+        return unreadable_wheel
+
+    index = provider.coordinator.index
+    ver_str = str(version)
+
     # Only the rung the ladder gave up on can name the reason: an earlier rung
     # skipped offline says nothing about what this one read.
     last_url = sdist.url if sdist is not None else metadata_url
@@ -139,7 +180,7 @@ def resolve_metadata(
         reason = "no PEP 658 metadata and no sdist available"
 
     msg = f"No metadata for {package}=={version}: {reason}"
-    raise MetadataError(msg)
+    return MetadataError(msg)
 
 
 def _report_offline_skip(
@@ -158,13 +199,16 @@ def _report_offline_skip(
 
 def _read_direct_wheel_metadata(
     provider: Provider, dist: DistFile | None, package: str, version: str
-) -> tuple[str | None, bool]:
+) -> tuple[str | None, bool, UnreadableLocalIndexError | None]:
     """Rungs 2 and 3: a PEP 658 sidecar read, then a local wheel read.
 
-    Returns ``(metadata_text, from_sdist)``; ``from_sdist`` is always ``False``
-    since both sources are wheel METADATA.  A recorded sidecar integrity error
-    is re-raised and fails the resolve; a contradictory local ``.dist-info``
-    reads back as ``None`` and the ladder steps on.
+    Returns ``(metadata_text, from_sdist, unreadable)``; ``from_sdist`` is
+    always ``False`` since both sources are wheel METADATA.  A recorded sidecar
+    integrity error is re-raised and fails the resolve; a contradictory local
+    ``.dist-info`` reads back as ``None`` and the ladder steps on.  A wheel
+    that cannot be opened comes back as ``unreadable`` rather than raising, so
+    the version's own sdist still gets a turn; the caller raises it when no
+    later rung answers.
     """
     index = provider.coordinator.index
     if isinstance(dist, WheelFile) and (url := dist.metadata_url) is not None:
@@ -175,14 +219,17 @@ def _read_direct_wheel_metadata(
         integrity_error = index.get_metadata_error(package, version, url)
         if integrity_error is not None:
             raise integrity_error
-        return index.get_metadata_with_origin(package, version, url)
+        text, from_sdist = index.get_metadata_with_origin(package, version, url)
+        return text, from_sdist, None
     if isinstance(dist, WheelFile) and dist.local_path is not None:
         try:
-            return read_wheel_metadata(dist.local_path), False
+            return read_wheel_metadata(dist.local_path), False, None
         except UnsupportedWheelError:
-            # A contradictory .dist-info is unusable, like an unreadable wheel.
-            return None, False
-    return None, False
+            # A contradictory .dist-info is unusable, like a corrupt archive.
+            return None, False, None
+        except UnreadableLocalIndexError as exc:
+            return None, False, exc
+    return None, False, None
 
 
 def _is_bare_remote_wheel(dist: DistFile | None) -> TypeGuard[WheelFile]:

--- a/nab-python/tests/test_local_index.py
+++ b/nab-python/tests/test_local_index.py
@@ -58,6 +58,23 @@ def _deny_access(monkeypatch: pytest.MonkeyPatch, method: str, target: Path) -> 
     monkeypatch.setattr(Path, method, denied)
 
 
+def _deny_zip_open(monkeypatch: pytest.MonkeyPatch, target: Path) -> None:
+    """Make opening ``target`` as a zip fail with EACCES.
+
+    ``zipfile`` opens the path itself, so :func:`_deny_access` does not reach
+    it, and a real chmod would not do: root ignores the mode bits and Windows
+    has none.
+    """
+    original = zipfile.ZipFile
+
+    def denied(file: Any, *args: Any, **kwargs: Any) -> zipfile.ZipFile:
+        if file == target:
+            raise PermissionError(errno.EACCES, "Permission denied", str(target))
+        return original(file, *args, **kwargs)
+
+    monkeypatch.setattr(zipfile, "ZipFile", denied)
+
+
 def _write_wheel(
     path: Path,
     name: str,
@@ -1371,6 +1388,23 @@ class TestReadWheelMetadata:
 
     def test_returns_none_for_non_wheel_filename(self, tmp_path: Path) -> None:
         assert read_wheel_metadata(tmp_path / "notes.txt") is None
+
+    def test_unreadable_wheel_raises_index_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A wheel the process cannot open must raise, not read back as None.
+        wheel = tmp_path / "foo-1.0-py3-none-any.whl"
+        with zipfile.ZipFile(wheel, "w") as zf:
+            zf.writestr(
+                "foo-1.0.dist-info/METADATA",
+                "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n",
+            )
+        _deny_zip_open(monkeypatch, wheel)
+
+        with pytest.raises(UnreadableLocalIndexError) as caught:
+            read_wheel_metadata(wheel)
+        assert str(wheel) in str(caught.value)
+        assert "Permission denied" in str(caught.value)
 
     def test_rejects_multiple_dist_info_dirs(self, tmp_path: Path) -> None:
         wheel = tmp_path / "foo-1.0-py3-none-any.whl"

--- a/nab-python/tests/test_provider.py
+++ b/nab-python/tests/test_provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import io
 import json
 import logging
@@ -13,7 +14,7 @@ import zipfile
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import ClassVar, cast
+from typing import Any, ClassVar, cast
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -181,6 +182,28 @@ def _done_event() -> threading.Event:
     ev = threading.Event()
     ev.set()
     return ev
+
+
+def _write_local_wheel(path: Path, name: str, version: str) -> None:
+    """Write a wheel at ``path`` carrying nothing but its own METADATA."""
+    with zipfile.ZipFile(path, "w") as zf:
+        member = f"{name}-{version}.dist-info/METADATA"
+        zf.writestr(member, make_metadata(name, version))
+
+
+def _deny_zip_open(monkeypatch: pytest.MonkeyPatch, target: Path) -> None:
+    """Make opening ``target`` as a zip fail with EACCES.
+
+    A real chmod would not do: root ignores the mode bits and Windows has none.
+    """
+    original = zipfile.ZipFile
+
+    def denied(file: Any, *args: Any, **kwargs: Any) -> zipfile.ZipFile:
+        if file == target:
+            raise PermissionError(errno.EACCES, "Permission denied", str(target))
+        return original(file, *args, **kwargs)
+
+    monkeypatch.setattr(zipfile, "ZipFile", denied)
 
 
 def _make_sdist_targz(body: bytes = b"[project]\nname = 'pkg'\n") -> bytes:
@@ -2329,6 +2352,57 @@ class TestGetDependencies:
         assert "bar" in deps
         assert V("2.0") in deps["bar"]
         assert V("1.0") not in deps["bar"]
+
+    def test_unreadable_local_wheel_fails_instead_of_pinning_older(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unreadable local wheel fails the resolve, not just the version.
+
+        Look-ahead treats a ``MetadataError`` as a rejection, so folding the
+        read failure into one would drop 1.0 and answer with 0.9.
+        """
+        readable = tmp_path / "foo-0.9-py3-none-any.whl"
+        _write_local_wheel(readable, "foo", "0.9")
+        refused = tmp_path / "foo-1.0-py3-none-any.whl"
+        _write_local_wheel(refused, "foo", "1.0")
+        _deny_zip_open(monkeypatch, refused)
+
+        coordinator = make_coordinator(
+            [
+                make_wheel("0.9", has_metadata=False, local_path=readable),
+                make_wheel("1.0", has_metadata=False, local_path=refused),
+            ],
+            package="foo",
+        )
+        root_reqs = {"foo": SpecifierSet(">=0").to_range()}
+        provider = Provider(coordinator, target=_PY312, root_requirements=root_reqs)
+
+        with pytest.raises(UnreadableLocalIndexError, match="Permission denied"):
+            provider.choose_version("foo", root_reqs["foo"])
+
+    def test_unreadable_local_wheel_falls_back_to_sdist(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The version's own sdist still answers for an unreadable local wheel."""
+        wheel_path = tmp_path / "foo-1.0-py3-none-any.whl"
+        _write_local_wheel(wheel_path, "foo", "1.0")
+        _deny_zip_open(monkeypatch, wheel_path)
+
+        coordinator = make_coordinator(
+            [
+                make_wheel("1.0", has_metadata=False, local_path=wheel_path),
+                make_sdist("1.0"),
+            ],
+            package="foo",
+            sdist_pkg_info=(
+                "Metadata-Version: 2.2\nName: foo\nVersion: 1.0\n"
+                "Requires-Dist: baz>=3\n"
+            ),
+        )
+        provider = Provider(coordinator, target=_PY312)
+
+        deps = provider.get_dependencies("foo", V("1.0"))
+        assert "baz" in deps
 
     def test_local_wheel_with_mismatched_dist_info_rejected(
         self, tmp_path: Path


### PR DESCRIPTION
A wheel in a local wheelhouse that the process cannot open, an EACCES from a permission or mount fault for example, came back from read_wheel_metadata as None, the same answer as a wheel that carries no METADATA. The metadata ladder then ran out of rungs and raised MetadataError, which look-ahead treats as a rejection, so a lock against that wheelhouse quietly dropped the newest version and pinned an older wheel. An unreadable sdist in the same directory already fails with UnreadableLocalIndexError, so which error you got depended on which artifact happened to be unreadable.

read_wheel_metadata now raises UnreadableLocalIndexError when the archive will not open, and keeps the None answer for an archive that opens but does not parse, or that holds no METADATA. The provider carries that error to the end of the ladder so the version's own sdist still gets its turn, and raises it only when no later rung answers.
