### PR TITLE
parse benchmark UTC timestamps on Python 3.10

### DIFF
--- a/nab-python/benchmarks/benchmark_datetime.py
+++ b/nab-python/benchmarks/benchmark_datetime.py
@@ -1,0 +1,70 @@
+"""Datetime parsing shared by the benchmark runners and result validator."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+
+__all__ = ["is_valid_datetime", "parse_datetime"]
+
+_HOUR = r"(?:[01][0-9]|2[0-3])"
+_MINUTE_OR_SECOND = r"[0-5][0-9]"
+_BENCHMARK_DATETIME = re.compile(
+    rf"""
+    (?P<date>[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}})
+    (?:
+        (?P<time>[T ]{_HOUR}:{_MINUTE_OR_SECOND}:{_MINUTE_OR_SECOND})
+        (?:\.(?P<fraction>[0-9]+))?
+        (?P<offset>Z|[+-]{_HOUR}(?::?{_MINUTE_OR_SECOND})?)?
+    )?
+    """,
+    re.VERBOSE,
+)
+
+
+def _normalize_offset(value: str | None) -> str:
+    """Return an offset in the colon form Python 3.10 accepts."""
+    if value is None:
+        return ""
+    if value == "Z":
+        return "+00:00"
+
+    digits = value[1:].replace(":", "")
+    return f"{value[0]}{digits[:2]}:{digits[2:] or '00'}"
+
+
+def _fromisoformat_value(value: str) -> str:
+    """Validate and normalize a benchmark cutoff for supported Python versions."""
+    match = _BENCHMARK_DATETIME.fullmatch(value)
+    if match is None:
+        message = f"Invalid benchmark datetime: {value!r}"
+        raise ValueError(message)
+
+    date = match.group("date")
+    time = match.group("time")
+    if time is None:
+        return date
+
+    fraction = match.group("fraction")
+    normalized_fraction = "" if fraction is None else "." + fraction[:6].ljust(6, "0")
+    offset = _normalize_offset(match.group("offset"))
+    return f"{date}{time}{normalized_fraction}{offset}"
+
+
+def parse_datetime(value: str) -> datetime:
+    """Parse a benchmark cutoff, treating a missing offset as UTC."""
+    parsed = datetime.fromisoformat(_fromisoformat_value(value))
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def is_valid_datetime(value: object) -> bool:
+    """Return whether ``value`` is a supported benchmark cutoff."""
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        parse_datetime(value)
+    except ValueError:
+        return False
+    return True

--- a/nab-python/benchmarks/canary.py
+++ b/nab-python/benchmarks/canary.py
@@ -20,12 +20,12 @@ import statistics
 import subprocess
 import sys
 import time
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+    from datetime import datetime
 
     from nab_python.target import ResolveTarget
 
@@ -34,6 +34,7 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib  # type: ignore[no-redef]
 
+from benchmark_datetime import parse_datetime
 from benchmark_host import (
     BenchmarkHost,
     BenchmarkTimeout,
@@ -292,13 +293,6 @@ def _full_marker_environment(
     if overlay:
         env.update(overlay)
     return env
-
-
-def parse_datetime(value: str) -> datetime:
-    dt = datetime.fromisoformat(value)
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt
 
 
 def get_git_commit() -> str:

--- a/nab-python/benchmarks/scenarios.py
+++ b/nab-python/benchmarks/scenarios.py
@@ -18,12 +18,12 @@ import os
 import subprocess
 import sys
 import time
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+    from datetime import datetime
 
     from nab_python.target import ResolveTarget
 
@@ -32,6 +32,7 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib  # type: ignore[no-redef]
 
+from benchmark_datetime import parse_datetime
 from benchmark_host import (
     HOST_TAG_MISMATCH_REASON,
     BenchmarkHost,
@@ -833,14 +834,6 @@ def _full_marker_environment(
     if overlay:
         env.update(overlay)
     return env
-
-
-def parse_datetime(value: str) -> datetime:
-    """Parse an ISO 8601 datetime string to a timezone-aware datetime."""
-    dt = datetime.fromisoformat(value)
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt
 
 
 SCENARIO_WALL_TIMEOUT_SECONDS = 120

--- a/nab-python/benchmarks/universal_result.py
+++ b/nab-python/benchmarks/universal_result.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import math
-from datetime import datetime
+
+from benchmark_datetime import is_valid_datetime
 
 RESULT_SCHEMA_VERSION = 3
 MANIFEST_FILENAME = "_manifest.json"
@@ -140,16 +141,6 @@ def _valid_string_list(value: object, *, unique: bool = False) -> bool:
     )
 
 
-def _valid_datetime(value: object) -> bool:
-    if not isinstance(value, str) or not value:
-        return False
-    try:
-        datetime.fromisoformat(value)
-    except ValueError:
-        return False
-    return True
-
-
 def _valid_input(value: object, reason: object) -> bool:
     if not isinstance(value, dict):
         return False
@@ -183,7 +174,7 @@ def _valid_input(value: object, reason: object) -> bool:
         and isinstance(value["reason"], str)
         and reason == value["reason"]
         and ("constraints" not in value or _valid_string_list(value["constraints"]))
-        and ("datetime" not in value or _valid_datetime(value["datetime"]))
+        and ("datetime" not in value or is_valid_datetime(value["datetime"]))
     )
 
 

--- a/nab-python/benchmarks/universal_scenarios.py
+++ b/nab-python/benchmarks/universal_scenarios.py
@@ -27,7 +27,6 @@ import sys
 import time
 from contextlib import contextmanager
 from dataclasses import replace
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -40,6 +39,7 @@ else:
     # nab pins py>=3.10 but the import fallback matches scenarios.py
     import tomli as tomllib  # type: ignore[no-redef] # pragma: no cover
 
+from benchmark_datetime import parse_datetime
 from universal_result import (
     MANIFEST_FILENAME,
     RESULT_SCHEMA_VERSION,
@@ -185,14 +185,6 @@ def get_git_source_state() -> dict[str, str | bool | None]:
         else None
     )
     return {"commit": commit, "dirty": dirty, "diff_hash": diff_hash}
-
-
-def parse_datetime(value: str) -> datetime:
-    """Parse an ISO 8601 datetime; default to UTC if naive."""
-    dt = datetime.fromisoformat(value)
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt
 
 
 def check_lock_consistency(result: ResolveResult) -> tuple[bool, list[str]]:

--- a/nab-python/tests/test_benchmark_datetime.py
+++ b/nab-python/tests/test_benchmark_datetime.py
@@ -1,0 +1,178 @@
+"""Tests for benchmark datetime parsing."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_BENCHMARKS = Path(__file__).resolve().parents[1] / "benchmarks"
+_FRACTION_WIDTHS = [
+    ("", 0),
+    (".1", 100_000),
+    (".12", 120_000),
+    (".123", 123_000),
+    (".1234", 123_400),
+    (".12345", 123_450),
+    (".123456", 123_456),
+    (".1234567", 123_456),
+    (".123456789", 123_456),
+]
+_OFFSET_CASES = [
+    ("+05:30", timedelta(hours=5, minutes=30)),
+    ("-05:30", -timedelta(hours=5, minutes=30)),
+    ("+0000", timedelta()),
+    ("+00", timedelta()),
+    ("-0530", -timedelta(hours=5, minutes=30)),
+    ("-05", -timedelta(hours=5)),
+]
+_UNSUPPORTED_VALUES = [
+    "2025-W22-7T00:00:00Z",
+    "20250601T000000Z",
+    "2025-06-01T00:00:00,1Z",
+    "2025-06-01T00:00Z",
+    "2025-06-01t00:00:00Z",
+    "2025-06-01T00:00:00.",
+    "2025-06-01T00:00:00+000",
+    "2025-06-01Z",
+    "2025-06-01T00:00:00Z trailing",
+]
+_TIME_SUFFIXES = ["", "Z", "+12", "+1230", "+12:30", "-12", "-1230", "-12:30"]
+_OUT_OF_RANGE_VALUES = [
+    "2025-06-01T23:60:00Z",
+    "2025-06-01T23:59:60Z",
+    "2025-06-01T23:59:59+24",
+    "2025-06-01T23:59:59+2400",
+    "2025-06-01T23:59:59+24:00",
+    "2025-06-01T23:59:59-24",
+    "2025-06-01T23:59:59+1260",
+    "2025-06-01T23:59:59+12:60",
+    "2025-06-01T23:59:59-12:60",
+]
+
+
+def _load_harness(name: str) -> ModuleType:
+    """Load one benchmark script with its sibling imports available."""
+    spec = importlib.util.spec_from_file_location(
+        f"_benchmark_datetime_{name}", _BENCHMARKS / f"{name}.py"
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+
+    sys.path.insert(0, str(_BENCHMARKS))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.remove(str(_BENCHMARKS))
+    return module
+
+
+def _assert_rejected(module: ModuleType, value: str) -> None:
+    with pytest.raises(ValueError, match="Invalid benchmark datetime"):
+        module.parse_datetime(value)
+    assert module.is_valid_datetime(value) is False
+
+
+@pytest.mark.parametrize("harness", ["scenarios", "canary", "universal_scenarios"])
+def test_runners_accept_utc_suffix(harness: str) -> None:
+    module = _load_harness(harness)
+
+    assert module.parse_datetime("2025-06-01T00:00:00.1Z") == datetime(
+        2025, 6, 1, microsecond=100_000, tzinfo=timezone.utc
+    )
+
+
+@pytest.mark.parametrize("suffix", ["", "Z", "+00:00"])
+@pytest.mark.parametrize(("fraction", "microsecond"), _FRACTION_WIDTHS)
+def test_accepts_fraction_widths(
+    suffix: str,
+    fraction: str,
+    microsecond: int,
+) -> None:
+    module = _load_harness("benchmark_datetime")
+
+    assert module.parse_datetime(f"2025-06-01T00:00:00{fraction}{suffix}") == datetime(
+        2025, 6, 1, microsecond=microsecond, tzinfo=timezone.utc
+    )
+
+
+@pytest.mark.parametrize(("offset_text", "offset"), _OFFSET_CASES)
+def test_accepts_colon_and_basic_offsets(
+    offset_text: str,
+    offset: timedelta,
+) -> None:
+    module = _load_harness("benchmark_datetime")
+
+    timestamp = f"2025-06-01T00:00:00.123456789{offset_text}"
+    assert module.parse_datetime(timestamp) == datetime(
+        2025, 6, 1, microsecond=123_456, tzinfo=timezone(offset)
+    )
+
+
+def test_bare_date_is_not_rewritten() -> None:
+    module = _load_harness("benchmark_datetime")
+
+    assert module._fromisoformat_value("2025-06-01") == "2025-06-01"
+    assert module.parse_datetime("2025-06-01") == datetime(
+        2025, 6, 1, tzinfo=timezone.utc
+    )
+
+
+def test_accepts_space_separator() -> None:
+    module = _load_harness("benchmark_datetime")
+
+    assert module.parse_datetime("2025-06-01 00:00:00") == datetime(
+        2025, 6, 1, tzinfo=timezone.utc
+    )
+
+
+def test_accepts_upper_range_boundaries() -> None:
+    module = _load_harness("benchmark_datetime")
+
+    assert module.parse_datetime("2025-06-01T23:59:59.9+23:59") == datetime(
+        2025,
+        6,
+        1,
+        23,
+        59,
+        59,
+        900_000,
+        tzinfo=timezone(timedelta(hours=23, minutes=59)),
+    )
+
+
+@pytest.mark.parametrize("suffix", _TIME_SUFFIXES)
+@pytest.mark.parametrize("fraction", ["", ".1"])
+def test_rejects_24_hour_for_each_supported_form(
+    suffix: str,
+    fraction: str,
+) -> None:
+    module = _load_harness("benchmark_datetime")
+
+    _assert_rejected(module, f"2025-06-01T24:00:00{fraction}{suffix}")
+
+
+@pytest.mark.parametrize("value", _OUT_OF_RANGE_VALUES)
+def test_rejects_out_of_range_fields(value: str) -> None:
+    module = _load_harness("benchmark_datetime")
+
+    _assert_rejected(module, value)
+
+
+@pytest.mark.parametrize("value", _UNSUPPORTED_VALUES)
+def test_rejects_unsupported_forms(value: str) -> None:
+    module = _load_harness("benchmark_datetime")
+
+    _assert_rejected(module, value)
+
+
+@pytest.mark.parametrize("value", [None, "", "not-a-date"])
+def test_validator_rejects_invalid_values(value: object) -> None:
+    module = _load_harness("benchmark_datetime")
+
+    assert module.is_valid_datetime(value) is False

--- a/nab-python/tests/test_universal_benchmark.py
+++ b/nab-python/tests/test_universal_benchmark.py
@@ -390,10 +390,32 @@ def test_result_contract_validates_optional_input_fields() -> None:
             "lock_consistent": True,
         }
     )
-    data["input"].update({"constraints": ["foo<2"], "datetime": "2025-06-01 00:00:00"})
-    assert module.result_is_well_formed(data) is True
+    data["input"]["constraints"] = ["foo<2"]
+    for datetime_value in (
+        "2025-06-01",
+        "2025-06-01 00:00:00",
+        "2025-06-01T00:00:00.123456789Z",
+        "2025-06-01T00:00:00.1+05:30",
+        "2025-06-01T00:00:00.1-05:30",
+        "2025-06-01T00:00:00.1+0000",
+        "2025-06-01T00:00:00.1+00",
+        "2025-06-01T23:59:59.9+23:59",
+    ):
+        data["input"]["datetime"] = datetime_value
+        assert module.result_is_well_formed(data) is True
 
-    for field, value in (("constraints", []), ("datetime", "not-a-date")):
+    for field, value in (
+        ("constraints", []),
+        ("datetime", "not-a-date"),
+        ("datetime", "2025-W22-7T00:00:00Z"),
+        ("datetime", "20250601T000000Z"),
+        ("datetime", "2025-06-01T00:00:00,1Z"),
+        ("datetime", "2025-06-01T24:00:00Z"),
+        ("datetime", "2025-06-01T23:60:00Z"),
+        ("datetime", "2025-06-01T23:59:60Z"),
+        ("datetime", "2025-06-01T23:59:59+24"),
+        ("datetime", "2025-06-01T23:59:59+12:60"),
+    ):
         invalid = json.loads(json.dumps(data))
         invalid["input"][field] = value
         assert module.result_is_well_formed(invalid) is False


### PR DESCRIPTION
Round-tripping the canonical `2025-06-01T00:00:00Z` benchmark cutoff failed on Python 3.10 before resolution. Standard, canary, and universal benchmarks now use one version-independent cutoff parser, and persisted universal results validate the same grammar.
